### PR TITLE
JVNAUTOSCI-900: Fix Jira search/jql pagination

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -2538,11 +2538,12 @@ def _jira_search_input_schema() -> Schema:
         optional={
             "max_results": (int,),
             "start_at": (int,),
+            "next_page_token": (str,),
             "fields": (list,),
         },
         allow_unknown=True,
         description=(
-            "jira_search input: jql (str, required) plus optional max_results, start_at, and fields (list of field names)."
+            "jira_search input: jql (str, required) plus optional max_results, next_page_token, start_at (deprecated), and fields (list of field names)."
         ),
     )
 
@@ -3461,6 +3462,7 @@ def _jira_search(**kwargs):
             jql=jql,
             max_results=kwargs.get("max_results"),
             start_at=kwargs.get("start_at"),
+            next_page_token=kwargs.get("next_page_token"),
             fields=kwargs.get("fields"),
         )
 

--- a/src/backend/integrations/internal_mcp/jira_proxy_mcp.py
+++ b/src/backend/integrations/internal_mcp/jira_proxy_mcp.py
@@ -60,6 +60,7 @@ class JiraMCPProxy:
         jql: str,
         max_results: Optional[int] = None,
         start_at: Optional[int] = None,
+        next_page_token: Optional[str] = None,
         fields: Optional[list[str]] = None,
     ) -> Dict[str, Any]:
         arguments: Dict[str, Any] = {"jql": jql}
@@ -67,6 +68,8 @@ class JiraMCPProxy:
             arguments["max_results"] = max_results
         if isinstance(start_at, int):
             arguments["start_at"] = start_at
+        if isinstance(next_page_token, str) and next_page_token.strip():
+            arguments["next_page_token"] = next_page_token.strip()
         if fields:
             arguments["fields"] = fields
         return await self._call("jira_search", arguments)

--- a/src/backend/integrations/jira_client.py
+++ b/src/backend/integrations/jira_client.py
@@ -84,16 +84,24 @@ class JiraClient:
         fields: t.Optional[t.List[str]] = None,
         max_results: int = 50,
         start_at: int = 0,
+        next_page_token: t.Optional[str] = None,
     ) -> dict:
         self._ensure_config()
         payload = {
             "jql": jql,
             "maxResults": max_results,
-            "startAt": start_at,
         }
+        # Jira Cloud /rest/api/3/search/jql uses nextPageToken pagination.
+        # Avoid sending deprecated startAt, as some instances reject it.
+        if next_page_token:
+            payload["nextPageToken"] = next_page_token
+        elif start_at not in (0, None):
+            raise JiraConfigurationError(
+                "Deprecated pagination parameter: start_at. Use next_page_token instead."
+            )
         if fields:
             payload["fields"] = fields
-        url = f"{self.site_base}/rest/api/3/search"
+        url = f"{self.site_base}/rest/api/3/search/jql"
         resp = self._session.post(url, json=payload, timeout=60)
         if resp.status_code == 401:
             raise JiraConfigurationError("Unauthorized: check email/token validity")

--- a/src/backend/mcp_server/mcp_server.py
+++ b/src/backend/mcp_server/mcp_server.py
@@ -145,7 +145,24 @@ async def list_tools() -> List[types.Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "jql": {"type": "string", "description": "JQL query string"}
+                    "jql": {"type": "string", "description": "JQL query string"},
+                    "fields": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional Jira fields to include (e.g. ['summary','status']).",
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Maximum number of issues to return (Jira max is typically 100).",
+                    },
+                    "next_page_token": {
+                        "type": "string",
+                        "description": "Pagination token returned by Jira /search/jql (preferred over deprecated start_at).",
+                    },
+                    "start_at": {
+                        "type": "integer",
+                        "description": "Deprecated: Jira /search/jql uses next_page_token pagination (cursor-based).",
+                    },
                 },
                 "required": ["jql"],
             },
@@ -212,11 +229,34 @@ async def call_tool(
 ) -> Sequence[types.TextContent]:
     if name == "jira_search":
         jql = arguments["jql"]
-        search_params: Dict[str, Any] = {"jql": jql}
+        payload: Dict[str, Any] = {
+            "jql": jql,
+            "maxResults": 50,
+        }
+        max_results = arguments.get("max_results")
+        if isinstance(max_results, int):
+            payload["maxResults"] = max_results
+
+        # Jira Cloud /rest/api/3/search/jql uses cursor pagination via nextPageToken.
+        # Avoid sending deprecated startAt, as some instances reject it with HTTP 400.
+        start_at = arguments.get("start_at")
+        if isinstance(start_at, int) and start_at not in (0, None):
+            error = {
+                "success": False,
+                "error": "Deprecated pagination parameter: start_at. Use next_page_token instead.",
+            }
+            return [types.TextContent(type="text", text=json.dumps(error, indent=2))]
+
+        next_page_token = arguments.get("next_page_token")
+        if isinstance(next_page_token, str) and next_page_token.strip():
+            payload["nextPageToken"] = next_page_token.strip()
+
         fields = arguments.get("fields")
         if isinstance(fields, list) and fields:
-            search_params["fields"] = ",".join(str(f) for f in fields)
-        result = jira_get("search", params=search_params)
+            payload["fields"] = [str(f) for f in fields]
+
+        # Jira Cloud is deprecating GET /search?jql=... for some usage; prefer POST /search/jql.
+        result = jira_post("search/jql", payload)
         text = json.dumps(result, indent=2)
         return [types.TextContent(type="text", text=text)]
 


### PR DESCRIPTION
Fix Jira /rest/api/3/search/jql payload to use nextPageToken (no deprecated startAt), and thread next_page_token through internal MCP proxy.