### PR TITLE
JVNAUTOSCI-937: Improve CODE/GUID handling + chat buttonify

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -174,6 +174,40 @@ function extractBoldQuotedInstruction(text) {
     return instruction;
 }
 
+function extractQuotedInstruction(text) {
+    const value = String(text ?? '').trim();
+    if (!value) return null;
+
+    // Support curly or straight quotes.
+    const m = value.match(/^(?:“|")(.+?)(?:”|")\s*$/);
+    if (!m) return null;
+
+    const instruction = String(m[1] ?? '').trim();
+    if (!instruction) return null;
+    return instruction;
+}
+
+function isAllowedUnquotedBlockquoteInstruction(text) {
+    const value = String(text ?? '').trim();
+    if (!value) return false;
+
+    // Purposefully narrow: broken-windows fix for known UI phrasing.
+    // (Avoid turning arbitrary bolded blockquotes into buttons.)
+    const compact = value.replace(/\s+/g, ' ');
+    return /^Proceed with creation using verified parents and contribution[-‑–—]based modelling\?$/i.test(compact);
+}
+
+function shouldButtonifyInlineQuotedInstruction(instruction) {
+    const value = String(instruction ?? '').trim();
+    if (!value) return false;
+    const compact = value.replace(/\s+/g, ' ');
+
+    if (/^(yes|no)$/i.test(compact)) return true;
+    if (/^Create the core paper representation now \(paper \+ authors \+ core contribution only\)\.?$/i.test(compact)) return true;
+    if (/^Create the full representation as specified\.?$/i.test(compact)) return true;
+    return false;
+}
+
 function extractBoldQuotedInstructionFromStrong(strongEl) {
     if (!strongEl) return null;
 
@@ -432,26 +466,52 @@ function convertQuotedInstructionBlockquotesToButtons(root) {
 
             const pElementChildren = Array.from(p.children ?? []);
             const strongCandidates = pElementChildren.filter((el) => el && el.tagName === 'STRONG');
-            if (strongCandidates.length !== 1) continue;
-            const strong = strongCandidates[0];
-
-            // Allow harmless formatting elements that do not contribute text.
-            if (pElementChildren.some((el) => el !== strong && el.tagName !== 'BR')) {
-                continue;
-            }
-
-            // No non-whitespace text nodes inside the paragraph.
-            const pNodes = Array.from(p.childNodes ?? []);
-            if (pNodes.some((n) => n.nodeType === Node.TEXT_NODE && String(n.textContent ?? '').trim())) {
-                continue;
-            }
-
-            const instruction = extractBoldQuotedInstructionFromStrong(strong);
-            if (!instruction) continue;
-
-            // Ensure the blockquote text is exactly the quoted strong text (no extra content).
             const normalise = (s) => String(s ?? '').trim().replace(/\s+/g, ' ');
-            if (normalise(block.textContent) !== normalise(strong.textContent)) continue;
+
+            let instruction = null;
+
+            if (strongCandidates.length === 1) {
+                const strong = strongCandidates[0];
+
+                // Allow harmless formatting elements that do not contribute text.
+                if (pElementChildren.some((el) => el !== strong && el.tagName !== 'BR')) {
+                    continue;
+                }
+
+                // No non-whitespace text nodes inside the paragraph.
+                const pNodes = Array.from(p.childNodes ?? []);
+                if (pNodes.some((n) => n.nodeType === Node.TEXT_NODE && String(n.textContent ?? '').trim())) {
+                    continue;
+                }
+
+                instruction = extractBoldQuotedInstructionFromStrong(strong);
+                if (!instruction) {
+                    const candidate = normalise(strong.textContent);
+                    if (isAllowedUnquotedBlockquoteInstruction(candidate)) {
+                        instruction = candidate;
+                    }
+                }
+                if (!instruction) continue;
+
+                // Ensure the blockquote text is exactly the expected paragraph text (no extra content).
+                if (normalise(block.textContent) !== normalise(p.textContent)) continue;
+            } else {
+                // Also support plain quoted text without bold:
+                // <blockquote><p>“...”</p></blockquote>
+                // Allow only <br> tags and no other nested markup.
+                if (pElementChildren.some((el) => el && el.tagName !== 'BR')) {
+                    continue;
+                }
+
+                const pNodes = Array.from(p.childNodes ?? []);
+                if (pNodes.some((n) => n.nodeType === Node.ELEMENT_NODE && n.tagName && n.tagName !== 'BR')) {
+                    continue;
+                }
+
+                instruction = extractQuotedInstruction(p.textContent);
+                if (!instruction) continue;
+                if (normalise(block.textContent) !== normalise(p.textContent)) continue;
+            }
 
             const btn = document.createElement('button');
             btn.type = 'button';
@@ -478,6 +538,53 @@ function convertQuotedInstructionBlockquotesToButtons(root) {
             wrapper.className = 'chat-insert-prompt-wrapper';
             wrapper.appendChild(btn);
             block.replaceWith(wrapper);
+        } catch (_) {
+            // Ignore detached nodes or DOM mutation races.
+        }
+    }
+}
+
+function convertInlineQuotedStrongSegmentsToButtons(root) {
+    if (!root || !root.querySelectorAll) return;
+
+    const strongEls = Array.from(root.querySelectorAll('strong'));
+    for (const strong of strongEls) {
+        try {
+            if (!strong || !strong.closest) continue;
+            if (strong.closest('pre, code, a, button')) continue;
+            if (strong.closest('blockquote')) continue;
+            if (strong.closest('ul, ol')) continue;
+            if (strong.closest('.chat-insert-prompt-wrapper')) continue;
+
+            const instruction = extractBoldQuotedInstructionFromStrong(strong);
+            if (!instruction) continue;
+            if (!shouldButtonifyInlineQuotedInstruction(instruction)) continue;
+
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'chat-insert-prompt-button';
+            btn.textContent = instruction;
+            btn.title = 'Insert into chat prompt and send (Shift inserts without sending)';
+            btn.setAttribute('aria-label', `Insert into chat prompt: ${instruction}`);
+            btn.addEventListener('click', (e) => {
+                try {
+                    e.preventDefault();
+                    e.stopPropagation();
+                } catch (_) {
+                    // Ignore.
+                }
+                insertTextIntoChatPrompt(instruction);
+
+                const shiftHeld = !!(e && e.shiftKey);
+                if (!shiftHeld) {
+                    submitChatPromptImmediately();
+                }
+            });
+
+            const wrapper = document.createElement('span');
+            wrapper.className = 'chat-insert-prompt-inline-wrapper';
+            wrapper.appendChild(btn);
+            strong.replaceWith(wrapper);
         } catch (_) {
             // Ignore detached nodes or DOM mutation races.
         }
@@ -565,6 +672,7 @@ async function renderChatMarkdownIntoContainer(container, text) {
 
     container.innerHTML = html;
     convertQuotedInstructionBlockquotesToButtons(container);
+    convertInlineQuotedStrongSegmentsToButtons(container);
     convertReplyOptionsListsToButtons(container);
     try {
         container.dataset.renderMode = 'rendered';
@@ -613,6 +721,7 @@ function setVonMessageRenderMode(messageTextEl, mode, originalText, debugData) {
     if (cachedHtml) {
         messageTextEl.innerHTML = cachedHtml;
         convertQuotedInstructionBlockquotesToButtons(messageTextEl);
+        convertInlineQuotedStrongSegmentsToButtons(messageTextEl);
         cartouchifyVontologyTokensInElement(messageTextEl, { skipSelectors: ['pre', 'code', 'a'], allowStandaloneCodeTokens: true, allowStandaloneCodeBlockTokens: true });
         hydrateChatConceptCartouches(messageTextEl);
         return;
@@ -967,6 +1076,11 @@ export function __testOnly_convertQuotedInstructionBlockquotesToButtons(root) {
 // Export for testing.
 export function __testOnly_convertReplyOptionsListsToButtons(root) {
     convertReplyOptionsListsToButtons(root);
+}
+
+// Export for testing.
+export function __testOnly_convertInlineQuotedStrongSegmentsToButtons(root) {
+    convertInlineQuotedStrongSegmentsToButtons(root);
 }
 
 function deriveLlmDebugWarnings(debugData) {

--- a/src/frontend/web/von_interface/static/js/conceptTab.js
+++ b/src/frontend/web/von_interface/static/js/conceptTab.js
@@ -2481,6 +2481,41 @@ export async function fetchInstancesWithSuffix(conceptId, suffix) {
 // Names Management Functions
 let currentConceptNames = [];
 
+function isUuidLike(text) {
+  const t = (text || '').toString().trim();
+  if (!t) return false;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(t);
+}
+
+function isHexObjectIdLike(text) {
+  const t = (text || '').toString().trim();
+  if (!t) return false;
+  // MongoDB ObjectId-ish (24 hex chars).
+  return /^[0-9a-f]{24}$/i.test(t);
+}
+
+function isVonConceptIdLike(text) {
+  const t = (text || '').toString().trim();
+  return t.startsWith('#V#');
+}
+
+function getDisplayLanguageForName(nameObj) {
+  const type = (nameObj?.type || '').toString().trim().toUpperCase();
+  const language = (nameObj?.language || '').toString().trim();
+  const text = (nameObj?.name || nameObj?.text || '').toString().trim();
+
+  // JVNAUTOSCI-937: GUID-like CODE values are not natural-language text.
+  // This is display-only; we do not rewrite stored language codes.
+  if (type === 'VONGUID') return 'guid';
+  if (type === 'CODE' && (isUuidLike(text) || isHexObjectIdLike(text))) return 'guid';
+  if (type === 'CODE' && language.toLowerCase() === 'vonguid') return 'guid';
+
+  // JVNAUTOSCI-937: Von concept IDs are CODE identifiers (display-only language `id-von`).
+  if (type === 'CODE' && isVonConceptIdLike(text)) return 'id-von';
+
+  return language || 'en-NZ';
+}
+
 /**
  * Get the preferred language from settings
  * @returns {Promise<string>} The preferred language code
@@ -2600,8 +2635,6 @@ export async function displayConceptNames(names = [], suffix = '') {
   if (currentConceptNames.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'names-empty-state';
-    empty.style.color = '#6b7280';
-    empty.style.fontStyle = 'italic';
     empty.textContent = 'No names yet. Add one below.';
     namesList.appendChild(empty);
     return;
@@ -2654,8 +2687,10 @@ export async function displayConceptNames(names = [], suffix = '') {
       return spaced;
     };
 
-    // Inline edit behavior
-    nameText.addEventListener('click', () => {
+    const isCodeName = (nameObj.type || '').toString().trim().toUpperCase() === 'CODE';
+
+    // Inline edit behaviour (JVNAUTOSCI-937): CODE names are read-only (for now).
+    if (!isCodeName) nameText.addEventListener('click', () => {
       try {
         const original = nameObj.name || nameObj.text || '';
         // Only propose CamelCase spacing for Latin languages and when text looks Latin-script
@@ -2718,7 +2753,7 @@ export async function displayConceptNames(names = [], suffix = '') {
 
     const languageBadge = document.createElement('span');
     languageBadge.className = 'name-language-badge';
-    languageBadge.textContent = nameObj.language || 'en-NZ';
+    languageBadge.textContent = getDisplayLanguageForName(nameObj);
 
     nameMeta.appendChild(typeBadge);
     nameMeta.appendChild(languageBadge);
@@ -2728,7 +2763,11 @@ export async function displayConceptNames(names = [], suffix = '') {
     deleteBtn.className = 'name-delete-button';
     deleteBtn.innerHTML = '×';
     deleteBtn.title = 'Remove this name';
-    deleteBtn.disabled = currentConceptNames.length === 1;
+    deleteBtn.disabled = currentConceptNames.length === 1 || isCodeName;
+
+    if (isCodeName) {
+      deleteBtn.title = 'CODE names are read-only and cannot be removed';
+    }
 
     if (!deleteBtn.disabled) {
       deleteBtn.addEventListener('click', () => deleteName(index, suffix));
@@ -2837,6 +2876,11 @@ export async function deleteName(index, suffix = '') {
   }
 
   const nameToDelete = currentConceptNames[index];
+
+  if ((nameToDelete?.type || '').toString().trim().toUpperCase() === 'CODE') {
+    setNamesStatusMessage(suffix, 'CODE names are read-only and cannot be removed', 'red', true);
+    return;
+  }
 
   try {
     setNamesStatusMessage(suffix, 'Deleting...', 'blue');

--- a/src/frontend/web/von_interface/static/js/predicateExtentDisplay.js
+++ b/src/frontend/web/von_interface/static/js/predicateExtentDisplay.js
@@ -7,6 +7,7 @@
 
 import { createOrActivateConceptTab } from './dynamicTabs.js';
 import { fetchPredicateExtent } from './predicateUtils.js';
+import { selectBestNameForContext } from './utils/nameSelection.js';
 
 /**
  * Cache for concept display names to avoid repeated fetches.
@@ -46,7 +47,6 @@ async function getConceptMetadata(conceptId) {
         }
 
         const doc = await resp.json();
-        const currentLang = document.documentElement.lang || 'en';
 
         // Use kind from backend (type, predicate, or individual)
         const kind = doc.kind || 'unknown';
@@ -67,42 +67,7 @@ async function getConceptMetadata(conceptId) {
             return metadata;
         }
 
-        // Filter by language
-        let filtered = names.filter(n => n && n.language === currentLang);
-        if (filtered.length === 0) {
-            // Try base language
-            const langBase = currentLang.split('-')[0];
-            filtered = names.filter(n => n && (n.language === langBase || (n.language || '').startsWith(langBase + '-')));
-        }
-        if (filtered.length === 0) {
-            filtered = names;
-        }
-
-        // Collect candidates (prefer abbrev, then text, then name)
-        const candidates = [];
-        for (const n of filtered) {
-            if (n) {
-                if (typeof n.abbrev === 'string' && n.abbrev.trim()) {
-                    candidates.push(n.abbrev.trim());
-                }
-                if (typeof n.text === 'string' && n.text.trim()) {
-                    candidates.push(n.text.trim());
-                }
-                if (typeof n.name === 'string' && n.name.trim()) {
-                    candidates.push(n.name.trim());
-                }
-            }
-        }
-
-        if (candidates.length === 0) {
-            const metadata = { displayName: conceptId, kind };
-            conceptMetadataCache.set(conceptId, metadata);
-            return metadata;
-        }
-
-        // Choose shortest
-        candidates.sort((a, b) => a.length - b.length || a.localeCompare(b));
-        const displayName = candidates[0];
+        const displayName = selectBestNameForContext(names) || doc.name || doc.display_name || conceptId;
         const metadata = { displayName, kind };
         conceptMetadataCache.set(conceptId, metadata);
         return metadata;

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -1,4 +1,5 @@
 import {
+    __testOnly_convertInlineQuotedStrongSegmentsToButtons,
     __testOnly_convertQuotedInstructionBlockquotesToButtons,
     __testOnly_convertReplyOptionsListsToButtons,
     __testOnly_deriveLlmDebugWarnings,
@@ -260,6 +261,74 @@ describe('chat insert prompt button behaviour', () => {
 
         expect(String(promptInput.value)).toContain('Do the thing');
         expect(sendButton.click).toHaveBeenCalledTimes(0);
+    });
+
+    test('supports blockquotes with plain quoted text (no strong)', () => {
+        const sendButton = document.getElementById('sendButton');
+        const promptInput = document.getElementById('promptInput');
+
+        sendButton.click = jest.fn();
+
+        const root = document.createElement('div');
+        root.innerHTML = '<blockquote><p>“Create the full representation as specified.”</p></blockquote>';
+        __testOnly_convertQuotedInstructionBlockquotesToButtons(root);
+
+        const btn = root.querySelector('.chat-insert-prompt-button');
+        expect(btn).not.toBeNull();
+        expect(btn.textContent).toBe('Create the full representation as specified.');
+
+        btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+        expect(String(promptInput.value)).toContain('Create the full representation as specified.');
+        expect(sendButton.click).toHaveBeenCalledTimes(1);
+    });
+
+    test('supports unquoted strong blockquote confirmation prompt', () => {
+        const sendButton = document.getElementById('sendButton');
+        const promptInput = document.getElementById('promptInput');
+
+        sendButton.click = jest.fn();
+
+        const root = document.createElement('div');
+        root.innerHTML =
+            '<blockquote><p><strong>Proceed with creation using verified parents and contribution‑based modelling?</strong></p></blockquote>';
+        __testOnly_convertQuotedInstructionBlockquotesToButtons(root);
+
+        const btn = root.querySelector('.chat-insert-prompt-button');
+        expect(btn).not.toBeNull();
+        expect(btn.textContent).toBe('Proceed with creation using verified parents and contribution‑based modelling?');
+
+        btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(String(promptInput.value)).toContain('Proceed with creation using verified parents and contribution‑based modelling?');
+        expect(sendButton.click).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('chat inline insert prompt button behaviour', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <button id="sendButton"></button>
+            <textarea id="promptInput"></textarea>
+        `;
+    });
+
+    test('inline quoted strong (e.g. “Yes”) becomes an insert button', () => {
+        const sendButton = document.getElementById('sendButton');
+        const promptInput = document.getElementById('promptInput');
+
+        sendButton.click = jest.fn();
+
+        const root = document.createElement('div');
+        root.innerHTML = '<p>If you say <strong>“Yes”</strong>, I will do the thing.</p>';
+        __testOnly_convertInlineQuotedStrongSegmentsToButtons(root);
+
+        const btn = root.querySelector('.chat-insert-prompt-button');
+        expect(btn).not.toBeNull();
+        expect(btn.textContent).toBe('Yes');
+
+        btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(String(promptInput.value)).toContain('Yes');
+        expect(sendButton.click).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/src/frontend/web/von_interface/static/js/utils/nameSelection.js
+++ b/src/frontend/web/von_interface/static/js/utils/nameSelection.js
@@ -1,5 +1,40 @@
 const DEFAULT_LANGUAGE = 'en-NZ';
 
+function _isUuidLike(text) {
+    const t = (text || '').toString().trim();
+    if (!t) return false;
+    // RFC 4122 style UUIDs (case-insensitive)
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(t);
+}
+
+function _isHexObjectIdLike(text) {
+    const t = (text || '').toString().trim();
+    if (!t) return false;
+    // MongoDB ObjectId-ish (24 hex chars).
+    return /^[0-9a-f]{24}$/i.test(t);
+}
+
+function _isVonConceptIdLike(text) {
+    const t = (text || '').toString().trim();
+    return t.startsWith('#V#');
+}
+
+function _isGuidLikeCandidate(candidate) {
+    if (!candidate) return false;
+    const type = (candidate.type || '').toString().trim().toUpperCase();
+    const language = (candidate.language || '').toString().trim().toLowerCase();
+    const text = (candidate.text || '').toString().trim();
+
+    // Display preference ordering (JVNAUTOSCI-937): GUID/UUID is last resort.
+    if (type === 'VONGUID') return true;
+    if (type === 'CODE' && language === 'vonguid') return true;
+    return _isUuidLike(text) || _isHexObjectIdLike(text);
+}
+
+function _guidPenalty(candidate) {
+    return _isGuidLikeCandidate(candidate) ? 1 : 0;
+}
+
 export function getPreferredLanguage() {
     try {
         const stored = localStorage.getItem('von_preferred_language');
@@ -55,6 +90,7 @@ function _typeScore(type) {
     if (type === 'NL') return 0;
     if (type === 'ABBR') return 1;
     if (type === 'CODE') return 2;
+    if (type === 'VONGUID') return 3;
     return 3;
 }
 
@@ -104,11 +140,30 @@ export function selectBestNameForContext(names, preferredLanguage = getPreferred
             continue;
         }
 
-        const prevScore = [_languageScore(prev.language, preferredLanguage), _typeScore(prev.type), prev.text.length];
-        const nextScore = [_languageScore(c.language, preferredLanguage), _typeScore(c.type), c.text.length];
+        // Ordering (JVNAUTOSCI-937):
+        // 1) NL in preferred language
+        // 2) other NL fallbacks
+        // 3) CODE identifiers (incl. ID-von) only if no NL
+        // 4) GUID/UUID last
+        const prevScore = [
+            _languageScore(prev.language, preferredLanguage),
+            _typeScore(prev.type),
+            _guidPenalty(prev),
+            prev.text.length
+        ];
+        const nextScore = [
+            _languageScore(c.language, preferredLanguage),
+            _typeScore(c.type),
+            _guidPenalty(c),
+            c.text.length
+        ];
         if (
             nextScore[0] < prevScore[0] ||
-            (nextScore[0] === prevScore[0] && (nextScore[1] < prevScore[1] || (nextScore[1] === prevScore[1] && nextScore[2] < prevScore[2])))
+            (nextScore[0] === prevScore[0] &&
+                (nextScore[1] < prevScore[1] ||
+                    (nextScore[1] === prevScore[1] &&
+                        (nextScore[2] < prevScore[2] ||
+                            (nextScore[2] === prevScore[2] && nextScore[3] < prevScore[3])))))
         ) {
             bestByText.set(key, c);
         }
@@ -123,6 +178,10 @@ export function selectBestNameForContext(names, preferredLanguage = getPreferred
         const aType = _typeScore(a.type);
         const bType = _typeScore(b.type);
         if (aType !== bType) return aType - bType;
+
+        const aGuid = _guidPenalty(a);
+        const bGuid = _guidPenalty(b);
+        if (aGuid !== bGuid) return aGuid - bGuid;
 
         return a.text.length - b.text.length || a.text.localeCompare(b.text);
     });

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -4559,6 +4559,30 @@ button.prompt-vontology-cartouche {
     background-color: #f9f9f9;
 }
 
+.names-empty-state {
+    color: #6b7280;
+    font-style: italic;
+    padding: 6px 8px;
+}
+
+.names-technical-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 4px 4px 8px 4px;
+    font-size: 12px;
+    color: #6b7280;
+}
+
+.names-technical-toggle-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
 /* NUCLEAR OPTION - Maximum specificity cartouche rules */
 html body div[id^="namesList_"] .name-cartouche,
 html body .names-list-container .name-cartouche,

--- a/tests/frontend/nameSelection.test.js
+++ b/tests/frontend/nameSelection.test.js
@@ -38,4 +38,50 @@ describe('nameSelection', () => {
 
         expect(selectBestNameForContext(names, 'en-NZ')).toBe('country');
     });
+
+    test('ignores technical Von ID CODE names', () => {
+        const names = [
+            { name: '#V#person', language: 'en-NZ', type: 'CODE' },
+            { name: 'Person', language: 'en-NZ', type: 'NL' }
+        ];
+
+        expect(selectBestNameForContext(names, 'en-NZ')).toBe('Person');
+    });
+
+    test('ignores UUID/GUID CODE names (including vonGUID language)', () => {
+        const names = [
+            { name: '2f1c3c9b-7b9c-4d1a-9b79-0c3d1a2b3c4d', language: 'en-NZ', type: 'CODE' },
+            { name: '2f1c3c9b-7b9c-4d1a-9b79-0c3d1a2b3c4d', language: 'vonGUID', type: 'CODE' },
+            { name: 'Human', language: 'en-NZ', type: 'NL' }
+        ];
+
+        expect(selectBestNameForContext(names, 'en-NZ')).toBe('Human');
+    });
+
+    test('ignores ObjectId-like CODE names (24 hex) when NL exists', () => {
+        const names = [
+            { name: '6959bf0c1de296491ab69cb6', language: 'en-NZ', type: 'CODE' },
+            { name: 'Human', language: 'en-NZ', type: 'NL' }
+        ];
+
+        expect(selectBestNameForContext(names, 'en-NZ')).toBe('Human');
+    });
+
+    test('falls back to ID-von CODE before GUID-like CODE', () => {
+        const names = [
+            { name: '#V#thing', language: 'en-NZ', type: 'CODE' },
+            { name: '2f1c3c9b-7b9c-4d1a-9b79-0c3d1a2b3c4d', language: 'en-NZ', type: 'CODE' }
+        ];
+
+        expect(selectBestNameForContext(names, 'en-NZ')).toBe('#V#thing');
+    });
+
+    test('falls back to ID-von CODE before ObjectId-like CODE', () => {
+        const names = [
+            { name: '#V#thing', language: 'en-NZ', type: 'CODE' },
+            { name: '6959bf0c1de296491ab69cb6', language: 'en-NZ', type: 'CODE' }
+        ];
+
+        expect(selectBestNameForContext(names, 'en-NZ')).toBe('#V#thing');
+    });
 });


### PR DESCRIPTION
Summary
- Names UI: treat GUID/ID-von CODE names as non-NL; hide GUIDs by ranking them last; show badges (id-von/guid) for CODE values (display-only).
- Names UI: CODE names are read-only and now also undeletable.
- Predicate extent tables: use shared name-selection heuristic.
- Chat: expand buttonify rules for quoted/unquoted blockquotes + inline quoted-strong prompts.

Tests
- 
pm run test:frontend

Notes
- No database rewrites; UI-only behaviour.