### PR TITLE
JVNAUTOSCI-873: RAG concept tools + text-relation hooks

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -202,12 +202,16 @@ def _search_concepts(**kwargs):
 
 def _upsert_text_relation(**kwargs):
     from ...services.text_value_service import upsert_text_for_concept
+    from ...services.rag_text_relation_change_hook_service import (
+        maybe_sync_concept_text_relations_to_rag,
+    )
 
     concept_id = kwargs.get("concept_id")
     predicate = kwargs.get("predicate")
     text = kwargs.get("text")
     language = kwargs.get("language", "en-NZ")
     context = kwargs.get("context")
+    namespace = kwargs.get("namespace")
 
     if not concept_id:
         return {"error": "Missing 'concept_id' parameter"}
@@ -223,6 +227,14 @@ def _upsert_text_relation(**kwargs):
             text=text,
             lang=language,
             context=context,
+        )
+
+        # Best-effort hook: if the orchestrator provided an authenticated namespace,
+        # keep concept text-relations RAG index fresh.
+        maybe_sync_concept_text_relations_to_rag(
+            namespace=namespace,
+            concept_id=concept_id,
+            predicate=predicate,
         )
 
         text_preview = text[:100] + "..." if len(text) > 100 else text
@@ -275,11 +287,15 @@ def _get_text_relations(**kwargs):
 
 def _update_text_relation(**kwargs):
     from ...services.text_value_service import update_text_relation_text
+    from ...services.rag_text_relation_change_hook_service import (
+        maybe_sync_concept_text_relations_to_rag,
+    )
 
     concept_id = kwargs.get("concept_id")
     relation_id = kwargs.get("relation_id")
     new_text = kwargs.get("new_text")
     language = kwargs.get("language", "en-NZ")
+    namespace = kwargs.get("namespace")
 
     if not concept_id:
         return {"error": "Missing 'concept_id' parameter"}
@@ -294,6 +310,12 @@ def _update_text_relation(**kwargs):
             relation_id=relation_id,
             new_text=new_text,
             lang=language,
+        )
+
+        maybe_sync_concept_text_relations_to_rag(
+            namespace=namespace,
+            concept_id=concept_id,
+            predicate=result.get("predicate"),
         )
 
         old_preview = str(result.get("old_text", ""))[:100]
@@ -315,6 +337,9 @@ def _delete_text_relation(**kwargs):
         delete_text_relation,
         delete_text_relation_by_predicate_and_text,
     )
+    from ...services.rag_text_relation_change_hook_service import (
+        maybe_delete_text_relation_doc_from_rag,
+    )
 
     concept_id = kwargs.get("concept_id")
     relation_id = kwargs.get("relation_id")
@@ -322,6 +347,7 @@ def _delete_text_relation(**kwargs):
     text = kwargs.get("text")
     language = kwargs.get("language")
     garbage_collect = bool(kwargs.get("garbage_collect"))
+    namespace = kwargs.get("namespace")
 
     if not concept_id:
         return {"error": "Missing 'concept_id' parameter"}
@@ -334,6 +360,12 @@ def _delete_text_relation(**kwargs):
                 relation_id=relation_id,
                 garbage_collect=garbage_collect,
             )
+
+            maybe_delete_text_relation_doc_from_rag(
+                namespace=namespace,
+                relation_id=relation_id,
+            )
+
             return {
                 "success": True,
                 "deleted_relation_id": relation_id,
@@ -354,6 +386,12 @@ def _delete_text_relation(**kwargs):
                 lang=language,
                 garbage_collect=garbage_collect,
             )
+
+            maybe_delete_text_relation_doc_from_rag(
+                namespace=namespace,
+                relation_id=result.get("relation_id"),
+            )
+
             return {
                 "success": True,
                 "deleted_relation_id": result.get("relation_id"),
@@ -2106,6 +2144,13 @@ def _search_knowledge_base(**kwargs):
             org_concept_id = kwargs.get("organisation_concept_id")
             if isinstance(org_concept_id, str) and org_concept_id.strip():
                 permissions_context["organisation_concept_id"] = org_concept_id.strip()
+            elif (
+                isinstance(kwargs.get("org_id"), str)
+                and str(kwargs.get("org_id")).strip()
+            ):
+                permissions_context["organisation_concept_id"] = str(
+                    kwargs.get("org_id")
+                ).strip()
 
             # If the namespace is in the user@org form, it contains enough
             # information to derive both IDs without trusting arbitrary inputs.
@@ -2121,6 +2166,23 @@ def _search_knowledge_base(**kwargs):
                     if not org_part_clean.startswith("#V#"):
                         org_part_clean = f"#V#{org_part_clean}"
                     permissions_context["organisation_concept_id"] = org_part_clean
+
+        # Optional semantic filtering (handled by the backend).
+        mode = kwargs.get("mode")
+        if isinstance(mode, str) and mode.strip():
+            permissions_context["mode"] = mode.strip()
+
+        requested_type = kwargs.get("type")
+        if isinstance(requested_type, str) and requested_type.strip():
+            permissions_context["type"] = requested_type.strip()
+
+        predicate = kwargs.get("predicate")
+        if isinstance(predicate, str) and predicate.strip():
+            permissions_context["predicate"] = predicate.strip()
+
+        predicates = kwargs.get("predicates")
+        if isinstance(predicates, list):
+            permissions_context["predicates"] = predicates
 
         start = time.perf_counter()
         results = service.query(
@@ -2174,6 +2236,11 @@ def _search_knowledge_base_input_schema() -> Schema:
         optional={
             "top_k": (int,),
             "namespace": (str, type(None)),
+            "mode": (str,),
+            "type": (str,),
+            "predicate": (str,),
+            "predicates": (list,),
+            "org_id": (str,),
         },
         allow_unknown=True,
         description="search_knowledge_base input: query (str), top_k (int, default 5), namespace (str, optional filter)",
@@ -2191,6 +2258,240 @@ def _search_knowledge_base_output_schema() -> Schema:
         },
         allow_unknown=True,
         description="search_knowledge_base output: results (list of {id, score, text, metadata}), count (int), or error (str)",
+    )
+
+
+def _search_concept_descriptions(**kwargs):
+    """Semantic search over concept descriptions only.
+
+    This is a thin wrapper over search_knowledge_base that applies:
+    - mode=concepts
+    - predicate=hasDescription
+    """
+
+    wrapped = dict(kwargs)
+    wrapped.setdefault("mode", "concepts")
+    wrapped.setdefault("predicate", "hasDescription")
+    return _search_knowledge_base(**wrapped)
+
+
+def _search_concept_descriptions_input_schema() -> Schema:
+    return Schema(
+        required={"query": str},
+        optional={
+            "top_k": (int,),
+            "namespace": (str, type(None)),
+            "org_id": (str,),
+        },
+        allow_unknown=True,
+        description="search_concept_descriptions input: query (str), top_k (int, default 5), namespace (str, required for security)",
+    )
+
+
+def _search_concept_descriptions_output_schema() -> Schema:
+    return _search_knowledge_base_output_schema()
+
+
+def _index_concept_text(**kwargs):
+    """Force reindex for a single concept's text relations within a namespace."""
+
+    concept_id = kwargs.get("concept_id")
+    if not isinstance(concept_id, str) or not concept_id.strip():
+        return {"success": False, "error": "Missing required parameter: concept_id"}
+
+    ns_report = _resolve_rag_namespace_from_kwargs(kwargs)
+    ns = ns_report.get("namespace")
+    if not ns:
+        return {
+            "error": "namespace_required",
+            "message": "RAG indexing requires authenticated user context (namespace)",
+            **ns_report,
+            "success": False,
+        }
+
+    from ...services.rag_text_relation_sync_service import sync_text_relations_to_rag
+
+    payload = sync_text_relations_to_rag(
+        namespace=ns,
+        concept_ids=[concept_id.strip()],
+        predicates=kwargs.get("predicates"),
+        languages=kwargs.get("languages"),
+        limit=int(kwargs.get("limit", 5000)),
+        batch_size=int(kwargs.get("batch_size", 200)),
+    )
+    return {**payload, **ns_report}
+
+
+def _index_concept_text_input_schema() -> Schema:
+    return Schema(
+        required={"concept_id": str},
+        optional={
+            "namespace": (str, type(None)),
+            "predicates": (list,),
+            "languages": (list,),
+            "limit": (int,),
+            "batch_size": (int,),
+        },
+        allow_unknown=True,
+        description="index_concept_text input: concept_id (str), namespace (str, optional), and optional predicate/language filters",
+    )
+
+
+def _index_concept_text_output_schema() -> Schema:
+    return Schema(
+        required={},
+        optional={
+            "success": (bool, type(None)),
+            "error": (str, type(None)),
+            "namespace": (str, type(None)),
+            "total_candidates": (int, type(None)),
+            "added": (int, type(None)),
+            "failed": (int, type(None)),
+        },
+        allow_unknown=True,
+        description="index_concept_text output: sync report payload",
+    )
+
+
+def _get_related_concepts(**kwargs):
+    """Find concepts with similar descriptions (vector similarity)."""
+
+    concept_id = kwargs.get("concept_id")
+    if not isinstance(concept_id, str) or not concept_id.strip():
+        return {"success": False, "error": "Missing required parameter: concept_id"}
+
+    ns_report = _resolve_rag_namespace_from_kwargs(kwargs)
+    ns = ns_report.get("namespace")
+    if not ns:
+        return {
+            "error": "namespace_required",
+            "message": "RAG search requires authenticated user context (namespace)",
+            **ns_report,
+            "success": False,
+        }
+
+    # Attempt to seed the similarity query from the concept description text.
+    # We scope access by (user, org) implied by the namespace to avoid cross-namespace reads.
+    seed_text = kwargs.get("seed_text")
+    if not isinstance(seed_text, str) or not seed_text.strip():
+        try:
+            from ...security.access_control import (
+                override_current_user,
+                override_current_organisation,
+            )
+            from ...services.text_value_service import get_texts_for_concept
+
+            user_part = None
+            org_part = None
+            if isinstance(ns, str) and "@" in ns:
+                user_part, org_part = ns.split("@", 1)
+            user_part = (user_part or "").strip() or None
+            org_part = (org_part or "").strip() or None
+            if org_part and not org_part.startswith("#V#"):
+                org_part = f"#V#{org_part}"
+
+            with (
+                override_current_user(user_part),
+                override_current_organisation(org_part),
+            ):
+                texts = get_texts_for_concept(
+                    concept_id.strip(), predicate="hasDescription", limit=1
+                )
+            if texts and isinstance(texts[0], dict):
+                seed_text = texts[0].get("text")
+        except Exception:
+            seed_text = None
+
+    if not isinstance(seed_text, str) or not seed_text.strip():
+        return {
+            "success": False,
+            "error": "missing_seed_text",
+            "message": "No hasDescription text found for concept; pass seed_text explicitly to proceed",
+            **ns_report,
+        }
+
+    from ...services.rag_service import get_rag_service, RAGBackendUnavailable
+
+    try:
+        service = get_rag_service()
+
+        user_id = None
+        org_id = None
+        if isinstance(ns, str) and "@" in ns:
+            user_id, org_id = ns.split("@", 1)
+            user_id = user_id.strip() or None
+            org_id = org_id.strip() or None
+            if org_id and not org_id.startswith("#V#"):
+                org_id = f"#V#{org_id}"
+
+        permissions_context = {
+            "mode": "concepts",
+            "predicate": "hasDescription",
+        }
+        if user_id:
+            permissions_context["user_id"] = user_id
+        if org_id:
+            permissions_context["organisation_concept_id"] = org_id
+
+        results = service.query(
+            query_text=seed_text.strip(),
+            top_k=int(kwargs.get("top_k", 10)),
+            namespace=ns,
+            permissions_context=permissions_context,
+        )
+    except RAGBackendUnavailable as e:
+        return {"success": False, "error": f"RAG service unavailable: {e}", **ns_report}
+
+    filtered = []
+    for row in results or []:
+        if not isinstance(row, dict):
+            continue
+        meta = row.get("metadata")
+        if not isinstance(meta, dict):
+            continue
+        if (
+            meta.get("concept_id") == concept_id.strip()
+            or meta.get("subject_concept_id") == concept_id.strip()
+        ):
+            continue
+        filtered.append(row)
+
+    return {
+        "success": True,
+        "concept_id": concept_id.strip(),
+        "seed_text": seed_text.strip(),
+        "results": filtered,
+        "count": len(filtered),
+        **ns_report,
+    }
+
+
+def _get_related_concepts_input_schema() -> Schema:
+    return Schema(
+        required={"concept_id": str},
+        optional={
+            "namespace": (str, type(None)),
+            "top_k": (int,),
+            "seed_text": (str,),
+        },
+        allow_unknown=True,
+        description="get_related_concepts input: concept_id (str), namespace (str, required), optional top_k and seed_text",
+    )
+
+
+def _get_related_concepts_output_schema() -> Schema:
+    return Schema(
+        required={},
+        optional={
+            "success": (bool, type(None)),
+            "error": (str, type(None)),
+            "concept_id": (str, type(None)),
+            "seed_text": (str, type(None)),
+            "results": (list, type(None)),
+            "count": (int, type(None)),
+        },
+        allow_unknown=True,
+        description="get_related_concepts output: similar concept description chunks",
     )
 
 
@@ -3994,6 +4295,42 @@ def build_default_catalogue() -> MethodCatalogue:
             category="read",
             timeout_sec=30.0,
             description="Search the internal knowledge base (RAG) for documents and indexed content. Use when user asks about internal documents, policies, or specific indexed knowledge that is not in the ontology or on the public web. Returns semantically relevant text chunks.",
+        ),
+        MethodDefinition(
+            name="search_concept_descriptions",
+            handler=_search_concept_descriptions,
+            input_schema=_search_concept_descriptions_input_schema(),
+            output_schema=_search_concept_descriptions_output_schema(),
+            category="read",
+            timeout_sec=30.0,
+            description=(
+                "Semantic search over concept descriptions only (hasDescription text relations) for the current namespace. "
+                "Use when user asks to search the knowledge base but only within concept descriptions."
+            ),
+        ),
+        MethodDefinition(
+            name="get_related_concepts",
+            handler=_get_related_concepts,
+            input_schema=_get_related_concepts_input_schema(),
+            output_schema=_get_related_concepts_output_schema(),
+            category="read",
+            timeout_sec=30.0,
+            description=(
+                "Find concepts with similar descriptions (vector similarity) within the current namespace. "
+                "Returns description chunks and metadata for related concepts."
+            ),
+        ),
+        MethodDefinition(
+            name="index_concept_text",
+            handler=_index_concept_text,
+            input_schema=_index_concept_text_input_schema(),
+            output_schema=_index_concept_text_output_schema(),
+            category="write",
+            timeout_sec=60.0,
+            description=(
+                "Force reindex a specific concept's text relations into RAG for the current namespace. "
+                "Useful after bulk edits or when RAG appears stale."
+            ),
         ),
         # Jira MCP tools
         MethodDefinition(

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -76,6 +76,10 @@ from src.backend.services.text_value_service import (
     delete_text_relation,
     delete_text_relation_by_predicate_and_text,
 )
+from src.backend.services.rag_text_relation_change_hook_service import (
+    maybe_delete_text_relation_doc_from_rag,
+    maybe_sync_concept_text_relations_to_rag,
+)
 from src.backend.services.annotation_extraction_service import extract_annotations
 from src.backend.services.concept_merge_service import merge_concepts
 from src.backend.services.settings_service import (
@@ -327,6 +331,10 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional namespace (e.g., #V#user@org). When provided, triggers a best-effort RAG reindex for the concept; otherwise no automatic indexing occurs.",
+                    },
                     "concept_id": {
                         "type": "string",
                         "description": "The concept to attach text to (e.g., '#V#my_concept')",
@@ -385,6 +393,10 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional namespace (e.g., #V#user@org). When provided, triggers a best-effort RAG reindex for the concept; otherwise no automatic indexing occurs.",
+                    },
                     "concept_id": {
                         "type": "string",
                         "description": "The concept owning the text relation",
@@ -411,6 +423,10 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional namespace (e.g., #V#user@org). When provided, triggers a best-effort RAG delete/reindex; otherwise no automatic indexing occurs.",
+                    },
                     "concept_id": {
                         "type": "string",
                         "description": "The concept owning the text relation",
@@ -1552,6 +1568,11 @@ async def _handle_von_chat_run(arguments: dict[str, Any]) -> list[TextContent]:
 
 async def _handle_upsert_text_relation(arguments: dict[str, Any]) -> list[TextContent]:
     """Handle upsert_text_relation tool call."""
+    namespace = (
+        arguments.get("namespace")
+        if isinstance(arguments.get("namespace"), str)
+        else None
+    )
     concept_id = arguments.get("concept_id")
     predicate = arguments.get("predicate")
     text = arguments.get("text")
@@ -1572,6 +1593,12 @@ async def _handle_upsert_text_relation(arguments: dict[str, Any]) -> list[TextCo
             text=text,
             lang=language,
             context=context,
+        )
+
+        maybe_sync_concept_text_relations_to_rag(
+            namespace=namespace,
+            concept_id=concept_id,
+            predicate=predicate,
         )
 
         text_preview = text[:100] + "..." if len(text) > 100 else text
@@ -1625,6 +1652,11 @@ async def _handle_get_text_relations(arguments: dict[str, Any]) -> list[TextCont
 
 async def _handle_update_text_relation(arguments: dict[str, Any]) -> list[TextContent]:
     """Handle update_text_relation tool call."""
+    namespace = (
+        arguments.get("namespace")
+        if isinstance(arguments.get("namespace"), str)
+        else None
+    )
     concept_id = arguments.get("concept_id")
     relation_id = arguments.get("relation_id")
     new_text = arguments.get("new_text")
@@ -1645,6 +1677,11 @@ async def _handle_update_text_relation(arguments: dict[str, Any]) -> list[TextCo
             lang=language,
         )
 
+        maybe_sync_concept_text_relations_to_rag(
+            namespace=namespace,
+            concept_id=concept_id,
+        )
+
         old_preview = str(result.get("old_text", ""))[:100]
         new_preview = new_text[:100] + "..." if len(new_text) > 100 else new_text
 
@@ -1662,6 +1699,11 @@ async def _handle_update_text_relation(arguments: dict[str, Any]) -> list[TextCo
 
 async def _handle_delete_text_relation(arguments: dict[str, Any]) -> list[TextContent]:
     """Handle delete_text_relation tool call."""
+    namespace = (
+        arguments.get("namespace")
+        if isinstance(arguments.get("namespace"), str)
+        else None
+    )
     concept_id = arguments.get("concept_id")
     relation_id = arguments.get("relation_id")
     predicate = arguments.get("predicate")
@@ -1680,6 +1722,12 @@ async def _handle_delete_text_relation(arguments: dict[str, Any]) -> list[TextCo
                 relation_id=relation_id,
                 garbage_collect=garbage_collect,
             )
+
+            maybe_delete_text_relation_doc_from_rag(
+                namespace=namespace,
+                relation_id=relation_id,
+            )
+
             payload = {
                 "success": True,
                 "deleted_relation_id": relation_id,
@@ -1700,6 +1748,12 @@ async def _handle_delete_text_relation(arguments: dict[str, Any]) -> list[TextCo
                 lang=language,
                 garbage_collect=garbage_collect,
             )
+
+            maybe_delete_text_relation_doc_from_rag(
+                namespace=namespace,
+                relation_id=result.get("relation_id"),
+            )
+
             payload = {
                 "success": True,
                 "deleted_relation_id": result.get("relation_id"),

--- a/src/backend/mcp_server/rag_mcp_stdio_server.py
+++ b/src/backend/mcp_server/rag_mcp_stdio_server.py
@@ -221,8 +221,121 @@ async def list_tools() -> list[Tool]:
                         "description": "Number of results to return",
                         "default": 5,
                     },
+                    "mode": {
+                        "type": "string",
+                        "description": "Semantic search mode (chat|concepts|all). Default all.",
+                        "default": "all",
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Filter by document type (chat_message|text_relation).",
+                    },
+                    "predicate": {
+                        "type": "string",
+                        "description": "Filter by predicate (e.g. hasDescription).",
+                    },
+                    "predicates": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Filter by multiple predicates.",
+                    },
                 },
                 "required": ["query"],
+            },
+        ),
+        Tool(
+            name="search_concept_descriptions",
+            description=(
+                "Semantic search over concept descriptions only (hasDescription text relations) for the given namespace."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional namespace (e.g. #V#user@org). Defaults to env VON_DEFAULT_NAMESPACE.",
+                    },
+                    "query": {"type": "string", "description": "Search query text"},
+                    "top_k": {
+                        "type": "integer",
+                        "description": "Number of results to return",
+                        "default": 5,
+                    },
+                    "org_id": {
+                        "type": "string",
+                        "description": "Optional organisation concept id (alias for organisation_concept_id).",
+                    },
+                },
+                "required": ["query"],
+            },
+        ),
+        Tool(
+            name="get_related_concepts",
+            description=(
+                "Find concepts with similar descriptions (vector similarity) within the given namespace."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional namespace (e.g. #V#user@org). Defaults to env VON_DEFAULT_NAMESPACE.",
+                    },
+                    "concept_id": {
+                        "type": "string",
+                        "description": "Concept ID to find related concepts for (e.g. #V#my_concept).",
+                    },
+                    "top_k": {
+                        "type": "integer",
+                        "description": "Number of related results to return",
+                        "default": 10,
+                    },
+                    "seed_text": {
+                        "type": "string",
+                        "description": "Optional override for the seed description text.",
+                    },
+                },
+                "required": ["concept_id"],
+            },
+        ),
+        Tool(
+            name="index_concept_text",
+            description=(
+                "Force reindex a single concept's text relations for the given namespace."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional namespace (e.g. #V#user@org). Defaults to env VON_DEFAULT_NAMESPACE.",
+                    },
+                    "concept_id": {
+                        "type": "string",
+                        "description": "Concept ID to reindex (e.g. #V#my_concept).",
+                    },
+                    "predicates": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional predicate filter (e.g. hasName, hasDescription)",
+                    },
+                    "languages": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional language filter (e.g. en-NZ)",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max relations to consider",
+                        "default": 5000,
+                    },
+                    "batch_size": {
+                        "type": "integer",
+                        "description": "Upsert batch size",
+                        "default": 200,
+                    },
+                },
+                "required": ["concept_id"],
             },
         ),
         Tool(
@@ -271,6 +384,11 @@ _TOOL_HANDLERS: dict[str, Callable[[dict[str, Any]], Awaitable[list[TextContent]
     "rag_list_indexed": _tool_handler(internal_catalogue._rag_list_indexed),
     "rag_get_item": _tool_handler(internal_catalogue._rag_get_item),
     "search_knowledge_base": _tool_handler(internal_catalogue._search_knowledge_base),
+    "search_concept_descriptions": _tool_handler(
+        internal_catalogue._search_concept_descriptions
+    ),
+    "get_related_concepts": _tool_handler(internal_catalogue._get_related_concepts),
+    "index_concept_text": _tool_handler(internal_catalogue._index_concept_text),
     "rag_sync_text_relations": _tool_handler(
         internal_catalogue._rag_sync_text_relations
     ),

--- a/src/backend/server/routes/concept_routes.py
+++ b/src/backend/server/routes/concept_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, jsonify, current_app
+from flask import Blueprint, request, jsonify, current_app, session
 from flask.typing import ResponseReturnValue
 import json
 from datetime import datetime
@@ -18,6 +18,10 @@ from ...services.text_value_service import (
     delete_text_relation,
     delete_text_relation_by_predicate_and_text,
 )
+from ...services.rag_text_relation_change_hook_service import (
+    maybe_delete_text_relation_doc_from_rag,
+    maybe_sync_concept_text_relations_to_rag,
+)
 from ...vontology.utils_vontology import (
     get_vontology_node_and_descendant_ids,
     get_concept_notes,
@@ -28,6 +32,26 @@ from bson import (
 )  # Required for converting string IDs if necessary, though service should handle
 
 concept_bp = Blueprint("concepts", __name__)  # Define blueprint
+
+
+def _get_request_namespace() -> str | None:
+    session_namespace = session.get("namespace")
+    if (
+        isinstance(session_namespace, str)
+        and session_namespace.strip()
+        and session_namespace.strip().startswith("#V#")
+    ):
+        return session_namespace.strip()
+
+    user_concept_id = session.get("user_concept_id")
+    if (
+        isinstance(user_concept_id, str)
+        and user_concept_id.strip()
+        and user_concept_id.strip().startswith("#V#")
+    ):
+        return user_concept_id.strip()
+
+    return None
 
 
 @concept_bp.route("/", methods=["GET"])
@@ -1054,6 +1078,12 @@ def upsert_concept_text_route(concept_id: str):
             provenance=provenance,
             context=context,
         )
+
+        maybe_sync_concept_text_relations_to_rag(
+            namespace=_get_request_namespace(),
+            concept_id=concept_id,
+            predicate=predicate,
+        )
         status = 201 if result.get("relation_created") else 200
         if result.get("context_updated"):
             status = 200
@@ -1087,6 +1117,11 @@ def update_concept_text_relation_route(concept_id: str, relation_id: str):
             new_text=new_text,
             lang=lang,
             provenance={"source": "update_text_relation"},
+        )
+
+        maybe_sync_concept_text_relations_to_rag(
+            namespace=_get_request_namespace(),
+            concept_id=concept_id,
         )
         return jsonify(result), 200
     except ValueError as ve:
@@ -1130,6 +1165,11 @@ def delete_concept_text_by_predicate_route(concept_id: str):
             lang=lang,
             context=context,
         )
+
+        maybe_delete_text_relation_doc_from_rag(
+            namespace=_get_request_namespace(),
+            relation_id=result.get("relation_id"),
+        )
         return jsonify(result), 200
     except ValueError as ve:
         return jsonify(error=str(ve)), 404
@@ -1146,6 +1186,11 @@ def delete_concept_text_relation_route(concept_id: str, relation_id: str):
     """Delete a specific text relation (e.g., remove a note)."""
     try:
         result = delete_text_relation(concept_id, relation_id)
+
+        maybe_delete_text_relation_doc_from_rag(
+            namespace=_get_request_namespace(),
+            relation_id=relation_id,
+        )
         return jsonify(result), 200
     except ValueError as ve:
         return jsonify(error=str(ve)), 404

--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, request, current_app
+from flask import Blueprint, jsonify, request, current_app, session
 import os
 import tracemalloc
 import json  # Add json import for file parsing
@@ -2971,6 +2971,29 @@ def add_relationship_route():
         if is_text_predicate:
             try:
                 from ...services.text_value_service import upsert_text_for_concept
+                from ...services.rag_text_relation_change_hook_service import (
+                    maybe_sync_concept_text_relations_to_rag,
+                )
+
+                namespace = None
+                try:
+                    session_namespace = session.get("namespace")
+                    if (
+                        isinstance(session_namespace, str)
+                        and session_namespace.strip()
+                        and session_namespace.strip().startswith("#V#")
+                    ):
+                        namespace = session_namespace.strip()
+                    else:
+                        user_concept_id = session.get("user_concept_id")
+                        if (
+                            isinstance(user_concept_id, str)
+                            and user_concept_id.strip()
+                            and user_concept_id.strip().startswith("#V#")
+                        ):
+                            namespace = user_concept_id.strip()
+                except Exception:
+                    namespace = None
 
                 result = upsert_text_for_concept(
                     subject_concept_id=source_id,
@@ -2978,6 +3001,12 @@ def add_relationship_route():
                     text=target_id,  # target_id is actually the text value for text predicates
                     lang="en",
                     provenance={"source": "relationship_add_redirect"},
+                )
+
+                maybe_sync_concept_text_relations_to_rag(
+                    namespace=namespace,
+                    concept_id=source_id,
+                    predicate=kind,
                 )
                 current_app.logger.info(
                     f"Redirected binary text predicate {kind} to text relations API: {result}"
@@ -3701,11 +3730,39 @@ def remove_relationship_route():
                 from ...services.text_value_service import (
                     delete_text_relation_by_predicate_and_text,
                 )
+                from ...services.rag_text_relation_change_hook_service import (
+                    maybe_delete_text_relation_doc_from_rag,
+                )
+
+                namespace = None
+                try:
+                    session_namespace = session.get("namespace")
+                    if (
+                        isinstance(session_namespace, str)
+                        and session_namespace.strip()
+                        and session_namespace.strip().startswith("#V#")
+                    ):
+                        namespace = session_namespace.strip()
+                    else:
+                        user_concept_id = session.get("user_concept_id")
+                        if (
+                            isinstance(user_concept_id, str)
+                            and user_concept_id.strip()
+                            and user_concept_id.strip().startswith("#V#")
+                        ):
+                            namespace = user_concept_id.strip()
+                except Exception:
+                    namespace = None
 
                 result = delete_text_relation_by_predicate_and_text(
                     subject_concept_id=source_id,
                     predicate=kind,
                     text=target_id,  # target_id is actually the text value for text predicates
+                )
+
+                maybe_delete_text_relation_doc_from_rag(
+                    namespace=namespace,
+                    relation_id=result.get("relation_id"),
                 )
                 current_app.logger.info(
                     f"Redirected binary text predicate {kind} removal to text relations API: {result}"

--- a/src/backend/services/rag_backends/llamaindex_backend.py
+++ b/src/backend/services/rag_backends/llamaindex_backend.py
@@ -257,6 +257,61 @@ class LlamaIndexRAGService(RAGService):
             if not isinstance(metadata, dict):
                 return False
 
+            # Optional semantic filtering.
+            # Backwards compatible: if no filter keys provided, behaviour is unchanged.
+            mode = permissions_context.get("mode")
+            requested_type = permissions_context.get("type")
+            predicate = permissions_context.get("predicate")
+            predicates = permissions_context.get("predicates")
+
+            # Normalise filter inputs.
+            requested_types: List[str] = []
+            if isinstance(requested_type, str) and requested_type.strip():
+                requested_types = [requested_type.strip()]
+
+            if isinstance(mode, str):
+                m = mode.strip().lower()
+                if m == "chat":
+                    requested_types = ["chat_message"]
+                elif m == "concepts":
+                    requested_types = ["text_relation"]
+                elif m == "all" or not m:
+                    pass
+
+            if requested_types:
+                actual_type = metadata.get("type")
+                # Defensive fallback for older indices missing explicit type.
+                if not isinstance(actual_type, str) or not actual_type.strip():
+                    src = metadata.get("source")
+                    doc_id = metadata.get("id")
+                    if src == "vontology_text_relation":
+                        actual_type = "text_relation"
+                    elif src == "chat_history":
+                        actual_type = "chat_message"
+                    elif isinstance(doc_id, str) and doc_id.startswith(
+                        "text_relation:"
+                    ):
+                        actual_type = "text_relation"
+
+                if not isinstance(actual_type, str):
+                    return False
+                if actual_type not in requested_types:
+                    return False
+
+            # Predicate filter (only meaningful for text_relation docs).
+            if isinstance(predicate, str) and predicate.strip():
+                if metadata.get("predicate") != predicate.strip():
+                    return False
+            elif isinstance(predicates, list):
+                allow = {
+                    str(p).strip()
+                    for p in predicates
+                    if isinstance(p, str) and p.strip()
+                }
+                if allow:
+                    if metadata.get("predicate") not in allow:
+                        return False
+
             user_id = permissions_context.get("user_id")
             if user_id:
                 if normalise_concept_id_for_compare(

--- a/src/backend/services/rag_text_relation_change_hook_service.py
+++ b/src/backend/services/rag_text_relation_change_hook_service.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def maybe_sync_concept_text_relations_to_rag(
+    *,
+    namespace: Optional[str],
+    concept_id: str,
+    predicate: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Best-effort: reindex a concept's text relations into RAG.
+
+    This is intentionally fail-closed: if `namespace` is missing, we do nothing.
+    """
+
+    if not namespace or not isinstance(namespace, str) or not namespace.strip():
+        return {"success": False, "skipped": True, "reason": "namespace_required"}
+
+    if not isinstance(concept_id, str) or not concept_id.strip():
+        return {"success": False, "skipped": True, "reason": "concept_id_required"}
+
+    predicates = None
+    if isinstance(predicate, str) and predicate.strip():
+        predicates = [predicate.strip()]
+
+    try:
+        from src.backend.services.rag_text_relation_sync_service import (
+            sync_text_relations_to_rag,
+        )
+
+        return sync_text_relations_to_rag(
+            namespace=namespace.strip(),
+            concept_ids=[concept_id.strip()],
+            predicates=predicates,
+            limit=5000,
+        )
+    except Exception as exc:
+        logger.warning(
+            "[rag_text_relations] RAG sync failed concept_id=%s namespace=%s: %s",
+            concept_id,
+            namespace,
+            exc,
+        )
+        return {
+            "success": False,
+            "skipped": False,
+            "error": f"RAG sync failed: {exc}",
+        }
+
+
+def maybe_delete_text_relation_doc_from_rag(
+    *,
+    namespace: Optional[str],
+    relation_id: Optional[str],
+) -> Dict[str, Any]:
+    """Best-effort: delete a single text relation doc from the RAG store."""
+
+    if not namespace or not isinstance(namespace, str) or not namespace.strip():
+        return {"success": False, "skipped": True, "reason": "namespace_required"}
+
+    if not relation_id or not isinstance(relation_id, str) or not relation_id.strip():
+        return {"success": False, "skipped": True, "reason": "relation_id_required"}
+
+    doc_id = f"text_relation:{relation_id.strip()}"
+
+    try:
+        from src.backend.services.rag_service import get_rag_service
+
+        rag = get_rag_service()
+        deleted = rag.delete_documents([doc_id], namespace=namespace.strip())
+        return {"success": True, "deleted": int(deleted), "doc_id": doc_id}
+    except Exception as exc:
+        logger.warning(
+            "[rag_text_relations] RAG delete failed relation_id=%s namespace=%s: %s",
+            relation_id,
+            namespace,
+            exc,
+        )
+        return {
+            "success": False,
+            "skipped": False,
+            "error": f"RAG delete failed: {exc}",
+            "doc_id": doc_id,
+        }

--- a/src/backend/services/rag_text_relation_sync_service.py
+++ b/src/backend/services/rag_text_relation_sync_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
@@ -296,6 +297,10 @@ def collect_text_relation_docs_for_namespace(
     namespace: str,
     predicates: Optional[Sequence[str]] = None,
     languages: Optional[Sequence[str]] = None,
+    concept_ids: Optional[Sequence[str]] = None,
+    updated_since: Optional[datetime] = None,
+    skip: int = 0,
+    sort: Optional[List] = None,
     limit: int = 5000,
 ) -> List[TextRelationRagDoc]:
     """Collect text-relations as RAG documents for a single namespace.
@@ -308,10 +313,30 @@ def collect_text_relation_docs_for_namespace(
     user_id, org_id = _parse_namespace(namespace)
 
     rel_filter: Dict[str, Any] = {}
+    concept_allow: Optional[set[str]] = None
+    if concept_ids:
+        concept_allow = {c for c in concept_ids if isinstance(c, str) and c.strip()}
+        if concept_allow:
+            rel_filter["subject_concept_id"] = {"$in": sorted(concept_allow)}
+
     if predicates:
         rel_filter["predicate"] = {"$in": list(predicates)}
 
-    relations = list(TextRelationsRepository.find(rel_filter, limit=int(limit)))
+    if updated_since is not None:
+        rel_filter["updated_at"] = {"$gte": updated_since}
+
+    safe_skip = max(int(skip), 0)
+    safe_limit = max(int(limit), 0)
+    safe_sort = sort if sort is not None else [("_id", 1)]
+
+    relations = list(
+        TextRelationsRepository.find(
+            rel_filter,
+            sort=safe_sort,
+            skip=safe_skip,
+            limit=safe_limit,
+        )
+    )
     if not relations:
         return []
 
@@ -335,6 +360,9 @@ def collect_text_relation_docs_for_namespace(
             or not isinstance(subject_concept_id, str)
             or not predicate
         ):
+            continue
+
+        if concept_allow is not None and subject_concept_id not in concept_allow:
             continue
 
         if subject_concept_id not in concept_visibility:
@@ -367,15 +395,22 @@ def collect_text_relation_docs_for_namespace(
         )
 
         metadata = {
+            # Distinguish from chat history docs.
+            "type": "text_relation",
             "source": "vontology_text_relation",
+            # Preferred canonical key for concept.
+            "concept_id": subject_concept_id,
             "subject_concept_id": subject_concept_id,
             "predicate": str(predicate),
             "relation_id": relation_id_str,
             "text_value_id": str(text_value_oid),
             "lang": str(lang),
+            "language": str(lang),
             # Required for query-time filtering.
             "user_id": user_id,
             "organisation_concept_id": org_id,
+            # Alias to match Jira ticket naming.
+            "org_id": org_id,
         }
 
         docs.append(
@@ -394,6 +429,10 @@ def sync_text_relations_to_rag(
     namespace: str,
     predicates: Optional[Sequence[str]] = None,
     languages: Optional[Sequence[str]] = None,
+    concept_ids: Optional[Sequence[str]] = None,
+    updated_since: Optional[datetime] = None,
+    skip: int = 0,
+    sort: Optional[List] = None,
     limit: int = 5000,
     batch_size: int = 200,
 ) -> Dict[str, Any]:
@@ -408,6 +447,10 @@ def sync_text_relations_to_rag(
         namespace=namespace,
         predicates=predicates,
         languages=languages,
+        concept_ids=concept_ids,
+        updated_since=updated_since,
+        skip=skip,
+        sort=sort,
         limit=limit,
     )
 

--- a/src/utilities/reindex_text_relations.py
+++ b/src/utilities/reindex_text_relations.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import argparse
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable, List, Optional, Sequence
+
+from src.backend.db.repositories.text_value_repository import TextRelationsRepository
+from src.backend.services.rag_service import RAGBackendUnavailable, get_rag_service
+from src.backend.services.rag_text_relation_sync_service import (
+    TextRelationRagDoc,
+    collect_text_relation_docs_for_namespace,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ReindexArgs:
+    namespace: str
+    predicates: Optional[List[str]]
+    languages: Optional[List[str]]
+    concept_ids: Optional[List[str]]
+    updated_since: Optional[datetime]
+    dry_run: bool
+    page_size: int
+    batch_size: int
+    scan_limit: int
+
+
+def _parse_iso_datetime(value: str) -> datetime:
+    raw = value.strip()
+    if not raw:
+        raise ValueError("since value is empty")
+
+    # Allow Z suffix.
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        # Allow date-only input.
+        try:
+            dt = datetime.fromisoformat(raw + "T00:00:00")
+        except ValueError as exc:
+            raise ValueError(
+                "since must be ISO format (e.g. 2025-12-01 or 2025-12-01T12:34:56Z)"
+            ) from exc
+
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+
+    return dt
+
+
+def _normalise_list(values: Optional[Sequence[str]]) -> Optional[List[str]]:
+    if not values:
+        return None
+
+    cleaned: List[str] = []
+    for item in values:
+        if not isinstance(item, str):
+            continue
+        parts = [p.strip() for p in item.split(",")]
+        for p in parts:
+            if p:
+                cleaned.append(p)
+
+    return cleaned or None
+
+
+def _resolve_namespace(
+    *, namespace: Optional[str], user: Optional[str], org: Optional[str]
+) -> str:
+    if namespace and namespace.strip():
+        return namespace.strip()
+
+    if user or org:
+        if not (user and org):
+            raise ValueError("--user and --org must be provided together")
+        return f"{user.strip()}@{org.strip()}"
+
+    raise ValueError("--namespace is required (or provide both --user and --org)")
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> ReindexArgs:
+    parser = argparse.ArgumentParser(
+        description="Bulk reindex Vontology text relations into the RAG store."
+    )
+
+    parser.add_argument(
+        "--namespace",
+        help="Namespace in the form '#V#user@#V#organisation'",
+    )
+    parser.add_argument(
+        "--user",
+        help="Namespace user part (requires --org)",
+    )
+    parser.add_argument(
+        "--org",
+        help="Namespace organisation part (requires --user). Can be '#V#org' or 'org'.",
+    )
+
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Reindex all visible relations in the namespace (default if no other filters).",
+    )
+
+    parser.add_argument(
+        "--predicate",
+        action="append",
+        help="Only index relations with this predicate (repeatable, or comma-separated).",
+    )
+    parser.add_argument(
+        "--language",
+        action="append",
+        help="Only index text values with this language (repeatable, or comma-separated).",
+    )
+    parser.add_argument(
+        "--concept-id",
+        action="append",
+        help="Only index relations for these concept ids (repeatable, or comma-separated).",
+    )
+
+    parser.add_argument(
+        "--since",
+        help="Only index relations updated at or after this ISO datetime/date.",
+    )
+
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Scan and count, but do not write to the RAG store.",
+    )
+
+    parser.add_argument(
+        "--page-size",
+        type=int,
+        default=5000,
+        help="How many raw relations to scan per DB page (default: 5000).",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=200,
+        help="How many RAG docs to upsert per batch (default: 200).",
+    )
+    parser.add_argument(
+        "--scan-limit",
+        type=int,
+        default=0,
+        help="Maximum raw relations to scan (0 = no limit).",
+    )
+
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    namespace = _resolve_namespace(
+        namespace=args.namespace, user=args.user, org=args.org
+    )
+    predicates = _normalise_list(args.predicate)
+    languages = _normalise_list(args.language)
+    concept_ids = _normalise_list(args.concept_id)
+
+    updated_since = _parse_iso_datetime(args.since) if args.since else None
+
+    page_size = max(int(args.page_size), 1)
+    batch_size = max(int(args.batch_size), 1)
+    scan_limit = max(int(args.scan_limit), 0)
+
+    # Keep --all as a compatibility flag (it currently has no effect beyond intent).
+    _ = bool(args.all)
+
+    return ReindexArgs(
+        namespace=namespace,
+        predicates=predicates,
+        languages=languages,
+        concept_ids=concept_ids,
+        updated_since=updated_since,
+        dry_run=bool(args.dry_run),
+        page_size=page_size,
+        batch_size=batch_size,
+        scan_limit=scan_limit,
+    )
+
+
+def _chunks(
+    items: List[TextRelationRagDoc], n: int
+) -> Iterable[List[TextRelationRagDoc]]:
+    step = max(int(n), 1)
+    for i in range(0, len(items), step):
+        yield items[i : i + step]
+
+
+def run_reindex(args: ReindexArgs) -> int:
+    rel_filter: dict[str, Any] = {}
+    if args.predicates:
+        rel_filter["predicate"] = {"$in": list(args.predicates)}
+    if args.updated_since is not None:
+        rel_filter["updated_at"] = {"$gte": args.updated_since}
+    if args.concept_ids:
+        rel_filter["subject_concept_id"] = {"$in": list(args.concept_ids)}
+
+    total_raw = TextRelationsRepository.count_documents(rel_filter)
+    raw_to_scan = total_raw
+    if args.scan_limit:
+        raw_to_scan = min(raw_to_scan, args.scan_limit)
+
+    logger.info(
+        "Starting reindex: namespace=%s raw_total=%s raw_scan=%s dry_run=%s",
+        args.namespace,
+        total_raw,
+        raw_to_scan,
+        args.dry_run,
+    )
+
+    rag = None
+    if not args.dry_run:
+        try:
+            rag = get_rag_service()
+        except RAGBackendUnavailable as exc:
+            logger.error("RAG service unavailable: %s", exc)
+            return 2
+
+    total_candidates = 0
+    added = 0
+    failed = 0
+
+    raw_skip = 0
+    sort = [("_id", 1)]
+
+    while raw_skip < raw_to_scan:
+        docs = collect_text_relation_docs_for_namespace(
+            namespace=args.namespace,
+            predicates=args.predicates,
+            languages=args.languages,
+            concept_ids=args.concept_ids,
+            updated_since=args.updated_since,
+            skip=raw_skip,
+            sort=sort,
+            limit=min(args.page_size, raw_to_scan - raw_skip),
+        )
+
+        total_candidates += len(docs)
+
+        if rag is not None and docs:
+            for batch in _chunks(docs, args.batch_size):
+                payload = [
+                    {"id": d.doc_id, "text": d.text, "metadata": d.metadata}
+                    for d in batch
+                ]
+                ok, bad = rag.upsert_documents(payload, namespace=args.namespace)
+                added += int(ok)
+                failed += int(bad)
+
+        raw_skip += args.page_size
+
+        if raw_skip % max(args.page_size * 2, 1) == 0:
+            logger.info(
+                "Progress: scanned=%s/%s candidates=%s added=%s failed=%s",
+                min(raw_skip, raw_to_scan),
+                raw_to_scan,
+                total_candidates,
+                added,
+                failed,
+            )
+
+    success = failed == 0
+    logger.info(
+        "Finished reindex: success=%s candidates=%s added=%s failed=%s",
+        success,
+        total_candidates,
+        added,
+        failed,
+    )
+
+    if args.dry_run:
+        return 0
+
+    return 0 if success else 1
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO)
+
+    try:
+        args = parse_args(argv)
+    except ValueError as exc:
+        logger.error("Invalid arguments: %s", exc)
+        return 2
+
+    return run_reindex(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/backend/test_internal_mcp_rag_concept_tools.py
+++ b/tests/backend/test_internal_mcp_rag_concept_tools.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+def test_internal_mcp_catalogue_registers_rag_concept_tools():
+    from src.backend.integrations.internal_mcp.catalogue import build_default_catalogue
+
+    catalogue = build_default_catalogue()
+    methods = set(catalogue.list_methods())
+
+    assert "search_concept_descriptions" in methods
+    assert "get_related_concepts" in methods
+    assert "index_concept_text" in methods

--- a/tests/backend/test_rag_query_filtering.py
+++ b/tests/backend/test_rag_query_filtering.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def _make_retrieved_node(
+    *, metadata: dict, content: str = "content", score: float = 0.5
+):
+    inner = MagicMock()
+    inner.metadata = metadata
+    inner.ref_doc_id = metadata.get("doc_id") or "ref"
+    inner.node_id = "node"
+    inner.get_content.return_value = content
+
+    wrapper = MagicMock()
+    wrapper.node = inner
+    wrapper.score = score
+    return wrapper
+
+
+def test_llamaindex_backend_filters_by_type_and_predicate(tmp_path: Path):
+    with patch(
+        "src.backend.services.rag_backends.llamaindex_backend.ServiceContext.from_defaults",
+        return_value=MagicMock(),
+    ):
+        from src.backend.services.rag_backends.llamaindex_backend import (
+            LlamaIndexRAGService,
+        )
+
+        rag = LlamaIndexRAGService(persistence_dir=str(tmp_path / "rag_storage"))
+
+        nodes = [
+            _make_retrieved_node(
+                metadata={
+                    "type": "chat_message",
+                    "user_id": "#V#user",
+                    "organisation_concept_id": "#V#org",
+                },
+                content="chat",
+            ),
+            _make_retrieved_node(
+                metadata={
+                    "type": "text_relation",
+                    "source": "vontology_text_relation",
+                    "predicate": "hasDescription",
+                    "user_id": "#V#user",
+                    "organisation_concept_id": "#V#org",
+                },
+                content="desc",
+            ),
+            _make_retrieved_node(
+                metadata={
+                    "type": "text_relation",
+                    "source": "vontology_text_relation",
+                    "predicate": "hasNote",
+                    "user_id": "#V#user",
+                    "organisation_concept_id": "#V#org",
+                },
+                content="note",
+            ),
+        ]
+
+        fake_retriever = MagicMock()
+        fake_retriever.retrieve.return_value = nodes
+
+        fake_index = MagicMock()
+        fake_index.as_retriever.return_value = fake_retriever
+
+        rag._indices["#V#user@org"] = fake_index
+
+        results = rag.query(
+            "causal",
+            namespace="#V#user@org",
+            top_k=10,
+            permissions_context={
+                "user_id": "#V#user",
+                "organisation_concept_id": "#V#org",
+                "type": "text_relation",
+                "predicate": "hasDescription",
+            },
+        )
+
+        assert [r["text"] for r in results] == ["desc"]
+
+
+def test_llamaindex_backend_filters_by_mode_chat(tmp_path: Path):
+    with patch(
+        "src.backend.services.rag_backends.llamaindex_backend.ServiceContext.from_defaults",
+        return_value=MagicMock(),
+    ):
+        from src.backend.services.rag_backends.llamaindex_backend import (
+            LlamaIndexRAGService,
+        )
+
+        rag = LlamaIndexRAGService(persistence_dir=str(tmp_path / "rag_storage"))
+
+        nodes = [
+            _make_retrieved_node(
+                metadata={
+                    "type": "chat_message",
+                    "user_id": "#V#user",
+                    "organisation_concept_id": "#V#org",
+                },
+                content="chat",
+            ),
+            _make_retrieved_node(
+                metadata={
+                    "type": "text_relation",
+                    "source": "vontology_text_relation",
+                    "predicate": "hasDescription",
+                    "user_id": "#V#user",
+                    "organisation_concept_id": "#V#org",
+                },
+                content="desc",
+            ),
+        ]
+
+        fake_retriever = MagicMock()
+        fake_retriever.retrieve.return_value = nodes
+
+        fake_index = MagicMock()
+        fake_index.as_retriever.return_value = fake_retriever
+
+        rag._indices["#V#user@org"] = fake_index
+
+        results = rag.query(
+            "hello",
+            namespace="#V#user@org",
+            top_k=10,
+            permissions_context={
+                "user_id": "#V#user",
+                "organisation_concept_id": "#V#org",
+                "mode": "chat",
+            },
+        )
+
+        assert [r["text"] for r in results] == ["chat"]

--- a/tests/backend/test_rag_text_relation_sync_service.py
+++ b/tests/backend/test_rag_text_relation_sync_service.py
@@ -56,7 +56,7 @@ def test_sync_text_relations_indexes_visible_concepts(monkeypatch):
     # Two relations: one visible, one not.
     monkeypatch.setattr(
         "src.backend.db.repositories.text_value_repository.TextRelationsRepository.find",
-        lambda _filter, limit=0: [
+        lambda _filter, projection=None, sort=None, skip=0, limit=0: [
             {
                 "_id": "r1",
                 "subject_concept_id": "#V#allowed",
@@ -69,7 +69,7 @@ def test_sync_text_relations_indexes_visible_concepts(monkeypatch):
                 "predicate": "hasDescription",
                 "object_text_id": "000000000000000000000002",
             },
-        ],
+        ][skip : (skip + limit) if limit else None],
     )
 
     def _tv_find_one(filter_doc, _projection=None):
@@ -98,11 +98,15 @@ def test_sync_text_relations_indexes_visible_concepts(monkeypatch):
     assert "Hello world" in doc["text"]
 
     meta = doc["metadata"]
+    assert meta["type"] == "text_relation"
     assert meta["source"] == "vontology_text_relation"
+    assert meta["concept_id"] == "#V#allowed"
     assert meta["subject_concept_id"] == "#V#allowed"
     assert meta["predicate"] == "hasDescription"
     assert meta["relation_id"] == "r1"
+    assert meta["language"] == "en-NZ"
 
     # Required for permission filtering.
     assert meta["user_id"] == "#V#user"
     assert meta["organisation_concept_id"] == "#V#org"
+    assert meta["org_id"] == "#V#org"

--- a/tests/backend/test_reindex_text_relations_cli.py
+++ b/tests/backend/test_reindex_text_relations_cli.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.utilities.reindex_text_relations import ReindexArgs, parse_args, run_reindex
+from src.backend.services.rag_text_relation_sync_service import TextRelationRagDoc
+
+
+def test_parse_args_accepts_namespace_directly():
+    args = parse_args(["--namespace", "#V#u@#V#org", "--dry-run"])
+    assert args.namespace == "#V#u@#V#org"
+    assert args.dry_run is True
+
+
+def test_parse_args_builds_namespace_from_user_and_org():
+    args = parse_args(["--user", "#V#u", "--org", "org", "--dry-run"])
+    assert args.namespace == "#V#u@org"
+
+
+def test_parse_args_splits_repeatable_lists_and_csv():
+    args = parse_args(
+        [
+            "--namespace",
+            "#V#u@#V#org",
+            "--predicate",
+            "hasDescription,hasName",
+            "--predicate",
+            "hasContent",
+            "--language",
+            "en-NZ,fr",
+            "--concept-id",
+            "#V#c1,#V#c2",
+            "--dry-run",
+        ]
+    )
+    assert args.predicates == ["hasDescription", "hasName", "hasContent"]
+    assert args.languages == ["en-NZ", "fr"]
+    assert args.concept_ids == ["#V#c1", "#V#c2"]
+
+
+def test_parse_args_parses_since_date_to_utc_midnight():
+    args = parse_args(
+        ["--namespace", "#V#u@#V#org", "--since", "2025-12-01", "--dry-run"]
+    )
+    assert isinstance(args.updated_since, datetime)
+    assert args.updated_since.tzinfo is not None
+    assert args.updated_since == datetime(2025, 12, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_run_reindex_dry_run_does_not_call_rag(monkeypatch: pytest.MonkeyPatch):
+    from src.utilities import reindex_text_relations as mod
+
+    def _boom():
+        raise AssertionError("get_rag_service should not be called in dry-run")
+
+    monkeypatch.setattr(mod, "get_rag_service", _boom)
+    monkeypatch.setattr(mod.TextRelationsRepository, "count_documents", lambda _f: 0)
+    monkeypatch.setattr(
+        mod, "collect_text_relation_docs_for_namespace", lambda **_k: []
+    )
+
+    args = ReindexArgs(
+        namespace="#V#u@#V#org",
+        predicates=None,
+        languages=None,
+        concept_ids=None,
+        updated_since=None,
+        dry_run=True,
+        page_size=10,
+        batch_size=2,
+        scan_limit=0,
+    )
+
+    assert run_reindex(args) == 0
+
+
+def test_run_reindex_upserts_documents(monkeypatch: pytest.MonkeyPatch):
+    from src.utilities import reindex_text_relations as mod
+
+    calls = {"upserts": 0, "namespace": None, "count": 0}
+
+    class _FakeRag:
+        def upsert_documents(self, docs, namespace: str):
+            calls["upserts"] += 1
+            calls["namespace"] = namespace
+            calls["count"] += len(docs)
+            return len(docs), 0
+
+    monkeypatch.setattr(mod, "get_rag_service", lambda: _FakeRag())
+    monkeypatch.setattr(mod.TextRelationsRepository, "count_documents", lambda _f: 1)
+
+    doc = TextRelationRagDoc(
+        doc_id="text_relation:1", text="hello", metadata={"k": "v"}
+    )
+    monkeypatch.setattr(
+        mod, "collect_text_relation_docs_for_namespace", lambda **_k: [doc]
+    )
+
+    args = ReindexArgs(
+        namespace="#V#u@#V#org",
+        predicates=None,
+        languages=None,
+        concept_ids=None,
+        updated_since=None,
+        dry_run=False,
+        page_size=1,
+        batch_size=10,
+        scan_limit=1,
+    )
+
+    assert run_reindex(args) == 0
+    assert calls["upserts"] == 1
+    assert calls["namespace"] == "#V#u@#V#org"
+    assert calls["count"] == 1


### PR DESCRIPTION
Problem:
- Concept-centric RAG workflows need helper tools (search descriptions / related concepts) and better freshness on text-relation edits.

Change:
- Add RAG helper tools: search_concept_descriptions, get_related_concepts, index_concept_text.
- Add best-effort text relation change hooks to keep RAG in sync (skips when namespace missing).
- Add bulk reindex CLI for text relations.
- Add backend tests for filtering + tool registration + CLI + metadata.

Tests:
- pytest: tests/backend/test_rag_text_relation_sync_service.py
- pytest: tests/backend/test_rag_query_filtering.py
- pytest: tests/backend/test_internal_mcp_rag_concept_tools.py
- pytest: tests/backend/test_reindex_text_relations_cli.py