### PR TITLE
JVNAUTOSCI-734: Gmail MCP integration

### DIFF
--- a/.githooks/pre-commit.ps1
+++ b/.githooks/pre-commit.ps1
@@ -1,0 +1,32 @@
+#!/usr/bin/env pwsh
+# Blocks staged runtime data from data/rag_storage, data/raw, or logs.
+$blockedPatterns = @(
+    '^data/rag_storage/',
+    '^data/raw/',
+    '^data/.+\.json$',
+    '^logs/'
+)
+
+$staged = git diff --cached --name-only
+if (-not $staged) {
+    exit 0
+}
+
+$hits = @()
+foreach ($file in $staged) {
+    foreach ($pattern in $blockedPatterns) {
+        if ($file -match $pattern) {
+            $hits += $file
+            break
+        }
+    }
+}
+
+if ($hits.Count -gt 0) {
+    Write-Host "Blocked committing runtime data files:" -ForegroundColor Red
+    $hits | Sort-Object -Unique | ForEach-Object { Write-Host " - $_" }
+    Write-Host "Remove from index or move out of blocked paths, then commit again." -ForegroundColor Yellow
+    exit 1
+}
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ data/raw/mongo_dump/
 # arXiv papers storage (external MCP server)
 data/arxiv_papers/
 
+# Local RAG stores (runtime artifacts, never commit)
+data/rag_storage/
+
 # Database backup dumps (exclude committed artifacts going forward)
 backups/
 !backups/.gitkeep

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,12 @@
 
 This document provides an overview of key files within the `docs` directory that are primarily intended for use by AI systems (like GitHub Copilot or other automated agents) working on the Von-Private project. Understanding the purpose of these files will help AI agents contribute more effectively and maintain project context.
 
-**All AI agents must read this file and the `docs/engineering/software_engineering.md` and `docs/engineering/JIRA_issue_management.md` files before starting any work.**
+**All AI agents must read this file and the `docs/engineering/security_considerations.md` file before starting any work.**
 
 > **TL;DR FOR AGENTS (READ FIRST)**
 > 1. Use **New Zealand English** spelling always (behaviour, colour, organisation, realise).
 > 2. **PowerShell is the default shell**. Do **NOT** emit Bash heredocs (`<<EOF`), `export VAR=`, `$(cmd)` substitution, or `source venv/bin/activate` unless the user explicitly asks for a Bash variant. Provide `$env:VAR = 'value'`, here-strings, or `pdm run` patterns.
+- **Pre-commit guardrails**: enable hooks with `git config core.hooksPath .githooks` to block committing runtime data (e.g., `data/rag_storage`, `data/raw`, `logs`).
 > 3. Never auto-start the server; wait for explicit user instruction.
 > 4. Prefer clarity over clever chaining: separate lines instead of `&&` unless failure short‑circuit is required.
 > 5. Large multi-line Python → use a here-string variable then `python -c $code` (PowerShell) or propose a committed script.

--- a/docs/engineering/gmail_mcp_plan.md
+++ b/docs/engineering/gmail_mcp_plan.md
@@ -1,0 +1,46 @@
+# Gmail MCP Plan (JVNAUTOSCI-734)
+
+## Use cases
+- **Von mailbox**: Headless processing of agent-facing mail (e.g., agent-mailbox@example.com) with predictable labels/queries. Favour read + label mutation only.
+- **User/organisation mail**: Opt-in per user, per token. No cross-account reuse of Von's token.
+
+## Design choices
+- **Profile-based config**: Multiple Gmail profiles, each with its own token, scopes, and optional label/query filters. Config via `VON_GMAIL_PROFILES` JSON or legacy env fallbacks for a single `von-service` profile.
+- **Read-first posture**: Default scopes are read-only. Mutation scope (`gmail.modify`) only when explicitly requested via env flag (`VON_GMAIL_MUTATION=true`) or profile scopes.
+- **No interactive flows**: The service does not auto-run OAuth flows; tokens must be provisioned out of band to avoid unexpected prompts.
+- **Separation of credentials**: Never reuse Von's token for user mail. Profiles are resolved explicitly by ID on each call.
+
+## Initial surface (MVP)
+- **Service helpers** (in code now): `list_messages`, `get_message`, `get_attachment`, per-profile.
+- **Planned MCP tools** (next step):
+  - `gmail_list_messages(profile, query?, label_ids?, max_results?)`
+  - `gmail_get_message(profile, message_id, format?)`
+  - `gmail_get_attachment(profile, message_id, attachment_id)`
+  - `gmail_list_labels(profile)`
+  - Guard mutation calls behind explicit `allow_mutation` flag.
+- **Query shaping**: Optional `query_prefix` in profiles for inbox scoping (e.g., `label:agent-inbox`).
+
+## Configuration
+- Preferred: `VON_GMAIL_PROFILES` JSON (list or object) with fields:
+  - `profile_id` (required)
+  - `token_path` (required)
+  - `credentials_path` (optional, for refresh if needed)
+  - `user_id` (default `me`)
+  - `scopes` (default read-only)
+  - `label_filter` (optional array)
+  - `query_prefix` (optional string)
+- Fallback single-profile envs:
+  - `VON_GMAIL_TOKEN_PATH` (required)
+  - `VON_GMAIL_CLIENT_SECRET_PATH` or `GOOGLE_CLIENT_SECRET_PATH` (optional, refresh only)
+  - `VON_GMAIL_USER`, `VON_GMAIL_LABELS` (comma-separated), `VON_GMAIL_QUERY_PREFIX`, `VON_GMAIL_MUTATION` (boolean)
+
+## Phases
+1) **Service layer (done)**: Profile loader + Gmail helpers with tests.
+2) **MCP stdio server**: Expose tools above; profile required per call; read-only default.
+3) **Internal MCP gateway**: Add proxy methods to `catalogue.py` and stdio HTTP parity.
+4) **UI/hooks (optional)**: Wire Von UI or orchestrator to select profile and call tools; add audit logging via `knowledge_interaction_logger` for mailbox actions.
+
+## Risks / mitigations
+- Missing tokens → explicit errors; no interactive flows.
+- Scope creep → read-only default, mutation behind flag.
+- Profile mix-ups → explicit profile ID per call and separate token paths.

--- a/docs/engineering/gmail_mcp_plan.md
+++ b/docs/engineering/gmail_mcp_plan.md
@@ -33,6 +33,7 @@
   - `VON_GMAIL_TOKEN_PATH` (required)
   - `VON_GMAIL_CLIENT_SECRET_PATH` or `GOOGLE_CLIENT_SECRET_PATH` (optional, refresh only)
   - `VON_GMAIL_USER`, `VON_GMAIL_LABELS` (comma-separated), `VON_GMAIL_QUERY_PREFIX`, `VON_GMAIL_MUTATION` (boolean)
+- Optional default: `VON_GMAIL_DEFAULT_PROFILE` can be set to auto-fill Gmail tool calls when UI/local profile is not provided. The settings page now allows a "Gmail profile ID" text field stored in the browser (localStorage key `von_gmail_profile`).
 
 ## Phases
 1) **Service layer (done)**: Profile loader + Gmail helpers with tests.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "von-private",
+  "name": "von",
   "version": "1.0.0",
   "description": "Von (or vonNeumarkt) is a suite of AI enriched tools for helping academic researchers",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "von",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Von (or vonNeumarkt) is a suite of AI enriched tools for helping academic researchers",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Strong-AI-Lab/Von-Private.git"
+    "url": "git+https://github.com/Strong-AI-Lab/Von.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/Strong-AI-Lab/Von-Private/issues"
+    "url": "https://github.com/Strong-AI-Lab/Von/issues"
   },
-  "homepage": "https://github.com/Strong-AI-Lab/Von-Private#readme",
+  "homepage": "https://github.com/Strong-AI-Lab/Von#readme",
   "devDependencies": {
     "@babel/core": "^7.28.0",
     "@babel/preset-env": "^7.28.0",

--- a/src/backend/integrations/google/gmail_service.py
+++ b/src/backend/integrations/google/gmail_service.py
@@ -9,12 +9,15 @@ from __future__ import annotations
 
 import json
 import os
+import logging
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Mapping, Optional
 
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_SCOPES: List[str] = [
     "https://www.googleapis.com/auth/gmail.readonly",
@@ -70,6 +73,44 @@ class GmailProfile:
 def _persist_credentials(token_path: str, creds: Credentials) -> None:
     with open(token_path, "w", encoding="utf-8") as token_file:
         token_file.write(creds.to_json())
+
+
+def _log_gmail_audit(
+    action: str,
+    *,
+    profile_id: str,
+    audit_context: Optional[Mapping[str, object]] = None,
+    query: Optional[str] = None,
+    label_ids: Optional[List[str]] = None,
+    message_id: Optional[str] = None,
+    attachment_id: Optional[str] = None,
+    allow_mutation: Optional[bool] = None,
+    max_results: Optional[int] = None,
+) -> None:
+    """Record a minimal audit trail for Gmail tool calls without leaking content.
+
+    Only structural identifiers and small metadata are logged; message bodies and
+    attachments are never logged.
+    """
+
+    try:
+        safe_labels = list(label_ids[:10]) if label_ids else None
+        trimmed_query = (query or "")[:100] if query else None
+        record: Dict[str, object] = {
+            "profile_id": profile_id,
+            "query_preview": trimmed_query,
+            "label_ids": safe_labels,
+            "message_id": message_id,
+            "attachment_id": attachment_id,
+            "allow_mutation": allow_mutation,
+            "max_results": max_results,
+        }
+        record = {k: v for k, v in record.items() if v is not None}
+        if audit_context:
+            record["audit_context"] = {k: v for k, v in audit_context.items() if v is not None}
+        logger.info("[gmail_audit] action=%s payload=%s", action, record)
+    except Exception:  # pragma: no cover - audit should never break callers
+        logger.exception("[gmail_audit] Failed to log Gmail action: %s", action)
 
 
 def _parse_profiles(raw: str) -> Dict[str, GmailProfile]:
@@ -192,8 +233,17 @@ def list_messages(
     label_ids: Optional[List[str]] = None,
     max_results: int = 25,
     profiles: Optional[Dict[str, GmailProfile]] = None,
+    audit_context: Optional[Mapping[str, object]] = None,
 ) -> Dict:
     profile = get_profile(profile_id, profiles)
+    _log_gmail_audit(
+        "list_messages",
+        profile_id=profile.profile_id,
+        audit_context=audit_context,
+        query=query,
+        label_ids=label_ids,
+        max_results=max_results,
+    )
     service = get_service(profile_id, profiles)
 
     label_ids = label_ids or profile.label_filter or None
@@ -212,8 +262,15 @@ def get_message(
     message_id: str,
     format: str = "metadata",
     profiles: Optional[Dict[str, GmailProfile]] = None,
+    audit_context: Optional[Mapping[str, object]] = None,
 ) -> Dict:
     profile = get_profile(profile_id, profiles)
+    _log_gmail_audit(
+        "get_message",
+        profile_id=profile.profile_id,
+        audit_context=audit_context,
+        message_id=message_id,
+    )
     service = get_service(profile_id, profiles)
 
     request = (
@@ -229,8 +286,16 @@ def get_attachment(
     message_id: str,
     attachment_id: str,
     profiles: Optional[Dict[str, GmailProfile]] = None,
+    audit_context: Optional[Mapping[str, object]] = None,
 ) -> Dict:
     profile = get_profile(profile_id, profiles)
+    _log_gmail_audit(
+        "get_attachment",
+        profile_id=profile.profile_id,
+        audit_context=audit_context,
+        message_id=message_id,
+        attachment_id=attachment_id,
+    )
     service = get_service(profile_id, profiles)
 
     request = (
@@ -245,8 +310,14 @@ def get_attachment(
 def list_labels(
     profile_id: str,
     profiles: Optional[Dict[str, GmailProfile]] = None,
+    audit_context: Optional[Mapping[str, object]] = None,
 ) -> Dict:
     profile = get_profile(profile_id, profiles)
+    _log_gmail_audit(
+        "list_labels",
+        profile_id=profile.profile_id,
+        audit_context=audit_context,
+    )
     service = get_service(profile_id, profiles)
 
     request = service.users().labels().list(userId=profile.user_id)
@@ -260,6 +331,7 @@ def modify_labels(
     remove_labels: Optional[List[str]] = None,
     allow_mutation: bool = False,
     profiles: Optional[Dict[str, GmailProfile]] = None,
+    audit_context: Optional[Mapping[str, object]] = None,
 ) -> Dict:
     """Modify labels on a message when mutation is explicitly enabled.
 
@@ -273,6 +345,14 @@ def modify_labels(
         raise ValueError("Label mutation requires allow_mutation=True")
 
     profile = get_profile(profile_id, profiles)
+    _log_gmail_audit(
+        "modify_labels",
+        profile_id=profile.profile_id,
+        audit_context=audit_context,
+        message_id=message_id,
+        label_ids=(add_labels or []) + (remove_labels or []),
+        allow_mutation=allow_mutation,
+    )
     if MUTATION_SCOPE not in profile.scopes:
         raise PermissionError("Profile scopes do not include gmail.modify")
 

--- a/src/backend/integrations/google/gmail_service.py
+++ b/src/backend/integrations/google/gmail_service.py
@@ -1,0 +1,292 @@
+"""Gmail utility layer for MCP/email workflows.
+
+Provides profile-based access to Gmail with read-focused helpers suitable
+for Von's agent and user mailboxes. Profiles are loaded from environment
+variables to avoid hardcoding credentials. The helpers are intentionally
+read-only and require explicit opt-in for any mutation scopes.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+DEFAULT_SCOPES: List[str] = [
+    "https://www.googleapis.com/auth/gmail.readonly",
+]
+
+MUTATION_SCOPE: str = "https://www.googleapis.com/auth/gmail.modify"
+
+PROFILES_ENV_VAR = "VON_GMAIL_PROFILES"
+
+
+@dataclass
+class GmailProfile:
+    """Configuration for a Gmail access profile."""
+
+    profile_id: str
+    token_path: str
+    credentials_path: str = ""
+    user_id: str = "me"
+    scopes: List[str] = field(default_factory=lambda: list(DEFAULT_SCOPES))
+    label_filter: Optional[List[str]] = None
+    query_prefix: Optional[str] = None
+
+    def ensure_credentials(self) -> Credentials:
+        """Load and refresh credentials from the token file.
+
+        The helper never launches interactive OAuth flows. If the token file is
+        missing or cannot be refreshed, the caller must provision a token
+        out-of-band to avoid unexpected prompts in headless environments.
+        """
+
+        if not self.token_path:
+            raise ValueError("token_path is required for Gmail profile")
+
+        if not os.path.exists(self.token_path):
+            raise FileNotFoundError(
+                f"Token file not found for profile '{self.profile_id}': {self.token_path}"
+            )
+
+        creds = Credentials.from_authorized_user_file(self.token_path, scopes=self.scopes)
+
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+            _persist_credentials(self.token_path, creds)
+        elif not creds or not creds.valid:
+            raise RuntimeError(
+                "Invalid or non-refreshable Gmail credentials. Provide a valid token file"
+                f" for profile '{self.profile_id}'."
+            )
+
+        return creds
+
+
+def _persist_credentials(token_path: str, creds: Credentials) -> None:
+    with open(token_path, "w", encoding="utf-8") as token_file:
+        token_file.write(creds.to_json())
+
+
+def _parse_profiles(raw: str) -> Dict[str, GmailProfile]:
+    parsed = json.loads(raw)
+    profiles: Dict[str, GmailProfile] = {}
+
+    if isinstance(parsed, dict):
+        entries: Iterable = parsed.values()
+    elif isinstance(parsed, list):
+        entries = parsed
+    else:
+        raise ValueError("Profiles payload must be a list or object")
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("Each profile entry must be an object")
+
+        profile_id = entry.get("profile_id") or entry.get("id")
+        token_path = entry.get("token_path") or entry.get("token")
+        if not profile_id or not token_path:
+            raise ValueError("Each profile requires profile_id and token_path")
+
+        credentials_path = entry.get("credentials_path") or entry.get("client_secret_path", "")
+        scopes = entry.get("scopes") or list(DEFAULT_SCOPES)
+        label_filter = entry.get("label_filter")
+        query_prefix = entry.get("query_prefix")
+
+        profiles[profile_id] = GmailProfile(
+            profile_id=profile_id,
+            token_path=token_path,
+            credentials_path=credentials_path,
+            user_id=entry.get("user_id", "me"),
+            scopes=scopes,
+            label_filter=label_filter if isinstance(label_filter, list) else None,
+            query_prefix=query_prefix,
+        )
+
+    return profiles
+
+
+def load_profiles_from_env() -> Dict[str, GmailProfile]:
+    """Load Gmail profiles from environment variables.
+
+    Preferred: VON_GMAIL_PROFILES containing JSON (list or object). Each entry
+    should specify at minimum profile_id and token_path. Optional fields:
+    credentials_path, user_id, scopes, label_filter, query_prefix.
+
+    Fallback: VON_GMAIL_TOKEN_PATH (mandatory) and optional
+    VON_GMAIL_CLIENT_SECRET_PATH / GOOGLE_CLIENT_SECRET_PATH,
+    VON_GMAIL_USER, VON_GMAIL_LABELS (comma-separated),
+    VON_GMAIL_QUERY_PREFIX. This populates a single profile named
+    "von-service".
+    """
+
+    env_profiles = os.getenv(PROFILES_ENV_VAR)
+    if env_profiles:
+        return _parse_profiles(env_profiles)
+
+    token_path = os.getenv("VON_GMAIL_TOKEN_PATH")
+    if not token_path:
+        return {}
+
+    labels_raw = os.getenv("VON_GMAIL_LABELS")
+    label_filter = [label.strip() for label in labels_raw.split(",") if label.strip()] if labels_raw else None
+
+    return {
+        "von-service": GmailProfile(
+            profile_id="von-service",
+            token_path=token_path,
+            credentials_path=
+                os.getenv("VON_GMAIL_CLIENT_SECRET_PATH")
+                or os.getenv("GOOGLE_CLIENT_SECRET_PATH")
+                or "",
+            user_id=os.getenv("VON_GMAIL_USER", "me"),
+            scopes=_pick_scopes(os.getenv("VON_GMAIL_MUTATION", "false")),
+            label_filter=label_filter,
+            query_prefix=os.getenv("VON_GMAIL_QUERY_PREFIX"),
+        )
+    }
+
+
+def _pick_scopes(request_mutation: str) -> List[str]:
+    wants_mutation = request_mutation.lower() in {"1", "true", "yes"}
+    if wants_mutation:
+        return [MUTATION_SCOPE, *DEFAULT_SCOPES]
+    return list(DEFAULT_SCOPES)
+
+
+def get_profile(profile_id: str, profiles: Optional[Dict[str, GmailProfile]] = None) -> GmailProfile:
+    candidates = profiles or load_profiles_from_env()
+    if not candidates:
+        raise RuntimeError("No Gmail profiles configured. Set VON_GMAIL_PROFILES or VON_GMAIL_TOKEN_PATH.")
+
+    profile = candidates.get(profile_id)
+    if not profile:
+        raise KeyError(f"Profile '{profile_id}' not found. Available: {sorted(candidates.keys())}")
+    return profile
+
+
+def get_service(profile_id: str, profiles: Optional[Dict[str, GmailProfile]] = None):
+    profile = get_profile(profile_id, profiles)
+    creds = profile.ensure_credentials()
+    return build("gmail", "v1", credentials=creds, cache_discovery=False)
+
+
+def _compose_query(profile: GmailProfile, query: Optional[str]) -> Optional[str]:
+    parts = []
+    if profile.query_prefix:
+        parts.append(profile.query_prefix)
+    if query:
+        parts.append(query)
+    if not parts:
+        return None
+    return " ".join(parts)
+
+
+def list_messages(
+    profile_id: str,
+    query: Optional[str] = None,
+    label_ids: Optional[List[str]] = None,
+    max_results: int = 25,
+    profiles: Optional[Dict[str, GmailProfile]] = None,
+) -> Dict:
+    profile = get_profile(profile_id, profiles)
+    service = get_service(profile_id, profiles)
+
+    label_ids = label_ids or profile.label_filter or None
+    composed_query = _compose_query(profile, query)
+
+    request = (
+        service.users()
+        .messages()
+        .list(userId=profile.user_id, q=composed_query, labelIds=label_ids, maxResults=max_results)
+    )
+    return request.execute() or {}
+
+
+def get_message(
+    profile_id: str,
+    message_id: str,
+    format: str = "metadata",
+    profiles: Optional[Dict[str, GmailProfile]] = None,
+) -> Dict:
+    profile = get_profile(profile_id, profiles)
+    service = get_service(profile_id, profiles)
+
+    request = (
+        service.users()
+        .messages()
+        .get(userId=profile.user_id, id=message_id, format=format)
+    )
+    return request.execute() or {}
+
+
+def get_attachment(
+    profile_id: str,
+    message_id: str,
+    attachment_id: str,
+    profiles: Optional[Dict[str, GmailProfile]] = None,
+) -> Dict:
+    profile = get_profile(profile_id, profiles)
+    service = get_service(profile_id, profiles)
+
+    request = (
+        service.users()
+        .messages()
+        .attachments()
+        .get(userId=profile.user_id, messageId=message_id, id=attachment_id)
+    )
+    return request.execute() or {}
+
+
+def list_labels(
+    profile_id: str,
+    profiles: Optional[Dict[str, GmailProfile]] = None,
+) -> Dict:
+    profile = get_profile(profile_id, profiles)
+    service = get_service(profile_id, profiles)
+
+    request = service.users().labels().list(userId=profile.user_id)
+    return request.execute() or {}
+
+
+def modify_labels(
+    profile_id: str,
+    message_id: str,
+    add_labels: Optional[List[str]] = None,
+    remove_labels: Optional[List[str]] = None,
+    allow_mutation: bool = False,
+    profiles: Optional[Dict[str, GmailProfile]] = None,
+) -> Dict:
+    """Modify labels on a message when mutation is explicitly enabled.
+
+    To avoid accidental writes, callers must set allow_mutation=True and ensure
+    the profile includes the gmail.modify scope. Otherwise, a ValueError is
+    raised. This function does not mark read/unread implicitly; callers choose
+    labels (e.g., 'UNREAD').
+    """
+
+    if not allow_mutation:
+        raise ValueError("Label mutation requires allow_mutation=True")
+
+    profile = get_profile(profile_id, profiles)
+    if MUTATION_SCOPE not in profile.scopes:
+        raise PermissionError("Profile scopes do not include gmail.modify")
+
+    service = get_service(profile_id, profiles)
+    request = (
+        service.users()
+        .messages()
+        .modify(
+            userId=profile.user_id,
+            id=message_id,
+            body={
+                "addLabelIds": add_labels or [],
+                "removeLabelIds": remove_labels or [],
+            },
+        )
+    )
+    return request.execute() or {}

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -1465,6 +1465,98 @@ def _rag_get_item(**kwargs):
     }
 
 
+# Gmail MCP handlers (read-only surface)
+def _gmail_list_messages(**kwargs):
+    from ...integrations.google import gmail_service as gs
+
+    profile = kwargs.get("profile") or kwargs.get("profile_id")
+    if not profile:
+        return {"error": "Missing required parameter: profile", "success": False}
+
+    try:
+        return gs.list_messages(
+            profile_id=profile,
+            query=kwargs.get("query"),
+            label_ids=kwargs.get("label_ids"),
+            max_results=kwargs.get("max_results") or 25,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {"error": f"Gmail list failed: {exc}", "success": False}
+
+
+def _gmail_get_message(**kwargs):
+    from ...integrations.google import gmail_service as gs
+
+    profile = kwargs.get("profile") or kwargs.get("profile_id")
+    message_id = kwargs.get("message_id")
+    if not profile or not message_id:
+        return {"error": "Missing required parameters: profile and message_id", "success": False}
+
+    try:
+        return gs.get_message(
+            profile_id=profile,
+            message_id=message_id,
+            format=kwargs.get("format", "metadata"),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {"error": f"Gmail get message failed: {exc}", "success": False}
+
+
+def _gmail_get_attachment(**kwargs):
+    from ...integrations.google import gmail_service as gs
+
+    profile = kwargs.get("profile") or kwargs.get("profile_id")
+    message_id = kwargs.get("message_id")
+    attachment_id = kwargs.get("attachment_id")
+    if not profile or not message_id or not attachment_id:
+        return {"error": "Missing required parameters: profile, message_id, attachment_id", "success": False}
+
+    try:
+        return gs.get_attachment(
+            profile_id=profile,
+            message_id=message_id,
+            attachment_id=attachment_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {"error": f"Gmail get attachment failed: {exc}", "success": False}
+
+
+def _gmail_list_labels(**kwargs):
+    from ...integrations.google import gmail_service as gs
+
+    profile = kwargs.get("profile") or kwargs.get("profile_id")
+    if not profile:
+        return {"error": "Missing required parameter: profile", "success": False}
+
+    try:
+        return gs.list_labels(profile_id=profile)
+    except Exception as exc:  # noqa: BLE001
+        return {"error": f"Gmail list labels failed: {exc}", "success": False}
+
+
+def _gmail_modify_labels(**kwargs):
+    from ...integrations.google import gmail_service as gs
+
+    profile = kwargs.get("profile") or kwargs.get("profile_id")
+    message_id = kwargs.get("message_id")
+    allow_mutation = bool(kwargs.get("allow_mutation"))
+    if not profile or not message_id:
+        return {"error": "Missing required parameters: profile and message_id", "success": False}
+    if not allow_mutation:
+        return {"error": "allow_mutation must be true to modify labels", "success": False}
+
+    try:
+        return gs.modify_labels(
+            profile_id=profile,
+            message_id=message_id,
+            add_labels=kwargs.get("add_labels"),
+            remove_labels=kwargs.get("remove_labels"),
+            allow_mutation=allow_mutation,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {"error": f"Gmail modify labels failed: {exc}", "success": False}
+
+
 # Jira MCP handlers
 def _jira_search(**kwargs):
     import asyncio
@@ -1555,6 +1647,43 @@ def build_default_catalogue() -> MethodCatalogue:
     jira_get_issue_output_schema = _jira_generic_output_schema("get_issue")
     jira_add_comment_output_schema = _jira_generic_output_schema("add_comment")
     jira_transition_output_schema = _jira_generic_output_schema("transition")
+    gmail_list_messages_input_schema = Schema(
+        required={"profile": str},
+        optional={
+            "query": str,
+            "label_ids": list,
+            "max_results": (int, type(None)),
+        },
+        allow_unknown=False,
+        description="List Gmail messages for a profile with optional query/labels (read-only)."
+    )
+    gmail_get_message_input_schema = Schema(
+        required={"profile": str, "message_id": str},
+        optional={"format": str},
+        allow_unknown=False,
+        description="Fetch a Gmail message for a profile (formats: metadata|full|raw|minimal)."
+    )
+    gmail_get_attachment_input_schema = Schema(
+        required={"profile": str, "message_id": str, "attachment_id": str},
+        optional={},
+        allow_unknown=False,
+        description="Fetch a Gmail attachment for a profile (base64 payload)."
+    )
+    gmail_list_labels_input_schema = Schema(
+        required={"profile": str},
+        optional={},
+        allow_unknown=False,
+        description="List Gmail labels for a profile (read-only)."
+    )
+    gmail_modify_labels_input_schema = Schema(
+        required={"profile": str, "message_id": str, "allow_mutation": bool},
+        optional={
+            "add_labels": list,
+            "remove_labels": list,
+        },
+        allow_unknown=False,
+        description="Add/remove labels on a Gmail message. Requires allow_mutation=true and gmail.modify scope."
+    )
     definitions: List[MethodDefinition] = [
         MethodDefinition(
             name="get_context",
@@ -1763,6 +1892,52 @@ def build_default_catalogue() -> MethodCatalogue:
             category="read",
             timeout_sec=15.0,
             description="Extract and return the main text content from a specific URL. Use when user provides a URL and wants to read, analyse, or extract information from that specific web page. Returns cleaned text content and page title. Useful for reading articles, documentation, or any web page content. Example: 'read this article: https://example.com/article', 'extract content from this URL'.",
+        ),
+        # Gmail MCP tools (read-only surface)
+        MethodDefinition(
+            name="gmail_list_messages",
+            handler=_gmail_list_messages,
+            input_schema=gmail_list_messages_input_schema,
+            output_schema=Schema(required={}, optional={}, allow_unknown=True, description="Gmail API list response"),
+            category="read",
+            timeout_sec=20.0,
+            description="List Gmail messages for a profile with optional query and label filters. Read-only; relies on pre-provisioned tokens per profile.",
+        ),
+        MethodDefinition(
+            name="gmail_get_message",
+            handler=_gmail_get_message,
+            input_schema=gmail_get_message_input_schema,
+            output_schema=Schema(required={}, optional={}, allow_unknown=True, description="Gmail API message response"),
+            category="read",
+            timeout_sec=20.0,
+            description="Fetch a Gmail message for a profile. Supports Gmail API formats metadata|full|raw|minimal. Read-only; profile token required.",
+        ),
+        MethodDefinition(
+            name="gmail_get_attachment",
+            handler=_gmail_get_attachment,
+            input_schema=gmail_get_attachment_input_schema,
+            output_schema=Schema(required={}, optional={}, allow_unknown=True, description="Gmail API attachment response"),
+            category="read",
+            timeout_sec=20.0,
+            description="Fetch a Gmail attachment for a profile (base64 data). Read-only; profile token required.",
+        ),
+        MethodDefinition(
+            name="gmail_list_labels",
+            handler=_gmail_list_labels,
+            input_schema=gmail_list_labels_input_schema,
+            output_schema=Schema(required={}, optional={}, allow_unknown=True, description="Gmail API labels response"),
+            category="read",
+            timeout_sec=15.0,
+            description="List Gmail labels for a profile. Read-only; useful to discover label IDs for queries.",
+        ),
+        MethodDefinition(
+            name="gmail_modify_labels",
+            handler=_gmail_modify_labels,
+            input_schema=gmail_modify_labels_input_schema,
+            output_schema=Schema(required={}, optional={}, allow_unknown=True, description="Gmail API modify response"),
+            category="write",
+            timeout_sec=20.0,
+            description="Add/remove labels on a Gmail message. Requires allow_mutation=true and profile with gmail.modify scope.",
         ),
         MethodDefinition(
             name="search_knowledge_base",

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -1479,6 +1479,11 @@ def _gmail_list_messages(**kwargs):
             query=kwargs.get("query"),
             label_ids=kwargs.get("label_ids"),
             max_results=kwargs.get("max_results") or 25,
+            audit_context={
+                "namespace": kwargs.get("namespace"),
+                "source": "internal_mcp_gateway",
+                "tool": "gmail_list_messages",
+            },
         )
     except Exception as exc:  # noqa: BLE001
         return {"error": f"Gmail list failed: {exc}", "success": False}
@@ -1497,6 +1502,11 @@ def _gmail_get_message(**kwargs):
             profile_id=profile,
             message_id=message_id,
             format=kwargs.get("format", "metadata"),
+            audit_context={
+                "namespace": kwargs.get("namespace"),
+                "source": "internal_mcp_gateway",
+                "tool": "gmail_get_message",
+            },
         )
     except Exception as exc:  # noqa: BLE001
         return {"error": f"Gmail get message failed: {exc}", "success": False}
@@ -1516,6 +1526,11 @@ def _gmail_get_attachment(**kwargs):
             profile_id=profile,
             message_id=message_id,
             attachment_id=attachment_id,
+            audit_context={
+                "namespace": kwargs.get("namespace"),
+                "source": "internal_mcp_gateway",
+                "tool": "gmail_get_attachment",
+            },
         )
     except Exception as exc:  # noqa: BLE001
         return {"error": f"Gmail get attachment failed: {exc}", "success": False}
@@ -1529,7 +1544,14 @@ def _gmail_list_labels(**kwargs):
         return {"error": "Missing required parameter: profile", "success": False}
 
     try:
-        return gs.list_labels(profile_id=profile)
+        return gs.list_labels(
+            profile_id=profile,
+            audit_context={
+                "namespace": kwargs.get("namespace"),
+                "source": "internal_mcp_gateway",
+                "tool": "gmail_list_labels",
+            },
+        )
     except Exception as exc:  # noqa: BLE001
         return {"error": f"Gmail list labels failed: {exc}", "success": False}
 
@@ -1552,6 +1574,11 @@ def _gmail_modify_labels(**kwargs):
             add_labels=kwargs.get("add_labels"),
             remove_labels=kwargs.get("remove_labels"),
             allow_mutation=allow_mutation,
+            audit_context={
+                "namespace": kwargs.get("namespace"),
+                "source": "internal_mcp_gateway",
+                "tool": "gmail_modify_labels",
+            },
         )
     except Exception as exc:  # noqa: BLE001
         return {"error": f"Gmail modify labels failed: {exc}", "success": False}

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -37,10 +37,12 @@ class InternalMCPChatOrchestrator:
         gateway: InternalMCPGateway,
         logger: logging.Logger | None = None,
         max_tool_invocations: int = 1,
+        default_gmail_profile: str | None = None,
     ) -> None:
         self._gateway = gateway
         self._logger = logger or logging.getLogger(__name__)
         self._max_tool_invocations = max(0, int(max_tool_invocations))
+        self._default_gmail_profile = default_gmail_profile
 
     def _tool_listing(self) -> str:
         """Generate a concise listing of available tools for the system prompt.
@@ -73,6 +75,21 @@ class InternalMCPChatOrchestrator:
                 params = f" (params: {', '.join(params_list)})"
             else:
                 params = ""
+
+                    # Inject Gmail profile if applicable and missing
+                    if tool_name.startswith("gmail_"):
+                        if not payload.get("profile") and selected_gmail_profile:
+                            payload["profile"] = selected_gmail_profile
+                            self._logger.info(
+                                "[mcp_orchestrator] Injected gmail_profile=%s into tool=%s payload",
+                                selected_gmail_profile,
+                                tool_name,
+                            )
+                        elif not payload.get("profile"):
+                            self._logger.warning(
+                                "[mcp_orchestrator] Gmail tool=%s invoked without profile and no default configured",
+                                tool_name,
+                            )
 
             lines.append(f"- {name}{params}: {description}")
         return "\n".join(lines)
@@ -280,6 +297,7 @@ class InternalMCPChatOrchestrator:
         llm_client: Any,
         model: Optional[str],
         user_namespace: Optional[str] = None,
+        gmail_profile: Optional[str] = None,
     ) -> OrchestratorResult:
         if not self._gateway.enabled or self._max_tool_invocations <= 0:
             response = llm_client.generate(prompt, context=context, model=model)
@@ -349,6 +367,7 @@ class InternalMCPChatOrchestrator:
 
         invocations: List[Mapping[str, Any]] = []
         tool_messages: List[Mapping[str, Any]] = []
+        selected_gmail_profile = gmail_profile or self._default_gmail_profile
 
         # Support chained tool calls up to max_tool_invocations limit (JVNAUTOSCI-699)
         iteration_count = 0

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -76,21 +76,6 @@ class InternalMCPChatOrchestrator:
             else:
                 params = ""
 
-                    # Inject Gmail profile if applicable and missing
-                    if tool_name.startswith("gmail_"):
-                        if not payload.get("profile") and selected_gmail_profile:
-                            payload["profile"] = selected_gmail_profile
-                            self._logger.info(
-                                "[mcp_orchestrator] Injected gmail_profile=%s into tool=%s payload",
-                                selected_gmail_profile,
-                                tool_name,
-                            )
-                        elif not payload.get("profile"):
-                            self._logger.warning(
-                                "[mcp_orchestrator] Gmail tool=%s invoked without profile and no default configured",
-                                tool_name,
-                            )
-
             lines.append(f"- {name}{params}: {description}")
         return "\n".join(lines)
 
@@ -398,6 +383,20 @@ class InternalMCPChatOrchestrator:
 
             # Execute the tool
             try:
+                if tool_name.startswith("gmail_"):
+                    if not payload.get("profile") and selected_gmail_profile:
+                        payload["profile"] = selected_gmail_profile
+                        self._logger.info(
+                            "[mcp_orchestrator] Injected gmail_profile=%s into tool=%s payload",
+                            selected_gmail_profile,
+                            tool_name,
+                        )
+                    elif not payload.get("profile"):
+                        self._logger.warning(
+                            "[mcp_orchestrator] Gmail tool=%s invoked without profile and no default configured",
+                            tool_name,
+                        )
+
                 # Inject user_namespace into payload if provided and not already present
                 if user_namespace and "namespace" not in payload:
                     payload["namespace"] = user_namespace

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -1109,6 +1109,19 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:
                     text=json.dumps({"error": "Missing required parameters: source_id, predicate, and target"})
                 )]
 
+            try:
+                result = _add_relationship(
+                    source_id=source_id,
+                    predicate=predicate,
+                    target=target
+                )
+                return [TextContent(type="text", text=json.dumps(result, indent=2))]
+            except Exception as e:
+                return [TextContent(
+                    type="text",
+                    text=json.dumps({"error": f"Failed to add relationship: {str(e)}"})
+                )]
+
         elif name == "remove_relationship":
             source_id = arguments.get("source_id")
             predicate = arguments.get("predicate")
@@ -1131,19 +1144,6 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:
                 return [TextContent(
                     type="text",
                     text=json.dumps({"error": f"Failed to remove relationship: {str(e)}"})
-                )]
-
-            try:
-                result = _add_relationship(
-                    source_id=source_id,
-                    predicate=predicate,
-                    target=target
-                )
-                return [TextContent(type="text", text=json.dumps(result, indent=2))]
-            except Exception as e:
-                return [TextContent(
-                    type="text",
-                    text=json.dumps({"error": f"Failed to add relationship: {str(e)}"})
                 )]
 
         elif name == "delete_concept":

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -59,6 +59,7 @@ from src.backend.integrations.internal_mcp.search_proxy_mcp import (
     get_search_proxy,
     SearchProxyError,
 )
+from src.backend.integrations.google import gmail_service
 from src.backend.services.rag_service import get_rag_service, RAGBackendUnavailable
 
 # Create MCP server instance
@@ -360,6 +361,72 @@ async def list_tools() -> list[Tool]:
                     "url": {"type": "string", "description": "URL to extract content from"}
                 },
                 "required": ["url"]
+            }
+        ),
+        Tool(
+            name="gmail_list_messages",
+            description="List Gmail messages for a profile with optional label and query filters (read-only).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "profile": {"type": "string", "description": "Profile ID configured via env"},
+                    "query": {"type": "string", "description": "Optional Gmail search query"},
+                    "label_ids": {"type": "array", "items": {"type": "string"}, "description": "Optional label IDs to filter"},
+                    "max_results": {"type": "integer", "description": "Maximum results to return"}
+                },
+                "required": ["profile"]
+            }
+        ),
+        Tool(
+            name="gmail_get_message",
+            description="Fetch a Gmail message by ID for a profile (formats: metadata|full|raw).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "profile": {"type": "string", "description": "Profile ID configured via env"},
+                    "message_id": {"type": "string", "description": "Gmail message ID"},
+                    "format": {"type": "string", "enum": ["metadata", "full", "raw", "minimal"], "default": "metadata", "description": "Gmail API format"}
+                },
+                "required": ["profile", "message_id"]
+            }
+        ),
+        Tool(
+            name="gmail_get_attachment",
+            description="Fetch a Gmail attachment by message and attachment ID for a profile (base64 payload).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "profile": {"type": "string", "description": "Profile ID configured via env"},
+                    "message_id": {"type": "string", "description": "Gmail message ID"},
+                    "attachment_id": {"type": "string", "description": "Gmail attachment ID"}
+                },
+                "required": ["profile", "message_id", "attachment_id"]
+            }
+        ),
+        Tool(
+            name="gmail_list_labels",
+            description="List Gmail labels for a profile (read-only).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "profile": {"type": "string", "description": "Profile ID configured via env"}
+                },
+                "required": ["profile"]
+            }
+        ),
+        Tool(
+            name="gmail_modify_labels",
+            description="Add/remove labels on a Gmail message for a profile. Requires allow_mutation=true and gmail.modify scope.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "profile": {"type": "string", "description": "Profile ID configured via env"},
+                    "message_id": {"type": "string", "description": "Gmail message ID"},
+                    "add_labels": {"type": "array", "items": {"type": "string"}, "description": "Labels to add"},
+                    "remove_labels": {"type": "array", "items": {"type": "string"}, "description": "Labels to remove"},
+                    "allow_mutation": {"type": "boolean", "description": "Must be true to permit mutation"}
+                },
+                "required": ["profile", "message_id", "allow_mutation"]
             }
         ),
         Tool(
@@ -927,6 +994,87 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:
                 return [TextContent(type="text", text=json.dumps({"error": str(e)}))]
             except Exception as e:
                 return [TextContent(type="text", text=json.dumps({"error": f"Unexpected error: {e}"}))]
+
+        elif name == "gmail_list_messages":
+            profile = arguments.get("profile") or arguments.get("profile_id")
+            if not profile:
+                return [TextContent(type="text", text=json.dumps({"error": "Missing required parameter: profile"}))]
+
+            try:
+                result = gmail_service.list_messages(
+                    profile_id=profile,
+                    query=arguments.get("query"),
+                    label_ids=arguments.get("label_ids"),
+                    max_results=arguments.get("max_results", 25),
+                )
+                return [TextContent(type="text", text=json.dumps(result, indent=2))]
+            except Exception as e:
+                return [TextContent(type="text", text=json.dumps({"error": f"Gmail list failed: {e}"}))]
+
+        elif name == "gmail_get_message":
+            profile = arguments.get("profile") or arguments.get("profile_id")
+            message_id = arguments.get("message_id")
+            if not profile or not message_id:
+                return [TextContent(type="text", text=json.dumps({"error": "Missing required parameters: profile and message_id"}))]
+
+            try:
+                result = gmail_service.get_message(
+                    profile_id=profile,
+                    message_id=message_id,
+                    format=arguments.get("format", "metadata"),
+                )
+                return [TextContent(type="text", text=json.dumps(result, indent=2))]
+            except Exception as e:
+                return [TextContent(type="text", text=json.dumps({"error": f"Gmail get message failed: {e}"}))]
+
+        elif name == "gmail_get_attachment":
+            profile = arguments.get("profile") or arguments.get("profile_id")
+            message_id = arguments.get("message_id")
+            attachment_id = arguments.get("attachment_id")
+            if not profile or not message_id or not attachment_id:
+                return [TextContent(type="text", text=json.dumps({"error": "Missing required parameters: profile, message_id, attachment_id"}))]
+
+            try:
+                result = gmail_service.get_attachment(
+                    profile_id=profile,
+                    message_id=message_id,
+                    attachment_id=attachment_id,
+                )
+                return [TextContent(type="text", text=json.dumps(result, indent=2))]
+            except Exception as e:
+                return [TextContent(type="text", text=json.dumps({"error": f"Gmail get attachment failed: {e}"}))]
+
+        elif name == "gmail_list_labels":
+            profile = arguments.get("profile") or arguments.get("profile_id")
+            if not profile:
+                return [TextContent(type="text", text=json.dumps({"error": "Missing required parameter: profile"}))]
+
+            try:
+                result = gmail_service.list_labels(profile_id=profile)
+                return [TextContent(type="text", text=json.dumps(result, indent=2))]
+            except Exception as e:
+                return [TextContent(type="text", text=json.dumps({"error": f"Gmail list labels failed: {e}"}))]
+
+        elif name == "gmail_modify_labels":
+            profile = arguments.get("profile") or arguments.get("profile_id")
+            message_id = arguments.get("message_id")
+            allow_mutation = bool(arguments.get("allow_mutation"))
+            if not profile or not message_id:
+                return [TextContent(type="text", text=json.dumps({"error": "Missing required parameters: profile and message_id"}))]
+            if not allow_mutation:
+                return [TextContent(type="text", text=json.dumps({"error": "allow_mutation must be true to modify labels"}))]
+
+            try:
+                result = gmail_service.modify_labels(
+                    profile_id=profile,
+                    message_id=message_id,
+                    add_labels=arguments.get("add_labels"),
+                    remove_labels=arguments.get("remove_labels"),
+                    allow_mutation=allow_mutation,
+                )
+                return [TextContent(type="text", text=json.dumps(result, indent=2))]
+            except Exception as e:
+                return [TextContent(type="text", text=json.dumps({"error": f"Gmail modify labels failed: {e}"}))]
 
         elif name == "add_relationship":
             source_id = arguments.get("source_id")

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -1006,6 +1006,10 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:
                     query=arguments.get("query"),
                     label_ids=arguments.get("label_ids"),
                     max_results=arguments.get("max_results", 25),
+                    audit_context={
+                        "source": "mcp_stdio",
+                        "tool": name,
+                    },
                 )
                 return [TextContent(type="text", text=json.dumps(result, indent=2))]
             except Exception as e:
@@ -1022,6 +1026,10 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:
                     profile_id=profile,
                     message_id=message_id,
                     format=arguments.get("format", "metadata"),
+                    audit_context={
+                        "source": "mcp_stdio",
+                        "tool": name,
+                    },
                 )
                 return [TextContent(type="text", text=json.dumps(result, indent=2))]
             except Exception as e:
@@ -1039,6 +1047,10 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:
                     profile_id=profile,
                     message_id=message_id,
                     attachment_id=attachment_id,
+                    audit_context={
+                        "source": "mcp_stdio",
+                        "tool": name,
+                    },
                 )
                 return [TextContent(type="text", text=json.dumps(result, indent=2))]
             except Exception as e:
@@ -1050,7 +1062,13 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:
                 return [TextContent(type="text", text=json.dumps({"error": "Missing required parameter: profile"}))]
 
             try:
-                result = gmail_service.list_labels(profile_id=profile)
+                result = gmail_service.list_labels(
+                    profile_id=profile,
+                    audit_context={
+                        "source": "mcp_stdio",
+                        "tool": name,
+                    },
+                )
                 return [TextContent(type="text", text=json.dumps(result, indent=2))]
             except Exception as e:
                 return [TextContent(type="text", text=json.dumps({"error": f"Gmail list labels failed: {e}"}))]
@@ -1071,6 +1089,10 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:
                     add_labels=arguments.get("add_labels"),
                     remove_labels=arguments.get("remove_labels"),
                     allow_mutation=allow_mutation,
+                    audit_context={
+                        "source": "mcp_stdio",
+                        "tool": name,
+                    },
                 )
                 return [TextContent(type="text", text=json.dumps(result, indent=2))]
             except Exception as e:

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -561,6 +561,151 @@
             }
         },
         {
+            "name": "gmail_list_messages",
+            "description": "List Gmail messages for a profile with optional query and label filters (read-only). Profile must be configured via environment.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "profile": {
+                        "type": "string",
+                        "description": "Profile ID configured via env"
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Optional Gmail search query"
+                    },
+                    "label_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Optional Gmail label IDs"
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Maximum number of messages to return"
+                    }
+                },
+                "required": [
+                    "profile"
+                ]
+            }
+        },
+        {
+            "name": "gmail_get_message",
+            "description": "Fetch a Gmail message for a profile (formats: metadata|full|raw|minimal). Read-only; profile token required.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "profile": {
+                        "type": "string",
+                        "description": "Profile ID configured via env"
+                    },
+                    "message_id": {
+                        "type": "string",
+                        "description": "Gmail message ID"
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": [
+                            "metadata",
+                            "full",
+                            "raw",
+                            "minimal"
+                        ],
+                        "default": "metadata",
+                        "description": "Gmail API format"
+                    }
+                },
+                "required": [
+                    "profile",
+                    "message_id"
+                ]
+            }
+        },
+        {
+            "name": "gmail_get_attachment",
+            "description": "Fetch a Gmail attachment for a profile (base64 payload). Read-only; profile token required.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "profile": {
+                        "type": "string",
+                        "description": "Profile ID configured via env"
+                    },
+                    "message_id": {
+                        "type": "string",
+                        "description": "Gmail message ID"
+                    },
+                    "attachment_id": {
+                        "type": "string",
+                        "description": "Gmail attachment ID"
+                    }
+                },
+                "required": [
+                    "profile",
+                    "message_id",
+                    "attachment_id"
+                ]
+            }
+        },
+        {
+            "name": "gmail_list_labels",
+            "description": "List Gmail labels for a profile. Read-only; useful to discover label IDs for filtering.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "profile": {
+                        "type": "string",
+                        "description": "Profile ID configured via env"
+                    }
+                },
+                "required": [
+                    "profile"
+                ]
+            }
+        },
+        {
+            "name": "gmail_modify_labels",
+            "description": "Add/remove labels on a Gmail message for a profile. Requires allow_mutation=true and gmail.modify scope.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "profile": {
+                        "type": "string",
+                        "description": "Profile ID configured via env"
+                    },
+                    "message_id": {
+                        "type": "string",
+                        "description": "Gmail message ID"
+                    },
+                    "add_labels": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Labels to add"
+                    },
+                    "remove_labels": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Labels to remove"
+                    },
+                    "allow_mutation": {
+                        "type": "boolean",
+                        "description": "Must be true to permit mutation"
+                    }
+                },
+                "required": [
+                    "profile",
+                    "message_id",
+                    "allow_mutation"
+                ]
+            }
+        },
+        {
             "name": "search_arxiv",
             "description": "Search arXiv.org for scholarly articles. Use when user asks to find papers by author, keyword, topic, or date range. Returns list of papers with id, title, authors, summary, and publication date. Supports boolean operators in query (AND, OR, NOT). Example: 'causal reasoning AND neural networks'. Results can be sorted by relevance, submission date, or last updated date.",
             "inputSchema": {

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -208,6 +208,7 @@ def generate():
     request_user_id = data.get("user_id")
     request_org_id = data.get("org_id")
     request_language = data.get("language", "en-NZ")
+    request_gmail_profile = data.get("gmail_profile")
 
     # Session management
     if "session_id" not in session:
@@ -356,6 +357,7 @@ def generate():
                     llm_client=llm_client,
                     model=model_name,
                     user_namespace=user_namespace,
+                    gmail_profile=request_gmail_profile,
                 )
                 response_text = orchestrator_result.response_text
                 tool_messages = [dict(msg) for msg in orchestrator_result.extra_messages]

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -119,6 +119,7 @@ def create_flask_app(
                 gateway=gateway_instance,
                 logger=app.logger.getChild("mcp_orchestrator") if app.logger else None,
                 max_tool_invocations=8,  # JVNAUTOSCI-699: Allow complex chained workflows
+                default_gmail_profile=os.getenv("VON_GMAIL_DEFAULT_PROFILE") or None,
             )
         except Exception as exc:  # pragma: no cover - defensive bootstrap
             try:

--- a/src/backend/services/namespace_service.py
+++ b/src/backend/services/namespace_service.py
@@ -119,7 +119,12 @@ def get_user_id(namespace: str) -> str:
     Raises:
         ValueError: If namespace format is invalid
     """
-    return parse_namespace(namespace)["user_id"]
+    parsed = parse_namespace(namespace)
+    user_id = parsed.get("user_id")
+    if not user_id:
+        raise ValueError(f"Namespace missing user_id: {namespace}")
+
+    return user_id
 
 
 def get_org_id(namespace: str) -> Optional[str]:
@@ -152,4 +157,8 @@ def normalize_namespace(namespace: str) -> str:
         ValueError: If namespace format is invalid
     """
     parsed = parse_namespace(namespace)
-    return derive_namespace(parsed["user_id"], parsed.get("org_id"))
+    user_id = parsed.get("user_id")
+    if not user_id:
+        raise ValueError(f"Namespace missing user_id: {namespace}")
+
+    return derive_namespace(user_id, parsed.get("org_id"))

--- a/src/backend/services/rag_sync_service.py
+++ b/src/backend/services/rag_sync_service.py
@@ -56,18 +56,32 @@ def sync_to_chat_store(namespace: Optional[str] = None, limit: int = 1000) -> di
 
     indexed = collect_indexed_sessions(limit=limit)
     added = 0
+    failed = 0
     for item in indexed:
+        doc = {
+            "id": item.get("id"),
+            "text": item.get("text", ""),
+            "metadata": item.get("metadata", {}),
+        }
+        if item.get("embedding"):
+            doc["embedding"] = item["embedding"]
+
         try:
-            service.upsert(id=item['id'], text=item['text'], metadata=item['metadata'], namespace=namespace, embedding=item.get('embedding'))
-            added += 1
+            success_count, failure_count = service.upsert_documents([doc], namespace=namespace)
         except Exception:
-            # Fallback: if embedding is not compatible, let backend compute it
-            try:
-                service.upsert(id=item['id'], text=item['text'], metadata=item['metadata'], namespace=namespace)
-                added += 1
-            except Exception:
-                pass
-    return {"success": True, "added": added, "total_indexed": len(indexed)}
+            # Retry without embedding if backend rejects it
+            doc.pop("embedding", None)
+            success_count, failure_count = service.upsert_documents([doc], namespace=namespace)
+
+        added += success_count
+        failed += failure_count
+
+    return {
+        "success": failed == 0,
+        "added": added,
+        "failed": failed,
+        "total_indexed": len(indexed),
+    }
 
 def sync_one_session(session_id: str, namespace: Optional[str] = None) -> dict:
     """Synchronise a single already-indexed interaction_session into the chat RAG store."""
@@ -109,15 +123,26 @@ def sync_one_session(session_id: str, namespace: Optional[str] = None) -> dict:
     upsert_doc = {
         "id": str(doc['_id']),
         "text": text,
-        "metadata": metadata
+        "metadata": metadata,
     }
     embedding = doc.get('embedding')
+    if isinstance(embedding, list) and embedding:
+        upsert_doc["embedding"] = embedding
+
     ns = namespace or "chat_history"
     try:
-        if isinstance(embedding, list) and embedding:
-            service.upsert(id=upsert_doc['id'], text=upsert_doc['text'], metadata=upsert_doc['metadata'], namespace=ns, embedding=embedding)
-        else:
-            service.upsert(id=upsert_doc['id'], text=upsert_doc['text'], metadata=upsert_doc['metadata'], namespace=ns)
+        success_count, failure_count = service.upsert_documents([upsert_doc], namespace=ns)
     except Exception as e:
-        return {"success": False, "error": f"Upsert failed: {e}", "session_id": session_id}
-    return {"success": True, "upserted": 1, "namespace": ns, "session_id": session_id}
+        if "embedding" in upsert_doc:
+            upsert_doc.pop("embedding", None)
+            try:
+                success_count, failure_count = service.upsert_documents([upsert_doc], namespace=ns)
+            except Exception as nested_e:
+                return {"success": False, "error": f"Upsert failed: {nested_e}", "session_id": session_id}
+        else:
+            return {"success": False, "error": f"Upsert failed: {e}", "session_id": session_id}
+
+    if failure_count > 0 or success_count == 0:
+        return {"success": False, "error": "Upsert failed", "session_id": session_id}
+
+    return {"success": True, "upserted": success_count, "namespace": ns, "session_id": session_id}

--- a/src/frontend/web/von_interface/static/js/apiService.js
+++ b/src/frontend/web/von_interface/static/js/apiService.js
@@ -88,6 +88,12 @@ export function getUserContext() {
     ctx.language = 'en-NZ';
   }
 
+  try {
+    ctx.gmail_profile = localStorage.getItem('von_gmail_profile') || null;
+  } catch (e) {
+    ctx.gmail_profile = null;
+  }
+
   return ctx;
 }
 

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -355,7 +355,8 @@ async function handleSendPrompt() {
                 prompt: promptText,
                 user_id: userContext.user_id,
                 org_id: userContext.org_id,
-                language: userContext.language
+                language: userContext.language,
+                gmail_profile: userContext.gmail_profile
             })
         });
 

--- a/src/frontend/web/von_interface/static/js/settingsPage.js
+++ b/src/frontend/web/von_interface/static/js/settingsPage.js
@@ -18,6 +18,7 @@ const LS_USER_KEY = 'von_current_user';
 const LS_ORG_KEY = 'von_current_org';
 const LS_LANG_KEY = 'von_preferred_language';
 const LS_AUTO_RELOAD = 'von:autoReloadOnRestart';
+const LS_GMAIL_PROFILE = 'von_gmail_profile';
 
 function getStoredJson(key) {
   try { return JSON.parse(localStorage.getItem(key) || 'null'); } catch { return null; }
@@ -119,6 +120,17 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Persist language preference (with current organisation if available)
     persistCurrentUserPreferences();
   });
+
+  const gmailProfileInput = document.getElementById('gmailProfileInput');
+  if (gmailProfileInput) {
+    try { gmailProfileInput.value = localStorage.getItem(LS_GMAIL_PROFILE) || ''; } catch { gmailProfileInput.value = ''; }
+    gmailProfileInput.addEventListener('input', () => {
+      try {
+        const val = gmailProfileInput.value.trim();
+        if (val) localStorage.setItem(LS_GMAIL_PROFILE, val); else localStorage.removeItem(LS_GMAIL_PROFILE);
+      } catch { /* ignore localStorage errors */ }
+    });
+  }
 });
 
 // Auto Reload on Restart toggle
@@ -195,10 +207,12 @@ document.getElementById('resetLocalPrefsButton')?.addEventListener('click', () =
     localStorage.removeItem(LS_USER_KEY);
     localStorage.removeItem(LS_ORG_KEY);
     localStorage.removeItem(LS_LANG_KEY);
+    localStorage.removeItem(LS_GMAIL_PROFILE);
     // Reset selects visually
     const userSel = document.getElementById('currentUserSelect'); if (userSel) userSel.selectedIndex = 0;
     const orgSel = document.getElementById('currentOrganisationSelect'); if (orgSel) orgSel.selectedIndex = 0;
     const langSel = document.getElementById('preferredLanguageSelect'); if (langSel) langSel.value = 'en-NZ';
+    const gmailProfileInput = document.getElementById('gmailProfileInput'); if (gmailProfileInput) gmailProfileInput.value = '';
     if (window.parent?.updateModelInfoFooterDisplay) { window.parent.updateModelInfoFooterDisplay(); }
     showStatusMessage('settingsStatusMessage', 'Local preferences cleared');
   } catch (e) {

--- a/src/frontend/web/von_interface/templates/settings_tab.html
+++ b/src/frontend/web/von_interface/templates/settings_tab.html
@@ -108,6 +108,10 @@
                 <!-- Options populated by languageConfig.js -->
             </select>
             <small>This will be the default language for new names and text entries.</small>
+            <label for="gmailProfileInput" class="mt-2">Gmail profile ID (for MCP tools):</label>
+            <input type="text" id="gmailProfileInput" placeholder="e.g., von-mail" />
+            <small class="settings-note">Profile IDs must match the backend Gmail profiles configured via environment
+                (VON_GMAIL_PROFILES). Leave blank to disable Gmail calls.</small>
             <div class="inline-form inline-form-tight mt-8-align-center">
                 <button type="button" id="resetLocalPrefsButton" class="btn-danger"
                     title="Clear stored user/org/language preferences for this browser">Reset Local Preferences</button>

--- a/tests/backend/test_gmail_service.py
+++ b/tests/backend/test_gmail_service.py
@@ -1,0 +1,147 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.backend.integrations.google import gmail_service as gs
+
+
+def test_load_profiles_from_env_json_list(monkeypatch):
+    payload = [
+        {
+            "profile_id": "von",
+            "token_path": "/tmp/von_token.json",
+            "user_id": "von_user",
+            "label_filter": ["INBOX", "LABEL_X"],
+            "query_prefix": "label:agent-inbox",
+        },
+        {
+            "profile_id": "user",
+            "token_path": "/tmp/user_token.json",
+            "scopes": [gs.MUTATION_SCOPE],
+        },
+    ]
+    monkeypatch.setenv(gs.PROFILES_ENV_VAR, json.dumps(payload))
+
+    profiles = gs.load_profiles_from_env()
+
+    assert set(profiles.keys()) == {"von", "user"}
+    assert profiles["von"].label_filter == ["INBOX", "LABEL_X"]
+    assert profiles["von"].query_prefix == "label:agent-inbox"
+    assert profiles["user"].scopes == [gs.MUTATION_SCOPE]
+
+
+def test_load_profiles_from_fallback_env(monkeypatch):
+    monkeypatch.delenv(gs.PROFILES_ENV_VAR, raising=False)
+    monkeypatch.setenv("VON_GMAIL_TOKEN_PATH", "/tmp/token.json")
+    monkeypatch.setenv("VON_GMAIL_LABELS", "INBOX,IMPORTANT ")
+    monkeypatch.setenv("VON_GMAIL_MUTATION", "true")
+
+    profiles = gs.load_profiles_from_env()
+
+    assert set(profiles.keys()) == {"von-service"}
+    profile = profiles["von-service"]
+    assert profile.label_filter == ["INBOX", "IMPORTANT"]
+    assert gs.MUTATION_SCOPE in profile.scopes
+
+
+def test_get_profile_missing(monkeypatch):
+    monkeypatch.delenv(gs.PROFILES_ENV_VAR, raising=False)
+    monkeypatch.delenv("VON_GMAIL_TOKEN_PATH", raising=False)
+    with pytest.raises(RuntimeError):
+        gs.get_profile("anything")
+
+
+@patch("src.backend.integrations.google.gmail_service.build")
+@patch("src.backend.integrations.google.gmail_service.os.path.exists", return_value=True)
+@patch("src.backend.integrations.google.gmail_service.Credentials.from_authorized_user_file")
+def test_get_service_uses_existing_credentials(mock_creds_loader, mock_exists, mock_build, monkeypatch):
+    creds = MagicMock(valid=True, expired=False, refresh_token=None)
+    mock_creds_loader.return_value = creds
+
+    monkeypatch.setenv("VON_GMAIL_TOKEN_PATH", "/tmp/token.json")
+    profiles = gs.load_profiles_from_env()
+
+    service = gs.get_service("von-service", profiles)
+
+    assert service == mock_build.return_value
+    mock_build.assert_called_once()
+    mock_creds_loader.assert_called_once()
+    creds.refresh.assert_not_called()
+
+
+@patch("src.backend.integrations.google.gmail_service._persist_credentials")
+@patch("src.backend.integrations.google.gmail_service.build")
+@patch("src.backend.integrations.google.gmail_service.os.path.exists", return_value=True)
+@patch("src.backend.integrations.google.gmail_service.Credentials.from_authorized_user_file")
+def test_get_service_refreshes_and_persists(mock_creds_loader, mock_exists, mock_build, mock_persist, monkeypatch):
+    creds = MagicMock(valid=False, expired=True, refresh_token="token")
+    mock_creds_loader.return_value = creds
+
+    monkeypatch.setenv("VON_GMAIL_TOKEN_PATH", "/tmp/token.json")
+    profiles = gs.load_profiles_from_env()
+
+    gs.get_service("von-service", profiles)
+
+    creds.refresh.assert_called_once()
+    mock_persist.assert_called_once()
+    mock_build.assert_called_once()
+
+
+@patch("src.backend.integrations.google.gmail_service.get_service")
+@patch("src.backend.integrations.google.gmail_service.get_profile")
+def test_list_and_get_message(mock_get_profile, mock_get_service):
+    mock_profile = SimpleNamespace(user_id="me", label_filter=["INBOX"], query_prefix="from:someone")
+    mock_get_profile.return_value = mock_profile
+
+    messages_mock = MagicMock()
+    users_mock = MagicMock()
+    service_mock = MagicMock()
+    service_mock.users.return_value = users_mock
+    users_mock.messages.return_value = messages_mock
+    messages_mock.list.return_value.execute.return_value = {"messages": []}
+    messages_mock.get.return_value.execute.return_value = {"id": "123"}
+    attachments_mock = MagicMock()
+    messages_mock.attachments.return_value = attachments_mock
+    attachments_mock.get.return_value.execute.return_value = {"data": "abc"}
+    labels_mock = MagicMock()
+    users_mock.labels.return_value = labels_mock
+    labels_mock.list.return_value.execute.return_value = {"labels": []}
+    mock_get_service.return_value = service_mock
+
+    list_result = gs.list_messages("any", query="subject:test")
+    message_result = gs.get_message("any", message_id="123")
+    attachment_result = gs.get_attachment("any", message_id="123", attachment_id="att")
+    labels_result = gs.list_labels("any")
+
+    assert list_result == {"messages": []}
+    messages_mock.list.assert_called_once()
+    assert message_result == {"id": "123"}
+    assert attachment_result == {"data": "abc"}
+    assert labels_result == {"labels": []}
+
+
+def test_modify_labels_guard(monkeypatch):
+    monkeypatch.setenv("VON_GMAIL_TOKEN_PATH", "/tmp/token.json")
+    profiles = {
+        "p": gs.GmailProfile(
+            profile_id="p",
+            token_path="/tmp/token.json",
+            scopes=list(gs.DEFAULT_SCOPES),
+        )
+    }
+
+    with pytest.raises(ValueError):
+        gs.modify_labels("p", "mid", add_labels=["X"], allow_mutation=False, profiles=profiles)
+
+    profiles["p"].scopes = [gs.MUTATION_SCOPE]
+    with patch("src.backend.integrations.google.gmail_service.get_service") as mock_service:
+        svc = MagicMock()
+        mock_service.return_value = svc
+        svc.users.return_value.messages.return_value.modify.return_value.execute.return_value = {"id": "mid"}
+
+        result = gs.modify_labels("p", "mid", add_labels=["X"], allow_mutation=True, profiles=profiles)
+
+        assert result == {"id": "mid"}
+        svc.users.return_value.messages.return_value.modify.assert_called_once()

--- a/tests/backend/test_orchestrator_gmail_profile.py
+++ b/tests/backend/test_orchestrator_gmail_profile.py
@@ -1,0 +1,96 @@
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.backend.integrations.internal_mcp.orchestrator import InternalMCPChatOrchestrator
+
+
+class DummyGateway:
+    def __init__(self):
+        self.enabled = True
+        self.calls = []
+
+    def describe_methods(self):
+        return {
+            "gmail_list_messages": {
+                "description": "",
+                "input_schema": {"required": ["profile"], "optional": {}},
+            }
+        }
+
+    def invoke(self, method_name, payload):
+        self.calls.append((method_name, dict(payload)))
+
+        class Result:
+            def __init__(self):
+                self.payload = {"ok": True}
+                self.duration_ms = 1.0
+
+        return Result()
+
+
+class DummyLLM:
+    def __init__(self, responses):
+        self.responses = list(responses)
+
+    def generate(self, prompt, context=None, model=None):
+        if not self.responses:
+            raise RuntimeError("No responses left in DummyLLM")
+        return self.responses.pop(0)
+
+def test_injects_default_gmail_profile_into_payload():
+    gateway = DummyGateway()
+    llm = DummyLLM([
+        '{"action": "call_tool", "tool": "gmail_list_messages", "payload": {}}',
+        "Final response",
+    ])
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=gateway,  # type: ignore[arg-type]
+        max_tool_invocations=1,
+        default_gmail_profile="service-profile",
+    )
+
+    result = orchestrator.run(
+        prompt="hello",
+        context=None,
+        llm_client=llm,
+        model="test-model",
+        user_namespace="#V#user",
+    )
+
+    assert gateway.calls, "Gateway should have been invoked"
+    method_name, payload = gateway.calls[0]
+    assert method_name == "gmail_list_messages"
+    assert payload["profile"] == "service-profile"
+    assert payload["namespace"] == "#V#user"
+    assert result.response_text == "Final response"
+
+
+def test_gmail_profile_prefers_request_over_default():
+    gateway = DummyGateway()
+    llm = DummyLLM([
+        '{"action": "call_tool", "tool": "gmail_list_messages", "payload": {}}',
+        "All good",
+    ])
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=gateway,  # type: ignore[arg-type]
+        max_tool_invocations=1,
+        default_gmail_profile="default-profile",
+    )
+
+    result = orchestrator.run(
+        prompt="hi",
+        context=None,
+        llm_client=llm,
+        model="test-model",
+        user_namespace="#V#user",
+        gmail_profile="user-picked",
+    )
+
+    assert gateway.calls, "Gateway should have been invoked"
+    _, payload = gateway.calls[0]
+    assert payload["profile"] == "user-picked"
+    assert payload["namespace"] == "#V#user"
+    assert result.response_text == "All good"


### PR DESCRIPTION
## Summary
- Add profile-based Gmail service with read-first defaults, audit logging, and opt-in label mutation guard
- Expose Gmail tools (list messages, get message, attachments, labels, modify labels) via internal MCP, stdio server, and manifest; inject default profile in orchestrator and settings UI
- Tidy namespace/RAG handling and add coverage for Gmail service and orchestrator profile injection

## Testing
- Not run (not requested)