### PR TITLE
JVNAUTOSCI-895: Interaction session recovery + cartouche hydration scroll sync

### DIFF
--- a/src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js
+++ b/src/frontend/web/von_interface/static/js/components/promptCartoucheOverlay.js
@@ -27,6 +27,33 @@ const promptConceptMetaCache = new Map();
 // Map<fullId, Promise<meta|null>>
 const promptConceptMetaPending = new Map();
 
+function computeEffectiveOverlayScrollTop(textarea, overlayInner) {
+    if (!textarea || !overlayInner) {
+        return 0;
+    }
+
+    const scrollTop = Math.max(0, Number(textarea.scrollTop) || 0);
+    const clientHeight = Math.max(0, Number(textarea.clientHeight) || 0);
+    const textareaScrollHeight = Math.max(0, Number(textarea.scrollHeight) || 0);
+    const overlayScrollHeight = Math.max(0, Number(overlayInner.scrollHeight) || 0);
+
+    const textareaMaxScroll = Math.max(0, textareaScrollHeight - clientHeight);
+    const overlayMaxScroll = Math.max(0, overlayScrollHeight - clientHeight);
+
+    // If the overlay isn't taller than the textarea scroll range, use the native scrollTop.
+    if (overlayMaxScroll <= textareaMaxScroll + 0.5) {
+        return scrollTop;
+    }
+
+    // If the textarea can't scroll at all, we have no input range to map.
+    if (textareaMaxScroll <= 0.5) {
+        return 0;
+    }
+
+    const ratio = Math.max(0, Math.min(1, scrollTop / textareaMaxScroll));
+    return ratio * overlayMaxScroll;
+}
+
 export function makeNonTriggerVontologyId(fullId) {
     const raw = String(fullId ?? '');
     return raw.replace(/^#([Vv])#/, (_, v) => `#${v}${ZWSP}#`);
@@ -527,6 +554,8 @@ export function initializePromptCartoucheOverlay(textarea) {
     let scheduledId = null;
     let scheduledVia = null;
 
+    let scrollSyncTimer = null;
+
     const schedule = (fn) => {
         if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
             scheduledVia = 'raf';
@@ -550,6 +579,27 @@ export function initializePromptCartoucheOverlay(textarea) {
         scheduledVia = null;
     };
 
+    const syncScrollTransforms = () => {
+        const effectiveScrollTop = computeEffectiveOverlayScrollTop(textarea, parts.inner);
+        try {
+            parts.inner.style.transform = `translateY(-${effectiveScrollTop}px)`;
+        } catch (_) {
+            // Ignore.
+        }
+    };
+
+    const scheduleScrollSync = () => {
+        if (scrollSyncTimer != null) {
+            return;
+        }
+
+        // Use setTimeout so Jest fake timers can deterministically flush it.
+        scrollSyncTimer = window.setTimeout(() => {
+            scrollSyncTimer = null;
+            syncScrollTransforms();
+        }, 0);
+    };
+
     const updateOverlayCaret = () => {
         cancelSchedule();
 
@@ -566,6 +616,10 @@ export function initializePromptCartoucheOverlay(textarea) {
             return;
         }
 
+        // Cartouche hydration can change wrapping/height without changing textarea.scrollTop.
+        // Keep the overlay scroll translation in sync before measuring caret position.
+        syncScrollTransforms();
+
         // If the real textarea caret ended up inside a token (common after a click, because the
         // hidden token text length differs from the rendered cartouche width), snap it out before
         // measuring and before the next keystroke mutates the token.
@@ -579,7 +633,8 @@ export function initializePromptCartoucheOverlay(textarea) {
 
         // Mirror the scroll translation so measurements match visible overlay.
         try {
-            parts.mirror.style.transform = `translateY(-${textarea.scrollTop}px)`;
+            const effectiveScrollTop = computeEffectiveOverlayScrollTop(textarea, parts.inner);
+            parts.mirror.style.transform = `translateY(-${effectiveScrollTop}px)`;
         } catch (_) {
             // Ignore.
         }
@@ -607,7 +662,11 @@ export function initializePromptCartoucheOverlay(textarea) {
     // Keep overlay updated.
     const rerender = () => {
         renderOverlay(textarea, parts.content);
-        hydratePromptCartouches(parts.content, scheduleCaretUpdate);
+        hydratePromptCartouches(parts.content, () => {
+            scheduleScrollSync();
+            scheduleCaretUpdate();
+        });
+        scheduleScrollSync();
         scheduleCaretUpdate();
     };
 
@@ -619,15 +678,12 @@ export function initializePromptCartoucheOverlay(textarea) {
     textarea.addEventListener('focus', scheduleCaretUpdate);
     textarea.addEventListener('blur', scheduleCaretUpdate);
     textarea.addEventListener('scroll', () => {
-        try {
-            parts.inner.style.transform = `translateY(-${textarea.scrollTop}px)`;
-        } catch (_) {
-            // Ignore.
-        }
+        syncScrollTransforms();
         scheduleCaretUpdate();
     });
     window.addEventListener('resize', () => {
         syncOverlayStyles(textarea, parts.overlay, parts.inner, parts.mirror);
+        scheduleScrollSync();
         scheduleCaretUpdate();
     });
 

--- a/src/frontend/web/von_interface/static/js/conceptTab.js
+++ b/src/frontend/web/von_interface/static/js/conceptTab.js
@@ -1048,6 +1048,87 @@ export async function handleSaveConceptOrNotes(suffix = '') {
 let deleteConfirmationPending = false;
 let deleteConfirmationTimeout = null;
 
+function getActiveConceptTabSuffix() {
+  try {
+    const active = document.querySelector('.tab-content.active');
+    if (active && typeof active.id === 'string' && active.id.startsWith('conceptTab_')) {
+      return active.id.replace('conceptTab_', '');
+    }
+  } catch (_) {
+    // ignore
+  }
+  return '';
+}
+
+function getElementForSuffix(baseId, suffix) {
+  if (suffix) {
+    return document.getElementById(`${baseId}_${suffix}`) || document.getElementById(baseId);
+  }
+  return document.getElementById(baseId);
+}
+
+function isMissingInteractionSessionMessage(message) {
+  const msg = String(message || '').toLowerCase();
+  return msg.includes('interaction session not found') ||
+    msg.includes('no active interaction session') ||
+    (msg.includes('interaction') && msg.includes('session') && msg.includes('not found')) ||
+    (msg.includes('interaction') && msg.includes('session') && msg.includes('expired'));
+}
+
+function resetInteractionUiToStep1(statusMessage, suffix = '') {
+  try {
+    currentInteractionId = null;
+  } catch (_) {
+    // ignore
+  }
+
+  const step1 = getElementForSuffix('conceptStep1', suffix);
+  const step2 = getElementForSuffix('conceptStep2', suffix);
+  const step3 = getElementForSuffix('conceptStep3', suffix);
+  const step1Status = getElementForSuffix('conceptStep1Status', suffix);
+  const step2Status = getElementForSuffix('conceptStep2Status', suffix);
+  const questionEl = getElementForSuffix('followUpQuestion', suffix);
+  const answerEl = getElementForSuffix('conceptAnswer', suffix);
+  const submitBtn = getElementForSuffix('submitAnswerButton', suffix);
+
+  if (step3) step3.style.display = 'none';
+  if (step2) step2.style.display = 'none';
+  if (step1) step1.style.display = 'block';
+
+  if (questionEl) {
+    try {
+      annotateElementText(questionEl, '');
+    } catch (_) {
+      questionEl.textContent = '';
+    }
+  }
+
+  if (answerEl) {
+    answerEl.value = '';
+    answerEl.disabled = true;
+  }
+  if (submitBtn) {
+    submitBtn.disabled = true;
+  }
+
+  const msg = statusMessage || 'Interaction session expired. Please start a new interaction.';
+  if (step1Status) {
+    step1Status.textContent = msg;
+    step1Status.style.color = 'orange';
+  }
+  if (step2Status) {
+    step2Status.textContent = msg;
+    step2Status.style.color = 'orange';
+  }
+
+  // Defensive: re-enable any list radios
+  try {
+    document.querySelectorAll('input[type="radio"][name^="selectedconcept"]').forEach(r => r.disabled = false);
+  } catch (_) {
+    // ignore
+  }
+}
+
 export async function handleDeleteConcept() {
   const currentlySelectedconceptId = getCurrentlySelectedConceptId();
   if (!currentlySelectedconceptId || currentlySelectedconceptId === 'undefined') {
@@ -1456,7 +1537,7 @@ async function handleSubmitAnswer() {
   const currentQuestion = elements.followUpQuestionP ? elements.followUpQuestionP.textContent : "";
 
   if (!currentInteractionId) {
-    alert("No active interaction session.");
+    resetInteractionUiToStep1('No active interaction session. Please start a new interaction.', getActiveConceptTabSuffix());
     return;
   }
   if (!answer) {
@@ -1491,7 +1572,12 @@ async function handleSubmitAnswer() {
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({ error: "Failed to submit answer. Server returned an error." }));
-      throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+      const msg = errorData.error || `HTTP error! status: ${response.status}`;
+      if (isMissingInteractionSessionMessage(msg)) {
+        resetInteractionUiToStep1('Interaction session expired. Please start a new interaction.', getActiveConceptTabSuffix());
+        return;
+      }
+      throw new Error(msg);
     }
 
     const data = await response.json();
@@ -1592,6 +1678,10 @@ async function handleSubmitAnswer() {
 
   } catch (error) {
     console.error("Error in handleSubmitAnswer:", error);
+    if (isMissingInteractionSessionMessage(error?.message)) {
+      resetInteractionUiToStep1('Interaction session expired. Please start a new interaction.', getActiveConceptTabSuffix());
+      return;
+    }
     elements.conceptStep2Status.textContent = `Error: ${error.message}`;
     elements.conceptStep2Status.style.color = "red";
   }

--- a/src/frontend/web/von_interface/static/js/test/promptCartoucheOverlay.test.js
+++ b/src/frontend/web/von_interface/static/js/test/promptCartoucheOverlay.test.js
@@ -44,4 +44,29 @@ describe('prompt cartouche overlay', () => {
         const cartouches = content.querySelectorAll('button.prompt-vontology-cartouche');
         expect(cartouches.length).toBe(1);
     });
+
+    test('re-syncs overlay scroll translation when overlay becomes taller than textarea scroll range', () => {
+        const textarea = document.querySelector('#promptInput');
+
+        // Simulate a scrollable textarea.
+        Object.defineProperty(textarea, 'clientHeight', { value: 200, configurable: true });
+        Object.defineProperty(textarea, 'scrollHeight', { value: 1000, configurable: true });
+        textarea.scrollTop = 800; // max scrollTop given values above
+
+        initializePromptCartoucheOverlay(textarea);
+
+        const wrapper = textarea.parentElement;
+        const inner = wrapper.querySelector('.prompt-input-overlay-inner');
+        expect(inner).not.toBeNull();
+
+        // Simulate the overlay content being taller (e.g., after cartouche hydration changes wrapping).
+        // overlayMaxScroll = 1400 - 200 = 1200 vs textareaMaxScroll = 1000 - 200 = 800
+        Object.defineProperty(inner, 'scrollHeight', { value: 1400, configurable: true });
+
+        // Force the queued scroll sync to run.
+        jest.runAllTimers();
+
+        // With mapping: effectiveScrollTop = 800/800 * 1200 = 1200
+        expect(inner.style.transform).toBe('translateY(-1200px)');
+    });
 });

--- a/tests/frontend/interactionSessionRecovery.test.js
+++ b/tests/frontend/interactionSessionRecovery.test.js
@@ -1,0 +1,105 @@
+/** @jest-environment jsdom */
+
+/**
+ * Regression test for JVNAUTOSCI-895
+ * When the backend reports a missing/expired interaction session, the UI should
+ * reset to Step 1 and prompt the user to start a new interaction.
+ */
+
+import {
+    handleStartInteraction,
+    initializeConceptTabDomElementsWithSuffix,
+    setupConceptTabEventListenersWithSuffix,
+} from "../../src/frontend/web/von_interface/static/js/conceptTab.js";
+import { setCurrentlySelectedConceptId } from "../../src/frontend/web/von_interface/static/js/state.js";
+
+function okJson(data) {
+    return {
+        ok: true,
+        status: 200,
+        json: async () => data,
+    };
+}
+
+function errorJson(status, data) {
+    return {
+        ok: false,
+        status,
+        json: async () => data,
+    };
+}
+
+describe("Concept interaction session recovery", () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+      <div class="tab-content active" id="conceptTab_s1"></div>
+
+      <div id="conceptStep1_s1" style="display:block"></div>
+      <div id="conceptStep2_s1" style="display:none"></div>
+      <div id="conceptStep3_s1" style="display:none"></div>
+
+      <div id="conceptStep1Status_s1"></div>
+      <div id="conceptStep2Status_s1"></div>
+
+      <p id="followUpQuestion_s1"></p>
+      <textarea id="conceptNotes_s1"></textarea>
+      <input id="conceptAnswer_s1" />
+
+      <button id="startInteractionButton_s1"></button>
+      <button id="submitAnswerButton_s1"></button>
+      <button id="cancelInteractionButton_s1"></button>
+      <button id="endInteractionButton_s1"></button>
+      <button id="resetConceptTabButton_s1"></button>
+
+      <p id="finalResult_s1"></p>
+    `;
+
+        setCurrentlySelectedConceptId("#V#test_concept");
+        initializeConceptTabDomElementsWithSuffix("s1");
+        setupConceptTabEventListenersWithSuffix("s1");
+
+        global.fetch = jest.fn(async (url) => {
+            const u = String(url);
+            if (u.includes("/start_interaction")) {
+                return okJson({ interaction_id: "interaction-1" });
+            }
+            if (u.includes("/generate_initial_question")) {
+                return okJson({ question: "What is your goal?" });
+            }
+            if (u.includes("/submit_answer")) {
+                return errorJson(404, { error: "Interaction session not found" });
+            }
+            throw new Error(`Unexpected fetch URL in test: ${u}`);
+        });
+    });
+
+    it("resets to Step 1 when session is missing", async () => {
+        await handleStartInteraction();
+
+        const step1 = document.getElementById("conceptStep1_s1");
+        const step2 = document.getElementById("conceptStep2_s1");
+        const answer = document.getElementById("conceptAnswer_s1");
+
+        expect(step1.style.display).toBe("none");
+        expect(step2.style.display).toBe("block");
+        expect(answer.disabled).toBe(false);
+
+        answer.value = "My answer";
+
+        document.getElementById("submitAnswerButton_s1").click();
+        await new Promise((r) => setTimeout(r, 0));
+
+        const status = document.getElementById("conceptStep1Status_s1").textContent;
+        expect(status.toLowerCase()).toContain("interaction session");
+        expect(status.toLowerCase()).toContain("start");
+
+        expect(step1.style.display).toBe("block");
+        expect(step2.style.display).toBe("none");
+        expect(answer.disabled).toBe(true);
+
+        const startBtn = document.getElementById("startInteractionButton_s1");
+        const submitBtn = document.getElementById("submitAnswerButton_s1");
+        expect(startBtn.disabled).toBe(false);
+        expect(submitBtn.disabled).toBe(true);
+    });
+});


### PR DESCRIPTION
Implements JVNAUTOSCI-895 frontend resilience improvements:

- Interaction session recovery: when the backend reports a missing/expired interaction session, the UI resets back to Step 1 instead of leaving the user stuck.
- Prompt cartouche overlay: resynchronises overlay scroll translation after async cartouche hydration changes wrapping/height (fixes the “overlap until manual resize” behaviour).

Tests:
- `npm run test:frontend`