### PR TITLE
JVNAUTOSCI-822: Add lightweight text tools + summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,18 @@ When To Act Automatically:
 - Consolidate duplicated DOM update logic into a single helper before expanding features (prevents regression drift).
 - Add a regression test for every state/format loss bug fix (load → edit → save → re-edit cycle) before declaring completion.
 
+Jira assignee updates (do not misinterpret tooling):
+- If an issue is created without an assignee (or with the wrong one), it can usually be fixed retrospectively using the Atlassian MCP edit tool.
+- Preferred pattern (assignee by accountId):
+  ```python
+  mcp_atlassian_editJiraIssue(
+      cloudId="...",
+      issueIdOrKey="JVNAUTOSCI-XXX",
+      fields={"assignee": {"accountId": "<account_id>"}}
+  )
+  ```
+- Do not create a duplicate issue just to correct assignee unless the edit call fails due to permissions or workflow restrictions.
+
 When To Ask (Legitimate Blockers Only):
 - Ambiguous or missing JIRA issue key (multiple candidates, unparsable branch name).
 - Atlassian cloudId lookup fails after all retries.

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -321,6 +321,7 @@ def _delete_text_relation(**kwargs):
     predicate = kwargs.get("predicate")
     text = kwargs.get("text")
     language = kwargs.get("language")
+    garbage_collect = bool(kwargs.get("garbage_collect"))
 
     if not concept_id:
         return {"error": "Missing 'concept_id' parameter"}
@@ -331,12 +332,18 @@ def _delete_text_relation(**kwargs):
             result = delete_text_relation(
                 subject_concept_id=concept_id,
                 relation_id=relation_id,
+                garbage_collect=garbage_collect,
             )
             return {
                 "success": True,
                 "deleted_relation_id": relation_id,
-                "deleted_text_preview": str(result.get("text", ""))[:100],
-                "text_value_cleaned_up": result.get("orphaned", False),
+                "deleted_text_preview": None,
+                "text_value_cleaned_up": bool(
+                    result.get(
+                        "orphaned_text_value_deleted",
+                        result.get("text_value_cleaned_up", False),
+                    )
+                ),
             }
         elif predicate and text:
             # Delete by predicate + text match
@@ -345,17 +352,123 @@ def _delete_text_relation(**kwargs):
                 predicate=predicate,
                 text=text,
                 lang=language,
+                garbage_collect=garbage_collect,
             )
             return {
                 "success": True,
                 "deleted_relation_id": result.get("relation_id"),
                 "deleted_text_preview": text[:100],
-                "text_value_cleaned_up": result.get("orphaned_text_value_deleted", False),
+                "text_value_cleaned_up": result.get(
+                    "orphaned_text_value_deleted", False
+                ),
             }
         else:
-            return {"error": "Must provide either relation_id or both predicate and text"}
+            return {
+                "error": "Must provide either relation_id or both predicate and text"
+            }
     except Exception as exc:
         return {"error": f"Failed to delete text relation: {exc}"}
+
+
+def _get_text_relations_summary(**kwargs):
+    from ...services.text_value_service import get_text_relations_summary
+
+    concept_id = kwargs.get("concept_id")
+    predicates = kwargs.get("predicates")
+    languages = kwargs.get("languages")
+    max_relation_ids_per_group = kwargs.get("max_relation_ids_per_group", 25)
+
+    if not concept_id:
+        return {"error": "Missing 'concept_id' parameter", "success": False}
+
+    try:
+        return get_text_relations_summary(
+            concept_id,
+            predicates=predicates,
+            languages=languages,
+            max_relation_ids_per_group=max_relation_ids_per_group,
+        )
+    except Exception as exc:
+        return {"error": f"Failed to summarise text relations: {exc}", "success": False}
+
+
+def _upsert_singleton_text_relation(**kwargs):
+    from ...services.text_value_service import upsert_singleton_text_relation
+
+    concept_id = kwargs.get("concept_id")
+    predicate = kwargs.get("predicate")
+    text = kwargs.get("text")
+    language = kwargs.get("language", "en-NZ")
+    policy = kwargs.get("policy", "replace_others")
+    garbage_collect = kwargs.get("garbage_collect")
+    provenance = kwargs.get("provenance")
+    context = kwargs.get("context")
+
+    if not concept_id:
+        return {"error": "Missing 'concept_id' parameter", "success": False}
+    if not predicate:
+        return {"error": "Missing 'predicate' parameter", "success": False}
+    if not text:
+        return {"error": "Missing 'text' parameter", "success": False}
+
+    try:
+        return upsert_singleton_text_relation(
+            subject_concept_id=concept_id,
+            predicate=predicate,
+            text=text,
+            lang=language,
+            policy=policy,
+            provenance=provenance,
+            context=context,
+            garbage_collect=(
+                True if garbage_collect is None else bool(garbage_collect)
+            ),
+        )
+    except Exception as exc:
+        return {
+            "error": f"Failed to upsert singleton text relation: {exc}",
+            "success": False,
+        }
+
+
+def _concept_exists(**kwargs):
+    from ...db.repositories.concepts_repository import ConceptsRepository
+    from ...security.access_control import can_access_concept
+
+    concept_id = kwargs.get("concept_id")
+    if not concept_id:
+        return {"error": "Missing 'concept_id' parameter", "success": False}
+
+    try:
+        doc = ConceptsRepository.find_one({"concept_id": concept_id}, {"_id": 1})
+        exists = bool(doc)
+        accessible = can_access_concept(concept_id)
+        return {
+            "success": True,
+            "concept_id": concept_id,
+            "exists": exists,
+            "accessible": accessible,
+        }
+    except Exception as exc:
+        return {"error": f"Failed to check concept existence: {exc}", "success": False}
+
+
+def _fetch_concept_content(**kwargs):
+    from ...vontology.utils_vontology import get_vontology_node_content
+
+    concept_id = kwargs.get("concept_id")
+    reconstruct_md = kwargs.get("reconstruct_md", True)
+    if not concept_id:
+        return {"error": "Missing 'concept_id' parameter", "success": False}
+
+    try:
+        payload = get_vontology_node_content(
+            concept_id, reconstruct_md=bool(reconstruct_md)
+        )
+        payload["success"] = "error" not in payload
+        return payload
+    except Exception as exc:
+        return {"error": f"Failed to fetch concept content: {exc}", "success": False}
 
 
 def _add_names_to_concept(**kwargs):
@@ -1303,9 +1416,111 @@ def _delete_text_relation_input_schema() -> Schema:
             "predicate": (str, type(None)),
             "text": (str, type(None)),
             "language": (str, type(None)),
+            "garbage_collect": (bool,),
         },
         allow_unknown=True,
-        description="delete_text_relation input: concept_id (str), relation_id (str, optional - preferred method), predicate (str, optional for predicate+text deletion), text (str, optional with predicate), language (str, optional)",
+        description="delete_text_relation input: concept_id (str), relation_id (str, optional - preferred method), predicate (str, optional for predicate+text deletion), text (str, optional with predicate), language (str, optional), garbage_collect (bool, optional - if true, delete orphaned text_values)",
+    )
+
+
+def _get_text_relations_summary_input_schema() -> Schema:
+    return Schema(
+        required={"concept_id": str},
+        optional={
+            "predicates": (list, type(None)),
+            "languages": (list, type(None)),
+            "max_relation_ids_per_group": (int, type(None)),
+        },
+        allow_unknown=True,
+        description="get_text_relations_summary input: concept_id (str), predicates (list[str] optional), languages (list[str] optional), max_relation_ids_per_group (int optional, default 25)",
+    )
+
+
+def _get_text_relations_summary_output_schema() -> Schema:
+    return Schema(
+        required={
+            "success": bool,
+            "concept_id": str,
+            "groups": list,
+            "groups_found": int,
+            "total_relations_scanned": int,
+            "max_relation_ids_per_group": int,
+        },
+        optional={"error": (str, type(None))},
+        allow_unknown=True,
+        description="get_text_relations_summary output: success, concept_id, groups[{predicate, language, count, relation_ids, latest_relation_id, latest_updated_at}], groups_found, total_relations_scanned",
+    )
+
+
+def _upsert_singleton_text_relation_input_schema() -> Schema:
+    return Schema(
+        required={
+            "concept_id": str,
+            "predicate": str,
+            "text": str,
+        },
+        optional={
+            "language": str,
+            "policy": str,
+            "garbage_collect": (bool, type(None)),
+            "provenance": (dict, type(None)),
+            "context": (dict, type(None)),
+        },
+        allow_unknown=True,
+        description="upsert_singleton_text_relation input: concept_id (str), predicate (str), text (str), language (str optional default en-NZ), policy (str optional default replace_others), garbage_collect (bool optional default true), provenance/context (dict optional)",
+    )
+
+
+def _upsert_singleton_text_relation_output_schema() -> Schema:
+    return Schema(
+        required={
+            "success": bool,
+            "concept_id": str,
+            "predicate": str,
+            "language": str,
+            "kept_relation_id": str,
+            "replaced_relation_ids": list,
+            "replaced_count": int,
+            "relation_created": bool,
+        },
+        optional={
+            "text_value_id": (str, type(None)),
+            "error": (str, type(None)),
+        },
+        allow_unknown=True,
+        description="upsert_singleton_text_relation output: success, kept_relation_id, replaced_relation_ids/count, relation_created, text_value_id",
+    )
+
+
+def _concept_exists_input_schema() -> Schema:
+    return Schema(
+        required={"concept_id": str},
+        optional={},
+        allow_unknown=True,
+        description="concept_exists input: concept_id (str)",
+    )
+
+
+def _concept_exists_output_schema() -> Schema:
+    return Schema(
+        required={
+            "success": bool,
+            "concept_id": str,
+            "exists": bool,
+            "accessible": bool,
+        },
+        optional={"error": (str, type(None))},
+        allow_unknown=True,
+        description="concept_exists output: success, concept_id, exists (bool), accessible (bool)",
+    )
+
+
+def _fetch_concept_content_input_schema() -> Schema:
+    return Schema(
+        required={"concept_id": str},
+        optional={"reconstruct_md": (bool, type(None))},
+        allow_unknown=True,
+        description="fetch_concept_content input: concept_id (str), reconstruct_md (bool optional default true)",
     )
 
 
@@ -2882,6 +3097,38 @@ def build_default_catalogue() -> MethodCatalogue:
             output_schema=_delete_text_relation_output_schema(),
             category="write",
             description="Delete a specific text relation by relation ID or by predicate+text match. Optionally garbage-collects orphaned text values. Use to remove unwanted text attachments from concepts.",
+        ),
+        MethodDefinition(
+            name="get_text_relations_summary",
+            handler=_get_text_relations_summary,
+            input_schema=_get_text_relations_summary_input_schema(),
+            output_schema=_get_text_relations_summary_output_schema(),
+            category="read",
+            description="Return a lightweight summary of text relations for a concept: counts + relation IDs grouped by predicate/language (no full text bodies). Use to quickly decide what to fetch next.",
+        ),
+        MethodDefinition(
+            name="upsert_singleton_text_relation",
+            handler=_upsert_singleton_text_relation,
+            input_schema=_upsert_singleton_text_relation_input_schema(),
+            output_schema=_upsert_singleton_text_relation_output_schema(),
+            category="write",
+            description="Upsert a text relation and enforce singleton semantics for (concept, predicate, language) by replacing any other relations in the same group.",
+        ),
+        MethodDefinition(
+            name="concept_exists",
+            handler=_concept_exists,
+            input_schema=_concept_exists_input_schema(),
+            output_schema=_concept_exists_output_schema(),
+            category="read",
+            description="Minimal existence/accessibility check for a concept_id. Use before expensive fetch operations or when you need to validate user input.",
+        ),
+        MethodDefinition(
+            name="fetch_concept_content",
+            handler=_fetch_concept_content,
+            input_schema=_fetch_concept_content_input_schema(),
+            output_schema=None,
+            category="read",
+            description="Fetch rendered markdown content for a concept (content_html + md_content + raw_doc). Use reconstruct_md=false to avoid masking missing md_content.",
         ),
         MethodDefinition(
             name="add_names",

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -52,6 +52,7 @@ from datetime import datetime, timezone
 from src.backend.vontology.utils_vontology import (
     create_vontology_concept,
     get_all_vontology_nodes_with_details,
+    get_vontology_node_content,
     get_vontology_tree,
     simulate_or_delete_concept,
 )
@@ -69,6 +70,8 @@ from src.backend.services.concept_search_service import search_concepts
 from src.backend.services.text_value_service import (
     upsert_text_for_concept,
     get_texts_for_concept,
+    get_text_relations_summary,
+    upsert_singleton_text_relation,
     update_text_relation_text,
     delete_text_relation,
     delete_text_relation_by_predicate_and_text,
@@ -427,6 +430,118 @@ async def list_tools() -> list[Tool]:
                     "language": {
                         "type": "string",
                         "description": "Optional: language code for predicate+text deletion",
+                    },
+                    "garbage_collect": {
+                        "type": "boolean",
+                        "description": "Optional: when true, delete orphaned text_values after relation removal",
+                        "default": False,
+                    },
+                },
+                "required": ["concept_id"],
+            },
+        ),
+        Tool(
+            name="get_text_relations_summary",
+            description="Return a lightweight summary of text relations for a concept: counts + relation IDs grouped by predicate/language (no full text bodies).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "concept_id": {
+                        "type": "string",
+                        "description": "The concept to summarise text relations for",
+                    },
+                    "predicates": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional: filter by predicate allow-list",
+                    },
+                    "languages": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional: filter by language allow-list (derived from text_values.lang)",
+                    },
+                    "max_relation_ids_per_group": {
+                        "type": "integer",
+                        "default": 25,
+                        "description": "Cap for relation IDs returned per predicate/language bucket",
+                    },
+                },
+                "required": ["concept_id"],
+            },
+        ),
+        Tool(
+            name="upsert_singleton_text_relation",
+            description="Upsert a text relation and enforce singleton semantics for (concept, predicate, language) by replacing any other relations in the same group.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "concept_id": {
+                        "type": "string",
+                        "description": "The concept to attach text to",
+                    },
+                    "predicate": {
+                        "type": "string",
+                        "description": "Text predicate (e.g., 'hasDescription')",
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "Text to attach",
+                    },
+                    "language": {
+                        "type": "string",
+                        "default": "en-NZ",
+                        "description": "Language code for the singleton group",
+                    },
+                    "policy": {
+                        "type": "string",
+                        "default": "replace_others",
+                        "description": "Singleton policy (currently only replace_others)",
+                    },
+                    "garbage_collect": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "When true, garbage-collect orphaned text_values for replaced relations",
+                    },
+                    "provenance": {
+                        "type": "object",
+                        "description": "Optional provenance metadata",
+                    },
+                    "context": {
+                        "type": "object",
+                        "description": "Optional relation context metadata",
+                    },
+                },
+                "required": ["concept_id", "predicate", "text"],
+            },
+        ),
+        Tool(
+            name="concept_exists",
+            description="Minimal existence/accessibility check for a concept_id.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "concept_id": {
+                        "type": "string",
+                        "description": "The concept ID to check",
+                    }
+                },
+                "required": ["concept_id"],
+            },
+        ),
+        Tool(
+            name="fetch_concept_content",
+            description="Fetch rendered markdown content for a concept (content_html + md_content + raw_doc). Use reconstruct_md=false to avoid masking missing md_content.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "concept_id": {
+                        "type": "string",
+                        "description": "The concept ID to fetch",
+                    },
+                    "reconstruct_md": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "When false, do not reconstruct md_content if it is missing",
                     },
                 },
                 "required": ["concept_id"],
@@ -1552,6 +1667,7 @@ async def _handle_delete_text_relation(arguments: dict[str, Any]) -> list[TextCo
     predicate = arguments.get("predicate")
     text = arguments.get("text")
     language = arguments.get("language")
+    garbage_collect = bool(arguments.get("garbage_collect"))
 
     if not concept_id:
         return [_json_error("Missing concept_id parameter")]
@@ -1562,12 +1678,18 @@ async def _handle_delete_text_relation(arguments: dict[str, Any]) -> list[TextCo
             result = delete_text_relation(
                 subject_concept_id=concept_id,
                 relation_id=relation_id,
+                garbage_collect=garbage_collect,
             )
             payload = {
                 "success": True,
                 "deleted_relation_id": relation_id,
-                "deleted_text_preview": str(result.get("text", ""))[:100],
-                "text_value_cleaned_up": result.get("orphaned", False),
+                "deleted_text_preview": None,
+                "text_value_cleaned_up": bool(
+                    result.get(
+                        "orphaned_text_value_deleted",
+                        result.get("text_value_cleaned_up", False),
+                    )
+                ),
             }
         elif predicate and text:
             # Delete by predicate + text match
@@ -1576,15 +1698,22 @@ async def _handle_delete_text_relation(arguments: dict[str, Any]) -> list[TextCo
                 predicate=predicate,
                 text=text,
                 lang=language,
+                garbage_collect=garbage_collect,
             )
             payload = {
                 "success": True,
                 "deleted_relation_id": result.get("relation_id"),
                 "deleted_text_preview": text[:100],
-                "text_value_cleaned_up": result.get("orphaned_text_value_deleted", False),
+                "text_value_cleaned_up": result.get(
+                    "orphaned_text_value_deleted", False
+                ),
             }
         else:
-            return [_json_error("Must provide either relation_id or both predicate and text")]
+            return [
+                _json_error(
+                    "Must provide either relation_id or both predicate and text"
+                )
+            ]
 
         return [_json_text(payload)]
     except Exception as exc:
@@ -1711,6 +1840,93 @@ async def _handle_fetch_concept(arguments: dict[str, Any]) -> list[TextContent]:
         return [_json_text(concept)]
     except Exception as exc:
         return [_json_error(str(exc))]
+
+
+async def _handle_get_text_relations_summary(
+    arguments: dict[str, Any],
+) -> list[TextContent]:
+    concept_id = arguments.get("concept_id")
+    if not concept_id:
+        return [_json_error("Missing concept_id parameter")]
+
+    try:
+        payload = get_text_relations_summary(
+            concept_id,
+            predicates=arguments.get("predicates"),
+            languages=arguments.get("languages"),
+            max_relation_ids_per_group=arguments.get("max_relation_ids_per_group", 25),
+        )
+        return [_json_text(payload)]
+    except Exception as exc:
+        return [_json_error(f"Failed to summarise text relations: {exc}")]
+
+
+async def _handle_upsert_singleton_text_relation(
+    arguments: dict[str, Any],
+) -> list[TextContent]:
+    concept_id = arguments.get("concept_id")
+    predicate = arguments.get("predicate")
+    text = arguments.get("text")
+
+    if not concept_id:
+        return [_json_error("Missing concept_id parameter")]
+    if not predicate:
+        return [_json_error("Missing predicate parameter")]
+    if not text:
+        return [_json_error("Missing text parameter")]
+
+    try:
+        payload = upsert_singleton_text_relation(
+            subject_concept_id=concept_id,
+            predicate=predicate,
+            text=text,
+            lang=arguments.get("language", "en-NZ"),
+            policy=arguments.get("policy", "replace_others"),
+            provenance=arguments.get("provenance"),
+            context=arguments.get("context"),
+            garbage_collect=arguments.get("garbage_collect", True),
+        )
+        return [_json_text(payload)]
+    except Exception as exc:
+        return [_json_error(f"Failed to upsert singleton text relation: {exc}")]
+
+
+async def _handle_concept_exists(arguments: dict[str, Any]) -> list[TextContent]:
+    from src.backend.security.access_control import can_access_concept
+
+    concept_id = arguments.get("concept_id")
+    if not concept_id:
+        return [_json_error("Missing concept_id parameter")]
+
+    try:
+        doc = ConceptsRepository.find_one({"concept_id": concept_id}, {"_id": 1})
+        payload = {
+            "success": True,
+            "concept_id": concept_id,
+            "exists": bool(doc),
+            "accessible": can_access_concept(concept_id),
+        }
+        return [_json_text(payload)]
+    except Exception as exc:
+        return [_json_error(f"Failed to check concept existence: {exc}")]
+
+
+async def _handle_fetch_concept_content(
+    arguments: dict[str, Any],
+) -> list[TextContent]:
+    concept_id = arguments.get("concept_id")
+    if not concept_id:
+        return [_json_error("Missing concept_id parameter")]
+
+    reconstruct_md = arguments.get("reconstruct_md", True)
+    try:
+        payload = get_vontology_node_content(
+            concept_id, reconstruct_md=bool(reconstruct_md)
+        )
+        payload["success"] = "error" not in payload
+        return [_json_text(payload)]
+    except Exception as exc:
+        return [_json_error(f"Failed to fetch concept content: {exc}")]
 
 
 async def _handle_search_concepts(arguments: dict[str, Any]) -> list[TextContent]:
@@ -2086,9 +2302,13 @@ _TOOL_HANDLERS: dict[str, Callable[[dict[str, Any]], Awaitable[list[TextContent]
     "get_text_relations": _handle_get_text_relations,
     "update_text_relation": _handle_update_text_relation,
     "delete_text_relation": _handle_delete_text_relation,
+    "get_text_relations_summary": _handle_get_text_relations_summary,
+    "upsert_singleton_text_relation": _handle_upsert_singleton_text_relation,
     "add_names": _handle_add_names,
     "get_tree": _handle_get_tree,
     "fetch_concept": _handle_fetch_concept,
+    "fetch_concept_content": _handle_fetch_concept_content,
+    "concept_exists": _handle_concept_exists,
     "search_concepts": _handle_search_concepts,
     "vontology_concept_search": _handle_search_concepts,
     "extract_annotations": _handle_extract_annotations,

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -206,6 +206,132 @@
                     "language": {
                         "type": "string",
                         "description": "Optional: language code for predicate+text deletion"
+                    },
+                    "garbage_collect": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Optional: when true, delete orphaned text_values after relation removal"
+                    }
+                },
+                "required": [
+                    "concept_id"
+                ]
+            }
+        },
+        {
+            "name": "get_text_relations_summary",
+            "description": "Return a lightweight summary of text relations for a concept: counts + relation IDs grouped by predicate/language (no full text bodies).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "concept_id": {
+                        "type": "string",
+                        "description": "The concept to summarise text relations for"
+                    },
+                    "predicates": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Optional: filter by predicate allow-list"
+                    },
+                    "languages": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Optional: filter by language allow-list (derived from text_values.lang)"
+                    },
+                    "max_relation_ids_per_group": {
+                        "type": "integer",
+                        "default": 25,
+                        "description": "Cap for relation IDs returned per predicate/language bucket"
+                    }
+                },
+                "required": [
+                    "concept_id"
+                ]
+            }
+        },
+        {
+            "name": "upsert_singleton_text_relation",
+            "description": "Upsert a text relation and enforce singleton semantics for (concept, predicate, language) by replacing any other relations in the same group.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "concept_id": {
+                        "type": "string",
+                        "description": "The concept to attach text to"
+                    },
+                    "predicate": {
+                        "type": "string",
+                        "description": "Text predicate (e.g., 'hasDescription')"
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "Text to attach"
+                    },
+                    "language": {
+                        "type": "string",
+                        "default": "en-NZ",
+                        "description": "Language code for the singleton group"
+                    },
+                    "policy": {
+                        "type": "string",
+                        "default": "replace_others",
+                        "description": "Singleton policy (currently only replace_others)"
+                    },
+                    "garbage_collect": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "When true, garbage-collect orphaned text_values for replaced relations"
+                    },
+                    "provenance": {
+                        "type": "object",
+                        "description": "Optional provenance metadata"
+                    },
+                    "context": {
+                        "type": "object",
+                        "description": "Optional relation context metadata"
+                    }
+                },
+                "required": [
+                    "concept_id",
+                    "predicate",
+                    "text"
+                ]
+            }
+        },
+        {
+            "name": "concept_exists",
+            "description": "Minimal existence/accessibility check for a concept_id.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "concept_id": {
+                        "type": "string",
+                        "description": "The concept ID to check"
+                    }
+                },
+                "required": [
+                    "concept_id"
+                ]
+            }
+        },
+        {
+            "name": "fetch_concept_content",
+            "description": "Fetch rendered markdown content for a concept (content_html + md_content + raw_doc). Use reconstruct_md=false to avoid masking missing md_content.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "concept_id": {
+                        "type": "string",
+                        "description": "The concept ID to fetch"
+                    },
+                    "reconstruct_md": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "When false, do not reconstruct md_content if it is missing"
                     }
                 },
                 "required": [

--- a/src/backend/services/text_value_service.py
+++ b/src/backend/services/text_value_service.py
@@ -348,6 +348,7 @@ def delete_text_relation_by_predicate_and_text(
     *,
     lang: Optional[str] = None,
     context: Optional[Dict[str, Any]] = None,
+    garbage_collect: bool = False,
 ) -> Dict[str, Any]:
     """Delete a text relation by predicate and text value. Optionally garbage-collect orphaned text values.
 
@@ -372,9 +373,7 @@ def delete_text_relation_by_predicate_and_text(
     )
     if not text_value:
         # Legacy fallback: direct text/lang lookup
-        text_value = TextValuesRepository.find_one(
-            {"text": raw_text, "lang": lang}
-        )
+        text_value = TextValuesRepository.find_one({"text": raw_text, "lang": lang})
     if not text_value:
         text_value = TextValuesRepository.find_one({"text": raw_text})
     if not text_value:
@@ -418,11 +417,12 @@ def delete_text_relation_by_predicate_and_text(
 
     # Check if the text value is now orphaned
     orphaned = False
-    others = TextRelationsRepository.find_one({"object_text_id": text_value_id})
-    if not others:
-        # Safe to delete the text value
-        TextValuesRepository.delete_one({"_id": ObjectId(text_value_id)})
-        orphaned = True
+    if garbage_collect:
+        others = TextRelationsRepository.find_one({"object_text_id": text_value_id})
+        if not others:
+            # Safe to delete the text value
+            TextValuesRepository.delete_one({"_id": ObjectId(text_value_id)})
+            orphaned = True
 
     return {
         "deleted": True,
@@ -433,7 +433,12 @@ def delete_text_relation_by_predicate_and_text(
     }
 
 
-def delete_text_relation(subject_concept_id: str, relation_id: str) -> Dict[str, Any]:
+def delete_text_relation(
+    subject_concept_id: str,
+    relation_id: str,
+    *,
+    garbage_collect: bool = False,
+) -> Dict[str, Any]:
     """Delete a specific text relation. Optionally garbage-collect orphaned text values.
 
     For now, we retain the TextValue (shared across relations) unless unreferenced;
@@ -449,7 +454,7 @@ def delete_text_relation(subject_concept_id: str, relation_id: str) -> Dict[str,
     tv_id = rel.get("object_text_id")
     TextRelationsRepository.delete_one({"_id": ObjectId(relation_id)})
     orphaned = False
-    if tv_id:
+    if tv_id and garbage_collect:
         # Check if any other relation references this text value
         others = TextRelationsRepository.find_one({"object_text_id": tv_id})
         if not others:
@@ -463,12 +468,244 @@ def delete_text_relation(subject_concept_id: str, relation_id: str) -> Dict[str,
     }
 
 
+def get_text_relations_summary(
+    subject_concept_id: str,
+    *,
+    predicates: Optional[List[str]] = None,
+    languages: Optional[List[str]] = None,
+    max_relation_ids_per_group: int = 25,
+) -> Dict[str, Any]:
+    """Return counts + relation IDs grouped by predicate/language.
+
+    This is intentionally "lightweight": it does not return full text bodies.
+
+    Notes:
+    - Text relation documents do not store language directly; language is derived from
+      the referenced text_values documents.
+    - `languages` is therefore a post-filter applied after resolving text value lang.
+    """
+    if not can_access_concept(subject_concept_id):
+        raise PermissionError("User cannot view text for an inaccessible concept")
+
+    pred_filter: Dict[str, Any] = {"subject_concept_id": subject_concept_id}
+    if predicates:
+        pred_filter["predicate"] = {
+            "$in": [p for p in predicates if isinstance(p, str)]
+        }
+
+    rels = list(
+        TextRelationsRepository.find(
+            pred_filter,
+            projection={
+                "_id": 1,
+                "predicate": 1,
+                "object_text_id": 1,
+                "created_at": 1,
+                "updated_at": 1,
+            },
+        )
+    )
+
+    tv_object_ids: List[ObjectId] = []
+    tv_string_ids: List[str] = []
+    for rel in rels:
+        tv_id = rel.get("object_text_id")
+        if not tv_id:
+            continue
+        if isinstance(tv_id, ObjectId):
+            tv_object_ids.append(tv_id)
+        elif isinstance(tv_id, str):
+            try:
+                tv_object_ids.append(ObjectId(tv_id))
+            except (InvalidId, TypeError):
+                tv_string_ids.append(tv_id)
+
+    tv_lang_by_id: Dict[str, str] = {}
+    if tv_object_ids:
+        for tv in TextValuesRepository.find(
+            {"_id": {"$in": tv_object_ids}},
+            projection={"lang": 1},
+        ):
+            tv_lang_by_id[str(tv.get("_id"))] = str(tv.get("lang") or "")
+    if tv_string_ids:
+        # Some stored ids may be non-ObjectId strings.
+        for tv in TextValuesRepository.find(
+            {"_id": {"$in": tv_string_ids}},
+            projection={"lang": 1},
+        ):
+            tv_lang_by_id[str(tv.get("_id"))] = str(tv.get("lang") or "")
+
+    language_allow = None
+    if languages:
+        language_allow = {str(lang) for lang in languages if isinstance(lang, str)}
+
+    grouped: Dict[tuple[str, str], Dict[str, Any]] = {}
+    for rel in rels:
+        predicate = str(rel.get("predicate") or "")
+        tv_id = rel.get("object_text_id")
+        tv_id_str = str(tv_id) if tv_id is not None else ""
+        lang = tv_lang_by_id.get(tv_id_str) or ""
+
+        if language_allow is not None and lang not in language_allow:
+            continue
+
+        key = (predicate, lang)
+        bucket = grouped.get(key)
+        if bucket is None:
+            bucket = {
+                "predicate": predicate,
+                "language": lang,
+                "count": 0,
+                "relation_ids": [],
+                "latest_relation_id": None,
+                "latest_updated_at": None,
+            }
+            grouped[key] = bucket
+
+        bucket["count"] += 1
+        rel_id = str(rel.get("_id"))
+        if rel_id:
+            if len(bucket["relation_ids"]) < max_relation_ids_per_group:
+                bucket["relation_ids"].append(rel_id)
+
+        updated_at = rel.get("updated_at") or rel.get("created_at")
+        if updated_at is not None:
+            current_latest = bucket.get("latest_updated_at")
+            if current_latest is None or updated_at > current_latest:
+                bucket["latest_updated_at"] = updated_at
+                bucket["latest_relation_id"] = rel_id
+
+    summary_items = list(grouped.values())
+    summary_items.sort(
+        key=lambda x: (x.get("predicate") or "", x.get("language") or "")
+    )
+    for item in summary_items:
+        # Make datetime JSON-friendly
+        dt = item.get("latest_updated_at")
+        if isinstance(dt, datetime):
+            item["latest_updated_at"] = dt.isoformat()
+
+    return {
+        "success": True,
+        "concept_id": subject_concept_id,
+        "groups": summary_items,
+        "groups_found": len(summary_items),
+        "total_relations_scanned": len(rels),
+        "max_relation_ids_per_group": max_relation_ids_per_group,
+    }
+
+
+def upsert_singleton_text_relation(
+    *,
+    subject_concept_id: str,
+    predicate: str,
+    text: str,
+    lang: str = "en-NZ",
+    policy: str = "replace_others",
+    provenance: Optional[Dict[str, Any]] = None,
+    context: Optional[Dict[str, Any]] = None,
+    garbage_collect: bool = True,
+) -> Dict[str, Any]:
+    """Upsert text and enforce singleton semantics for (concept, predicate, language).
+
+    `policy='replace_others'` means: after inserting/upserting the desired relation,
+    delete all other relations for the same subject+predicate whose text_value language
+    matches `lang`.
+    """
+    if policy != "replace_others":
+        raise ValueError("Unsupported policy (expected 'replace_others')")
+
+    result = upsert_text_for_concept(
+        subject_concept_id=subject_concept_id,
+        predicate=predicate,
+        text=text,
+        lang=lang,
+        provenance=provenance,
+        context=context,
+    )
+    kept_relation_id = str(result.get("relation_id") or "")
+
+    rels = list(
+        TextRelationsRepository.find(
+            {
+                "subject_concept_id": subject_concept_id,
+                "predicate": predicate,
+            },
+            projection={"_id": 1, "object_text_id": 1},
+        )
+    )
+
+    tv_object_ids: List[ObjectId] = []
+    tv_ids_raw: List[str] = []
+    for rel in rels:
+        tv_id = rel.get("object_text_id")
+        if tv_id is None:
+            continue
+        if isinstance(tv_id, ObjectId):
+            tv_object_ids.append(tv_id)
+        else:
+            tv_id_str = str(tv_id)
+            try:
+                tv_object_ids.append(ObjectId(tv_id_str))
+            except (InvalidId, TypeError):
+                tv_ids_raw.append(tv_id_str)
+
+    tv_lang_by_id: Dict[str, str] = {}
+    if tv_object_ids:
+        for tv in TextValuesRepository.find(
+            {"_id": {"$in": tv_object_ids}},
+            projection={"lang": 1},
+        ):
+            tv_lang_by_id[str(tv.get("_id"))] = str(tv.get("lang") or "")
+    if tv_ids_raw:
+        for tv in TextValuesRepository.find(
+            {"_id": {"$in": tv_ids_raw}},
+            projection={"lang": 1},
+        ):
+            tv_lang_by_id[str(tv.get("_id"))] = str(tv.get("lang") or "")
+
+    replaced_relation_ids: List[str] = []
+    lang_normalised = (lang or "").strip()
+    for rel in rels:
+        rel_id = str(rel.get("_id"))
+        if not rel_id or rel_id == kept_relation_id:
+            continue
+
+        tv_id = rel.get("object_text_id")
+        tv_id_str = str(tv_id) if tv_id is not None else ""
+        rel_lang = tv_lang_by_id.get(tv_id_str) or ""
+
+        if rel_lang != lang_normalised:
+            continue
+
+        delete_text_relation(
+            subject_concept_id,
+            rel_id,
+            garbage_collect=garbage_collect,
+        )
+        replaced_relation_ids.append(rel_id)
+
+    return {
+        "success": True,
+        "concept_id": subject_concept_id,
+        "predicate": predicate,
+        "language": lang,
+        "kept_relation_id": kept_relation_id,
+        "replaced_relation_ids": replaced_relation_ids,
+        "replaced_count": len(replaced_relation_ids),
+        "relation_created": bool(result.get("relation_created")),
+        "text_value_id": result.get("text_value_id"),
+    }
+
+
 __all__ = [
     "RelationPredicate",
     "create_text_value",
     "link_text_to_concept",
     "upsert_text_for_concept",
+    "upsert_singleton_text_relation",
     "get_texts_for_concept",
+    "get_text_relations_summary",
     "update_text_relation_text",
     "delete_text_relation_by_predicate_and_text",
     "delete_text_relation",

--- a/src/backend/vontology/utils_vontology.py
+++ b/src/backend/vontology/utils_vontology.py
@@ -1307,7 +1307,7 @@ def get_all_vontology_nodes_with_details(identifier: str = "Thing"):
         }
 
 
-def get_vontology_node_content(identifier: str) -> dict:
+def get_vontology_node_content(identifier: str, *, reconstruct_md: bool = True) -> dict:
     """
     Fetches a Vontology concept's details from MongoDB by its path, concept_id, or _id.
     Renders markdown content to HTML.
@@ -1395,7 +1395,7 @@ def get_vontology_node_content(identifier: str) -> dict:
 
     md_content = doc.get("md_content")
 
-    if md_content is None:
+    if md_content is None and reconstruct_md:
         logger.warning(
             f"Markdown content (md_content) missing for '{identifier}'. Reconstructing basic version."
         )
@@ -1417,7 +1417,7 @@ def get_vontology_node_content(identifier: str) -> dict:
         if notes:
             md_content += f"## Notes\n\n{notes}\n"
 
-    html = markdown.markdown(md_content)
+    html = markdown.markdown(md_content or "")
 
     # Normalize relationship fields to always be arrays for inference simplicity
     rels = doc.get("relationships", {}) or {}

--- a/tests/backend/test_text_relations_summary_and_singleton.py
+++ b/tests/backend/test_text_relations_summary_and_singleton.py
@@ -1,0 +1,139 @@
+import pytest
+
+from src.backend.db.repositories.concepts_repository import ConceptsRepository
+from src.backend.db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
+from src.backend.security.access_control import bypass_access_control
+from src.backend.services.text_value_service import (
+    get_text_relations_summary,
+    upsert_singleton_text_relation,
+    upsert_text_for_concept,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_collections():
+    db = TextValuesRepository.db()
+    if db is None:
+        yield
+        return
+
+    concepts = ConceptsRepository.collection()
+    relations = TextRelationsRepository.collection()
+    text_values = TextValuesRepository.collection()
+
+    if concepts is None or relations is None or text_values is None:
+        yield
+        return
+
+    concepts.delete_many({})
+    relations.delete_many({})
+    text_values.delete_many({})
+    yield
+    concepts.delete_many({})
+    relations.delete_many({})
+    text_values.delete_many({})
+
+
+def test_get_text_relations_summary_groups_and_caps_relation_ids():
+    if TextValuesRepository.db() is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concept_id = "#V#text_summary_test_concept"
+    concepts = ConceptsRepository.collection()
+    if concepts is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concepts.insert_one({"concept_id": concept_id, "relationships": {}})
+
+    with bypass_access_control():
+        upsert_text_for_concept(
+            subject_concept_id=concept_id,
+            predicate="hasDescription",
+            text="first",
+            lang="en-NZ",
+        )
+        upsert_text_for_concept(
+            subject_concept_id=concept_id,
+            predicate="hasDescription",
+            text="second",
+            lang="en-NZ",
+        )
+        upsert_text_for_concept(
+            subject_concept_id=concept_id,
+            predicate="hasDescription",
+            text="troisième",
+            lang="fr",
+        )
+
+        summary = get_text_relations_summary(
+            concept_id,
+            max_relation_ids_per_group=1,
+        )
+
+    assert summary["success"] is True
+    assert summary["concept_id"] == concept_id
+    assert summary["groups_found"] == 2
+    assert summary["total_relations_scanned"] == 3
+
+    groups = {(g["predicate"], g["language"]): g for g in summary["groups"]}
+    en_group = groups[("hasDescription", "en-NZ")]
+    fr_group = groups[("hasDescription", "fr")]
+
+    assert en_group["count"] == 2
+    assert fr_group["count"] == 1
+
+    assert len(en_group["relation_ids"]) <= 1
+    assert len(fr_group["relation_ids"]) <= 1
+
+
+def test_upsert_singleton_text_relation_replaces_others_for_language():
+    if TextValuesRepository.db() is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concept_id = "#V#singleton_text_test_concept"
+    concepts = ConceptsRepository.collection()
+    if concepts is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concepts.insert_one({"concept_id": concept_id, "relationships": {}})
+
+    with bypass_access_control():
+        upsert_text_for_concept(
+            subject_concept_id=concept_id,
+            predicate="hasDescription",
+            text="old one",
+            lang="en-NZ",
+        )
+        upsert_text_for_concept(
+            subject_concept_id=concept_id,
+            predicate="hasDescription",
+            text="old two",
+            lang="en-NZ",
+        )
+
+        result = upsert_singleton_text_relation(
+            subject_concept_id=concept_id,
+            predicate="hasDescription",
+            text="new description",
+            lang="en-NZ",
+            garbage_collect=True,
+        )
+
+    assert result["success"] is True
+    assert result["concept_id"] == concept_id
+    assert result["predicate"] == "hasDescription"
+    assert result["language"] == "en-NZ"
+    assert result["kept_relation_id"]
+    assert result["replaced_count"] == 2
+    assert len(result["replaced_relation_ids"]) == 2
+
+    remaining = list(
+        TextRelationsRepository.find(
+            {"subject_concept_id": concept_id, "predicate": "hasDescription"},
+            projection={"_id": 1},
+        )
+    )
+    assert len(remaining) == 1

--- a/tests/backend/test_vontology_node_content_md_reconstruction.py
+++ b/tests/backend/test_vontology_node_content_md_reconstruction.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src.backend.vontology import utils_vontology
+from src.backend.db.repositories.concepts_repository import ConceptsRepository
 
 
 @pytest.fixture(autouse=True)
@@ -18,9 +19,13 @@ def test_reconstructed_md_content_omits_boilerplate_metadata_fields():
     if db is None:
         pytest.skip("MongoDB not configured for this test run")
 
+    concepts = ConceptsRepository.collection()
+    if concepts is None:
+        pytest.skip("MongoDB not configured for this test run")
+
     concept_id = "#V#verified_entity_representation_agentic_workflow_design"
 
-    db["vontology_nodes"].insert_one(
+    concepts.insert_one(
         {
             "concept_id": concept_id,
             "names": [
@@ -50,3 +55,40 @@ def test_reconstructed_md_content_omits_boilerplate_metadata_fields():
     assert "Source Concept" not in md
     assert "SubConcept Of" not in md
     assert "Instance Of" not in md
+
+
+def test_reconstruct_md_false_preserves_missing_md_content():
+    db = utils_vontology.get_db()
+    if db is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concepts = ConceptsRepository.collection()
+    if concepts is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concept_id = "#V#md_content_missing_reconstruct_md_false"
+
+    concepts.insert_one(
+        {
+            "concept_id": concept_id,
+            "names": [
+                {
+                    "name": "md_content missing reconstruct_md false",
+                    "type": "NL",
+                    "language": "en-NZ",
+                }
+            ],
+            "relationships": {
+                "is_an_instance_of": [],
+                "is_a_type_of": [],
+            },
+            # Intentionally no md_content.
+        }
+    )
+
+    payload = utils_vontology.get_vontology_node_content(
+        concept_id, reconstruct_md=False
+    )
+    assert "error" not in payload
+    assert payload.get("md_content") is None
+    assert payload.get("content_html") == ""


### PR DESCRIPTION
Adds lightweight text relation summary/singleton helpers across MCP gateways and updates the MCP manifest. Includes backend tests; validated locally via 'pdm run pytest' with VON_USE_MOCK_DB=1.