### PR TITLE
JVNAUTOSCI-909: Fix upsert_text_relation schema + tests

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -214,11 +214,11 @@ def _upsert_text_relation(**kwargs):
     namespace = kwargs.get("namespace")
 
     if not concept_id:
-        return {"error": "Missing 'concept_id' parameter"}
+        return {"success": False, "error": "Missing 'concept_id' parameter"}
     if not predicate:
-        return {"error": "Missing 'predicate' parameter"}
+        return {"success": False, "error": "Missing 'predicate' parameter"}
     if not text:
-        return {"error": "Missing 'text' parameter"}
+        return {"success": False, "error": "Missing 'text' parameter"}
 
     try:
         result = upsert_text_for_concept(
@@ -248,7 +248,7 @@ def _upsert_text_relation(**kwargs):
             "language": language,
         }
     except Exception as exc:
-        return {"error": f"Failed to upsert text relation: {exc}"}
+        return {"success": False, "error": f"Failed to upsert text relation: {exc}"}
 
 
 def _get_text_relations(**kwargs):
@@ -1386,11 +1386,12 @@ def _upsert_text_relation_input_schema() -> Schema:
             "text": str,
         },
         optional={
+            "namespace": (str, type(None)),
             "language": str,
             "context": (dict, type(None)),
         },
         allow_unknown=True,
-        description="upsert_text_relation input: concept_id (str), predicate (str, e.g., 'hasContent', 'hasDescription'), text (str), language (str, optional, default 'en-NZ'), context (dict, optional metadata)",
+        description="upsert_text_relation input: concept_id (str), predicate (str, e.g., 'hasContent', 'hasDescription'), text (str), namespace (str, optional), language (str, optional, default 'en-NZ'), context (dict, optional metadata)",
     )
 
 

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -353,7 +353,7 @@ async def list_tools() -> list[Tool]:
                         "description": "Language code (ISO 639-1/BCP 47): en-NZ (default), en-US, fr, de, mi, zh, etc.",
                     },
                     "context": {
-                        "type": "object",
+                        "type": ["object", "null"],
                         "description": "Optional metadata (e.g., {'text_type': 'NL', 'author': 'system'})",
                     },
                 },
@@ -1580,11 +1580,11 @@ async def _handle_upsert_text_relation(arguments: dict[str, Any]) -> list[TextCo
     context = arguments.get("context")
 
     if not concept_id:
-        return [_json_error("Missing concept_id parameter")]
+        return [_json_text({"success": False, "error": "Missing concept_id parameter"})]
     if not predicate:
-        return [_json_error("Missing predicate parameter")]
+        return [_json_text({"success": False, "error": "Missing predicate parameter"})]
     if not text:
-        return [_json_error("Missing text parameter")]
+        return [_json_text({"success": False, "error": "Missing text parameter"})]
 
     try:
         result = upsert_text_for_concept(
@@ -1613,7 +1613,11 @@ async def _handle_upsert_text_relation(arguments: dict[str, Any]) -> list[TextCo
         }
         return [_json_text(payload)]
     except Exception as exc:
-        return [_json_error(f"Failed to upsert text relation: {exc}")]
+        return [
+            _json_text(
+                {"success": False, "error": f"Failed to upsert text relation: {exc}"}
+            )
+        ]
 
 
 async def _handle_get_text_relations(arguments: dict[str, Any]) -> list[TextContent]:

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -93,6 +93,10 @@
             "inputSchema": {
                 "type": "object",
                 "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional namespace (e.g., #V#user@org). When provided, triggers a best-effort RAG reindex for the concept; otherwise no automatic indexing occurs."
+                    },
                     "concept_id": {
                         "type": "string",
                         "description": "The concept to attach text to (e.g., '#V#my_concept')"
@@ -111,7 +115,10 @@
                         "description": "Language code (ISO 639-1/BCP 47): en-NZ (default), en-US, fr, de, mi, zh, etc."
                     },
                     "context": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "description": "Optional metadata (e.g., {'text_type': 'NL', 'author': 'system'})"
                     }
                 },

--- a/tests/backend/test_chat_auxiliary_prompt_service.py
+++ b/tests/backend/test_chat_auxiliary_prompt_service.py
@@ -129,8 +129,11 @@ def test_get_user_specific_prompt_fragments_queries_multiple_scoping_predicates(
     assert isinstance(filter_doc, dict)
     type_filter = filter_doc.get("relationships.is_an_instance_of")
     assert isinstance(type_filter, dict)
+    # Default prompt type scoping includes the NZ spelling plus a legacy US-spelling
+    # concept ID that has been observed in stored data.
     assert type_filter.get("$in") == [
         "#V#von_chat_behaviour_prompt",
+        "#V#von_chat_behavior_prompt",
         "#V#von_llm_prompt",
     ]
 

--- a/tests/backend/test_text_value_fingerprint_preserves_newlines.py
+++ b/tests/backend/test_text_value_fingerprint_preserves_newlines.py
@@ -1,5 +1,6 @@
 import pytest
 
+from bson import ObjectId
 from src.backend.db.repositories.concepts_repository import ConceptsRepository
 from src.backend.db.repositories.text_value_repository import (
     TextRelationsRepository,
@@ -67,6 +68,6 @@ def test_upsert_does_not_dedup_away_newlines():
 
     assert first["text_value_id"] != second["text_value_id"]
 
-    tv = TextValuesRepository.find_one({"_id": second["text_value_id"]})
+    tv = TextValuesRepository.find_one({"_id": ObjectId(second["text_value_id"])})
     assert tv is not None
     assert tv.get("text") == "Hello\nworld"


### PR DESCRIPTION
Summary\n- Fixes schema consistency for upsert_text_relation across internal MCP catalogue, MCP stdio server, and external manifest.\n- Error paths now return schema-compliant payloads including success: false.\n- Input schema supports optional namespace and allows context=null.\n\nTests\n- Python: 298 passed\n- Frontend: npm run test:frontend (18/18 suites, 49 tests)