### PR TITLE
Feature/jvnautosci 747 issue8 creating concepts does not work in UI

### DIFF
--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -253,6 +253,50 @@ def get_tree():
     return jsonify({**tree_data, '_cache': {'hit': False, 'build_sec': build_secs, 'alloc_kb': alloc_kb, 'ttl_sec': _TREE_CACHE_TTL_SECONDS, 'hits': 0}})
 
 
+@vontology_bp.route('/ensure_thing', methods=['POST'])
+def ensure_thing_route():
+    """Endpoint to ensure Thing root concept exists and link any orphan concepts.
+    
+    This is called automatically by the frontend when it detects an empty or incomplete ontology.
+    It will:
+    1. Create Thing if it doesn't exist
+    2. Link any orphan concepts (types without parents) to Thing
+    
+    Returns:
+        JSON with thing_created, thing_concept_id, orphans_linked, orphan_ids
+    """
+    current_app.logger.info("Received request for /api/vontology/ensure_thing")
+    
+    try:
+        from ...vontology.utils_vontology import ensure_thing_exists_and_link_orphans
+        
+        result = ensure_thing_exists_and_link_orphans()
+        
+        if "error" in result:
+            current_app.logger.error(f"Error ensuring Thing exists: {result['error']}")
+            return jsonify({"success": False, "message": result['error']}), 500
+        
+        # Invalidate tree cache since we modified the ontology structure
+        with _TREE_CACHE_LOCK:
+            _TREE_CACHE.clear()
+        
+        current_app.logger.info(
+            f"Thing ensured: created={result['thing_created']}, orphans_linked={result['orphans_linked']}"
+        )
+        
+        return jsonify({
+            "success": True,
+            "thing_created": result['thing_created'],
+            "thing_concept_id": result['thing_concept_id'],
+            "orphans_linked": result['orphans_linked'],
+            "orphan_ids": result['orphan_ids']
+        }), 200
+        
+    except Exception as e:
+        current_app.logger.error(f"Unexpected error in ensure_thing: {e}", exc_info=True)
+        return jsonify({"success": False, "message": f"Internal error: {str(e)}"}), 500
+
+
 def _build_tree_job(job_id: str) -> None:
     """Background worker that constructs the Vontology tree whilst tracking progress."""
     try:
@@ -580,7 +624,7 @@ def create_concept_route():
         current_app.logger.warning("Received non-JSON or empty payload for /create_concept.")
         return jsonify({"success": False, "message": "Request body must be JSON."}), 400
 
-    parent_id = data.get("parent_id")
+    parent_id = data.get("parent_id")  # Optional: None for root concept creation
     new_concept_name = data.get("new_concept_name")
     # ONTOLOGICAL FLAG: create_as_instance determines type vs individual creation
     # - False (default): Creates a TYPE (has is_a_type_of relationships, can be subtype AND instance)
@@ -590,9 +634,14 @@ def create_concept_route():
 
     current_app.logger.info(f"Request details - Parent ID: {parent_id}, New Concept: {new_concept_name}, Create as instance: {create_as_instance}")
 
-    if not parent_id or not new_concept_name:
-        current_app.logger.warning("Missing 'parent_id' or 'new_concept_name' in /create_concept request.")
-        return jsonify({"success": False, "message": "Missing 'parent_id' or 'new_concept_name'."}), 400
+    # CHICKEN-AND-EGG FIX: Allow root concept creation without parent_id
+    if not new_concept_name:
+        current_app.logger.warning("Missing 'new_concept_name' in /create_concept request.")
+        return jsonify({"success": False, "message": "Missing 'new_concept_name'."}), 400
+    
+    # parent_id is optional - if omitted, creates a root concept
+    if not parent_id:
+        current_app.logger.info("No parent_id provided - creating root concept")
 
     try:
         # Create concept without user attribution for privacy

--- a/src/backend/services/concept_service.py
+++ b/src/backend/services/concept_service.py
@@ -201,16 +201,14 @@ def create_concept(
 
     now = datetime.now(timezone.utc)
 
-    # Persist display name canonically in names[]; avoid writing legacy top-level name
+    # Persist display name using text_relations (modern approach) instead of legacy names[] field
     # Determine relationship shape based on creation kind
     parent_ids = parent_concept_ids or []
     is_instance_of = parent_ids if create_as_instance else []
     is_a_type_of = [] if create_as_instance else parent_ids
 
     concept_doc: Dict[str, Any] = {
-        "names": (
-            [{"name": name.strip(), "language": "en-NZ", "type": "NL"}] if isinstance(name, str) and name.strip() else []
-        ),
+        # DO NOT include "names" field - will be created as text_relations below
         "created_at": now,
         "updated_at": now,
         "attributes": attributes or {},
@@ -238,8 +236,25 @@ def create_concept(
         # Fetch the document to ensure all defaults/triggers (if any) are included
         created_concept = concepts_coll.find_one({"_id": result.inserted_id})
 
+        # CRITICAL: Create name as text_relation immediately (modern approach)
+        # This prevents migrate-on-read from triggering and creating duplicates
+        concept_identifier = concept_doc.get("concept_id")
+        if concept_identifier and name and name.strip():
+            try:
+                from .text_value_service import upsert_text_for_concept
+                upsert_text_for_concept(
+                    subject_concept_id=concept_identifier,
+                    predicate='hasName',
+                    text=name.strip(),
+                    lang='en-NZ',
+                    context={'name_type': 'NL'}
+                )
+                logger.info(f"[create_concept] Created hasName text_relation for {concept_identifier}: {name}")
+            except Exception as name_err:
+                # Non-fatal: concept is created, just name relation failed
+                logger.warning(f"[create_concept] Failed to create hasName relation for {concept_identifier}: {name_err}")
+
         try:
-            concept_identifier = concept_doc.get("concept_id")
             if concept_identifier:
                 ConceptsRepository.reconcile_relationships(
                     concept_identifier,

--- a/src/backend/vontology/utils_vontology.py
+++ b/src/backend/vontology/utils_vontology.py
@@ -3069,6 +3069,122 @@ def create_vontology_concept(
         }
 
 
+def ensure_thing_exists_and_link_orphans() -> Dict[str, Any]:
+    """
+    Ensures that the Thing root concept exists in the database.
+    If it doesn't exist, creates it.
+    If it exists but there are orphan concepts (types with no parent), links them to Thing.
+    
+    Returns:
+        Dict with keys:
+        - thing_created: bool indicating if Thing was newly created
+        - thing_concept_id: str with Thing's concept_id
+        - orphans_linked: int count of orphan concepts linked to Thing
+        - orphan_ids: list of concept_ids that were linked
+    """
+    from ..services.concept_service import create_concept
+    from ..db.repositories.concepts_repository import ConceptsRepository
+    
+    logger.info("[ensure_thing_exists] Checking for Thing root concept")
+    
+    # Check if Thing already exists
+    thing_concept = ConceptsRepository.find_one({"concept_id": THING_PRIMARY_ID})
+    thing_created = False
+    
+    if not thing_concept:
+        # Create Thing as root concept with rich metadata following OWL conventions
+        logger.info("[ensure_thing_exists] Thing not found, creating root concept")
+        try:
+            thing_concept = create_concept(
+                name="Thing",
+                concept_id=THING_PRIMARY_ID,
+                parent_concept_ids=[],  # No parent - it's the root
+                create_as_instance=False,  # It's a type
+                description="Thing is the root concept in an ontology, encompassing all entities, whether physical or abstract, real or conceptual. It serves as the broadest possible category, providing a common ancestor for every concept in the ontology.",
+                notes="This is the universal root following OWL (Web Ontology Language) conventions. All concepts without explicit parent relationships are children of Thing. This prevents orphaned concepts in the hierarchy.",
+                attributes={
+                    "domain": "Ontology",
+                    "role": "root",
+                    "standard": "OWL"
+                },
+                system_tags=["root", "ontology", "foundational", "owl"],
+                user_tags=[]
+            )
+            thing_created = True
+            logger.info(f"[ensure_thing_exists] Created Thing with rich metadata: {thing_concept.get('concept_id')}")
+        except Exception as e:
+            logger.error(f"[ensure_thing_exists] Failed to create Thing: {e}")
+            return {
+                "thing_created": False,
+                "thing_concept_id": None,
+                "orphans_linked": 0,
+                "orphan_ids": [],
+                "error": str(e)
+            }
+    else:
+        logger.info("[ensure_thing_exists] Thing already exists")
+    
+    # Find orphan concepts (types with empty or missing is_a_type_of)
+    orphan_concepts = list(ConceptsRepository.find({
+        "$and": [
+            # Has no instance-of (it's not an instance)
+            {"$or": [
+                {"relationships.is_an_instance_of": {"$exists": False}},
+                {"relationships.is_an_instance_of": []},
+                {"relationships.is_an_instance_of": ""}
+            ]},
+            # Has empty or missing is_a_type_of (it's an orphan type)
+            {"$or": [
+                {"relationships.is_a_type_of": {"$exists": False}},
+                {"relationships.is_a_type_of": []},
+                {"relationships.is_a_type_of": ""}
+            ]},
+            # Not Thing itself
+            {"concept_id": {"$ne": THING_PRIMARY_ID}}
+        ]
+    }))
+    
+    orphans_linked = 0
+    orphan_ids = []
+    
+    if orphan_concepts:
+        logger.info(f"[ensure_thing_exists] Found {len(orphan_concepts)} orphan concepts, linking to Thing")
+        
+        for orphan in orphan_concepts:
+            try:
+                orphan_id = orphan.get("concept_id")
+                if not orphan_id:
+                    continue
+                
+                # Update orphan to have Thing as parent
+                ConceptsRepository.update_one(
+                    {"concept_id": orphan_id},
+                    {"$set": {"relationships.is_a_type_of": [THING_PRIMARY_ID]}}
+                )
+                
+                # Update Thing to have this orphan as child (reciprocal relationship)
+                ConceptsRepository.update_one(
+                    {"concept_id": THING_PRIMARY_ID},
+                    {"$addToSet": {"relationships.has_subtype": orphan_id}}
+                )
+                
+                orphans_linked += 1
+                orphan_ids.append(orphan_id)
+                logger.info(f"[ensure_thing_exists] Linked orphan {orphan_id} to Thing")
+                
+            except Exception as e:
+                logger.warning(f"[ensure_thing_exists] Failed to link orphan {orphan_id}: {e}")
+    
+    logger.info(f"[ensure_thing_exists] Complete - created={thing_created}, orphans_linked={orphans_linked}")
+    
+    return {
+        "thing_created": thing_created,
+        "thing_concept_id": THING_PRIMARY_ID,
+        "orphans_linked": orphans_linked,
+        "orphan_ids": orphan_ids
+    }
+
+
 # Note: add_upward_closure_nodes defined later (duplicate removed - keeping complete implementation at line 2949)
 def _invalidate_vontology_caches_duplicate_removed(affected_concepts: list, correlation_id: str) -> None:
     """

--- a/src/frontend/web/von_interface/static/js/vontology.js
+++ b/src/frontend/web/von_interface/static/js/vontology.js
@@ -948,8 +948,75 @@ export async function fetchAndRenderVontologyTree() {
     if (treeData.error) {
       console.error("[fetchAndRenderVontologyTree] Error from server:", treeData.error);
       elements.vontologyTreeContainer.innerHTML = `<p>Error loading Vontology tree: ${treeData.error}</p>`;
-    } else if (treeData.tree) {
+    } else if (treeData.tree !== undefined && treeData.tree !== null) {
       debugLog("[fetchAndRenderVontologyTree] treeData.tree structure:", JSON.stringify(treeData.tree, null, 2));
+      
+      // CHICKEN-AND-EGG FIX: Check if tree is empty array (database is empty)
+      if (Array.isArray(treeData.tree) && treeData.tree.length === 0) {
+        console.log("[fetchAndRenderVontologyTree] Tree is empty - auto-creating Thing root concept");
+        
+        // Show loading message
+        elements.vontologyTreeContainer.innerHTML = `
+          <div style="padding: 20px; text-align: center; color: #666;">
+            <p style="font-size: 1.2em; margin-bottom: 10px;">🌱 <strong>Empty Vontology</strong></p>
+            <p>Automatically creating "Thing" root concept...</p>
+            <div style="margin-top: 15px;">
+              <div style="display: inline-block; width: 200px; height: 4px; background: #eee; border-radius: 2px; overflow: hidden;">
+                <div style="width: 100%; height: 100%; background: linear-gradient(90deg, #2b8cff, #68d1ff); animation: slide 1.5s infinite;"></div>
+              </div>
+            </div>
+          </div>
+        `;
+        
+        // Auto-create Thing
+        try {
+          const response = await fetch('/vontology/api/vontology/ensure_thing', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' }
+          });
+          
+          const result = await response.json();
+          
+          if (result.success) {
+            console.log(`[fetchAndRenderVontologyTree] Thing auto-created: created=${result.thing_created}, orphans_linked=${result.orphans_linked}`);
+            
+            // Show success message briefly
+            elements.vontologyTreeContainer.innerHTML = `
+              <div style="padding: 20px; text-align: center; color: #2b8cff;">
+                <p style="font-size: 1.2em; margin-bottom: 10px;">✅ <strong>Thing Created!</strong></p>
+                <p>Root concept established. Refreshing tree...</p>
+              </div>
+            `;
+            
+            // Refresh the tree after a brief delay
+            setTimeout(() => {
+              console.log("[fetchAndRenderVontologyTree] Refreshing tree after Thing creation");
+              handleRefreshTree();
+            }, 800);
+            
+            hideProgressBar();
+            return;
+          } else {
+            throw new Error(result.message || 'Failed to create Thing');
+          }
+        } catch (error) {
+          console.error("[fetchAndRenderVontologyTree] Failed to auto-create Thing:", error);
+          
+          // Show error with manual fallback
+          elements.vontologyTreeContainer.innerHTML = `
+            <div style="padding: 20px; text-align: center; color: #666;">
+              <p style="font-size: 1.2em; margin-bottom: 10px; color: #ff4444;">⚠️ <strong>Auto-creation Failed</strong></p>
+              <p style="color: #ff4444; margin-bottom: 15px;">${error.message}</p>
+              <p>You can create the root concept manually below.</p>
+            </div>
+          `;
+          
+          // Enable manual creation mode as fallback
+          handleNodeSelect(null, null, null, false, { mutateConceptTab: false });
+          hideProgressBar();
+          return;
+        }
+      }
       clearContainer(elements.vontologyTreeContainer);
       progressMgr.updateProgress(0.1, `${__vontologyEstimatedTotal ? '0/' + __vontologyEstimatedTotal : ''}`);
       __vontologyRenderCount = 0;
@@ -1008,6 +1075,75 @@ export async function fetchAndRenderVontologyTree() {
           }
         }
       } else if (typeof processedTree === 'object' && processedTree !== null) {
+        // CHICKEN-AND-EGG FIX: Check for auto-injected Thing placeholder before rendering
+        // The backend auto-injects a Thing node even when DB is empty (mongo_id will be "")
+        const isPlaceholderTree = processedTree.id === '#V#thing' && 
+                                 processedTree.mongo_id === '' &&
+                                 (!processedTree.children || processedTree.children.length === 0);
+        
+        if (isPlaceholderTree) {
+          console.log("[fetchAndRenderVontologyTree] Detected auto-injected Thing placeholder - auto-creating real Thing");
+          
+          // Show loading message
+          elements.vontologyTreeContainer.innerHTML = `
+            <div style="padding: 20px; text-align: center; color: #666;">
+              <p style="font-size: 1.2em; margin-bottom: 10px;">🌱 <strong>Empty Vontology</strong></p>
+              <p>Creating "Thing" root concept...</p>
+              <div style="margin-top: 15px;">
+                <div style="display: inline-block; width: 200px; height: 4px; background: #eee; border-radius: 2px; overflow: hidden;">
+                  <div style="width: 100%; height: 100%; background: linear-gradient(90deg, #2b8cff, #68d1ff); animation: slide 1.5s infinite;"></div>
+                </div>
+              </div>
+            </div>
+          `;
+          
+          // Auto-create Thing
+          try {
+            const response = await fetch('/vontology/api/vontology/ensure_thing', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' }
+            });
+            
+            const result = await response.json();
+            
+            if (result.success) {
+              console.log(`[fetchAndRenderVontologyTree] Thing auto-created from placeholder: created=${result.thing_created}, orphans_linked=${result.orphans_linked}`);
+              
+              // Show success and refresh
+              elements.vontologyTreeContainer.innerHTML = `
+                <div style="padding: 20px; text-align: center; color: #2b8cff;">
+                  <p style="font-size: 1.2em; margin-bottom: 10px;">✅ <strong>Thing Created!</strong></p>
+                  <p>Refreshing tree...</p>
+                </div>
+              `;
+              
+              setTimeout(() => {
+                handleRefreshTree();
+              }, 800);
+              
+              hideProgressBar();
+              return;
+            } else {
+              throw new Error(result.message || 'Failed to create Thing');
+            }
+          } catch (error) {
+            console.error("[fetchAndRenderVontologyTree] Failed to auto-create Thing from placeholder:", error);
+            
+            // Show error with manual fallback
+            elements.vontologyTreeContainer.innerHTML = `
+              <div style="padding: 20px; text-align: center; color: #666;">
+                <p style="font-size: 1.2em; margin-bottom: 10px; color: #ff4444;">⚠️ <strong>Auto-creation Failed</strong></p>
+                <p style="color: #ff4444; margin-bottom: 15px;">${error.message}</p>
+                <p>Manual creation mode enabled below.</p>
+              </div>
+            `;
+            
+            handleNodeSelect(null, null, null, false, { mutateConceptTab: false });
+            hideProgressBar();
+            return;
+          }
+        }
+        
         // Build subtree counts cache once
         subtreeCountMap = buildSubtreeCountCache([processedTree], entityCounts);
         debugLog("[fetchAndRenderVontologyTree] processedTree is a single object, processing as the root.");
@@ -1060,7 +1196,21 @@ export async function fetchAndRenderVontologyTree() {
       }
 
     } else {
-      elements.vontologyTreeContainer.innerHTML = '<p>Vontology tree data is empty or invalid.</p>';
+      // CHICKEN-AND-EGG FIX: Empty database - show helpful message and enable root creation
+      console.log("[fetchAndRenderVontologyTree] Tree is empty - enabling root concept creation mode");
+      elements.vontologyTreeContainer.innerHTML = `
+        <div style="padding: 20px; text-align: center; color: #666;">
+          <p style="font-size: 1.2em; margin-bottom: 10px;">🌱 <strong>Empty Vontology</strong></p>
+          <p>No concepts exist yet. Create your first root concept below.</p>
+          <p style="font-size: 0.9em; margin-top: 10px; color: #888;">
+            Tip: Start with "Thing" as the root of your ontology.
+          </p>
+        </div>
+      `;
+      
+      // Enable empty-tree creation mode by triggering handleNodeSelect with null
+      // This will show the creation panel with appropriate messaging
+      handleNodeSelect(null, null, null, false, { mutateConceptTab: false });
     }
   } catch (error) {
     console.error("[fetchAndRenderVontologyTree] Error during Vontology tree fetch or render:", error);
@@ -2160,17 +2310,29 @@ export async function handleNodeSelect(nodeName, nodeId, mongoId, createConceptT
   console.log(`[handleNodeSelect] Node selected: Name='${nodeName}', ID='${nodeId}', MongoID='${mongoId}', createConceptTab='${createConceptTab}'`);
   const mutateConceptTab = options.mutateConceptTab !== false; // default true
 
+  // CHICKEN-AND-EGG FIX: Check if this is empty tree mode (all params null)
+  const isEmptyTreeMode = !nodeName && !nodeId && !mongoId;
+
   // Prefer the semantic concept_id (nodeId, e.g. '#V#person') for API calls
   // since backend endpoints expect concept identifiers; fall back to mongoId
   // only if the concept_id is missing.
   const identifier = nodeId || mongoId;
-  debugLog(`[handleNodeSelect] Using identifier for API calls: ${identifier} (nodeId=${nodeId}, mongoId=${mongoId})`);
+  debugLog(`[handleNodeSelect] Using identifier for API calls: ${identifier} (nodeId=${nodeId}, mongoId=${mongoId}, emptyTreeMode=${isEmptyTreeMode})`);
 
   // 1. Update UI for selected node path display
   if (elements.selectedNodePathSpan) {
-    // If an Individual tab is active, prefer singular; otherwise types may display plurals elsewhere.
-    // Here we keep the node label itself as provided (nodeName), and include the ID.
-    elements.selectedNodePathSpan.textContent = `Selected: ${nodeName} (${nodeId})`; // Initial update with concept ID
+    if (isEmptyTreeMode) {
+      // Empty tree mode - show special message
+      elements.selectedNodePathSpan.textContent = 'Empty ontology - create root concept below';
+      elements.selectedNodePathSpan.style.fontStyle = 'italic';
+      elements.selectedNodePathSpan.style.color = '#888';
+    } else {
+      // If an Individual tab is active, prefer singular; otherwise types may display plurals elsewhere.
+      // Here we keep the node label itself as provided (nodeName), and include the ID.
+      elements.selectedNodePathSpan.textContent = `Selected: ${nodeName} (${nodeId})`; // Initial update with concept ID
+      elements.selectedNodePathSpan.style.fontStyle = 'normal';
+      elements.selectedNodePathSpan.style.color = '';
+    }
     // Add/Update forced-visible badge
     const existingBadge = elements.selectedNodePathSpan.querySelector('.forced-visible-badge');
     // Determine if current node is visible only due to temporary reveal or forced filter state
@@ -2277,12 +2439,46 @@ export async function handleNodeSelect(nodeName, nodeId, mongoId, createConceptT
 
   // 6. Handle the "Create Concept" section visibility and state
   if (elements.createConceptDiv) {
-    if (nodeId) {
+    if (isEmptyTreeMode) {
+      // CHICKEN-AND-EGG FIX: Empty tree mode - show creation UI with special instructions
+      elements.createConceptDiv.classList.remove('hidden');
+      elements.createConceptDiv.style.removeProperty('display');
+      if (elements.createConceptStatusP) {
+        elements.createConceptStatusP.textContent = 'Create root concept (typically "Thing"):';
+        elements.createConceptStatusP.style.fontWeight = 'bold';
+        elements.createConceptStatusP.style.color = '#2b8cff';
+      }
+      // Enable creation UI
+      if (elements.newConceptNameInput) {
+        elements.newConceptNameInput.value = '';
+        elements.newConceptNameInput.disabled = false;
+        elements.newConceptNameInput.placeholder = 'e.g., Thing';
+      }
+      // Only show Create Type button in root mode (no parent)
+      if (elements.createTypeButton) {
+        elements.createTypeButton.disabled = false;
+        elements.createTypeButton.textContent = 'Create Root Concept';
+        elements.createTypeButton.style.display = '';
+      }
+      // Hide instance button in root mode (can't create instance without types)
+      if (elements.createInstanceButton) {
+        elements.createInstanceButton.style.display = 'none';
+      }
+    } else if (nodeId) {
       elements.createConceptDiv.classList.remove('hidden');
       // Clear any conflicting inline style from older logic
       elements.createConceptDiv.style.removeProperty('display');
       if (elements.createConceptStatusP) {
         elements.createConceptStatusP.textContent = `Create new concept under: ${nodeName}`;
+        elements.createConceptStatusP.style.fontWeight = 'normal';
+        elements.createConceptStatusP.style.color = '';
+      }
+      // Show both buttons in normal mode
+      if (elements.createTypeButton) {
+        elements.createTypeButton.style.display = '';
+      }
+      if (elements.createInstanceButton) {
+        elements.createInstanceButton.style.display = '';
       }
     } else {
       elements.createConceptDiv.classList.add('hidden');
@@ -2292,12 +2488,12 @@ export async function handleNodeSelect(nodeName, nodeId, mongoId, createConceptT
         elements.createConceptStatusP.textContent = '';
       }
     }
-    if (elements.newConceptNameInput) {
+    if (elements.newConceptNameInput && !isEmptyTreeMode) {
       elements.newConceptNameInput.value = '';
     }
 
-    // Disable create actions if no type is selected
-    const disabled = !nodeId;
+    // Disable create actions if no type is selected (unless empty tree mode)
+    const disabled = !nodeId && !isEmptyTreeMode;
     if (elements.createTypeButton) elements.createTypeButton.disabled = disabled;
     if (elements.createInstanceButton) elements.createInstanceButton.disabled = disabled;
     if (elements.newConceptNameInput) elements.newConceptNameInput.disabled = disabled;
@@ -3438,7 +3634,12 @@ export async function handleCreateType() {
     return;
   }
 
-  if (!parentId) {
+  // CHICKEN-AND-EGG FIX: Allow root creation when tree is empty (no parentId)
+  // Check if tree is truly empty by looking for any vontology-node-name elements
+  const hasExistingNodes = document.querySelector('.vontology-node-name[data-concept-id]') !== null;
+  const isRootCreation = !parentId && !hasExistingNodes;
+  
+  if (!parentId && !isRootCreation) {
     if (elements.createConceptStatusP) {
       elements.createConceptStatusP.textContent = "Please select a parent node first.";
       elements.createConceptStatusP.style.color = "red";
@@ -3450,20 +3651,37 @@ export async function handleCreateType() {
     if (elements.createTypeButton) elements.createTypeButton.disabled = true;
     if (elements.createInstanceButton) elements.createInstanceButton.disabled = true;
     if (elements.createConceptStatusP) {
-      elements.createConceptStatusP.textContent = "Creating type...";
+      elements.createConceptStatusP.textContent = isRootCreation ? "Creating root concept..." : "Creating type...";
       elements.createConceptStatusP.style.color = "black";
     }
 
-    const response = await postJson('/vontology/api/vontology/create_concept', {
+    // CHICKEN-AND-EGG FIX: For root creation, omit parent_id entirely
+    const requestPayload = {
       new_concept_name: newConceptName,
-      parent_id: parentId,
       create_as_instance: false
-    });
+    };
+    if (!isRootCreation && parentId) {
+      requestPayload.parent_id = parentId;
+    }
+
+    const response = await postJson('/vontology/api/vontology/create_concept', requestPayload);
 
     const createdConceptId = response?.concept_id || response?.concept?.concept_id;
     const createdConceptName = response?.concept?.name || newConceptName;
     const createdMongoId = response?.concept?.mongo_id;
-    if (createdConceptId) {
+    
+    if (isRootCreation) {
+      // For root creation, refresh the entire tree to show the new root
+      console.log('[handleCreateType] Root concept created, refreshing tree...');
+      await handleRefreshTree();
+      // Auto-select the newly created root
+      if (createdConceptId) {
+        setTimeout(() => {
+          selectVontologyNodeByIdentifier(createdConceptId, false);
+        }, 500);
+      }
+    } else if (createdConceptId) {
+      // Normal node insertion
       await insertNodeIntoVontologyTree(parentId, {
         id: createdConceptId,
         name: createdConceptName,

--- a/src/frontend/web/von_interface/static/js/vontology.js
+++ b/src/frontend/web/von_interface/static/js/vontology.js
@@ -3807,6 +3807,29 @@ export function initializeVontologyTab() {
     });
   }
 
+  // CRITICAL FIX: Wire up create concept buttons
+  if (elements.createTypeButton) {
+    elements.createTypeButton.addEventListener('click', async () => {
+      await handleCreateType();
+    });
+    console.log('[initializeVontologyTab] Create Type button wired up');
+  }
+
+  if (elements.createInstanceButton) {
+    elements.createInstanceButton.addEventListener('click', async () => {
+      await handleCreateInstance();
+    });
+    console.log('[initializeVontologyTab] Create Instance button wired up');
+  }
+
+  // Also wire up refresh tree button while we're at it
+  if (elements.refreshTreeButton) {
+    elements.refreshTreeButton.addEventListener('click', () => {
+      handleRefreshTree();
+    });
+    console.log('[initializeVontologyTab] Refresh Tree button wired up');
+  }
+
   if (elements.vontologyTreeContainer) {
     console.log("Calling fetchAndRenderVontologyTree...");
     fetchAndRenderVontologyTree();


### PR DESCRIPTION
## Issues Fixed
Resolves **Issue #8: Creating concepts does not work in UI**

1. **Non-Functional Create Buttons** - Clicking Create Type/Instance did nothing
2. **Duplicate Text Relations** - Each concept created 2+ duplicate hasName entries  
3. **Chicken-and-Egg Problem** - Empty database couldn't bootstrap without parent selection

## What has been done

### Commit 1: Wire up create buttons and fix duplicates
**Files:** `vontology.js`, `concept_service.py`

- Added missing event listeners for Create Type/Instance buttons
- Removed legacy `names[]` field from concept creation
- Create text_relations directly via `upsert_text_for_concept` (no migrate-on-read duplicates)
- Non-fatal error handling for name relation creation

**Result:** Buttons work, no more duplicates

### Commit 2: Auto-create Thing root
**Files:** `utils_vontology.py` (+116 lines), `vontology_routes.py` (+44 lines), `vontology.js` (modified)

**Backend:**
- New `ensure_thing_exists_and_link_orphans()` function
- Creates Thing with OWL metadata: description, notes, attributes (`domain: "Ontology", role: "root", standard: "OWL"`), system_tags
- Finds and links orphan concepts (types without parents) to Thing  
- New POST `/ensure_thing` endpoint with cache invalidation

**Frontend:**
- Detects empty tree (both `[]` and placeholder Thing with `mongo_id: ""`)
- Auto-calls `/ensure_thing`
- Shows: Loading animation → Success message → Auto-refresh
- Falls back to manual creation on error

**Result:** Zero-click setup, orphans auto-linked, OWL-compliant root