### PR TITLE
JVNAUTOSCI-819: Cartouche + search UX polish

### DIFF
--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -636,12 +636,27 @@ def get_node_content_route():
         return jsonify({"error": "Missing 'identifier' parameter."}), 400
     try:
         data = get_vontology_node_content(identifier)
+
+        # Heuristic: strip trailing punctuation accidentally attached to #V# identifiers.
+        # This reduces noisy 404s when IDs appear at sentence boundaries (e.g. "#V#foo.").
+        if (
+            isinstance(identifier, str)
+            and identifier.startswith("#V#")
+            and "error" in data
+        ):
+            stripped = identifier.rstrip(".,:;!?)]}…")
+            if stripped != identifier and stripped.startswith("#V#"):
+                retry = get_vontology_node_content(stripped)
+                if "error" not in retry:
+                    data = retry
         if raw_only:
             # Provide a trimmed payload emphasizing raw_doc. Keep concept_id and display_name for context.
             # Avoid leaking rendered HTML/derived md_content when raw_only requested.
             trimmed = {
                 "concept_id": data.get("concept_id"),
                 "display_name": data.get("display_name"),
+                "kind": data.get("kind"),
+                "computed_kind": data.get("computed_kind"),
                 "raw_doc": data.get("raw_doc"),
             }
             # Preserve description only if it exists inside preserved_fields but not elsewhere

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -106,7 +106,7 @@ async function renderChatMarkdownIntoContainer(container, text) {
     }
 
     // Preserve clickable #V# tokens, but never inside code blocks.
-    cartouchifyVontologyTokensInElement(container, { skipSelectors: ['pre', 'code', 'a'] });
+    cartouchifyVontologyTokensInElement(container, { skipSelectors: ['pre', 'code', 'a'], allowStandaloneCodeTokens: true });
     hydrateChatConceptCartouches(container);
 }
 
@@ -145,7 +145,7 @@ function setVonMessageRenderMode(messageTextEl, mode, originalText, debugData) {
     const cachedHtml = messageTextEl?.dataset?.renderedHtml;
     if (cachedHtml) {
         messageTextEl.innerHTML = cachedHtml;
-        cartouchifyVontologyTokensInElement(messageTextEl, { skipSelectors: ['pre', 'code', 'a'] });
+        cartouchifyVontologyTokensInElement(messageTextEl, { skipSelectors: ['pre', 'code', 'a'], allowStandaloneCodeTokens: true });
         hydrateChatConceptCartouches(messageTextEl);
         return;
     }

--- a/src/frontend/web/von_interface/static/js/main.js
+++ b/src/frontend/web/von_interface/static/js/main.js
@@ -3,6 +3,7 @@ import { createOrActivateConceptTab } from './dynamicTabs.js';
 import { getLanguageDisplayName } from './languageConfig.js';
 import './suppressTooltips.js';
 import { activateTab, loadTabData, setupTabNavigation } from './tabNavigation.js';
+import { handleSelectConceptByIdDetail } from './utils/selectConceptByIdHandler.js';
 import { isVontologyBusy, loadKeyConceptsForUser, preloadVontologyData, selectVontologyNodeByIdentifier, setupVontologySearchUI } from './vontology.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -50,22 +51,13 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Global handler: clicking a Vontology token navigates to concept and selects node
   document.addEventListener('von:selectConceptById', (e) => {
-    const conceptId = e?.detail?.conceptId;
-    const createConceptTab = !!e?.detail?.createConceptTab;
-    if (!conceptId) return;
     try {
-      const normalizedId = conceptId.startsWith('#V#') ? conceptId : `#V#${conceptId}`;
-      if (createConceptTab) {
-        // When createConceptTab is true, create the concept tab but keep the user on the current tab.
-        // (Open in the background; do not switch focus.)
-        createOrActivateConceptTab(normalizedId, normalizedId, false);
-      } else {
-        // Original behaviour: switch to Vontology tab and select node
-        activateTab('vontologyTab');
-        setTimeout(() => {
-          selectVontologyNodeByIdentifier(normalizedId, createConceptTab);
-        }, 0);
-      }
+      // Async handler (do not block UI thread).
+      void handleSelectConceptByIdDetail(e?.detail, {
+        createOrActivateConceptTab,
+        activateTab,
+        selectVontologyNodeByIdentifier
+      });
     } catch (err) {
       console.warn('Failed to handle von:selectConceptById:', err);
     }

--- a/src/frontend/web/von_interface/static/js/settingsPage.js
+++ b/src/frontend/web/von_interface/static/js/settingsPage.js
@@ -22,6 +22,7 @@ const LS_GMAIL_PROFILE = 'von_gmail_profile';
 const RUNTIME_REFRESH_MS = 12000;
 
 let runtimeIntervalId = null;
+let runtimeAbortController = null;
 
 function formatUptime(ms) {
   const totalSec = Math.floor(ms / 1000);
@@ -115,7 +116,9 @@ async function loadRuntimeStatus(manualRefresh = false) {
   }
 
   try {
+    try { runtimeAbortController?.abort(); } catch { }
     const controller = new AbortController();
+    runtimeAbortController = controller;
     const timeout = setTimeout(() => controller.abort(), 8000);
     const res = await fetch('/health', { cache: 'no-store', signal: controller.signal });
     clearTimeout(timeout);
@@ -139,6 +142,10 @@ async function loadRuntimeStatus(manualRefresh = false) {
 
     await loadRagStatus(ragPending);
   } catch (err) {
+    if (err && err.name === 'AbortError') {
+      // Expected when a newer poll supersedes an older one or the page is unloading.
+      return;
+    }
     console.warn('Failed to load runtime status', err);
     if (localEl) localEl.textContent = '—';
     if (publicEl) publicEl.textContent = '—';
@@ -168,6 +175,16 @@ function setupRuntimeSection() {
     runtimeIntervalId = setInterval(loadRuntimeStatus, RUNTIME_REFRESH_MS);
   }
 }
+
+window.addEventListener('beforeunload', () => {
+  try {
+    if (runtimeIntervalId) {
+      clearInterval(runtimeIntervalId);
+      runtimeIntervalId = null;
+    }
+  } catch { }
+  try { runtimeAbortController?.abort(); } catch { }
+});
 
 function getStoredJson(key) {
   try { return JSON.parse(localStorage.getItem(key) || 'null'); } catch { return null; }

--- a/src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js
+++ b/src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js
@@ -1,0 +1,406 @@
+import { showToast } from './toast.js';
+
+export function normaliseVontologyId(value) {
+    const raw = (value || '').toString().trim();
+    if (!raw) return '';
+
+    // Normalise prefix.
+    let id = raw.startsWith('#V#') ? raw : `#V#${raw}`;
+
+    // Heuristic: strip common sentence-ending punctuation accidentally attached to concept IDs.
+    // This fixes cases like "#V#llm_workflow." or "#V#ai_agent_workflow:".
+    // We only strip from the end; periods inside IDs (e.g. initials) are preserved.
+    const trailingJunk = new Set(['.', ',', ':', ';', '!', '?', ')', ']', '}', '…']);
+    while (id.length > 3 && trailingJunk.has(id[id.length - 1])) {
+        id = id.slice(0, -1);
+    }
+
+    return id;
+}
+
+function deriveNameFromConceptId(conceptId) {
+    return (conceptId || '').toString().replace(/^#V#/, '');
+}
+
+function normaliseKind(kind) {
+    const k = (kind || '').toString().toLowerCase().trim();
+    if (k === 'instance') return 'individual';
+    if (k === 'individual' || k === 'type' || k === 'predicate') return k;
+    return '';
+}
+
+async function conceptExists(conceptId, fetchFn) {
+    const id = normaliseVontologyId(conceptId);
+    if (!id) return false;
+    const url = `/vontology/api/vontology/node_content?identifier=${encodeURIComponent(id)}`;
+    let res;
+    try {
+        res = await fetchFn(url, { method: 'GET', headers: { 'Accept': 'application/json' } });
+    } catch (_) {
+        // Network failures should not be treated as "missing".
+        throw new Error('Failed to check concept existence');
+    }
+    if (res.ok) return true;
+    if (res.status === 404) return false;
+    throw new Error(`Concept existence check failed (HTTP ${res.status})`);
+}
+
+async function createConceptForId(conceptId, options, fetchFn) {
+    const id = normaliseVontologyId(conceptId);
+    if (!id) throw new Error('Concept ID is required');
+
+    const createAsInstance = !!options?.createAsInstance;
+    const parentId = normaliseVontologyId(options?.parentId || '#V#thing');
+    const name = deriveNameFromConceptId(id);
+
+    const payload = {
+        new_concept_name: name,
+        parent_id: parentId,
+        create_as_instance: createAsInstance
+    };
+
+    const res = await fetchFn('/vontology/api/vontology/create_concept', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+        body: JSON.stringify(payload)
+    });
+
+    // Idempotency: treat conflicts as success (another click/window created it).
+    if (res.status === 409) {
+        return id;
+    }
+
+    const text = await res.text();
+    if (!res.ok) {
+        throw new Error(`Create concept failed (HTTP ${res.status}): ${text.slice(0, 240)}`);
+    }
+
+    try {
+        const json = JSON.parse(text);
+        return json?.concept_id || json?.concept?.concept_id || id;
+    } catch (_) {
+        return id;
+    }
+}
+
+function defaultCreateOptionsFromKind(kind) {
+    const k = normaliseKind(kind);
+    return {
+        createAsInstance: k === 'individual',
+        parentId: k === 'predicate' ? '#V#predicate' : '#V#thing'
+    };
+}
+
+function kindLabel(kind) {
+    const k = normaliseKind(kind);
+    if (k === 'individual') return 'individual';
+    if (k === 'predicate') return 'predicate';
+    return 'type';
+}
+
+function formatKindLabel(kind) {
+    const k = normaliseKind(kind);
+    if (k === 'predicate') return 'Predicate';
+    if (k === 'individual') return 'Individual';
+    return 'Type';
+}
+
+function normaliseKindClass(kind) {
+    const k = normaliseKind(kind);
+    if (k === 'type' || k === 'predicate' || k === 'individual') return k;
+    return 'type';
+}
+
+async function fetchConceptMetadata(conceptId, fetchFn) {
+    const id = normaliseVontologyId(conceptId);
+    if (!id) return null;
+
+    const url = `/vontology/api/vontology/node_content?identifier=${encodeURIComponent(id)}&raw_only=1`;
+    let res;
+    try {
+        res = await fetchFn(url, { method: 'GET', headers: { 'Accept': 'application/json' } });
+    } catch (_) {
+        return null;
+    }
+
+    if (!res.ok) return null;
+
+    try {
+        const json = await res.json();
+        return {
+            displayName: json?.display_name || null,
+            kind: json?.kind || json?.computed_kind || null
+        };
+    } catch (_) {
+        return null;
+    }
+}
+
+function updateCartouchesForConcept(conceptId, metadata) {
+    const id = normaliseVontologyId(conceptId);
+    if (!id || !metadata) return;
+
+    const cartouches = Array.from(document.querySelectorAll('.vontology-cartouche'));
+    for (const el of cartouches) {
+        try {
+            if (el?.dataset?.fullConceptId !== id) continue;
+
+            const displayName = metadata.displayName || deriveNameFromConceptId(id);
+            const nameEl = el.querySelector('.vontology-cartouche-name');
+            if (nameEl) nameEl.textContent = displayName;
+
+            const kind = metadata.kind || '';
+            const kindEl = el.querySelector('.vontology-cartouche-kind');
+            if (kindEl) {
+                const kindClass = normaliseKindClass(kind);
+                kindEl.className = `vontology-cartouche-kind ${kindClass}`;
+                kindEl.textContent = formatKindLabel(kind);
+            }
+            el.dataset.kind = kind;
+        } catch (_) {
+            // Ignore per-cartouche update failures.
+        }
+    }
+}
+
+function _createModalElement() {
+    const modal = document.createElement('div');
+    modal.className = 'modal';
+    modal.setAttribute('aria-hidden', 'true');
+    modal.setAttribute('role', 'dialog');
+
+    const content = document.createElement('div');
+    content.className = 'modal-content';
+    modal.appendChild(content);
+
+    return { modal, content };
+}
+
+function _defaultParentForCreateKind(kind) {
+    const k = normaliseKind(kind);
+    return k === 'predicate' ? '#V#predicate' : '#V#thing';
+}
+
+/**
+ * Option B: show a small modal to choose kind (type/individual/predicate) and optional parent.
+ * Exported for testing.
+ */
+export function openCreateConceptModal(conceptId, initialKind) {
+    const id = normaliseVontologyId(conceptId);
+    const k0 = normaliseKind(initialKind) || 'type';
+
+    if (!id) return Promise.resolve(null);
+
+    return new Promise((resolve) => {
+        const { modal, content } = _createModalElement();
+
+        const titleId = `createConceptTitle_${Math.random().toString(16).slice(2)}`;
+        modal.setAttribute('aria-labelledby', titleId);
+
+        const h2 = document.createElement('h2');
+        h2.id = titleId;
+        h2.textContent = 'Create missing concept';
+
+        const intro = document.createElement('p');
+        intro.textContent = `Create ${id} in the Vontology.`;
+
+        const form = document.createElement('div');
+        form.className = 'create-concept-modal-form';
+
+        const kindRow = document.createElement('div');
+        kindRow.className = 'create-concept-modal-row';
+        const kindLabelEl = document.createElement('label');
+        kindLabelEl.textContent = 'Kind:';
+        kindLabelEl.htmlFor = `${titleId}_kind`;
+        const kindSelect = document.createElement('select');
+        kindSelect.id = `${titleId}_kind`;
+        kindSelect.innerHTML = [
+            '<option value="type">Type</option>',
+            '<option value="individual">Individual</option>',
+            '<option value="predicate">Predicate</option>'
+        ].join('');
+        kindSelect.value = k0;
+        kindRow.appendChild(kindLabelEl);
+        kindRow.appendChild(kindSelect);
+
+        const parentRow = document.createElement('div');
+        parentRow.className = 'create-concept-modal-row';
+        const parentLabelEl = document.createElement('label');
+        parentLabelEl.textContent = 'Parent (optional):';
+        parentLabelEl.htmlFor = `${titleId}_parent`;
+        const parentInput = document.createElement('input');
+        parentInput.id = `${titleId}_parent`;
+        parentInput.type = 'text';
+        parentInput.placeholder = _defaultParentForCreateKind(k0);
+        parentInput.autocomplete = 'off';
+        parentRow.appendChild(parentLabelEl);
+        parentRow.appendChild(parentInput);
+
+        const hint = document.createElement('p');
+        hint.className = 'create-concept-modal-hint';
+        hint.textContent = 'Leave parent blank to use the default.';
+
+        form.appendChild(kindRow);
+        form.appendChild(parentRow);
+        form.appendChild(hint);
+
+        const actions = document.createElement('div');
+        actions.className = 'modal-actions';
+        const cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
+        cancelBtn.textContent = 'Cancel';
+        const createBtn = document.createElement('button');
+        createBtn.type = 'button';
+        createBtn.textContent = 'Create';
+        actions.appendChild(cancelBtn);
+        actions.appendChild(createBtn);
+
+        content.appendChild(h2);
+        content.appendChild(intro);
+        content.appendChild(form);
+        content.appendChild(actions);
+
+        function cleanup(result) {
+            try {
+                modal.classList.remove('open');
+                modal.setAttribute('aria-hidden', 'true');
+                modal.remove();
+            } catch (_) { }
+            resolve(result);
+        }
+
+        function computeResult() {
+            const k = normaliseKind(kindSelect.value) || 'type';
+            const parentRaw = (parentInput.value || '').toString().trim();
+            const parentId = normaliseVontologyId(parentRaw || _defaultParentForCreateKind(k));
+            if (!parentId) {
+                showToast('Parent concept ID is invalid.', 'error');
+                return null;
+            }
+            return {
+                createAsInstance: k === 'individual' || k === 'predicate',
+                parentId,
+                kind: k
+            };
+        }
+
+        kindSelect.addEventListener('change', () => {
+            parentInput.placeholder = _defaultParentForCreateKind(kindSelect.value);
+        });
+
+        createBtn.addEventListener('click', () => {
+            const result = computeResult();
+            if (!result) return;
+            cleanup(result);
+        });
+        cancelBtn.addEventListener('click', () => cleanup(null));
+
+        modal.addEventListener('click', (e) => {
+            // Backdrop click closes.
+            if (e.target === modal) cleanup(null);
+        });
+        modal.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                cleanup(null);
+            }
+        });
+
+        document.body.appendChild(modal);
+        modal.classList.add('open');
+        modal.setAttribute('aria-hidden', 'false');
+        // Keep the header visible even if focus triggers scroll.
+        try { content.scrollTop = 0; } catch (_) { }
+
+        // Focus kind selector for quick keyboard interaction, but avoid scrolling.
+        try {
+            if (typeof kindSelect.focus === 'function') {
+                kindSelect.focus({ preventScroll: true });
+            }
+        } catch (_) {
+            try { kindSelect.focus(); } catch (_) { }
+        }
+
+        try { content.scrollTop = 0; } catch (_) { }
+    });
+}
+
+function deriveKindFromCreateOptions(createOpts, fallbackKind) {
+    const explicit = normaliseKind(createOpts?.kind);
+    if (explicit) return explicit;
+
+    const k = normaliseKind(fallbackKind);
+
+    const parentId = normaliseVontologyId(createOpts?.parentId);
+    if (createOpts?.createAsInstance && parentId === '#V#predicate') return 'predicate';
+    if (createOpts?.createAsInstance) return 'individual';
+    if (k) return k;
+    return 'type';
+}
+
+/**
+ * Handles the global 'von:selectConceptById' event detail payload.
+ *
+ * Deps must provide:
+ * - createOrActivateConceptTab(conceptId, displayName, activate)
+ * - activateTab(tabId)
+ * - selectVontologyNodeByIdentifier(conceptId, createConceptTab)
+ * Optional:
+ * - fetchFn (default window.fetch)
+ * - confirmFn/promptFn (default window.confirm/prompt)
+ */
+export async function handleSelectConceptByIdDetail(detail, deps) {
+    const conceptIdRaw = detail?.conceptId;
+    const createConceptTab = !!detail?.createConceptTab;
+    const kind = detail?.kind || null;
+    const modifierKeys = detail?.modifierKeys || {};
+
+    const id = normaliseVontologyId(conceptIdRaw);
+    if (!id) return;
+
+    const fetchFn = deps?.fetchFn || fetch;
+
+    if (!createConceptTab) {
+        deps.activateTab('vontologyTab');
+        setTimeout(() => {
+            deps.selectVontologyNodeByIdentifier(id, createConceptTab);
+        }, 0);
+        return;
+    }
+
+    let exists = false;
+    try {
+        exists = await conceptExists(id, fetchFn);
+    } catch (err) {
+        console.warn('[selectConceptById] existence check failed', err);
+        // Fall back to existing behaviour: open tab anyway.
+        deps.createOrActivateConceptTab(id, id, false);
+        return;
+    }
+
+    if (exists) {
+        const metadata = await fetchConceptMetadata(id, fetchFn);
+        updateCartouchesForConcept(id, metadata);
+        deps.createOrActivateConceptTab(id, metadata?.displayName || id, false);
+        return;
+    }
+
+    const chooseCreateOptionsFn = deps?.chooseCreateOptionsFn;
+    const createOpts = chooseCreateOptionsFn
+        ? await chooseCreateOptionsFn({ conceptId: id, kind, modifierKeys })
+        : await openCreateConceptModal(id, kind);
+    if (!createOpts) return;
+
+    try {
+        const chosenKind = deriveKindFromCreateOptions(createOpts, kind);
+        showToast(`Creating ${kindLabel(chosenKind)}…`, 'info');
+        await createConceptForId(id, createOpts, fetchFn);
+        const metadata = await fetchConceptMetadata(id, fetchFn);
+        updateCartouchesForConcept(id, metadata);
+        deps.createOrActivateConceptTab(id, metadata?.displayName || id, false);
+        showToast('Concept created.', 'info');
+    } catch (err) {
+        console.warn('[selectConceptById] create failed', err);
+        showToast(`Failed to create concept: ${(err && err.message) ? err.message : 'Unknown error'}`, 'error');
+    }
+}

--- a/src/frontend/web/von_interface/static/js/utils/textDecorator.js
+++ b/src/frontend/web/von_interface/static/js/utils/textDecorator.js
@@ -83,6 +83,134 @@ function normaliseKindClass(kind) {
 	return 'type';
 }
 
+let cartoucheContextMenu = null;
+let lastCartoucheContextMenuTriggerEl = null;
+let lastCartoucheContextMenuOpenAt = 0;
+
+async function copyToClipboard(text) {
+	const value = String(text ?? '');
+	if (!value) return;
+
+	// Prefer async Clipboard API.
+	try {
+		if (navigator?.clipboard?.writeText) {
+			await navigator.clipboard.writeText(value);
+			return;
+		}
+	} catch (_) {
+		// Fall through to legacy approach.
+	}
+
+	// Legacy fallback.
+	const textarea = document.createElement('textarea');
+	textarea.value = value;
+	textarea.setAttribute('readonly', '');
+	textarea.style.position = 'fixed';
+	textarea.style.left = '-9999px';
+	textarea.style.top = '-9999px';
+	document.body.appendChild(textarea);
+	textarea.focus();
+	textarea.select();
+	try {
+		document.execCommand('copy');
+	} finally {
+		try { textarea.remove(); } catch (_) { }
+	}
+}
+
+function hideCartoucheContextMenu() {
+	if (cartoucheContextMenu) {
+		cartoucheContextMenu.style.display = 'none';
+		cartoucheContextMenu.innerHTML = '';
+	}
+}
+
+function openCartoucheContextMenu(evt, triggerEl, fullConceptId) {
+	if (!cartoucheContextMenu) {
+		cartoucheContextMenu = document.createElement('div');
+		cartoucheContextMenu.className = 'cartouche-context-menu';
+		cartoucheContextMenu.style.position = 'fixed';
+		cartoucheContextMenu.style.zIndex = '10000';
+		cartoucheContextMenu.style.minWidth = '160px';
+		cartoucheContextMenu.style.background = '#ffffff';
+		cartoucheContextMenu.style.border = '1px solid #d1d5db';
+		cartoucheContextMenu.style.borderRadius = '6px';
+		cartoucheContextMenu.style.boxShadow = '0 4px 12px rgba(0,0,0,0.15)';
+		cartoucheContextMenu.style.padding = '4px 0';
+		cartoucheContextMenu.style.fontSize = '14px';
+		cartoucheContextMenu.setAttribute('role', 'menu');
+		cartoucheContextMenu.setAttribute('aria-label', 'Concept actions');
+		document.body.appendChild(cartoucheContextMenu);
+
+		// Global dismissal handlers.
+		document.addEventListener('click', (e) => {
+			try {
+				// Ignore the synthetic (or immediate) click that may follow a contextmenu invocation.
+				if (lastCartoucheContextMenuTriggerEl && e.target === lastCartoucheContextMenuTriggerEl) {
+					if (Date.now() - lastCartoucheContextMenuOpenAt < 60) {
+						return;
+					}
+				}
+				if (cartoucheContextMenu && !cartoucheContextMenu.contains(e.target)) hideCartoucheContextMenu();
+			} catch (_) { /* no-op */ }
+		});
+		document.addEventListener('keydown', (e) => {
+			if (e.key === 'Escape') hideCartoucheContextMenu();
+		});
+		window.addEventListener('blur', hideCartoucheContextMenu);
+	}
+
+	// If the document was reset (e.g., in tests) and the element was removed, re-attach it.
+	if (cartoucheContextMenu && !document.body.contains(cartoucheContextMenu)) {
+		document.body.appendChild(cartoucheContextMenu);
+	}
+
+	lastCartoucheContextMenuTriggerEl = triggerEl;
+	lastCartoucheContextMenuOpenAt = Date.now();
+
+	// Build menu items.
+	cartoucheContextMenu.innerHTML = '';
+
+	const item = document.createElement('button');
+	item.type = 'button';
+	item.className = 'cartouche-context-menu-item';
+	item.setAttribute('role', 'menuitem');
+	item.textContent = 'Copy concept ID';
+	item.style.width = '100%';
+	item.style.textAlign = 'left';
+	item.style.padding = '8px 12px';
+	item.style.background = 'transparent';
+	item.style.border = 'none';
+	item.style.cursor = 'pointer';
+	item.style.color = '#1f2937';
+	item.addEventListener('click', async () => {
+		try {
+			await copyToClipboard(fullConceptId);
+		} finally {
+			hideCartoucheContextMenu();
+		}
+	});
+
+	cartoucheContextMenu.appendChild(item);
+
+	// Position.
+	const x = evt.clientX;
+	const y = evt.clientY;
+	cartoucheContextMenu.style.left = x + 'px';
+	cartoucheContextMenu.style.top = y + 'px';
+	requestAnimationFrame(() => {
+		const rect = cartoucheContextMenu.getBoundingClientRect();
+		let nx = rect.left, ny = rect.top;
+		const vw = window.innerWidth, vh = window.innerHeight;
+		if (rect.right > vw) nx = Math.max(4, vw - rect.width - 4);
+		if (rect.bottom > vh) ny = Math.max(4, vh - rect.height - 4);
+		cartoucheContextMenu.style.left = nx + 'px';
+		cartoucheContextMenu.style.top = ny + 'px';
+	});
+
+	cartoucheContextMenu.style.display = 'block';
+}
+
 export function createVontologyCartouche(conceptId, opts = {}) {
 	const idRaw = (conceptId || '').toString();
 	const fullId = idRaw.startsWith('#V#') ? idRaw : `#V#${idRaw}`;
@@ -107,6 +235,7 @@ export function createVontologyCartouche(conceptId, opts = {}) {
 	const kindClass = normaliseKindClass(opts.kind);
 	kind.className = `vontology-cartouche-kind ${kindClass}`;
 	kind.textContent = opts.kind ? formatKindLabel(opts.kind) : '…';
+	btn.dataset.kind = (opts.kind || '').toString();
 
 	btn.appendChild(name);
 	btn.appendChild(id);
@@ -119,8 +248,28 @@ export function createVontologyCartouche(conceptId, opts = {}) {
 		if (!raw) return;
 		btn.dispatchEvent(new CustomEvent('von:selectConceptById', {
 			bubbles: true,
-			detail: { conceptId: raw, createConceptTab: true }
+			detail: {
+				conceptId: raw,
+				createConceptTab: true,
+				kind: btn.dataset.kind || null,
+				modifierKeys: {
+					shiftKey: !!e.shiftKey,
+					altKey: !!e.altKey,
+					ctrlKey: !!e.ctrlKey,
+					metaKey: !!e.metaKey
+				}
+			}
 		}));
+	});
+
+	btn.addEventListener('contextmenu', (e) => {
+		try {
+			e.preventDefault();
+			e.stopPropagation();
+			openCartoucheContextMenu(e, btn, fullId);
+		} catch (err) {
+			console.warn('[textDecorator] cartouche context menu failed', err);
+		}
 	});
 
 	return btn;

--- a/src/frontend/web/von_interface/static/js/utils/textDecorator.js
+++ b/src/frontend/web/von_interface/static/js/utils/textDecorator.js
@@ -332,6 +332,40 @@ function normaliseVontologyTokensForDisplay(text) {
 	return output;
 }
 
+function extractStandaloneVontologyToken(text) {
+	const normalised = normaliseVontologyTokensForDisplay(String(text ?? '')).trim();
+	if (!normalised) return null;
+	const m = normalised.match(/^#V#([A-Za-z0-9_\./:–\-]+)$/);
+	return m ? m[1] : null;
+}
+
+function cartouchifyStandaloneVontologyCodeSpans(root, options = {}) {
+	if (!root || !root.querySelectorAll) return;
+
+	const codeNodes = Array.from(root.querySelectorAll('code'));
+	for (const codeEl of codeNodes) {
+		try {
+			// Never replace code blocks.
+			if (codeEl.closest('pre')) continue;
+			// Avoid nesting inside links and existing cartouches.
+			if (codeEl.closest('a')) continue;
+			if (codeEl.closest('.vontology-cartouche')) continue;
+
+			// Only when the code span is purely text.
+			if (codeEl.childElementCount !== 0) continue;
+
+			const token = extractStandaloneVontologyToken(codeEl.textContent);
+			if (!token) continue;
+
+			const cartouche = createVontologyCartouche(`#V#${token}`, { variant: 'inline-code' });
+			cartouche.classList.add('vontology-cartouche-inline-code');
+			codeEl.replaceWith(cartouche);
+		} catch (_) {
+			// Ignore detached nodes or DOM mutation races.
+		}
+	}
+}
+
 /**
  * Traverse existing DOM content and replace raw #V# tokens in text nodes with
  * clickable anchors. This is useful after Markdown rendering.
@@ -425,6 +459,10 @@ export function cartouchifyVontologyTokensInElement(root, options = {}) {
 		} catch (_) {
 			// If the node was detached mid-iteration, ignore.
 		}
+	}
+
+	if (options && options.allowStandaloneCodeTokens) {
+		cartouchifyStandaloneVontologyCodeSpans(root, options);
 	}
 }
 

--- a/src/frontend/web/von_interface/static/js/utils/toast.js
+++ b/src/frontend/web/von_interface/static/js/utils/toast.js
@@ -1,0 +1,28 @@
+// Lightweight toast helper. Uses existing CSS classes in styles.css (.toast, .toast-info, .toast-error).
+
+export function showToast(message, variant = 'info', opts = {}) {
+    const text = String(message ?? '').trim();
+    if (!text) return;
+
+    const v = (variant || 'info').toString().toLowerCase();
+    const ms = Number.isFinite(opts.durationMs) ? Number(opts.durationMs) : 4000;
+
+    const el = document.createElement('div');
+    el.className = `toast ${v === 'error' ? 'toast-error' : 'toast-info'}`;
+    el.textContent = text;
+
+    try {
+        document.body.appendChild(el);
+    } catch (_) {
+        return;
+    }
+
+    setTimeout(() => {
+        try {
+            el.style.opacity = '0';
+        } catch (_) { /* no-op */ }
+        setTimeout(() => {
+            try { el.remove(); } catch (_) { /* no-op */ }
+        }, 350);
+    }, ms);
+}

--- a/src/frontend/web/von_interface/static/js/vontology.js
+++ b/src/frontend/web/von_interface/static/js/vontology.js
@@ -950,11 +950,11 @@ export async function fetchAndRenderVontologyTree() {
       elements.vontologyTreeContainer.innerHTML = `<p>Error loading Vontology tree: ${treeData.error}</p>`;
     } else if (treeData.tree !== undefined && treeData.tree !== null) {
       debugLog("[fetchAndRenderVontologyTree] treeData.tree structure:", JSON.stringify(treeData.tree, null, 2));
-      
+
       // CHICKEN-AND-EGG FIX: Check if tree is empty array (database is empty)
       if (Array.isArray(treeData.tree) && treeData.tree.length === 0) {
         console.log("[fetchAndRenderVontologyTree] Tree is empty - auto-creating Thing root concept");
-        
+
         // Show loading message
         elements.vontologyTreeContainer.innerHTML = `
           <div style="padding: 20px; text-align: center; color: #666;">
@@ -967,19 +967,19 @@ export async function fetchAndRenderVontologyTree() {
             </div>
           </div>
         `;
-        
+
         // Auto-create Thing
         try {
           const response = await fetch('/vontology/api/vontology/ensure_thing', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
           });
-          
+
           const result = await response.json();
-          
+
           if (result.success) {
             console.log(`[fetchAndRenderVontologyTree] Thing auto-created: created=${result.thing_created}, orphans_linked=${result.orphans_linked}`);
-            
+
             // Show success message briefly
             elements.vontologyTreeContainer.innerHTML = `
               <div style="padding: 20px; text-align: center; color: #2b8cff;">
@@ -987,13 +987,13 @@ export async function fetchAndRenderVontologyTree() {
                 <p>Root concept established. Refreshing tree...</p>
               </div>
             `;
-            
+
             // Refresh the tree after a brief delay
             setTimeout(() => {
               console.log("[fetchAndRenderVontologyTree] Refreshing tree after Thing creation");
               handleRefreshTree();
             }, 800);
-            
+
             hideProgressBar();
             return;
           } else {
@@ -1001,7 +1001,7 @@ export async function fetchAndRenderVontologyTree() {
           }
         } catch (error) {
           console.error("[fetchAndRenderVontologyTree] Failed to auto-create Thing:", error);
-          
+
           // Show error with manual fallback
           elements.vontologyTreeContainer.innerHTML = `
             <div style="padding: 20px; text-align: center; color: #666;">
@@ -1010,7 +1010,7 @@ export async function fetchAndRenderVontologyTree() {
               <p>You can create the root concept manually below.</p>
             </div>
           `;
-          
+
           // Enable manual creation mode as fallback
           handleNodeSelect(null, null, null, false, { mutateConceptTab: false });
           hideProgressBar();
@@ -1077,13 +1077,13 @@ export async function fetchAndRenderVontologyTree() {
       } else if (typeof processedTree === 'object' && processedTree !== null) {
         // CHICKEN-AND-EGG FIX: Check for auto-injected Thing placeholder before rendering
         // The backend auto-injects a Thing node even when DB is empty (mongo_id will be "")
-        const isPlaceholderTree = processedTree.id === '#V#thing' && 
-                                 processedTree.mongo_id === '' &&
-                                 (!processedTree.children || processedTree.children.length === 0);
-        
+        const isPlaceholderTree = processedTree.id === '#V#thing' &&
+          processedTree.mongo_id === '' &&
+          (!processedTree.children || processedTree.children.length === 0);
+
         if (isPlaceholderTree) {
           console.log("[fetchAndRenderVontologyTree] Detected auto-injected Thing placeholder - auto-creating real Thing");
-          
+
           // Show loading message
           elements.vontologyTreeContainer.innerHTML = `
             <div style="padding: 20px; text-align: center; color: #666;">
@@ -1096,19 +1096,19 @@ export async function fetchAndRenderVontologyTree() {
               </div>
             </div>
           `;
-          
+
           // Auto-create Thing
           try {
             const response = await fetch('/vontology/api/vontology/ensure_thing', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' }
             });
-            
+
             const result = await response.json();
-            
+
             if (result.success) {
               console.log(`[fetchAndRenderVontologyTree] Thing auto-created from placeholder: created=${result.thing_created}, orphans_linked=${result.orphans_linked}`);
-              
+
               // Show success and refresh
               elements.vontologyTreeContainer.innerHTML = `
                 <div style="padding: 20px; text-align: center; color: #2b8cff;">
@@ -1116,11 +1116,11 @@ export async function fetchAndRenderVontologyTree() {
                   <p>Refreshing tree...</p>
                 </div>
               `;
-              
+
               setTimeout(() => {
                 handleRefreshTree();
               }, 800);
-              
+
               hideProgressBar();
               return;
             } else {
@@ -1128,7 +1128,7 @@ export async function fetchAndRenderVontologyTree() {
             }
           } catch (error) {
             console.error("[fetchAndRenderVontologyTree] Failed to auto-create Thing from placeholder:", error);
-            
+
             // Show error with manual fallback
             elements.vontologyTreeContainer.innerHTML = `
               <div style="padding: 20px; text-align: center; color: #666;">
@@ -1137,13 +1137,13 @@ export async function fetchAndRenderVontologyTree() {
                 <p>Manual creation mode enabled below.</p>
               </div>
             `;
-            
+
             handleNodeSelect(null, null, null, false, { mutateConceptTab: false });
             hideProgressBar();
             return;
           }
         }
-        
+
         // Build subtree counts cache once
         subtreeCountMap = buildSubtreeCountCache([processedTree], entityCounts);
         debugLog("[fetchAndRenderVontologyTree] processedTree is a single object, processing as the root.");
@@ -1207,7 +1207,7 @@ export async function fetchAndRenderVontologyTree() {
           </p>
         </div>
       `;
-      
+
       // Enable empty-tree creation mode by triggering handleNodeSelect with null
       // This will show the creation panel with appropriate messaging
       handleNodeSelect(null, null, null, false, { mutateConceptTab: false });
@@ -3478,62 +3478,79 @@ async function selectSearchItem(item) {
     }
   } catch (_) { /* non-fatal */ }
   clearSearchResults();
-  try {
-    if (item.kind === 'individual') {
-      try {
-        const resp = await fetch(`/vontology/api/vontology/node_content?identifier=${encodeURIComponent(item.id)}`);
-        if (resp.ok) {
-          const nodeData = await resp.json();
-          const candidatesRaw = nodeData?.is_an_instance_of || nodeData?.is_a || [];
-          // Normalize to concept_id strings
-          const candidateIds = [];
-          if (Array.isArray(candidatesRaw)) {
-            for (const c of candidatesRaw) {
-              if (!c) continue;
-              if (typeof c === 'string') candidateIds.push(c);
-              else if (c.concept_id) candidateIds.push(c.concept_id);
-              else if (c.id) candidateIds.push(c.id);
-              else if (c['@id']) candidateIds.push(c['@id']);
-            }
-          }
 
-          if (candidateIds.length) {
-            try {
-              const chosenType = await chooseBestTypeForIndividual(candidateIds);
-              if (chosenType) {
-                // Reveal and select the chosen TYPE in the tree (don't create a concept tab)
-                try { selectVontologyNodeByIdentifier(chosenType, /*createConceptTab*/ false); } catch (_) { }
-              } else {
-                console.debug('[selectSearchItem] No chosen type returned; skipping tree reveal for instance', item.id);
-              }
-            } catch (e) {
-              console.warn('[selectSearchItem] Error choosing best type for individual:', e);
-            }
-          } else {
-            console.debug('[selectSearchItem] No is_an_instance_of candidates found for individual', item.id);
-          }
-        } else {
-          console.debug('[selectSearchItem] node_content lookup failed for', item.id, 'status', resp.status);
-        }
-      } catch (e) {
-        console.warn('[selectSearchItem] Failed to fetch node_content for individual', item.id, e);
-      }
-    } else {
-      if (__vontologyTreeReady) {
-        try { selectVontologyNodeByIdentifier(item.id, false); } catch (_) { }
-      } else {
-        __pendingTreeSelections.push(item.id);
-      }
-    }
-  } catch (err) {
-    console.warn('[selectSearchItem] Error during tree reveal logic:', err);
-  }
+  // Open the concept tab immediately so selection never feels "dead".
+  // Any slower tree-reveal work runs in the background.
   try {
     // Use backend's three-way kind classification directly
-    const evt = new CustomEvent('open-concept-tab', { detail: { conceptId: item.id, conceptName: item.name || item.id, kind: item.kind, activate: false } });
+    const evt = new CustomEvent('open-concept-tab', {
+      detail: {
+        conceptId: item.id,
+        conceptName: item.name || item.id,
+        kind: item.kind,
+        activate: false
+      }
+    });
     document.dispatchEvent(evt);
   } catch (e) {
     console.error('[selectSearchItem] Failed to dispatch open-concept-tab event', e);
+  }
+
+  try {
+    void (async () => {
+      try {
+        if (item.kind === 'individual') {
+          try {
+            const resp = await fetch(`/vontology/api/vontology/node_content?identifier=${encodeURIComponent(item.id)}`);
+            if (resp.ok) {
+              const nodeData = await resp.json();
+              const candidatesRaw = nodeData?.is_an_instance_of || nodeData?.is_a || [];
+              // Normalize to concept_id strings
+              const candidateIds = [];
+              if (Array.isArray(candidatesRaw)) {
+                for (const c of candidatesRaw) {
+                  if (!c) continue;
+                  if (typeof c === 'string') candidateIds.push(c);
+                  else if (c.concept_id) candidateIds.push(c.concept_id);
+                  else if (c.id) candidateIds.push(c.id);
+                  else if (c['@id']) candidateIds.push(c['@id']);
+                }
+              }
+
+              if (candidateIds.length) {
+                try {
+                  const chosenType = await chooseBestTypeForIndividual(candidateIds);
+                  if (chosenType) {
+                    // Reveal and select the chosen TYPE in the tree (don't create a concept tab)
+                    try { selectVontologyNodeByIdentifier(chosenType, /*createConceptTab*/ false); } catch (_) { }
+                  } else {
+                    console.debug('[selectSearchItem] No chosen type returned; skipping tree reveal for instance', item.id);
+                  }
+                } catch (e) {
+                  console.warn('[selectSearchItem] Error choosing best type for individual:', e);
+                }
+              } else {
+                console.debug('[selectSearchItem] No is_an_instance_of candidates found for individual', item.id);
+              }
+            } else {
+              console.debug('[selectSearchItem] node_content lookup failed for', item.id, 'status', resp.status);
+            }
+          } catch (e) {
+            console.warn('[selectSearchItem] Failed to fetch node_content for individual', item.id, e);
+          }
+        } else {
+          if (__vontologyTreeReady) {
+            try { selectVontologyNodeByIdentifier(item.id, false); } catch (_) { }
+          } else {
+            __pendingTreeSelections.push(item.id);
+          }
+        }
+      } catch (bgErr) {
+        console.warn('[selectSearchItem] Error during background tree reveal logic:', bgErr);
+      }
+    })();
+  } catch (err) {
+    console.warn('[selectSearchItem] Error during tree reveal logic:', err);
   }
   finally {
     if (inputEl) {
@@ -3638,7 +3655,7 @@ export async function handleCreateType() {
   // Check if tree is truly empty by looking for any vontology-node-name elements
   const hasExistingNodes = document.querySelector('.vontology-node-name[data-concept-id]') !== null;
   const isRootCreation = !parentId && !hasExistingNodes;
-  
+
   if (!parentId && !isRootCreation) {
     if (elements.createConceptStatusP) {
       elements.createConceptStatusP.textContent = "Please select a parent node first.";
@@ -3669,7 +3686,7 @@ export async function handleCreateType() {
     const createdConceptId = response?.concept_id || response?.concept?.concept_id;
     const createdConceptName = response?.concept?.name || newConceptName;
     const createdMongoId = response?.concept?.mongo_id;
-    
+
     if (isRootCreation) {
       // For root creation, refresh the entire tree to show the new root
       console.log('[handleCreateType] Root concept created, refreshing tree...');
@@ -4188,18 +4205,18 @@ function selectConcept(concept) {
 export async function filterRedundantNodes(tree, entityCounts, forcedVisibleIds = new Set()) {
   /**
    * Filter redundant nodes from the tree while preserving complete ontology paths.
-   * 
+   *
    * MODIFIED (JVNAUTOSCI-748): Fixed issue where intermediate nodes were being filtered out,
    * breaking the hierarchy display. The filter now:
-   * 
+   *
    * 1. PRESERVES all nodes that have children (they're part of valid paths)
    * 2. PRESERVES all leaf nodes (they're valid type concepts even without instances)
    * 3. PRESERVES nodes without entity count data (common for pure types)
    * 4. Only filters legacy nodes (non-#V# prefixed)
-   * 
+   *
    * Previous behavior: Would collapse intermediate nodes with no entities and one child,
    * causing chains like Thing -> AI -> ML -> DL to display as only Thing -> DL.
-   * 
+   *
    * New behavior: Maintains complete hierarchy structure, showing all intermediate
    * concepts regardless of entity counts.
    */
@@ -4274,13 +4291,13 @@ export async function filterRedundantNodes(tree, entityCounts, forcedVisibleIds 
   function isRedundant(node) {
     // MODIFIED: A node is redundant ONLY if it's truly isolated (no children with entities in subtree)
     // We should NOT collapse intermediate nodes that form valid paths in the ontology hierarchy
-    // 
+    //
     // Original logic was too aggressive: it would skip intermediate nodes with no entities and one child
     // This breaks hierarchical paths like: Thing -> AI -> ML -> DL -> Networks -> Transformers
     //
     // NEW RULE: Never consider a node redundant if it has any descendants (directly or indirectly)
     // This preserves the complete ontology structure while still filtering truly empty branches
-    
+
     if (!node.id || !entityCounts[node.id]) {
       return false; // No entity count data, keep the node to be safe
     }
@@ -4339,7 +4356,7 @@ export async function filterRedundantNodes(tree, entityCounts, forcedVisibleIds 
       // MODIFIED: Don't apply redundancy collapsing - preserve the hierarchy
       // The old logic would skip intermediate nodes, breaking the tree structure
       filteredChildren.push(filteredChild);
-      
+
       if ((i + 1) % RENDER_BATCH_SIZE === 0) {
         await yieldThread();
       }
@@ -4359,12 +4376,12 @@ export async function filterRedundantNodes(tree, entityCounts, forcedVisibleIds 
         const node = nodes[i];
         debugLog(`[filterRedundantNodes] Root node ${i}: ${node.name} (${node.id})`);
         const isLeaf = !node.children || node.children.length === 0;
-        
+
         // MODIFIED: If a node has children, it's part of the hierarchy - always keep it
         // Only filter root nodes that are truly empty (no children, no entities)
         const hasChildren = node.children && node.children.length > 0;
         const shouldKeep = isForcedVisible(node) || hasChildren || isLeaf || hasEntitiesInSubtree(node);
-        
+
         if (!shouldKeep) {
           debugLog(`[filterRedundantNodes] FILTERING OUT disconnected root: ${node.name} (${node.id}) - no entities in subtree`);
         } else {
@@ -4383,10 +4400,10 @@ export async function filterRedundantNodes(tree, entityCounts, forcedVisibleIds 
     } else if (nodes) {
       const isLeaf = !nodes.children || nodes.children.length === 0;
       const hasChildren = nodes.children && nodes.children.length > 0;
-      
+
       // MODIFIED: If a node has children, it's part of the hierarchy - keep it
       const shouldKeep = isForcedVisible(nodes) || hasChildren || isLeaf || hasEntitiesInSubtree(nodes);
-      
+
       if (!shouldKeep) {
         debugLog(`[filterRedundantNodes] Filtering out single disconnected node: ${nodes.name} (${nodes.id}) - no entities in subtree`);
         return null;
@@ -4410,6 +4427,9 @@ export function __test_setTreeReady(val) { if (typeof val === 'boolean') { __von
 export function __test_getPendingSelections() { return Array.isArray(__pendingTreeSelections) ? [...__pendingTreeSelections] : []; }
 // Export for testing
 export function __test_clearPendingSelections() { if (Array.isArray(__pendingTreeSelections)) { __pendingTreeSelections.length = 0; } }
+
+// Export for testing
+export function __test_selectSearchItem(item) { return selectSearchItem(item); }
 
 
 // Build a map of how many times each node appears as a child in the tree

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -3175,6 +3175,22 @@ button.prompt-vontology-cartouche {
     border-color: #ffeeba;
 }
 
+/* Inline-code cartouches: only used when a <code> span contains exactly one #V#... token. */
+.vontology-cartouche.vontology-cartouche-inline-code {
+    padding: 1px 8px;
+    border-color: #d8b4fe;
+    background: #faf5ff;
+}
+
+.vontology-cartouche.vontology-cartouche-inline-code .vontology-cartouche-name {
+    font-weight: 500;
+}
+
+.vontology-cartouche.vontology-cartouche-inline-code .vontology-cartouche-id {
+    font-weight: 700;
+    color: #6d28d9;
+}
+
 .prompt-vontology-cartouche-remove {
     margin-left: 4px;
     font-weight: 700;

--- a/src/frontend/web/von_interface/templates/von_interface.html
+++ b/src/frontend/web/von_interface/templates/von_interface.html
@@ -146,12 +146,13 @@
     .modal {
       display: none;
       position: fixed;
-      z-index: 1000;
+      z-index: 20000;
       left: 0;
       top: 0;
       width: 100%;
       height: 100%;
       background: rgba(0, 0, 0, 0.4);
+      overflow: auto;
     }
 
     .modal.open {
@@ -160,12 +161,14 @@
 
     .modal-content {
       background: #fff;
-      margin: 10% auto;
+      margin: 5vh auto;
       padding: 16px;
       border: 1px solid #888;
       width: 90%;
       max-width: 520px;
       border-radius: 6px;
+      max-height: 90vh;
+      overflow-y: auto;
     }
 
     .modal-actions {

--- a/tests/frontend/chatTabMarkdownRender.test.js
+++ b/tests/frontend/chatTabMarkdownRender.test.js
@@ -48,6 +48,8 @@ describe('chat markdown rendering (assistant)', () => {
             '',
             '- Item',
             '',
+            'Inline code token: `#V#yejin_choi`',
+            '',
             '[good](https://example.com)',
             '',
             'See #V#person',
@@ -64,6 +66,7 @@ describe('chat markdown rendering (assistant)', () => {
         const assistantHtml = [
             '<h1>Title</h1>',
             '<ul><li>Item</li></ul>',
+            '<p>Inline code token: <code>#V#yejin_choi</code></p>',
             '<p><a href="https://example.com" target="_blank" rel="noopener noreferrer">good</a></p>',
             '<p>See #V#person</p>',
             '<pre><code>#V#person</code></pre>',
@@ -79,6 +82,12 @@ describe('chat markdown rendering (assistant)', () => {
             }
 
             if (typeof url === 'string' && url.startsWith('/vontology/api/vontology/node_content')) {
+                if (url.includes('identifier=%23V%23yejin_choi')) {
+                    return Promise.resolve({
+                        ok: true,
+                        json: async () => ({ display_name: 'Yejin Choi', kind: 'individual' })
+                    });
+                }
                 return Promise.resolve({
                     ok: true,
                     json: async () => ({ display_name: 'Person', kind: 'type' })
@@ -158,12 +167,18 @@ describe('chat markdown rendering (assistant)', () => {
         const cartouche = assistantMarkdown.querySelector('.vontology-cartouche[data-full-concept-id="#V#person"]');
         expect(cartouche).not.toBeNull();
 
+        // Inline code tokens should become cartouches, but only when the <code> span contains exactly the token.
+        const codeCartouche = assistantMarkdown.querySelector('.vontology-cartouche.vontology-cartouche-inline-code[data-full-concept-id="#V#yejin_choi"]');
+        expect(codeCartouche).not.toBeNull();
+
         // Allow async hydration to resolve (fetch + microtasks).
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(cartouche.textContent).toContain('Person');
         expect(cartouche.textContent).toContain('#V#person');
         expect(cartouche.textContent).toContain('Type');
+
+        expect(codeCartouche.textContent).toContain('#V#yejin_choi');
 
         // But must not linkify inside code blocks.
         const codeBlock = assistantMarkdown.querySelector('pre');

--- a/tests/frontend/createConceptModal.test.js
+++ b/tests/frontend/createConceptModal.test.js
@@ -1,0 +1,58 @@
+/** @jest-environment jsdom */
+
+const handlerPath = '../../src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js';
+
+describe('openCreateConceptModal', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="root"></div>';
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('default parent for predicate is #V#predicate when blank', async () => {
+        const { openCreateConceptModal } = require(handlerPath);
+
+        const p = openCreateConceptModal('#V#has_affiliation', 'predicate');
+
+        const modal = document.querySelector('.modal');
+        expect(modal).not.toBeNull();
+        expect(modal.classList.contains('open')).toBe(true);
+
+        const kindSelect = modal.querySelector('select');
+        expect(kindSelect).not.toBeNull();
+        expect(kindSelect.value).toBe('predicate');
+
+        const parentInput = modal.querySelector('input');
+        expect(parentInput).not.toBeNull();
+        expect(parentInput.value).toBe('');
+        expect(parentInput.placeholder).toBe('#V#predicate');
+
+        const buttons = Array.from(modal.querySelectorAll('button'));
+        const createBtn = buttons.find(b => b.textContent === 'Create');
+        expect(createBtn).not.toBeUndefined();
+
+        createBtn.click();
+
+        const result = await p;
+        expect(result).toEqual({ createAsInstance: true, parentId: '#V#predicate', kind: 'predicate' });
+    });
+
+    test('cancel returns null', async () => {
+        const { openCreateConceptModal } = require(handlerPath);
+
+        const p = openCreateConceptModal('#V#person', 'type');
+        const modal = document.querySelector('.modal');
+        expect(modal).not.toBeNull();
+
+        const buttons = Array.from(modal.querySelectorAll('button'));
+        const cancelBtn = buttons.find(b => b.textContent === 'Cancel');
+        expect(cancelBtn).not.toBeUndefined();
+
+        cancelBtn.click();
+
+        const result = await p;
+        expect(result).toBeNull();
+    });
+});

--- a/tests/frontend/selectConceptByIdHandler.test.js
+++ b/tests/frontend/selectConceptByIdHandler.test.js
@@ -1,0 +1,123 @@
+/** @jest-environment jsdom */
+
+const handlerPath = '../../src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js';
+const decoratorPath = '../../src/frontend/web/von_interface/static/js/utils/textDecorator.js';
+
+describe('handleSelectConceptByIdDetail', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<div></div>';
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('existing concept opens background tab (no create)', async () => {
+        const { handleSelectConceptByIdDetail } = require(handlerPath);
+        const { createVontologyCartouche } = require(decoratorPath);
+
+        const cartouche = createVontologyCartouche('person');
+        document.body.appendChild(cartouche);
+
+        const createOrActivateConceptTab = jest.fn();
+        const activateTab = jest.fn();
+        const selectVontologyNodeByIdentifier = jest.fn();
+
+        const fetchFn = jest.fn((url) => {
+            if (typeof url === 'string' && url.startsWith('/vontology/api/vontology/node_content')) {
+                if (url.includes('raw_only=1')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({ display_name: 'Person', kind: 'type', concept_id: '#V#person' })
+                    });
+                }
+                // existence check
+                return Promise.resolve({ ok: true, status: 200, text: async () => JSON.stringify({}) });
+            }
+            return Promise.resolve({ ok: true, status: 200, text: async () => JSON.stringify({}) });
+        });
+
+        await handleSelectConceptByIdDetail(
+            { conceptId: 'person', createConceptTab: true, kind: 'type', modifierKeys: {} },
+            { createOrActivateConceptTab, activateTab, selectVontologyNodeByIdentifier, fetchFn }
+        );
+
+        expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#person', 'Person', false);
+        // Should not try to create.
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+
+        expect(cartouche.querySelector('.vontology-cartouche-name').textContent).toBe('Person');
+        expect(cartouche.querySelector('.vontology-cartouche-kind').textContent).toBe('Type');
+    });
+
+    test('missing concept prompts and creates then opens', async () => {
+        const { handleSelectConceptByIdDetail } = require(handlerPath);
+        const { createVontologyCartouche } = require(decoratorPath);
+
+        const cartouche = createVontologyCartouche('disambiguation_result');
+        document.body.appendChild(cartouche);
+
+        const createOrActivateConceptTab = jest.fn();
+        const activateTab = jest.fn();
+        const selectVontologyNodeByIdentifier = jest.fn();
+        const chooseCreateOptionsFn = jest.fn(async () => ({ createAsInstance: false, parentId: '#V#thing', kind: 'type' }));
+
+        let created = false;
+        const fetchFn = jest.fn((url, opts) => {
+            if (typeof url === 'string' && url.startsWith('/vontology/api/vontology/node_content')) {
+                // Before creation: missing. After creation: metadata exists.
+                if (url.includes('raw_only=1')) {
+                    if (!created) {
+                        return Promise.resolve({ ok: false, status: 404, text: async () => 'not found' });
+                    }
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({ display_name: 'Disambiguation result', kind: 'type', concept_id: '#V#disambiguation_result' })
+                    });
+                }
+                return Promise.resolve({ ok: false, status: 404, text: async () => 'not found' });
+            }
+            if (typeof url === 'string' && url === '/vontology/api/vontology/create_concept') {
+                const body = JSON.parse(opts.body);
+                expect(body.new_concept_name).toBe('disambiguation_result');
+                expect(body.parent_id).toBe('#V#thing');
+                expect(body.create_as_instance).toBe(false);
+                created = true;
+                return Promise.resolve({ ok: true, status: 200, text: async () => JSON.stringify({ concept_id: '#V#disambiguation_result' }) });
+            }
+            return Promise.resolve({ ok: true, status: 200, text: async () => JSON.stringify({}) });
+        });
+
+        await handleSelectConceptByIdDetail(
+            { conceptId: '#V#disambiguation_result', createConceptTab: true, kind: 'type', modifierKeys: {} },
+            { createOrActivateConceptTab, activateTab, selectVontologyNodeByIdentifier, fetchFn, chooseCreateOptionsFn }
+        );
+
+        expect(chooseCreateOptionsFn).toHaveBeenCalled();
+        expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#disambiguation_result', 'Disambiguation result', false);
+        // Existence check + create + metadata fetch.
+        expect(fetchFn).toHaveBeenCalledTimes(3);
+
+        expect(cartouche.querySelector('.vontology-cartouche-name').textContent).toBe('Disambiguation result');
+        expect(cartouche.querySelector('.vontology-cartouche-kind').textContent).toBe('Type');
+    });
+
+    test('createConceptTab false switches to Vontology tab and selects node', async () => {
+        const { handleSelectConceptByIdDetail } = require(handlerPath);
+
+        const createOrActivateConceptTab = jest.fn();
+        const activateTab = jest.fn();
+        const selectVontologyNodeByIdentifier = jest.fn();
+
+        await handleSelectConceptByIdDetail(
+            { conceptId: 'person', createConceptTab: false },
+            { createOrActivateConceptTab, activateTab, selectVontologyNodeByIdentifier, fetchFn: jest.fn() }
+        );
+
+        expect(activateTab).toHaveBeenCalledWith('vontologyTab');
+        // selection is delayed via setTimeout; sanity check it was scheduled
+        expect(selectVontologyNodeByIdentifier).not.toHaveBeenCalled();
+    });
+});

--- a/tests/frontend/textDecoratorCartoucheContextMenu.test.js
+++ b/tests/frontend/textDecoratorCartoucheContextMenu.test.js
@@ -1,0 +1,58 @@
+/** @jest-environment jsdom */
+
+const modulePath = '../../src/frontend/web/von_interface/static/js/utils/textDecorator.js';
+
+describe('Vontology cartouche context menu', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="root"></div>';
+        // Clipboard API mock
+        Object.defineProperty(global.navigator, 'clipboard', {
+            value: { writeText: jest.fn().mockResolvedValue(undefined) },
+            configurable: true
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('right-click shows Copy concept ID action', async () => {
+        const { createVontologyCartouche } = require(modulePath);
+
+        const cartouche = createVontologyCartouche('person', { name: 'Person', kind: 'type' });
+        document.getElementById('root').appendChild(cartouche);
+
+        cartouche.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: 10, clientY: 10 }));
+
+        const menu = document.querySelector('.cartouche-context-menu');
+        expect(menu).not.toBeNull();
+        expect(menu.style.display).toBe('block');
+
+        const item = menu.querySelector('button.cartouche-context-menu-item');
+        expect(item).not.toBeNull();
+
+        item.click();
+        // Allow async clipboard write to resolve.
+        await new Promise(r => setTimeout(r, 0));
+
+        expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith('#V#person');
+    });
+
+    test('click dispatches von:selectConceptById with kind + modifierKeys', () => {
+        const { createVontologyCartouche } = require(modulePath);
+
+        const cartouche = createVontologyCartouche('ai_researcher', { name: 'AI Researcher', kind: 'type' });
+        document.getElementById('root').appendChild(cartouche);
+
+        const seen = [];
+        document.addEventListener('von:selectConceptById', (e) => { seen.push(e.detail); });
+
+        cartouche.dispatchEvent(new MouseEvent('click', { bubbles: true, shiftKey: true }));
+
+        expect(seen.length).toBe(1);
+        expect(seen[0].conceptId).toBe('ai_researcher');
+        expect(seen[0].createConceptTab).toBe(true);
+        expect(seen[0].kind).toBe('type');
+        expect(seen[0].modifierKeys.shiftKey).toBe(true);
+    });
+});

--- a/tests/frontend/vontologySearchSelection.test.js
+++ b/tests/frontend/vontologySearchSelection.test.js
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment jsdom
+ */
+
+describe('Global Vontology search selection', () => {
+    test('selectSearchItem dispatches open-concept-tab immediately', async () => {
+        // We require the module directly so we can call the exported helper.
+        const vontology = require('../../src/frontend/web/von_interface/static/js/vontology.js');
+        const { elements } = require('../../src/frontend/web/von_interface/static/js/domUtils.js');
+
+        // Minimal DOM elements expected by selectSearchItem.
+        const input = document.createElement('input');
+        input.id = 'vontology-search-input';
+        document.body.appendChild(input);
+
+        // Initialise the shared elements map used by the module.
+        elements.vontologySearchInput = input;
+
+        const events = [];
+        document.addEventListener('open-concept-tab', (e) => events.push(e.detail));
+
+        // Arrange: Make fetch hang so any awaited work would stall forever.
+        global.fetch = jest.fn(() => new Promise(() => { }));
+
+        // Act: trigger selection.
+        const promise = vontology.__test_selectSearchItem({ id: '#V#person', name: 'Person', kind: 'individual' });
+
+        // Assert: event must be dispatched synchronously before any awaits.
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({ conceptId: '#V#person', kind: 'individual' });
+
+        // Clean up: allow any pending promise to settle if it can.
+        void promise;
+    });
+});


### PR DESCRIPTION
- Make global search selection open concept tabs immediately (slow tree/type work runs in background)
- Add regression test for immediate open
- Render inline Markdown code spans that are exactly a single #V#... token as a cartouche (code blocks/mixed code unchanged)
- Add styling + extend chat markdown test

Tests: npm run test:frontend