### PR TITLE
JVNAUTOSCI-797: User-specific chat prompts + introspection tools

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -1723,6 +1723,232 @@ def _jira_get_auth_config(**kwargs):
     return inspect_jira_auth_config()
 
 
+def _chat_get_prompt_context(
+    *,
+    namespace: str | None = None,
+    include_content: bool = False,
+    max_chars: int | None = 2000,
+    **_kwargs,
+):
+    """Return user-specific prompt context that affects chat.
+
+    This is intended for debugging/inspection: which `#V#von_llm_prompt` concepts
+    are linked to the authenticated user (namespace) and what content they
+    contribute.
+    """
+
+    if not namespace or not isinstance(namespace, str) or not namespace.strip():
+        return {"success": False, "error": "namespace is required"}
+
+    if not isinstance(include_content, bool):
+        include_content = False
+
+    if max_chars is None:
+        max_chars_int = 2000
+    else:
+        try:
+            max_chars_int = int(max_chars)
+        except (TypeError, ValueError):
+            max_chars_int = 2000
+    max_chars_int = max(0, min(max_chars_int, 20000))
+
+    from src.backend.services.chat_auxiliary_prompt_service import (
+        build_user_specific_system_prompt,
+        get_user_specific_prompt_fragments,
+    )
+
+    fragments = get_user_specific_prompt_fragments(namespace)
+    prompt_concept_ids = [f.get("concept_id") for f in fragments if isinstance(f.get("concept_id"), str)]
+
+    prompt_text = build_user_specific_system_prompt(namespace)
+    if isinstance(prompt_text, str) and max_chars_int and len(prompt_text) > max_chars_int:
+        prompt_text = prompt_text[:max_chars_int] + f"\n... [truncated {len(prompt_text) - max_chars_int} chars]"
+
+    prompt_concepts = []
+    for fragment in fragments:
+        concept_id = fragment.get("concept_id")
+        if not isinstance(concept_id, str):
+            continue
+        item = {"concept_id": concept_id}
+        if include_content:
+            content = fragment.get("content")
+            item["content"] = content if isinstance(content, str) else ""
+        prompt_concepts.append(item)
+
+    return {
+        "success": True,
+        "namespace": namespace,
+        "prompt_concept_ids": prompt_concept_ids,
+        "prompt_concepts": prompt_concepts,
+        "prompt_text": prompt_text or "",
+        "prompt_count": len(prompt_concept_ids),
+    }
+
+
+def _settings_get_public(*, user_concept_id: str | None = None, organisation_concept_id: str | None = None, **_kwargs):
+    """Return a safe subset of settings (no secrets).
+
+    This intentionally excludes any secret values (API tokens, passwords). It may
+    include *names* of env vars (e.g., which env var holds a key) as that is not
+    a secret.
+    """
+
+    from src.backend.server.routes.settings_routes import get_all_settings_data
+    from src.backend.services.settings_service import resolve_llm_setting
+
+    settings = get_all_settings_data() or {}
+    try:
+        settings["resolved_llm"] = resolve_llm_setting(
+            user_concept_id=user_concept_id,
+            org_concept_id=organisation_concept_id,
+        )
+    except Exception:
+        settings["resolved_llm"] = None
+
+    return {"success": True, "settings": settings}
+
+
+def _chat_introspect(
+    *,
+    namespace: str | None = None,
+    organisation_concept_id: str | None = None,
+    include_prompt_content: bool = False,
+    include_tool_guidance_preview: bool = False,
+    max_preview_chars: int | None = 800,
+    include_runtime_status: bool = True,
+    **_kwargs,
+):
+    """Return a compact description of what influences chat context.
+
+    Primary goal: allow the assistant (via MCP) to determine what system prompt
+    influences are active (including Vontology-stored prompts) and what model
+    configuration is in effect, without exposing secrets.
+    """
+
+    import hashlib
+
+    from src.backend.integrations.internal_mcp.orchestrator import InternalMCPChatOrchestrator
+    from src.backend.languagemodels.llm_interface import get_active_model_name
+    from src.backend.services.settings_service import get_active_llm_setting, resolve_llm_setting
+
+    if not namespace or not isinstance(namespace, str) or not namespace.strip():
+        return {"success": False, "error": "namespace is required"}
+
+    # Clamp preview size
+    if max_preview_chars is None:
+        max_preview_chars_int = 800
+    else:
+        try:
+            max_preview_chars_int = int(max_preview_chars)
+        except (TypeError, ValueError):
+            max_preview_chars_int = 800
+    max_preview_chars_int = max(0, min(max_preview_chars_int, 5000))
+
+    # User-specific prompt fragments (JVNAUTOSCI-797)
+    from src.backend.services.chat_auxiliary_prompt_service import (
+        build_user_specific_system_prompt,
+        get_user_specific_prompt_fragments,
+    )
+
+    fragments = get_user_specific_prompt_fragments(namespace)
+    prompt_concept_ids = [f.get("concept_id") for f in fragments if isinstance(f.get("concept_id"), str)]
+    auxiliary_prompt_text = build_user_specific_system_prompt(namespace) or ""
+
+    prompt_concepts: list[dict] = []
+    for fragment in fragments:
+        concept_id = fragment.get("concept_id")
+        if not isinstance(concept_id, str):
+            continue
+        item = {"concept_id": concept_id}
+        if include_prompt_content:
+            content = fragment.get("content")
+            item["content"] = content if isinstance(content, str) else ""
+        prompt_concepts.append(item)
+
+    # Model / provider information
+    try:
+        active_model_name = get_active_model_name()
+    except Exception:
+        active_model_name = None
+
+    try:
+        active_llm = get_active_llm_setting()
+    except Exception:
+        active_llm = None
+
+    try:
+        resolved_llm = resolve_llm_setting(user_concept_id=namespace, org_concept_id=organisation_concept_id)
+    except Exception:
+        resolved_llm = None
+
+    gateway_enabled = None
+    orchestrator_max_tool_invocations = None
+    if include_runtime_status:
+        try:
+            from flask import current_app
+
+            gateway = current_app.config.get("INTERNAL_MCP_GATEWAY")
+            orchestrator = current_app.config.get("INTERNAL_MCP_ORCHESTRATOR")
+            gateway_enabled = getattr(gateway, "enabled", None)
+            orchestrator_max_tool_invocations = getattr(orchestrator, "_max_tool_invocations", None)
+        except Exception:
+            gateway_enabled = None
+            orchestrator_max_tool_invocations = None
+
+    # Tool-guidance fingerprint (stable-ish) without dumping full text by default
+    tool_guidance_text = ""
+    tool_guidance_hash = None
+    tool_guidance_preview = None
+
+    try:
+        # Prefer the live orchestrator (includes the real tool listing) when available.
+        live_orchestrator = None
+        try:
+            from flask import current_app
+
+            live_orchestrator = current_app.config.get("INTERNAL_MCP_ORCHESTRATOR")
+        except Exception:
+            live_orchestrator = None
+
+        if live_orchestrator is not None and hasattr(live_orchestrator, "_instruction_message"):
+            tool_guidance_text = live_orchestrator._instruction_message(  # type: ignore[attr-defined]
+                user_namespace=namespace,
+                auxiliary_system_prompt=auxiliary_prompt_text,
+            )
+        else:
+            class _StubGateway:
+                def describe_methods(self):
+                    return {}
+
+            dummy_orchestrator = InternalMCPChatOrchestrator(gateway=_StubGateway())  # type: ignore[arg-type]
+            tool_guidance_text = dummy_orchestrator._instruction_message(
+                user_namespace=namespace,
+                auxiliary_system_prompt=auxiliary_prompt_text,
+            )
+
+        tool_guidance_hash = hashlib.sha256(tool_guidance_text.encode("utf-8")).hexdigest()
+        if include_tool_guidance_preview and max_preview_chars_int:
+            tool_guidance_preview = tool_guidance_text[:max_preview_chars_int]
+    except Exception:
+        tool_guidance_hash = None
+
+    return {
+        "success": True,
+        "namespace": namespace,
+        "organisation_concept_id": organisation_concept_id,
+        "active_model_name": active_model_name,
+        "active_llm": active_llm,
+        "resolved_llm": resolved_llm,
+        "prompt_concept_ids": prompt_concept_ids,
+        "prompt_concepts": prompt_concepts,
+        "prompt_count": len(prompt_concept_ids),
+        "tool_guidance_hash": tool_guidance_hash,
+        "tool_guidance_preview": tool_guidance_preview,
+        "gateway_enabled": gateway_enabled,
+        "orchestrator_max_tool_invocations": orchestrator_max_tool_invocations,
+    }
+
+
 def build_default_catalogue() -> MethodCatalogue:
     """Return a catalogue pre-populated with the baseline method set."""
 
@@ -1800,6 +2026,113 @@ def build_default_catalogue() -> MethodCatalogue:
             ),
             category="read",
             description="Get current server-side context: active LLM model (string), provider, language preference, and runtime settings. NOTE: User and organisation information is managed client-side (localStorage) per JVNAUTOSCI-628 and may not be available here. Use when you need to know what model/language is configured.",
+        ),
+        MethodDefinition(
+            name="chat_get_prompt_context",
+            handler=_chat_get_prompt_context,
+            input_schema=Schema(
+                required={"namespace": str},
+                optional={
+                    "include_content": bool,
+                    "max_chars": (int, type(None)),
+                },
+                allow_unknown=False,
+                description=(
+                    "Return the effective user-specific prompt context derived from Vontology "
+                    "for the given authenticated namespace (concept ID), including which prompt "
+                    "concept IDs are contributing to chat. Use for debugging what influences chat."
+                ),
+            ),
+            output_schema=Schema(
+                required={
+                    "success": bool,
+                    "namespace": str,
+                    "prompt_concept_ids": list,
+                    "prompt_concepts": list,
+                    "prompt_text": str,
+                    "prompt_count": int,
+                },
+                optional={"error": str},
+                allow_unknown=False,
+                description="User-specific chat prompt context for debugging and transparency.",
+            ),
+            category="read",
+            description=(
+                "Report which Vontology `#V#von_llm_prompt` concepts (linked via `#V#specific_to_von_user`) "
+                "apply to the authenticated user namespace and optionally include their content."
+            ),
+        ),
+        MethodDefinition(
+            name="chat_introspect",
+            handler=_chat_introspect,
+            input_schema=Schema(
+                required={"namespace": str},
+                optional={
+                    "organisation_concept_id": (str, type(None)),
+                    "include_prompt_content": bool,
+                    "include_tool_guidance_preview": bool,
+                    "max_preview_chars": (int, type(None)),
+                    "include_runtime_status": bool,
+                },
+                allow_unknown=False,
+                description=(
+                    "Return a compact snapshot of what influences chat for an authenticated namespace, "
+                    "including active model information, user-specific prompt concept IDs, and a tool-guidance "
+                    "fingerprint (hash)."
+                ),
+            ),
+            output_schema=Schema(
+                required={
+                    "success": bool,
+                    "namespace": str,
+                    "organisation_concept_id": (str, type(None)),
+                    "active_model_name": (str, type(None)),
+                    "active_llm": (dict, type(None)),
+                    "resolved_llm": (dict, type(None)),
+                    "prompt_concept_ids": list,
+                    "prompt_concepts": list,
+                    "prompt_count": int,
+                    "tool_guidance_hash": (str, type(None)),
+                    "tool_guidance_preview": (str, type(None)),
+                    "gateway_enabled": (bool, type(None)),
+                    "orchestrator_max_tool_invocations": (int, type(None)),
+                },
+                optional={"error": str},
+                allow_unknown=False,
+                description="Chat context introspection snapshot (safe, no secrets).",
+            ),
+            category="read",
+            description=(
+                "Introspect chat context influences for a user: model configuration, Vontology prompt concepts, "
+                "and tool-guidance fingerprint. Useful for debugging and transparency."
+            ),
+        ),
+        MethodDefinition(
+            name="settings_get_public",
+            handler=_settings_get_public,
+            input_schema=Schema(
+                required={},
+                optional={
+                    "user_concept_id": (str, type(None)),
+                    "organisation_concept_id": (str, type(None)),
+                },
+                allow_unknown=False,
+                description="Return non-secret settings and resolved LLM config for optional user/org scope.",
+            ),
+            output_schema=Schema(
+                required={
+                    "success": bool,
+                    "settings": dict,
+                },
+                optional={"error": str},
+                allow_unknown=True,
+                description="Public settings snapshot (no secrets).",
+            ),
+            category="read",
+            description=(
+                "Return a safe subset of settings (no secrets), including the active LLM and resolved LLM when "
+                "user/org IDs are provided."
+            ),
         ),
         MethodDefinition(
             name="get_tree",

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -79,7 +79,11 @@ class InternalMCPChatOrchestrator:
             lines.append(f"- {name}{params}: {description}")
         return "\n".join(lines)
 
-    def _instruction_message(self, user_namespace: str | None = None) -> str:
+    def _instruction_message(
+        self,
+        user_namespace: str | None = None,
+        auxiliary_system_prompt: str | None = None,
+    ) -> str:
         """Build system instruction emphasizing immediate tool invocation behavior.
 
         Design rationale (JVNAUTOSCI-698): Focus on BEHAVIOR (invoke immediately)
@@ -100,7 +104,7 @@ class InternalMCPChatOrchestrator:
                 "If user asks about their RAG data/sessions/indexed content, explain they need to log in first.\n"
             )
 
-        return (
+        base_message = (
             "You have access to internal MCP tools.\n\n"
             "⚠️ WHEN TO USE TOOLS (CHECK THESE FIRST) ⚠️\n"
             "If user asks for RECENT, CURRENT, LATEST, NEW, or BREAKING information → USE search_web\n"
@@ -131,6 +135,15 @@ class InternalMCPChatOrchestrator:
             "Available tools:\n"
             f"{listing}"
         )
+
+        if auxiliary_system_prompt and isinstance(auxiliary_system_prompt, str) and auxiliary_system_prompt.strip():
+            base_message += (
+                "\n\n"
+                "USER-SPECIFIC SYSTEM PROMPT (from Vontology):\n"
+                f"{auxiliary_system_prompt.strip()}\n"
+            )
+
+        return base_message
 
     def _is_json_action_response(self, response: str) -> bool:
         """Detect if response is ONLY a JSON action object (common LLM failure mode).
@@ -296,14 +309,18 @@ class InternalMCPChatOrchestrator:
     def _build_augmented_context(
         self,
         context: Optional[Sequence[Mapping[str, Any]]],
-        user_namespace: str | None = None
+        user_namespace: str | None = None,
+        auxiliary_system_prompt: str | None = None,
     ) -> List[Mapping[str, Any]]:
         base: List[Mapping[str, Any]] = []
         if context:
             for msg in context:
                 if isinstance(msg, Mapping):
                     base.append(dict(msg))
-        instruction_msg = self._instruction_message(user_namespace=user_namespace)
+        instruction_msg = self._instruction_message(
+            user_namespace=user_namespace,
+            auxiliary_system_prompt=auxiliary_system_prompt,
+        )
 
         # Log the size of the instruction message for diagnostics
         instruction_chars = len(instruction_msg)
@@ -326,12 +343,17 @@ class InternalMCPChatOrchestrator:
         model: Optional[str],
         user_namespace: Optional[str] = None,
         gmail_profile: Optional[str] = None,
+        auxiliary_system_prompt: str | None = None,
     ) -> OrchestratorResult:
         if not self._gateway.enabled or self._max_tool_invocations <= 0:
             response = llm_client.generate(prompt, context=context, model=model)
             return OrchestratorResult(response_text=response, extra_messages=(), tool_invocations=())
 
-        augmented_context = self._build_augmented_context(context, user_namespace=user_namespace)
+        augmented_context = self._build_augmented_context(
+            context,
+            user_namespace=user_namespace,
+            auxiliary_system_prompt=auxiliary_system_prompt,
+        )
         response = llm_client.generate(prompt, context=augmented_context, model=model)
 
         # JVNAUTOSCI-698: Detect if response is a JSON action that should trigger tool execution

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -264,6 +264,28 @@ def generate():
         # Build system message with user and organization context from request
         system_message_parts = []
 
+        # ---------------------------------------------------------
+        # JVNAUTOSCI-797: user-specific system prompt from Vontology
+        # ---------------------------------------------------------
+        auxiliary_system_prompt = None
+        if user_concept_id:
+            try:
+                from ...services.chat_auxiliary_prompt_service import build_user_specific_system_prompt
+
+                auxiliary_system_prompt = build_user_specific_system_prompt(user_concept_id)
+                if auxiliary_system_prompt:
+                    current_app.logger.info(
+                        "[CHAT_PROMPT] Loaded %d chars of user-specific prompt for %s",
+                        len(auxiliary_system_prompt),
+                        user_concept_id,
+                    )
+            except Exception as e:
+                current_app.logger.warning(
+                    "[CHAT_PROMPT] Failed loading user-specific prompt for %s: %s",
+                    user_concept_id,
+                    e,
+                )
+
         # Try to get user name from concept if user_id provided
         if request_user_id:
             try:
@@ -312,6 +334,18 @@ def generate():
                 existing_system = enhanced_context[0]["content"]
                 if not any(part in existing_system for part in system_message_parts):
                     enhanced_context[0]["content"] = f"{existing_system} | {' | '.join(system_message_parts)}"
+
+        # Ensure user-specific system prompt is included even when the orchestrator
+        # is disabled/unavailable.
+        if auxiliary_system_prompt:
+            user_prompt_message = {
+                "role": "system",
+                "content": "USER-SPECIFIC SYSTEM PROMPT (from Vontology):\n" + auxiliary_system_prompt,
+            }
+            if not enhanced_context or enhanced_context[0].get("role") != "system":
+                enhanced_context.insert(0, user_prompt_message)
+            else:
+                enhanced_context.insert(1, user_prompt_message)
 
         # Log the enhanced context being sent to the model for debugging
         current_app.logger.info(f"Enhanced context being sent to model: {len(enhanced_context)} messages")
@@ -447,6 +481,7 @@ def generate():
                     model=model_name,
                     user_namespace=user_namespace,
                     gmail_profile=request_gmail_profile,
+                    auxiliary_system_prompt=auxiliary_system_prompt,
                 )
                 response_text = orchestrator_result.response_text
                 tool_messages = [dict(msg) for msg in orchestrator_result.extra_messages]

--- a/src/backend/services/chat_auxiliary_prompt_service.py
+++ b/src/backend/services/chat_auxiliary_prompt_service.py
@@ -1,0 +1,77 @@
+"""Chat auxiliary prompt retrieval.
+
+JVNAUTOSCI-797: Allow chat to include user-specific system prompts stored in the
+Vontology as instances of `#V#von_llm_prompt` linked to the current user.
+
+The UI provides a selected user concept ID, but the backend must only apply
+prompts for the effective authenticated user.
+
+This module keeps the logic small and testable.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from src.backend.db.repositories.concepts_repository import ConceptsRepository
+from src.backend.services.concept_service import get_concept_by_concept_id
+
+
+_VON_LLM_PROMPT_TYPE = "#V#von_llm_prompt"
+_SPECIFIC_TO_USER_PREDICATE = "#V#specific_to_von_user"
+
+
+def build_user_specific_system_prompt(user_concept_id: str) -> Optional[str]:
+    """Build a system prompt string for the given authenticated user.
+
+    We locate concepts that:
+    - are instances of `#V#von_llm_prompt`, and
+    - are linked to the user via `#V#specific_to_von_user`.
+
+    If multiple prompts exist, we concatenate them in a deterministic order.
+    """
+
+    if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+        return None
+
+    user_concept_id = user_concept_id.strip()
+
+    relationship_field = f"relationships.{_SPECIFIC_TO_USER_PREDICATE}"
+
+    prompt_candidates = ConceptsRepository.find(
+        {
+            "relationships.is_an_instance_of": _VON_LLM_PROMPT_TYPE,
+            relationship_field: user_concept_id,
+        },
+        projection={"concept_id": 1, "name": 1},
+        sort=[("concept_id", 1)],
+        limit=50,
+    )
+
+    prompt_ids: List[str] = []
+    for doc in prompt_candidates:
+        concept_id = doc.get("concept_id") if isinstance(doc, dict) else None
+        if isinstance(concept_id, str) and concept_id.startswith("#V#"):
+            prompt_ids.append(concept_id)
+
+    if not prompt_ids:
+        return None
+
+    prompt_texts: List[str] = []
+    for concept_id in prompt_ids:
+        try:
+            concept = get_concept_by_concept_id(concept_id)
+        except Exception:
+            continue
+
+        if not isinstance(concept, dict):
+            continue
+
+        content = concept.get("content")
+        if isinstance(content, str) and content.strip():
+            prompt_texts.append(content.strip())
+
+    if not prompt_texts:
+        return None
+
+    return "\n\n".join(prompt_texts)

--- a/src/backend/services/chat_auxiliary_prompt_service.py
+++ b/src/backend/services/chat_auxiliary_prompt_service.py
@@ -11,7 +11,7 @@ This module keeps the logic small and testable.
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from src.backend.db.repositories.concepts_repository import ConceptsRepository
 from src.backend.services.concept_service import get_concept_by_concept_id
@@ -31,8 +31,26 @@ def build_user_specific_system_prompt(user_concept_id: str) -> Optional[str]:
     If multiple prompts exist, we concatenate them in a deterministic order.
     """
 
-    if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+    fragments = get_user_specific_prompt_fragments(user_concept_id)
+    prompt_texts = [fragment["content"] for fragment in fragments if fragment.get("content")]
+    if not prompt_texts:
         return None
+
+    return "\n\n".join(prompt_texts)
+
+
+def get_user_specific_prompt_fragments(user_concept_id: str) -> List[Dict[str, Any]]:
+    """Return the list of Vontology prompt fragments for a user.
+
+    Each fragment is a dict with:
+    - concept_id: str
+    - content: str
+
+    The list is returned in deterministic order.
+    """
+
+    if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+        return []
 
     user_concept_id = user_concept_id.strip()
 
@@ -55,9 +73,9 @@ def build_user_specific_system_prompt(user_concept_id: str) -> Optional[str]:
             prompt_ids.append(concept_id)
 
     if not prompt_ids:
-        return None
+        return []
 
-    prompt_texts: List[str] = []
+    fragments: List[Dict[str, Any]] = []
     for concept_id in prompt_ids:
         try:
             concept = get_concept_by_concept_id(concept_id)
@@ -69,9 +87,6 @@ def build_user_specific_system_prompt(user_concept_id: str) -> Optional[str]:
 
         content = concept.get("content")
         if isinstance(content, str) and content.strip():
-            prompt_texts.append(content.strip())
+            fragments.append({"concept_id": concept_id, "content": content.strip()})
 
-    if not prompt_texts:
-        return None
-
-    return "\n\n".join(prompt_texts)
+    return fragments

--- a/tests/backend/test_chat_auxiliary_prompt_service.py
+++ b/tests/backend/test_chat_auxiliary_prompt_service.py
@@ -1,0 +1,57 @@
+import pytest
+
+
+def test_build_user_specific_system_prompt_returns_none_for_blank_user_id(monkeypatch):
+    from src.backend.services.chat_auxiliary_prompt_service import build_user_specific_system_prompt
+
+    assert build_user_specific_system_prompt("") is None
+    assert build_user_specific_system_prompt("   ") is None
+
+
+def test_build_user_specific_system_prompt_concatenates_multiple_prompts(monkeypatch):
+    from src.backend.services import chat_auxiliary_prompt_service as service
+
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: [
+            {"concept_id": "#V#prompt_a"},
+            {"concept_id": "#V#prompt_b"},
+        ],
+    )
+
+    def _fake_get(concept_id):
+        if concept_id == "#V#prompt_a":
+            return {"concept_id": concept_id, "content": "First"}
+        if concept_id == "#V#prompt_b":
+            return {"concept_id": concept_id, "content": "Second\n"}
+        raise AssertionError(f"Unexpected concept_id {concept_id}")
+
+    monkeypatch.setattr(service, "get_concept_by_concept_id", _fake_get)
+
+    result = service.build_user_specific_system_prompt("#V#michael_witbrock")
+    assert result == "First\n\nSecond"
+
+
+def test_build_user_specific_system_prompt_skips_missing_content(monkeypatch):
+    from src.backend.services import chat_auxiliary_prompt_service as service
+
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: [
+            {"concept_id": "#V#prompt_a"},
+            {"concept_id": "#V#prompt_b"},
+        ],
+    )
+
+    def _fake_get(concept_id):
+        if concept_id == "#V#prompt_a":
+            return {"concept_id": concept_id, "content": "   "}
+        if concept_id == "#V#prompt_b":
+            return {"concept_id": concept_id, "content": None}
+        raise AssertionError(f"Unexpected concept_id {concept_id}")
+
+    monkeypatch.setattr(service, "get_concept_by_concept_id", _fake_get)
+
+    assert service.build_user_specific_system_prompt("#V#michael_witbrock") is None

--- a/tests/backend/test_chat_auxiliary_prompt_service.py
+++ b/tests/backend/test_chat_auxiliary_prompt_service.py
@@ -55,3 +55,27 @@ def test_build_user_specific_system_prompt_skips_missing_content(monkeypatch):
     monkeypatch.setattr(service, "get_concept_by_concept_id", _fake_get)
 
     assert service.build_user_specific_system_prompt("#V#michael_witbrock") is None
+
+
+def test_get_user_specific_prompt_fragments_returns_ids_and_content(monkeypatch):
+    from src.backend.services import chat_auxiliary_prompt_service as service
+
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: [
+            {"concept_id": "#V#prompt_a"},
+            {"concept_id": "#V#prompt_b"},
+        ],
+    )
+
+    def _fake_get(concept_id):
+        return {"concept_id": concept_id, "content": f"Content for {concept_id}"}
+
+    monkeypatch.setattr(service, "get_concept_by_concept_id", _fake_get)
+
+    fragments = service.get_user_specific_prompt_fragments("#V#michael_witbrock")
+    assert fragments == [
+        {"concept_id": "#V#prompt_a", "content": "Content for #V#prompt_a"},
+        {"concept_id": "#V#prompt_b", "content": "Content for #V#prompt_b"},
+    ]

--- a/tests/backend/test_internal_mcp_chat_prompt_tools.py
+++ b/tests/backend/test_internal_mcp_chat_prompt_tools.py
@@ -1,0 +1,123 @@
+"""Smoke tests for chat prompt introspection tools in the internal MCP catalogue.
+
+These tests avoid hitting the real database and only verify registration and
+basic handler behaviour.
+"""
+
+from src.backend.integrations.internal_mcp.catalogue import (
+    build_default_catalogue,
+    _chat_get_prompt_context,
+    _chat_introspect,
+    _settings_get_public,
+)
+
+
+def test_chat_prompt_tool_registered_in_catalogue():
+    catalogue = build_default_catalogue()
+    names = set(catalogue.list_methods())
+    assert "chat_get_prompt_context" in names
+    assert "chat_introspect" in names
+    assert "settings_get_public" in names
+
+
+def test_chat_get_prompt_context_requires_namespace():
+    result = _chat_get_prompt_context(namespace=None)
+    assert result.get("success") is False
+    assert "namespace" in (result.get("error") or "")
+
+
+def test_chat_introspect_requires_namespace():
+    result = _chat_introspect(namespace=None)
+    assert result.get("success") is False
+    assert "namespace" in (result.get("error") or "")
+
+
+def test_chat_get_prompt_context_returns_prompt_metadata(monkeypatch):
+    # Patch service imports used inside handler
+    monkeypatch.setattr(
+        "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
+        lambda _namespace: [
+            {"concept_id": "#V#prompt_a", "content": "Alpha"},
+            {"concept_id": "#V#prompt_b", "content": "Beta"},
+        ],
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_auxiliary_prompt_service.build_user_specific_system_prompt",
+        lambda _namespace: "Alpha\n\nBeta",
+    )
+
+    result = _chat_get_prompt_context(namespace="#V#michael_witbrock", include_content=False)
+    assert result.get("success") is True
+    assert result["namespace"] == "#V#michael_witbrock"
+    assert result["prompt_concept_ids"] == ["#V#prompt_a", "#V#prompt_b"]
+    assert result["prompt_count"] == 2
+    assert result["prompt_text"] == "Alpha\n\nBeta"
+
+    # No content when include_content=False
+    assert result["prompt_concepts"] == [{"concept_id": "#V#prompt_a"}, {"concept_id": "#V#prompt_b"}]
+
+
+def test_chat_get_prompt_context_includes_content_when_requested(monkeypatch):
+    monkeypatch.setattr(
+        "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
+        lambda _namespace: [
+            {"concept_id": "#V#prompt_a", "content": "Alpha"},
+        ],
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_auxiliary_prompt_service.build_user_specific_system_prompt",
+        lambda _namespace: "Alpha",
+    )
+
+    result = _chat_get_prompt_context(namespace="#V#michael_witbrock", include_content=True)
+    assert result.get("success") is True
+    assert result["prompt_concepts"] == [{"concept_id": "#V#prompt_a", "content": "Alpha"}]
+
+
+def test_chat_introspect_returns_model_and_prompt_fingerprint(monkeypatch):
+    monkeypatch.setattr(
+        "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
+        lambda _namespace: [{"concept_id": "#V#prompt_a", "content": "Alpha"}],
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_auxiliary_prompt_service.build_user_specific_system_prompt",
+        lambda _namespace: "Alpha",
+    )
+    monkeypatch.setattr(
+        "src.backend.languagemodels.llm_interface.get_active_model_name",
+        lambda: "test-model",
+    )
+    monkeypatch.setattr(
+        "src.backend.services.settings_service.get_active_llm_setting",
+        lambda: {"provider": "test", "model": "test-model"},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.settings_service.resolve_llm_setting",
+        lambda **_kwargs: {"provider": "resolved", "model": "resolved-model"},
+    )
+
+    result = _chat_introspect(namespace="#V#michael_witbrock", organisation_concept_id="#V#uoa")
+    assert result.get("success") is True
+    assert result["active_model_name"] == "test-model"
+    assert result["organisation_concept_id"] == "#V#uoa"
+    assert result["resolved_llm"] == {"provider": "resolved", "model": "resolved-model"}
+    assert result["prompt_concept_ids"] == ["#V#prompt_a"]
+    assert result["tool_guidance_hash"], "expected a tool guidance hash"
+    assert "gateway_enabled" in result
+    assert "orchestrator_max_tool_invocations" in result
+
+
+def test_settings_get_public_returns_settings(monkeypatch):
+    monkeypatch.setattr(
+        "src.backend.server.routes.settings_routes.get_all_settings_data",
+        lambda: {"active_llm": {"provider": "x", "model": "y"}},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.settings_service.resolve_llm_setting",
+        lambda **_kwargs: {"provider": "x", "model": "y"},
+    )
+
+    result = _settings_get_public(user_concept_id="#V#michael_witbrock")
+    assert result.get("success") is True
+    assert "settings" in result
+    assert result["settings"]["active_llm"]["model"] == "y"

--- a/tests/backend/test_von_generate_auxiliary_prompt.py
+++ b/tests/backend/test_von_generate_auxiliary_prompt.py
@@ -1,0 +1,98 @@
+import pytest
+from flask import Flask
+
+
+class _CapturingLLM:
+    def __init__(self):
+        self.calls = []
+
+    def generate(self, prompt, context=None, model=None):
+        self.calls.append({"prompt": prompt, "context": context, "model": model})
+        return "ok"
+
+
+class _CapturingOrchestrator:
+    def __init__(self):
+        self.calls = []
+
+    def run(self, **kwargs):
+        self.calls.append(kwargs)
+
+        from src.backend.integrations.internal_mcp.orchestrator import OrchestratorResult
+
+        return OrchestratorResult(response_text="ok", extra_messages=[], tool_invocations=[])
+
+
+@pytest.fixture()
+def app(monkeypatch):
+    from src.backend.server.routes.von_routes import von_bp
+
+    monkeypatch.setenv("VON_INTERNAL_MCP_ALLOW_USER_TOOL_CALLS", "0")
+
+    # Force an authenticated user for the request.
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#michael_witbrock",
+    )
+
+    # Stub auxiliary prompt builder.
+    monkeypatch.setattr(
+        "src.backend.services.chat_auxiliary_prompt_service.build_user_specific_system_prompt",
+        lambda _user_id: "Please be terse.",
+    )
+
+    llm = _CapturingLLM()
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_llm_client",
+        lambda **_kwargs: llm,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_active_model_name",
+        lambda: "test-model",
+    )
+
+    flask_app = Flask(__name__)
+    flask_app.secret_key = "test-secret"
+    flask_app.config["TESTING"] = True
+    flask_app.config["PROPAGATE_EXCEPTIONS"] = True
+    flask_app.register_blueprint(von_bp, url_prefix="/von")
+
+    flask_app.config["CONTEXT"] = []
+    flask_app.config["_TEST_LLM"] = llm
+
+    return flask_app
+
+
+def test_generate_passes_auxiliary_prompt_to_orchestrator(app):
+    orchestrator = _CapturingOrchestrator()
+    app.config["INTERNAL_MCP_ORCHESTRATOR"] = orchestrator
+    app.config["INTERNAL_MCP_GATEWAY"] = object()
+
+    client = app.test_client()
+    resp = client.post("/von/generate", json={"prompt": "Hello"})
+    if resp.status_code != 200:
+        raise AssertionError(f"Unexpected status {resp.status_code}: {resp.get_json() or resp.get_data(as_text=True)}")
+
+    assert orchestrator.calls, "expected orchestrator.run() to be called"
+    call = orchestrator.calls[0]
+    assert call.get("auxiliary_system_prompt") == "Please be terse."
+
+
+def test_generate_includes_auxiliary_prompt_without_orchestrator(app):
+    app.config["INTERNAL_MCP_ORCHESTRATOR"] = None
+    app.config["INTERNAL_MCP_GATEWAY"] = None
+
+    client = app.test_client()
+    resp = client.post("/von/generate", json={"prompt": "Hello"})
+    if resp.status_code != 200:
+        raise AssertionError(f"Unexpected status {resp.status_code}: {resp.get_json() or resp.get_data(as_text=True)}")
+
+    llm = app.config["_TEST_LLM"]
+    assert llm.calls, "expected llm.generate() to be called"
+
+    context = llm.calls[0]["context"]
+    assert context and context[0]["role"] == "system"
+
+    system_texts = [m["content"] for m in context if m.get("role") == "system"]
+    assert any("USER-SPECIFIC SYSTEM PROMPT" in text for text in system_texts)
+    assert any("Please be terse." in text for text in system_texts)


### PR DESCRIPTION
Implements user-specific auxiliary system prompts sourced from Vontology (#V#von_llm_prompt linked via #V#specific_to_von_user), appended to existing tool-guidance system prompt.

Also adds read-only internal MCP introspection tools:
- chat_introspect (active model + prompt concept IDs + tool-guidance hash/preview + resolved LLM when org supplied)
- chat_get_prompt_context (prompt-only view)
- settings_get_public (non-secret settings snapshot + resolved LLM)

Commits:
- 662e635 JVNAUTOSCI-797: Apply user-specific chat auxiliary prompts
- 86d00f2 JVNAUTOSCI-797: Add MCP chat/settings introspection

Tests:
- Backend pytest suite and frontend tests previously run green on this branch.