### PR TITLE
JVNAUTOSCI-913: Structured errors for relationship tools

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -592,30 +592,67 @@ def _add_relationship(**kwargs):
     from ...db.repositories.concepts_repository import ConceptsRepository
     from ...services.text_value_service import upsert_text_for_concept
 
+    def _err(
+        code: str,
+        message: str,
+        *,
+        details: dict | None = None,
+    ) -> dict:
+        # Keep backward compatibility: preserve the top-level 'error' string.
+        return {
+            "success": False,
+            "error": message,
+            "error_code": code,
+            "error_details": details or {},
+        }
+
     source_id = kwargs.get("source_id")
     predicate = kwargs.get("predicate")
     target = kwargs.get("target")
 
     if not source_id:
-        return {"success": False, "error": "Missing 'source_id' parameter"}
+        return _err(
+            "missing_parameter",
+            "Missing 'source_id' parameter",
+            details={"missing": ["source_id"]},
+        )
     if not predicate:
-        return {"success": False, "error": "Missing 'predicate' parameter"}
+        return _err(
+            "missing_parameter",
+            "Missing 'predicate' parameter",
+            details={"missing": ["predicate"]},
+        )
     if not target:
-        return {"success": False, "error": "Missing 'target' parameter"}
+        return _err(
+            "missing_parameter",
+            "Missing 'target' parameter",
+            details={"missing": ["target"]},
+        )
 
     if source_id == target:
-        return {"success": False, "error": "Source and target cannot be the same"}
+        return _err(
+            "relationship_self_reference",
+            "Source and target cannot be the same",
+            details={"source_id": source_id, "target": target},
+        )
 
     try:
         repo = ConceptsRepository
 
+        from ...vontology.code_concepts_registry import (
+            build_virtual_concept_doc,
+            is_code_concept_id,
+        )
+        from ...vontology.utils_vontology import is_predicate
+
         # Check if source exists
         src = repo.find_one({"concept_id": source_id})
         if not src:
-            return {
-                "success": False,
-                "error": f"Source concept '{source_id}' not found",
-            }
+            return _err(
+                "source_concept_not_found",
+                f"Source concept '{source_id}' not found",
+                details={"role": "source", "concept_id": source_id},
+            )
 
         # Common text predicates are frequently provided either as plain predicate IDs
         # (e.g. 'hasContent') or V-prefixed IDs (e.g. '#V#hasContent'). Treat these
@@ -684,7 +721,11 @@ def _add_relationship(**kwargs):
         # Check if target concept exists
         tgt = repo.find_one({"concept_id": target})
         if not tgt:
-            return {"success": False, "error": f"Target concept '{target}' not found"}
+            return _err(
+                "target_concept_not_found",
+                f"Target concept '{target}' not found",
+                details={"role": "target", "concept_id": target},
+            )
 
         # Map common predicate names to database field names
         predicate_map = {
@@ -696,6 +737,62 @@ def _add_relationship(**kwargs):
             "instance": "has_instance",
         }
         rel_kind = predicate_map.get(predicate, predicate)
+
+        # Canonicalise known legacy predicate ids.
+        # JVNAUTOSCI-913: todo membership was previously represented via '#V#has_item'.
+        if rel_kind == "#V#has_item":
+            rel_kind = "#V#has_todo_item"
+
+        # Guardrail: concept-to-concept relationship predicates must be either:
+        # - one of the structural relationship kinds (is_a_type_of, has_subtype, ...), or
+        # - a Vontology predicate concept id (starts with #V# and exists as a predicate).
+        from ...db.repositories.concepts_repository import RELATIONSHIP_KINDS
+
+        if isinstance(rel_kind, str) and rel_kind in RELATIONSHIP_KINDS:
+            pass
+        elif isinstance(rel_kind, str) and rel_kind.startswith("#V#"):
+            pred_doc = repo.find_one(
+                {"concept_id": rel_kind}, {"concept_id": 1, "relationships": 1}
+            )
+            if pred_doc is None and is_code_concept_id(rel_kind):
+                pred_doc = build_virtual_concept_doc(rel_kind)
+            if pred_doc is None:
+                return _err(
+                    "predicate_concept_not_found",
+                    (
+                        f"Predicate concept '{rel_kind}' not found. "
+                        "Create it as a predicate in the Vontology (e.g. as an instance of #V#predicate) "
+                        "before using it as a relationship."
+                    ),
+                    details={
+                        "role": "predicate",
+                        "predicate": rel_kind,
+                        "predicate_input": predicate,
+                    },
+                )
+            if not is_predicate(pred_doc):
+                return _err(
+                    "predicate_concept_not_typed",
+                    (
+                        f"Concept '{rel_kind}' exists but is not typed as a predicate. "
+                        "Predicates must be instances of #V#predicate (or a predicate subtype)."
+                    ),
+                    details={
+                        "role": "predicate",
+                        "predicate": rel_kind,
+                        "predicate_input": predicate,
+                        "required_instance_of": "#V#predicate",
+                    },
+                )
+        else:
+            return _err(
+                "invalid_relationship_predicate",
+                (
+                    "Invalid relationship predicate. For concept-to-concept relationships, "
+                    "use a structural predicate (e.g. 'typeOf', 'instance_of') or a '#V#...' predicate concept id."
+                ),
+                details={"predicate_input": predicate, "predicate_canonical": rel_kind},
+            )
 
         # Read current relationships
         existing = (
@@ -739,36 +836,106 @@ def _add_relationship(**kwargs):
                 "added": update_result.modified_count > 0,
             }
         else:
-            return {"success": False, "error": "Failed to add relationship"}
+            return _err(
+                "relationship_add_failed",
+                "Failed to add relationship",
+                details={
+                    "source_id": source_id,
+                    "predicate": rel_kind,
+                    "target": target,
+                },
+            )
 
     except Exception as e:
-        return {"success": False, "error": f"Exception: {str(e)}"}
+        return _err(
+            "exception",
+            f"Exception: {str(e)}",
+            details={
+                "source_id": source_id,
+                "predicate": predicate,
+                "target": target,
+                "exception_type": type(e).__name__,
+            },
+        )
 
 
 def _remove_relationship(**kwargs):
     """Remove a relationship between two concepts. Text relations removal is not supported here."""
     from ...db.repositories.concepts_repository import ConceptsRepository
 
+    def _err(
+        code: str,
+        message: str,
+        *,
+        details: dict | None = None,
+    ) -> dict:
+        # Keep backward compatibility: preserve the top-level 'error' string.
+        return {
+            "success": False,
+            "error": message,
+            "error_code": code,
+            "error_details": details or {},
+        }
+
     source_id = kwargs.get("source_id")
     predicate = kwargs.get("predicate")
     target = kwargs.get("target")
 
     if not source_id:
-        return {"success": False, "error": "Missing 'source_id' parameter"}
+        return _err(
+            "missing_parameter",
+            "Missing 'source_id' parameter",
+            details={"missing": ["source_id"]},
+        )
     if not predicate:
-        return {"success": False, "error": "Missing 'predicate' parameter"}
+        return _err(
+            "missing_parameter",
+            "Missing 'predicate' parameter",
+            details={"missing": ["predicate"]},
+        )
     if not target:
-        return {"success": False, "error": "Missing 'target' parameter"}
+        return _err(
+            "missing_parameter",
+            "Missing 'target' parameter",
+            details={"missing": ["target"]},
+        )
 
     try:
         repo = ConceptsRepository
+
+        from ...vontology.code_concepts_registry import (
+            build_virtual_concept_doc,
+            is_code_concept_id,
+        )
+        from ...vontology.utils_vontology import is_predicate
+
         # Verify source concept exists
         src = repo.find_one({"concept_id": source_id})
         if not src:
-            return {
-                "success": False,
-                "error": f"Source concept '{source_id}' not found",
-            }
+            return _err(
+                "source_concept_not_found",
+                f"Source concept '{source_id}' not found",
+                details={"role": "source", "concept_id": source_id},
+            )
+
+        # This tool only supports concept-to-concept relationships. Provide an
+        # explicit, agent-readable error when users attempt to remove text relations.
+        predicate_str = (
+            predicate.strip() if isinstance(predicate, str) else str(predicate)
+        )
+        predicate_normalised = (
+            predicate_str[3:] if predicate_str.startswith("#V#") else predicate_str
+        )
+        well_known_text_predicates = {"hasContent", "hasDescription", "hasName"}
+        if predicate_normalised in well_known_text_predicates:
+            return _err(
+                "unsupported_text_relation_removal",
+                "Text relation removal is not supported by remove_relationship",
+                details={
+                    "predicate_input": predicate,
+                    "predicate": predicate_normalised,
+                },
+            )
 
         # Map common predicate aliases to stored field names
         predicate_map = {
@@ -780,6 +947,80 @@ def _remove_relationship(**kwargs):
             "instance": "has_instance",
         }
         rel_kind = predicate_map.get(predicate, predicate)
+
+        # Canonicalise known legacy predicate ids.
+        # JVNAUTOSCI-913: todo membership was previously represented via '#V#has_item'.
+        if rel_kind == "#V#has_item":
+            rel_kind = "#V#has_todo_item"
+
+        # Determine if this is a text predicate (binary_text_predicate instance)
+        if isinstance(rel_kind, str) and rel_kind.startswith("#V#"):
+            pred_doc = repo.find_one(
+                {"concept_id": rel_kind}, {"relationships.is_an_instance_of": 1}
+            )
+            if pred_doc:
+                instance_of = pred_doc.get("relationships", {}).get(
+                    "is_an_instance_of", []
+                )
+                if isinstance(instance_of, str):
+                    instance_of = [instance_of]
+                if "#V#binary_text_predicate" in instance_of:
+                    return _err(
+                        "unsupported_text_relation_removal",
+                        "Text relation removal is not supported by remove_relationship",
+                        details={"predicate": rel_kind, "predicate_input": predicate},
+                    )
+
+        # Guardrail: concept-to-concept relationship predicates must be either:
+        # - one of the structural relationship kinds (is_a_type_of, has_subtype, ...), or
+        # - a Vontology predicate concept id (starts with #V# and exists as a predicate).
+        from ...db.repositories.concepts_repository import RELATIONSHIP_KINDS
+
+        if isinstance(rel_kind, str) and rel_kind in RELATIONSHIP_KINDS:
+            pass
+        elif isinstance(rel_kind, str) and rel_kind.startswith("#V#"):
+            pred_doc = repo.find_one(
+                {"concept_id": rel_kind}, {"concept_id": 1, "relationships": 1}
+            )
+            if pred_doc is None and is_code_concept_id(rel_kind):
+                pred_doc = build_virtual_concept_doc(rel_kind)
+            if pred_doc is None:
+                return _err(
+                    "predicate_concept_not_found",
+                    (
+                        f"Predicate concept '{rel_kind}' not found. "
+                        "Create it as a predicate in the Vontology (e.g. as an instance of #V#predicate) "
+                        "before using it as a relationship."
+                    ),
+                    details={
+                        "role": "predicate",
+                        "predicate": rel_kind,
+                        "predicate_input": predicate,
+                    },
+                )
+            if not is_predicate(pred_doc):
+                return _err(
+                    "predicate_concept_not_typed",
+                    (
+                        f"Concept '{rel_kind}' exists but is not typed as a predicate. "
+                        "Predicates must be instances of #V#predicate (or a predicate subtype)."
+                    ),
+                    details={
+                        "role": "predicate",
+                        "predicate": rel_kind,
+                        "predicate_input": predicate,
+                        "required_instance_of": "#V#predicate",
+                    },
+                )
+        else:
+            return _err(
+                "invalid_relationship_predicate",
+                (
+                    "Invalid relationship predicate. For concept-to-concept relationships, "
+                    "use a structural predicate (e.g. 'typeOf', 'instance_of') or a '#V#...' predicate concept id."
+                ),
+                details={"predicate_input": predicate, "predicate_canonical": rel_kind},
+            )
 
         # Ensure the relationship field exists (optional sanity)
         existing = (
@@ -829,7 +1070,16 @@ def _remove_relationship(**kwargs):
                 "removed": False,
             }
     except Exception as e:
-        return {"success": False, "error": f"Exception: {str(e)}"}
+        return _err(
+            "exception",
+            f"Exception: {str(e)}",
+            details={
+                "source_id": source_id,
+                "predicate": predicate,
+                "target": target,
+                "exception_type": type(e).__name__,
+            },
+        )
 
 
 # arXiv MCP proxy handlers
@@ -1670,9 +1920,11 @@ def _add_relationship_output_schema() -> Schema:
             "text_value_id": (str, type(None)),
             "relation_id": (str, type(None)),
             "error": (str, type(None)),
+            "error_code": (str, type(None)),
+            "error_details": (dict, type(None)),
         },
         allow_unknown=True,
-        description="add_relationship output: success (bool), relationship_type (str), message (str), source_id (str), predicate (str), target (str), already_existed (bool), added (bool), text_value_id (str), relation_id (str), error (str)",
+        description="add_relationship output: success (bool), relationship_type (str), message (str), source_id (str), predicate (str), target (str), already_existed (bool), added (bool), text_value_id (str), relation_id (str), error (str), error_code (str), error_details (dict)",
     )
 
 
@@ -1702,9 +1954,11 @@ def _remove_relationship_output_schema() -> Schema:
             "already_absent": (bool, type(None)),
             "message": (str, type(None)),
             "error": (str, type(None)),
+            "error_code": (str, type(None)),
+            "error_details": (dict, type(None)),
         },
         allow_unknown=True,
-        description="remove_relationship output: success (bool), source_id, predicate, target, removed (bool), already_absent (bool when relation was not present), message, error",
+        description="remove_relationship output: success (bool), source_id, predicate, target, removed (bool), already_absent (bool when relation was not present), message, error, error_code (str), error_details (dict)",
     )
 
 
@@ -3682,9 +3936,11 @@ def _chat_get_prompt_context(
         },
         "behaviour_prompt": {"prompt_id": None, "preview": prompt_text or ""},
         "narration_prompt": {
-            "prompt_id": narration_prompt_concept_ids[0]
-            if narration_prompt_concept_ids
-            else None,
+            "prompt_id": (
+                narration_prompt_concept_ids[0]
+                if narration_prompt_concept_ids
+                else None
+            ),
             "preview": narration_preview,
         },
     }

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -2239,8 +2239,22 @@ async def _handle_add_relationship(arguments: dict[str, Any]) -> list[TextConten
     predicate = arguments.get("predicate")
     target = arguments.get("target")
     if not source_id or not predicate or not target:
+        missing: list[str] = []
+        if not source_id:
+            missing.append("source_id")
+        if not predicate:
+            missing.append("predicate")
+        if not target:
+            missing.append("target")
         return [
-            _json_error("Missing required parameters: source_id, predicate, and target")
+            _json_text(
+                {
+                    "success": False,
+                    "error": "Missing required parameters: source_id, predicate, and target",
+                    "error_code": "missing_parameter",
+                    "error_details": {"missing": missing},
+                }
+            )
         ]
     try:
         result = _add_relationship(
@@ -2248,7 +2262,16 @@ async def _handle_add_relationship(arguments: dict[str, Any]) -> list[TextConten
         )
         return [_json_text(result)]
     except Exception as exc:
-        return [_json_error(f"Failed to add relationship: {str(exc)}")]
+        return [
+            _json_text(
+                {
+                    "success": False,
+                    "error": f"Failed to add relationship: {str(exc)}",
+                    "error_code": "exception",
+                    "error_details": {"exception_type": type(exc).__name__},
+                }
+            )
+        ]
 
 
 async def _handle_remove_relationship(arguments: dict[str, Any]) -> list[TextContent]:
@@ -2256,8 +2279,22 @@ async def _handle_remove_relationship(arguments: dict[str, Any]) -> list[TextCon
     predicate = arguments.get("predicate")
     target = arguments.get("target")
     if not source_id or not predicate or not target:
+        missing: list[str] = []
+        if not source_id:
+            missing.append("source_id")
+        if not predicate:
+            missing.append("predicate")
+        if not target:
+            missing.append("target")
         return [
-            _json_error("Missing required parameters: source_id, predicate, and target")
+            _json_text(
+                {
+                    "success": False,
+                    "error": "Missing required parameters: source_id, predicate, and target",
+                    "error_code": "missing_parameter",
+                    "error_details": {"missing": missing},
+                }
+            )
         ]
     try:
         result = _remove_relationship(
@@ -2265,7 +2302,16 @@ async def _handle_remove_relationship(arguments: dict[str, Any]) -> list[TextCon
         )
         return [_json_text(result)]
     except Exception as exc:
-        return [_json_error(f"Failed to remove relationship: {str(exc)}")]
+        return [
+            _json_text(
+                {
+                    "success": False,
+                    "error": f"Failed to remove relationship: {str(exc)}",
+                    "error_code": "exception",
+                    "error_details": {"exception_type": type(exc).__name__},
+                }
+            )
+        ]
 
 
 async def _handle_delete_concept(arguments: dict[str, Any]) -> list[TextContent]:

--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -2940,8 +2940,53 @@ def add_relationship_route():
                 400,
             )
 
+            # Canonicalise known legacy predicate ids.
+            # JVNAUTOSCI-913: todo membership was previously represented via '#V#has_item'.
+            if kind == "#V#has_item":
+                kind = "#V#has_todo_item"
+
     try:
         repo = ConceptsRepository
+
+        from ...vontology.code_concepts_registry import (
+            build_virtual_concept_doc,
+            is_code_concept_id,
+        )
+        from ...vontology.utils_vontology import is_predicate
+
+        if is_dynamic_predicate:
+            predicate_doc = repo.find_one(
+                {"concept_id": kind}, {"concept_id": 1, "relationships": 1}
+            )
+            if predicate_doc is None and is_code_concept_id(kind):
+                predicate_doc = build_virtual_concept_doc(kind)
+
+            if predicate_doc is None:
+                return (
+                    jsonify(
+                        {
+                            "success": False,
+                            "error": (
+                                f"Predicate concept '{kind}' not found. Create it as a predicate concept "
+                                "(e.g. instance of #V#predicate) before using it as a relationship."
+                            ),
+                        }
+                    ),
+                    400,
+                )
+            if not is_predicate(predicate_doc):
+                return (
+                    jsonify(
+                        {
+                            "success": False,
+                            "error": (
+                                f"Concept '{kind}' exists but is not typed as a predicate. "
+                                "Predicates must be instances of #V#predicate (or a predicate subtype)."
+                            ),
+                        }
+                    ),
+                    400,
+                )
 
         # Check if this is a binary text predicate (expects text values, not concept references)
         is_text_predicate = False

--- a/tests/backend/test_internal_mcp_add_relationship_predicate_validation.py
+++ b/tests/backend/test_internal_mcp_add_relationship_predicate_validation.py
@@ -1,0 +1,143 @@
+import pytest
+
+
+def test_add_relationship_rejects_non_vontology_predicate_keys(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    calls = {"find_one": [], "update_one": []}
+
+    def _fake_find_one(filter_doc, projection=None):
+        calls["find_one"].append({"filter": filter_doc, "projection": projection})
+        cid = filter_doc.get("concept_id")
+        if cid == "#V#source":
+            return {"concept_id": "#V#source", "relationships": {}}
+        if cid == "#V#target":
+            return {"concept_id": "#V#target", "relationships": {}}
+        return None
+
+    def _fake_update_one(filter_doc, update_doc, upsert=False):
+        calls["update_one"].append(
+            {"filter": filter_doc, "update": update_doc, "upsert": upsert}
+        )
+        raise AssertionError("update_one should not be called for invalid predicates")
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _fake_find_one,
+    )
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.update_one",
+        _fake_update_one,
+    )
+
+    result = catalogue._add_relationship(
+        source_id="#V#source", predicate="has_item", target="#V#target"
+    )
+
+    assert result["success"] is False
+    assert result.get("error_code") == "invalid_relationship_predicate"
+    assert "Invalid relationship predicate" in (result.get("error") or "")
+
+
+def test_add_relationship_rejects_missing_dynamic_predicate_concepts(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    def _fake_find_one(filter_doc, projection=None):
+        cid = filter_doc.get("concept_id")
+        if cid == "#V#source":
+            return {"concept_id": "#V#source", "relationships": {}}
+        if cid == "#V#target":
+            return {"concept_id": "#V#target", "relationships": {}}
+        # Predicate concept does not exist
+        return None
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _fake_find_one,
+    )
+
+    result = catalogue._add_relationship(
+        source_id="#V#source", predicate="#V#has_item", target="#V#target"
+    )
+
+    assert result["success"] is False
+    assert result.get("error_code") == "predicate_concept_not_found"
+    assert "Predicate concept '#V#has_todo_item' not found" in (
+        result.get("error") or ""
+    )
+
+
+def test_add_relationship_rejects_dynamic_concepts_that_are_not_predicates(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    def _fake_find_one(filter_doc, projection=None):
+        cid = filter_doc.get("concept_id")
+        if cid == "#V#source":
+            return {"concept_id": "#V#source", "relationships": {}}
+        if cid == "#V#target":
+            return {"concept_id": "#V#target", "relationships": {}}
+        if cid == "#V#has_todo_item":
+            # Exists, but is not typed as a predicate
+            return {
+                "concept_id": "#V#has_todo_item",
+                "relationships": {"is_an_instance_of": []},
+            }
+        return None
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _fake_find_one,
+    )
+
+    result = catalogue._add_relationship(
+        source_id="#V#source", predicate="#V#has_todo_item", target="#V#target"
+    )
+
+    assert result["success"] is False
+    assert result.get("error_code") == "predicate_concept_not_typed"
+    assert "is not typed as a predicate" in (result.get("error") or "")
+
+
+def test_add_relationship_returns_structured_error_for_missing_source(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    def _fake_find_one(filter_doc, projection=None):
+        # Source is missing
+        return None
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _fake_find_one,
+    )
+
+    result = catalogue._add_relationship(
+        source_id="#V#source", predicate="typeOf", target="#V#target"
+    )
+
+    assert result["success"] is False
+    assert result.get("error_code") == "source_concept_not_found"
+    assert result.get("error_details", {}).get("concept_id") == "#V#source"
+
+
+def test_add_relationship_returns_structured_error_for_missing_target(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    def _fake_find_one(filter_doc, projection=None):
+        cid = filter_doc.get("concept_id")
+        if cid == "#V#source":
+            return {"concept_id": "#V#source", "relationships": {}}
+        # Target is missing
+        return None
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _fake_find_one,
+    )
+
+    result = catalogue._add_relationship(
+        source_id="#V#source", predicate="typeOf", target="#V#target"
+    )
+
+    assert result["success"] is False
+    assert result.get("error_code") == "target_concept_not_found"
+    assert result.get("error_details", {}).get("concept_id") == "#V#target"

--- a/tests/backend/test_internal_mcp_remove_relationship_errors.py
+++ b/tests/backend/test_internal_mcp_remove_relationship_errors.py
@@ -1,0 +1,96 @@
+import pytest
+
+
+def test_remove_relationship_rejects_non_vontology_predicate_keys(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    def _fake_find_one(filter_doc, projection=None):
+        cid = filter_doc.get("concept_id")
+        if cid == "#V#source":
+            return {"concept_id": "#V#source", "relationships": {}}
+        return None
+
+    def _fake_update_one(filter_doc, update_doc, upsert=False):
+        raise AssertionError("update_one should not be called for invalid predicates")
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _fake_find_one,
+    )
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.update_one",
+        _fake_update_one,
+    )
+
+    result = catalogue._remove_relationship(
+        source_id="#V#source", predicate="has_item", target="#V#target"
+    )
+
+    assert result["success"] is False
+    assert result.get("error_code") == "invalid_relationship_predicate"
+
+
+def test_remove_relationship_rejects_missing_dynamic_predicate_concepts(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    def _fake_find_one(filter_doc, projection=None):
+        cid = filter_doc.get("concept_id")
+        if cid == "#V#source":
+            return {"concept_id": "#V#source", "relationships": {}}
+        # Predicate concept does not exist
+        return None
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _fake_find_one,
+    )
+
+    result = catalogue._remove_relationship(
+        source_id="#V#source", predicate="#V#has_item", target="#V#target"
+    )
+
+    assert result["success"] is False
+    assert result.get("error_code") == "predicate_concept_not_found"
+    assert "#V#has_todo_item" in (result.get("error") or "")
+
+
+def test_remove_relationship_returns_structured_error_for_missing_source(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    def _fake_find_one(filter_doc, projection=None):
+        # Source is missing
+        return None
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _fake_find_one,
+    )
+
+    result = catalogue._remove_relationship(
+        source_id="#V#source", predicate="typeOf", target="#V#target"
+    )
+
+    assert result["success"] is False
+    assert result.get("error_code") == "source_concept_not_found"
+    assert result.get("error_details", {}).get("concept_id") == "#V#source"
+
+
+def test_remove_relationship_rejects_text_relation_predicates(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    def _fake_find_one(filter_doc, projection=None):
+        if filter_doc.get("concept_id") == "#V#source":
+            return {"concept_id": "#V#source", "relationships": {}}
+        return None
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _fake_find_one,
+    )
+
+    result = catalogue._remove_relationship(
+        source_id="#V#source", predicate="hasContent", target="hello"
+    )
+
+    assert result["success"] is False
+    assert result.get("error_code") == "unsupported_text_relation_removal"

--- a/utilities/audit_virtual_predicates.py
+++ b/utilities/audit_virtual_predicates.py
@@ -1,0 +1,286 @@
+"""Audit relationship/text-relation predicates for "virtual" usage.
+
+This is a read-only / dry-run audit.
+
+It reports relationship keys and text relation predicates that are NOT backed by
+an *actual persisted* predicate concept in the Vontology (i.e. a MongoDB concept
+document with a concept_id starting with "#V#" that is typed as a predicate via
+(is_an_instance_of ...) and `is_predicate()`.
+
+Notes:
+- Structural relationship keys (e.g. is_a_type_of) are excluded.
+- Plain text-relation predicates like "hasContent" will be reported, because
+  they are not predicate concepts.
+- Code-only predicate concepts (see `code_concepts_registry.py`) are reported as
+  "code_only_virtual" because they are not persisted.
+
+PowerShell examples:
+    pdm run python utilities/audit_virtual_predicates.py
+    pdm run python utilities/audit_virtual_predicates.py --limit-concepts 5000 --limit-text-relations 20000
+
+"""
+
+from __future__ import annotations
+
+import sys
+import argparse
+import json
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+
+_STRUCTURAL_RELATIONSHIP_KEYS = {
+    "is_a_type_of",
+    "has_subtype",
+    "is_an_instance_of",
+    "has_instance",
+    "related_to",
+}
+
+_KNOWN_NON_PREDICATE_RELATIONSHIP_KEYS = {
+    "linked_to",
+    "most_salient_type",
+}
+
+# Canonical mappings for known legacy relationship keys.
+# JVNAUTOSCI-913: historical todo list membership relations were stored under 'has_item'.
+_CANONICAL_PREDICATE_ID_OVERRIDES = {
+    "has_item": "#V#has_todo_item",
+    "#V#has_item": "#V#has_todo_item",
+}
+
+
+@dataclass(frozen=True)
+class PredicateUsage:
+    predicate: str
+    count: int
+    kind: str
+    mapped_to: Optional[str] = None
+    sample_subjects: Optional[List[str]] = None
+
+
+def _normalise_values(raw: Any) -> List[str]:
+    if isinstance(raw, list):
+        return [v for v in raw if isinstance(v, str) and v.strip()]
+    if isinstance(raw, str) and raw.strip():
+        return [raw]
+    return []
+
+
+def _iter_relationship_predicate_keys(relationships: Dict[str, Any]) -> Iterable[str]:
+    for key, value in relationships.items():
+        if key in _STRUCTURAL_RELATIONSHIP_KEYS:
+            continue
+        if key in _KNOWN_NON_PREDICATE_RELATIONSHIP_KEYS:
+            continue
+        # Only report if it actually has content.
+        if not _normalise_values(value):
+            continue
+        yield key
+
+
+def _classify_predicate_id(predicate: str) -> tuple[str, Optional[str]]:
+    """Return (kind, mapped_to).
+
+    kind values:
+    - structural_or_non_predicate (should not appear here)
+    - plain_string
+    - actual_predicate_concept
+    - missing_predicate_concept
+    - existing_non_predicate_concept
+    - code_only_virtual
+    """
+
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.vontology.code_concepts_registry import is_code_concept_id
+    from src.backend.vontology.utils_vontology import is_predicate
+
+    mapped_to = _CANONICAL_PREDICATE_ID_OVERRIDES.get(predicate)
+    effective = mapped_to or predicate
+
+    if not isinstance(effective, str) or not effective:
+        return "plain_string", mapped_to
+
+    if not effective.startswith("#V#"):
+        return "plain_string", mapped_to
+
+    doc = ConceptsRepository.find_one(
+        {"concept_id": effective}, {"concept_id": 1, "relationships": 1}
+    )
+    if doc is None:
+        if is_code_concept_id(effective):
+            return "code_only_virtual", mapped_to
+        return "missing_predicate_concept", mapped_to
+
+    if is_predicate(doc):
+        return "actual_predicate_concept", mapped_to
+
+    return "existing_non_predicate_concept", mapped_to
+
+
+def audit(
+    *,
+    limit_concepts: Optional[int],
+    limit_text_relations: Optional[int],
+    sample_size: int,
+) -> Dict[str, Any]:
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.db.repositories.text_value_repository import (
+        TextRelationsRepository,
+    )
+
+    concepts_coll = ConceptsRepository.collection()
+    if concepts_coll is None:
+        raise RuntimeError("Concepts collection not available")
+
+    relationship_predicate_counts: Counter[str] = Counter()
+    relationship_predicate_samples: dict[str, list[str]] = defaultdict(list)
+
+    scanned_concepts = 0
+    cursor = concepts_coll.find(
+        {"relationships": {"$exists": True}}, {"concept_id": 1, "relationships": 1}
+    )
+    for doc in cursor:
+        scanned_concepts += 1
+        if limit_concepts is not None and scanned_concepts > limit_concepts:
+            break
+
+        concept_id = doc.get("concept_id")
+        relationships = doc.get("relationships")
+        if not isinstance(concept_id, str) or not isinstance(relationships, dict):
+            continue
+
+        for pred_key in _iter_relationship_predicate_keys(relationships):
+            relationship_predicate_counts[pred_key] += 1
+            if len(relationship_predicate_samples[pred_key]) < sample_size:
+                relationship_predicate_samples[pred_key].append(concept_id)
+
+    text_predicate_counts: Counter[str] = Counter()
+    text_predicate_samples: dict[str, list[str]] = defaultdict(list)
+
+    scanned_text_relations = 0
+    tr_cursor = TextRelationsRepository.find(
+        {},
+        {"predicate": 1, "subject_concept_id": 1},
+    )
+    for tr in tr_cursor:
+        scanned_text_relations += 1
+        if (
+            limit_text_relations is not None
+            and scanned_text_relations > limit_text_relations
+        ):
+            break
+
+        pred = tr.get("predicate")
+        subject = tr.get("subject_concept_id")
+        if not isinstance(pred, str) or not pred.strip():
+            continue
+
+        pred = pred.strip()
+        text_predicate_counts[pred] += 1
+        if (
+            isinstance(subject, str)
+            and subject
+            and len(text_predicate_samples[pred]) < sample_size
+        ):
+            text_predicate_samples[pred].append(subject)
+
+    relationship_usages: list[PredicateUsage] = []
+    for predicate, count in relationship_predicate_counts.most_common():
+        kind, mapped_to = _classify_predicate_id(predicate)
+        relationship_usages.append(
+            PredicateUsage(
+                predicate=predicate,
+                count=count,
+                kind=kind,
+                mapped_to=mapped_to,
+                sample_subjects=relationship_predicate_samples.get(predicate) or None,
+            )
+        )
+
+    text_usages: list[PredicateUsage] = []
+    for predicate, count in text_predicate_counts.most_common():
+        kind, mapped_to = _classify_predicate_id(predicate)
+        text_usages.append(
+            PredicateUsage(
+                predicate=predicate,
+                count=count,
+                kind=kind,
+                mapped_to=mapped_to,
+                sample_subjects=text_predicate_samples.get(predicate) or None,
+            )
+        )
+
+    def _summarise(usages: list[PredicateUsage]) -> dict[str, int]:
+        summary: Counter[str] = Counter()
+        for usage in usages:
+            summary[usage.kind] += usage.count
+        return dict(summary)
+
+    return {
+        "success": True,
+        "scanned": {
+            "concepts": scanned_concepts,
+            "text_relations": scanned_text_relations,
+        },
+        "relationship_predicates": {
+            "summary": _summarise(relationship_usages),
+            "items": [u.__dict__ for u in relationship_usages],
+        },
+        "text_relation_predicates": {
+            "summary": _summarise(text_usages),
+            "items": [u.__dict__ for u in text_usages],
+        },
+        "notes": [
+            "Kinds: actual_predicate_concept (persisted predicate), code_only_virtual (registered in code only), missing_predicate_concept (not found), existing_non_predicate_concept (found but not predicate-typed), plain_string (not a #V# concept id).",
+            "Plain text predicates like 'hasContent' are expected in text_relations and will appear as plain_string.",
+            "Legacy override mappings are reported via mapped_to (e.g. has_item -> #V#has_todo_item).",
+        ],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Dry-run audit for relationship keys and text relation predicates that are not backed by persisted predicate concepts."
+        )
+    )
+    parser.add_argument(
+        "--limit-concepts",
+        type=int,
+        default=None,
+        help="Only scan the first N concept docs (debugging aid).",
+    )
+    parser.add_argument(
+        "--limit-text-relations",
+        type=int,
+        default=None,
+        help="Only scan the first N text_relations docs (debugging aid).",
+    )
+    parser.add_argument(
+        "--sample-size",
+        type=int,
+        default=5,
+        help="How many sample subject concept_ids to include per predicate.",
+    )
+
+    args = parser.parse_args()
+
+    result = audit(
+        limit_concepts=args.limit_concepts,
+        limit_text_relations=args.limit_text_relations,
+        sample_size=max(0, int(args.sample_size)),
+    )
+
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/utilities/migrate_virtual_relationship_predicates.py
+++ b/utilities/migrate_virtual_relationship_predicates.py
@@ -1,0 +1,373 @@
+"""Repair invalid relationship predicate keys in the concepts collection.
+
+This script exists to clean up legacy or accidental writes where arbitrary strings
+(e.g. "has_item") were used as keys under the "relationships" subdocument.
+
+Target state:
+- Structural relationship fields remain as-is (e.g. is_a_type_of, is_an_instance_of).
+- Predicate-like relationship fields MUST use compliant Vontology concept ids
+  (start with "#V#").
+
+The script can:
+- Report invalid relationship keys.
+- Optionally rewrite invalid keys to compliant "#V#..." ids.
+- Optionally create missing predicate concept nodes so rewritten keys are not
+  "virtual".
+
+It is designed to be idempotent.
+
+PowerShell examples:
+    pdm run python utilities/migrate_virtual_relationship_predicates.py
+
+    pdm run python utilities/migrate_virtual_relationship_predicates.py --apply
+
+    pdm run python utilities/migrate_virtual_relationship_predicates.py --apply --create-predicate-concepts
+
+"""
+
+from __future__ import annotations
+
+import sys
+import argparse
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+
+_STRUCTURAL_RELATIONSHIP_KEYS = {
+    "is_a_type_of",
+    "has_subtype",
+    "is_an_instance_of",
+    "has_instance",
+    "related_to",
+}
+
+# Known relationship fields that are not predicates but are legitimately persisted.
+# These should NOT be migrated into predicate concepts.
+_KNOWN_NON_PREDICATE_RELATIONSHIP_KEYS = {
+    "linked_to",
+    "most_salient_type",
+}
+
+
+# Canonical mappings for known legacy relationship keys.
+#
+# JVNAUTOSCI-913: historical todo list membership relations were accidentally
+# stored under 'has_item' (a non-Vontology predicate key). The canonical predicate
+# concept id is '#V#has_todo_item'.
+_CANONICAL_PREDICATE_ID_OVERRIDES = {
+    "has_item": "#V#has_todo_item",
+    "#V#has_item": "#V#has_todo_item",
+}
+
+
+@dataclass(frozen=True)
+class MigrationChange:
+    concept_id: str
+    old_key: str
+    new_key: str
+    moved_count: int
+    removed_old_key: bool
+
+
+def _normalise_relationship_values(raw: Any) -> List[str]:
+    if isinstance(raw, list):
+        return [v for v in raw if isinstance(v, str) and v.strip()]
+    if isinstance(raw, str) and raw.strip():
+        return [raw]
+    return []
+
+
+def _iter_invalid_relationship_keys(relationships: Dict[str, Any]) -> Iterable[str]:
+    for key, value in relationships.items():
+        if key in _STRUCTURAL_RELATIONSHIP_KEYS:
+            continue
+        if key in _KNOWN_NON_PREDICATE_RELATIONSHIP_KEYS:
+            continue
+        if isinstance(key, str) and key.startswith("#V#"):
+            continue
+        # Ignore empty/none buckets quietly
+        if not _normalise_relationship_values(value):
+            continue
+        yield key
+
+
+def _canonicalise_predicate_id(raw_key: str) -> Optional[str]:
+    if not isinstance(raw_key, str):
+        return None
+
+    raw_key = raw_key.strip()
+    if not raw_key:
+        return None
+
+    override = _CANONICAL_PREDICATE_ID_OVERRIDES.get(raw_key)
+    if override:
+        return override
+
+    if raw_key.startswith("#V#"):
+        return raw_key
+
+    # Use the same normaliser as concept creation.
+    from src.backend.utils.concept_id_utils import canonicalise_vontology_concept_id
+
+    return canonicalise_vontology_concept_id(raw_key)
+
+
+def _ensure_predicate_concept_exists(predicate_id: str) -> bool:
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.services.concept_service import create_concept
+    from src.backend.vontology.code_concepts_registry import is_code_concept_id
+
+    if is_code_concept_id(predicate_id):
+        return True
+
+    existing = ConceptsRepository.find_one(
+        {"concept_id": predicate_id}, {"concept_id": 1}
+    )
+    if existing:
+        return True
+
+    # Create as an instance of #V#predicate. The type itself may be virtual;
+    # that is acceptable for research prototype workflows.
+    base_name = predicate_id[3:] if predicate_id.startswith("#V#") else predicate_id
+
+    created = create_concept(
+        name=base_name,
+        concept_id=predicate_id,
+        parent_concept_ids=["#V#predicate"],
+        create_as_instance=True,
+        description=(
+            "Auto-created predicate concept to replace a legacy relationship key."
+        ),
+    )
+    return bool(created)
+
+
+def _ensure_predicate_concept_is_typed(predicate_id: str) -> bool:
+    """Ensure an existing predicate concept is typed as a predicate.
+
+    This adds relationships.is_an_instance_of += '#V#predicate' when needed.
+
+    We do not maintain the inverse edge here because '#V#predicate' may be a
+    code-only concept in some environments.
+    """
+
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.vontology.code_concepts_registry import is_code_concept_id
+    from src.backend.vontology.utils_vontology import is_predicate
+
+    if is_code_concept_id(predicate_id):
+        return False
+
+    doc = ConceptsRepository.find_one(
+        {"concept_id": predicate_id}, {"concept_id": 1, "relationships": 1}
+    )
+    if not doc:
+        return False
+
+    if is_predicate(doc):
+        return False
+
+    ConceptsRepository.update_one(
+        {"concept_id": predicate_id},
+        {"$addToSet": {"relationships.is_an_instance_of": "#V#predicate"}},
+    )
+    return True
+
+
+def run(
+    *,
+    apply: bool,
+    create_predicate_concepts: bool,
+    ensure_predicate_typing: bool,
+    limit: Optional[int],
+) -> Dict[str, Any]:
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.db.repositories.text_value_repository import (
+        TextRelationsRepository,
+    )
+
+    coll = ConceptsRepository.collection()
+    if coll is None:
+        raise RuntimeError("Concepts collection not available")
+
+    projection = {"concept_id": 1, "relationships": 1}
+
+    cursor = coll.find({"relationships": {"$exists": True}}, projection)
+    changes: List[MigrationChange] = []
+    invalid_key_counts: Counter[str] = Counter()
+    created_predicates: Counter[str] = Counter()
+    typed_predicates: Counter[str] = Counter()
+    existing_vkey_predicates_scanned: Counter[str] = Counter()
+    existing_vkey_predicates_created: Counter[str] = Counter()
+    text_vkey_predicates_scanned: Counter[str] = Counter()
+    text_vkey_predicates_created: Counter[str] = Counter()
+
+    scanned = 0
+    for doc in cursor:
+        scanned += 1
+        if limit is not None and scanned > limit:
+            break
+
+        concept_id = doc.get("concept_id")
+        relationships = doc.get("relationships")
+        if not isinstance(concept_id, str) or not concept_id:
+            continue
+        if not isinstance(relationships, dict):
+            continue
+
+        invalid_keys = list(_iter_invalid_relationship_keys(relationships))
+        for old_key in invalid_keys:
+            invalid_key_counts[old_key] += 1
+
+            new_key = _canonicalise_predicate_id(old_key)
+            if not new_key or not new_key.startswith("#V#"):
+                continue
+
+            values = _normalise_relationship_values(relationships.get(old_key))
+            if not values:
+                continue
+
+            if create_predicate_concepts:
+                if _ensure_predicate_concept_exists(new_key):
+                    created_predicates[new_key] += 1
+                if ensure_predicate_typing:
+                    if _ensure_predicate_concept_is_typed(new_key):
+                        typed_predicates[new_key] += 1
+
+            if not apply:
+                changes.append(
+                    MigrationChange(
+                        concept_id=concept_id,
+                        old_key=old_key,
+                        new_key=new_key,
+                        moved_count=len(values),
+                        removed_old_key=True,
+                    )
+                )
+                continue
+
+            # Merge values into the new key, avoid duplicates.
+            update_ops: Dict[str, Any] = {
+                "$addToSet": {f"relationships.{new_key}": {"$each": values}},
+                "$unset": {f"relationships.{old_key}": ""},
+            }
+
+            coll.update_one({"concept_id": concept_id}, update_ops)
+            changes.append(
+                MigrationChange(
+                    concept_id=concept_id,
+                    old_key=old_key,
+                    new_key=new_key,
+                    moved_count=len(values),
+                    removed_old_key=True,
+                )
+            )
+
+        # Optional: if requested, ensure predicate concepts exist for existing
+        # compliant relationship keys that are currently "missing".
+        if create_predicate_concepts:
+            for rel_key in relationships.keys():
+                if not isinstance(rel_key, str) or not rel_key.startswith("#V#"):
+                    continue
+                if rel_key in _STRUCTURAL_RELATIONSHIP_KEYS:
+                    continue
+                if rel_key in _KNOWN_NON_PREDICATE_RELATIONSHIP_KEYS:
+                    continue
+
+                # Ignore empty buckets.
+                if not _normalise_relationship_values(relationships.get(rel_key)):
+                    continue
+
+                existing_vkey_predicates_scanned[rel_key] += 1
+
+                if _ensure_predicate_concept_exists(rel_key):
+                    existing_vkey_predicates_created[rel_key] += 1
+                if ensure_predicate_typing:
+                    if _ensure_predicate_concept_is_typed(rel_key):
+                        typed_predicates[rel_key] += 1
+
+    # Also cover #V#... predicates used in text relations.
+    if create_predicate_concepts:
+        for tr in TextRelationsRepository.find({}, {"predicate": 1}):
+            predicate = tr.get("predicate")
+            if not isinstance(predicate, str) or not predicate.startswith("#V#"):
+                continue
+
+            text_vkey_predicates_scanned[predicate] += 1
+
+            if _ensure_predicate_concept_exists(predicate):
+                text_vkey_predicates_created[predicate] += 1
+            if ensure_predicate_typing:
+                if _ensure_predicate_concept_is_typed(predicate):
+                    typed_predicates[predicate] += 1
+
+    return {
+        "success": True,
+        "apply": apply,
+        "create_predicate_concepts": create_predicate_concepts,
+        "ensure_predicate_typing": ensure_predicate_typing,
+        "scanned": scanned,
+        "invalid_key_counts": dict(invalid_key_counts),
+        "changes": [change.__dict__ for change in changes],
+        "created_predicates": dict(created_predicates),
+        "typed_predicates": dict(typed_predicates),
+        "existing_vkey_predicates_scanned": dict(existing_vkey_predicates_scanned),
+        "existing_vkey_predicates_created": dict(existing_vkey_predicates_created),
+        "text_vkey_predicates_scanned": dict(text_vkey_predicates_scanned),
+        "text_vkey_predicates_created": dict(text_vkey_predicates_created),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Migrate invalid relationship keys (e.g. 'has_item') to compliant '#V#...' predicate ids."
+        )
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply changes (default is dry-run/report only).",
+    )
+    parser.add_argument(
+        "--create-predicate-concepts",
+        action="store_true",
+        help="Create missing predicate concept nodes for migrated keys.",
+    )
+    parser.add_argument(
+        "--ensure-predicate-typing",
+        action="store_true",
+        help=(
+            "Ensure predicate concepts are typed as predicates by adding is_an_instance_of '#V#predicate' when missing."
+        ),
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Only scan the first N concepts (debugging aid).",
+    )
+
+    args = parser.parse_args()
+    result = run(
+        apply=bool(args.apply),
+        create_predicate_concepts=bool(args.create_predicate_concepts),
+        ensure_predicate_typing=bool(args.ensure_predicate_typing),
+        limit=args.limit,
+    )
+
+    # Keep output simple and machine-readable.
+    import json
+
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds structured, agent-readable errors (`error_code`, `error_details`) for MCP relationship assertions.
- Applies the same contract to both `add_relationship` and `remove_relationship`.

## Details
- Validates that dynamic relationship predicates (`#V#...`) exist and are typed as predicates.
- Rejects text-relation removals via `remove_relationship` with `unsupported_text_relation_removal`.
- Canonicalises legacy `#V#has_item` to `#V#has_todo_item`.

## Testing
- `pdm run pytest tests/backend/test_internal_mcp_add_relationship_text_predicates.py`
- `pdm run pytest tests/backend/test_internal_mcp_add_relationship_predicate_validation.py`
- `pdm run pytest tests/backend/test_internal_mcp_remove_relationship_errors.py`