### PR TITLE
feat: Add Today/Yesterday formatting to chat timestamps

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
+};

--- a/docs/AINotes.md
+++ b/docs/AINotes.md
@@ -1,0 +1,14 @@
+# AI Notes
+
+## Current Status
+- **Date**: 2025-11-24
+- **Recent Activity**:
+  - Refactored chat interface to `chat_tab.html`.
+  - Improved chat timestamp formatting in `chatTab.js` (added Today/Yesterday support).
+  - Added unit tests for `chatTab.js`.
+  - Merged PR #14 (`feature/chat-timestamp-and-refactor`).
+  - Cleaned up merged branches (`chore/setup-ensurepip-repair`).
+- **Immediate Focus**: Awaiting user instructions.
+
+## Todo
+- [ ] (Add new tasks here)

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -346,9 +346,19 @@ function formatChatTimestamp(isoString) {
         now.getMonth() === date.getMonth() &&
         now.getFullYear() === date.getFullYear();
 
+    // Check if it was yesterday
+    const yesterday = new Date(now);
+    yesterday.setDate(now.getDate() - 1);
+    const isYesterday = yesterday.getDate() === date.getDate() &&
+        yesterday.getMonth() === date.getMonth() &&
+        yesterday.getFullYear() === date.getFullYear();
+
     if (isToday) {
-        // Today: Time only
-        return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        // Today: "Today HH:MM"
+        return 'Today ' + date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    } else if (isYesterday) {
+        // Yesterday: "Yesterday HH:MM"
+        return 'Yesterday ' + date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     } else if (diffDays < 7) {
         // Within a week: Day + Time
         return date.toLocaleString([], { weekday: 'short', hour: '2-digit', minute: '2-digit' });
@@ -736,5 +746,5 @@ export const resetChat = handleResetContext;
 export const handleChatResponse = appendMessage;
 export const exportConversationJson = handleExportConversationJson;
 export const exportConversationMarkdown = handleExportConversationMarkdown;
-export { updateHistoryLength };
+export { formatChatTimestamp, updateHistoryLength };
 

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -1,0 +1,59 @@
+import { formatChatTimestamp } from '../chatTab';
+
+// Mock dependencies to avoid import errors
+jest.mock('../apiService.js', () => ({
+    annotateTurn: jest.fn(),
+    getUserContext: jest.fn()
+}));
+jest.mock('../domUtils.js', () => ({
+    elements: {},
+    renderSpanSuggestions: jest.fn()
+}));
+jest.mock('../utils/textDecorator.js', () => ({
+    annotateElementText: jest.fn()
+}));
+
+describe('formatChatTimestamp', () => {
+    // Helper to create a date relative to now
+    const createDate = (daysAgo, hours = 12, minutes = 0) => {
+        const date = new Date();
+        date.setDate(date.getDate() - daysAgo);
+        date.setHours(hours, minutes, 0, 0);
+        return date;
+    };
+
+    test('returns formatted time for today', () => {
+        const today = new Date();
+        const isoString = today.toISOString();
+        const result = formatChatTimestamp(isoString);
+        expect(result).toMatch(/^Today /);
+    });
+
+    test('returns formatted time for yesterday', () => {
+        const yesterday = createDate(1);
+        const isoString = yesterday.toISOString();
+        const result = formatChatTimestamp(isoString);
+        expect(result).toMatch(/^Yesterday /);
+    });
+
+    test('returns day and time for within a week', () => {
+        const threeDaysAgo = createDate(3);
+        const isoString = threeDaysAgo.toISOString();
+        const result = formatChatTimestamp(isoString);
+        expect(result).not.toContain('Today');
+        expect(result).not.toContain('Yesterday');
+        // Check for day name (Mon, Tue, etc.)
+        const dayName = threeDaysAgo.toLocaleString([], { weekday: 'short' });
+        expect(result).toContain(dayName);
+    });
+
+    test('returns date and time for older dates', () => {
+        const tenDaysAgo = createDate(10);
+        const isoString = tenDaysAgo.toISOString();
+        const result = formatChatTimestamp(isoString);
+        expect(result).not.toContain('Today');
+        expect(result).not.toContain('Yesterday');
+        const month = tenDaysAgo.toLocaleString([], { month: 'short' });
+        expect(result).toContain(month);
+    });
+});


### PR DESCRIPTION
Updates the chat timestamp formatter to explicitly show 'Today' and 'Yesterday' for better readability. Includes unit tests and babel config for testing.