### PR TITLE
JVNAUTOSCI-899: Chat markdown insert buttons + concept tab loading

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -32,6 +32,157 @@ function escapeHtml(value) {
         .replace(/'/g, '&#39;');
 }
 
+function extractBoldQuotedInstruction(text) {
+    const value = String(text ?? '').trim();
+    if (!value) return null;
+
+    // Match either curly quotes or straight quotes.
+    // Example: “Apply the hierarchy fix.” or "Apply the hierarchy fix.".
+    const m = value.match(/^(?:“|")(.+?)(?:”|")\s*$/);
+    if (!m) return null;
+
+    const instruction = String(m[1] ?? '').trim();
+    if (!instruction) return null;
+    return instruction;
+}
+
+function extractBoldQuotedInstructionFromStrong(strongEl) {
+    if (!strongEl) return null;
+
+    // Reconstruct text while preserving inline-code intent by re-adding backticks.
+    // This keeps the inserted prompt closer to the original markdown source.
+    const parts = [];
+    const nodes = Array.from(strongEl.childNodes ?? []);
+    for (const node of nodes) {
+        if (node.nodeType === Node.TEXT_NODE) {
+            parts.push(String(node.textContent ?? ''));
+            continue;
+        }
+
+        if (node.nodeType !== Node.ELEMENT_NODE) {
+            return null;
+        }
+
+        const el = node;
+        if (el.tagName === 'CODE') {
+            // Disallow nested markup inside <code> for this transform.
+            if (el.querySelector && el.querySelector('*')) return null;
+            const codeText = String(el.textContent ?? '');
+            parts.push('`' + codeText + '`');
+            continue;
+        }
+
+        // Any other tag means it is no longer the exact **"..."** pattern.
+        return null;
+    }
+
+    return extractBoldQuotedInstruction(parts.join(''));
+}
+
+function insertTextIntoChatPrompt(text) {
+    const promptInput = document.getElementById('promptInput');
+    if (!promptInput) return;
+
+    const insertRaw = String(text ?? '').trim();
+    if (!insertRaw) return;
+
+    try {
+        promptInput.focus();
+    } catch (_) {
+        // Ignore.
+    }
+
+    const base = String(promptInput.value ?? '');
+    const hasSelection =
+        typeof promptInput.selectionStart === 'number' &&
+        typeof promptInput.selectionEnd === 'number';
+
+    const start = hasSelection ? promptInput.selectionStart : base.length;
+    const end = hasSelection ? promptInput.selectionEnd : base.length;
+
+    const atEnd = start === base.length && end === base.length;
+    const prefix = atEnd && base.trim() && !base.endsWith('\n') ? '\n' : '';
+    const insertText = `${prefix}${insertRaw}`;
+
+    if (typeof promptInput.setRangeText === 'function') {
+        promptInput.setRangeText(insertText, start, end, 'end');
+    } else {
+        const before = base.slice(0, start);
+        const after = base.slice(end);
+        promptInput.value = `${before}${insertText}${after}`;
+    }
+
+    try {
+        promptInput.dispatchEvent(new Event('input', { bubbles: true }));
+    } catch (_) {
+        // Ignore.
+    }
+}
+
+function convertQuotedInstructionBlockquotesToButtons(root) {
+    if (!root || !root.querySelectorAll) return;
+
+    const blocks = Array.from(root.querySelectorAll('blockquote'));
+    for (const block of blocks) {
+        try {
+            // Match the exact pattern (as rendered HTML):
+            // <blockquote><p><strong>"..."</strong></p></blockquote>
+            // i.e., one direct <p>, containing only one direct <strong>, whose content is fully quoted.
+            const elementChildren = Array.from(block.children ?? []);
+            if (elementChildren.length !== 1) continue;
+            const p = elementChildren[0];
+            if (!p || p.tagName !== 'P') continue;
+
+            // No non-whitespace text nodes at the blockquote level.
+            const blockNodes = Array.from(block.childNodes ?? []);
+            if (blockNodes.some((n) => n.nodeType === Node.TEXT_NODE && String(n.textContent ?? '').trim())) {
+                continue;
+            }
+
+            const pElementChildren = Array.from(p.children ?? []);
+            if (pElementChildren.length !== 1) continue;
+            const strong = pElementChildren[0];
+            if (!strong || strong.tagName !== 'STRONG') continue;
+
+            // No non-whitespace text nodes inside the paragraph.
+            const pNodes = Array.from(p.childNodes ?? []);
+            if (pNodes.some((n) => n.nodeType === Node.TEXT_NODE && String(n.textContent ?? '').trim())) {
+                continue;
+            }
+
+            const instruction = extractBoldQuotedInstructionFromStrong(strong);
+            if (!instruction) continue;
+
+            // Ensure the blockquote text is exactly the quoted strong text (no extra content).
+            const normalise = (s) => String(s ?? '').trim().replace(/\s+/g, ' ');
+            if (normalise(block.textContent) !== normalise(strong.textContent)) continue;
+
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'chat-insert-prompt-button';
+            btn.textContent = instruction;
+            btn.title = 'Insert into chat prompt';
+            btn.setAttribute('aria-label', `Insert into chat prompt: ${instruction}`);
+            btn.addEventListener('click', (e) => {
+                try {
+                    e.preventDefault();
+                    e.stopPropagation();
+                } catch (_) {
+                    // Ignore.
+                }
+                insertTextIntoChatPrompt(instruction);
+            });
+
+            const wrapper = document.createElement('div');
+            wrapper.className = 'chat-insert-prompt-wrapper';
+            wrapper.appendChild(btn);
+            block.replaceWith(wrapper);
+        } catch (_) {
+            // Ignore detached nodes or DOM mutation races.
+        }
+    }
+}
+
 // Cache concept metadata used for cartouches in chat transcript.
 // Map<fullId, { name: string, kind: string, source?: string, provisional?: boolean }>
 const chatConceptMetaCache = new Map();
@@ -112,6 +263,7 @@ async function renderChatMarkdownIntoContainer(container, text) {
     }
 
     container.innerHTML = html;
+    convertQuotedInstructionBlockquotesToButtons(container);
     try {
         container.dataset.renderMode = 'rendered';
     } catch (_) {
@@ -119,7 +271,7 @@ async function renderChatMarkdownIntoContainer(container, text) {
     }
 
     // Preserve clickable #V# tokens, but never inside code blocks.
-    cartouchifyVontologyTokensInElement(container, { skipSelectors: ['pre', 'code', 'a'], allowStandaloneCodeTokens: true });
+    cartouchifyVontologyTokensInElement(container, { skipSelectors: ['pre', 'code', 'a'], allowStandaloneCodeTokens: true, allowStandaloneCodeBlockTokens: true });
     hydrateChatConceptCartouches(container);
 }
 
@@ -158,7 +310,8 @@ function setVonMessageRenderMode(messageTextEl, mode, originalText, debugData) {
     const cachedHtml = messageTextEl?.dataset?.renderedHtml;
     if (cachedHtml) {
         messageTextEl.innerHTML = cachedHtml;
-        cartouchifyVontologyTokensInElement(messageTextEl, { skipSelectors: ['pre', 'code', 'a'], allowStandaloneCodeTokens: true });
+        convertQuotedInstructionBlockquotesToButtons(messageTextEl);
+        cartouchifyVontologyTokensInElement(messageTextEl, { skipSelectors: ['pre', 'code', 'a'], allowStandaloneCodeTokens: true, allowStandaloneCodeBlockTokens: true });
         hydrateChatConceptCartouches(messageTextEl);
         return;
     }

--- a/src/frontend/web/von_interface/static/js/main.js
+++ b/src/frontend/web/von_interface/static/js/main.js
@@ -1,5 +1,5 @@
 import { initializeDomElements, initializeInfoPopup, loadAndDisplayGlobalModelInFooter } from './domUtils.js';
-import { createOrActivateConceptTab } from './dynamicTabs.js';
+import { closeDynamicConceptTab, createOrActivateConceptTab } from './dynamicTabs.js';
 import { getLanguageDisplayName } from './languageConfig.js';
 import { escapeHtml } from './markdownUtils.js';
 import './suppressTooltips.js';
@@ -56,6 +56,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       // Async handler (do not block UI thread).
       void handleSelectConceptByIdDetail(e?.detail, {
         createOrActivateConceptTab,
+        closeDynamicConceptTab,
         activateTab,
         selectVontologyNodeByIdentifier
       });

--- a/src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js
+++ b/src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js
@@ -371,28 +371,63 @@ export async function handleSelectConceptByIdDetail(detail, deps) {
         return;
     }
 
+    // Normal click: open in background.
+    // Shift-click: open and switch to it.
+    const shouldActivate = !!modifierKeys.shiftKey;
+
+    // Open the tab immediately (optimistic) so the UI responds even if the backend
+    // is busy (e.g., single-threaded server while chat generation is in flight).
+    // Metadata will be hydrated below when available.
+    try {
+        deps.createOrActivateConceptTab(id, 'Loading…', shouldActivate);
+    } catch (_) {
+        // Best-effort; keep going.
+    }
+
     let exists = false;
     try {
         exists = await conceptExists(id, fetchFn);
     } catch (err) {
         console.warn('[selectConceptById] existence check failed', err);
-        // Fall back to existing behaviour: open tab anyway.
-        deps.createOrActivateConceptTab(id, id, false);
+        // Fall back to existing behaviour: ensure the tab exists.
+        deps.createOrActivateConceptTab(id, 'Loading…', shouldActivate);
         return;
     }
 
     if (exists) {
         const metadata = await fetchConceptMetadata(id, fetchFn);
         updateCartouchesForConcept(id, metadata);
-        deps.createOrActivateConceptTab(id, metadata?.displayName || id, false);
+        deps.createOrActivateConceptTab(id, metadata?.displayName || id, shouldActivate);
         return;
+    }
+
+    // Concept does not exist: remove the optimistic tab rather than leaving a
+    // dead "Loading…" tab around.
+    try {
+        deps?.closeDynamicConceptTab?.(id);
+    } catch (_) {
+        // Best-effort; keep going.
     }
 
     const chooseCreateOptionsFn = deps?.chooseCreateOptionsFn;
     const createOpts = chooseCreateOptionsFn
         ? await chooseCreateOptionsFn({ conceptId: id, kind, modifierKeys })
         : await openCreateConceptModal(id, kind);
-    if (!createOpts) return;
+    if (!createOpts) {
+        try {
+            deps?.closeDynamicConceptTab?.(id);
+        } catch (_) {
+            // Best-effort; keep going.
+        }
+        return;
+    }
+
+    // Re-open a loading tab now that the user has confirmed creation.
+    try {
+        deps.createOrActivateConceptTab(id, 'Loading…', shouldActivate);
+    } catch (_) {
+        // Best-effort; keep going.
+    }
 
     try {
         const chosenKind = deriveKindFromCreateOptions(createOpts, kind);
@@ -400,7 +435,7 @@ export async function handleSelectConceptByIdDetail(detail, deps) {
         await createConceptForId(id, createOpts, fetchFn);
         const metadata = await fetchConceptMetadata(id, fetchFn);
         updateCartouchesForConcept(id, metadata);
-        deps.createOrActivateConceptTab(id, metadata?.displayName || id, false);
+        deps.createOrActivateConceptTab(id, metadata?.displayName || id, shouldActivate);
         showToast('Concept created.', 'info');
     } catch (err) {
         console.warn('[selectConceptById] create failed', err);

--- a/src/frontend/web/von_interface/static/js/utils/textDecorator.js
+++ b/src/frontend/web/von_interface/static/js/utils/textDecorator.js
@@ -341,6 +341,40 @@ function extractStandaloneVontologyToken(text) {
 	return m ? m[1] : null;
 }
 
+function cartouchifyStandaloneVontologyCodeBlocks(root, options = {}) {
+	if (!root || !root.querySelectorAll) return;
+
+	const codeNodes = Array.from(root.querySelectorAll('pre > code'));
+	for (const codeEl of codeNodes) {
+		try {
+			const preEl = codeEl.parentElement;
+			if (!preEl || preEl.tagName.toLowerCase() !== 'pre') continue;
+
+			// Avoid replacing within links or existing cartouches.
+			if (preEl.closest('a')) continue;
+			if (preEl.closest('.vontology-cartouche')) continue;
+
+			// Only when the <code> node is purely text and the <pre> contains nothing else.
+			if (codeEl.childElementCount !== 0) continue;
+			if (preEl.childElementCount !== 1) continue;
+
+			const token = extractStandaloneVontologyToken(codeEl.textContent);
+			if (!token) continue;
+
+			const cartouche = createVontologyCartouche(`#V#${token}`, { variant: 'code-block' });
+			cartouche.classList.add('vontology-cartouche-code-block');
+
+			const wrapper = document.createElement('div');
+			wrapper.className = 'vontology-cartouche-block';
+			wrapper.appendChild(cartouche);
+
+			preEl.replaceWith(wrapper);
+		} catch (_) {
+			// Ignore detached nodes or DOM mutation races.
+		}
+	}
+}
+
 function cartouchifyStandaloneVontologyCodeSpans(root, options = {}) {
 	if (!root || !root.querySelectorAll) return;
 
@@ -465,6 +499,10 @@ export function cartouchifyVontologyTokensInElement(root, options = {}) {
 
 	if (options && options.allowStandaloneCodeTokens) {
 		cartouchifyStandaloneVontologyCodeSpans(root, options);
+	}
+
+	if (options && options.allowStandaloneCodeBlockTokens) {
+		cartouchifyStandaloneVontologyCodeBlocks(root, options);
 	}
 }
 

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -5684,6 +5684,37 @@ body.settings-body {
     margin: 0.8em 0;
 }
 
+.chat-markdown.markdown-rendered .chat-insert-prompt-wrapper {
+    margin: 0.8em 0;
+}
+
+.chat-markdown.markdown-rendered .chat-insert-prompt-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 12px;
+    border-radius: 8px;
+    border: 1px solid #cbd5e1;
+    background: #f8fafc;
+    color: #0f172a;
+    font: inherit;
+    cursor: pointer;
+}
+
+.chat-markdown.markdown-rendered .chat-insert-prompt-button:hover {
+    background: #eef2ff;
+    border-color: #a5b4fc;
+}
+
+.chat-markdown.markdown-rendered .chat-insert-prompt-button:active {
+    background: #e0e7ff;
+}
+
+/* Standalone fenced code blocks containing exactly one #V#... token become a block cartouche. */
+.chat-markdown.markdown-rendered .vontology-cartouche-block {
+    margin: 0.8em 0;
+}
+
 /* Heading styles for markdown */
 .markdown-rendered h1,
 .markdown-rendered h2,
@@ -5755,6 +5786,16 @@ body.settings-body {
     font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
     font-size: 0.85em;
     line-height: 1.45;
+}
+
+.markdown-rendered .vontology-cartouche-block {
+    display: flex;
+    align-items: flex-start;
+    margin: 1em 0;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    padding: 12px 16px;
 }
 
 .markdown-rendered pre code {

--- a/tests/frontend/chatTabMarkdownRender.test.js
+++ b/tests/frontend/chatTabMarkdownRender.test.js
@@ -31,7 +31,7 @@ describe('chat markdown rendering (assistant)', () => {
         delete global.fetch;
     });
 
-    test('renders markdown for GPT-5.2 responses safely and preserves #V# token linkification (not inside code blocks)', async () => {
+    test('renders markdown for GPT-5.2 responses safely and preserves #V# token linkification (including standalone fenced IDs)', async () => {
         const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
         getUserContext.mockReturnValue({
             user_id: 'user',
@@ -58,6 +58,11 @@ describe('chat markdown rendering (assistant)', () => {
             '#V#person',
             '```',
             '',
+            '```',
+            '#V#person',
+            '#V#thing',
+            '```',
+            '',
             '[bad](javascript:alert(1))',
             '',
             '<script>window.hacked=1</script>'
@@ -70,6 +75,7 @@ describe('chat markdown rendering (assistant)', () => {
             '<p><a href="https://example.com" target="_blank" rel="noopener noreferrer">good</a></p>',
             '<p>See #V#person</p>',
             '<pre><code>#V#person</code></pre>',
+            '<pre><code>#V#person\n#V#thing</code></pre>',
             '<p>bad</p>'
         ].join('\n');
 
@@ -180,11 +186,16 @@ describe('chat markdown rendering (assistant)', () => {
 
         expect(codeCartouche.textContent).toContain('#V#yejin_choi');
 
-        // But must not linkify inside code blocks.
-        const codeBlock = assistantMarkdown.querySelector('pre');
-        expect(codeBlock).not.toBeNull();
-        expect(codeBlock.querySelector('.vontology-cartouche')).toBeNull();
-        expect(codeBlock.textContent).toContain('#V#person');
+        // A fenced code block containing only a single concept ID becomes a cartouche.
+        const codeBlockCartouche = assistantMarkdown.querySelector('.vontology-cartouche-block .vontology-cartouche[data-full-concept-id="#V#person"]');
+        expect(codeBlockCartouche).not.toBeNull();
+
+        // But real/multi-line code blocks remain untouched.
+        const codeBlocks = Array.from(assistantMarkdown.querySelectorAll('pre'));
+        expect(codeBlocks.length).toBeGreaterThanOrEqual(1);
+        const multiLine = codeBlocks.find((el) => (el.textContent || '').includes('#V#thing'));
+        expect(multiLine).toBeTruthy();
+        expect(multiLine.querySelector('.vontology-cartouche')).toBeNull();
     });
 
     test('renders markdown for user messages when markdown is detected', async () => {
@@ -271,7 +282,7 @@ describe('chat markdown rendering (assistant)', () => {
         expect(cartouche).not.toBeNull();
     });
 
-    test('recovers when rendered HTML drops leading # (V#person) and still avoids code blocks', async () => {
+    test('recovers when rendered HTML drops leading # (V#person) and still cartouchifies standalone fenced IDs', async () => {
         const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
         getUserContext.mockReturnValue({
             user_id: 'user',
@@ -342,10 +353,92 @@ describe('chat markdown rendering (assistant)', () => {
         expect(cartouche.textContent).toContain('Person');
         expect(cartouche.textContent).toContain('#V#person');
 
-        // But V#person inside code must not be cartouchified.
-        const codeBlock = assistantMarkdown.querySelector('pre');
-        expect(codeBlock).not.toBeNull();
-        expect(codeBlock.querySelector('.vontology-cartouche')).toBeNull();
-        expect(codeBlock.textContent).toContain('V#person');
+        // Standalone fenced IDs should cartouchify even if the leading '#' was dropped.
+        const fencedCartouche = assistantMarkdown.querySelector('.vontology-cartouche-block .vontology-cartouche[data-full-concept-id="#V#person"]');
+        expect(fencedCartouche).not.toBeNull();
+    });
+
+    test('turns quoted bold blockquotes into insert buttons for the chat prompt', async () => {
+        const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        getUserContext.mockReturnValue({
+            user_id: 'user',
+            org_id: 'org',
+            language: 'en-NZ',
+            gmail_profile: null
+        });
+
+        const promptInput = document.getElementById('promptInput');
+        promptInput.value = 'test prompt';
+
+        const assistantHtml = [
+            '<p>Do this:</p>',
+            '<blockquote><p><strong>“Apply the hierarchy fix.”</strong></p></blockquote>',
+            '<blockquote><p><strong>“Create <code>work_specification</code> and re-anchor <code>task_specification</code>.”</strong></p></blockquote>',
+            // Should NOT match: extra text outside <strong>.
+            '<blockquote><p><strong>“Do the thing.”</strong> now</p></blockquote>',
+            // Should NOT match: missing quotes.
+            '<blockquote><p><strong>Apply the hierarchy fix.</strong></p></blockquote>'
+        ].join('\n');
+
+        global.fetch = jest.fn((url) => {
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ history_length: 0, authenticated: true })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/api/render_markdown')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ html: assistantHtml })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/api/search')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ results: [] })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/generate')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ response: 'ok', llm_debug: { model: 'gpt-5.2' } })
+                });
+            }
+
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        await sendMessage();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        const scrollableField = document.getElementById('scrollableField');
+        const assistantMarkdown = scrollableField.querySelector('.chat-markdown.markdown-rendered');
+        expect(assistantMarkdown).not.toBeNull();
+
+        const buttons = Array.from(assistantMarkdown.querySelectorAll('button.chat-insert-prompt-button'));
+        expect(buttons.length).toBe(2);
+
+        const simpleButton = buttons.find((b) => (b.textContent || '').includes('Apply the hierarchy fix.'));
+        expect(simpleButton).toBeTruthy();
+
+        const codeButton = buttons.find((b) => (b.textContent || '').includes('work_specification'));
+        expect(codeButton).toBeTruthy();
+        expect(codeButton.textContent).toContain('`work_specification`');
+        expect(codeButton.textContent).toContain('`task_specification`');
+
+        const remainingBlockquotes = Array.from(assistantMarkdown.querySelectorAll('blockquote'));
+        expect(remainingBlockquotes.length).toBe(2);
+
+        // Make insertion deterministic.
+        promptInput.value = 'Alpha';
+        promptInput.setSelectionRange(promptInput.value.length, promptInput.value.length);
+
+        simpleButton.click();
+
+        expect(promptInput.value).toBe('Alpha\nApply the hierarchy fix.');
     });
 });

--- a/tests/frontend/selectConceptByIdHandler.test.js
+++ b/tests/frontend/selectConceptByIdHandler.test.js
@@ -43,12 +43,48 @@ describe('handleSelectConceptByIdDetail', () => {
             { createOrActivateConceptTab, activateTab, selectVontologyNodeByIdentifier, fetchFn }
         );
 
+        expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#person', 'Loading…', false);
         expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#person', 'Person', false);
         // Should not try to create.
         expect(fetchFn).toHaveBeenCalledTimes(2);
 
         expect(cartouche.querySelector('.vontology-cartouche-name').textContent).toBe('Person');
         expect(cartouche.querySelector('.vontology-cartouche-kind').textContent).toBe('Type');
+    });
+
+    test('shift-click activates the concept tab', async () => {
+        const { handleSelectConceptByIdDetail } = require(handlerPath);
+        const { createVontologyCartouche } = require(decoratorPath);
+
+        const cartouche = createVontologyCartouche('person');
+        document.body.appendChild(cartouche);
+
+        const createOrActivateConceptTab = jest.fn();
+        const activateTab = jest.fn();
+        const selectVontologyNodeByIdentifier = jest.fn();
+
+        const fetchFn = jest.fn((url) => {
+            if (typeof url === 'string' && url.startsWith('/vontology/api/vontology/node_content')) {
+                if (url.includes('raw_only=1')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({ display_name: 'Person', kind: 'type', concept_id: '#V#person' })
+                    });
+                }
+                // existence check
+                return Promise.resolve({ ok: true, status: 200, text: async () => JSON.stringify({}) });
+            }
+            return Promise.resolve({ ok: true, status: 200, text: async () => JSON.stringify({}) });
+        });
+
+        await handleSelectConceptByIdDetail(
+            { conceptId: 'person', createConceptTab: true, kind: 'type', modifierKeys: { shiftKey: true } },
+            { createOrActivateConceptTab, activateTab, selectVontologyNodeByIdentifier, fetchFn }
+        );
+
+        expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#person', 'Loading…', true);
+        expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#person', 'Person', true);
     });
 
     test('missing concept prompts and creates then opens', async () => {
@@ -96,6 +132,7 @@ describe('handleSelectConceptByIdDetail', () => {
         );
 
         expect(chooseCreateOptionsFn).toHaveBeenCalled();
+        expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#disambiguation_result', 'Loading…', false);
         expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#disambiguation_result', 'Disambiguation result', false);
         // Existence check + create + metadata fetch.
         expect(fetchFn).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
- Chat: convert exact quoted bold blockquotes into an 'insert into prompt' button (supports inline code)\n- Chat: cartouchify standalone fenced #V#... code blocks only\n- Concept tabs: optimistic open uses 'Loading…' and closes tab if concept missing; shift-click activates tab\n\nTests: npm run test:frontend