### PR TITLE
JVNAUTOSCI-788: Virtual predicates, backups, and text relations UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This document provides an overview of key files within the `docs` directory that
 > 3. Never auto-start the server; wait for explicit user instruction.
 > 4. Prefer clarity over clever chaining: separate lines instead of `&&` unless failure short‑circuit is required.
 > 5. Large multi-line Python → use a here-string variable then `python -c $code` (PowerShell) or propose a committed script.
+> 5.1. When providing paste-ready text (e.g., `.env` snippets, JSON tool calls, commands), wrap it in fenced code blocks so Markdown does not reformat or linkify it.
 > 6. If the user pastes Bash that fails, convert it to valid PowerShell rather than trying to “fix” heredocs.
 > 7. Keep changes minimal, well‑scoped, and update related tests/documentation.
 > 8. When uncertain, ask succinctly—do not guess or fabricate behaviour.
@@ -85,6 +86,7 @@ Failure Handling Patterns:
   - If it still fails, re-check the session by calling the accessible-resources tool once; if that also fails, then ask the user to use the provider’s **Restart Server** action (extension-managed MCP providers have a restart command in the MCP Servers UI).
   - If **Restart Server** does not resolve it, ask the user to restart VS Code’s extension host (or run **Developer: Reload Window**) and then retry.
   - Do not loop indefinitely: cap total retries per operation (e.g., 2) and surface the last error with a clear recommended next action.
+  - Do **NOT** “hack around” Atlassian MCP failures by creating ad-hoc scripts (e.g. temporary Python) or by calling Jira REST directly. Fix the MCP session instead (bounded retry → accessible-resources check → MCP server restart → Reload Window). If the cloudId is the blocker, use the documented tenant-info browser fallback.
 - Cache/Data Structure Sensitivity: Never reorder or shrink tuple/dict cache structures relied upon by diagnostics (append only; update summariser accordingly).
 
 Language & Shell Consistency:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -627,7 +627,9 @@ To ensure a standardized, stable, and secure way for AI agents to interact with 
 
 ### Available MCP Server Endpoints
 
-The server is located at `src/backend/mcp_server/mcp_server.py` and, when running, is typically available at `http://127.0.0.1:5002`.
+The Vontology MCP server is provided as a **stdio** MCP server (no HTTP port) via `src/backend/mcp_server/mcp_stdio_server.py`.
+
+Von's main web server runs separately (default `http://127.0.0.1:5000` when launched via `run.ps1`) and exposes admin endpoints such as `/admin/rag_status` on that same port.
 
 | Endpoint                  | Method | Description                                                                                             |
 | ------------------------- | ------ | ------------------------------------------------------------------------------------------------------- |

--- a/docs/engineering/mcp_tools_best_practices.md
+++ b/docs/engineering/mcp_tools_best_practices.md
@@ -333,10 +333,11 @@ db['vontology_nodes'].update_one(
 ### ❌ DON'T: Use HTTP endpoints when MCP tools are available
 
 ```bash
-# ❌ WRONG - MCP tools provide same functionality
-curl -X POST http://localhost:5002/upsert_text_relation \
+# ❌ WRONG - Prefer MCP (stdio) for agent workflows in VS Code.
+# HTTP routes are for Von's web server/admin endpoints, not MCP tool calls.
+curl -X POST http://localhost:5000/vontology/api/vontology/create_concept \
   -H "Content-Type: application/json" \
-  -d '{"concept_id": "#V#x", "predicate": "hasContent", "text": "..."}'
+  -d '{"parent_id": "#V#thing", "new_concept_name": "example"}'
 ```
 
 ### ❌ DON'T: Import internal service modules in agent workflows
@@ -490,8 +491,8 @@ mcp_add_relationship(
 
 **Fix**:
 1. Check [vontology_mcp.json](../../src/backend/mcp_server/vontology_mcp.json) for tool list
-2. Verify server running: `curl http://localhost:5002/health`
-3. Use correct interface: stdio for VS Code, HTTP for external clients
+2. Verify Von web server running: `curl http://localhost:5000/health`
+3. Use correct interface: stdio for VS Code (see `.vscode/mcp.json`), HTTP only for Von web routes/admin endpoints
 
 ### Issue: Parameter validation failed
 

--- a/docs/engineering/vonrag_mcp_integration.md
+++ b/docs/engineering/vonrag_mcp_integration.md
@@ -23,7 +23,9 @@ After editing `.vscode/mcp.json`, reload VS Code (or restart the MCP servers) so
 
 ## Namespace requirement
 
-All tools require an explicit `namespace` and fail closed when it is missing. This reduces accidental cross-namespace access during local development.
+Tools accept an optional `namespace`. If omitted, the server will fall back to `VON_DEFAULT_NAMESPACE` from the repo-root `.env`.
+
+It still fails closed if neither `namespace` nor `VON_DEFAULT_NAMESPACE` is set. This reduces accidental cross-namespace access during local development.
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "id": "von-private-vontology-provider",
         "path": "./src/backend/mcp_server/vontology_mcp.json",
         "requestHandler": {
-          "url": "http://127.0.0.1:5002",
+          "url": "http://127.0.0.1:5000",
           "command": "von-mcp-server.start"
         }
       }

--- a/run.ps1
+++ b/run.ps1
@@ -38,6 +38,10 @@ param(
     [switch]$DisableLogReady,
     [switch]$HealthDebug,
     [switch]$ShowRelationCoverage,
+    # On-demand backups
+    [switch]$BackupDryRun,
+    [string]$BackupTag = 'manual',
+    [string]$BackupOutDir,
     # Auto-update (continuous self-updating runner)
     [int]$UpdateIntervalMinutes = 60,
     [string]$UpdateBranch = 'main',
@@ -58,10 +62,42 @@ $LogsDir = Join-Path $Root 'logs'
 New-Item -ItemType Directory -Force -Path $RunDir | Out-Null
 New-Item -ItemType Directory -Force -Path $LogsDir | Out-Null
 
-# Preferred backup root: use W:\ drive if present (e.g. larger / external volume) else fall back to repo local 'backups'.
-$BackupRoot = if (Test-Path 'W:\') { 'W:\von_backups' } else { Join-Path $Root 'backups' }
-try { New-Item -ItemType Directory -Force -Path $BackupRoot | Out-Null } catch { }
-$env:VON_BACKUP_ROOT = $BackupRoot
+# Backup root resolution:
+# - Prefer explicit VON_BACKUP_ROOT if already present in environment.
+# - Else prefer W:\von_backups if W: exists and is writable.
+# - Else fall back to repo-local 'backups'.
+$BackupRoot = $null
+
+if ($env:VON_BACKUP_ROOT -and $env:VON_BACKUP_ROOT.ToString().Trim()) {
+    $preferred = $env:VON_BACKUP_ROOT.ToString().Trim().Trim('"')
+    try {
+        New-Item -ItemType Directory -Force -Path $preferred | Out-Null
+        $BackupRoot = $preferred
+    }
+    catch {
+        Write-LauncherLog "[backup] WARN: Cannot create/write VON_BACKUP_ROOT='$preferred'; falling back to automatic selection."
+    }
+}
+
+if (-not $BackupRoot -and (Test-Path 'W:\')) {
+    $preferred = 'W:\von_backups'
+    try {
+        New-Item -ItemType Directory -Force -Path $preferred | Out-Null
+        $BackupRoot = $preferred
+    }
+    catch {
+        Write-LauncherLog "[backup] WARN: Cannot create/write $preferred; falling back to repo local backups."
+    }
+}
+
+if (-not $BackupRoot) {
+    $BackupRoot = Join-Path $Root 'backups'
+    try { New-Item -ItemType Directory -Force -Path $BackupRoot | Out-Null } catch { }
+}
+
+if (-not $BackupOutDir) {
+    $BackupOutDir = $BackupRoot
+}
 
 # Ensure logging helper is available before any functions that emit log lines.
 if (-not (Get-Command Write-LauncherLog -ErrorAction SilentlyContinue)) {
@@ -223,17 +259,268 @@ function Write-PidFile {
 function Remove-PidFile { if (Test-Path $PidFile) { Remove-Item $PidFile -Force -ErrorAction SilentlyContinue } }
 
 # Daily remote backup logic (auto every 24h) ---------------------------------
+
+function Find-NextAllowedValue {
+    param(
+        [Parameter(Mandatory = $true)] [int[]]$AllowedValues,
+        [Parameter(Mandatory = $true)] [int]$Start
+    )
+    foreach ($v in $AllowedValues) {
+        if ($v -ge $Start) { return $v }
+    }
+    return $null
+}
+
+function Convert-CronTokenToInt {
+    param(
+        [Parameter(Mandatory = $true)] [string]$Token,
+        [Parameter(Mandatory = $true)] [int]$Min,
+        [Parameter(Mandatory = $true)] [int]$Max,
+        [Parameter(Mandatory = $false)] [hashtable]$NameMap,
+        [Parameter(Mandatory = $false)] [switch]$IsDayOfWeek
+    )
+    $t = $Token.Trim()
+    if ($t -match '^\d+$') {
+        $v = [int]$t
+        if ($IsDayOfWeek -and $v -eq 7) { $v = 0 }
+        if ($v -lt $Min -or $v -gt $Max) { throw "Cron value '$t' out of bounds [$Min,$Max]." }
+        return $v
+    }
+    if ($NameMap) {
+        $k = $t.ToUpperInvariant()
+        if ($NameMap.ContainsKey($k)) {
+            $v = [int]$NameMap[$k]
+            if ($IsDayOfWeek -and $v -eq 7) { $v = 0 }
+            if ($v -lt $Min -or $v -gt $Max) { throw "Cron value '$t' out of bounds [$Min,$Max]." }
+            return $v
+        }
+    }
+    throw "Unsupported cron token '$t'."
+}
+
+function Parse-CronField {
+    param(
+        [Parameter(Mandatory = $true)] [string]$Field,
+        [Parameter(Mandatory = $true)] [int]$Min,
+        [Parameter(Mandatory = $true)] [int]$Max,
+        [Parameter(Mandatory = $false)] [switch]$IsDayOfWeek,
+        [Parameter(Mandatory = $false)] [hashtable]$NameMap
+    )
+    $fieldTrim = $Field.Trim()
+    if (-not $fieldTrim) { throw "Invalid cron field (empty)." }
+
+    $allowed = New-Object 'System.Boolean[]' ($Max + 1)
+    $isStar = $false
+
+    if ($fieldTrim -eq '*') {
+        $isStar = $true
+        for ($i = $Min; $i -le $Max; $i++) { $allowed[$i] = $true }
+    }
+    else {
+        $parts = $fieldTrim -split ','
+        foreach ($rawPart in $parts) {
+            $part = $rawPart.Trim()
+            if (-not $part) { continue }
+
+            # Supported forms: *, */n, a, a-b, a/n, a-b/n (lists via commas)
+            if (-not ($part -match '^(?<base>[^/]+?)(?:\/(?<step>\d+))?$')) {
+                throw "Unsupported cron token '$part' in field '$Field'."
+            }
+            $base = $Matches['base'].Trim()
+            $step = 1
+            if ($Matches['step']) {
+                $step = [int]$Matches['step']
+                if ($step -lt 1) { throw "Invalid cron step '/$step' in field '$Field'." }
+            }
+
+            $start = $null
+            $end = $null
+            if ($base -eq '*') {
+                $start = $Min
+                $end = $Max
+            }
+            elseif ($base -match '^(?<a>[^-]+)-(?<b>[^-]+)$') {
+                $start = Convert-CronTokenToInt -Token $Matches['a'] -Min $Min -Max $Max -NameMap $NameMap -IsDayOfWeek:$IsDayOfWeek
+                $end = Convert-CronTokenToInt -Token $Matches['b'] -Min $Min -Max $Max -NameMap $NameMap -IsDayOfWeek:$IsDayOfWeek
+            }
+            else {
+                $start = Convert-CronTokenToInt -Token $base -Min $Min -Max $Max -NameMap $NameMap -IsDayOfWeek:$IsDayOfWeek
+                $end = $start
+            }
+
+            if ($start -lt $Min -or $end -gt $Max -or $start -gt $end) {
+                throw "Cron value range '$base' out of bounds [$Min,$Max] in field '$Field'."
+            }
+
+            for ($v = $start; $v -le $end; $v += $step) {
+                $vv = $v
+                if ($IsDayOfWeek -and $vv -eq 7) { $vv = 0 }
+                $allowed[$vv] = $true
+            }
+        }
+    }
+
+    $allowedValues = @()
+    for ($i = $Min; $i -le $Max; $i++) {
+        if ($allowed[$i]) { $allowedValues += $i }
+    }
+    if (-not $allowedValues -or $allowedValues.Count -eq 0) {
+        throw "Cron field '$Field' selects no values."
+    }
+
+    return @{
+        Allowed       = $allowed
+        AllowedValues = [int[]]$allowedValues
+        IsStar        = $isStar
+        Min           = $Min
+        Max           = $Max
+    }
+}
+
+function Parse-CronSchedule {
+    param([Parameter(Mandatory = $true)] [string]$Schedule)
+
+    $tokens = ($Schedule.Trim() -split '\s+')
+    if ($tokens.Count -ne 5) {
+        throw "Cron schedule must have 5 fields: '<minute> <hour> <day-of-month> <month> <day-of-week>'."
+    }
+
+    $monthNames = @{
+        'JAN' = 1; 'FEB' = 2; 'MAR' = 3; 'APR' = 4; 'MAY' = 5; 'JUN' = 6;
+        'JUL' = 7; 'AUG' = 8; 'SEP' = 9; 'OCT' = 10; 'NOV' = 11; 'DEC' = 12
+    }
+    $dowNames = @{
+        'SUN' = 0; 'MON' = 1; 'TUE' = 2; 'WED' = 3; 'THU' = 4; 'FRI' = 5; 'SAT' = 6
+    }
+
+    $minute = Parse-CronField -Field $tokens[0] -Min 0 -Max 59
+    $hour = Parse-CronField -Field $tokens[1] -Min 0 -Max 23
+    $dom = Parse-CronField -Field $tokens[2] -Min 1 -Max 31
+    $month = Parse-CronField -Field $tokens[3] -Min 1 -Max 12 -NameMap $monthNames
+    $dow = Parse-CronField -Field $tokens[4] -Min 0 -Max 7 -IsDayOfWeek -NameMap $dowNames
+
+    return @{
+        Minute     = $minute
+        Hour       = $hour
+        DayOfMonth = $dom
+        Month      = $month
+        DayOfWeek  = $dow
+        Raw        = $Schedule
+    }
+}
+
+function Test-CronDayMatch {
+    param(
+        [Parameter(Mandatory = $true)] $Cron,
+        [Parameter(Mandatory = $true)] [datetime]$UtcDateTime
+    )
+
+    $day = $UtcDateTime.Day
+    $dow = [int]$UtcDateTime.DayOfWeek  # Sunday=0
+    $domOk = $Cron.DayOfMonth.Allowed[$day]
+    $dowOk = $Cron.DayOfWeek.Allowed[$dow]
+
+    # Vixie-style semantics: if both DOM and DOW are restricted (not '*'), match if either matches.
+    if ($Cron.DayOfMonth.IsStar -and $Cron.DayOfWeek.IsStar) { return $true }
+    if ($Cron.DayOfMonth.IsStar) { return $dowOk }
+    if ($Cron.DayOfWeek.IsStar) { return $domOk }
+    return ($domOk -or $dowOk)
+}
+
+function Test-CronMatch {
+    param(
+        [Parameter(Mandatory = $true)] $Cron,
+        [Parameter(Mandatory = $true)] [datetime]$UtcDateTime
+    )
+
+    if (-not $Cron.Month.Allowed[$UtcDateTime.Month]) { return $false }
+    if (-not (Test-CronDayMatch -Cron $Cron -UtcDateTime $UtcDateTime)) { return $false }
+    if (-not $Cron.Hour.Allowed[$UtcDateTime.Hour]) { return $false }
+    if (-not $Cron.Minute.Allowed[$UtcDateTime.Minute]) { return $false }
+    return $true
+}
+
+function Get-NextCronOccurrenceUtc {
+    param(
+        [Parameter(Mandatory = $true)] $Cron,
+        [Parameter(Mandatory = $true)] [datetime]$AfterUtc
+    )
+
+    $after = $AfterUtc
+    if ($after.Kind -ne [DateTimeKind]::Utc) { $after = $after.ToUniversalTime() }
+
+    # Round down to minute, then advance by one minute (cron has minute granularity).
+    $dt = [datetime]::new($after.Year, $after.Month, $after.Day, $after.Hour, $after.Minute, 0, [DateTimeKind]::Utc).AddMinutes(1)
+    $limit = $dt.AddDays(370)
+
+    while ($dt -le $limit) {
+        # Month
+        if (-not $Cron.Month.Allowed[$dt.Month]) {
+            $nextMonth = Find-NextAllowedValue -AllowedValues $Cron.Month.AllowedValues -Start ($dt.Month + 1)
+            $year = $dt.Year
+            if ($null -eq $nextMonth) {
+                $year = $year + 1
+                $nextMonth = $Cron.Month.AllowedValues[0]
+            }
+            $dt = [datetime]::new($year, $nextMonth, 1, 0, 0, 0, [DateTimeKind]::Utc)
+            continue
+        }
+
+        # Day (DOM/DOW)
+        if (-not (Test-CronDayMatch -Cron $Cron -UtcDateTime $dt)) {
+            $dt = [datetime]::new($dt.Year, $dt.Month, $dt.Day, 0, 0, 0, [DateTimeKind]::Utc).AddDays(1)
+            continue
+        }
+
+        # Hour
+        if (-not $Cron.Hour.Allowed[$dt.Hour]) {
+            $nextHour = Find-NextAllowedValue -AllowedValues $Cron.Hour.AllowedValues -Start ($dt.Hour + 1)
+            if ($null -ne $nextHour) {
+                $dt = [datetime]::new($dt.Year, $dt.Month, $dt.Day, $nextHour, 0, 0, [DateTimeKind]::Utc)
+            }
+            else {
+                $dt = [datetime]::new($dt.Year, $dt.Month, $dt.Day, 0, 0, 0, [DateTimeKind]::Utc).AddDays(1)
+            }
+            continue
+        }
+
+        # Minute
+        if (-not $Cron.Minute.Allowed[$dt.Minute]) {
+            $nextMinute = Find-NextAllowedValue -AllowedValues $Cron.Minute.AllowedValues -Start ($dt.Minute + 1)
+            if ($null -ne $nextMinute) {
+                $dt = [datetime]::new($dt.Year, $dt.Month, $dt.Day, $dt.Hour, $nextMinute, 0, [DateTimeKind]::Utc)
+            }
+            else {
+                $dt = [datetime]::new($dt.Year, $dt.Month, $dt.Day, $dt.Hour, 0, 0, [DateTimeKind]::Utc).AddHours(1)
+            }
+            continue
+        }
+
+        if (Test-CronMatch -Cron $Cron -UtcDateTime $dt) { return $dt }
+        $dt = $dt.AddMinutes(1)
+    }
+
+    return $null
+}
+
 function Invoke-DailyBackupIfDue {
     <#
         Performs a non-blocking (background job) backup of the remote DB
         at most once per interval (default 24h) using scripts/backup_von_db.py.
         Skips if VON_DISABLE_DAILY_BACKUP is set to a truthy value.
-        Interval override via VON_BACKUP_INTERVAL_HOURS env.
+        Supports schedule via VON_BACKUP_SCHEDULE (cron-like string) using 5 fields:
+        "<minute> <hour> <day-of-month> <month> <day-of-week>".
+        Falls back to interval-based schedule via VON_BACKUP_INTERVAL_HOURS if the cron
+        string is missing or unsupported.
         Writes ISO8601 UTC timestamp to last_backup_utc.txt sentinel on success.
         Logs are prefixed with [daily-backup].
     #>
     if ($env:VON_DISABLE_DAILY_BACKUP -and $env:VON_DISABLE_DAILY_BACKUP.ToString() -match '^(1|true|yes)$') {
         return
+    }
+    $schedule = $null
+    if ($env:VON_BACKUP_SCHEDULE -and $env:VON_BACKUP_SCHEDULE.ToString().Trim()) {
+        $schedule = $env:VON_BACKUP_SCHEDULE.ToString().Trim().Trim('"')
     }
     $intervalHours = 24
     try { if ($env:VON_BACKUP_INTERVAL_HOURS) { $intervalHours = [int]$env:VON_BACKUP_INTERVAL_HOURS } } catch { }
@@ -245,31 +532,56 @@ function Invoke-DailyBackupIfDue {
     }
     $nowUtc = (Get-Date).ToUniversalTime()
     $due = $true
-    if ($last) {
-        $hours = ($nowUtc - $last).TotalHours
-        if ($hours -lt $intervalHours) { $due = $false }
+    if ($schedule) {
+        try {
+            $cron = Parse-CronSchedule -Schedule $schedule
+            $effectiveLast = if ($last) { $last } else { $nowUtc.AddDays(-370) }
+            $next = Get-NextCronOccurrenceUtc -Cron $cron -AfterUtc $effectiveLast
+            if ($null -eq $next -or $next -gt $nowUtc) { $due = $false }
+        }
+        catch {
+            Write-LauncherLog "[daily-backup] WARN: Unsupported VON_BACKUP_SCHEDULE='$schedule' ($($_.Exception.Message)); falling back to interval ${intervalHours}h."
+            $schedule = $null
+        }
+    }
+    if (-not $schedule) {
+        if ($last) {
+            $hours = ($nowUtc - $last).TotalHours
+            if ($hours -lt $intervalHours) { $due = $false }
+        }
     }
     if (-not $due) { return }
     # Avoid launching duplicate job
     $existingJob = Get-Job -Name 'von_daily_backup' -ErrorAction SilentlyContinue | Where-Object { $_.State -in 'Running', 'NotStarted' }
     if ($existingJob) { return }
+    $backupScript = Join-Path $Root 'scripts/backup_von_db.py'
+    if (-not (Test-Path $backupScript)) {
+        Write-LauncherLog "[daily-backup] WARN: backup script missing: $backupScript (skipping)"
+        return
+    }
     $pdmExe = if (Test-Path (Join-Path $Root '.venv\Scripts\pdm.exe')) { Join-Path $Root '.venv\Scripts\pdm.exe' } else { 'pdm' }
     Write-LauncherLog "[daily-backup] Launching background backup (interval ${intervalHours}h)..."
     Start-Job -Name 'von_daily_backup' -ScriptBlock {
-        param($pdmExe, $root, $runDir, $sentinelPath, $backupRoot)
+        param($pdmExe, $root, $runDir, $sentinelPath, $backupRoot, $backupScript)
         try {
             Set-Location $root
             # Force remote; disable local fallback for this backup invocation
             $env:MONGO_ALLOW_LOCAL_FALLBACK = '0'
-            $env:VON_BACKUP_ROOT = $backupRoot
-            & $pdmExe run python scripts/backup_von_db.py --apply --out-dir $backupRoot --tag auto-daily 2>&1 | ForEach-Object { "[daily-backup] $_" }
+            & $pdmExe run python $backupScript --apply --out-dir $backupRoot --tag auto-daily 2>&1 | ForEach-Object { "[daily-backup] $_" }
+            if ($LASTEXITCODE -ne 0) { throw "backup script failed with exit code $LASTEXITCODE" }
             (Get-Date).ToUniversalTime().ToString('o') | Set-Content $sentinelPath
             Write-Host '[daily-backup] Completed.'
         }
         catch {
             Write-Host ("[daily-backup] ERROR: {0}" -f $_.Exception.Message)
         }
-    } -ArgumentList $pdmExe, $Root, $RunDir, $sentinel, $BackupRoot | Out-Null
+    } -ArgumentList $pdmExe, $Root, $RunDir, $sentinel, $BackupRoot, $backupScript | Out-Null
+}
+
+# Backward-compatible convenience: if called as ".\run.ps1 -BackupDryRun" (no explicit action)
+# then run the backup action, even if the server is already running.
+if ($Action -eq 'start' -and ($BackupDryRun -or $BackupTag -or $BackupOutDir)) {
+    $Action = 'backup'
 }
 
 # Test DB periodic refresh logic (every 4 hours) ------------------------------
@@ -1468,7 +1780,7 @@ function Show-Help {
     @'
 Von Launcher Help
     Usage: .\run.ps1 [action] [options]
-    Actions: start | foreground | stop | status | restart | logs | check | autoupdate | rag-worker | help
+    Actions: start | foreground | stop | status | restart | logs | check | backup | autoupdate | rag-worker | help
     Options:
         -Port <int>            (reserved future multi-instance)
     -NoBrowser             Do not auto open browser
@@ -1484,6 +1796,9 @@ Von Launcher Help
         -ReadyLogPatterns <p>  One or more substrings that indicate readiness (log shortcut)
         -DisableLogReady       Disable log pattern readiness shortcut
         -HealthDebug           Verbose health polling diagnostics
+        -BackupDryRun           For backup action: do not run mongodump (prints what would happen)
+        -BackupTag <tag>        For backup action: tag suffix for backup dir (default manual)
+        -BackupOutDir <path>    For backup action: output root dir (default VON_BACKUP_ROOT)
         -UpdateIntervalMinutes <n>  Minutes between git update checks (autoupdate action; default 60)
         -UpdateBranch <name>        Branch to track (default main)
         -UpdateNoRestartIfRunning   Skip restart if server already running (still pull code)
@@ -1494,6 +1809,9 @@ Von Launcher Help
         .\run.ps1 status
         .\run.ps1 check          # returns exit code (0 healthy, 2 unhealthy, 3 not running)
         .\run.ps1 logs -Tail 200 -Follow
+        .\run.ps1 backup -BackupDryRun
+        .\run.ps1 backup -BackupTag manual
+        .\run.ps1 backup -BackupTag pre-change -BackupOutDir .\backups
         .\run.ps1 stop
     .\run.ps1 stop 12345        # kill specific PID directly
     .\run.ps1 stop force        # detect by port, verify command line, then kill
@@ -1502,6 +1820,39 @@ Von Launcher Help
         .\run.ps1 autoupdate -UpdateIntervalMinutes 30 -UpdateBranch main
 '
 '@ | Write-Host
+}
+
+function Invoke-BackupNow {
+    <#
+        Run an on-demand DB backup without restarting the server.
+        Defaults:
+          - Output directory: VON_BACKUP_ROOT (resolved at launch)
+          - Tag: "manual"
+          - Mode: apply unless -BackupDryRun
+    #>
+    $backupScript = Join-Path $Root 'scripts/backup_von_db.py'
+    if (-not (Test-Path $backupScript)) {
+        Write-LauncherLog "[backup] ERROR: backup script missing: $backupScript"
+        return
+    }
+    $pdm = if (Test-Path (Join-Path $Root '.venv\Scripts\pdm.exe')) { Join-Path $Root '.venv\Scripts\pdm.exe' } else { 'pdm' }
+    $tag = if ($BackupTag) { $BackupTag } else { 'manual' }
+    $outDir = if ($BackupOutDir) { $BackupOutDir } else { $BackupRoot }
+    $apply = -not $BackupDryRun
+    $mode = if ($apply) { 'apply' } else { 'dry-run' }
+    Write-LauncherLog "[backup] Starting backup (mode=$mode tag=$tag out=$outDir root=$BackupRoot)"
+
+    $args = @('run', 'python', $backupScript)
+    if ($apply) { $args += '--apply' }
+    $args += @('--out-dir', $outDir, '--tag', $tag)
+    & $pdm @args
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -eq 0) {
+        Write-LauncherLog "[backup] OK"
+    }
+    else {
+        Write-LauncherLog "[backup] ERROR exit=$exitCode"
+    }
 }
 
 switch ($Action) {
@@ -1576,6 +1927,7 @@ switch ($Action) {
             else { Write-LauncherLog ("UNHEALTHY PID={0}" -f $proc.Id); exit 2 }
         }
     }
+    'backup' { Invoke-BackupNow }
     'autoupdate' {
         Write-LauncherLog "Starting auto-update loop (branch=$UpdateBranch interval=${UpdateIntervalMinutes}m)... Press Ctrl+C to stop."
         # Ensure git is available

--- a/scripts/_create_jira_issue_tmp.py
+++ b/scripts/_create_jira_issue_tmp.py
@@ -1,0 +1,128 @@
+import base64
+import json
+import os
+from typing import Any
+
+import requests
+from dotenv import load_dotenv
+
+
+def adf_paragraph(text: str) -> dict[str, Any]:
+    return {"type": "paragraph", "content": [{"type": "text", "text": text}]}
+
+
+def main() -> None:
+    load_dotenv(dotenv_path=".env", override=False)
+
+    base_url = (
+        os.getenv("ATLASSIAN_BASE_URL") or os.getenv("ATLASSIAN_SITE_BASE") or ""
+    ).rstrip("/")
+    email = (os.getenv("ATLASSIAN_EMAIL") or "").strip()
+    token = (os.getenv("ATLASSIAN_API_TOKEN") or "").strip()
+
+    if not base_url or not email or not token:
+        missing = [
+            key
+            for key, val in [
+                ("ATLASSIAN_BASE_URL/ATLASSIAN_SITE_BASE", base_url),
+                ("ATLASSIAN_EMAIL", email),
+                ("ATLASSIAN_API_TOKEN", token),
+            ]
+            if not val
+        ]
+        raise SystemExit("Missing Jira credentials in .env: " + ", ".join(missing))
+
+    auth = base64.b64encode(f"{email}:{token}".encode("utf-8")).decode("ascii")
+    headers = {
+        "Authorization": f"Basic {auth}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+    # Best-effort assignee
+    account_id = None
+    try:
+        myself = requests.get(
+            f"{base_url}/rest/api/3/myself", headers=headers, timeout=30
+        )
+        myself.raise_for_status()
+        account_id = (myself.json() or {}).get("accountId")
+    except Exception:
+        account_id = None
+
+    summary = "Vontology-defined concept views + agentic rendering workflows"
+
+    description_lines = [
+        "Introduce a flexible, ontology-driven UI view system where what is displayed (and how) for a concept type is defined in the Vontology, and rendered via an agentic workflow.",
+        "",
+        "Motivation",
+        "- Current UI hard-codes which predicates appear in which sections (e.g. Content/Notes/Text Fields).",
+        "- We want per-concept-type view definitions that can evolve without frontend code changes.",
+        "- Support richer artefacts: figures, code blocks, images, videos, simulations, and interactive components (e.g. maps).",
+        "",
+        "Proposed Vontology representation (sketch)",
+        "- Concepts (examples): #V#ui_view_spec, #V#ui_component, #V#ui_render_workflow, #V#ui_data_binding, #V#map_component",
+        "- Predicates (examples): #V#hasViewSpec, #V#hasSection, #V#hasComponent, #V#bindsPredicate, #V#hasRenderPolicy, #V#hasSchema",
+        "- Use text relations for JSON config (schemas, props, policies).",
+        "",
+        "Agentic rendering workflow (sketch)",
+        "- Planner reads view spec for (concept, view context) and produces a render plan.",
+        "- Executor resolves data bindings, runs transforms (markdown render, summarisation, chart extraction), and returns a safe component model.",
+        "- Safe-by-default: sanitised HTML, no remote scripts, explicit allow-list for embeds, provenance badges.",
+        "",
+        "Example: map component defined in Vontology",
+        "- #V#map_component hasSchema: { provider, bbox, layers, markerPredicate, style }",
+        "- Bind markers to predicates like #V#hasLocation or derived annotations.",
+        "",
+        "Deliverables / acceptance criteria",
+        "- Minimal Vontology schema for view specs + components + bindings (concepts + predicates + example instances).",
+        "- Thin backend endpoint returning a resolved view model for a concept (initially read-only).",
+        "- Frontend renderer supports at least: table component + rich text component.",
+        "- Demonstrate one concept type using a custom view spec without frontend hard-coding.",
+        "",
+        "Notes",
+        "- Keep this research-prototype friendly: make the core extensible, avoid big framework rewrites.",
+    ]
+
+    description_doc = {
+        "type": "doc",
+        "version": 1,
+        "content": [adf_paragraph(line) for line in description_lines],
+    }
+
+    payload: dict[str, Any] = {
+        "fields": {
+            "project": {"key": "JVNAUTOSCI"},
+            "summary": summary,
+            "issuetype": {"name": "Task"},
+            "description": description_doc,
+        }
+    }
+
+    if account_id:
+        payload["fields"]["assignee"] = {"accountId": account_id}
+
+    resp = requests.post(
+        f"{base_url}/rest/api/3/issue",
+        headers=headers,
+        data=json.dumps(payload),
+        timeout=30,
+    )
+    resp.raise_for_status()
+    created = resp.json() or {}
+    key = created.get("key")
+
+    print(
+        json.dumps(
+            {
+                "created": True,
+                "key": key,
+                "url": f"{base_url}/browse/{key}" if key else None,
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backup_von_db.py
+++ b/scripts/backup_von_db.py
@@ -1,0 +1,347 @@
+"""Create a mongodump backup of the configured Von MongoDB database.
+
+This script exists primarily for use by run.ps1 (auto-daily backups), but can
+also be used manually.
+
+It writes backups in the same directory structure produced by `mongodump`:
+    <out-dir>/<db_name>_<timestamp>Z_<tag>/<db_name>/*.bson + *.metadata.json
+
+Optional features are driven by environment variables:
+- VON_BACKUP_RETENTION_DAYS (int; -1 = keep forever)
+- VON_BACKUP_MAX_STORAGE_MB (int; -1 = unlimited)
+- VON_BACKUP_COMPRESSION_ENABLED (truthy/falsey)
+- VON_BACKUP_ENCRYPTION_ENABLED (truthy/falsey)
+- VON_BACKUP_ENCRYPTION_KEY (Fernet key; required if encryption enabled)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+
+def _env_truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _env_int(value: str | None, *, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value.strip())
+    except Exception:
+        return default
+
+
+@dataclass(frozen=True)
+class BackupPrelude:
+    db_name: str
+    tag: str
+    timestamp_utc: str
+    mongo_uri_redacted: str
+
+
+def _utc_timestamp_compact() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
+
+
+def _utc_timestamp_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _get_db_name() -> str:
+    name = os.environ.get("VON_DB_NAME")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    return "von_db"
+
+
+def _redact_mongo_uri(uri: str) -> str:
+    if not uri:
+        return uri
+    if "@" not in uri:
+        return uri
+    # mongodb://user:pass@host/db -> mongodb://user:***@host/db
+    try:
+        prefix, rest = uri.split("://", 1)
+        if "@" not in rest:
+            return uri
+        creds, host_part = rest.split("@", 1)
+        user = creds.split(":", 1)[0] if ":" in creds else creds
+        return f"{prefix}://{user}:***@{host_part}"
+    except Exception:
+        return uri
+
+
+def _ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _iter_backup_artifacts(out_root: Path) -> Iterable[Path]:
+    if not out_root.exists():
+        return []
+    # Backups are either directories (<db>_YYYYMMDD_HHMMSSZ_tag) or compressed files.
+    items = []
+    for p in out_root.iterdir():
+        if p.is_dir():
+            items.append(p)
+        elif p.is_file() and (p.name.endswith(".zip") or p.name.endswith(".zip.enc")):
+            items.append(p)
+    return items
+
+
+def _artifact_mtime_utc(path: Path) -> datetime:
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+
+
+def _artifact_size_bytes(path: Path) -> int:
+    if path.is_file():
+        return path.stat().st_size
+    total = 0
+    for f in path.rglob("*"):
+        if f.is_file():
+            try:
+                total += f.stat().st_size
+            except FileNotFoundError:
+                continue
+    return total
+
+
+def _compress_backup_dir_to_zip(backup_root: Path) -> Path:
+    import zipfile
+
+    zip_path = backup_root.with_suffix(backup_root.suffix + ".zip")
+    # Ensure deterministic-ish paths: store paths relative to backup_root.
+    with zipfile.ZipFile(zip_path, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for p in backup_root.rglob("*"):
+            if not p.is_file():
+                continue
+            arcname = p.relative_to(backup_root)
+            zf.write(p, arcname.as_posix())
+    # Propagate timestamp to the zip file (so retention works on either form).
+    ts = backup_root.stat().st_mtime
+    os.utime(zip_path, (ts, ts))
+    return zip_path
+
+
+def _encrypt_file_fernet(input_path: Path, *, key: str) -> Path:
+    from cryptography.fernet import Fernet
+
+    f = Fernet(key.encode("utf-8"))
+    data = input_path.read_bytes()
+    encrypted = f.encrypt(data)
+    out_path = input_path.with_suffix(input_path.suffix + ".enc")
+    out_path.write_bytes(encrypted)
+    # Carry timestamp forward
+    ts = input_path.stat().st_mtime
+    os.utime(out_path, (ts, ts))
+    return out_path
+
+
+def _apply_retention_and_storage_limits(
+    *,
+    out_root: Path,
+    retention_days: int,
+    max_storage_mb: int,
+    protect_paths: set[Path] | None = None,
+) -> None:
+    protect_paths = protect_paths or set()
+    artifacts = list(_iter_backup_artifacts(out_root))
+    if not artifacts:
+        return
+
+    now = datetime.now(timezone.utc)
+
+    # Retention policy
+    if retention_days >= 0:
+        cutoff = now.timestamp() - (retention_days * 86400)
+        for p in sorted(artifacts, key=lambda x: _artifact_mtime_utc(x)):
+            if p in protect_paths:
+                continue
+            if _artifact_mtime_utc(p).timestamp() < cutoff:
+                if p.is_dir():
+                    import shutil
+
+                    shutil.rmtree(p, ignore_errors=True)
+                else:
+                    try:
+                        p.unlink()
+                    except FileNotFoundError:
+                        pass
+
+    # Max storage policy (delete oldest first)
+    if max_storage_mb >= 0:
+        max_bytes = max_storage_mb * 1024 * 1024
+        artifacts = [p for p in _iter_backup_artifacts(out_root) if p.exists()]
+        sizes = {p: _artifact_size_bytes(p) for p in artifacts}
+        total = sum(sizes.values())
+        if total <= max_bytes:
+            return
+
+        for p in sorted(artifacts, key=lambda x: _artifact_mtime_utc(x)):
+            if total <= max_bytes:
+                break
+            if p in protect_paths:
+                continue
+            if p.is_dir():
+                import shutil
+
+                shutil.rmtree(p, ignore_errors=True)
+            else:
+                try:
+                    p.unlink()
+                except FileNotFoundError:
+                    pass
+            total -= sizes.get(p, 0)
+
+
+def _run_mongodump(*, mongo_uri: str, db_name: str, out_path: Path) -> None:
+    cmd = [
+        "mongodump",
+        "--uri",
+        mongo_uri,
+        "--db",
+        db_name,
+        "--out",
+        str(out_path),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Backup Von MongoDB database via mongodump"
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually perform the backup (default: dry-run).",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=str,
+        default=os.environ.get("VON_BACKUP_ROOT") or "backups",
+        help="Output directory root for backups (default: VON_BACKUP_ROOT or ./backups).",
+    )
+    parser.add_argument(
+        "--tag",
+        type=str,
+        default="manual",
+        help="Tag suffix for the backup directory name (default: manual).",
+    )
+
+    args = parser.parse_args(argv)
+
+    db_name = _get_db_name()
+    tag = (args.tag or "manual").strip() or "manual"
+
+    out_root = Path(args.out_dir).expanduser().resolve()
+    backup_dir_name = f"{db_name}_{_utc_timestamp_compact()}_{tag}"
+    backup_root = out_root / backup_dir_name
+
+    mongo_uri = os.environ.get("MONGO_URI") or "mongodb://localhost:27017/"
+
+    retention_days = _env_int(os.environ.get("VON_BACKUP_RETENTION_DAYS"), default=-1)
+    max_storage_mb = _env_int(os.environ.get("VON_BACKUP_MAX_STORAGE_MB"), default=-1)
+    compression_enabled = _env_truthy(os.environ.get("VON_BACKUP_COMPRESSION_ENABLED"))
+    encryption_enabled = _env_truthy(os.environ.get("VON_BACKUP_ENCRYPTION_ENABLED"))
+    encryption_key = (os.environ.get("VON_BACKUP_ENCRYPTION_KEY") or "").strip()
+
+    prelude = BackupPrelude(
+        db_name=db_name,
+        tag=tag,
+        timestamp_utc=_utc_timestamp_iso(),
+        mongo_uri_redacted=_redact_mongo_uri(mongo_uri),
+    )
+
+    if not args.apply:
+        print("[backup] DRY-RUN")
+        print(f"[backup] Would create: {backup_root}")
+        print(f"[backup] Would dump DB: {db_name}")
+        print(f"[backup] Using MONGO_URI: {prelude.mongo_uri_redacted}")
+        print(
+            "[backup] Policy: "
+            f"retention_days={retention_days} max_storage_mb={max_storage_mb} "
+            f"compression={compression_enabled} encryption={encryption_enabled}"
+        )
+        if encryption_enabled:
+            if not encryption_key:
+                print(
+                    "[backup] WARN: encryption enabled but VON_BACKUP_ENCRYPTION_KEY is empty"
+                )
+            else:
+                print(f"[backup] Encryption key looks set (len={len(encryption_key)}).")
+        return 0
+
+    _ensure_dir(out_root)
+    _ensure_dir(backup_root)
+
+    # Write a prelude file at the backup root (helpful provenance when copying around).
+    (backup_root / "prelude.json").write_text(
+        json.dumps(asdict(prelude), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    print(f"[backup] Running mongodump into: {backup_root}")
+    _run_mongodump(mongo_uri=mongo_uri, db_name=db_name, out_path=backup_root)
+
+    # Basic sanity check: ensure the expected database folder exists.
+    db_dir = backup_root / db_name
+    if not db_dir.exists():
+        raise RuntimeError(
+            f"Backup completed but expected folder not found: {db_dir} (mongodump output missing?)"
+        )
+
+    final_artifact: Path = backup_root
+
+    if compression_enabled:
+        print(f"[backup] Compressing to zip: {backup_root}.zip")
+        zip_path = _compress_backup_dir_to_zip(backup_root)
+        final_artifact = zip_path
+        # Remove uncompressed directory once zipped (to avoid doubling storage).
+        import shutil
+
+        shutil.rmtree(backup_root, ignore_errors=True)
+
+    if encryption_enabled:
+        if not encryption_key:
+            raise RuntimeError(
+                "VON_BACKUP_ENCRYPTION_ENABLED is set but VON_BACKUP_ENCRYPTION_KEY is empty."
+            )
+        # Fernet keys must be urlsafe-base64 32-byte keys.
+        try:
+            encrypted_path = _encrypt_file_fernet(final_artifact, key=encryption_key)
+        except Exception as e:
+            raise RuntimeError(
+                "Backup encryption failed. Ensure VON_BACKUP_ENCRYPTION_KEY is a valid Fernet key "
+                "(e.g. from cryptography.fernet.Fernet.generate_key())."
+            ) from e
+        # Remove the plaintext zip once encrypted.
+        try:
+            final_artifact.unlink()
+        except FileNotFoundError:
+            pass
+        final_artifact = encrypted_path
+
+    # Enforce retention and storage limits across the output root.
+    _apply_retention_and_storage_limits(
+        out_root=out_root,
+        retention_days=retention_days,
+        max_storage_mb=max_storage_mb,
+        protect_paths={final_artifact} if final_artifact.exists() else set(),
+    )
+
+    print(f"[backup] Completed: {final_artifact}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -2298,7 +2298,13 @@ def _rag_get_status(**kwargs):
         ns_report = _resolve_rag_namespace_from_kwargs(kwargs)
         ns = ns_report.get("namespace") or os.environ.get("VON_DEFAULT_NAMESPACE")
         detail = kwargs.get("detail")
-        url = "http://127.0.0.1:5002/admin/rag_status"
+        base_url = (
+            os.environ.get("VON_HTTP_BASE_URL")
+            or os.environ.get("VON_WEB_BASE_URL")
+            or "http://127.0.0.1:5000"
+        )
+        base_url = base_url.rstrip("/")
+        url = f"{base_url}/admin/rag_status"
         if ns:
             url = f"{url}?namespace={ns}"
         if detail:
@@ -2368,6 +2374,10 @@ def _resolve_rag_collection_from_kwargs(kwargs: dict) -> dict[str, object]:
         "chat_history": "chat_history_sessions",
         "chat_history_session": "chat_history_sessions",
         "chat_history_sessions": "chat_history_sessions",
+        "text_relations": "vontology_text_relations",
+        "text_relation": "vontology_text_relations",
+        "text": "vontology_text_relations",
+        "vontology_text_relations": "vontology_text_relations",
     }
     effective = aliases.get(lowered, lowered)
     return {
@@ -2449,6 +2459,25 @@ def _rag_list_collections(**kwargs):
             "get_supported_reason": "not_addressable",
             "item_kind": "rag_chunk",
             "source_system": "rag.llamaindex",
+        },
+        {
+            "collection": "vontology_text_relations",
+            "label": "Vontology text relations",
+            "description": (
+                "Concept-linked text values stored in MongoDB (text_relations + text_values), such as hasName/hasDescription/hasContent. "
+                "These can be indexed into the vector-store so they are discoverable via search_knowledge_base. "
+                "Use rag_sync_text_relations to (re)index them for a namespace."
+            ),
+            "list_tool": "rag_list_indexed",
+            "get_tool": "rag_get_item",
+            "search_tool": "search_knowledge_base",
+            "list_supported": True,
+            "get_supported": True,
+            "search_supported": True,
+            "list_supported_reason": None,
+            "get_supported_reason": None,
+            "item_kind": "vontology_text_relation",
+            "source_system": "mongo.text_relations",
         },
     ]
 
@@ -2627,6 +2656,93 @@ def _rag_list_indexed(**kwargs):
             source_system="mongo.chat_history",
         )
 
+    if collection == "vontology_text_relations":
+        from ...services.rag_text_relation_sync_service import (
+            list_text_relation_index_items,
+        )
+
+        scan_limit = int(kwargs.get("scan_limit", 5000))
+        predicates = kwargs.get("predicates")
+        if predicates is not None and not isinstance(predicates, list):
+            return {
+                "error": "invalid_predicates",
+                "message": "predicates must be an array of strings",
+                "collection": collection,
+                **collection_report,
+                "effective_namespace": ns,
+                "effective_namespace_source": ns_report.get("namespace_source"),
+                **ns_report,
+                "success": False,
+            }
+
+        languages = kwargs.get("languages")
+        if languages is not None and not isinstance(languages, list):
+            return {
+                "error": "invalid_languages",
+                "message": "languages must be an array of strings",
+                "collection": collection,
+                **collection_report,
+                "effective_namespace": ns,
+                "effective_namespace_source": ns_report.get("namespace_source"),
+                **ns_report,
+                "success": False,
+            }
+
+        report = list_text_relation_index_items(
+            namespace=ns,
+            limit=limit,
+            offset=offset,
+            scan_limit=scan_limit,
+            predicates=predicates,
+            languages=languages,
+        )
+
+        raw_items = report.get("items") if isinstance(report, dict) else None
+        items = []
+        if isinstance(raw_items, list):
+            for row in raw_items:
+                if not isinstance(row, dict):
+                    continue
+                items.append(
+                    {
+                        "collection": collection,
+                        "session_id": row.get("relation_id"),
+                        "relation_id": row.get("relation_id"),
+                        "subject_concept_id": row.get("subject_concept_id"),
+                        "predicate": row.get("predicate"),
+                        "lang": row.get("lang"),
+                        "preview_length": row.get("preview_length"),
+                        "updated_at": row.get("updated_at"),
+                        "namespace": ns,
+                        "item_kind": "vontology_text_relation",
+                        "source_system": "mongo.text_relations",
+                        "namespace_source": ns_report.get("namespace_source"),
+                    }
+                )
+
+        payload = {
+            "collection": collection,
+            **collection_report,
+            "items": items,
+            "total": report.get("total") if isinstance(report, dict) else None,
+            "scanned": report.get("scanned") if isinstance(report, dict) else None,
+            "scan_limit": (
+                report.get("scan_limit") if isinstance(report, dict) else scan_limit
+            ),
+            "limit": limit,
+            "offset": offset,
+            "effective_namespace": ns,
+            "effective_namespace_source": ns_report.get("namespace_source"),
+            **ns_report,
+            "success": True,
+        }
+
+        return _with_rag_provenance(
+            payload=payload,
+            item_kind="rag_text_relation_list",
+            source_system="mongo.text_relations",
+        )
+
     return {
         "error": "unknown_collection",
         "message": f"Unknown collection: {collection}",
@@ -2754,6 +2870,45 @@ def _rag_get_item(**kwargs):
             source_system="mongo.chat_history",
         )
 
+    if collection == "vontology_text_relations":
+        from ...services.rag_text_relation_sync_service import get_text_relation_preview
+
+        doc = get_text_relation_preview(namespace=ns, relation_id=session_id)
+        if doc is None:
+            return {
+                "error": "not_found",
+                "collection": collection,
+                **collection_report,
+                "effective_namespace": ns,
+                "effective_namespace_source": ns_report.get("namespace_source"),
+                **ns_report,
+                "success": False,
+            }
+
+        payload = {
+            "collection": collection,
+            **collection_report,
+            "session_id": session_id,
+            "relation_id": doc.metadata.get("relation_id"),
+            "subject_concept_id": doc.metadata.get("subject_concept_id"),
+            "predicate": doc.metadata.get("predicate"),
+            "lang": doc.metadata.get("lang"),
+            "namespace": ns,
+            "preview": (doc.text or "")[:4000],
+            "item_kind": "vontology_text_relation",
+            "source_system": "mongo.text_relations",
+            "namespace_source": ns_report.get("namespace_source"),
+            "effective_namespace": ns,
+            "effective_namespace_source": ns_report.get("namespace_source"),
+            **ns_report,
+            "success": True,
+        }
+        return _with_rag_provenance(
+            payload=payload,
+            item_kind="rag_text_relation_item",
+            source_system="mongo.text_relations",
+        )
+
     return {
         "error": "unknown_collection",
         "message": f"Unknown collection: {collection}",
@@ -2764,6 +2919,59 @@ def _rag_get_item(**kwargs):
         **ns_report,
         "success": False,
     }
+
+
+def _rag_sync_text_relations(**kwargs):
+    from ...services.rag_text_relation_sync_service import sync_text_relations_to_rag
+
+    ns_report = _resolve_rag_namespace_from_kwargs(kwargs)
+    ns = ns_report.get("namespace")
+
+    # SECURITY: Require namespace for RAG access - prevents cross-user data leakage
+    if not ns:
+        return {
+            "error": "namespace_required",
+            "message": "RAG sync requires an explicit namespace (e.g. #V#user@org)",
+            **ns_report,
+            "success": False,
+        }
+
+    predicates = kwargs.get("predicates")
+    if predicates is not None and not isinstance(predicates, list):
+        return {
+            "error": "invalid_predicates",
+            "message": "predicates must be an array of strings",
+            **ns_report,
+            "success": False,
+        }
+
+    languages = kwargs.get("languages")
+    if languages is not None and not isinstance(languages, list):
+        return {
+            "error": "invalid_languages",
+            "message": "languages must be an array of strings",
+            **ns_report,
+            "success": False,
+        }
+
+    limit = int(kwargs.get("limit", 5000))
+    batch_size = int(kwargs.get("batch_size", 200))
+
+    payload = sync_text_relations_to_rag(
+        namespace=ns,
+        predicates=predicates,
+        languages=languages,
+        limit=limit,
+        batch_size=batch_size,
+    )
+    if isinstance(payload, dict):
+        payload.update(ns_report)
+        payload = _with_rag_provenance(
+            payload=payload,
+            item_kind="rag_sync_text_relations",
+            source_system="services.rag_text_relation_sync_service",
+        )
+    return payload
 
 
 # Gmail MCP handlers (read-only surface)
@@ -3905,6 +4113,31 @@ def build_default_catalogue() -> MethodCatalogue:
             output_schema=None,
             category="read",
             description="Get one indexed item (session) with a safe text preview. Respects namespace isolation.",
+        ),
+        MethodDefinition(
+            name="rag_sync_text_relations",
+            handler=_rag_sync_text_relations,
+            input_schema=Schema(
+                required={},
+                optional={
+                    "namespace": (str, type(None)),
+                    "predicates": (list,),
+                    "languages": (list,),
+                    "limit": (int,),
+                    "batch_size": (int,),
+                },
+                allow_unknown=True,
+                description=(
+                    "Index Vontology text relations (text_relations + text_values) into the vector-store for a namespace."
+                ),
+            ),
+            output_schema=None,
+            category="write",
+            timeout_sec=60.0,
+            description=(
+                "Upsert Vontology text relations into the RAG vector-store so they are discoverable via search_knowledge_base. "
+                "Requires an explicit namespace."
+            ),
         ),
     ]
 

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -434,6 +434,7 @@ def _upsert_singleton_text_relation(**kwargs):
 def _concept_exists(**kwargs):
     from ...db.repositories.concepts_repository import ConceptsRepository
     from ...security.access_control import can_access_concept
+    from ...vontology.code_concepts_registry import is_code_concept_id
 
     concept_id = kwargs.get("concept_id")
     if not concept_id:
@@ -441,7 +442,7 @@ def _concept_exists(**kwargs):
 
     try:
         doc = ConceptsRepository.find_one({"concept_id": concept_id}, {"_id": 1})
-        exists = bool(doc)
+        exists = bool(doc) or is_code_concept_id(concept_id)
         accessible = can_access_concept(concept_id)
         return {
             "success": True,

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -1893,6 +1893,7 @@ async def _handle_upsert_singleton_text_relation(
 
 async def _handle_concept_exists(arguments: dict[str, Any]) -> list[TextContent]:
     from src.backend.security.access_control import can_access_concept
+    from src.backend.vontology.code_concepts_registry import is_code_concept_id
 
     concept_id = arguments.get("concept_id")
     if not concept_id:
@@ -1903,7 +1904,7 @@ async def _handle_concept_exists(arguments: dict[str, Any]) -> list[TextContent]
         payload = {
             "success": True,
             "concept_id": concept_id,
-            "exists": bool(doc),
+            "exists": bool(doc) or is_code_concept_id(concept_id),
             "accessible": can_access_concept(concept_id),
         }
         return [_json_text(payload)]

--- a/src/backend/mcp_server/rag_mcp_stdio_server.py
+++ b/src/backend/mcp_server/rag_mcp_stdio_server.py
@@ -60,16 +60,25 @@ def _json_text(payload: Any) -> TextContent:
 
 def _require_namespace(arguments: dict[str, Any]) -> str | None:
     ns = arguments.get("namespace")
-    if not isinstance(ns, str) or not ns.strip():
-        return None
-    return ns.strip()
+    if isinstance(ns, str) and ns.strip():
+        return ns.strip()
+
+    env_ns = os.getenv("VON_DEFAULT_NAMESPACE")
+    if isinstance(env_ns, str) and env_ns.strip():
+        arguments["namespace"] = env_ns.strip()
+        return env_ns.strip()
+
+    return None
 
 
 def _namespace_required_error() -> dict[str, Any]:
     return {
         "success": False,
         "error": "namespace_required",
-        "message": "RAG access requires an explicit namespace (e.g. #V#user@org)",
+        "message": (
+            "RAG access requires a namespace. Provide 'namespace' (e.g. #V#user@org) "
+            "or set VON_DEFAULT_NAMESPACE in .env"
+        ),
     }
 
 
@@ -106,10 +115,10 @@ async def list_tools() -> list[Tool]:
                 "properties": {
                     "namespace": {
                         "type": "string",
-                        "description": "Required namespace (e.g. #V#user@org)",
+                        "description": "Optional namespace (e.g. #V#user@org). Defaults to env VON_DEFAULT_NAMESPACE.",
                     }
                 },
-                "required": ["namespace"],
+                "required": [],
             },
         ),
         Tool(
@@ -122,7 +131,7 @@ async def list_tools() -> list[Tool]:
                 "properties": {
                     "namespace": {
                         "type": "string",
-                        "description": "Required namespace (e.g. #V#user@org)",
+                        "description": "Optional namespace (e.g. #V#user@org). Defaults to env VON_DEFAULT_NAMESPACE.",
                     },
                     "detail": {
                         "type": "boolean",
@@ -130,7 +139,7 @@ async def list_tools() -> list[Tool]:
                         "default": False,
                     },
                 },
-                "required": ["namespace"],
+                "required": [],
             },
         ),
         Tool(
@@ -144,11 +153,11 @@ async def list_tools() -> list[Tool]:
                 "properties": {
                     "namespace": {
                         "type": "string",
-                        "description": "Required namespace (e.g. #V#user@org)",
+                        "description": "Optional namespace (e.g. #V#user@org). Defaults to env VON_DEFAULT_NAMESPACE.",
                     },
                     "collection": {
                         "type": "string",
-                        "description": "Collection selector (ka_sessions|chat_history_sessions)",
+                        "description": "Collection selector (ka_sessions|chat_history_sessions|vontology_text_relations)",
                         "default": "ka_sessions",
                     },
                     "limit": {
@@ -162,7 +171,7 @@ async def list_tools() -> list[Tool]:
                         "default": 0,
                     },
                 },
-                "required": ["namespace"],
+                "required": [],
             },
         ),
         Tool(
@@ -175,11 +184,11 @@ async def list_tools() -> list[Tool]:
                 "properties": {
                     "namespace": {
                         "type": "string",
-                        "description": "Required namespace (e.g. #V#user@org)",
+                        "description": "Optional namespace (e.g. #V#user@org). Defaults to env VON_DEFAULT_NAMESPACE.",
                     },
                     "collection": {
                         "type": "string",
-                        "description": "Collection selector (ka_sessions|chat_history_sessions)",
+                        "description": "Collection selector (ka_sessions|chat_history_sessions|vontology_text_relations)",
                         "default": "ka_sessions",
                     },
                     "session_id": {
@@ -187,7 +196,7 @@ async def list_tools() -> list[Tool]:
                         "description": "Session identifier (Mongo _id for KA sessions, session_id for chat sessions)",
                     },
                 },
-                "required": ["namespace", "session_id"],
+                "required": ["session_id"],
             },
         ),
         Tool(
@@ -201,7 +210,7 @@ async def list_tools() -> list[Tool]:
                 "properties": {
                     "namespace": {
                         "type": "string",
-                        "description": "Required namespace (e.g. #V#user@org)",
+                        "description": "Optional namespace (e.g. #V#user@org). Defaults to env VON_DEFAULT_NAMESPACE.",
                     },
                     "query": {
                         "type": "string",
@@ -213,7 +222,44 @@ async def list_tools() -> list[Tool]:
                         "default": 5,
                     },
                 },
-                "required": ["namespace", "query"],
+                "required": ["query"],
+            },
+        ),
+        Tool(
+            name="rag_sync_text_relations",
+            description=(
+                "Index Vontology text relations (text_relations + text_values) into the vector-store for the given namespace. "
+                "After syncing, they become discoverable via search_knowledge_base."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional namespace (e.g. #V#user@org). Defaults to env VON_DEFAULT_NAMESPACE.",
+                    },
+                    "predicates": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional predicate filter (e.g. hasName, hasDescription)",
+                    },
+                    "languages": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional language filter (e.g. en-NZ)",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max relations to consider",
+                        "default": 5000,
+                    },
+                    "batch_size": {
+                        "type": "integer",
+                        "description": "Upsert batch size",
+                        "default": 200,
+                    },
+                },
+                "required": [],
             },
         ),
     ]
@@ -225,6 +271,9 @@ _TOOL_HANDLERS: dict[str, Callable[[dict[str, Any]], Awaitable[list[TextContent]
     "rag_list_indexed": _tool_handler(internal_catalogue._rag_list_indexed),
     "rag_get_item": _tool_handler(internal_catalogue._rag_get_item),
     "search_knowledge_base": _tool_handler(internal_catalogue._search_knowledge_base),
+    "rag_sync_text_relations": _tool_handler(
+        internal_catalogue._rag_sync_text_relations
+    ),
 }
 
 

--- a/src/backend/security/access_control.py
+++ b/src/backend/security/access_control.py
@@ -17,6 +17,7 @@ from ..db.mongo_client import get_concepts_collection
 # Context state
 # ---------------------------------------------------------------------------
 _MANUAL_USER: ContextVar[Optional[str]] = ContextVar("access_manual_user", default=None)
+_MANUAL_ORG: ContextVar[Optional[str]] = ContextVar("access_manual_org", default=None)
 _BYPASS: ContextVar[bool] = ContextVar("access_bypass", default=False)
 _EVALUATOR: ContextVar["AccessEvaluator | None"] = ContextVar(
     "access_evaluator", default=None
@@ -226,12 +227,13 @@ def build_visibility_filter() -> Optional[Dict[str, Any]]:
     user_id = get_effective_user_concept_id()
 
     # Get user's current organisation context (Phase 1)
-    user_org_id = None
-    try:
-        if has_request_context():
-            user_org_id = session.get("organisation_concept_id")
-    except Exception:
-        pass
+    user_org_id = _MANUAL_ORG.get()
+    if user_org_id is None:
+        try:
+            if has_request_context():
+                user_org_id = session.get("organisation_concept_id")
+        except Exception:
+            pass
 
     # Get user email for detailed logging
     user_email = "unknown"
@@ -417,6 +419,15 @@ def override_current_user(concept_id: Optional[str]):
     finally:
         _EVALUATOR.reset(eval_token)
         _MANUAL_USER.reset(token)
+
+
+@contextmanager
+def override_current_organisation(concept_id: Optional[str]):
+    token = _MANUAL_ORG.set(_normalise_concept_id(concept_id))
+    try:
+        yield
+    finally:
+        _MANUAL_ORG.reset(token)
 
 
 @contextmanager

--- a/src/backend/security/access_control.py
+++ b/src/backend/security/access_control.py
@@ -77,6 +77,22 @@ class AccessEvaluator:
         normalised = _normalise_concept_id(concept_id)
         if normalised is None:
             return True
+
+        # Virtual concepts that are registered as code-handled predicates should be
+        # considered visible, even when no MongoDB concept document exists.
+        # This supports UI navigation and text-relations (e.g., adding hasName).
+        try:
+            from ..vontology.code_concepts_registry import (  # local import avoids cycles
+                is_code_concept_id,
+            )
+
+            if is_code_concept_id(normalised):
+                self._cache[normalised] = True
+                return True
+        except Exception:
+            # Best-effort: fall through to Mongo lookup.
+            pass
+
         if normalised == self.user_id:
             self._cache[normalised] = True
             return True

--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -45,7 +45,6 @@ from ...vontology.utils_vontology import (
     is_type,
     is_predicate,
 )
-from ...db.mongo_client import get_db, CONCEPTS_COLLECTION_NAME
 from ...db.repositories.concepts_repository import ConceptsRepository
 from ...services.settings_service import get_setting
 from ...services.concept_service import (
@@ -58,7 +57,7 @@ from ...services.text_value_service import get_texts_for_concept
 from ...services.concept_search_service import (
     search_concepts as search_concepts_service,
 )
-from ...security.access_control import cache_scope_key
+from ...security.access_control import cache_scope_key, bypass_access_control
 from ...utilities.salient_recompute import recompute_salient_predicates
 
 vontology_bp = Blueprint("vontology", __name__)
@@ -1537,13 +1536,15 @@ def analyze_import_preview(nodes_to_import):
 
     # Get all existing concept IDs for comparison
     try:
-        db = get_db()
-        if db is not None:
-            concepts_collection = db[CONCEPTS_COLLECTION_NAME]
-            existing_concepts = concepts_collection.find({}, {"concept_id": 1})
-            existing_concept_ids = {doc["concept_id"] for doc in existing_concepts}
-        else:
-            existing_concept_ids = set()
+        # Use the repository as the single concept DB access point.
+        # Import preview is an admin-style operation, so explicitly bypass access control.
+        with bypass_access_control():
+            existing_concepts = ConceptsRepository.find({}, {"concept_id": 1})
+            existing_concept_ids = {
+                doc.get("concept_id")
+                for doc in existing_concepts
+                if isinstance(doc, dict) and isinstance(doc.get("concept_id"), str)
+            }
     except Exception as e:
         current_app.logger.error(f"Error fetching existing concepts for preview: {e}")
         existing_concept_ids = set()
@@ -2550,6 +2551,51 @@ def get_node_instances():
             }
             instances.append(instance_data)
 
+        # Virtual fallback: surface code-handled concepts as instances where appropriate.
+        try:
+            from ...vontology.code_concepts_registry import (
+                iter_code_concepts,
+                build_virtual_concept_doc,
+                MENTIONED_IN_VON_CODE_ID,
+                PREDICATE_TYPE_ID,
+            )
+
+            want_virtual = node_id in {MENTIONED_IN_VON_CODE_ID, PREDICATE_TYPE_ID}
+            if want_virtual:
+                existing_ids = {
+                    inst.get("id")
+                    for inst in instances
+                    if isinstance(inst, dict) and isinstance(inst.get("id"), str)
+                }
+                for cc in iter_code_concepts():
+                    if cc.concept_id in existing_ids:
+                        continue
+                    vdoc = build_virtual_concept_doc(cc.concept_id)
+                    if not isinstance(vdoc, dict):
+                        continue
+                    inst_of = (vdoc.get("relationships") or {}).get(
+                        "is_an_instance_of"
+                    ) or []
+                    if isinstance(inst_of, str):
+                        inst_list = [inst_of]
+                    elif isinstance(inst_of, list):
+                        inst_list = [x for x in inst_of if isinstance(x, str)]
+                    else:
+                        inst_list = []
+                    if node_id not in inst_list:
+                        continue
+                    instances.append(
+                        {
+                            "id": cc.concept_id,
+                            "name": cc.display_name,
+                            "notes": "",
+                        }
+                    )
+
+                instances.sort(key=lambda item: (item.get("name") or "").lower())
+        except Exception:
+            pass
+
         current_app.logger.debug(
             f"Found {len(instances)} instances for concept {node_id}"
         )
@@ -2603,6 +2649,18 @@ def get_relationships_route():
             return repo.find_one({"concept_id": ident})
 
         doc = _find_by_identifier(identifier)
+        if not doc:
+            # Some built-in predicate concepts are handled in code only and may not
+            # exist as MongoDB concept documents. Treat those as virtual concepts.
+            try:
+                from ...vontology.code_concepts_registry import (
+                    build_virtual_concept_doc,
+                )
+
+                doc = build_virtual_concept_doc(identifier)
+            except Exception:
+                doc = None
+
         if not doc:
             return (
                 jsonify(

--- a/src/backend/services/concept_service.py
+++ b/src/backend/services/concept_service.py
@@ -58,10 +58,6 @@ from ..vontology.utils_vontology import (
 from pymongo.database import Database  # For type hinting db
 
 from ..db import mongo_client
-from ..db.mongo_client import (
-    get_concepts_collection,
-    CONCEPTS_COLLECTION_NAME,
-)  # Corrected import
 from ..db.repositories.concepts_repository import ConceptsRepository
 
 # from src.backend.languagemodels.llm_interface import OllamaClient # ADDED: Import OllamaClient
@@ -503,6 +499,24 @@ def get_concept_by_concept_id(concept_id: str) -> Optional[Dict[str, Any]]:
                 concept_doc["kind"] = "unknown"
 
             return concept_doc
+
+        # Virtual fallback for code-handled concepts (read-only).
+        try:
+            if isinstance(concept_id, str) and concept_id.startswith("#V#"):
+                from ..vontology.code_concepts_registry import build_virtual_concept_doc
+
+                virtual_doc = build_virtual_concept_doc(concept_id)
+                if isinstance(virtual_doc, dict) and virtual_doc.get("concept_id"):
+                    virtual_doc = {**virtual_doc}
+                    virtual_doc.setdefault("id", f"virtual:{concept_id}")
+                    virtual_doc.setdefault(
+                        "kind",
+                        virtual_doc.get("metadata", {}).get("concept_type", "unknown"),
+                    )
+                    return virtual_doc
+        except Exception:
+            pass
+
         raise ConceptNotFoundError(f"concept with concept_id '{concept_id}' not found.")
     except Exception as e:
         if isinstance(e, ConceptNotFoundError):
@@ -1519,20 +1533,6 @@ def get_concept_name_by_id(concept_id: str) -> Optional[str]:
         return None
     except Exception as e:
         logger.warning(f"Error looking up concept name for {concept_id}: {e}")
-        return None
-
-
-def get_concepts_collection_DEPRECATED() -> Optional[Collection]:
-    """DEPRECATED: This was incorrectly returning the 'concepts' collection.
-    Use the correct get_concepts_collection() from mongo_client instead.
-    """
-    try:
-        db = mongo_client.get_db()
-        if db is None:
-            return None
-        return db[CONCEPTS_COLLECTION_NAME]
-    except Exception as e:
-        logger.error(f"Failed to get 'concepts' collection: {e}", exc_info=True)
         return None
 
 
@@ -2836,9 +2836,8 @@ def export_concepts(
         f"Exporting concepts: concept_id={concept_id}, include_descendants={include_descendants}, format={format}"
     )
 
-    # Use direct collection accessor so tests can patch get_concepts_collection
-    concepts_coll = get_concepts_collection()
-    if concepts_coll is None:
+    # Ensure DB is available (repository is the only supported access path)
+    if ConceptsRepository.collection() is None:
         logger.error("concepts collection is not available for export_concepts.")
         raise ConceptServiceError("Database collection 'concepts' not available.")
 

--- a/src/backend/services/rag_text_relation_sync_service.py
+++ b/src/backend/services/rag_text_relation_sync_service.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from bson import ObjectId
+from bson.errors import InvalidId
+
+from src.backend.db.mongo_client import get_concepts_collection
+from src.backend.db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
+from src.backend.security.access_control import (
+    apply_concept_query_filter,
+    override_current_organisation,
+    override_current_user,
+)
+from src.backend.services.rag_service import RAGBackendUnavailable, get_rag_service
+
+
+@dataclass(frozen=True)
+class TextRelationRagDoc:
+    doc_id: str
+    text: str
+    metadata: Dict[str, Any]
+
+
+def list_text_relation_index_items(
+    *,
+    namespace: str,
+    limit: int = 20,
+    offset: int = 0,
+    scan_limit: int = 5000,
+    predicates: Optional[Sequence[str]] = None,
+    languages: Optional[Sequence[str]] = None,
+) -> Dict[str, Any]:
+    """Return lightweight previews of text relations visible in a namespace.
+
+    This is intended for inspection ("what would be indexed?") rather than bulk export.
+    Results are filtered by concept visibility for the user/org encoded in the namespace.
+
+    Note: `total` is the number of *visible* relations within `scan_limit`.
+    """
+
+    user_id, org_id = _parse_namespace(namespace)
+    rel_filter: Dict[str, Any] = {}
+    if predicates:
+        rel_filter["predicate"] = {"$in": list(predicates)}
+
+    safe_limit = max(int(limit), 0)
+    safe_offset = max(int(offset), 0)
+    safe_scan_limit = max(int(scan_limit), 0)
+
+    relations = TextRelationsRepository.find(
+        rel_filter,
+        projection={
+            "_id": 1,
+            "subject_concept_id": 1,
+            "predicate": 1,
+            "object_text_id": 1,
+            "updated_at": 1,
+        },
+        sort=[("updated_at", -1)],
+        limit=safe_scan_limit,
+    )
+
+    items: List[Dict[str, Any]] = []
+    concept_visibility: Dict[str, bool] = {}
+
+    total_visible = 0
+    scanned = 0
+
+    for rel in relations:
+        scanned += 1
+        if not isinstance(rel, dict):
+            continue
+
+        relation_id = rel.get("_id")
+        relation_id_str = str(relation_id) if relation_id else None
+        subject_concept_id = rel.get("subject_concept_id")
+        predicate = rel.get("predicate")
+        object_text_id = rel.get("object_text_id")
+
+        if (
+            not relation_id_str
+            or not isinstance(subject_concept_id, str)
+            or not predicate
+            or not object_text_id
+        ):
+            continue
+
+        if subject_concept_id not in concept_visibility:
+            concept_visibility[subject_concept_id] = _concept_visible_in_namespace(
+                concept_id=subject_concept_id, user_id=user_id, org_id=org_id
+            )
+        if not concept_visibility[subject_concept_id]:
+            continue
+
+        text_value_oid = _safe_object_id(object_text_id)
+        if text_value_oid is None:
+            continue
+
+        tv = TextValuesRepository.find_one(
+            {"_id": text_value_oid}, {"text": 1, "lang": 1}
+        )
+        if not isinstance(tv, dict):
+            continue
+
+        text = tv.get("text")
+        lang = tv.get("lang") or "en-NZ"
+        if not isinstance(text, str) or not text.strip():
+            continue
+        if languages and isinstance(lang, str) and lang not in set(languages):
+            continue
+
+        visible_index = total_visible
+        total_visible += 1
+        if safe_limit and visible_index < safe_offset:
+            continue
+        if safe_limit and len(items) >= safe_limit:
+            continue
+
+        items.append(
+            {
+                "relation_id": relation_id_str,
+                "subject_concept_id": subject_concept_id,
+                "predicate": str(predicate),
+                "text_value_id": str(text_value_oid),
+                "lang": str(lang),
+                "preview_length": len(text),
+                "updated_at": (
+                    str(rel.get("updated_at")) if rel.get("updated_at") else None
+                ),
+            }
+        )
+
+    return {
+        "items": items,
+        "total": total_visible,
+        "scanned": scanned,
+        "limit": safe_limit,
+        "offset": safe_offset,
+        "scan_limit": safe_scan_limit,
+    }
+
+
+def get_text_relation_preview(
+    *,
+    namespace: str,
+    relation_id: str,
+) -> Optional[TextRelationRagDoc]:
+    """Fetch one visible text relation and return its full RAG document representation."""
+
+    user_id, org_id = _parse_namespace(namespace)
+
+    if not isinstance(relation_id, str) or not relation_id.strip():
+        return None
+
+    relation_key: Any
+    relation_oid = _safe_object_id(relation_id.strip())
+    relation_key = relation_oid if relation_oid is not None else relation_id.strip()
+
+    rel = TextRelationsRepository.find_one(
+        {"_id": relation_key},
+        {
+            "_id": 1,
+            "subject_concept_id": 1,
+            "predicate": 1,
+            "object_text_id": 1,
+            "context": 1,
+            "created_at": 1,
+            "updated_at": 1,
+        },
+    )
+    if not isinstance(rel, dict):
+        return None
+
+    subject_concept_id = rel.get("subject_concept_id")
+    predicate = rel.get("predicate")
+    object_text_id = rel.get("object_text_id")
+
+    if not isinstance(subject_concept_id, str) or not predicate or not object_text_id:
+        return None
+
+    if not _concept_visible_in_namespace(
+        concept_id=subject_concept_id, user_id=user_id, org_id=org_id
+    ):
+        return None
+
+    text_value_oid = _safe_object_id(object_text_id)
+    if text_value_oid is None:
+        return None
+
+    tv = TextValuesRepository.find_one({"_id": text_value_oid})
+    if not isinstance(tv, dict):
+        return None
+
+    text = tv.get("text")
+    lang = tv.get("lang") or "en-NZ"
+    if not isinstance(text, str) or not text.strip():
+        return None
+
+    rag_text = _build_rag_text(
+        concept_id=subject_concept_id,
+        predicate=str(predicate),
+        lang=str(lang),
+        text=text,
+    )
+
+    relation_id_str = str(rel.get("_id"))
+    metadata = {
+        "source": "vontology_text_relation",
+        "subject_concept_id": subject_concept_id,
+        "predicate": str(predicate),
+        "relation_id": relation_id_str,
+        "text_value_id": str(text_value_oid),
+        "lang": str(lang),
+        "user_id": user_id,
+        "organisation_concept_id": org_id,
+        "created_at": str(rel.get("created_at")) if rel.get("created_at") else None,
+        "updated_at": str(rel.get("updated_at")) if rel.get("updated_at") else None,
+    }
+
+    return TextRelationRagDoc(
+        doc_id=f"text_relation:{relation_id_str}",
+        text=rag_text,
+        metadata=metadata,
+    )
+
+
+def _parse_namespace(namespace: str) -> Tuple[str, str]:
+    """Parse a namespace of the form '#V#user@org' into (user_id, organisation_id)."""
+    if not isinstance(namespace, str) or not namespace.strip():
+        raise ValueError("namespace is required")
+
+    cleaned = namespace.strip()
+    if "@" not in cleaned:
+        raise ValueError(
+            "namespace must be of the form '#V#user@org' (missing '@' separator)"
+        )
+
+    user_part, org_part = cleaned.split("@", 1)
+    user_id = user_part.strip()
+    org_id = org_part.strip()
+
+    if not user_id:
+        raise ValueError("namespace user part is empty")
+    if not org_id:
+        raise ValueError("namespace organisation part is empty")
+
+    # Ensure org is a concept id.
+    if not org_id.startswith("#V#"):
+        org_id = f"#V#{org_id}"
+
+    return user_id, org_id
+
+
+def _safe_object_id(value: Any) -> ObjectId | None:
+    if isinstance(value, ObjectId):
+        return value
+    if isinstance(value, str):
+        try:
+            return ObjectId(value)
+        except (InvalidId, TypeError):
+            return None
+    return None
+
+
+def _concept_visible_in_namespace(
+    *, concept_id: str, user_id: str, org_id: str
+) -> bool:
+    coll = get_concepts_collection()
+    if coll is None:
+        # Fail-open for dev tooling when DB is not available.
+        return True
+
+    with override_current_user(user_id), override_current_organisation(org_id):
+        query = apply_concept_query_filter({"concept_id": concept_id})
+        doc = coll.find_one(query, {"_id": 1})
+        return bool(doc)
+
+
+def _build_rag_text(*, concept_id: str, predicate: str, lang: str, text: str) -> str:
+    # Keep the body searchable, but also add a small structured header.
+    return (
+        f"Concept: {concept_id}\n"
+        f"Predicate: {predicate}\n"
+        f"Language: {lang}\n\n"
+        f"{text.strip()}"
+    )
+
+
+def collect_text_relation_docs_for_namespace(
+    *,
+    namespace: str,
+    predicates: Optional[Sequence[str]] = None,
+    languages: Optional[Sequence[str]] = None,
+    limit: int = 5000,
+) -> List[TextRelationRagDoc]:
+    """Collect text-relations as RAG documents for a single namespace.
+
+    Notes:
+    - Filters by concept visibility for the (user, organisation) implied by the namespace.
+    - Stamps metadata user/org so LlamaIndex permission filtering works.
+    """
+
+    user_id, org_id = _parse_namespace(namespace)
+
+    rel_filter: Dict[str, Any] = {}
+    if predicates:
+        rel_filter["predicate"] = {"$in": list(predicates)}
+
+    relations = list(TextRelationsRepository.find(rel_filter, limit=int(limit)))
+    if not relations:
+        return []
+
+    docs: List[TextRelationRagDoc] = []
+
+    # Small cache to avoid repeated concept lookups.
+    concept_visibility: Dict[str, bool] = {}
+
+    for rel in relations:
+        if not isinstance(rel, dict):
+            continue
+
+        relation_id = rel.get("_id")
+        relation_id_str = str(relation_id) if relation_id else None
+        subject_concept_id = rel.get("subject_concept_id")
+        predicate = rel.get("predicate")
+        object_text_id = rel.get("object_text_id")
+
+        if (
+            not relation_id_str
+            or not isinstance(subject_concept_id, str)
+            or not predicate
+        ):
+            continue
+
+        if subject_concept_id not in concept_visibility:
+            concept_visibility[subject_concept_id] = _concept_visible_in_namespace(
+                concept_id=subject_concept_id, user_id=user_id, org_id=org_id
+            )
+        if not concept_visibility[subject_concept_id]:
+            continue
+
+        text_value_oid = _safe_object_id(object_text_id)
+        if text_value_oid is None:
+            continue
+
+        tv = TextValuesRepository.find_one({"_id": text_value_oid})
+        if not isinstance(tv, dict):
+            continue
+
+        text = tv.get("text")
+        lang = tv.get("lang") or "en-NZ"
+        if not isinstance(text, str) or not text.strip():
+            continue
+        if languages and isinstance(lang, str) and lang not in set(languages):
+            continue
+
+        rag_text = _build_rag_text(
+            concept_id=subject_concept_id,
+            predicate=str(predicate),
+            lang=str(lang),
+            text=text,
+        )
+
+        metadata = {
+            "source": "vontology_text_relation",
+            "subject_concept_id": subject_concept_id,
+            "predicate": str(predicate),
+            "relation_id": relation_id_str,
+            "text_value_id": str(text_value_oid),
+            "lang": str(lang),
+            # Required for query-time filtering.
+            "user_id": user_id,
+            "organisation_concept_id": org_id,
+        }
+
+        docs.append(
+            TextRelationRagDoc(
+                doc_id=f"text_relation:{relation_id_str}",
+                text=rag_text,
+                metadata=metadata,
+            )
+        )
+
+    return docs
+
+
+def sync_text_relations_to_rag(
+    *,
+    namespace: str,
+    predicates: Optional[Sequence[str]] = None,
+    languages: Optional[Sequence[str]] = None,
+    limit: int = 5000,
+    batch_size: int = 200,
+) -> Dict[str, Any]:
+    """Upsert text relation docs into the RAG store for a namespace."""
+
+    try:
+        rag = get_rag_service()
+    except RAGBackendUnavailable as exc:
+        return {"success": False, "error": f"RAG service unavailable: {exc}"}
+
+    docs = collect_text_relation_docs_for_namespace(
+        namespace=namespace,
+        predicates=predicates,
+        languages=languages,
+        limit=limit,
+    )
+
+    added = 0
+    failed = 0
+
+    def _chunks(
+        items: List[TextRelationRagDoc], n: int
+    ) -> Iterable[List[TextRelationRagDoc]]:
+        step = max(int(n), 1)
+        for i in range(0, len(items), step):
+            yield items[i : i + step]
+
+    for batch in _chunks(docs, batch_size):
+        payload = [
+            {"id": d.doc_id, "text": d.text, "metadata": d.metadata} for d in batch
+        ]
+        ok, bad = rag.upsert_documents(payload, namespace=namespace)
+        added += int(ok)
+        failed += int(bad)
+
+    return {
+        "success": failed == 0,
+        "namespace": namespace,
+        "total_candidates": len(docs),
+        "added": added,
+        "failed": failed,
+    }

--- a/src/backend/utilities/salient_recompute.py
+++ b/src/backend/utilities/salient_recompute.py
@@ -11,7 +11,8 @@ import json
 import time
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 
-from ..db.mongo_client import CONCEPTS_COLLECTION_NAME, get_db  # type: ignore
+from ..db.repositories.concepts_repository import ConceptsRepository
+from ..security.access_control import bypass_access_control
 from ..vontology.utils_vontology import (  # type: ignore
     SALIENT_SCOPE_FIELD,
     SALIENT_SCOPE_INSTANCE_KEY,
@@ -29,25 +30,20 @@ UPDATED_LIST_LIMIT = 100
 
 def fetch_type_docs(limit: Optional[int] = None):
     """Fetch all type documents (concept ids beginning with #V#)."""
-    db = get_db()
-    if db is None:
-        raise RuntimeError("Database unavailable (get_db returned None)")
-
-    coll = db[CONCEPTS_COLLECTION_NAME]
-    cursor = coll.find(
-        {"concept_id": {"$regex": "^#V#"}},
-        {
-            "concept_id": 1,
-            "relationships.is_a_type_of": 1,
-            f"relationships.{DIRECT_FIELD}": 1,
-            INHERITED_FIELD: 1,
-            STAMP_FIELD: 1,
-            SALIENT_SCOPE_FIELD: 1,
-        },
-    )
-    if limit:
-        cursor = cursor.limit(int(limit))
-    return list(cursor)
+    with bypass_access_control():
+        docs = ConceptsRepository.find(
+            {"concept_id": {"$regex": "^#V#"}},
+            {
+                "concept_id": 1,
+                "relationships.is_a_type_of": 1,
+                f"relationships.{DIRECT_FIELD}": 1,
+                INHERITED_FIELD: 1,
+                STAMP_FIELD: 1,
+                SALIENT_SCOPE_FIELD: 1,
+            },
+            limit=int(limit) if limit else 0,
+        )
+        return list(docs)
 
 
 def build_graph(
@@ -136,48 +132,47 @@ def recompute_salient_predicates(
             max_len = max(max_len, len(inherited))
 
     # Write / dry-run accounting
-    db = get_db()
-    if db is None:
-        raise RuntimeError(
-            "Database unavailable (get_db returned None) during write phase"
-        )
-    coll = db[CONCEPTS_COLLECTION_NAME]
     now_stamp = int(time.time())
     scope_updates = 0
     updated_ids: List[str] = []
 
     if not dry_run:
-        for cid, inherited_list in inherited_cache.items():
-            doc = doc_by_id[cid]
-            existing = doc.get(INHERITED_FIELD)
-            direct_values = direct_map.get(cid, [])
-            scope_existing = normalise_salient_scope_map(doc.get(SALIENT_SCOPE_FIELD))
-            scope_target = {
-                SALIENT_SCOPE_INSTANCE_KEY: list(
-                    scope_existing.get(SALIENT_SCOPE_INSTANCE_KEY, [])
-                ),
-                SALIENT_SCOPE_TYPE_KEY: ordered_union(direct_values),
-                SALIENT_SCOPE_UNCLASSIFIED_KEY: list(
-                    scope_existing.get(SALIENT_SCOPE_UNCLASSIFIED_KEY, [])
-                ),
-            }
-            scope_changed = scope_target != scope_existing
-            changed = force or existing != inherited_list
-
-            if changed or cycles_detected or scope_changed:
-                update_doc = {
-                    INHERITED_FIELD: inherited_list,
-                    STAMP_FIELD: now_stamp,
-                    ERROR_FIELD: bool(cycles_detected),
+        with bypass_access_control():
+            for cid, inherited_list in inherited_cache.items():
+                doc = doc_by_id[cid]
+                existing = doc.get(INHERITED_FIELD)
+                direct_values = direct_map.get(cid, [])
+                scope_existing = normalise_salient_scope_map(
+                    doc.get(SALIENT_SCOPE_FIELD)
+                )
+                scope_target = {
+                    SALIENT_SCOPE_INSTANCE_KEY: list(
+                        scope_existing.get(SALIENT_SCOPE_INSTANCE_KEY, [])
+                    ),
+                    SALIENT_SCOPE_TYPE_KEY: ordered_union(direct_values),
+                    SALIENT_SCOPE_UNCLASSIFIED_KEY: list(
+                        scope_existing.get(SALIENT_SCOPE_UNCLASSIFIED_KEY, [])
+                    ),
                 }
-                if scope_changed:
-                    update_doc[SALIENT_SCOPE_FIELD] = scope_target
-                coll.update_one({"concept_id": cid}, {"$set": update_doc})
-                updated += 1
-                if len(updated_ids) < UPDATED_LIST_LIMIT:
-                    updated_ids.append(cid)
-                if scope_changed:
-                    scope_updates += 1
+                scope_changed = scope_target != scope_existing
+                changed = force or existing != inherited_list
+
+                if changed or cycles_detected or scope_changed:
+                    update_doc = {
+                        INHERITED_FIELD: inherited_list,
+                        STAMP_FIELD: now_stamp,
+                        ERROR_FIELD: bool(cycles_detected),
+                    }
+                    if scope_changed:
+                        update_doc[SALIENT_SCOPE_FIELD] = scope_target
+                    ConceptsRepository.update_one(
+                        {"concept_id": cid}, {"$set": update_doc}
+                    )
+                    updated += 1
+                    if len(updated_ids) < UPDATED_LIST_LIMIT:
+                        updated_ids.append(cid)
+                    if scope_changed:
+                        scope_updates += 1
     else:
         for cid, inherited_list in inherited_cache.items():
             doc = doc_by_id[cid]

--- a/src/backend/vontology/code_concepts_registry.py
+++ b/src/backend/vontology/code_concepts_registry.py
@@ -1,0 +1,119 @@
+"""Registry for virtual concepts that are primarily handled in code.
+
+These concepts may not be persisted in MongoDB, but the UI and MCP tooling still
+benefit from treating them as first-class for discovery, rendering, and
+navigation.
+
+This module is deliberately read-only: it does not perform any database writes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional
+
+
+MENTIONED_IN_VON_CODE_ID = "#V#mentioned_in_von_code"
+PREDICATE_TYPE_ID = "#V#predicate"
+
+
+@dataclass(frozen=True)
+class CodeConcept:
+    concept_id: str
+    display_name: str
+    kind: str
+    md_content: str
+
+
+def _predicate_md(concept_id: str, display_name: str) -> str:
+    return (
+        f"# {display_name}\n\n"
+        "This is a built-in Von predicate that is used by code.\n\n"
+        "It is treated as a first-class concept for UI navigation and inspection, "
+        "even when it is not persisted as a MongoDB concept document.\n"
+    )
+
+
+# These are the canonical text-relation predicates supported by the backend.
+#
+# Note: The text-relations layer also supports non-#V# predicates (e.g. "hasContent"),
+# but the UI expects concept-like identifiers for cartouches and navigation.
+_CODE_PREDICATE_CONCEPTS: Dict[str, CodeConcept] = {
+    "#V#hasName": CodeConcept(
+        concept_id="#V#hasName",
+        display_name="hasName",
+        kind="predicate",
+        md_content=_predicate_md("#V#hasName", "hasName"),
+    ),
+    "#V#hasDescription": CodeConcept(
+        concept_id="#V#hasDescription",
+        display_name="hasDescription",
+        kind="predicate",
+        md_content=_predicate_md("#V#hasDescription", "hasDescription"),
+    ),
+    "#V#hasContent": CodeConcept(
+        concept_id="#V#hasContent",
+        display_name="hasContent",
+        kind="predicate",
+        md_content=_predicate_md("#V#hasContent", "hasContent"),
+    ),
+    "#V#hasNote": CodeConcept(
+        concept_id="#V#hasNote",
+        display_name="hasNote",
+        kind="predicate",
+        md_content=_predicate_md("#V#hasNote", "hasNote"),
+    ),
+    "#V#hasInteraction": CodeConcept(
+        concept_id="#V#hasInteraction",
+        display_name="hasInteraction",
+        kind="predicate",
+        md_content=_predicate_md("#V#hasInteraction", "hasInteraction"),
+    ),
+}
+
+
+def iter_code_concepts() -> Iterable[CodeConcept]:
+    return _CODE_PREDICATE_CONCEPTS.values()
+
+
+def is_code_concept_id(concept_id: str) -> bool:
+    return concept_id in _CODE_PREDICATE_CONCEPTS
+
+
+def get_code_concept(concept_id: str) -> Optional[CodeConcept]:
+    return _CODE_PREDICATE_CONCEPTS.get(concept_id)
+
+
+def build_virtual_concept_doc(concept_id: str) -> Optional[dict]:
+    """Return a Mongo-shaped concept document for a registered code concept.
+
+    The shape is intentionally compatible with `is_predicate()` and similar helpers.
+    """
+
+    cc = get_code_concept(concept_id)
+    if cc is None:
+        return None
+
+    if cc.kind == "predicate":
+        instance_of = [PREDICATE_TYPE_ID, MENTIONED_IN_VON_CODE_ID]
+        type_of = []
+    else:
+        instance_of = [MENTIONED_IN_VON_CODE_ID]
+        type_of = []
+
+    return {
+        "concept_id": cc.concept_id,
+        "name": cc.display_name,
+        "names": [{"name": cc.display_name, "type": "NL", "language": "en-NZ"}],
+        "relationships": {
+            "is_a_type_of": type_of,
+            "is_an_instance_of": instance_of,
+        },
+        "path": cc.concept_id,
+        "md_content": cc.md_content,
+        "metadata": {
+            "concept_type": cc.kind,
+            "virtual": True,
+            "mentioned_in_von_code": True,
+        },
+    }

--- a/src/backend/vontology/utils_vontology.py
+++ b/src/backend/vontology/utils_vontology.py
@@ -1365,7 +1365,22 @@ def get_vontology_node_content(identifier: str, *, reconstruct_md: bool = True) 
         logger.warning(
             f"Concept '{identifier}' not found in MongoDB (searched by id, path, and potentially name)."
         )
-        return {"error": f"Concept '{identifier}' not found in MongoDB."}
+        # Virtual fallback: some concept-like identifiers are primarily handled in code.
+        # These should still render in the UI (cartouches/tabs/tree) without requiring
+        # database mutation.
+        try:
+            if isinstance(identifier, str) and identifier.startswith("#V#"):
+                from .code_concepts_registry import build_virtual_concept_doc
+
+                virtual_doc = build_virtual_concept_doc(identifier)
+                if isinstance(virtual_doc, dict) and virtual_doc.get("concept_id"):
+                    doc = virtual_doc
+        except Exception:
+            # Fall through to the standard not-found response.
+            doc = None
+
+        if not doc:
+            return {"error": f"Concept '{identifier}' not found in MongoDB."}
 
     # Convert _id to string for JSON serialization before returning
     if "_id" in doc:
@@ -1711,6 +1726,27 @@ def get_vontology_tree(root_concept: str = "Thing"):
                 },
             )
         )
+        # Inject virtual code concepts so they can render in the tree even when not
+        # persisted as concept documents.
+        try:
+            from .code_concepts_registry import (
+                iter_code_concepts,
+                build_virtual_concept_doc,
+            )
+
+            existing_ids = {
+                d.get("concept_id")
+                for d in docs
+                if isinstance(d, dict) and isinstance(d.get("concept_id"), str)
+            }
+            for cc in iter_code_concepts():
+                if cc.concept_id in existing_ids:
+                    continue
+                vdoc = build_virtual_concept_doc(cc.concept_id)
+                if isinstance(vdoc, dict) and vdoc.get("concept_id"):
+                    docs.append(vdoc)
+        except Exception:
+            pass
         total = len(docs)
         if not total:
             return {"tree": []}
@@ -1719,7 +1755,8 @@ def get_vontology_tree(root_concept: str = "Thing"):
         types: list[dict] = []
         skipped = 0
         for d in docs:
-            if is_pure_instance(d):
+            # Keep predicates in the tree even though they are often pure instances.
+            if is_pure_instance(d) and not is_predicate(d):
                 skipped += 1
                 continue
             if not d.get("concept_id"):
@@ -1788,6 +1825,32 @@ def get_vontology_tree(root_concept: str = "Thing"):
                 parent = parents_list[0]
             else:
                 parent = thing_id  # orphan fallback
+
+            # Predicates: prefer attaching under an appropriate predicate type.
+            if is_predicate(d) and not parents_list:
+                inst_raw = rel.get("is_an_instance_of")
+                if isinstance(inst_raw, str):
+                    inst_list = [inst_raw]
+                elif isinstance(inst_raw, list):
+                    inst_list = [
+                        x for x in inst_raw if isinstance(x, str) and x.strip()
+                    ]
+                else:
+                    inst_list = []
+
+                preferred_predicate_parents = [
+                    "#V#predicate",
+                    "#V#relation",
+                    "#V#property",
+                    "#V#binary_predicate",
+                    "#V#unary_predicate",
+                    "#V#n_ary_predicate",
+                    "#V#ternary_predicate",
+                ]
+                for candidate in preferred_predicate_parents + inst_list:
+                    if candidate != cid and candidate in id_to_node:
+                        parent = candidate
+                        break
 
             # Final fallback if chosen parent missing
             if (

--- a/src/frontend/web/von_interface/static/js/conceptTab.js
+++ b/src/frontend/web/von_interface/static/js/conceptTab.js
@@ -2898,6 +2898,43 @@ export async function loadConceptNames(conceptId, suffix = '') {
 export async function loadConceptAttributes(conceptId, suffix = '') {
   console.log('loadConceptAttributes called with conceptId:', conceptId, 'suffix:', suffix);
 
+  const updateVerticalResizeHandleIfOverflow = (el) => {
+    if (!el) return;
+    try {
+      el.classList.add('von-vertical-resize-if-overflow');
+      const apply = () => {
+        try {
+          const overflowing = el.scrollHeight > el.clientHeight + 1;
+
+          if (overflowing) {
+            el.dataset.vonResizeEnabled = '1';
+          }
+          const resizeEnabled = overflowing || el.dataset.vonResizeEnabled === '1';
+          el.classList.toggle('von-overflowing', resizeEnabled);
+
+          if (resizeEnabled && typeof window !== 'undefined' && typeof window.getComputedStyle === 'function') {
+            const computed = window.getComputedStyle(el);
+            const computedMaxHeight = computed?.maxHeight;
+            const maxHeightIsClamping = !!computedMaxHeight && computedMaxHeight !== 'none' && computedMaxHeight !== '0px';
+
+            if (maxHeightIsClamping) {
+              if (!el.style.height || el.style.height === 'auto') {
+                el.style.height = `${el.clientHeight}px`;
+              }
+              el.style.maxHeight = 'none';
+            }
+          }
+        } catch (_) { /* ignore */ }
+      };
+      if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(apply);
+      }
+      setTimeout(apply, 0);
+    } catch (_) {
+      /* ignore */
+    }
+  };
+
   const getSuffixElement = (baseId) => {
     const id = suffix ? `${baseId}_${suffix}` : baseId;
     return document.getElementById(id);
@@ -2937,6 +2974,43 @@ export async function loadConceptAttributes(conceptId, suffix = '') {
       rel => rel.predicate && rel.predicate !== 'hasName' && rel.predicate !== '#V#hasName'
     );
 
+    // Predicates already shown in specialised sections above the Text Relations list.
+    const recapPredicates = new Set([
+      'hasDescription', '#V#hasDescription',
+      'hasContent', '#V#hasContent',
+      'hasNote', '#V#hasNote'
+    ]);
+
+    const recapAttributes = attributes.filter(a => recapPredicates.has(a.predicate));
+    const otherAttributes = attributes.filter(a => !recapPredicates.has(a.predicate));
+
+    const normalisePredicateLabel = (predicate) => String(predicate || '').replace(/^#V#/, '');
+    const parseTimestamp = (attr) => {
+      const raw = attr?.updated_at || attr?.created_at;
+      if (!raw) return null;
+      const d = new Date(raw);
+      return Number.isNaN(d.getTime()) ? null : d;
+    };
+
+    const formatTimestamp = (d) => {
+      if (!d) return 'N/A';
+      try {
+        // Keep compact but readable; NZ locale if available.
+        return d.toLocaleString('en-NZ');
+      } catch (_) {
+        return d.toISOString();
+      }
+    };
+
+    const normaliseRecapDisplayText = (text) => {
+      const raw = String(text ?? '');
+      // Suppress blank lines (keeps single newlines for readability).
+      return raw
+        .replace(/\r\n/g, '\n')
+        .replace(/\n[\t \u00A0]*\n+/g, '\n')
+        .trim();
+    };
+
     console.log('Filtered attributes (excluding names):', attributes);
 
     if (attributes.length === 0) {
@@ -2949,8 +3023,75 @@ export async function loadConceptAttributes(conceptId, suffix = '') {
       return;
     }
 
-    // Display each attribute
-    attributes.forEach(attr => {
+    // Recap table for attributes that are already shown above (Content/Notes/Description)
+    if (recapAttributes.length) {
+      const recapWrap = document.createElement('div');
+      recapWrap.className = 'attributes-recap-table-wrap';
+
+      const table = document.createElement('table');
+      table.className = 'attributes-recap-table';
+
+      // Sort newest-first to match the typical "latest at top" feel.
+      const sorted = [...recapAttributes].sort((a, b) => {
+        const da = parseTimestamp(a);
+        const db = parseTimestamp(b);
+        const ta = da ? da.getTime() : 0;
+        const tb = db ? db.getTime() : 0;
+        return tb - ta;
+      });
+
+      const showTimestampColumn = sorted.some(attr => parseTimestamp(attr) !== null);
+
+      table.innerHTML = `
+        <thead>
+          <tr>
+            <th>Predicate</th>
+            <th>Object(s)</th>
+            ${showTimestampColumn ? '<th>Timestamp</th>' : ''}
+          </tr>
+        </thead>
+        <tbody></tbody>
+      `;
+
+      const tbodyUpdated = table.querySelector('tbody');
+
+      sorted.forEach(attr => {
+        const tr = document.createElement('tr');
+
+        const tdPred = document.createElement('td');
+        const predPill = document.createElement('span');
+        predPill.className = 'attributes-recap-predicate-pill';
+        predPill.textContent = normalisePredicateLabel(attr.predicate);
+        tdPred.appendChild(predPill);
+
+        const tdObj = document.createElement('td');
+        const objDiv = document.createElement('div');
+        objDiv.className = 'attributes-recap-object von-vertical-resize-if-overflow';
+        const displayText = normaliseRecapDisplayText(attr.text);
+        objDiv.textContent = displayText;
+        objDiv.title = displayText;
+        tdObj.appendChild(objDiv);
+        updateVerticalResizeHandleIfOverflow(objDiv);
+
+        tr.appendChild(tdPred);
+        tr.appendChild(tdObj);
+
+        if (showTimestampColumn) {
+          const tdTs = document.createElement('td');
+          const ts = parseTimestamp(attr);
+          tdTs.textContent = formatTimestamp(ts);
+          tr.appendChild(tdTs);
+        }
+
+        tbodyUpdated.appendChild(tr);
+      });
+
+      recapWrap.appendChild(table);
+      attributesList.appendChild(recapWrap);
+    }
+
+    // Display remaining attributes using the existing cartouche layout
+    otherAttributes.forEach(attr => {
       const cartouche = document.createElement('div');
       cartouche.className = 'attribute-cartouche';
       cartouche.style.display = 'flex';
@@ -2968,7 +3109,7 @@ export async function loadConceptAttributes(conceptId, suffix = '') {
       predicateLabel.style.color = '#374151';
       predicateLabel.style.minWidth = '120px';
       // Remove #V# prefix for display
-      const displayPredicate = attr.predicate.replace(/^#V#/, '');
+      const displayPredicate = normalisePredicateLabel(attr.predicate);
       predicateLabel.textContent = displayPredicate + ':';
 
       // Text value
@@ -2976,8 +3117,14 @@ export async function loadConceptAttributes(conceptId, suffix = '') {
       textValue.className = 'attribute-text';
       textValue.style.flex = '1';
       textValue.style.color = '#1f2937';
+      textValue.style.display = 'block';
+      textValue.style.whiteSpace = 'pre-wrap';
+      textValue.style.maxHeight = '180px';
+      textValue.style.overflow = 'auto';
       textValue.textContent = attr.text || '';
       textValue.title = attr.text || '';
+
+      updateVerticalResizeHandleIfOverflow(textValue);
 
       // Language badge (if not default)
       const langBadge = document.createElement('span');
@@ -2999,6 +3146,17 @@ export async function loadConceptAttributes(conceptId, suffix = '') {
 
       attributesList.appendChild(cartouche);
     });
+
+    // If there are no non-recap attributes, keep the section informative.
+    if (!otherAttributes.length && recapAttributes.length) {
+      const note = document.createElement('div');
+      note.className = 'attributes-empty-state';
+      note.style.color = '#6b7280';
+      note.style.fontStyle = 'italic';
+      note.style.marginTop = '6px';
+      note.textContent = 'No additional text relations beyond the sections shown above.';
+      attributesList.appendChild(note);
+    }
 
   } catch (error) {
     console.error('Error loading concept attributes:', error);

--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -103,6 +103,43 @@ function injectIconContent(el, key, label) {
 function upgradeActionButtonIcons(scope = document) {
     try { scope.querySelectorAll('.round-icon-button').forEach(btn => injectIconContent(btn)); } catch (_) { }
 }// Utility: Copy text to clipboard with modern API and fallback
+
+function updateVerticalResizeHandleIfOverflow(el) {
+    if (!el || typeof el !== 'object') return;
+    try {
+        el.classList.add('von-vertical-resize-if-overflow');
+        // Defer measurement to allow layout + fonts to settle.
+        const apply = () => {
+            try {
+                const overflowing = el.scrollHeight > el.clientHeight + 1;
+                if (overflowing) {
+                    el.dataset.vonResizeEnabled = '1';
+                }
+                const resizeEnabled = overflowing || el.dataset.vonResizeEnabled === '1';
+                el.classList.toggle('von-overflowing', resizeEnabled);
+
+                if (resizeEnabled && typeof window !== 'undefined' && typeof window.getComputedStyle === 'function') {
+                    const computed = window.getComputedStyle(el);
+                    const computedMaxHeight = computed?.maxHeight;
+                    const maxHeightIsClamping = !!computedMaxHeight && computedMaxHeight !== 'none' && computedMaxHeight !== '0px';
+                    if (maxHeightIsClamping) {
+                        if (!el.style.height || el.style.height === 'auto') {
+                            el.style.height = `${el.clientHeight}px`;
+                        }
+                        el.style.maxHeight = 'none';
+                    }
+                }
+            } catch (_) { /* ignore */ }
+        };
+        if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(apply);
+        }
+        setTimeout(apply, 0);
+    } catch (_) {
+        /* ignore */
+    }
+}
+
 async function copyToClipboard(text, button) {
     try {
         if (navigator.clipboard && window.isSecureContext) {
@@ -3464,6 +3501,11 @@ async function populateNotesSection(conceptId, suffix) {
                    </div>`;
                 listEl.appendChild(item);
 
+                try {
+                    const viewEl = item.querySelector('.note-view');
+                    updateVerticalResizeHandleIfOverflow(viewEl);
+                } catch (_) { /* ignore */ }
+
                 if (isMarkdown) {
                     const viewEl = item.querySelector('.note-view');
                     if (viewEl) {
@@ -3471,6 +3513,7 @@ async function populateNotesSection(conceptId, suffix) {
                             viewEl.innerHTML = html || '<i>(empty)</i>';
                             // Markdown is injected as HTML; do not preserve whitespace formatting.
                             viewEl.style.whiteSpace = 'normal';
+                            updateVerticalResizeHandleIfOverflow(viewEl);
                         }).catch(() => {
                             // Leave plaintext fallback.
                         });
@@ -3518,16 +3561,22 @@ async function populateNotesSection(conceptId, suffix) {
                         const full = viewEl.getAttribute('data-full') || '';
                         const truncated = full.length > 800;
                         viewEl.innerHTML = truncated ? escapeHtml(full.slice(0, 800)) + '…' : escapeHtml(full);
+                        viewEl.style.removeProperty('height');
                         viewEl.style.maxHeight = '220px';
                         viewEl.style.overflow = 'auto';
+                        updateVerticalResizeHandleIfOverflow(viewEl);
                         expandBtn.dataset.icon = 'expand';
                         expandBtn.title = 'Show more';
                         expandBtn.setAttribute('aria-label', 'Show full note');
                         expandBtn.dataset.expanded = '0';
                     } else {
                         viewEl.innerHTML = escapeHtml(viewEl.getAttribute('data-full') || '');
+                        viewEl.style.removeProperty('height');
                         viewEl.style.maxHeight = 'none';
                         viewEl.style.overflow = 'visible';
+                        delete viewEl.dataset.vonResizeEnabled;
+                        viewEl.classList.remove('von-overflowing');
+                        updateVerticalResizeHandleIfOverflow(viewEl);
                         expandBtn.dataset.icon = 'collapse';
                         expandBtn.title = 'Show less';
                         expandBtn.setAttribute('aria-label', 'Show less of note');
@@ -3587,12 +3636,20 @@ async function populateNotesSection(conceptId, suffix) {
                     viewEl.setAttribute('data-truncated', truncated ? '1' : '0');
                     if (truncated) {
                         viewEl.innerHTML = safeFull.slice(0, 800) + '…';
+                        viewEl.style.removeProperty('height');
                         viewEl.style.maxHeight = '220px';
+                        viewEl.style.overflow = 'auto';
                         if (expandBtn) { expandBtn.style.display = 'flex'; expandBtn.dataset.icon = 'expand'; expandBtn.dataset.expanded = '0'; }
                     } else {
                         viewEl.innerHTML = safeFull;
+                        viewEl.style.removeProperty('height');
+                        viewEl.style.maxHeight = 'none';
+                        viewEl.style.overflow = 'visible';
+                        delete viewEl.dataset.vonResizeEnabled;
+                        viewEl.classList.remove('von-overflowing');
                         if (expandBtn) { expandBtn.style.display = 'none'; }
                     }
+                    updateVerticalResizeHandleIfOverflow(viewEl);
                     status.textContent = 'Saved';
                     editWrap.classList.add('hidden'); viewEl.classList.remove('hidden'); editBtn.disabled = false;
                     if (expandBtn) expandBtn.focus(); else editBtn.focus();
@@ -3745,17 +3802,25 @@ async function populateContentSection(conceptId, suffix) {
         const statusEl = section.querySelector(`#contentStatus_${suffix}`);
         const addBtn = section.querySelector(`#addContentButton_${suffix}`);
 
+        const isContentPredicate = (p) => p === 'hasContent' || p === '#V#hasContent';
+
         const fetchContent = async () => {
             statusEl.textContent = 'Loading content...';
             try {
-                const res = await fetch(`/api/concepts/${encodeURIComponent(currentConceptId)}/texts?predicate=hasContent&limit=200`, {
+                // Fetch all texts then filter by predicate client-side so we include both legacy-style
+                // '#V#hasContent' and canonical 'hasContent'.
+                const res = await fetch(`/api/concepts/${encodeURIComponent(currentConceptId)}/texts?limit=200`, {
                     cache: 'no-store',
                     headers: { 'Cache-Control': 'no-cache' }
                 });
                 const data = await res.json().catch(() => ({}));
                 if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
-                renderContent(Array.isArray(data.texts) ? data.texts : []);
-                statusEl.textContent = data.count ? `${data.count} content item${data.count === 1 ? '' : 's'}` : 'No content yet.';
+                const allTexts = Array.isArray(data.texts) ? data.texts : [];
+                const contentTexts = allTexts.filter(t => isContentPredicate(t?.predicate));
+                renderContent(contentTexts);
+                statusEl.textContent = contentTexts.length
+                    ? `${contentTexts.length} content item${contentTexts.length === 1 ? '' : 's'}`
+                    : 'No content yet.';
             } catch (e) {
                 statusEl.textContent = `Failed to load content: ${e.message}`;
             }
@@ -3812,6 +3877,11 @@ async function populateContentSection(conceptId, suffix) {
                    </div>`;
                 listEl.appendChild(item);
 
+                try {
+                    const viewEl = item.querySelector('.content-view');
+                    updateVerticalResizeHandleIfOverflow(viewEl);
+                } catch (_) { /* ignore */ }
+
                 if (isMarkdown) {
                     const viewEl = item.querySelector('.content-view');
                     if (viewEl) {
@@ -3819,6 +3889,7 @@ async function populateContentSection(conceptId, suffix) {
                             viewEl.innerHTML = html || '<i>(empty)</i>';
                             // Markdown is injected as HTML; do not preserve whitespace formatting.
                             viewEl.style.whiteSpace = 'normal';
+                            updateVerticalResizeHandleIfOverflow(viewEl);
                         }).catch(() => {
                             // Leave plaintext fallback.
                         });
@@ -3866,16 +3937,22 @@ async function populateContentSection(conceptId, suffix) {
                         const full = viewEl.getAttribute('data-full') || '';
                         const truncated = full.length > 1000;
                         viewEl.innerHTML = truncated ? escapeHtml(full.slice(0, 1000)) + '…' : escapeHtml(full);
+                        viewEl.style.removeProperty('height');
                         viewEl.style.maxHeight = '250px';
                         viewEl.style.overflow = 'auto';
+                        updateVerticalResizeHandleIfOverflow(viewEl);
                         expandBtn.dataset.icon = 'expand';
                         expandBtn.title = 'Show more';
                         expandBtn.setAttribute('aria-label', 'Show full content');
                         expandBtn.dataset.expanded = '0';
                     } else {
                         viewEl.innerHTML = escapeHtml(viewEl.getAttribute('data-full') || '');
+                        viewEl.style.removeProperty('height');
                         viewEl.style.maxHeight = 'none';
                         viewEl.style.overflow = 'visible';
+                        delete viewEl.dataset.vonResizeEnabled;
+                        viewEl.classList.remove('von-overflowing');
+                        updateVerticalResizeHandleIfOverflow(viewEl);
                         expandBtn.dataset.icon = 'collapse';
                         expandBtn.title = 'Show less';
                         expandBtn.setAttribute('aria-label', 'Show less of content');
@@ -3935,12 +4012,20 @@ async function populateContentSection(conceptId, suffix) {
                     viewEl.setAttribute('data-truncated', truncated ? '1' : '0');
                     if (truncated) {
                         viewEl.innerHTML = safeFull.slice(0, 1000) + '…';
+                        viewEl.style.removeProperty('height');
                         viewEl.style.maxHeight = '250px';
+                        viewEl.style.overflow = 'auto';
                         if (expandBtn) { expandBtn.style.display = 'flex'; expandBtn.dataset.icon = 'expand'; expandBtn.dataset.expanded = '0'; }
                     } else {
                         viewEl.innerHTML = safeFull;
+                        viewEl.style.removeProperty('height');
+                        viewEl.style.maxHeight = 'none';
+                        viewEl.style.overflow = 'visible';
+                        delete viewEl.dataset.vonResizeEnabled;
+                        viewEl.classList.remove('von-overflowing');
                         if (expandBtn) { expandBtn.style.display = 'none'; }
                     }
+                    updateVerticalResizeHandleIfOverflow(viewEl);
                     status.textContent = 'Saved';
                     editWrap.classList.add('hidden'); viewEl.classList.remove('hidden'); editBtn.disabled = false;
                     if (expandBtn) expandBtn.focus(); else editBtn.focus();

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -1583,6 +1583,91 @@ textarea:focus {
     border-color: #888;
 }
 
+/* Resize handle only when content is overflowing */
+.von-vertical-resize-if-overflow {
+    overflow: auto;
+    resize: none;
+}
+
+.von-vertical-resize-if-overflow.von-overflowing {
+    resize: vertical;
+}
+
+/* Text Relations recap table (compact, like predicate/text_relations listing) */
+.attributes-recap-table-wrap {
+    margin: 6px 0 10px 0;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    overflow: hidden;
+    background: #fff;
+}
+
+.attributes-recap-table {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: auto;
+}
+
+/* Column sizing: keep predicate as narrow as possible */
+.attributes-recap-table th:first-child,
+.attributes-recap-table td:first-child {
+    width: 1%;
+    white-space: nowrap;
+}
+
+/* If a timestamp column is present, keep it compact too */
+.attributes-recap-table th:last-child,
+.attributes-recap-table td:last-child {
+    white-space: nowrap;
+}
+
+.attributes-recap-table thead th {
+    text-align: left;
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: #374151;
+    background: #f9fafb;
+    padding: 10px 12px;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.attributes-recap-table tbody td {
+    padding: 10px 12px;
+    border-bottom: 1px solid #f1f5f9;
+    vertical-align: top;
+    font-size: 0.85rem;
+    color: #111827;
+}
+
+.attributes-recap-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.attributes-recap-predicate-pill {
+    display: inline-block;
+    padding: 3px 8px;
+    border-radius: 999px;
+    background: #eef2ff;
+    color: #3730a3;
+    border: 1px solid #c7d2fe;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.attributes-recap-object {
+    line-height: 1.35;
+    max-height: calc(3 * 1.35em);
+    overflow: auto;
+    white-space: pre-wrap;
+    padding-right: 6px;
+}
+
+.attributes-recap-source {
+    color: #1d4ed8;
+    font-style: italic;
+    white-space: nowrap;
+}
+
 /* Ensure the interaction (bottom) notes editor spans full available width */
 #updatedNotesDisplay {
     max-width: 100%;

--- a/src/frontend/web/von_interface/templates/concept_tab.html
+++ b/src/frontend/web/von_interface/templates/concept_tab.html
@@ -123,7 +123,7 @@
 
   <!-- Text Relations/Text Fields Section -->
   <div id="attributesSection" class="concept-list-subsection">
-    <h3 class="concept-list-title">Text Fields</h3>
+    <h3 class="concept-list-title">Text Relations</h3>
     <div id="attributesDisplay">
       <div id="attributesList" class="attributes-list-container">
         <!-- Text fields will be populated dynamically -->

--- a/tests/backend/test_internal_mcp_rag_get_status_url.py
+++ b/tests/backend/test_internal_mcp_rag_get_status_url.py
@@ -1,0 +1,56 @@
+import pytest
+
+
+class _StubResponse:
+    def __init__(self, *, ok: bool, payload: dict, status_code: int = 200):
+        self.ok = ok
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return dict(self._payload)
+
+
+def test_rag_get_status_defaults_to_von_web_port_5000(monkeypatch):
+    monkeypatch.delenv("VON_HTTP_BASE_URL", raising=False)
+    monkeypatch.delenv("VON_WEB_BASE_URL", raising=False)
+    monkeypatch.setenv("VON_DEFAULT_NAMESPACE", "#V#test_user")
+
+    captured = {}
+
+    def _fake_get(url, timeout):
+        captured["url"] = url
+        captured["timeout"] = timeout
+        return _StubResponse(ok=True, payload={"total": 1, "indexed": 1})
+
+    monkeypatch.setattr("requests.get", _fake_get)
+
+    from src.backend.integrations.internal_mcp.catalogue import _rag_get_status
+
+    payload = _rag_get_status()
+
+    assert captured["timeout"] == 5
+    assert captured["url"].startswith("http://127.0.0.1:5000/admin/rag_status")
+    assert "namespace=#V#test_user" in captured["url"]
+    assert payload.get("success") is not False
+
+
+def test_rag_get_status_honours_configured_http_base_url(monkeypatch):
+    monkeypatch.setenv("VON_HTTP_BASE_URL", "http://127.0.0.1:5999")
+    monkeypatch.setenv("VON_DEFAULT_NAMESPACE", "#V#test_user")
+
+    captured = {}
+
+    def _fake_get(url, timeout):
+        captured["url"] = url
+        captured["timeout"] = timeout
+        return _StubResponse(ok=True, payload={"total": 2, "indexed": 2})
+
+    monkeypatch.setattr("requests.get", _fake_get)
+
+    from src.backend.integrations.internal_mcp.catalogue import _rag_get_status
+
+    _rag_get_status(detail=True)
+
+    assert captured["url"].startswith("http://127.0.0.1:5999/admin/rag_status")
+    assert "detail=1" in captured["url"]

--- a/tests/backend/test_rag_provenance_contract.py
+++ b/tests/backend/test_rag_provenance_contract.py
@@ -170,8 +170,10 @@ def test_search_knowledge_base_derives_permissions_context_from_namespace(monkey
     }
 
 
-def test_rag_list_collections_requires_namespace():
+def test_rag_list_collections_requires_namespace(monkeypatch):
     from src.backend.integrations.internal_mcp import catalogue as cat
+
+    monkeypatch.delenv("VON_DEFAULT_NAMESPACE", raising=False)
 
     result = cat._rag_list_collections()
     assert result["success"] is False
@@ -192,6 +194,7 @@ def test_rag_list_collections_includes_expected_collections():
     assert "ka_sessions" in collections
     assert "chat_history_sessions" in collections
     assert "rag_documents" in collections
+    assert "vontology_text_relations" in collections
 
     # Capability flags prevent the model inferring behaviour from missing tools.
     by_name = {c["collection"]: c for c in result["collections"]}
@@ -199,6 +202,11 @@ def test_rag_list_collections_includes_expected_collections():
     assert by_name["ka_sessions"]["get_supported"] is True
     assert by_name["rag_documents"]["list_supported"] is False
     assert by_name["rag_documents"]["get_supported"] is False
+
+    # Text relations are discoverable via search once indexed.
+    assert by_name["vontology_text_relations"]["search_supported"] is True
+    assert by_name["vontology_text_relations"]["list_supported"] is True
+    assert by_name["vontology_text_relations"]["get_supported"] is True
 
 
 def test_rag_list_indexed_supports_chat_history_sessions(monkeypatch):

--- a/tests/backend/test_rag_text_relation_sync_service.py
+++ b/tests/backend/test_rag_text_relation_sync_service.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import pytest
+
+
+class _ConceptsCollection:
+    def __init__(self, visible_concepts: set[str]):
+        self.visible_concepts = set(visible_concepts)
+
+    def find_one(
+        self, query: Dict[str, Any], _projection: Optional[Dict[str, Any]] = None
+    ):
+        # Our service wraps the base filter with apply_concept_query_filter, so concept_id may be
+        # nested under $and. Extract it loosely.
+        def _extract_concept_id(q: Any) -> Optional[str]:
+            if isinstance(q, dict):
+                if "concept_id" in q and isinstance(q["concept_id"], str):
+                    return q["concept_id"]
+                if "$and" in q and isinstance(q["$and"], list):
+                    for part in q["$and"]:
+                        found = _extract_concept_id(part)
+                        if found:
+                            return found
+                if "$or" in q and isinstance(q["$or"], list):
+                    for part in q["$or"]:
+                        found = _extract_concept_id(part)
+                        if found:
+                            return found
+            return None
+
+        concept_id = _extract_concept_id(query)
+        if concept_id and concept_id in self.visible_concepts:
+            return {"_id": "ok"}
+        return None
+
+
+class _StubRAG:
+    def __init__(self):
+        self.upserts = []
+
+    def upsert_documents(self, docs, *, namespace=None, allow_partial_failures=True):
+        self.upserts.extend(docs)
+        return (len(docs), 0)
+
+
+def test_sync_text_relations_indexes_visible_concepts(monkeypatch):
+    from src.backend.services import rag_text_relation_sync_service as svc
+
+    # Visible concept set for the namespace.
+    monkeypatch.setattr(
+        svc, "get_concepts_collection", lambda: _ConceptsCollection({"#V#allowed"})
+    )
+
+    # Two relations: one visible, one not.
+    monkeypatch.setattr(
+        "src.backend.db.repositories.text_value_repository.TextRelationsRepository.find",
+        lambda _filter, limit=0: [
+            {
+                "_id": "r1",
+                "subject_concept_id": "#V#allowed",
+                "predicate": "hasDescription",
+                "object_text_id": "000000000000000000000001",
+            },
+            {
+                "_id": "r2",
+                "subject_concept_id": "#V#blocked",
+                "predicate": "hasDescription",
+                "object_text_id": "000000000000000000000002",
+            },
+        ],
+    )
+
+    def _tv_find_one(filter_doc, _projection=None):
+        oid = filter_doc.get("_id")
+        if str(oid) == "000000000000000000000001":
+            return {"_id": oid, "text": "Hello world", "lang": "en-NZ"}
+        if str(oid) == "000000000000000000000002":
+            return {"_id": oid, "text": "Should not index", "lang": "en-NZ"}
+        return None
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.text_value_repository.TextValuesRepository.find_one",
+        _tv_find_one,
+    )
+
+    rag = _StubRAG()
+    monkeypatch.setattr(svc, "get_rag_service", lambda *_args, **_kwargs: rag)
+
+    result = svc.sync_text_relations_to_rag(namespace="#V#user@org", limit=100)
+    assert result["success"] is True
+
+    # Only the visible concept relation should be upserted.
+    assert len(rag.upserts) == 1
+    doc = rag.upserts[0]
+    assert doc["id"] == "text_relation:r1"
+    assert "Hello world" in doc["text"]
+
+    meta = doc["metadata"]
+    assert meta["source"] == "vontology_text_relation"
+    assert meta["subject_concept_id"] == "#V#allowed"
+    assert meta["predicate"] == "hasDescription"
+    assert meta["relation_id"] == "r1"
+
+    # Required for permission filtering.
+    assert meta["user_id"] == "#V#user"
+    assert meta["organisation_concept_id"] == "#V#org"

--- a/tests/backend/test_rag_text_relations_mcp_read_tools.py
+++ b/tests/backend/test_rag_text_relations_mcp_read_tools.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+
+def test_rag_list_indexed_supports_vontology_text_relations(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    monkeypatch.setattr(
+        "src.backend.db.connection_manager.get_db",
+        lambda: object(),
+    )
+
+    monkeypatch.setattr(
+        "src.backend.services.rag_text_relation_sync_service.list_text_relation_index_items",
+        lambda **_kwargs: {
+            "items": [
+                {
+                    "relation_id": "r1",
+                    "subject_concept_id": "#V#x",
+                    "predicate": "hasDescription",
+                    "text_value_id": "t1",
+                    "lang": "en-NZ",
+                    "preview_length": 12,
+                    "updated_at": "2025-01-01T00:00:00Z",
+                }
+            ],
+            "total": 1,
+            "scanned": 1,
+            "limit": 10,
+            "offset": 0,
+            "scan_limit": 5000,
+        },
+    )
+
+    result = cat._rag_list_indexed(
+        namespace="#V#user@org",
+        collection="vontology_text_relations",
+        limit=10,
+        offset=0,
+    )
+
+    assert result["success"] is True
+    assert result["collection"] == "vontology_text_relations"
+    assert result["provenance"]["item_kind"] == "rag_text_relation_list"
+
+    assert result["items"]
+    item = result["items"][0]
+    assert item["item_kind"] == "vontology_text_relation"
+    assert item["source_system"] == "mongo.text_relations"
+    assert item["session_id"] == "r1"
+
+
+def test_rag_get_item_supports_vontology_text_relations(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    monkeypatch.setattr(
+        "src.backend.db.connection_manager.get_db",
+        lambda: object(),
+    )
+
+    class _Doc:
+        def __init__(self):
+            self.text = (
+                "Concept: #V#x\nPredicate: hasDescription\nLanguage: en-NZ\n\nHello"
+            )
+            self.metadata = {
+                "relation_id": "r1",
+                "subject_concept_id": "#V#x",
+                "predicate": "hasDescription",
+                "lang": "en-NZ",
+            }
+
+    monkeypatch.setattr(
+        "src.backend.services.rag_text_relation_sync_service.get_text_relation_preview",
+        lambda **_kwargs: _Doc(),
+    )
+
+    result = cat._rag_get_item(
+        namespace="#V#user@org",
+        collection="vontology_text_relations",
+        session_id="r1",
+    )
+
+    assert result["success"] is True
+    assert result["collection"] == "vontology_text_relations"
+    assert result["provenance"]["item_kind"] == "rag_text_relation_item"
+    assert "Hello" in result["preview"]

--- a/tests/backend/test_virtual_code_predicate_concepts.py
+++ b/tests/backend/test_virtual_code_predicate_concepts.py
@@ -1,0 +1,240 @@
+"""Regression tests for virtual code-handled predicate concepts.
+
+These predicates (e.g. #V#hasContent) may be stored as text-relation predicates even
+when no MongoDB concept document exists. The UI should still be able to render
+cartouches/tabs/tree/instances without prompting to create a missing concept.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from src.backend.vontology import utils_vontology
+
+
+def _flatten_tree_ids(node: dict) -> list[str]:
+    out: list[str] = []
+
+    def rec(n: dict):
+        if not isinstance(n, dict):
+            return
+        cid = n.get("id") or n.get("concept_id")
+        if isinstance(cid, str):
+            out.append(cid)
+        for ch in n.get("children") or []:
+            rec(ch)
+
+    rec(node)
+    return out
+
+
+def test_node_content_virtual_code_predicate_when_missing(monkeypatch):
+    monkeypatch.setattr(
+        utils_vontology.ConceptsRepository, "find_one", lambda *a, **k: None
+    )
+
+    payload = utils_vontology.get_vontology_node_content("#V#hasContent")
+
+    assert "error" not in payload
+    assert payload.get("concept_id") == "#V#hasContent"
+    assert payload.get("kind") == "predicate"
+    assert payload.get("display_name") == "hasContent"
+
+
+def test_tree_includes_virtual_code_predicates_under_predicate_type(monkeypatch):
+    def _fake_find(*_args, **_kwargs):
+        return [
+            {
+                "concept_id": "#V#thing",
+                "name": "Thing",
+                "names": [{"name": "Thing", "type": "NL", "language": "en-NZ"}],
+                "relationships": {"is_a_type_of": [], "is_an_instance_of": []},
+                "path": "#V#thing",
+            },
+            {
+                "concept_id": "#V#predicate",
+                "name": "Predicate",
+                "names": [{"name": "Predicate", "type": "NL", "language": "en-NZ"}],
+                "relationships": {
+                    "is_a_type_of": ["#V#thing"],
+                    "is_an_instance_of": [],
+                },
+                "path": "#V#predicate",
+            },
+        ]
+
+    monkeypatch.setattr(utils_vontology.ConceptsRepository, "find", _fake_find)
+
+    tree_payload = utils_vontology.get_vontology_tree()
+    assert "error" not in tree_payload
+    tree = tree_payload.get("tree")
+    assert isinstance(tree, list) and tree
+
+    root = tree[0]
+    ids = _flatten_tree_ids(root)
+
+    assert "#V#hasContent" in ids
+
+    # Also check the structural expectation: hasContent is placed somewhere under #V#predicate.
+    # We do this by locating the predicate node and verifying it contains the child.
+    def find_node(n: dict, target: str) -> dict | None:
+        if not isinstance(n, dict):
+            return None
+        if n.get("id") == target:
+            return n
+        for ch in n.get("children") or []:
+            found = find_node(ch, target)
+            if found:
+                return found
+        return None
+
+    predicate_node = find_node(root, "#V#predicate")
+    assert predicate_node is not None
+    predicate_child_ids = _flatten_tree_ids(predicate_node)
+    assert "#V#hasContent" in predicate_child_ids
+
+
+@pytest.fixture
+def app_client(monkeypatch):
+    """Provide a Flask test client with side effects stubbed out."""
+
+    # Stub Google auth dependencies pulled in by utils_flask -> auth_routes imports.
+    fake_flow_module = types.ModuleType("google_auth_oauthlib.flow")
+
+    class _DummyFlow:
+        def __init__(self, *args, **kwargs):
+            self.credentials = types.SimpleNamespace(id_token="dummy-token")
+            self.redirect_uri = kwargs.get("redirect_uri")
+            self.client_config = {"web": {"redirect_uris": [self.redirect_uri]}}
+
+        @classmethod
+        def from_client_config(cls, *args, **kwargs):
+            return cls(**kwargs)
+
+        def authorization_url(self, *args, **kwargs):
+            return "https://auth.example", "state-token"
+
+        def fetch_token(self, *args, **kwargs):
+            return None
+
+    fake_flow_module.Flow = _DummyFlow  # type: ignore[attr-defined]
+    sys.modules["google_auth_oauthlib"] = types.ModuleType("google_auth_oauthlib")
+    sys.modules["google_auth_oauthlib"].flow = fake_flow_module  # type: ignore[attr-defined]
+    sys.modules["google_auth_oauthlib.flow"] = fake_flow_module
+
+    fake_id_token_module = types.ModuleType("google.oauth2.id_token")
+    fake_id_token_module.verify_oauth2_token = lambda *args, **kwargs: {  # type: ignore[attr-defined]
+        "sub": "dummy-user"
+    }
+
+    fake_credentials_module = types.ModuleType("google.oauth2.credentials")
+
+    class _DummyCredentials:
+        def __init__(self, id_token: str = "dummy-token"):
+            self.id_token = id_token
+
+    fake_credentials_module.Credentials = _DummyCredentials  # type: ignore[attr-defined]
+
+    fake_service_account_module = types.ModuleType("google.oauth2.service_account")
+
+    class _DummyServiceAccountCredentials:
+        def __init__(self, *args, **kwargs):
+            self.project_id = kwargs.get("project_id")
+
+    fake_service_account_module.Credentials = _DummyServiceAccountCredentials  # type: ignore[attr-defined]
+
+    fake_oauth2_package = types.ModuleType("google.oauth2")
+    fake_oauth2_package.id_token = fake_id_token_module  # type: ignore[attr-defined]
+    fake_oauth2_package.credentials = fake_credentials_module  # type: ignore[attr-defined]
+    fake_oauth2_package.service_account = fake_service_account_module  # type: ignore[attr-defined]
+
+    sys.modules["google.oauth2"] = fake_oauth2_package
+    sys.modules["google.oauth2.id_token"] = fake_id_token_module
+    sys.modules["google.oauth2.credentials"] = fake_credentials_module
+    sys.modules["google.oauth2.service_account"] = fake_service_account_module
+
+    import src.backend.server.utils_flask as utils_flask
+
+    monkeypatch.setattr(utils_flask, "ensure_monitor_started", lambda: None)
+    monkeypatch.setattr(
+        utils_flask,
+        "prompt_concept_health_status",
+        lambda: {"available": True, "source_field": "stub"},
+    )
+
+    app = utils_flask.create_flask_app(
+        list_models_func=lambda: ["dummy-model"],
+        generate_func=lambda prompt, context, model: "ok",
+    )
+    app.config["TESTING"] = True
+
+    with app.test_client() as client:
+        yield app, client
+
+
+def test_instances_includes_virtual_code_concepts_for_mentioned_in_von_code(
+    app_client, monkeypatch
+):
+    _, client = app_client
+
+    # Avoid hitting Mongo; ensure route still exposes code concepts.
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.ConceptsRepository.find",
+        lambda *a, **k: [],
+    )
+
+    resp = client.get(
+        "/vontology/api/vontology/instances?node_id=%23V%23mentioned_in_von_code"
+    )
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    ids = {item.get("id") for item in payload.get("instances") or []}
+    assert "#V#hasContent" in ids
+
+
+def test_relationships_route_allows_virtual_code_predicate(app_client, monkeypatch):
+    _, client = app_client
+
+    # Ensure the primary concept lookup misses Mongo.
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.ConceptsRepository.find_one",
+        lambda *a, **k: None,
+    )
+    # Avoid any accidental Mongo reads during ID resolution.
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.ConceptsRepository.find",
+        lambda *a, **k: [],
+    )
+
+    resp = client.get(
+        "/vontology/api/vontology/relationships?identifier=%23V%23hasContent"
+    )
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload.get("success") is True
+    assert payload.get("concept_id") == "#V#hasContent"
+
+
+def test_upsert_name_for_virtual_code_predicate_concept(app_client, monkeypatch):
+    _, client = app_client
+
+    # Avoid real DB writes. We only want to verify that access control no longer
+    # blocks virtual code predicate concepts.
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes.upsert_text_for_concept",
+        lambda **kwargs: {
+            "relation_id": "dummy",
+            "relation_created": True,
+            "context_updated": False,
+            "text_id": "dummy_text_id",
+        },
+    )
+
+    resp = client.post(
+        "/api/concepts/%23V%23hasContent/texts",
+        json={"predicate": "hasName", "text": "hasContent", "lang": "en"},
+    )
+    assert resp.status_code in (200, 201)

--- a/tests/frontend/contentSectionPredicateNormalisation.test.js
+++ b/tests/frontend/contentSectionPredicateNormalisation.test.js
@@ -1,0 +1,97 @@
+/** @jest-environment jsdom */
+
+const dynamicTabsModulePath = '../../src/frontend/web/von_interface/static/js/dynamicTabs.js';
+
+// Mock dynamicTabs dependencies so we can load the module in isolation.
+jest.mock('../../src/frontend/web/von_interface/static/js/annotationTab.js', () => ({
+    initializeAnnotationTab: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/conceptTab.js', () => ({
+    fetchConceptListWithSuffix: jest.fn(),
+    fetchSubtypesWithSuffix: jest.fn(),
+    initializeNamesForm: jest.fn(),
+    loadConceptAttributes: jest.fn(),
+    loadConceptNames: jest.fn(),
+    selectConceptWithSuffix: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
+    getCurrentUserConceptId: jest.fn(() => null)
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/languageConfig.js', () => ({
+    DEFAULT_LANGUAGE: 'en-NZ'
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/markdownUtils.js', () => ({
+    detectMarkdown: jest.fn(() => false),
+    renderSmartTextAsync: jest.fn(async () => '')
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/predicateView.js', () => ({
+    destroyPredicateView: jest.fn(),
+    initializePredicateView: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/state.js', () => ({
+    getConceptTypeDisplayNames: jest.fn(() => ({})),
+    setCurrentConceptType: jest.fn(),
+    setCurrentlySelectedConceptId: jest.fn(),
+    setSelectedConceptOriginalName: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/tabNavigation.js', () => ({
+    activateTab: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/vontology.js', () => ({
+    getKeyConceptIds: jest.fn(() => new Set()),
+    updateTabHeaderStarButtons: jest.fn(),
+    updateTreeKeyConceptBadge: jest.fn()
+}));
+
+const { populateContentSection } = require(dynamicTabsModulePath);
+
+describe('Content section predicate normalisation', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="conceptStep1_t"></div>
+            <div id="typeDescriptionSection_t"></div>
+        `;
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        delete global.fetch;
+    });
+
+    test("renders both 'hasContent' and '#V#hasContent'", async () => {
+        global.fetch = jest.fn(async (url) => {
+            if (typeof url === 'string' && url.startsWith('/api/concepts/')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        texts: [
+                            { relation_id: 'r1', predicate: 'hasContent', text: 'A' },
+                            { relation_id: 'r2', predicate: '#V#hasContent', text: 'B' },
+                            { relation_id: 'r3', predicate: 'hasDescription', text: 'C' }
+                        ],
+                        count: 3
+                    })
+                };
+            }
+            throw new Error(`Unexpected fetch URL: ${url}`);
+        });
+
+        await populateContentSection('#V#x', 't');
+
+        const list = document.getElementById('contentList_t');
+        const status = document.getElementById('contentStatus_t');
+
+        expect(list).toBeTruthy();
+        expect(status).toBeTruthy();
+        expect(list.querySelectorAll('.content-item').length).toBe(2);
+        expect(status.textContent).toMatch(/2 content items?/);
+    });
+});

--- a/tests/test_backup_von_db.py
+++ b/tests/test_backup_von_db.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from scripts.backup_von_db import _apply_retention_and_storage_limits
+
+
+def _touch(path: Path, *, age_seconds: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.suffix:
+        path.write_bytes(b"x" * 10)
+    else:
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "dummy.txt").write_text("x" * 10, encoding="utf-8")
+    ts = time.time() - age_seconds
+    os.utime(path, (ts, ts))
+
+
+def test_retention_deletes_old_backups(tmp_path: Path) -> None:
+    out_root = tmp_path / "backups"
+    old_dir = out_root / "von_db_20000101_000000Z_auto-daily"
+    new_dir = out_root / "von_db_20990101_000000Z_auto-daily"
+
+    _touch(old_dir, age_seconds=60 * 60 * 24 * 10)
+    _touch(new_dir, age_seconds=60)
+
+    _apply_retention_and_storage_limits(
+        out_root=out_root,
+        retention_days=1,
+        max_storage_mb=-1,
+        protect_paths=set(),
+    )
+
+    assert not old_dir.exists()
+    assert new_dir.exists()
+
+
+def test_max_storage_deletes_oldest_first(tmp_path: Path) -> None:
+    out_root = tmp_path / "backups"
+    old_zip = out_root / "von_db_20000101_000000Z_auto-daily.zip"
+    new_zip = out_root / "von_db_20990101_000000Z_auto-daily.zip"
+
+    _touch(old_zip, age_seconds=60 * 60 * 24 * 10)
+    _touch(new_zip, age_seconds=60)
+
+    # 1 file is 10 bytes; set limit so only one can remain.
+    _apply_retention_and_storage_limits(
+        out_root=out_root,
+        retention_days=-1,
+        max_storage_mb=0,  # 0 MB forces deletion until <= 0 bytes (but protect new)
+        protect_paths={new_zip},
+    )
+
+    assert new_zip.exists()
+    # old must be deleted to try to satisfy storage cap
+    assert not old_zip.exists()
+
+
+@pytest.mark.parametrize(
+    "retention_days,max_storage_mb",
+    [(-1, -1), (30, -1), (-1, 100)],
+)
+def test_no_crash_on_empty(
+    tmp_path: Path, retention_days: int, max_storage_mb: int
+) -> None:
+    out_root = tmp_path / "backups"
+    _apply_retention_and_storage_limits(
+        out_root=out_root,
+        retention_days=retention_days,
+        max_storage_mb=max_storage_mb,
+        protect_paths=set(),
+    )


### PR DESCRIPTION
Summary:
- Adds cron-style backup scheduling + on-demand backups in run.ps1.
- Normalises Text Relations UX (resizable overflow areas, recap table, predicate-width tweaks, blank-line suppression).
- Treats code-handled predicate IDs (e.g. #V#hasContent) as virtual concepts across access control, tree, routes, and MCP.

Tests:
- npm run test:frontend
- pytest tests/backend/test_virtual_code_predicate_concepts.py tests/test_backup_von_db.py