### PR TITLE
JVNAUTOSCI-894: Index spoken presenter narration in RAG

### DIFF
--- a/docs/AINotes.md
+++ b/docs/AINotes.md
@@ -1,346 +1,45 @@
-# AI Notes
+"AINotes" is a living scratchpad for agents.
 
-## Agent Reminder (Config Lookup)
+Goal: help a fresh agent get oriented in <2 minutes.
 
+Rules of thumb:
+- Keep this file short and current.
+- Prefer pointers over prose.
+- When something is no longer relevant, delete it (or move it to the archive).
+
+Last updated: 2026-01-02
+
+---
+
+## Now (current focus)
+- Fix/verify: interaction-session UX issues (see current branch name in git).
+- Run focused tests after UI changes: `npm run test:frontend`.
+
+## Next (likely follow-ups)
+- Add a short regression note here when a bug is fixed (1–2 bullets), then move details to Jira/PR.
+- Keep Phase/initiative tracking in Jira rather than in this file.
+
+## Quick operational notes
+
+### Safe `.env` lookup
 If you need values from `.env`, prefer the allowlisted helper script instead of reading the file directly:
 
 - Script: `utilities/get_safe_env.py`
 - Example: `pdm run python utilities/get_safe_env.py VON_DB_NAME`
 
-It only prints allowlisted keys and redacts secret-like values (tokens, passwords, etc.).
+### Test database hygiene
+When running tests that require `VON_DB_NAME=test_von_db`, ensure the environment is reset afterwards.
 
-## Current Status
-  1. Integration testing of full Phase 1 flow
-  2. Proceed with Phase 2 (UI components and org selector)
-  3. Or address any issues/feedback from Phase 1 review
+### Server safety
+Do not auto-start the server as part of automation unless explicitly requested.
 
-## Current Status
-- **Date**: 2025-12-04 (Updated: JVNAUTOSCI-799 Detector & Autocomplete Fixes Complete)
-- **Current Work**: JVNAUTOSCI-799 Structured Tool Calling (Bug Fixes Complete)
-- **Branch**: JVNAUTOSCI-799-structured-tool-calling-for-internal-mcp-replace
-- **Latest Fixes**:
-  - ✅ **CRITICAL FIX**: Detector prompt missing `{response}` placeholder (was breaking tool-call detection)
-  - ✅ **BUG FIX**: conceptAutocomplete.js line 239 TypeError (undefined property access)
-  - ✅ **UI IMPROVEMENT**: Renamed "Attributes" → "Text Fields" for clarity
-  - ✅ **TASK CREATED**: JVNAUTOSCI-807 (ubiquitous predicate reflection in Vontology)
-- **Previous Work**: JVNAUTOSCI-789 Phase 2 (80% complete)
-  1. ✅ Backend API endpoints (3/3)
-  2. ✅ Frontend UI component (1/1)
-  3. ✅ Vontology membership model (1/1)
-  4. ✅ Migration script (1/1)
-  5. ⏳ Integration tests (framework complete, pending user review)
-## Phase 1 Implementation Summary (COMPLETE)
-## Phase 2 Implementation Summary (80% COMPLETE)
+## High-signal references
+- Agent rules: `AGENTS.md`
+- User-facing overview: `USER_GUIDE.md`
+- Engineering notes: `docs/engineering/`
+- Archive (historical details): `docs/AINotes_archive.md`
 
-### What Was Done
-**JVNAUTOSCI-789: UI Integration for Organisation and Role Selection**
-
-Implemented Phase 2 infrastructure for user-facing organisation switching and persistent membership model:
-
-#### Deliverable 1: Organisation Membership Service ✅
-- File: `src/backend/services/organisation_membership_service.py` (410 lines)
-- Purpose: Vontology-based membership management with memberOf predicates
-- Key Functions:
-  - `create_organisation_membership()` → Creates memberOf relationship + hasRole text relation
-  - `get_user_memberships()` → Retrieves user's organisations and roles
-  - `get_organisation_members()` → Lists org members with optional role filtering
-  - `update_user_role()` → Updates user's role in organisation
-  - `remove_organisation_membership()` → Removes user from organisation
-- Data Model: Uses memberOf edge relationships + hasRole text relations with org context
-- Access Control: Integrates with access_control system for permission checking
-- Testing: 20 comprehensive unit tests (100% pass rate) covering all functions and error paths
-
-#### Deliverable 2: Backend API Endpoints ✅
-- Modified: `src/backend/server/routes/von_routes.py`
-- Endpoint 1: `POST /api/session/set_organisation`
-  - Switches user's organisation context in Flask session
-  - Derives composite namespace using namespace_service
-  - Returns updated session context with new namespace
-  - Enables future RAG filtering by org context
-- Endpoint 2: `GET /api/session/context`
-  - Returns current user's session context (user, org, role, namespace)
-  - Derives missing namespace if not in session
-  - Graceful fallback to user-only namespace if no org
-- Endpoint 3: `GET /api/organisations/my_organisations`
-  - Lists organisations user belongs to
-  - Returns each org with user's role
-  - Uses role_resolver for Phase 1 stub data (will use membership model in Phase 3)
-- Lines Added: ~120 lines of endpoint handlers
-
-#### Deliverable 3: Frontend Organisation Selector Component ✅
-- File: `src/frontend/web/von_interface/static/js/components/orgSelector.js` (165 lines)
-- Purpose: User-facing organisation switching UI
-- Key Functions:
-  - `loadMyOrganisations()` → Fetches user's orgs from API
-  - `getSessionContext()` → Retrieves current session state
-  - `switchOrganisation(orgConceptId)` → POST to set_organisation, updates localStorage
-  - `renderOrgSelector(containerId)` → Builds dropdown UI with current org highlighted
-  - `displayContextIndicator(containerId)` → Shows "user @ org (role)" badge
-  - `setupOrgSwitchListener(callback)` → Dispatches CustomEvent on org switch
-- LocalStorage Keys: `von_org_context` (JSON with concept_id, namespace), `von_org_role`
-- Event System: Dispatches 'orgSwitched' CustomEvent for other components to listen
-- Integration Point: Called by settingsPage.js in settings interface
-
-#### Deliverable 4: Settings Interface Integration ✅
-- Modified: `src/frontend/web/von_interface/static/js/settingsPage.js`
-  - Imports orgSelector component functions
-  - Calls `renderOrgSelector('orgSelectorContainer')` on page load
-  - Attaches listener to org switch events (ready for RAG namespace updates)
-- Modified: `src/frontend/web/von_interface/templates/settings_tab.html`
-  - Replaced old org dropdown with Phase 2 selector component
-  - Added `<div id="orgSelectorContainer">` placeholder for dynamic rendering
-  - Updated section description for org-scoped RAG context
-
-#### Deliverable 5: Component Styling ✅
-- Modified: `src/frontend/web/von_interface/static/styles.css`
-- Added ~80 lines of CSS for organisation selector:
-  - `.org-selector-wrapper`: Flex container with subtle background
-  - `.org-dropdown`: Styled select with hover/focus states
-  - `.context-indicator`: Badge styling for org context display
-  - `.org-context` (blue) vs `.personal-context` (green) badges
-
-#### Deliverable 6: Migration Script ✅
-- File: `src/backend/utilities/migrate_org_memberships.py` (270 lines)
-- Purpose: One-time migration from Phase 1 stub mappings to Vontology memberships
-- Features:
-  - Reads `STUB_ROLE_MAPPINGS` from `role_resolver.py`
-  - Creates `memberOf` relationships + `hasRole` text relations for each mapping
-  - Validates concept existence before creating relationships
-  - Idempotent: Safe to run multiple times (checks existing relationships)
-  - Logging: Detailed progress reporting with optional --verbose flag
-  - Dry-run: `--dry-run` flag to preview changes without executing
-- Usage: `python migrate_org_memberships.py [--dry-run] [--verbose]`
-- Error Handling: Logs failures but continues processing other mappings
-
-#### Deliverable 7: Bug Fix ✅
-- Fixed: `src/backend/db/repositories/meta_relations_repository.py`
-  - Changed absolute import `from backend.db.mongo_client` to relative `from ..mongo_client`
-  - Enables scripts like migration to import services without sys.path conflicts
-
-### Test Results
-- **Membership Service Tests**: 20/20 PASSED ✅
-  - Create membership (success, already exists, invalid IDs, access denied, not found)
-  - Get memberships (success, empty, invalid ID, access denied)
-  - Get members (success, with role filter, invalid ID)
-  - Update role (success, not member, no change)
-  - Remove membership (success, invalid ID)
-- **All Backend Tests**: 82 passed, 3 skipped ✅
-  - No regressions from Phase 1
-  - All 20 new membership tests passing
-  - All existing tests (62) still passing
-
-### Git Commits
-1. `bbf85c1`: Phase 2 - Vontology membership model and migration script (1697 insertions)
-
-### Design Decisions
-1. **Membership Storage**: Uses memberOf edge relationships (concepts repository) + hasRole text relations
-2. **Role Association**: Stored in text relations with org_id in context (decouples role from namespace)
-3. **Event System**: CustomEvent-based communication (decouples components, enables future extensibility)
-4. **LocalStorage**: Session data persisted for quick access (syncs with Flask session on startup)
-5. **Graceful Degradation**: Falls back to user-only namespace if no org selected
-6. **Migration Strategy**: One-time script keeps Phase 1 data intact while populating Vontology
-7. **Access Control**: Integrates existing permission system, prepared for Phase 3 RBAC
-
-### Phase 2 Scope (From JVNAUTOSCI-789)
-- ✅ Create organisation selector UI component
-- ✅ Implement session organisation switching endpoint
-- ✅ Implement session context retrieval endpoint
-- ✅ Create Vontology membership model (memberOf + hasRole)
-- ✅ Create migration script for stub mappings
-- ✅ Implement membership service with full CRUD
-- ✅ Comprehensive membership tests (20 tests, 100% pass rate)
-- ⏳ Integration tests (framework ready, pending execution)
-- ⏳ Documentation updates
-
-### Known Limitations & Next Steps
-- Membership service tested in isolation (integration tests pending)
-- Migration script not yet executed (requires running database)
-- Phase 3 will replace stub role mappings with database-backed RBAC
-- Phase 3 will add role management UI and audit logging
-
-### What's Next
-**Phase 2 (Final)**: Integration Testing & Documentation
-- Write end-to-end tests for full org switching flow
-- Test UI component interactions with backend
-- Test migration script against real database
-- Update user documentation and API docs
-- Deploy and validate in development environment
-
-**Phase 3**: Production-Ready RBAC
-- Replace hardcoded role mappings with membership model lookups
-- Implement granular permission system (move from stub roles)
-- Add role management UI in admin panel
-- Add audit logging for membership and role changes
-- Implement role-based access control for all resources
-
----
-### What Was Done
-## Phase 1 Implementation Summary (COMPLETE ✅)
-**JVNAUTOSCI-787: Composite User@Org Namespace Model for RAG Isolation**
-[Previous Phase 1 details remain unchanged below...]
-
-Implemented complete Phase 1 infrastructure for multi-tenant organisation-scoped RAG content isolation:
-
-#### Deliverable 1: Namespace Service ✅
-- File: `src/backend/services/namespace_service.py` (145 lines)
-- Purpose: Centralised namespace derivation, parsing, and validation
-- Key Functions:
-  - `derive_namespace(user_id, org_id, role)` → `#V#user@org` (org-scoped) or `#V#user` (user-only)
-  - `parse_namespace(namespace)` → Extracts user_id and org_id
-  - `is_org_scoped(namespace)` → Boolean check
-  - `get_user_id(namespace)`, `get_org_id(namespace)` → Accessors
-  - `normalize_namespace(namespace)` → Standardisation and validation
-- Validation: Alphanumeric + underscores only (no spaces, special chars, quotes)
-- Testing: 35 comprehensive unit tests (100% pass rate)
-
-#### Deliverable 2: Stub Role Resolver ✅
-- File: `src/backend/security/role_resolver.py` (140 lines)
-- Purpose: Placeholder role system for Phase 1, designed for Phase 3 database replacement
-- Key Functions:
-  - `get_user_role(user_id, org_id)` → Returns role (default "member")
-  - `get_effective_permissions(role)` → Set of permissions for role
-  - `has_permission(user_id, org_id, permission)` → Permission check
-  - `get_all_user_organisations(user_id)` → List of orgs user belongs to
-- Hardcoded Mappings: `{"michael_witbrock": {"sail": "admin"}}`
-- Roles: viewer, member, contributor, admin, owner
-- Note: Phase 3 will replace hardcoded mappings with database-backed RBAC
-
-#### Deliverable 3: Session Schema Updates ✅
-- Modified: `src/backend/models/concept_models.py`
-- Extended `ConceptInteraction` class with:
-  - `organisation_concept_id: Optional[str]` → Links interaction to org
-  - `role_in_org: Optional[str]` → User's role in org (from resolver)
-  - `namespace: Optional[str]` → Derived composite namespace
-- Backward Compatible: All fields optional, existing code unaffected
-- Updated: `src/backend/services/concept_service.py::start_interaction_session()`
-  - Now derives composite namespace using namespace_service
-  - Reads org_id and role_in_org from Flask session
-  - Falls back gracefully to user-only namespace if no org context
-
-#### Deliverable 4: Access Control Extensions ✅
-- Modified: `src/backend/security/access_control.py`
-- Enhanced `build_visibility_filter()` function:
-  - Now reads `organisation_concept_id` from Flask session
-  - Applies org-specific visibility filters (filters concepts by user AND org)
-  - Log message: "Including org-specific concepts for org={user_org_id}"
-  - Maintains backward compatibility with user-only sessions
-
-#### Deliverable 5: RAG Metadata Integration ✅
-- Modified: `src/backend/services/chat_history_service.py`
-  - Added `get_session_context()` helper
-  - `add_message_to_history()` now includes org metadata in RAG documents
-  - Metadata: user_id, session_id, role, timestamp, type, organisation_concept_id, role_in_org
-- Modified: `src/backend/services/rag_sync_service.py`
-  - `collect_indexed_sessions()` fetches org fields from interaction_sessions
-  - `sync_one_session()` preserves org metadata when syncing to RAG
-- Modified: `src/backend/services/rag_backends/llamaindex_backend.py`
-  - `query()` method now supports organisation_concept_id filtering
-  - MetadataFilters include both user_id AND organisation_concept_id
-  - Implements org-scoped access control at RAG retrieval level
-- Modified: `src/backend/integrations/internal_mcp/catalogue.py`
-  - `_search_knowledge_base()` now passes permissions_context with org_id to RAG query
-- Modified: `src/backend/mcp_server/mcp_stdio_server.py`
-  - search_knowledge_base handler now includes org context
-- Modified: `src/backend/mcp_server/mcp_server.py`
-  - search_knowledge_base endpoint now includes session-based org context to queries
-
-### Test Results
-- **Namespace Service Tests**: 35/35 PASSED ✅
-  - Derivation (9 tests)
-  - Parsing (8 tests)
-  - Helpers (9 tests)
-  - Edge cases (9 tests)
-- **All Backend Tests**: 62 passed, 3 skipped ✅
-  - No regressions
-  - Chat history segmentation fixed (sys.path issue)
-  - RAG service tests all passing
-
-### Git Commits
-1. `a8445b0`: Phase 1 Composite Namespace Model + Stub Resolver + Tests (597 insertions)
-2. `f15ea96`: Phase 1 RAG Metadata Integration for Org-Scoped Content (130 insertions)
-3. `9723a97`: Fix test_chat_history_segmentation.py import path (8 insertions)
-
-### Design Decisions
-1. **Namespace Format**: `#V#{user_id}@{org_id}` (simple, parseable, consistent with #V# naming)
-2. **Role Storage**: In metadata/session, not in namespace (allows role changes without namespace change)
-3. **Graceful Degradation**: Sessions without org context fall back to user-only namespace
-4. **Query Filtering**: AND logic (both user AND org must match for org-scoped queries)
-5. **Backward Compatibility**: All new fields optional, no breaking changes
-6. **Test Pattern**: sys.path injection in test file (handles pytest context issues)
-
-### Phase 1 Scope (From JVNAUTOSCI-787)
-- ✅ Composite namespace derivation with user@org format
-- ✅ Namespace parsing and validation utilities
-- ✅ Stub role resolver with hardcoded mappings
-- ✅ Session model updates for org and role tracking
-- ✅ Access control extensions for org-specific visibility
-- ✅ RAG metadata inclusion (org_id and role_in_org)
-- ✅ RAG query filtering by organisation
-- ✅ Comprehensive test coverage (35 namespace tests)
-- ✅ All backend tests passing (62 passed, 3 skipped)
-
-### Known Limitations & Phase 3 Tasks
-- Role mappings currently hardcoded (Phase 3: Database-backed RBAC)
-- No UI for organisation selection (Phase 2: UI components)
-- No database model for organisation memberships (Phase 2: Vontology integration)
-- RAG filtering basic AND logic (Future: More complex permission rules)
-
-### What's Next
-**Phase 2**: UI and Vontology Integration
-- Create UI components for organisation selector
-- Implement `/api/session/set_organisation` endpoint
-- Create Vontology-based organisation model
-- Document organisation membership workflows
-
-**Phase 3**: Production-Ready RBAC
-- Replace hardcoded role mappings with database
-- Implement granular permission model
-- Add role management UI
-- Add audit logging for role changes
-
-## Previous Status (Before Phase 1)
-- **Date**: 2025-12-04
-- **Recent Activity**:
-  - Added quote and space validation to concept name generation (JVNAUTOSCI-760)
-  - Created reusable `validate_concept_name_for_id()` helper function in utils_vontology.py
-  - Updated linkification regex to remove spaces from allowed character set (consistent with validation)
-  - Concept IDs now disallow: quotes (reserved for text boundaries), spaces (use underscores/hyphens)
-
-## Todo
-- [ ] Integration testing of full Phase 1 flow (namespace → access control → RAG queries)
-- [ ] Phase 2 implementation: UI components for org selector
-- [ ] Phase 2 implementation: Organisation membership Vontology model
-- [ ] Phase 3 implementation: Database-backed RBAC system
-
-## Technical Debt & Refactoring Notes
-
-### Type Safety Enforcement (CRITICAL - Identified December 2025)
-
-**Problem:** Multiple instances of `# type: ignore` comments appeared during JVNAUTOSCI-800 cleanup, particularly in scenarios like wrapper pattern usage (`_RestrictedGateway`). These ignores are a symptom of insufficient type enforcement in the codebase.
-
-**Root Cause:** Some architectural patterns (wrapper classes, duck typing) and legacy code don't leverage proper typing:
-- Wrapper classes that delegate to underlying implementations without using Protocol or abstract base classes
-- Functions accepting loosely-typed arguments (Any, dict) when more specific types would be appropriate
-- Missing TypedDict or dataclass definitions for structured data
-- Inconsistent use of Optional/Union vs None coercion
-
-**Recommendation:** Establish a **type enforcement strategy** for the refactoring backlog:
-1. **Enable strict type checking** in Pyright configuration (`pyrightConfig: {"typeCheckingMode": "strict"}` in pyrightconfig.json)
-2. **Use Protocol/ABC** for wrapper patterns instead of relying on duck typing and type ignores
-3. **Define explicit types** for complex dictionaries (TypedDict or dataclasses)
-4. **Replace Any types** with specific union types or protocols where feasible
-5. **Document intentional type mismatches** with inline comments (not just `# type: ignore`)
-
-**Example Fix Pattern:**
-- **Before:** `gateway: Any` → cast to InternalMCPGateway → needs `# type: ignore[arg-type]`
-- **After:** Define `ManagedGateway` Protocol, implement wrapper against Protocol → type safe, no ignores needed
-
-**Affected Files Requiring Review:**
-- `src/backend/mcp_server/mcp_stdio_server.py` (line 1238: _RestrictedGateway wrapper)
-- `src/backend/services/rag_service.py` (dict-based operations)
-- `src/backend/integrations/internal_mcp/catalogue.py` (Tool definitions with flexible schemas)
-- `src/backend/services/chat_auxiliary_prompt_service.py` (context dict handling)
-
-**Priority:** Medium - not blocking, but should be addressed in next major refactoring cycle to improve IDE support and prevent subtle type-related bugs.
+## Recent decisions / changes worth remembering
+- Presenter “spoken vs screen” behaviour is documented in Jira (JVNAUTOSCI-894); avoid duplicating the write-up here.
 
 

--- a/docs/AINotes_archive.md
+++ b/docs/AINotes_archive.md
@@ -1,0 +1,181 @@
+# AI Notes Archive
+
+Archived from `docs/AINotes.md` on 2026-01-02.
+
+---
+
+# AI Notes
+
+## Agent Reminder (Config Lookup)
+
+If you need values from `.env`, prefer the allowlisted helper script instead of reading the file directly:
+
+- Script: `utilities/get_safe_env.py`
+- Example: `pdm run python utilities/get_safe_env.py VON_DB_NAME`
+
+It only prints allowlisted keys and redacts secret-like values (tokens, passwords, etc.).
+
+## Current Status
+  1. Integration testing of full Phase 1 flow
+  2. Proceed with Phase 2 (UI components and org selector)
+  3. Or address any issues/feedback from Phase 1 review
+
+---
+
+## What Was Done
+**JVNAUTOSCI-789: UI Integration for Organisation and Role Selection**
+
+Implemented Phase 2 infrastructure for user-facing organisation switching and persistent membership model:
+
+#### Deliverable 1: Organisation Membership Service ✅
+- File: `src/backend/services/organisation_membership_service.py` (410 lines)
+- Purpose: Vontology-based membership management with memberOf predicates
+- Key Functions:
+  - `create_organisation_membership()` → Creates memberOf relationship + hasRole text relation
+  - `get_user_memberships()` → Retrieves user's organisations and roles
+  - `get_organisation_members()` → Lists org members with optional role filtering
+  - `update_user_role()` → Updates user's role in organisation
+  - `remove_organisation_membership()` → Removes user from organisation
+- Data Model: Uses memberOf edge relationships + hasRole text relations with org context
+- Access Control: Integrates with access_control system for permission checking
+- Testing: 20 comprehensive unit tests (100% pass rate) covering all functions and error paths
+
+#### Deliverable 2: Backend API Endpoints ✅
+- Modified: `src/backend/server/routes/von_routes.py`
+- Endpoint 1: `POST /api/session/set_organisation`
+  - Switches user's organisation context in Flask session
+
+  ### What Was Done
+  - `role_in_org: Optional[str]` → User's role in org (from resolver)
+  - `namespace: Optional[str]` → Derived composite namespace
+- Backward Compatible: All fields optional, existing code unaffected
+- Updated: `src/backend/services/concept_service.py::start_interaction_session()`
+  - Now derives composite namespace using namespace_service
+  - Reads org_id and role_in_org from Flask session
+  - Falls back gracefully to user-only namespace if no org context
+
+#### Deliverable 4: Access Control Extensions ✅
+- Modified: `src/backend/security/access_control.py`
+- Enhanced `build_visibility_filter()` function:
+  - Now reads `organisation_concept_id` from Flask session
+  - Applies org-specific visibility filters (filters concepts by user AND org)
+  - Log message: "Including org-specific concepts for org={user_org_id}"
+  - Maintains backward compatibility with user-only sessions
+
+#### Deliverable 5: RAG Metadata Integration ✅
+- Modified: `src/backend/services/chat_history_service.py`
+  - Added `get_session_context()` helper
+  - `add_message_to_history()` now includes org metadata in RAG documents
+  - Metadata: user_id, session_id, role, timestamp, type, organisation_concept_id, role_in_org
+- Modified: `src/backend/services/rag_sync_service.py`
+  - `collect_indexed_sessions()` fetches org fields from interaction_sessions
+  - `sync_one_session()` preserves org metadata when syncing to RAG
+- Modified: `src/backend/services/rag_backends/llamaindex_backend.py`
+  - `query()` method now supports organisation_concept_id filtering
+  - MetadataFilters include both user_id AND organisation_concept_id
+  - Implements org-scoped access control at RAG retrieval level
+- Modified: `src/backend/integrations/internal_mcp/catalogue.py`
+  - `_search_knowledge_base()` now passes permissions_context with org_id to RAG query
+- Modified: `src/backend/mcp_server/mcp_stdio_server.py`
+  - search_knowledge_base handler now includes org context
+- Modified: `src/backend/mcp_server/mcp_server.py`
+  - search_knowledge_base endpoint now includes session-based org context to queries
+
+### Test Results
+- **Namespace Service Tests**: 35/35 PASSED ✅
+  - Derivation (9 tests)
+  - Parsing (8 tests)
+  - Helpers (9 tests)
+  - Edge cases (9 tests)
+- **All Backend Tests**: 62 passed, 3 skipped ✅
+  - No regressions
+  - Chat history segmentation fixed (sys.path issue)
+  - RAG service tests all passing
+
+### Git Commits
+1. `a8445b0`: Phase 1 Composite Namespace Model + Stub Resolver + Tests (597 insertions)
+2. `f15ea96`: Phase 1 RAG Metadata Integration for Org-Scoped Content (130 insertions)
+3. `9723a97`: Fix test_chat_history_segmentation.py import path (8 insertions)
+
+### Design Decisions
+1. **Namespace Format**: `#V#{user_id}@{org_id}` (simple, parseable, consistent with #V# naming)
+2. **Role Storage**: In metadata/session, not in namespace (allows role changes without namespace change)
+3. **Graceful Degradation**: Sessions without org context fall back to user-only namespace
+4. **Query Filtering**: AND logic (both user AND org must match for org-scoped queries)
+5. **Backward Compatibility**: All new fields optional, no breaking changes
+6. **Test Pattern**: sys.path injection in test file (handles pytest context issues)
+
+### Phase 1 Scope (From JVNAUTOSCI-787)
+- ✅ Composite namespace derivation with user@org format
+- ✅ Namespace parsing and validation utilities
+- ✅ Stub role resolver with hardcoded mappings
+- ✅ Session model updates for org and role tracking
+- ✅ Access control extensions for org-specific visibility
+- ✅ RAG metadata inclusion (org_id and role_in_org)
+- ✅ RAG query filtering by organisation
+- ✅ Comprehensive test coverage (35 namespace tests)
+- ✅ All backend tests passing (62 passed, 3 skipped)
+
+### Known Limitations & Phase 3 Tasks
+- Role mappings currently hardcoded (Phase 3: Database-backed RBAC)
+- No UI for organisation selection (Phase 2: UI components)
+- No database model for organisation memberships (Phase 2: Vontology integration)
+- RAG filtering basic AND logic (Future: More complex permission rules)
+
+### What's Next
+**Phase 2**: UI and Vontology Integration
+- Create UI components for organisation selector
+- Implement `/api/session/set_organisation` endpoint
+- Create Vontology-based organisation model
+- Document organisation membership workflows
+
+**Phase 3**: Production-Ready RBAC
+- Replace hardcoded role mappings with database
+- Implement granular permission model
+- Add role management UI
+- Add audit logging for role changes
+
+## Previous Status (Before Phase 1)
+- **Date**: 2025-12-04
+- **Recent Activity**:
+  - Added quote and space validation to concept name generation (JVNAUTOSCI-760)
+  - Created reusable `validate_concept_name_for_id()` helper function in utils_vontology.py
+  - Updated linkification regex to remove spaces from allowed character set (consistent with validation)
+  - Concept IDs now disallow: quotes (reserved for text boundaries), spaces (use underscores/hyphens)
+
+## Todo
+- [ ] Integration testing of full Phase 1 flow (namespace → access control → RAG queries)
+- [ ] Phase 2 implementation: UI components for org selector
+- [ ] Phase 2 implementation: Organisation membership Vontology model
+- [ ] Phase 3 implementation: Database-backed RBAC system
+
+## Technical Debt & Refactoring Notes
+
+### Type Safety Enforcement (CRITICAL - Identified December 2025)
+
+**Problem:** Multiple instances of `# type: ignore` comments appeared during JVNAUTOSCI-800 cleanup, particularly in scenarios like wrapper pattern usage (`_RestrictedGateway`). These ignores are a symptom of insufficient type enforcement in the codebase.
+
+**Root Cause:** Some architectural patterns (wrapper classes, duck typing) and legacy code don't leverage proper typing:
+- Wrapper classes that delegate to underlying implementations without using Protocol or abstract base classes
+- Functions accepting loosely-typed arguments (Any, dict) when more specific types would be appropriate
+- Missing TypedDict or dataclass definitions for structured data
+- Inconsistent use of Optional/Union vs None coercion
+
+**Recommendation:** Establish a **type enforcement strategy** for the refactoring backlog:
+1. **Enable strict type checking** in Pyright configuration (`pyrightConfig: {"typeCheckingMode": "strict"}` in pyrightconfig.json)
+2. **Use Protocol/ABC** for wrapper patterns instead of relying on duck typing and type ignores
+3. **Define explicit types** for complex dictionaries (TypedDict or dataclasses)
+4. **Replace Any types** with specific union types or protocols where feasible
+5. **Document intentional type mismatches** with inline comments (not just `# type: ignore`)
+
+**Example Fix Pattern:**
+- **Before:** `gateway: Any` → cast to InternalMCPGateway → needs `# type: ignore[arg-type]`
+- **After:** Define `ManagedGateway` Protocol, implement wrapper against Protocol → type safe, no ignores needed
+
+**Affected Files Requiring Review:**
+- `src/backend/mcp_server/mcp_stdio_server.py` (line 1238: _RestrictedGateway wrapper)
+- `src/backend/services/rag_service.py` (dict-based operations)
+- `src/backend/integrations/internal_mcp/catalogue.py` (Tool definitions with flexible schemas)
+- `src/backend/services/chat_auxiliary_prompt_service.py` (context dict handling)
+
+**Priority:** Medium - not blocking, but should be addressed in next major refactoring cycle to improve IDE support and prevent subtle type-related bugs.

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -615,6 +615,36 @@ def _add_relationship(**kwargs):
                 "error": f"Source concept '{source_id}' not found",
             }
 
+        # Common text predicates are frequently provided either as plain predicate IDs
+        # (e.g. 'hasContent') or V-prefixed IDs (e.g. '#V#hasContent'). Treat these
+        # as text relations without requiring a predicate concept to exist.
+        predicate_str = (
+            predicate.strip() if isinstance(predicate, str) else str(predicate)
+        )
+        predicate_normalised = (
+            predicate_str[3:] if predicate_str.startswith("#V#") else predicate_str
+        )
+        well_known_text_predicates = {"hasContent", "hasDescription", "hasName"}
+        if predicate_normalised in well_known_text_predicates:
+            target_text = target if isinstance(target, str) else str(target)
+            result = upsert_text_for_concept(
+                subject_concept_id=source_id,
+                predicate=predicate_normalised,
+                text=target_text,
+                lang="en",
+                provenance={"source": "add_relationship"},
+            )
+            return {
+                "success": True,
+                "relationship_type": "text_relation",
+                "source_id": source_id,
+                "predicate": predicate_normalised,
+                "predicate_input": predicate,
+                "target": target_text,
+                "text_value_id": str(result.get("text_value_id")),
+                "relation_id": str(result.get("relation_id")),
+            }
+
         # Determine if this is a text predicate (binary_text_predicate instance)
         is_text_predicate = False
         if predicate.startswith("#V#"):
@@ -3532,9 +3562,12 @@ def _chat_get_prompt_context(
 ):
     """Return user-specific prompt context that affects chat.
 
-    This is intended for debugging/inspection: which `#V#von_llm_prompt` concepts
-    are linked to the authenticated user (namespace) and what content they
-    contribute.
+    This is intended for debugging/inspection: which prompt concepts are linked
+    to the authenticated user (namespace) and what content they contribute.
+
+    Prompts are purpose-specific types:
+    - `#V#von_chat_behaviour_prompt` (system behaviour)
+    - `#V#von_chat_narration_prompt` (TTS / presenter narration)
     """
 
     if not namespace or not isinstance(namespace, str) or not namespace.strip():
@@ -3557,12 +3590,36 @@ def _chat_get_prompt_context(
         get_user_specific_prompt_fragments,
     )
 
-    fragments = get_user_specific_prompt_fragments(namespace)
-    prompt_concept_ids = [
-        f.get("concept_id") for f in fragments if isinstance(f.get("concept_id"), str)
+    behaviour_fragments = get_user_specific_prompt_fragments(
+        namespace,
+        prompt_types=(
+            "#V#von_chat_behaviour_prompt",
+            "#V#von_chat_behavior_prompt",
+        ),
+    )
+    narration_fragments = get_user_specific_prompt_fragments(
+        namespace,
+        prompt_types=("#V#von_chat_narration_prompt",),
+    )
+
+    behaviour_prompt_concept_ids = [
+        f.get("concept_id")
+        for f in behaviour_fragments
+        if isinstance(f.get("concept_id"), str)
+    ]
+    narration_prompt_concept_ids = [
+        f.get("concept_id")
+        for f in narration_fragments
+        if isinstance(f.get("concept_id"), str)
     ]
 
-    prompt_text = build_user_specific_system_prompt(namespace)
+    prompt_text = build_user_specific_system_prompt(
+        namespace,
+        prompt_types=(
+            "#V#von_chat_behaviour_prompt",
+            "#V#von_chat_behavior_prompt",
+        ),
+    )
     if (
         isinstance(prompt_text, str)
         and max_chars_int
@@ -3573,24 +3630,35 @@ def _chat_get_prompt_context(
             + f"\n... [truncated {len(prompt_text) - max_chars_int} chars]"
         )
 
-    prompt_concepts = []
-    for fragment in fragments:
-        concept_id = fragment.get("concept_id")
-        if not isinstance(concept_id, str):
-            continue
-        item = {"concept_id": concept_id}
-        if include_content:
-            content = fragment.get("content")
-            item["content"] = content if isinstance(content, str) else ""
-        prompt_concepts.append(item)
+    def _format_fragments(fragments_list):
+        prompt_concepts_local = []
+        for fragment in fragments_list:
+            concept_id = fragment.get("concept_id")
+            if not isinstance(concept_id, str):
+                continue
+            item = {"concept_id": concept_id}
+            if include_content:
+                content = fragment.get("content")
+                item["content"] = content if isinstance(content, str) else ""
+            prompt_concepts_local.append(item)
+        return prompt_concepts_local
+
+    behaviour_prompt_concepts = _format_fragments(behaviour_fragments)
+    narration_prompt_concepts = _format_fragments(narration_fragments)
 
     return {
         "success": True,
         "namespace": namespace,
-        "prompt_concept_ids": prompt_concept_ids,
-        "prompt_concepts": prompt_concepts,
+        # Backwards-compatible fields expected by some callers.
+        "prompt_concept_ids": list(behaviour_prompt_concept_ids),
+        "prompt_concepts": behaviour_prompt_concepts,
+        # Purpose-specific fields.
+        "behaviour_prompt_concept_ids": behaviour_prompt_concept_ids,
+        "behaviour_prompt_concepts": behaviour_prompt_concepts,
+        "narration_prompt_concept_ids": narration_prompt_concept_ids,
+        "narration_prompt_concepts": narration_prompt_concepts,
         "prompt_text": prompt_text or "",
-        "prompt_count": len(prompt_concept_ids),
+        "prompt_count": len(behaviour_prompt_concept_ids),
     }
 
 
@@ -3669,14 +3737,42 @@ def _chat_introspect(
         get_user_specific_prompt_fragments,
     )
 
-    fragments = get_user_specific_prompt_fragments(namespace)
-    prompt_concept_ids = [
-        f.get("concept_id") for f in fragments if isinstance(f.get("concept_id"), str)
+    behaviour_fragments = get_user_specific_prompt_fragments(
+        namespace,
+        prompt_types=(
+            "#V#von_chat_behaviour_prompt",
+            "#V#von_chat_behavior_prompt",
+        ),
+    )
+    narration_fragments = get_user_specific_prompt_fragments(
+        namespace,
+        prompt_types=("#V#von_chat_narration_prompt",),
+    )
+
+    behaviour_prompt_concept_ids = [
+        f.get("concept_id")
+        for f in behaviour_fragments
+        if isinstance(f.get("concept_id"), str)
     ]
-    auxiliary_prompt_text = build_user_specific_system_prompt(namespace) or ""
+    narration_prompt_concept_ids = [
+        f.get("concept_id")
+        for f in narration_fragments
+        if isinstance(f.get("concept_id"), str)
+    ]
+
+    auxiliary_prompt_text = (
+        build_user_specific_system_prompt(
+            namespace,
+            prompt_types=(
+                "#V#von_chat_behaviour_prompt",
+                "#V#von_chat_behavior_prompt",
+            ),
+        )
+        or ""
+    )
 
     prompt_concepts: list[dict] = []
-    for fragment in fragments:
+    for fragment in behaviour_fragments:
         concept_id = fragment.get("concept_id")
         if not isinstance(concept_id, str):
             continue
@@ -3685,6 +3781,17 @@ def _chat_introspect(
             content = fragment.get("content")
             item["content"] = content if isinstance(content, str) else ""
         prompt_concepts.append(item)
+
+    narration_prompt_concepts: list[dict] = []
+    for fragment in narration_fragments:
+        concept_id = fragment.get("concept_id")
+        if not isinstance(concept_id, str):
+            continue
+        item = {"concept_id": concept_id}
+        if include_prompt_content:
+            content = fragment.get("content")
+            item["content"] = content if isinstance(content, str) else ""
+        narration_prompt_concepts.append(item)
 
     # Model / provider information
     try:
@@ -3769,9 +3876,14 @@ def _chat_introspect(
         "active_model_name": active_model_name,
         "active_llm": active_llm,
         "resolved_llm": resolved_llm,
-        "prompt_concept_ids": prompt_concept_ids,
+        # Backwards-compatible fields.
+        "prompt_concept_ids": list(behaviour_prompt_concept_ids),
         "prompt_concepts": prompt_concepts,
-        "prompt_count": len(prompt_concept_ids),
+        "prompt_count": len(behaviour_prompt_concept_ids),
+        # Purpose-specific fields.
+        "behaviour_prompt_concept_ids": behaviour_prompt_concept_ids,
+        "narration_prompt_concept_ids": narration_prompt_concept_ids,
+        "narration_prompt_concepts": narration_prompt_concepts,
         "tool_guidance_hash": tool_guidance_hash,
         "tool_guidance_preview": tool_guidance_preview,
         "gateway_enabled": gateway_enabled,

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -1455,10 +1455,31 @@ class InternalMCPChatOrchestrator:
             for msg in context:
                 if isinstance(msg, Mapping):
                     base.append(dict(msg))
+
+        # Preserve presenter-mode protocol messages even when context trimming
+        # would otherwise drop them (system message at index 0 is always kept).
+        presenter_protocol: str | None = None
+        filtered: list[Mapping[str, Any]] = []
+        for msg in base:
+            role = msg.get("role") if isinstance(msg, Mapping) else None
+            content = msg.get("content") if isinstance(msg, Mapping) else None
+            if (
+                role == "system"
+                and isinstance(content, str)
+                and content.lstrip().startswith("PRESENTER MODE PROTOCOL:")
+            ):
+                presenter_protocol = content.strip()
+                continue
+            filtered.append(msg)
+        base = [dict(m) if isinstance(m, Mapping) else m for m in filtered]
+
         instruction_msg = self._instruction_message(
             user_namespace=user_namespace,
             auxiliary_system_prompt=auxiliary_system_prompt,
         )
+
+        if presenter_protocol:
+            instruction_msg = f"{instruction_msg}\n\n{presenter_protocol}\n"
 
         # Log the size of the instruction message for diagnostics
         instruction_chars = len(instruction_msg)

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -335,6 +335,50 @@ def generate():
     # REFACTORING_NOTE: Use the new factory to get the correct client and model
     # Get user and org context for per-user/org LLM settings
     try:
+
+        def _extract_presenter_channels(text: str) -> dict[str, object] | None:
+            """Extract presenter-style output blocks.
+
+            Expected format (v1):
+              <spoken>...talk track...</spoken>
+              <screen>...what to display...</screen>
+
+            Returns None when no tags are present.
+            """
+
+            if not isinstance(text, str) or not text:
+                return None
+
+            import re
+
+            def _find_block(tag: str) -> str | None:
+                pattern = rf"<{tag}>\\s*(.*?)\\s*</{tag}>"
+                m = re.search(pattern, text, flags=re.DOTALL | re.IGNORECASE)
+                if not m:
+                    return None
+                value = m.group(1)
+                if not isinstance(value, str):
+                    return None
+                value = value.strip()
+                return value if value else None
+
+            spoken = _find_block("spoken")
+            screen = _find_block("screen")
+
+            if spoken is None and screen is None:
+                return None
+
+            # Backwards-compatible defaults.
+            screen_text = screen if screen is not None else text.strip()
+            spoken_text = spoken if spoken is not None else screen_text
+
+            return {
+                "format": "tagged_blocks_v1",
+                "extracted": True,
+                "screen": screen_text,
+                "spoken": spoken_text,
+            }
+
         from ...security.access_control import get_effective_user_concept_id
 
         user_concept_id = get_effective_user_concept_id()
@@ -1635,6 +1679,13 @@ def generate():
                     }
                 ]
 
+        presenter_channels = _extract_presenter_channels(response_text)
+        if presenter_channels is not None:
+            # Screen channel becomes the stored/displayed response.
+            screen_text_value = presenter_channels.get("screen")
+            if isinstance(screen_text_value, str) and screen_text_value.strip():
+                response_text = screen_text_value.strip()
+
         if tool_invocations:
             current_app.logger.info(
                 "[mcp_orchestrator] Tool invocations: %s", tool_invocations
@@ -1746,6 +1797,7 @@ def generate():
             },
             "messages": current_turn_messages,
             "response": response_text,
+            "presenter_channels": presenter_channels,
             "user_prompt": user_prompt_debug,
             "namespace_report": namespace_report,
             "internal_mcp": {
@@ -1820,6 +1872,15 @@ def generate():
         return jsonify(
             {
                 "response": response_text,
+                "response_channels": (
+                    {
+                        "screen": presenter_channels.get("screen"),
+                        "spoken": presenter_channels.get("spoken"),
+                        "format": presenter_channels.get("format"),
+                    }
+                    if isinstance(presenter_channels, dict)
+                    else None
+                ),
                 "llm_debug": llm_debug_info,
                 "rag_trace": rag_trace,
             }

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -307,6 +307,8 @@ def generate():
     data = request.get_json()
     prompt_text = data.get("prompt", "")
 
+    presenter_mode_requested = bool(data.get("presenter_mode"))
+
     request_start_perf = time.perf_counter()
 
     interaction_timestamp_utc = (
@@ -352,7 +354,7 @@ def generate():
             import re
 
             def _find_block(tag: str) -> str | None:
-                pattern = rf"<{tag}>\\s*(.*?)\\s*</{tag}>"
+                pattern = rf"<{tag}>\s*(.*?)\s*</{tag}>"
                 m = re.search(pattern, text, flags=re.DOTALL | re.IGNORECASE)
                 if not m:
                     return None
@@ -368,9 +370,14 @@ def generate():
             if spoken is None and screen is None:
                 return None
 
-            # Backwards-compatible defaults.
-            screen_text = screen if screen is not None else text.strip()
-            spoken_text = spoken if spoken is not None else screen_text
+            # Defaults:
+            # - If only <spoken> is provided, display it on-screen too (otherwise we'd render the raw tags).
+            # - If only <screen> is provided, do NOT fabricate spoken from screen; let the client fall back.
+            screen_text = screen if screen is not None else spoken
+            spoken_text = spoken
+
+            if screen_text is None:
+                screen_text = text.strip()
 
             return {
                 "format": "tagged_blocks_v1",
@@ -423,11 +430,14 @@ def generate():
         # JVNAUTOSCI-797: user-specific system prompt from Vontology
         # ---------------------------------------------------------
         auxiliary_system_prompt = None
+        narration_prompt_text = None
         user_prompt_debug = {
             "effective_user_concept_id": user_concept_id,
             "loaded": False,
             "chars": 0,
             "prompt_concept_ids": [],
+            "behaviour_prompt_concept_ids": [],
+            "narration_prompt_concept_ids": [],
         }
         if user_concept_id:
             try:
@@ -435,15 +445,37 @@ def generate():
                     get_user_specific_prompt_fragments,
                 )
 
-                prompt_fragments = get_user_specific_prompt_fragments(user_concept_id)
-                user_prompt_debug["prompt_concept_ids"] = [
+                behaviour_prompt_fragments = get_user_specific_prompt_fragments(
+                    user_concept_id,
+                    prompt_types=(
+                        "#V#von_chat_behaviour_prompt",
+                        "#V#von_chat_behavior_prompt",
+                    ),
+                )
+                narration_prompt_fragments = get_user_specific_prompt_fragments(
+                    user_concept_id,
+                    prompt_types=("#V#von_chat_narration_prompt",),
+                )
+
+                user_prompt_debug["behaviour_prompt_concept_ids"] = [
                     frag.get("concept_id")
-                    for frag in prompt_fragments
+                    for frag in behaviour_prompt_fragments
                     if isinstance(frag, dict)
                     and isinstance(frag.get("concept_id"), str)
                 ]
+                user_prompt_debug["narration_prompt_concept_ids"] = [
+                    frag.get("concept_id")
+                    for frag in narration_prompt_fragments
+                    if isinstance(frag, dict)
+                    and isinstance(frag.get("concept_id"), str)
+                ]
+                # Backwards-compatible field name used by the UI/debug tools.
+                user_prompt_debug["prompt_concept_ids"] = list(
+                    user_prompt_debug["behaviour_prompt_concept_ids"]
+                )
+
                 prompt_texts = []
-                for frag in prompt_fragments:
+                for frag in behaviour_prompt_fragments:
                     if not isinstance(frag, dict):
                         continue
                     content = frag.get("content")
@@ -457,6 +489,23 @@ def generate():
                 )
                 auxiliary_system_prompt = (
                     auxiliary_system_prompt.strip() if auxiliary_system_prompt else None
+                )
+
+                narration_texts = []
+                for frag in narration_prompt_fragments:
+                    if not isinstance(frag, dict):
+                        continue
+                    content = frag.get("content")
+                    if not isinstance(content, str):
+                        continue
+                    if not content.strip():
+                        continue
+                    narration_texts.append(content)
+                narration_prompt_text = "\n\n".join(
+                    text.strip() for text in narration_texts if text and text.strip()
+                )
+                narration_prompt_text = (
+                    narration_prompt_text.strip() if narration_prompt_text else None
                 )
 
                 if auxiliary_system_prompt:
@@ -1114,6 +1163,31 @@ def generate():
             else:
                 enhanced_context.insert(1, user_prompt_message)
 
+        # ---------------------------------------------------------
+        # JVNAUTOSCI-894: Presenter-mode response protocol
+        # ---------------------------------------------------------
+        if presenter_mode_requested:
+            presenter_protocol_message = {
+                "role": "system",
+                "content": (
+                    "PRESENTER MODE PROTOCOL:\n"
+                    "- Output EXACTLY TWO tagged blocks and nothing else:\n"
+                    "  <spoken>...brief talk track...</spoken>\n"
+                    "  <screen>...full on-screen content...</screen>\n"
+                    "- <spoken> is what will be read aloud (TTS). Keep it short (1–4 sentences), conversational, and focused on the user's intent and what you did / what to do next. Do not read long lists, code blocks, or raw markdown.\n"
+                    "- <screen> is what will be shown. It may include structured markdown, code blocks, and full details.\n"
+                    "- Do not include <spoken>/<screen> tags inside code blocks.\n"
+                    "- Use New Zealand English spelling."
+                    + (
+                        "\n\nVON CHAT NARRATION PROMPT (from Vontology):\n"
+                        + narration_prompt_text
+                        if narration_prompt_text
+                        else ""
+                    )
+                ),
+            }
+            enhanced_context.insert(0, presenter_protocol_message)
+
         # Log the enhanced context being sent to the model for debugging
         current_app.logger.info(
             f"Enhanced context being sent to model: {len(enhanced_context)} messages"
@@ -1680,6 +1754,104 @@ def generate():
                 ]
 
         presenter_channels = _extract_presenter_channels(response_text)
+
+        def _extract_spoken_only(text: str) -> str | None:
+            if not isinstance(text, str) or not text:
+                return None
+            import re
+
+            m = re.search(
+                r"<spoken>\s*(.*?)\s*</spoken>", text, flags=re.DOTALL | re.IGNORECASE
+            )
+            if not m:
+                return None
+            value = m.group(1)
+            if not isinstance(value, str):
+                return None
+            cleaned = value.strip()
+            return cleaned or None
+
+        spoken_backfill_second_pass_attempted = False
+        spoken_backfill_second_pass_reason = None
+
+        # If presenter mode was requested but the model didn't produce a usable
+        # <spoken> channel, generate it in a second pass for reliability.
+        #
+        # Note: The model may emit only <screen>...</screen>. In that case,
+        # we still generate <spoken> using the narration prompt rather than
+        # falling back to reading the screen/markdown verbatim.
+        needs_spoken_backfill = False
+        if presenter_mode_requested:
+            if presenter_channels is None:
+                needs_spoken_backfill = True
+                spoken_backfill_second_pass_reason = "missing_presenter_channels"
+            elif isinstance(presenter_channels, dict):
+                spoken_value = presenter_channels.get("spoken")
+                if not isinstance(spoken_value, str) or not spoken_value.strip():
+                    needs_spoken_backfill = True
+                    spoken_backfill_second_pass_reason = "missing_spoken"
+            else:
+                needs_spoken_backfill = True
+                spoken_backfill_second_pass_reason = "missing_presenter_channels"
+
+        if needs_spoken_backfill:
+            try:
+                spoken_backfill_second_pass_attempted = True
+                if isinstance(presenter_channels, dict) and isinstance(
+                    presenter_channels.get("screen"), str
+                ):
+                    screen_text = str(presenter_channels.get("screen") or "").strip()
+                else:
+                    screen_text = (
+                        response_text.strip()
+                        if isinstance(response_text, str)
+                        else str(response_text)
+                    )
+
+                narration_system = (
+                    "You are Von. Produce a short talk track for text-to-speech. "
+                    "Return ONLY one block: <spoken>...</spoken>. "
+                    "Do not include <screen>. Do not include code blocks. "
+                    "Use New Zealand English spelling."
+                    + (
+                        "\n\nVON CHAT NARRATION PROMPT (from Vontology):\n"
+                        + narration_prompt_text
+                        if narration_prompt_text
+                        else ""
+                    )
+                )
+
+                narration_user = (
+                    "User message:\n"
+                    f"{prompt_text}\n\n"
+                    "On-screen content (do not read verbatim if long; summarise):\n"
+                    f"{screen_text}\n"
+                )
+
+                narration_response = llm_client.generate(
+                    prompt="Generate <spoken> talk track",
+                    context=[
+                        {"role": "system", "content": narration_system},
+                        {"role": "user", "content": narration_user},
+                    ],
+                    model=model_name,
+                )
+
+                spoken_fallback = _extract_spoken_only(str(narration_response))
+                if spoken_fallback:
+                    base_channels = (
+                        dict(presenter_channels)
+                        if isinstance(presenter_channels, dict)
+                        else {}
+                    )
+                    base_channels["screen"] = screen_text
+                    base_channels["spoken"] = spoken_fallback
+                    base_channels["format"] = "narration_fallback_v1"
+                    presenter_channels = base_channels
+            except Exception:
+                # Defensive: never fail the request just because narration generation failed.
+                presenter_channels = presenter_channels
+
         if presenter_channels is not None:
             # Screen channel becomes the stored/displayed response.
             screen_text_value = presenter_channels.get("screen")
@@ -1798,6 +1970,8 @@ def generate():
             "messages": current_turn_messages,
             "response": response_text,
             "presenter_channels": presenter_channels,
+            "spoken_backfill_second_pass_attempted": spoken_backfill_second_pass_attempted,
+            "spoken_backfill_second_pass_reason": spoken_backfill_second_pass_reason,
             "user_prompt": user_prompt_debug,
             "namespace_report": namespace_report,
             "internal_mcp": {
@@ -1947,7 +2121,7 @@ def history():
 
     try:
         segments = chat_history_service.get_chat_history_segments(
-            user_concept_id, session_id
+            user_concept_id, session_id, include_locations=True
         )
         total_segments = len(segments)
 
@@ -1978,6 +2152,216 @@ def history():
     except Exception as e:
         print(f"Error retrieving history: {e}")
         return jsonify({"error": str(e)}), 500
+
+
+@von_bp.route("/history/backfill_spoken", methods=["POST"])
+def history_backfill_spoken():
+    """Generate and persist missing <spoken> talk track for a stored assistant turn.
+
+    This is intended for legacy history turns where presenter channels were not
+    generated or persisted at the time. The backfill:
+    - requires authentication
+    - does not touch session `updated_at` (so it won't reorder session recency)
+    """
+
+    from ...security.access_control import get_effective_user_concept_id
+
+    user_concept_id = get_effective_user_concept_id()
+    if not user_concept_id:
+        return jsonify({"error": "Not authenticated"}), 401
+
+    data = request.get_json(silent=True) or {}
+    history_location = data.get("history_location")
+    if not isinstance(history_location, dict):
+        history_location = {}
+
+    target_session_id = history_location.get("session_id") or data.get("session_id")
+    history_index = history_location.get("history_index")
+    if history_index is None:
+        history_index = data.get("history_index")
+
+    if not isinstance(target_session_id, str) or not target_session_id.strip():
+        return jsonify({"error": "session_id is required"}), 400
+    if not isinstance(history_index, int) or history_index < 0:
+        return jsonify({"error": "history_index must be a non-negative integer"}), 400
+
+    force = bool(data.get("force"))
+
+    # Fetch the stored assistant message and associated previous user prompt.
+    try:
+        chat_history_coll = chat_history_service.get_chat_history_collection_service()
+        if chat_history_coll is None:
+            return (
+                jsonify({"error": "Could not connect to chat history collection."}),
+                500,
+            )
+
+        doc = chat_history_coll.find_one(
+            {"user_id": user_concept_id, "session_id": target_session_id},
+            {"history": 1},
+        )
+        history = (doc or {}).get("history") or []
+        if not isinstance(history, list) or history_index >= len(history):
+            return jsonify({"error": "History entry not found"}), 404
+
+        entry = history[history_index]
+        if not isinstance(entry, dict) or entry.get("role") != "assistant":
+            return (
+                jsonify({"error": "Target history entry is not an assistant message"}),
+                400,
+            )
+
+        screen_text = entry.get("content")
+        if not isinstance(screen_text, str) or not screen_text.strip():
+            return jsonify({"error": "Assistant message has no content"}), 400
+        screen_text = screen_text.strip()
+
+        existing_debug = entry.get("llm_debug_data")
+        existing_channels = None
+        if isinstance(existing_debug, dict):
+            existing_channels = existing_debug.get("presenter_channels")
+        if not force and isinstance(existing_channels, dict):
+            spoken_existing = existing_channels.get("spoken")
+            if isinstance(spoken_existing, str) and spoken_existing.strip():
+                return jsonify(
+                    {
+                        "status": "already_present",
+                        "presenter_channels": existing_channels,
+                        "updated": False,
+                    }
+                )
+
+        prompt_text = ""
+        for i in range(history_index - 1, -1, -1):
+            msg = history[i]
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") == "system" and msg.get("content") == "__RESET__":
+                # Stop at reset boundary.
+                break
+            if msg.get("role") == "user":
+                candidate = msg.get("content")
+                if isinstance(candidate, str) and candidate.strip():
+                    prompt_text = candidate.strip()
+                break
+
+    except Exception as e:
+        return jsonify({"error": f"Failed reading history: {e}"}), 500
+
+    # Load narration prompt fragments (best-effort).
+    narration_prompt_text = None
+    try:
+        from ...services.chat_auxiliary_prompt_service import (
+            get_user_specific_prompt_fragments,
+        )
+
+        narration_prompt_fragments = get_user_specific_prompt_fragments(
+            user_concept_id,
+            prompt_types=("#V#von_chat_narration_prompt",),
+        )
+        narration_texts = []
+        for frag in narration_prompt_fragments:
+            if not isinstance(frag, dict):
+                continue
+            content = frag.get("content")
+            if not isinstance(content, str) or not content.strip():
+                continue
+            narration_texts.append(content)
+        narration_prompt_text = "\n\n".join(
+            text.strip() for text in narration_texts if text and text.strip()
+        )
+        narration_prompt_text = (
+            narration_prompt_text.strip() if narration_prompt_text else None
+        )
+    except Exception:
+        narration_prompt_text = None
+
+    # Generate spoken talk track.
+    try:
+        org_concept_id = session.get("organisation_concept_id") if session else None
+        llm_client = get_llm_client(
+            user_concept_id=user_concept_id, org_concept_id=org_concept_id
+        )
+        model_name = get_active_model_name()
+
+        def _extract_spoken_only(text: str) -> str | None:
+            if not isinstance(text, str) or not text:
+                return None
+            import re
+
+            m = re.search(
+                r"<spoken>\s*(.*?)\s*</spoken>",
+                text,
+                flags=re.DOTALL | re.IGNORECASE,
+            )
+            if not m:
+                return None
+            value = m.group(1)
+            if not isinstance(value, str):
+                return None
+            cleaned = value.strip()
+            return cleaned or None
+
+        narration_system = (
+            "You are Von. Produce a short talk track for text-to-speech. "
+            "Return ONLY one block: <spoken>...</spoken>. "
+            "Do not include <screen>. Do not include code blocks. "
+            "Use New Zealand English spelling."
+            + (
+                "\n\nVON CHAT NARRATION PROMPT (from Vontology):\n"
+                + narration_prompt_text
+                if narration_prompt_text
+                else ""
+            )
+        )
+
+        narration_user = (
+            "User message:\n"
+            f"{prompt_text}\n\n"
+            "On-screen content (do not read verbatim if long; summarise):\n"
+            f"{screen_text}\n"
+        )
+
+        narration_response = llm_client.generate(
+            prompt="Generate <spoken> talk track",
+            context=[
+                {"role": "system", "content": narration_system},
+                {"role": "user", "content": narration_user},
+            ],
+            model=model_name,
+        )
+
+        spoken = _extract_spoken_only(str(narration_response))
+        if not spoken:
+            return jsonify({"status": "no_spoken_generated", "updated": False}), 200
+
+        presenter_channels = {
+            "screen": screen_text,
+            "spoken": spoken,
+            "format": "narration_fallback_v1",
+        }
+
+        update_result = (
+            chat_history_service.upsert_presenter_channels_for_history_message(
+                user_id=user_concept_id,
+                session_id=target_session_id,
+                history_index=history_index,
+                presenter_channels=presenter_channels,
+                generated_at=datetime.now(timezone.utc),
+                force=force,
+            )
+        )
+
+        return jsonify(
+            {
+                "status": "ok",
+                "presenter_channels": presenter_channels,
+                "updated": bool(update_result.get("updated")),
+                "matched": bool(update_result.get("matched")),
+            }
+        )
+    except Exception as e:
+        return jsonify({"error": f"Failed generating spoken talk track: {e}"}), 500
 
 
 @von_bp.route("/history/length", methods=["GET"])

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -1771,6 +1771,50 @@ def generate():
             cleaned = value.strip()
             return cleaned or None
 
+        def _coerce_spoken_text(text: object) -> str | None:
+            """Best-effort normalisation for narration responses.
+
+            The narration second-pass *should* return <spoken>...</spoken>, but in
+            practice models sometimes return plain text. Accept either format.
+            """
+
+            if text is None:
+                return None
+
+            raw = str(text).strip()
+            if not raw:
+                return None
+
+            tagged = _extract_spoken_only(raw)
+            if tagged:
+                return tagged
+
+            import re
+
+            # Strip any accidental tagged blocks and code fences.
+            raw = re.sub(r"</?spoken>", "", raw, flags=re.IGNORECASE)
+            raw = re.sub(r"</?screen>", "", raw, flags=re.IGNORECASE)
+            raw = re.sub(r"```.*?```", "", raw, flags=re.DOTALL)
+            raw = raw.replace("`", "")
+            raw = raw.strip()
+
+            if not raw:
+                return None
+
+            # Keep it short for TTS.
+            max_chars = 800
+            if len(raw) > max_chars:
+                clipped = raw[:max_chars].rstrip()
+                # Prefer clipping at a sentence boundary.
+                for sep in (". ", "! ", "? "):
+                    cut = clipped.rfind(sep)
+                    if cut > 200:
+                        clipped = clipped[: cut + 1]
+                        break
+                raw = clipped.strip()
+
+            return raw or None
+
         spoken_backfill_second_pass_attempted = False
         spoken_backfill_second_pass_reason = None
 
@@ -1837,7 +1881,11 @@ def generate():
                     model=model_name,
                 )
 
-                spoken_fallback = _extract_spoken_only(str(narration_response))
+                spoken_fallback = _coerce_spoken_text(narration_response)
+                if not spoken_fallback:
+                    # Last resort: derive a short talk track from the screen text.
+                    spoken_fallback = _coerce_spoken_text(screen_text)
+
                 if spoken_fallback:
                     base_channels = (
                         dict(presenter_channels)

--- a/src/backend/services/chat_auxiliary_prompt_service.py
+++ b/src/backend/services/chat_auxiliary_prompt_service.py
@@ -11,15 +11,42 @@ This module keeps the logic small and testable.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+import logging
+import os
 
 from src.backend.db.repositories.concepts_repository import ConceptsRepository
 from src.backend.services.concept_service import get_concept_by_concept_id
 from src.backend.services.text_value_service import get_texts_for_concept
 
+_VON_CHAT_BEHAVIOUR_PROMPT_TYPE = "#V#von_chat_behaviour_prompt"
+# Legacy/alternate ID (US spelling) observed in stored concepts.
+_VON_CHAT_BEHAVIOR_PROMPT_TYPE = "#V#von_chat_behavior_prompt"
+_VON_CHAT_NARRATION_PROMPT_TYPE = "#V#von_chat_narration_prompt"
+_LEGACY_VON_LLM_PROMPT_TYPE = "#V#von_llm_prompt"
+_SPECIFIC_TO_USER_PREDICATE_CANDIDATES = (
+    "#V#specific_to_von_user",
+    "specific_to_von_user",
+    "specific_to_user",
+)
 
-_VON_LLM_PROMPT_TYPE = "#V#von_llm_prompt"
-_SPECIFIC_TO_USER_PREDICATE = "#V#specific_to_von_user"
+
+logger = logging.getLogger(__name__)
+
+
+def _debug_user_prompt_logging_enabled() -> bool:
+    value = os.getenv("VON_DEBUG_USER_PROMPT_LOADING", "")
+    value = value.strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def _normalise_predicate_id(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    value = value.strip()
+    if value.startswith("#V#"):
+        return value[3:]
+    return value
 
 
 def _get_prompt_content_for_concept(concept_id: str) -> Optional[str]:
@@ -50,7 +77,8 @@ def _get_prompt_content_for_concept(concept_id: str) -> Optional[str]:
     for text in texts:
         if not isinstance(text, dict):
             continue
-        if text.get("predicate") not in {"hasContent", "hasDescription"}:
+        predicate = _normalise_predicate_id(text.get("predicate"))
+        if predicate not in {"hasContent", "hasDescription"}:
             continue
         text_value = text.get("text")
         if not isinstance(text_value, str):
@@ -63,7 +91,7 @@ def _get_prompt_content_for_concept(concept_id: str) -> Optional[str]:
         return None
 
     def _sort_key(item: Dict[str, Any]) -> tuple[int, int, str]:
-        predicate = item.get("predicate")
+        predicate = _normalise_predicate_id(item.get("predicate"))
         lang = item.get("lang")
         text_value_id = item.get("text_value_id")
 
@@ -80,17 +108,23 @@ def _get_prompt_content_for_concept(concept_id: str) -> Optional[str]:
     return joined if joined else None
 
 
-def build_user_specific_system_prompt(user_concept_id: str) -> Optional[str]:
+def build_user_specific_system_prompt(
+    user_concept_id: str,
+    *,
+    prompt_types: Sequence[str] | None = None,
+) -> Optional[str]:
     """Build a system prompt string for the given authenticated user.
 
     We locate concepts that:
-    - are instances of `#V#von_llm_prompt`, and
+    - are instances of `#V#von_chat_behaviour_prompt` (or legacy `#V#von_llm_prompt`), and
     - are linked to the user via `#V#specific_to_von_user`.
 
     If multiple prompts exist, we concatenate them in a deterministic order.
     """
 
-    fragments = get_user_specific_prompt_fragments(user_concept_id)
+    fragments = get_user_specific_prompt_fragments(
+        user_concept_id, prompt_types=prompt_types
+    )
     prompt_texts = [
         fragment["content"] for fragment in fragments if fragment.get("content")
     ]
@@ -100,7 +134,36 @@ def build_user_specific_system_prompt(user_concept_id: str) -> Optional[str]:
     return "\n\n".join(prompt_texts)
 
 
-def get_user_specific_prompt_fragments(user_concept_id: str) -> List[Dict[str, Any]]:
+def _normalise_prompt_types(
+    prompt_types: Sequence[str] | None,
+) -> Tuple[str, ...]:
+    if prompt_types is None:
+        # Default behaviour: apply the user's chat behaviour prompt. We keep
+        # the legacy type as a fallback so restored data continues to work.
+        return (
+            _VON_CHAT_BEHAVIOUR_PROMPT_TYPE,
+            _VON_CHAT_BEHAVIOR_PROMPT_TYPE,
+            _LEGACY_VON_LLM_PROMPT_TYPE,
+        )
+
+    normalised: List[str] = []
+    for value in prompt_types:
+        if not isinstance(value, str):
+            continue
+        value = value.strip()
+        if not value:
+            continue
+        if value not in normalised:
+            normalised.append(value)
+
+    return tuple(normalised)
+
+
+def get_user_specific_prompt_fragments(
+    user_concept_id: str,
+    *,
+    prompt_types: Sequence[str] | None = None,
+) -> List[Dict[str, Any]]:
     """Return the list of Vontology prompt fragments for a user.
 
     Each fragment is a dict with:
@@ -115,14 +178,29 @@ def get_user_specific_prompt_fragments(user_concept_id: str) -> List[Dict[str, A
 
     user_concept_id = user_concept_id.strip()
 
-    relationship_field = f"relationships.{_SPECIFIC_TO_USER_PREDICATE}"
+    debug_enabled = _debug_user_prompt_logging_enabled()
+
+    type_candidates = _normalise_prompt_types(prompt_types)
+    if not type_candidates:
+        return []
+
+    relationship_fields = [
+        f"relationships.{predicate}"
+        for predicate in _SPECIFIC_TO_USER_PREDICATE_CANDIDATES
+        if isinstance(predicate, str) and predicate.strip()
+    ]
+
+    projection = {"concept_id": 1, "name": 1}
+    if debug_enabled:
+        for field in relationship_fields:
+            projection[field] = 1
 
     prompt_candidates = ConceptsRepository.find(
         {
-            "relationships.is_an_instance_of": _VON_LLM_PROMPT_TYPE,
-            relationship_field: user_concept_id,
+            "relationships.is_an_instance_of": {"$in": list(type_candidates)},
+            "$or": [{field: user_concept_id} for field in relationship_fields],
         },
-        projection={"concept_id": 1, "name": 1},
+        projection=projection,
         sort=[("concept_id", 1)],
         limit=50,
     )
@@ -132,6 +210,28 @@ def get_user_specific_prompt_fragments(user_concept_id: str) -> List[Dict[str, A
         concept_id = doc.get("concept_id") if isinstance(doc, dict) else None
         if isinstance(concept_id, str) and concept_id.startswith("#V#"):
             prompt_ids.append(concept_id)
+
+            if debug_enabled:
+                relationships = (
+                    doc.get("relationships") if isinstance(doc, dict) else None
+                )
+                match_predicate = None
+                if isinstance(relationships, dict):
+                    for predicate in _SPECIFIC_TO_USER_PREDICATE_CANDIDATES:
+                        values = relationships.get(predicate)
+                        if isinstance(values, list) and user_concept_id in values:
+                            match_predicate = predicate
+                            break
+                        if isinstance(values, str) and values == user_concept_id:
+                            match_predicate = predicate
+                            break
+
+                logger.debug(
+                    "User prompt concept loaded: concept_id=%s user_concept_id=%s match_predicate=%s",
+                    concept_id,
+                    user_concept_id,
+                    match_predicate or "(unknown)",
+                )
 
     if not prompt_ids:
         return []

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -137,6 +137,47 @@ def _split_history_into_segments(
     return segments
 
 
+def _split_history_into_segments_with_locations(
+    history: List[Dict[str, Any]],
+    *,
+    session_id: str,
+) -> List[List[Dict[str, Any]]]:
+    """Split history into segments, attaching stable location metadata.
+
+    The `history_index` refers to the index in the raw stored `history` array,
+    including reset markers. This allows later targeted updates via
+    `history.<index>` without ambiguity.
+    """
+
+    segments: List[List[Dict[str, Any]]] = []
+    current: List[Dict[str, Any]] = []
+
+    if not isinstance(session_id, str) or not session_id:
+        session_id = ""
+
+    for idx, entry in enumerate(history):
+        if not isinstance(entry, dict):
+            continue
+        if _is_reset_marker(entry):
+            if current:
+                segments.append(current)
+            current = []
+            continue
+
+        # Copy to avoid mutating the stored dict.
+        copied = dict(entry)
+        copied["history_location"] = {
+            "session_id": session_id,
+            "history_index": idx,
+        }
+        current.append(copied)
+
+    if current:
+        segments.append(current)
+
+    return segments
+
+
 def get_chat_history(user_id: str, session_id: str) -> List[Dict[str, Any]]:
     """
     Retrieves the chat history for a specific user and session.
@@ -167,7 +208,10 @@ def get_chat_history(user_id: str, session_id: str) -> List[Dict[str, Any]]:
 
 
 def get_chat_history_segments(
-    user_id: str, session_id: str
+    user_id: str,
+    session_id: str,
+    *,
+    include_locations: bool = False,
 ) -> List[List[Dict[str, Any]]]:
     """
     Return chat history split into segments separated by reset markers.
@@ -198,13 +242,104 @@ def get_chat_history_segments(
             history = doc.get("history") or []
             if not isinstance(history, list) or not history:
                 continue
-            all_segments.extend(_split_history_into_segments(history))
+
+            sid = doc.get("session_id")
+            sid = sid if isinstance(sid, str) else ""
+
+            if include_locations:
+                all_segments.extend(
+                    _split_history_into_segments_with_locations(history, session_id=sid)
+                )
+            else:
+                all_segments.extend(_split_history_into_segments(history))
 
         return all_segments
     except PyMongoError as e:
         logger.error(f"Error retrieving segmented chat history: {e}", exc_info=True)
         raise ChatHistoryServiceError(
             f"Could not retrieve segmented chat history: {e}"
+        ) from e
+
+
+def upsert_presenter_channels_for_history_message(
+    *,
+    user_id: str,
+    session_id: str,
+    history_index: int,
+    presenter_channels: Dict[str, Any],
+    generated_at: Optional[datetime] = None,
+    force: bool = False,
+) -> Dict[str, Any]:
+    """Persist presenter channels onto a stored history message.
+
+    Safety properties:
+    - Does NOT touch the session document's `updated_at` (avoids breaking recency ordering).
+    - By default, does not overwrite an existing `presenter_channels.spoken`.
+
+    Returns a dict describing whether an update occurred.
+    """
+
+    if not isinstance(user_id, str) or not user_id:
+        raise ChatHistoryServiceError("user_id is required")
+    if not isinstance(session_id, str) or not session_id:
+        raise ChatHistoryServiceError("session_id is required")
+    if not isinstance(history_index, int) or history_index < 0:
+        raise ChatHistoryServiceError("history_index must be a non-negative integer")
+    if not isinstance(presenter_channels, dict) or not presenter_channels:
+        raise ChatHistoryServiceError("presenter_channels must be a non-empty dict")
+
+    chat_history_coll = get_chat_history_collection_service()
+    if chat_history_coll is None:
+        raise ChatHistoryServiceError("Could not connect to chat history collection.")
+
+    try:
+        doc = chat_history_coll.find_one(
+            {"user_id": user_id, "session_id": session_id}, {"history": 1}
+        )
+        history = (doc or {}).get("history") or []
+        if not isinstance(history, list) or history_index >= len(history):
+            return {"updated": False, "reason": "index_out_of_range"}
+
+        entry = history[history_index]
+        if not isinstance(entry, dict):
+            return {"updated": False, "reason": "entry_not_dict"}
+        if entry.get("role") != "assistant":
+            return {"updated": False, "reason": "not_assistant"}
+
+        existing_debug = entry.get("llm_debug_data")
+        existing_channels = None
+        if isinstance(existing_debug, dict):
+            existing_channels = existing_debug.get("presenter_channels")
+
+        if not force and isinstance(existing_channels, dict):
+            existing_spoken = existing_channels.get("spoken")
+            if isinstance(existing_spoken, str) and existing_spoken.strip():
+                return {"updated": False, "reason": "spoken_already_present"}
+
+        if generated_at is None:
+            generated_at = datetime.now(timezone.utc)
+
+        set_fields: Dict[str, Any] = {
+            f"history.{history_index}.llm_debug_data.presenter_channels": presenter_channels,
+            f"history.{history_index}.llm_debug_data.presenter_channels_generated_at": generated_at,
+        }
+
+        result = chat_history_coll.update_one(
+            {"user_id": user_id, "session_id": session_id}, {"$set": set_fields}
+        )
+
+        return {
+            "updated": bool(getattr(result, "modified_count", 0) > 0),
+            "matched": bool(getattr(result, "matched_count", 0) > 0),
+        }
+    except PyMongoError as e:
+        logger.error(
+            "Error upserting presenter channels for history message: %s",
+            e,
+            exc_info=True,
+        )
+        raise ChatHistoryServiceError(
+            f"Could not update history message presenter channels: {e}"
         ) from e
 
 

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -17,6 +17,78 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+_DETERMINISTIC_RAG_DOC_NAMESPACE = uuid.UUID("8c5a7fa9-9a7c-4f0f-8c1f-f4ad7f9f6fd7")
+
+
+def _derive_rag_namespace(
+    *, session_context: Dict[str, Any], user_id: str
+) -> Optional[str]:
+    ns = session_context.get("namespace")
+    if isinstance(ns, str) and ns.strip():
+        return ns.strip()
+
+    org_id = session_context.get("organisation_concept_id") or session_context.get(
+        "org_id"
+    )
+    if isinstance(org_id, str) and org_id.strip():
+        try:
+            from src.backend.services.namespace_service import derive_namespace
+
+            user_slug = user_id[3:] if user_id.startswith("#V#") else user_id
+            org_slug = org_id[3:] if org_id.startswith("#V#") else org_id
+            return derive_namespace(user_slug, org_slug)
+        except Exception:
+            return None
+
+    return None
+
+
+def _build_rag_metadata(
+    *,
+    session_context: Dict[str, Any],
+    user_id: str,
+    session_id: str,
+    role: str,
+    channel: Optional[str] = None,
+    history_index: Optional[int] = None,
+    generated_at: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {
+        "user_id": user_id,
+        "session_id": session_id,
+        "role": role,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "type": "chat_message",
+    }
+    if isinstance(channel, str) and channel.strip():
+        metadata["channel"] = channel.strip()
+    if isinstance(history_index, int) and history_index >= 0:
+        metadata["history_index"] = history_index
+    if isinstance(generated_at, datetime):
+        metadata["generated_at"] = generated_at.isoformat()
+
+    org_concept_id = session_context.get("organisation_concept_id")
+    if org_concept_id:
+        from ..utils.concept_id_utils import ensure_v_concept_prefix
+
+        metadata["organisation_concept_id"] = (
+            ensure_v_concept_prefix(org_concept_id) or org_concept_id
+        )
+    if session_context.get("role_in_org"):
+        metadata["role_in_org"] = session_context["role_in_org"]
+
+    return metadata
+
+
+def _truncate_for_rag(text: str, *, max_chars: int = 5000) -> str:
+    if not isinstance(text, str):
+        return ""
+    txt = text
+    if len(txt) > max_chars:
+        txt = txt[:max_chars]
+    return txt
+
+
 def get_session_context() -> Dict[str, Any]:
     """
     Get organisation and role context from Flask session.
@@ -328,8 +400,49 @@ def upsert_presenter_channels_for_history_message(
             {"user_id": user_id, "session_id": session_id}, {"$set": set_fields}
         )
 
+        updated = bool(getattr(result, "modified_count", 0) > 0)
+
+        # If we generated spoken narration for an existing stored message, index it to RAG
+        # so it is retrievable later.
+        if updated and get_rag_service:
+            try:
+                rag = get_rag_service()
+                spoken = presenter_channels.get("spoken")
+                if isinstance(spoken, str) and spoken.strip():
+                    session_context = get_session_context()
+                    ns = _derive_rag_namespace(
+                        session_context=session_context, user_id=user_id
+                    )
+                    if not isinstance(ns, str) or not ns.strip():
+                        ns = "chat_history"
+
+                    doc_id = str(
+                        uuid.uuid5(
+                            _DETERMINISTIC_RAG_DOC_NAMESPACE,
+                            f"{user_id}|{session_id}|{history_index}|spoken",
+                        )
+                    )
+                    doc = {
+                        "id": doc_id,
+                        "text": _truncate_for_rag(spoken.strip()),
+                        "metadata": _build_rag_metadata(
+                            session_context=session_context,
+                            user_id=user_id,
+                            session_id=session_id,
+                            role="assistant",
+                            channel="spoken",
+                            history_index=history_index,
+                            generated_at=generated_at,
+                        ),
+                    }
+                    rag.upsert_documents([doc], namespace=ns)
+            except Exception as e:
+                logger.warning(
+                    "Failed to index backfilled spoken narration to RAG: %s", e
+                )
+
         return {
-            "updated": bool(getattr(result, "modified_count", 0) > 0),
+            "updated": updated,
             "matched": bool(getattr(result, "matched_count", 0) > 0),
         }
     except PyMongoError as e:
@@ -373,21 +486,7 @@ def add_message_to_history(
         session_context = get_session_context()
 
         # Determine namespace used for both persistence and RAG indexing.
-        # Prefer an explicit session namespace, else derive one from user/org when possible.
-        ns = session_context.get("namespace")
-        if not isinstance(ns, str) or not ns.strip():
-            org_id = session_context.get(
-                "organisation_concept_id"
-            ) or session_context.get("org_id")
-            if isinstance(org_id, str) and org_id.strip():
-                try:
-                    from src.backend.services.namespace_service import derive_namespace
-
-                    user_slug = user_id[3:] if user_id.startswith("#V#") else user_id
-                    org_slug = org_id[3:] if org_id.startswith("#V#") else org_id
-                    ns = derive_namespace(user_slug, org_slug)
-                except Exception:
-                    ns = None
+        ns = _derive_rag_namespace(session_context=session_context, user_id=user_id)
 
         # Add timestamp to message (and llm_debug_data if present)
         message_with_timestamp = {**message, "timestamp": datetime.now(timezone.utc)}
@@ -421,34 +520,45 @@ def add_message_to_history(
                 # Only index string content that isn't empty
                 if isinstance(content, str) and content.strip():
                     # Skip indexing tool outputs that are just "truncated" markers or very small
-                    if len(content) > 5000:  # Truncate for indexing if huge
-                        content = content[:5000]
+                    content = _truncate_for_rag(content)
 
                     # Get session context for organisation and role
-                    doc_id = str(uuid.uuid4())
-                    metadata = {
-                        "user_id": user_id,
-                        "session_id": session_id,
-                        "role": message.get("role", "unknown"),
-                        "timestamp": datetime.now(timezone.utc).isoformat(),
-                        "type": "chat_message",
+                    role = message.get("role", "unknown")
+                    doc = {
+                        "id": str(uuid.uuid4()),
+                        "text": content,
+                        "metadata": _build_rag_metadata(
+                            session_context=session_context,
+                            user_id=user_id,
+                            session_id=session_id,
+                            role=role,
+                            channel=None,
+                        ),
                     }
-
-                    # Include organisation and role metadata if available
-                    org_concept_id = session_context.get("organisation_concept_id")
-                    if org_concept_id:
-                        from ..utils.concept_id_utils import ensure_v_concept_prefix
-
-                        metadata["organisation_concept_id"] = (
-                            ensure_v_concept_prefix(org_concept_id) or org_concept_id
-                        )
-                    if session_context.get("role_in_org"):
-                        metadata["role_in_org"] = session_context["role_in_org"]
-
-                    doc = {"id": doc_id, "text": content, "metadata": metadata}
                     if not isinstance(ns, str) or not ns.strip():
                         ns = "chat_history"
                     rag.upsert_documents([doc], namespace=ns)
+
+                    # If this is an assistant message in presenter mode, also index the spoken talk track.
+                    if role == "assistant" and isinstance(llm_debug_data, dict):
+                        presenter_channels = llm_debug_data.get("presenter_channels")
+                        if isinstance(presenter_channels, dict):
+                            spoken = presenter_channels.get("spoken")
+                            if isinstance(spoken, str) and spoken.strip():
+                                spoken_txt = spoken.strip()
+                                if spoken_txt != content.strip():
+                                    spoken_doc = {
+                                        "id": str(uuid.uuid4()),
+                                        "text": _truncate_for_rag(spoken_txt),
+                                        "metadata": _build_rag_metadata(
+                                            session_context=session_context,
+                                            user_id=user_id,
+                                            session_id=session_id,
+                                            role=role,
+                                            channel="spoken",
+                                        ),
+                                    }
+                                    rag.upsert_documents([spoken_doc], namespace=ns)
 
                     # Track indexing progress per chat session for status UI.
                     try:

--- a/src/frontend/web/von_interface/static/js/chat.js
+++ b/src/frontend/web/von_interface/static/js/chat.js
@@ -1,5 +1,5 @@
-import { elements, addMessageToChat, renderSpanSuggestions } from './domUtils.js';
-import { postJson, annotateTurn } from './apiService.js';
+import { annotateTurn, postJson } from './apiService.js';
+import { addMessageToChat, elements, renderSpanSuggestions } from './domUtils.js';
 
 export async function sendMessageToServer() {
   const prompt = elements.promptInput.value.trim();
@@ -7,13 +7,13 @@ export async function sendMessageToServer() {
   if (elements.loadingIndicator) elements.loadingIndicator.style.display = 'block';
   if (elements.vonIntro) elements.vonIntro.style.display = 'none';
   const userTurnId = `u-${Date.now()}`;
-  addMessageToChat('user', prompt, {turnId: userTurnId});
+  addMessageToChat('user', prompt, { turnId: userTurnId });
   elements.promptInput.value = '';
   try {
-    const data = await postJson('/von/generate', { prompt });
+    const data = await postJson('/von/generate', { prompt, presenter_mode: true });
     const assistantText = data.response || data.message || 'No response';
     const assistantTurnId = `a-${Date.now()}`;
-    addMessageToChat('assistant', assistantText, {turnId: assistantTurnId});
+    addMessageToChat('assistant', assistantText, { turnId: assistantTurnId });
 
     // Send annotations for both turns (user and assistant). For now we send minimal payloads.
     try {
@@ -23,7 +23,7 @@ export async function sendMessageToServer() {
         turn_id: userTurnId,
         speaker: 'user',
         text: prompt
-      }).then(() => {}).catch((e) => console.debug('Annotation user failed', e));
+      }).then(() => { }).catch((e) => console.debug('Annotation user failed', e));
 
       // Annotate assistant turn and render suggestions inline when available
       annotateTurn({
@@ -68,7 +68,7 @@ document.addEventListener('annotation:candidateSelected', (ev) => {
   try {
     // optimistic UI update: show immediate timing placeholder
     import('./domUtils.js').then(mod => mod.setAnnotationTiming(turnId, '…'));
-  } catch (_) {}
+  } catch (_) { }
 
   // POST acceptance to backend
   (async () => {
@@ -79,17 +79,17 @@ document.addEventListener('annotation:candidateSelected', (ev) => {
         body: JSON.stringify({ turn_id: turnId, span: span, candidate: candidate, user_id: getCurrentUser().id })
       });
       const elapsed = Date.now() - start;
-      try { import('./domUtils.js').then(mod => mod.setAnnotationTiming(turnId, elapsed)); } catch(_){}
+      try { import('./domUtils.js').then(mod => mod.setAnnotationTiming(turnId, elapsed)); } catch (_) { }
       if (!resp.ok) {
         console.warn('Annotation accept failed', resp.status);
       } else {
         console.debug('Annotation accepted persisted', await resp.json());
         // Optimistic UI: mark candidate as accepted and show undo
-        try { import('./domUtils.js').then(mod => mod.markCandidateAccepted(turnId, candidate.id || candidate.concept_id || candidate.conceptId || candidate.name, candidate.name || candidate.id)); } catch(_){}
+        try { import('./domUtils.js').then(mod => mod.markCandidateAccepted(turnId, candidate.id || candidate.concept_id || candidate.conceptId || candidate.name, candidate.name || candidate.id)); } catch (_) { }
       }
     } catch (e) {
       const elapsed = Date.now() - start;
-      try { import('./domUtils.js').then(mod => mod.setAnnotationTiming(turnId, elapsed)); } catch(_){}
+      try { import('./domUtils.js').then(mod => mod.setAnnotationTiming(turnId, elapsed)); } catch (_) { }
       console.error('Error sending accept', e);
     }
   })();

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -22,6 +22,75 @@ const transcriptTurns = [];
 let historySegmentsShown = 1;
 let totalHistorySegments = 1;
 
+// Cool-down for failed history talk-track backfills so we do not spam the server.
+// Map<turnId, { at: number, error: string }>
+const historySpokenBackfillFailures = new Map();
+const HISTORY_SPOKEN_BACKFILL_FAILURE_COOLDOWN_MS = 30_000;
+
+function stripMarkdownForSpeech(text) {
+    const input = String(text ?? '');
+    if (!input.trim()) {
+        return '';
+    }
+
+    let value = input;
+
+    // Remove fenced code blocks entirely.
+    value = value.replace(/```[\s\S]*?```/g, ' ');
+
+    // Replace inline code with its content.
+    value = value.replace(/`([^`]+)`/g, '$1');
+
+    // Replace markdown links [text](url) -> text.
+    value = value.replace(/\[([^\]]+)\]\([^\)]+\)/g, '$1');
+
+    // Remove images ![alt](url) -> alt.
+    value = value.replace(/!\[([^\]]*)\]\([^\)]+\)/g, '$1');
+
+    // Remove headings/bullets/quotes markers.
+    value = value
+        .replace(/^\s{0,3}#{1,6}\s+/gm, '')
+        .replace(/^\s{0,3}>\s?/gm, '')
+        .replace(/^\s*[-*+]\s+/gm, '')
+        .replace(/^\s*\d+\.[\s]+/gm, '');
+
+    // Remove emphasis markers.
+    value = value.replace(/\*\*([^*]+)\*\*/g, '$1');
+    value = value.replace(/\*([^*]+)\*/g, '$1');
+    value = value.replace(/__([^_]+)__/g, '$1');
+    value = value.replace(/_([^_]+)_/g, '$1');
+
+    // Remove horizontal rules.
+    value = value.replace(/^\s*---+\s*$/gm, ' ');
+
+    // Collapse whitespace.
+    value = value.replace(/[ \t]+/g, ' ');
+    value = value.replace(/\n{3,}/g, '\n\n');
+    value = value.trim();
+
+    return value;
+}
+
+function deriveNarrationFromScreenText(screenText, options = {}) {
+    const cleaned = stripMarkdownForSpeech(screenText);
+    if (!cleaned) {
+        return '';
+    }
+
+    const maxChars = Number.isFinite(options.maxChars) ? options.maxChars : 900;
+    if (cleaned.length <= maxChars) {
+        return cleaned;
+    }
+
+    // Prefer not to cut mid-sentence if possible.
+    const slice = cleaned.slice(0, maxChars);
+    const lastBreak = Math.max(slice.lastIndexOf('. '), slice.lastIndexOf('? '), slice.lastIndexOf('! '));
+    if (lastBreak > 200) {
+        return slice.slice(0, lastBreak + 1).trim() + '…';
+    }
+    return slice.trim() + '…';
+}
+
 function normalisePresenterChannels(value) {
     if (!value || typeof value !== 'object') {
         return null;
@@ -977,6 +1046,11 @@ function toggleSpeakTurn(turnId, text, button) {
         return;
     }
 
+    const trimmed = String(text ?? '').trim();
+    if (!trimmed) {
+        return;
+    }
+
     const isAlreadyActive = activeTtsTurnId === turnId;
     if (isAlreadyActive) {
         stopSpeaking();
@@ -998,7 +1072,7 @@ function toggleSpeakTurn(turnId, text, button) {
     let utterance = null;
     try {
         const settings = getChatSpeechSettings();
-        utterance = speakText(text, {
+        utterance = speakText(trimmed, {
             language: settings.tts.language,
             rate: settings.tts.rate,
             pitch: settings.tts.pitch,
@@ -1488,8 +1562,12 @@ function rehydrateHistory(scrollableField, historyMessages, options = {}) {
 
             // Restore debug data before rendering so markdown gating can see model info.
             const hasDebugData = msg.role === 'assistant' && !!msg.llm_debug_data;
-            if (hasDebugData) {
-                llmDebugData.set(turnId, msg.llm_debug_data);
+            if (msg.role === 'assistant') {
+                const merged = {
+                    ...(msg.llm_debug_data && typeof msg.llm_debug_data === 'object' ? msg.llm_debug_data : {}),
+                    history_location: msg.history_location || null
+                };
+                llmDebugData.set(turnId, merged);
             }
 
             appendMessage(label, msg.content, turnId, hasDebugData, true, msg.timestamp);
@@ -1864,6 +1942,10 @@ async function handleSendPrompt() {
 
         // Get user context from localStorage to send to backend
         const userContext = getUserContext();
+        // Presenter-mode controls whether the backend produces two-channel output
+        // (screen + spoken). This should be enabled regardless of whether auto-TTS
+        // is enabled, so clicking Speak later never needs to read raw markdown.
+        const presenterMode = true;
 
         const response = await fetch('/von/generate', {
             method: 'POST',
@@ -1876,7 +1958,8 @@ async function handleSendPrompt() {
                 user_id: userContext.user_id,
                 org_id: userContext.org_id,
                 language: userContext.language,
-                gmail_profile: userContext.gmail_profile
+                gmail_profile: userContext.gmail_profile,
+                presenter_mode: presenterMode
             })
         });
 
@@ -1899,7 +1982,8 @@ async function handleSendPrompt() {
         if (response.ok) {
             // Store LLM debug data if available
             if (data.llm_debug) {
-                const responseChannels = normalisePresenterChannels(data.response_channels);
+                const presenterChannelsRaw = data.presenter_channels || data.response_channels || data?.metadata?.presenter_channels;
+                const responseChannels = normalisePresenterChannels(presenterChannelsRaw);
                 const screenText = responseChannels?.screen ? responseChannels.screen : String(data.response ?? '');
                 const spokenText = responseChannels?.spoken ? responseChannels.spoken : null;
                 const enriched = enrichDebugDataWithSpeechPlanning(data.llm_debug, {
@@ -1913,7 +1997,8 @@ async function handleSendPrompt() {
 
             const fastpathMeta = data.fastpath || (data.llm_debug && data.llm_debug.fastpath) || null;
 
-            const responseChannels = normalisePresenterChannels(data.response_channels);
+            const presenterChannelsRaw = data.presenter_channels || data.response_channels || data?.metadata?.presenter_channels;
+            const responseChannels = normalisePresenterChannels(presenterChannelsRaw);
             const screenText = responseChannels?.screen ? responseChannels.screen : String(data.response ?? '');
             const spokenText = responseChannels?.spoken ? responseChannels.spoken : null;
 
@@ -2059,27 +2144,88 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
 
             // Add message content
             const messageContent = document.createElement('div');
-            messageContent.style.cssText = 'flex: 1; line-height: 1.5;';
+            // IMPORTANT: in a flex row, children default to min-width:auto, which can
+            // force horizontal overflow and clip the header control buttons when the
+            // left header text is long. min-width:0 allows proper wrapping/shrinking.
+            messageContent.style.cssText = 'flex: 1; min-width: 0; line-height: 1.5;';
 
             const rawText = String(message ?? '');
 
-            let ttsTextForTurn = (typeof ttsText === 'string' && ttsText.trim()) ? ttsText : null;
-            if (!ttsTextForTurn && turnId) {
+            const screenTextForTurn = rawText;
+            let spokenTextForTurn = (typeof ttsText === 'string' && ttsText.trim()) ? ttsText : null;
+            if (!spokenTextForTurn && turnId) {
                 const debugDataForTurn = llmDebugData.get(turnId);
                 const channels = normalisePresenterChannels(debugDataForTurn?.presenter_channels);
-                if (channels?.spoken) {
-                    ttsTextForTurn = channels.spoken;
+                if (channels?.spoken && channels.spoken.trim()) {
+                    spokenTextForTurn = channels.spoken;
                 }
             }
-            if (!ttsTextForTurn) {
-                ttsTextForTurn = rawText;
+
+            async function ensureHistorySpokenTalkTrack() {
+                if (!isHistory || !turnId) {
+                    return null;
+                }
+
+                const recentFailure = historySpokenBackfillFailures.get(turnId);
+                if (recentFailure && (Date.now() - recentFailure.at) < HISTORY_SPOKEN_BACKFILL_FAILURE_COOLDOWN_MS) {
+                    return null;
+                }
+
+                const debugDataForTurn = llmDebugData.get(turnId);
+                const historyLocation = debugDataForTurn?.history_location;
+                if (!historyLocation || typeof historyLocation !== 'object') {
+                    return null;
+                }
+
+                try {
+                    const resp = await fetch('/von/history/backfill_spoken', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ history_location: historyLocation })
+                    });
+
+                    const data = await resp.json().catch(() => ({}));
+                    if (!resp.ok) {
+                        const errMsg = (data && typeof data.error === 'string' && data.error.trim())
+                            ? data.error.trim()
+                            : `HTTP ${resp.status}`;
+                        historySpokenBackfillFailures.set(turnId, { at: Date.now(), error: errMsg, shownAt: null });
+                        console.warn('[chatTab] backfill_spoken failed:', data);
+                        return null;
+                    }
+
+                    const channels = normalisePresenterChannels(data?.presenter_channels);
+                    if (!channels?.spoken || !channels.spoken.trim()) {
+                        return null;
+                    }
+
+                    // Cache the generated channels in-memory so subsequent clicks work.
+                    const existing = llmDebugData.get(turnId);
+                    llmDebugData.set(turnId, {
+                        ...(existing && typeof existing === 'object' ? existing : {}),
+                        presenter_channels: channels
+                    });
+
+                    // Clear any previous failure cool-down.
+                    historySpokenBackfillFailures.delete(turnId);
+
+                    return channels.spoken;
+                } catch (err) {
+                    console.warn('[chatTab] backfill_spoken request failed:', err);
+                    const errMsg = err && typeof err.message === 'string' && err.message.trim()
+                        ? err.message.trim()
+                        : 'Request failed';
+                    historySpokenBackfillFailures.set(turnId, { at: Date.now(), error: errMsg, shownAt: null });
+                    return null;
+                }
             }
 
             const messageHeader = document.createElement('div');
-            messageHeader.style.cssText = 'font-weight: bold; color: #007bff; margin-bottom: 5px; font-size: 0.9em; display: flex; align-items: center; gap: 8px;';
+            messageHeader.style.cssText = 'font-weight: bold; color: #007bff; margin-bottom: 5px; font-size: 0.9em; display: flex; flex-wrap: wrap; align-items: center; gap: 8px;';
 
             const headerText = document.createElement('span');
             headerText.textContent = `Von • ${displayTimestamp}${historySuffix}`;
+            headerText.style.minWidth = '0';
             messageHeader.appendChild(headerText);
 
             // Add fast-path indicator if the server bypassed the LLM.
@@ -2170,7 +2316,50 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
 
             const rightControls = document.createElement('span');
             rightControls.className = 'chat-message-controls';
-            rightControls.style.cssText = 'margin-left: auto; display: inline-flex; align-items: center; gap: 6px;';
+            rightControls.style.cssText = 'margin-left: auto; display: inline-flex; align-items: center; gap: 6px; flex: 0 0 auto;';
+
+            const showTtsNotice = (text, options = {}) => {
+                const msg = String(text ?? '').trim();
+                if (!msg) {
+                    return;
+                }
+
+                const existing = rightControls.querySelector('.chat-tts-notice');
+                if (existing) {
+                    try { existing.remove(); } catch (_) { /* ignore */ }
+                }
+
+                const notice = document.createElement('span');
+                notice.className = 'chat-tts-notice';
+                notice.textContent = msg;
+                notice.title = msg;
+                notice.setAttribute('role', 'status');
+                notice.setAttribute('aria-live', 'polite');
+                notice.style.cssText = [
+                    'display: inline-flex',
+                    'align-items: center',
+                    'max-width: 320px',
+                    'padding: 1px 6px',
+                    'border-radius: 10px',
+                    'font-size: 0.78em',
+                    'line-height: 1.2',
+                    'background: #fff3cd',
+                    'border: 1px solid #ffeeba',
+                    'color: #856404',
+                    'white-space: nowrap',
+                    'overflow: hidden',
+                    'text-overflow: ellipsis'
+                ].join(';');
+
+                rightControls.insertBefore(notice, rightControls.firstChild);
+
+                const durationMs = Number.isFinite(options.durationMs) ? options.durationMs : 4500;
+                if (durationMs > 0) {
+                    setTimeout(() => {
+                        try { notice.remove(); } catch (_) { /* ignore */ }
+                    }, durationMs);
+                }
+            };
 
             // Render-mode badge: shows whether this message is in Rendered/Text mode.
             const renderModeBadge = document.createElement('span');
@@ -2183,20 +2372,78 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
             speakButton.className = 'btn-mini chat-tts-button';
             speakButton.type = 'button';
             speakButton.textContent = 'Speak';
-            speakButton.title = 'Speak this response aloud';
+            speakButton.title = 'Speak the talk track aloud (Shift+click to speak the on-screen text)';
             if (!ttsSupported) {
                 speakButton.disabled = true;
                 speakButton.title = 'Text-to-speech is not supported in this browser.';
             }
-            speakButton.addEventListener('click', (e) => {
+            speakButton.addEventListener('click', async (e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                toggleSpeakTurn(turnId, ttsTextForTurn, speakButton);
+
+                const wantsScreen = !!(e && e.shiftKey);
+                const getScreenTextForSpeech = () => {
+                    const displayed = (messageText && (messageText.innerText || messageText.textContent))
+                        ? (messageText.innerText || messageText.textContent)
+                        : screenTextForTurn;
+                    return stripMarkdownForSpeech(displayed);
+                };
+
+                let desiredText = wantsScreen ? getScreenTextForSpeech() : (spokenTextForTurn || '');
+                if (!wantsScreen && !String(desiredText ?? '').trim() && isHistory) {
+                    // For legacy history turns, try to backfill a talk track on-demand.
+                    const originalLabel = speakButton.textContent;
+                    const originalTitle = speakButton.title;
+                    const originalDisabled = speakButton.disabled;
+                    try {
+                        speakButton.disabled = true;
+                        speakButton.textContent = 'Generating…';
+                        speakButton.title = 'Generating talk track…';
+
+                        const backfilled = await ensureHistorySpokenTalkTrack();
+                        if (typeof backfilled === 'string' && backfilled.trim()) {
+                            spokenTextForTurn = backfilled;
+                            desiredText = backfilled;
+                        }
+                    } finally {
+                        speakButton.disabled = originalDisabled;
+                        speakButton.textContent = originalLabel;
+                        speakButton.title = originalTitle;
+                    }
+                }
+
+                // If no talk track is available, derive a plain narration from the screen text.
+                // Never speak raw markdown.
+                if (!String(desiredText ?? '').trim() && !wantsScreen) {
+                    const failure = turnId ? historySpokenBackfillFailures.get(turnId) : null;
+                    const reason = failure?.error ? ` (talk track unavailable: ${failure.error})` : '';
+                    desiredText = deriveNarrationFromScreenText(screenTextForTurn);
+                    speakButton.title = `Speaking a derived narration${reason}. Shift+click speaks the on-screen text.`;
+
+                    if (failure && typeof failure === 'object') {
+                        const shouldShow = !failure.shownAt || (typeof failure.at === 'number' && failure.shownAt < failure.at);
+                        if (shouldShow) {
+                            const errShort = typeof failure.error === 'string' ? failure.error.trim() : '';
+                            const msg = errShort
+                                ? `Talk track unavailable — speaking on-screen text (${errShort})`
+                                : 'Talk track unavailable — speaking on-screen text';
+                            showTtsNotice(msg);
+                            historySpokenBackfillFailures.set(turnId, { ...failure, shownAt: Date.now() });
+                        }
+                    }
+                }
+
+                if (!String(desiredText ?? '').trim()) {
+                    speakButton.title = 'Nothing to speak.';
+                    return;
+                }
+
+                toggleSpeakTurn(turnId, desiredText, speakButton);
             });
             rightControls.appendChild(speakButton);
 
             const messageText = document.createElement('div');
-            messageText.style.cssText = 'color: #333; white-space: pre-wrap; text-align: left; font-weight: 400;';
+            messageText.style.cssText = 'color: #333; white-space: pre-wrap; text-align: left; font-weight: 400; overflow-wrap: anywhere; word-break: break-word;';
             try {
                 const debugData = turnId ? llmDebugData.get(turnId) : null;
                 const canRenderMarkdown = shouldRenderMarkdownForAssistant(rawText, debugData);
@@ -2250,8 +2497,10 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
 
                 // Auto-speak new assistant responses when enabled.
                 if (!isHistory && turnId && ttsSupported && isChatTtsEnabled()) {
-                    // Ensure we speak the original model output (not rendered HTML).
-                    toggleSpeakTurn(turnId, ttsTextForTurn, speakButton);
+                    // Auto-speak uses the talk track only (never the screen channel).
+                    if (spokenTextForTurn && spokenTextForTurn.trim()) {
+                        toggleSpeakTurn(turnId, spokenTextForTurn, speakButton);
+                    }
                 }
             } catch (e) {
                 console.error('[chatTab] Failed to render Von message:', e);
@@ -2773,5 +3022,26 @@ export const exportConversationMarkdown = handleExportConversationMarkdown;
 export const setLlmDebugDataForTurn = (turnId, debugData) => {
     llmDebugData.set(turnId, debugData);
 };
+// Export for testing
+export const __test_only__rehydrateHistory = rehydrateHistory;
+
+// Export for testing.
+export function __testOnly_resetChatTtsState() {
+    try {
+        stopSpeaking();
+    } catch (_) {
+        // Ignore.
+    }
+    try {
+        clearActiveTtsUi();
+    } catch (_) {
+        // Ignore.
+    }
+    try {
+        historySpokenBackfillFailures.clear();
+    } catch (_) {
+        // Ignore.
+    }
+}
 export { formatChatTimestamp, showLlmDebugPopup, updateHistoryLength };
 

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -22,6 +22,65 @@ const transcriptTurns = [];
 let historySegmentsShown = 1;
 let totalHistorySegments = 1;
 
+function normalisePresenterChannels(value) {
+    if (!value || typeof value !== 'object') {
+        return null;
+    }
+
+    const screen = typeof value.screen === 'string' ? value.screen : null;
+    const spoken = typeof value.spoken === 'string' ? value.spoken : null;
+    const format = typeof value.format === 'string' ? value.format : null;
+
+    const hasAny = (screen && screen.trim()) || (spoken && spoken.trim());
+    if (!hasAny) {
+        return null;
+    }
+
+    return {
+        screen: screen && screen.trim() ? screen : null,
+        spoken: spoken && spoken.trim() ? spoken : null,
+        format
+    };
+}
+
+function enrichDebugDataWithSpeechPlanning(debugData, options = {}) {
+    if (!debugData || typeof debugData !== 'object') {
+        return debugData;
+    }
+
+    const presenterChannels = normalisePresenterChannels(
+        options.presenterChannels || debugData.presenter_channels
+    );
+
+    const screenText =
+        (typeof options.screenText === 'string' && options.screenText.trim())
+            ? options.screenText
+            : (presenterChannels?.screen || (typeof debugData.response === 'string' ? debugData.response : ''));
+
+    const spokenText =
+        (typeof options.spokenText === 'string' && options.spokenText.trim())
+            ? options.spokenText
+            : (presenterChannels?.spoken || '');
+
+    const ttsText = (spokenText && spokenText.trim()) ? spokenText : screenText;
+    const ttsSource = (spokenText && spokenText.trim()) ? 'spoken' : 'screen';
+
+    const speechPlanning = {
+        enabled_by_protocol: !!presenterChannels,
+        presenter_format: presenterChannels?.format || null,
+        tts_source: ttsSource,
+        screen_chars: typeof screenText === 'string' ? screenText.length : 0,
+        spoken_chars: typeof spokenText === 'string' ? spokenText.length : 0,
+        tts_chars: typeof ttsText === 'string' ? ttsText.length : 0
+    };
+
+    return {
+        ...debugData,
+        presenter_channels: presenterChannels || debugData.presenter_channels || null,
+        speech_planning: speechPlanning
+    };
+}
+
 function escapeHtml(value) {
     const text = String(value ?? '');
     return text
@@ -1840,14 +1899,26 @@ async function handleSendPrompt() {
         if (response.ok) {
             // Store LLM debug data if available
             if (data.llm_debug) {
-                llmDebugData.set(assistantTurnId, data.llm_debug);
+                const responseChannels = normalisePresenterChannels(data.response_channels);
+                const screenText = responseChannels?.screen ? responseChannels.screen : String(data.response ?? '');
+                const spokenText = responseChannels?.spoken ? responseChannels.spoken : null;
+                const enriched = enrichDebugDataWithSpeechPlanning(data.llm_debug, {
+                    presenterChannels: responseChannels,
+                    screenText,
+                    spokenText
+                });
+                llmDebugData.set(assistantTurnId, enriched);
                 console.log('[chatTab] Stored LLM debug data for turn:', assistantTurnId);
             }
 
             const fastpathMeta = data.fastpath || (data.llm_debug && data.llm_debug.fastpath) || null;
 
+            const responseChannels = normalisePresenterChannels(data.response_channels);
+            const screenText = responseChannels?.screen ? responseChannels.screen : String(data.response ?? '');
+            const spokenText = responseChannels?.spoken ? responseChannels.spoken : null;
+
             // Append assistant message with turnId and llm_debug flag
-            appendMessage('Von', data.response, assistantTurnId, !!data.llm_debug, false, null, fastpathMeta);
+            appendMessage('Von', screenText, assistantTurnId, !!data.llm_debug, false, null, fastpathMeta, spokenText);
             // Annotate assistant turn and render suggestions when returned - only if toggle is enabled
             const annotationToggle = document.getElementById('annotationToggle');
             if (annotationToggle && annotationToggle.checked) {
@@ -1856,7 +1927,7 @@ async function handleSendPrompt() {
                         conversation_id: elements.conversationId || 'local',
                         turn_id: assistantTurnId,
                         speaker: 'assistant',
-                        text: data.response
+                        text: screenText
                     }).then((resp) => {
                         console.info('[annotations] annotateTurn response (chatTab)', resp);
                         if (resp && resp.suggestions) {
@@ -1964,7 +2035,7 @@ function formatChatTimestamp(isoString) {
     }
 }
 
-function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory = false, timestampStr = null, fastpathMeta = null) {
+function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory = false, timestampStr = null, fastpathMeta = null, ttsText = null) {
     const scrollableField = document.getElementById('scrollableField');
     if (!scrollableField) {
         console.error('[chatTab] appendMessage: scrollableField not found!');
@@ -1991,6 +2062,18 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
             messageContent.style.cssText = 'flex: 1; line-height: 1.5;';
 
             const rawText = String(message ?? '');
+
+            let ttsTextForTurn = (typeof ttsText === 'string' && ttsText.trim()) ? ttsText : null;
+            if (!ttsTextForTurn && turnId) {
+                const debugDataForTurn = llmDebugData.get(turnId);
+                const channels = normalisePresenterChannels(debugDataForTurn?.presenter_channels);
+                if (channels?.spoken) {
+                    ttsTextForTurn = channels.spoken;
+                }
+            }
+            if (!ttsTextForTurn) {
+                ttsTextForTurn = rawText;
+            }
 
             const messageHeader = document.createElement('div');
             messageHeader.style.cssText = 'font-weight: bold; color: #007bff; margin-bottom: 5px; font-size: 0.9em; display: flex; align-items: center; gap: 8px;';
@@ -2108,7 +2191,7 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
             speakButton.addEventListener('click', (e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                toggleSpeakTurn(turnId, rawText, speakButton);
+                toggleSpeakTurn(turnId, ttsTextForTurn, speakButton);
             });
             rightControls.appendChild(speakButton);
 
@@ -2168,7 +2251,7 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
                 // Auto-speak new assistant responses when enabled.
                 if (!isHistory && turnId && ttsSupported && isChatTtsEnabled()) {
                     // Ensure we speak the original model output (not rendered HTML).
-                    toggleSpeakTurn(turnId, rawText, speakButton);
+                    toggleSpeakTurn(turnId, ttsTextForTurn, speakButton);
                 }
             } catch (e) {
                 console.error('[chatTab] Failed to render Von message:', e);
@@ -2326,7 +2409,8 @@ function initializeLlmDebugPopup() {
 
 // Show LLM debug popup for a specific turn
 function showLlmDebugPopup(turnId) {
-    const debugData = llmDebugData.get(turnId);
+    const debugDataRaw = llmDebugData.get(turnId);
+    const debugData = enrichDebugDataWithSpeechPlanning(debugDataRaw, { turnId });
     if (!debugData) {
         console.warn('[chatTab] No debug data for turn:', turnId);
         return;
@@ -2354,6 +2438,11 @@ function showLlmDebugPopup(turnId) {
         model: debugData.model || 'Unknown',
         message_count: debugData.messages?.length || 0
     };
+
+    if (debugData.presenter_channels || debugData.speech_planning) {
+        metadata.speech_planning = debugData.speech_planning || null;
+        metadata.presenter_channels = debugData.presenter_channels || null;
+    }
 
     // LLM interaction telemetry (JVNAUTOSCI-877)
     const llmInteraction = (debugData && typeof debugData === 'object') ? debugData.llm_interaction : null;
@@ -2544,7 +2633,7 @@ function handleExportConversationJson() {
         metadata: {
             exported_at: new Date().toISOString(),
             total_turns: llmDebugData.size,
-            format_version: '1.0'
+            format_version: '1.1'
         },
         turns: []
     };
@@ -2561,10 +2650,11 @@ function handleExportConversationJson() {
 
     // Build conversation data
     for (const [turnId, debugData] of sortedEntries) {
+        const enrichedDebugData = enrichDebugDataWithSpeechPlanning(debugData, { turnId });
         conversationData.turns.push({
             turn_id: turnId,
-            timestamp: new Date(debugData.timestamp || Date.now()).toISOString(),
-            debug_data: debugData
+            timestamp: new Date((debugData && debugData.timestamp) || Date.now()).toISOString(),
+            debug_data: enrichedDebugData
         });
     }
 

--- a/src/frontend/web/von_interface/static/js/speech.js
+++ b/src/frontend/web/von_interface/static/js/speech.js
@@ -4,6 +4,24 @@
 //
 // Keep this module safe to import in test environments (no top-level browser-only refs).
 
+const DEFAULT_CANCEL_SETTLE_MS = 120;
+
+let pendingSpeakTimerId = null;
+
+function clearPendingSpeakTimer(root) {
+    if (!pendingSpeakTimerId) {
+        return;
+    }
+
+    try {
+        root?.clearTimeout?.(pendingSpeakTimerId);
+    } catch (_) {
+        // Ignore.
+    }
+
+    pendingSpeakTimerId = null;
+}
+
 function getSpeechRecognitionCtor() {
     const root = typeof globalThis !== 'undefined' ? globalThis : null;
     if (!root) {
@@ -140,6 +158,8 @@ export function stopSpeaking() {
         return;
     }
 
+    clearPendingSpeakTimer(root);
+
     try {
         root.speechSynthesis.cancel();
     } catch (_) {
@@ -151,6 +171,15 @@ export function speakText(text, options = {}) {
     const root = typeof globalThis !== 'undefined' ? globalThis : null;
     if (!root || !root.speechSynthesis || typeof root.SpeechSynthesisUtterance !== 'function') {
         throw new Error('Text-to-speech is not supported in this browser.');
+    }
+
+    clearPendingSpeakTimer(root);
+
+    // Prompt browsers (notably Chrome) to load voices early.
+    try {
+        root.speechSynthesis.getVoices?.();
+    } catch (_) {
+        // Ignore.
     }
 
     const utterance = new root.SpeechSynthesisUtterance(String(text ?? ''));
@@ -186,6 +215,26 @@ export function speakText(text, options = {}) {
         // Ignore.
     }
 
-    root.speechSynthesis.speak(utterance);
+    // Workaround for Web Speech quirks where calling speak() immediately after cancel()
+    // can clip the first words of an utterance.
+    const settleMs =
+        typeof options.cancelSettleMs === 'number'
+            ? options.cancelSettleMs
+            : DEFAULT_CANCEL_SETTLE_MS;
+
+    const doSpeak = () => {
+        pendingSpeakTimerId = null;
+        try {
+            root.speechSynthesis.speak(utterance);
+        } catch (_) {
+            // Ignore.
+        }
+    };
+
+    if (settleMs > 0 && typeof root.setTimeout === 'function') {
+        pendingSpeakTimerId = root.setTimeout(doSpeak, settleMs);
+    } else {
+        doSpeak();
+    }
     return utterance;
 }

--- a/src/frontend/web/von_interface/static/js/utils/textDecorator.js
+++ b/src/frontend/web/von_interface/static/js/utils/textDecorator.js
@@ -10,7 +10,7 @@ export function parseVontologyTokens(text) {
 	const input = String(text);
 	const segments = [];
 	// Regex: start marker #V#, then one or more of allowed id chars, stop at space, quote, backtick, or end
-	// Allow alphanumerics, underscores, hyphens (including en-dash –), periods, slashes, colons, parentheses
+	// Allow alphanumerics, underscores, hyphens (including en-dash – and em dash —), periods, slashes, colons, parentheses
 	// Spaces in concept names are normalized to underscores during ID generation, so no spaces in IDs
 	// Quotes and backticks are forbidden in concept names and serve as text boundaries
 	// Using space/quote/backtick as terminators eliminates ambiguity and runaway link concerns
@@ -18,7 +18,7 @@ export function parseVontologyTokens(text) {
 	// NOTE: Parentheses are not allowed in concept IDs
 	// Also treat common punctuation as a valid token boundary so we can cartouchify IDs
 	// at sentence boundaries (e.g., "#V#foo.", "(#V#bar)").
-	const tokenRe = /#V#([A-Za-z0-9_\./:–\-]+?)(?=[\s"'`\.,:;!?\)\]\}…]|$)/g;
+	const tokenRe = /#V#([A-Za-z0-9_\./:–—\-]+?)(?=[\s"'`\.,:;!?\)\]\}…]|$)/g;
 
 	let lastIndex = 0;
 	let match;
@@ -327,7 +327,7 @@ function normaliseVontologyTokensForDisplay(text) {
 	// "V#person" -> "#V#person" (but do NOT rewrite "#V#person").
 	// Prefix capture avoids lookbehind to keep browser support broad.
 	output = output.replace(
-		/(^|[^#])([Vv])#([A-Za-z0-9_\./:–\-]+?)(?=[\s"'`\.,:;!?\)\]\}…]|$)/g,
+		/(^|[^#])([Vv])#([A-Za-z0-9_\./:–—\-]+?)(?=[\s"'`\.,:;!?\)\]\}…]|$)/g,
 		(_, prefix, _v, conceptId) => `${prefix}#V#${conceptId}`
 	);
 
@@ -337,7 +337,7 @@ function normaliseVontologyTokensForDisplay(text) {
 function extractStandaloneVontologyToken(text) {
 	const normalised = normaliseVontologyTokensForDisplay(String(text ?? '')).trim();
 	if (!normalised) return null;
-	const m = normalised.match(/^#V#([A-Za-z0-9_\./:–\-]+)$/);
+	const m = normalised.match(/^#V#([A-Za-z0-9_\./:–—\-]+)$/);
 	return m ? m[1] : null;
 }
 

--- a/tests/backend/test_chat_auxiliary_prompt_service.py
+++ b/tests/backend/test_chat_auxiliary_prompt_service.py
@@ -102,9 +102,52 @@ def test_get_user_specific_prompt_fragments_falls_back_to_text_relations(monkeyp
         "get_texts_for_concept",
         lambda _cid: [
             {"predicate": "hasName", "text": "Ignored"},
-            {"predicate": "hasContent", "lang": "en-NZ", "text": "Primary"},
+            {"predicate": "#V#hasContent", "lang": "en-NZ", "text": "Primary"},
         ],
     )
 
     fragments = service.get_user_specific_prompt_fragments("#V#michael_witbrock")
     assert fragments == [{"concept_id": "#V#prompt_a", "content": "Primary"}]
+
+
+def test_get_user_specific_prompt_fragments_queries_multiple_scoping_predicates(
+    monkeypatch,
+):
+    from src.backend.services import chat_auxiliary_prompt_service as service
+
+    captured = {}
+
+    def _fake_find(filter_doc, **_kwargs):
+        captured["filter"] = filter_doc
+        return []
+
+    monkeypatch.setattr(service.ConceptsRepository, "find", _fake_find)
+
+    service.get_user_specific_prompt_fragments("#V#michael_witbrock")
+
+    filter_doc = captured.get("filter")
+    assert isinstance(filter_doc, dict)
+    type_filter = filter_doc.get("relationships.is_an_instance_of")
+    assert isinstance(type_filter, dict)
+    assert type_filter.get("$in") == [
+        "#V#von_chat_behaviour_prompt",
+        "#V#von_llm_prompt",
+    ]
+
+    ors = filter_doc.get("$or")
+    assert isinstance(ors, list)
+
+    expected_fields = {
+        "relationships.#V#specific_to_von_user",
+        "relationships.specific_to_von_user",
+        "relationships.specific_to_user",
+    }
+    seen_fields = set()
+    for clause in ors:
+        assert isinstance(clause, dict)
+        ((key, value),) = clause.items()
+        if key in expected_fields:
+            seen_fields.add(key)
+            assert value == "#V#michael_witbrock"
+
+    assert seen_fields == expected_fields

--- a/tests/backend/test_chat_history_rag_namespace.py
+++ b/tests/backend/test_chat_history_rag_namespace.py
@@ -53,3 +53,54 @@ def test_add_message_to_history_uses_composite_namespace_for_rag_upsert():
         update_doc["$set"]["namespace"]
         == "#V#michael_witbrock@university_of_auckland_strong_ai_lab"
     )
+
+
+def test_add_message_to_history_indexes_spoken_presenter_channel_to_rag():
+    mock_coll = MagicMock()
+    mock_rag = MagicMock()
+    mock_rag.upsert_documents.return_value = (1, 0)
+
+    with (
+        patch(
+            "src.backend.services.chat_history_service.get_chat_history_collection_service",
+            return_value=mock_coll,
+        ),
+        patch(
+            "src.backend.services.chat_history_service.get_session_context",
+            return_value={
+                "org_id": "university_of_auckland_strong_ai_lab",
+                "role_in_org": "member",
+                "namespace": "#V#michael_witbrock@university_of_auckland_strong_ai_lab",
+            },
+        ),
+        patch(
+            "src.backend.services.chat_history_service.get_rag_service",
+            return_value=mock_rag,
+        ),
+    ):
+        chat_history_service.add_message_to_history(
+            user_id="#V#michael_witbrock",
+            session_id="session-123",
+            message={"role": "assistant", "content": "Screen answer."},
+            llm_debug_data={
+                "presenter_channels": {
+                    "screen": "Screen answer.",
+                    "spoken": "Spoken answer.",
+                    "format": "presenter_protocol_v1",
+                }
+            },
+        )
+
+    # First call indexes the screen content. Second call indexes spoken.
+    assert mock_rag.upsert_documents.call_count == 2
+
+    screen_call = mock_rag.upsert_documents.call_args_list[0]
+    spoken_call = mock_rag.upsert_documents.call_args_list[1]
+
+    screen_docs = screen_call.args[0]
+    assert screen_docs[0]["text"] == "Screen answer."
+    assert screen_docs[0]["metadata"].get("channel") is None
+
+    spoken_docs = spoken_call.args[0]
+    assert spoken_docs[0]["text"] == "Spoken answer."
+    assert spoken_docs[0]["metadata"]["channel"] == "spoken"

--- a/tests/backend/test_internal_mcp_add_relationship_text_predicates.py
+++ b/tests/backend/test_internal_mcp_add_relationship_text_predicates.py
@@ -1,0 +1,81 @@
+import pytest
+
+
+def test_add_relationship_treats_prefixed_hascontent_as_text_relation(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    calls = {"find_one": [], "upsert": []}
+
+    def _fake_find_one(filter_doc, projection=None):
+        calls["find_one"].append({"filter": filter_doc, "projection": projection})
+        if filter_doc.get("concept_id") == "#V#source":
+            return {"concept_id": "#V#source", "relationships": {}}
+        return None
+
+    def _fake_upsert_text_for_concept(
+        *, subject_concept_id, predicate, text, lang=None, provenance=None
+    ):
+        calls["upsert"].append(
+            {
+                "subject_concept_id": subject_concept_id,
+                "predicate": predicate,
+                "text": text,
+                "lang": lang,
+                "provenance": provenance,
+            }
+        )
+        return {"text_value_id": "tv1", "relation_id": "rel1"}
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _fake_find_one,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.upsert_text_for_concept",
+        _fake_upsert_text_for_concept,
+    )
+
+    result = catalogue._add_relationship(
+        source_id="#V#source", predicate="#V#hasContent", target="Hello"
+    )
+
+    assert result["success"] is True
+    assert result["relationship_type"] == "text_relation"
+    assert result["predicate"] == "hasContent"
+    assert result["predicate_input"] == "#V#hasContent"
+
+    assert len(calls["upsert"]) == 1
+    assert calls["upsert"][0]["predicate"] == "hasContent"
+    assert calls["upsert"][0]["text"] == "Hello"
+
+
+def test_add_relationship_treats_plain_hasdescription_as_text_relation(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    def _fake_find_one(filter_doc, projection=None):
+        if filter_doc.get("concept_id") == "#V#source":
+            return {"concept_id": "#V#source", "relationships": {}}
+        return None
+
+    def _fake_upsert_text_for_concept(
+        *, subject_concept_id, predicate, text, lang=None, provenance=None
+    ):
+        return {"text_value_id": "tv2", "relation_id": "rel2"}
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _fake_find_one,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.upsert_text_for_concept",
+        _fake_upsert_text_for_concept,
+    )
+
+    result = catalogue._add_relationship(
+        source_id="#V#source", predicate="hasDescription", target="Desc"
+    )
+
+    assert result["success"] is True
+    assert result["relationship_type"] == "text_relation"
+    assert result["predicate"] == "hasDescription"
+    assert result["predicate_input"] == "hasDescription"

--- a/tests/backend/test_internal_mcp_chat_prompt_tools.py
+++ b/tests/backend/test_internal_mcp_chat_prompt_tools.py
@@ -36,14 +36,24 @@ def test_chat_get_prompt_context_returns_prompt_metadata(monkeypatch):
     # Patch service imports used inside handler
     monkeypatch.setattr(
         "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
-        lambda _namespace: [
-            {"concept_id": "#V#prompt_a", "content": "Alpha"},
-            {"concept_id": "#V#prompt_b", "content": "Beta"},
-        ],
+        lambda _namespace, **kwargs: (
+            [
+                {"concept_id": "#V#prompt_a", "content": "Alpha"},
+                {"concept_id": "#V#prompt_b", "content": "Beta"},
+            ]
+            if kwargs.get("prompt_types")
+            == ("#V#von_chat_behaviour_prompt", "#V#von_chat_behavior_prompt")
+            else []
+        ),
     )
     monkeypatch.setattr(
         "src.backend.services.chat_auxiliary_prompt_service.build_user_specific_system_prompt",
-        lambda _namespace: "Alpha\n\nBeta",
+        lambda _namespace, **kwargs: (
+            "Alpha\n\nBeta"
+            if kwargs.get("prompt_types")
+            == ("#V#von_chat_behaviour_prompt", "#V#von_chat_behavior_prompt")
+            else ""
+        ),
     )
 
     result = _chat_get_prompt_context(
@@ -65,13 +75,21 @@ def test_chat_get_prompt_context_returns_prompt_metadata(monkeypatch):
 def test_chat_get_prompt_context_includes_content_when_requested(monkeypatch):
     monkeypatch.setattr(
         "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
-        lambda _namespace: [
-            {"concept_id": "#V#prompt_a", "content": "Alpha"},
-        ],
+        lambda _namespace, **kwargs: (
+            [{"concept_id": "#V#prompt_a", "content": "Alpha"}]
+            if kwargs.get("prompt_types")
+            == ("#V#von_chat_behaviour_prompt", "#V#von_chat_behavior_prompt")
+            else []
+        ),
     )
     monkeypatch.setattr(
         "src.backend.services.chat_auxiliary_prompt_service.build_user_specific_system_prompt",
-        lambda _namespace: "Alpha",
+        lambda _namespace, **kwargs: (
+            "Alpha"
+            if kwargs.get("prompt_types")
+            == ("#V#von_chat_behaviour_prompt", "#V#von_chat_behavior_prompt")
+            else ""
+        ),
     )
 
     result = _chat_get_prompt_context(
@@ -86,11 +104,21 @@ def test_chat_get_prompt_context_includes_content_when_requested(monkeypatch):
 def test_chat_introspect_returns_model_and_prompt_fingerprint(monkeypatch):
     monkeypatch.setattr(
         "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
-        lambda _namespace: [{"concept_id": "#V#prompt_a", "content": "Alpha"}],
+        lambda _namespace, **kwargs: (
+            [{"concept_id": "#V#prompt_a", "content": "Alpha"}]
+            if kwargs.get("prompt_types")
+            == ("#V#von_chat_behaviour_prompt", "#V#von_chat_behavior_prompt")
+            else []
+        ),
     )
     monkeypatch.setattr(
         "src.backend.services.chat_auxiliary_prompt_service.build_user_specific_system_prompt",
-        lambda _namespace: "Alpha",
+        lambda _namespace, **kwargs: (
+            "Alpha"
+            if kwargs.get("prompt_types")
+            == ("#V#von_chat_behaviour_prompt", "#V#von_chat_behavior_prompt")
+            else ""
+        ),
     )
     monkeypatch.setattr(
         "src.backend.languagemodels.llm_interface.get_active_model_name",

--- a/tests/backend/test_internal_mcp_orchestrator_context_limits.py
+++ b/tests/backend/test_internal_mcp_orchestrator_context_limits.py
@@ -169,6 +169,40 @@ def test_orchestrator_limits_context_by_chars():
     assert first_idx > 0
 
 
+def test_orchestrator_preserves_presenter_protocol_when_trimming_context():
+    gateway = cast(Any, _StubGateway())
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=gateway,
+        max_tool_invocations=1,
+        max_context_chars=8_000,
+    )
+
+    presenter_protocol = {
+        "role": "system",
+        "content": (
+            "PRESENTER MODE PROTOCOL:\n"
+            "- Output EXACTLY TWO tagged blocks and nothing else:\n"
+            "  <spoken>...brief talk track...</spoken>\n"
+            "  <screen>...full on-screen content...</screen>\n"
+        ),
+    }
+
+    # Force trimming with many large messages; presenter protocol would normally
+    # be at risk of being dropped if it were not merged into the retained system
+    # instruction message.
+    context = [presenter_protocol] + [
+        {"role": "user", "content": f"msg-{i}:" + ("a" * 2_000)} for i in range(30)
+    ]
+
+    llm = _CapturingLLM(["ok"])
+    result = orchestrator.run(prompt="hi", context=context, llm_client=llm, model=None)
+
+    assert result.response_text == "ok"
+    sent_context = llm.calls[0]["context"]
+    assert sent_context and sent_context[0]["role"] == "system"
+    assert "PRESENTER MODE PROTOCOL:" in sent_context[0]["content"]
+
+
 def test_orchestrator_truncates_tool_payload_in_context():
     gateway = cast(Any, _StubGateway())
     orchestrator = InternalMCPChatOrchestrator(

--- a/tests/backend/test_von_generate_auxiliary_prompt.py
+++ b/tests/backend/test_von_generate_auxiliary_prompt.py
@@ -42,9 +42,12 @@ def app(monkeypatch):
     # Stub auxiliary prompt loader.
     monkeypatch.setattr(
         "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
-        lambda _user_id: [
-            {"concept_id": "#V#test_prompt", "content": "Please be terse."}
-        ],
+        lambda _user_id, **kwargs: (
+            [{"concept_id": "#V#test_prompt", "content": "Please be terse."}]
+            if kwargs.get("prompt_types")
+            == ("#V#von_chat_behaviour_prompt", "#V#von_chat_behavior_prompt")
+            else []
+        ),
     )
 
     llm = _CapturingLLM()

--- a/tests/backend/test_von_generate_llm_debug_stored_context.py
+++ b/tests/backend/test_von_generate_llm_debug_stored_context.py
@@ -46,7 +46,7 @@ def app(monkeypatch):
 
     monkeypatch.setattr(
         "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
-        lambda _user_id: [],
+        lambda _user_id, **_kwargs: [],
     )
 
     flask_app = Flask(__name__)

--- a/tests/backend/test_von_generate_llm_debug_user_prompt.py
+++ b/tests/backend/test_von_generate_llm_debug_user_prompt.py
@@ -35,10 +35,15 @@ def app(monkeypatch):
 
     monkeypatch.setattr(
         "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
-        lambda _user_id: [
-            {"concept_id": "#V#prompt1", "content": "First prompt."},
-            {"concept_id": "#V#prompt2", "content": "Second prompt."},
-        ],
+        lambda _user_id, **kwargs: (
+            [
+                {"concept_id": "#V#prompt1", "content": "First prompt."},
+                {"concept_id": "#V#prompt2", "content": "Second prompt."},
+            ]
+            if kwargs.get("prompt_types")
+            == ("#V#von_chat_behaviour_prompt", "#V#von_chat_behavior_prompt")
+            else []
+        ),
     )
 
     flask_app = Flask(__name__)

--- a/tests/backend/test_von_generate_presenter_protocol.py
+++ b/tests/backend/test_von_generate_presenter_protocol.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from flask import Flask
+from typing import Protocol
+
+
+class _LLMProtocol(Protocol):
+    def generate(self, prompt, context, model) -> str:  # pragma: no cover
+        ...
+
+
+class _StubLLM:
+    def __init__(self, response_text: str):
+        self._response_text = response_text
+        self.calls: list[dict] = []
+
+    def generate(self, prompt, context, model):
+        self.calls.append({"prompt": prompt, "context": list(context), "model": model})
+        return self._response_text
+
+
+class _StubLLMSequence:
+    def __init__(self, responses: list[str]):
+        self._responses = list(responses)
+        self.calls: list[dict] = []
+
+    def generate(self, prompt, context, model):
+        self.calls.append({"prompt": prompt, "context": list(context), "model": model})
+        if not self._responses:
+            raise AssertionError("No stubbed LLM responses remaining")
+        return self._responses.pop(0)
+
+
+def _make_app(monkeypatch, llm: _LLMProtocol) -> Flask:
+    from src.backend.server.routes.von_routes import von_bp
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_llm_client",
+        lambda **_kwargs: llm,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_active_model_name",
+        lambda: "test-model",
+    )
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: None,
+    )
+
+    flask_app = Flask(__name__)
+    flask_app.secret_key = "test-secret"
+    flask_app.register_blueprint(von_bp, url_prefix="/von")
+
+    flask_app.config["CONTEXT"] = []
+    flask_app.config["INTERNAL_MCP_ORCHESTRATOR"] = None
+    flask_app.config["INTERNAL_MCP_GATEWAY"] = None
+
+    return flask_app
+
+
+def test_generate_extracts_presenter_blocks_and_returns_response_channels(monkeypatch):
+    llm = _StubLLM(
+        "<spoken>Hello there.</spoken>\n<screen>Here is the on-screen content.</screen>"
+    )
+    app = _make_app(monkeypatch, llm)
+
+    client = app.test_client()
+    resp = client.post(
+        "/von/generate",
+        json={"prompt": "Hello", "presenter_mode": True},
+    )
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+
+    assert body["response"] == "Here is the on-screen content."
+    assert body["response_channels"] == {
+        "screen": "Here is the on-screen content.",
+        "spoken": "Hello there.",
+        "format": "tagged_blocks_v1",
+    }
+
+    llm_debug = body["llm_debug"]
+    assert llm_debug["presenter_channels"]["screen"] == "Here is the on-screen content."
+    assert llm_debug["presenter_channels"]["spoken"] == "Hello there."
+    assert llm_debug.get("spoken_backfill_second_pass_attempted") is False
+    assert llm_debug.get("spoken_backfill_second_pass_reason") is None
+
+    assert len(llm.calls) == 1
+    sent_context = llm.calls[0]["context"]
+    assert sent_context
+    assert sent_context[0]["role"] == "system"
+    assert "PRESENTER MODE PROTOCOL" in sent_context[0]["content"]
+
+
+def test_generate_generates_spoken_when_only_screen_tag_present(monkeypatch):
+    llm = _StubLLMSequence(
+        [
+            "<screen>Only screen.</screen>",
+            "<spoken>Short talk track.</spoken>",
+        ]
+    )
+    app = _make_app(monkeypatch, llm)
+
+    client = app.test_client()
+    resp = client.post(
+        "/von/generate",
+        json={"prompt": "Hello", "presenter_mode": True},
+    )
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+
+    assert body["response"] == "Only screen."
+    assert body["response_channels"] == {
+        "screen": "Only screen.",
+        "spoken": "Short talk track.",
+        "format": "narration_fallback_v1",
+    }
+
+    llm_debug = body["llm_debug"]
+    assert llm_debug.get("spoken_backfill_second_pass_attempted") is True
+    assert llm_debug.get("spoken_backfill_second_pass_reason") == "missing_spoken"
+
+    assert len(llm.calls) == 2
+    assert llm.calls[1]["prompt"] == "Generate <spoken> talk track"
+
+
+def test_generate_presenter_mode_falls_back_to_second_pass_spoken(monkeypatch):
+    llm = _StubLLMSequence(
+        [
+            "This is the full on-screen answer with details.",
+            "<spoken>Short summary for TTS.</spoken>",
+        ]
+    )
+    app = _make_app(monkeypatch, llm)
+
+    client = app.test_client()
+    resp = client.post(
+        "/von/generate",
+        json={"prompt": "Hello", "presenter_mode": True},
+    )
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+
+    assert body["response"] == "This is the full on-screen answer with details."
+    assert body["response_channels"] == {
+        "screen": "This is the full on-screen answer with details.",
+        "spoken": "Short summary for TTS.",
+        "format": "narration_fallback_v1",
+    }
+
+    llm_debug = body["llm_debug"]
+    assert llm_debug.get("spoken_backfill_second_pass_attempted") is True
+    assert (
+        llm_debug.get("spoken_backfill_second_pass_reason")
+        == "missing_presenter_channels"
+    )
+
+    assert len(llm.calls) == 2
+    assert llm.calls[1]["prompt"] == "Generate <spoken> talk track"

--- a/tests/backend/test_von_generate_presenter_protocol.py
+++ b/tests/backend/test_von_generate_presenter_protocol.py
@@ -180,7 +180,10 @@ def test_generate_accepts_plain_text_from_narration_second_pass(monkeypatch):
     assert resp.status_code == 200
     body = resp.get_json()
 
-    assert body["response"] == "This is the full on-screen answer with **markdown** and details."
+    assert (
+        body["response"]
+        == "This is the full on-screen answer with **markdown** and details."
+    )
     assert body["response_channels"] == {
         "screen": "This is the full on-screen answer with **markdown** and details.",
         "spoken": "Short summary for TTS.",

--- a/tests/backend/test_von_generate_presenter_protocol.py
+++ b/tests/backend/test_von_generate_presenter_protocol.py
@@ -160,3 +160,39 @@ def test_generate_presenter_mode_falls_back_to_second_pass_spoken(monkeypatch):
 
     assert len(llm.calls) == 2
     assert llm.calls[1]["prompt"] == "Generate <spoken> talk track"
+
+
+def test_generate_accepts_plain_text_from_narration_second_pass(monkeypatch):
+    llm = _StubLLMSequence(
+        [
+            "This is the full on-screen answer with **markdown** and details.",
+            "Short summary for TTS.",
+        ]
+    )
+    app = _make_app(monkeypatch, llm)
+
+    client = app.test_client()
+    resp = client.post(
+        "/von/generate",
+        json={"prompt": "Hello", "presenter_mode": True},
+    )
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+
+    assert body["response"] == "This is the full on-screen answer with **markdown** and details."
+    assert body["response_channels"] == {
+        "screen": "This is the full on-screen answer with **markdown** and details.",
+        "spoken": "Short summary for TTS.",
+        "format": "narration_fallback_v1",
+    }
+
+    llm_debug = body["llm_debug"]
+    assert llm_debug.get("spoken_backfill_second_pass_attempted") is True
+    assert (
+        llm_debug.get("spoken_backfill_second_pass_reason")
+        == "missing_presenter_channels"
+    )
+
+    assert len(llm.calls) == 2
+    assert llm.calls[1]["prompt"] == "Generate <spoken> talk track"

--- a/tests/backend/test_von_generate_prompt_introspection_fastpath.py
+++ b/tests/backend/test_von_generate_prompt_introspection_fastpath.py
@@ -55,12 +55,17 @@ def app(monkeypatch):
     # Keep user prompt loader stable.
     monkeypatch.setattr(
         "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
-        lambda _user_id: [
-            {
-                "concept_id": "#V#general_von_chat_prompt_for_witbrock",
-                "content": "Please be terse.",
-            }
-        ],
+        lambda _user_id, **kwargs: (
+            [
+                {
+                    "concept_id": "#V#general_von_chat_prompt_for_witbrock",
+                    "content": "Please be terse.",
+                }
+            ]
+            if kwargs.get("prompt_types")
+            == ("#V#von_chat_behaviour_prompt", "#V#von_chat_behavior_prompt")
+            else []
+        ),
     )
 
     llm = _FailingLLM()
@@ -218,12 +223,17 @@ def test_prompt_introspection_fastpath_disabled_by_default_does_not_trigger(
     # Keep user prompt loader stable.
     monkeypatch.setattr(
         "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
-        lambda _user_id: [
-            {
-                "concept_id": "#V#general_von_chat_prompt_for_witbrock",
-                "content": "Please be terse.",
-            }
-        ],
+        lambda _user_id, **kwargs: (
+            [
+                {
+                    "concept_id": "#V#general_von_chat_prompt_for_witbrock",
+                    "content": "Please be terse.",
+                }
+            ]
+            if kwargs.get("prompt_types")
+            == ("#V#von_chat_behaviour_prompt", "#V#von_chat_behavior_prompt")
+            else []
+        ),
     )
 
     class _NonFailingLLM:

--- a/tests/backend/test_von_history_backfill_spoken.py
+++ b/tests/backend/test_von_history_backfill_spoken.py
@@ -1,0 +1,182 @@
+"""Tests for on-demand backfill of historical <spoken> talk tracks."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+
+class _StubLLM:
+    def __init__(self, response_text: str):
+        self._response_text = response_text
+        self.calls: list[dict] = []
+
+    def generate(self, prompt, context, model):
+        self.calls.append({"prompt": prompt, "context": list(context), "model": model})
+        return self._response_text
+
+
+@pytest.fixture
+def app_client(monkeypatch):
+    # Use mongomock so tests do not require a running Mongo.
+    monkeypatch.setenv("VON_USE_MOCK_DB", "1")
+
+    # Stub Google auth deps pulled in by utils_flask -> auth_routes imports.
+    import sys
+
+    fake_flow_module = types.ModuleType("google_auth_oauthlib.flow")
+
+    class _DummyFlow:
+        def __init__(self, *args, **kwargs):
+            self.credentials = types.SimpleNamespace(id_token="dummy-token")
+            self.redirect_uri = kwargs.get("redirect_uri")
+            self.client_config = {"web": {"redirect_uris": [self.redirect_uri]}}
+
+        @classmethod
+        def from_client_config(cls, *args, **kwargs):
+            return cls(**kwargs)
+
+        def authorization_url(self, *args, **kwargs):
+            return "https://auth.example", "state-token"
+
+        def fetch_token(self, *args, **kwargs):
+            return None
+
+    fake_flow_module.Flow = _DummyFlow  # type: ignore[attr-defined]
+    sys.modules["google_auth_oauthlib"] = types.ModuleType("google_auth_oauthlib")
+    sys.modules["google_auth_oauthlib"].flow = fake_flow_module  # type: ignore[attr-defined]
+    sys.modules["google_auth_oauthlib.flow"] = fake_flow_module
+
+    fake_id_token_module = types.ModuleType("google.oauth2.id_token")
+    fake_id_token_module.verify_oauth2_token = lambda *args, **kwargs: {  # type: ignore[attr-defined]
+        "sub": "dummy-user"
+    }
+
+    fake_credentials_module = types.ModuleType("google.oauth2.credentials")
+
+    class _DummyCredentials:
+        def __init__(self, id_token: str = "dummy-token"):
+            self.id_token = id_token
+
+    fake_credentials_module.Credentials = _DummyCredentials  # type: ignore[attr-defined]
+
+    fake_service_account_module = types.ModuleType("google.oauth2.service_account")
+
+    class _DummyServiceAccountCredentials:
+        def __init__(self, *args, **kwargs):
+            self.project_id = kwargs.get("project_id")
+
+    fake_service_account_module.Credentials = _DummyServiceAccountCredentials  # type: ignore[attr-defined]
+
+    fake_oauth2_package = types.ModuleType("google.oauth2")
+    fake_oauth2_package.id_token = fake_id_token_module  # type: ignore[attr-defined]
+    fake_oauth2_package.credentials = fake_credentials_module  # type: ignore[attr-defined]
+    fake_oauth2_package.service_account = fake_service_account_module  # type: ignore[attr-defined]
+
+    sys.modules["google.oauth2"] = fake_oauth2_package
+    sys.modules["google.oauth2.id_token"] = fake_id_token_module
+    sys.modules["google.oauth2.credentials"] = fake_credentials_module
+    sys.modules["google.oauth2.service_account"] = fake_service_account_module
+
+    import src.backend.server.utils_flask as utils_flask
+
+    monkeypatch.setattr(utils_flask, "ensure_monitor_started", lambda: None)
+    monkeypatch.setattr(
+        utils_flask,
+        "prompt_concept_health_status",
+        lambda: {"available": True, "source_field": "stub"},
+    )
+
+    app = utils_flask.create_flask_app(
+        list_models_func=lambda: ["dummy-model"],
+        generate_func=lambda prompt, context, model: "ok",
+    )
+    app.config["TESTING"] = True
+
+    with app.test_client() as client:
+        yield app, client
+
+
+def _insert_history_doc(*, user_id: str, session_id: str, history: list[dict]):
+    from src.backend.db.mongo_client import get_db
+    from src.backend.models.chat_history_model import chat_history_collection_name
+
+    db = get_db()
+    assert db is not None
+    coll = db[chat_history_collection_name]
+    coll.insert_one({"user_id": user_id, "session_id": session_id, "history": history})
+
+
+def test_backfill_spoken_requires_authentication(app_client):
+    _, client = app_client
+
+    resp = client.post(
+        "/von/history/backfill_spoken",
+        json={"history_location": {"session_id": "s", "history_index": 0}},
+    )
+
+    assert resp.status_code == 401
+    assert resp.get_json()["error"] == "Not authenticated"
+
+
+def test_backfill_spoken_generates_and_persists_presenter_channels(
+    app_client, monkeypatch
+):
+    _, client = app_client
+
+    user_id = "#V#tester"
+    session_id = "sess-1"
+    history = [
+        {"role": "user", "content": "What is this?"},
+        {"role": "assistant", "content": "Here is the answer on screen."},
+    ]
+    _insert_history_doc(user_id=user_id, session_id=session_id, history=history)
+
+    llm = _StubLLM("<spoken>Short talk track.</spoken>")
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_llm_client",
+        lambda **_kwargs: llm,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_active_model_name",
+        lambda: "test-model",
+    )
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: user_id,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
+        lambda *_args, **_kwargs: [],
+    )
+
+    resp = client.post(
+        "/von/history/backfill_spoken",
+        json={"history_location": {"session_id": session_id, "history_index": 1}},
+    )
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["status"] == "ok"
+    assert body["presenter_channels"]["spoken"] == "Short talk track."
+    assert body["presenter_channels"]["screen"] == "Here is the answer on screen."
+    assert body["presenter_channels"]["format"] == "narration_fallback_v1"
+
+    assert len(llm.calls) == 1
+    assert llm.calls[0]["prompt"] == "Generate <spoken> talk track"
+
+    # Verify persistence to the history message.
+    from src.backend.db.mongo_client import get_db
+    from src.backend.models.chat_history_model import chat_history_collection_name
+
+    db = get_db()
+    assert db is not None
+    coll = db[chat_history_collection_name]
+    stored = coll.find_one({"user_id": user_id, "session_id": session_id})
+    assert stored is not None
+    stored_history = stored["history"]
+    assert (
+        stored_history[1]["llm_debug_data"]["presenter_channels"]["spoken"]
+        == "Short talk track."
+    )

--- a/tests/backend/test_von_history_backfill_spoken.py
+++ b/tests/backend/test_von_history_backfill_spoken.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import types
+import uuid
 
 import pytest
 
@@ -151,6 +152,24 @@ def test_backfill_spoken_generates_and_persists_presenter_channels(
         lambda *_args, **_kwargs: [],
     )
 
+    mock_rag = types.SimpleNamespace()
+    mock_rag.calls = []
+
+    def _upsert_documents(docs, namespace=None):
+        mock_rag.calls.append({"docs": docs, "namespace": namespace})
+        return (len(docs), 0)
+
+    mock_rag.upsert_documents = _upsert_documents
+
+    monkeypatch.setattr(
+        "src.backend.services.chat_history_service.get_rag_service",
+        lambda: mock_rag,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_history_service.get_session_context",
+        lambda: {"namespace": "#V#tester@university_of_auckland_strong_ai_lab"},
+    )
+
     resp = client.post(
         "/von/history/backfill_spoken",
         json={"history_location": {"session_id": session_id, "history_index": 1}},
@@ -180,3 +199,22 @@ def test_backfill_spoken_generates_and_persists_presenter_channels(
         stored_history[1]["llm_debug_data"]["presenter_channels"]["spoken"]
         == "Short talk track."
     )
+
+    # Verify the spoken narration was also indexed into RAG.
+    assert len(mock_rag.calls) == 1
+    assert (
+        mock_rag.calls[0]["namespace"]
+        == "#V#tester@university_of_auckland_strong_ai_lab"
+    )
+    docs = mock_rag.calls[0]["docs"]
+    assert len(docs) == 1
+    assert docs[0]["text"] == "Short talk track."
+    assert docs[0]["metadata"]["channel"] == "spoken"
+
+    expected_id = str(
+        uuid.uuid5(
+            uuid.UUID("8c5a7fa9-9a7c-4f0f-8c1f-f4ad7f9f6fd7"),
+            f"{user_id}|{session_id}|1|spoken",
+        )
+    )
+    assert docs[0]["id"] == expected_id

--- a/tests/frontend/chatPresenterModeRequest.test.js
+++ b/tests/frontend/chatPresenterModeRequest.test.js
@@ -1,0 +1,38 @@
+/** @jest-environment jsdom */
+
+import { sendMessageToServer } from '../../src/frontend/web/von_interface/static/js/chat.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    postJson: jest.fn(),
+    annotateTurn: jest.fn(() => Promise.resolve({}))
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
+    elements: {
+        promptInput: { value: 'Hello' },
+        loadingIndicator: { style: { display: 'none' } },
+        vonIntro: { style: { display: 'block' } },
+        conversationId: 'local',
+        scrollableField: null
+    },
+    addMessageToChat: jest.fn(),
+    renderSpanSuggestions: jest.fn()
+}));
+
+describe('chat.js presenter mode request', () => {
+    test('sendMessageToServer posts with presenter_mode: true', async () => {
+        const { postJson } = await import(
+            '../../src/frontend/web/von_interface/static/js/apiService.js'
+        );
+
+        postJson.mockResolvedValue({ response: 'ok' });
+
+        await sendMessageToServer();
+
+        expect(postJson).toHaveBeenCalledTimes(1);
+        expect(postJson).toHaveBeenCalledWith('/von/generate', {
+            prompt: 'Hello',
+            presenter_mode: true
+        });
+    });
+});

--- a/tests/frontend/chatTabSpeechPlanning.test.js
+++ b/tests/frontend/chatTabSpeechPlanning.test.js
@@ -1,0 +1,127 @@
+/** @jest-environment jsdom */
+
+const chatTabModulePath = '../../src/frontend/web/von_interface/static/js/chatTab.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    annotateTurn: jest.fn(),
+    getUserContext: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
+    elements: {},
+    renderSpanSuggestions: jest.fn()
+}));
+
+const { sendMessage, showLlmDebugPopup } = require(chatTabModulePath);
+
+describe('chat speech planning (presenter channels)', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="scrollableField"></div>
+            <div id="loadingIndicator" aria-hidden="true"></div>
+            <button id="sendButton"></button>
+            <button id="abortButton" aria-hidden="true"></button>
+            <textarea id="promptInput"></textarea>
+            <input type="checkbox" id="annotationToggle" />
+            <input type="checkbox" id="ttsToggle" />
+
+            <div id="chatLlmDebugPopup" class="hidden" aria-hidden="true" data-current-debug-data=""></div>
+            <button id="closeChatLlmDebug"></button>
+            <button id="copyChatLlmDebugJson"></button>
+            <div id="chatLlmDebugMeta"></div>
+            <pre id="chatLlmDebugMessages"></pre>
+            <pre id="chatLlmDebugResponse"></pre>
+            <div id="chatLlmDebugToolsSection" class="hidden"></div>
+            <pre id="chatLlmDebugTools"></pre>
+            <div id="chatLlmDebugAuxSection" class="hidden"></div>
+            <pre id="chatLlmDebugAux"></pre>
+        `;
+
+        // Enable TTS in the environment.
+        global.SpeechSynthesisUtterance = function (text) {
+            this.text = text;
+            this.lang = '';
+            this.rate = 1;
+            this.pitch = 1;
+            this.volume = 1;
+        };
+
+        global.speechSynthesis = {
+            speak: jest.fn(),
+            cancel: jest.fn(),
+            getVoices: jest.fn(() => [])
+        };
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        delete global.fetch;
+        delete global.SpeechSynthesisUtterance;
+        delete global.speechSynthesis;
+    });
+
+    test('Speak uses spoken channel and debug popup includes speech_planning', async () => {
+        const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        getUserContext.mockReturnValue({
+            user_id: 'user',
+            org_id: 'org',
+            language: 'en-NZ',
+            gmail_profile: null
+        });
+
+        const promptInput = document.getElementById('promptInput');
+        promptInput.value = 'test prompt';
+
+        global.fetch = jest.fn((url) => {
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ history_length: 0, authenticated: true })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/generate')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        response: 'SCREEN TEXT',
+                        response_channels: {
+                            screen: 'SCREEN TEXT',
+                            spoken: 'SPOKEN TEXT',
+                            format: 'tagged_blocks_v1'
+                        },
+                        llm_debug: { model: 'gpt-5.2', response: 'SCREEN TEXT', messages: [] }
+                    })
+                });
+            }
+
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        await sendMessage();
+
+        const speakButton = document.querySelector('.chat-tts-button');
+        expect(speakButton).toBeTruthy();
+
+        speakButton.click();
+
+        expect(global.speechSynthesis.speak).toHaveBeenCalled();
+        const utterance = global.speechSynthesis.speak.mock.calls[0][0];
+        expect(utterance.text).toBe('SPOKEN TEXT');
+
+        const messageContainers = Array.from(document.querySelectorAll('.message-container'));
+        const assistantContainer = messageContainers.find((el) => {
+            const turnId = el?.dataset?.turnId;
+            return typeof turnId === 'string' && turnId.startsWith('a-');
+        });
+        const assistantTurnId = assistantContainer?.dataset?.turnId;
+        expect(assistantTurnId).toBeTruthy();
+
+        showLlmDebugPopup(assistantTurnId);
+        const popup = document.getElementById('chatLlmDebugPopup');
+        const jsonText = popup.dataset.currentDebugData;
+        expect(jsonText).toContain('speech_planning');
+        expect(jsonText).toContain('tts_source');
+        expect(jsonText).toContain('spoken');
+    });
+});

--- a/tests/frontend/chatTabSpeechPlanning.test.js
+++ b/tests/frontend/chatTabSpeechPlanning.test.js
@@ -12,7 +12,7 @@ jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
     renderSpanSuggestions: jest.fn()
 }));
 
-const { sendMessage, showLlmDebugPopup } = require(chatTabModulePath);
+const { sendMessage, showLlmDebugPopup, __test_only__rehydrateHistory, __testOnly_resetChatTtsState } = require(chatTabModulePath);
 
 describe('chat speech planning (presenter channels)', () => {
     beforeEach(() => {
@@ -51,6 +51,9 @@ describe('chat speech planning (presenter channels)', () => {
             cancel: jest.fn(),
             getVoices: jest.fn(() => [])
         };
+
+        // Ensure module-level TTS state does not leak between tests.
+        __testOnly_resetChatTtsState();
     });
 
     afterEach(() => {
@@ -85,7 +88,7 @@ describe('chat speech planning (presenter channels)', () => {
                     ok: true,
                     json: async () => ({
                         response: 'SCREEN TEXT',
-                        response_channels: {
+                        presenter_channels: {
                             screen: 'SCREEN TEXT',
                             spoken: 'SPOKEN TEXT',
                             format: 'tagged_blocks_v1'
@@ -105,6 +108,10 @@ describe('chat speech planning (presenter channels)', () => {
 
         speakButton.click();
 
+        // speech.js intentionally delays speak() briefly after cancel() to avoid
+        // first-words clipping in some browsers.
+        await new Promise((resolve) => setTimeout(resolve, 150));
+
         expect(global.speechSynthesis.speak).toHaveBeenCalled();
         const utterance = global.speechSynthesis.speak.mock.calls[0][0];
         expect(utterance.text).toBe('SPOKEN TEXT');
@@ -123,5 +130,225 @@ describe('chat speech planning (presenter channels)', () => {
         expect(jsonText).toContain('speech_planning');
         expect(jsonText).toContain('tts_source');
         expect(jsonText).toContain('spoken');
+    });
+
+    test('Shift+click Speak uses screen channel (accessibility)', async () => {
+        const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        getUserContext.mockReturnValue({
+            user_id: 'user',
+            org_id: 'org',
+            language: 'en-NZ',
+            gmail_profile: null
+        });
+
+        const promptInput = document.getElementById('promptInput');
+        promptInput.value = 'test prompt';
+
+        global.fetch = jest.fn((url) => {
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ history_length: 0, authenticated: true })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/generate')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        response: 'Here is **bold**, and `code`.',
+                        presenter_channels: {
+                            screen: 'Here is **bold**, and `code`.',
+                            spoken: 'SPOKEN TEXT',
+                            format: 'tagged_blocks_v1'
+                        },
+                        llm_debug: { model: 'gpt-5.2', response: 'SCREEN TEXT', messages: [] }
+                    })
+                });
+            }
+
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        await sendMessage();
+
+        const speakButton = document.querySelector('.chat-tts-button');
+        expect(speakButton).toBeTruthy();
+
+        speakButton.dispatchEvent(new MouseEvent('click', { bubbles: true, shiftKey: true }));
+
+        await new Promise((resolve) => setTimeout(resolve, 150));
+
+        expect(global.speechSynthesis.speak).toHaveBeenCalled();
+        const utterance = global.speechSynthesis.speak.mock.calls[0][0];
+        expect(utterance.text).toBe('Here is bold, and code.');
+    });
+
+    test('Default Speak derives narration when spoken missing (never raw markdown)', async () => {
+        const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        getUserContext.mockReturnValue({
+            user_id: 'user',
+            org_id: 'org',
+            language: 'en-NZ',
+            gmail_profile: null
+        });
+
+        const promptInput = document.getElementById('promptInput');
+        promptInput.value = 'test prompt';
+
+        global.fetch = jest.fn((url) => {
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ history_length: 0, authenticated: true })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/generate')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        response: 'Here is **bold**, and `code`.',
+                        presenter_channels: {
+                            screen: 'Here is **bold**, and `code`.',
+                            spoken: null,
+                            format: 'tagged_blocks_v1'
+                        },
+                        llm_debug: { model: 'gpt-5.2', response: 'SCREEN TEXT', messages: [] }
+                    })
+                });
+            }
+
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        await sendMessage();
+
+        const speakButton = document.querySelector('.chat-tts-button');
+        expect(speakButton).toBeTruthy();
+
+        speakButton.click();
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        expect(global.speechSynthesis.speak).toHaveBeenCalled();
+        const utterance1 = global.speechSynthesis.speak.mock.calls[0][0];
+        expect(utterance1.text).toBe('Here is bold, and code.');
+
+        // Stop the current speech (same turnId), then speak again with Shift held.
+        speakButton.click();
+
+        speakButton.dispatchEvent(new MouseEvent('click', { bubbles: true, shiftKey: true }));
+
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        expect(global.speechSynthesis.speak).toHaveBeenCalled();
+        const utterance2 = global.speechSynthesis.speak.mock.calls[1][0];
+        expect(utterance2.text).toBe('Here is bold, and code.');
+    });
+
+    test('History Speak backfills spoken talk track on-demand', async () => {
+        // Arrange: history contains an assistant turn with no presenter channels.
+        const scrollableField = document.getElementById('scrollableField');
+        expect(scrollableField).toBeTruthy();
+
+        global.fetch = jest.fn((url, init) => {
+            if (typeof url === 'string' && url.startsWith('/von/history/backfill_spoken')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        status: 'ok',
+                        presenter_channels: {
+                            screen: 'SCREEN TEXT',
+                            spoken: 'SPOKEN FROM BACKFILL',
+                            format: 'narration_fallback_v1'
+                        },
+                        updated: true
+                    })
+                });
+            }
+
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        __test_only__rehydrateHistory(scrollableField, [
+            { role: 'user', content: 'Hi', timestamp: '2026-01-02T00:00:00Z' },
+            {
+                role: 'assistant',
+                content: 'SCREEN TEXT',
+                timestamp: '2026-01-02T00:00:01Z',
+                history_location: { session_id: 'sess-1', history_index: 1 }
+            }
+        ]);
+
+        const speakButton = document.querySelector('.chat-tts-button');
+        expect(speakButton).toBeTruthy();
+
+        // Act
+        speakButton.click();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        await new Promise((resolve) => setTimeout(resolve, 200));
+
+        // Assert
+        expect(global.fetch).toHaveBeenCalled();
+        expect(global.speechSynthesis.speak).toHaveBeenCalled();
+        const utterance = global.speechSynthesis.speak.mock.calls[0][0];
+        expect(utterance.text).toBe('SPOKEN FROM BACKFILL');
+    });
+
+    test('History Speak falls back to on-screen text when backfill fails (and cools down)', async () => {
+        const scrollableField = document.getElementById('scrollableField');
+        expect(scrollableField).toBeTruthy();
+
+        let backfillCalls = 0;
+        global.fetch = jest.fn((url, init) => {
+            if (typeof url === 'string' && url.startsWith('/von/history/backfill_spoken')) {
+                backfillCalls += 1;
+                return Promise.resolve({
+                    ok: false,
+                    status: 404,
+                    json: async () => ({ error: 'History entry not found' })
+                });
+            }
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        __test_only__rehydrateHistory(scrollableField, [
+            { role: 'user', content: 'Hi', timestamp: '2026-01-02T00:00:00Z' },
+            {
+                role: 'assistant',
+                content: 'SCREEN TEXT',
+                timestamp: '2026-01-02T00:00:01Z',
+                history_location: { session_id: 'sess-1', history_index: 1 }
+            }
+        ]);
+
+        const speakButton = document.querySelector('.chat-tts-button');
+        expect(speakButton).toBeTruthy();
+
+        speakButton.click();
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        expect(global.speechSynthesis.speak).toHaveBeenCalled();
+        const utterance1 = global.speechSynthesis.speak.mock.calls[0][0];
+        expect(utterance1.text).toBe('SCREEN TEXT');
+
+        const notice1 = document.querySelector('.chat-tts-notice');
+        expect(notice1).toBeTruthy();
+        expect(String(notice1.textContent || '')).toContain('Talk track unavailable');
+
+        expect(backfillCalls).toBe(1);
+
+        // Second click stops the current speech (toggle behaviour).
+        speakButton.click();
+
+        // The click handler is async (history backfill/cool-down). Give it a tick to
+        // restore the button state before clicking again.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        // Third click within cooldown should speak again without retrying backfill.
+        speakButton.click();
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        expect(global.speechSynthesis.speak).toHaveBeenCalled();
+        const utterance2 = global.speechSynthesis.speak.mock.calls[1][0];
+        expect(utterance2.text).toBe('SCREEN TEXT');
+        expect(backfillCalls).toBe(1);
     });
 });

--- a/tests/frontend/speech.test.js
+++ b/tests/frontend/speech.test.js
@@ -15,7 +15,7 @@ describe('speech TTS utilities', () => {
         expect(getSpeechSynthesisVoices()).toEqual([]);
     });
 
-    test('speakText applies voiceUri when available', () => {
+    test('speakText applies voiceUri when available', async () => {
         const voice = { voiceURI: 'voice-1', name: 'Test voice', lang: 'en-NZ' };
 
         global.speechSynthesis = {
@@ -42,6 +42,10 @@ describe('speech TTS utilities', () => {
         });
 
         expect(global.speechSynthesis.cancel).toHaveBeenCalled();
+
+        // speech.js intentionally delays speak() briefly after cancel() to avoid
+        // first-words clipping in some browsers.
+        await new Promise((resolve) => setTimeout(resolve, 150));
         expect(global.speechSynthesis.speak).toHaveBeenCalledWith(utterance);
         expect(utterance.lang).toBe('en-NZ');
         expect(utterance.rate).toBe(1.2);

--- a/tests/frontend/textDecoratorTokenBoundaries.test.js
+++ b/tests/frontend/textDecoratorTokenBoundaries.test.js
@@ -43,4 +43,20 @@ describe('Vontology token boundaries', () => {
         expect(buttonNode.nextSibling.nodeType).toBe(Node.TEXT_NODE);
         expect(buttonNode.nextSibling.nodeValue).toBe(').');
     });
+
+    test('cartouchifies standalone #V# token in code blocks with em dash', () => {
+        const { cartouchifyVontologyTokensInElement } = require(modulePath);
+
+        const root = document.getElementById('root');
+        root.innerHTML = '<pre><code>#V#mjw_todo_list_—_2026-01-03</code></pre>';
+
+        cartouchifyVontologyTokensInElement(root, {
+            skipSelectors: ['pre', 'code', 'a'],
+            allowStandaloneCodeBlockTokens: true
+        });
+
+        const cartouches = root.querySelectorAll('.vontology-cartouche');
+        expect(cartouches.length).toBe(1);
+        expect(cartouches[0].dataset.fullConceptId).toBe('#V#mjw_todo_list_—_2026-01-03');
+    });
 });


### PR DESCRIPTION
Indexes presenter-mode spoken talk tracks into RAG.

- `add_message_to_history`: upserts an additional RAG document for `presenter_channels.spoken` (metadata includes `channel=spoken`).
- `upsert_presenter_channels_for_history_message`: when backfilling spoken, also indexes it into RAG with a deterministic doc id (idempotent).
- Adds/updates backend tests covering both paths.

Tests:
- pytest tests/backend/test_chat_history_rag_namespace.py
- pytest tests/backend/test_von_history_backfill_spoken.py
- pytest tests/backend/test_von_generate_presenter_protocol.py