### PR TITLE
Added tooltip to non-descriptive icon buttons

### DIFF
--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -1974,10 +1974,10 @@ async function ensureUnifiedDescriptionSection(conceptId, suffix) {
                   <div id="typeDescriptionDisplay_${suffix}" class="concept-type-description editable-description" tabindex="0">${initialHtml}</div>
                   <textarea id="typeDescriptionTextarea_${suffix}" class="description-editor hidden" placeholder="Enter description..." rows="6"></textarea>
                   <div class="desc-actions text-block-actions">
-                    <button id="typeCopyDescription_${suffix}" class="round-icon-button" title="Copy description to clipboard" aria-label="Copy description to clipboard" data-icon="copy"></button>
-                    <button id="typeAnnotateDescription_${suffix}" class="round-icon-button" title="Annotate description" aria-label="Annotate description" data-icon="annotate"></button>
-                    <button id="typeEditDescriptionButton_${suffix}" class="round-icon-button" title="Edit description" aria-label="Edit description" data-icon="edit"></button>
-                    <button id="typeDeleteDescriptionButton_${suffix}" class="round-icon-button" title="Delete description" aria-label="Delete description" data-icon="delete"></button>
+                    <button id="typeCopyDescription_${suffix}" class="round-icon-button" title="Copy description to clipboard" aria-label="Copy description to clipboard" data-icon="copy" data-keep-title="true"></button>
+                    <button id="typeAnnotateDescription_${suffix}" class="round-icon-button" title="Annotate description" aria-label="Annotate description" data-icon="annotate" data-keep-title="true"></button>
+                    <button id="typeEditDescriptionButton_${suffix}" class="round-icon-button" title="Edit description" aria-label="Edit description" data-icon="edit" data-keep-title="true"></button>
+                    <button id="typeDeleteDescriptionButton_${suffix}" class="round-icon-button" title="Delete description" aria-label="Delete description" data-icon="delete" data-keep-title="true"></button>
                   </div>
                   <div id="typeDescriptionEditActions_${suffix}" class="description-edit-actions hidden">
                     <button id="typeEditDescriptionSave_${suffix}" class="small-btn">Save</button>
@@ -2006,10 +2006,10 @@ async function ensureUnifiedDescriptionSection(conceptId, suffix) {
                   <div id="typeDescriptionDisplay_${suffix}" class="concept-type-description editable-description" tabindex="0"><i>Loading description...</i></div>
                   <textarea id="typeDescriptionTextarea_${suffix}" class="description-editor hidden" placeholder="Enter description..." rows="6"></textarea>
                   <div class="desc-actions text-block-actions">
-                    <button id="typeCopyDescription_${suffix}" class="round-icon-button" title="Copy description to clipboard" aria-label="Copy description to clipboard" data-icon="copy"></button>
-                    <button id="typeAnnotateDescription_${suffix}" class="round-icon-button" title="Annotate description" aria-label="Annotate description" data-icon="annotate"></button>
-                    <button id="typeEditDescriptionButton_${suffix}" class="round-icon-button" title="Edit description" aria-label="Edit description" data-icon="edit"></button>
-                    <button id="typeDeleteDescriptionButton_${suffix}" class="round-icon-button" title="Delete description" aria-label="Delete description" data-icon="delete"></button>
+                    <button id="typeCopyDescription_${suffix}" class="round-icon-button" title="Copy description to clipboard" aria-label="Copy description to clipboard" data-icon="copy" data-keep-title="true"></button>
+                    <button id="typeAnnotateDescription_${suffix}" class="round-icon-button" title="Annotate description" aria-label="Annotate description" data-icon="annotate" data-keep-title="true"></button>
+                    <button id="typeEditDescriptionButton_${suffix}" class="round-icon-button" title="Edit description" aria-label="Edit description" data-icon="edit" data-keep-title="true"></button>
+                    <button id="typeDeleteDescriptionButton_${suffix}" class="round-icon-button" title="Delete description" aria-label="Delete description" data-icon="delete" data-keep-title="true"></button>
                   </div>
                   <div id="typeDescriptionEditActions_${suffix}" class="description-edit-actions hidden">
                     <button id="typeEditDescriptionSave_${suffix}" class="small-btn">Save</button>
@@ -2464,6 +2464,7 @@ export function attachRawDataButton(headerH2, conceptId, kind, containerEl) {
         };
         btn.title = baseTooltip();
         btn.setAttribute('aria-label', baseTooltip());
+        btn.setAttribute('data-keep-title', 'true');
         btn.textContent = '{ }'; // lightweight icon
 
         // Place it at the far right within the header
@@ -2527,6 +2528,7 @@ export function attachRawDataButton(headerH2, conceptId, kind, containerEl) {
             relBtn.textContent = '[ ]';
             relBtn.title = 'list relations';
             relBtn.setAttribute('aria-label', 'list relations');
+            relBtn.setAttribute('data-keep-title', 'true');
             relBtn.style.fontFamily = 'monospace';
             relBtn.style.fontSize = '0.9rem';
             relBtn.style.padding = '2px 6px';
@@ -2571,6 +2573,7 @@ function attachKeyConceptStarButton(headerH2, conceptId) {
         btn.type = 'button';
         btn.className = 'key-concept-star-button';
         btn.setAttribute('aria-label', 'Toggle key concept');
+        btn.setAttribute('data-keep-title', 'true');
         btn.style.display = 'inline-block';  // Ensure it's visible
 
         // Get current key concept state
@@ -3352,11 +3355,11 @@ async function populateNotesSection(conceptId, suffix) {
                       </div>
                    </div>
                    <div class="note-actions text-block-actions">
-                             <button type="button" class="round-icon-button note-copy-btn" title="Copy note to clipboard" aria-label="Copy note to clipboard" data-icon="copy"></button>
-                             <button type="button" class="round-icon-button note-expand-btn" title="Show more" aria-label="Show full note" data-icon="expand" ${truncated ? '' : 'style="display:none;"'}></button>
-                             <button type="button" class="round-icon-button note-annotate-btn" title="Annotate note" aria-label="Annotate note" data-icon="annotate"></button>
-                             <button type="button" class="round-icon-button note-edit-btn" title="Edit note" aria-label="Edit note" data-icon="edit"></button>
-                             <button type="button" class="round-icon-button note-delete-btn" title="Delete note" aria-label="Delete note" data-icon="delete"></button>
+                             <button type="button" class="round-icon-button note-copy-btn" title="Copy note to clipboard" aria-label="Copy note to clipboard" data-icon="copy" data-keep-title="true"></button>
+                             <button type="button" class="round-icon-button note-expand-btn" title="Show more" aria-label="Show full note" data-icon="expand" data-keep-title="true" ${truncated ? '' : 'style="display:none;"'}></button>
+                             <button type="button" class="round-icon-button note-annotate-btn" title="Annotate note" aria-label="Annotate note" data-icon="annotate" data-keep-title="true"></button>
+                             <button type="button" class="round-icon-button note-edit-btn" title="Edit note" aria-label="Edit note" data-icon="edit" data-keep-title="true"></button>
+                             <button type="button" class="round-icon-button note-delete-btn" title="Delete note" aria-label="Delete note" data-icon="delete" data-keep-title="true"></button>
                    </div>`;
                 listEl.appendChild(item);
                 wireNoteItem(item, n);
@@ -5113,6 +5116,7 @@ function attachAnalysisButtons(headerDiv, conceptId, kind) {
         flagBtn.className = 'analysis-flag-button';
         flagBtn.title = 'Toggle analysis flag';
         flagBtn.setAttribute('aria-label', 'Toggle analysis flag for later analysis');
+        flagBtn.setAttribute('data-keep-title', 'true');
         flagBtn.innerHTML = '🏴'; // Flag emoji
         flagBtn.style.padding = '2px 6px';
         flagBtn.style.border = '1px solid #d1d5db';
@@ -5127,6 +5131,7 @@ function attachAnalysisButtons(headerDiv, conceptId, kind) {
         orgBtn.className = 'org-relation-button';
         orgBtn.title = 'Toggle organization relation';
         orgBtn.setAttribute('aria-label', 'Toggle specific_to_organisation relationship');
+        orgBtn.setAttribute('data-keep-title', 'true');
         orgBtn.innerHTML = '🏢'; // Building emoji
         orgBtn.style.padding = '2px 6px';
         orgBtn.style.border = '1px solid #d1d5db';
@@ -5141,6 +5146,7 @@ function attachAnalysisButtons(headerDiv, conceptId, kind) {
         userBtn.className = 'user-relation-button';
         userBtn.title = 'Toggle user relation';
         userBtn.setAttribute('aria-label', 'Toggle specific_to_user relationship');
+        userBtn.setAttribute('data-keep-title', 'true');
         userBtn.innerHTML = '👤'; // Person emoji
         userBtn.style.padding = '2px 6px';
         userBtn.style.border = '1px solid #d1d5db';
@@ -5183,6 +5189,7 @@ function attachDeleteConceptButton(headerDiv, conceptId, kind) {
         btn.className = 'delete-concept-button';
         btn.title = 'Delete this concept';
         btn.setAttribute('aria-label', 'Delete this concept');
+        btn.setAttribute('data-keep-title', 'true');
         btn.textContent = '🗑️';
         btn.style.padding = '2px 6px';
         btn.style.border = '1px solid #d1d5db';

--- a/src/frontend/web/von_interface/templates/concept_tab.html
+++ b/src/frontend/web/von_interface/templates/concept_tab.html
@@ -11,10 +11,10 @@
   </div>
   <!-- Legacy single-note notes UI removed; multi-note relations UI injected dynamically -->
   <!-- Keep Start Interaction Button -->
-  <button id="startInteractionButton">Start Interaction</button>
+  <button id="startInteractionButton" title="Begin an interactive Q&A session to gather information about this concept">Start Interaction</button>
   <!-- Add Save Notes Button (initially hidden/disabled) -->
-  <button id="saveNotesButton" class="concept-save-button">Save</button>
-  <button id="suggestInfoButton" class="concept-save-button">Suggest Missing Info</button>
+  <button id="saveNotesButton" class="concept-save-button" title="Save changes to concept notes">Save</button>
+  <button id="suggestInfoButton" class="concept-save-button" title="Use AI to suggest missing information for this concept">Suggest Missing Info</button>
   <p id="conceptStep1Status" class="concept-status"></p>
 </div>
 
@@ -35,11 +35,11 @@
 
   <label for="conceptAnswer">Your Answer:</label><br>
   <div class="concept-answer-container">
-    <input type="text" id="conceptAnswer" name="conceptAnswer" class="concept-answer-input">
-    <button id="submitAnswerButton">Submit Answer</button>
+    <input type="text" id="conceptAnswer" name="conceptAnswer" class="concept-answer-input" title="Enter your answer to the follow-up question">
+    <button id="submitAnswerButton" title="Submit your answer and continue the interaction">Submit Answer</button>
   </div>
-  <button id="cancelInteractionButton" class="concept-cancel-button">Cancel Interaction</button>
-  <button id="endInteractionButton" class="concept-end-button">End Interaction</button>
+  <button id="cancelInteractionButton" class="concept-cancel-button" title="Cancel the current interaction session">Cancel Interaction</button>
+  <button id="endInteractionButton" class="concept-end-button" title="End the interaction and finalize the information gathered">End Interaction</button>
 
   <!-- Display of the last Q&A exchange -->
   <div id="lastQADisplay" class="concept-last-qa-display">
@@ -59,7 +59,7 @@
 <!-- Step 3: Final Result -->
 <div id="conceptStep3" class="concept-step">
   <p id="finalResult" class="concept-final-result"></p>
-  <button id="resetConceptTabButton">Start New Interaction</button>
+  <button id="resetConceptTabButton" title="Reset the tab to start a new interaction">Start New Interaction</button>
 </div>
 
 <!-- Concept list display area moved under Instances section -->
@@ -76,13 +76,13 @@
         placeholder="Enter description for this type..." rows="6"></textarea>
       <div class="desc-actions text-block-actions">
         <button id="typeCopyDescription" class="round-icon-button" title="Copy description to clipboard"
-          aria-label="Copy description to clipboard" data-icon="copy"></button>
+          aria-label="Copy description to clipboard" data-icon="copy" data-keep-title="true"></button>
         <button id="typeAnnotateDescription" class="round-icon-button" title="Annotate description"
-          aria-label="Annotate description" data-icon="annotate"></button>
+          aria-label="Annotate description" data-icon="annotate" data-keep-title="true"></button>
         <button id="typeEditDescriptionButton" class="round-icon-button" title="Edit description"
-          aria-label="Edit description" data-icon="edit"></button>
+          aria-label="Edit description" data-icon="edit" data-keep-title="true"></button>
         <button id="typeDeleteDescriptionButton" class="round-icon-button" title="Delete description"
-          aria-label="Delete description" data-icon="delete"></button>
+          aria-label="Delete description" data-icon="delete" data-keep-title="true"></button>
       </div>
       <div id="typeDescriptionEditActions" class="description-edit-actions hidden">
         <button id="typeEditDescriptionSave" class="small-btn">Save</button>
@@ -109,7 +109,7 @@
           <option value="CODE">Code</option>
           <option value="ABBR">Abbreviation</option>
         </select>
-        <button id="addNameButton" type="button">Add Name</button>
+        <button id="addNameButton" type="button" title="Add this name to the concept">Add Name</button>
         <span id="namesStatus" class="concept-status"></span>
       </div>
     </div>
@@ -120,8 +120,8 @@
       <!-- Subtypes will be populated dynamically -->
     </ul>
     <div class="concept-create-form">
-      <input id="newSubtypeInput" type="text" placeholder="New subtype name" />
-      <button id="createSubtypeButton" type="button" class="concept-add-button">+ Add Subtype</button>
+      <input id="newSubtypeInput" type="text" placeholder="New subtype name" title="Enter a name for the new subtype" />
+      <button id="createSubtypeButton" type="button" class="concept-add-button" title="Create a new subtype under this concept">+ Add Subtype</button>
     </div>
     <p id="subtypesStatus" class="concept-status"></p>
   </div>
@@ -142,10 +142,10 @@
     <ul id="conceptListUl">
       <!-- List will be populated dynamically with instances -->
     </ul>
-    <button id="refreshConceptListButton">Refresh List</button>
+    <button id="refreshConceptListButton" title="Refresh the list of instances from the database">Refresh List</button>
     <div class="concept-create-form">
-      <input id="newInstanceInput" type="text" placeholder="New instance name" />
-      <button id="createInstanceButton" type="button" class="concept-add-button">+ Add Instance</button>
+      <input id="newInstanceInput" type="text" placeholder="New instance name" title="Enter a name for the new instance" />
+      <button id="createInstanceButton" type="button" class="concept-add-button" title="Create a new instance of this type">+ Add Instance</button>
     </div>
     <p id="instancesStatus" class="concept-status"></p>
   </div>
@@ -159,11 +159,11 @@
   </div>
   <div id="relationshipsAddForm" class="mt-2 flex gap-2 ai-center flex-wrap">
     <label for="relationshipKindSelect" class="sr-only">Relationship kind</label>
-    <select id="relationshipKindSelect" aria-label="Relationship kind">
+    <select id="relationshipKindSelect" aria-label="Relationship kind" title="Select the type of relationship to add">
       <!-- Options will be populated dynamically depending on tab kind -->
     </select>
-    <input id="relationshipTargetInput" type="text" placeholder="#V#target_concept_id" class="flex-1 minw-220" />
-    <button id="relationshipAddButton" type="button">Add</button>
+    <input id="relationshipTargetInput" type="text" placeholder="#V#target_concept_id" class="flex-1 minw-220" title="Enter the concept ID of the target concept" />
+    <button id="relationshipAddButton" type="button" title="Add this relationship to the concept">Add</button>
     <span id="relationshipsStatus" class="concept-status ml-2"></span>
   </div>
 </div>


### PR DESCRIPTION

Changes:

Added [data-keep-title="true"] attribute to icon buttons to preserve tooltips (suppressTooltips.js exemption)
Applied to description action buttons (📋 Copy, 📝 Annotate, ✏️ Edit, 🗑️ Delete)
Applied to note action buttons (✏️ Edit, 🗑️ Delete, 📋 Copy)
Applied to analysis buttons (🏴 Flag, 🏢 Organization, 👤 User)
Applied to header utility buttons (⭐ Star, { } Raw JSON, [ ] Text Relations, 🗑️ Delete)