### PR TITLE
JVNAUTOSCI-821: Tool-use regression fixes and md_content fallback cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,9 @@ Purpose: Eliminate unnecessary confirmation prompts for standard, codified workf
 
 When To Act Automatically:
 - After implementing a fix & tests pass: Post JIRA comment (summary, root cause, fix, tests, risk, follow-ups) then transition issue to the correct state (usually Done) without asking.
+- When creating a new JIRA issue: assign it to the current user by default (unless the user explicitly names a different assignee).
 - Retry transient Atlassian 5xx or rate limit errors up to 3 times with exponential backoff (~30s total) before surfacing failure.
+- When a somewhat complex operation already has a lightweight LLM heuristic path (e.g. missing tool-use detection), prefer improving the heuristic behaviour (prompt/context/inputs) over adding brittle, case-specific string matching that will break as natural language phrasing evolves.
 - Preserve raw user-authored text in UI workflows (store original in dataset/raw attribute) whenever rendered/HTML transformations occur — pattern originates from description markdown preservation.
 - Consolidate duplicated DOM update logic into a single helper before expanding features (prevents regression drift).
 - Add a regression test for every state/format loss bug fix (load → edit → save → re-edit cycle) before declaring completion.
@@ -401,7 +403,7 @@ Please use the correct project key when creating new issues.
 
 To ensure consistency and maintain a clean history, all agents must follow this workflow for every task:
 
-1.  **JIRA Issue**: Ensure a JIRA issue exists for the task. If not, create one and assign it to the user (Project: `JVNAUTOSCI`).
+1.  **JIRA Issue**: Ensure a JIRA issue exists for the task. If not, create one and assign it to the current user by default (Project: `JVNAUTOSCI`) unless the user explicitly requests a different assignee.
 2.  **Branching**: Create a new branch from `main` using the JIRA key: `git checkout -b JVNAUTOSCI-XXX-short-description`.
 3.  **Implementation**:
     *   Make changes.

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -50,6 +50,10 @@ class _MissingToolCallDetectorSpec:
 class ToolCallParsingError(Exception):
     """Raised when a model returns an invalid tool call payload."""
 
+    def __init__(self, message: str, *, raw_response: str | None = None) -> None:
+        super().__init__(message)
+        self.raw_response = raw_response
+
 
 class InternalMCPChatOrchestrator:
     """Simple loop that allows the Von assistant to call internal tools."""
@@ -420,6 +424,9 @@ class InternalMCPChatOrchestrator:
             "- DO NOT say 'I will call' or 'Let me call' - just call it\n"
             "- You MAY batch multiple tool calls in ONE message as a JSON array (keep it to <= 4 calls)\n"
             "- After you receive the tool result (role 'tool'), respond naturally to the user\n\n"
+            "VERIFICATION & CONSISTENCY RULES:\n"
+            "- If the user doubts whether a specific concept_id exists (e.g. '#V#...') or challenges a claim about Vontology state, ALWAYS verify first using fetch_concept (or search_concepts) before responding.\n"
+            "- Do NOT reply with prose-only 'we should verify' / 'I will not assert unless I can verify' without actually calling a tool.\n\n"
             "If you output JSON, the system will execute that tool call immediately.\n\n"
             "IMPORTANT: arXiv paper conversions (PDF to markdown) can take 5-10 minutes.\n"
             "If read_paper fails, the paper may still be converting. Check with list_papers.\n\n"
@@ -997,7 +1004,8 @@ class InternalMCPChatOrchestrator:
             parsed, end = decoder.raw_decode(raw)
         except json.JSONDecodeError as exc:
             raise ToolCallParsingError(
-                "Tool call was not executed: invalid JSON in tool call response."
+                "Tool call was not executed: invalid JSON in tool call response.",
+                raw_response=text,
             ) from exc
 
         trailing = raw[end:].strip()
@@ -1047,7 +1055,8 @@ class InternalMCPChatOrchestrator:
                 if tool_call is None:
                     if looks_like_tool_call:
                         raise ToolCallParsingError(
-                            "Tool call was not executed: tool call batch must be a JSON array of tool-call objects."
+                            "Tool call was not executed: tool call batch must be a JSON array of tool-call objects.",
+                            raw_response=text,
                         )
                     return None
                 tool_calls.append(tool_call)
@@ -1056,7 +1065,8 @@ class InternalMCPChatOrchestrator:
         else:
             if looks_like_tool_call:
                 raise ToolCallParsingError(
-                    "Tool call was not executed: tool call must be a JSON object or array."
+                    "Tool call was not executed: tool call must be a JSON object or array.",
+                    raw_response=text,
                 )
             return None
 
@@ -1064,7 +1074,8 @@ class InternalMCPChatOrchestrator:
         if trailing:
             if trailing.startswith("{") or trailing.startswith("["):
                 raise ToolCallParsingError(
-                    "Tool call was not executed: multiple JSON values were emitted in one response."
+                    "Tool call was not executed: multiple JSON values were emitted in one response.",
+                    raw_response=text,
                 )
 
             snippet = trailing
@@ -1081,7 +1092,8 @@ class InternalMCPChatOrchestrator:
                 "["
             ):
                 raise ToolCallParsingError(
-                    "Tool call was not executed: multiple JSON values were emitted in one response."
+                    "Tool call was not executed: multiple JSON values were emitted in one response.",
+                    raw_response=text,
                 )
             snippet = post_fence_trailing
             if len(snippet) > 120:
@@ -1157,7 +1169,8 @@ class InternalMCPChatOrchestrator:
             parsed, end = decoder.raw_decode(raw)
         except json.JSONDecodeError as exc:
             raise ToolCallParsingError(
-                "Tool call was not executed: invalid JSON in tool call response."
+                "Tool call was not executed: invalid JSON in tool call response.",
+                raw_response=text,
             ) from exc
 
         is_tool_call = False
@@ -1198,7 +1211,8 @@ class InternalMCPChatOrchestrator:
         if trailing and is_tool_call:
             if trailing.startswith("{") or trailing.startswith("["):
                 raise ToolCallParsingError(
-                    "Tool call was not executed: multiple tool calls were emitted in one response."
+                    "Tool call was not executed: multiple tool calls were emitted in one response.",
+                    raw_response=text,
                 )
 
             # Some models append explanatory prose after a valid JSON tool call.
@@ -1219,7 +1233,8 @@ class InternalMCPChatOrchestrator:
                 "["
             ):
                 raise ToolCallParsingError(
-                    "Tool call was not executed: multiple tool calls were emitted in one response."
+                    "Tool call was not executed: multiple tool calls were emitted in one response.",
+                    raw_response=text,
                 )
             snippet = post_fence_trailing
             if len(snippet) > 120:
@@ -1242,7 +1257,8 @@ class InternalMCPChatOrchestrator:
         if not isinstance(parsed, MutableMapping):
             if looks_like_tool_call:
                 raise ToolCallParsingError(
-                    "Tool call was not executed: tool call must be a JSON object."
+                    "Tool call was not executed: tool call must be a JSON object.",
+                    raw_response=text,
                 )
             return None
 
@@ -1587,6 +1603,13 @@ class InternalMCPChatOrchestrator:
                     # Fallback to legacy heuristic only when classifier unavailable
                     if self._looks_like_missing_tool_call(response):
                         retry_reason = "heuristic missing tool call"
+                elif llm_flag is False:
+                    # Backstop: the LLM classifier can miss obvious cases.
+                    # If our conservative heuristic triggers, do the single retry anyway.
+                    if self._looks_like_missing_tool_call(response):
+                        retry_reason = (
+                            "heuristic missing tool call (classifier said no)"
+                        )
 
             # Always append a compact detection summary for UI debugging
             try:
@@ -1618,9 +1641,39 @@ class InternalMCPChatOrchestrator:
                     "Your previous message described an action that requires MCP tools, but you did not emit a tool call. "
                     "NOW respond with ONLY a tool-call JSON object or a JSON array of tool-call objects (no prose, no Markdown)."
                 )
+
+                try:
+                    aux_llm_calls.append(
+                        {
+                            "type": "missing_tool_call_retry",
+                            "stage": "prompt",
+                            "retry_reason": retry_reason,
+                            "prompt_preview": retry_prompt[:800],
+                        }
+                    )
+                except Exception:  # pragma: no cover - best effort only
+                    pass
+
                 retry_response = llm_client.generate(
                     retry_prompt, context=augmented_context, model=model
                 )
+
+                try:
+                    aux_llm_calls.append(
+                        {
+                            "type": "missing_tool_call_retry",
+                            "stage": "response",
+                            "retry_reason": retry_reason,
+                            "response_preview": (
+                                retry_response[:800]
+                                if isinstance(retry_response, str)
+                                else str(retry_response)[:800]
+                            ),
+                        }
+                    )
+                except Exception:  # pragma: no cover - best effort only
+                    pass
+
                 try:
                     retry_calls = self._extract_tool_calls(retry_response)
                 except ToolCallParsingError:

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -55,6 +55,18 @@ def _truncate_large_tool_results(
     return result
 
 
+def _truncate_debug_payload(raw: str | None, max_chars: int = 4000) -> str | None:
+    """Limit rejected tool payloads before surfacing them in LLM debug info."""
+    if raw is None:
+        return None
+
+    payload = raw if isinstance(raw, str) else str(raw)
+    if len(payload) <= max_chars:
+        return payload
+
+    return payload[:max_chars] + f"\n... [truncated {len(payload) - max_chars} chars]"
+
+
 def _limit_context_size(context: list[dict], max_messages: int = 20) -> list[dict]:
     """
     Keep only the most recent messages in context to prevent unbounded growth.
@@ -1245,7 +1257,21 @@ def generate():
                     f"({exc})\n\n"
                     "Please try again. If this keeps happening, copy the LLM debug output so we can reproduce it."
                 )
-                tool_invocations = []
+                rejected_tool_call = _truncate_debug_payload(
+                    getattr(exc, "raw_response", None)
+                )
+                tool_messages = []
+                tool_invocations = [
+                    {
+                        "tool": "__tool_call_parse_error__",
+                        "payload": (
+                            {"raw_tool_call": rejected_tool_call}
+                            if rejected_tool_call is not None
+                            else {}
+                        ),
+                        "error": str(exc),
+                    }
+                ]
 
         if tool_invocations:
             current_app.logger.info(
@@ -1310,6 +1336,44 @@ def generate():
         # Calculate tool statistics if tools were used
         tool_stats = _calculate_tool_stats(tool_messages) if tool_messages else None
 
+        # Capture a compact summary of the tool catalogue that the agent was shown.
+        # This improves trace transparency without storing the full system prompt.
+        tool_catalogue_summary = None
+        if gateway is not None:
+            try:
+                methods_snapshot = gateway.describe_methods()
+                if isinstance(methods_snapshot, dict):
+                    method_names = sorted(
+                        [
+                            name
+                            for name in methods_snapshot.keys()
+                            if isinstance(name, str)
+                        ]
+                    )
+                    try:
+                        import hashlib
+                        import json
+
+                        digest = hashlib.sha256(
+                            json.dumps(
+                                method_names,
+                                separators=(",", ":"),
+                                ensure_ascii=True,
+                            ).encode("utf-8")
+                        ).hexdigest()
+                    except Exception:
+                        digest = None
+
+                    sample_cap = 25
+                    tool_catalogue_summary = {
+                        "method_count": len(method_names),
+                        "sha256": digest,
+                        "sample": method_names[:sample_cap],
+                        "sample_truncated": len(method_names) > sample_cap,
+                    }
+            except Exception:
+                tool_catalogue_summary = None
+
         llm_debug_info = {
             "interaction_timestamp_utc": interaction_timestamp_utc,
             "model": model_name,
@@ -1324,6 +1388,7 @@ def generate():
                     else False
                 ),
                 "orchestrator_present": orchestrator is not None,
+                "tool_catalogue": tool_catalogue_summary,
             },
             "context_stats": {
                 "sent_to_llm": context_stats,  # What was actually sent this turn

--- a/src/backend/vontology/utils_vontology.py
+++ b/src/backend/vontology/utils_vontology.py
@@ -1405,41 +1405,17 @@ def get_vontology_node_content(identifier: str) -> dict:
         # Use accessor functions for description and notes
         description = get_concept_description(doc)
         notes = get_concept_notes(doc)
-        subconcept_of = doc.get("relationships", {}).get("is_a_type_of", "None (Root)")
-        instance_of = doc.get("relationships", {}).get("is_an_instance_of", "None")
-        source_concept = doc.get("source_concept", "N/A")
 
-        subconcept_of_str = "None (Root)"
-        if isinstance(subconcept_of, list):
-            subconcept_of_str = (
-                ", ".join(subconcept_of) if subconcept_of else "None (Root)"
-            )
-        elif isinstance(subconcept_of, str) and subconcept_of:
-            subconcept_of_str = subconcept_of
-
-        instance_of_str = "None"
-        if isinstance(instance_of, list):
-            instance_of_str = (
-                ", ".join(str(item) for item in instance_of) if instance_of else "None"
-            )
-        elif isinstance(instance_of, str) and instance_of:
-            instance_of_str = instance_of
-        elif instance_of:  # Handle other types like ObjectId
-            instance_of_str = str(instance_of)
-
+        # NOTE: Older versions reconstructed md_content with boilerplate metadata
+        # (Source Concept/SubConcept Of/Instance Of). Those placeholders are noisy
+        # and redundant with UI fields, so keep the fallback minimal.
         md_content = f"# {name}\n\n"
-        md_content += f"**Source Concept**: {source_concept}\n"
-        md_content += f"**SubConcept Of**: {subconcept_of_str}\n"
-        md_content += f"**Instance Of**: {instance_of_str}\n\n"
 
-        # Handle description and notes
         if description:
-            md_content += f"**Description**:\n{description}\n\n"
-        else:
-            md_content += f"**Description**: None\n\n"
+            md_content += f"## Description\n\n{description}\n\n"
 
         if notes:
-            md_content += f"**Notes**:\n{notes}\n"
+            md_content += f"## Notes\n\n{notes}\n"
 
     html = markdown.markdown(md_content)
 

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -4,6 +4,7 @@ import { initializeConceptAutocomplete } from './components/conceptAutocomplete.
 import { initializePromptCartoucheOverlay, normaliseVontologyIdsForBackend } from './components/promptCartoucheOverlay.js';
 import { elements, renderSpanSuggestions } from './domUtils.js';
 import { detectMarkdown, renderMarkdownViaServer } from './markdownUtils.js';
+import { selectBestNameForContext } from './utils/nameSelection.js';
 import { cartouchifyElementText, cartouchifyVontologyTokensInElement } from './utils/textDecorator.js';
 
 // Store LLM debug data for each turn
@@ -223,7 +224,16 @@ async function fetchConceptMetaForChat(fullId) {
         const nodeRes = await fetch(nodeUrl, { cache: 'no-store' });
         if (nodeRes.ok) {
             const node = await nodeRes.json();
+            const preferredLanguage = getUserContext()?.language || 'en-NZ';
+            const rawNames =
+                node?.raw_doc?.names ||
+                node?.node?.raw_doc?.names ||
+                node?.names ||
+                node?.node?.names ||
+                null;
+            const bestName = selectBestNameForContext(rawNames, preferredLanguage);
             const name =
+                bestName ||
                 node?.display_name ||
                 node?.name ||
                 node?.node?.display_name ||
@@ -1089,6 +1099,8 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
             const messageContent = document.createElement('div');
             messageContent.style.cssText = 'flex: 1; line-height: 1.5;';
 
+            const rawText = String(message ?? '');
+
             const messageHeader = document.createElement('div');
             messageHeader.style.cssText = 'font-weight: bold; color: #007bff; margin-bottom: 5px; font-size: 0.9em; display: flex; align-items: center; gap: 8px;';
 
@@ -1106,6 +1118,46 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
                 badge.style.cssText = 'display: inline-flex; align-items: center; padding: 1px 6px; border-radius: 10px; font-size: 0.8em; background: #fff3cd; border: 1px solid #ffeeba; color: #856404;';
                 messageHeader.appendChild(badge);
             }
+
+            const copyMarkdownButton = document.createElement('button');
+            copyMarkdownButton.className = 'btn-mini chat-copy-markdown';
+            copyMarkdownButton.textContent = 'MD';
+            copyMarkdownButton.title = 'Copy this agent message as Markdown to clipboard';
+            copyMarkdownButton.addEventListener('click', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+
+                const originalContent = copyMarkdownButton.innerHTML;
+                const markdownString = rawText.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+                if (!markdownString.trim()) {
+                    indicateClipboardResult(copyMarkdownButton, originalContent, false);
+                    return;
+                }
+
+                const markSuccess = () => indicateClipboardResult(copyMarkdownButton, originalContent, true);
+                const markFailure = (err) => {
+                    console.error('[chatTab] Failed to copy agent Markdown:', err);
+                    indicateClipboardResult(copyMarkdownButton, originalContent, false);
+                };
+
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    navigator.clipboard.writeText(markdownString)
+                        .then(markSuccess)
+                        .catch((err) => {
+                            if (copyTextFallback(markdownString)) {
+                                markSuccess();
+                            } else {
+                                markFailure(err);
+                            }
+                        });
+                } else if (copyTextFallback(markdownString)) {
+                    markSuccess();
+                } else {
+                    markFailure(new Error('Clipboard unsupported'));
+                }
+            });
+
+            let copyButtonAppended = false;
 
             // Add LLM debug button if debug data available
             if (hasLlmDebug && turnId) {
@@ -1128,6 +1180,9 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
                 llmDebugButton.addEventListener('click', () => showLlmDebugPopup(turnId));
                 messageHeader.appendChild(llmDebugButton);
 
+                messageHeader.appendChild(copyMarkdownButton);
+                copyButtonAppended = true;
+
                 const warnings = deriveLlmDebugWarnings(debugData);
                 const warningIndicator = createChatDebugWarningIndicator(warnings);
                 if (warningIndicator) {
@@ -1135,36 +1190,23 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
                 }
             }
 
+            if (!copyButtonAppended) {
+                messageHeader.appendChild(copyMarkdownButton);
+            }
+
+            const rightControls = document.createElement('span');
+            rightControls.className = 'chat-message-controls';
+            rightControls.style.cssText = 'margin-left: auto; display: inline-flex; align-items: center; gap: 6px;';
+
             // Render-mode badge: shows whether this message is in Rendered/Text mode.
             const renderModeBadge = document.createElement('span');
             renderModeBadge.className = 'chat-render-mode-badge';
-            messageHeader.appendChild(renderModeBadge);
-
-            // Add delete button
-            if (turnId) {
-                const deleteButton = document.createElement('button');
-                deleteButton.className = 'btn-mini btn-delete-exchange';
-                deleteButton.textContent = '✕';
-                deleteButton.title = 'Delete this exchange';
-                deleteButton.style.cssText = 'margin-left: auto; color: #666; background: transparent; border: none; cursor: pointer; font-size: 1.2em; padding: 0 4px; line-height: 1;';
-                deleteButton.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    deleteExchange(turnId, false);
-                });
-                deleteButton.addEventListener('mouseover', () => {
-                    deleteButton.style.color = '#d9534f';
-                });
-                deleteButton.addEventListener('mouseout', () => {
-                    deleteButton.style.color = '#666';
-                });
-                messageHeader.appendChild(deleteButton);
-            }
+            rightControls.appendChild(renderModeBadge);
 
             const messageText = document.createElement('div');
             messageText.style.cssText = 'color: #333; white-space: pre-wrap; text-align: left; font-weight: 400;';
             try {
                 const debugData = turnId ? llmDebugData.get(turnId) : null;
-                const rawText = String(message ?? '');
                 const canRenderMarkdown = shouldRenderMarkdownForAssistant(rawText, debugData);
 
                 if (canRenderMarkdown) {
@@ -1189,7 +1231,21 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
                             model: debugData?.model
                         });
                     });
-                    messageHeader.appendChild(toggleButton);
+                    rightControls.appendChild(toggleButton);
+                }
+
+                // Add delete button after the toggle so the close (✕) is right-most.
+                if (turnId) {
+                    const deleteButton = document.createElement('button');
+                    deleteButton.className = 'btn-mini btn-delete-exchange';
+                    deleteButton.type = 'button';
+                    deleteButton.textContent = '✕';
+                    deleteButton.title = 'Delete this exchange';
+                    deleteButton.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        deleteExchange(turnId, false);
+                    });
+                    rightControls.appendChild(deleteButton);
                 }
 
                 renderAssistantMessageContent(messageText, rawText, debugData);
@@ -1203,6 +1259,8 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
                 console.error('[chatTab] Failed to render Von message:', e);
                 messageText.textContent = String(message);
             }
+
+            messageHeader.appendChild(rightControls);
 
             messageContent.appendChild(messageHeader);
             messageContent.appendChild(messageText);
@@ -1252,18 +1310,12 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
             if (turnId) {
                 const deleteButton = document.createElement('button');
                 deleteButton.className = 'btn-mini btn-delete-exchange';
+                deleteButton.type = 'button';
                 deleteButton.textContent = '✕';
                 deleteButton.title = 'Delete this exchange';
-                deleteButton.style.cssText = 'margin-left: auto; color: #666; background: transparent; border: none; cursor: pointer; font-size: 1.2em; padding: 0 4px; line-height: 1;';
                 deleteButton.addEventListener('click', (e) => {
                     e.stopPropagation();
                     deleteExchange(turnId, true);
-                });
-                deleteButton.addEventListener('mouseover', () => {
-                    deleteButton.style.color = '#d9534f';
-                });
-                deleteButton.addEventListener('mouseout', () => {
-                    deleteButton.style.color = '#666';
                 });
                 messageHeader.appendChild(deleteButton);
             }

--- a/src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js
+++ b/src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js
@@ -5,6 +5,7 @@
 // (#V\u200B#...) into the textarea so autocomplete does not re-trigger.
 // The overlay renders those tokens as cartouches and supports removal.
 
+import { getPreferredLanguage, selectBestNameForContext } from '../utils/nameSelection.js';
 import { createVontologyCartouche } from '../utils/textDecorator.js';
 
 const ZWSP = '\u200B';
@@ -235,7 +236,16 @@ async function fetchConceptMeta(fullId) {
             const nodeResp = await fetch(nodeUrl, { cache: 'no-store' });
             if (nodeResp.ok) {
                 const node = await nodeResp.json();
+                const preferredLanguage = getPreferredLanguage();
+                const rawNames =
+                    node?.raw_doc?.names ||
+                    node?.node?.raw_doc?.names ||
+                    node?.names ||
+                    node?.node?.names ||
+                    null;
+                const bestName = selectBestNameForContext(rawNames, preferredLanguage);
                 const name =
+                    bestName ||
                     node?.display_name ||
                     node?.name ||
                     node?.node?.display_name ||

--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -1286,6 +1286,18 @@ async function reloadConceptTab(conceptId) {
         // This refreshes notes, names, and all UI elements
         selectConceptWithSuffix(conceptData, suffix);
 
+        // Refresh text-relation driven sections (notes/content/description). These sections can stay mounted
+        // across reloads, so we explicitly ask them to refresh for the current concept.
+        try {
+            await ensureUnifiedDescriptionSection(conceptId, suffix);
+        } catch (_) { /* ignore */ }
+        try {
+            await populateNotesSection(conceptId, suffix);
+        } catch (_) { /* ignore */ }
+        try {
+            await populateContentSection(conceptId, suffix);
+        } catch (_) { /* ignore */ }
+
         // Reload names explicitly to ensure they're fresh
         await loadConceptNames(conceptId, suffix);
 
@@ -3349,7 +3361,18 @@ async function populateNotesSection(conceptId, suffix) {
         const containerParent = document.getElementById(`conceptStep1_${suffix}`) || document.getElementById('conceptStep1');
         if (!containerParent) return;
         const existing = document.getElementById(`notesMultiSection_${suffix}`);
-        if (existing) return; // already mounted
+        if (existing) {
+            try {
+                if (typeof existing.__refreshForConcept === 'function') {
+                    await existing.__refreshForConcept(conceptId);
+                    return;
+                }
+            } catch (_) { /* ignore */ }
+            // Older DOM from previous versions: remove and rebuild to avoid stale concept binding.
+            try { existing.remove(); } catch (_) { /* ignore */ }
+        }
+
+        let currentConceptId = conceptId;
 
         const section = document.createElement('div');
         section.id = `notesMultiSection_${suffix}`;
@@ -3377,7 +3400,10 @@ async function populateNotesSection(conceptId, suffix) {
         const fetchNotes = async () => {
             statusEl.textContent = 'Loading notes...';
             try {
-                const res = await fetch(`/api/concepts/${encodeURIComponent(conceptId)}/texts?predicate=hasNote&limit=200`);
+                const res = await fetch(`/api/concepts/${encodeURIComponent(currentConceptId)}/texts?predicate=hasNote&limit=200`, {
+                    cache: 'no-store',
+                    headers: { 'Cache-Control': 'no-cache' }
+                });
                 const data = await res.json().catch(() => ({}));
                 if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
                 renderNotes(Array.isArray(data.texts) ? data.texts : []);
@@ -3385,6 +3411,14 @@ async function populateNotesSection(conceptId, suffix) {
             } catch (e) {
                 statusEl.textContent = `Failed to load notes: ${e.message}`;
             }
+        };
+
+        // Allow callers to reuse this section for another concept without remounting.
+        section.__refreshForConcept = async (newConceptId) => {
+            if (typeof newConceptId === 'string' && newConceptId.trim()) {
+                currentConceptId = newConceptId;
+            }
+            await fetchNotes();
         };
 
         const renderNotes = (notes) => {
@@ -3409,8 +3443,8 @@ async function populateNotesSection(conceptId, suffix) {
                 displayHtml = truncated ? safeText.slice(0, 800) + '…' : safeText || '<i>(empty)</i>';
                 const viewClasses = isMarkdown ? 'note-view markdown-rendered' : 'note-view';
                 const viewStyle = isMarkdown
-                    ? 'white-space:normal;font-size:0.85rem;line-height:1.25;max-height:220px;overflow:hidden;'
-                    : 'white-space:pre-wrap;font-size:0.85rem;line-height:1.25;max-height:220px;overflow:hidden;';
+                    ? 'white-space:normal;font-size:0.85rem;line-height:1.25;max-height:220px;overflow:auto;'
+                    : 'white-space:pre-wrap;font-size:0.85rem;line-height:1.25;max-height:220px;overflow:auto;';
                 item.innerHTML = `
                                                  <div class="${viewClasses}" data-full="${safeText}" data-truncated="${truncated ? '1' : '0'}" style="${viewStyle}">${displayHtml}</div>
                    <div class="note-edit hidden" style="margin-top:4px;">
@@ -3485,6 +3519,7 @@ async function populateNotesSection(conceptId, suffix) {
                         const truncated = full.length > 800;
                         viewEl.innerHTML = truncated ? escapeHtml(full.slice(0, 800)) + '…' : escapeHtml(full);
                         viewEl.style.maxHeight = '220px';
+                        viewEl.style.overflow = 'auto';
                         expandBtn.dataset.icon = 'expand';
                         expandBtn.title = 'Show more';
                         expandBtn.setAttribute('aria-label', 'Show full note');
@@ -3492,6 +3527,7 @@ async function populateNotesSection(conceptId, suffix) {
                     } else {
                         viewEl.innerHTML = escapeHtml(viewEl.getAttribute('data-full') || '');
                         viewEl.style.maxHeight = 'none';
+                        viewEl.style.overflow = 'visible';
                         expandBtn.dataset.icon = 'collapse';
                         expandBtn.title = 'Show less';
                         expandBtn.setAttribute('aria-label', 'Show less of note');
@@ -3539,7 +3575,7 @@ async function populateNotesSection(conceptId, suffix) {
                 } catch (_) { /* ignore */ }
                 status.textContent = 'Saving...'; saveBtn.disabled = true;
                 try {
-                    const resp = await fetch(`/api/concepts/${encodeURIComponent(conceptId)}/texts/${encodeURIComponent(note.relation_id)}`, {
+                    const resp = await fetch(`/api/concepts/${encodeURIComponent(currentConceptId)}/texts/${encodeURIComponent(note.relation_id)}`, {
                         method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ text: newText })
                     });
                     const data = await resp.json().catch(() => ({}));
@@ -3578,7 +3614,7 @@ async function populateNotesSection(conceptId, suffix) {
                 }
                 status.textContent = 'Deleting...'; delBtn.disabled = true;
                 try {
-                    const resp = await fetch(`/api/concepts/${encodeURIComponent(conceptId)}/texts/${encodeURIComponent(note.relation_id)}`, { method: 'DELETE' });
+                    const resp = await fetch(`/api/concepts/${encodeURIComponent(currentConceptId)}/texts/${encodeURIComponent(note.relation_id)}`, { method: 'DELETE' });
                     const data = await resp.json().catch(() => ({}));
                     if (!resp.ok || data.error) throw new Error(data.error || `HTTP ${resp.status}`);
                     item.remove();
@@ -3595,8 +3631,8 @@ async function populateNotesSection(conceptId, suffix) {
             if (annotateBtn) {
                 annotateBtn.dataset.hasDirectAnnotate = '1';
                 annotateBtn.addEventListener('click', () => {
-                    const info = dynamicConceptTabs.get(conceptId);
-                    const conceptName = info?.conceptName || conceptId;
+                    const info = dynamicConceptTabs.get(currentConceptId);
+                    const conceptName = info?.conceptName || currentConceptId;
                     document.dispatchEvent(new CustomEvent('open-annotation-tab', {
                         detail: { text: note.text || '', conceptName, source: 'note' }
                     }));
@@ -3638,7 +3674,7 @@ async function populateNotesSection(conceptId, suffix) {
                 } catch (_) { /* ignore */ }
                 cStatus.textContent = 'Creating...'; createBtn.disabled = true;
                 try {
-                    const resp = await fetch(`/api/concepts/${encodeURIComponent(conceptId)}/texts`, {
+                    const resp = await fetch(`/api/concepts/${encodeURIComponent(currentConceptId)}/texts`, {
                         method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ predicate: 'hasNote', text: txt })
                     });
                     const data = await resp.json().catch(() => ({}));
@@ -3670,7 +3706,18 @@ async function populateContentSection(conceptId, suffix) {
         const containerParent = document.getElementById(`conceptStep1_${suffix}`) || document.getElementById('conceptStep1');
         if (!containerParent) return;
         const existing = document.getElementById(`contentMultiSection_${suffix}`);
-        if (existing) return; // already mounted
+        if (existing) {
+            try {
+                if (typeof existing.__refreshForConcept === 'function') {
+                    await existing.__refreshForConcept(conceptId);
+                    return;
+                }
+            } catch (_) { /* ignore */ }
+            // Older DOM from previous versions: remove and rebuild to avoid stale concept binding.
+            try { existing.remove(); } catch (_) { /* ignore */ }
+        }
+
+        let currentConceptId = conceptId;
 
         const section = document.createElement('div');
         section.id = `contentMultiSection_${suffix}`;
@@ -3701,7 +3748,10 @@ async function populateContentSection(conceptId, suffix) {
         const fetchContent = async () => {
             statusEl.textContent = 'Loading content...';
             try {
-                const res = await fetch(`/api/concepts/${encodeURIComponent(conceptId)}/texts?predicate=hasContent&limit=200`);
+                const res = await fetch(`/api/concepts/${encodeURIComponent(currentConceptId)}/texts?predicate=hasContent&limit=200`, {
+                    cache: 'no-store',
+                    headers: { 'Cache-Control': 'no-cache' }
+                });
                 const data = await res.json().catch(() => ({}));
                 if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
                 renderContent(Array.isArray(data.texts) ? data.texts : []);
@@ -3709,6 +3759,14 @@ async function populateContentSection(conceptId, suffix) {
             } catch (e) {
                 statusEl.textContent = `Failed to load content: ${e.message}`;
             }
+        };
+
+        // Allow callers to reuse this section for another concept without remounting.
+        section.__refreshForConcept = async (newConceptId) => {
+            if (typeof newConceptId === 'string' && newConceptId.trim()) {
+                currentConceptId = newConceptId;
+            }
+            await fetchContent();
         };
 
         const renderContent = (contentItems) => {
@@ -3733,8 +3791,8 @@ async function populateContentSection(conceptId, suffix) {
                 displayHtml = truncated ? safeText.slice(0, 1000) + '…' : safeText || '<i>(empty)</i>';
                 const viewClasses = isMarkdown ? 'content-view markdown-rendered' : 'content-view';
                 const viewStyle = isMarkdown
-                    ? 'white-space:normal;font-size:0.85rem;line-height:1.25;max-height:250px;overflow:hidden;'
-                    : 'white-space:pre-wrap;font-size:0.85rem;line-height:1.25;max-height:250px;overflow:hidden;';
+                    ? 'white-space:normal;font-size:0.85rem;line-height:1.25;max-height:250px;overflow:auto;'
+                    : 'white-space:pre-wrap;font-size:0.85rem;line-height:1.25;max-height:250px;overflow:auto;';
                 item.innerHTML = `
                                                  <div class="${viewClasses}" data-full="${safeText}" data-truncated="${truncated ? '1' : '0'}" style="${viewStyle}">${displayHtml}</div>
                    <div class="content-edit hidden" style="margin-top:4px;">
@@ -3809,6 +3867,7 @@ async function populateContentSection(conceptId, suffix) {
                         const truncated = full.length > 1000;
                         viewEl.innerHTML = truncated ? escapeHtml(full.slice(0, 1000)) + '…' : escapeHtml(full);
                         viewEl.style.maxHeight = '250px';
+                        viewEl.style.overflow = 'auto';
                         expandBtn.dataset.icon = 'expand';
                         expandBtn.title = 'Show more';
                         expandBtn.setAttribute('aria-label', 'Show full content');
@@ -3816,6 +3875,7 @@ async function populateContentSection(conceptId, suffix) {
                     } else {
                         viewEl.innerHTML = escapeHtml(viewEl.getAttribute('data-full') || '');
                         viewEl.style.maxHeight = 'none';
+                        viewEl.style.overflow = 'visible';
                         expandBtn.dataset.icon = 'collapse';
                         expandBtn.title = 'Show less';
                         expandBtn.setAttribute('aria-label', 'Show less of content');
@@ -3863,7 +3923,7 @@ async function populateContentSection(conceptId, suffix) {
                 } catch (_) { /* ignore */ }
                 status.textContent = 'Saving...'; saveBtn.disabled = true;
                 try {
-                    const resp = await fetch(`/api/concepts/${encodeURIComponent(conceptId)}/texts/${encodeURIComponent(content.relation_id)}`, {
+                    const resp = await fetch(`/api/concepts/${encodeURIComponent(currentConceptId)}/texts/${encodeURIComponent(content.relation_id)}`, {
                         method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ text: newText })
                     });
                     const data = await resp.json().catch(() => ({}));
@@ -3902,7 +3962,7 @@ async function populateContentSection(conceptId, suffix) {
                 }
                 status.textContent = 'Deleting...'; delBtn.disabled = true;
                 try {
-                    const resp = await fetch(`/api/concepts/${encodeURIComponent(conceptId)}/texts/${encodeURIComponent(content.relation_id)}`, { method: 'DELETE' });
+                    const resp = await fetch(`/api/concepts/${encodeURIComponent(currentConceptId)}/texts/${encodeURIComponent(content.relation_id)}`, { method: 'DELETE' });
                     const data = await resp.json().catch(() => ({}));
                     if (!resp.ok || data.error) throw new Error(data.error || `HTTP ${resp.status}`);
                     item.remove();
@@ -3919,8 +3979,8 @@ async function populateContentSection(conceptId, suffix) {
             if (annotateBtn) {
                 annotateBtn.dataset.hasDirectAnnotate = '1';
                 annotateBtn.addEventListener('click', () => {
-                    const info = dynamicConceptTabs.get(conceptId);
-                    const conceptName = info?.conceptName || conceptId;
+                    const info = dynamicConceptTabs.get(currentConceptId);
+                    const conceptName = info?.conceptName || currentConceptId;
                     document.dispatchEvent(new CustomEvent('open-annotation-tab', {
                         detail: { text: content.text || '', conceptName, source: 'content' }
                     }));
@@ -3962,7 +4022,7 @@ async function populateContentSection(conceptId, suffix) {
                 } catch (_) { /* ignore */ }
                 cStatus.textContent = 'Creating...'; createBtn.disabled = true;
                 try {
-                    const resp = await fetch(`/api/concepts/${encodeURIComponent(conceptId)}/texts`, {
+                    const resp = await fetch(`/api/concepts/${encodeURIComponent(currentConceptId)}/texts`, {
                         method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ predicate: 'hasContent', text: txt })
                     });
                     const data = await resp.json().catch(() => ({}));

--- a/src/frontend/web/von_interface/static/js/utils/nameSelection.js
+++ b/src/frontend/web/von_interface/static/js/utils/nameSelection.js
@@ -1,0 +1,134 @@
+const DEFAULT_LANGUAGE = 'en-NZ';
+
+export function getPreferredLanguage() {
+    try {
+        const stored = localStorage.getItem('von_preferred_language');
+        if (typeof stored === 'string' && stored.trim()) {
+            return stored.trim();
+        }
+    } catch (_) {
+        // ignore
+    }
+
+    try {
+        const docLang = document?.documentElement?.lang;
+        if (typeof docLang === 'string' && docLang.trim()) {
+            return docLang.trim();
+        }
+    } catch (_) {
+        // ignore
+    }
+
+    return DEFAULT_LANGUAGE;
+}
+
+function _normaliseNameEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    // Support both:
+    // - raw_doc.names: {name, language, type}
+    // - dynamicTabs-like: {text, language, abbrev, name, type}
+    const language = (entry.language ?? entry.lang ?? '').toString().trim();
+    const type = (entry.type ?? entry.name_type ?? '').toString().trim().toUpperCase();
+
+    const candidates = [];
+    const pushCandidate = (value) => {
+        const text = (value ?? '').toString().trim();
+        if (!text) return;
+        candidates.push({ text, language, type });
+    };
+
+    pushCandidate(entry.abbrev);
+    pushCandidate(entry.text);
+    pushCandidate(entry.name);
+
+    if (!candidates.length) {
+        return null;
+    }
+    return candidates;
+}
+
+function _typeScore(type) {
+    // Match existing tab logic: prefer NL, then ABBR, then CODE.
+    if (type === 'NL') return 0;
+    if (type === 'ABBR') return 1;
+    if (type === 'CODE') return 2;
+    return 3;
+}
+
+function _languageScore(language, preferredLanguage) {
+    const lang = (preferredLanguage || DEFAULT_LANGUAGE).toLowerCase();
+    const base = lang.split('-')[0];
+    const cand = (language || '').toLowerCase();
+    if (!cand) return 2;
+    if (cand === lang) return 0;
+    if (cand === base || cand.startsWith(base + '-')) return 1;
+    return 2;
+}
+
+/**
+ * Choose the best display label from a names array.
+ *
+ * Behaviour matches the dynamic tab label heuristic:
+ * - prefer exact preferred language, then base-language matches
+ * - prefer NL over ABBR over CODE
+ * - prefer shorter strings
+ */
+export function selectBestNameForContext(names, preferredLanguage = getPreferredLanguage()) {
+    if (!Array.isArray(names) || names.length === 0) {
+        return null;
+    }
+
+    const expanded = [];
+    for (const entry of names) {
+        const candidates = _normaliseNameEntry(entry);
+        if (!candidates) continue;
+        for (const c of candidates) {
+            expanded.push(c);
+        }
+    }
+
+    if (!expanded.length) {
+        return null;
+    }
+
+    // De-dupe by text, keeping the best-scoring metadata.
+    const bestByText = new Map();
+    for (const c of expanded) {
+        const key = c.text;
+        const prev = bestByText.get(key);
+        if (!prev) {
+            bestByText.set(key, c);
+            continue;
+        }
+
+        const prevScore = [_languageScore(prev.language, preferredLanguage), _typeScore(prev.type), prev.text.length];
+        const nextScore = [_languageScore(c.language, preferredLanguage), _typeScore(c.type), c.text.length];
+        if (
+            nextScore[0] < prevScore[0] ||
+            (nextScore[0] === prevScore[0] && (nextScore[1] < prevScore[1] || (nextScore[1] === prevScore[1] && nextScore[2] < prevScore[2])))
+        ) {
+            bestByText.set(key, c);
+        }
+    }
+
+    const unique = Array.from(bestByText.values());
+    unique.sort((a, b) => {
+        const aLang = _languageScore(a.language, preferredLanguage);
+        const bLang = _languageScore(b.language, preferredLanguage);
+        if (aLang !== bLang) return aLang - bLang;
+
+        const aType = _typeScore(a.type);
+        const bType = _typeScore(b.type);
+        if (aType !== bType) return aType - bType;
+
+        return a.text.length - b.text.length || a.text.localeCompare(b.text);
+    });
+
+    return unique[0]?.text || null;
+}
+
+export { DEFAULT_LANGUAGE };
+

--- a/src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js
+++ b/src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js
@@ -1,3 +1,4 @@
+import { getPreferredLanguage, selectBestNameForContext } from './nameSelection.js';
 import { showToast } from './toast.js';
 
 export function normaliseVontologyId(value) {
@@ -127,8 +128,10 @@ async function fetchConceptMetadata(conceptId, fetchFn) {
 
     try {
         const json = await res.json();
+        const preferredLanguage = getPreferredLanguage();
+        const bestName = selectBestNameForContext(json?.raw_doc?.names, preferredLanguage);
         return {
-            displayName: json?.display_name || null,
+            displayName: bestName || json?.display_name || null,
             kind: json?.kind || json?.computed_kind || null
         };
     } catch (_) {

--- a/src/frontend/web/von_interface/static/js/utils/textDecorator.js
+++ b/src/frontend/web/von_interface/static/js/utils/textDecorator.js
@@ -16,7 +16,9 @@ export function parseVontologyTokens(text) {
 	// Using space/quote/backtick as terminators eliminates ambiguity and runaway link concerns
 	// This supports concept IDs like: #V#person, #V#michael_witbrock_business_trip_akl_mel_26_29_nov_2025_air_nz
 	// NOTE: Parentheses are not allowed in concept IDs
-	const tokenRe = /#V#([A-Za-z0-9_\./:–\-]+?)(?=[\s"'`]|$)/g;
+	// Also treat common punctuation as a valid token boundary so we can cartouchify IDs
+	// at sentence boundaries (e.g., "#V#foo.", "(#V#bar)").
+	const tokenRe = /#V#([A-Za-z0-9_\./:–\-]+?)(?=[\s"'`\.,:;!?\)\]\}…]|$)/g;
 
 	let lastIndex = 0;
 	let match;
@@ -325,7 +327,7 @@ function normaliseVontologyTokensForDisplay(text) {
 	// "V#person" -> "#V#person" (but do NOT rewrite "#V#person").
 	// Prefix capture avoids lookbehind to keep browser support broad.
 	output = output.replace(
-		/(^|[^#])([Vv])#([A-Za-z0-9_\./:–\-]+?)(?=[\s"'`]|$)/g,
+		/(^|[^#])([Vv])#([A-Za-z0-9_\./:–\-]+?)(?=[\s"'`\.,:;!?\)\]\}…]|$)/g,
 		(_, prefix, _v, conceptId) => `${prefix}#V#${conceptId}`
 	);
 

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -853,6 +853,23 @@ body {
     border-color: #004085;
 }
 
+/* Copy agent message (markdown) button in chat messages */
+.chat-copy-markdown {
+    font-size: 0.75rem;
+    padding: 2px 6px;
+    background: #f1f5f9;
+    color: #0f172a;
+    border: 1px solid #cbd5e1;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.chat-copy-markdown:hover {
+    background: #e2e8f0;
+    border-color: #94a3b8;
+}
+
 /* Chat message view toggle (Rendered/Text) */
 .chat-render-toggle {
     font-size: 0.75rem;
@@ -868,6 +885,26 @@ body {
 .chat-render-toggle:hover {
     background: #e2e8f0;
     border-color: #94a3b8;
+}
+
+/* Clipboard feedback states for small buttons */
+.btn-mini.success-feedback {
+    background-color: #28a745;
+    color: white;
+    border: 1px solid #28a745;
+    border-radius: 4px;
+}
+
+.btn-mini.error-feedback {
+    background-color: #dc3545;
+    color: white;
+    border: 1px solid #dc3545;
+    border-radius: 4px;
+    animation: shake 0.3s ease;
+}
+
+.btn-mini .btn-icon {
+    font-weight: 700;
 }
 
 .llm-debug-warning-container {
@@ -1514,12 +1551,27 @@ button:hover {
 /* Secondary variant (for non-primary actions like Reset) */
 /* Delete exchange button styling */
 .btn-delete-exchange {
-    transition: color 0.15s ease-in-out;
-    opacity: 0.7;
+    margin-left: 6px;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    font-size: 1rem;
+    border: none;
+    background: transparent;
+    color: #64748b;
+    border-radius: 6px;
+    transition: color 0.15s ease-in-out, background 0.15s ease-in-out, opacity 0.15s ease-in-out;
+    opacity: 0.85;
 }
 
 .btn-delete-exchange:hover {
     opacity: 1;
+    color: #d9534f;
+    background: rgba(217, 83, 79, 0.08);
 }
 
 .btn-delete-exchange:focus {
@@ -2653,6 +2705,11 @@ footer {
     min-height: 0;
 }
 
+/* Chat needs a bit more horizontal room than other tabs. */
+#chatTab>.content-wrapper {
+    max-width: 980px;
+}
+
 .main-title {
     text-align: center;
     margin-bottom: 20px;
@@ -3178,8 +3235,8 @@ button.prompt-vontology-cartouche {
 /* Inline-code cartouches: only used when a <code> span contains exactly one #V#... token. */
 .vontology-cartouche.vontology-cartouche-inline-code {
     padding: 1px 8px;
-    border-color: #d8b4fe;
-    background: #faf5ff;
+    border-color: #cbd5e1;
+    background: #f8fafc;
 }
 
 .vontology-cartouche.vontology-cartouche-inline-code .vontology-cartouche-name {
@@ -3188,7 +3245,7 @@ button.prompt-vontology-cartouche {
 
 .vontology-cartouche.vontology-cartouche-inline-code .vontology-cartouche-id {
     font-weight: 700;
-    color: #6d28d9;
+    color: #334155;
 }
 
 .prompt-vontology-cartouche-remove {
@@ -4561,6 +4618,15 @@ html body .names-list-container .name-cartouche .name-delete-button:disabled:hov
     justify-content: flex-end;
     padding: 10px 12px;
     border-top: 1px solid #e5e7eb;
+}
+
+/* Text relations (attributes): keep long values contained and scrollable */
+.attribute-cartouche .attribute-text {
+    display: block;
+    max-height: 7rem;
+    overflow: auto;
+    white-space: pre-wrap;
+    line-height: 1.25;
 }
 
 /* Annotation JSON lightweight panel (anchored, no full-screen overlay) */

--- a/tests/backend/test_orchestrator_extraction.py
+++ b/tests/backend/test_orchestrator_extraction.py
@@ -1,5 +1,6 @@
 import pytest
 import sys
+from typing import Any, Mapping
 from pathlib import Path
 
 # Add project root to path
@@ -43,6 +44,14 @@ class _RecorderLLM:
         if not self.responses:
             raise RuntimeError("No responses left in _RecorderLLM")
         return self.responses.pop(0)
+
+
+def test_instruction_message_requires_verification_tool_calls_for_concept_existence():
+    orchestrator = InternalMCPChatOrchestrator(gateway=_DummyGateway())  # type: ignore[arg-type]
+    message = orchestrator._instruction_message(user_namespace="#V#user")
+    assert "VERIFICATION & CONSISTENCY RULES" in message
+    assert "fetch_concept" in message
+    assert "search_concepts" in message
 
 
 def test_extract_tool_calls_accepts_single_tool_call():
@@ -212,9 +221,7 @@ def test_looks_like_missing_tool_call_ignores_short_explanatory_text():
 
 def test_looks_like_missing_tool_call_ignores_long_prose():
     """Test that long prose responses (>500 chars) don't trigger false positives."""
-    text = (
-        "I'm going to explain this carefully. " * 20  # Makes it > 500 chars
-    )
+    text = "I'm going to explain this carefully. " * 20  # Makes it > 500 chars
     orchestrator = InternalMCPChatOrchestrator(gateway=_DummyGateway())  # type: ignore[arg-type]
     assert not orchestrator._looks_like_missing_tool_call(text)
 
@@ -230,7 +237,7 @@ def test_llm_detector_returns_true_on_yes():
     )
 
     llm = _RecorderLLM(["YES"])
-    aux_log: list[dict] = []
+    aux_log: list[Mapping[str, Any]] = []
     decision = orchestrator._llm_detects_missing_tool_call(
         "I'm going to search the web",
         llm,
@@ -256,7 +263,7 @@ def test_llm_detector_strips_vontology_model_prefix_before_calling_llm():
     )
 
     llm = _RecorderLLM(["NO"])
-    aux_log: list[dict] = []
+    aux_log: list[Mapping[str, Any]] = []
     decision = orchestrator._llm_detects_missing_tool_call(
         "I will fetch that now",
         llm,
@@ -281,7 +288,7 @@ def test_llm_detector_appends_response_when_placeholder_missing():
     )
 
     llm = _RecorderLLM(["YES"])
-    aux_log: list[dict] = []
+    aux_log: list[Mapping[str, Any]] = []
     decision = orchestrator._llm_detects_missing_tool_call(
         "I'll fetch JVNAUTOSCI-803 now",
         llm,
@@ -306,7 +313,7 @@ def test_llm_detector_uses_fallback_model_when_missing():
     )
 
     llm = _RecorderLLM(["NO"])
-    aux_log: list[dict] = []
+    aux_log: list[Mapping[str, Any]] = []
     decision = orchestrator._llm_detects_missing_tool_call(
         "Normal explanatory text",
         llm,
@@ -351,6 +358,51 @@ def test_run_retries_when_llm_detector_flags_missing_tool_call():
     )
 
     # Should have attempted a tool after classifier said YES
+    assert gateway.calls
+    method_name, payload = gateway.calls[0]
+    assert method_name == "test"
+    assert payload.get("namespace") == "#V#user"
+    assert result.tool_invocations
+    assert result.response_text == "Final response"
+    assert result.aux_llm_calls
+
+
+def test_run_retries_when_classifier_misses_but_heuristic_triggers():
+    gateway = _DummyGateway()
+    llm = _RecorderLLM(
+        [
+            # Initial response: promises tool-backed actions, includes a strong heuristic trigger.
+            (
+                "I’ll do one thing only in this turn: create the concept and then verify it.\n\n"
+                "Proceeding now.\n\n"
+                "Next message will contain the tool output."  # No tool JSON payload
+            ),
+            "NO",  # classifier verdict (incorrect)
+            '{"action": "call_tool", "tool": "test", "payload": {}}',  # retry emits tool call
+            "Final response",  # follow-up after tool invocation
+        ]
+    )
+
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=gateway,  # type: ignore[arg-type]
+        max_tool_invocations=1,
+    )
+    orchestrator._missing_tool_call_detector_loaded = True
+    orchestrator._missing_tool_call_detector = _MissingToolCallDetectorSpec(
+        action_id="#V#detect_missing_tool_call_action",
+        prompt_id="#V#missing_tool_call_detection_prompt",
+        prompt_text="Answer YES or NO for: {response}",
+        model="detector-model",
+    )
+
+    result = orchestrator.run(
+        prompt="hello",
+        context=None,
+        llm_client=llm,
+        model="primary-model",
+        user_namespace="#V#user",
+    )
+
     assert gateway.calls
     method_name, payload = gateway.calls[0]
     assert method_name == "test"

--- a/tests/backend/test_von_generate_llm_debug_parse_error.py
+++ b/tests/backend/test_von_generate_llm_debug_parse_error.py
@@ -1,0 +1,65 @@
+import pytest
+from flask import Flask
+
+from src.backend.integrations.internal_mcp import ToolCallParsingError
+
+
+class _DummyLLM:
+    def generate(self, *_args, **_kwargs):
+        raise AssertionError("generate should not be called when parsing fails")
+
+
+class _FailingOrchestrator:
+    def run(self, *_args, **_kwargs):
+        raise ToolCallParsingError(
+            "Tool call was not executed: invalid JSON in tool call response.",
+            raw_response='{"action":"call_tool"} trailing',
+        )
+
+
+@pytest.fixture()
+def app(monkeypatch):
+    from src.backend.server.routes.von_routes import von_bp
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_llm_client",
+        lambda **_kwargs: _DummyLLM(),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_active_model_name",
+        lambda: "test-model",
+    )
+
+    flask_app = Flask(__name__)
+    flask_app.secret_key = "test-secret"
+    flask_app.register_blueprint(von_bp, url_prefix="/von")
+
+    flask_app.config["CONTEXT"] = []
+    flask_app.config["INTERNAL_MCP_ORCHESTRATOR"] = _FailingOrchestrator()
+    flask_app.config["INTERNAL_MCP_GATEWAY"] = None
+
+    return flask_app
+
+
+def test_llm_debug_contains_rejected_tool_payload(app):
+    client = app.test_client()
+
+    resp = client.post("/von/generate", json={"prompt": "please run tool"})
+    assert resp.status_code == 200
+
+    body = resp.get_json()
+    assert body["response"].startswith(
+        "Tool call was not executed due to an MCP serialisation error."
+    )
+
+    llm_debug = body["llm_debug"]
+    invocations = llm_debug["tool_invocations"]
+    assert invocations, "expected parse error to be recorded in tool invocations"
+
+    invocation = invocations[0]
+    assert invocation["method"] == "__tool_call_parse_error__"
+    assert (
+        invocation["arguments"].get("raw_tool_call")
+        == '{"action":"call_tool"} trailing'
+    )
+    assert "invalid JSON in tool call response" in invocation["error"]

--- a/tests/backend/test_vontology_node_content_md_reconstruction.py
+++ b/tests/backend/test_vontology_node_content_md_reconstruction.py
@@ -1,0 +1,52 @@
+import pytest
+
+from src.backend.vontology import utils_vontology
+
+
+@pytest.fixture(autouse=True)
+def clean_vontology_nodes_collection():
+    db = utils_vontology.get_db()
+    if db is not None:
+        db["vontology_nodes"].delete_many({})
+    yield
+    if db is not None:
+        db["vontology_nodes"].delete_many({})
+
+
+def test_reconstructed_md_content_omits_boilerplate_metadata_fields():
+    db = utils_vontology.get_db()
+    if db is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concept_id = "#V#verified_entity_representation_agentic_workflow_design"
+
+    db["vontology_nodes"].insert_one(
+        {
+            "concept_id": concept_id,
+            "names": [
+                {
+                    "name": "Verified Entity Representation Agentic Workflow Design",
+                    "type": "NL",
+                    "language": "en-NZ",
+                }
+            ],
+            "relationships": {
+                "is_an_instance_of": ["#V#von_agentic_component_design_document"],
+                "is_a_type_of": [],
+            },
+            # Intentionally no md_content.
+            # Intentionally no source_concept.
+            # Description/notes are stored in text relations in newer schema; here we just ensure fallback doesn't invent boilerplate.
+        }
+    )
+
+    payload = utils_vontology.get_vontology_node_content(concept_id)
+    assert "error" not in payload
+
+    md = payload.get("md_content")
+    assert isinstance(md, str)
+
+    assert md.startswith("# ")
+    assert "Source Concept" not in md
+    assert "SubConcept Of" not in md
+    assert "Instance Of" not in md

--- a/tests/frontend/nameSelection.test.js
+++ b/tests/frontend/nameSelection.test.js
@@ -1,0 +1,41 @@
+import { selectBestNameForContext } from '../../src/frontend/web/von_interface/static/js/utils/nameSelection.js';
+
+describe('nameSelection', () => {
+    test('prefers exact language match over others', () => {
+        const names = [
+            { name: 'Person', language: 'en', type: 'NL' },
+            { name: 'Human being', language: 'en-NZ', type: 'NL' }
+        ];
+
+        expect(selectBestNameForContext(names, 'en-NZ')).toBe('Human being');
+    });
+
+    test('falls back to base-language match when region differs', () => {
+        const names = [
+            { name: 'Person', language: 'en', type: 'NL' },
+            { name: 'Personne', language: 'fr', type: 'NL' }
+        ];
+
+        expect(selectBestNameForContext(names, 'en-NZ')).toBe('Person');
+    });
+
+    test('prefers NL over ABBR over CODE, then shortest', () => {
+        const names = [
+            { name: 'European Union', language: 'en-NZ', type: 'NL' },
+            { name: 'EU', language: 'en-NZ', type: 'ABBR' },
+            { name: 'Mx4r...', language: 'en-NZ', type: 'CODE' }
+        ];
+
+        // Mirrors the existing tab heuristic: NL beats ABBR even if longer.
+        expect(selectBestNameForContext(names, 'en-NZ')).toBe('European Union');
+    });
+
+    test('within same language/type, chooses shorter', () => {
+        const names = [
+            { name: 'member country', language: 'en-NZ', type: 'NL' },
+            { name: 'country', language: 'en-NZ', type: 'NL' }
+        ];
+
+        expect(selectBestNameForContext(names, 'en-NZ')).toBe('country');
+    });
+});

--- a/tests/frontend/textDecoratorTokenBoundaries.test.js
+++ b/tests/frontend/textDecoratorTokenBoundaries.test.js
@@ -1,0 +1,46 @@
+/** @jest-environment jsdom */
+
+const modulePath = '../../src/frontend/web/von_interface/static/js/utils/textDecorator.js';
+
+describe('Vontology token boundaries', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="root"></div>';
+    });
+
+    test('cartouchifies #V# tokens followed by punctuation', () => {
+        const { cartouchifyVontologyTokensInElement } = require(modulePath);
+
+        const root = document.getElementById('root');
+        root.textContent = 'See #V#person.';
+
+        cartouchifyVontologyTokensInElement(root);
+
+        const cartouches = root.querySelectorAll('.vontology-cartouche');
+        expect(cartouches.length).toBe(1);
+        expect(cartouches[0].dataset.fullConceptId).toBe('#V#person');
+
+        const buttonNode = cartouches[0];
+        expect(buttonNode.nextSibling).not.toBeNull();
+        expect(buttonNode.nextSibling.nodeType).toBe(Node.TEXT_NODE);
+        expect(buttonNode.nextSibling.nodeValue).toBe('.');
+    });
+
+    test('cartouchifies #V# tokens inside parentheses at sentence boundaries', () => {
+        const { cartouchifyVontologyTokensInElement } = require(modulePath);
+
+        const root = document.getElementById('root');
+        root.textContent = 'See (#V#person).';
+
+        cartouchifyVontologyTokensInElement(root);
+
+        const cartouches = root.querySelectorAll('.vontology-cartouche');
+        expect(cartouches.length).toBe(1);
+        expect(cartouches[0].dataset.fullConceptId).toBe('#V#person');
+
+        // Ensure trailing punctuation is preserved as text (" )." after the cartouche).
+        const buttonNode = cartouches[0];
+        expect(buttonNode.nextSibling).not.toBeNull();
+        expect(buttonNode.nextSibling.nodeType).toBe(Node.TEXT_NODE);
+        expect(buttonNode.nextSibling.nodeValue).toBe(').');
+    });
+});


### PR DESCRIPTION
Implements JVNAUTOSCI-821.

Key changes:
- Remove obsolete `md_content` reconstruction boilerplate (Source Concept/SubConcept Of/Instance Of) for concepts missing `md_content`.
- Improve tool-call parse error observability and UI refresh behaviour for text relations.
- Add small frontend utilities/tests for name selection and token boundary handling.

Tests:
- `pdm run pytest -q tests/backend/test_vontology_node_content_md_reconstruction.py`

Follow-up:
- JVNAUTOSCI-822 tracks MCP/tooling improvements.
