### PR TITLE
JVNAUTOSCI-938: Concept Names preferences + recovery tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,7 @@ Low-signal tool families for typical Von work (candidates to prune first when cl
 - In this Jira project, a **Task can have an Epic as its `parent`**.
 - This is not just UI-only: it can be set via tooling by updating the issue field `parent` to the Epic key (e.g. `{"parent": {"key": "JVNAUTOSCI-885"}}`).
 - Agents should prefer setting `parent` automatically when creating follow-on Tasks under an Epic, rather than leaving manual linkage instructions behind.
+- **Verified 4 Jan 2026:** `mcp_atlassian_editJiraIssue(cloudId=..., issueIdOrKey=..., fields={"parent": {"key": "JVNAUTOSCI-537"}})` successfully set a Task’s Epic parent, even when the tool’s `editmeta` did not list `parent` as editable.
 
 **Creating Subtasks under a Task:**
 ```python

--- a/scripts/merge_and_delete_hyphen_concept.py
+++ b/scripts/merge_and_delete_hyphen_concept.py
@@ -1,0 +1,424 @@
+"""Merge a hyphenated concept into its underscore canonical concept, then delete the hyphen concept.
+
+This is a recovery/cleanup utility for the concept-id normalisation collision (hyphen vs underscore).
+
+Safety properties:
+- Dry-run by default.
+- Refuses to touch MongoDB Atlas unless --allow-remote is provided.
+- Never overwrites non-empty scalar fields on the target; it only adds missing data.
+- For text relations: it re-links (subject,predicate,object_text_id) onto the target if missing.
+- Optionally updates references in other concepts' relationships arrays (recommended).
+
+Typical usage (PowerShell):
+  # Dry-run (prints summary only)
+  pdm run python scripts/merge_and_delete_hyphen_concept.py --allow-remote
+
+  # Apply merge + update references + delete hyphen concept
+  pdm run python scripts/merge_and_delete_hyphen_concept.py --allow-remote --apply --delete-hyphen --update-references
+
+Notes:
+- Requires MONGO_URI to point at the target Mongo instance (Atlas).
+- Uses VON_DB_NAME if set; otherwise defaults to 'von_db'.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from pymongo import MongoClient
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _is_atlas_uri(uri: str) -> bool:
+    lowered = (uri or "").strip().lower()
+    return lowered.startswith("mongodb+srv://") or ".mongodb.net" in lowered
+
+
+def _redact_uri_for_log(uri: str) -> str:
+    if not uri:
+        return ""
+    # Redact credentials if present
+    try:
+        scheme, rest = uri.split("://", 1)
+        authority = rest.split("/", 1)[0]
+        tail = rest[len(authority) :]
+        if "@" in authority:
+            authority = "***@" + authority.split("@", 1)[1]
+        return f"{scheme}://{authority}{tail}"
+    except Exception:
+        return "<redacted>"
+
+
+@dataclass(frozen=True)
+class MergeSummary:
+    source_concept_found: bool
+    target_concept_found: bool
+    relations_to_add: int
+    relations_added: int
+    relations_skipped_existing: int
+    source_relations_deleted: int
+    target_names_added: int
+    target_relationship_values_added: int
+    reference_docs_scanned: int
+    reference_docs_updated: int
+    hyphen_concept_deleted: bool
+
+
+def _union_list(existing: List[Any], incoming: Iterable[Any]) -> Tuple[List[Any], int]:
+    seen = set(existing)
+    added = 0
+    out = list(existing)
+    for v in incoming:
+        if v not in seen:
+            out.append(v)
+            seen.add(v)
+            added += 1
+    return out, added
+
+
+def _merge_names(
+    target: Dict[str, Any], source: Dict[str, Any]
+) -> Tuple[Dict[str, Any], int]:
+    # Names can be stored under 'names' in a few shapes; we only union list-of-dicts or list-of-strings.
+    target_names = target.get("names")
+    source_names = source.get("names")
+
+    if not source_names:
+        return target, 0
+
+    if target_names is None:
+        target["names"] = source_names
+        return target, len(source_names) if isinstance(source_names, list) else 1
+
+    if not isinstance(target_names, list) or not isinstance(source_names, list):
+        return target, 0
+
+    def _key(n: Any) -> Any:
+        if isinstance(n, dict):
+            return (
+                n.get("name") or n.get("text") or "",
+                n.get("language") or n.get("lang") or "",
+                n.get("type") or n.get("name_type") or "",
+            )
+        return n
+
+    existing_keys = {_key(n) for n in target_names}
+    added = 0
+    for n in source_names:
+        k = _key(n)
+        if k not in existing_keys:
+            target_names.append(n)
+            existing_keys.add(k)
+            added += 1
+    target["names"] = target_names
+    return target, added
+
+
+def _merge_relationships(
+    target: Dict[str, Any], source: Dict[str, Any]
+) -> Tuple[Dict[str, Any], int]:
+    # Merge only when both have a dict at 'relationships'.
+    t_rel = target.get("relationships")
+    s_rel = source.get("relationships")
+    if not isinstance(t_rel, dict) or not isinstance(s_rel, dict):
+        return target, 0
+
+    total_added = 0
+    for k, v in s_rel.items():
+        if not isinstance(v, list):
+            continue
+        t_list = t_rel.get(k)
+        if t_list is None:
+            t_rel[k] = list(v)
+            total_added += len(v)
+            continue
+        if isinstance(t_list, list):
+            merged, added = _union_list(t_list, v)
+            t_rel[k] = merged
+            total_added += added
+
+    target["relationships"] = t_rel
+    return target, total_added
+
+
+def _link_text_relations(
+    *,
+    db,
+    source_concept_id: str,
+    target_concept_id: str,
+    apply: bool,
+) -> Tuple[int, int, int, int]:
+    rels = list(db["text_relations"].find({"subject_concept_id": source_concept_id}))
+    to_add = 0
+    added = 0
+    skipped = 0
+
+    for rel in rels:
+        predicate = rel.get("predicate")
+        object_text_id = rel.get("object_text_id")
+        if not predicate or not object_text_id:
+            continue
+
+        to_add += 1
+        existing = db["text_relations"].find_one(
+            {
+                "subject_concept_id": target_concept_id,
+                "predicate": predicate,
+                "object_text_id": object_text_id,
+            }
+        )
+        if existing:
+            skipped += 1
+            continue
+
+        if apply:
+            db["text_relations"].insert_one(
+                {
+                    "subject_concept_id": target_concept_id,
+                    "predicate": predicate,
+                    "object_text_id": object_text_id,
+                    "context": {
+                        "merged_from": {
+                            "source_concept_id": source_concept_id,
+                            "source_relation_id": str(rel.get("_id", "")),
+                        }
+                    },
+                    "created_at": _utc_now(),
+                    "updated_at": _utc_now(),
+                }
+            )
+            added += 1
+
+    deleted = 0
+    if apply:
+        deleted = (
+            db["text_relations"]
+            .delete_many({"subject_concept_id": source_concept_id})
+            .deleted_count
+        )
+
+    return to_add, added, skipped, deleted
+
+
+def _update_relationship_references(
+    *,
+    db,
+    source_concept_id: str,
+    target_concept_id: str,
+    apply: bool,
+) -> Tuple[int, int]:
+    """Replace occurrences of source_concept_id with target_concept_id in relationships arrays."""
+
+    relationship_fields = [
+        "relationships.is_an_instance_of",
+        "relationships.is_a_type_of",
+        "relationships.has_subtype",
+        "relationships.has_instance",
+        "relationships.related_to",
+        "relationships.linked_to",
+    ]
+
+    # Find candidate docs (broad but bounded).
+    query_or = [{f: source_concept_id} for f in relationship_fields]
+    cursor = db["concepts"].find(
+        {"$or": query_or}, {"concept_id": 1, "relationships": 1}
+    )
+
+    scanned = 0
+    updated = 0
+    for doc in cursor:
+        scanned += 1
+        rel = doc.get("relationships")
+        if not isinstance(rel, dict):
+            continue
+
+        changed = False
+        for field in [
+            "is_an_instance_of",
+            "is_a_type_of",
+            "has_subtype",
+            "has_instance",
+            "related_to",
+            "linked_to",
+        ]:
+            values = rel.get(field)
+            if not isinstance(values, list):
+                continue
+            new_values = [
+                target_concept_id if v == source_concept_id else v for v in values
+            ]
+            if new_values != values:
+                rel[field] = new_values
+                changed = True
+
+        if changed:
+            updated += 1
+            if apply:
+                db["concepts"].update_one(
+                    {"_id": doc["_id"]},
+                    {"$set": {"relationships": rel, "updated_at": _utc_now()}},
+                )
+
+    return scanned, updated
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Merge hyphen concept into underscore concept, then delete hyphen concept (Atlas-safe)."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Perform writes (default dry-run).",
+    )
+    parser.add_argument(
+        "--delete-hyphen",
+        action="store_true",
+        help="Delete the hyphen concept document after merge.",
+    )
+    parser.add_argument(
+        "--update-references",
+        action="store_true",
+        help="Update other concepts' relationships to replace hyphen ID with underscore ID.",
+    )
+    parser.add_argument(
+        "--allow-remote",
+        action="store_true",
+        help="Allow mongodb+srv / Atlas URIs (required for this task).",
+    )
+    parser.add_argument(
+        "--mongo-uri",
+        default=os.environ.get("MONGO_URI", ""),
+        help="MongoDB URI (defaults to env MONGO_URI).",
+    )
+    parser.add_argument(
+        "--db-name",
+        default=os.environ.get("VON_DB_NAME", "von_db"),
+        help="Database name (defaults to env VON_DB_NAME or 'von_db').",
+    )
+    parser.add_argument(
+        "--source-concept-id",
+        default="#V#a_community-driven_vision_for_a_new_knowledge_resource_for_ai",
+        help="Hyphen concept ID (source).",
+    )
+    parser.add_argument(
+        "--target-concept-id",
+        default="#V#a_community_driven_vision_for_a_new_knowledge_resource_for_ai",
+        help="Underscore concept ID (target).",
+    )
+
+    args = parser.parse_args(argv)
+
+    if not args.mongo_uri:
+        print("MONGO_URI is not set; refusing to run.", file=sys.stderr)
+        return 2
+
+    atlas = _is_atlas_uri(args.mongo_uri)
+    if atlas and not args.allow_remote:
+        print(
+            "Refusing to run against a remote/Atlas-like Mongo URI without --allow-remote.",
+            file=sys.stderr,
+        )
+        return 2
+
+    client = MongoClient(args.mongo_uri)
+    db = client[args.db_name]
+
+    source = db["concepts"].find_one({"concept_id": args.source_concept_id})
+    target = db["concepts"].find_one({"concept_id": args.target_concept_id})
+
+    if not source:
+        print("Source (hyphen) concept not found.")
+        return 2
+    if not target:
+        print("Target (underscore) concept not found.")
+        return 2
+
+    target_names_added = 0
+    target_relationship_values_added = 0
+
+    # Merge names + relationships in-memory
+    merged_target = dict(target)
+    merged_target, names_added = _merge_names(merged_target, source)
+    merged_target, rel_added = _merge_relationships(merged_target, source)
+    target_names_added += names_added
+    target_relationship_values_added += rel_added
+
+    if args.apply:
+        set_fields: Dict[str, Any] = {}
+        # Only set fields we touched
+        if names_added:
+            set_fields["names"] = merged_target.get("names")
+        if rel_added:
+            set_fields["relationships"] = merged_target.get("relationships")
+        if set_fields:
+            set_fields["updated_at"] = _utc_now()
+            db["concepts"].update_one({"_id": target["_id"]}, {"$set": set_fields})
+
+    # Merge text relations
+    to_add, added, skipped, source_deleted = _link_text_relations(
+        db=db,
+        source_concept_id=args.source_concept_id,
+        target_concept_id=args.target_concept_id,
+        apply=args.apply,
+    )
+
+    ref_scanned = 0
+    ref_updated = 0
+    if args.update_references:
+        ref_scanned, ref_updated = _update_relationship_references(
+            db=db,
+            source_concept_id=args.source_concept_id,
+            target_concept_id=args.target_concept_id,
+            apply=args.apply,
+        )
+
+    hyphen_deleted = False
+    if args.apply and args.delete_hyphen:
+        deleted = (
+            db["concepts"]
+            .delete_many({"concept_id": args.source_concept_id})
+            .deleted_count
+        )
+        hyphen_deleted = deleted > 0
+
+    summary = MergeSummary(
+        source_concept_found=True,
+        target_concept_found=True,
+        relations_to_add=to_add,
+        relations_added=added,
+        relations_skipped_existing=skipped,
+        source_relations_deleted=source_deleted,
+        target_names_added=target_names_added,
+        target_relationship_values_added=target_relationship_values_added,
+        reference_docs_scanned=ref_scanned,
+        reference_docs_updated=ref_updated,
+        hyphen_concept_deleted=hyphen_deleted,
+    )
+
+    print(
+        {
+            "db": args.db_name,
+            "mongo_uri": _redact_uri_for_log(args.mongo_uri),
+            "apply": bool(args.apply),
+            "delete_hyphen": bool(args.delete_hyphen),
+            "update_references": bool(args.update_references),
+            "source": args.source_concept_id,
+            "target": args.target_concept_id,
+            "summary": summary.__dict__,
+        }
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/recover_paper_notes.py
+++ b/scripts/recover_paper_notes.py
@@ -1,0 +1,324 @@
+"""Recover hasNote text relations for a concept from a restored backup DB.
+
+This script is designed for safe, idempotent recovery:
+- Reads hasNote relations + text_values from a *source* DB (e.g., a restored backup).
+- Upserts the same text into the *target* DB using the normal service path
+  (text_value_service.upsert_text_for_concept), so fingerprints and uniqueness
+  rules are respected.
+
+Default behaviour is DRY-RUN (no writes). Use --apply to perform writes.
+
+PowerShell example:
+  pdm run python scripts/recover_paper_notes.py
+
+  pdm run python scripts/recover_paper_notes.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from bson import ObjectId
+from pymongo import MongoClient
+
+
+# Ensure repo root is on sys.path so `src.*` imports work when running as a script.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+@dataclass(frozen=True)
+class SourceNote:
+    relation_id: str
+    text_value_id: str
+    text: str
+    lang: str
+    created_at: Optional[datetime]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso_utc(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def _assert_target_is_local_mongo(mongo_uri: str) -> None:
+    """Safety guard: refuse writes to non-local MongoDB URIs.
+
+    This recovery workflow is intended to operate only on a local MongoDB.
+    """
+    lowered = (mongo_uri or "").strip().lower()
+    if lowered.startswith("mongodb+srv://") or ".mongodb.net" in lowered:
+        raise RuntimeError(
+            "Refusing to run against a mongodb+srv / Atlas-like MONGO_URI. "
+            "Set --mongo-uri to a local MongoDB (e.g. mongodb://localhost:27017)."
+        )
+
+
+def _read_source_notes(
+    *,
+    mongo_uri: str,
+    source_db: str,
+    source_concept_id: str,
+) -> List[SourceNote]:
+    client = MongoClient(mongo_uri)
+    db = client[source_db]
+
+    rels = list(
+        db["text_relations"].find(
+            {"subject_concept_id": source_concept_id, "predicate": "hasNote"}
+        )
+    )
+
+    notes: List[SourceNote] = []
+    for rel in rels:
+        object_text_id = rel.get("object_text_id")
+        if not object_text_id:
+            continue
+
+        tv_id = ObjectId(object_text_id)
+        tv = db["text_values"].find_one({"_id": tv_id})
+        if not tv:
+            continue
+
+        text = tv.get("text")
+        lang = tv.get("lang")
+        if not isinstance(text, str) or not isinstance(lang, str):
+            continue
+
+        created_at = tv.get("created_at")
+        if created_at is not None and not isinstance(created_at, datetime):
+            created_at = None
+
+        notes.append(
+            SourceNote(
+                relation_id=str(rel.get("_id", "")),
+                text_value_id=str(tv.get("_id", "")),
+                text=text,
+                lang=lang,
+                created_at=created_at,
+            )
+        )
+
+    # Prefer stable order: oldest first.
+    notes.sort(key=lambda n: n.created_at or datetime.min.replace(tzinfo=timezone.utc))
+    return notes
+
+
+def _describe_plan(
+    *,
+    target_concept_id: str,
+    notes: Iterable[SourceNote],
+) -> Dict[str, Any]:
+    # Imports live here so env vars (MONGO_URI / VON_DB_NAME) are already set.
+    from src.backend.db.repositories.text_value_repository import (  # noqa: WPS433
+        TextRelationsRepository,
+        TextValuesRepository,
+    )
+    from src.backend.services.text_value_service import (  # noqa: WPS433
+        _compute_fingerprint,
+        _prepare_persisted_text,
+    )
+
+    planned: List[Dict[str, Any]] = []
+    will_create_text_values = 0
+    will_create_relations = 0
+
+    for note in notes:
+        persisted = _prepare_persisted_text(note.text)
+        fp = _compute_fingerprint(persisted, note.lang)
+
+        existing_tv = TextValuesRepository.find_one(
+            {"fingerprint": fp, "lang": note.lang}
+        )
+        existing_tv_id = (
+            str(existing_tv["_id"]) if existing_tv and existing_tv.get("_id") else None
+        )
+
+        relation_exists = False
+        if existing_tv_id:
+            existing_rel = TextRelationsRepository.find_one(
+                {
+                    "subject_concept_id": target_concept_id,
+                    "predicate": "hasNote",
+                    "object_text_id": existing_tv_id,
+                }
+            )
+            relation_exists = bool(existing_rel)
+
+        tv_action = "reuse" if existing_tv_id else "create"
+        rel_action = "skip" if relation_exists else "create"
+
+        if tv_action == "create":
+            will_create_text_values += 1
+        if rel_action == "create":
+            will_create_relations += 1
+
+        planned.append(
+            {
+                "source_text_value_id": note.text_value_id,
+                "source_relation_id": note.relation_id,
+                "lang": note.lang,
+                "fingerprint": fp,
+                "text_preview": (
+                    (persisted[:160] + "…") if len(persisted) > 160 else persisted
+                ),
+                "target_text_value_action": tv_action,
+                "target_relation_action": rel_action,
+                "target_existing_text_value_id": existing_tv_id,
+            }
+        )
+
+    return {
+        "notes_found": len(list(notes)) if not isinstance(notes, list) else len(notes),
+        "planned_items": planned,
+        "summary": {
+            "will_create_text_values": will_create_text_values,
+            "will_create_relations": will_create_relations,
+        },
+    }
+
+
+def _apply(
+    *,
+    target_concept_id: str,
+    notes: List[SourceNote],
+    source_db: str,
+    source_concept_id: str,
+) -> List[Dict[str, Any]]:
+    # Imports live here so env vars (MONGO_URI / VON_DB_NAME) are already set.
+    from src.backend.services.text_value_service import (  # noqa: WPS433
+        upsert_text_for_concept,
+    )
+
+    results: List[Dict[str, Any]] = []
+
+    for note in notes:
+        provenance = {
+            "recovered_from_backup": True,
+            "recovered_at_utc": _iso_utc(_utc_now()),
+            "source_db": source_db,
+            "source_concept_id": source_concept_id,
+            "source_relation_id": note.relation_id,
+            "source_text_value_id": note.text_value_id,
+        }
+        context = {
+            "recovered_from": {
+                "source_db": source_db,
+                "source_concept_id": source_concept_id,
+                "source_relation_id": note.relation_id,
+                "source_text_value_id": note.text_value_id,
+            }
+        }
+
+        res = upsert_text_for_concept(
+            subject_concept_id=target_concept_id,
+            predicate="hasNote",
+            text=note.text,
+            lang=note.lang,
+            provenance=provenance,
+            context=context,
+        )
+        results.append(res)
+
+    return results
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Recover hasNote text relations from restored backup DB into current DB.",
+    )
+    parser.add_argument(
+        "--mongo-uri",
+        default="mongodb://localhost:27017",
+        help="MongoDB connection string (default: mongodb://localhost:27017)",
+    )
+    parser.add_argument(
+        "--source-db",
+        default="von_db_restore_20260103_225836Z_manual",
+        help="Source database name (restored backup)",
+    )
+    parser.add_argument(
+        "--target-db",
+        default="von_db",
+        help="Target database name (current)",
+    )
+    parser.add_argument(
+        "--source-concept-id",
+        default="#V#a_community-driven_vision_for_a_new_knowledge_resource_for_ai",
+        help="Concept ID to read notes from (source DB)",
+    )
+    parser.add_argument(
+        "--target-concept-id",
+        default="#V#a_community_driven_vision_for_a_new_knowledge_resource_for_ai",
+        help="Concept ID to attach notes to (target DB)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Perform writes (default is dry-run)",
+    )
+
+    args = parser.parse_args(argv)
+
+    # Ensure repositories/services operate on the intended *local* target.
+    # (Process-local only; does not persist anywhere.)
+    _assert_target_is_local_mongo(args.mongo_uri)
+
+    import os
+
+    os.environ["MONGO_URI"] = args.mongo_uri
+    os.environ["VON_DB_NAME"] = args.target_db
+
+    notes = _read_source_notes(
+        mongo_uri=args.mongo_uri,
+        source_db=args.source_db,
+        source_concept_id=args.source_concept_id,
+    )
+
+    if not notes:
+        print(
+            "No hasNote relations found in source DB for that concept. Nothing to do.",
+            file=sys.stderr,
+        )
+        return 2
+
+    plan = _describe_plan(target_concept_id=args.target_concept_id, notes=notes)
+    print("Recovery plan (dry-run):")
+    print(plan["summary"])
+
+    if not args.apply:
+        print("Dry-run only. Re-run with --apply to perform the recovery.")
+        return 0
+
+    print("Applying recovery (upsert_text_for_concept)...")
+    results = _apply(
+        target_concept_id=args.target_concept_id,
+        notes=notes,
+        source_db=args.source_db,
+        source_concept_id=args.source_concept_id,
+    )
+
+    created = sum(1 for r in results if r.get("relation_created"))
+    updated_context = sum(1 for r in results if r.get("context_updated"))
+    print(
+        {
+            "notes_processed": len(results),
+            "relations_created": created,
+            "relations_context_updated": updated_context,
+        }
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backend/services/concept_service.py
+++ b/src/backend/services/concept_service.py
@@ -663,6 +663,65 @@ def enrich_concept_with_text_relations(
         for item in names_from_relations
     ]
 
+    # Ensure CODE identifiers are present for UI/debugging (JVNAUTOSCI-938):
+    # Some concepts may not have had CODE names persisted historically, but users
+    # expect to see IDs (e.g., #V#..., db ObjectId, stable guid) in the Names section.
+    def _looks_like_object_id(value: str) -> bool:
+        if not isinstance(value, str):
+            return False
+        s = value.strip()
+        if len(s) != 24:
+            return False
+        try:
+            int(s, 16)
+            return True
+        except Exception:
+            return False
+
+    existing_keys = set()
+    for n in concept.get("names", []) or []:
+        if not isinstance(n, dict):
+            continue
+        existing_keys.add(
+            (
+                str(n.get("name") or "").strip(),
+                str(n.get("language") or "").strip() or "en-NZ",
+                str(n.get("type") or "").strip().upper() or "NL",
+            )
+        )
+
+    def _add_code_name(text: Optional[str]) -> None:
+        if not text or not isinstance(text, str):
+            return
+        cleaned = text.strip()
+        if not cleaned:
+            return
+        key = (cleaned, "en-NZ", "CODE")
+        if key in existing_keys:
+            return
+        concept.setdefault("names", []).append(
+            {
+                "name": cleaned,
+                "language": "en-NZ",
+                "type": "CODE",
+                "relation_id": None,
+            }
+        )
+        existing_keys.add(key)
+
+    # Always include the ontological ID itself.
+    _add_code_name(concept_id)
+
+    # Include db document ID when it looks like a Mongo ObjectId.
+    maybe_db_id = concept.get("id")
+    if isinstance(maybe_db_id, str) and _looks_like_object_id(maybe_db_id):
+        _add_code_name(maybe_db_id)
+
+    # Include stable UUID (JVNAUTOSCI-730).
+    maybe_guid = concept.get("guid")
+    if isinstance(maybe_guid, str) and maybe_guid.strip():
+        _add_code_name(maybe_guid)
+
     # MIGRATE-ON-READ: Legacy description field → text relations
     legacy_description = concept.get("description")
     if (

--- a/src/frontend/web/von_interface/static/js/conceptTab.js
+++ b/src/frontend/web/von_interface/static/js/conceptTab.js
@@ -43,6 +43,97 @@ export function initializeConceptTabState() {
 // Global interaction state
 let currentInteractionId = null;
 
+// Browser-local preference: show CODE names in Names section (default: true)
+const LS_SHOW_CODE_NAMES = 'von_show_code_names';
+// Browser-local preference: filter NL names to preferred language (default: false)
+const LS_FILTER_NL_NAMES_TO_PREFERRED_LANGUAGE = 'von_filter_nl_names_to_preferred_language';
+// Browser-local preferred language key (used by settings page)
+const LS_PREFERRED_LANGUAGE = 'von_preferred_language';
+function getShowCodeNamesSetting() {
+  try {
+    const raw = localStorage.getItem(LS_SHOW_CODE_NAMES);
+    if (raw === null || raw === undefined) {
+      return true;
+    }
+    return String(raw) === 'true';
+  } catch {
+    return true;
+  }
+}
+
+function getFilterNlNamesToPreferredLanguageSetting() {
+  try {
+    const raw = localStorage.getItem(LS_FILTER_NL_NAMES_TO_PREFERRED_LANGUAGE);
+    if (raw === null || raw === undefined) {
+      return false;
+    }
+    return String(raw) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function getSelectedConceptIdForSuffix(suffix) {
+  try {
+    const containerId = suffix ? `conceptTab_${suffix}` : 'conceptTab';
+    const container = document.getElementById(containerId) || document;
+    const expectedRadioName = suffix ? `selectedconcept_${suffix}` : 'selectedconcept';
+    const radios = container.querySelectorAll('input[type="radio"]');
+    for (const radio of radios) {
+      if (radio?.name === expectedRadioName && radio.checked) {
+        return radio.value;
+      }
+    }
+  } catch (_) {
+    // ignore
+  }
+  return getCurrentlySelectedConceptId();
+}
+
+function listOpenConceptTabSuffixes() {
+  const suffixes = new Set(['']);
+  try {
+    document.querySelectorAll('.tab-content').forEach((el) => {
+      const id = String(el?.id || '');
+      if (!id) return;
+      if (id === 'conceptTab') {
+        suffixes.add('');
+        return;
+      }
+      if (id.startsWith('conceptTab_')) {
+        suffixes.add(id.replace('conceptTab_', ''));
+      }
+    });
+  } catch (_) {
+    // ignore
+  }
+  return Array.from(suffixes);
+}
+
+function refreshNamesForAllOpenConceptTabs() {
+  const suffixes = listOpenConceptTabSuffixes();
+  for (const suffix of suffixes) {
+    const conceptId = getSelectedConceptIdForSuffix(suffix);
+    if (!conceptId) {
+      continue;
+    }
+    void loadConceptNames(conceptId, suffix);
+  }
+}
+
+// If settings change while a concept is open, refresh names in all open concept tabs (incl. suffix tabs).
+try {
+  window.addEventListener('von-preferences-changed', (evt) => {
+    const key = evt?.detail?.key;
+    if (![LS_SHOW_CODE_NAMES, LS_FILTER_NL_NAMES_TO_PREFERRED_LANGUAGE, LS_PREFERRED_LANGUAGE].includes(key)) {
+      return;
+    }
+    refreshNamesForAllOpenConceptTabs();
+  });
+} catch (_) {
+  // ignore
+}
+
 // Save button state management
 let originalNotes = '';
 let updateSaveButtonStateTimeout = null;
@@ -2522,6 +2613,14 @@ function getDisplayLanguageForName(nameObj) {
  */
 async function getPreferredLanguage() {
   try {
+    const local = String(localStorage.getItem(LS_PREFERRED_LANGUAGE) || '').trim();
+    if (local) {
+      return local;
+    }
+  } catch (_) {
+    // ignore
+  }
+  try {
     const response = await fetch('/api/settings/');
     if (response.ok) {
       const settings = await response.json();
@@ -3000,7 +3099,25 @@ export async function loadConceptNames(conceptId, suffix = '') {
     const concept = await response.json();
     console.log('Loaded concept data:', concept);
 
-    const names = concept.names || [];
+    let names = concept.names || [];
+    if (!getShowCodeNamesSetting() && Array.isArray(names)) {
+      names = names.filter((n) => {
+        const type = (n?.type ?? n?.context?.name_type ?? 'NL');
+        return String(type || '').trim().toUpperCase() !== 'CODE';
+      });
+    }
+
+    if (getFilterNlNamesToPreferredLanguageSetting() && Array.isArray(names)) {
+      const preferredLanguage = await getPreferredLanguage();
+      names = names.filter((n) => {
+        const type = String(n?.type ?? n?.context?.name_type ?? 'NL').trim().toUpperCase();
+        if (type !== 'NL') {
+          return true;
+        }
+        const lang = String(n?.language ?? n?.lang ?? 'en-NZ').trim() || 'en-NZ';
+        return lang === preferredLanguage;
+      });
+    }
     console.log('Extracted names array:', names);
 
     await displayConceptNames(names, suffix);

--- a/src/frontend/web/von_interface/static/js/settingsPage.js
+++ b/src/frontend/web/von_interface/static/js/settingsPage.js
@@ -33,6 +33,8 @@ const LS_TTS_VOLUME = 'chatTtsVolume';
 const LS_STT_LANGUAGE = 'chatSttLanguage';
 const LS_STT_CONTINUOUS = 'chatSttContinuous';
 const LS_STT_INTERIM_RESULTS = 'chatSttInterimResults';
+const LS_SHOW_CODE_NAMES = 'von_show_code_names';
+const LS_FILTER_NL_NAMES_TO_PREFERRED_LANGUAGE = 'von_filter_nl_names_to_preferred_language';
 const RUNTIME_REFRESH_MS = 12000;
 
 let runtimeIntervalId = null;
@@ -105,6 +107,36 @@ function parseBoolSetting(value, fallbackValue) {
     return fallbackValue;
   }
   return String(value) === 'true';
+}
+
+function setShowCodeNamesSetting(value) {
+  safeLocalStorageSet(LS_SHOW_CODE_NAMES, value ? 'true' : 'false');
+  try {
+    window.dispatchEvent(new CustomEvent('von-preferences-changed', {
+      detail: { key: LS_SHOW_CODE_NAMES, value: !!value }
+    }));
+  } catch (_) {
+    // ignore
+  }
+}
+
+function getShowCodeNamesSetting() {
+  return parseBoolSetting(safeLocalStorageGet(LS_SHOW_CODE_NAMES), true);
+}
+
+function setFilterNlNamesToPreferredLanguageSetting(value) {
+  safeLocalStorageSet(LS_FILTER_NL_NAMES_TO_PREFERRED_LANGUAGE, value ? 'true' : 'false');
+  try {
+    window.dispatchEvent(new CustomEvent('von-preferences-changed', {
+      detail: { key: LS_FILTER_NL_NAMES_TO_PREFERRED_LANGUAGE, value: !!value }
+    }));
+  } catch (_) {
+    // ignore
+  }
+}
+
+function getFilterNlNamesToPreferredLanguageSetting() {
+  return parseBoolSetting(safeLocalStorageGet(LS_FILTER_NL_NAMES_TO_PREFERRED_LANGUAGE), false);
 }
 
 function getPreferredLanguage() {
@@ -358,6 +390,29 @@ function setupSpeechSettingsSection() {
     sttInterimToggle.addEventListener('change', (e) => {
       safeLocalStorageSet(LS_STT_INTERIM_RESULTS, e.target.checked ? 'true' : 'false');
     });
+  }
+}
+
+function setupConceptUiSettings() {
+  const showCodeToggle = document.getElementById('settingsShowCodeNamesToggle');
+  if (showCodeToggle) {
+    showCodeToggle.checked = getShowCodeNamesSetting();
+    showCodeToggle.addEventListener('change', () => {
+      setShowCodeNamesSetting(!!showCodeToggle.checked);
+    });
+  }
+
+  const nlFilterToggle = document.getElementById('settingsFilterNlNamesToPreferredLanguageToggle');
+  if (nlFilterToggle) {
+    nlFilterToggle.checked = getFilterNlNamesToPreferredLanguageSetting();
+    nlFilterToggle.addEventListener('change', () => {
+      setFilterNlNamesToPreferredLanguageSetting(!!nlFilterToggle.checked);
+    });
+  }
+
+  const langLabel = document.getElementById('settingsPreferredLanguageForNlFilter');
+  if (langLabel) {
+    langLabel.textContent = getPreferredLanguage();
   }
 }
 
@@ -633,6 +688,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Initialize all settings sections
   await loadAndDisplaySettings();
   setupSpeechSettingsSection();
+  setupConceptUiSettings();
   // Load DB info
   try { await loadAndDisplayDbInfo(); } catch { }
   // Load deprecation metrics
@@ -689,6 +745,17 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('preferredLanguageSelect')?.addEventListener('change', () => {
     const val = document.getElementById('preferredLanguageSelect')?.value;
     if (val) localStorage.setItem(LS_LANG_KEY, val); else localStorage.removeItem(LS_LANG_KEY);
+    try {
+      const langLabel = document.getElementById('settingsPreferredLanguageForNlFilter');
+      if (langLabel) {
+        langLabel.textContent = getPreferredLanguage();
+      }
+      window.dispatchEvent(new CustomEvent('von-preferences-changed', {
+        detail: { key: LS_LANG_KEY, value: getPreferredLanguage() }
+      }));
+    } catch (_) {
+      // ignore
+    }
     // Emit event so footer or other UI can react
     if (window.parent) { window.parent.document.dispatchEvent(new CustomEvent('von:settingsChanged')); }
     // Persist language preference (with current organisation if available)
@@ -794,11 +861,20 @@ document.getElementById('resetLocalPrefsButton')?.addEventListener('click', () =
     localStorage.removeItem(LS_ORG_KEY);
     localStorage.removeItem(LS_LANG_KEY);
     localStorage.removeItem(LS_GMAIL_PROFILE);
+    localStorage.removeItem(LS_SHOW_CODE_NAMES);
+    localStorage.removeItem(LS_FILTER_NL_NAMES_TO_PREFERRED_LANGUAGE);
     // Reset selects visually
     const userSel = document.getElementById('currentUserSelect'); if (userSel) userSel.selectedIndex = 0;
     const orgSel = document.getElementById('currentOrganisationSelect'); if (orgSel) orgSel.selectedIndex = 0;
     const langSel = document.getElementById('preferredLanguageSelect'); if (langSel) langSel.value = 'en-NZ';
     const gmailProfileInput = document.getElementById('gmailProfileInput'); if (gmailProfileInput) gmailProfileInput.value = '';
+    const showCodeToggle = document.getElementById('settingsShowCodeNamesToggle'); if (showCodeToggle) showCodeToggle.checked = true;
+    setShowCodeNamesSetting(true);
+    const nlFilterToggle = document.getElementById('settingsFilterNlNamesToPreferredLanguageToggle');
+    if (nlFilterToggle) nlFilterToggle.checked = false;
+    setFilterNlNamesToPreferredLanguageSetting(false);
+    const langLabel = document.getElementById('settingsPreferredLanguageForNlFilter');
+    if (langLabel) langLabel.textContent = getPreferredLanguage();
     if (window.parent?.updateModelInfoFooterDisplay) { window.parent.updateModelInfoFooterDisplay(); }
     showStatusMessage('settingsStatusMessage', 'Local preferences cleared');
   } catch (e) {

--- a/src/frontend/web/von_interface/templates/settings_tab.html
+++ b/src/frontend/web/von_interface/templates/settings_tab.html
@@ -178,6 +178,24 @@
                 <!-- Options populated by languageConfig.js -->
             </select>
             <small>This will be the default language for new names and text entries.</small>
+
+            <div class="inline-form inline-form-tight mt-2">
+                <input type="checkbox" id="settingsShowCodeNamesToggle" />
+                <label for="settingsShowCodeNamesToggle" class="ml-1"
+                    title="When enabled, CODE names (e.g., concept ids, GUIDs) are shown in the Names section.">Show
+                    CODE names in concepts</label>
+            </div>
+            <small class="settings-note">Stored only in this browser (localStorage). Default: enabled.</small>
+
+            <div class="inline-form inline-form-tight mt-2">
+                <input type="checkbox" id="settingsFilterNlNamesToPreferredLanguageToggle" />
+                <label for="settingsFilterNlNamesToPreferredLanguageToggle" class="ml-1"
+                    title="When enabled, Natural Language (NL) names are filtered to only show those in your preferred language.">Only
+                    show [NL] names in preferred language (<span
+                        id="settingsPreferredLanguageForNlFilter">en-NZ</span>)</label>
+            </div>
+            <small class="settings-note">Non-NL names (e.g., ABBR/CODE) are not filtered. Stored only in this browser.
+                Default: disabled.</small>
             <div class="inline-form inline-form-tight mt-8-align-center">
                 <button type="button" id="resetLocalPrefsButton" class="btn-danger"
                     title="Clear stored user/org/language preferences for this browser">Reset Local Preferences</button>


### PR DESCRIPTION
- Add browser-local settings to show/hide CODE names and filter NL names to preferred language (refreshes across suffix tabs)
- Ensure backend concept payload includes CODE identifiers by default
- Add safe recovery utilities for hyphen/underscore concept-id collision and note recovery

Tests: `npm run test:frontend`
