### PR TITLE
JVNAUTOSCI-808: Unify prompt/output cartouches

### DIFF
--- a/src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js
+++ b/src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js
@@ -11,7 +11,8 @@ const SEARCH_API = '/von/api/search';
 
 // Match #V\u200B#<id> and #v\u200B#<id>
 // Mirrors the allowed id character set used elsewhere.
-const NON_TRIGGER_TOKEN_RE = /#([Vv])\u200B#([A-Za-z0-9_\(\)\./:–\-]+?)(?=[\s"'`]|$)/g;
+// NOTE: Parentheses NOT allowed in concept IDs (they use underscores)
+const NON_TRIGGER_TOKEN_RE = /#([Vv])\u200B#([A-Za-z0-9_\./:–\-]+?)(?=[\s"'`]|$)/g;
 
 // For normalising before send.
 const NON_TRIGGER_PREFIX_RE = /#([Vv])\u200B#/g;

--- a/src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js
+++ b/src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js
@@ -5,6 +5,8 @@
 // (#V\u200B#...) into the textarea so autocomplete does not re-trigger.
 // The overlay renders those tokens as cartouches and supports removal.
 
+import { createVontologyCartouche } from '../utils/textDecorator.js';
+
 const ZWSP = '\u200B';
 
 const SEARCH_API = '/von/api/search';
@@ -131,26 +133,10 @@ function normaliseKindClass(kind) {
 }
 
 function createPromptCartouche(fullId, start, end) {
-    const btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = 'vontology-cartouche prompt-vontology-cartouche';
-    btn.dataset.fullConceptId = fullId;
+    const btn = createVontologyCartouche(fullId);
+    btn.classList.add('prompt-vontology-cartouche');
     btn.dataset.start = String(start);
     btn.dataset.end = String(end);
-    btn.title = 'Concept reference';
-    btn.setAttribute('aria-label', `Concept reference ${fullId}`);
-
-    const name = document.createElement('span');
-    name.className = 'vontology-cartouche-name';
-    name.textContent = '…';
-
-    const id = document.createElement('span');
-    id.className = 'vontology-cartouche-id';
-    id.textContent = fullId;
-
-    const kind = document.createElement('span');
-    kind.className = 'vontology-cartouche-kind type';
-    kind.textContent = '…';
 
     const remove = document.createElement('span');
     remove.className = 'prompt-vontology-cartouche-remove';
@@ -158,10 +144,6 @@ function createPromptCartouche(fullId, start, end) {
     remove.setAttribute('role', 'button');
     remove.setAttribute('aria-label', `Remove concept ${fullId}`);
     remove.tabIndex = -1;
-
-    btn.appendChild(name);
-    btn.appendChild(id);
-    btn.appendChild(kind);
     btn.appendChild(remove);
 
     return btn;

--- a/src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js
+++ b/src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js
@@ -305,6 +305,11 @@ function updatePromptCartouche(cartoucheEl, meta) {
         const kindClass = normaliseKindClass(meta.kind);
         kindEl.className = `vontology-cartouche-kind ${kindClass}`;
         kindEl.textContent = meta.kind ? formatKindLabel(meta.kind) : 'Type';
+        // Also apply kind class to the button itself for consistent styling
+        cartoucheEl.className = cartoucheEl.className.replace(/\b(type|individual|predicate)\b/g, '');
+        if (kindClass && kindClass !== 'type') {
+            cartoucheEl.classList.add(kindClass);
+        }
     }
 }
 

--- a/src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js
+++ b/src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js
@@ -377,7 +377,7 @@ export function initializePromptCartoucheOverlay(textarea) {
             if (!Number.isFinite(start) || !Number.isFinite(end)) return;
             removeTokenRangeFromTextarea(textarea, start, end);
         }
-    });
+    }, true);
 
     parts.overlay.addEventListener('keydown', (event) => {
         const key = event.key;

--- a/src/frontend/web/von_interface/static/js/utils/textDecorator.js
+++ b/src/frontend/web/von_interface/static/js/utils/textDecorator.js
@@ -14,8 +14,9 @@ export function parseVontologyTokens(text) {
 	// Spaces in concept names are normalized to underscores during ID generation, so no spaces in IDs
 	// Quotes and backticks are forbidden in concept names and serve as text boundaries
 	// Using space/quote/backtick as terminators eliminates ambiguity and runaway link concerns
-	// This supports concept IDs like: #V#person, #V#michael_witbrock_business_trip_akl–mel_26-29_nov_2025_(air_nz)
-	const tokenRe = /#V#([A-Za-z0-9_\(\)\./:–\-]+?)(?=[\s"'`]|$)/g;
+	// This supports concept IDs like: #V#person, #V#michael_witbrock_business_trip_akl_mel_26_29_nov_2025_air_nz
+	// NOTE: Parentheses are not allowed in concept IDs
+	const tokenRe = /#V#([A-Za-z0-9_\./:–\-]+?)(?=[\s"'`]|$)/g;
 
 	let lastIndex = 0;
 	let match;

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -3087,8 +3087,8 @@ button.prompt-vontology-cartouche.vontology-cartouche {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    padding: 3px 8px;
-    border-radius: 12px;
+    padding: 4px 12px;
+    border-radius: 20px;
     border: 1px solid;
     font-size: 13px;
     font-weight: 500;
@@ -3122,17 +3122,17 @@ button.prompt-vontology-cartouche.type:hover {
     color: #204a72;
 }
 
-/* Individual cartouche in prompt */
+/* Individual cartouche in prompt (green) */
 button.prompt-vontology-cartouche.individual {
-    background: #f7f9f2;
-    border-color: #cfe3b4;
-    color: #2f4a1f;
+    background: #dcfce7;
+    border-color: #86efac;
+    color: #166534;
 }
 
 button.prompt-vontology-cartouche.individual:hover {
-    background: #ecf3e0;
-    border-color: #bbd89f;
-    color: #2f4a1f;
+    background: #bbf7d0;
+    border-color: #4ade80;
+    color: #166534;
 }
 
 /* Predicate cartouche in prompt */

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -3081,71 +3081,41 @@ footer {
     word-break: break-word;
 }
 
-/* Prompt cartouche styling - align with output cartouches */
-button.prompt-vontology-cartouche,
-button.prompt-vontology-cartouche.vontology-cartouche {
+/* Vontology cartouches (shared styling across prompt + output) */
+.vontology-cartouche {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    padding: 4px 12px;
-    border-radius: 20px;
-    border: 1px solid;
+    padding: 2px 10px;
+    border-radius: 999px;
+    border: 1px solid #cbd5e1;
+    background: #f1f5f9;
+    color: #0f172a;
     font-size: 13px;
-    font-weight: 500;
-    text-decoration: none !important;
+    line-height: 1.2;
     cursor: pointer;
+    white-space: nowrap;
+    text-decoration: none !important;
+}
+
+.vontology-cartouche:hover {
+    background: #e2e8f0;
+}
+
+.vontology-cartouche:focus {
+    outline: 2px solid #3b82f6;
+    outline-offset: 1px;
+}
+
+.vontology-cartouche.unresolved {
+    opacity: 0.85;
+}
+
+/* Prompt overlay needs pointer events enabled for cartouches */
+button.prompt-vontology-cartouche {
     pointer-events: auto;
     margin: 0 2px;
     vertical-align: baseline;
-    transition: all 0.15s ease;
-    background: #f3f4f6;
-    border-color: #d1d5db;
-    color: #374151;
-}
-
-button.prompt-vontology-cartouche:hover,
-button.prompt-vontology-cartouche.vontology-cartouche:hover {
-    background: #e5e7eb;
-    border-color: #9ca3af;
-}
-
-/* Type cartouche in prompt */
-button.prompt-vontology-cartouche.type {
-    background: #eef6ff;
-    border-color: #b6dbff;
-    color: #204a72;
-}
-
-button.prompt-vontology-cartouche.type:hover {
-    background: #d9ebff;
-    border-color: #9ac9ff;
-    color: #204a72;
-}
-
-/* Individual cartouche in prompt (green) */
-button.prompt-vontology-cartouche.individual {
-    background: #dcfce7;
-    border-color: #86efac;
-    color: #166534;
-}
-
-button.prompt-vontology-cartouche.individual:hover {
-    background: #bbf7d0;
-    border-color: #4ade80;
-    color: #166534;
-}
-
-/* Predicate cartouche in prompt */
-button.prompt-vontology-cartouche.predicate {
-    background: #f5f0ff;
-    border-color: #d4c5f9;
-    color: #4a3871;
-}
-
-button.prompt-vontology-cartouche.predicate:hover {
-    background: #ede5ff;
-    border-color: #c5b3f3;
-    color: #4a3871;
 }
 
 /* Cartouche internal elements */
@@ -3192,6 +3162,12 @@ button.prompt-vontology-cartouche.predicate:hover {
     cursor: pointer;
     line-height: 1;
     padding: 0 2px;
+    display: none;
+}
+
+.prompt-vontology-cartouche:hover .prompt-vontology-cartouche-remove,
+.prompt-vontology-cartouche:focus-within .prompt-vontology-cartouche-remove {
+    display: inline;
 }
 
 .prompt-vontology-cartouche-remove:hover {
@@ -5217,69 +5193,7 @@ body.settings-body {
 }
 
 /* Chat transcript: concept cartouches for inline #V# tokens (inside markdown-rendered content) */
-.chat-markdown.markdown-rendered .vontology-cartouche {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 2px 10px;
-    border-radius: 999px;
-    border: 1px solid #cbd5e1;
-    background: #f1f5f9;
-    color: #0f172a;
-    font-size: 0.85em;
-    line-height: 1.2;
-    cursor: pointer;
-    white-space: nowrap;
-}
-
-.chat-markdown.markdown-rendered .vontology-cartouche:hover {
-    background: #e2e8f0;
-}
-
-.chat-markdown.markdown-rendered .vontology-cartouche:focus {
-    outline: 2px solid #3b82f6;
-    outline-offset: 1px;
-}
-
-.chat-markdown.markdown-rendered .vontology-cartouche .vontology-cartouche-name {
-    font-weight: 600;
-}
-
-.chat-markdown.markdown-rendered .vontology-cartouche .vontology-cartouche-id {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-    font-size: 0.92em;
-    color: #475569;
-}
-
-.chat-markdown.markdown-rendered .vontology-cartouche .vontology-cartouche-kind {
-    display: inline-block;
-    font-size: 0.8em;
-    padding: 1px 6px;
-    border-radius: 999px;
-    border: 1px solid transparent;
-}
-
-.chat-markdown.markdown-rendered .vontology-cartouche .vontology-cartouche-kind.type {
-    background-color: #cfe2ff;
-    color: #084298;
-    border-color: #b6d4fe;
-}
-
-.chat-markdown.markdown-rendered .vontology-cartouche .vontology-cartouche-kind.individual {
-    background-color: #d4edda;
-    color: #155724;
-    border-color: #c3e6cb;
-}
-
-.chat-markdown.markdown-rendered .vontology-cartouche .vontology-cartouche-kind.predicate {
-    background-color: #fff3cd;
-    color: #997404;
-    border-color: #ffeeba;
-}
-
-.chat-markdown.markdown-rendered .vontology-cartouche.unresolved {
-    opacity: 0.85;
-}
+/* Uses shared .vontology-cartouche styling (see prompt cartouche overlay section). */
 
 .chat-markdown.markdown-rendered h2 {
     font-size: 1.05em;

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -3081,17 +3081,117 @@ footer {
     word-break: break-word;
 }
 
-button.prompt-vontology-cartouche {
+/* Prompt cartouche styling - align with output cartouches */
+button.prompt-vontology-cartouche,
+button.prompt-vontology-cartouche.vontology-cartouche {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 8px;
+    border-radius: 12px;
+    border: 1px solid;
+    font-size: 13px;
+    font-weight: 500;
+    text-decoration: none !important;
+    cursor: pointer;
     pointer-events: auto;
     margin: 0 2px;
     vertical-align: baseline;
+    transition: all 0.15s ease;
+    background: #f3f4f6;
+    border-color: #d1d5db;
+    color: #374151;
+}
+
+button.prompt-vontology-cartouche:hover,
+button.prompt-vontology-cartouche.vontology-cartouche:hover {
+    background: #e5e7eb;
+    border-color: #9ca3af;
+}
+
+/* Type cartouche in prompt */
+button.prompt-vontology-cartouche.type {
+    background: #eef6ff;
+    border-color: #b6dbff;
+    color: #204a72;
+}
+
+button.prompt-vontology-cartouche.type:hover {
+    background: #d9ebff;
+    border-color: #9ac9ff;
+    color: #204a72;
+}
+
+/* Individual cartouche in prompt */
+button.prompt-vontology-cartouche.individual {
+    background: #f7f9f2;
+    border-color: #cfe3b4;
+    color: #2f4a1f;
+}
+
+button.prompt-vontology-cartouche.individual:hover {
+    background: #ecf3e0;
+    border-color: #bbd89f;
+    color: #2f4a1f;
+}
+
+/* Predicate cartouche in prompt */
+button.prompt-vontology-cartouche.predicate {
+    background: #f5f0ff;
+    border-color: #d4c5f9;
+    color: #4a3871;
+}
+
+button.prompt-vontology-cartouche.predicate:hover {
+    background: #ede5ff;
+    border-color: #c5b3f3;
+    color: #4a3871;
+}
+
+/* Cartouche internal elements */
+.vontology-cartouche-name {
+    font-weight: 600;
+}
+
+.vontology-cartouche-id {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.92em;
+    color: #475569;
+}
+
+.vontology-cartouche-kind {
+    display: inline-block;
+    font-size: 0.8em;
+    padding: 1px 6px;
+    border-radius: 999px;
+    border: 1px solid transparent;
+}
+
+.vontology-cartouche-kind.type {
+    background-color: #cfe2ff;
+    color: #084298;
+    border-color: #b6d4fe;
+}
+
+.vontology-cartouche-kind.individual {
+    background-color: #d4edda;
+    color: #155724;
+    border-color: #c3e6cb;
+}
+
+.vontology-cartouche-kind.predicate {
+    background-color: #fff3cd;
+    color: #997404;
+    border-color: #ffeeba;
 }
 
 .prompt-vontology-cartouche-remove {
-    margin-left: 6px;
+    margin-left: 4px;
     font-weight: 700;
     opacity: 0.7;
     cursor: pointer;
+    line-height: 1;
+    padding: 0 2px;
 }
 
 .prompt-vontology-cartouche-remove:hover {


### PR DESCRIPTION
Unifies prompt (input overlay) and chat/output cartouches so they share the same DOM builder and base CSS.

Changes:
- Globalised .vontology-cartouche styling so prompt and chat use identical pill styling.
- Prompt overlay now uses createVontologyCartouche() to match output cartouche DOM.
- Prompt remove (×) click handled in capture phase so it works even when the cartouche button has its own click handler.

Tests:
- npm run test:frontend (17/17)