### PR TITLE
feat: Add auto-detection and repair for corrupted Python environments

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -170,6 +170,8 @@ $CurrentLog = Join-Path $LogsDir "von_${Port}_current.log"
 $Timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
 $NewLog = Join-Path $LogsDir "von_${Port}_${Timestamp}.log"
 
+$script:RepairAttempted = $false
+
 function Get-ExistingProcess {
     if (-not (Test-Path $PidFile)) { return $null }
     $content = Get-Content $PidFile -ErrorAction SilentlyContinue | Where-Object { $_ }
@@ -492,9 +494,35 @@ function Start-VonServer {
                 catch { $procCheck = $null }
                 if (-not $procCheck) {
                     Write-LauncherLog "ERROR: Server process exited early before listening on port $Port. Showing last 40 log lines:"
+                    $logTail = @()
                     if (Test-Path $CurrentLog) {
-                        try { Get-Content $CurrentLog -Tail 40 | ForEach-Object { Write-Host $_ } } catch { Write-LauncherLog "(Log tail unavailable: $($_.Exception.Message))" }
+                        try { 
+                            $logTail = Get-Content $CurrentLog -Tail 40 
+                            $logTail | ForEach-Object { Write-Host $_ } 
+                        } catch { Write-LauncherLog "(Log tail unavailable: $($_.Exception.Message))" }
                     }
+
+                    # Auto-repair logic for missing dependencies
+                    if (-not $script:RepairAttempted) {
+                        $logText = $logTail -join "`n"
+                        if ($logText -match "ModuleNotFoundError" -or $logText -match "ImportError") {
+                            Write-LauncherLog "Detected missing dependencies. Attempting auto-repair..."
+                            $script:RepairAttempted = $true
+                            
+                            $setupScript = Join-Path $Root "setup_py.ps1"
+                            if (Test-Path $setupScript) {
+                                & $setupScript
+                                if ($LASTEXITCODE -eq 0) {
+                                    Write-LauncherLog "Repair completed successfully. Retrying server start..."
+                                    Start-VonServer
+                                    return
+                                } else {
+                                    Write-LauncherLog "Repair failed."
+                                }
+                            }
+                        }
+                    }
+
                     Write-LauncherLog "Aborting start. (Use -HealthDebug for verbose retries)"
                     return
                 }

--- a/setup_py.ps1
+++ b/setup_py.ps1
@@ -330,13 +330,41 @@ function Initialize-Windows {
     Write-Host "Installing dependencies with PDM..." -ForegroundColor Cyan
     & .venv\Scripts\pdm install --verbose
 
-    # Verify installation
-    if (Test-Path ".venv\Lib\site-packages") {
+    # Verify installation and attempt repair if needed
+    Write-Host "Verifying installation..." -ForegroundColor Cyan
+    $verificationScript = "
+try:
+    import flask
+    import pymongo
+    import pdm
+    print('VERIFICATION_SUCCESS')
+except ImportError as e:
+    print(f'VERIFICATION_FAILED: {e}')
+    exit(1)
+"
+    $verificationResult = & .venv\Scripts\python.exe -c $verificationScript 2>&1
+
+    if ($LASTEXITCODE -eq 0 -and $verificationResult -match "VERIFICATION_SUCCESS") {
         Write-Host "PDM successfully installed packages." -ForegroundColor Green
     }
     else {
-        Write-Host "Error: Package installation failed." -ForegroundColor Red
-        exit 1
+        Write-Host "Verification failed: $verificationResult" -ForegroundColor Red
+        Write-Host "Attempting auto-repair of dependencies..." -ForegroundColor Yellow
+
+        # Attempt 1: Force reinstall PDM and sync
+        Write-Host "Reinstalling PDM and syncing..." -ForegroundColor Cyan
+        & .venv\Scripts\python.exe -m pip install --upgrade pdm
+        & .venv\Scripts\pdm sync --clean --verbose
+
+        # Verify again
+        $verificationResult = & .venv\Scripts\python.exe -c $verificationScript 2>&1
+        if ($LASTEXITCODE -eq 0 -and $verificationResult -match "VERIFICATION_SUCCESS") {
+            Write-Host "Repair successful." -ForegroundColor Green
+        }
+        else {
+            Write-Host "Repair failed. Please try running setup with -Reset." -ForegroundColor Red
+            exit 1
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds robustness to the setup and run scripts. setup_py.ps1 now verifies the installation by importing critical modules and attempts to repair (reinstall PDM, sync) if verification fails. un.ps1 detects early server exit due to missing modules and triggers the repair automatically.