### PR TITLE
JVNAUTOSCI-941: Fix batched tool execution + make execution caps configurable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -634,6 +634,14 @@ export async function handleSubmit(event) {
 
 ### CRITICAL: Test Database Environment Variable Hygiene
 
+**Agent rule (required):** before running any pytest command, set `VON_DB_NAME=test_von_db` (recommended). The test suite refuses to run against `VON_DB_NAME=von_db`.
+
+- Prefer the VS Code task `pytest:backend (test db)`.
+- If running manually in PowerShell, use a scoped scriptblock so you don’t accidentally leave it set:
+  ```powershell
+  & { $env:VON_DB_NAME = 'test_von_db'; pdm run pytest tests/backend -q }
+  ```
+
 **Problem:** Setting `VON_DB_NAME=test_von_db` to run tests and forgetting to reset it can cause the production server to run against test data, leading to data loss or corruption.
 
 **Prevention Mechanisms (Added October 2025):**

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Any, List
 
 from .gateway import MethodCatalogue, MethodDefinition
 from .schemas import Schema
@@ -686,9 +686,9 @@ def _add_relationship(**kwargs):
 
         # Determine if this is a text predicate (binary_text_predicate instance)
         is_text_predicate = False
-        if predicate.startswith("#V#"):
+        if predicate_str.startswith("#V#"):
             pred_doc = repo.find_one(
-                {"concept_id": predicate}, {"relationships.is_an_instance_of": 1}
+                {"concept_id": predicate_str}, {"relationships.is_an_instance_of": 1}
             )
             if pred_doc:
                 instance_of = pred_doc.get("relationships", {}).get(
@@ -702,7 +702,7 @@ def _add_relationship(**kwargs):
         if is_text_predicate:
             result = upsert_text_for_concept(
                 subject_concept_id=source_id,
-                predicate=predicate,
+                predicate=predicate_str,
                 text=target,
                 lang="en",
                 provenance={"source": "add_relationship"},
@@ -711,7 +711,7 @@ def _add_relationship(**kwargs):
                 "success": True,
                 "relationship_type": "text_relation",
                 "source_id": source_id,
-                "predicate": predicate,
+                "predicate": predicate_str,
                 "target": target,
                 "text_value_id": str(result.get("text_value_id")),
                 "relation_id": str(result.get("relation_id")),
@@ -736,12 +736,7 @@ def _add_relationship(**kwargs):
             "subtype": "has_subtype",
             "instance": "has_instance",
         }
-        rel_kind = predicate_map.get(predicate, predicate)
-
-        # Canonicalise known legacy predicate ids.
-        # JVNAUTOSCI-913: todo membership was previously represented via '#V#has_item'.
-        if rel_kind == "#V#has_item":
-            rel_kind = "#V#has_todo_item"
+        rel_kind = predicate_map.get(predicate_str, predicate_str)
 
         # Guardrail: concept-to-concept relationship predicates must be either:
         # - one of the structural relationship kinds (is_a_type_of, has_subtype, ...), or
@@ -794,48 +789,129 @@ def _add_relationship(**kwargs):
                 details={"predicate_input": predicate, "predicate_canonical": rel_kind},
             )
 
-        # Read current relationships
+        # For structural predicates, maintain inverse consistency like the HTTP API.
+        inverse_map = {
+            "is_a_type_of": ("has_subtype", target, source_id),
+            "has_subtype": ("is_a_type_of", target, source_id),
+            "is_an_instance_of": ("has_instance", target, source_id),
+            "has_instance": ("is_an_instance_of", target, source_id),
+            "related_to": ("related_to", target, source_id),
+        }
+        has_inverse = isinstance(rel_kind, str) and rel_kind in inverse_map
+
+        # Ensure relationship storage is list-typed for the forward predicate.
+        # This prevents $addToSet failures when legacy data stored a single string.
+        repo._ensure_relationship_array(source_id, rel_kind)
+
+        forward_exists_before = False
         existing = (
             repo.find_one({"concept_id": source_id}, {f"relationships.{rel_kind}": 1})
             or {}
         )
         rels = existing.get("relationships") or {}
         curr = rels.get(rel_kind)
+        if isinstance(curr, list):
+            forward_exists_before = target in curr
+        elif isinstance(curr, str):
+            forward_exists_before = target == curr
 
-        # Normalize to array
-        if isinstance(curr, str):
-            curr_list = [curr] if curr else []
-        elif isinstance(curr, list):
-            curr_list = curr
-        else:
-            curr_list = []
-
-        # Check if already exists
-        if target in curr_list:
-            return {
-                "success": True,
-                "message": "Relationship already exists",
-                "source_id": source_id,
-                "predicate": rel_kind,
-                "target": target,
-                "already_existed": True,
-            }
-
-        # Add the relationship
-        update_result = repo.update_one(
+        forward_update = repo.update_one(
             {"concept_id": source_id},
             {"$addToSet": {f"relationships.{rel_kind}": target}},
         )
 
-        if update_result.modified_count > 0 or update_result.matched_count > 0:
-            return {
-                "success": True,
-                "source_id": source_id,
-                "predicate": rel_kind,
-                "target": target,
-                "added": update_result.modified_count > 0,
-            }
-        else:
+        inverse_payload = None
+        inverse_failed = None
+        if has_inverse:
+            inv_kind, inv_src, inv_tgt = inverse_map[rel_kind]
+            try:
+                repo._ensure_relationship_array(inv_src, inv_kind)
+                inverse_update = repo.update_one(
+                    {"concept_id": inv_src},
+                    {"$addToSet": {f"relationships.{inv_kind}": inv_tgt}},
+                )
+                if (
+                    inverse_update.matched_count > 0
+                    and inverse_update.modified_count == 0
+                ):
+                    # Defensive verification: if we didn't modify anything, ensure the
+                    # inverse edge is actually present (it may have already existed or
+                    # been added concurrently).
+                    inv_existing = (
+                        repo.find_one(
+                            {"concept_id": inv_src},
+                            {f"relationships.{inv_kind}": 1},
+                        )
+                        or {}
+                    )
+                    inv_rels = inv_existing.get("relationships") or {}
+                    inv_curr = inv_rels.get(inv_kind)
+                    inverse_present_after = False
+                    if isinstance(inv_curr, list):
+                        inverse_present_after = inv_tgt in inv_curr
+                    elif isinstance(inv_curr, str):
+                        inverse_present_after = inv_tgt == inv_curr
+                    if not inverse_present_after:
+                        inverse_failed = {
+                            "predicate": inv_kind,
+                            "source_id": inv_src,
+                            "target": inv_tgt,
+                            "exception_type": "InverseNoOp",
+                            "error": "Inverse relationship update did not persist",
+                        }
+                inverse_payload = {
+                    "predicate": inv_kind,
+                    "source_id": inv_src,
+                    "target": inv_tgt,
+                    "added": inverse_update.modified_count > 0,
+                    "matched": inverse_update.matched_count > 0,
+                }
+            except Exception as exc:
+                inverse_failed = {
+                    "predicate": inv_kind,
+                    "source_id": inv_src,
+                    "target": inv_tgt,
+                    "exception_type": type(exc).__name__,
+                    "error": str(exc),
+                }
+
+        forward_ok = forward_update.matched_count > 0
+        forward_added = forward_update.modified_count > 0
+
+        if forward_ok and not forward_added and not forward_exists_before:
+            # Defensive verification: if we didn't modify anything and the edge did
+            # not appear to exist pre-write, confirm the edge exists post-write.
+            # This prevents returning success when the update is effectively a no-op.
+            verify = (
+                repo.find_one(
+                    {"concept_id": source_id},
+                    {f"relationships.{rel_kind}": 1},
+                )
+                or {}
+            )
+            verify_rels = verify.get("relationships") or {}
+            verify_curr = verify_rels.get(rel_kind)
+            present_after = False
+            if isinstance(verify_curr, list):
+                present_after = target in verify_curr
+            elif isinstance(verify_curr, str):
+                present_after = target == verify_curr
+            if present_after:
+                forward_exists_before = True
+            else:
+                return _err(
+                    "relationship_add_noop",
+                    "Relationship update did not persist",
+                    details={
+                        "source_id": source_id,
+                        "predicate": rel_kind,
+                        "target": target,
+                        "matched": forward_update.matched_count > 0,
+                        "modified": forward_update.modified_count > 0,
+                    },
+                )
+
+        if not forward_ok:
             return _err(
                 "relationship_add_failed",
                 "Failed to add relationship",
@@ -845,6 +921,36 @@ def _add_relationship(**kwargs):
                     "target": target,
                 },
             )
+
+        if inverse_failed:
+            return _err(
+                "relationship_add_partial_failure",
+                "Relationship added, but inverse relationship update failed",
+                details={
+                    "forward": {
+                        "source_id": source_id,
+                        "predicate": rel_kind,
+                        "target": target,
+                        "added": forward_added,
+                        "already_existed": bool(
+                            forward_exists_before and not forward_added
+                        ),
+                    },
+                    "inverse_failed": inverse_failed,
+                },
+            )
+
+        response: dict[str, Any] = {
+            "success": True,
+            "source_id": source_id,
+            "predicate": rel_kind,
+            "target": target,
+            "added": forward_added,
+            "already_existed": bool(forward_exists_before and not forward_added),
+        }
+        if inverse_payload:
+            response["inverse"] = inverse_payload
+        return response
 
     except Exception as e:
         return _err(
@@ -947,11 +1053,6 @@ def _remove_relationship(**kwargs):
             "instance": "has_instance",
         }
         rel_kind = predicate_map.get(predicate, predicate)
-
-        # Canonicalise known legacy predicate ids.
-        # JVNAUTOSCI-913: todo membership was previously represented via '#V#has_item'.
-        if rel_kind == "#V#has_item":
-            rel_kind = "#V#has_todo_item"
 
         # Determine if this is a text predicate (binary_text_predicate instance)
         if isinstance(rel_kind, str) and rel_kind.startswith("#V#"):
@@ -4113,6 +4214,7 @@ def _chat_introspect(
 
     gateway_enabled = None
     orchestrator_max_tool_invocations = None
+    orchestrator_tool_batch_cap = None
     if include_runtime_status:
         try:
             from flask import current_app
@@ -4123,9 +4225,11 @@ def _chat_introspect(
             orchestrator_max_tool_invocations = getattr(
                 orchestrator, "_max_tool_invocations", None
             )
+            orchestrator_tool_batch_cap = getattr(orchestrator, "_tool_batch_cap", None)
         except Exception:
             gateway_enabled = None
             orchestrator_max_tool_invocations = None
+            orchestrator_tool_batch_cap = None
 
     # Tool-guidance fingerprint (stable-ish) without dumping full text by default
     tool_guidance_text = ""
@@ -4188,6 +4292,7 @@ def _chat_introspect(
         "tool_guidance_preview": tool_guidance_preview,
         "gateway_enabled": gateway_enabled,
         "orchestrator_max_tool_invocations": orchestrator_max_tool_invocations,
+        "orchestrator_tool_batch_cap": orchestrator_tool_batch_cap,
     }
 
 
@@ -4346,6 +4451,7 @@ def build_default_catalogue() -> MethodCatalogue:
                     "tool_guidance_preview": (str, type(None)),
                     "gateway_enabled": (bool, type(None)),
                     "orchestrator_max_tool_invocations": (int, type(None)),
+                    "orchestrator_tool_batch_cap": (int, type(None)),
                 },
                 optional={"error": str},
                 allow_unknown=False,

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -157,6 +157,7 @@ class InternalMCPChatOrchestrator:
         gateway: InternalMCPGateway,
         logger: logging.Logger | None = None,
         max_tool_invocations: int = 1,
+        tool_batch_cap: int = 4,
         default_gmail_profile: str | None = None,
         max_context_chars: int | None = None,
         max_tool_result_chars: int | None = None,
@@ -165,6 +166,7 @@ class InternalMCPChatOrchestrator:
         self._gateway = gateway
         self._logger = logger or logging.getLogger(__name__)
         self._max_tool_invocations = max(0, int(max_tool_invocations))
+        self._tool_batch_cap = max(1, int(tool_batch_cap))
         self._default_gmail_profile = default_gmail_profile
 
         # Vontology-backed missing-tool-call detector (lazy loaded)
@@ -211,6 +213,39 @@ class InternalMCPChatOrchestrator:
             },
             classifier_prompt_ids=self._TURN_SELECTOR_PROMPTS,
         )
+
+    def configure_execution_caps(
+        self,
+        *,
+        max_tool_invocations: int | None = None,
+        tool_batch_cap: int | None = None,
+    ) -> None:
+        """Update execution caps in-place.
+
+        This is intentionally lightweight so callers (e.g., /von/generate) can
+        apply persisted Settings without requiring a server restart.
+        """
+
+        if max_tool_invocations is not None:
+            try:
+                coerced = int(max_tool_invocations)
+            except Exception:
+                coerced = self._max_tool_invocations
+            # Safety clamp.
+            self._max_tool_invocations = max(0, min(50, coerced))
+
+        if tool_batch_cap is not None:
+            try:
+                coerced = int(tool_batch_cap)
+            except Exception:
+                coerced = self._tool_batch_cap
+            self._tool_batch_cap = max(1, min(50, coerced))
+
+    def get_execution_caps(self) -> dict[str, int]:
+        return {
+            "max_tool_invocations": int(self._max_tool_invocations),
+            "tool_batch_cap": int(self._tool_batch_cap),
+        }
 
     @staticmethod
     def _coerce_int(
@@ -2630,6 +2665,8 @@ class InternalMCPChatOrchestrator:
         first_iteration_structured = use_structured and has_valid_tool_call
 
         while iteration_count < self._max_tool_invocations:
+            remaining_tool_calls: list[_ToolCallRequest] = []
+
             # Skip extraction on first iteration if structured calling already did it
             if first_iteration_structured:
                 first_iteration_structured = False  # Only skip once
@@ -2697,9 +2734,10 @@ class InternalMCPChatOrchestrator:
             remaining = self._max_tool_invocations - iteration_count
             if remaining <= 0:
                 break
-            batch_cap = 4
+            batch_cap = max(1, int(getattr(self, "_tool_batch_cap", 4)))
             allowed = min(remaining, batch_cap)
             if len(tool_calls) > allowed:
+                remaining_tool_calls = tool_calls[allowed:]
                 tool_calls = tool_calls[:allowed]
 
             # Add the assistant JSON response once per batch.
@@ -2862,6 +2900,14 @@ class InternalMCPChatOrchestrator:
 
                 augmented_context.append({"role": "tool", "content": tool_payload})
                 tool_messages.append({"role": "tool", "content": tool_payload})
+
+            # If the model provided more tool calls than the batch cap, execute them
+            # (up to max_tool_invocations) before asking for a final answer. This
+            # prevents the assistant from prematurely narrating completion after only
+            # the first batch executes (JVNAUTOSCI-941).
+            if remaining_tool_calls and iteration_count < self._max_tool_invocations:
+                current_response = json.dumps(remaining_tool_calls)
+                continue
 
             follow_up_prompt = (
                 "Provide a final answer to the user now that the tool result is available. "

--- a/src/backend/server/routes/settings_routes.py
+++ b/src/backend/server/routes/settings_routes.py
@@ -27,6 +27,10 @@ from ...services.settings_service import (
     set_org_llm_setting,
     get_disable_remote_ollama_scan,
     set_disable_remote_ollama_scan,
+    get_internal_mcp_max_tool_invocations,
+    set_internal_mcp_max_tool_invocations,
+    get_internal_mcp_tool_batch_cap,
+    set_internal_mcp_tool_batch_cap,
 )
 from ...services.concept_service import list_concepts, get_concept_by_id
 from ...languagemodels.llm_interface import OpenAIClient
@@ -486,6 +490,8 @@ def get_all_settings_data():
             "openai_api_key_env_var": get_openai_env_var(),
             "fetch_counts_on_load": get_fetch_counts_on_load(),
             "disable_remote_ollama_scan": get_disable_remote_ollama_scan(),
+            "internal_mcp_max_tool_invocations": get_internal_mcp_max_tool_invocations(),
+            "internal_mcp_tool_batch_cap": get_internal_mcp_tool_batch_cap(),
         }
     except Exception as e:
         current_app.logger.error(f"Error retrieving settings data: {e}", exc_info=True)
@@ -569,6 +575,16 @@ def save_all_settings():
                 disabled = False
             set_disable_remote_ollama_scan(disabled)
             current_app.logger.info(f"disable_remote_ollama_scan set to: {disabled}")
+
+        if "internal_mcp_max_tool_invocations" in data:
+            set_internal_mcp_max_tool_invocations(
+                data.get("internal_mcp_max_tool_invocations")
+            )
+            current_app.logger.info("internal_mcp_max_tool_invocations updated")
+
+        if "internal_mcp_tool_batch_cap" in data:
+            set_internal_mcp_tool_batch_cap(data.get("internal_mcp_tool_batch_cap"))
+            current_app.logger.info("internal_mcp_tool_batch_cap updated")
 
         # user/org/language fields intentionally ignored (browser-local)
 

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -9,6 +9,10 @@ from ...languagemodels.llm_interface import get_llm_client, get_active_model_nam
 from .settings_routes import get_all_settings_data
 from ...integrations.internal_mcp import ToolCallParsingError
 from ...services import chat_history_service
+from ...services.settings_service import (
+    get_internal_mcp_max_tool_invocations,
+    get_internal_mcp_tool_batch_cap,
+)
 from ...workflows import (
     CHAT_NARRATION_WORKFLOW_ID,
     WorkflowExecutionTrace,
@@ -1744,6 +1748,14 @@ def generate():
                     "[NAMESPACE] Calling orchestrator.run() with user_namespace=%s",
                     user_namespace,
                 )
+                try:
+                    orchestrator.configure_execution_caps(
+                        max_tool_invocations=get_internal_mcp_max_tool_invocations(),
+                        tool_batch_cap=get_internal_mcp_tool_batch_cap(),
+                    )
+                except Exception:
+                    # Defensive: never fail the request due to settings refresh.
+                    pass
                 orchestrator_start_perf = time.perf_counter()
                 orchestrator_result = orchestrator.run(
                     prompt=prompt_text,

--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -2940,11 +2940,6 @@ def add_relationship_route():
                 400,
             )
 
-            # Canonicalise known legacy predicate ids.
-            # JVNAUTOSCI-913: todo membership was previously represented via '#V#has_item'.
-            if kind == "#V#has_item":
-                kind = "#V#has_todo_item"
-
     try:
         repo = ConceptsRepository
 

--- a/src/backend/services/settings_service.py
+++ b/src/backend/services/settings_service.py
@@ -33,6 +33,10 @@ PREFERRED_LANGUAGE_SETTING_NAME = "preferred_language"
 FETCH_COUNTS_ON_LOAD_SETTING_NAME = "fetch_counts_on_load"
 DISABLE_REMOTE_OLLAMA_SCAN_SETTING_NAME = "disable_remote_ollama_scan"
 
+# Internal MCP orchestrator caps (Settings → Agent Configuration)
+INTERNAL_MCP_MAX_TOOL_INVOCATIONS_SETTING_NAME = "internal_mcp_max_tool_invocations"
+INTERNAL_MCP_TOOL_BATCH_CAP_SETTING_NAME = "internal_mcp_tool_batch_cap"
+
 # Prefixes for contextual (scoped) LLM settings (Phase 2 scaffold)
 _ACTIVE_LLM_USER_PREFIX = f"{ACTIVE_LLM_SETTING_NAME}:user:"
 _ACTIVE_LLM_ORG_PREFIX = f"{ACTIVE_LLM_SETTING_NAME}:org:"
@@ -665,6 +669,74 @@ def set_disable_remote_ollama_scan(disabled: bool) -> bool:
         # Coerce permissively but persist canonical bool
         disabled = bool(disabled)
     return update_setting(DISABLE_REMOTE_OLLAMA_SCAN_SETTING_NAME, disabled)
+
+
+def _coerce_int_setting(
+    value: Any,
+    *,
+    default: int,
+    min_value: int,
+    max_value: int,
+) -> int:
+    if value is None:
+        return default
+
+    parsed: int | None = None
+    if isinstance(value, bool):
+        # Avoid treating True/False as 1/0 for numeric settings.
+        parsed = None
+    elif isinstance(value, int):
+        parsed = value
+    elif isinstance(value, float):
+        try:
+            parsed = int(value)
+        except Exception:
+            parsed = None
+    elif isinstance(value, str):
+        try:
+            parsed = int(value.strip())
+        except Exception:
+            parsed = None
+
+    if parsed is None:
+        return default
+
+    return max(min_value, min(max_value, parsed))
+
+
+def get_internal_mcp_max_tool_invocations() -> int:
+    """Return the maximum number of internal MCP tool calls per chat turn.
+
+    Defaults to 8 when unset/invalid.
+    """
+
+    val = get_setting(INTERNAL_MCP_MAX_TOOL_INVOCATIONS_SETTING_NAME)
+    return _coerce_int_setting(val, default=8, min_value=0, max_value=50)
+
+
+def set_internal_mcp_max_tool_invocations(value: Any) -> bool:
+    """Persist the max internal MCP tool invocations (canonical int, clamped)."""
+
+    coerced = _coerce_int_setting(value, default=8, min_value=0, max_value=50)
+    return update_setting(INTERNAL_MCP_MAX_TOOL_INVOCATIONS_SETTING_NAME, coerced)
+
+
+def get_internal_mcp_tool_batch_cap() -> int:
+    """Return the maximum number of tool calls executed per batch.
+
+    This is a guardrail against very large tool-call lists per iteration.
+    Defaults to 4 when unset/invalid.
+    """
+
+    val = get_setting(INTERNAL_MCP_TOOL_BATCH_CAP_SETTING_NAME)
+    return _coerce_int_setting(val, default=4, min_value=1, max_value=50)
+
+
+def set_internal_mcp_tool_batch_cap(value: Any) -> bool:
+    """Persist the tool-call batch cap (canonical int, clamped)."""
+
+    coerced = _coerce_int_setting(value, default=4, min_value=1, max_value=50)
+    return update_setting(INTERNAL_MCP_TOOL_BATCH_CAP_SETTING_NAME, coerced)
 
 
 # Ollama hosts settings functions

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -1526,6 +1526,41 @@ function deriveLlmDebugWarnings(debugData) {
         return warnings;
     }
 
+    const responseText = (typeof debugData.response === 'string') ? debugData.response : '';
+    const toolInvocations = Array.isArray(debugData.tool_invocations) ? debugData.tool_invocations : [];
+    const toolStatsCount = (debugData.tool_stats && Number.isFinite(debugData.tool_stats.tool_count))
+        ? Number(debugData.tool_stats.tool_count)
+        : null;
+    const executedToolCount = toolInvocations.length || (toolStatsCount ?? 0);
+
+    // Heuristic: detect when the assistant claims it performed N operations but we
+    // only executed M tool calls. This often indicates tool truncation/early stop.
+    // (e.g., “Done — 9 links” but tool_invocations contains 4 items).
+    if (responseText) {
+        const patterns = [
+            /\b(?:done|complete|completed)\s*[—\-:]\s*(\d+)\b/gi,
+            /\b(?:added|linked|created|removed|updated|executed)\s+(\d+)\b/gi,
+            /\b(\d+)\s+(?:links?|relationships?|relations?|tool\s*calls?|tools?)\b/gi
+        ];
+
+        let claimed = null;
+        for (const re of patterns) {
+            let match;
+            while ((match = re.exec(responseText)) !== null) {
+                const n = Number(match[1]);
+                if (Number.isFinite(n)) {
+                    claimed = claimed == null ? n : Math.max(claimed, n);
+                }
+            }
+        }
+
+        if (claimed != null && claimed > 0 && executedToolCount >= 0 && claimed > executedToolCount) {
+            warnings.push(
+                `Response claims ${claimed} operations, but only ${executedToolCount} tool invocations were recorded.`
+            );
+        }
+    }
+
     if (typeof debugData.error === 'string' && debugData.error.trim()) {
         warnings.push(`Backend error: ${debugData.error.trim()}`);
     }

--- a/src/frontend/web/von_interface/static/js/settingsPage.js
+++ b/src/frontend/web/von_interface/static/js/settingsPage.js
@@ -1007,6 +1007,24 @@ async function loadAndDisplaySettings() {
       }
     } catch { }
 
+    // Populate internal MCP execution caps
+    try {
+      const maxInvEl = document.getElementById('internalMcpMaxToolInvocations');
+      if (maxInvEl) {
+        const raw = Object.prototype.hasOwnProperty.call(settings, 'internal_mcp_max_tool_invocations')
+          ? settings.internal_mcp_max_tool_invocations
+          : 8;
+        maxInvEl.value = String(clampNumber(raw, 0, 50, 8));
+      }
+      const batchCapEl = document.getElementById('internalMcpToolBatchCap');
+      if (batchCapEl) {
+        const raw = Object.prototype.hasOwnProperty.call(settings, 'internal_mcp_tool_batch_cap')
+          ? settings.internal_mcp_tool_batch_cap
+          : 4;
+        batchCapEl.value = String(clampNumber(raw, 1, 50, 4));
+      }
+    } catch { }
+
     // Populate preferred language setting
     const languageSelect = document.getElementById('preferredLanguageSelect');
     if (languageSelect) {
@@ -1192,6 +1210,18 @@ async function saveAllSettings(changedProvider = null) {
     openai_api_key_env_var: document.getElementById('openaiApiKeyEnvVar')?.value,
     fetch_counts_on_load: !!document.getElementById('fetchCountsOnLoadToggle')?.checked,
     disable_remote_ollama_scan: !!document.getElementById('disableRemoteOllamaScanToggle')?.checked,
+    internal_mcp_max_tool_invocations: clampNumber(
+      document.getElementById('internalMcpMaxToolInvocations')?.value,
+      0,
+      50,
+      8,
+    ),
+    internal_mcp_tool_batch_cap: clampNumber(
+      document.getElementById('internalMcpToolBatchCap')?.value,
+      1,
+      50,
+      4,
+    ),
   };
 
   try {

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -511,4 +511,20 @@ describe('LLM debug warnings (presenter channel health)', () => {
             'Spoken backfill attempted but spoken channel is still missing (missing_spoken).'
         );
     });
+
+    test('flags when response claims more operations than executed tools', () => {
+        const warnings = __testOnly_deriveLlmDebugWarnings({
+            response: 'Done — 9 links added.',
+            tool_invocations: [
+                { method: 'add_relationship', arguments: { i: 0 } },
+                { method: 'add_relationship', arguments: { i: 1 } },
+                { method: 'add_relationship', arguments: { i: 2 } },
+                { method: 'add_relationship', arguments: { i: 3 } }
+            ]
+        });
+
+        expect(warnings).toContain(
+            'Response claims 9 operations, but only 4 tool invocations were recorded.'
+        );
+    });
 });

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -5307,6 +5307,15 @@ body.settings-body {
     margin-bottom: 10px;
 }
 
+/* Tool Execution Caps inputs (settings_tab) */
+#internalMcpMaxToolInvocations {
+    width: 110px;
+}
+
+#internalMcpToolBatchCap {
+    width: 90px;
+}
+
 #dbInfoContent {
     font-size: 0.95em;
     color: #333;

--- a/src/frontend/web/von_interface/templates/settings_tab.html
+++ b/src/frontend/web/von_interface/templates/settings_tab.html
@@ -153,6 +153,21 @@
             </div>
             <div id="agentGmailOauthStatus" class="settings-note mt-1">Agent Gmail OAuth: unknown</div>
             <div id="gmailProfileStatus" class="settings-note">Gmail profile target: unknown</div>
+
+            <h3 class="mt-3">Tool Execution Caps</h3>
+            <p class="settings-note">Controls internal MCP tool chaining. Changes apply immediately for new chat turns.
+                Larger values can increase latency and tool load.</p>
+
+            <div class="inline-form inline-form-tight">
+                <label for="internalMcpMaxToolInvocations" class="mr-1">Max tool invocations per turn:</label>
+                <input type="number" id="internalMcpMaxToolInvocations" min="0" max="50" step="1" value="8"
+                    class="mr-2" />
+
+                <label for="internalMcpToolBatchCap" class="mr-1">Tool calls per batch:</label>
+                <input type="number" id="internalMcpToolBatchCap" min="1" max="50" step="1" value="4" />
+            </div>
+            <small class="settings-note">Defaults: 8 invocations, batch cap 4. Set invocations to 0 to disable tool
+                calls (chat still works).</small>
         </section>
 
         <section id="current-user-settings">

--- a/tests/backend/test_internal_mcp_add_relationship_inverse.py
+++ b/tests/backend/test_internal_mcp_add_relationship_inverse.py
@@ -1,0 +1,118 @@
+import types
+
+
+def test_add_relationship_adds_inverse_for_structural_predicates(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    calls = {"ensure": [], "find_one": [], "update_one": []}
+
+    def _fake_find_one(filter_doc, projection=None):
+        calls["find_one"].append({"filter": filter_doc, "projection": projection})
+        cid = filter_doc.get("concept_id")
+        if cid == "#V#source":
+            # Existence check
+            if projection is None:
+                return {"concept_id": "#V#source", "relationships": {}}
+            # Relationship-read check
+            return {"concept_id": "#V#source", "relationships": {"is_a_type_of": []}}
+        if cid == "#V#target":
+            if projection is None:
+                return {"concept_id": "#V#target", "relationships": {}}
+            return {"concept_id": "#V#target", "relationships": {"has_subtype": []}}
+        return None
+
+    def _fake_ensure_relationship_array(concept_id, rel_kind):
+        calls["ensure"].append({"concept_id": concept_id, "rel_kind": rel_kind})
+        return False
+
+    def _fake_update_one(filter_doc, update_doc, upsert=False):
+        calls["update_one"].append(
+            {"filter": filter_doc, "update": update_doc, "upsert": upsert}
+        )
+        return types.SimpleNamespace(modified_count=1, matched_count=1)
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _fake_find_one,
+    )
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository._ensure_relationship_array",
+        _fake_ensure_relationship_array,
+    )
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.update_one",
+        _fake_update_one,
+    )
+
+    result = catalogue._add_relationship(
+        source_id="#V#source", predicate="typeOf", target="#V#target"
+    )
+
+    assert result["success"] is True
+    assert result["predicate"] == "is_a_type_of"
+    assert result.get("inverse", {}).get("predicate") == "has_subtype"
+    assert result.get("inverse", {}).get("source_id") == "#V#target"
+    assert result.get("inverse", {}).get("target") == "#V#source"
+
+    assert calls["ensure"] == [
+        {"concept_id": "#V#source", "rel_kind": "is_a_type_of"},
+        {"concept_id": "#V#target", "rel_kind": "has_subtype"},
+    ]
+    assert len(calls["update_one"]) == 2
+
+
+def test_add_relationship_when_forward_exists_still_ensures_inverse(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    calls = {"ensure": [], "update_one": []}
+
+    def _fake_find_one(filter_doc, projection=None):
+        cid = filter_doc.get("concept_id")
+        if cid == "#V#source":
+            if projection is None:
+                return {"concept_id": "#V#source", "relationships": {}}
+            # Forward already exists
+            return {
+                "concept_id": "#V#source",
+                "relationships": {"is_a_type_of": ["#V#target"]},
+            }
+        if cid == "#V#target":
+            if projection is None:
+                return {"concept_id": "#V#target", "relationships": {}}
+            return {"concept_id": "#V#target", "relationships": {"has_subtype": []}}
+        return None
+
+    def _fake_ensure_relationship_array(concept_id, rel_kind):
+        calls["ensure"].append({"concept_id": concept_id, "rel_kind": rel_kind})
+        return False
+
+    def _fake_update_one(filter_doc, update_doc, upsert=False):
+        calls["update_one"].append(
+            {"filter": filter_doc, "update": update_doc, "upsert": upsert}
+        )
+        # Forward update is idempotent (already had it), inverse update adds it.
+        if filter_doc.get("concept_id") == "#V#source":
+            return types.SimpleNamespace(modified_count=0, matched_count=1)
+        return types.SimpleNamespace(modified_count=1, matched_count=1)
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _fake_find_one,
+    )
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository._ensure_relationship_array",
+        _fake_ensure_relationship_array,
+    )
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.update_one",
+        _fake_update_one,
+    )
+
+    result = catalogue._add_relationship(
+        source_id="#V#source", predicate="typeOf", target="#V#target"
+    )
+
+    assert result["success"] is True
+    assert result["already_existed"] is True
+    assert result.get("inverse", {}).get("added") is True
+    assert len(calls["update_one"]) == 2

--- a/tests/backend/test_internal_mcp_add_relationship_predicate_validation.py
+++ b/tests/backend/test_internal_mcp_add_relationship_predicate_validation.py
@@ -62,9 +62,7 @@ def test_add_relationship_rejects_missing_dynamic_predicate_concepts(monkeypatch
 
     assert result["success"] is False
     assert result.get("error_code") == "predicate_concept_not_found"
-    assert "Predicate concept '#V#has_todo_item' not found" in (
-        result.get("error") or ""
-    )
+    assert "Predicate concept '#V#has_item' not found" in (result.get("error") or "")
 
 
 def test_add_relationship_rejects_dynamic_concepts_that_are_not_predicates(monkeypatch):

--- a/tests/backend/test_internal_mcp_cap_settings.py
+++ b/tests/backend/test_internal_mcp_cap_settings.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from src.backend.integrations.internal_mcp.orchestrator import (
+    InternalMCPChatOrchestrator,
+)
+from src.backend.services import settings_service
+
+
+class _StubGateway:
+    enabled = True
+
+    def describe_methods(self):
+        return {}
+
+    def invoke(self, tool_name, payload=None):
+        raise RuntimeError("not used")
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, 8),
+        ("", 8),
+        ("not-a-number", 8),
+        (True, 8),
+        (-5, 0),
+        (0, 0),
+        (7, 7),
+        (999, 50),
+        ("12", 12),
+    ],
+)
+def test_get_internal_mcp_max_tool_invocations_clamps(
+    raw: Any, expected: int, monkeypatch
+):
+    monkeypatch.setattr(settings_service, "get_setting", lambda _name: raw)
+    assert settings_service.get_internal_mcp_max_tool_invocations() == expected
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, 4),
+        ("", 4),
+        ("not-a-number", 4),
+        (True, 4),
+        (0, 1),
+        (1, 1),
+        (7, 7),
+        (999, 50),
+        ("12", 12),
+    ],
+)
+def test_get_internal_mcp_tool_batch_cap_clamps(raw: Any, expected: int, monkeypatch):
+    monkeypatch.setattr(settings_service, "get_setting", lambda _name: raw)
+    assert settings_service.get_internal_mcp_tool_batch_cap() == expected
+
+
+def test_set_internal_mcp_max_tool_invocations_persists_clamped_value(monkeypatch):
+    captured = {}
+
+    def _update_setting(name, value):
+        captured["name"] = name
+        captured["value"] = value
+        return True
+
+    monkeypatch.setattr(settings_service, "update_setting", _update_setting)
+
+    assert settings_service.set_internal_mcp_max_tool_invocations(999) is True
+    assert (
+        captured["name"]
+        == settings_service.INTERNAL_MCP_MAX_TOOL_INVOCATIONS_SETTING_NAME
+    )
+    assert captured["value"] == 50
+
+
+def test_set_internal_mcp_tool_batch_cap_persists_clamped_value(monkeypatch):
+    captured = {}
+
+    def _update_setting(name, value):
+        captured["name"] = name
+        captured["value"] = value
+        return True
+
+    monkeypatch.setattr(settings_service, "update_setting", _update_setting)
+
+    assert settings_service.set_internal_mcp_tool_batch_cap(0) is True
+    assert captured["name"] == settings_service.INTERNAL_MCP_TOOL_BATCH_CAP_SETTING_NAME
+    assert captured["value"] == 1
+
+
+def test_orchestrator_configure_execution_caps_clamps():
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=cast(Any, _StubGateway()),
+        max_tool_invocations=8,
+        tool_batch_cap=4,
+    )
+
+    orchestrator.configure_execution_caps(max_tool_invocations=999, tool_batch_cap=0)
+
+    caps = orchestrator.get_execution_caps()
+    assert caps["max_tool_invocations"] == 50
+    assert caps["tool_batch_cap"] == 1

--- a/tests/backend/test_internal_mcp_orchestrator_batch_execution.py
+++ b/tests/backend/test_internal_mcp_orchestrator_batch_execution.py
@@ -1,0 +1,76 @@
+import json
+from typing import Any, cast
+
+from src.backend.integrations.internal_mcp.orchestrator import (
+    InternalMCPChatOrchestrator,
+)
+
+
+class _StubResult:
+    def __init__(self, payload, duration_ms=1.0):
+        self.payload = payload
+        self.duration_ms = duration_ms
+
+
+class _CapturingGateway:
+    enabled = True
+
+    def __init__(self):
+        self.invocations = []
+
+    def describe_methods(self):
+        return {}
+
+    def invoke(self, tool_name, payload=None):
+        self.invocations.append({"tool": tool_name, "payload": payload})
+        return _StubResult({"ok": True})
+
+
+class _CapturingLLM:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def generate(self, prompt, *, context=None, model=None):
+        self.calls.append({"prompt": prompt, "context": context, "model": model})
+        if self._responses:
+            return self._responses.pop(0)
+        return "ok"
+
+
+def test_orchestrator_executes_all_tool_calls_in_single_list_response():
+    """Regression test for JVNAUTOSCI-941.
+
+    Previously, if the model emitted a list of >4 tool calls, the orchestrator
+    executed only the first batch (cap=4) and then asked for a final answer.
+    The model could respond with a summary that *assumed* all calls ran.
+
+    We now execute the remaining tool calls from the same list before prompting
+    for a final answer.
+    """
+
+    gateway = cast(Any, _CapturingGateway())
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=gateway,
+        max_tool_invocations=20,
+        max_context_chars=80_000,
+    )
+
+    tool_calls = [
+        {"action": "call_tool", "tool": "dummy", "payload": {"i": i}} for i in range(9)
+    ]
+
+    llm = _CapturingLLM([json.dumps(tool_calls), "done"])
+
+    result = orchestrator.run(
+        prompt="link authors", context=[], llm_client=llm, model=None
+    )
+
+    assert result.response_text == "done"
+    assert len(result.tool_invocations) == 9
+    assert [inv.get("payload", {}).get("i") for inv in result.tool_invocations] == list(
+        range(9)
+    )
+    assert len(gateway.invocations) == 9
+    # Initial tool call list + single follow-up answer.
+    assert len(llm.calls) == 2

--- a/tests/backend/test_internal_mcp_remove_relationship_errors.py
+++ b/tests/backend/test_internal_mcp_remove_relationship_errors.py
@@ -51,7 +51,7 @@ def test_remove_relationship_rejects_missing_dynamic_predicate_concepts(monkeypa
 
     assert result["success"] is False
     assert result.get("error_code") == "predicate_concept_not_found"
-    assert "#V#has_todo_item" in (result.get("error") or "")
+    assert "#V#has_item" in (result.get("error") or "")
 
 
 def test_remove_relationship_returns_structured_error_for_missing_source(monkeypatch):


### PR DESCRIPTION
## Summary
- Fixes batched tool execution so the orchestrator continues executing tool calls beyond the per-batch cap (up to the per-turn cap) before producing a final answer.
- Adds Settings → Agent Configuration controls to view/change tool execution caps, persisted server-side and applied per request.
- Hardens internal MCP `add_relationship` behaviour and improves failure signalling/inverse-edge handling.

## Tests
- Backend: `pytest` (test DB) ✅
- Frontend: `npm test` ✅
