### PR TITLE
JVNAUTOSCI-840: Extract retry policy into explicit decision

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -66,6 +66,23 @@ class _ModelTurnInterpretation:
 
 
 @dataclass(frozen=True)
+class _MissingToolCallAssessment:
+    """Assessment result for whether a single tool-call retry should occur.
+
+    This isolates *policy* (when to retry) from orchestration mechanics so the
+    retry behaviour can evolve without tangling more logic into `run()`.
+    """
+
+    path: str
+    is_json_action: bool
+    fenced_json: bool
+    classifier_used: bool
+    classifier_verdict: bool | None
+    retry_reason: str | None
+    tool_call_parse_error: ToolCallParsingError | None
+
+
+@dataclass(frozen=True)
 class _MissingToolCallDetectorSpec:
     """Declarative definition of the missing-tool-call detector."""
 
@@ -975,9 +992,7 @@ class InternalMCPChatOrchestrator:
         except (json.JSONDecodeError, TypeError):
             return False
 
-    def _extract_tool_calls(
-        self, text: str
-    ) -> list[_ToolCallRequest] | None:
+    def _extract_tool_calls(self, text: str) -> list[_ToolCallRequest] | None:
         """Extract one or more tool-call objects from the model response.
 
         Accepts either a single tool-call JSON object or a JSON array of tool-call
@@ -1424,6 +1439,88 @@ class InternalMCPChatOrchestrator:
             heuristic_missing_tool_call=heuristic_missing,
         )
 
+    def _assess_missing_tool_call(
+        self,
+        *,
+        response_text: str,
+        use_structured: bool,
+        interpretation: _ModelTurnInterpretation | None,
+        llm_client: Any,
+        model: str | None,
+        aux_log: list[Mapping[str, Any]],
+        tool_call_parse_error: ToolCallParsingError | None,
+    ) -> _MissingToolCallAssessment:
+        """Decide whether to attempt a single retry for a missing tool call."""
+
+        path = "structured" if use_structured else "legacy"
+
+        is_json_action = (
+            interpretation.is_json_action
+            if (not use_structured and interpretation is not None)
+            else self._is_json_action_response(response_text)
+        )
+
+        fenced_detected = (
+            interpretation.fenced_tool_call_json
+            if (not use_structured and interpretation is not None)
+            else self._contains_fenced_tool_call_json(response_text)
+        )
+
+        heuristic_missing = (
+            interpretation.heuristic_missing_tool_call
+            if (not use_structured and interpretation is not None)
+            else self._looks_like_missing_tool_call(response_text)
+        )
+
+        classifier_used = False
+        classifier_verdict: bool | None = None
+        retry_reason: str | None = None
+
+        if tool_call_parse_error is not None:
+            retry_reason = "tool call parse error"
+
+        if retry_reason is None and fenced_detected:
+            retry_reason = "fenced tool-call JSON detected"
+
+        if retry_reason is None:
+            llm_flag = self._llm_detects_missing_tool_call(
+                response_text,
+                llm_client,
+                fallback_model=model,
+                aux_log=aux_log,
+            )
+
+            if llm_flag is not None:
+                classifier_used = True
+                classifier_verdict = llm_flag
+
+            if llm_flag is True:
+                retry_reason = "LLM classifier flagged missing tool call"
+            elif llm_flag is None:
+                # Fallback to legacy heuristic only when classifier unavailable.
+                if heuristic_missing:
+                    retry_reason = "heuristic missing tool call"
+            elif llm_flag is False:
+                # Backstop: the LLM classifier can miss obvious cases.
+                if heuristic_missing:
+                    retry_reason = "heuristic missing tool call (classifier said no)"
+
+        return _MissingToolCallAssessment(
+            path=path,
+            is_json_action=is_json_action,
+            fenced_json=fenced_detected,
+            classifier_used=classifier_used,
+            classifier_verdict=classifier_verdict,
+            retry_reason=retry_reason,
+            tool_call_parse_error=tool_call_parse_error,
+        )
+
+    def _missing_tool_call_retry_prompt(self) -> str:
+        return (
+            "Your previous message described an action that requires MCP tools, but you did not emit a tool call. "
+            "NOW respond with ONLY a tool-call JSON object or a JSON array of tool-call objects (no prose, no Markdown)."
+        )
+
     def run(
         self,
         *,
@@ -1568,6 +1665,7 @@ class InternalMCPChatOrchestrator:
                     response = llm_response.text_response or ""
                     tool_calls = [
                         {
+                            self._ACTION_FIELD: self._CALL_ACTION,
                             self._TOOL_FIELD: tc.tool_name,
                             self._PAYLOAD_FIELD: tc.payload,
                             "_call_id": tc.call_id,  # Preserve for tracing (JVNAUTOSCI-803)
@@ -1662,68 +1760,33 @@ class InternalMCPChatOrchestrator:
                 )
 
             # Gather richer diagnostics for debug panels and logs
-            fenced_detected = (
-                interpretation.fenced_tool_call_json
-                if (not use_structured and interpretation is not None)
-                else self._contains_fenced_tool_call_json(response)
+            assessment = self._assess_missing_tool_call(
+                response_text=response,
+                use_structured=use_structured,
+                interpretation=interpretation,
+                llm_client=llm_client,
+                model=model,
+                aux_log=aux_llm_calls,
+                tool_call_parse_error=tool_call_parse_error,
             )
-            classifier_verdict: Optional[bool] = None
-            classifier_used = False
-            retry_reason: Optional[str] = None
-
-            if tool_call_parse_error is not None:
-                retry_reason = "tool call parse error"
-
-            if retry_reason is None and fenced_detected:
-                retry_reason = "fenced tool-call JSON detected"
-            if retry_reason is None:
-                llm_flag = self._llm_detects_missing_tool_call(
-                    response,
-                    llm_client,
-                    fallback_model=model,
-                    aux_log=aux_llm_calls,
-                )
-
-                if llm_flag is not None:
-                    classifier_used = True
-                    classifier_verdict = llm_flag
-                if llm_flag is True:
-                    retry_reason = "LLM classifier flagged missing tool call"
-                elif llm_flag is None:
-                    # Fallback to legacy heuristic only when classifier unavailable
-                    if (
-                        interpretation.heuristic_missing_tool_call
-                        if (not use_structured and interpretation is not None)
-                        else self._looks_like_missing_tool_call(response)
-                    ):
-                        retry_reason = "heuristic missing tool call"
-                elif llm_flag is False:
-                    # Backstop: the LLM classifier can miss obvious cases.
-                    # If our conservative heuristic triggers, do the single retry anyway.
-                    if (
-                        interpretation.heuristic_missing_tool_call
-                        if (not use_structured and interpretation is not None)
-                        else self._looks_like_missing_tool_call(response)
-                    ):
-                        retry_reason = (
-                            "heuristic missing tool call (classifier said no)"
-                        )
 
             # Always append a compact detection summary for UI debugging
             try:
                 aux_llm_calls.append(
                     {
                         "type": "missing_tool_call_detection",
-                        "path": "structured" if use_structured else "legacy",
-                        "is_json_action": is_json_action,
-                        "fenced_json": fenced_detected,
-                        "classifier_used": classifier_used,
+                        "path": assessment.path,
+                        "is_json_action": assessment.is_json_action,
+                        "fenced_json": assessment.fenced_json,
+                        "classifier_used": assessment.classifier_used,
                         "classifier_verdict": (
                             "yes"
-                            if classifier_verdict is True
-                            else "no" if classifier_verdict is False else "unavailable"
+                            if assessment.classifier_verdict is True
+                            else "no"
+                            if assessment.classifier_verdict is False
+                            else "unavailable"
                         ),
-                        "retry_reason": retry_reason or "",
+                        "retry_reason": assessment.retry_reason or "",
                         "parse_error": (
                             str(tool_call_parse_error)
                             if tool_call_parse_error is not None
@@ -1734,23 +1797,20 @@ class InternalMCPChatOrchestrator:
             except Exception:  # pragma: no cover - best effort only
                 pass
 
-            if retry_reason:
+            if assessment.retry_reason:
                 self._logger.info(
                     "[mcp_orchestrator] Model response looks like a missing tool call (%s); retrying once (model=%s).",
-                    retry_reason,
+                    assessment.retry_reason,
                     model or "default",
                 )
-                retry_prompt = (
-                    "Your previous message described an action that requires MCP tools, but you did not emit a tool call. "
-                    "NOW respond with ONLY a tool-call JSON object or a JSON array of tool-call objects (no prose, no Markdown)."
-                )
+                retry_prompt = self._missing_tool_call_retry_prompt()
 
                 try:
                     aux_llm_calls.append(
                         {
                             "type": "missing_tool_call_retry",
                             "stage": "prompt",
-                            "retry_reason": retry_reason,
+                            "retry_reason": assessment.retry_reason,
                             "prompt_preview": retry_prompt[:800],
                         }
                     )
@@ -1766,7 +1826,7 @@ class InternalMCPChatOrchestrator:
                         {
                             "type": "missing_tool_call_retry",
                             "stage": "response",
-                            "retry_reason": retry_reason,
+                            "retry_reason": assessment.retry_reason,
                             "response_preview": (
                                 retry_response[:800]
                                 if isinstance(retry_response, str)

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -8,6 +8,7 @@ import os
 from dataclasses import dataclass
 from typing import (
     Any,
+    cast,
     Dict,
     Iterable,
     List,
@@ -976,7 +977,7 @@ class InternalMCPChatOrchestrator:
 
     def _extract_tool_calls(
         self, text: str
-    ) -> Optional[List[MutableMapping[str, Any]]]:
+    ) -> list[_ToolCallRequest] | None:
         """Extract one or more tool-call objects from the model response.
 
         Accepts either a single tool-call JSON object or a JSON array of tool-call
@@ -1048,15 +1049,17 @@ class InternalMCPChatOrchestrator:
 
         trailing = raw[end:].strip()
 
-        def _normalise_tool_call(candidate: Any) -> Optional[MutableMapping[str, Any]]:
+        def _normalise_tool_call(candidate: Any) -> _ToolCallRequest | None:
             if not isinstance(candidate, MutableMapping):
                 return None
 
-            has_tool = isinstance(candidate.get(self._TOOL_FIELD), str)
-            has_payload = isinstance(
-                candidate.get(self._PAYLOAD_FIELD, {}), MutableMapping
-            )
-            has_action = candidate.get(self._ACTION_FIELD) == self._CALL_ACTION
+            tool_name = candidate.get(self._TOOL_FIELD)
+            payload_value = candidate.get(self._PAYLOAD_FIELD)
+            action_value = candidate.get(self._ACTION_FIELD)
+
+            has_tool = isinstance(tool_name, str)
+            has_payload = isinstance(payload_value, MutableMapping)
+            has_action = action_value == self._CALL_ACTION
 
             missing_action = self._ACTION_FIELD not in candidate
             strict_shape = set(candidate.keys()) <= {
@@ -1069,9 +1072,7 @@ class InternalMCPChatOrchestrator:
                 describe_methods = getattr(self._gateway, "describe_methods", None)
                 if callable(describe_methods):
                     catalogue = describe_methods()
-                tool_name = candidate.get(self._TOOL_FIELD)
                 if isinstance(catalogue, Mapping) and tool_name in catalogue:
-                    candidate[self._ACTION_FIELD] = self._CALL_ACTION
                     has_action = True
                 else:
                     return None
@@ -1079,9 +1080,19 @@ class InternalMCPChatOrchestrator:
             if not (has_action and has_tool and has_payload):
                 return None
 
-            return candidate
+            tool_call: _ToolCallRequest = {
+                self._ACTION_FIELD: self._CALL_ACTION,
+                self._TOOL_FIELD: tool_name,
+                self._PAYLOAD_FIELD: cast(MutableMapping[str, Any], payload_value),
+            }
 
-        tool_calls: List[MutableMapping[str, Any]] = []
+            call_id = candidate.get("_call_id")
+            if isinstance(call_id, str) and call_id:
+                tool_call["_call_id"] = call_id
+
+            return tool_call
+
+        tool_calls: list[_ToolCallRequest] = []
         if isinstance(parsed, MutableMapping):
             tool_call = _normalise_tool_call(parsed)
             if tool_call is None:

--- a/tests/backend/test_orchestrator_extraction.py
+++ b/tests/backend/test_orchestrator_extraction.py
@@ -91,6 +91,77 @@ def test_interpret_model_turn_captures_tool_call_parse_error():
     assert isinstance(interpretation.tool_call_parse_error, ToolCallParsingError)
 
 
+def test_assess_missing_tool_call_prefers_parse_error_over_fence_and_classifier():
+    orchestrator = InternalMCPChatOrchestrator(gateway=_DummyGateway())  # type: ignore[arg-type]
+    llm = _RecorderLLM(["NO"])
+    aux_log: list[Mapping[str, Any]] = []
+
+    assessment = orchestrator._assess_missing_tool_call(
+        response_text="{bad json",
+        use_structured=False,
+        interpretation=None,
+        llm_client=llm,
+        model="primary-model",
+        aux_log=aux_log,
+        tool_call_parse_error=ToolCallParsingError("bad", raw_response="{bad json"),
+    )
+
+    assert assessment.retry_reason == "tool call parse error"
+
+
+def test_assess_missing_tool_call_uses_fenced_json_reason_without_classifier_call():
+    orchestrator = InternalMCPChatOrchestrator(gateway=_DummyGateway())  # type: ignore[arg-type]
+    llm = _RecorderLLM(["YES"])  # Would be consumed if classifier were called.
+    aux_log: list[Mapping[str, Any]] = []
+
+    interpretation = orchestrator._interpret_model_turn(
+        "```json\n{\"action\":\"call_tool\",\"tool\":\"test\",\"payload\":{}}\n```"
+    )
+
+    assessment = orchestrator._assess_missing_tool_call(
+        response_text=interpretation.response_text,
+        use_structured=False,
+        interpretation=interpretation,
+        llm_client=llm,
+        model="primary-model",
+        aux_log=aux_log,
+        tool_call_parse_error=None,
+    )
+
+    assert assessment.retry_reason == "fenced tool-call JSON detected"
+    assert not llm.calls
+
+
+def test_assess_missing_tool_call_backstops_classifier_no_with_heuristic_yes():
+    orchestrator = InternalMCPChatOrchestrator(gateway=_DummyGateway())  # type: ignore[arg-type]
+    orchestrator._missing_tool_call_detector_loaded = True
+    orchestrator._missing_tool_call_detector = _MissingToolCallDetectorSpec(
+        action_id="#V#detect_missing_tool_call_action",
+        prompt_id="#V#missing_tool_call_detection_prompt",
+        prompt_text="Answer YES or NO for: {response}",
+        model="detector-model",
+    )
+
+    llm = _RecorderLLM(["NO"])
+    aux_log: list[Mapping[str, Any]] = []
+
+    response_text = "I'll do that now and execute the tools."
+    interpretation = orchestrator._interpret_model_turn(response_text)
+    assert interpretation.heuristic_missing_tool_call
+
+    assessment = orchestrator._assess_missing_tool_call(
+        response_text=interpretation.response_text,
+        use_structured=False,
+        interpretation=interpretation,
+        llm_client=llm,
+        model="primary-model",
+        aux_log=aux_log,
+        tool_call_parse_error=None,
+    )
+
+    assert assessment.retry_reason == "heuristic missing tool call (classifier said no)"
+
+
 def test_extract_tool_calls_accepts_fenced_json_array_batch():
     text = (
         "Here is the tool batch:\n"


### PR DESCRIPTION
Implements JVNAUTOSCI-840 (subtask of JVNAUTOSCI-838).

Changes:
- Introduce `_MissingToolCallAssessment` and `_assess_missing_tool_call()` to centralise the single-retry policy for missing tool calls.
- Add `_missing_tool_call_retry_prompt()` helper for a single source of truth for the retry prompt.
- Make structured tool-call conversion include `action: call_tool` so tool-call typing is consistent across paths.
- Add unit tests for the assessment policy (parse-error precedence, fenced JSON behaviour, heuristic backstop when classifier says no).

Verification:
- `pdm run pyright`
- `pytest tests/backend/test_orchestrator_extraction.py`