### PR TITLE
JVNAUTOSCI-818: Prevent #V# tokens becoming headings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,6 +336,8 @@ console.log('Parent position:', parentStyles.position); // Should be 'relative' 
 4. **Element truly missing from DOM** → Then investigate JavaScript/template issues
 
 **Priority**: CSS visibility issues are 10x more common than missing DOM elements. Start with comprehensive CSS analysis.
+
+**When the element exists but looks wrong (e.g., centred, oddly indented, unexpectedly bold):** ask the user to use Chrome DevTools (Elements tab) to copy the element's `outerHTML` and capture key computed styles (especially `display`, `white-space`, `text-align`, `font-weight`, `margin`, `padding`, and `line-height`) for the element and its nearest container. This is often the fastest way to spot a single inherited CSS rule or an unexpected wrapper like `<h1>`.
 ## Core AI-Focused Documents
 
 1.  **`docs/AINotes.md`**

--- a/src/backend/services/markdown_render_service.py
+++ b/src/backend/services/markdown_render_service.py
@@ -169,6 +169,101 @@ def _normalise_nested_list_indentation(text: str) -> str:
     return "\n".join(lines)
 
 
+def _ensure_blank_line_before_top_level_lists(markdown_text: str) -> str:
+    """Insert a blank line before a top-level list that immediately follows a paragraph.
+
+    Python-Markdown (especially with sane_lists) can fail to recognise a list that starts
+    immediately after a paragraph line with no intervening blank line. This normaliser
+    makes that intent explicit while preserving fenced code blocks.
+    """
+
+    if not markdown_text:
+        return markdown_text
+
+    lines = markdown_text.replace("\r\n", "\n").split("\n")
+    out: list[str] = []
+    in_fence = False
+
+    top_level_list_re = re.compile(r"^([-*+])\s+\S")
+    top_level_ordered_re = re.compile(r"^(\d+)\.\s+\S")
+
+    for line in lines:
+        if re.match(r"^\s*```", line):
+            in_fence = not in_fence
+            out.append(line)
+            continue
+
+        if in_fence:
+            out.append(line)
+            continue
+
+        is_top_level_list = bool(
+            top_level_list_re.match(line) or top_level_ordered_re.match(line)
+        )
+        if is_top_level_list and out:
+            prev = out[-1]
+            if prev.strip() != "":
+                # Avoid injecting extra blanks between successive list blocks.
+                if not re.match(r"^\s*([-*+]|\d+\.|>|#{1,6}\s)", prev):
+                    out.append("")
+
+        out.append(line)
+
+    return "\n".join(out)
+
+
+def _escape_vontology_hash_headings(markdown_text: str) -> str:
+    """Escape leading #V# tokens so they cannot be parsed as Markdown headings.
+
+    Python-Markdown accepts ATX headings without requiring a space after the
+    leading '#'. This means a plain concept ID like:
+
+        #V#disambiguation_workflow
+
+    can get misparsed as a heading (<h1>) instead of plain text. We escape only
+    the specific '#V#' prefix, outside fenced code blocks, so that users can
+    still write normal headings.
+
+    Future hardening idea (JVNAUTOSCI-818): if more Markdown edge cases appear,
+    consider a full encode/decode pipeline: replace '#V#' with a highly unlikely
+    sentinel token before Markdown rendering (outside fences), then decode it
+    back to '#V#' afterwards. That avoids all Markdown syntax interactions in a
+    single, reliable step.
+    """
+
+    if not markdown_text:
+        return markdown_text
+
+    lines = markdown_text.replace("\r\n", "\n").split("\n")
+    out: list[str] = []
+    in_fence = False
+
+    # Cases we need to cover:
+    # - Start of a line:        "#V#foo"
+    # - Start of list content:  "- #V#foo" (can become a heading inside <li>)
+    # - Blockquotes:            "> #V#foo" (can become a heading inside <blockquote>)
+    start_of_line_re = re.compile(r"^(\s*)(?<!\\)#V#")
+    list_item_re = re.compile(r"^(\s*(?:[-*+]|\d+\.))(\s+)(?<!\\)#V#")
+    blockquote_re = re.compile(r"^(\s*>\s*)(?<!\\)#V#")
+
+    for line in lines:
+        if re.match(r"^\s*```", line):
+            in_fence = not in_fence
+            out.append(line)
+            continue
+
+        if in_fence:
+            out.append(line)
+            continue
+
+        updated = start_of_line_re.sub(r"\1\\#V#", line, count=1)
+        updated = list_item_re.sub(r"\1\2\\#V#", updated, count=1)
+        updated = blockquote_re.sub(r"\1\\#V#", updated, count=1)
+        out.append(updated)
+
+    return "\n".join(out)
+
+
 def render_markdown_to_safe_html(
     text: str, *, extensions: Iterable[str] | None = None
 ) -> str:
@@ -180,7 +275,9 @@ def render_markdown_to_safe_html(
     if not text:
         return ""
 
-    text = _normalise_nested_list_indentation(str(text))
+    text = _ensure_blank_line_before_top_level_lists(str(text))
+    text = _escape_vontology_hash_headings(text)
+    text = _normalise_nested_list_indentation(text)
 
     exts = (
         list(extensions)

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -48,6 +48,40 @@ function shouldRenderMarkdownForAssistant(message, debugData) {
     return detectMarkdown(text);
 }
 
+function updateChatRenderModeBadge(badgeEl, messageTextEl, details = {}) {
+    if (!badgeEl || !messageTextEl) {
+        return;
+    }
+
+    const renderMode = String(messageTextEl?.dataset?.renderMode || 'text');
+    const modeLabel = renderMode === 'rendered' ? 'Rendered' : 'Text';
+    badgeEl.textContent = `View: ${modeLabel}`;
+
+    const shouldRenderMarkdown = details.shouldRenderMarkdown === true;
+    const canRenderMarkdown = details.canRenderMarkdown === true;
+    const model = details.model ? String(details.model) : '';
+
+    badgeEl.classList.toggle('rendered', renderMode === 'rendered');
+    badgeEl.classList.toggle('text', renderMode !== 'rendered');
+
+    const reasons = [];
+    if (model) {
+        reasons.push(`model=${model}`);
+    }
+    reasons.push(`renderMode=${renderMode}`);
+
+    if (renderMode !== 'rendered') {
+        if (!canRenderMarkdown) {
+            reasons.push('no-toggle (markdown not detected)');
+        }
+        if (!shouldRenderMarkdown) {
+            reasons.push('shouldRenderMarkdownForAssistant=false');
+        }
+    }
+
+    badgeEl.title = reasons.join(' • ');
+}
+
 async function renderChatMarkdownIntoContainer(container, text) {
     const markdownText = String(text ?? '');
     const html = await renderMarkdownViaServer(markdownText);
@@ -80,6 +114,11 @@ function setVonMessageRenderMode(messageTextEl, mode, originalText, debugData) {
     if (!messageTextEl) {
         return;
     }
+
+    // Hard override: chat transcript containers can inherit centring/boldness.
+    // Keep message text consistently left-aligned in both raw and rendered modes.
+    messageTextEl.style.textAlign = 'left';
+    messageTextEl.style.fontWeight = '400';
 
     const raw = String(originalText ?? '');
     const nextMode = mode === 'text' ? 'text' : 'rendered';
@@ -124,6 +163,10 @@ function setVonMessageRenderMode(messageTextEl, mode, originalText, debugData) {
 function renderAssistantMessageContent(container, message, debugData) {
     const text = String(message ?? '');
     const shouldRenderMarkdown = shouldRenderMarkdownForAssistant(text, debugData);
+
+    // Hard override: chat transcript containers can inherit centring/boldness.
+    container.style.textAlign = 'left';
+    container.style.fontWeight = '400';
 
     if (!shouldRenderMarkdown) {
         try {
@@ -1092,6 +1135,11 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
                 }
             }
 
+            // Render-mode badge: shows whether this message is in Rendered/Text mode.
+            const renderModeBadge = document.createElement('span');
+            renderModeBadge.className = 'chat-render-mode-badge';
+            messageHeader.appendChild(renderModeBadge);
+
             // Add delete button
             if (turnId) {
                 const deleteButton = document.createElement('button');
@@ -1113,7 +1161,7 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
             }
 
             const messageText = document.createElement('div');
-            messageText.style.cssText = 'color: #333; white-space: pre-wrap;';
+            messageText.style.cssText = 'color: #333; white-space: pre-wrap; text-align: left; font-weight: 400;';
             try {
                 const debugData = turnId ? llmDebugData.get(turnId) : null;
                 const rawText = String(message ?? '');
@@ -1134,11 +1182,23 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
                         toggleButton.title = nextMode === 'text'
                             ? 'Show the rendered markdown view'
                             : 'Show the original (raw) text';
+
+                        updateChatRenderModeBadge(renderModeBadge, messageText, {
+                            canRenderMarkdown: true,
+                            shouldRenderMarkdown: shouldRenderMarkdownForAssistant(rawText, debugData),
+                            model: debugData?.model
+                        });
                     });
                     messageHeader.appendChild(toggleButton);
                 }
 
                 renderAssistantMessageContent(messageText, rawText, debugData);
+
+                updateChatRenderModeBadge(renderModeBadge, messageText, {
+                    canRenderMarkdown,
+                    shouldRenderMarkdown: shouldRenderMarkdownForAssistant(rawText, debugData),
+                    model: debugData?.model
+                });
             } catch (e) {
                 console.error('[chatTab] Failed to render Von message:', e);
                 messageText.textContent = String(message);
@@ -1209,7 +1269,7 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
             }
 
             const messageText = document.createElement('div');
-            messageText.style.cssText = 'color: #333; white-space: pre-wrap;';
+            messageText.style.cssText = 'color: #333; white-space: pre-wrap; text-align: left; font-weight: 400;';
             const userText = String(message ?? '');
             const shouldRenderUserMarkdown = sender === 'User' && detectMarkdown(userText);
             if (shouldRenderUserMarkdown) {

--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -3408,8 +3408,11 @@ async function populateNotesSection(conceptId, suffix) {
                 truncated = safeText.length > 800;
                 displayHtml = truncated ? safeText.slice(0, 800) + '…' : safeText || '<i>(empty)</i>';
                 const viewClasses = isMarkdown ? 'note-view markdown-rendered' : 'note-view';
+                const viewStyle = isMarkdown
+                    ? 'white-space:normal;font-size:0.85rem;line-height:1.25;max-height:220px;overflow:hidden;'
+                    : 'white-space:pre-wrap;font-size:0.85rem;line-height:1.25;max-height:220px;overflow:hidden;';
                 item.innerHTML = `
-                         <div class="${viewClasses}" data-full="${safeText}" data-truncated="${truncated ? '1' : '0'}" style="white-space:pre-wrap;font-size:0.85rem;line-height:1.25;max-height:220px;overflow:hidden;">${displayHtml}</div>
+                                                 <div class="${viewClasses}" data-full="${safeText}" data-truncated="${truncated ? '1' : '0'}" style="${viewStyle}">${displayHtml}</div>
                    <div class="note-edit hidden" style="margin-top:4px;">
                       <textarea class="note-textarea" style="width:100%;min-height:120px;font-family:monospace;font-size:0.8rem;padding:6px;">${escapeHtml(n.text || '')}</textarea>
                       <div style="margin-top:4px;display:flex;gap:8px;align-items:center;">
@@ -3432,6 +3435,8 @@ async function populateNotesSection(conceptId, suffix) {
                     if (viewEl) {
                         void renderSmartTextAsync(noteText, true).then((html) => {
                             viewEl.innerHTML = html || '<i>(empty)</i>';
+                            // Markdown is injected as HTML; do not preserve whitespace formatting.
+                            viewEl.style.whiteSpace = 'normal';
                         }).catch(() => {
                             // Leave plaintext fallback.
                         });
@@ -3727,8 +3732,11 @@ async function populateContentSection(conceptId, suffix) {
                 truncated = safeText.length > 1000;
                 displayHtml = truncated ? safeText.slice(0, 1000) + '…' : safeText || '<i>(empty)</i>';
                 const viewClasses = isMarkdown ? 'content-view markdown-rendered' : 'content-view';
+                const viewStyle = isMarkdown
+                    ? 'white-space:normal;font-size:0.85rem;line-height:1.25;max-height:250px;overflow:hidden;'
+                    : 'white-space:pre-wrap;font-size:0.85rem;line-height:1.25;max-height:250px;overflow:hidden;';
                 item.innerHTML = `
-                         <div class="${viewClasses}" data-full="${safeText}" data-truncated="${truncated ? '1' : '0'}" style="white-space:pre-wrap;font-size:0.85rem;line-height:1.25;max-height:250px;overflow:hidden;">${displayHtml}</div>
+                                                 <div class="${viewClasses}" data-full="${safeText}" data-truncated="${truncated ? '1' : '0'}" style="${viewStyle}">${displayHtml}</div>
                    <div class="content-edit hidden" style="margin-top:4px;">
                       <textarea class="content-textarea" style="width:100%;min-height:150px;font-family:monospace;font-size:0.8rem;padding:6px;">${escapeHtml(c.text || '')}</textarea>
                       <div style="margin-top:4px;display:flex;gap:8px;align-items:center;">
@@ -3751,6 +3759,8 @@ async function populateContentSection(conceptId, suffix) {
                     if (viewEl) {
                         void renderSmartTextAsync(contentText, true).then((html) => {
                             viewEl.innerHTML = html || '<i>(empty)</i>';
+                            // Markdown is injected as HTML; do not preserve whitespace formatting.
+                            viewEl.style.whiteSpace = 'normal';
                         }).catch(() => {
                             // Leave plaintext fallback.
                         });

--- a/src/frontend/web/von_interface/static/js/markdownUtils.js
+++ b/src/frontend/web/von_interface/static/js/markdownUtils.js
@@ -12,10 +12,10 @@ export function detectMarkdown(text) {
         /\*[^*\s][^*]*[^*\s]\*/,    // Italic text (*text*) - must have content without spaces at edges
         /`[^`\s][^`]*[^`\s]*`/,     // Inline code (`code`) - must have content without spaces at edges
         /^```[\s\S]*?```$/m,        // Fenced code blocks
-        /^[-*+]\s+.+$/m,            // Lists (- * +)
-        /^\d+\.\s+.+$/m,            // Ordered lists (1. 2.)
+        /^\s*[-*+]\s+.+$/m,         // Lists (- * +) (allow leading indentation)
+        /^\s*\d+\.\s+.+$/m,         // Ordered lists (1. 2.) (allow leading indentation)
         /\[[^\]]+\]\([^)\s]+\)/,    // Links [text](url)
-        /^>\s+.+$/m                 // Blockquotes (> text)
+        /^\s*>\s+.+$/m              // Blockquotes (> text) (allow leading indentation)
     ];
 
     return patterns.some(pattern => pattern.test(text));

--- a/src/frontend/web/von_interface/static/js/utils/textDecorator.js
+++ b/src/frontend/web/von_interface/static/js/utils/textDecorator.js
@@ -158,6 +158,31 @@ function shouldSkipTextNode(textNode, skipSelectors) {
 	return false;
 }
 
+function normaliseVontologyTokensForDisplay(text) {
+	const input = String(text ?? '');
+	if (!input) {
+		return input;
+	}
+
+	let output = input;
+
+	// Normalise non-trigger tokens that include a ZWSP: #V\u200B#id -> #V#id.
+	output = output.replace(/#([Vv])\u200B#/g, '#V#');
+
+	// Normalise lower-case variants.
+	output = output.replace(/#v#/g, '#V#');
+
+	// Recover from a regression where the leading '#' is dropped in display text:
+	// "V#person" -> "#V#person" (but do NOT rewrite "#V#person").
+	// Prefix capture avoids lookbehind to keep browser support broad.
+	output = output.replace(
+		/(^|[^#])([Vv])#([A-Za-z0-9_\./:–\-]+?)(?=[\s"'`]|$)/g,
+		(_, prefix, _v, conceptId) => `${prefix}#V#${conceptId}`
+	);
+
+	return output;
+}
+
 /**
  * Traverse existing DOM content and replace raw #V# tokens in text nodes with
  * clickable anchors. This is useful after Markdown rendering.
@@ -183,7 +208,7 @@ export function linkifyVontologyTokensInElement(root, options = {}) {
 
 	for (const textNode of textNodes) {
 		const value = textNode.nodeValue;
-		if (!value || !value.includes('#V#')) {
+		if (!value) {
 			continue;
 		}
 
@@ -191,7 +216,12 @@ export function linkifyVontologyTokensInElement(root, options = {}) {
 			continue;
 		}
 
-		const frag = createAnnotatedFragment(value);
+		const normalised = normaliseVontologyTokensForDisplay(value);
+		if (!normalised.includes('#V#')) {
+			continue;
+		}
+
+		const frag = createAnnotatedFragment(normalised);
 		try {
 			textNode.parentNode.insertBefore(frag, textNode);
 			textNode.parentNode.removeChild(textNode);
@@ -226,7 +256,7 @@ export function cartouchifyVontologyTokensInElement(root, options = {}) {
 
 	for (const textNode of textNodes) {
 		const value = textNode.nodeValue;
-		if (!value || !value.includes('#V#')) {
+		if (!value) {
 			continue;
 		}
 
@@ -234,7 +264,12 @@ export function cartouchifyVontologyTokensInElement(root, options = {}) {
 			continue;
 		}
 
-		const frag = createCartoucheFragment(value);
+		const normalised = normaliseVontologyTokensForDisplay(value);
+		if (!normalised.includes('#V#')) {
+			continue;
+		}
+
+		const frag = createCartoucheFragment(normalised);
 		try {
 			textNode.parentNode.insertBefore(frag, textNode);
 			textNode.parentNode.removeChild(textNode);

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -3076,6 +3076,25 @@ footer {
     white-space: nowrap;
 }
 
+/* Chat header render-mode badge (Rendered/Text) */
+.chat-render-mode-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 6px;
+    border-radius: 999px;
+    font-size: 0.78em;
+    background: #f3f4f6;
+    border: 1px solid #e5e7eb;
+    color: #374151;
+    white-space: nowrap;
+}
+
+.chat-render-mode-badge.rendered {
+    background: #ecfdf5;
+    border-color: #a7f3d0;
+    color: #065f46;
+}
+
 .prompt-input-overlay-inner {
     white-space: pre-wrap;
     word-break: break-word;
@@ -3093,6 +3112,7 @@ footer {
     color: #0f172a;
     font-size: 13px;
     line-height: 1.2;
+    font-weight: 400;
     cursor: pointer;
     white-space: nowrap;
     text-decoration: none !important;
@@ -5179,6 +5199,9 @@ body.settings-body {
 .markdown-rendered {
     line-height: 1.6;
     color: #374151;
+    /* Prevent parent containers (e.g. system messages) from centring/bolding markdown blocks */
+    text-align: left;
+    font-weight: 400;
 }
 
 /* Chat transcript markdown: keep hierarchy readable without huge headings */
@@ -5308,7 +5331,9 @@ body.settings-body {
 }
 
 .markdown-rendered li {
+    display: list-item;
     margin: 0.25em 0;
+    text-align: left;
 }
 
 .markdown-rendered ul {

--- a/tests/backend/test_render_markdown_routes.py
+++ b/tests/backend/test_render_markdown_routes.py
@@ -162,3 +162,56 @@ def test_render_markdown_renders_nested_lists(app_client):
         li.get_text(" ", strip=True) for li in nested_ul.find_all("li", recursive=False)
     ]
     assert nested_items == ["a", "b", "c"]
+
+
+def test_render_markdown_renders_list_after_paragraph_without_blank_line(app_client):
+    _, client = app_client
+
+    markdown = """5) How to represent this in the ontology (pragmatic approach)
+- Create the new types once:
+  - #V#disambiguation_input_profile (type)
+  - #V#disambiguation_result (type)
+"""
+
+    resp = client.post("/von/api/render_markdown", json={"text": markdown})
+    assert resp.status_code == 200
+
+    html = resp.get_json()["html"]
+    soup = BeautifulSoup(html, "html.parser")
+
+    uls = soup.find_all("ul")
+    assert uls, "Expected at least one <ul> to be rendered"
+
+    # Ensure the first list item is present.
+    list_text = soup.get_text(" ", strip=True)
+    assert "Create the new types once:" in list_text
+
+
+def test_render_markdown_does_not_parse_vontology_ids_as_headings(app_client):
+    _, client = app_client
+
+    # Python-Markdown accepts headings without requiring a space after '#'. A list
+    # item like "- #V#foo" can therefore be misparsed as a heading (<h1>) inside
+    # a <li>.
+    markdown = """- Types (class-level concepts)
+  - #V#disambiguation_workflow (type) — already exists; can be the generic workflow backbone.
+  - #V#disambiguation_input_profile (type) — represents the input knowledge state used to drive a disambiguation instance.
+
+> #V#disambiguation_result (type) — quoted example should also not become a heading.
+"""
+
+    resp = client.post("/von/api/render_markdown", json={"text": markdown})
+    assert resp.status_code == 200
+
+    html = resp.get_json()["html"]
+    soup = BeautifulSoup(html, "html.parser")
+
+    assert soup.find("h1") is None
+
+    text = soup.get_text(" ", strip=True)
+    assert "#V#disambiguation_workflow" in text
+    assert "#V#disambiguation_input_profile" in text
+    assert "#V#disambiguation_result" in text
+
+    # Ensure the normaliser does not leak markdown escape backslashes into HTML.
+    assert "\\#V#" not in html

--- a/tests/frontend/chatTabMarkdownRender.test.js
+++ b/tests/frontend/chatTabMarkdownRender.test.js
@@ -125,6 +125,15 @@ describe('chat markdown rendering (assistant)', () => {
         const assistantMarkdown = scrollableField.querySelector('.chat-markdown.markdown-rendered');
         expect(assistantMarkdown).not.toBeNull();
 
+        const assistantHeader = assistantMarkdown.closest('.message-container')?.querySelector('div');
+        const renderBadge = assistantHeader?.querySelector('.chat-render-mode-badge');
+        expect(renderBadge).toBeTruthy();
+        expect(renderBadge.textContent).toContain('View: Rendered');
+
+        // Chat transcript should not inherit centring/boldness from surrounding containers.
+        expect(assistantMarkdown.style.textAlign).toBe('left');
+        expect(assistantMarkdown.style.fontWeight).toBe('400');
+
         expect(assistantMarkdown.querySelector('h1')).not.toBeNull();
         expect(assistantMarkdown.querySelector('ul')).not.toBeNull();
         expect(assistantMarkdown.textContent).toContain('Title');
@@ -236,10 +245,92 @@ describe('chat markdown rendering (assistant)', () => {
 
         const userMarkdown = userContainer.querySelector('.chat-markdown.markdown-rendered');
         expect(userMarkdown).not.toBeNull();
+
+        // Chat transcript should not inherit centring/boldness from surrounding containers.
+        expect(userMarkdown.style.textAlign).toBe('left');
+        expect(userMarkdown.style.fontWeight).toBe('400');
         expect(userMarkdown.querySelector('h1')).not.toBeNull();
         expect(userMarkdown.textContent).toContain('Title');
 
         const cartouche = userMarkdown.querySelector('.vontology-cartouche[data-full-concept-id="#V#person"]');
         expect(cartouche).not.toBeNull();
+    });
+
+    test('recovers when rendered HTML drops leading # (V#person) and still avoids code blocks', async () => {
+        const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        getUserContext.mockReturnValue({
+            user_id: 'user',
+            org_id: 'org',
+            language: 'en-NZ',
+            gmail_profile: null
+        });
+
+        const promptInput = document.getElementById('promptInput');
+        promptInput.value = 'test prompt';
+
+        const assistantHtml = [
+            '<ul><li>State A<ul><li>V#person</li></ul></li></ul>',
+            '<pre><code>V#person</code></pre>'
+        ].join('\n');
+
+        global.fetch = jest.fn((url) => {
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ history_length: 0, authenticated: true })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/vontology/api/vontology/node_content')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ display_name: 'Person', kind: 'type' })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/api/render_markdown')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ html: assistantHtml })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/api/search')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ results: [{ id: '#V#person', name: 'Person', kind: 'type' }] })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/generate')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ response: 'ok', llm_debug: { model: 'gpt-5.2' } })
+                });
+            }
+
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        await sendMessage();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        const scrollableField = document.getElementById('scrollableField');
+        const assistantMarkdown = scrollableField.querySelector('.chat-markdown.markdown-rendered');
+        expect(assistantMarkdown).not.toBeNull();
+
+        // The list item should become a cartouche even though input was V#person.
+        const cartouche = assistantMarkdown.querySelector('.vontology-cartouche[data-full-concept-id="#V#person"]');
+        expect(cartouche).not.toBeNull();
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(cartouche.textContent).toContain('Person');
+        expect(cartouche.textContent).toContain('#V#person');
+
+        // But V#person inside code must not be cartouchified.
+        const codeBlock = assistantMarkdown.querySelector('pre');
+        expect(codeBlock).not.toBeNull();
+        expect(codeBlock.querySelector('.vontology-cartouche')).toBeNull();
+        expect(codeBlock.textContent).toContain('V#person');
     });
 });

--- a/tests/frontend/markdownUtils.test.js
+++ b/tests/frontend/markdownUtils.test.js
@@ -1,8 +1,18 @@
 /** @jest-environment jsdom */
 
-const { simpleMarkdownToHtml } = require('../../src/frontend/web/von_interface/static/js/markdownUtils.js');
+const { detectMarkdown, simpleMarkdownToHtml } = require('../../src/frontend/web/von_interface/static/js/markdownUtils.js');
 
 describe('markdownUtils', () => {
+    test('detectMarkdown recognises indented list markers', () => {
+        const input = [
+            '5) Section',
+            '  - Item A',
+            '    - Item B'
+        ].join('\n');
+
+        expect(detectMarkdown(input)).toBe(true);
+    });
+
     test('removes orphan bullet-only line before fenced code block', () => {
         const input = [
             'Once you confirm, I will immediately perform:',


### PR DESCRIPTION
Fixes Python-Markdown parsing of #V# concept IDs as headings (including inside list items/quotes) and adds regression coverage.

Tests:
- pdm run pytest -q tests/backend/test_render_markdown_routes.py
- npm run test:frontend