### PR TITLE
JVNAUTOSCI-891: Include individuals in concept autocomplete

### DIFF
--- a/src/frontend/web/von_interface/static/js/components/conceptAutocomplete.js
+++ b/src/frontend/web/von_interface/static/js/components/conceptAutocomplete.js
@@ -22,6 +22,8 @@ const MAX_RESULTS = 8;
 const SEARCH_API = '/vontology/api/vontology/search';
 const SEARCH_PARAM = 'q';
 const MAX_QUERY_CHARS = 80;
+const INCLUDE_INDIVIDUALS = true;
+const FALLBACK_SUBSTRING = true;
 
 let autocompleteState = {
     isOpen: false,
@@ -76,6 +78,17 @@ export function closeAutocomplete() {
     autocompleteState.results = [];
 }
 
+// Export for testing
+export function buildConceptSearchUrl(query) {
+    const q = String(query ?? '').trim();
+    const params = new URLSearchParams();
+    params.set(SEARCH_PARAM, q);
+    params.set('limit', String(MAX_RESULTS));
+    if (INCLUDE_INDIVIDUALS) params.set('include_individuals', 'true');
+    if (FALLBACK_SUBSTRING) params.set('fallback_substring', 'true');
+    return `${SEARCH_API}?${params.toString()}`;
+}
+
 /**
  * Search for concepts matching the query
  */
@@ -86,9 +99,7 @@ async function searchConcepts(query) {
             return;
         }
 
-        const response = await fetch(
-            `${SEARCH_API}?${SEARCH_PARAM}=${encodeURIComponent(query)}&limit=${MAX_RESULTS}`
-        );
+        const response = await fetch(buildConceptSearchUrl(query));
 
         if (!response.ok) {
             console.warn('Concept search failed:', response.status);

--- a/src/frontend/web/von_interface/static/js/test/conceptAutocomplete.test.js
+++ b/src/frontend/web/von_interface/static/js/test/conceptAutocomplete.test.js
@@ -1,4 +1,4 @@
-import { getTriggerSearchText } from '../components/conceptAutocomplete.js';
+import { buildConceptSearchUrl, getTriggerSearchText } from '../components/conceptAutocomplete.js';
 
 describe('conceptAutocomplete trigger parsing', () => {
     test('returns null when no trigger present', () => {
@@ -28,5 +28,15 @@ describe('conceptAutocomplete trigger parsing', () => {
         const result = getTriggerSearchText(text, cursorPos);
         expect(result).not.toBeNull();
         expect(result.searchText).toBe('organisational_role');
+    });
+});
+
+describe('conceptAutocomplete search URL building', () => {
+    test('includes individuals and substring fallback (aligns with global search)', () => {
+        const url = buildConceptSearchUrl('ger');
+        expect(url).toContain('/vontology/api/vontology/search?');
+        expect(url).toContain('q=ger');
+        expect(url).toContain('include_individuals=true');
+        expect(url).toContain('fallback_substring=true');
     });
 });


### PR DESCRIPTION
Fixes inline `#V#...` autocomplete returning Types only by aligning it with global search parameters (`include_individuals=true`, plus substring fallback).

Tests:
- `npm run test:frontend`