### PR TITLE
JVNAUTOSCI-730: Introduce stable GUIDs for concepts

### DIFF
--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -419,6 +419,22 @@ def create_flask_app(
         except Exception:
             pass
 
+        # GUID coverage stats
+        guid_stats = {}
+        try:
+            from ..db.mongo_client import get_concepts_collection
+            coll = get_concepts_collection()
+            if coll is not None:
+                total_concepts = coll.count_documents({})
+                with_guid = coll.count_documents({'guid': {'$exists': True}})
+                guid_stats = {
+                    'total_concepts': total_concepts,
+                    'with_guid': with_guid,
+                    'coverage_percent': round((with_guid / total_concepts * 100), 1) if total_concepts > 0 else 0
+                }
+        except Exception:
+            guid_stats = {'error': 'unavailable'}
+
         search_proxy_stats = {}
         try:
             from ..integrations.internal_mcp import search_proxy_mcp as _search_proxy_mod  # type: ignore
@@ -452,6 +468,7 @@ def create_flask_app(
             'instance_counts_cache': counts_cache,
             'salient_cache': salient_cache,
             'entity_counts': entity_counts_stats,
+            'guid_stats': guid_stats,
             'search_proxy': search_proxy_stats,
             'python_version': sys.version.split()[0]
         }

--- a/src/backend/services/concept_service.py
+++ b/src/backend/services/concept_service.py
@@ -37,6 +37,7 @@ from pymongo.errors import DuplicateKeyError
 from bson import ObjectId
 import logging
 import os
+import uuid  # Added for GUID generation
 import traceback # Added for error logging
 from datetime import datetime, timezone # Ensure timezone is imported
 import requests # Added for requests.exceptions.ConnectionError
@@ -209,6 +210,7 @@ def create_concept(
 
     concept_doc: Dict[str, Any] = {
         # DO NOT include "names" field - will be created as text_relations below
+        "guid": str(uuid.uuid4()),  # JVNAUTOSCI-730: Stable GUID
         "created_at": now,
         "updated_at": now,
         "attributes": attributes or {},
@@ -269,6 +271,16 @@ def create_concept(
                         subject_concept_id=concept_identifier,
                         predicate='hasName',
                         text=str(concept_doc['_id']),
+                        lang='en-NZ',
+                        context={'name_type': 'CODE'}
+                    )
+
+                # 4. Register stable GUID as CODE name (JVNAUTOSCI-730)
+                if 'guid' in concept_doc:
+                    upsert_text_for_concept(
+                        subject_concept_id=concept_identifier,
+                        predicate='hasName',
+                        text=concept_doc['guid'],
                         lang='en-NZ',
                         context={'name_type': 'CODE'}
                     )
@@ -593,7 +605,7 @@ def update_concept(concept_id: str, update_data: Dict[str, Any]) -> Dict[str, An
 
     # REFACTORING_NOTE: Prevent modification of certain fields.
     # Client should not send these, but good to enforce on server-side.
-    immutable_fields = ["_id", "created_at", "vontology_path"]
+    immutable_fields = ["_id", "created_at", "vontology_path", "guid"]
     for field in immutable_fields:
         if field in update_data:
             raise InvalidConceptDataError(f"Field '{field}' cannot be modified.")

--- a/src/utilities/migrate_guids.py
+++ b/src/utilities/migrate_guids.py
@@ -1,0 +1,72 @@
+import sys
+import os
+import uuid
+import logging
+
+# Add src to path
+# Add project root
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+# Add src directory so 'backend' can be imported directly if needed
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.backend.db.mongo_client import get_concepts_collection
+from src.backend.services.text_value_service import upsert_text_for_concept
+
+# Setup logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def migrate_guids():
+    logger.info("Starting GUID migration...")
+
+    concepts_coll = get_concepts_collection()
+    if concepts_coll is None:
+        logger.error("Could not get concepts collection")
+        return
+
+    # Find concepts without a guid field
+    query = {"guid": {"$exists": False}}
+    total_to_migrate = concepts_coll.count_documents(query)
+    logger.info(f"Found {total_to_migrate} concepts missing GUIDs")
+
+    cursor = concepts_coll.find(query)
+
+    migrated_count = 0
+    error_count = 0
+
+    for concept in cursor:
+        try:
+            concept_id = concept.get('concept_id')
+            if not concept_id:
+                logger.warning(f"Skipping document with no concept_id: {concept.get('_id')}")
+                continue
+
+            new_guid = str(uuid.uuid4())
+
+            # Update document
+            concepts_coll.update_one(
+                {"_id": concept["_id"]},
+                {"$set": {"guid": new_guid}}
+            )
+
+            # Register as name
+            upsert_text_for_concept(
+                subject_concept_id=concept_id,
+                predicate='hasName',
+                text=new_guid,
+                lang='en-NZ',
+                context={'name_type': 'CODE'}
+            )
+
+            migrated_count += 1
+            if migrated_count % 100 == 0:
+                logger.info(f"Migrated {migrated_count} concepts...")
+
+        except Exception as e:
+            logger.error(f"Error migrating concept {concept.get('_id')}: {e}")
+            error_count += 1
+
+    logger.info(f"Migration complete. Migrated: {migrated_count}, Errors: {error_count}")
+
+if __name__ == "__main__":
+    migrate_guids()

--- a/tests/backend/test_guid_migration.py
+++ b/tests/backend/test_guid_migration.py
@@ -1,0 +1,100 @@
+import sys
+import os
+import unittest
+import uuid
+from unittest.mock import MagicMock, patch
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'src')))
+
+from backend.services.concept_service import create_concept, update_concept, InvalidConceptDataError
+from utilities.migrate_guids import migrate_guids
+
+class TestGuidMigration(unittest.TestCase):
+    @patch('backend.services.concept_service.ConceptsRepository')
+    @patch('backend.services.text_value_service.upsert_text_for_concept')
+    def test_create_concept_generates_guid(self, mock_upsert, mock_repo):
+        print("Testing create_concept_generates_guid...")
+        mock_collection = MagicMock()
+        mock_repo.collection.return_value = mock_collection
+
+        # Capture the doc passed to insert_one
+        captured_doc = {}
+
+        def side_effect_insert(doc):
+            captured_doc.update(doc)
+            doc['_id'] = 'mock_oid'
+            res = MagicMock()
+            res.inserted_id = 'mock_oid'
+            return res
+        mock_collection.insert_one.side_effect = side_effect_insert
+
+        # Mock find_one to return the captured doc
+        def side_effect_find_one(query):
+            if query.get('_id') == 'mock_oid':
+                return captured_doc
+            return None
+        mock_collection.find_one.side_effect = side_effect_find_one
+
+        # Call create_concept
+        result = create_concept(
+            name="New Concept",
+            concept_id="#V#new_concept",
+            create_as_instance=False
+        )
+
+        # Verify result has guid
+        self.assertIn('guid', result)
+        # Verify it looks like a UUID
+        try:
+            uuid.UUID(result['guid'])
+        except ValueError:
+            self.fail("Generated guid is not a valid UUID")
+
+        # Verify upsert called for guid
+        calls = mock_upsert.call_args_list
+        guid_call = [c for c in calls if c.kwargs.get('text') == result['guid'] and c.kwargs.get('context', {}).get('name_type') == 'CODE']
+        self.assertTrue(guid_call, "GUID not registered as CODE name")
+
+    @patch('backend.services.concept_service.ConceptsRepository')
+    def test_update_concept_immutability(self, mock_repo):
+        print("Testing update_concept_immutability...")
+        mock_collection = MagicMock()
+        mock_repo.collection.return_value = mock_collection
+
+        # Try to update guid
+        with self.assertRaises(InvalidConceptDataError):
+            update_concept('some_id', {'guid': 'new_guid'})
+
+    @patch('utilities.migrate_guids.get_concepts_collection')
+    @patch('utilities.migrate_guids.upsert_text_for_concept')
+    def test_migration_script(self, mock_upsert, mock_get_coll):
+        print("Testing migration_script...")
+        mock_collection = MagicMock()
+        mock_get_coll.return_value = mock_collection
+
+        # Mock concepts without GUID
+        mock_concepts = [
+            {'_id': 'doc1', 'concept_id': '#V#c1'},
+            {'_id': 'doc2', 'concept_id': '#V#c2'}
+        ]
+        mock_collection.find.return_value = mock_concepts
+        mock_collection.count_documents.return_value = 2
+
+        # Run migration
+        migrate_guids()
+
+        # Verify update_one called twice with a guid
+        self.assertEqual(mock_collection.update_one.call_count, 2)
+
+        # Check args of first update
+        args, _ = mock_collection.update_one.call_args_list[0]
+        filter_arg, update_arg = args
+        self.assertEqual(filter_arg['_id'], 'doc1')
+        self.assertIn('guid', update_arg['$set'])
+
+        # Verify upsert called twice
+        self.assertEqual(mock_upsert.call_count, 2)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Updated create_concept to generate UUIDv4 GUIDs
- Updated update_concept to enforce GUID immutability
- Added migration script to backfill GUIDs
- Updated /diag endpoint to show GUID coverage
- Added tests for GUID generation and immutability

Title: JVNAUTOSCI-730: Introduce stable GUIDs for concepts

Description:
This PR introduces stable, immutable GUIDs (UUIDv4) for all Vontology concepts to ensure reliable referencing independent of mutable names.

Key Changes:

GUID Generation: Updated concept_service.py to generate a UUIDv4 guid for every new concept.
Immutability: Added logic to prevent updates to the guid field after creation.
Migration: Included [migrate_guids.py](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code%20Insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to backfill GUIDs for all existing concepts (2263 concepts updated).
Diagnostics: Updated /diag endpoint in utils_flask.py to report GUID coverage statistics.
Testing: Added [test_guid_migration.py](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code%20Insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to verify generation and immutability.
Verification:

Migration script ran successfully on the development database (100% coverage).
New tests in test_guid_migration.py pass.