### PR TITLE
JVNAUTOSCI-839: Centralise model-turn interpretation

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -13,8 +13,11 @@ from typing import (
     List,
     Mapping,
     MutableMapping,
+    NotRequired,
     Optional,
+    Required,
     Sequence,
+    TypedDict,
 )
 
 from .gateway import InternalMCPGateway
@@ -37,6 +40,13 @@ class OrchestratorResult:
     aux_llm_calls: Sequence[Mapping[str, Any]]
 
 
+class _ToolCallRequest(TypedDict):
+    action: Required[str]
+    tool: Required[str]
+    payload: Required[MutableMapping[str, Any]]
+    _call_id: NotRequired[str]
+
+
 @dataclass(frozen=True)
 class _ModelTurnInterpretation:
     """Interpreted model output for a single assistant turn.
@@ -47,7 +57,7 @@ class _ModelTurnInterpretation:
     """
 
     response_text: str
-    tool_calls: Optional[List[MutableMapping[str, Any]]]
+    tool_calls: list[_ToolCallRequest] | None
     tool_call_parse_error: ToolCallParsingError | None
     is_json_action: bool
     fenced_tool_call_json: bool
@@ -1387,7 +1397,7 @@ class InternalMCPChatOrchestrator:
         fenced_detected = self._contains_fenced_tool_call_json(text)
         heuristic_missing = self._looks_like_missing_tool_call(text)
 
-        tool_calls: Optional[List[MutableMapping[str, Any]]] = None
+        tool_calls: list[_ToolCallRequest] | None = None
         tool_call_parse_error: ToolCallParsingError | None = None
         try:
             tool_calls = self._extract_tool_calls(text)
@@ -1617,6 +1627,7 @@ class InternalMCPChatOrchestrator:
         # Only warn if we fail to parse/execute it.
         # Skip detection for structured path - it handles tool calls natively
         tool_call_parse_error: ToolCallParsingError | None = None
+        interpretation: _ModelTurnInterpretation | None = None
 
         if not use_structured:
             interpretation = self._interpret_model_turn(response)
@@ -1642,7 +1653,7 @@ class InternalMCPChatOrchestrator:
             # Gather richer diagnostics for debug panels and logs
             fenced_detected = (
                 interpretation.fenced_tool_call_json
-                if not use_structured
+                if (not use_structured and interpretation is not None)
                 else self._contains_fenced_tool_call_json(response)
             )
             classifier_verdict: Optional[bool] = None
@@ -1671,7 +1682,7 @@ class InternalMCPChatOrchestrator:
                     # Fallback to legacy heuristic only when classifier unavailable
                     if (
                         interpretation.heuristic_missing_tool_call
-                        if not use_structured
+                        if (not use_structured and interpretation is not None)
                         else self._looks_like_missing_tool_call(response)
                     ):
                         retry_reason = "heuristic missing tool call"
@@ -1680,7 +1691,7 @@ class InternalMCPChatOrchestrator:
                     # If our conservative heuristic triggers, do the single retry anyway.
                     if (
                         interpretation.heuristic_missing_tool_call
-                        if not use_structured
+                        if (not use_structured and interpretation is not None)
                         else self._looks_like_missing_tool_call(response)
                     ):
                         retry_reason = (

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -38,6 +38,23 @@ class OrchestratorResult:
 
 
 @dataclass(frozen=True)
+class _ModelTurnInterpretation:
+    """Interpreted model output for a single assistant turn.
+
+    This object centralises parsing and classification of model output so that
+    higher-level policy (retry/fallback decisions) is not coupled to ad-hoc
+    parsing and exception handling.
+    """
+
+    response_text: str
+    tool_calls: Optional[List[MutableMapping[str, Any]]]
+    tool_call_parse_error: ToolCallParsingError | None
+    is_json_action: bool
+    fenced_tool_call_json: bool
+    heuristic_missing_tool_call: bool
+
+
+@dataclass(frozen=True)
 class _MissingToolCallDetectorSpec:
     """Declarative definition of the missing-tool-call detector."""
 
@@ -1356,6 +1373,36 @@ class InternalMCPChatOrchestrator:
         base.insert(0, {"role": "system", "content": instruction_msg})
         return self._limit_context_for_llm(base)
 
+    def _interpret_model_turn(self, response: Any) -> _ModelTurnInterpretation:
+        """Parse and classify a single model response.
+
+        Never raises `ToolCallParsingError`. If parsing fails, the error is
+        captured in the returned interpretation so recovery policy can be
+        applied consistently.
+        """
+
+        text = response if isinstance(response, str) else str(response)
+
+        is_json_action = self._is_json_action_response(text)
+        fenced_detected = self._contains_fenced_tool_call_json(text)
+        heuristic_missing = self._looks_like_missing_tool_call(text)
+
+        tool_calls: Optional[List[MutableMapping[str, Any]]] = None
+        tool_call_parse_error: ToolCallParsingError | None = None
+        try:
+            tool_calls = self._extract_tool_calls(text)
+        except ToolCallParsingError as exc:
+            tool_call_parse_error = exc
+
+        return _ModelTurnInterpretation(
+            response_text=text,
+            tool_calls=tool_calls,
+            tool_call_parse_error=tool_call_parse_error,
+            is_json_action=is_json_action,
+            fenced_tool_call_json=fenced_detected,
+            heuristic_missing_tool_call=heuristic_missing,
+        )
+
     def run(
         self,
         *,
@@ -1572,14 +1619,11 @@ class InternalMCPChatOrchestrator:
         tool_call_parse_error: ToolCallParsingError | None = None
 
         if not use_structured:
-            is_json_action = self._is_json_action_response(response)
-
-            # Extract potential tool request(s)
-            try:
-                tool_calls = self._extract_tool_calls(response)
-            except ToolCallParsingError as exc:
-                tool_calls = None
-                tool_call_parse_error = exc
+            interpretation = self._interpret_model_turn(response)
+            response = interpretation.response_text
+            is_json_action = interpretation.is_json_action
+            tool_calls = interpretation.tool_calls
+            tool_call_parse_error = interpretation.tool_call_parse_error
             has_valid_tool_call = bool(tool_calls)
         else:
             # Structured path already extracted tool calls above
@@ -1596,7 +1640,11 @@ class InternalMCPChatOrchestrator:
                 )
 
             # Gather richer diagnostics for debug panels and logs
-            fenced_detected = self._contains_fenced_tool_call_json(response)
+            fenced_detected = (
+                interpretation.fenced_tool_call_json
+                if not use_structured
+                else self._contains_fenced_tool_call_json(response)
+            )
             classifier_verdict: Optional[bool] = None
             classifier_used = False
             retry_reason: Optional[str] = None
@@ -1621,12 +1669,20 @@ class InternalMCPChatOrchestrator:
                     retry_reason = "LLM classifier flagged missing tool call"
                 elif llm_flag is None:
                     # Fallback to legacy heuristic only when classifier unavailable
-                    if self._looks_like_missing_tool_call(response):
+                    if (
+                        interpretation.heuristic_missing_tool_call
+                        if not use_structured
+                        else self._looks_like_missing_tool_call(response)
+                    ):
                         retry_reason = "heuristic missing tool call"
                 elif llm_flag is False:
                     # Backstop: the LLM classifier can miss obvious cases.
                     # If our conservative heuristic triggers, do the single retry anyway.
-                    if self._looks_like_missing_tool_call(response):
+                    if (
+                        interpretation.heuristic_missing_tool_call
+                        if not use_structured
+                        else self._looks_like_missing_tool_call(response)
+                    ):
                         retry_reason = (
                             "heuristic missing tool call (classifier said no)"
                         )

--- a/tests/backend/test_orchestrator_extraction.py
+++ b/tests/backend/test_orchestrator_extraction.py
@@ -74,6 +74,23 @@ def test_extract_tool_calls_accepts_json_array_batch():
     assert calls[1]["payload"]["a"] == 1
 
 
+def test_interpret_model_turn_ignores_non_tool_json_without_error():
+    orchestrator = InternalMCPChatOrchestrator(gateway=_DummyGateway())  # type: ignore[arg-type]
+    interpretation = orchestrator._interpret_model_turn('{"foo": 1, "bar": [1, 2]}')
+    assert interpretation.tool_calls is None
+    assert interpretation.tool_call_parse_error is None
+    assert interpretation.is_json_action is False
+
+
+def test_interpret_model_turn_captures_tool_call_parse_error():
+    orchestrator = InternalMCPChatOrchestrator(gateway=_DummyGateway())  # type: ignore[arg-type]
+    interpretation = orchestrator._interpret_model_turn(
+        '{"action":"call_tool","tool":"test","payload":{}'
+    )
+    assert interpretation.tool_calls is None
+    assert isinstance(interpretation.tool_call_parse_error, ToolCallParsingError)
+
+
 def test_extract_tool_calls_accepts_fenced_json_array_batch():
     text = (
         "Here is the tool batch:\n"


### PR DESCRIPTION
Implements JVNAUTOSCI-839 (subtask of JVNAUTOSCI-838): introduce a central, typed model-turn interpretation seam so parsing/classification signals are derived once and are unit-testable.

Changes:
- Add _ModelTurnInterpretation + _interpret_model_turn() and wire legacy path through it
- Tighten tool-call request typing via TypedDict
- Add regression/unit tests for interpretation behaviour and parse-error capture

Tests:
- pytest tests/backend/test_orchestrator_extraction.py
- pytest tests/backend/test_von_generate_llm_debug_parse_error.py