### PR TITLE
JVNAUTOSCI-809: Rendered/raw toggle, safe markdown rendering, nested lists fix, and input overlay fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ dependencies = [
     "uvicorn>=0.38.0",
     "cryptography>=43.0.0",
     "google-genai>=1.55.0",
+    "bleach>=6.3.0",
 ]
 
 [build-system]

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -1552,6 +1552,35 @@ def search_concepts_endpoint():
         return jsonify({"error": str(e)}), 500
 
 
+@von_bp.route("/api/render_markdown", methods=["POST"])
+def render_markdown_endpoint():
+    """Render markdown to sanitised HTML.
+
+    Request JSON:
+    - text: markdown string
+
+    Response JSON:
+    - html: sanitised HTML string
+    """
+
+    try:
+        from ...services.markdown_render_service import render_markdown_to_safe_html
+
+        data = request.get_json(silent=True) or {}
+        text = data.get("text", "")
+        if not isinstance(text, str):
+            return jsonify({"error": "Field 'text' must be a string"}), 400
+
+        if len(text) > 200_000:
+            return jsonify({"error": "Markdown payload too large"}), 413
+
+        html = render_markdown_to_safe_html(text)
+        return jsonify({"html": html}), 200
+    except Exception as e:
+        current_app.logger.error(f"render_markdown error: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
 @von_bp.route("/reset", methods=["POST"])
 def reset_context():
     """Reset the conversation context."""

--- a/src/backend/services/markdown_render_service.py
+++ b/src/backend/services/markdown_render_service.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from bs4 import BeautifulSoup
+import markdown as markdown_lib
+
+
+_DISALLOWED_TAGS = {
+    "script",
+    "style",
+    "iframe",
+    "object",
+    "embed",
+    "link",
+    "meta",
+}
+
+_ALLOWED_TAGS = {
+    "p",
+    "br",
+    "strong",
+    "em",
+    "code",
+    "pre",
+    "blockquote",
+    "ul",
+    "ol",
+    "li",
+    "a",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "hr",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
+}
+
+_ALLOWED_ATTRS = {
+    "a": {"href", "title", "target", "rel"},
+    "code": {"class"},
+    "pre": {"class"},
+    "th": {"colspan", "rowspan"},
+    "td": {"colspan", "rowspan"},
+}
+
+
+def _is_safe_href(href: str | None) -> bool:
+    if not href:
+        return False
+
+    raw = str(href).strip()
+    lower = raw.lower()
+
+    if lower.startswith(("javascript:", "data:", "vbscript:")):
+        return False
+
+    # Allow anchors and relative paths.
+    if raw.startswith(("#", "/", "./", "../")):
+        return True
+
+    return lower.startswith(("http://", "https://", "mailto:"))
+
+
+def _is_external_http_href(href: str | None) -> bool:
+    if not href:
+        return False
+    lower = str(href).strip().lower()
+    return lower.startswith(("http://", "https://"))
+
+
+def sanitise_rendered_html(html: str) -> str:
+    """Sanitise rendered HTML using an allow-list.
+
+    Treat all markdown input as untrusted. We only preserve a conservative set
+    of tags/attributes required for chat and concept notes rendering.
+    """
+
+    soup = BeautifulSoup(html or "", "html.parser")
+
+    for bad in soup.find_all(list(_DISALLOWED_TAGS)):
+        bad.decompose()
+
+    for tag in soup.find_all(True):
+        if tag.name not in _ALLOWED_TAGS:
+            tag.unwrap()
+            continue
+
+        allowed_attrs = _ALLOWED_ATTRS.get(tag.name, set())
+        for attr in list(tag.attrs.keys()):
+            if attr not in allowed_attrs:
+                del tag.attrs[attr]
+
+        if tag.name == "a":
+            href = tag.get("href")
+            if not _is_safe_href(href):
+                if "href" in tag.attrs:
+                    del tag.attrs["href"]
+            else:
+                tag["rel"] = "noopener noreferrer"
+                if _is_external_http_href(href):
+                    tag["target"] = "_blank"
+                elif "target" in tag.attrs:
+                    del tag.attrs["target"]
+
+    return str(soup)
+
+
+_LIST_MARKER_RE = re.compile(r"^(?:[-*+]|\d+\.)\s+")
+_NESTED_LIST_MARKER_2SP_RE = re.compile(r"^  (?:[-*+]|\d+\.)\s+")
+
+
+def _normalise_nested_list_indentation(text: str) -> str:
+    """Normalise some common nested-list markdown patterns.
+
+    Python-Markdown expects nested lists to be indented by at least four
+    spaces. Users often write nested list items with two spaces (CommonMark-
+    style), e.g.:
+
+    - read:
+      - a
+      - b
+
+    Without normalisation this gets flattened into a single list. This helper
+    promotes two-space-indented list items to four spaces when they immediately
+    follow a top-level list item.
+    """
+
+    lines = text.splitlines()
+
+    seen_top_level_list_item = False
+    in_promoted_nested_block = False
+
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+
+        if not stripped:
+            continue
+
+        is_top_level_list_item = (not line.startswith(" ")) and bool(
+            _LIST_MARKER_RE.match(line)
+        )
+        if is_top_level_list_item:
+            seen_top_level_list_item = True
+            in_promoted_nested_block = False
+            continue
+
+        is_two_space_list_item = bool(_NESTED_LIST_MARKER_2SP_RE.match(line))
+        if is_two_space_list_item and (
+            seen_top_level_list_item or in_promoted_nested_block
+        ):
+            lines[idx] = "    " + line[2:]
+            in_promoted_nested_block = True
+            continue
+
+        # Any non-indented, non-list content breaks the list nesting context.
+        if not line.startswith(" "):
+            seen_top_level_list_item = False
+            in_promoted_nested_block = False
+
+    return "\n".join(lines)
+
+
+def render_markdown_to_safe_html(
+    text: str, *, extensions: Iterable[str] | None = None
+) -> str:
+    """Render markdown to sanitised HTML.
+
+    The output is safe to insert with innerHTML.
+    """
+
+    if not text:
+        return ""
+
+    text = _normalise_nested_list_indentation(str(text))
+
+    exts = (
+        list(extensions)
+        if extensions is not None
+        else [
+            "fenced_code",
+            "tables",
+            "sane_lists",
+            "nl2br",
+        ]
+    )
+
+    rendered = markdown_lib.markdown(str(text), extensions=exts, output_format="html")
+    return sanitise_rendered_html(rendered)

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -1,8 +1,10 @@
 // Chat Tab Module
 import { annotateTurn, getUserContext } from './apiService.js';
 import { initializeConceptAutocomplete } from './components/conceptAutocomplete.js';
+import { initializePromptCartoucheOverlay, normaliseVontologyIdsForBackend } from './components/promptCartoucheOverlay.js';
 import { elements, renderSpanSuggestions } from './domUtils.js';
-import { annotateElementText } from './utils/textDecorator.js';
+import { detectMarkdown, renderMarkdownViaServer } from './markdownUtils.js';
+import { cartouchifyElementText, cartouchifyVontologyTokensInElement } from './utils/textDecorator.js';
 
 // Store LLM debug data for each turn
 const llmDebugData = new Map();
@@ -10,6 +12,261 @@ const llmDebugData = new Map();
 const transcriptTurns = [];
 let historySegmentsShown = 1;
 let totalHistorySegments = 1;
+
+// Cache concept metadata used for cartouches in chat transcript.
+// Map<fullId, { name: string, kind: string } | null>
+const chatConceptMetaCache = new Map();
+// Map<fullId, Promise<meta|null>> for in-flight lookups.
+const chatConceptMetaPending = new Map();
+
+function isMarkdownProducingModel(model) {
+    if (!model) {
+        return false;
+    }
+    const modelName = String(model).trim().toLowerCase();
+    return modelName.startsWith('gpt-5.2');
+}
+
+function shouldRenderMarkdownForAssistant(message, debugData) {
+    const text = String(message ?? '');
+
+    if (isMarkdownProducingModel(debugData?.model)) {
+        // Treat as markdown-friendly even when detection is ambiguous.
+        return true;
+    }
+
+    return detectMarkdown(text);
+}
+
+async function renderChatMarkdownIntoContainer(container, text) {
+    const markdownText = String(text ?? '');
+    const html = await renderMarkdownViaServer(markdownText);
+
+    // Cache rendered HTML so we can toggle without re-fetching.
+    try {
+        container.dataset.renderedHtml = html;
+    } catch (_) {
+        // Ignore dataset failures.
+    }
+
+    // If the user has toggled to raw text while this request was in-flight, do not overwrite.
+    if (container?.dataset?.renderMode === 'text') {
+        return;
+    }
+
+    container.innerHTML = html;
+    try {
+        container.dataset.renderMode = 'rendered';
+    } catch (_) {
+        // Ignore.
+    }
+
+    // Preserve clickable #V# tokens, but never inside code blocks.
+    cartouchifyVontologyTokensInElement(container, { skipSelectors: ['pre', 'code', 'a'] });
+    hydrateChatConceptCartouches(container);
+}
+
+function setVonMessageRenderMode(messageTextEl, mode, originalText, debugData) {
+    if (!messageTextEl) {
+        return;
+    }
+
+    const raw = String(originalText ?? '');
+    const nextMode = mode === 'text' ? 'text' : 'rendered';
+
+    try {
+        messageTextEl.dataset.originalText = raw;
+        messageTextEl.dataset.renderMode = nextMode;
+    } catch (_) {
+        // Ignore.
+    }
+
+    if (nextMode === 'text') {
+        // Raw view: show the original model output exactly, no markdown and no cartouches.
+        messageTextEl.classList.remove('markdown-rendered', 'chat-markdown');
+        messageTextEl.style.whiteSpace = 'pre-wrap';
+        messageTextEl.textContent = raw;
+        return;
+    }
+
+    // Rendered view: use cached HTML if available, else re-render via server.
+    messageTextEl.classList.add('markdown-rendered', 'chat-markdown');
+    messageTextEl.style.whiteSpace = 'normal';
+
+    const cachedHtml = messageTextEl?.dataset?.renderedHtml;
+    if (cachedHtml) {
+        messageTextEl.innerHTML = cachedHtml;
+        cartouchifyVontologyTokensInElement(messageTextEl, { skipSelectors: ['pre', 'code', 'a'] });
+        hydrateChatConceptCartouches(messageTextEl);
+        return;
+    }
+
+    // Keep a safe plaintext fallback while the request is in-flight.
+    messageTextEl.textContent = raw;
+    void renderChatMarkdownIntoContainer(messageTextEl, raw).catch((err) => {
+        console.error('[chatTab] Server markdown render failed; falling back to plain text:', err);
+        if (messageTextEl?.dataset?.renderMode === 'rendered') {
+            messageTextEl.textContent = raw;
+        }
+    });
+}
+
+function renderAssistantMessageContent(container, message, debugData) {
+    const text = String(message ?? '');
+    const shouldRenderMarkdown = shouldRenderMarkdownForAssistant(text, debugData);
+
+    if (!shouldRenderMarkdown) {
+        try {
+            container.dataset.originalText = text;
+            container.dataset.renderMode = 'text';
+        } catch (_) {
+            // Ignore.
+        }
+        container.classList.remove('markdown-rendered', 'chat-markdown');
+        container.style.whiteSpace = 'pre-wrap';
+        cartouchifyElementText(container, text);
+        hydrateChatConceptCartouches(container);
+        return;
+    }
+
+    container.classList.add('markdown-rendered', 'chat-markdown');
+    container.style.whiteSpace = 'normal';
+
+    try {
+        container.dataset.originalText = text;
+        container.dataset.renderMode = 'rendered';
+    } catch (_) {
+        // Ignore.
+    }
+
+    // Render asynchronously so we can rely on the server-side markdown/sanitisation.
+    // Keep a safe plaintext fallback in-place while the request is in-flight.
+    container.textContent = text;
+    void renderChatMarkdownIntoContainer(container, text).catch((err) => {
+        console.error('[chatTab] Server markdown render failed; falling back to plain text:', err);
+        container.textContent = text;
+    });
+}
+
+function formatKindLabel(kind) {
+    const k = (kind || '').toString().toLowerCase();
+    if (k === 'predicate') return 'Predicate';
+    if (k === 'individual') return 'Individual';
+    return 'Type';
+}
+
+function normaliseKindClass(kind) {
+    const k = (kind || '').toString().toLowerCase();
+    if (k === 'predicate' || k === 'individual' || k === 'type') {
+        return k;
+    }
+    return 'type';
+}
+
+async function fetchConceptMetaForChat(fullId) {
+    try {
+        // Prefer an exact lookup rather than fuzzy search: avoids incorrect labels.
+        const nodeUrl = `/vontology/api/vontology/node_content?identifier=${encodeURIComponent(fullId)}`;
+        const nodeRes = await fetch(nodeUrl, { cache: 'no-store' });
+        if (nodeRes.ok) {
+            const node = await nodeRes.json();
+            const name =
+                node?.display_name ||
+                node?.name ||
+                node?.node?.display_name ||
+                node?.node?.name ||
+                fullId;
+            const kind = node?.kind || node?.node?.kind || 'type';
+            return { name: String(name), kind: String(kind) };
+        }
+
+        // Fallback to search endpoint if node_content is unavailable.
+        const url = `/von/api/search?q=${encodeURIComponent(fullId)}&limit=8`;
+        const res = await fetch(url, { cache: 'no-store' });
+        if (!res.ok) return null;
+
+        const data = await res.json();
+        const results = Array.isArray(data?.results) ? data.results : [];
+        const match = results.find(r => r && r.id === fullId);
+        if (!match || !match.id) return null;
+
+        return {
+            name: match.name || match.id,
+            kind: match.kind || 'type'
+        };
+    } catch (err) {
+        console.debug('[chatTab] fetchConceptMetaForChat failed', err);
+        return null;
+    }
+}
+
+function updateCartoucheElement(cartoucheEl, meta) {
+    if (!cartoucheEl) return;
+    if (!meta) {
+        cartoucheEl.classList.add('unresolved');
+        return;
+    }
+
+    const nameEl = cartoucheEl.querySelector('.vontology-cartouche-name');
+    const kindEl = cartoucheEl.querySelector('.vontology-cartouche-kind');
+
+    if (nameEl) {
+        nameEl.textContent = meta.name || (cartoucheEl.dataset.fullConceptId || '');
+    }
+    if (kindEl) {
+        const kindClass = normaliseKindClass(meta.kind);
+        kindEl.className = `vontology-cartouche-kind ${kindClass}`;
+        kindEl.textContent = formatKindLabel(meta.kind);
+    }
+}
+
+function hydrateChatConceptCartouches(root) {
+    if (!root || typeof root.querySelectorAll !== 'function') {
+        return;
+    }
+
+    const cartouches = Array.from(root.querySelectorAll('.vontology-cartouche[data-full-concept-id]'));
+    if (cartouches.length === 0) {
+        return;
+    }
+
+    const uniqueIds = new Set();
+    for (const el of cartouches) {
+        const fullId = el.dataset.fullConceptId;
+        if (fullId) {
+            uniqueIds.add(fullId);
+        }
+    }
+
+    for (const fullId of uniqueIds) {
+        if (chatConceptMetaCache.has(fullId)) {
+            const cached = chatConceptMetaCache.get(fullId);
+            cartouches
+                .filter(el => el.dataset.fullConceptId === fullId)
+                .forEach(el => updateCartoucheElement(el, cached));
+            continue;
+        }
+
+        if (!chatConceptMetaPending.has(fullId)) {
+            const p = fetchConceptMetaForChat(fullId).then((meta) => {
+                chatConceptMetaCache.set(fullId, meta);
+                chatConceptMetaPending.delete(fullId);
+                return meta;
+            });
+            chatConceptMetaPending.set(fullId, p);
+        }
+
+        chatConceptMetaPending.get(fullId)
+            .then((meta) => {
+                cartouches
+                    .filter(el => el.dataset.fullConceptId === fullId)
+                    .forEach(el => updateCartoucheElement(el, meta));
+            })
+            .catch(() => {
+                // Ignore lookup failures; leave placeholders.
+            });
+    }
+}
 
 function deriveLlmDebugWarnings(debugData) {
     const warnings = [];
@@ -328,16 +585,14 @@ function rehydrateHistory(scrollableField, historyMessages, options = {}) {
         if (msg.role === 'user' || msg.role === 'assistant') {
             const turnId = `history-${msg.role}-${index}`;
             const label = msg.role === 'user' ? 'User' : 'Von';
-            
-            // Check if this assistant message has debug data
-            const hasDebugData = msg.role === 'assistant' && !!msg.llm_debug_data;
-            
-            appendMessage(label, msg.content, turnId, hasDebugData, true, msg.timestamp);
 
-            // Restore LLM debug data if present (for assistant messages)
+            // Restore debug data before rendering so markdown gating can see model info.
+            const hasDebugData = msg.role === 'assistant' && !!msg.llm_debug_data;
             if (hasDebugData) {
                 llmDebugData.set(turnId, msg.llm_debug_data);
             }
+
+            appendMessage(label, msg.content, turnId, hasDebugData, true, msg.timestamp);
         }
     });
 
@@ -450,6 +705,9 @@ export function initializeChatTab() {
     // Initialize concept autocomplete for #V# trigger
     initializeConceptAutocomplete(promptInput);
 
+    // Render non-trigger (#V\u200B#...) concept tokens as cartouches in the prompt.
+    initializePromptCartoucheOverlay(promptInput);
+
     loadChatHistory();
     updateHistoryLength();
     console.log("Chat tab initialized successfully");
@@ -481,6 +739,7 @@ function restorePromptEditingState(request) {
     }
 
     promptInput.value = request.promptRaw || '';
+    promptInput.dispatchEvent(new Event('input', { bubbles: true }));
 
     try {
         const valueLength = promptInput.value.length;
@@ -547,7 +806,8 @@ async function handleSendPrompt() {
     const promptRaw = promptInput.value;
     const selectionStart = typeof promptInput.selectionStart === 'number' ? promptInput.selectionStart : null;
     const selectionEnd = typeof promptInput.selectionEnd === 'number' ? promptInput.selectionEnd : null;
-    const promptText = promptRaw.trim();
+    const promptForSend = normaliseVontologyIdsForBackend(promptRaw);
+    const promptText = promptForSend.trim();
 
     if (!promptText) {
         alert('Please enter a prompt.');
@@ -578,6 +838,7 @@ async function handleSendPrompt() {
 
     // Clear input
     promptInput.value = '';
+    promptInput.dispatchEvent(new Event('input', { bubbles: true }));
     let request = null;
     try {
         request = {
@@ -795,6 +1056,17 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
 
             // Add LLM debug button if debug data available
             if (hasLlmDebug && turnId) {
+                const debugData = llmDebugData.get(turnId);
+
+                // Compact model badge (visible at-a-glance)
+                if (debugData && debugData.model) {
+                    const modelBadge = document.createElement('span');
+                    modelBadge.className = 'chat-llm-model-badge';
+                    modelBadge.textContent = String(debugData.model);
+                    modelBadge.title = 'LLM model used for this turn';
+                    messageHeader.appendChild(modelBadge);
+                }
+
                 const llmDebugButton = document.createElement('button');
                 llmDebugButton.className = 'btn-mini llm-debug-button';
                 llmDebugButton.textContent = 'LLM ⓘ';
@@ -803,7 +1075,6 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
                 llmDebugButton.addEventListener('click', () => showLlmDebugPopup(turnId));
                 messageHeader.appendChild(llmDebugButton);
 
-                const debugData = llmDebugData.get(turnId);
                 const warnings = deriveLlmDebugWarnings(debugData);
                 const warningIndicator = createChatDebugWarningIndicator(warnings);
                 if (warningIndicator) {
@@ -834,9 +1105,32 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
             const messageText = document.createElement('div');
             messageText.style.cssText = 'color: #333; white-space: pre-wrap;';
             try {
-                annotateElementText(messageText, message);
+                const debugData = turnId ? llmDebugData.get(turnId) : null;
+                const rawText = String(message ?? '');
+                const canRenderMarkdown = shouldRenderMarkdownForAssistant(rawText, debugData);
+
+                if (canRenderMarkdown) {
+                    const toggleButton = document.createElement('button');
+                    toggleButton.className = 'btn-mini chat-render-toggle';
+                    toggleButton.textContent = 'Text';
+                    toggleButton.title = 'Show the original (raw) text';
+                    toggleButton.addEventListener('click', (e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        const currentMode = messageText?.dataset?.renderMode || 'rendered';
+                        const nextMode = currentMode === 'text' ? 'rendered' : 'text';
+                        setVonMessageRenderMode(messageText, nextMode, rawText, debugData);
+                        toggleButton.textContent = nextMode === 'text' ? 'Rendered' : 'Text';
+                        toggleButton.title = nextMode === 'text'
+                            ? 'Show the rendered markdown view'
+                            : 'Show the original (raw) text';
+                    });
+                    messageHeader.appendChild(toggleButton);
+                }
+
+                renderAssistantMessageContent(messageText, rawText, debugData);
             } catch (e) {
-                console.error('[chatTab] annotateElementText failed for Von message:', e);
+                console.error('[chatTab] Failed to render Von message:', e);
                 messageText.textContent = String(message);
             }
 
@@ -906,11 +1200,24 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
 
             const messageText = document.createElement('div');
             messageText.style.cssText = 'color: #333; white-space: pre-wrap;';
-            try {
-                annotateElementText(messageText, message);
-            } catch (e) {
-                console.error('[chatTab] annotateElementText failed for User/Error message:', e);
-                messageText.textContent = String(message);
+            const userText = String(message ?? '');
+            const shouldRenderUserMarkdown = sender === 'User' && detectMarkdown(userText);
+            if (shouldRenderUserMarkdown) {
+                messageText.classList.add('markdown-rendered', 'chat-markdown');
+                messageText.style.whiteSpace = 'normal';
+                messageText.textContent = userText;
+                void renderChatMarkdownIntoContainer(messageText, userText).catch((err) => {
+                    console.error('[chatTab] Server markdown render failed for user message; falling back to plain text:', err);
+                    messageText.textContent = userText;
+                });
+            } else {
+                try {
+                    cartouchifyElementText(messageText, userText);
+                    hydrateChatConceptCartouches(messageText);
+                } catch (e) {
+                    console.error('[chatTab] cartouchifyElementText failed for User/Error message:', e);
+                    messageText.textContent = userText;
+                }
             }
 
             messageContainer.appendChild(messageHeader);

--- a/src/frontend/web/von_interface/static/js/components/conceptAutocomplete.js
+++ b/src/frontend/web/von_interface/static/js/components/conceptAutocomplete.js
@@ -13,6 +13,8 @@
  * - Graceful fallback if search unavailable
  */
 
+import { makeNonTriggerVontologyId } from './promptCartoucheOverlay.js';
+
 const TRIGGER_PATTERN = /#[Vv]#/;
 const DEBOUNCE_MS = 200;
 const MAX_RESULTS = 8;
@@ -234,6 +236,8 @@ function insertConcept(conceptId) {
         return;
     }
 
+    const insertedId = makeNonTriggerVontologyId(conceptId);
+
     const text = ta.value;
     const cursorPos = ta.selectionStart;
 
@@ -262,15 +266,15 @@ function insertConcept(conceptId) {
     // Replace from trigger to cursor position
     const before = text.substring(0, triggerIdx);
     const after = text.substring(cursorPos);
-    ta.value = before + conceptId + after;
+    ta.value = before + insertedId + after;
 
     // Move cursor after inserted concept ID
-    const newPos = triggerIdx + conceptId.length;
+    const newPos = triggerIdx + insertedId.length;
     ta.selectionStart = newPos;
     ta.selectionEnd = newPos;
     ta.focus();
 
-    console.log(`[conceptAutocomplete] Inserted ${conceptId} at position ${triggerIdx}`);
+    console.log(`[conceptAutocomplete] Inserted ${insertedId} at position ${triggerIdx}`);
 
     // Trigger input event for any listeners
     ta.dispatchEvent(new Event('input', { bubbles: true }));

--- a/src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js
+++ b/src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js
@@ -76,7 +76,15 @@ function syncOverlayStyles(textarea, overlay, inner) {
         inner.style.fontWeight = cs.fontWeight;
         inner.style.lineHeight = cs.lineHeight;
         inner.style.letterSpacing = cs.letterSpacing;
-        inner.style.color = cs.color;
+        // The textarea text is intentionally made transparent (we draw text in the overlay).
+        // Do not copy its colour, otherwise the overlay becomes transparent too.
+        // Prefer caretColour if set; otherwise fall back to CSS.
+        const caretColour = cs.caretColor;
+        if (caretColour && caretColour !== 'auto') {
+            inner.style.color = caretColour;
+        } else {
+            inner.style.removeProperty('color');
+        }
         inner.style.textAlign = cs.textAlign;
     } catch (_) {
         // Best-effort only.

--- a/src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js
+++ b/src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js
@@ -1,0 +1,408 @@
+// Prompt cartouche overlay
+//
+// Implements an in-place “rich textarea” overlay for Vontology concept IDs.
+// When a concept is inserted from autocomplete, we insert a non-trigger form
+// (#V\u200B#...) into the textarea so autocomplete does not re-trigger.
+// The overlay renders those tokens as cartouches and supports removal.
+
+const ZWSP = '\u200B';
+
+const SEARCH_API = '/von/api/search';
+
+// Match #V\u200B#<id> and #v\u200B#<id>
+// Mirrors the allowed id character set used elsewhere.
+const NON_TRIGGER_TOKEN_RE = /#([Vv])\u200B#([A-Za-z0-9_\(\)\./:–\-]+?)(?=[\s"'`]|$)/g;
+
+// For normalising before send.
+const NON_TRIGGER_PREFIX_RE = /#([Vv])\u200B#/g;
+
+// Cache concept metadata used for prompt cartouches.
+// Map<fullId, { name: string, kind: string } | null>
+const promptConceptMetaCache = new Map();
+// Map<fullId, Promise<meta|null>>
+const promptConceptMetaPending = new Map();
+
+export function makeNonTriggerVontologyId(fullId) {
+    const raw = String(fullId ?? '');
+    return raw.replace(/^#([Vv])#/, (_, v) => `#${v}${ZWSP}#`);
+}
+
+export function normaliseVontologyIdsForBackend(text) {
+    const input = String(text ?? '');
+    // Normalise both #V\u200B# and #v\u200B# to canonical #V#.
+    return input.replace(NON_TRIGGER_PREFIX_RE, '#V#');
+}
+
+function ensureOverlay(textarea) {
+    if (!textarea || !textarea.parentNode) {
+        return null;
+    }
+
+    const parent = textarea.parentElement;
+    if (parent && parent.classList.contains('prompt-input-wrapper')) {
+        const overlay = parent.querySelector('.prompt-input-overlay');
+        const inner = parent.querySelector('.prompt-input-overlay-inner');
+        if (overlay && inner) {
+            return { wrapper: parent, overlay, inner };
+        }
+    }
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'prompt-input-wrapper';
+
+    const overlay = document.createElement('div');
+    overlay.className = 'prompt-input-overlay';
+
+    const inner = document.createElement('div');
+    inner.className = 'prompt-input-overlay-inner';
+    overlay.appendChild(inner);
+
+    // Wrap the textarea in-place.
+    const insertBeforeTarget = textarea;
+    insertBeforeTarget.parentNode.insertBefore(wrapper, insertBeforeTarget);
+    wrapper.appendChild(textarea);
+    wrapper.appendChild(overlay);
+
+    return { wrapper, overlay, inner };
+}
+
+function syncOverlayStyles(textarea, overlay, inner) {
+    try {
+        const cs = getComputedStyle(textarea);
+        overlay.style.borderRadius = cs.borderRadius;
+        inner.style.padding = cs.padding;
+        inner.style.fontFamily = cs.fontFamily;
+        inner.style.fontSize = cs.fontSize;
+        inner.style.fontWeight = cs.fontWeight;
+        inner.style.lineHeight = cs.lineHeight;
+        inner.style.letterSpacing = cs.letterSpacing;
+        inner.style.color = cs.color;
+        inner.style.textAlign = cs.textAlign;
+    } catch (_) {
+        // Best-effort only.
+    }
+}
+
+function clearChildren(node) {
+    while (node && node.firstChild) {
+        node.removeChild(node.firstChild);
+    }
+}
+
+function extractNonTriggerTokensWithPositions(text) {
+    const input = String(text ?? '');
+    const matches = [];
+    let match;
+    NON_TRIGGER_TOKEN_RE.lastIndex = 0;
+    while ((match = NON_TRIGGER_TOKEN_RE.exec(input)) !== null) {
+        matches.push({
+            start: match.index,
+            end: NON_TRIGGER_TOKEN_RE.lastIndex,
+            prefixChar: match[1],
+            conceptId: match[2],
+            rawText: match[0]
+        });
+    }
+    return matches;
+}
+
+function formatKindLabel(kind) {
+    const k = String(kind ?? '').toLowerCase();
+    if (k === 'predicate') return 'Predicate';
+    if (k === 'individual') return 'Individual';
+    return 'Type';
+}
+
+function normaliseKindClass(kind) {
+    const k = String(kind ?? '').toLowerCase();
+    if (k === 'predicate' || k === 'individual' || k === 'type') {
+        return k;
+    }
+    return 'type';
+}
+
+function createPromptCartouche(fullId, start, end) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'vontology-cartouche prompt-vontology-cartouche';
+    btn.dataset.fullConceptId = fullId;
+    btn.dataset.start = String(start);
+    btn.dataset.end = String(end);
+    btn.title = 'Concept reference';
+    btn.setAttribute('aria-label', `Concept reference ${fullId}`);
+
+    const name = document.createElement('span');
+    name.className = 'vontology-cartouche-name';
+    name.textContent = '…';
+
+    const id = document.createElement('span');
+    id.className = 'vontology-cartouche-id';
+    id.textContent = fullId;
+
+    const kind = document.createElement('span');
+    kind.className = 'vontology-cartouche-kind type';
+    kind.textContent = '…';
+
+    const remove = document.createElement('span');
+    remove.className = 'prompt-vontology-cartouche-remove';
+    remove.textContent = '×';
+    remove.setAttribute('role', 'button');
+    remove.setAttribute('aria-label', `Remove concept ${fullId}`);
+    remove.tabIndex = -1;
+
+    btn.appendChild(name);
+    btn.appendChild(id);
+    btn.appendChild(kind);
+    btn.appendChild(remove);
+
+    return btn;
+}
+
+function renderOverlay(textarea, inner) {
+    const value = String(textarea?.value ?? '');
+    clearChildren(inner);
+
+    if (!value) {
+        // Let the native placeholder do its job.
+        return;
+    }
+
+    const tokens = extractNonTriggerTokensWithPositions(value);
+    if (tokens.length === 0) {
+        inner.appendChild(document.createTextNode(value));
+        return;
+    }
+
+    let lastIndex = 0;
+    for (const token of tokens) {
+        if (token.start > lastIndex) {
+            inner.appendChild(document.createTextNode(value.slice(lastIndex, token.start)));
+        }
+        const fullId = `#V#${token.conceptId}`;
+        inner.appendChild(createPromptCartouche(fullId, token.start, token.end));
+        lastIndex = token.end;
+    }
+    if (lastIndex < value.length) {
+        inner.appendChild(document.createTextNode(value.slice(lastIndex)));
+    }
+}
+
+function removeTokenRangeFromTextarea(textarea, start, end) {
+    if (!textarea) {
+        return;
+    }
+    const value = String(textarea.value ?? '');
+    let removeStart = Math.max(0, Math.min(start, value.length));
+    let removeEnd = Math.max(0, Math.min(end, value.length));
+    if (removeEnd < removeStart) {
+        [removeStart, removeEnd] = [removeEnd, removeStart];
+    }
+
+    // Trim a single adjacent space for nicer ergonomics.
+    if (value[removeEnd] === ' ') {
+        removeEnd += 1;
+    } else if (removeStart > 0 && value[removeStart - 1] === ' ') {
+        removeStart -= 1;
+    }
+
+    textarea.value = value.slice(0, removeStart) + value.slice(removeEnd);
+    try {
+        textarea.setSelectionRange(removeStart, removeStart);
+    } catch (_) {
+        // Best-effort.
+    }
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    try {
+        textarea.focus();
+    } catch (_) {
+        // Ignore.
+    }
+}
+
+function findTokenAtPosition(text, pos) {
+    const tokens = extractNonTriggerTokensWithPositions(text);
+    for (const token of tokens) {
+        if (pos >= token.start && pos <= token.end) {
+            return token;
+        }
+    }
+    return null;
+}
+
+async function fetchConceptMeta(fullId) {
+    if (promptConceptMetaCache.has(fullId)) {
+        return promptConceptMetaCache.get(fullId);
+    }
+    if (promptConceptMetaPending.has(fullId)) {
+        return promptConceptMetaPending.get(fullId);
+    }
+
+    const promise = (async () => {
+        try {
+            // Prefer exact node lookup for accuracy.
+            const nodeUrl = `/vontology/api/vontology/node_content?identifier=${encodeURIComponent(fullId)}`;
+            const nodeResp = await fetch(nodeUrl, { cache: 'no-store' });
+            if (nodeResp.ok) {
+                const node = await nodeResp.json();
+                const name =
+                    node?.display_name ||
+                    node?.name ||
+                    node?.node?.display_name ||
+                    node?.node?.name ||
+                    fullId;
+                const kind = node?.kind || node?.node?.kind || 'type';
+                const meta = { name: String(name), kind: String(kind) };
+                promptConceptMetaCache.set(fullId, meta);
+                return meta;
+            }
+
+            // Fallback to search endpoint if node_content is unavailable.
+            const resp = await fetch(`${SEARCH_API}?q=${encodeURIComponent(fullId)}&limit=8`);
+            if (!resp.ok) {
+                promptConceptMetaCache.set(fullId, null);
+                return null;
+            }
+            const data = await resp.json();
+            const results = Array.isArray(data?.results) ? data.results : [];
+            const match = results.find(r => String(r?.id) === fullId);
+            if (!match) {
+                promptConceptMetaCache.set(fullId, null);
+                return null;
+            }
+            const meta = { name: String(match.name ?? ''), kind: String(match.kind ?? '') };
+            promptConceptMetaCache.set(fullId, meta);
+            return meta;
+        } catch (_) {
+            promptConceptMetaCache.set(fullId, null);
+            return null;
+        } finally {
+            promptConceptMetaPending.delete(fullId);
+        }
+    })();
+
+    promptConceptMetaPending.set(fullId, promise);
+    return promise;
+}
+
+function updatePromptCartouche(cartoucheEl, meta) {
+    if (!cartoucheEl || !meta) {
+        return;
+    }
+    const nameEl = cartoucheEl.querySelector('.vontology-cartouche-name');
+    if (nameEl && meta.name) {
+        nameEl.textContent = meta.name;
+    }
+    const kindEl = cartoucheEl.querySelector('.vontology-cartouche-kind');
+    if (kindEl) {
+        const kindClass = normaliseKindClass(meta.kind);
+        kindEl.className = `vontology-cartouche-kind ${kindClass}`;
+        kindEl.textContent = meta.kind ? formatKindLabel(meta.kind) : 'Type';
+    }
+}
+
+function hydratePromptCartouches(root) {
+    if (!root) {
+        return;
+    }
+    const elements = Array.from(root.querySelectorAll('button.prompt-vontology-cartouche[data-full-concept-id]'));
+    const unique = new Set(elements.map(el => el.dataset.fullConceptId).filter(Boolean));
+    for (const fullId of unique) {
+        fetchConceptMeta(fullId).then(meta => {
+            if (!meta) return;
+            for (const el of elements) {
+                if (el.dataset.fullConceptId === fullId) {
+                    updatePromptCartouche(el, meta);
+                }
+            }
+        });
+    }
+}
+
+export function initializePromptCartoucheOverlay(textarea) {
+    const parts = ensureOverlay(textarea);
+    if (!parts) {
+        return;
+    }
+
+    parts.wrapper.dataset.initialised = '1';
+    syncOverlayStyles(textarea, parts.overlay, parts.inner);
+
+    // Keep overlay updated.
+    const rerender = () => {
+        renderOverlay(textarea, parts.inner);
+        hydratePromptCartouches(parts.inner);
+    };
+
+    textarea.addEventListener('input', rerender);
+    textarea.addEventListener('scroll', () => {
+        try {
+            parts.inner.style.transform = `translateY(-${textarea.scrollTop}px)`;
+        } catch (_) {
+            // Ignore.
+        }
+    });
+    window.addEventListener('resize', () => syncOverlayStyles(textarea, parts.overlay, parts.inner));
+
+    // If the caret lands inside a cartouche token, treat backspace/delete as removing the whole token.
+    textarea.addEventListener('keydown', (event) => {
+        const key = event.key;
+        if (key !== 'Backspace' && key !== 'Delete') {
+            return;
+        }
+        if (typeof textarea.selectionStart !== 'number' || typeof textarea.selectionEnd !== 'number') {
+            return;
+        }
+        if (textarea.selectionStart !== textarea.selectionEnd) {
+            return;
+        }
+        const pos = textarea.selectionStart;
+        const token = findTokenAtPosition(textarea.value, pos);
+        if (!token) {
+            return;
+        }
+        event.preventDefault();
+        removeTokenRangeFromTextarea(textarea, token.start, token.end);
+    });
+
+    // Handle remove click and keyboard removal on the cartouche itself.
+    parts.overlay.addEventListener('click', (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) {
+            return;
+        }
+        const removeEl = target.closest('.prompt-vontology-cartouche-remove');
+        if (removeEl) {
+            event.preventDefault();
+            event.stopPropagation();
+            const btn = removeEl.closest('button.prompt-vontology-cartouche');
+            if (!btn) return;
+            const start = Number(btn.dataset.start);
+            const end = Number(btn.dataset.end);
+            if (!Number.isFinite(start) || !Number.isFinite(end)) return;
+            removeTokenRangeFromTextarea(textarea, start, end);
+        }
+    });
+
+    parts.overlay.addEventListener('keydown', (event) => {
+        const key = event.key;
+        if (key !== 'Backspace' && key !== 'Delete') {
+            return;
+        }
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) {
+            return;
+        }
+        const btn = target.closest('button.prompt-vontology-cartouche');
+        if (!btn) {
+            return;
+        }
+        const start = Number(btn.dataset.start);
+        const end = Number(btn.dataset.end);
+        if (!Number.isFinite(start) || !Number.isFinite(end)) return;
+        event.preventDefault();
+        removeTokenRangeFromTextarea(textarea, start, end);
+    });
+
+    // Initial render.
+    rerender();
+}

--- a/src/frontend/web/von_interface/static/js/conceptTab.js
+++ b/src/frontend/web/von_interface/static/js/conceptTab.js
@@ -1,7 +1,7 @@
 import { deleteJson, getJson, patchJson, postJson, putJson } from './apiService.js';
 import { elements, getCurrentUserConceptId, getUserClientId } from './domUtils.js';
 import { populateLanguageSelect } from './languageConfig.js';
-import { simpleMarkdownToHtml } from './markdownUtils.js';
+import { renderMarkdownViaServer } from './markdownUtils.js';
 import { checkDuplicateName, normalizeConceptName, recordNameNormalizationMetric } from './nameUtils.js';
 import {
   defaultSelectedConceptType,
@@ -12,8 +12,16 @@ import {
   setCurrentlySelectedConceptId,
   setSelectedConceptOriginalName
 } from './state.js';
-import { annotateElementText } from './utils/textDecorator.js';
+import { annotateElementText, linkifyVontologyTokensInElement } from './utils/textDecorator.js';
 import { chooseBestTypeForIndividual, insertNodeIntoVontologyTree, selectVontologyNodeByIdentifier } from './vontology.js';
+
+async function renderConceptMarkdownInto(container, markdownText) {
+  const text = String(markdownText ?? '');
+  container.textContent = text;
+  const html = await renderMarkdownViaServer(text);
+  container.innerHTML = html;
+  linkifyVontologyTokensInElement(container, { skipSelectors: ['pre', 'code', 'a'] });
+}
 
 // Initialize concept tab state (moved to function to avoid module load issues)
 export function initializeConceptTabState() {
@@ -2039,11 +2047,10 @@ export function setupConceptTabEventListenersWithSuffix(suffix = '') {
       if (!notesRendered || !notesTextarea) return;
       const hidden = notesRendered.classList.contains('hidden');
       if (hidden) {
-        try {
-          notesRendered.innerHTML = simpleMarkdownToHtml(notesTextarea.value || '');
-        } catch (e) {
-          notesRendered.textContent = notesTextarea.value || '';
-        }
+        const raw = notesTextarea.value || '';
+        void renderConceptMarkdownInto(notesRendered, raw).catch(() => {
+          notesRendered.textContent = raw;
+        });
         notesRendered.classList.remove('hidden');
         toggleNotesRenderButton.textContent = 'Show Raw Markdown';
       } else {
@@ -2068,12 +2075,10 @@ export function setupConceptTabEventListenersWithSuffix(suffix = '') {
     }
     const isHidden = renderedContainer.classList.contains('hidden');
     if (isHidden) {
-      try {
-        const raw = descriptionEl.textContent || '';
-        renderedContainer.innerHTML = simpleMarkdownToHtml(raw);
-      } catch (e) {
-        renderedContainer.textContent = descriptionEl.textContent || '';
-      }
+      const raw = descriptionEl.textContent || '';
+      void renderConceptMarkdownInto(renderedContainer, raw).catch(() => {
+        renderedContainer.textContent = raw;
+      });
       renderedContainer.classList.remove('hidden');
       if (buttonEl) buttonEl.textContent = 'Show Raw Markdown';
       descriptionEl.style.display = 'none';
@@ -2107,7 +2112,10 @@ function ensureDescriptionRendered(suffix) {
         descriptionEl.insertAdjacentElement('afterend', rc);
       }
       if (rc.classList.contains('hidden')) {
-        try { rc.innerHTML = simpleMarkdownToHtml(descriptionEl.textContent || ''); } catch { rc.textContent = descriptionEl.textContent || ''; }
+        const raw = descriptionEl.textContent || '';
+        void renderConceptMarkdownInto(rc, raw).catch(() => {
+          rc.textContent = raw;
+        });
         rc.classList.remove('hidden');
         if (btn) btn.textContent = 'Show Raw Markdown';
         descriptionEl.style.display = 'none';
@@ -3230,6 +3238,8 @@ async function handleCreateInstance(suffix = '') {
 function refreshRenderedConceptNotes() {
   if (!elements || !elements.conceptNotesRendered) return;
   const raw = (elements.updatedNotesContent && elements.updatedNotesContent.value) || (elements.conceptNotesInput && elements.conceptNotesInput.value) || '';
-  elements.conceptNotesRendered.innerHTML = simpleMarkdownToHtml(raw.trim());
+  void renderConceptMarkdownInto(elements.conceptNotesRendered, raw.trim()).catch(() => {
+    elements.conceptNotesRendered.textContent = raw.trim();
+  });
 }
 

--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -7,7 +7,7 @@ import { initializeAnnotationTab } from './annotationTab.js';
 import { fetchConceptListWithSuffix, fetchSubtypesWithSuffix, initializeNamesForm, loadConceptAttributes, loadConceptNames, selectConceptWithSuffix } from './conceptTab.js';
 import { getCurrentUserConceptId } from './domUtils.js';
 import { DEFAULT_LANGUAGE } from './languageConfig.js';
-import { detectMarkdown, renderSmartText } from './markdownUtils.js';
+import { detectMarkdown, renderSmartTextAsync } from './markdownUtils.js';
 import { destroyPredicateView, initializePredicateView } from './predicateView.js';
 import { getConceptTypeDisplayNames, setCurrentConceptType, setCurrentlySelectedConceptId, setSelectedConceptOriginalName } from './state.js';
 import { activateTab } from './tabNavigation.js';
@@ -3107,14 +3107,14 @@ async function populateTypeDescription(conceptId, suffix) {
             // Reset markdown-rendered class then render
             display.className = (display.className || '').replace(/\bmarkdown-rendered\b/g, '').trim();
             if (text) {
-                try {
-                    // Always render with HTML escaping (escapeHtml=true) to properly handle markdown
-                    display.innerHTML = renderSmartText(text, true);
-                    if (detectMarkdown(text)) display.classList.add('markdown-rendered');
-                } catch (e) {
-                    // Fallback: plain text escape
+                const isMarkdown = detectMarkdown(text);
+                if (isMarkdown) display.classList.add('markdown-rendered');
+                display.textContent = text;
+                void renderSmartTextAsync(text, true).then((html) => {
+                    display.innerHTML = html;
+                }).catch(() => {
                     display.textContent = text;
-                }
+                });
             } else {
                 display.innerHTML = '<i>No description available.</i>';
             }
@@ -3404,16 +3404,9 @@ async function populateNotesSection(conceptId, suffix) {
                 const noteText = n.text || '';
                 const isMarkdown = detectMarkdown(noteText);
                 let displayHtml; let safeText; let truncated = false;
-                if (isMarkdown) {
-                    const renderedHtml = renderSmartText(noteText, true);
-                    truncated = renderedHtml.length > 800;
-                    displayHtml = truncated ? renderedHtml.slice(0, 800) + '…' : renderedHtml || '<i>(empty)</i>';
-                    safeText = escapeHtml(noteText);
-                } else {
-                    safeText = escapeHtml(noteText);
-                    truncated = safeText.length > 800;
-                    displayHtml = truncated ? safeText.slice(0, 800) + '…' : safeText || '<i>(empty)</i>';
-                }
+                safeText = escapeHtml(noteText);
+                truncated = safeText.length > 800;
+                displayHtml = truncated ? safeText.slice(0, 800) + '…' : safeText || '<i>(empty)</i>';
                 const viewClasses = isMarkdown ? 'note-view markdown-rendered' : 'note-view';
                 item.innerHTML = `
                          <div class="${viewClasses}" data-full="${safeText}" data-truncated="${truncated ? '1' : '0'}" style="white-space:pre-wrap;font-size:0.85rem;line-height:1.25;max-height:220px;overflow:hidden;">${displayHtml}</div>
@@ -3433,6 +3426,18 @@ async function populateNotesSection(conceptId, suffix) {
                              <button type="button" class="round-icon-button note-delete-btn" title="Delete note" aria-label="Delete note" data-icon="delete" data-keep-title="true"></button>
                    </div>`;
                 listEl.appendChild(item);
+
+                if (isMarkdown) {
+                    const viewEl = item.querySelector('.note-view');
+                    if (viewEl) {
+                        void renderSmartTextAsync(noteText, true).then((html) => {
+                            viewEl.innerHTML = html || '<i>(empty)</i>';
+                        }).catch(() => {
+                            // Leave plaintext fallback.
+                        });
+                    }
+                }
+
                 wireNoteItem(item, n);
                 try {
                     // Adaptive layout: align edge + orientation switch for note actions (mirror description actions)
@@ -3718,16 +3723,9 @@ async function populateContentSection(conceptId, suffix) {
                 const contentText = c.text || '';
                 const isMarkdown = detectMarkdown(contentText);
                 let displayHtml; let safeText; let truncated = false;
-                if (isMarkdown) {
-                    const renderedHtml = renderSmartText(contentText, true);
-                    truncated = renderedHtml.length > 1000;
-                    displayHtml = truncated ? renderedHtml.slice(0, 1000) + '…' : renderedHtml || '<i>(empty)</i>';
-                    safeText = escapeHtml(contentText);
-                } else {
-                    safeText = escapeHtml(contentText);
-                    truncated = safeText.length > 1000;
-                    displayHtml = truncated ? safeText.slice(0, 1000) + '…' : safeText || '<i>(empty)</i>';
-                }
+                safeText = escapeHtml(contentText);
+                truncated = safeText.length > 1000;
+                displayHtml = truncated ? safeText.slice(0, 1000) + '…' : safeText || '<i>(empty)</i>';
                 const viewClasses = isMarkdown ? 'content-view markdown-rendered' : 'content-view';
                 item.innerHTML = `
                          <div class="${viewClasses}" data-full="${safeText}" data-truncated="${truncated ? '1' : '0'}" style="white-space:pre-wrap;font-size:0.85rem;line-height:1.25;max-height:250px;overflow:hidden;">${displayHtml}</div>
@@ -3747,6 +3745,18 @@ async function populateContentSection(conceptId, suffix) {
                              <button type="button" class="round-icon-button content-delete-btn" title="Delete content" aria-label="Delete content" data-icon="delete"></button>
                    </div>`;
                 listEl.appendChild(item);
+
+                if (isMarkdown) {
+                    const viewEl = item.querySelector('.content-view');
+                    if (viewEl) {
+                        void renderSmartTextAsync(contentText, true).then((html) => {
+                            viewEl.innerHTML = html || '<i>(empty)</i>';
+                        }).catch(() => {
+                            // Leave plaintext fallback.
+                        });
+                    }
+                }
+
                 wireContentItem(item, c);
                 try {
                     // Adaptive layout: align edge + orientation switch for content actions

--- a/src/frontend/web/von_interface/static/js/main.js
+++ b/src/frontend/web/von_interface/static/js/main.js
@@ -56,8 +56,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     try {
       const normalizedId = conceptId.startsWith('#V#') ? conceptId : `#V#${conceptId}`;
       if (createConceptTab) {
-        // When createConceptTab is true, just create/activate the concept tab without switching to Vontology
-        selectVontologyNodeByIdentifier(normalizedId, createConceptTab);
+        // When createConceptTab is true, create the concept tab but keep the user on the current tab.
+        // (Open in the background; do not switch focus.)
+        createOrActivateConceptTab(normalizedId, normalizedId, false);
       } else {
         // Original behaviour: switch to Vontology tab and select node
         activateTab('vontologyTab');

--- a/src/frontend/web/von_interface/static/js/markdownUtils.js
+++ b/src/frontend/web/von_interface/static/js/markdownUtils.js
@@ -21,10 +21,70 @@ export function detectMarkdown(text) {
     return patterns.some(pattern => pattern.test(text));
 }
 
+function escapeHtml(text) {
+    return String(text).replace(/[&<>"']/g, (c) => (
+        {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;'
+        }[c]
+    ));
+}
+
+export function renderPlainTextToHtml(text) {
+    if (text == null) {
+        return '';
+    }
+    return escapeHtml(String(text)).replace(/\n/g, '<br>');
+}
+
+function sanitiseHref(rawHref) {
+    if (!rawHref) {
+        return null;
+    }
+
+    const href = String(rawHref).trim();
+    const lower = href.toLowerCase();
+
+    // Block common XSS vectors.
+    if (lower.startsWith('javascript:') || lower.startsWith('data:') || lower.startsWith('vbscript:')) {
+        return null;
+    }
+
+    // Allow anchors and same-origin relative links.
+    if (href.startsWith('#') || href.startsWith('/') || href.startsWith('./') || href.startsWith('../')) {
+        return href;
+    }
+
+    // Allow basic safe schemes.
+    if (lower.startsWith('http://') || lower.startsWith('https://') || lower.startsWith('mailto:')) {
+        return href;
+    }
+
+    return null;
+}
+
+function isExternalHttpLink(href) {
+    const lower = String(href || '').trim().toLowerCase();
+    return lower.startsWith('http://') || lower.startsWith('https://');
+}
+
 export function simpleMarkdownToHtml(markdown) {
     if (!markdown || typeof markdown !== 'string') return '';
 
-    let html = markdown;
+    // Common LLM pattern: an orphan bullet line immediately before a fenced code block,
+    // e.g. "-\n```..." or "•\n```...". This renders as an ugly empty bullet.
+    // Drop the orphan bullet-only line when it directly precedes a fenced block.
+    let preprocessed = markdown.replace(/\r\n/g, '\n');
+    preprocessed = preprocessed.replace(
+        /^(?:\s*(?:[-*+]|\d+\.)\s*|\s*[•◦▪▫]\s*)$(?=\n(?:\s*\n)*```[A-Za-z0-9_-]*\s*\n)/gm,
+        ''
+    );
+
+    // Treat markdown as untrusted input: escape raw HTML first so tags cannot execute.
+    let html = escapeHtml(preprocessed);
 
     // Process fenced code blocks first (to avoid interference with other patterns)
     html = html.replace(/```([\s\S]*?)```/g, '<pre><code>$1</code></pre>');
@@ -34,17 +94,26 @@ export function simpleMarkdownToHtml(markdown) {
     html = html.replace(/^## (.*$)/gim, '<h2>$1</h2>');
     html = html.replace(/^# (.*$)/gim, '<h1>$1</h1>');
 
-    // Bold
-    html = html.replace(/\*\*(.*)\*\*/gim, '<strong>$1</strong>');
+    // Bold (non-greedy)
+    html = html.replace(/\*\*([^*\n][\s\S]*?)\*\*/gim, '<strong>$1</strong>');
 
-    // Italic
-    html = html.replace(/\*(.*)\*/gim, '<em>$1</em>');
+    // Italic (conservative: avoid matching bold markers)
+    html = html.replace(/(^|[^*])\*([^*\n][\s\S]*?)\*([^*]|$)/gim, '$1<em>$2</em>$3');
 
     // Inline code
     html = html.replace(/`([^`]+)`/gim, '<code>$1</code>');
 
-    // Links
-    html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/gim, '<a href="$2">$1</a>');
+    // Links (sanitise href; never allow javascript: etc.)
+    html = html.replace(/\[([^\]]+)\]\(([^)\s]+)\)/gim, (match, text, href) => {
+        const safeHref = sanitiseHref(href);
+        const safeText = String(text);
+        if (!safeHref) {
+            return safeText;
+        }
+
+        const targetAttr = isExternalHttpLink(safeHref) ? ' target="_blank"' : '';
+        return `<a href="${escapeHtml(safeHref)}"${targetAttr} rel="noopener noreferrer">${safeText}</a>`;
+    });
 
     // Process lists before line breaks
     // Unordered lists
@@ -72,17 +141,65 @@ export function simpleMarkdownToHtml(markdown) {
     html = html.replace(/(<\/(?:h[1-6]|ul|ol|blockquote|pre)>)<\/p>/g, '$1');
 
     return html;
-} export function renderSmartText(text, escapeHtml = true) {
+}
+
+export function renderSmartText(text, escapeHtmlOutput = true) {
     if (!text) return '<em>(no content)</em>';
 
     if (detectMarkdown(text)) {
         return simpleMarkdownToHtml(text);
-    } else if (escapeHtml) {
-        // Plain text - escape HTML and preserve whitespace
-        const escaped = text.replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
-        return escaped.replace(/\n/g, '<br>');
-    } else {
-        // Already escaped or HTML content
-        return text;
     }
+
+    if (escapeHtmlOutput) {
+        // Plain text - escape HTML and preserve whitespace
+        return escapeHtml(text).replace(/\n/g, '<br>');
+    }
+
+    // Caller asserts this is safe.
+    return String(text);
+}
+
+export async function renderMarkdownViaServer(markdown) {
+    const text = String(markdown ?? '');
+    if (!text) {
+        return '';
+    }
+
+    try {
+        const res = await fetch('/von/api/render_markdown', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ text })
+        });
+
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+            throw new Error(data?.error || `render_markdown failed (${res.status})`);
+        }
+
+        if (typeof data?.html === 'string') {
+            return data.html;
+        }
+
+        throw new Error('render_markdown response missing html');
+    } catch (err) {
+        console.warn('[markdownUtils] renderMarkdownViaServer failed; falling back to client renderer', err);
+        return simpleMarkdownToHtml(text);
+    }
+}
+
+export async function renderSmartTextAsync(text, escapeHtmlOutput = true) {
+    if (!text) {
+        return '<em>(no content)</em>';
+    }
+
+    if (detectMarkdown(String(text))) {
+        return renderMarkdownViaServer(String(text));
+    }
+
+    if (escapeHtmlOutput) {
+        return renderPlainTextToHtml(String(text));
+    }
+
+    return String(text);
 }

--- a/src/frontend/web/von_interface/static/js/utils/textDecorator.js
+++ b/src/frontend/web/von_interface/static/js/utils/textDecorator.js
@@ -45,8 +45,9 @@ export function createAnnotatedFragment(text) {
 	for (const seg of segments) {
 		if (seg.type === 'token' && seg.conceptId) {
 			const a = document.createElement('a');
-			// Avoid real navigation in browsers and jsdom tests
-			a.href = 'javascript:void(0)';
+			// Avoid javascript: URLs (treat all content as untrusted).
+			// We still use an anchor for consistent styling + accessibility.
+			a.href = '#';
 			a.textContent = seg.text;
 			a.className = 'vontology-token';
 			a.dataset.conceptId = seg.conceptId;
@@ -66,6 +67,182 @@ export function createAnnotatedFragment(text) {
 	return frag;
 }
 
+function formatKindLabel(kind) {
+	const k = (kind || '').toString().toLowerCase();
+	if (k === 'predicate') return 'Predicate';
+	if (k === 'individual') return 'Individual';
+	return 'Type';
+}
+
+function normaliseKindClass(kind) {
+	const k = (kind || '').toString().toLowerCase();
+	if (k === 'predicate' || k === 'individual' || k === 'type') {
+		return k;
+	}
+	return 'type';
+}
+
+export function createVontologyCartouche(conceptId, opts = {}) {
+	const idRaw = (conceptId || '').toString();
+	const fullId = idRaw.startsWith('#V#') ? idRaw : `#V#${idRaw}`;
+
+	const btn = document.createElement('button');
+	btn.type = 'button';
+	btn.className = 'vontology-cartouche';
+	btn.dataset.conceptId = idRaw.startsWith('#V#') ? idRaw.slice(3) : idRaw;
+	btn.dataset.fullConceptId = fullId;
+	btn.title = opts.title || 'Open concept tab';
+	btn.setAttribute('aria-label', opts.ariaLabel || `Open concept ${fullId}`);
+
+	const name = document.createElement('span');
+	name.className = 'vontology-cartouche-name';
+	name.textContent = opts.name || '…';
+
+	const id = document.createElement('span');
+	id.className = 'vontology-cartouche-id';
+	id.textContent = fullId;
+
+	const kind = document.createElement('span');
+	const kindClass = normaliseKindClass(opts.kind);
+	kind.className = `vontology-cartouche-kind ${kindClass}`;
+	kind.textContent = opts.kind ? formatKindLabel(opts.kind) : '…';
+
+	btn.appendChild(name);
+	btn.appendChild(id);
+	btn.appendChild(kind);
+
+	btn.addEventListener('click', (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+		const raw = btn.dataset.conceptId;
+		if (!raw) return;
+		btn.dispatchEvent(new CustomEvent('von:selectConceptById', {
+			bubbles: true,
+			detail: { conceptId: raw, createConceptTab: true }
+		}));
+	});
+
+	return btn;
+}
+
+export function createCartoucheFragment(text) {
+	const frag = document.createDocumentFragment();
+	const segments = parseVontologyTokens(text);
+	for (const seg of segments) {
+		if (seg.type === 'token' && seg.conceptId) {
+			frag.appendChild(createVontologyCartouche(seg.conceptId));
+		} else {
+			frag.appendChild(document.createTextNode(seg.text));
+		}
+	}
+	return frag;
+}
+
+function shouldSkipTextNode(textNode, skipSelectors) {
+	const parent = textNode && textNode.parentElement;
+	if (!parent || !Array.isArray(skipSelectors) || skipSelectors.length === 0) {
+		return false;
+	}
+
+	for (const selector of skipSelectors) {
+		try {
+			if (parent.closest(selector)) {
+				return true;
+			}
+		} catch (_) {
+			// Ignore invalid selectors.
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Traverse existing DOM content and replace raw #V# tokens in text nodes with
+ * clickable anchors. This is useful after Markdown rendering.
+ *
+ * By default, skips linkification inside <pre>/<code> blocks and existing <a> tags.
+ */
+export function linkifyVontologyTokensInElement(root, options = {}) {
+	if (!root) {
+		return;
+	}
+
+	const skipSelectors = Array.isArray(options.skipSelectors)
+		? options.skipSelectors
+		: ['pre', 'code', 'a'];
+
+	const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+	const textNodes = [];
+	let node = walker.nextNode();
+	while (node) {
+		textNodes.push(node);
+		node = walker.nextNode();
+	}
+
+	for (const textNode of textNodes) {
+		const value = textNode.nodeValue;
+		if (!value || !value.includes('#V#')) {
+			continue;
+		}
+
+		if (shouldSkipTextNode(textNode, skipSelectors)) {
+			continue;
+		}
+
+		const frag = createAnnotatedFragment(value);
+		try {
+			textNode.parentNode.insertBefore(frag, textNode);
+			textNode.parentNode.removeChild(textNode);
+		} catch (_) {
+			// If the node was detached mid-iteration, ignore.
+		}
+	}
+}
+
+/**
+ * Traverse existing DOM content and replace raw #V# tokens in text nodes with
+ * cartouche buttons (name/id/kind placeholders).
+ *
+ * By default, skips cartouchification inside <pre>/<code> blocks and existing <a> tags.
+ */
+export function cartouchifyVontologyTokensInElement(root, options = {}) {
+	if (!root) {
+		return;
+	}
+
+	const skipSelectors = Array.isArray(options.skipSelectors)
+		? options.skipSelectors
+		: ['pre', 'code', 'a'];
+
+	const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+	const textNodes = [];
+	let node = walker.nextNode();
+	while (node) {
+		textNodes.push(node);
+		node = walker.nextNode();
+	}
+
+	for (const textNode of textNodes) {
+		const value = textNode.nodeValue;
+		if (!value || !value.includes('#V#')) {
+			continue;
+		}
+
+		if (shouldSkipTextNode(textNode, skipSelectors)) {
+			continue;
+		}
+
+		const frag = createCartoucheFragment(value);
+		try {
+			textNode.parentNode.insertBefore(frag, textNode);
+			textNode.parentNode.removeChild(textNode);
+		} catch (_) {
+			// If the node was detached mid-iteration, ignore.
+		}
+	}
+}
+
 /**
  * Replace all children of container with the annotated fragment for given text
  */
@@ -73,5 +250,11 @@ export function annotateElementText(container, text) {
 	if (!container) return;
 	while (container.firstChild) container.removeChild(container.firstChild);
 	container.appendChild(createAnnotatedFragment(text ?? ''));
+}
+
+export function cartouchifyElementText(container, text) {
+	if (!container) return;
+	while (container.firstChild) container.removeChild(container.firstChild);
+	container.appendChild(createCartoucheFragment(text ?? ''));
 }
 

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -853,6 +853,23 @@ body {
     border-color: #004085;
 }
 
+/* Chat message view toggle (Rendered/Text) */
+.chat-render-toggle {
+    font-size: 0.75rem;
+    padding: 2px 6px;
+    background: #f1f5f9;
+    color: #0f172a;
+    border: 1px solid #cbd5e1;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.chat-render-toggle:hover {
+    background: #e2e8f0;
+    border-color: #94a3b8;
+}
+
 .llm-debug-warning-container {
     position: relative;
     display: inline-flex;
@@ -3017,6 +3034,70 @@ footer {
     width: 100%;
 }
 
+/* Prompt cartouche overlay (rich textarea overlay) */
+.prompt-input-wrapper {
+    position: relative;
+    width: 100%;
+}
+
+.prompt-input-wrapper .prompt-input {
+    position: relative;
+    z-index: 2;
+    background: transparent;
+    color: transparent;
+    caret-color: #0f172a;
+}
+
+.prompt-input-wrapper .prompt-input::placeholder {
+    color: #64748b;
+    opacity: 1;
+}
+
+.prompt-input-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    pointer-events: none;
+    overflow: hidden;
+    background: transparent;
+    color: #0f172a;
+}
+
+/* Chat header model badge (small, non-intrusive) */
+.chat-llm-model-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 6px;
+    border-radius: 999px;
+    font-size: 0.78em;
+    background: #eef2ff;
+    border: 1px solid #c7d2fe;
+    color: #3730a3;
+    white-space: nowrap;
+}
+
+.prompt-input-overlay-inner {
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+button.prompt-vontology-cartouche {
+    pointer-events: auto;
+    margin: 0 2px;
+    vertical-align: baseline;
+}
+
+.prompt-vontology-cartouche-remove {
+    margin-left: 6px;
+    font-weight: 700;
+    opacity: 0.7;
+    cursor: pointer;
+}
+
+.prompt-vontology-cartouche-remove:hover {
+    opacity: 1;
+}
+
 .settings-iframe {
     width: 100%;
     min-height: 600px;
@@ -5022,6 +5103,106 @@ body.settings-body {
 .markdown-rendered {
     line-height: 1.6;
     color: #374151;
+}
+
+/* Chat transcript markdown: keep hierarchy readable without huge headings */
+.chat-markdown.markdown-rendered {
+    font-size: 0.95rem;
+}
+
+.chat-markdown.markdown-rendered h1 {
+    font-size: 1.15em;
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+/* Chat transcript: concept cartouches for inline #V# tokens (inside markdown-rendered content) */
+.chat-markdown.markdown-rendered .vontology-cartouche {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 10px;
+    border-radius: 999px;
+    border: 1px solid #cbd5e1;
+    background: #f1f5f9;
+    color: #0f172a;
+    font-size: 0.85em;
+    line-height: 1.2;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.chat-markdown.markdown-rendered .vontology-cartouche:hover {
+    background: #e2e8f0;
+}
+
+.chat-markdown.markdown-rendered .vontology-cartouche:focus {
+    outline: 2px solid #3b82f6;
+    outline-offset: 1px;
+}
+
+.chat-markdown.markdown-rendered .vontology-cartouche .vontology-cartouche-name {
+    font-weight: 600;
+}
+
+.chat-markdown.markdown-rendered .vontology-cartouche .vontology-cartouche-id {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.92em;
+    color: #475569;
+}
+
+.chat-markdown.markdown-rendered .vontology-cartouche .vontology-cartouche-kind {
+    display: inline-block;
+    font-size: 0.8em;
+    padding: 1px 6px;
+    border-radius: 999px;
+    border: 1px solid transparent;
+}
+
+.chat-markdown.markdown-rendered .vontology-cartouche .vontology-cartouche-kind.type {
+    background-color: #cfe2ff;
+    color: #084298;
+    border-color: #b6d4fe;
+}
+
+.chat-markdown.markdown-rendered .vontology-cartouche .vontology-cartouche-kind.individual {
+    background-color: #d4edda;
+    color: #155724;
+    border-color: #c3e6cb;
+}
+
+.chat-markdown.markdown-rendered .vontology-cartouche .vontology-cartouche-kind.predicate {
+    background-color: #fff3cd;
+    color: #997404;
+    border-color: #ffeeba;
+}
+
+.chat-markdown.markdown-rendered .vontology-cartouche.unresolved {
+    opacity: 0.85;
+}
+
+.chat-markdown.markdown-rendered h2 {
+    font-size: 1.05em;
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.chat-markdown.markdown-rendered h3 {
+    font-size: 1.0em;
+}
+
+.chat-markdown.markdown-rendered h4,
+.chat-markdown.markdown-rendered h5,
+.chat-markdown.markdown-rendered h6 {
+    font-size: 0.95em;
+}
+
+.chat-markdown.markdown-rendered p {
+    margin: 0.6em 0;
+}
+
+.chat-markdown.markdown-rendered pre {
+    margin: 0.8em 0;
 }
 
 /* Heading styles for markdown */

--- a/tests/backend/test_render_markdown_routes.py
+++ b/tests/backend/test_render_markdown_routes.py
@@ -1,0 +1,164 @@
+"""Tests for /von/api/render_markdown.
+
+These tests ensure markdown is rendered to HTML and that the output is sanitised.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+from bs4 import BeautifulSoup
+import pytest
+
+
+@pytest.fixture
+def app_client(monkeypatch):
+    """Provide a Flask test client with side effects stubbed out."""
+
+    # Stub Google auth dependencies pulled in by utils_flask -> auth_routes imports.
+    fake_flow_module = types.ModuleType("google_auth_oauthlib.flow")
+
+    class _DummyFlow:
+        def __init__(self, *args, **kwargs):
+            self.credentials = types.SimpleNamespace(id_token="dummy-token")
+            self.redirect_uri = kwargs.get("redirect_uri")
+            self.client_config = {"web": {"redirect_uris": [self.redirect_uri]}}
+
+        @classmethod
+        def from_client_config(cls, *args, **kwargs):
+            return cls(**kwargs)
+
+        def authorization_url(self, *args, **kwargs):
+            return "https://auth.example", "state-token"
+
+        def fetch_token(self, *args, **kwargs):
+            return None
+
+    fake_flow_module.Flow = _DummyFlow  # type: ignore[attr-defined]
+    sys.modules["google_auth_oauthlib"] = types.ModuleType("google_auth_oauthlib")
+    sys.modules["google_auth_oauthlib"].flow = fake_flow_module  # type: ignore[attr-defined]
+    sys.modules["google_auth_oauthlib.flow"] = fake_flow_module
+
+    fake_id_token_module = types.ModuleType("google.oauth2.id_token")
+    fake_id_token_module.verify_oauth2_token = lambda *args, **kwargs: {  # type: ignore[attr-defined]
+        "sub": "dummy-user"
+    }
+
+    fake_credentials_module = types.ModuleType("google.oauth2.credentials")
+
+    class _DummyCredentials:
+        def __init__(self, id_token: str = "dummy-token"):
+            self.id_token = id_token
+
+    fake_credentials_module.Credentials = _DummyCredentials  # type: ignore[attr-defined]
+
+    fake_service_account_module = types.ModuleType("google.oauth2.service_account")
+
+    class _DummyServiceAccountCredentials:
+        def __init__(self, *args, **kwargs):
+            self.project_id = kwargs.get("project_id")
+
+    fake_service_account_module.Credentials = _DummyServiceAccountCredentials  # type: ignore[attr-defined]
+
+    fake_oauth2_package = types.ModuleType("google.oauth2")
+    fake_oauth2_package.id_token = fake_id_token_module  # type: ignore[attr-defined]
+    fake_oauth2_package.credentials = fake_credentials_module  # type: ignore[attr-defined]
+    fake_oauth2_package.service_account = fake_service_account_module  # type: ignore[attr-defined]
+
+    sys.modules["google.oauth2"] = fake_oauth2_package
+    sys.modules["google.oauth2.id_token"] = fake_id_token_module
+    sys.modules["google.oauth2.credentials"] = fake_credentials_module
+    sys.modules["google.oauth2.service_account"] = fake_service_account_module
+
+    import src.backend.server.utils_flask as utils_flask
+
+    monkeypatch.setattr(utils_flask, "ensure_monitor_started", lambda: None)
+    monkeypatch.setattr(
+        utils_flask,
+        "prompt_concept_health_status",
+        lambda: {"available": True, "source_field": "stub"},
+    )
+
+    app = utils_flask.create_flask_app(
+        list_models_func=lambda: ["dummy-model"],
+        generate_func=lambda prompt, context, model: "ok",
+    )
+    app.config["TESTING"] = True
+
+    with app.test_client() as client:
+        yield app, client
+
+
+def test_render_markdown_renders_html(app_client):
+    _, client = app_client
+
+    markdown = "# Title\n\n- Item\n\n```python\nprint('x')\n```"
+    resp = client.post("/von/api/render_markdown", json={"text": markdown})
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data.get("html"), str)
+
+    html = data["html"]
+    assert "<h1" in html
+    assert "Title" in html
+    assert "<ul" in html
+    assert "<pre" in html
+    assert "<code" in html
+
+
+def test_render_markdown_sanitises_scripts_and_js_links(app_client):
+    _, client = app_client
+
+    markdown = """
+# XSS
+
+<script>window.hacked=1</script>
+
+[bad](javascript:alert(1))
+
+<img src=x onerror=alert(1)>
+""".strip()
+
+    resp = client.post("/von/api/render_markdown", json={"text": markdown})
+
+    assert resp.status_code == 200
+    html = resp.get_json()["html"].lower()
+
+    assert "<script" not in html
+    assert "javascript:" not in html
+    assert "<img" not in html
+
+
+def test_render_markdown_validates_payload(app_client):
+    _, client = app_client
+
+    resp = client.post("/von/api/render_markdown", json={"text": 123})
+    assert resp.status_code == 400
+
+
+def test_render_markdown_renders_nested_lists(app_client):
+    _, client = app_client
+
+    markdown = "- read:\n  - a\n  - b\n  - c\n"
+    resp = client.post("/von/api/render_markdown", json={"text": markdown})
+
+    assert resp.status_code == 200
+    html = resp.get_json()["html"]
+
+    soup = BeautifulSoup(html, "html.parser")
+    top_ul = soup.find("ul")
+    assert top_ul is not None
+
+    top_lis = top_ul.find_all("li", recursive=False)
+    assert len(top_lis) == 1
+    assert "read:" in top_lis[0].get_text(" ", strip=True)
+
+    nested_ul = top_lis[0].find("ul")
+    assert nested_ul is not None
+
+    nested_items = [
+        li.get_text(" ", strip=True) for li in nested_ul.find_all("li", recursive=False)
+    ]
+    assert nested_items == ["a", "b", "c"]

--- a/tests/frontend/chatTabAbort.test.js
+++ b/tests/frontend/chatTabAbort.test.js
@@ -13,7 +13,8 @@ jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
 }));
 
 jest.mock('../../src/frontend/web/von_interface/static/js/utils/textDecorator.js', () => ({
-    annotateElementText: jest.fn()
+    cartouchifyElementText: jest.fn(),
+    cartouchifyVontologyTokensInElement: jest.fn()
 }));
 
 const { formatChatTimestamp, sendMessage } = require(chatTabModulePath);

--- a/tests/frontend/chatTabMarkdownRender.test.js
+++ b/tests/frontend/chatTabMarkdownRender.test.js
@@ -1,0 +1,245 @@
+/** @jest-environment jsdom */
+
+const chatTabModulePath = '../../src/frontend/web/von_interface/static/js/chatTab.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    annotateTurn: jest.fn(),
+    getUserContext: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
+    elements: {},
+    renderSpanSuggestions: jest.fn()
+}));
+
+const { sendMessage } = require(chatTabModulePath);
+
+describe('chat markdown rendering (assistant)', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="scrollableField"></div>
+            <div id="loadingIndicator" aria-hidden="true"></div>
+            <button id="sendButton"></button>
+            <button id="abortButton" aria-hidden="true"></button>
+            <textarea id="promptInput"></textarea>
+            <input type="checkbox" id="annotationToggle" />
+        `;
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        delete global.fetch;
+    });
+
+    test('renders markdown for GPT-5.2 responses safely and preserves #V# token linkification (not inside code blocks)', async () => {
+        const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        getUserContext.mockReturnValue({
+            user_id: 'user',
+            org_id: 'org',
+            language: 'en-NZ',
+            gmail_profile: null
+        });
+
+        const promptInput = document.getElementById('promptInput');
+        promptInput.value = 'test prompt';
+
+        const assistantResponse = [
+            '# Title',
+            '',
+            '- Item',
+            '',
+            '[good](https://example.com)',
+            '',
+            'See #V#person',
+            '',
+            '```',
+            '#V#person',
+            '```',
+            '',
+            '[bad](javascript:alert(1))',
+            '',
+            '<script>window.hacked=1</script>'
+        ].join('\n');
+
+        const assistantHtml = [
+            '<h1>Title</h1>',
+            '<ul><li>Item</li></ul>',
+            '<p><a href="https://example.com" target="_blank" rel="noopener noreferrer">good</a></p>',
+            '<p>See #V#person</p>',
+            '<pre><code>#V#person</code></pre>',
+            '<p>bad</p>'
+        ].join('\n');
+
+        global.fetch = jest.fn((url) => {
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ history_length: 0, authenticated: true })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/vontology/api/vontology/node_content')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ display_name: 'Person', kind: 'type' })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/api/search')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        results: [
+                            { id: '#V#person', name: 'Person', kind: 'type' }
+                        ]
+                    })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/api/render_markdown')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ html: assistantHtml })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/generate')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        response: assistantResponse,
+                        llm_debug: { model: 'gpt-5.2' }
+                    })
+                });
+            }
+
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        await sendMessage();
+
+        // Markdown rendering is now async (server-backed), so allow a tick.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        const scrollableField = document.getElementById('scrollableField');
+        const assistantMarkdown = scrollableField.querySelector('.chat-markdown.markdown-rendered');
+        expect(assistantMarkdown).not.toBeNull();
+
+        expect(assistantMarkdown.querySelector('h1')).not.toBeNull();
+        expect(assistantMarkdown.querySelector('ul')).not.toBeNull();
+        expect(assistantMarkdown.textContent).toContain('Title');
+        expect(assistantMarkdown.textContent).toContain('Item');
+
+        // XSS hardening: scripts should not be injected.
+        expect(assistantMarkdown.querySelector('script')).toBeNull();
+        expect(global.window.hacked).toBeUndefined();
+
+        // XSS hardening: javascript: links should not appear.
+        const hrefs = Array.from(assistantMarkdown.querySelectorAll('a'))
+            .map(a => (a.getAttribute('href') || '').toLowerCase());
+        expect(hrefs.some(h => h.startsWith('javascript:'))).toBe(false);
+
+        // External http(s) links open in a new tab.
+        const externalLink = Array.from(assistantMarkdown.querySelectorAll('a'))
+            .find(a => (a.getAttribute('href') || '') === 'https://example.com');
+        expect(externalLink).toBeTruthy();
+        expect(externalLink.getAttribute('target')).toBe('_blank');
+
+        // #V# token cartouches should be present in normal text.
+        const cartouche = assistantMarkdown.querySelector('.vontology-cartouche[data-full-concept-id="#V#person"]');
+        expect(cartouche).not.toBeNull();
+
+        // Allow async hydration to resolve (fetch + microtasks).
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(cartouche.textContent).toContain('Person');
+        expect(cartouche.textContent).toContain('#V#person');
+        expect(cartouche.textContent).toContain('Type');
+
+        // But must not linkify inside code blocks.
+        const codeBlock = assistantMarkdown.querySelector('pre');
+        expect(codeBlock).not.toBeNull();
+        expect(codeBlock.querySelector('.vontology-cartouche')).toBeNull();
+        expect(codeBlock.textContent).toContain('#V#person');
+    });
+
+    test('renders markdown for user messages when markdown is detected', async () => {
+        const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        getUserContext.mockReturnValue({
+            user_id: 'user',
+            org_id: 'org',
+            language: 'en-NZ',
+            gmail_profile: null
+        });
+
+        const promptInput = document.getElementById('promptInput');
+        promptInput.value = [
+            '# Title',
+            '',
+            '- Item',
+            '',
+            'See #V#person'
+        ].join('\n');
+
+        const renderedHtml = [
+            '<h1>Title</h1>',
+            '<ul><li>Item</li></ul>',
+            '<p>See #V#person</p>'
+        ].join('\n');
+
+        global.fetch = jest.fn((url, opts) => {
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ history_length: 0, authenticated: true })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/vontology/api/vontology/node_content')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ display_name: 'Person', kind: 'type' })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/api/render_markdown')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ html: renderedHtml })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/api/search')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ results: [{ id: '#V#person', name: 'Person', kind: 'type' }] })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/generate')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ response: 'ok', llm_debug: { model: 'gpt-5.2' } })
+                });
+            }
+
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        await sendMessage();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        const scrollableField = document.getElementById('scrollableField');
+        const messageContainers = Array.from(scrollableField.querySelectorAll('.message-container'));
+        const userContainer = messageContainers.find(el => (el.textContent || '').includes('User •'));
+        expect(userContainer).toBeTruthy();
+
+        const userMarkdown = userContainer.querySelector('.chat-markdown.markdown-rendered');
+        expect(userMarkdown).not.toBeNull();
+        expect(userMarkdown.querySelector('h1')).not.toBeNull();
+        expect(userMarkdown.textContent).toContain('Title');
+
+        const cartouche = userMarkdown.querySelector('.vontology-cartouche[data-full-concept-id="#V#person"]');
+        expect(cartouche).not.toBeNull();
+    });
+});

--- a/tests/frontend/conceptAutocomplete.test.js
+++ b/tests/frontend/conceptAutocomplete.test.js
@@ -134,4 +134,37 @@ describe('conceptAutocomplete', () => {
             done();
         }, 300);
     });
+
+    test('selecting a concept inserts a non-trigger token (#V\u200B#...)', (done) => {
+        initializeConceptAutocomplete(textarea);
+
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                ok: true,
+                json: () =>
+                    Promise.resolve({
+                        results: [{ id: '#V#person', name: 'Person', kind: 'type' }],
+                    }),
+            })
+        );
+
+        textarea.value = '#V#pe';
+        textarea.selectionStart = textarea.value.length;
+        textarea.selectionEnd = textarea.value.length;
+
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+
+        setTimeout(() => {
+            const dropdown = document.querySelector('.concept-autocomplete-dropdown');
+            const first = dropdown
+                ? dropdown.querySelector('.concept-autocomplete-item[data-concept-id="#V#person"]')
+                : null;
+            expect(first).toBeTruthy();
+            first.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+            const ZWSP = '\u200B';
+            expect(textarea.value).toBe(`#V${ZWSP}#person`);
+            done();
+        }, 300);
+    });
 });

--- a/tests/frontend/markdownUtils.test.js
+++ b/tests/frontend/markdownUtils.test.js
@@ -1,0 +1,44 @@
+/** @jest-environment jsdom */
+
+const { simpleMarkdownToHtml } = require('../../src/frontend/web/von_interface/static/js/markdownUtils.js');
+
+describe('markdownUtils', () => {
+    test('removes orphan bullet-only line before fenced code block', () => {
+        const input = [
+            'Once you confirm, I will immediately perform:',
+            '',
+            '•',
+            '',
+            '```',
+            'add_relationship',
+            'source: #V#gpt-4o',
+            '```',
+            '',
+        ].join('\n');
+
+        const html = simpleMarkdownToHtml(input);
+
+        // No stray bullet rendered.
+        expect(html).not.toContain('•');
+        // Code block still present.
+        expect(html).toContain('<pre><code>');
+        expect(html).toContain('add_relationship');
+    });
+
+    test('removes orphan dash bullet-only line before fenced code block', () => {
+        const input = [
+            'Do this:',
+            '',
+            '-',
+            '',
+            '```json',
+            '{"a": 1}',
+            '```',
+        ].join('\n');
+
+        const html = simpleMarkdownToHtml(input);
+        expect(html).not.toContain('<br>-<br>');
+        expect(html).toContain('<pre><code>');
+        expect(html).toContain('{&quot;a&quot;: 1}');
+    });
+});

--- a/tests/frontend/promptCartoucheOverlay.test.js
+++ b/tests/frontend/promptCartoucheOverlay.test.js
@@ -1,0 +1,44 @@
+/** @jest-environment jsdom */
+
+const {
+    initializePromptCartoucheOverlay,
+    makeNonTriggerVontologyId,
+    normaliseVontologyIdsForBackend,
+} = require('../../src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js');
+
+describe('promptCartoucheOverlay', () => {
+    let textarea;
+
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        textarea = document.createElement('textarea');
+        textarea.className = 'prompt-input';
+        textarea.placeholder = 'Talk with Von here...';
+        document.body.appendChild(textarea);
+    });
+
+    test('normaliseVontologyIdsForBackend converts non-trigger prefix back to #V#', () => {
+        const raw = `Hello ${makeNonTriggerVontologyId('#V#person')} world`;
+        expect(normaliseVontologyIdsForBackend(raw)).toBe('Hello #V#person world');
+    });
+
+    test('overlay renders cartouche and remove deletes token from textarea', () => {
+        initializePromptCartoucheOverlay(textarea);
+
+        textarea.value = `Hello ${makeNonTriggerVontologyId('#V#person')} world`;
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+
+        const wrapper = textarea.closest('.prompt-input-wrapper');
+        expect(wrapper).toBeTruthy();
+
+        const cartouche = wrapper.querySelector('button.prompt-vontology-cartouche');
+        expect(cartouche).toBeTruthy();
+        expect(cartouche.dataset.fullConceptId).toBe('#V#person');
+
+        const remove = cartouche.querySelector('.prompt-vontology-cartouche-remove');
+        expect(remove).toBeTruthy();
+        remove.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+        expect(textarea.value).toBe('Hello world');
+    });
+});


### PR DESCRIPTION
Summary:\n- Adds per-message toggle to switch Von outputs between rendered markdown and original text\n- Renders markdown server-side with sanitisation (safe HTML) across chat and concept notes\n- Fixes nested list rendering (proper nested <ul> structure) with backend tests\n- Fixes chat input overlay text visibility regression\n\nDetails:\n- Backend: /von/api/render_markdown endpoint; Python-Markdown + allow-list sanitisation; indentation normaliser for nested lists\n- Frontend: chat toggle + caching, cartouche hydration, prompt overlay style sync\n- Tests: Jest frontend and Pytest backend (BeautifulSoup assertions for nested lists)\n\nJIRA: JVNAUTOSCI-809\nBranch: JVNAUTOSCI-809-chat-ui-render-markdown-outputs-nicely-for-markdo\n\nNotes:\n- Earlier commits referenced JVNAUTOSCI-799 in messages; final linking comment and branch clearly attribute to JVNAUTOSCI-809.\n- Verified tests locally (frontend + backend focused).