### PR TITLE
JVNAUTOSCI-939: avoid dynamic tab ID collisions

### DIFF
--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -433,17 +433,18 @@ export { getOpenInstanceIdsForType, getOpenSubtypeTypeIds };
 export function createOrActivateConceptTab(conceptId, conceptName, activate = true, options = {}) {
     console.log(`[dynamicTabs] Creating/activating concept tab for: ${conceptId} (${conceptName})`);
 
-    // Generate a unique tab ID based on the concept ID
-    const tabId = generateTabId(conceptId);
-
     // Check if tab already exists
-    if (dynamicConceptTabs.has(conceptId)) {
+    const existing = dynamicConceptTabs.get(conceptId);
+    if (existing) {
         console.log(`[dynamicTabs] Tab already exists for ${conceptId}${activate ? ', activating it' : ', not activating (per flag)'}`);
         if (activate) {
-            activateTab(tabId);
+            activateTab(existing.tabId);
         }
-        return tabId;
+        return existing.tabId;
     }
+
+    // Generate a unique tab ID based on the concept ID
+    const tabId = generateTabId(conceptId);
 
     // Create new dynamic concept tab
     createDynamicConceptTab(conceptId, conceptName, tabId, options.kind, { newlyCreated: options.newlyCreated });
@@ -986,8 +987,10 @@ export async function loadDynamicConceptTabContent(tabId, conceptId) {
 
         const html = await response.text();
 
-        // Make IDs unique for this dynamic tab
-        const uniqueIdSuffix = conceptId.replace(/[^a-zA-Z0-9]/g, '_');
+        // Make IDs unique for this dynamic tab.
+        // IMPORTANT: Do not rely solely on a non-alnum scrub of conceptId, as that can collide
+        // for IDs that differ only by punctuation (e.g., hyphen vs underscore).
+        const uniqueIdSuffix = makeUniqueDomSuffix(conceptId);
         let modifiedHtml = html.replace(/id="([^"]+)"/g, `id="$1_${uniqueIdSuffix}"`);
         // Inject data attribute on the header span without duplicating the suffix
         const headerIdWithSuffix = `conceptTypeDisplayNamePluralElement_${uniqueIdSuffix}`;
@@ -1156,9 +1159,26 @@ export async function loadDynamicConceptTabContent(tabId, conceptId) {
  * @returns {string} A safe tab ID (e.g., "conceptTab_Person")
  */
 function generateTabId(conceptId) {
-    // Remove special characters and create a safe ID
-    const safeName = conceptId.replace(/[^a-zA-Z0-9]/g, '_');
-    return `conceptTab_${safeName}`;
+    const suffix = makeUniqueDomSuffix(conceptId);
+    return `conceptTab_${suffix}`;
+}
+
+function stableDomHash(value) {
+    // FNV-1a 32-bit hash: fast, deterministic, good enough for DOM ID suffixing.
+    const text = String(value ?? '');
+    let hash = 2166136261;
+    for (let i = 0; i < text.length; i++) {
+        hash ^= text.charCodeAt(i);
+        hash = Math.imul(hash, 16777619);
+    }
+    return (hash >>> 0).toString(36);
+}
+
+function makeUniqueDomSuffix(conceptId) {
+    const raw = String(conceptId ?? '');
+    const base = raw.startsWith('#V#') ? raw.slice(3) : raw;
+    const safeBase = base.replace(/[^a-zA-Z0-9]/g, '_').slice(0, 40) || 'concept';
+    return `${safeBase}_${stableDomHash(raw)}`;
 }
 
 /**
@@ -1309,7 +1329,7 @@ async function reloadConceptTab(conceptId) {
 
     try {
         // Calculate the suffix used for this tab's DOM elements
-        const suffix = conceptId.replace(/[^a-zA-Z0-9]/g, '_');
+        const suffix = makeUniqueDomSuffix(conceptId);
 
         // Show loading state on both tab button and refresh icon
         const tabButton = document.querySelector(`[data-tab-id="${conceptId}"] .tab-name`);
@@ -1395,7 +1415,7 @@ async function reloadConceptTab(conceptId) {
         }
 
         // Remove loading animation from refresh button on error
-        const suffix = conceptId.replace(/[^a-zA-Z0-9]/g, '_');
+        const suffix = makeUniqueDomSuffix(conceptId);
         const refreshButton = document.getElementById(`refreshConceptButton_${suffix}`);
         if (refreshButton) {
             refreshButton.classList.remove('loading');

--- a/tests/frontend/dynamicTabsIdCollision.test.js
+++ b/tests/frontend/dynamicTabsIdCollision.test.js
@@ -1,0 +1,96 @@
+/** @jest-environment jsdom */
+
+const dynamicTabsModulePath = '../../src/frontend/web/von_interface/static/js/dynamicTabs.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/annotationTab.js', () => ({
+    initializeAnnotationTab: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/conceptTab.js', () => ({
+    fetchConceptListWithSuffix: jest.fn(),
+    fetchSubtypesWithSuffix: jest.fn(),
+    initializeNamesForm: jest.fn(),
+    loadConceptAttributes: jest.fn(),
+    loadConceptNames: jest.fn(),
+    selectConceptWithSuffix: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
+    getCurrentUserConceptId: jest.fn(() => '#V#user')
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/languageConfig.js', () => ({
+    DEFAULT_LANGUAGE: 'en-NZ'
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/markdownUtils.js', () => ({
+    detectMarkdown: jest.fn(() => false),
+    renderSmartTextAsync: jest.fn(async (text) => String(text ?? ''))
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/predicateView.js', () => ({
+    destroyPredicateView: jest.fn(),
+    initializePredicateView: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/state.js', () => ({
+    getConceptTypeDisplayNames: jest.fn(() => ({ singular: 'Concept', plural: 'Concepts' })),
+    setCurrentConceptType: jest.fn(),
+    setCurrentlySelectedConceptId: jest.fn(),
+    setSelectedConceptOriginalName: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/tabNavigation.js', () => ({
+    activateTab: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/vontology.js', () => ({
+    getKeyConceptIds: jest.fn(() => new Set()),
+    updateTabHeaderStarButtons: jest.fn(),
+    updateTreeKeyConceptBadge: jest.fn()
+}));
+
+describe('dynamic concept tab IDs', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="tabContainer" class="tab-container">
+                <div class="tab-button" data-tab="chatTab">Chat</div>
+                <div class="tab-button" data-tab="vontologyTab">Vontology</div>
+                <div class="tab-button" data-tab="importExportTab">Import/Export</div>
+            </div>
+            <div class="tab-content-area"></div>
+        `;
+
+        global.fetch = jest.fn(async () => ({ ok: false, status: 404, text: async () => '' }));
+    });
+
+    afterEach(() => {
+        jest.resetModules();
+        jest.restoreAllMocks();
+        delete global.fetch;
+    });
+
+    test('does not collide for concept IDs differing only by punctuation', () => {
+        const { createOrActivateConceptTab } = require(dynamicTabsModulePath);
+
+        const idA = '#V#foo_bar';
+        const idB = '#V#foo-bar';
+
+        const tabIdA = createOrActivateConceptTab(idA, 'Foo', false, { kind: 'type' });
+        const tabIdB = createOrActivateConceptTab(idB, 'Foo', false, { kind: 'type' });
+
+        expect(tabIdA).not.toEqual(tabIdB);
+
+        const tabButtons = Array.from(
+            document.querySelectorAll('#tabContainer .tab-button.closable[data-concept-id]')
+        );
+        expect(tabButtons).toHaveLength(2);
+        expect(tabButtons[0].dataset.tab).not.toEqual(tabButtons[1].dataset.tab);
+
+        const contents = Array.from(document.querySelectorAll('.tab-content-area .tab-content'));
+        expect(contents).toHaveLength(2);
+
+        const contentIds = contents.map((el) => el.id);
+        expect(new Set(contentIds).size).toBe(2);
+    });
+});


### PR DESCRIPTION
Relates to JVNAUTOSCI-939.

- Avoids dynamic concept tab ID/DOM suffix collisions when concept IDs differ only by punctuation (e.g. hyphen vs underscore)
- Adds a regression test covering the collision case