### PR TITLE
JVNAUTOSCI-836: unify session scoping + RAG namespace

### DIFF
--- a/docs/engineering/access_control_and_namespaces.md
+++ b/docs/engineering/access_control_and_namespaces.md
@@ -1,0 +1,214 @@
+# Access Control and Namespaces (Vontology + RAG)
+
+This document describes **how access control and namespace isolation currently work in Von**, based on code paths in the repository. It is written for engineering clarity ("what actually happens") and highlights a few known mismatches between intended and implemented behaviour.
+
+Von is a **research prototype**. The mechanisms here are primarily about preventing accidental cross-user data access in trusted-user scenarios, not hard multi-tenant security.
+
+Related work items:
+- JVNAUTOSCI-144 (Epic): parent epic for doc representation + RAG work.
+- JVNAUTOSCI-760 (Task): namespaces and access control groundwork (includes multiple subtasks).
+- JVNAUTOSCI-836 (Task): refine/clarify the model (effective namespace, document representation, etc.).
+
+## Key terms
+
+- **Authenticated user**: A user recognised by the backend (Flask session) as a specific Vontology person/user concept.
+- **Effective user**: The user identity the backend actually uses for access control. This is server-authoritative.
+- **Organisation**: A Vontology concept representing an organisation; membership and roles may be stored in the Vontology.
+- **Namespace**: A string used to partition RAG-indexed content and (in some flows) chat session history. Namespaces are used as a query filter.
+
+## Executive summary (as implemented)
+
+- Vontology concept visibility is filtered by `relationships.specific_to_user` and `relationships.specific_to_org`.
+- User identity comes from the **server session** (fallback: validated `X-User-Concept-ID` header), not from client JSON.
+- RAG tools are **fail-closed** without a namespace.
+- RAG query backends (e.g., LlamaIndex) can additionally filter by metadata keys like `user_id` and `organisation_concept_id`, but only if those keys are provided via `permissions_context`.
+- There are currently **multiple namespace sources** (user-only namespace vs user@org namespace) that are not yet fully unified.
+
+## 1) Identity: where user context comes from
+
+### Source of truth
+
+The authoritative identity is derived by the backend.
+
+- `src/backend/security/access_control.py` provides `get_effective_user_concept_id()`.
+  - Primary: `session["user_concept_id"]` (set on login).
+  - Fallback: `X-User-Concept-ID` header, **only if validated** as a person/von_user concept.
+  - If neither exists/valid, the request is treated as unauthenticated.
+
+### Important security property
+
+The `/generate` endpoint explicitly does **not** trust client-provided `user_id` for security reasons. Unauthenticated users can still chat, but RAG access is unavailable.
+
+See: docs/engineering/security_considerations.md.
+
+## 2) Vontology access control (concepts + relationships)
+
+### Visibility model
+
+Vontology concepts are filtered using a visibility query applied to MongoDB queries/pipelines.
+
+- `src/backend/security/access_control.py`:
+  - `build_visibility_filter(user_concept_id, organisation_concept_id)` constructs a Mongo query that:
+    - allows concepts not scoped to any user/org
+    - allows concepts scoped to the authenticated user
+    - allows concepts scoped to the selected organisation (if present)
+  - `apply_concept_query_filter()` and `apply_pipeline_filter()` apply the filter.
+
+### Relationship sanitisation
+
+Even when a concept is visible, some of its outgoing relationship values may point at concept IDs the user cannot access.
+
+- `sanitize_concept_document()` prunes relationship value lists down to concept IDs that pass access checks.
+
+Practical consequence:
+- The UI or tools may see a concept but with fewer relationship targets than exist globally.
+
+### Organisation context
+
+Organisation scoping depends on what the backend considers the active organisation.
+
+- `access_control.py` reads organisation context from the Flask session (e.g., `session["organisation_concept_id"]` in the routes that set it).
+
+## 3) Roles and permissions (RBAC)
+
+### Current status
+
+RBAC is present but **not a complete system** yet.
+
+- `src/backend/security/role_resolver.py` contains a Phase 1 stub mapping (hardcoded user/org → role → permissions).
+- `src/backend/services/organisation_membership_service.py` persists membership and roles in the Vontology:
+  - membership relationship: `memberOf`
+  - role stored via a text relation predicate like `#V#hasRole` with a context containing the organisation ID
+
+Practical consequence:
+- Some code paths can read role/permissions from stubs, while the Vontology contains a richer representation that is not consistently used everywhere.
+
+## 4) Namespaces: derivation and intended meaning
+
+### Namespace formats
+
+The namespace service supports:
+- user-only namespace: `#V#<user>`
+- user@org namespace: `#V#<user>@<org>`
+
+See:
+- `src/backend/services/namespace_service.py` (`derive_namespace`, parsing/normalisation/validation helpers).
+
+### How namespaces are set in the session
+
+Organisation selection routes derive and store a composite namespace in session.
+
+- `src/backend/server/routes/von_routes.py` includes endpoints like `/api/session/set_organisation` and `/api/session/context`.
+  - These set or return:
+    - `session["organisation_concept_id"]`
+    - `session["role_in_org"]`
+    - `session["namespace"]` (often `#V#user@org`)
+
+### How namespaces are passed into tool execution
+
+The `/generate` route currently derives a namespace from the authenticated user concept ID and passes that into the orchestrator as `user_namespace`.
+
+- Key behavioural point: **this is currently user-only**, and may not incorporate `session["namespace"]` (user@org) even when an organisation is selected.
+
+This is one of the main “model mismatch” items tracked by JVNAUTOSCI-836.
+
+## 5) RAG tools: namespace isolation and metadata filtering
+
+### Fail-closed namespace requirement
+
+The internal MCP RAG tools (used by the chat orchestrator) require a namespace.
+
+- `src/backend/integrations/internal_mcp/catalogue.py`:
+  - RAG list/get/search handlers check for a namespace; if missing, they return an error such as `namespace_required`.
+  - list/get typically filter MongoDB `interaction_sessions` by `namespace` (and often `indexing_status`).
+
+### RAG backend filtering
+
+The backend that actually performs semantic search can apply additional filtering.
+
+Example: LlamaIndex backend
+- `src/backend/services/rag_backends/llamaindex_backend.py`:
+  - If `permissions_context` includes `user_id`, it adds a metadata filter `user_id == ...`.
+  - If `permissions_context` includes `organisation_concept_id`, it adds a metadata filter `organisation_concept_id == ...`.
+
+Important implication:
+- Namespace filtering alone partitions content, but **metadata filtering is an additional guard** when it is correctly populated.
+
+### Permissions context wiring (known mismatch)
+
+Some internal tool handlers build a `permissions_context` from Flask session values. There is at least one known inconsistency where the code checks `org_id` rather than `organisation_concept_id`.
+
+Practical consequence:
+- The LlamaIndex metadata filter may be applied for user_id but not for organisation, even when an organisation is selected.
+
+(Recommendation is in the “Alignment tasks” section below.)
+
+## 6) RAG indexing / sync: what gets stored
+
+Indexed chat sessions are stored in MongoDB (`interaction_sessions`) and are synchronised into the vector store.
+
+- `src/backend/services/rag_sync_service.py`:
+  - includes org/role metadata when present (e.g., `organisation_concept_id`, `role_in_org`).
+  - has a default namespace in some flows (e.g., `chat_history`) if a session does not have one.
+
+Practical consequence:
+- There can be legacy or backfilled sessions with a namespace that does not match the current “effective namespace” derivation rules.
+- Backfills exist to populate namespaces for older sessions.
+
+## 7) The “requested vs effective namespace” mental model
+
+It helps to distinguish:
+
+- **Requested namespace**: what the UI or request body might imply (e.g., org selected in local storage).
+- **Session namespace**: what backend session endpoints have stored (e.g., `#V#user@org`).
+- **Effective namespace**: what the backend actually passes into tool calls (currently often derived from user concept ID only).
+- **Storage namespace**: what is persisted on `interaction_sessions.namespace` and used for listing/getting.
+
+Today, these can diverge. JVNAUTOSCI-836’s “effective namespace resolver” work is the right direction: compute one authoritative effective namespace per request and use it consistently for:
+- RAG tool invocations
+- interaction session writes
+- RAG sync
+
+## 8) Recommended alignment tasks (engineering)
+
+These are concrete changes that would reduce confusion and tighten isolation:
+
+1. Make `/generate` use the same effective namespace source as `/api/session/context`.
+   - If `session["namespace"]` is present, prefer it over user-only derivation.
+
+2. Standardise session keys for organisation.
+   - Ensure internal tool `permissions_context` uses `organisation_concept_id` consistently (not `org_id`).
+
+3. Ensure RAG sync defaults match the effective namespace model.
+   - Avoid “chat_history” as a silent default unless it is explicitly the intended global namespace.
+
+4. Document the invariants.
+   - “No namespace → no RAG access.”
+   - “Namespace used for list/get must match namespace used for indexing/sync.”
+
+## 9) Jira relationship tidy-up (760 / 836 / 144)
+
+Current state (as observed):
+- JVNAUTOSCI-760 and JVNAUTOSCI-836 are linked as **Relates**.
+- Both are under epic JVNAUTOSCI-144.
+
+Suggested tidy structure:
+- Keep both as tasks under JVNAUTOSCI-144 (that part is already clean).
+- Replace or supplement “Relates” with a directional dependency that reflects actual execution order:
+  - If JVNAUTOSCI-836 is the architectural consolidation needed to finish remaining 760 subtasks cleanly, set **JVNAUTOSCI-760 blocks JVNAUTOSCI-836** or vice versa (choose the direction that matches real sequencing).
+  - If 836 is the “model + refactor” that enables reliable org-scoped namespaces, consider: **JVNAUTOSCI-760 blocks JVNAUTOSCI-836** only if 760 must land first; otherwise **JVNAUTOSCI-836 blocks JVNAUTOSCI-760** for any remaining namespace-sensitive subtasks.
+
+Rule of thumb:
+- Use **Relates** for thematic association.
+- Use **Blocks/Depends on** when it changes what can be shipped next.
+
+## Appendix: primary code touchpoints
+
+- Identity + concept visibility filtering: `src/backend/security/access_control.py`
+- Namespace derivation: `src/backend/services/namespace_service.py`
+- Stub RBAC: `src/backend/security/role_resolver.py`
+- Organisation membership persistence: `src/backend/services/organisation_membership_service.py`
+- Chat/generate route + session org selection: `src/backend/server/routes/von_routes.py`
+- Internal MCP RAG tools: `src/backend/integrations/internal_mcp/catalogue.py`
+- RAG sync: `src/backend/services/rag_sync_service.py`
+- RAG backend metadata filtering: `src/backend/services/rag_backends/llamaindex_backend.py`

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -2032,12 +2032,18 @@ def _search_knowledge_base(**kwargs):
                 "success": False,
             }
 
-        # Build permissions context from Flask session for org-scoped RAG filtering
+        # Build permissions context from Flask session for org-scoped RAG filtering.
+        # IMPORTANT: Use concept IDs (e.g. #V#user) rather than email/usernames.
         permissions_context = {}
         try:
             from flask import session as flask_session
 
-            if flask_session.get("user_id"):
+            user_concept_id = flask_session.get("user_concept_id")
+            if isinstance(user_concept_id, str) and user_concept_id.strip():
+                permissions_context["user_id"] = user_concept_id.strip()
+            elif flask_session.get("user_id"):
+                # Backwards compatibility: some sessions store a non-concept user_id.
+                # Fall back to that only if we don't have a concept ID.
                 permissions_context["user_id"] = flask_session.get("user_id")
             org_concept_id = flask_session.get("organisation_concept_id")
             if not org_concept_id:
@@ -2194,9 +2200,12 @@ def _rag_get_status(**kwargs):
 
     try:
         ns = kwargs.get("namespace") or os.environ.get("VON_DEFAULT_NAMESPACE")
+        detail = kwargs.get("detail")
         url = "http://127.0.0.1:5002/admin/rag_status"
         if ns:
             url = f"{url}?namespace={ns}"
+        if detail:
+            url = f"{url}{'&' if '?' in url else '?'}detail=1"
         res = requests.get(url, timeout=5)
         if res.ok:
             return res.json()
@@ -3441,7 +3450,7 @@ def build_default_catalogue() -> MethodCatalogue:
             ),
             output_schema=None,
             category="read",
-            description="List all RAG-indexed chat sessions/conversations for the current user. Returns total count and session metadata. Use this to answer 'how many RAG sessions' or 'what conversations are indexed'. Namespace filtered automatically.",
+            description="List all RAG-indexed interaction sessions (KA sessions) for the current user. Returns total count and session metadata. Use this to answer 'how many KA sessions are indexed'. Namespace filtered automatically.",
         ),
         MethodDefinition(
             name="rag_get_item",

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -2039,10 +2039,12 @@ def _search_knowledge_base(**kwargs):
 
             if flask_session.get("user_id"):
                 permissions_context["user_id"] = flask_session.get("user_id")
-            if flask_session.get("org_id"):
-                permissions_context["organisation_concept_id"] = flask_session.get(
-                    "org_id"
-                )
+            org_concept_id = flask_session.get("organisation_concept_id")
+            if not org_concept_id:
+                # Backwards compatibility for older session key.
+                org_concept_id = flask_session.get("org_id")
+            if org_concept_id:
+                permissions_context["organisation_concept_id"] = org_concept_id
         except (ImportError, RuntimeError):
             # Not in Flask context - use user_id from kwargs if available
             if isinstance(user_id, str) and user_id.strip():

--- a/src/backend/server/routes/concept_routes.py
+++ b/src/backend/server/routes/concept_routes.py
@@ -808,8 +808,24 @@ def submit_concept_answer_route(concept_id: str):
         # The call below would be more like:
         # result = concept_service.process_answer_for_interaction(interaction_id, answer, concept_id)
         # Since `submit_concept_answer` is what's in the service, we'll call that,
-        # acknowledging the `session` parameter issue.        # Fetch the interaction session by ID
-        session = concept_service.get_interaction_session_by_id(interaction_id)
+        # acknowledging the `session` parameter issue.
+
+        # Use the centralized and secure method to get the effective user concept ID
+        from ...security.access_control import get_effective_user_concept_id
+
+        user_id = get_effective_user_concept_id()
+        if not user_id:
+            return (
+                jsonify(
+                    error="Missing user context: provide X-User-Client-ID header or establish session"
+                ),
+                400,
+            )
+
+        # Fetch the interaction session by ID (scoped to effective user/org)
+        session = concept_service.get_interaction_session_by_id(
+            interaction_id, user_id=user_id
+        )
         if not session:
             current_app.logger.warning(
                 f"Interaction session not found for ID: {interaction_id}"
@@ -906,8 +922,21 @@ def resume_interaction_route(concept_id: str):
         if not data or "interaction_id" not in data:
             return jsonify(error="interaction_id is required"), 400
 
+        from ...security.access_control import get_effective_user_concept_id
+
+        user_id = get_effective_user_concept_id()
+        if not user_id:
+            return (
+                jsonify(
+                    error="Missing user context: provide X-User-Client-ID header or establish session"
+                ),
+                400,
+            )
+
         interaction_id = data["interaction_id"]
-        resumed_session = concept_service.resume_interaction_session(interaction_id)
+        resumed_session = concept_service.resume_interaction_session(
+            interaction_id, user_id=user_id
+        )
 
         return jsonify(resumed_session), 200
 

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -1093,6 +1093,215 @@ def generate():
             )
 
         # ---------------------------------------------------------
+        # Tool-backed RAG counts (avoid KA vs chat-history confusion)
+        # ---------------------------------------------------------
+        # We bypass the LLM for simple factual questions about indexed sessions,
+        # because the assistant can otherwise confuse:
+        # - interaction sessions (KA sessions) vs
+        # - chat history sessions.
+        def _is_rag_counts_question(text: str) -> bool:
+            lowered = (text or "").strip().lower()
+            if not lowered:
+                return False
+
+            # Keep this intentionally narrow to avoid hijacking normal chat.
+            count_triggers = (
+                "how many",
+                "count",
+                "number of",
+            )
+            domain_triggers = (
+                "indexed",
+                "rag",
+            )
+            chat_triggers = (
+                "chat session",
+                "chat sessions",
+                "chat history",
+            )
+            ka_triggers = (
+                "ka",
+                "interaction session",
+                "interaction sessions",
+            )
+
+            has_count = any(t in lowered for t in count_triggers)
+            has_domain = any(t in lowered for t in domain_triggers)
+            refers_chat = any(t in lowered for t in chat_triggers)
+            refers_ka = any(t in lowered for t in ka_triggers)
+
+            # Examples:
+            # - "How many indexed chat sessions can you see?"
+            # - "How many chat history sessions are indexed?"
+            # - "How many KA sessions are indexed?"
+            return has_count and has_domain and (refers_chat or refers_ka)
+
+        if (
+            user_concept_id
+            and user_namespace
+            and gateway is not None
+            and getattr(gateway, "enabled", False)
+            and _is_rag_counts_question(prompt_text)
+        ):
+            import json as _json
+
+            user_id_for_history: str = user_concept_id
+
+            tool_invocations = []
+            try:
+                tool_result = gateway.invoke(
+                    "rag_get_status",
+                    {"namespace": user_namespace, "detail": 1},
+                )
+                payload = tool_result.payload
+                duration_ms = getattr(tool_result, "duration_ms", None)
+
+                tool_payload = _json.dumps(
+                    {
+                        "tool": "rag_get_status",
+                        "status": "ok",
+                        "duration_ms": duration_ms,
+                        "payload": payload,
+                    },
+                    default=str,
+                )
+                tool_messages = [{"role": "tool", "content": tool_payload}]
+                tool_invocations = [
+                    {
+                        "tool": "rag_get_status",
+                        "payload": {"namespace": user_namespace, "detail": 1},
+                        "duration_ms": duration_ms,
+                        "direct_user_call": False,
+                    }
+                ]
+
+                # Summarise counts in a way that makes the KA vs chat distinction explicit.
+                rs = payload if isinstance(payload, dict) else {}
+                ka_indexed = rs.get("indexed")
+                ch_sessions = rs.get("chat_history_sessions_in_namespace")
+                if ch_sessions is None:
+                    ch_sessions = rs.get("chat_history_sessions")
+
+                ch_details = rs.get("chat_history_session_details")
+                fully_indexed = None
+                any_indexed = None
+                if isinstance(ch_details, list) and ch_details:
+
+                    def _as_int(value):
+                        try:
+                            return int(value)
+                        except Exception:
+                            return 0
+
+                    fully_indexed = 0
+                    any_indexed = 0
+                    for row in ch_details:
+                        if not isinstance(row, dict):
+                            continue
+                        missing = _as_int(row.get("messages_missing_index"))
+                        ok = _as_int(row.get("rag_indexed_success"))
+                        fail = _as_int(row.get("rag_indexed_failed"))
+                        indexed_total = row.get("messages_indexed_total")
+                        indexed_total_int = (
+                            _as_int(indexed_total)
+                            if indexed_total is not None
+                            else (ok + fail)
+                        )
+
+                        if indexed_total_int > 0:
+                            any_indexed += 1
+                        if missing <= 0:
+                            fully_indexed += 1
+
+                parts = []
+                parts.append(
+                    f"Chat history sessions (in namespace): {ch_sessions if ch_sessions is not None else '—'}"
+                )
+                if any_indexed is not None:
+                    parts.append(
+                        f"Chat history sessions with any indexed messages: {any_indexed}"
+                    )
+                if fully_indexed is not None:
+                    parts.append(
+                        f"Chat history sessions fully indexed (missing=0): {fully_indexed}"
+                    )
+                parts.append(
+                    f"KA interaction sessions indexed: {ka_indexed if ka_indexed is not None else '—'}"
+                )
+
+                response_text = (
+                    "Here are the server-truth counts (RAG status), keeping chat history separate from KA interaction sessions:\n\n"
+                    + "\n".join(f"- {p}" for p in parts)
+                )
+            except Exception as exc:
+                response_text = (
+                    f"I could not retrieve RAG status via internal tools: {exc}"
+                )
+                tool_messages = []
+
+            # Persist messages in history/context.
+            chat_history_service.add_message_to_history(
+                user_id_for_history,
+                session_id,
+                {"role": "user", "content": prompt_text},
+            )
+            for tool_msg in _truncate_large_tool_results(
+                tool_messages, max_tool_content_chars=5000
+            ):
+                chat_history_service.add_message_to_history(
+                    user_id_for_history, session_id, tool_msg
+                )
+            chat_history_service.add_message_to_history(
+                user_id_for_history,
+                session_id,
+                {"role": "assistant", "content": response_text},
+            )
+            current_app.config["CONTEXT"] = _limit_context_size(
+                current_app.config["CONTEXT"], max_messages=20
+            )
+
+            context_stats = _calculate_context_stats(context)
+            current_context_stats = _calculate_context_stats(
+                current_app.config["CONTEXT"]
+            )
+            tool_stats = _calculate_tool_stats(tool_messages) if tool_messages else None
+
+            llm_debug_info = {
+                "interaction_timestamp_utc": interaction_timestamp_utc,
+                "model": model_name,
+                "messages": (
+                    [{"role": "user", "content": prompt_text}] + tool_messages
+                ),
+                "response": response_text,
+                "user_prompt": user_prompt_debug,
+                "context_stats": {
+                    "sent_to_llm": context_stats,
+                    "stored_context": current_context_stats,
+                },
+                "tool_stats": tool_stats,
+                "tool_invocations": tool_invocations,
+                "fastpath": {
+                    "name": "rag_counts",
+                    "bypassed_llm": True,
+                    "used_tool": bool(tool_messages),
+                    "enabled": True,
+                },
+            }
+            llm_debug_info["warnings"] = _derive_llm_debug_warnings(llm_debug_info)
+
+            return jsonify(
+                {
+                    "response": response_text,
+                    "fastpath": {
+                        "name": "rag_counts",
+                        "bypassed_llm": True,
+                        "used_tool": bool(tool_messages),
+                    },
+                    "llm_debug": llm_debug_info,
+                }
+            )
+
+        # ---------------------------------------------------------
         # Optional debug mode: allow user-issued tool calls
         # ---------------------------------------------------------
         # This is disabled by default because it bypasses the LLM's behavioural

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -1056,24 +1056,37 @@ def generate():
         # Derive user namespace for MCP tool isolation (JVNAUTOSCI-760)
         user_namespace = None
         if user_concept_id:
-            # Convert concept ID to namespace format (#V#michael_witbrock)
-            # Handle both full concept ID and person ID formats
-            if user_concept_id.startswith("#V#"):
-                user_namespace = user_concept_id
-            else:
-                # Normalize to namespace format
-                user_id_normalized = (
-                    user_concept_id.lower()
-                    .replace(" ", "_")
-                    .replace("#v#", "")
-                    .replace("#", "")
+            session_namespace = session.get("namespace")
+            if (
+                isinstance(session_namespace, str)
+                and session_namespace.strip()
+                and session_namespace.startswith("#V#")
+            ):
+                user_namespace = session_namespace.strip()
+                current_app.logger.info(
+                    "[NAMESPACE] Using session namespace=%s for user_concept_id=%s",
+                    user_namespace,
+                    user_concept_id,
                 )
-                user_namespace = f"#V#{user_id_normalized}"
-            current_app.logger.info(
-                "[NAMESPACE] Derived user_namespace=%s from user_concept_id=%s",
-                user_namespace,
-                user_concept_id,
-            )
+            else:
+                # Convert concept ID to namespace format (#V#michael_witbrock)
+                # Handle both full concept ID and person ID formats
+                if user_concept_id.startswith("#V#"):
+                    user_namespace = user_concept_id
+                else:
+                    # Normalize to namespace format
+                    user_id_normalized = (
+                        user_concept_id.lower()
+                        .replace(" ", "_")
+                        .replace("#v#", "")
+                        .replace("#", "")
+                    )
+                    user_namespace = f"#V#{user_id_normalized}"
+                current_app.logger.info(
+                    "[NAMESPACE] Derived user_namespace=%s from user_concept_id=%s",
+                    user_namespace,
+                    user_concept_id,
+                )
         else:
             current_app.logger.warning(
                 "[NAMESPACE] No user_concept_id - user_namespace=None (RAG unavailable)"

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -444,22 +444,25 @@ def create_flask_app(
                 if "interactions" in db.list_collection_names()
                 else None
             )
-            # Optional namespace filter: expects sessions to store a 'namespace' field
+            # Optional namespace filter: interaction_sessions may store either a
+            # user-only namespace (#V#user) or a composite namespace (#V#user@org).
+            # For backwards compatibility, if a composite namespace is provided we
+            # scope to BOTH values.
             ns = request.args.get("namespace")
-            session_ns = ns
-            # interaction_sessions currently use a user-only namespace (e.g. #V#user),
-            # while chat history uses a composite user@organisation namespace.
-            # If a composite namespace is provided, normalise to user-only for
-            # interaction_sessions filtering.
+            session_ns_values: list[str] | None = None
             if ns:
+                session_ns_values = [ns]
                 try:
                     from src.backend.services.namespace_service import parse_namespace
 
                     parsed = parse_namespace(ns)
                     if parsed.get("user_id"):
-                        session_ns = f"#V#{parsed['user_id']}"
+                        user_only = f"#V#{parsed['user_id']}"
+                        if user_only not in session_ns_values:
+                            session_ns_values.append(user_only)
                 except Exception:
-                    session_ns = ns
+                    # If the namespace is not parseable, treat it as an opaque key.
+                    pass
 
             # Diagnostics: explain scoping precisely.
             missing_namespace_filter = {
@@ -470,14 +473,17 @@ def create_flask_app(
                 ]
             }
 
-            sess_filter = {"namespace": session_ns} if session_ns else {}
+            if session_ns_values:
+                sess_filter = {"namespace": {"$in": session_ns_values}}
+            else:
+                sess_filter = {}
             total_sessions = sessions_coll.count_documents({})
             scoped_sessions = sessions_coll.count_documents(sess_filter or {})
             sessions_missing_namespace = sessions_coll.count_documents(
                 missing_namespace_filter
             )
             sessions_other_namespace = None
-            if session_ns:
+            if session_ns_values:
                 sessions_other_namespace = max(
                     0, total_sessions - scoped_sessions - sessions_missing_namespace
                 )
@@ -488,7 +494,9 @@ def create_flask_app(
                     {
                         "$project": {
                             "namespace": {"$ifNull": ["$namespace", "__MISSING__"]},
-                            "indexing_status": {"$ifNull": ["$indexing_status", "__NONE__"]},
+                            "indexing_status": {
+                                "$ifNull": ["$indexing_status", "__NONE__"]
+                            },
                         }
                     },
                     {
@@ -612,6 +620,7 @@ def create_flask_app(
                 "chat_history_sessions_in_namespace": 0,
                 "chat_history_sessions_missing_namespace": 0,
                 "chat_history_sessions_other_namespace": 0,
+                "chat_history_session_details": None,
                 "chat_history_backfill_available": False,
                 "chat_history_backfill_reason": None,
                 "chat_history_backfill_session_namespace": None,
@@ -634,6 +643,13 @@ def create_flask_app(
                         user_id_for_ns = None
 
                 match = {"user_id": user_id_for_ns} if user_id_for_ns else {}
+
+                include_detail = request.args.get("detail", "").lower() in {
+                    "1",
+                    "true",
+                    "yes",
+                    "on",
+                }
 
                 pipeline = [
                     {"$match": match},
@@ -716,9 +732,172 @@ def create_flask_app(
                         "chat_history_sessions_in_namespace": sessions_in_namespace,
                         "chat_history_sessions_missing_namespace": sessions_missing_namespace,
                         "chat_history_sessions_other_namespace": sessions_other_namespace,
+                        "chat_history_session_details": None,
                         "chat_history_backfill_available": False,
                         "chat_history_backfill_reason": None,
                     }
+
+                # Optional per-session breakdown (for diagnostics / UI modal).
+                # Only return details when a namespace is provided so we can scope
+                # by user_id safely.
+                if include_detail and user_id_for_ns:
+                    try:
+                        details_pipeline = [
+                            {"$match": match},
+                            {
+                                "$project": {
+                                    "_id": 0,
+                                    "session_id": 1,
+                                    "namespace": 1,
+                                    "rag_indexed_success": {
+                                        "$ifNull": ["$rag_indexed_success", 0]
+                                    },
+                                    "rag_indexed_failed": {
+                                        "$ifNull": ["$rag_indexed_failed", 0]
+                                    },
+                                    "messages_stored": {
+                                        "$cond": [
+                                            {"$isArray": "$history"},
+                                            {"$size": "$history"},
+                                            {"$ifNull": ["$message_count", 0]},
+                                        ]
+                                    },
+                                    "messages_non_reset": {
+                                        "$cond": [
+                                            {"$isArray": "$history"},
+                                            {
+                                                "$size": {
+                                                    "$filter": {
+                                                        "input": "$history",
+                                                        "as": "m",
+                                                        "cond": {
+                                                            "$not": {
+                                                                "$and": [
+                                                                    {
+                                                                        "$eq": [
+                                                                            "$$m.role",
+                                                                            "system",
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "$eq": [
+                                                                            "$$m.content",
+                                                                            "__RESET__",
+                                                                        ]
+                                                                    },
+                                                                ]
+                                                            }
+                                                        },
+                                                    }
+                                                }
+                                            },
+                                            {"$ifNull": ["$message_count", 0]},
+                                        ]
+                                    },
+                                    "messages_indexable": {
+                                        "$cond": [
+                                            {"$isArray": "$history"},
+                                            {
+                                                "$size": {
+                                                    "$filter": {
+                                                        "input": "$history",
+                                                        "as": "m",
+                                                        "cond": {
+                                                            "$and": [
+                                                                {
+                                                                    "$not": {
+                                                                        "$and": [
+                                                                            {
+                                                                                "$eq": [
+                                                                                    "$$m.role",
+                                                                                    "system",
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "$eq": [
+                                                                                    "$$m.content",
+                                                                                    "__RESET__",
+                                                                                ]
+                                                                            },
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$eq": [
+                                                                        {
+                                                                            "$type": "$$m.content"
+                                                                        },
+                                                                        "string",
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "$gt": [
+                                                                        {
+                                                                            "$strLenCP": {
+                                                                                "$trim": {
+                                                                                    "input": "$$m.content"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        0,
+                                                                    ]
+                                                                },
+                                                            ]
+                                                        },
+                                                    }
+                                                }
+                                            },
+                                            {"$ifNull": ["$message_count", 0]},
+                                        ]
+                                    },
+                                    "in_namespace": {
+                                        "$cond": [
+                                            {"$eq": ["$namespace", ns]},
+                                            True,
+                                            False,
+                                        ]
+                                    },
+                                }
+                            },
+                            {
+                                "$addFields": {
+                                    "messages_indexed_total": {
+                                        "$add": [
+                                            "$rag_indexed_success",
+                                            "$rag_indexed_failed",
+                                        ]
+                                    },
+                                }
+                            },
+                            {
+                                "$addFields": {
+                                    "messages_missing_index": {
+                                        "$max": [
+                                            0,
+                                            {
+                                                "$subtract": [
+                                                    "$messages_indexable",
+                                                    "$messages_indexed_total",
+                                                ]
+                                            },
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "$sort": {
+                                    "messages_missing_index": -1,
+                                    "messages_non_reset": -1,
+                                }
+                            },
+                            {"$limit": 100},
+                        ]
+
+                        details = list(chat_history_coll.aggregate(details_pipeline))
+                        chat_summary["chat_history_session_details"] = details
+                    except Exception:
+                        # Best-effort diagnostics only; never fail rag_status.
+                        chat_summary["chat_history_session_details"] = None
 
                 # Availability is based on being logged in AND the requested namespace matching
                 # the current session-derived namespace (prevents cross-user actions).
@@ -778,7 +957,10 @@ def create_flask_app(
                     "eligible_sessions": eligible_sessions,
                     "eligible_interactions": eligible_interactions,
                     "namespace": ns,
-                    "session_namespace": session_ns,
+                    "session_namespace": (
+                        session_ns_values[0] if session_ns_values else None
+                    ),
+                    "session_namespaces": session_ns_values,
                     **chat_summary,
                 }
             )
@@ -843,6 +1025,164 @@ def create_flask_app(
         except Exception as e:
             return jsonify(error="unexpected", detail=str(e)), 500
 
+    @app.route("/admin/chat_history_reindex", methods=["POST"])
+    def admin_chat_history_reindex():
+        """Reindex chat history messages for the current user/namespace into RAG.
+
+        This is intended to repair older sessions that were never indexed, while
+        keeping namespace isolation intact.
+
+                Optional JSON body:
+                    {
+                        "max_sessions": int,
+                        "max_messages": int,
+                        "reset_counters": bool,
+                        "dry_run": bool,
+                        "session_ids": [str],
+
+                        # Chunked mode (recommended for reliability):
+                        # If provided, requires exactly one session_id.
+                        "chunk_start": int,
+                        "chunk_size": int
+                    }
+        """
+        try:
+            from flask import session as flask_session
+            from src.backend.services.namespace_service import derive_namespace
+            from src.backend.services import chat_history_service
+
+            sess_user_slug = _get_session_user_slug(flask_session)
+            sess_user_concept_id = flask_session.get("user_concept_id")
+
+            if not (sess_user_slug or sess_user_concept_id):
+                return jsonify(error="Not authenticated"), 401
+
+            sess_org_raw = flask_session.get(
+                "organisation_concept_id"
+            ) or flask_session.get("org_id")
+            sess_org = _slug_from_maybe_concept_id(sess_org_raw)
+            sess_role = flask_session.get("role_in_org")
+
+            target_ns = request.args.get("namespace") or flask_session.get("namespace")
+            if not target_ns and sess_user_slug:
+                target_ns = derive_namespace(sess_user_slug, sess_org)
+
+            if not isinstance(target_ns, str) or not target_ns:
+                return jsonify(error="Not authenticated"), 401
+
+            # Prevent cross-user / cross-namespace actions.
+            sess_ns = flask_session.get("namespace")
+            if not sess_ns and sess_user_slug:
+                sess_ns = derive_namespace(sess_user_slug, sess_org)
+            if sess_ns != target_ns:
+                return (
+                    jsonify(error="namespace_mismatch", session_namespace=sess_ns),
+                    403,
+                )
+
+            user_concept_id = (
+                sess_user_concept_id
+                if isinstance(sess_user_concept_id, str) and sess_user_concept_id
+                else (f"#V#{sess_user_slug}" if sess_user_slug else None)
+            )
+            if not user_concept_id:
+                return jsonify(error="Not authenticated"), 401
+
+            body = request.get_json(silent=True) or {}
+            max_sessions = int(body.get("max_sessions", 50))
+            max_messages = int(body.get("max_messages", 5000))
+            reset_counters = bool(body.get("reset_counters", True))
+            dry_run = bool(body.get("dry_run", False))
+            session_ids = body.get("session_ids")
+            if not isinstance(session_ids, list):
+                session_ids = None
+
+            chunk_start = body.get("chunk_start")
+            chunk_size = body.get("chunk_size")
+            use_chunked = chunk_start is not None or chunk_size is not None
+
+            if use_chunked:
+                if (
+                    not session_ids
+                    or len(session_ids) != 1
+                    or not isinstance(session_ids[0], str)
+                ):
+                    return (
+                        jsonify(
+                            error="invalid_request",
+                            detail="chunked reindex requires exactly one session_id",
+                        ),
+                        400,
+                    )
+                sid = session_ids[0]
+                try:
+                    import time
+
+                    t0 = time.monotonic()
+                except Exception:
+                    t0 = None
+
+                try:
+                    app.logger.info(
+                        "[chat_history_reindex] chunk start user=%s ns=%s session=%s chunk_start=%s chunk_size=%s dry_run=%s",
+                        user_concept_id,
+                        target_ns,
+                        sid,
+                        int(chunk_start or 0),
+                        int(chunk_size or 25),
+                        bool(dry_run),
+                    )
+                except Exception:
+                    pass
+
+                res = chat_history_service.reindex_chat_history_session_chunk(
+                    user_concept_id=user_concept_id,
+                    target_namespace=target_ns,
+                    organisation_concept_id=sess_org,
+                    role_in_org=sess_role,
+                    session_id=sid,
+                    chunk_start=int(chunk_start or 0),
+                    chunk_size=int(chunk_size or 25),
+                    reset_counters=reset_counters,
+                    dry_run=dry_run,
+                )
+
+                try:
+                    elapsed_ms = (
+                        int((time.monotonic() - t0) * 1000) if t0 is not None else None
+                    )
+                    app.logger.info(
+                        "[chat_history_reindex] chunk done user=%s ns=%s session=%s attempted=%s ok=%s failed=%s next=%s done=%s elapsed_ms=%s errors=%s",
+                        user_concept_id,
+                        target_ns,
+                        sid,
+                        res.get("messages_indexed_attempted"),
+                        res.get("messages_indexed_success"),
+                        res.get("messages_indexed_failed"),
+                        res.get("next_chunk_start"),
+                        res.get("done"),
+                        elapsed_ms,
+                        len(res.get("errors") or []),
+                    )
+                except Exception:
+                    pass
+                return jsonify(res)
+
+            res = chat_history_service.reindex_chat_history_for_user_namespace(
+                user_concept_id=user_concept_id,
+                target_namespace=target_ns,
+                organisation_concept_id=sess_org,
+                role_in_org=sess_role,
+                session_ids=session_ids,
+                max_sessions=max_sessions,
+                max_messages=max_messages,
+                reset_counters=reset_counters,
+                dry_run=dry_run,
+            )
+            return jsonify(res)
+        except Exception as e:
+            return jsonify(error="unexpected", detail=str(e)), 500
+
     @app.route("/admin/rag_integrity", methods=["POST"])
     def admin_rag_integrity():
         db = get_db()
@@ -852,21 +1192,31 @@ def create_flask_app(
         interactions_coll = (
             db["interactions"] if "interactions" in db.list_collection_names() else None
         )
+        # Optional namespace filter: interaction_sessions may store either a user-only
+        # namespace (#V#user) or a composite namespace (#V#user@org). For backwards
+        # compatibility, if a composite namespace is provided we scope to BOTH values.
         ns = request.args.get("namespace")
-        session_ns = ns
+        session_ns_values: list[str] | None = None
         if ns:
+            session_ns_values = [ns]
             try:
                 from src.backend.services.namespace_service import parse_namespace
 
                 parsed = parse_namespace(ns)
                 if parsed.get("user_id"):
-                    session_ns = f"#V#{parsed['user_id']}"
+                    user_only = f"#V#{parsed['user_id']}"
+                    if user_only not in session_ns_values:
+                        session_ns_values.append(user_only)
             except Exception:
-                session_ns = ns
+                # If the namespace is not parseable, treat it as an opaque key.
+                pass
 
-        sess_filter = {"namespace": session_ns} if session_ns else {}
+        sess_filter = (
+            {"namespace": {"$in": session_ns_values}} if session_ns_values else {}
+        )
         result = {
             "sessions": sessions_coll.count_documents(sess_filter or {}),
+            "scoped_sessions": sessions_coll.count_documents(sess_filter or {}),
             "interactions": (
                 interactions_coll.count_documents({})
                 if interactions_coll is not None
@@ -896,7 +1246,8 @@ def create_flask_app(
             "eligible_interactions": 0,
             "anomalies": [],
             "namespace": ns,
-            "session_namespace": session_ns,
+            "session_namespace": (session_ns_values[0] if session_ns_values else None),
+            "session_namespaces": session_ns_values,
         }
         if interactions_coll is not None:
             result["eligible_interactions"] = interactions_coll.count_documents(
@@ -1316,14 +1667,14 @@ def create_flask_app(
     def db_status():
         """Return current database connection status (fallback vs Atlas) for UI indicator.
 
-                Response schema:
-                    {
-                        "using_fallback": bool | null,
-                        "atlas_detected": bool | null,
-                        "effective_host": str | null,   # redacted host:port only
-                        "timestamp": iso8601,
-                    }
-                """
+        Response schema:
+            {
+                "using_fallback": bool | null,
+                "atlas_detected": bool | null,
+                "effective_host": str | null,   # redacted host:port only
+                "timestamp": iso8601,
+            }
+        """
         from datetime import datetime, timezone as _tz
 
         using_fallback = None

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -26,13 +26,15 @@ def get_session_context() -> Dict[str, Any]:
         from flask import session as flask_session
 
         return {
-            "org_id": flask_session.get("org_id"),
+            # Prefer current key, fall back to legacy.
+            "organisation_concept_id": flask_session.get("organisation_concept_id")
+            or flask_session.get("org_id"),
             "role_in_org": flask_session.get("role_in_org"),
             "namespace": flask_session.get("namespace"),
         }
     except (ImportError, RuntimeError):
         # Not in Flask context or session not available
-        return {"org_id": None, "role_in_org": None}
+        return {"organisation_concept_id": None, "role_in_org": None}
 
 
 class ChatHistoryServiceError(Exception):
@@ -288,8 +290,9 @@ def add_message_to_history(
                     }
 
                     # Include organisation and role metadata if available
-                    if session_context.get("org_id"):
-                        metadata["organisation_concept_id"] = session_context["org_id"]
+                    org_concept_id = session_context.get("organisation_concept_id")
+                    if org_concept_id:
+                        metadata["organisation_concept_id"] = org_concept_id
                     if session_context.get("role_in_org"):
                         metadata["role_in_org"] = session_context["role_in_org"]
 
@@ -297,9 +300,25 @@ def add_message_to_history(
                     if not isinstance(ns, str) or not ns.strip():
                         ns = "chat_history"
                     rag.upsert_documents([doc], namespace=ns)
+
+                    # Track indexing progress per chat session for status UI.
+                    try:
+                        chat_history_coll.update_one(
+                            {"user_id": user_id, "session_id": session_id},
+                            {"$inc": {"rag_indexed_success": 1}},
+                        )
+                    except Exception:
+                        pass
             except Exception as e:
                 # Log but don't fail the chat request
                 logger.warning(f"Failed to index chat message to RAG: {e}")
+                try:
+                    chat_history_coll.update_one(
+                        {"user_id": user_id, "session_id": session_id},
+                        {"$inc": {"rag_indexed_failed": 1}},
+                    )
+                except Exception:
+                    pass
 
     except PyMongoError as e:
         logger.error(f"Error adding message to history: {e}", exc_info=True)
@@ -695,3 +714,416 @@ def backfill_chat_history_for_user(
     except PyMongoError as e:
         logger.error(f"Error during chat history backfill: {e}", exc_info=True)
         raise ChatHistoryServiceError(f"Backfill failed: {e}") from e
+
+
+def reindex_chat_history_for_user_namespace(
+    *,
+    user_concept_id: str,
+    target_namespace: str,
+    organisation_concept_id: Optional[str] = None,
+    role_in_org: Optional[str] = None,
+    session_ids: Optional[List[str]] = None,
+    max_sessions: int = 50,
+    max_messages: int = 5000,
+    reset_counters: bool = True,
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """Reindex chat history messages into RAG for sessions already in a namespace.
+
+    This exists because older chat sessions may have:
+    - never been indexed (RAG not available at the time), or
+    - been indexed with non-deterministic IDs (hard to deduplicate), or
+    - missing/incorrect per-session counters.
+
+    Behaviour:
+    - Scopes to documents with {user_id=user_concept_id, namespace=target_namespace}
+    - Indexes only non-reset messages with non-empty string content
+    - Uses deterministic IDs (idempotent) so repeated runs are safe
+    - Optionally resets rag_indexed_success/failed per session before reindexing
+    """
+
+    if not isinstance(user_concept_id, str) or not user_concept_id:
+        raise ChatHistoryServiceError("user_concept_id is required")
+    if not isinstance(target_namespace, str) or not target_namespace:
+        raise ChatHistoryServiceError("target_namespace is required")
+
+    chat_history_coll = get_chat_history_collection_service()
+    if chat_history_coll is None:
+        raise ChatHistoryServiceError("Could not connect to chat history collection.")
+
+    safe_max_sessions = 50
+    if isinstance(max_sessions, int) and max_sessions > 0:
+        safe_max_sessions = min(max_sessions, 2000)
+
+    safe_max_messages = 5000
+    if isinstance(max_messages, int) and max_messages > 0:
+        safe_max_messages = min(max_messages, 200000)
+
+    rag = None
+    if get_rag_service:
+        try:
+            rag = get_rag_service()
+        except Exception:
+            rag = None
+
+    query: Dict[str, Any] = {
+        "user_id": user_concept_id,
+        "namespace": target_namespace,
+    }
+    if session_ids:
+        query["session_id"] = {"$in": [sid for sid in session_ids if sid]}
+
+    sessions_examined = 0
+    sessions_reindexed = 0
+    messages_indexed_attempted = 0
+    messages_indexed_success = 0
+    messages_indexed_failed = 0
+    errors: List[Dict[str, Any]] = []
+
+    deterministic_namespace_uuid = uuid.UUID("8c5a7fa9-9a7c-4f0f-8c1f-f4ad7f9f6fd7")
+
+    try:
+        cursor = chat_history_coll.find(query)
+
+        for doc in cursor:
+            if sessions_examined >= safe_max_sessions:
+                break
+            sessions_examined += 1
+
+            session_id = doc.get("session_id")
+            if not isinstance(session_id, str) or not session_id:
+                continue
+
+            if reset_counters and not dry_run:
+                try:
+                    chat_history_coll.update_one(
+                        {"_id": doc["_id"]},
+                        {"$set": {"rag_indexed_success": 0, "rag_indexed_failed": 0}},
+                    )
+                except Exception:
+                    # Best-effort only.
+                    pass
+
+            history = doc.get("history") or []
+            if not isinstance(history, list) or not history:
+                continue
+
+            did_any = False
+            for idx, msg in enumerate(history):
+                if messages_indexed_attempted >= safe_max_messages:
+                    break
+                if not isinstance(msg, dict) or _is_reset_marker(msg):
+                    continue
+
+                content = msg.get("content")
+                if not isinstance(content, str) or not content.strip():
+                    continue
+
+                messages_indexed_attempted += 1
+                did_any = True
+
+                if rag is None or dry_run:
+                    messages_indexed_success += 1
+                    continue
+
+                try:
+                    ts = _coerce_datetime(msg.get("timestamp"))
+                    doc_id = str(
+                        uuid.uuid5(
+                            deterministic_namespace_uuid,
+                            f"{target_namespace}|{user_concept_id}|{session_id}|{idx}",
+                        )
+                    )
+                    text = content.strip()
+                    if len(text) > 5000:
+                        text = text[:5000]
+
+                    metadata = {
+                        "type": "chat_message",
+                        "user_id": user_concept_id,
+                        "session_id": session_id,
+                        "role": msg.get("role", "unknown"),
+                        "timestamp": ts.isoformat() if ts else None,
+                        "organisation_concept_id": organisation_concept_id,
+                        "role_in_org": role_in_org,
+                        "reindexed": True,
+                    }
+
+                    rag.upsert_documents(
+                        [{"id": doc_id, "text": text, "metadata": metadata}],
+                        namespace=target_namespace,
+                    )
+                    messages_indexed_success += 1
+
+                    try:
+                        chat_history_coll.update_one(
+                            {"user_id": user_concept_id, "session_id": session_id},
+                            {"$inc": {"rag_indexed_success": 1}},
+                        )
+                    except Exception:
+                        pass
+                except Exception as e:
+                    messages_indexed_failed += 1
+                    errors.append(
+                        {
+                            "type": "index_failed",
+                            "session_id": session_id,
+                            "message_index": idx,
+                            "error": str(e),
+                        }
+                    )
+                    try:
+                        chat_history_coll.update_one(
+                            {"user_id": user_concept_id, "session_id": session_id},
+                            {"$inc": {"rag_indexed_failed": 1}},
+                        )
+                    except Exception:
+                        pass
+
+            if did_any:
+                sessions_reindexed += 1
+
+        return {
+            "status": "ok",
+            "user_concept_id": user_concept_id,
+            "target_namespace": target_namespace,
+            "dry_run": bool(dry_run),
+            "reset_counters": bool(reset_counters),
+            "sessions_examined": sessions_examined,
+            "sessions_reindexed": sessions_reindexed,
+            "messages_indexed_attempted": messages_indexed_attempted,
+            "messages_indexed_success": messages_indexed_success,
+            "messages_indexed_failed": messages_indexed_failed,
+            "errors": errors,
+        }
+    except PyMongoError as e:
+        logger.error(f"Error during chat history reindex: {e}", exc_info=True)
+        raise ChatHistoryServiceError(f"Reindex failed: {e}") from e
+
+
+def reindex_chat_history_session_chunk(
+    *,
+    user_concept_id: str,
+    target_namespace: str,
+    session_id: str,
+    organisation_concept_id: Optional[str] = None,
+    role_in_org: Optional[str] = None,
+    chunk_start: int = 0,
+    chunk_size: int = 25,
+    reset_counters: bool = False,
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """Reindex a single chat history session in small chunks.
+
+    This exists to make long-running reindex operations reliable:
+    - Each call processes at most `chunk_size` indexable messages.
+    - Returns `next_chunk_start` so the client can resume.
+
+    `chunk_start` is an index into the raw `history` list (not filtered).
+    This keeps resumption stable across calls.
+    """
+
+    if not isinstance(user_concept_id, str) or not user_concept_id:
+        raise ChatHistoryServiceError("user_concept_id is required")
+    if not isinstance(target_namespace, str) or not target_namespace:
+        raise ChatHistoryServiceError("target_namespace is required")
+    if not isinstance(session_id, str) or not session_id:
+        raise ChatHistoryServiceError("session_id is required")
+
+    safe_chunk_start = 0
+    if isinstance(chunk_start, int) and chunk_start > 0:
+        safe_chunk_start = min(chunk_start, 1_000_000)
+
+    safe_chunk_size = 25
+    if isinstance(chunk_size, int) and chunk_size > 0:
+        safe_chunk_size = min(chunk_size, 500)
+
+    chat_history_coll = get_chat_history_collection_service()
+    if chat_history_coll is None:
+        raise ChatHistoryServiceError("Could not connect to chat history collection.")
+
+    rag = None
+    if get_rag_service:
+        try:
+            rag = get_rag_service()
+        except Exception:
+            rag = None
+
+    doc = chat_history_coll.find_one(
+        {
+            "user_id": user_concept_id,
+            "namespace": target_namespace,
+            "session_id": session_id,
+        },
+        {"history": 1, "_id": 1},
+    )
+    if not doc:
+        return {
+            "status": "not_found",
+            "user_concept_id": user_concept_id,
+            "target_namespace": target_namespace,
+            "session_id": session_id,
+            "chunk_start": safe_chunk_start,
+            "chunk_size": safe_chunk_size,
+            "done": True,
+        }
+
+    history = doc.get("history") or []
+    if not isinstance(history, list) or not history:
+        return {
+            "status": "ok",
+            "user_concept_id": user_concept_id,
+            "target_namespace": target_namespace,
+            "session_id": session_id,
+            "chunk_start": safe_chunk_start,
+            "chunk_size": safe_chunk_size,
+            "history_len": 0,
+            "indexable_total": 0,
+            "messages_indexed_attempted": 0,
+            "messages_indexed_success": 0,
+            "messages_indexed_failed": 0,
+            "errors": [],
+            "next_chunk_start": 0,
+            "done": True,
+        }
+
+    history_len = len(history)
+    indexable_total = 0
+    for msg in history:
+        if not isinstance(msg, dict) or _is_reset_marker(msg):
+            continue
+        content = msg.get("content")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        indexable_total += 1
+
+    if reset_counters and not dry_run:
+        try:
+            chat_history_coll.update_one(
+                {"_id": doc["_id"]},
+                {"$set": {"rag_indexed_success": 0, "rag_indexed_failed": 0}},
+            )
+        except Exception:
+            pass
+
+    deterministic_namespace_uuid = uuid.UUID("8c5a7fa9-9a7c-4f0f-8c1f-f4ad7f9f6fd7")
+    docs_to_upsert: List[Dict[str, Any]] = []
+    errors: List[Dict[str, Any]] = []
+
+    next_chunk_start = history_len
+    for idx in range(safe_chunk_start, history_len):
+        msg = history[idx]
+        if not isinstance(msg, dict) or _is_reset_marker(msg):
+            continue
+
+        content = msg.get("content")
+        if not isinstance(content, str) or not content.strip():
+            continue
+
+        ts = _coerce_datetime(msg.get("timestamp"))
+        doc_id = str(
+            uuid.uuid5(
+                deterministic_namespace_uuid,
+                f"{target_namespace}|{user_concept_id}|{session_id}|{idx}",
+            )
+        )
+        text = content.strip()
+        if len(text) > 5000:
+            text = text[:5000]
+
+        metadata = {
+            "type": "chat_message",
+            "user_id": user_concept_id,
+            "session_id": session_id,
+            "role": msg.get("role", "unknown"),
+            "timestamp": ts.isoformat() if ts else None,
+            "organisation_concept_id": organisation_concept_id,
+            "role_in_org": role_in_org,
+            "reindexed": True,
+        }
+
+        docs_to_upsert.append({"id": doc_id, "text": text, "metadata": metadata})
+
+        if len(docs_to_upsert) >= safe_chunk_size:
+            next_chunk_start = idx + 1
+            break
+
+    if not docs_to_upsert:
+        return {
+            "status": "ok",
+            "user_concept_id": user_concept_id,
+            "target_namespace": target_namespace,
+            "session_id": session_id,
+            "chunk_start": safe_chunk_start,
+            "chunk_size": safe_chunk_size,
+            "history_len": history_len,
+            "indexable_total": indexable_total,
+            "messages_indexed_attempted": 0,
+            "messages_indexed_success": 0,
+            "messages_indexed_failed": 0,
+            "errors": [],
+            "next_chunk_start": history_len,
+            "done": True,
+        }
+
+    messages_indexed_attempted = len(docs_to_upsert)
+    messages_indexed_success = 0
+    messages_indexed_failed = 0
+
+    if rag is None or dry_run:
+        messages_indexed_success = messages_indexed_attempted
+    else:
+        try:
+            s, f = rag.upsert_documents(
+                docs_to_upsert,
+                namespace=target_namespace,
+                allow_partial_failures=True,
+            )
+            messages_indexed_success += int(s or 0)
+            messages_indexed_failed += int(f or 0)
+        except Exception as e:
+            # Best-effort: treat the whole chunk as failed.
+            messages_indexed_failed += messages_indexed_attempted
+            errors.append(
+                {
+                    "type": "index_failed",
+                    "session_id": session_id,
+                    "chunk_start": safe_chunk_start,
+                    "chunk_size": safe_chunk_size,
+                    "error": str(e),
+                }
+            )
+
+    if not dry_run:
+        try:
+            if messages_indexed_success:
+                chat_history_coll.update_one(
+                    {"user_id": user_concept_id, "session_id": session_id},
+                    {"$inc": {"rag_indexed_success": messages_indexed_success}},
+                )
+            if messages_indexed_failed:
+                chat_history_coll.update_one(
+                    {"user_id": user_concept_id, "session_id": session_id},
+                    {"$inc": {"rag_indexed_failed": messages_indexed_failed}},
+                )
+        except Exception:
+            pass
+
+    done = next_chunk_start >= history_len
+
+    return {
+        "status": "ok",
+        "user_concept_id": user_concept_id,
+        "target_namespace": target_namespace,
+        "session_id": session_id,
+        "chunk_start": safe_chunk_start,
+        "chunk_size": safe_chunk_size,
+        "history_len": history_len,
+        "indexable_total": indexable_total,
+        "messages_indexed_attempted": messages_indexed_attempted,
+        "messages_indexed_success": messages_indexed_success,
+        "messages_indexed_failed": messages_indexed_failed,
+        "errors": errors,
+        "next_chunk_start": next_chunk_start,
+        "done": done,
+    }

--- a/src/backend/services/concept_service.py
+++ b/src/backend/services/concept_service.py
@@ -1786,12 +1786,24 @@ def get_active_interactions_for_concept(
 
     try:
         # Find active sessions for this concept and user
+        query: dict[str, Any] = {
+            "concept_id": ObjectId(concept_id),
+            "user_id": user_id,
+        }
+
+        # If an organisation is selected in the current request context, scope
+        # active interactions to that organisation.
+        try:
+            from flask import session as flask_session
+
+            org_id = flask_session.get("organisation_concept_id")
+            if org_id:
+                query["organisation_concept_id"] = org_id
+        except Exception:
+            pass
+
         active_sessions = list(
-            sessions_coll.find(
-                {
-                    "concept_id": ObjectId(concept_id),
-                }
-            ).sort("last_updated_time", -1)
+            sessions_coll.find(query).sort("last_updated_time", -1)
         )  # Most recent first
 
         # Convert ObjectId to string for JSON serialization
@@ -1815,7 +1827,10 @@ def get_active_interactions_for_concept(
         raise ConceptServiceError(f"Could not retrieve active interactions: {e}") from e
 
 
-def resume_interaction_session(interaction_id: str) -> Dict[str, Any]:
+def resume_interaction_session(
+    interaction_id: str,
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
     """Resumes an existing interaction session by returning its current state.
 
     Args:
@@ -1831,7 +1846,7 @@ def resume_interaction_session(interaction_id: str) -> Dict[str, Any]:
     logger.info(f"Resuming interaction session: {interaction_id}")
 
     try:
-        session = get_interaction_session_by_id(interaction_id)
+        session = get_interaction_session_by_id(interaction_id, user_id=user_id)
         if not session:
             raise ConceptServiceError(f"Interaction session {interaction_id} not found")
 
@@ -2598,7 +2613,11 @@ def update_concept_description(concept_id: str, new_description: str) -> bool:
         return False
 
 
-def get_interaction_session_by_id(interaction_id: str) -> Optional[Dict[str, Any]]:
+def get_interaction_session_by_id(
+    interaction_id: str,
+    user_id: Optional[str] = None,
+    organisation_concept_id: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
     """Retrieves an interaction session by its ID.
 
     Args:
@@ -2618,8 +2637,33 @@ def get_interaction_session_by_id(interaction_id: str) -> Optional[Dict[str, Any
 
     sessions_coll = db[interaction_session_collection_name]
 
+    query: dict[str, Any]
     try:
-        session = sessions_coll.find_one({"_id": ObjectId(interaction_id)})
+        query = {"_id": ObjectId(interaction_id)}
+    except Exception as e:
+        logger.error(
+            f"Error retrieving interaction session with ID {interaction_id}: {e}"
+        )
+        raise ConceptServiceError(
+            f"Invalid interaction ID format or database error for ID {interaction_id}."
+        ) from e
+
+    if user_id:
+        query["user_id"] = user_id
+
+    if organisation_concept_id is None:
+        try:
+            from flask import session as flask_session
+
+            organisation_concept_id = flask_session.get("organisation_concept_id")
+        except Exception:
+            organisation_concept_id = None
+
+    if organisation_concept_id:
+        query["organisation_concept_id"] = organisation_concept_id
+
+    try:
+        session = sessions_coll.find_one(query)
         if session:
             logger.info(f"Found interaction session with ID: {interaction_id}")
             return session

--- a/src/backend/services/rag_backends/llamaindex_backend.py
+++ b/src/backend/services/rag_backends/llamaindex_backend.py
@@ -1,13 +1,24 @@
-"""
+"""src.backend.services.rag_backends.llamaindex_backend
+
 LlamaIndex RAG Backend Implementation (Apache-2.0)
 
 This module implements the RAGService protocol using LlamaIndex.
 It is imported lazily to avoid hard dependencies.
+
+Namespace behaviour:
+- The RAGService interface supports a `namespace` argument on upsert/query/delete.
+- This backend treats namespace as a hard isolation boundary by persisting a
+    separate on-disk index per namespace.
+- Documents are also stamped with `metadata["namespace"]` to aid debugging and
+    allow defensive filtering.
 """
 
+import hashlib
 import os
+import re
 from typing import Iterable, Dict, Any, Optional, List, Tuple
-from ..rag_service import RAGService, RAGBackendUnavailable
+
+from ..rag_service import RAGService
 
 try:
     from llama_index import (
@@ -27,38 +38,76 @@ except ImportError as e:
 class LlamaIndexRAGService(RAGService):
     def __init__(self, persistence_dir: str = "./data/rag_storage"):
         self.persistence_dir = persistence_dir
-        self.index = None
 
-        # Ensure persistence directory exists
-        if not os.path.exists(self.persistence_dir):
-            os.makedirs(self.persistence_dir)
+        # Cache of namespace -> index instance
+        self._indices: Dict[str, Any] = {}
+
+        # Ensure base persistence directory exists
+        os.makedirs(self.persistence_dir, exist_ok=True)
 
         # Initialize ServiceContext (can be customized with specific LLM/Embed model)
         # For now, we rely on env vars (OPENAI_API_KEY) or defaults
         # Note: In 0.9.x ServiceContext.from_defaults() uses OpenAI by default if key is present
         self.service_context = ServiceContext.from_defaults()
 
-        # Try to load existing index
+    def _resolve_effective_namespace(self, namespace: Optional[str]) -> str:
+        # Keep behaviour consistent with other parts of the system that may
+        # set VON_DEFAULT_NAMESPACE.
+        return namespace or os.getenv("VON_DEFAULT_NAMESPACE") or "chat_history"
+
+    def _namespace_dirname(self, namespace: str) -> str:
+        """Return a filesystem-safe, collision-resistant directory name."""
+        normalised = namespace.strip()
+        safe = re.sub(r"[^A-Za-z0-9._-]+", "_", normalised)
+        digest = hashlib.sha1(normalised.encode("utf-8")).hexdigest()[:12]
+        return f"{safe}_{digest}"
+
+    def _namespace_persist_dir(self, namespace: str) -> str:
+        # Group namespace indices under a single subdirectory to avoid mixing
+        # with legacy flat storage.
+        return os.path.join(
+            self.persistence_dir, "namespaces", self._namespace_dirname(namespace)
+        )
+
+    def _maybe_load_index(self, namespace: str) -> Any:
+        if namespace in self._indices:
+            return self._indices[namespace]
+
+        persist_dir = self._namespace_persist_dir(namespace)
+        if not os.path.isdir(persist_dir):
+            return None
+
+        # Avoid calling LlamaIndex load on an empty directory.
         try:
-            storage_context = StorageContext.from_defaults(
-                persist_dir=self.persistence_dir
-            )
-            self.index = load_index_from_storage(
+            if not os.listdir(persist_dir):
+                return None
+        except Exception:
+            return None
+
+        try:
+            storage_context = StorageContext.from_defaults(persist_dir=persist_dir)
+            index = load_index_from_storage(
                 storage_context, service_context=self.service_context
             )
         except Exception:
-            # If load fails (e.g. empty dir), start with empty index
-            self.index = None
+            return None
 
-    def _get_or_create_index(self, documents: List[Document] = []) -> Any:
-        if self.index:
-            return self.index
+        self._indices[namespace] = index
+        return index
 
-        self.index = VectorStoreIndex.from_documents(
+    def _get_or_create_index(self, namespace: str, documents: List[Document]) -> Any:
+        index = self._maybe_load_index(namespace)
+        if index is not None:
+            return index
+
+        persist_dir = self._namespace_persist_dir(namespace)
+        os.makedirs(persist_dir, exist_ok=True)
+        index = VectorStoreIndex.from_documents(
             documents, service_context=self.service_context
         )
-        self.index.storage_context.persist(persist_dir=self.persistence_dir)
-        return self.index
+        index.storage_context.persist(persist_dir=persist_dir)
+        self._indices[namespace] = index
+        return index
 
     def upsert_documents(
         self,
@@ -72,7 +121,9 @@ class LlamaIndexRAGService(RAGService):
         LlamaIndex 0.9.x simple index doesn't support granular updates easily without a vector store.
         For this implementation, we will convert dicts to Documents and insert them.
         """
-        llama_docs = []
+        effective_namespace = self._resolve_effective_namespace(namespace)
+
+        llama_docs: List[Document] = []
         for doc in docs:
             # Convert dict to LlamaIndex Document
             text = doc.get("text", "")
@@ -88,21 +139,59 @@ class LlamaIndexRAGService(RAGService):
             else:
                 l_doc = Document(text=text)
 
+            # Stamp namespace into metadata to support filtering/debugging.
+            if not isinstance(metadata, dict):
+                metadata = {}
+            metadata["namespace"] = effective_namespace
             l_doc.metadata = metadata
             llama_docs.append(l_doc)
 
         if not llama_docs:
             return (0, 0)
 
-        if self.index is None:
-            self._get_or_create_index(llama_docs)
-        else:
-            # For simple VectorStoreIndex, insert() adds to the index
-            for l_doc in llama_docs:
-                self.index.insert(l_doc)
-            self.index.storage_context.persist(persist_dir=self.persistence_dir)
+        index = self._maybe_load_index(effective_namespace)
+        if index is None:
+            index = self._get_or_create_index(effective_namespace, llama_docs)
+            return (len(llama_docs), 0)
 
-        return (len(llama_docs), 0)
+        success = 0
+        failed = 0
+
+        def _persist() -> None:
+            index.storage_context.persist(
+                persist_dir=self._namespace_persist_dir(effective_namespace)
+            )
+
+        # Prefer bulk insertion when supported (significantly faster for embedding-backed indices).
+        try:
+            insert_documents = getattr(index, "insert_documents", None)
+            if callable(insert_documents):
+                insert_documents(llama_docs)
+                success = len(llama_docs)
+                _persist()
+                return (success, failed)
+        except Exception:
+            # Fall back to per-document insertion below.
+            pass
+
+        # Fallback: per-document insertion, optionally allowing partial failures.
+        for l_doc in llama_docs:
+            try:
+                index.insert(l_doc)
+                success += 1
+            except Exception:
+                failed += 1
+                if not allow_partial_failures:
+                    raise
+
+        if success > 0:
+            try:
+                _persist()
+            except Exception:
+                # Persist failures should not mask successful indexing.
+                pass
+
+        return (success, failed)
 
     def delete_documents(
         self,
@@ -114,19 +203,23 @@ class LlamaIndexRAGService(RAGService):
         Delete documents from the index.
         Note: Simple VectorStoreIndex delete might be limited depending on the store.
         """
-        if not self.index:
+        effective_namespace = self._resolve_effective_namespace(namespace)
+        index = self._maybe_load_index(effective_namespace)
+        if not index:
             return 0
 
         count = 0
         for doc_id in ids:
             try:
-                self.index.delete_ref_doc(doc_id, delete_from_docstore=True)
+                index.delete_ref_doc(doc_id, delete_from_docstore=True)
                 count += 1
             except Exception:
                 pass
 
         if count > 0:
-            self.index.storage_context.persist(persist_dir=self.persistence_dir)
+            index.storage_context.persist(
+                persist_dir=self._namespace_persist_dir(effective_namespace)
+            )
 
         return count
 
@@ -139,50 +232,37 @@ class LlamaIndexRAGService(RAGService):
         hybrid: bool = True,
         permissions_context: Optional[Dict[str, Any]] = None,
     ) -> List[Dict[str, Any]]:
-        if not self.index:
+        effective_namespace = self._resolve_effective_namespace(namespace)
+        index = self._maybe_load_index(effective_namespace)
+        if not index:
             return []
 
-        filters = None
-        if permissions_context:
-            try:
-                from llama_index.vector_stores.types import (
-                    MetadataFilters,
-                    MetadataFilter,
-                )
-
-                filter_list = []
-
-                # Filter by user_id if present
-                if "user_id" in permissions_context:
-                    filter_list.append(
-                        MetadataFilter(
-                            key="user_id", value=permissions_context["user_id"]
-                        )
-                    )
-
-                # Filter by organisation_concept_id if present (org-scoped access)
-                if (
-                    "organisation_concept_id" in permissions_context
-                    and permissions_context["organisation_concept_id"]
-                ):
-                    filter_list.append(
-                        MetadataFilter(
-                            key="organisation_concept_id",
-                            value=permissions_context["organisation_concept_id"],
-                        )
-                    )
-
-                if filter_list:
-                    filters = MetadataFilters(filters=filter_list)
-            except ImportError:
-                # Fallback or log warning if types cannot be imported (unlikely given check)
-                pass
-
-        retriever = self.index.as_retriever(similarity_top_k=top_k, filters=filters)
+        # Note: Metadata filtering support varies by vector store implementation.
+        # To ensure correctness, we do coarse retrieval first then apply filtering
+        # locally.
+        retriever = index.as_retriever(similarity_top_k=max(top_k * 10, top_k))
         nodes = retriever.retrieve(query_text)
+
+        def _matches_permissions(metadata: Any) -> bool:
+            if not permissions_context:
+                return True
+            if not isinstance(metadata, dict):
+                return False
+
+            user_id = permissions_context.get("user_id")
+            if user_id and metadata.get("user_id") != user_id:
+                return False
+
+            org_id = permissions_context.get("organisation_concept_id")
+            if org_id and metadata.get("organisation_concept_id") != org_id:
+                return False
+
+            return True
 
         results = []
         for node in nodes:
+            if not _matches_permissions(getattr(node.node, "metadata", None)):
+                continue
             results.append(
                 {
                     "id": node.node.ref_doc_id or node.node.node_id,
@@ -191,6 +271,9 @@ class LlamaIndexRAGService(RAGService):
                     "score": node.score,
                 }
             )
+
+            if len(results) >= top_k:
+                break
 
         return results
 

--- a/src/backend/services/rag_sync_service.py
+++ b/src/backend/services/rag_sync_service.py
@@ -17,6 +17,7 @@ def collect_indexed_sessions(limit: int = 1000) -> List[dict]:
         {"indexing_status": "indexed"},
         {
             "_id": 1,
+            "namespace": 1,
             "embedding": 1,
             "summary": 1,
             "history": 1,
@@ -44,6 +45,8 @@ def collect_indexed_sessions(limit: int = 1000) -> List[dict]:
             "indexed_at": str(doc.get("indexed_at")) if doc.get("indexed_at") else None,
             "source": "interaction_session",
         }
+        if doc.get("namespace"):
+            metadata["namespace"] = doc["namespace"]
         if doc.get("user_id"):
             metadata["user_id"] = doc["user_id"]
         if doc.get("organisation_concept_id"):
@@ -54,6 +57,7 @@ def collect_indexed_sessions(limit: int = 1000) -> List[dict]:
         items.append(
             {
                 "id": str(doc.get("_id")),
+                "namespace": doc.get("namespace"),
                 "text": text,
                 "embedding": doc.get("embedding"),
                 "metadata": metadata,
@@ -72,6 +76,12 @@ def sync_to_chat_store(namespace: Optional[str] = None, limit: int = 1000) -> di
     added = 0
     failed = 0
     for item in indexed:
+        target_namespace = (
+            namespace
+            or item.get("namespace")
+            or (item.get("metadata") or {}).get("namespace")
+            or "chat_history"
+        )
         doc = {
             "id": item.get("id"),
             "text": item.get("text", ""),
@@ -82,13 +92,13 @@ def sync_to_chat_store(namespace: Optional[str] = None, limit: int = 1000) -> di
 
         try:
             success_count, failure_count = service.upsert_documents(
-                [doc], namespace=namespace
+                [doc], namespace=target_namespace
             )
         except Exception:
             # Retry without embedding if backend rejects it
             doc.pop("embedding", None)
             success_count, failure_count = service.upsert_documents(
-                [doc], namespace=namespace
+                [doc], namespace=target_namespace
             )
 
         added += success_count
@@ -112,6 +122,7 @@ def sync_one_session(session_id: str, namespace: Optional[str] = None) -> dict:
         {"_id": ObjectId(session_id), "indexing_status": "indexed"},
         {
             "_id": 1,
+            "namespace": 1,
             "embedding": 1,
             "summary": 1,
             "history": 1,
@@ -152,6 +163,8 @@ def sync_one_session(session_id: str, namespace: Optional[str] = None) -> dict:
         "indexed_at": str(doc.get("indexed_at")) if doc.get("indexed_at") else None,
         "source": "interaction_session",
     }
+    if doc.get("namespace"):
+        metadata["namespace"] = doc["namespace"]
     if doc.get("user_id"):
         metadata["user_id"] = doc["user_id"]
     if doc.get("organisation_concept_id"):
@@ -168,7 +181,7 @@ def sync_one_session(session_id: str, namespace: Optional[str] = None) -> dict:
     if isinstance(embedding, list) and embedding:
         upsert_doc["embedding"] = embedding
 
-    ns = namespace or "chat_history"
+    ns = namespace or doc.get("namespace") or "chat_history"
     try:
         success_count, failure_count = service.upsert_documents(
             [upsert_doc], namespace=ns

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -714,7 +714,8 @@ async function updateHistoryLength() {
                                     rehydrateHistory(scrollableField2, history, {
                                         scrollToBottom: true,
                                         preserveScroll: false,
-                                        showResetNotice: false
+                                        showResetNotice: false,
+                                        forceScrollToBottom: true
                                     });
 
                                     modal.classList.remove('open');
@@ -779,7 +780,8 @@ async function loadChatHistory(options = {}) {
         segments,
         scrollToBottom = true,
         preserveScroll = false,
-        showResetNotice = false
+        showResetNotice = false,
+        forceScrollToBottom = false
     } = options;
 
     const scrollableField = document.getElementById('scrollableField');
@@ -810,7 +812,8 @@ async function loadChatHistory(options = {}) {
             rehydrateHistory(scrollableField, data.history, {
                 scrollToBottom,
                 preserveScroll,
-                showResetNotice
+                showResetNotice,
+                forceScrollToBottom
             });
 
             updateHistoryBanner();
@@ -830,11 +833,35 @@ async function loadChatHistory(options = {}) {
     }
 }
 
+function forceScrollToBottomWithRetries(scrollableField, options = {}) {
+    const { attempts = 6 } = options;
+    const maxAttempts = Number.isInteger(attempts) && attempts > 0 ? attempts : 1;
+
+    const requestFrame = (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function')
+        ? window.requestAnimationFrame.bind(window)
+        : (cb) => setTimeout(cb, 0);
+
+    let remaining = maxAttempts;
+    const tick = () => {
+        if (!scrollableField || remaining <= 0) {
+            return;
+        }
+
+        scrollableField.scrollTop = scrollableField.scrollHeight;
+        remaining -= 1;
+        requestFrame(tick);
+    };
+
+    // A few frames is usually enough to catch delayed markdown/layout changes.
+    requestFrame(tick);
+}
+
 function rehydrateHistory(scrollableField, historyMessages, options = {}) {
     const {
         scrollToBottom = true,
         preserveScroll = false,
-        showResetNotice = false
+        showResetNotice = false,
+        forceScrollToBottom = false
     } = options;
 
     const previousScrollHeight = scrollableField.scrollHeight;
@@ -874,6 +901,10 @@ function rehydrateHistory(scrollableField, historyMessages, options = {}) {
             scrollableField.scrollTop = previousScrollTop + Math.max(delta, 0);
         } else if (scrollToBottom) {
             scrollableField.scrollTop = scrollableField.scrollHeight;
+
+            if (forceScrollToBottom) {
+                forceScrollToBottomWithRetries(scrollableField);
+            }
         }
         // Update history display to reflect new context count
         updateHistoryLength();
@@ -1212,8 +1243,9 @@ async function handleResetContext() {
             historySegmentsShown = 1;
             const loaded = await loadChatHistory({
                 segments: 1,
-                scrollToBottom: false,
-                showResetNotice: true
+                scrollToBottom: true,
+                showResetNotice: true,
+                forceScrollToBottom: true
             });
 
             if (!loaded) {

--- a/src/frontend/web/von_interface/static/js/main.js
+++ b/src/frontend/web/von_interface/static/js/main.js
@@ -1,6 +1,7 @@
 import { initializeDomElements, initializeInfoPopup, loadAndDisplayGlobalModelInFooter } from './domUtils.js';
 import { createOrActivateConceptTab } from './dynamicTabs.js';
 import { getLanguageDisplayName } from './languageConfig.js';
+import { escapeHtml } from './markdownUtils.js';
 import './suppressTooltips.js';
 import { activateTab, loadTabData, setupTabNavigation } from './tabNavigation.js';
 import { handleSelectConceptByIdDetail } from './utils/selectConceptByIdHandler.js';
@@ -470,7 +471,7 @@ function startHealthPolling() {
         try {
           const controller2 = new AbortController();
           const timeout2 = setTimeout(() => controller2.abort(), 5000);
-          const ns = (localStorage.getItem('von_namespace') || localStorage.getItem('current_user_namespace')) || '';
+          const ns = (localStorage.getItem('current_user_namespace') || localStorage.getItem('von_namespace')) || '';
           const res2 = await fetch(ns ? (`/admin/rag_status?namespace=${encodeURIComponent(ns)}`) : '/admin/rag_status', { cache: 'no-store', signal: controller2.signal });
           clearTimeout(timeout2);
           if (res2.ok) {
@@ -489,7 +490,7 @@ function startHealthPolling() {
               const chOtherNs = (typeof rs.chat_history_sessions_other_namespace === 'number') ? rs.chat_history_sessions_other_namespace : null;
 
               const titleParts = [
-                `Sessions indexed=${i}`,
+                `KA sessions indexed=${i}`,
                 `pending=${p}`,
                 `failed=${f}`
               ];
@@ -506,20 +507,20 @@ function startHealthPolling() {
               if (p === 0) {
                 if (chSessions || chMessages || chOk || chFail) {
                   if (chFail > 0) {
-                    ragSpan.textContent = `Indexed ${i} • Chat ${chOk}/${chFail} failed`;
+                    ragSpan.textContent = `KA ${i} • Chat ${chOk}/${chFail} failed`;
                   } else {
-                    ragSpan.textContent = `Indexed ${i} • Chat ${chOk}`;
+                    ragSpan.textContent = `KA ${i} • Chat ${chOk}`;
                   }
                 } else {
-                  ragSpan.textContent = `Indexed ${i}`;
+                  ragSpan.textContent = `KA ${i}`;
                 }
                 ragSpan.title = title;
                 ragSpan.classList.remove('rag-active');
               } else {
                 if (chFail > 0) {
-                  ragSpan.textContent = `Indexed ${i} • ${p} pending • Chat ${chFail} failed`;
+                  ragSpan.textContent = `KA ${i} • ${p} pending • Chat ${chFail} failed`;
                 } else {
-                  ragSpan.textContent = `Indexed ${i} • ${p} pending`;
+                  ragSpan.textContent = `KA ${i} • ${p} pending`;
                 }
                 ragSpan.title = title;
                 ragSpan.classList.add('rag-active');
@@ -573,6 +574,434 @@ function startHealthPolling() {
             ragModal.setAttribute('aria-hidden', 'false');
             ragModalBody.innerHTML = '<p>Loading…</p>';
 
+            // Prepare modal action buttons (idempotent)
+            const modalActions = ragModal.querySelector('.modal-actions');
+            if (modalActions && !modalActions._ragExtrasWired) {
+              modalActions._ragExtrasWired = true;
+
+              function formatDuration(ms) {
+                const safeMs = (typeof ms === 'number' && ms >= 0) ? ms : 0;
+                const totalSeconds = Math.round(safeMs / 1000);
+                const s = totalSeconds % 60;
+                const totalMinutes = Math.floor(totalSeconds / 60);
+                const m = totalMinutes % 60;
+                const h = Math.floor(totalMinutes / 60);
+                if (h > 0) return `${h}h ${m}m ${s}s`;
+                if (m > 0) return `${m}m ${s}s`;
+                return `${s}s`;
+              }
+
+              async function runChatHistoryReindex({ forcedSessionId = null, forcedChunkStart = 0, forceSkipConfirm = false } = {}) {
+                const modalActions = ragModal.querySelector('.modal-actions');
+                const activeNs = (modalActions && modalActions._ragActiveNamespace) ? modalActions._ragActiveNamespace : '';
+                const ns = activeNs || (localStorage.getItem('current_user_namespace') || localStorage.getItem('von_namespace')) || '';
+
+                const confirmMsg = forcedSessionId
+                  ? `Resume chat history reindex for namespace:\n\n${ns || '(no namespace)'}\n\nSession:\n${forcedSessionId}\n\nThis may take a few minutes.`
+                  : `Reindex chat history for namespace:\n\n${ns || '(no namespace)'}\n\nThis may take a few minutes.`;
+                if (!forceSkipConfirm) {
+                  const ok = window.confirm(confirmMsg);
+                  if (!ok) return;
+                }
+
+                // Build a target list from the last-loaded detailed status so we can show progress and
+                // identify exactly which session fails.
+                const status = window.__vonLastRagStatusJson || null;
+                const details = Array.isArray(status?.chat_history_session_details)
+                  ? status.chat_history_session_details
+                  : [];
+
+                let targets = details
+                  .filter(d => (d && typeof d.session_id === 'string' && d.session_id) && (typeof d.messages_missing_index === 'number') && d.messages_missing_index > 0)
+                  .sort((a, b) => (b.messages_missing_index || 0) - (a.messages_missing_index || 0));
+
+                if (forcedSessionId) {
+                  targets = targets.filter(t => t && t.session_id === forcedSessionId);
+                }
+
+                if (!targets.length) {
+                  ragModalBody.innerHTML = ragModalBody.innerHTML + '<hr/><p><em>No missing chat history messages detected to reindex.</em></p>';
+                  return;
+                }
+
+                const totalMissingPlanned = targets.reduce((sum, t) => sum + (t?.messages_missing_index || 0), 0);
+                let elapsedMsTotal = 0;
+                let processedTotal = 0;
+
+                const progressToken = Date.now();
+                const progressId = `ragReindexProgress_${progressToken}`;
+                const progressTextId = `ragReindexProgressText_${progressToken}`;
+                const msgProgressId = `ragReindexMsgProgress_${progressToken}`;
+                const msgProgressTextId = `ragReindexMsgProgressText_${progressToken}`;
+                ragModalBody.innerHTML = ragModalBody.innerHTML + [
+                  '<hr/>',
+                  '<h3>Chat history reindex</h3>',
+                  `<p><em>Reindex running…</em></p>`,
+                  `<p><strong>Namespace:</strong> ${escapeHtml(ns || '(no namespace)')}</p>`,
+                  `<p><strong>Sessions to reindex:</strong> ${targets.length}</p>`,
+                  `<progress id="${progressId}" max="${targets.length}" value="0" style="width:100%;"></progress>`,
+                  `<div id="${progressTextId}" style="margin-top:6px;"></div>`,
+                  `<progress id="${msgProgressId}" max="1" value="0" style="width:100%;margin-top:10px;"></progress>`,
+                  `<div id="${msgProgressTextId}" style="margin-top:6px;"></div>`
+                ].join('');
+
+                const progressEl = document.getElementById(progressId);
+                const progressTextEl = document.getElementById(progressTextId);
+                const msgProgressEl = document.getElementById(msgProgressId);
+                const msgProgressTextEl = document.getElementById(msgProgressTextId);
+
+                const startedAt = new Date().toISOString();
+                const perSessionResults = [];
+                const aggregate = {
+                  sessions_targeted: targets.length,
+                  sessions_completed: 0,
+                  messages_indexed_attempted: 0,
+                  messages_indexed_success: 0,
+                  messages_indexed_failed: 0,
+                  errors: []
+                };
+
+                let lastSid = null;
+                let lastChunkStart = null;
+                let lastChunkNo = null;
+
+                for (let i = 0; i < targets.length; i++) {
+                  const t = targets[i];
+                  const sid = t.session_id;
+                  const missing = t.messages_missing_index;
+                  lastSid = sid;
+
+                  if (progressEl) progressEl.value = i;
+                  if (progressTextEl) {
+                    const etaTxt = (processedTotal > 0 && totalMissingPlanned > 0)
+                      ? (() => {
+                        const remaining = Math.max(0, totalMissingPlanned - processedTotal);
+                        const avgMsPerMsg = elapsedMsTotal / Math.max(1, processedTotal);
+                        return ` • ETA ~${formatDuration(remaining * avgMsPerMsg)}`;
+                      })()
+                      : '';
+                    progressTextEl.textContent = `Reindexing session ${i + 1}/${targets.length}: ${sid} (missing ${missing})${etaTxt}`;
+                  }
+
+                  // Chunked mode: avoids long requests and gives per-message progress.
+                  const url = ns ? (`/admin/chat_history_reindex?namespace=${encodeURIComponent(ns)}`) : '/admin/chat_history_reindex';
+                  // Larger sessions can take a long time to embed/index; use smaller chunks.
+                  const chunkSize = (missing && missing >= 200) ? 10 : 25;
+                  let chunkStart = (forcedSessionId && sid === forcedSessionId && typeof forcedChunkStart === 'number' && forcedChunkStart > 0)
+                    ? forcedChunkStart
+                    : 0;
+                  let chunkNo = 0;
+                  let sessionIndexableTotal = null;
+                  let sessionProcessed = 0;
+                  const sessionChunks = [];
+                  let sessionHadFailure = false;
+
+                  // Adaptive timeout for slow embedding/indexing. Starts at 2 min, grows on AbortError.
+                  let timeoutMs = 120000;
+                  const maxTimeoutMs = 15 * 60 * 1000;
+
+                  while (true) {
+                    chunkNo += 1;
+                    lastChunkNo = chunkNo;
+                    lastChunkStart = chunkStart;
+
+                    let res;
+                    const chunkAttemptStarted = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+
+                    // Retry loop for slow chunks and transient HTTP errors.
+                    for (let attempt = 1; attempt <= 3; attempt++) {
+                      const controllerR = new AbortController();
+                      const timeoutR = setTimeout(() => controllerR.abort(), timeoutMs);
+                      try {
+                        res = await fetch(url, {
+                          method: 'POST',
+                          headers: { 'Content-Type': 'application/json' },
+                          body: JSON.stringify({
+                            reset_counters: (chunkNo === 1),
+                            dry_run: false,
+                            session_ids: [sid],
+                            chunk_start: chunkStart,
+                            chunk_size: chunkSize
+                          }),
+                          cache: 'no-store',
+                          signal: controllerR.signal
+                        });
+
+                        // Retry on transient server/proxy issues.
+                        if (!res.ok && (res.status === 429 || res.status === 502 || res.status === 503 || res.status === 504)) {
+                          const delayMs = Math.min(15000, 1000 * Math.pow(2, attempt - 1));
+                          await new Promise(resolve => setTimeout(resolve, delayMs));
+                          continue;
+                        }
+
+                        break;
+                      } catch (err) {
+                        const name = err && err.name ? err.name : '';
+                        if (name === 'AbortError') {
+                          // The server may still be processing; increase timeout and retry this same chunk.
+                          timeoutMs = Math.min(maxTimeoutMs, Math.max(timeoutMs * 2, 180000));
+                          const delayMs = Math.min(3000, 500 * attempt);
+                          await new Promise(resolve => setTimeout(resolve, delayMs));
+                          continue;
+                        }
+                        throw err;
+                      } finally {
+                        clearTimeout(timeoutR);
+                      }
+                    }
+
+                    if (!res) {
+                      const err = {
+                        type: 'timeout',
+                        session_id: sid,
+                        chunk_start: chunkStart,
+                        chunk_no: chunkNo,
+                        message: 'Request timed out; server may still be processing.'
+                      };
+                      aggregate.errors.push(err);
+                      sessionHadFailure = true;
+                      perSessionResults.push({ session_id: sid, ok: false, error: err, chunks: sessionChunks });
+
+                      window.__vonLastRagReindexJson = {
+                        status: 'error',
+                        namespace: ns,
+                        started_at: startedAt,
+                        failed_session_id: sid,
+                        failed_at_session_index: i,
+                        failed_chunk_no: chunkNo,
+                        failed_chunk_start: chunkStart,
+                        per_session_results: perSessionResults,
+                        aggregate
+                      };
+
+                      ragModalBody.innerHTML = ragModalBody.innerHTML + `<hr/><p><strong>Reindex timed out.</strong> Session ${escapeHtml(sid)} (chunk ${chunkNo}, start ${chunkStart}).</p><p><em>The server may still be processing this chunk. Reopen this status to see progress, then you can retry or resume reindex if needed.</em></p>`;
+                      return;
+                    }
+
+                    if (!res.ok) {
+                      const txt = await res.text();
+                      const err = {
+                        type: 'http_error',
+                        session_id: sid,
+                        chunk_start: chunkStart,
+                        chunk_no: chunkNo,
+                        http_status: res.status,
+                        response_text: txt || ''
+                      };
+                      aggregate.errors.push(err);
+                      sessionHadFailure = true;
+                      perSessionResults.push({ session_id: sid, ok: false, error: err, chunks: sessionChunks });
+
+                      window.__vonLastRagReindexJson = {
+                        status: 'error',
+                        namespace: ns,
+                        started_at: startedAt,
+                        failed_session_id: sid,
+                        failed_at_session_index: i,
+                        failed_chunk_no: chunkNo,
+                        failed_chunk_start: chunkStart,
+                        per_session_results: perSessionResults,
+                        aggregate
+                      };
+
+                      ragModalBody.innerHTML = ragModalBody.innerHTML + `<hr/><p><strong>Reindex failed.</strong> Session ${escapeHtml(sid)} (chunk ${chunkNo}, start ${chunkStart}) returned HTTP ${res.status}.</p><pre style="white-space:pre-wrap;max-height:220px;overflow:auto;">${escapeHtml(txt || '')}</pre>`;
+                      return;
+                    }
+
+                    const js = await res.json();
+                    const chunkFinished = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+                    const chunkElapsedMs = Math.max(0, Math.round(chunkFinished - chunkAttemptStarted));
+                    sessionChunks.push({ ...js, client_elapsed_ms: chunkElapsedMs, client_timeout_ms: timeoutMs, client_chunk_no: chunkNo });
+
+                    if (typeof js?.indexable_total === 'number') {
+                      sessionIndexableTotal = js.indexable_total;
+                    }
+
+                    const attempted = (js?.messages_indexed_attempted || 0);
+                    const ok = (js?.messages_indexed_success || 0);
+                    const fail = (js?.messages_indexed_failed || 0);
+                    const errors = Array.isArray(js?.errors) ? js.errors : [];
+
+                    aggregate.messages_indexed_attempted += attempted;
+                    aggregate.messages_indexed_success += ok;
+                    aggregate.messages_indexed_failed += fail;
+                    if (errors.length) {
+                      aggregate.errors.push(...errors.map(e => ({ ...e, session_id: e.session_id || sid })));
+                    }
+
+                    const chunkProcessed = (ok + fail);
+                    sessionProcessed += chunkProcessed;
+                    if (chunkProcessed > 0) {
+                      processedTotal += chunkProcessed;
+                      elapsedMsTotal += chunkElapsedMs;
+                    }
+
+                    if (msgProgressEl) {
+                      msgProgressEl.max = (sessionIndexableTotal || Math.max(1, (missing || 1)));
+                      msgProgressEl.value = Math.min(msgProgressEl.max, sessionProcessed);
+                    }
+                    if (msgProgressTextEl) {
+                      const totalTxt = sessionIndexableTotal ? String(sessionIndexableTotal) : String(missing || '?');
+                      const etaTxt = (processedTotal > 0 && totalMissingPlanned > 0)
+                        ? (() => {
+                          const remaining = Math.max(0, totalMissingPlanned - processedTotal);
+                          const avgMsPerMsg = elapsedMsTotal / Math.max(1, processedTotal);
+                          return ` • ETA ~${formatDuration(remaining * avgMsPerMsg)}`;
+                        })()
+                        : '';
+                      msgProgressTextEl.textContent = `Session progress: ${sessionProcessed}/${totalTxt} messages (chunk ${chunkNo})${etaTxt}`;
+                    }
+
+                    const next = (typeof js?.next_chunk_start === 'number') ? js.next_chunk_start : null;
+                    const done = !!js?.done;
+                    if (done || next === null || next === chunkStart) {
+                      break;
+                    }
+                    chunkStart = next;
+                  }
+
+                  aggregate.sessions_completed += 1;
+                  perSessionResults.push({ session_id: sid, ok: !sessionHadFailure, chunks: sessionChunks });
+                }
+
+                if (progressEl) progressEl.value = targets.length;
+                if (progressTextEl) progressTextEl.textContent = `Completed ${targets.length}/${targets.length} sessions.`;
+                if (msgProgressEl) {
+                  msgProgressEl.value = msgProgressEl.max;
+                }
+                if (msgProgressTextEl) {
+                  msgProgressTextEl.textContent = 'Session progress: complete.';
+                }
+
+                const finishedAt = new Date().toISOString();
+                window.__vonLastRagReindexJson = {
+                  status: 'ok',
+                  namespace: ns,
+                  started_at: startedAt,
+                  finished_at: finishedAt,
+                  per_session_results: perSessionResults,
+                  aggregate
+                };
+
+                const summary = [
+                  '<hr/>',
+                  '<h3>Chat history reindex result</h3>',
+                  '<ul>',
+                  `<li><strong>Sessions targeted:</strong> ${aggregate.sessions_targeted}</li>`,
+                  `<li><strong>Sessions completed:</strong> ${aggregate.sessions_completed}</li>`,
+                  `<li><strong>Messages attempted:</strong> ${aggregate.messages_indexed_attempted}</li>`,
+                  `<li><strong>Messages indexed:</strong> ${aggregate.messages_indexed_success}</li>`,
+                  `<li><strong>Messages failed:</strong> ${aggregate.messages_indexed_failed}</li>`,
+                  `<li><strong>Total errors recorded:</strong> ${aggregate.errors.length}</li>`,
+                  '</ul>',
+                  '<p><em>Tip: reopen this modal to refresh the status table.</em></p>'
+                ].join('');
+                ragModalBody.innerHTML = ragModalBody.innerHTML + summary;
+              }
+
+              const copyBtn = document.createElement('button');
+              copyBtn.className = 'btn-mini';
+              copyBtn.textContent = 'Copy JSON';
+              copyBtn.title = 'Copy the raw RAG status JSON payload (and last reindex/backfill action, if any)';
+              copyBtn.addEventListener('click', async () => {
+                try {
+                  const payload = {
+                    rag_status: window.__vonLastRagStatusJson || null,
+                    last_chat_history_backfill: window.__vonLastRagBackfillJson || null,
+                    last_chat_history_reindex: window.__vonLastRagReindexJson || null,
+                  };
+                  const txt = JSON.stringify(payload, null, 2);
+                  if (!txt) {
+                    ragModalBody.innerHTML = ragModalBody.innerHTML + '<hr/><p><em>No JSON payload available yet. Open the modal again after it loads.</em></p>';
+                    return;
+                  }
+                  await navigator.clipboard.writeText(txt);
+                  ragModalBody.innerHTML = ragModalBody.innerHTML + '<hr/><p><em>Copied JSON to clipboard.</em></p>';
+                } catch (e) {
+                  ragModalBody.innerHTML = ragModalBody.innerHTML + '<hr/><p><em>Copy failed.</em></p>';
+                }
+              });
+
+              const reindexBtn = document.createElement('button');
+              reindexBtn.className = 'btn-mini';
+              reindexBtn.textContent = 'Reindex chat history';
+              reindexBtn.title = 'Reindex chat history messages into RAG for your current namespace';
+              reindexBtn.hidden = true;
+              reindexBtn.addEventListener('click', async () => {
+                try {
+                  reindexBtn.disabled = true;
+                  if (modalActions) {
+                    modalActions._ragActionInProgress = true;
+                  }
+                  await runChatHistoryReindex();
+
+                } catch (e) {
+                  const name = e && e.name ? e.name : 'Error';
+                  const msg = e && e.message ? e.message : '';
+                  const timedOutNote = name === 'AbortError'
+                    ? '<p><em>Request timed out. The server may still be processing; reopen this status to see progress.</em></p>'
+                    : '';
+                  const errObj = { type: 'exception', name, message: msg };
+                  window.__vonLastRagReindexJson = {
+                    status: 'error',
+                    namespace: (localStorage.getItem('current_user_namespace') || localStorage.getItem('von_namespace')) || null,
+                    error: errObj
+                  };
+                  ragModalBody.innerHTML = ragModalBody.innerHTML + `<hr/><p><strong>Reindex error.</strong> ${escapeHtml(name)}${msg ? `: ${escapeHtml(msg)}` : ''}</p>${timedOutNote}<p><em>You can use “Copy JSON” to capture this failure.</em></p>`;
+                } finally {
+                  reindexBtn.disabled = false;
+                  try {
+                    const modalActions = ragModal.querySelector('.modal-actions');
+                    if (modalActions) {
+                      modalActions._ragActionInProgress = false;
+                    }
+                  } catch (_) { /* ignore */ }
+                }
+              });
+
+              const resumeBtn = document.createElement('button');
+              resumeBtn.className = 'btn-mini';
+              resumeBtn.textContent = 'Resume reindex';
+              resumeBtn.title = 'Resume chat history reindex from the last recorded failure (session + chunk start)';
+              resumeBtn.hidden = true;
+              resumeBtn.addEventListener('click', async () => {
+                try {
+                  const last = window.__vonLastRagReindexJson || null;
+                  const sid = (last && last.status === 'error') ? (last.failed_session_id || null) : null;
+                  const chunkStart = (last && last.status === 'error' && typeof last.failed_chunk_start === 'number') ? last.failed_chunk_start : 0;
+                  if (!sid) {
+                    ragModalBody.innerHTML = ragModalBody.innerHTML + '<hr/><p><em>No resumable reindex failure recorded yet.</em></p>';
+                    return;
+                  }
+
+                  resumeBtn.disabled = true;
+                  if (modalActions) {
+                    modalActions._ragActionInProgress = true;
+                  }
+                  await runChatHistoryReindex({ forcedSessionId: sid, forcedChunkStart: chunkStart });
+                } catch (e) {
+                  const name = e && e.name ? e.name : 'Error';
+                  const msg = e && e.message ? e.message : '';
+                  ragModalBody.innerHTML = ragModalBody.innerHTML + `<hr/><p><strong>Resume error.</strong> ${escapeHtml(name)}${msg ? `: ${escapeHtml(msg)}` : ''}</p>`;
+                } finally {
+                  resumeBtn.disabled = false;
+                  try {
+                    const modalActions = ragModal.querySelector('.modal-actions');
+                    if (modalActions) {
+                      modalActions._ragActionInProgress = false;
+                    }
+                  } catch (_) { /* ignore */ }
+                }
+              });
+
+              modalActions.appendChild(copyBtn);
+              modalActions.appendChild(reindexBtn);
+              modalActions.appendChild(resumeBtn);
+              modalActions._ragCopyBtn = copyBtn;
+              modalActions._ragReindexBtn = reindexBtn;
+              modalActions._ragResumeBtn = resumeBtn;
+            }
+
             if (ragChatBackfillBtn) {
               ragChatBackfillBtn.hidden = true;
               ragChatBackfillBtn.disabled = false;
@@ -580,12 +1009,33 @@ function startHealthPolling() {
             }
 
             const controller3 = new AbortController();
-            const timeout3 = setTimeout(() => controller3.abort(), 8000);
-            const ns2 = (localStorage.getItem('von_namespace') || localStorage.getItem('current_user_namespace')) || '';
-            const res3 = await fetch(ns2 ? (`/admin/rag_status?namespace=${encodeURIComponent(ns2)}`) : '/admin/rag_status', { cache: 'no-store', signal: controller3.signal });
+            const timeout3 = setTimeout(() => controller3.abort(), 15000);
+            const ns2 = (localStorage.getItem('current_user_namespace') || localStorage.getItem('von_namespace')) || '';
+            const url3 = ns2
+              ? (`/admin/rag_status?namespace=${encodeURIComponent(ns2)}&detail=1`)
+              : '/admin/rag_status';
+            let res3 = await fetch(url3, { cache: 'no-store', signal: controller3.signal });
             clearTimeout(timeout3);
+
+            // If a namespaced call fails (e.g., bad localStorage value), retry once without namespace.
+            if (!res3.ok && ns2) {
+              try {
+                res3 = await fetch('/admin/rag_status', { cache: 'no-store' });
+              } catch (_) { /* ignore */ }
+            }
+
             if (res3.ok) {
-              let rs = await res3.json();
+              let rs;
+              try {
+                rs = await res3.json();
+              } catch (_) {
+                const txt = await res3.text();
+                ragModalBody.innerHTML = `<p>Unable to load detailed status.</p><p><strong>Parse error.</strong> Response was not JSON.</p><pre style="white-space:pre-wrap;max-height:220px;overflow:auto;">${escapeHtml(txt || '')}</pre>`;
+                return;
+              }
+
+              // Save last JSON for Copy JSON.
+              try { window.__vonLastRagStatusJson = rs; } catch (_) { /* ignore */ }
               const backfillReason0 = rs?.chat_history_backfill_reason || null;
               const backfillSessionNs = rs?.chat_history_backfill_session_namespace || null;
               if (backfillReason0 === 'namespace_mismatch' && backfillSessionNs && backfillSessionNs !== ns2) {
@@ -596,7 +1046,7 @@ function startHealthPolling() {
                 try {
                   const controller3b = new AbortController();
                   const timeout3b = setTimeout(() => controller3b.abort(), 8000);
-                  const res3b = await fetch(`/admin/rag_status?namespace=${encodeURIComponent(backfillSessionNs)}`, { cache: 'no-store', signal: controller3b.signal });
+                  const res3b = await fetch(`/admin/rag_status?namespace=${encodeURIComponent(backfillSessionNs)}&detail=1`, { cache: 'no-store', signal: controller3b.signal });
                   clearTimeout(timeout3b);
                   if (res3b.ok) {
                     rs = await res3b.json();
@@ -615,6 +1065,24 @@ function startHealthPolling() {
               const eligI = (typeof rs.eligible_interactions === 'number') ? rs.eligible_interactions : null;
               const sessionNs = rs.session_namespace || null;
               const requestedNs = (typeof rs.namespace === 'string') ? rs.namespace : (ns2 || null);
+
+              // Keep the modal action namespace aligned with what the server reports.
+              // This prevents actions (like reindex) from accidentally using a stale
+              // user-only namespace from localStorage.
+              try {
+                const modalActions = ragModal.querySelector('.modal-actions');
+                if (modalActions) {
+                  modalActions._ragActiveNamespace = requestedNs || sessionNs || '';
+                }
+              } catch (_) { /* ignore */ }
+
+              // If we have a composite namespace, prefer it as the persisted current namespace.
+              try {
+                const prefer = requestedNs || sessionNs;
+                if (typeof prefer === 'string' && prefer.includes('@')) {
+                  localStorage.setItem('current_user_namespace', prefer);
+                }
+              } catch (_) { /* ignore */ }
               const sessMissing = (typeof rs.sessions_missing_namespace === 'number') ? rs.sessions_missing_namespace : null;
               const sessOther = (typeof rs.sessions_other_namespace === 'number') ? rs.sessions_other_namespace : null;
               const sessBreakdown = Array.isArray(rs.sessions_namespace_breakdown) ? rs.sessions_namespace_breakdown : [];
@@ -625,6 +1093,7 @@ function startHealthPolling() {
               const chInNs = (typeof rs.chat_history_sessions_in_namespace === 'number') ? rs.chat_history_sessions_in_namespace : null;
               const chMissingNs = (typeof rs.chat_history_sessions_missing_namespace === 'number') ? rs.chat_history_sessions_missing_namespace : null;
               const chOtherNs = (typeof rs.chat_history_sessions_other_namespace === 'number') ? rs.chat_history_sessions_other_namespace : null;
+              const chDetails = Array.isArray(rs.chat_history_session_details) ? rs.chat_history_session_details : null;
               const backfillAvailable = !!rs.chat_history_backfill_available;
               const backfillReason = rs.chat_history_backfill_reason || null;
 
@@ -660,7 +1129,7 @@ function startHealthPolling() {
               const html = [
                 requestedNs ? `<p><strong>Requested namespace:</strong> ${escapeHtml(requestedNs)}</p>` : '',
                 sessionNs ? `<p><strong>Session namespace:</strong> ${escapeHtml(sessionNs)}</p>` : '',
-                '<p><em>Note:</em> interaction sessions are scoped by a user-only namespace (e.g. <code>#V#user</code>). Chat history is scoped by a composite user@organisation namespace (e.g. <code>#V#user@org</code>).</p>',
+                '<p><em>Note:</em> interaction sessions may be stored under either a user-only namespace (e.g. <code>#V#user</code>) or a composite user@organisation namespace (e.g. <code>#V#user@org</code>). This status view scopes to the requested namespace and may include the user-only namespace for compatibility. Chat history is scoped by a composite user@organisation namespace.</p>',
                 '<ul>',
                 `<li><strong>Indexed:</strong> ${indexed}</li>`,
                 `<li><strong>Pending:</strong> ${pending}</li>`,
@@ -692,15 +1161,86 @@ function startHealthPolling() {
                   return `<li><strong>Sessions:</strong> ${chSessions}${suffix}</li>`;
                 })(),
                 `<li><strong>Messages (stored):</strong> ${chMessages}</li>`,
+                (() => {
+                  // Reset markers are stored in history but intentionally excluded from indexing.
+                  // Only available when we have per-session details.
+                  const details = Array.isArray(chDetails) ? chDetails : null;
+                  if (!details || !details.length) return '';
+                  const resetMarkers = details.reduce((acc, row) => {
+                    const stored = (typeof row?.messages_stored === 'number') ? row.messages_stored : 0;
+                    const nonReset = (typeof row?.messages_non_reset === 'number') ? row.messages_non_reset : 0;
+                    return acc + Math.max(0, stored - nonReset);
+                  }, 0);
+                  return `<li><strong>Reset markers:</strong> ${resetMarkers}</li>`;
+                })(),
                 `<li><strong>Messages indexed:</strong> ${chOk}</li>`,
                 `<li><strong>Messages failed:</strong> ${chFail}</li>`,
                 '</ul>'
               ].join('');
+
+              const renderChatSessionDetails = () => {
+                if (!chDetails || !chDetails.length) return '';
+
+                const rows = chDetails.slice(0, 60).map((row) => {
+                  const sid = (typeof row?.session_id === 'string') ? row.session_id : '(unknown session)';
+                  const nsRaw = (typeof row?.namespace === 'string') ? row.namespace : '(missing namespace)';
+                  const stored = (typeof row?.messages_stored === 'number') ? row.messages_stored : 0;
+                  const nonReset = (typeof row?.messages_non_reset === 'number') ? row.messages_non_reset : 0;
+                  const resetMarkers = Math.max(0, stored - nonReset);
+                  const indexable = (typeof row?.messages_indexable === 'number') ? row.messages_indexable : nonReset;
+                  const ok = (typeof row?.rag_indexed_success === 'number') ? row.rag_indexed_success : 0;
+                  const fail = (typeof row?.rag_indexed_failed === 'number') ? row.rag_indexed_failed : 0;
+                  const indexedTotal = (typeof row?.messages_indexed_total === 'number') ? row.messages_indexed_total : (ok + fail);
+                  const missing = (typeof row?.messages_missing_index === 'number') ? row.messages_missing_index : Math.max(0, indexable - indexedTotal);
+                  const inScope = (row?.in_namespace === true);
+                  const suffix = inScope ? ' (in requested namespace)' : '';
+                  return `<li><code>${escapeHtml(sid)}</code> — ${escapeHtml(nsRaw)}${escapeHtml(suffix)}: stored ${stored}, reset markers ${resetMarkers}, non-reset ${nonReset}, indexable ${indexable}, indexed ${indexedTotal} (ok ${ok}, failed ${fail}), missing ${missing}</li>`;
+                });
+
+                const truncated = chDetails.length > 60
+                  ? `<p><em>Showing 60 of ${chDetails.length} sessions (sorted by missing count).</em></p>`
+                  : '';
+
+                return [
+                  '<details>',
+                  '<summary>Chat sessions indexing breakdown</summary>',
+                  truncated,
+                  '<ul>',
+                  ...rows,
+                  '</ul>',
+                  '</details>'
+                ].join('');
+              };
               const needsBackfill = (chMissingNs && chMissingNs > 0) || (chOtherNs && chOtherNs > 0);
               const backfillNote = (!backfillAvailable && needsBackfill && backfillReason)
                 ? `<p><em>Backfill unavailable: ${backfillReason}</em></p>`
                 : '';
-              ragModalBody.innerHTML = html + renderBreakdown() + chatHtml + backfillNote;
+              ragModalBody.innerHTML = html + renderBreakdown() + chatHtml + renderChatSessionDetails() + backfillNote;
+
+              // Show reindex button when there are missing indexable messages and the
+              // user is allowed to run actions for this namespace.
+              try {
+                const modalActions = ragModal.querySelector('.modal-actions');
+                const reindexBtn = modalActions ? modalActions._ragReindexBtn : null;
+                const resumeBtn = modalActions ? modalActions._ragResumeBtn : null;
+                if (reindexBtn) {
+                  const hasMissing = !!(chDetails && chDetails.some(r => (r && typeof r.messages_missing_index === 'number' && r.messages_missing_index > 0)));
+                  reindexBtn.hidden = !(backfillAvailable && hasMissing);
+                }
+                if (resumeBtn) {
+                  const last = window.__vonLastRagReindexJson || null;
+                  const canResume = !!(
+                    backfillAvailable
+                    && last
+                    && last.status === 'error'
+                    && typeof last.failed_session_id === 'string'
+                    && last.failed_session_id
+                    && typeof last.failed_chunk_start === 'number'
+                    && last.failed_chunk_start >= 0
+                  );
+                  resumeBtn.hidden = !canResume;
+                }
+              } catch (_) { /* ignore */ }
 
               if (ragChatBackfillBtn) {
                 ragChatBackfillBtn.hidden = !(backfillAvailable && needsBackfill);
@@ -709,10 +1249,25 @@ function startHealthPolling() {
                 }
               }
             } else {
-              ragModalBody.innerHTML = '<p>Unable to load detailed status.</p>';
+              let details = '';
+              try {
+                const txt = await res3.text();
+                details = txt ? `<pre style="white-space:pre-wrap;max-height:220px;overflow:auto;">${escapeHtml(txt)}</pre>` : '';
+              } catch (_) { /* ignore */ }
+
+              const attempted = ns2 ? (`/admin/rag_status?namespace=${encodeURIComponent(ns2)}`) : '/admin/rag_status';
+              ragModalBody.innerHTML = `<p>Unable to load detailed status.</p><p><strong>HTTP ${res3.status}</strong> while fetching <code>${escapeHtml(attempted)}</code>.</p>${details}`;
             }
           } catch (_) {
-            ragModalBody.innerHTML = '<p>Unable to load detailed status.</p>';
+            const attempted = (() => {
+              try {
+                const ns2 = (localStorage.getItem('von_namespace') || localStorage.getItem('current_user_namespace')) || '';
+                return ns2 ? (`/admin/rag_status?namespace=${encodeURIComponent(ns2)}`) : '/admin/rag_status';
+              } catch (_) {
+                return '/admin/rag_status';
+              }
+            })();
+            ragModalBody.innerHTML = `<p>Unable to load detailed status.</p><p><em>Request failed or timed out.</em> Attempted <code>${escapeHtml(attempted)}</code>.</p>`;
           }
         });
 
@@ -723,6 +1278,13 @@ function startHealthPolling() {
               const ok = window.confirm('Backfill legacy chat history into your current namespace and re-index to RAG? This may take a minute.');
               if (!ok) return;
               ragChatBackfillBtn.disabled = true;
+
+              try {
+                const modalActions = ragModal.querySelector('.modal-actions');
+                if (modalActions) {
+                  modalActions._ragActionInProgress = true;
+                }
+              } catch (_) { /* ignore */ }
 
               ragModalBody.innerHTML = ragModalBody.innerHTML + '<hr/><p><em>Backfill running…</em></p>';
 
@@ -739,10 +1301,16 @@ function startHealthPolling() {
 
               if (!resB.ok) {
                 const txt = await resB.text();
+                window.__vonLastRagBackfillJson = {
+                  status: 'error',
+                  http_status: resB.status,
+                  response_text: txt || ''
+                };
                 ragModalBody.innerHTML = ragModalBody.innerHTML + `<hr/><p><strong>Backfill failed.</strong> ${txt}</p>`;
                 return;
               }
               const js = await resB.json();
+              window.__vonLastRagBackfillJson = js;
               const statusLine = js?.status ? `<p><strong>Status:</strong> ${js.status}</p>` : '';
               const errorLine = js?.error ? `<p><strong>Error:</strong> ${js.error}</p>` : '';
               const errors = Array.isArray(js?.errors) ? js.errors : [];
@@ -751,7 +1319,7 @@ function startHealthPolling() {
                   '<details>',
                   `<summary>Errors (${errors.length})</summary>`,
                   '<ul>',
-                  ...errors.slice(0, 20).map(e => `<li>${(e.session || 'session')} — ${(e.error || 'error')}</li>`),
+                  ...errors.slice(0, 20).map(e => `<li>${escapeHtml((e.session || 'session') + '')} — ${escapeHtml((e.error || 'error') + '')}</li>`),
                   '</ul>',
                   '</details>'
                 ].join('')
@@ -778,9 +1346,19 @@ function startHealthPolling() {
               const timedOutNote = name === 'AbortError'
                 ? '<p><em>Request timed out. The server may still be processing; reopen this status to see progress.</em></p>'
                 : '';
+              window.__vonLastRagBackfillJson = {
+                status: 'error',
+                error: { type: 'exception', name, message: msg }
+              };
               ragModalBody.innerHTML = ragModalBody.innerHTML + `<hr/><p><strong>Backfill error.</strong> ${name}${msg ? `: ${msg}` : ''}</p>${timedOutNote}`;
             } finally {
               ragChatBackfillBtn.disabled = false;
+              try {
+                const modalActions = ragModal.querySelector('.modal-actions');
+                if (modalActions) {
+                  modalActions._ragActionInProgress = false;
+                }
+              } catch (_) { /* ignore */ }
             }
           });
         }
@@ -790,7 +1368,7 @@ function startHealthPolling() {
               ragModalCheck.disabled = true;
               const controller4 = new AbortController();
               const timeout4 = setTimeout(() => controller4.abort(), 15000);
-              const ns3 = (localStorage.getItem('von_namespace') || localStorage.getItem('current_user_namespace')) || '';
+              const ns3 = (localStorage.getItem('current_user_namespace') || localStorage.getItem('von_namespace')) || '';
               const url4 = ns3 ? (`/admin/rag_integrity?namespace=${encodeURIComponent(ns3)}`) : '/admin/rag_integrity';
               const res4 = await fetch(url4, { method: 'POST', cache: 'no-store', signal: controller4.signal });
               clearTimeout(timeout4);
@@ -851,13 +1429,27 @@ function startHealthPolling() {
         // ragModalBody.parentElement.querySelector('.modal-actions').appendChild(syncBtn);
         if (ragModalClose) {
           ragModalClose.addEventListener('click', () => {
+            try {
+              const modalActions = ragModal.querySelector('.modal-actions');
+              if (modalActions && modalActions._ragActionInProgress) {
+                const ok = window.confirm('An admin action is still running. Close anyway?');
+                if (!ok) return;
+              }
+            } catch (_) { /* ignore */ }
             ragModal.classList.remove('open');
             ragModal.setAttribute('aria-hidden', 'true');
           });
         }
-        // Close on backdrop click
+        // Close on backdrop click (but do not allow accidental dismissal while a long-running
+        // admin action is in progress, because it makes errors hard to capture).
         ragModal.addEventListener('click', (ev) => {
           if (ev.target === ragModal) {
+            try {
+              const modalActions = ragModal.querySelector('.modal-actions');
+              if (modalActions && modalActions._ragActionInProgress) {
+                return;
+              }
+            } catch (_) { /* ignore */ }
             ragModal.classList.remove('open');
             ragModal.setAttribute('aria-hidden', 'true');
           }

--- a/src/frontend/web/von_interface/static/js/markdownUtils.js
+++ b/src/frontend/web/von_interface/static/js/markdownUtils.js
@@ -21,7 +21,7 @@ export function detectMarkdown(text) {
     return patterns.some(pattern => pattern.test(text));
 }
 
-function escapeHtml(text) {
+export function escapeHtml(text) {
     return String(text).replace(/[&<>"']/g, (c) => (
         {
             '&': '&amp;',

--- a/tests/backend/test_orchestrator_structured_calling.py
+++ b/tests/backend/test_orchestrator_structured_calling.py
@@ -15,7 +15,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.backend.integrations.internal_mcp.orchestrator import InternalMCPChatOrchestrator
+from src.backend.integrations.internal_mcp.orchestrator import (
+    InternalMCPChatOrchestrator,
+    _MissingToolCallDetectorSpec,
+)
 from src.backend.languagemodels.structured_tool_calling.types import (
     LLMResponse,
     ToolCall,
@@ -35,7 +38,10 @@ class MockLLMClientWithTools:
         return self._should_use_structured_value
 
     def generate(
-        self, prompt: str, context: Optional[Sequence[Mapping[str, Any]]] = None, model: Optional[str] = None
+        self,
+        prompt: str,
+        context: Optional[Sequence[Mapping[str, Any]]] = None,
+        model: Optional[str] = None,
     ) -> str:
         """Legacy generate method."""
         self.generate_called = True
@@ -71,7 +77,10 @@ class MockLLMClientLegacyOnly:
         self.generate_called = False
 
     def generate(
-        self, prompt: str, context: Optional[Sequence[Mapping[str, Any]]] = None, model: Optional[str] = None
+        self,
+        prompt: str,
+        context: Optional[Sequence[Mapping[str, Any]]] = None,
+        model: Optional[str] = None,
     ) -> str:
         """Legacy generate method."""
         self.generate_called = True
@@ -269,7 +278,9 @@ def test_structured_calling_with_no_tool_response(orchestrator, mock_gateway):
         def generate(self, prompt, context=None, model=None):
             return "Just a text response"
 
-        def generate_with_tools(self, prompt, available_tools, context=None, model=None, system_message=None):
+        def generate_with_tools(
+            self, prompt, available_tools, context=None, model=None, system_message=None
+        ):
             # Return response without tool calls
             return LLMResponse(text_response="Just a text response", tool_calls=[])
 
@@ -297,7 +308,9 @@ def test_structured_calling_exception_fallback(orchestrator, mock_gateway):
         def generate(self, prompt, context=None, model=None):
             return '{"tool": "search_knowledge_base", "payload": {"query": "fallback"}}'
 
-        def generate_with_tools(self, prompt, available_tools, context=None, model=None, system_message=None):
+        def generate_with_tools(
+            self, prompt, available_tools, context=None, model=None, system_message=None
+        ):
             raise RuntimeError("Structured calling failed")
 
     llm_client = MockLLMClientWithException()
@@ -314,6 +327,88 @@ def test_structured_calling_exception_fallback(orchestrator, mock_gateway):
     # Should have invoked tool via legacy path
     assert len(result.tool_invocations) == 1
     assert result.tool_invocations[0]["tool"] == "search_knowledge_base"
+
+
+def test_structured_path_missing_tool_call_emits_aux_logs_with_structured_path(
+    orchestrator,
+):
+    """Regression test: missing-tool-call recovery should preserve path='structured'.
+
+    When structured calling is enabled but the model returns no tool calls while
+    promising to use tools, the orchestrator should:
+    - run missing-tool-call detection/classifier
+    - retry once
+    - record aux_llm_calls entries tagged with path='structured'
+    """
+
+    class MockLLMClientStructuredMissingToolCall:
+        def __init__(self):
+            self.generate_called = 0
+            self.generate_with_tools_called = 0
+
+        def _should_use_structured_calling(self) -> bool:
+            return True
+
+        def generate(self, prompt: str, context=None, model=None):
+            # 1) classifier verdict
+            # 2) retry response (legacy JSON tool-call format)
+            # 3) final response after tool execution
+            self.generate_called += 1
+            if self.generate_called == 1:
+                return "YES"
+            if self.generate_called == 2:
+                return '{"action":"call_tool","tool":"search_knowledge_base","payload":{"query":"test query"}}'
+            return "Final response"
+
+        def generate_with_tools(
+            self,
+            prompt: str,
+            available_tools: List[ToolDefinition],
+            context=None,
+            model=None,
+            system_message=None,
+        ) -> LLMResponse:
+            self.generate_with_tools_called += 1
+            # Structured path: model promises a tool call but doesn't include one.
+            return LLMResponse(
+                text_response="I will search the knowledge base now.",
+                tool_calls=[],
+            )
+
+    llm_client = MockLLMClientStructuredMissingToolCall()
+
+    orchestrator._missing_tool_call_detector_loaded = True
+    orchestrator._missing_tool_call_detector = _MissingToolCallDetectorSpec(
+        action_id="#V#detect_missing_tool_call_action",
+        prompt_id="#V#missing_tool_call_detection_prompt",
+        prompt_text="Answer YES or NO for: {response}",
+        model="detector-model",
+    )
+
+    result = orchestrator.run(
+        prompt="Find test concept",
+        context=[],
+        llm_client=llm_client,
+        model="gpt-4",
+        user_namespace="#V#test_user",
+    )
+
+    assert llm_client.generate_with_tools_called == 1
+    assert llm_client.generate_called >= 2
+    assert len(result.tool_invocations) == 1
+    assert result.tool_invocations[0]["tool"] == "search_knowledge_base"
+    assert result.response_text == "Final response"
+    assert result.aux_llm_calls
+
+    aux_by_type: dict[str, list[Mapping[str, Any]]] = {}
+    for entry in result.aux_llm_calls:
+        if isinstance(entry, dict) and isinstance(entry.get("type"), str):
+            aux_by_type.setdefault(entry["type"], []).append(entry)
+
+    assert aux_by_type["missing_tool_call_detection"][0]["path"] == "structured"
+    assert aux_by_type["missing_tool_call_classifier"][0]["path"] == "structured"
+    for retry_entry in aux_by_type["missing_tool_call_retry"]:
+        assert retry_entry["path"] == "structured"
 
 
 if __name__ == "__main__":

--- a/tests/backend/test_rag_namespace_isolation.py
+++ b/tests/backend/test_rag_namespace_isolation.py
@@ -1,0 +1,95 @@
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def tmp_rag_storage(tmp_path: Path):
+    storage = tmp_path / "rag_storage"
+    storage.mkdir(parents=True, exist_ok=True)
+    yield storage
+    if storage.exists():
+        shutil.rmtree(storage, ignore_errors=True)
+
+
+def test_llamaindex_backend_uses_separate_persist_dirs_per_namespace(
+    tmp_rag_storage: Path,
+):
+    # Import inside test so patches apply cleanly.
+    with (
+        patch(
+            "src.backend.services.rag_backends.llamaindex_backend.ServiceContext.from_defaults",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "src.backend.services.rag_backends.llamaindex_backend.Document",
+            side_effect=lambda *args, **kwargs: MagicMock(metadata={}),
+        ),
+        patch(
+            "src.backend.services.rag_backends.llamaindex_backend.VectorStoreIndex.from_documents"
+        ) as mock_from_documents,
+    ):
+        index_a = MagicMock()
+        index_a.storage_context.persist = MagicMock()
+        index_b = MagicMock()
+        index_b.storage_context.persist = MagicMock()
+        mock_from_documents.side_effect = [index_a, index_b]
+
+        from src.backend.services.rag_backends.llamaindex_backend import (
+            LlamaIndexRAGService,
+        )
+
+        rag = LlamaIndexRAGService(persistence_dir=str(tmp_rag_storage))
+
+        rag.upsert_documents(
+            [{"id": "doc_a", "text": "A", "metadata": {}}], namespace="#V#user_a"
+        )
+        rag.upsert_documents(
+            [{"id": "doc_b", "text": "B", "metadata": {}}], namespace="#V#user_b"
+        )
+
+        assert mock_from_documents.call_count == 2
+
+        # Persist should have been called in different directories under .../namespaces/
+        persist_a = index_a.storage_context.persist.call_args.kwargs.get("persist_dir")
+        persist_b = index_b.storage_context.persist.call_args.kwargs.get("persist_dir")
+
+        assert persist_a != persist_b
+        assert str(tmp_rag_storage) in str(persist_a)
+        assert str(tmp_rag_storage) in str(persist_b)
+        assert "namespaces" in str(persist_a)
+        assert "namespaces" in str(persist_b)
+
+
+def test_llamaindex_backend_stamps_namespace_into_metadata(tmp_rag_storage: Path):
+    with (
+        patch(
+            "src.backend.services.rag_backends.llamaindex_backend.ServiceContext.from_defaults",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "src.backend.services.rag_backends.llamaindex_backend.VectorStoreIndex.from_documents",
+            return_value=MagicMock(storage_context=MagicMock(persist=MagicMock())),
+        ),
+        patch(
+            "src.backend.services.rag_backends.llamaindex_backend.Document"
+        ) as mock_doc,
+    ):
+        doc_instance = MagicMock()
+        doc_instance.metadata = {}
+        mock_doc.return_value = doc_instance
+
+        from src.backend.services.rag_backends.llamaindex_backend import (
+            LlamaIndexRAGService,
+        )
+
+        rag = LlamaIndexRAGService(persistence_dir=str(tmp_rag_storage))
+
+        rag.upsert_documents(
+            [{"id": "doc_a", "text": "hello", "metadata": {}}],
+            namespace="#V#user_a@org",
+        )
+
+        assert doc_instance.metadata.get("namespace") == "#V#user_a@org"

--- a/tests/backend/test_von_generate_prompt_introspection_fastpath.py
+++ b/tests/backend/test_von_generate_prompt_introspection_fastpath.py
@@ -275,3 +275,68 @@ def test_prompt_introspection_fastpath_disabled_by_default_does_not_trigger(
 
     llm_debug = data.get("llm_debug") or {}
     assert "prompt_introspection_fastpath" not in llm_debug
+
+
+def test_rag_counts_fastpath_bypasses_llm_and_separates_chat_vs_ka(app, monkeypatch):
+    # This fast-path is intentionally NOT gated by VON_DETERMINISTIC_INTROSPECTION,
+    # because it prevents KA vs chat-history confusion for factual status questions.
+
+    gateway_payload = {
+        "success": True,
+        "namespace": "#V#michael_witbrock@university_of_auckland_strong_ai_lab",
+        "indexed": 10,  # KA interaction sessions
+        "chat_history_sessions": 42,
+        "chat_history_sessions_in_namespace": 42,
+        "chat_history_session_details": [
+            {
+                "session_id": "s1",
+                "messages_missing_index": 0,
+                "rag_indexed_success": 3,
+                "rag_indexed_failed": 0,
+            },
+            {
+                "session_id": "s2",
+                "messages_missing_index": 0,
+                "rag_indexed_success": 5,
+                "rag_indexed_failed": 0,
+            },
+        ],
+    }
+
+    # Even if deterministic introspection is disabled, this path should run.
+    monkeypatch.delenv("VON_DETERMINISTIC_INTROSPECTION", raising=False)
+
+    gateway = _StubGateway(gateway_payload)
+    app.config["INTERNAL_MCP_GATEWAY"] = gateway
+    app.config["INTERNAL_MCP_ORCHESTRATOR"] = object()
+
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["namespace"] = "#V#michael_witbrock@university_of_auckland_strong_ai_lab"
+
+    resp = client.post(
+        "/von/generate",
+        json={"prompt": "How many indexed chat sessions can you see?"},
+    )
+    if resp.status_code != 200:
+        raise AssertionError(
+            f"Unexpected status {resp.status_code}: {resp.get_json() or resp.get_data(as_text=True)}"
+        )
+
+    data = resp.get_json() or {}
+    assert data.get("fastpath", {}).get("name") == "rag_counts"
+    assert data.get("fastpath", {}).get("bypassed_llm") is True
+
+    text = data.get("response", "")
+    assert "Chat history sessions" in text
+    assert "KA interaction sessions" in text
+    assert "42" in text
+    assert "10" in text
+
+    assert gateway.calls, "expected gateway.invoke() to be called"
+    assert gateway.calls[0]["method_name"] == "rag_get_status"
+    assert (
+        gateway.calls[0]["payload"].get("namespace")
+        == "#V#michael_witbrock@university_of_auckland_strong_ai_lab"
+    )
+    assert gateway.calls[0]["payload"].get("detail") == 1

--- a/utilities/resync_rag_namespace.py
+++ b/utilities/resync_rag_namespace.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+# Ensure project root is on sys.path so `import src...` works when this file is
+# executed directly.
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from src.backend.db.connection_manager import get_db
+from src.backend.services.namespace_service import derive_namespace
+from src.backend.services.rag_sync_service import sync_one_session
+
+
+@dataclass(frozen=True)
+class ResyncStats:
+    scanned: int
+    updated_namespace: int
+    synced_ok: int
+    synced_failed: int
+
+
+def _strip_v_prefix(concept_id: str) -> str:
+    if concept_id.startswith("#V#"):
+        return concept_id[3:]
+    return concept_id
+
+
+def resynchronise_user_org_sessions(
+    *,
+    user_concept_id: str,
+    organisation_concept_id: str,
+    limit: int,
+    dry_run: bool,
+    match_namespaces: list[str] | None = None,
+) -> ResyncStats:
+    db = get_db()
+    if db is None:
+        raise RuntimeError("Database unavailable")
+
+    coll = db["interaction_sessions"]
+
+    target_namespace = derive_namespace(
+        _strip_v_prefix(user_concept_id),
+        _strip_v_prefix(organisation_concept_id),
+    )
+
+    query: dict[str, Any] = {"indexing_status": "indexed"}
+    if match_namespaces:
+        query["namespace"] = {"$in": match_namespaces}
+    else:
+        query["user_id"] = user_concept_id
+        query["organisation_concept_id"] = organisation_concept_id
+
+    cursor = coll.find(query, {"_id": 1, "namespace": 1}).sort("indexed_at", -1)
+
+    if limit > 0:
+        cursor = cursor.limit(limit)
+
+    scanned = 0
+    updated_namespace = 0
+    synced_ok = 0
+    synced_failed = 0
+
+    for doc in cursor:
+        scanned += 1
+        session_id = str(doc.get("_id"))
+        current_ns = doc.get("namespace")
+
+        if current_ns != target_namespace:
+            if not dry_run:
+                coll.update_one(
+                    {"_id": doc.get("_id")},
+                    {"$set": {"namespace": target_namespace}},
+                )
+            updated_namespace += 1
+
+        if not dry_run:
+            result: dict[str, Any] = sync_one_session(session_id)
+            if result.get("success") is True:
+                synced_ok += 1
+            else:
+                synced_failed += 1
+
+    return ResyncStats(
+        scanned=scanned,
+        updated_namespace=updated_namespace,
+        synced_ok=synced_ok,
+        synced_failed=synced_failed,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Resynchronise already-indexed interaction sessions into the RAG store "
+            "under the correct composite namespace (user@organisation)."
+        )
+    )
+    parser.add_argument(
+        "--user-concept-id",
+        required=True,
+        help='User concept id, e.g. "#V#michael_witbrock"',
+    )
+    parser.add_argument(
+        "--organisation-concept-id",
+        required=True,
+        help='Organisation concept id, e.g. "#V#university_of_auckland_strong_ai_lab"',
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=200,
+        help="Maximum number of sessions to resynchronise (0 means no limit)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Scan and report only; do not write or sync",
+    )
+    parser.add_argument(
+        "--match-namespace",
+        action="append",
+        default=None,
+        help=(
+            "Only resynchronise sessions whose current namespace matches this value. "
+            "Repeatable. If omitted, falls back to filtering by user_id + organisation_concept_id."
+        ),
+    )
+
+    args = parser.parse_args()
+
+    stats = resynchronise_user_org_sessions(
+        user_concept_id=args.user_concept_id,
+        organisation_concept_id=args.organisation_concept_id,
+        limit=args.limit,
+        dry_run=args.dry_run,
+        match_namespaces=args.match_namespace,
+    )
+
+    target_namespace = derive_namespace(
+        _strip_v_prefix(args.user_concept_id),
+        _strip_v_prefix(args.organisation_concept_id),
+    )
+
+    print(
+        "Resynchronisation complete:\n"
+        f"- target namespace: {target_namespace}\n"
+        f"- scanned: {stats.scanned}\n"
+        f"- namespace updated: {stats.updated_namespace}\n"
+        f"- synced ok: {stats.synced_ok}\n"
+        f"- synced failed: {stats.synced_failed}\n"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:
- Prefer composite user@org namespace for /generate tool isolation.
- Align org key naming in RAG permissions context.
- Scope interaction_sessions reads/lists by effective user (and org when present).
- Propagate interaction session namespace through RAG sync.

Tests:
- pytest: test_rag_mcp.py; tests/backend/test_orchestrator_structured_calling.py; tests/backend/test_session_org_routes.py; tests/backend/test_workflow_trace_store.py