### PR TITLE
fix: Upgrade Jinja2 to >=3.1.6 to resolve security vulnerabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "httpx>=0.27.2",
     "idna>=3.10",
     "itsdangerous==2.2.0",
-    "Jinja2==3.1.4",
+    "Jinja2>=3.1.6",
     "MarkupSafe==2.1.5",
     "node==1.2.1",
     "npm==0.1.1",


### PR DESCRIPTION
This PR upgrades \Jinja2\ to version \>=3.1.6\ to address the following security vulnerabilities:
- **GHSA-cpwx-vrp4-4pq7**: Sandbox breakout through attr filter.
- **GHSA-gmj6-6f8f-6699**: Sandbox breakout through malicious filenames.
- **GHSA-q2x7-8rv6-6q7h**: Sandbox breakout through indirect reference to format method.

The dependency was previously pinned to \3.1.4\.