### PR TITLE
JVNAUTOSCI-844: Fix RAG permissions + add provenance/trace

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -10,6 +10,16 @@
       ],
       "cwd": "${workspaceFolder}"
     },
+    "vonrag": {
+      "type": "stdio",
+      "command": "pdm",
+      "args": [
+        "run",
+        "python",
+        "src/backend/mcp_server/rag_mcp_stdio_server.py"
+      ],
+      "cwd": "${workspaceFolder}"
+    },
     "arxiv": {
       "type": "stdio",
       "command": "uv",

--- a/docs/engineering/access_control_and_namespaces.md
+++ b/docs/engineering/access_control_and_namespaces.md
@@ -186,6 +186,14 @@ These are concrete changes that would reduce confusion and tighten isolation:
    - “No namespace → no RAG access.”
    - “Namespace used for list/get must match namespace used for indexing/sync.”
 
+5. Prefer provenance stamping for persisted artefacts (where practical).
+  - When Von persists objects that may later be surfaced to an agent or UI (e.g., indexed sessions, RAG chunks, summaries, tool outputs, sync markers), include lightweight provenance fields.
+  - Suggested minimum set:
+    - `item_kind` (what type of thing this is)
+    - `source_system` (what created it: DB collection, tool, pipeline, backend)
+    - `namespace` and `namespace_source` (how/why it was scoped)
+  - Rationale: this will matter when we add **projection of persisted objects into a virtual part of the Vontology** so the system can do coherent introspection (“what do you have stored and why?”) without confusing chat history, KA sessions, and retrieved RAG content.
+
 ## 9) Jira relationship tidy-up (760 / 836 / 144)
 
 Current state (as observed):

--- a/docs/engineering/vonrag_mcp_integration.md
+++ b/docs/engineering/vonrag_mcp_integration.md
@@ -1,0 +1,30 @@
+# vonrag MCP integration
+
+This repo includes a dedicated MCP stdio server that exposes a small, coherent RAG tool surface to IDE agents (e.g. VS Code Copilot).
+
+## Configuration
+
+The server is registered in `.vscode/mcp.json` as `vonrag`:
+
+- Command: `pdm run python src/backend/mcp_server/rag_mcp_stdio_server.py`
+- Working directory: `${workspaceFolder}`
+
+After editing `.vscode/mcp.json`, reload VS Code (or restart the MCP servers) so the new server is discovered.
+
+## Tools
+
+`vonrag` exposes:
+
+- `rag_list_collections` — discover available RAG collections/sources for a namespace
+- `rag_get_status` — status counts for a namespace (mirrors `/admin/rag_status`)
+- `rag_list_indexed` — list sessions for a namespace; use `collection=ka_sessions` or `collection=chat_history_sessions`
+- `rag_get_item` — fetch a single session by `session_id`; use `collection=...` to disambiguate
+- `search_knowledge_base` — semantic search over vector-store content for the namespace
+
+## Namespace requirement
+
+All tools require an explicit `namespace` and fail closed when it is missing. This reduces accidental cross-namespace access during local development.
+
+## Notes
+
+- These tools reuse the authoritative internal handlers in `src/backend/integrations/internal_mcp/catalogue.py`, so provenance stamping and collection semantics stay consistent across internal and external tool surfaces.

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -2004,9 +2004,57 @@ def _update_concept_output_schema() -> Schema:
 
 
 # RAG Tool Handlers and Schemas
+def _resolve_rag_namespace_from_kwargs(kwargs: dict) -> dict:
+    """Resolve namespace for RAG tools and report provenance.
+
+    SECURITY: Do not infer namespaces from arbitrary client-provided user ids.
+    Prefer explicit namespace (tool payload) and allow an env default for dev.
+    """
+
+    import os
+
+    raw = kwargs.get("namespace")
+    if isinstance(raw, str) and raw.strip():
+        return {
+            "namespace": raw.strip(),
+            "namespace_source": "request.namespace",
+            "namespace_resolution_note": None,
+        }
+
+    env_ns = os.environ.get("VON_DEFAULT_NAMESPACE")
+    if isinstance(env_ns, str) and env_ns.strip():
+        return {
+            "namespace": env_ns.strip(),
+            "namespace_source": "env.VON_DEFAULT_NAMESPACE",
+            "namespace_resolution_note": "fallback",
+        }
+
+    return {
+        "namespace": None,
+        "namespace_source": "missing",
+        "namespace_resolution_note": "namespace_required",
+    }
+
+
+def _with_rag_provenance(*, payload: dict, item_kind: str, source_system: str) -> dict:
+    result = dict(payload)
+    provenance = {
+        "item_kind": item_kind,
+        "source_system": source_system,
+        "namespace": payload.get("namespace"),
+        "namespace_source": payload.get("namespace_source"),
+    }
+    existing = result.get("provenance")
+    if isinstance(existing, dict):
+        provenance = {**existing, **provenance}
+    result["provenance"] = provenance
+    return result
+
+
 def _search_knowledge_base(**kwargs):
     from ...services.rag_service import get_rag_service, RAGBackendUnavailable
-    import os
+
+    import time
 
     query_text = kwargs.get("query")
     if not query_text:
@@ -2014,21 +2062,15 @@ def _search_knowledge_base(**kwargs):
 
     try:
         service = get_rag_service()  # Default backend
-        # Resolve effective namespace: prefer explicit, else env, else derive from user.id if provided
-        ns = kwargs.get("namespace")
-        if not ns:
-            ns = os.environ.get("VON_DEFAULT_NAMESPACE")
-        if not ns:
-            user = kwargs.get("user")
-            user_id = user.get("id") if isinstance(user, dict) else None
-            if isinstance(user_id, str) and user_id.strip():
-                ns = f"#V#{user_id.strip().lower().replace(' ', '_')}"
+        ns_report = _resolve_rag_namespace_from_kwargs(kwargs)
+        ns = ns_report.get("namespace")
 
         # SECURITY: Require namespace for RAG search - prevents cross-user data leakage
         if not ns:
             return {
                 "error": "namespace_required",
                 "message": "RAG search requires authenticated user context (namespace)",
+                **ns_report,
                 "success": False,
             }
 
@@ -2052,19 +2094,73 @@ def _search_knowledge_base(**kwargs):
             if org_concept_id:
                 permissions_context["organisation_concept_id"] = org_concept_id
         except (ImportError, RuntimeError):
-            # Not in Flask context - use user_id from kwargs if available
+            # Not in Flask context (e.g., external MCP stdio server).
+            # Derive the same effective filtering keys we use in-server when possible.
+            user = kwargs.get("user")
+            user_id = user.get("id") if isinstance(user, dict) else None
             if isinstance(user_id, str) and user_id.strip():
-                permissions_context["user_id"] = (
-                    user_id.strip().lower().replace(" ", "_")
-                )
+                # IMPORTANT: Use concept IDs verbatim (case sensitive, e.g. #V#person).
+                permissions_context["user_id"] = user_id.strip()
 
+            org_concept_id = kwargs.get("organisation_concept_id")
+            if isinstance(org_concept_id, str) and org_concept_id.strip():
+                permissions_context["organisation_concept_id"] = org_concept_id.strip()
+
+            # If the namespace is in the user@org form, it contains enough
+            # information to derive both IDs without trusting arbitrary inputs.
+            if isinstance(ns, str) and "@" in ns:
+                user_part, org_part = ns.split("@", 1)
+                if user_part.strip() and "user_id" not in permissions_context:
+                    permissions_context["user_id"] = user_part.strip()
+                if (
+                    org_part.strip()
+                    and "organisation_concept_id" not in permissions_context
+                ):
+                    org_part_clean = org_part.strip()
+                    if not org_part_clean.startswith("#V#"):
+                        org_part_clean = f"#V#{org_part_clean}"
+                    permissions_context["organisation_concept_id"] = org_part_clean
+
+        start = time.perf_counter()
         results = service.query(
             query_text=query_text,
             top_k=kwargs.get("top_k", 5),
             namespace=ns,
             permissions_context=permissions_context if permissions_context else None,
         )
-        return {"results": results, "count": len(results), "success": True}
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+
+        # Provenance-first: stamp RAG retrieval results so downstream consumers cannot
+        # mistake them for chat history or KA sessions.
+        stamped_results = []
+        if isinstance(results, list):
+            for row in results:
+                if not isinstance(row, dict):
+                    stamped_results.append(row)
+                    continue
+                meta = row.get("metadata")
+                if not isinstance(meta, dict):
+                    meta = {}
+                meta = {
+                    **meta,
+                    "item_kind": "rag_chunk",
+                    "source_system": "rag.llamaindex",
+                    "namespace": ns,
+                    "namespace_source": ns_report.get("namespace_source"),
+                }
+                stamped_results.append({**row, "metadata": meta})
+        else:
+            stamped_results = results
+
+        return {
+            "results": stamped_results,
+            "count": len(stamped_results) if isinstance(stamped_results, list) else 0,
+            "elapsed_ms": elapsed_ms,
+            "effective_namespace": ns,
+            "effective_namespace_source": ns_report.get("namespace_source"),
+            **ns_report,
+            "success": True,
+        }
     except RAGBackendUnavailable as e:
         return {"error": f"RAG service unavailable: {e}", "success": False}
     except Exception as e:
@@ -2199,7 +2295,8 @@ def _rag_get_status(**kwargs):
     import os
 
     try:
-        ns = kwargs.get("namespace") or os.environ.get("VON_DEFAULT_NAMESPACE")
+        ns_report = _resolve_rag_namespace_from_kwargs(kwargs)
+        ns = ns_report.get("namespace") or os.environ.get("VON_DEFAULT_NAMESPACE")
         detail = kwargs.get("detail")
         url = "http://127.0.0.1:5002/admin/rag_status"
         if ns:
@@ -2208,140 +2305,464 @@ def _rag_get_status(**kwargs):
             url = f"{url}{'&' if '?' in url else '?'}detail=1"
         res = requests.get(url, timeout=5)
         if res.ok:
-            return res.json()
+            payload = res.json()
+            if isinstance(payload, dict):
+                payload.update(ns_report)
+                payload = _with_rag_provenance(
+                    payload=payload,
+                    item_kind="rag_status_report",
+                    source_system="http.admin_rag_status",
+                )
+            return payload
         return {"error": f"HTTP {res.status_code}", "success": False}
     except Exception as e:
         return {"error": str(e), "success": False}
 
 
-def _rag_list_indexed(**kwargs):
-    from ...db.connection_manager import get_db
-    import os
+def _resolve_rag_collection_from_kwargs(kwargs: dict) -> dict[str, object]:
+    """Resolve a user-provided collection selector.
 
-    db = get_db()
-    if db is None:
-        return {"error": "db_unavailable", "success": False}
-    coll = db["interaction_sessions"]
-    limit = int(kwargs.get("limit", 20))
-    offset = int(kwargs.get("offset", 0))
+    This exists to prevent silent defaults: responses should echo what the
+    caller asked for vs what was actually used.
+    """
 
-    # Resolve effective namespace: prefer explicit, else env, else derive from user.id if provided
-    ns = kwargs.get("namespace")
-    if not ns:
-        ns = os.environ.get("VON_DEFAULT_NAMESPACE")
-    if not ns:
-        user = kwargs.get("user")
-        user_id = user.get("id") if isinstance(user, dict) else None
-        if isinstance(user_id, str) and user_id.strip():
-            ns = f"#V#{user_id.strip().lower().replace(' ', '_')}"
+    raw = kwargs.get("collection")
+    if raw is None:
+        return {
+            "requested_collection": None,
+            "effective_collection": "ka_sessions",
+            "collection_source": "default",
+            "collection_resolution_note": "default",
+        }
+
+    if not isinstance(raw, str):
+        return {
+            "requested_collection": raw,
+            "effective_collection": "ka_sessions",
+            "collection_source": "default",
+            "collection_resolution_note": "invalid",
+        }
+
+    cleaned = raw.strip()
+    if not cleaned:
+        return {
+            "requested_collection": raw,
+            "effective_collection": "ka_sessions",
+            "collection_source": "default",
+            "collection_resolution_note": "empty",
+        }
+
+    lowered = cleaned.lower()
+    aliases = {
+        "ka": "ka_sessions",
+        "ka_session": "ka_sessions",
+        "ka_sessions": "ka_sessions",
+        "interaction": "ka_sessions",
+        "interaction_session": "ka_sessions",
+        "interaction_sessions": "ka_sessions",
+        "indexed_sessions": "ka_sessions",
+        "indexed": "ka_sessions",
+        "chat": "chat_history_sessions",
+        "chat_session": "chat_history_sessions",
+        "chat_sessions": "chat_history_sessions",
+        "chat_history": "chat_history_sessions",
+        "chat_history_session": "chat_history_sessions",
+        "chat_history_sessions": "chat_history_sessions",
+    }
+    effective = aliases.get(lowered, lowered)
+    return {
+        "requested_collection": cleaned,
+        "effective_collection": effective,
+        "collection_source": (
+            "request.collection_alias" if effective != lowered else "request.collection"
+        ),
+        "collection_resolution_note": (
+            f"alias:{lowered}" if effective != lowered else None
+        ),
+    }
+
+
+def _rag_list_collections(**kwargs):
+    ns_report = _resolve_rag_namespace_from_kwargs(kwargs)
+    ns = ns_report.get("namespace")
 
     # SECURITY: Require namespace for RAG access - prevents cross-user data leakage
     if not ns:
         return {
             "error": "namespace_required",
             "message": "RAG access requires authenticated user context (namespace)",
+            **ns_report,
             "success": False,
         }
 
-    # Build query with namespace filter
-    query = {"indexing_status": "indexed", "namespace": ns}
+    collections = [
+        {
+            "collection": "ka_sessions",
+            "label": "Indexed KA interaction sessions",
+            "description": (
+                "Interaction sessions stored in MongoDB (interaction_sessions) that have been indexed. "
+                "Use when you want to list or inspect KA sessions, not individual vector-store chunks."
+            ),
+            "list_tool": "rag_list_indexed",
+            "get_tool": "rag_get_item",
+            "search_tool": "search_knowledge_base",
+            "list_supported": True,
+            "get_supported": True,
+            "search_supported": True,
+            "list_supported_reason": None,
+            "get_supported_reason": None,
+            "item_kind": "ka_interaction_session",
+            "source_system": "mongo.interaction_sessions",
+        },
+        {
+            "collection": "chat_history_sessions",
+            "label": "Chat history sessions",
+            "description": (
+                "Chat session documents stored in MongoDB (chat_history). These may be indexed into the vector store "
+                "incrementally per message. Use when you want to list or inspect chat sessions."
+            ),
+            "list_tool": "rag_list_indexed",
+            "get_tool": "rag_get_item",
+            "search_tool": "search_knowledge_base",
+            "list_supported": True,
+            "get_supported": True,
+            "search_supported": True,
+            "list_supported_reason": None,
+            "get_supported_reason": None,
+            "item_kind": "chat_history_session",
+            "source_system": "mongo.chat_history",
+        },
+        {
+            "collection": "rag_documents",
+            "label": "Vector-store documents/chunks",
+            "description": (
+                "Semantic search index content (vector-store chunks). Not directly listable yet; use search_knowledge_base "
+                "to retrieve relevant chunks, or rag_get_status for counts."
+            ),
+            "list_tool": None,
+            "get_tool": None,
+            "search_tool": "search_knowledge_base",
+            "list_supported": False,
+            "get_supported": False,
+            "search_supported": True,
+            "list_supported_reason": "not_listable",
+            "get_supported_reason": "not_addressable",
+            "item_kind": "rag_chunk",
+            "source_system": "rag.llamaindex",
+        },
+    ]
 
-    cursor = (
-        coll.find(
-            query,
-            {"_id": 1, "indexed_at": 1, "summary": 1, "history": 1, "namespace": 1},
-        )
-        .skip(offset)
-        .limit(limit)
-    )
-    items = []
-    for doc in cursor:
-        preview_len = 0
-        if isinstance(doc.get("summary"), str):
-            preview_len += len(doc["summary"])
-        history = doc.get("history") or []
-        if isinstance(history, list):
-            for h in history:
-                content = h.get("content")
-                if isinstance(content, str):
-                    preview_len += len(content)
-        items.append(
-            {
-                "session_id": str(doc.get("_id")),
-                "indexed_at": (
-                    str(doc.get("indexed_at")) if doc.get("indexed_at") else None
-                ),
-                "preview_length": preview_len,
-                "namespace": doc.get("namespace"),
-            }
-        )
-    total = coll.count_documents(query)
-    return {
-        "items": items,
-        "total": total,
-        "limit": limit,
-        "offset": offset,
-        "namespace": ns,
+    payload = {
+        "collections": collections,
+        "count": len(collections),
+        "effective_namespace": ns,
+        "effective_namespace_source": ns_report.get("namespace_source"),
+        **ns_report,
         "success": True,
+    }
+    return _with_rag_provenance(
+        payload=payload,
+        item_kind="rag_collection_list",
+        source_system="internal_mcp.catalogue",
+    )
+
+
+def _rag_list_indexed(**kwargs):
+    from ...db.connection_manager import get_db
+
+    db = get_db()
+    if db is None:
+        return {"error": "db_unavailable", "success": False}
+    collection_report = _resolve_rag_collection_from_kwargs(kwargs)
+    collection = collection_report.get("effective_collection")
+    limit = int(kwargs.get("limit", 20))
+    offset = int(kwargs.get("offset", 0))
+
+    ns_report = _resolve_rag_namespace_from_kwargs(kwargs)
+    ns = ns_report.get("namespace")
+
+    # SECURITY: Require namespace for RAG access - prevents cross-user data leakage
+    if not ns:
+        return {
+            "error": "namespace_required",
+            "message": "RAG access requires authenticated user context (namespace)",
+            **ns_report,
+            "success": False,
+        }
+
+    if not isinstance(collection, str) or not collection:
+        collection = "ka_sessions"
+
+    if collection == "ka_sessions":
+        coll = db["interaction_sessions"]
+
+        # Build query with namespace filter
+        query = {"indexing_status": "indexed", "namespace": ns}
+
+        cursor = (
+            coll.find(
+                query,
+                {
+                    "_id": 1,
+                    "indexed_at": 1,
+                    "summary": 1,
+                    "history": 1,
+                    "namespace": 1,
+                },
+            )
+            .skip(offset)
+            .limit(limit)
+        )
+        items = []
+        for doc in cursor:
+            preview_len = 0
+            if isinstance(doc.get("summary"), str):
+                preview_len += len(doc["summary"])
+            history = doc.get("history") or []
+            if isinstance(history, list):
+                for h in history:
+                    content = h.get("content")
+                    if isinstance(content, str):
+                        preview_len += len(content)
+            items.append(
+                {
+                    "collection": collection,
+                    "session_id": str(doc.get("_id")),
+                    "indexed_at": (
+                        str(doc.get("indexed_at")) if doc.get("indexed_at") else None
+                    ),
+                    "preview_length": preview_len,
+                    "namespace": doc.get("namespace"),
+                    "item_kind": "ka_interaction_session",
+                    "source_system": "mongo.interaction_sessions",
+                    "namespace_source": ns_report.get("namespace_source"),
+                }
+            )
+        total = coll.count_documents(query)
+        payload = {
+            "collection": collection,
+            **collection_report,
+            "items": items,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "effective_namespace": ns,
+            "effective_namespace_source": ns_report.get("namespace_source"),
+            **ns_report,
+            "success": True,
+        }
+
+        return _with_rag_provenance(
+            payload=payload,
+            item_kind="rag_indexed_session_list",
+            source_system="mongo.interaction_sessions",
+        )
+
+    if collection == "chat_history_sessions":
+        coll = db["chat_history"]
+
+        query = {"namespace": ns}
+        cursor = (
+            coll.find(
+                query,
+                {
+                    "session_id": 1,
+                    "created_at": 1,
+                    "updated_at": 1,
+                    "history": 1,
+                    "namespace": 1,
+                    "rag_indexed_success": 1,
+                    "rag_indexed_failed": 1,
+                },
+            )
+            .skip(offset)
+            .limit(limit)
+        )
+        items = []
+        for doc in cursor:
+            preview_len = 0
+            history = doc.get("history") or []
+            if isinstance(history, list):
+                for h in history:
+                    content = h.get("content")
+                    if isinstance(content, str):
+                        preview_len += len(content)
+            items.append(
+                {
+                    "collection": collection,
+                    "session_id": doc.get("session_id"),
+                    "created_at": (
+                        str(doc.get("created_at")) if doc.get("created_at") else None
+                    ),
+                    "updated_at": (
+                        str(doc.get("updated_at")) if doc.get("updated_at") else None
+                    ),
+                    "preview_length": preview_len,
+                    "message_count": len(history) if isinstance(history, list) else 0,
+                    "rag_indexed_success": doc.get("rag_indexed_success"),
+                    "rag_indexed_failed": doc.get("rag_indexed_failed"),
+                    "namespace": doc.get("namespace"),
+                    "item_kind": "chat_history_session",
+                    "source_system": "mongo.chat_history",
+                    "namespace_source": ns_report.get("namespace_source"),
+                }
+            )
+
+        total = coll.count_documents(query)
+        payload = {
+            "collection": collection,
+            **collection_report,
+            "items": items,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "effective_namespace": ns,
+            "effective_namespace_source": ns_report.get("namespace_source"),
+            **ns_report,
+            "success": True,
+        }
+        return _with_rag_provenance(
+            payload=payload,
+            item_kind="rag_chat_session_list",
+            source_system="mongo.chat_history",
+        )
+
+    return {
+        "error": "unknown_collection",
+        "message": f"Unknown collection: {collection}",
+        "collection": collection,
+        **collection_report,
+        "effective_namespace": ns,
+        "effective_namespace_source": ns_report.get("namespace_source"),
+        **ns_report,
+        "success": False,
     }
 
 
 def _rag_get_item(**kwargs):
     from ...db.connection_manager import get_db
     from bson import ObjectId
-    import os
 
     db = get_db()
     if db is None:
         return {"error": "db_unavailable", "success": False}
+    collection_report = _resolve_rag_collection_from_kwargs(kwargs)
+    collection = collection_report.get("effective_collection")
     session_id = kwargs.get("session_id")
     if not session_id:
         return {"error": "Missing session_id", "success": False}
 
-    # Resolve effective namespace: prefer explicit, else env, else derive from user.id if provided
-    ns = kwargs.get("namespace")
-    if not ns:
-        ns = os.environ.get("VON_DEFAULT_NAMESPACE")
-    if not ns:
-        user = kwargs.get("user")
-        user_id = user.get("id") if isinstance(user, dict) else None
-        if isinstance(user_id, str) and user_id.strip():
-            ns = f"#V#{user_id.strip().lower().replace(' ', '_')}"
+    ns_report = _resolve_rag_namespace_from_kwargs(kwargs)
+    ns = ns_report.get("namespace")
 
     # SECURITY: Require namespace for RAG access - prevents cross-user data leakage
     if not ns:
         return {
             "error": "namespace_required",
             "message": "RAG access requires authenticated user context (namespace)",
+            **ns_report,
             "success": False,
         }
 
-    coll = db["interaction_sessions"]
-    try:
-        query = {"_id": ObjectId(session_id), "namespace": ns}
-    except Exception:
-        query = {"_id": session_id, "namespace": ns}
+    if not isinstance(collection, str) or not collection:
+        collection = "ka_sessions"
 
-    doc = coll.find_one(query)
-    if not doc:
-        return {"error": "not_found", "success": False}
-    # Build a safe preview
-    preview = []
-    if isinstance(doc.get("summary"), str):
-        preview.append(doc["summary"])
-    history = doc.get("history") or []
-    if isinstance(history, list):
-        for h in history:
-            c = h.get("content")
-            if isinstance(c, str):
-                preview.append(c)
+    if collection == "ka_sessions":
+        coll = db["interaction_sessions"]
+        try:
+            query = {"_id": ObjectId(session_id), "namespace": ns}
+        except Exception:
+            query = {"_id": session_id, "namespace": ns}
+
+        doc = coll.find_one(query)
+        if not doc:
+            return {"error": "not_found", "success": False}
+
+        # Build a safe preview
+        preview = []
+        if isinstance(doc.get("summary"), str):
+            preview.append(doc["summary"])
+        history = doc.get("history") or []
+        if isinstance(history, list):
+            for h in history:
+                c = h.get("content")
+                if isinstance(c, str):
+                    preview.append(c)
+        payload = {
+            "collection": collection,
+            **collection_report,
+            "session_id": str(doc.get("_id")),
+            "indexing_status": doc.get("indexing_status"),
+            "indexed_at": (
+                str(doc.get("indexed_at")) if doc.get("indexed_at") else None
+            ),
+            "namespace": doc.get("namespace"),
+            "preview": "\n\n".join(preview)[:4000],
+            "item_kind": "ka_interaction_session",
+            "source_system": "mongo.interaction_sessions",
+            "namespace_source": ns_report.get("namespace_source"),
+            "effective_namespace": ns,
+            "effective_namespace_source": ns_report.get("namespace_source"),
+            **ns_report,
+            "success": True,
+        }
+
+        return _with_rag_provenance(
+            payload=payload,
+            item_kind="rag_indexed_session_item",
+            source_system="mongo.interaction_sessions",
+        )
+
+    if collection == "chat_history_sessions":
+        coll = db["chat_history"]
+        doc = coll.find_one({"session_id": session_id, "namespace": ns})
+        if not doc:
+            return {"error": "not_found", "success": False}
+
+        history = doc.get("history") or []
+        preview_parts = []
+        if isinstance(history, list):
+            for h in history:
+                c = h.get("content")
+                if isinstance(c, str):
+                    preview_parts.append(c)
+
+        payload = {
+            "collection": collection,
+            **collection_report,
+            "session_id": doc.get("session_id"),
+            "created_at": (
+                str(doc.get("created_at")) if doc.get("created_at") else None
+            ),
+            "updated_at": (
+                str(doc.get("updated_at")) if doc.get("updated_at") else None
+            ),
+            "namespace": doc.get("namespace"),
+            "message_count": len(history) if isinstance(history, list) else 0,
+            "preview": "\n\n".join(preview_parts)[:4000],
+            "item_kind": "chat_history_session",
+            "source_system": "mongo.chat_history",
+            "namespace_source": ns_report.get("namespace_source"),
+            "effective_namespace": ns,
+            "effective_namespace_source": ns_report.get("namespace_source"),
+            **ns_report,
+            "success": True,
+        }
+        return _with_rag_provenance(
+            payload=payload,
+            item_kind="rag_chat_session_item",
+            source_system="mongo.chat_history",
+        )
+
     return {
-        "session_id": str(doc.get("_id")),
-        "indexing_status": doc.get("indexing_status"),
-        "indexed_at": str(doc.get("indexed_at")) if doc.get("indexed_at") else None,
-        "namespace": doc.get("namespace"),
-        "preview": "\n\n".join(preview)[:4000],
-        "success": True,
+        "error": "unknown_collection",
+        "message": f"Unknown collection: {collection}",
+        "collection": collection,
+        **collection_report,
+        "effective_namespace": ns,
+        "effective_namespace_source": ns_report.get("namespace_source"),
+        **ns_report,
+        "success": False,
     }
 
 
@@ -3436,11 +3857,28 @@ def build_default_catalogue() -> MethodCatalogue:
             description="Get RAG status: totals, eligible counts, indexed/pending/failed/skipped. Mirrors /admin/rag_status.",
         ),
         MethodDefinition(
+            name="rag_list_collections",
+            handler=_rag_list_collections,
+            input_schema=Schema(
+                required={},
+                optional={"namespace": (str, type(None))},
+                allow_unknown=True,
+                description="List available RAG collections/sources for the current namespace",
+            ),
+            output_schema=None,
+            category="read",
+            description=(
+                "List available RAG collections/sources for the current user/namespace. "
+                "Use when user asks 'what is in my RAG store?' or needs to disambiguate KA sessions vs chat sessions vs vector chunks."
+            ),
+        ),
+        MethodDefinition(
             name="rag_list_indexed",
             handler=_rag_list_indexed,
             input_schema=Schema(
                 required={},
                 optional={
+                    "collection": (str, type(None)),
                     "limit": (int,),
                     "offset": (int,),
                     "namespace": (str, type(None)),
@@ -3457,7 +3895,10 @@ def build_default_catalogue() -> MethodCatalogue:
             handler=_rag_get_item,
             input_schema=Schema(
                 required={"session_id": str},
-                optional={"namespace": (str, type(None))},
+                optional={
+                    "namespace": (str, type(None)),
+                    "collection": (str, type(None)),
+                },
                 allow_unknown=True,
                 description="Fetch one indexed session with optional namespace filter",
             ),

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -76,6 +76,11 @@ class _MissingToolCallAssessment:
     path: str
     is_json_action: bool
     fenced_json: bool
+    classifier_invoked: bool
+    classifier_has_verdict: bool
+    # Backwards-compatible alias retained for existing debug consumers.
+    # Historically this effectively meant "classifier produced a yes/no verdict".
+    # It now means "classifier was invoked".
     classifier_used: bool
     classifier_verdict: bool | None
     retry_reason: str | None
@@ -108,6 +113,18 @@ class InternalMCPChatOrchestrator:
     _TOOL_FIELD = "tool"
     _PAYLOAD_FIELD = "payload"
     _MISSING_TOOL_CALL_ACTION_ID = "#V#detect_missing_tool_call_action"
+    _FALLBACK_MISSING_TOOL_CALL_PROMPT = (
+        "You are a strict classifier for an agent system that can call tools via JSON.\n"
+        "Your job: decide whether the assistant response *promises* to call tools (or says it is about to do so) "
+        "but does not actually emit a tool-call JSON object/array.\n\n"
+        "Rules:\n"
+        "- Answer ONLY 'YES' or 'NO'.\n"
+        "- Answer YES if the response contains phrases like 'I will', 'I’m going to', 'Proceeding now', 'Invoking', "
+        "or similar action narration *and* references tool-like actions (search, fetch, create/update, MCP, ontology).\n"
+        "- Answer NO for normal explanations, summaries, or questions that are not claiming to execute tools now.\n\n"
+        "Assistant response:\n"
+        "{response}\n"
+    )
 
     def __init__(
         self,
@@ -432,11 +449,11 @@ class InternalMCPChatOrchestrator:
         # Inform agent about authentication status and tool availability
         auth_status = ""
         if user_namespace:
-            auth_status = f"\n\n🔐 AUTHENTICATION STATUS: Authenticated (namespace: {user_namespace})\nRAG tools (search_knowledge_base, rag_list_indexed, rag_get_item) are AVAILABLE.\n"
+            auth_status = f"\n\n🔐 AUTHENTICATION STATUS: Authenticated (namespace: {user_namespace})\nRAG tools (rag_list_collections, search_knowledge_base, rag_list_indexed, rag_get_item) are AVAILABLE.\n"
         else:
             auth_status = (
                 "\n\n⚠️ AUTHENTICATION STATUS: NOT AUTHENTICATED\n"
-                "RAG tools (search_knowledge_base, rag_list_indexed, rag_get_item) are UNAVAILABLE.\n"
+                "RAG tools (rag_list_collections, search_knowledge_base, rag_list_indexed, rag_get_item) are UNAVAILABLE.\n"
                 "These tools require user authentication to prevent cross-user data access.\n"
                 "If user asks about their RAG data/sessions/indexed content, explain they need to log in first.\n"
             )
@@ -452,9 +469,10 @@ class InternalMCPChatOrchestrator:
             "If user asks a direct factual question needing verification → USE qna_search\n"
             "If searching within specific domain/context (e.g., site:example.com) → USE context_search\n"
             "If user asks about arXiv papers by author, topic, or ID → USE list_papers or read_paper\n"
-            'If user asks about RAG sessions/conversations ("how many", "what\'s indexed", "list sessions") → USE rag_list_indexed\n'
-            "If user wants to see RAG content from a specific session → USE rag_get_item\n"
-            "If user wants to search their indexed conversations by topic/keyword → USE search_knowledge_base\n\n"
+            'If user asks "what\'s in my RAG store?" or asks about RAG *collections/sources* → USE rag_list_collections\n'
+            'If user asks about RAG sessions ("how many", "what\'s indexed", "list sessions") → USE rag_list_indexed (often with collection=...)\n'
+            "If user wants to see RAG content from a specific session → USE rag_get_item (often with collection=...)\n"
+            "If user wants semantic/topic search over indexed content → USE search_knowledge_base\n\n"
             "CRITICAL: Your training data has a cutoff date. For anything described as current/recent/new, "
             "you MUST use search tools to get up-to-date information.\n\n"
             "HOW TO INVOKE A TOOL:\n"
@@ -509,7 +527,16 @@ class InternalMCPChatOrchestrator:
         if not text:
             return False
 
-        lowered = text.lower()
+        # Normalise common Unicode punctuation (smart quotes) so heuristics behave
+        # consistently across models and frontends.
+        normalised = (
+            text.replace("\u2019", "'")
+            .replace("\u2018", "'")
+            .replace("\u2032", "'")
+            .replace("\u201c", '"')
+            .replace("\u201d", '"')
+        )
+        lowered = normalised.lower()
         triggers = (
             "here is the actual ontology operation",
             "here's the actual ontology operation",
@@ -741,8 +768,22 @@ class InternalMCPChatOrchestrator:
     def _get_missing_tool_call_detector(self) -> Optional[_MissingToolCallDetectorSpec]:
         """Load the missing-tool-call detector spec from the Vontology (best effort)."""
 
+        fallback_enabled = os.getenv(
+            "VON_MISSING_TOOL_CALL_CLASSIFIER_FALLBACK", "1"
+        ).lower() in {"1", "true"}
+
+        def _fallback_spec() -> Optional[_MissingToolCallDetectorSpec]:
+            if not fallback_enabled:
+                return None
+            return _MissingToolCallDetectorSpec(
+                action_id="fallback_missing_tool_call_detector",
+                prompt_id=None,
+                prompt_text=self._FALLBACK_MISSING_TOOL_CALL_PROMPT,
+                model=None,
+            )
+
         if self._missing_tool_call_detector_loaded:
-            return self._missing_tool_call_detector
+            return self._missing_tool_call_detector or _fallback_spec()
 
         self._missing_tool_call_detector_loaded = True
 
@@ -767,8 +808,8 @@ class InternalMCPChatOrchestrator:
             action = None
 
         if not isinstance(action, Mapping):
-            self._missing_tool_call_detector = None
-            return None
+            self._missing_tool_call_detector = _fallback_spec()
+            return self._missing_tool_call_detector
 
         prompt_id = self._first_relationship_value(action, "#V#uses_prompt")
         model_id = self._first_relationship_value(action, "#V#uses_llm_model")
@@ -783,8 +824,8 @@ class InternalMCPChatOrchestrator:
                 self._MISSING_TOOL_CALL_ACTION_ID,
                 prompt_id or "",
             )
-            self._missing_tool_call_detector = None
-            return None
+            self._missing_tool_call_detector = _fallback_spec()
+            return self._missing_tool_call_detector
 
         self._missing_tool_call_detector = _MissingToolCallDetectorSpec(
             action_id=self._MISSING_TOOL_CALL_ACTION_ID,
@@ -802,20 +843,26 @@ class InternalMCPChatOrchestrator:
         fallback_model: Optional[str],
         aux_log: Optional[List[Mapping[str, Any]]] = None,
         path: str | None = None,
-    ) -> Optional[bool]:
+    ) -> tuple[bool, Optional[bool]]:
         """Run the Vontology-configured detector LLM to classify the response.
 
-        Returns True if the classifier says the model promised a tool call but
-        didn't emit one, False if the classifier says no, and None if detection
-        could not be performed (missing prompt/model or errors).
+        Returns (invoked, verdict).
+
+        invoked:
+            True if we attempted to call the classifier LLM.
+        verdict:
+            True if the classifier says the model promised a tool call but didn't
+            emit one, False if the classifier says no, and None if no yes/no
+            verdict could be obtained (unavailable prompt/model, errors, or
+            unexpected output).
         """
 
         if not isinstance(response, str) or not response.strip():
-            return None
+            return False, None
 
         detector = self._get_missing_tool_call_detector()
         if not detector or not detector.prompt_text:
-            return None
+            return False, None
 
         # Avoid ballooning the classifier input; we only need the last response.
         truncated_response = response.strip()
@@ -850,10 +897,10 @@ class InternalMCPChatOrchestrator:
                 model_name or "default",
                 exc,
             )
-            return None
+            return True, None
 
         if not isinstance(classifier_output, str):
-            return None
+            return True, None
 
         try:
             if aux_log is not None:
@@ -875,13 +922,13 @@ class InternalMCPChatOrchestrator:
         except Exception:  # pragma: no cover - defensive
             pass
 
-        verdict = classifier_output.strip().lower()
-        if verdict.startswith("yes"):
-            return True
-        if verdict.startswith("no"):
-            return False
+        verdict_text = classifier_output.strip().lower()
+        if verdict_text.startswith("yes"):
+            return True, True
+        if verdict_text.startswith("no"):
+            return True, False
 
-        return None
+        return True, None
 
     @staticmethod
     def _contains_fenced_tool_call_json(response: str) -> bool:
@@ -978,14 +1025,23 @@ class InternalMCPChatOrchestrator:
                 parsed[self._PAYLOAD_FIELD], dict
             )
 
-            # Some models omit the action field even when they are clearly
-            # attempting a tool call. Treat this as a likely tool call response
-            # for diagnostics (execution is handled separately).
+            # Some models omit the action field or emit tool-call-like JSON with
+            # extra diagnostics keys (e.g., status/duration_ms). Treat these as a
+            # likely tool-call attempt for diagnostics/recovery.
+            allowed_tool_like_keys = {
+                self._ACTION_FIELD,
+                self._TOOL_FIELD,
+                self._PAYLOAD_FIELD,
+                "status",
+                "duration_ms",
+                "error",
+                "_call_id",
+            }
             missing_action_but_tool_shape = (
                 self._ACTION_FIELD not in parsed
                 and has_tool
                 and has_payload
-                and set(parsed.keys()) <= {self._TOOL_FIELD, self._PAYLOAD_FIELD}
+                and set(parsed.keys()) <= allowed_tool_like_keys
             )
 
             return (
@@ -1474,7 +1530,8 @@ class InternalMCPChatOrchestrator:
             else self._looks_like_missing_tool_call(response_text)
         )
 
-        classifier_used = False
+        classifier_invoked = False
+        classifier_has_verdict = False
         classifier_verdict: bool | None = None
         retry_reason: str | None = None
 
@@ -1484,35 +1541,86 @@ class InternalMCPChatOrchestrator:
         if retry_reason is None and fenced_detected:
             retry_reason = "fenced tool-call JSON detected"
 
+        # If the model emits a tool-call-like JSON blob (often a tool result shape)
+        # but we did not extract an executable tool call, retry once and demand a
+        # pure tool-call JSON object/array.
+        if retry_reason is None and is_json_action:
+            retry_reason = "JSON tool-call output detected"
+
         if retry_reason is None:
-            llm_flag = self._llm_detects_missing_tool_call(
-                response_text,
-                llm_client,
-                fallback_model=model,
-                aux_log=aux_log,
-                path=path,
+            lowered = response_text.lower() if isinstance(response_text, str) else ""
+            mentions_tools = any(
+                token in lowered
+                for token in (
+                    "tool",
+                    "mcp",
+                    "ontology",
+                    "rag",
+                    "search",
+                    "fetch",
+                    "create",
+                    "update",
+                    "delete",
+                    "jira",
+                    "confluence",
+                    "gmail",
+                    "arxiv",
+                )
             )
 
+            detector = self._get_missing_tool_call_detector()
+            fallback_detector = bool(
+                detector
+                and isinstance(getattr(detector, "action_id", None), str)
+                and detector.action_id == "fallback_missing_tool_call_detector"
+            )
+
+            # If the conservative heuristic already fires and we're using the
+            # fallback classifier spec, skip the classifier call to avoid
+            # unnecessary extra LLM traffic (and to keep recovery deterministic
+            # in unit tests that stub the LLM client).
+            if heuristic_missing and fallback_detector:
+                retry_reason = "heuristic missing tool call"
+                llm_flag = None
+                classifier_invoked = False
+            elif not heuristic_missing and not mentions_tools:
+                # Normal prose: don't bother running the classifier.
+                llm_flag = None
+                classifier_invoked = False
+            else:
+                classifier_invoked, llm_flag = self._llm_detects_missing_tool_call(
+                    response_text,
+                    llm_client,
+                    fallback_model=model,
+                    aux_log=aux_log,
+                    path=path,
+                )
+
             if llm_flag is not None:
-                classifier_used = True
+                classifier_has_verdict = True
                 classifier_verdict = llm_flag
 
-            if llm_flag is True:
-                retry_reason = "LLM classifier flagged missing tool call"
-            elif llm_flag is None:
-                # Fallback to legacy heuristic only when classifier unavailable.
-                if heuristic_missing:
-                    retry_reason = "heuristic missing tool call"
-            elif llm_flag is False:
-                # Backstop: the LLM classifier can miss obvious cases.
-                if heuristic_missing:
-                    retry_reason = "heuristic missing tool call (classifier said no)"
+            if retry_reason is None:
+                if llm_flag is True:
+                    retry_reason = "LLM classifier flagged missing tool call"
+                elif llm_flag is None:
+                    # Fallback to legacy heuristic only when classifier unavailable.
+                    if heuristic_missing:
+                        retry_reason = "heuristic missing tool call"
+                elif llm_flag is False:
+                    # Backstop: the LLM classifier can miss obvious cases.
+                    if heuristic_missing:
+                        retry_reason = (
+                            "heuristic missing tool call (classifier said no)"
+                        )
 
         return _MissingToolCallAssessment(
             path=path,
             is_json_action=is_json_action,
             fenced_json=fenced_detected,
-            classifier_used=classifier_used,
+            classifier_invoked=classifier_invoked,
+            classifier_has_verdict=classifier_has_verdict,
+            classifier_used=classifier_invoked,
             classifier_verdict=classifier_verdict,
             retry_reason=retry_reason,
             tool_call_parse_error=tool_call_parse_error,
@@ -1816,13 +1924,17 @@ class InternalMCPChatOrchestrator:
                         "path": assessment.path,
                         "is_json_action": assessment.is_json_action,
                         "fenced_json": assessment.fenced_json,
+                        "classifier_invoked": assessment.classifier_invoked,
+                        "classifier_has_verdict": assessment.classifier_has_verdict,
                         "classifier_used": assessment.classifier_used,
                         "classifier_verdict": (
                             "yes"
                             if assessment.classifier_verdict is True
-                            else "no"
-                            if assessment.classifier_verdict is False
-                            else "unavailable"
+                            else (
+                                "no"
+                                if assessment.classifier_verdict is False
+                                else "unavailable"
+                            )
                         ),
                         "retry_reason": assessment.retry_reason or "",
                         "parse_error": (
@@ -1958,13 +2070,17 @@ class InternalMCPChatOrchestrator:
                                 "path": assessment.path,
                                 "is_json_action": assessment.is_json_action,
                                 "fenced_json": assessment.fenced_json,
+                                "classifier_invoked": assessment.classifier_invoked,
+                                "classifier_has_verdict": assessment.classifier_has_verdict,
                                 "classifier_used": assessment.classifier_used,
                                 "classifier_verdict": (
                                     "yes"
                                     if assessment.classifier_verdict is True
-                                    else "no"
-                                    if assessment.classifier_verdict is False
-                                    else "unavailable"
+                                    else (
+                                        "no"
+                                        if assessment.classifier_verdict is False
+                                        else "unavailable"
+                                    )
                                 ),
                                 "retry_reason": assessment.retry_reason or "",
                                 "parse_error": str(exc),

--- a/src/backend/mcp_server/rag_mcp_stdio_server.py
+++ b/src/backend/mcp_server/rag_mcp_stdio_server.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""MCP stdio server for Von RAG operations.
+
+This is a focused MCP server that exposes a small, coherent RAG surface to IDE
+agents (e.g. VS Code Copilot) without requiring the full Vontology tool set.
+
+Security note: this server is intended for trusted local development. It still
+fails closed on missing `namespace` to reduce accidental cross-namespace access.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from typing import Any, Awaitable, Callable
+
+# Avoid UnicodeEncodeError on Windows consoles (default cp1252) when any
+# dependency logs Unicode. MCP runs over stdio; we must not crash on encode.
+try:
+    stdout_reconfigure = getattr(sys.stdout, "reconfigure", None)
+    stderr_reconfigure = getattr(sys.stderr, "reconfigure", None)
+    if callable(stdout_reconfigure):
+        stdout_reconfigure(encoding="utf-8", errors="backslashreplace")
+    if callable(stderr_reconfigure):
+        stderr_reconfigure(encoding="utf-8", errors="backslashreplace")
+except Exception:  # pragma: no cover
+    pass
+
+# Adjust path to import from the project root
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+# Load repo-root .env for MCP stdio runs (VS Code MCP launches may not source .env).
+try:
+    from dotenv import load_dotenv  # type: ignore
+
+    load_dotenv(dotenv_path=os.path.join(project_root, ".env"), override=False)
+except Exception:
+    pass
+
+try:
+    from mcp.server import Server
+    from mcp.server.stdio import stdio_server
+    from mcp.types import Tool, TextContent
+except ImportError:
+    print("Error: MCP package not installed. Run: pdm add mcp", file=sys.stderr)
+    raise
+
+# Absolute imports (required when executed as a script)
+from src.backend.integrations.internal_mcp import catalogue as internal_catalogue
+
+
+app = Server("vonrag-mcp")
+
+
+def _json_text(payload: Any) -> TextContent:
+    return TextContent(type="text", text=json.dumps(payload, indent=2, default=str))
+
+
+def _require_namespace(arguments: dict[str, Any]) -> str | None:
+    ns = arguments.get("namespace")
+    if not isinstance(ns, str) or not ns.strip():
+        return None
+    return ns.strip()
+
+
+def _namespace_required_error() -> dict[str, Any]:
+    return {
+        "success": False,
+        "error": "namespace_required",
+        "message": "RAG access requires an explicit namespace (e.g. #V#user@org)",
+    }
+
+
+def _tool_handler(
+    fn: Callable[..., Any] | Callable[..., Awaitable[Any]],
+) -> Callable[[dict[str, Any]], Awaitable[list[TextContent]]]:
+    async def _inner(arguments: dict[str, Any]) -> list[TextContent]:
+        ns = _require_namespace(arguments)
+        if not ns:
+            return [_json_text(_namespace_required_error())]
+
+        # Pass through args to the authoritative internal handler.
+        maybe_result = fn(**arguments)
+        if asyncio.iscoroutine(maybe_result):
+            result = await maybe_result
+        else:
+            result = maybe_result
+        return [_json_text(result)]
+
+    return _inner
+
+
+@app.list_tools()
+async def list_tools() -> list[Tool]:
+    return [
+        Tool(
+            name="rag_list_collections",
+            description=(
+                "List available RAG collections/sources for the given namespace. "
+                "Use when asked 'what is in my RAG store?'"
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "description": "Required namespace (e.g. #V#user@org)",
+                    }
+                },
+                "required": ["namespace"],
+            },
+        ),
+        Tool(
+            name="rag_get_status",
+            description=(
+                "Get RAG status counts for the given namespace (mirrors /admin/rag_status)."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "description": "Required namespace (e.g. #V#user@org)",
+                    },
+                    "detail": {
+                        "type": "boolean",
+                        "description": "If true, return more detailed stats when available",
+                        "default": False,
+                    },
+                },
+                "required": ["namespace"],
+            },
+        ),
+        Tool(
+            name="rag_list_indexed",
+            description=(
+                "List indexed sessions for a namespace. Use collection=ka_sessions or collection=chat_history_sessions "
+                "to disambiguate."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "description": "Required namespace (e.g. #V#user@org)",
+                    },
+                    "collection": {
+                        "type": "string",
+                        "description": "Collection selector (ka_sessions|chat_history_sessions)",
+                        "default": "ka_sessions",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max items to return",
+                        "default": 20,
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "description": "Pagination offset",
+                        "default": 0,
+                    },
+                },
+                "required": ["namespace"],
+            },
+        ),
+        Tool(
+            name="rag_get_item",
+            description=(
+                "Fetch one indexed session/item by session_id for a namespace. Use collection=... to disambiguate."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "description": "Required namespace (e.g. #V#user@org)",
+                    },
+                    "collection": {
+                        "type": "string",
+                        "description": "Collection selector (ka_sessions|chat_history_sessions)",
+                        "default": "ka_sessions",
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": "Session identifier (Mongo _id for KA sessions, session_id for chat sessions)",
+                    },
+                },
+                "required": ["namespace", "session_id"],
+            },
+        ),
+        Tool(
+            name="search_knowledge_base",
+            description=(
+                "Semantic search over the vector-store RAG content for the given namespace. "
+                "Returns relevant chunks with provenance-stamped metadata."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "description": "Required namespace (e.g. #V#user@org)",
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Search query text",
+                    },
+                    "top_k": {
+                        "type": "integer",
+                        "description": "Number of results to return",
+                        "default": 5,
+                    },
+                },
+                "required": ["namespace", "query"],
+            },
+        ),
+    ]
+
+
+_TOOL_HANDLERS: dict[str, Callable[[dict[str, Any]], Awaitable[list[TextContent]]]] = {
+    "rag_list_collections": _tool_handler(internal_catalogue._rag_list_collections),
+    "rag_get_status": _tool_handler(internal_catalogue._rag_get_status),
+    "rag_list_indexed": _tool_handler(internal_catalogue._rag_list_indexed),
+    "rag_get_item": _tool_handler(internal_catalogue._rag_get_item),
+    "search_knowledge_base": _tool_handler(internal_catalogue._search_knowledge_base),
+}
+
+
+@app.call_tool()
+async def call_tool(name: str, arguments: Any) -> list[TextContent]:  # type: ignore[misc]
+    handler = _TOOL_HANDLERS.get(name)
+    if not handler:
+        return [_json_text({"success": False, "error": f"Unknown tool: {name}"})]
+
+    if not isinstance(arguments, dict):
+        arguments = {}
+
+    try:
+        return await handler(arguments)
+    except Exception as exc:  # Defensive: avoid crashing the stdio server
+        return [_json_text({"success": False, "error": str(exc)})]
+
+
+async def main() -> None:
+    async with stdio_server() as (read_stream, write_stream):
+        await app.run(read_stream, write_stream, app.create_initialization_options())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -1055,6 +1055,14 @@ def generate():
 
         # Derive user namespace for MCP tool isolation (JVNAUTOSCI-760)
         user_namespace = None
+        namespace_source = "missing"
+        namespace_report: dict[str, object] = {
+            "authenticated": bool(user_concept_id),
+            "user_concept_id": user_concept_id,
+            "session_namespace": session.get("namespace"),
+            "namespace": None,
+            "namespace_source": None,
+        }
         if user_concept_id:
             session_namespace = session.get("namespace")
             if (
@@ -1063,6 +1071,7 @@ def generate():
                 and session_namespace.startswith("#V#")
             ):
                 user_namespace = session_namespace.strip()
+                namespace_source = "session.namespace"
                 current_app.logger.info(
                     "[NAMESPACE] Using session namespace=%s for user_concept_id=%s",
                     user_namespace,
@@ -1073,6 +1082,7 @@ def generate():
                 # Handle both full concept ID and person ID formats
                 if user_concept_id.startswith("#V#"):
                     user_namespace = user_concept_id
+                    namespace_source = "user_concept_id"
                 else:
                     # Normalize to namespace format
                     user_id_normalized = (
@@ -1082,6 +1092,7 @@ def generate():
                         .replace("#", "")
                     )
                     user_namespace = f"#V#{user_id_normalized}"
+                    namespace_source = "derived_from_user_concept_id"
                 current_app.logger.info(
                     "[NAMESPACE] Derived user_namespace=%s from user_concept_id=%s",
                     user_namespace,
@@ -1091,6 +1102,21 @@ def generate():
             current_app.logger.warning(
                 "[NAMESPACE] No user_concept_id - user_namespace=None (RAG unavailable)"
             )
+
+        namespace_report["namespace"] = user_namespace
+        namespace_report["namespace_source"] = namespace_source
+
+        rag_trace: dict[str, object] = {
+            "authenticated": bool(user_concept_id),
+            "namespace": user_namespace,
+            "namespace_source": namespace_source,
+            "retrieval_attempted": False,
+            "retrieval_attempt_reason": (
+                None if user_concept_id else "not_authenticated"
+            ),
+            "tools_invoked": [],
+            "tool_results_included_in_prompt": False,
+        }
 
         # ---------------------------------------------------------
         # Tool-backed RAG counts (avoid KA vs chat-history confusion)
@@ -1425,6 +1451,7 @@ def generate():
                         "messages": current_turn_messages,
                         "response": response_text,
                         "user_prompt": user_prompt_debug,
+                        "namespace_report": namespace_report,
                         "context_stats": {
                             "sent_to_llm": context_stats,
                             "stored_context": current_context_stats,
@@ -1434,10 +1461,19 @@ def generate():
                         "aux_llm_calls": [],
                     }
 
+                    rag_trace["tools_invoked"] = [
+                        inv.get("tool")
+                        for inv in tool_invocations
+                        if isinstance(inv, dict) and isinstance(inv.get("tool"), str)
+                    ]
+                    rag_trace["retrieval_attempted"] = False
+                    rag_trace["retrieval_attempt_reason"] = "direct_tool_call"
+
                     return jsonify(
                         {
                             "response": response_text,
                             "llm_debug": llm_debug_info,
+                            "rag_trace": rag_trace,
                         }
                     )
 
@@ -1470,6 +1506,28 @@ def generate():
                 auxiliary_llm_calls = list(
                     getattr(orchestrator_result, "aux_llm_calls", [])
                 )
+
+                invoked_tools = []
+                for inv in tool_invocations:
+                    if not isinstance(inv, dict):
+                        continue
+                    name = inv.get("tool") or inv.get("method")
+                    if isinstance(name, str) and name:
+                        invoked_tools.append(name)
+
+                rag_trace["tools_invoked"] = invoked_tools
+                rag_trace["retrieval_attempted"] = (
+                    "search_knowledge_base" in invoked_tools
+                )
+                if rag_trace["retrieval_attempted"]:
+                    rag_trace["retrieval_attempt_reason"] = "tool_invoked"
+                else:
+                    rag_trace["retrieval_attempt_reason"] = (
+                        "no_rag_retrieval_tool_invoked"
+                        if user_concept_id
+                        else "not_authenticated"
+                    )
+                rag_trace["tool_results_included_in_prompt"] = bool(tool_messages)
             except ToolCallParsingError as exc:
                 current_app.logger.warning(
                     "[mcp_orchestrator] Invalid tool request payload: %s", exc
@@ -1602,6 +1660,7 @@ def generate():
             "messages": current_turn_messages,
             "response": response_text,
             "user_prompt": user_prompt_debug,
+            "namespace_report": namespace_report,
             "internal_mcp": {
                 "gateway_present": gateway is not None,
                 "gateway_enabled": (
@@ -1671,7 +1730,13 @@ def generate():
             current_app.config["CONTEXT"], max_messages=20
         )
 
-        return jsonify({"response": response_text, "llm_debug": llm_debug_info})
+        return jsonify(
+            {
+                "response": response_text,
+                "llm_debug": llm_debug_info,
+                "rag_trace": rag_trace,
+            }
+        )
     except Exception as e:
         print(f"Error during generation: {e}")  # Log error server-side
         # Return error with debug info showing the current turn only (not full context)
@@ -1700,7 +1765,12 @@ def generate():
             "tool_invocations": [],
         }
         error_debug_info["warnings"] = _derive_llm_debug_warnings(error_debug_info)
-        return jsonify({"error": str(e), "llm_debug": error_debug_info}), 500
+        body = {"error": str(e), "llm_debug": error_debug_info}
+        if "rag_trace" in locals():
+            body["rag_trace"] = rag_trace
+        if "namespace_report" in locals():
+            body["namespace_report"] = namespace_report
+        return jsonify(body), 500
 
 
 @von_bp.route("/history", methods=["GET"])

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -967,6 +967,149 @@ def create_flask_app(
         except Exception as e:
             return jsonify(error="unexpected", detail=str(e)), 500
 
+    @app.route("/admin/rag_runtime")
+    def rag_runtime():
+        """Return lightweight RAG runtime info for UI diagnostics.
+
+        Intended for local dev UX (e.g., showing which embedder is active).
+        Must never expose secrets (API keys, tokens).
+
+        Query params:
+          - namespace (optional)
+        """
+
+        import os
+
+        def _describe_component(obj):
+            if obj is None:
+                return None
+            try:
+                cls = obj.__class__
+                info = {
+                    "class_name": getattr(cls, "__name__", None),
+                    "module": getattr(cls, "__module__", None),
+                }
+                for attr in ("model_name", "model", "name"):
+                    try:
+                        v = getattr(obj, attr, None)
+                        if isinstance(v, str) and v.strip():
+                            info[attr] = v.strip()
+                    except Exception:
+                        pass
+                return info
+            except Exception:
+                return None
+
+        try:
+            from src.backend.services.rag_service import (
+                RAGBackendUnavailable,
+                peek_rag_service,
+            )
+
+            ns = request.args.get("namespace")
+
+            # Do not initialise a RAG backend just to render diagnostics.
+            # Initialising LlamaIndex (or its embedder) can be slow and can block
+            # the UI if the dev server is single-threaded.
+            service = peek_rag_service()
+
+            if service is None:
+                effective_namespace = ns or os.getenv("VON_DEFAULT_NAMESPACE")
+                return jsonify(
+                    {
+                        "success": True,
+                        "service_initialised": False,
+                        "requested_namespace": ns,
+                        "effective_namespace": effective_namespace,
+                        "backend": {
+                            "requested": "llamaindex",
+                            "class_name": None,
+                            "module": None,
+                        },
+                        "persistence_dir": None,
+                        "index_persist_dir": None,
+                        "index_cached": False,
+                        "embedder": None,
+                        "llm": None,
+                        "openai_key_present": bool(os.getenv("OPENAI_API_KEY")),
+                        "last_query": None,
+                        "note": "RAG service not initialised yet; open this panel again after the first RAG query/index operation.",
+                    }
+                )
+
+            effective_namespace = None
+            try:
+                resolver = getattr(service, "_resolve_effective_namespace", None)
+                if callable(resolver):
+                    effective_namespace = resolver(ns)
+                else:
+                    effective_namespace = ns or os.getenv("VON_DEFAULT_NAMESPACE")
+            except Exception:
+                effective_namespace = ns or os.getenv("VON_DEFAULT_NAMESPACE")
+
+            index_persist_dir = None
+            try:
+                ns_dir = getattr(service, "_namespace_persist_dir", None)
+                if callable(ns_dir) and isinstance(effective_namespace, str):
+                    index_persist_dir = ns_dir(effective_namespace)
+            except Exception:
+                index_persist_dir = None
+
+            index_cached = False
+            try:
+                indices = getattr(service, "_indices", None)
+                if isinstance(indices, dict) and isinstance(effective_namespace, str):
+                    index_cached = effective_namespace in indices
+            except Exception:
+                index_cached = False
+
+            embedder = None
+            llm = None
+            try:
+                sc = getattr(service, "service_context", None)
+                if sc is not None:
+                    embedder = _describe_component(getattr(sc, "embed_model", None))
+                    llm = _describe_component(getattr(sc, "llm", None))
+            except Exception:
+                pass
+
+            last_query = None
+            try:
+                last_query = getattr(service, "_last_query_info", None)
+            except Exception:
+                last_query = None
+
+            payload = {
+                "success": True,
+                "service_initialised": True,
+                "requested_namespace": ns,
+                "effective_namespace": effective_namespace,
+                "backend": {
+                    "class_name": service.__class__.__name__,
+                    "module": service.__class__.__module__,
+                },
+                "persistence_dir": getattr(service, "persistence_dir", None),
+                "index_persist_dir": index_persist_dir,
+                "index_cached": index_cached,
+                "embedder": embedder,
+                "llm": llm,
+                "openai_key_present": bool(os.getenv("OPENAI_API_KEY")),
+                "last_query": last_query,
+            }
+            return jsonify(payload)
+
+        except RAGBackendUnavailable as e:
+            return (
+                jsonify(
+                    success=False,
+                    error="rag_backend_unavailable",
+                    message=str(e),
+                ),
+                503,
+            )
+        except Exception as e:
+            return jsonify(success=False, error="unexpected", detail=str(e)), 500
+
     @app.route("/admin/chat_history_backfill", methods=["POST"])
     def admin_chat_history_backfill():
         """Backfill legacy chat history to the current user@org namespace and RAG.

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -31,10 +31,18 @@ def get_session_context() -> Dict[str, Any]:
             or flask_session.get("org_id"),
             "role_in_org": flask_session.get("role_in_org"),
             "namespace": flask_session.get("namespace"),
+            # Compatibility alias: some call sites historically looked up org_id.
+            "org_id": flask_session.get("organisation_concept_id")
+            or flask_session.get("org_id"),
         }
     except (ImportError, RuntimeError):
         # Not in Flask context or session not available
-        return {"organisation_concept_id": None, "role_in_org": None}
+        return {
+            "organisation_concept_id": None,
+            "role_in_org": None,
+            "namespace": None,
+            "org_id": None,
+        }
 
 
 class ChatHistoryServiceError(Exception):
@@ -233,7 +241,9 @@ def add_message_to_history(
         # Prefer an explicit session namespace, else derive one from user/org when possible.
         ns = session_context.get("namespace")
         if not isinstance(ns, str) or not ns.strip():
-            org_id = session_context.get("org_id")
+            org_id = session_context.get(
+                "organisation_concept_id"
+            ) or session_context.get("org_id")
             if isinstance(org_id, str) and org_id.strip():
                 try:
                     from src.backend.services.namespace_service import derive_namespace
@@ -292,7 +302,11 @@ def add_message_to_history(
                     # Include organisation and role metadata if available
                     org_concept_id = session_context.get("organisation_concept_id")
                     if org_concept_id:
-                        metadata["organisation_concept_id"] = org_concept_id
+                        from ..utils.concept_id_utils import ensure_v_concept_prefix
+
+                        metadata["organisation_concept_id"] = (
+                            ensure_v_concept_prefix(org_concept_id) or org_concept_id
+                        )
                     if session_context.get("role_in_org"):
                         metadata["role_in_org"] = session_context["role_in_org"]
 

--- a/src/backend/services/rag_backends/llamaindex_backend.py
+++ b/src/backend/services/rag_backends/llamaindex_backend.py
@@ -16,9 +16,12 @@ Namespace behaviour:
 import hashlib
 import os
 import re
+import time
+from datetime import datetime, timezone
 from typing import Iterable, Dict, Any, Optional, List, Tuple
 
 from ..rag_service import RAGService
+from ...utils.concept_id_utils import normalise_concept_id_for_compare
 
 try:
     from llama_index import (
@@ -49,6 +52,9 @@ class LlamaIndexRAGService(RAGService):
         # For now, we rely on env vars (OPENAI_API_KEY) or defaults
         # Note: In 0.9.x ServiceContext.from_defaults() uses OpenAI by default if key is present
         self.service_context = ServiceContext.from_defaults()
+
+        # Best-effort diagnostics for UI/debugging.
+        self._last_query_info: Dict[str, Any] | None = None
 
     def _resolve_effective_namespace(self, namespace: Optional[str]) -> str:
         # Keep behaviour consistent with other parts of the system that may
@@ -240,7 +246,9 @@ class LlamaIndexRAGService(RAGService):
         # Note: Metadata filtering support varies by vector store implementation.
         # To ensure correctness, we do coarse retrieval first then apply filtering
         # locally.
-        retriever = index.as_retriever(similarity_top_k=max(top_k * 10, top_k))
+        similarity_top_k = max(top_k * 10, top_k)
+        start = time.perf_counter()
+        retriever = index.as_retriever(similarity_top_k=similarity_top_k)
         nodes = retriever.retrieve(query_text)
 
         def _matches_permissions(metadata: Any) -> bool:
@@ -250,12 +258,18 @@ class LlamaIndexRAGService(RAGService):
                 return False
 
             user_id = permissions_context.get("user_id")
-            if user_id and metadata.get("user_id") != user_id:
-                return False
+            if user_id:
+                if normalise_concept_id_for_compare(
+                    metadata.get("user_id")
+                ) != normalise_concept_id_for_compare(user_id):
+                    return False
 
             org_id = permissions_context.get("organisation_concept_id")
-            if org_id and metadata.get("organisation_concept_id") != org_id:
-                return False
+            if org_id:
+                if normalise_concept_id_for_compare(
+                    metadata.get("organisation_concept_id")
+                ) != normalise_concept_id_for_compare(org_id):
+                    return False
 
             return True
 
@@ -274,6 +288,22 @@ class LlamaIndexRAGService(RAGService):
 
             if len(results) >= top_k:
                 break
+
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        try:
+            self._last_query_info = {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "effective_namespace": effective_namespace,
+                "query_length": len(query_text or ""),
+                "top_k": int(top_k),
+                "similarity_top_k": int(similarity_top_k),
+                "retrieved": len(nodes) if isinstance(nodes, list) else None,
+                "returned": len(results),
+                "elapsed_ms": elapsed_ms,
+            }
+        except Exception:
+            # Never let diagnostics interfere with retrieval.
+            pass
 
         return results
 

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -21,6 +21,9 @@ from __future__ import annotations
 from typing import Protocol, Iterable, Dict, Any, Optional, List, Tuple
 
 
+_RAG_SERVICE_SINGLETONS: dict[str, "RAGService"] = {}
+
+
 class RAGService(Protocol):
     """Protocol for pluggable RAG backends."""
 
@@ -81,6 +84,23 @@ class RAGBackendUnavailable(RuntimeError):
     pass
 
 
+def peek_rag_service(backend: Optional[str] = None) -> Optional[RAGService]:
+    """Return a cached RAG service instance without initialising anything.
+
+    This is useful for lightweight diagnostics endpoints (e.g., UI runtime hints)
+    where we must not trigger slow imports/model initialisation.
+    """
+
+    name = (backend or "llamaindex").lower()
+    return _RAG_SERVICE_SINGLETONS.get(name)
+
+
+def list_initialised_rag_backends() -> List[str]:
+    """Return backend names that already have an initialised singleton."""
+
+    return sorted(_RAG_SERVICE_SINGLETONS.keys())
+
+
 def get_rag_service(backend: Optional[str] = None) -> RAGService:
     """
     Factory to obtain a RAGService implementation.
@@ -91,17 +111,29 @@ def get_rag_service(backend: Optional[str] = None) -> RAGService:
     - default      → prefer LlamaIndex, fallback to Haystack
     """
     name = (backend or "llamaindex").lower()
+
+    cached = _RAG_SERVICE_SINGLETONS.get(name)
+    if cached is not None:
+        return cached
+
     if name == "llamaindex":
         try:
             from .rag_backends.llamaindex_backend import LlamaIndexRAGService  # type: ignore
 
-            return LlamaIndexRAGService()
+            service = LlamaIndexRAGService()
+            _RAG_SERVICE_SINGLETONS[name] = service
+            return service
         except Exception as e:
             # Fallback to Haystack if LlamaIndex not available
             try:
                 from .rag_backends.haystack_backend import HaystackRAGService  # type: ignore
 
-                return HaystackRAGService()
+                service = HaystackRAGService()
+                # Cache under both keys so callers asking for llamaindex do not
+                # repeatedly retry a failing import.
+                _RAG_SERVICE_SINGLETONS["haystack"] = service
+                _RAG_SERVICE_SINGLETONS[name] = service
+                return service
             except Exception:
                 raise RAGBackendUnavailable(
                     f"No RAG backend available (llamaindex failure: {e})"
@@ -110,7 +142,9 @@ def get_rag_service(backend: Optional[str] = None) -> RAGService:
         try:
             from .rag_backends.haystack_backend import HaystackRAGService  # type: ignore
 
-            return HaystackRAGService()
+            service = HaystackRAGService()
+            _RAG_SERVICE_SINGLETONS[name] = service
+            return service
         except Exception as e:
             raise RAGBackendUnavailable(f"Haystack backend unavailable: {e}")
     else:

--- a/src/backend/utils/concept_id_utils.py
+++ b/src/backend/utils/concept_id_utils.py
@@ -1,0 +1,54 @@
+"""Small helpers for working with Von concept identifiers.
+
+Concept identifiers in Von generally use the form `#V#<slug>`. Some legacy
+records (especially older RAG/chat metadata) may have stored the slug without
+the `#V#` prefix.
+
+These helpers are intentionally tiny and dependency-free so they can be used in
+security-sensitive pathways (e.g. permission checks) and easily unit tested.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+def normalise_concept_id_for_compare(value: object) -> Optional[str]:
+    """Return a normalised concept id suitable for equality comparisons.
+
+    Behaviour:
+    - `#V#foo` -> `foo`
+    - `foo` -> `foo`
+    - None / non-str / blank -> None
+    """
+
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    if cleaned.startswith("#V#"):
+        return cleaned[3:]
+    return cleaned
+
+
+def ensure_v_concept_prefix(value: object) -> Optional[str]:
+    """Ensure a concept id is in `#V#...` form.
+
+    Behaviour:
+    - `#V#foo` -> `#V#foo`
+    - `foo` -> `#V#foo`
+    - `#foo` -> `#V#foo`
+    - None / non-str / blank -> None
+    """
+
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    if cleaned.startswith("#V#"):
+        return cleaned
+    if cleaned.startswith("#"):
+        cleaned = cleaned.lstrip("#")
+    return f"#V#{cleaned}"

--- a/src/frontend/web/von_interface/static/js/main.js
+++ b/src/frontend/web/von_interface/static/js/main.js
@@ -349,6 +349,7 @@ function startHealthPolling() {
   const ragDetailsBtn = document.getElementById('ragIndexingValue');
   const ragModal = document.getElementById('ragStatusModal');
   const ragModalBody = ragModal ? document.getElementById('ragStatusBody') : null;
+  const ragRuntimeHint = ragModal ? document.getElementById('ragRuntimeHint') : null;
   const ragModalClose = ragModal ? document.getElementById('ragStatusClose') : null;
   const ragModalCheck = ragModal ? document.getElementById('ragStatusCheck') : null;
   const ragChatBackfillBtn = ragModal ? document.getElementById('ragChatBackfill') : null;
@@ -573,6 +574,59 @@ function startHealthPolling() {
             ragModal.classList.add('open');
             ragModal.setAttribute('aria-hidden', 'false');
             ragModalBody.innerHTML = '<p>Loading…</p>';
+
+            if (ragRuntimeHint) {
+              ragRuntimeHint.textContent = 'Runtime: loading…';
+              // Do not block status rendering on this diagnostic call.
+              void (async () => {
+                try {
+                  const controllerRt = new AbortController();
+                  const timeoutRt = setTimeout(() => controllerRt.abort(), 8000);
+                  const nsRt = (localStorage.getItem('current_user_namespace') || localStorage.getItem('von_namespace')) || '';
+                  const urlRt = nsRt
+                    ? (`/admin/rag_runtime?namespace=${encodeURIComponent(nsRt)}`)
+                    : '/admin/rag_runtime';
+                  const resRt = await fetch(urlRt, { cache: 'no-store', signal: controllerRt.signal });
+                  clearTimeout(timeoutRt);
+
+                  if (resRt.ok) {
+                    const rt = await resRt.json();
+                    try { window.__vonLastRagRuntimeJson = rt; } catch (_) { /* ignore */ }
+
+                    const serviceInitialised = (rt && typeof rt.service_initialised === 'boolean') ? rt.service_initialised : null;
+                    const backend = rt?.backend?.class_name || (serviceInitialised === false ? 'not initialised' : '—');
+                    const embedder = rt?.embedder?.class_name || (serviceInitialised === false ? '—' : '—');
+                    const embedModel = rt?.embedder?.model_name || rt?.embedder?.model || null;
+                    const lastMs = (typeof rt?.last_query?.elapsed_ms === 'number') ? rt.last_query.elapsed_ms : null;
+                    const lastAt = (typeof rt?.last_query?.timestamp === 'string') ? rt.last_query.timestamp : null;
+                    const openaiKey = (typeof rt?.openai_key_present === 'boolean') ? rt.openai_key_present : null;
+
+                    const parts = [];
+                    parts.push(`Backend: ${backend}`);
+                    if (serviceInitialised !== false) {
+                      parts.push(`Embedder: ${embedder}${embedModel ? ` (${embedModel})` : ''}`);
+                    }
+                    if (lastMs !== null) {
+                      parts.push(`Last search: ${lastMs}ms${lastAt ? ` @ ${lastAt}` : ''}`);
+                    }
+                    if (openaiKey === true) {
+                      parts.push('OpenAI key: present');
+                    } else if (openaiKey === false) {
+                      parts.push('OpenAI key: not set');
+                    }
+
+                    ragRuntimeHint.textContent = parts.join(' • ');
+                  } else {
+                    ragRuntimeHint.textContent = 'Runtime: unavailable';
+                  }
+                } catch (e) {
+                  const name = e && e.name ? e.name : '';
+                  ragRuntimeHint.textContent = (name === 'AbortError')
+                    ? 'Runtime: timed out'
+                    : 'Runtime: unavailable';
+                }
+              })();
+            }
 
             // Prepare modal action buttons (idempotent)
             const modalActions = ragModal.querySelector('.modal-actions');

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -6178,6 +6178,16 @@ body.settings-body {
     animation: pulse-rag 2s infinite;
 }
 
+.rag-runtime-hint {
+    font-size: 0.85rem;
+    color: #4b5563;
+    background: #f8fafc;
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    padding: 6px 8px;
+    margin: 8px 0 10px;
+}
+
 /* Organisation Selector Component */
 .org-selector-wrapper {
     display: flex;

--- a/src/frontend/web/von_interface/templates/von_interface.html
+++ b/src/frontend/web/von_interface/templates/von_interface.html
@@ -125,6 +125,7 @@
   <div id="ragStatusModal" class="modal" aria-hidden="true" role="dialog" aria-labelledby="ragStatusTitle">
     <div class="modal-content">
       <h2 id="ragStatusTitle">RAG Indexing Status</h2>
+      <div id="ragRuntimeHint" class="rag-runtime-hint" aria-live="polite">—</div>
       <div id="ragStatusBody">
         <p>Loading…</p>
       </div>

--- a/tests/backend/test_concept_id_utils.py
+++ b/tests/backend/test_concept_id_utils.py
@@ -1,0 +1,29 @@
+from src.backend.utils.concept_id_utils import (
+    ensure_v_concept_prefix,
+    normalise_concept_id_for_compare,
+)
+
+
+def test_normalise_concept_id_for_compare_handles_prefix_and_slug() -> None:
+    assert normalise_concept_id_for_compare("#V#university") == "university"
+    assert normalise_concept_id_for_compare("university") == "university"
+
+
+def test_normalise_concept_id_for_compare_handles_blanks() -> None:
+    assert normalise_concept_id_for_compare(None) is None
+    assert normalise_concept_id_for_compare(123) is None
+    assert normalise_concept_id_for_compare("") is None
+    assert normalise_concept_id_for_compare("   ") is None
+
+
+def test_ensure_v_concept_prefix_adds_prefix() -> None:
+    assert ensure_v_concept_prefix("university") == "#V#university"
+    assert ensure_v_concept_prefix("#university") == "#V#university"
+    assert ensure_v_concept_prefix("#V#university") == "#V#university"
+
+
+def test_ensure_v_concept_prefix_handles_blanks() -> None:
+    assert ensure_v_concept_prefix(None) is None
+    assert ensure_v_concept_prefix(123) is None
+    assert ensure_v_concept_prefix("") is None
+    assert ensure_v_concept_prefix("   ") is None

--- a/tests/backend/test_orchestrator_extraction.py
+++ b/tests/backend/test_orchestrator_extraction.py
@@ -82,6 +82,16 @@ def test_interpret_model_turn_ignores_non_tool_json_without_error():
     assert interpretation.is_json_action is False
 
 
+def test_interpret_model_turn_flags_tool_result_shaped_json_as_json_action():
+    orchestrator = InternalMCPChatOrchestrator(gateway=_DummyGateway())  # type: ignore[arg-type]
+    interpretation = orchestrator._interpret_model_turn(
+        '{"tool": "test", "status": "ok", "payload": {"x": 1}}'
+    )
+    assert interpretation.tool_calls is None
+    assert interpretation.tool_call_parse_error is None
+    assert interpretation.is_json_action is True
+
+
 def test_interpret_model_turn_captures_tool_call_parse_error():
     orchestrator = InternalMCPChatOrchestrator(gateway=_DummyGateway())  # type: ignore[arg-type]
     interpretation = orchestrator._interpret_model_turn(
@@ -115,7 +125,7 @@ def test_assess_missing_tool_call_uses_fenced_json_reason_without_classifier_cal
     aux_log: list[Mapping[str, Any]] = []
 
     interpretation = orchestrator._interpret_model_turn(
-        "```json\n{\"action\":\"call_tool\",\"tool\":\"test\",\"payload\":{}}\n```"
+        '```json\n{"action":"call_tool","tool":"test","payload":{}}\n```'
     )
 
     assessment = orchestrator._assess_missing_tool_call(
@@ -129,6 +139,30 @@ def test_assess_missing_tool_call_uses_fenced_json_reason_without_classifier_cal
     )
 
     assert assessment.retry_reason == "fenced tool-call JSON detected"
+    assert not llm.calls
+
+
+def test_assess_missing_tool_call_retries_on_json_action_without_classifier_call():
+    orchestrator = InternalMCPChatOrchestrator(gateway=_DummyGateway())  # type: ignore[arg-type]
+    llm = _RecorderLLM(["YES"])  # Would be consumed if classifier were called.
+    aux_log: list[Mapping[str, Any]] = []
+
+    interpretation = orchestrator._interpret_model_turn(
+        '{"tool": "test", "status": "ok", "payload": {"x": 1}}'
+    )
+    assert interpretation.is_json_action
+
+    assessment = orchestrator._assess_missing_tool_call(
+        response_text=interpretation.response_text,
+        use_structured=False,
+        interpretation=interpretation,
+        llm_client=llm,
+        model="primary-model",
+        aux_log=aux_log,
+        tool_call_parse_error=None,
+    )
+
+    assert assessment.retry_reason == "JSON tool-call output detected"
     assert not llm.calls
 
 
@@ -326,7 +360,7 @@ def test_llm_detector_returns_true_on_yes():
 
     llm = _RecorderLLM(["YES"])
     aux_log: list[Mapping[str, Any]] = []
-    decision = orchestrator._llm_detects_missing_tool_call(
+    invoked, decision = orchestrator._llm_detects_missing_tool_call(
         "I'm going to search the web",
         llm,
         fallback_model="fallback-model",
@@ -334,6 +368,7 @@ def test_llm_detector_returns_true_on_yes():
         path="legacy",
     )
 
+    assert invoked is True
     assert decision is True
     assert llm.calls[0]["model"] == "detector-model"
     assert llm.calls[0]["context"] is None
@@ -354,7 +389,7 @@ def test_llm_detector_strips_vontology_model_prefix_before_calling_llm():
 
     llm = _RecorderLLM(["NO"])
     aux_log: list[Mapping[str, Any]] = []
-    decision = orchestrator._llm_detects_missing_tool_call(
+    invoked, decision = orchestrator._llm_detects_missing_tool_call(
         "I will fetch that now",
         llm,
         fallback_model="fallback-model",
@@ -362,6 +397,7 @@ def test_llm_detector_strips_vontology_model_prefix_before_calling_llm():
         path="legacy",
     )
 
+    assert invoked is True
     assert decision is False
     assert llm.calls[0]["model"] == "gpt-4o-mini"
     assert aux_log and aux_log[0]["model_raw"] == "#V#gpt-4o-mini"
@@ -381,7 +417,7 @@ def test_llm_detector_appends_response_when_placeholder_missing():
 
     llm = _RecorderLLM(["YES"])
     aux_log: list[Mapping[str, Any]] = []
-    decision = orchestrator._llm_detects_missing_tool_call(
+    invoked, decision = orchestrator._llm_detects_missing_tool_call(
         "I'll fetch JVNAUTOSCI-803 now",
         llm,
         fallback_model="fallback-model",
@@ -389,6 +425,7 @@ def test_llm_detector_appends_response_when_placeholder_missing():
         path="legacy",
     )
 
+    assert invoked is True
     assert decision is True
     assert "fetch JVNAUTOSCI-803" in llm.calls[0]["prompt"]
     assert aux_log and aux_log[0]["prompt_placeholder_response"] is False
@@ -408,7 +445,7 @@ def test_llm_detector_uses_fallback_model_when_missing():
 
     llm = _RecorderLLM(["NO"])
     aux_log: list[Mapping[str, Any]] = []
-    decision = orchestrator._llm_detects_missing_tool_call(
+    invoked, decision = orchestrator._llm_detects_missing_tool_call(
         "Normal explanatory text",
         llm,
         fallback_model="fallback-model",
@@ -416,6 +453,7 @@ def test_llm_detector_uses_fallback_model_when_missing():
         path="legacy",
     )
 
+    assert invoked is True
     assert decision is False
     assert llm.calls[0]["model"] == "fallback-model"
     assert aux_log and aux_log[0]["model"] == "fallback-model"
@@ -518,6 +556,47 @@ def test_run_retries_when_classifier_misses_but_heuristic_triggers():
     assert result.aux_llm_calls
 
 
+def test_run_retries_when_response_uses_smart_quotes_promising_tool_use():
+    """Regression test: smart quotes should not bypass missing-tool-call detection.
+
+    Some models emit curly apostrophes (e.g., "I’m") which previously bypassed
+    the promise-pattern heuristic and prevented a retry.
+
+    When the fallback detector is active, the orchestrator should still recover
+    deterministically (without consuming an extra LLM turn for classification).
+    """
+
+    gateway = _DummyGateway()
+    llm = _RecorderLLM(
+        [
+            # Initial response: promises a tool-backed action, but emits no tool JSON.
+            "I’m going to search the knowledge base now.",
+            '{"action": "call_tool", "tool": "test", "payload": {}}',
+            "Final response",
+        ]
+    )
+
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=gateway,  # type: ignore[arg-type]
+        max_tool_invocations=1,
+    )
+
+    result = orchestrator.run(
+        prompt="hello",
+        context=None,
+        llm_client=llm,
+        model="primary-model",
+        user_namespace="#V#user",
+    )
+
+    assert gateway.calls
+    assert result.tool_invocations
+    assert result.response_text == "Final response"
+    aux_types = [entry.get("type") for entry in result.aux_llm_calls]
+    assert "missing_tool_call_detection" in aux_types
+    assert "missing_tool_call_retry" in aux_types
+
+
 def test_run_recovers_from_invalid_tool_call_json_with_retry():
     """Regression test: invalid JSON tool-call output should trigger a retry.
 
@@ -596,7 +675,10 @@ def test_run_recovers_from_late_turn_invalid_tool_call_json_with_retry():
 
     assert len(gateway.calls) == 2
     assert result.response_text == "Final response"
-    assert all(inv.get("tool") != "__tool_call_parse_error__" for inv in result.tool_invocations)
+    assert all(
+        inv.get("tool") != "__tool_call_parse_error__"
+        for inv in result.tool_invocations
+    )
 
     aux_types = [entry.get("type") for entry in result.aux_llm_calls]
     assert "missing_tool_call_detection" in aux_types
@@ -637,6 +719,12 @@ def test_run_surfaces_late_turn_parse_error_when_retry_also_invalid():
     )
 
     assert len(gateway.calls) == 1
-    assert "Tool call was not executed due to an MCP serialisation error" in result.response_text
-    assert any(inv.get("tool") == "__tool_call_parse_error__" for inv in result.tool_invocations)
+    assert (
+        "Tool call was not executed due to an MCP serialisation error"
+        in result.response_text
+    )
+    assert any(
+        inv.get("tool") == "__tool_call_parse_error__"
+        for inv in result.tool_invocations
+    )
     assert any(inv.get("tool") == "test" for inv in result.tool_invocations)

--- a/tests/backend/test_rag_provenance_contract.py
+++ b/tests/backend/test_rag_provenance_contract.py
@@ -1,0 +1,245 @@
+import pytest
+
+
+class _Cursor:
+    def __init__(self, docs):
+        self._docs = list(docs)
+
+    def skip(self, n):
+        self._docs = self._docs[int(n) :]
+        return self
+
+    def limit(self, n):
+        self._docs = self._docs[: int(n)]
+        return self
+
+    def __iter__(self):
+        return iter(self._docs)
+
+
+class _Collection:
+    def __init__(self, docs):
+        self._docs = list(docs)
+        self.last_find_query = None
+
+    def find(self, query, _projection=None):
+        self.last_find_query = dict(query)
+        docs = []
+        for doc in self._docs:
+            if query.get("indexing_status") and doc.get("indexing_status") != query.get(
+                "indexing_status"
+            ):
+                continue
+            if query.get("namespace") and doc.get("namespace") != query.get(
+                "namespace"
+            ):
+                continue
+            docs.append(doc)
+        return _Cursor(docs)
+
+    def find_one(self, query, _projection=None):
+        for doc in self.find(query, _projection=_projection):
+            return doc
+        return None
+
+    def count_documents(self, query):
+        return len(list(self.find(query)))
+
+
+class _DB:
+    def __init__(self, collections):
+        self._collections = dict(collections)
+
+    def __getitem__(self, key):
+        return self._collections[key]
+
+
+class _StubRAG:
+    def __init__(self, results):
+        self._results = results
+        self.last_permissions_context = None
+
+    def query(self, *, query_text, top_k, namespace, permissions_context=None):
+        self.last_permissions_context = permissions_context
+        return list(self._results)
+
+
+def test_rag_list_indexed_includes_provenance(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    docs = [
+        {
+            "_id": "s1",
+            "indexing_status": "indexed",
+            "indexed_at": "2025-01-01T00:00:00Z",
+            "namespace": "#V#user@org",
+            "summary": "hello",
+            "history": [{"content": "world"}],
+        }
+    ]
+
+    coll = _Collection(docs)
+    monkeypatch.setattr(
+        "src.backend.db.connection_manager.get_db",
+        lambda: _DB({"interaction_sessions": coll}),
+    )
+
+    result = cat._rag_list_indexed(namespace="#V#user@org", limit=10, offset=0)
+    assert result["success"] is True
+
+    # Echo effective scoping and defaults
+    assert result["requested_collection"] is None
+    assert result["effective_collection"] == "ka_sessions"
+    assert result["collection_source"] == "default"
+    assert result["effective_namespace"] == "#V#user@org"
+    assert result["effective_namespace_source"] == "request.namespace"
+
+    assert result["namespace"] == "#V#user@org"
+    assert result["namespace_source"] == "request.namespace"
+
+    assert "provenance" in result
+    assert result["provenance"]["item_kind"] == "rag_indexed_session_list"
+    assert result["provenance"]["source_system"] == "mongo.interaction_sessions"
+
+    assert result["items"], "expected at least one item"
+    item = result["items"][0]
+    assert item["item_kind"] == "ka_interaction_session"
+    assert item["source_system"] == "mongo.interaction_sessions"
+    assert item["namespace_source"] == "request.namespace"
+
+
+def test_search_knowledge_base_stamps_result_metadata(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    stub = _StubRAG(
+        results=[
+            {"id": "doc1", "score": 0.9, "text": "hi", "metadata": {"x": 1}},
+            {"id": "doc2", "score": 0.1, "text": "lo", "metadata": None},
+        ]
+    )
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue.get_rag_service",
+        lambda *_args, **_kwargs: stub,
+        raising=False,
+    )
+
+    # Patch the imported symbol in rag_service module (which catalogue imports from)
+    monkeypatch.setattr(
+        "src.backend.services.rag_service.get_rag_service",
+        lambda *_args, **_kwargs: stub,
+    )
+
+    result = cat._search_knowledge_base(query="test", namespace="#V#user@org")
+    assert result["success"] is True
+    assert result["namespace"] == "#V#user@org"
+    assert result["namespace_source"] == "request.namespace"
+
+    assert isinstance(result.get("elapsed_ms"), int)
+    assert result["elapsed_ms"] >= 0
+    assert result["effective_namespace"] == "#V#user@org"
+    assert result["effective_namespace_source"] == "request.namespace"
+
+    assert result["results"], "expected results"
+    for row in result["results"]:
+        assert "metadata" in row
+        assert row["metadata"]["item_kind"] == "rag_chunk"
+        assert row["metadata"]["source_system"] == "rag.llamaindex"
+        assert row["metadata"]["namespace"] == "#V#user@org"
+        assert row["metadata"]["namespace_source"] == "request.namespace"
+
+
+def test_search_knowledge_base_derives_permissions_context_from_namespace(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    stub = _StubRAG(results=[])
+
+    monkeypatch.setattr(
+        "src.backend.services.rag_service.get_rag_service",
+        lambda *_args, **_kwargs: stub,
+    )
+
+    cat._search_knowledge_base(
+        query="workflow",
+        namespace="#V#michael_witbrock@university_of_auckland_strong_ai_lab",
+    )
+
+    assert stub.last_permissions_context == {
+        "user_id": "#V#michael_witbrock",
+        "organisation_concept_id": "#V#university_of_auckland_strong_ai_lab",
+    }
+
+
+def test_rag_list_collections_requires_namespace():
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    result = cat._rag_list_collections()
+    assert result["success"] is False
+    assert result["error"] == "namespace_required"
+
+
+def test_rag_list_collections_includes_expected_collections():
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    result = cat._rag_list_collections(namespace="#V#user@org")
+    assert result["success"] is True
+    assert result["namespace"] == "#V#user@org"
+    assert result["namespace_source"] == "request.namespace"
+
+    assert result["provenance"]["item_kind"] == "rag_collection_list"
+    assert result["collections"]
+    collections = {c["collection"] for c in result["collections"]}
+    assert "ka_sessions" in collections
+    assert "chat_history_sessions" in collections
+    assert "rag_documents" in collections
+
+    # Capability flags prevent the model inferring behaviour from missing tools.
+    by_name = {c["collection"]: c for c in result["collections"]}
+    assert by_name["ka_sessions"]["list_supported"] is True
+    assert by_name["ka_sessions"]["get_supported"] is True
+    assert by_name["rag_documents"]["list_supported"] is False
+    assert by_name["rag_documents"]["get_supported"] is False
+
+
+def test_rag_list_indexed_supports_chat_history_sessions(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    chat_docs = [
+        {
+            "session_id": "chat-1",
+            "namespace": "#V#user@org",
+            "created_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-02T00:00:00Z",
+            "history": [{"content": "hello"}, {"content": "world"}],
+            "rag_indexed_success": 2,
+            "rag_indexed_failed": 0,
+        }
+    ]
+
+    chat_coll = _Collection(chat_docs)
+    monkeypatch.setattr(
+        "src.backend.db.connection_manager.get_db",
+        lambda: _DB({"chat_history": chat_coll}),
+    )
+
+    result = cat._rag_list_indexed(
+        namespace="#V#user@org",
+        collection="chat_history_sessions",
+        limit=10,
+        offset=0,
+    )
+    assert result["success"] is True
+    assert result["collection"] == "chat_history_sessions"
+
+    assert result["requested_collection"] == "chat_history_sessions"
+    assert result["effective_collection"] == "chat_history_sessions"
+    assert result["collection_source"] == "request.collection"
+    assert result["effective_namespace"] == "#V#user@org"
+
+    assert result["provenance"]["item_kind"] == "rag_chat_session_list"
+    assert result["provenance"]["source_system"] == "mongo.chat_history"
+
+    assert result["items"]
+    item = result["items"][0]
+    assert item["item_kind"] == "chat_history_session"
+    assert item["source_system"] == "mongo.chat_history"

--- a/tests/backend/test_von_generate_rag_trace.py
+++ b/tests/backend/test_von_generate_rag_trace.py
@@ -1,0 +1,134 @@
+import json
+
+import pytest
+from flask import Flask
+
+
+class _DummyLLM:
+    def generate(self, *_args, **_kwargs):
+        raise AssertionError("LLM generate() should not be called in these tests")
+
+
+class _StubOrchestratorResult:
+    def __init__(
+        self, response_text, extra_messages, tool_invocations, aux_llm_calls=()
+    ):
+        self.response_text = response_text
+        self.extra_messages = tuple(extra_messages)
+        self.tool_invocations = tuple(tool_invocations)
+        self.aux_llm_calls = tuple(aux_llm_calls)
+
+
+class _StubOrchestrator:
+    def _extract_json_blob(self, text: str):
+        try:
+            return json.loads(text)
+        except Exception:
+            return None
+
+    def run(self, **_kwargs):
+        return _StubOrchestratorResult(
+            response_text="ok",
+            extra_messages=[
+                {
+                    "role": "tool",
+                    "content": json.dumps({"tool": "search_knowledge_base"}),
+                }
+            ],
+            tool_invocations=[
+                {"tool": "search_knowledge_base", "payload": {"query": "x"}}
+            ],
+        )
+
+
+class _StubOrchestratorNoTools:
+    def _extract_json_blob(self, text: str):
+        try:
+            return json.loads(text)
+        except Exception:
+            return None
+
+    def run(self, **_kwargs):
+        return _StubOrchestratorResult(
+            response_text="ok",
+            extra_messages=[],
+            tool_invocations=[],
+        )
+
+
+class _StubGateway:
+    enabled = True
+
+    def describe_methods(self):
+        return {"search_knowledge_base": {"category": "read"}}
+
+
+@pytest.fixture()
+def app(monkeypatch):
+    from src.backend.server.routes.von_routes import von_bp
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_llm_client",
+        lambda **_kwargs: _DummyLLM(),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_active_model_name",
+        lambda: "test-model",
+    )
+
+    flask_app = Flask(__name__)
+    flask_app.secret_key = "test-secret"
+    flask_app.register_blueprint(von_bp, url_prefix="/von")
+
+    flask_app.config["CONTEXT"] = []
+    flask_app.config["INTERNAL_MCP_ORCHESTRATOR"] = _StubOrchestrator()
+    flask_app.config["INTERNAL_MCP_GATEWAY"] = _StubGateway()
+
+    return flask_app
+
+
+def test_generate_includes_rag_trace_when_authenticated(app):
+    client = app.test_client()
+
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#user"
+        sess["namespace"] = "#V#user@org"
+        sess["session_id"] = "test-session"
+
+    resp = client.post("/von/generate", json={"prompt": "What is in my RAG store?"})
+    assert resp.status_code == 200
+
+    body = resp.get_json()
+    assert body["response"] == "ok"
+
+    assert "rag_trace" in body
+    rag_trace = body["rag_trace"]
+    assert rag_trace["authenticated"] is True
+    assert rag_trace["namespace"] == "#V#user@org"
+    assert rag_trace["namespace_source"] == "session.namespace"
+    assert rag_trace["retrieval_attempted"] is True
+    assert "search_knowledge_base" in rag_trace["tools_invoked"]
+    assert rag_trace["tool_results_included_in_prompt"] is True
+
+    assert "llm_debug" in body
+    assert body["llm_debug"]["namespace_report"]["namespace"] == "#V#user@org"
+
+
+def test_generate_rag_trace_marks_unauthenticated(app):
+    client = app.test_client()
+
+    app.config["INTERNAL_MCP_ORCHESTRATOR"] = _StubOrchestratorNoTools()
+
+    with client.session_transaction() as sess:
+        sess["session_id"] = "test-session"
+
+    resp = client.post("/von/generate", json={"prompt": "What is in my RAG store?"})
+    assert resp.status_code == 200
+
+    body = resp.get_json()
+    assert "rag_trace" in body
+    rag_trace = body["rag_trace"]
+    assert rag_trace["authenticated"] is False
+    assert rag_trace["namespace"] is None
+    assert rag_trace["retrieval_attempted"] is False
+    assert rag_trace["retrieval_attempt_reason"] == "not_authenticated"


### PR DESCRIPTION
Summary:
- Normalise concept-id comparisons in RAG permission filtering (supports legacy org-id metadata).
- Ensure chat-history indexing writes #V#-prefixed organisation IDs.
- Add provenance stamping + namespace-resolution reporting to RAG tool outputs.
- Add focused vonrag MCP stdio server with collection-aware session listing.
- Add RAG runtime/status tracing hooks + regression tests.

Tests:
- pytest (focused backend suite): 51 passed.