### PR TITLE
JVNAUTOSCI-878: Blob store + Swift backend for durable artefact storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -931,6 +931,8 @@ uv tool install arxiv-mcp-server
 
 **Documentation**: See `docs/engineering/arxiv_mcp_integration.md` for detailed setup, usage patterns, and troubleshooting.
 
+For Catalyst Cloud (NZ) Swift configuration, see `docs/engineering/catalyst_cloud_swift_setup.md`.
+
 **Related Issues**:
 - JVNAUTOSCI-654: Plan external MCP integrations (arXiv) - Complete
 - JVNAUTOSCI-655: Implement internal MCP proxy for arXiv tools - Planned

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -897,7 +897,7 @@ Von can integrate with external MCP servers to access external services and data
         "run",
         "arxiv-mcp-server",
         "--storage-path",
-        "${workspaceFolder}/data/arxiv_papers"
+        "${workspaceFolder}/data/arxiv_cache"
       ]
     }
   }
@@ -910,13 +910,13 @@ uv tool install arxiv-mcp-server
 ```
 
 **Storage**:
-- **Current**: Local filesystem at `data/arxiv_papers/`
-- **Future**: OpenStack Swift object store (JVNAUTOSCI-658)
+- **Cache**: Local filesystem cache at `data/arxiv_cache/` (used by the external `arxiv-mcp-server`)
+- **Durable**: Von blob store (a general artefact store capability) — default local `data/blob_store/`, optionally OpenStack Swift (JVNAUTOSCI-878)
 
 **Available Tools**:
 - `search_arxiv`: Query by keywords, authors, categories, date ranges
 - `get_paper_metadata`: Retrieve title, authors, abstract, publication date, DOI
-- `download_paper`: Fetch PDF to local storage (future: remote object store)
+- `download_paper`: Fetch PDF and store it durably via the blob store (with a local cache)
 
 **Usage Example** (IDE/Copilot level):
 ```
@@ -936,7 +936,7 @@ uv tool install arxiv-mcp-server
 - JVNAUTOSCI-655: Implement internal MCP proxy for arXiv tools - Planned
 - JVNAUTOSCI-656: Automated arXiv monitoring for known authors - Planned
 - JVNAUTOSCI-657: Scholarly article concept auto-population - Planned
-- JVNAUTOSCI-658: Migrate arXiv storage to OpenStack Swift - Planned
+- JVNAUTOSCI-878: Migrate arXiv storage to OpenStack Swift object store - Planned
 
 ### Adding New External MCP Servers
 

--- a/docs/engineering/catalyst_cloud_swift_setup.md
+++ b/docs/engineering/catalyst_cloud_swift_setup.md
@@ -1,0 +1,176 @@
+# Catalyst Cloud (NZ) Swift setup for Von blob store
+
+This guide explains how to configure Von’s **Swift-backed blob store** against **Catalyst Cloud (New Zealand)**.
+
+Von supports a pluggable blob store backend:
+- **Cache**: arXiv’s external MCP server writes PDFs to a local cache directory (default `data/arxiv_cache/`).
+- **Durable store**: Von uploads artefacts (e.g. arXiv PDFs) to the configured blob store backend.
+
+This document focuses on configuring the **durable** Swift backend.
+
+## Prerequisites
+
+- You have a Catalyst Cloud account with access to a project/tenant that can use **Object Storage (Swift)**.
+- You have either:
+  - an **Application Credential** (recommended), or
+  - an **OpenStack RC file** (password-based auth).
+- You are on Windows using **PowerShell** (this repo’s default shell).
+
+## Safety and security
+
+- Do **not** commit credentials to git.
+- Prefer **Application Credentials** over password auth.
+- If you create `clouds.yaml`, keep it in your user profile (not in the repo).
+
+## 1) Install dependencies
+
+The Swift backend uses `openstacksdk`.
+
+If you have not installed dependencies for this repo yet:
+
+```powershell
+pdm install
+```
+
+## 2) Choose an authentication method
+
+Von’s Swift implementation supports standard OpenStack authentication via:
+- `OS_CLOUD` pointing at a `clouds.yaml` entry (recommended), or
+- environment variables (`OS_AUTH_URL`, `OS_USERNAME`, etc.).
+
+### Option A (recommended): `clouds.yaml` + `OS_CLOUD`
+
+Create this file:
+
+- `C:\Users\<you>\.config\openstack\clouds.yaml`
+
+Example (fill in values from Catalyst Cloud):
+
+```yaml
+clouds:
+  catalyst:
+    region_name: "<your-region>"
+    interface: "public"
+    identity_api_version: 3
+    auth:
+      auth_url: "<OS_AUTH_URL>"
+      application_credential_id: "<APP_CRED_ID>"
+      application_credential_secret: "<APP_CRED_SECRET>"
+```
+
+Then set:
+
+```powershell
+$env:OS_CLOUD = 'catalyst'
+```
+
+Notes:
+- `region_name` and `auth_url` must match the values Catalyst provides for your project.
+- If you maintain multiple OpenStack environments, add multiple entries under `clouds:`.
+
+### Option B: Environment variables (RC file values)
+
+If Catalyst provides a Bash-style RC file (`export OS_...`), copy the values into PowerShell instead:
+
+```powershell
+$env:OS_AUTH_URL = '<from RC file>'
+$env:OS_USERNAME = '<from RC file>'
+$env:OS_PASSWORD = '<from RC file>'
+$env:OS_PROJECT_NAME = '<from RC file>'
+$env:OS_USER_DOMAIN_NAME = '<from RC file or Default>'
+$env:OS_PROJECT_DOMAIN_NAME = '<from RC file or Default>'
+$env:OS_REGION_NAME = '<from RC file>'
+```
+
+If your RC file provides different variables (e.g. project/tenant IDs), prefer following Catalyst’s docs for your account configuration.
+
+## 3) Configure Von to use Swift
+
+Von selects the blob store backend via environment variables.
+
+Required:
+
+```powershell
+$env:VON_BLOB_STORE_BACKEND = 'swift'
+$env:VON_SWIFT_CONTAINER = 'von-artifacts'
+```
+
+Optional:
+
+```powershell
+# Store all Von objects under this prefix within the container
+$env:VON_SWIFT_PREFIX = 'von'
+
+# If you have a stable public base URL for object access, you can use it
+# to construct an HTTP(S) URI in BlobRef.uri. Otherwise Von will use
+# a 'swift://container/key' URI.
+$env:VON_SWIFT_PUBLIC_BASE_URL = '<https://...>'
+```
+
+### Create the container
+
+The container must exist. Create it in Catalyst Cloud’s dashboard, or via OpenStack CLI (if you have it installed and configured):
+
+```powershell
+openstack container create von-artifacts
+```
+
+## 4) Smoke test (no server start)
+
+This runs a minimal put/get/list round-trip using Von’s blob store factory.
+
+```powershell
+$code = @'
+from src.backend.services.blob_store import get_blob_store_from_env
+
+store = get_blob_store_from_env()
+ref = store.put_bytes(
+    "smoke_test/hello.txt",
+    b"kia ora",
+    content_type="text/plain",
+    metadata={"source": "catalyst_cloud_swift_setup"},
+)
+print("PUT:", ref)
+
+data = store.get_bytes("smoke_test/hello.txt")
+print("GET:", data)
+
+print("EXISTS:", store.exists("smoke_test/hello.txt"))
+print("LIST:", store.list("smoke_test"))
+'@
+
+pdm run python -c $code
+```
+
+Expected behaviour:
+- `PUT` prints a `BlobRef` with `backend='swift'`.
+- `GET` prints `b'kia ora'`.
+- `LIST` includes `smoke_test/hello.txt`.
+
+## 5) arXiv behaviour with Swift enabled
+
+With the Swift backend configured:
+- arXiv downloads will still be written to the local cache (default `data/arxiv_cache/`).
+- Von will upload the PDF to Swift under a key like `arxiv/papers/<arxiv-id>.pdf`.
+- Tool output will include `storage { backend, key, uri }` so downstream components can persist and retrieve the durable location.
+
+## Troubleshooting
+
+### Authentication errors
+
+- Confirm `OS_CLOUD` matches an entry in `clouds.yaml`, or that your `OS_...` environment variables are set correctly.
+- Confirm the credential/project has access to **Object Storage**.
+
+### Wrong region or endpoint
+
+- Catalyst Cloud values can vary by project and region. Use the `auth_url` and `region_name` provided for your account.
+
+### Container not found
+
+- Ensure `VON_SWIFT_CONTAINER` exists.
+- If you use a prefix, verify `VON_SWIFT_PREFIX` does not contain leading/trailing slashes.
+
+## Related documents
+
+- If you’re configuring arXiv MCP usage as well, see the arXiv MCP integration notes in `AGENTS.md`.
+- For general guidance on MCP tool design and reliability, see [docs/engineering/mcp_tools_best_practices.md](docs/engineering/mcp_tools_best_practices.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ dependencies = [
     "fastapi>=0.123.10",
     "uvicorn>=0.38.0",
     "cryptography>=43.0.0",
+    "openstacksdk>=4.0.0",
     "google-genai>=1.55.0",
     "bleach>=6.3.0",
 ]

--- a/src/backend/integrations/internal_mcp/arxiv_proxy.py
+++ b/src/backend/integrations/internal_mcp/arxiv_proxy.py
@@ -220,7 +220,9 @@ class ArxivMCPProxy:
         result = self._send_request("download_paper", arguments)
         return self._store_downloaded_pdf(result=result, arxiv_id=arxiv_id)
 
-    def _store_downloaded_pdf(self, *, result: Dict[str, Any], arxiv_id: str) -> Dict[str, Any]:
+    def _store_downloaded_pdf(
+        self, *, result: Dict[str, Any], arxiv_id: str
+    ) -> Dict[str, Any]:
         file_path = _extract_download_file_path(result)
         if not file_path:
             raise ArxivProxyError(

--- a/src/backend/integrations/internal_mcp/arxiv_proxy.py
+++ b/src/backend/integrations/internal_mcp/arxiv_proxy.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from src.backend.services.blob_store import get_blob_store_from_env
+
 logger = logging.getLogger(__name__)
 
 _LOG_TAG = "[arxiv_proxy]"
@@ -215,7 +217,50 @@ class ArxivMCPProxy:
                 _LOG_TAG,
             )
 
-        return self._send_request("download_paper", arguments)
+        result = self._send_request("download_paper", arguments)
+        return self._store_downloaded_pdf(result=result, arxiv_id=arxiv_id)
+
+    def _store_downloaded_pdf(self, *, result: Dict[str, Any], arxiv_id: str) -> Dict[str, Any]:
+        file_path = _extract_download_file_path(result)
+        if not file_path:
+            raise ArxivProxyError(
+                "arXiv download succeeded but no file path was returned by arxiv-mcp-server"
+            )
+
+        path = Path(file_path)
+        if not path.is_absolute():
+            # Some tools return a relative path; treat it as relative to the configured cache dir.
+            path = self._config.storage_path / path
+
+        if not path.exists():
+            raise ArxivProxyError(f"Downloaded PDF not found at: {path}")
+
+        blob_store = get_blob_store_from_env()
+        storage_key = _arxiv_pdf_blob_key(arxiv_id)
+
+        try:
+            ref = blob_store.put_bytes(
+                storage_key,
+                path.read_bytes(),
+                content_type="application/pdf",
+                metadata={
+                    "source": "arxiv",
+                    "arxiv_id": _normalise_arxiv_id(arxiv_id),
+                    "original_path": str(path),
+                },
+            )
+        except Exception as exc:
+            raise ArxivProxyError(f"Failed to store PDF in blob store: {exc}") from exc
+
+        stored = dict(result)
+        stored["arxiv_id"] = arxiv_id
+        stored["file_path"] = str(path)
+        stored["storage"] = {
+            "backend": ref.backend,
+            "key": ref.key,
+            "uri": ref.uri,
+        }
+        return stored
 
     def shutdown(self) -> None:
         """Terminate the subprocess gracefully."""
@@ -260,10 +305,14 @@ def get_arxiv_proxy() -> ArxivMCPProxy:
             import os
 
             workspace_root = Path(__file__).parent.parent.parent.parent.parent
-            storage_path = workspace_root / "data" / "arxiv_papers"
+            # This is a cache directory for the external arxiv-mcp-server. The durable
+            # storage location is the blob store (local or Swift).
+            storage_path = workspace_root / "data" / "arxiv_cache"
 
             # Allow override via environment variable
-            env_storage = os.environ.get("ARXIV_STORAGE_PATH")
+            env_storage = os.environ.get("ARXIV_CACHE_PATH") or os.environ.get(
+                "ARXIV_STORAGE_PATH"
+            )
             if env_storage:
                 storage_path = Path(env_storage)
 
@@ -284,3 +333,23 @@ def shutdown_arxiv_proxy() -> None:
         if _proxy_instance is not None:
             _proxy_instance.shutdown()
             _proxy_instance = None
+
+
+def _normalise_arxiv_id(arxiv_id: str) -> str:
+    value = arxiv_id.strip()
+    if value.lower().startswith("arxiv:"):
+        value = value.split(":", 1)[1].strip()
+    return value
+
+
+def _arxiv_pdf_blob_key(arxiv_id: str) -> str:
+    safe = _normalise_arxiv_id(arxiv_id).replace("/", "_")
+    return f"arxiv/papers/{safe}.pdf"
+
+
+def _extract_download_file_path(result: Dict[str, Any]) -> str | None:
+    for key in ("file_path", "path", "filepath", "filename"):
+        value = result.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None

--- a/src/backend/integrations/internal_mcp/arxiv_proxy_mcp.py
+++ b/src/backend/integrations/internal_mcp/arxiv_proxy_mcp.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional, List
 
+from src.backend.services.blob_store import get_blob_store_from_env
+
 from mcp.client.stdio import StdioServerParameters, stdio_client
 from mcp.client.session import ClientSession
 from mcp import types as mcp_types
@@ -183,7 +185,65 @@ class ArxivMCPProxy:
                 _LOG_TAG,
             )
 
-        return await self._call_tool("download_paper", arguments)
+        result = await self._call_tool("download_paper", arguments)
+        return self._store_downloaded_pdf(result=result, arxiv_id=arxiv_id)
+
+    def _store_downloaded_pdf(self, *, result: Any, arxiv_id: str) -> Dict[str, Any]:
+        if isinstance(result, dict) and "text" in result and isinstance(result["text"], str):
+            # Some versions return a single text payload.
+            try:
+                import json
+
+                parsed = json.loads(result["text"])
+                if isinstance(parsed, dict):
+                    result = parsed
+            except Exception:
+                pass
+
+        if not isinstance(result, dict):
+            raise ArxivProxyError(
+                f"Unexpected download_paper result type: {type(result).__name__}"
+            )
+
+        file_path = _extract_download_file_path(result)
+        if not file_path:
+            raise ArxivProxyError(
+                "arXiv download succeeded but no file path was returned by arxiv-mcp-server"
+            )
+
+        path = Path(file_path)
+        if not path.is_absolute():
+            path = self._config.storage_path / path
+
+        if not path.exists():
+            raise ArxivProxyError(f"Downloaded PDF not found at: {path}")
+
+        blob_store = get_blob_store_from_env()
+        storage_key = _arxiv_pdf_blob_key(arxiv_id)
+
+        try:
+            ref = blob_store.put_bytes(
+                storage_key,
+                path.read_bytes(),
+                content_type="application/pdf",
+                metadata={
+                    "source": "arxiv",
+                    "arxiv_id": _normalise_arxiv_id(arxiv_id),
+                    "original_path": str(path),
+                },
+            )
+        except Exception as exc:
+            raise ArxivProxyError(f"Failed to store PDF in blob store: {exc}") from exc
+
+        stored = dict(result)
+        stored["arxiv_id"] = arxiv_id
+        stored["file_path"] = str(path)
+        stored["storage"] = {
+            "backend": ref.backend,
+            "key": ref.key,
+            "uri": ref.uri,
+        }
+        return stored
 
     async def list_papers(self) -> Dict[str, Any]:
         """List all downloaded papers.
@@ -231,10 +291,13 @@ async def get_arxiv_proxy() -> ArxivMCPProxy:
             import os
 
             workspace_root = Path(__file__).parent.parent.parent.parent.parent
-            storage_path = workspace_root / "data" / "arxiv_papers"
+            # Cache directory for external arxiv-mcp-server. Durable storage is the blob store.
+            storage_path = workspace_root / "data" / "arxiv_cache"
 
             # Allow override via environment variable
-            env_storage = os.environ.get("ARXIV_STORAGE_PATH")
+            env_storage = os.environ.get("ARXIV_CACHE_PATH") or os.environ.get(
+                "ARXIV_STORAGE_PATH"
+            )
             if env_storage:
                 storage_path = Path(env_storage)
 
@@ -245,3 +308,23 @@ async def get_arxiv_proxy() -> ArxivMCPProxy:
             )
 
         return _proxy_instance
+
+
+def _normalise_arxiv_id(arxiv_id: str) -> str:
+    value = arxiv_id.strip()
+    if value.lower().startswith("arxiv:"):
+        value = value.split(":", 1)[1].strip()
+    return value
+
+
+def _arxiv_pdf_blob_key(arxiv_id: str) -> str:
+    safe = _normalise_arxiv_id(arxiv_id).replace("/", "_")
+    return f"arxiv/papers/{safe}.pdf"
+
+
+def _extract_download_file_path(result: Dict[str, Any]) -> str | None:
+    for key in ("file_path", "path", "filepath", "filename"):
+        value = result.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None

--- a/src/backend/integrations/internal_mcp/arxiv_proxy_mcp.py
+++ b/src/backend/integrations/internal_mcp/arxiv_proxy_mcp.py
@@ -189,7 +189,11 @@ class ArxivMCPProxy:
         return self._store_downloaded_pdf(result=result, arxiv_id=arxiv_id)
 
     def _store_downloaded_pdf(self, *, result: Any, arxiv_id: str) -> Dict[str, Any]:
-        if isinstance(result, dict) and "text" in result and isinstance(result["text"], str):
+        if (
+            isinstance(result, dict)
+            and "text" in result
+            and isinstance(result["text"], str)
+        ):
             # Some versions return a single text payload.
             try:
                 import json

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -1724,10 +1724,15 @@ def _download_paper_output_schema() -> Schema:
             "success": (bool, type(None)),
             "file_path": (str, type(None)),
             "arxiv_id": (str, type(None)),
+            "storage": (dict, type(None)),
             "error": (str, type(None)),
         },
         allow_unknown=True,
-        description="download_paper output: success (bool), file_path (str, location of downloaded PDF), arxiv_id (str), or error (str) if failed",
+        description=(
+            "download_paper output: success (bool), file_path (str, local cache path), "
+            "storage (dict with backend/key/uri for durable blob-store location), arxiv_id (str), "
+            "or error (str) if failed"
+        ),
     )
 
 
@@ -4146,7 +4151,7 @@ def build_default_catalogue() -> MethodCatalogue:
             output_schema=_download_paper_output_schema(),
             category="write",
             timeout_sec=60.0,
-            description="Download PDF of an arXiv paper to local storage (data/arxiv_papers/). Use when user asks to download/save/fetch a paper. Returns file path where PDF was saved. Accepts optional filename parameter for custom naming (defaults to arxiv_id.pdf).",
+            description="Download PDF of an arXiv paper, then store it in the configured blob store (local or OpenStack Swift). The external arXiv tool writes into a local cache directory; this tool returns both the local cache file_path and a durable storage.uri. Use when user asks to download/save/fetch a paper.",
         ),
         MethodDefinition(
             name="list_papers",
@@ -4155,7 +4160,7 @@ def build_default_catalogue() -> MethodCatalogue:
             output_schema=_list_papers_output_schema(),
             category="read",
             timeout_sec=15.0,
-            description="List all arXiv papers that have been downloaded to local storage (data/arxiv_papers/). Use when user asks 'what papers do I have?', 'list downloaded papers', or similar. Returns list of all locally stored papers with their metadata (title, authors, summary, links). No parameters required.",
+            description="List arXiv papers available in the local cache directory used by the external arXiv toolchain. This may not reflect all documents stored in the blob store. Use when user asks 'what papers do I have?' or similar.",
         ),
         MethodDefinition(
             name="read_paper",

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -802,7 +802,7 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="download_paper",
-            description="Download PDF of an arXiv paper to local storage (data/arxiv_papers/). Returns file path where PDF was saved.",
+            description="Download PDF of an arXiv paper and store it in the configured blob store (local or OpenStack Swift). Returns both a local cache file_path and a durable storage URI.",
             inputSchema={
                 "type": "object",
                 "properties": {

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -1005,7 +1005,7 @@
         },
         {
             "name": "download_paper",
-            "description": "Download PDF of an arXiv paper to local storage (data/arxiv_papers/). Use when user asks to download/save/fetch a paper. Returns file path where PDF was saved. Accepts optional filename parameter for custom naming (defaults to arxiv_id.pdf).",
+            "description": "Download PDF of an arXiv paper and store it in the configured blob store (local or OpenStack Swift). The external arXiv tool writes into a local cache directory; this tool returns both the local cache file path and a durable storage URI.",
             "inputSchema": {
                 "type": "object",
                 "properties": {

--- a/src/backend/services/blob_store.py
+++ b/src/backend/services/blob_store.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, Protocol
+
+
+@dataclass(frozen=True)
+class BlobRef:
+    backend: str
+    key: str
+    uri: str
+    content_type: str | None = None
+    size_bytes: int | None = None
+    etag: str | None = None
+    metadata: dict[str, str] | None = None
+
+
+class BlobStore(Protocol):
+    def put_bytes(
+        self,
+        key: str,
+        data: bytes,
+        *,
+        content_type: str | None = None,
+        metadata: Mapping[str, str] | None = None,
+    ) -> BlobRef: ...
+
+    def get_bytes(self, key: str) -> bytes: ...
+
+    def exists(self, key: str) -> bool: ...
+
+    def delete(self, key: str) -> None: ...
+
+    def list(self, prefix: str = "") -> list[str]: ...
+
+
+def _normalise_key(key: str) -> str:
+    key = key.strip().replace("\\", "/")
+    if not key:
+        raise ValueError("Blob key must not be empty")
+
+    posix = PurePosixPath(key)
+    if posix.is_absolute() or any(part == ".." for part in posix.parts):
+        raise ValueError(f"Unsafe blob key: {key!r}")
+
+    # Avoid leading './'
+    key = str(posix)
+    while key.startswith("./"):
+        key = key[2:]
+
+    if not key or key == ".":
+        raise ValueError("Blob key must not be empty")
+
+    return key
+
+
+class LocalBlobStore:
+    def __init__(self, root_dir: Path):
+        self._root_dir = root_dir
+
+    @property
+    def root_dir(self) -> Path:
+        return self._root_dir
+
+    def _resolve_path(self, key: str) -> Path:
+        safe_key = _normalise_key(key)
+        return self._root_dir / safe_key
+
+    def put_bytes(
+        self,
+        key: str,
+        data: bytes,
+        *,
+        content_type: str | None = None,
+        metadata: Mapping[str, str] | None = None,
+    ) -> BlobRef:
+        path = self._resolve_path(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+
+        # Metadata is stored as a sibling JSON file. This is intentionally simple and
+        # cross-platform; it also keeps the abstraction compatible with object stores.
+        if metadata:
+            meta_path = path.with_suffix(path.suffix + ".meta.json")
+            import json
+
+            meta_path.write_text(json.dumps(dict(metadata), indent=2), encoding="utf-8")
+
+        return BlobRef(
+            backend="local",
+            key=_normalise_key(key),
+            uri=str(path),
+            content_type=content_type,
+            size_bytes=len(data),
+            metadata=dict(metadata) if metadata else None,
+        )
+
+    def get_bytes(self, key: str) -> bytes:
+        path = self._resolve_path(key)
+        return path.read_bytes()
+
+    def exists(self, key: str) -> bool:
+        return self._resolve_path(key).exists()
+
+    def delete(self, key: str) -> None:
+        path = self._resolve_path(key)
+        if path.exists():
+            path.unlink()
+
+        meta_path = path.with_suffix(path.suffix + ".meta.json")
+        if meta_path.exists():
+            meta_path.unlink()
+
+    def list(self, prefix: str = "") -> list[str]:
+        safe_prefix = _normalise_key(prefix) if prefix else ""
+        base = self._root_dir / safe_prefix
+        if not base.exists():
+            return []
+
+        keys: list[str] = []
+        for path in base.rglob("*"):
+            if not path.is_file():
+                continue
+            if path.name.endswith(".meta.json"):
+                continue
+
+            rel = path.relative_to(self._root_dir).as_posix()
+            keys.append(rel)
+
+        keys.sort()
+        return keys
+
+
+class SwiftBlobStore:
+    """OpenStack Swift-backed blob store.
+
+    This is intentionally a generic capability (not arXiv-specific). arXiv is simply
+    one client that stores PDFs here.
+
+    Authentication uses standard OpenStack environment variables (OS_*) or OS_CLOUD.
+
+    Required env vars (unless using OS_CLOUD):
+    - OS_AUTH_URL
+    - OS_USERNAME
+    - OS_PASSWORD
+    - OS_PROJECT_NAME
+    - OS_USER_DOMAIN_NAME (often 'Default')
+    - OS_PROJECT_DOMAIN_NAME (often 'Default')
+
+    Required for this store:
+    - VON_SWIFT_CONTAINER
+
+    Optional:
+    - VON_SWIFT_PREFIX (e.g., 'von/')
+    - VON_SWIFT_PUBLIC_BASE_URL (used to construct a stable HTTP URL if available)
+    - OS_REGION_NAME
+    """
+
+    def __init__(
+        self,
+        *,
+        container: str,
+        prefix: str = "",
+        public_base_url: str | None = None,
+        cloud: str | None = None,
+    ):
+        self._container = container
+        self._prefix = prefix.strip("/")
+        self._public_base_url = public_base_url.rstrip("/") if public_base_url else None
+        self._cloud = cloud
+
+        self._conn = self._create_connection()
+
+    def _create_connection(self):
+        try:
+            import openstack
+            from openstack import connection
+        except Exception as exc:  # pragma: no cover
+            raise RuntimeError(
+                "OpenStack Swift backend requires 'openstacksdk'. Add it via PDM."
+            ) from exc
+
+        if self._cloud:
+            return openstack.connect(cloud=self._cloud)
+
+        def _require(name: str) -> str:
+            value = os.environ.get(name)
+            if not value:
+                raise ValueError(
+                    f"Missing required environment variable for Swift auth: {name}"
+                )
+            return value
+
+        auth_url = _require("OS_AUTH_URL")
+        username = _require("OS_USERNAME")
+        password = _require("OS_PASSWORD")
+        project_name = _require("OS_PROJECT_NAME")
+        user_domain_name = os.environ.get("OS_USER_DOMAIN_NAME", "Default")
+        project_domain_name = os.environ.get("OS_PROJECT_DOMAIN_NAME", "Default")
+        region_name = os.environ.get("OS_REGION_NAME")
+
+        return connection.Connection(
+            auth_url=auth_url,
+            username=username,
+            password=password,
+            project_name=project_name,
+            user_domain_name=user_domain_name,
+            project_domain_name=project_domain_name,
+            region_name=region_name,
+        )
+
+    def _full_key(self, key: str) -> str:
+        safe_key = _normalise_key(key)
+        if not self._prefix:
+            return safe_key
+        return f"{self._prefix}/{safe_key}"
+
+    def _build_uri(self, key: str) -> str:
+        full_key = self._full_key(key)
+        if self._public_base_url:
+            return f"{self._public_base_url}/{self._container}/{full_key}"
+        return f"swift://{self._container}/{full_key}"
+
+    def put_bytes(
+        self,
+        key: str,
+        data: bytes,
+        *,
+        content_type: str | None = None,
+        metadata: Mapping[str, str] | None = None,
+    ) -> BlobRef:
+        full_key = self._full_key(key)
+
+        # openstacksdk supports both bytes and file-like objects.
+        self._conn.object_store.create_object(
+            container=self._container,
+            name=full_key,
+            data=data,
+            content_type=content_type,
+            metadata=dict(metadata) if metadata else None,
+        )
+
+        return BlobRef(
+            backend="swift",
+            key=_normalise_key(key),
+            uri=self._build_uri(key),
+            content_type=content_type,
+            size_bytes=len(data),
+            metadata=dict(metadata) if metadata else None,
+        )
+
+    def get_bytes(self, key: str) -> bytes:
+        full_key = self._full_key(key)
+        # download_object returns bytes when 'outfile' is not provided.
+        return self._conn.object_store.download_object(
+            name=full_key, container=self._container
+        )
+
+    def exists(self, key: str) -> bool:
+        full_key = self._full_key(key)
+        obj = self._conn.object_store.get_object(
+            name=full_key, container=self._container
+        )
+        return obj is not None
+
+    def delete(self, key: str) -> None:
+        full_key = self._full_key(key)
+        self._conn.object_store.delete_object(
+            name=full_key, container=self._container, ignore_missing=True
+        )
+
+    def list(self, prefix: str = "") -> list[str]:
+        safe_prefix = _normalise_key(prefix) if prefix else ""
+        full_prefix = self._full_key(safe_prefix) if safe_prefix else self._prefix
+        if full_prefix and not full_prefix.endswith("/"):
+            full_prefix = full_prefix + "/"
+
+        keys: list[str] = []
+        for obj in self._conn.object_store.objects(
+            container=self._container,
+            prefix=full_prefix or None,
+        ):
+            name = getattr(obj, "name", None)
+            if not name or not isinstance(name, str):
+                continue
+
+            # Strip store-level prefix to return stable keys.
+            if self._prefix:
+                store_prefix = self._prefix + "/"
+                if name.startswith(store_prefix):
+                    name = name[len(store_prefix) :]
+
+            keys.append(_normalise_key(name))
+
+        keys.sort()
+        return keys
+
+
+def get_blob_store_from_env() -> BlobStore:
+    backend = (os.environ.get("VON_BLOB_STORE_BACKEND") or "local").strip().lower()
+
+    if backend == "local":
+        root = os.environ.get("VON_BLOB_STORE_LOCAL_ROOT")
+        if root:
+            root_dir = Path(root)
+        else:
+            workspace_root = Path(__file__).parent.parent.parent.parent
+            root_dir = workspace_root / "data" / "blob_store"
+        return LocalBlobStore(root_dir)
+
+    if backend == "swift":
+        container = os.environ.get("VON_SWIFT_CONTAINER")
+        if not container:
+            raise ValueError("VON_SWIFT_CONTAINER is required when backend=swift")
+
+        prefix = os.environ.get("VON_SWIFT_PREFIX", "")
+        public_base_url = os.environ.get("VON_SWIFT_PUBLIC_BASE_URL")
+        cloud = os.environ.get("OS_CLOUD")
+
+        return SwiftBlobStore(
+            container=container,
+            prefix=prefix,
+            public_base_url=public_base_url,
+            cloud=cloud,
+        )
+
+    raise ValueError(
+        "Unsupported VON_BLOB_STORE_BACKEND. Expected 'local' or 'swift'. "
+        f"Got: {backend!r}"
+    )

--- a/tests/test_blob_store.py
+++ b/tests/test_blob_store.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.backend.services.blob_store import LocalBlobStore, _normalise_key, get_blob_store_from_env
+
+
+def test_normalise_key_rejects_empty():
+    with pytest.raises(ValueError):
+        _normalise_key("")
+
+
+def test_normalise_key_rejects_absolute_or_parent_traversal():
+    with pytest.raises(ValueError):
+        _normalise_key("/etc/passwd")
+
+    with pytest.raises(ValueError):
+        _normalise_key("../secrets.txt")
+
+    with pytest.raises(ValueError):
+        _normalise_key("a/../b")
+
+
+def test_local_blob_store_put_get_exists_delete_and_list(tmp_path: Path):
+    store = LocalBlobStore(tmp_path)
+
+    ref = store.put_bytes(
+        "demo/thing.txt",
+        b"hello",
+        content_type="text/plain",
+        metadata={"owner": "test"},
+    )
+
+    assert ref.backend == "local"
+    assert store.exists("demo/thing.txt")
+    assert store.get_bytes("demo/thing.txt") == b"hello"
+
+    keys = store.list("demo")
+    assert keys == ["demo/thing.txt"]
+
+    store.delete("demo/thing.txt")
+    assert not store.exists("demo/thing.txt")
+
+
+def test_get_blob_store_from_env_defaults_to_local(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("VON_BLOB_STORE_BACKEND", raising=False)
+    monkeypatch.delenv("VON_BLOB_STORE_LOCAL_ROOT", raising=False)
+
+    store = get_blob_store_from_env()
+    assert isinstance(store, LocalBlobStore)
+
+
+def test_get_blob_store_from_env_swift_requires_container(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VON_BLOB_STORE_BACKEND", "swift")
+    monkeypatch.delenv("VON_SWIFT_CONTAINER", raising=False)
+
+    with pytest.raises(ValueError):
+        get_blob_store_from_env()

--- a/tests/test_blob_store.py
+++ b/tests/test_blob_store.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 import pytest
 
-from src.backend.services.blob_store import LocalBlobStore, _normalise_key, get_blob_store_from_env
+from src.backend.services.blob_store import (
+    LocalBlobStore,
+    _normalise_key,
+    get_blob_store_from_env,
+)
 
 
 def test_normalise_key_rejects_empty():
@@ -52,7 +56,9 @@ def test_get_blob_store_from_env_defaults_to_local(monkeypatch: pytest.MonkeyPat
     assert isinstance(store, LocalBlobStore)
 
 
-def test_get_blob_store_from_env_swift_requires_container(monkeypatch: pytest.MonkeyPatch):
+def test_get_blob_store_from_env_swift_requires_container(
+    monkeypatch: pytest.MonkeyPatch,
+):
     monkeypatch.setenv("VON_BLOB_STORE_BACKEND", "swift")
     monkeypatch.delenv("VON_SWIFT_CONTAINER", raising=False)
 


### PR DESCRIPTION
Implements a generic blob store abstraction with local and OpenStack Swift backends, and updates arXiv downloads to treat local output as a cache and upload PDFs to durable storage.

Docs:
- Catalyst Cloud Swift setup: docs/engineering/catalyst_cloud_swift_setup.md

Tests:
- pdm run pytest -q tests/test_blob_store.py