### PR TITLE
JVNAUTOSCI-764: Add visible refresh button to concept tabs

### DIFF
--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -4,7 +4,7 @@
 // Removed imported populateContentSection to avoid duplicate with local implementation below
 
 import { initializeAnnotationTab } from './annotationTab.js';
-import { initializeNamesForm, loadConceptNames, selectConceptWithSuffix } from './conceptTab.js';
+import { fetchConceptListWithSuffix, fetchSubtypesWithSuffix, initializeNamesForm, loadConceptNames, selectConceptWithSuffix } from './conceptTab.js';
 import { getCurrentUserConceptId } from './domUtils.js';
 import { DEFAULT_LANGUAGE } from './languageConfig.js';
 import { detectMarkdown, renderSmartText } from './markdownUtils.js';
@@ -90,7 +90,8 @@ const ICON_SVGS = {
     edit: '<svg aria-hidden="true" class="icon icon-edit" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>',
     delete: '<svg aria-hidden="true" class="icon icon-delete" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="M6 6l12 12"/></svg>',
     expand: '<svg aria-hidden="true" class="icon icon-expand" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" fill="none" stroke-width="2"><circle cx="5" cy="12" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="19" cy="12" r="1.6"/></svg>',
-    copy: '<svg aria-hidden="true" class="icon icon-copy" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>'
+    copy: '<svg aria-hidden="true" class="icon icon-copy" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>',
+    refresh: '<svg aria-hidden="true" class="icon icon-refresh" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 4v6h-6"/><path d="M1 20v-6h6"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>'
 };
 
 function injectIconContent(el, key, label) {
@@ -1281,6 +1282,17 @@ async function reloadConceptTab(conceptId) {
         // Reload names explicitly to ensure they're fresh
         await loadConceptNames(conceptId, suffix);
 
+        // Refresh lists for Type tabs (Instances and Subtypes)
+        const kind = (dynamicConceptTabs.get(conceptId) || {}).kind;
+        if (kind !== 'individual') {
+            try {
+                await fetchConceptListWithSuffix(conceptId, suffix);
+                await fetchSubtypesWithSuffix(conceptId, suffix);
+            } catch (listErr) {
+                console.warn('[dynamicTabs] Failed to refresh lists during reload', listErr);
+            }
+        }
+
         console.log(`[dynamicTabs] Concept tab reloaded successfully: ${conceptId}`);
 
         // Restore button text
@@ -1459,6 +1471,19 @@ async function initializeDynamicConceptTab(conceptId, uniqueIdSuffix) {
             console.log(`[dynamicTabs] Refresh button connected for ${conceptId}`);
         } else {
             console.warn(`[dynamicTabs] Refresh button not found for ${conceptId} (ID: refreshConceptListButton_${uniqueIdSuffix})`);
+        }
+
+        // Get the unique concept refresh button (header) for this tab
+        const refreshConceptButton = document.getElementById(`refreshConceptButton_${uniqueIdSuffix}`);
+        if (refreshConceptButton) {
+            const newBtn = refreshConceptButton.cloneNode(true);
+            refreshConceptButton.parentNode.replaceChild(newBtn, refreshConceptButton);
+            newBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                reloadConceptTab(conceptId);
+            });
+            // Inject icon if needed (though upgradeActionButtonIcons should handle it)
+            injectIconContent(newBtn, 'refresh', 'Refresh concept data');
         }
 
         // Initialize the concept tab with unique element IDs

--- a/src/frontend/web/von_interface/templates/concept_tab.html
+++ b/src/frontend/web/von_interface/templates/concept_tab.html
@@ -1,7 +1,8 @@
 <!-- Concept Tab Content (Previously Entity Tab) -->
 <div class="concept-header">
   <span id="conceptTypeDisplayNamePluralElement" class="concept-type-header"></span>
-  <!-- (Removed redundant left-side delete button: a primary delete control already exists elsewhere) -->
+  <button id="refreshConceptButton" class="round-icon-button" title="Refresh concept data"
+    aria-label="Refresh concept data" data-icon="refresh"></button>
 </div>
 
 <!-- Step 1: Initial Input -->
@@ -11,10 +12,12 @@
   </div>
   <!-- Legacy single-note notes UI removed; multi-note relations UI injected dynamically -->
   <!-- Keep Start Interaction Button -->
-  <button id="startInteractionButton" title="Begin an interactive Q&A session to gather information about this concept">Start Interaction</button>
+  <button id="startInteractionButton"
+    title="Begin an interactive Q&A session to gather information about this concept">Start Interaction</button>
   <!-- Add Save Notes Button (initially hidden/disabled) -->
   <button id="saveNotesButton" class="concept-save-button" title="Save changes to concept notes">Save</button>
-  <button id="suggestInfoButton" class="concept-save-button" title="Use AI to suggest missing information for this concept">Suggest Missing Info</button>
+  <button id="suggestInfoButton" class="concept-save-button"
+    title="Use AI to suggest missing information for this concept">Suggest Missing Info</button>
   <p id="conceptStep1Status" class="concept-status"></p>
 </div>
 
@@ -35,11 +38,14 @@
 
   <label for="conceptAnswer">Your Answer:</label><br>
   <div class="concept-answer-container">
-    <input type="text" id="conceptAnswer" name="conceptAnswer" class="concept-answer-input" title="Enter your answer to the follow-up question">
+    <input type="text" id="conceptAnswer" name="conceptAnswer" class="concept-answer-input"
+      title="Enter your answer to the follow-up question">
     <button id="submitAnswerButton" title="Submit your answer and continue the interaction">Submit Answer</button>
   </div>
-  <button id="cancelInteractionButton" class="concept-cancel-button" title="Cancel the current interaction session">Cancel Interaction</button>
-  <button id="endInteractionButton" class="concept-end-button" title="End the interaction and finalize the information gathered">End Interaction</button>
+  <button id="cancelInteractionButton" class="concept-cancel-button"
+    title="Cancel the current interaction session">Cancel Interaction</button>
+  <button id="endInteractionButton" class="concept-end-button"
+    title="End the interaction and finalize the information gathered">End Interaction</button>
 
   <!-- Display of the last Q&A exchange -->
   <div id="lastQADisplay" class="concept-last-qa-display">
@@ -121,7 +127,8 @@
     </ul>
     <div class="concept-create-form">
       <input id="newSubtypeInput" type="text" placeholder="New subtype name" title="Enter a name for the new subtype" />
-      <button id="createSubtypeButton" type="button" class="concept-add-button" title="Create a new subtype under this concept">+ Add Subtype</button>
+      <button id="createSubtypeButton" type="button" class="concept-add-button"
+        title="Create a new subtype under this concept">+ Add Subtype</button>
     </div>
     <p id="subtypesStatus" class="concept-status"></p>
   </div>
@@ -144,8 +151,10 @@
     </ul>
     <button id="refreshConceptListButton" title="Refresh the list of instances from the database">Refresh List</button>
     <div class="concept-create-form">
-      <input id="newInstanceInput" type="text" placeholder="New instance name" title="Enter a name for the new instance" />
-      <button id="createInstanceButton" type="button" class="concept-add-button" title="Create a new instance of this type">+ Add Instance</button>
+      <input id="newInstanceInput" type="text" placeholder="New instance name"
+        title="Enter a name for the new instance" />
+      <button id="createInstanceButton" type="button" class="concept-add-button"
+        title="Create a new instance of this type">+ Add Instance</button>
     </div>
     <p id="instancesStatus" class="concept-status"></p>
   </div>
@@ -162,7 +171,8 @@
     <select id="relationshipKindSelect" aria-label="Relationship kind" title="Select the type of relationship to add">
       <!-- Options will be populated dynamically depending on tab kind -->
     </select>
-    <input id="relationshipTargetInput" type="text" placeholder="#V#target_concept_id" class="flex-1 minw-220" title="Enter the concept ID of the target concept" />
+    <input id="relationshipTargetInput" type="text" placeholder="#V#target_concept_id" class="flex-1 minw-220"
+      title="Enter the concept ID of the target concept" />
     <button id="relationshipAddButton" type="button" title="Add this relationship to the concept">Add</button>
     <span id="relationshipsStatus" class="concept-status ml-2"></span>
   </div>


### PR DESCRIPTION
This PR adds a visible refresh button to the concept tab header and ensures that the reload functionality correctly updates the instances and subtypes lists in addition to the concept details.