### PR TITLE
JVNAUTOSCI-942: Reveal tool use during Thinking

### DIFF
--- a/src/backend/integrations/google/gmail_service.py
+++ b/src/backend/integrations/google/gmail_service.py
@@ -19,7 +19,7 @@ from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 
 try:  # Optional dependency: agent Gmail OAuth token store.
-    from backend.services.agent_gmail_token_store import (
+    from ...services.agent_gmail_token_store import (
         get_agent_gmail_token_payload as _get_agent_gmail_token_payload,
         get_agent_gmail_token_status as _get_agent_gmail_token_status,
         upsert_agent_gmail_tokens as _upsert_agent_gmail_tokens,

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -10,6 +10,7 @@ from dataclasses import asdict, dataclass
 from typing import (
     Any,
     cast,
+    Callable,
     Dict,
     Iterable,
     List,
@@ -169,6 +170,10 @@ class InternalMCPChatOrchestrator:
         self._tool_batch_cap = max(1, int(tool_batch_cap))
         self._default_gmail_profile = default_gmail_profile
 
+        # Optional progress callback for UI telemetry (JVNAUTOSCI-942).
+        # This must never be allowed to break tool execution.
+        self._progress_callback: Callable[[Mapping[str, Any]], None] | None = None
+
         # Vontology-backed missing-tool-call detector (lazy loaded)
         self._missing_tool_call_detector: Optional[_MissingToolCallDetectorSpec] = None
         self._missing_tool_call_detector_loaded: bool = False
@@ -246,6 +251,21 @@ class InternalMCPChatOrchestrator:
             "max_tool_invocations": int(self._max_tool_invocations),
             "tool_batch_cap": int(self._tool_batch_cap),
         }
+
+    def set_progress_callback(
+        self, callback: Callable[[Mapping[str, Any]], None] | None
+    ) -> None:
+        self._progress_callback = callback
+
+    def _emit_progress(self, info: Mapping[str, Any]) -> None:
+        callback = getattr(self, "_progress_callback", None)
+        if callback is None:
+            return
+        try:
+            callback(info)
+        except Exception:
+            # Progress is best-effort; never disrupt the main chat flow.
+            return
 
     @staticmethod
     def _coerce_int(
@@ -889,6 +909,9 @@ class InternalMCPChatOrchestrator:
                 "If user asks about their RAG data/sessions/indexed content, explain they need to log in first.\n"
             )
 
+        max_invocations = int(getattr(self, "_max_tool_invocations", 0))
+        batch_cap = int(getattr(self, "_tool_batch_cap", 4))
+
         base_message = (
             "You have access to internal MCP tools.\n\n"
             "⚠️ WHEN TO USE TOOLS (CHECK THESE FIRST) ⚠️\n"
@@ -916,7 +939,8 @@ class InternalMCPChatOrchestrator:
             "- DO NOT explain what you're going to do - just do it\n"
             "- DO NOT output JSON as an example or description - only output JSON when you want to invoke a tool NOW\n"
             "- DO NOT say 'I will call' or 'Let me call' - just call it\n"
-            "- You MAY batch multiple tool calls in ONE message as a JSON array (keep it to <= 4 calls)\n"
+            f"- You MAY batch multiple tool calls in ONE message as a JSON array (keep it to <= {batch_cap} calls)\n"
+            f"- Server limits: max tool invocations per turn = {max_invocations}; tool calls per batch = {batch_cap}\n"
             "- After you receive the tool result (role 'tool'), respond naturally to the user\n\n"
             "VERIFICATION & CONSISTENCY RULES:\n"
             "- If the user doubts whether a specific concept_id exists (e.g. '#V#...') or challenges a claim about Vontology state, ALWAYS verify first using fetch_concept (or search_concepts) before responding.\n"
@@ -2740,6 +2764,8 @@ class InternalMCPChatOrchestrator:
                 remaining_tool_calls = tool_calls[allowed:]
                 tool_calls = tool_calls[:allowed]
 
+            current_batch_size = len(tool_calls)
+
             # Add the assistant JSON response once per batch.
             if iteration_count == 0:
                 augmented_context.extend(
@@ -2848,6 +2874,20 @@ class InternalMCPChatOrchestrator:
                         invocation_record["call_id"] = call_id
                     invocations.append(invocation_record)
 
+                    self._emit_progress(
+                        {
+                            "status": "tool_invoked",
+                            "tool": tool_name,
+                            "batch_size": current_batch_size,
+                            "tool_calls_done": iteration_count,
+                            "tool_calls_cap": int(self._max_tool_invocations),
+                            "tool_calls_remaining": max(
+                                0, int(self._max_tool_invocations) - iteration_count
+                            ),
+                            "call_id": call_id,
+                        }
+                    )
+
                     if tool_step is not None:
                         try:
                             tool_step.finish_success(
@@ -2883,6 +2923,21 @@ class InternalMCPChatOrchestrator:
                     if call_id:
                         error_record["call_id"] = call_id
                     invocations.append(error_record)
+
+                    self._emit_progress(
+                        {
+                            "status": "tool_failed",
+                            "tool": tool_name,
+                            "batch_size": current_batch_size,
+                            "tool_calls_done": iteration_count,
+                            "tool_calls_cap": int(self._max_tool_invocations),
+                            "tool_calls_remaining": max(
+                                0, int(self._max_tool_invocations) - iteration_count
+                            ),
+                            "call_id": call_id,
+                            "error": str(exc),
+                        }
+                    )
 
                     if tool_step is not None:
                         try:

--- a/src/backend/server/routes/agent_gmail_oauth_routes.py
+++ b/src/backend/server/routes/agent_gmail_oauth_routes.py
@@ -6,11 +6,11 @@ from typing import Optional
 
 from flask import Blueprint, jsonify, redirect, request, session
 
-from backend.services.agent_gmail_oauth_service import (
+from ...services.agent_gmail_oauth_service import (
     AgentGmailOAuthService,
     AgentGmailOAuthError,
 )
-from backend.services.agent_gmail_token_store import (
+from ...services.agent_gmail_token_store import (
     get_agent_gmail_token_status,
     revoke_agent_gmail_tokens,
 )

--- a/src/backend/server/routes/auth_routes.py
+++ b/src/backend/server/routes/auth_routes.py
@@ -1,10 +1,11 @@
 from flask import Blueprint, request, redirect, session, url_for, jsonify
-from backend.auth_service import GoogleAuthService
-from backend.services.settings_service import (
+
+from ...auth_service import GoogleAuthService
+from ...services.settings_service import (
     set_current_user_by_email,
     get_current_user,
 )
-from backend.services.exceptions import MultipleUsersForEmailError
+from ...services.exceptions import MultipleUsersForEmailError
 import time
 
 auth_bp = Blueprint("auth_bp", __name__)

--- a/src/backend/server/routes/settings_routes.py
+++ b/src/backend/server/routes/settings_routes.py
@@ -26,7 +26,9 @@ from ...services.settings_service import (
     set_user_llm_setting,
     set_org_llm_setting,
     get_disable_remote_ollama_scan,
+    get_show_tool_use_during_thinking,
     set_disable_remote_ollama_scan,
+    set_show_tool_use_during_thinking,
     get_internal_mcp_max_tool_invocations,
     set_internal_mcp_max_tool_invocations,
     get_internal_mcp_tool_batch_cap,
@@ -492,6 +494,7 @@ def get_all_settings_data():
             "disable_remote_ollama_scan": get_disable_remote_ollama_scan(),
             "internal_mcp_max_tool_invocations": get_internal_mcp_max_tool_invocations(),
             "internal_mcp_tool_batch_cap": get_internal_mcp_tool_batch_cap(),
+            "show_tool_use_during_thinking": get_show_tool_use_during_thinking(),
         }
     except Exception as e:
         current_app.logger.error(f"Error retrieving settings data: {e}", exc_info=True)
@@ -585,6 +588,17 @@ def save_all_settings():
         if "internal_mcp_tool_batch_cap" in data:
             set_internal_mcp_tool_batch_cap(data.get("internal_mcp_tool_batch_cap"))
             current_app.logger.info("internal_mcp_tool_batch_cap updated")
+
+        if "show_tool_use_during_thinking" in data:
+            try:
+                enabled = bool(data.get("show_tool_use_during_thinking"))
+            except Exception:
+                enabled = True
+            set_show_tool_use_during_thinking(enabled)
+            current_app.logger.info(
+                "show_tool_use_during_thinking updated: %s",
+                enabled,
+            )
 
         # user/org/language fields intentionally ignored (browser-local)
 
@@ -1269,7 +1283,7 @@ def get_available_organisations():
         organisation_options = []
         for concept in unique_concepts:
             from ...services.concept_service import enrich_concept_with_text_relations
-            from backend.vontology.utils_vontology import (
+            from ...vontology.utils_vontology import (
                 get_concept_display_name_with_names_fallback,
             )
 

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -2,8 +2,11 @@ from flask import Blueprint, request, jsonify, render_template, current_app, ses
 import os
 import re
 import time
+import threading
+import secrets
 import uuid
 from datetime import datetime, timezone
+from typing import Any
 from workflows.onboarding_workflow import run_onboarding_workflow  # fixed import path
 from ...languagemodels.llm_interface import get_llm_client, get_active_model_name
 from .settings_routes import get_all_settings_data
@@ -12,6 +15,7 @@ from ...services import chat_history_service
 from ...services.settings_service import (
     get_internal_mcp_max_tool_invocations,
     get_internal_mcp_tool_batch_cap,
+    get_show_tool_use_during_thinking,
 )
 from ...workflows import (
     CHAT_NARRATION_WORKFLOW_ID,
@@ -29,6 +33,102 @@ _TEMPLATE_DIR = os.path.abspath(
     )
 )
 von_bp = Blueprint("von", __name__, template_folder=_TEMPLATE_DIR)
+
+
+# ----------------- Tool progress (JVNAUTOSCI-942) -----------------
+
+_TOOL_PROGRESS_TTL_SEC = 10 * 60
+_TOOL_PROGRESS_LOCK = threading.Lock()
+_TOOL_PROGRESS: dict[tuple[str, str], dict[str, Any]] = {}
+
+
+def _now_utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _get_tool_progress_scope_key() -> str:
+    """Return a stable scope key for tool-progress lookup.
+
+    - Authenticated: scope is user concept id
+    - Unauthenticated: scope is a session-scoped random token
+    """
+
+    user_concept_id = None
+    try:
+        from ...security.access_control import get_effective_user_concept_id
+
+        user_concept_id = get_effective_user_concept_id()
+    except Exception:
+        user_concept_id = session.get("user_concept_id")
+
+    if isinstance(user_concept_id, str) and user_concept_id.strip():
+        return f"user:{user_concept_id.strip()}"
+
+    if "tool_progress_scope" not in session:
+        session["tool_progress_scope"] = secrets.token_urlsafe(16)
+
+    return f"anon:{session.get('tool_progress_scope')}"
+
+
+def _prune_tool_progress() -> None:
+    cutoff = time.time() - _TOOL_PROGRESS_TTL_SEC
+    with _TOOL_PROGRESS_LOCK:
+        stale_keys = [
+            key
+            for key, value in _TOOL_PROGRESS.items()
+            if isinstance(value, dict)
+            and isinstance(value.get("updated_at_epoch"), (int, float))
+            and float(value["updated_at_epoch"]) < cutoff
+        ]
+        for key in stale_keys:
+            _TOOL_PROGRESS.pop(key, None)
+
+
+def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) -> None:
+    _prune_tool_progress()
+    now_epoch = time.time()
+    with _TOOL_PROGRESS_LOCK:
+        key = (scope_key, request_id)
+        existing = _TOOL_PROGRESS.get(key)
+        if not isinstance(existing, dict):
+            existing = {}
+        merged = {**existing, **(update or {})}
+        merged["updated_at"] = _now_utc_iso()
+        merged["updated_at_epoch"] = now_epoch
+        _TOOL_PROGRESS[key] = merged
+
+
+def _get_tool_progress(scope_key: str, request_id: str) -> dict[str, Any] | None:
+    _prune_tool_progress()
+    with _TOOL_PROGRESS_LOCK:
+        value = _TOOL_PROGRESS.get((scope_key, request_id))
+        return dict(value) if isinstance(value, dict) else None
+
+
+def _clear_tool_progress(scope_key: str, request_id: str) -> None:
+    with _TOOL_PROGRESS_LOCK:
+        _TOOL_PROGRESS.pop((scope_key, request_id), None)
+
+
+@von_bp.route("/progress/<request_id>", methods=["GET"])
+def get_generation_progress(request_id: str):
+    """Return the latest tool-execution progress for an in-flight generate() call."""
+
+    if (
+        not isinstance(request_id, str)
+        or not request_id.strip()
+        or len(request_id) > 200
+    ):
+        return jsonify({"error": "Invalid request_id"}), 400
+
+    scope_key = _get_tool_progress_scope_key()
+    state = _get_tool_progress(scope_key, request_id.strip())
+    if not state:
+        return jsonify({"status": "not_found"}), 404
+
+    # Do not leak internal epoch detail to the UI.
+    state.pop("updated_at_epoch", None)
+    return jsonify(state), 200
 
 
 def _truncate_large_tool_results(
@@ -941,6 +1041,16 @@ def generate():
     data = request.get_json()
     prompt_text = data.get("prompt", "")
 
+    client_request_id = data.get("client_request_id")
+    if (
+        isinstance(client_request_id, str)
+        and client_request_id.strip()
+        and len(client_request_id) <= 200
+    ):
+        request_id = client_request_id.strip()
+    else:
+        request_id = str(uuid.uuid4())
+
     presenter_mode_requested = bool(data.get("presenter_mode"))
 
     request_start_perf = time.perf_counter()
@@ -995,6 +1105,37 @@ def generate():
     except Exception:
         user_concept_id = None
         org_concept_id = None
+
+    progress_scope_key = _get_tool_progress_scope_key()
+    show_tool_use_progress = False
+    try:
+        show_tool_use_progress = bool(get_show_tool_use_during_thinking())
+    except Exception:
+        show_tool_use_progress = False
+
+    if show_tool_use_progress:
+        try:
+            max_calls = int(get_internal_mcp_max_tool_invocations())
+        except Exception:
+            max_calls = 0
+        try:
+            batch_cap = int(get_internal_mcp_tool_batch_cap())
+        except Exception:
+            batch_cap = 4
+        _set_tool_progress(
+            progress_scope_key,
+            request_id,
+            {
+                "status": "thinking",
+                "request_id": request_id,
+                "tool": None,
+                "batch_size": None,
+                "tool_calls_done": 0,
+                "tool_calls_cap": max_calls,
+                "tool_calls_remaining": max(0, max_calls),
+                "tool_batch_cap": batch_cap,
+            },
+        )
 
     try:
         llm_client = get_llm_client(
@@ -1756,16 +1897,40 @@ def generate():
                 except Exception:
                     # Defensive: never fail the request due to settings refresh.
                     pass
+
+                if show_tool_use_progress:
+
+                    def _progress_update(info: dict[str, Any]) -> None:
+                        payload = (
+                            dict(info)
+                            if isinstance(info, dict)
+                            else {"status": "unknown"}
+                        )
+                        payload.setdefault("request_id", request_id)
+                        _set_tool_progress(progress_scope_key, request_id, payload)
+
+                    try:
+                        orchestrator.set_progress_callback(_progress_update)
+                    except Exception:
+                        pass
+
                 orchestrator_start_perf = time.perf_counter()
-                orchestrator_result = orchestrator.run(
-                    prompt=prompt_text,
-                    context=enhanced_context,
-                    llm_client=llm_client,
-                    model=model_name,
-                    user_namespace=user_namespace,
-                    gmail_profile=request_gmail_profile,
-                    auxiliary_system_prompt=auxiliary_system_prompt,
-                )
+                try:
+                    orchestrator_result = orchestrator.run(
+                        prompt=prompt_text,
+                        context=enhanced_context,
+                        llm_client=llm_client,
+                        model=model_name,
+                        user_namespace=user_namespace,
+                        gmail_profile=request_gmail_profile,
+                        auxiliary_system_prompt=auxiliary_system_prompt,
+                    )
+                finally:
+                    if show_tool_use_progress:
+                        try:
+                            orchestrator.set_progress_callback(None)
+                        except Exception:
+                            pass
                 llm_interaction["duration_ms"] = (
                     time.perf_counter() - orchestrator_start_perf
                 ) * 1000.0
@@ -1808,6 +1973,16 @@ def generate():
                         else "not_authenticated"
                     )
                 rag_trace["tool_results_included_in_prompt"] = bool(tool_messages)
+
+                if show_tool_use_progress:
+                    _set_tool_progress(
+                        progress_scope_key,
+                        request_id,
+                        {
+                            "status": "completed",
+                            "request_id": request_id,
+                        },
+                    )
             except ToolCallParsingError as exc:
                 current_app.logger.warning(
                     "[mcp_orchestrator] Invalid tool request payload: %s", exc
@@ -1832,6 +2007,17 @@ def generate():
                         "error": str(exc),
                     }
                 ]
+
+                if show_tool_use_progress:
+                    _set_tool_progress(
+                        progress_scope_key,
+                        request_id,
+                        {
+                            "status": "error",
+                            "request_id": request_id,
+                            "error": str(exc),
+                        },
+                    )
 
         presenter_channels = _extract_presenter_channels(response_text)
 
@@ -2164,8 +2350,19 @@ def generate():
             except Exception:
                 tool_catalogue_summary = None
 
+        try:
+            applied_max_tool_invocations = int(get_internal_mcp_max_tool_invocations())
+        except Exception:
+            applied_max_tool_invocations = None
+
+        try:
+            applied_tool_batch_cap = int(get_internal_mcp_tool_batch_cap())
+        except Exception:
+            applied_tool_batch_cap = None
+
         llm_debug_info = {
             "interaction_timestamp_utc": interaction_timestamp_utc,
+            "request_id": request_id,
             "model": model_name,
             "llm_interaction": {
                 **llm_interaction,
@@ -2187,6 +2384,14 @@ def generate():
                     else False
                 ),
                 "orchestrator_present": orchestrator is not None,
+                "execution_caps": {
+                    "max_tool_invocations": applied_max_tool_invocations,
+                    "tool_batch_cap": applied_tool_batch_cap,
+                },
+                "tool_use_progress": {
+                    "enabled": show_tool_use_progress,
+                    "request_id": request_id,
+                },
                 "tool_catalogue": tool_catalogue_summary,
             },
             "context_stats": {
@@ -2250,6 +2455,7 @@ def generate():
 
         return jsonify(
             {
+                "request_id": request_id,
                 "response": response_text,
                 "response_channels": (
                     {
@@ -2279,8 +2485,25 @@ def generate():
             except:
                 pass
 
+        if "show_tool_use_progress" in locals() and show_tool_use_progress:
+            try:
+                _set_tool_progress(
+                    _get_tool_progress_scope_key(),
+                    request_id if "request_id" in locals() else "unknown",
+                    {
+                        "status": "error",
+                        "request_id": (
+                            request_id if "request_id" in locals() else "unknown"
+                        ),
+                        "error": str(e),
+                    },
+                )
+            except Exception:
+                pass
+
         error_debug_info = {
             "interaction_timestamp_utc": interaction_timestamp_utc,
+            "request_id": request_id,
             "model": model_name if "model_name" in locals() else "unknown",
             "messages": [{"role": "user", "content": prompt_text}],
             "response": None,
@@ -2292,7 +2515,11 @@ def generate():
             "tool_invocations": [],
         }
         error_debug_info["warnings"] = _derive_llm_debug_warnings(error_debug_info)
-        body = {"error": str(e), "llm_debug": error_debug_info}
+        body = {
+            "request_id": request_id,
+            "error": str(e),
+            "llm_debug": error_debug_info,
+        }
         if "rag_trace" in locals():
             body["rag_trace"] = rag_trace
         if "namespace_report" in locals():

--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -1469,7 +1469,7 @@ def analyze_import_preview(nodes_to_import):
     """
     Analyze import data and return detailed preview information.
     """
-    from backend.db.repositories.concepts_repository import ConceptsRepository
+    from ...db.repositories.concepts_repository import ConceptsRepository
     from ...vontology.utils_vontology import (
         detect_circular_references_in_import,
         break_cycles_in_import_nodes,

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -395,18 +395,11 @@ def create_flask_app(
                 print(f"[health] Public IP fetch failed: {e}")
                 public_ip = None
 
-        # RAG Indexing Status
-        rag_pending_count = 0
-        try:
-            db = get_db()
-            if db is not None:
-                # Use string "pending" to avoid importing model class and potential circular deps
-                rag_pending_count = db["interaction_sessions"].count_documents(
-                    {"indexing_status": "pending"}
-                )
-        except Exception as e:
-            print(f"[health] RAG status check failed: {e}")
-            rag_pending_count = -1  # Indicate error
+        # NOTE: Keep /health lightweight.
+        # Avoid DB calls here because the UI polls frequently and client-side aborts
+        # do not cancel server work. If a DB call hangs, it can occupy Waitress
+        # threads and block *all* endpoints (including /health) for minutes.
+        rag_pending_count = None
 
         return jsonify(
             status="healthy",
@@ -432,6 +425,51 @@ def create_flask_app(
           }
         """
         try:
+            # Cache results briefly to avoid self-DOS:
+            # the UI polls frequently and aborts client-side after ~5s, but the
+            # server keeps running DB work unless we short-circuit.
+            import threading
+            import time
+
+            t0 = time.perf_counter()
+
+            ttl_seconds = 10.0
+            if request.args.get("nocache") in {"1", "true", "yes", "on"}:
+                ttl_seconds = 0.0
+
+            ns = request.args.get("namespace")
+            include_detail = request.args.get("detail", "").lower() in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            }
+            cache_key = (ns or "", bool(include_detail))
+            cache = app.config.setdefault("_RAG_STATUS_CACHE", {})
+            lock = app.config.setdefault("_RAG_STATUS_CACHE_LOCK", threading.Lock())
+
+            if ttl_seconds > 0:
+                try:
+                    with lock:
+                        entry = cache.get(cache_key)
+                    if entry:
+                        cached_at = float(entry.get("at", 0.0) or 0.0)
+                        if (time.time() - cached_at) <= ttl_seconds:
+                            payload = entry.get("payload")
+                            if isinstance(payload, dict):
+                                response_payload = dict(payload)
+                                response_payload["cache_hit"] = True
+                                response_payload["server_elapsed_ms"] = int(
+                                    (time.perf_counter() - t0) * 1000
+                                )
+                                response_payload["cache_age_sec"] = max(
+                                    0.0, float(time.time() - cached_at)
+                                )
+                                return jsonify(response_payload)
+                except Exception:
+                    # If caching fails, fall back to computing.
+                    pass
+
             db = get_db()
             if db is None:
                 return jsonify(error="db_unavailable"), 503
@@ -450,7 +488,7 @@ def create_flask_app(
             # user-only namespace (#V#user) or a composite namespace (#V#user@org).
             # For backwards compatibility, if a composite namespace is provided we
             # scope to BOTH values.
-            ns = request.args.get("namespace")
+            # NOTE: ns/include_detail already parsed above for caching.
             session_ns_values: list[str] | None = None
             if ns:
                 session_ns_values = [ns]
@@ -645,13 +683,6 @@ def create_flask_app(
                         user_id_for_ns = None
 
                 match = {"user_id": user_id_for_ns} if user_id_for_ns else {}
-
-                include_detail = request.args.get("detail", "").lower() in {
-                    "1",
-                    "true",
-                    "yes",
-                    "on",
-                }
 
                 pipeline = [
                     {"$match": match},
@@ -943,29 +974,44 @@ def create_flask_app(
                     except Exception:
                         chat_summary["chat_history_backfill_available"] = False
                         chat_summary["chat_history_backfill_reason"] = "unavailable"
-            return jsonify(
-                {
-                    "total": total_sessions,
-                    "scoped_sessions": scoped_sessions,
-                    "indexed": indexed,
-                    "pending": pending,
-                    "failed": failed,
-                    "skipped": skipped,
-                    "sessions_missing_namespace": sessions_missing_namespace,
-                    "sessions_other_namespace": sessions_other_namespace,
-                    "sessions_namespace_breakdown": sessions_namespace_breakdown,
-                    "sessions": total_sessions,
-                    "interactions": total_interactions,
-                    "eligible_sessions": eligible_sessions,
-                    "eligible_interactions": eligible_interactions,
-                    "namespace": ns,
-                    "session_namespace": (
-                        session_ns_values[0] if session_ns_values else None
-                    ),
-                    "session_namespaces": session_ns_values,
-                    **chat_summary,
-                }
+            base_payload = {
+                "total": total_sessions,
+                "scoped_sessions": scoped_sessions,
+                "indexed": indexed,
+                "pending": pending,
+                "failed": failed,
+                "skipped": skipped,
+                "sessions_missing_namespace": sessions_missing_namespace,
+                "sessions_other_namespace": sessions_other_namespace,
+                "sessions_namespace_breakdown": sessions_namespace_breakdown,
+                "sessions": total_sessions,
+                "interactions": total_interactions,
+                "eligible_sessions": eligible_sessions,
+                "eligible_interactions": eligible_interactions,
+                "namespace": ns,
+                "session_namespace": (
+                    session_ns_values[0] if session_ns_values else None
+                ),
+                "session_namespaces": session_ns_values,
+                **chat_summary,
+            }
+
+            if ttl_seconds > 0:
+                try:
+                    with lock:
+                        cache[cache_key] = {
+                            "at": time.time(),
+                            "payload": base_payload,
+                        }
+                except Exception:
+                    pass
+
+            response_payload = dict(base_payload)
+            response_payload["cache_hit"] = False
+            response_payload["server_elapsed_ms"] = int(
+                (time.perf_counter() - t0) * 1000
             )
+            return jsonify(response_payload)
         except Exception as e:
             return jsonify(error="unexpected", detail=str(e)), 500
 

--- a/src/backend/services/agent_gmail_oauth_service.py
+++ b/src/backend/services/agent_gmail_oauth_service.py
@@ -15,12 +15,12 @@ if TYPE_CHECKING:  # pragma: no cover
 
 from googleapiclient.discovery import build
 
-from backend.integrations.google.gmail_service import (
+from ..integrations.google.gmail_service import (
     GmailProfile,
     get_profile,
     load_profiles_from_env,
 )
-from backend.services.agent_gmail_token_store import upsert_agent_gmail_tokens
+from .agent_gmail_token_store import upsert_agent_gmail_tokens
 
 logger = logging.getLogger(__name__)
 

--- a/src/backend/services/agent_gmail_token_store.py
+++ b/src/backend/services/agent_gmail_token_store.py
@@ -7,9 +7,9 @@ from typing import Any, Mapping, Optional
 
 from pymongo.collection import Collection
 
-from backend.db.mongo_client import get_agent_gmail_tokens_collection
-from backend.security.token_encryption import encrypt_json, decrypt_json
-from backend.utils.time_utils import utc_now
+from ..db.mongo_client import get_agent_gmail_tokens_collection
+from ..security.token_encryption import encrypt_json, decrypt_json
+from ..utils.time_utils import utc_now
 
 logger = logging.getLogger(__name__)
 

--- a/src/backend/services/settings_service.py
+++ b/src/backend/services/settings_service.py
@@ -37,6 +37,9 @@ DISABLE_REMOTE_OLLAMA_SCAN_SETTING_NAME = "disable_remote_ollama_scan"
 INTERNAL_MCP_MAX_TOOL_INVOCATIONS_SETTING_NAME = "internal_mcp_max_tool_invocations"
 INTERNAL_MCP_TOOL_BATCH_CAP_SETTING_NAME = "internal_mcp_tool_batch_cap"
 
+# Chat UI: show tool use during the “Thinking…” indicator (JVNAUTOSCI-942)
+SHOW_TOOL_USE_DURING_THINKING_SETTING_NAME = "show_tool_use_during_thinking"
+
 # Prefixes for contextual (scoped) LLM settings (Phase 2 scaffold)
 _ACTIVE_LLM_USER_PREFIX = f"{ACTIVE_LLM_SETTING_NAME}:user:"
 _ACTIVE_LLM_ORG_PREFIX = f"{ACTIVE_LLM_SETTING_NAME}:org:"
@@ -669,6 +672,32 @@ def set_disable_remote_ollama_scan(disabled: bool) -> bool:
         # Coerce permissively but persist canonical bool
         disabled = bool(disabled)
     return update_setting(DISABLE_REMOTE_OLLAMA_SCAN_SETTING_NAME, disabled)
+
+
+def get_show_tool_use_during_thinking() -> bool:
+    """Return whether the chat UI should show tool use while Von is thinking.
+
+    Defaults to True when unset or invalid.
+    """
+
+    val = get_setting(SHOW_TOOL_USE_DURING_THINKING_SETTING_NAME)
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        s = val.strip().lower()
+        if s in ("1", "true", "yes", "y", "on"):
+            return True
+        if s in ("0", "false", "no", "n", "off"):
+            return False
+    if isinstance(val, (int, float)):
+        return val != 0
+    return True
+
+
+def set_show_tool_use_during_thinking(enabled: bool) -> bool:
+    if not isinstance(enabled, bool):
+        enabled = bool(enabled)
+    return update_setting(SHOW_TOOL_USE_DURING_THINKING_SETTING_NAME, enabled)
 
 
 def _coerce_int_setting(

--- a/src/backend/services/settings_service.py
+++ b/src/backend/services/settings_service.py
@@ -736,17 +736,17 @@ def _coerce_int_setting(
 def get_internal_mcp_max_tool_invocations() -> int:
     """Return the maximum number of internal MCP tool calls per chat turn.
 
-    Defaults to 8 when unset/invalid.
+    Defaults to 30 when unset/invalid.
     """
 
     val = get_setting(INTERNAL_MCP_MAX_TOOL_INVOCATIONS_SETTING_NAME)
-    return _coerce_int_setting(val, default=8, min_value=0, max_value=50)
+    return _coerce_int_setting(val, default=30, min_value=0, max_value=50)
 
 
 def set_internal_mcp_max_tool_invocations(value: Any) -> bool:
     """Persist the max internal MCP tool invocations (canonical int, clamped)."""
 
-    coerced = _coerce_int_setting(value, default=8, min_value=0, max_value=50)
+    coerced = _coerce_int_setting(value, default=30, min_value=0, max_value=50)
     return update_setting(INTERNAL_MCP_MAX_TOOL_INVOCATIONS_SETTING_NAME, coerced)
 
 
@@ -754,17 +754,17 @@ def get_internal_mcp_tool_batch_cap() -> int:
     """Return the maximum number of tool calls executed per batch.
 
     This is a guardrail against very large tool-call lists per iteration.
-    Defaults to 4 when unset/invalid.
+    Defaults to 10 when unset/invalid.
     """
 
     val = get_setting(INTERNAL_MCP_TOOL_BATCH_CAP_SETTING_NAME)
-    return _coerce_int_setting(val, default=4, min_value=1, max_value=50)
+    return _coerce_int_setting(val, default=10, min_value=1, max_value=50)
 
 
 def set_internal_mcp_tool_batch_cap(value: Any) -> bool:
     """Persist the tool-call batch cap (canonical int, clamped)."""
 
-    coerced = _coerce_int_setting(value, default=4, min_value=1, max_value=50)
+    coerced = _coerce_int_setting(value, default=10, min_value=1, max_value=50)
     return update_setting(INTERNAL_MCP_TOOL_BATCH_CAP_SETTING_NAME, coerced)
 
 

--- a/src/backend/utilities/backfill_rag_indexing_status.py
+++ b/src/backend/utilities/backfill_rag_indexing_status.py
@@ -3,11 +3,13 @@ import os
 from datetime import datetime, timezone
 from typing import Any, Dict
 
-# Ensure src on path (run from repo root)
-sys.path.append(os.path.abspath("src"))
+# Ensure repo root on path (run from repo root)
+_repo_root = os.path.abspath(".")
+if _repo_root not in sys.path:
+    sys.path.append(_repo_root)
 
-from backend.db.connection_manager import get_db
-from backend.models.concept_models import IndexingStatus
+from src.backend.db.connection_manager import get_db
+from src.backend.models.concept_models import IndexingStatus
 
 """Backfill RAG Indexing Status
 

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -22,6 +22,187 @@ const transcriptTurns = [];
 let historySegmentsShown = 1;
 let totalHistorySegments = 1;
 
+// JVNAUTOSCI-942: Tool-use progress while "Thinking..."
+const DEFAULT_THINKING_TEXT = 'Thinking...';
+let showToolUseDuringThinkingSetting = true;
+let lastToolUseSettingRefreshMs = 0;
+const TOOL_USE_SETTING_REFRESH_COOLDOWN_MS = 30_000;
+
+function getLoadingIndicatorTextEl() {
+    const loadingIndicator = document.getElementById('loadingIndicator');
+    if (!loadingIndicator) {
+        return null;
+    }
+    return loadingIndicator.querySelector('.loading-indicator-text');
+}
+
+function setLoadingIndicatorText(text) {
+    const el = getLoadingIndicatorTextEl();
+    if (!el) {
+        return;
+    }
+    el.textContent = String(text ?? '').trim() || DEFAULT_THINKING_TEXT;
+}
+
+function createClientRequestId() {
+    try {
+        if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+            return crypto.randomUUID();
+        }
+    } catch (_) {
+        // Ignore.
+    }
+    return `req-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+async function refreshToolUseDuringThinkingSetting(force = false) {
+    const now = Date.now();
+    if (!force && now - lastToolUseSettingRefreshMs < TOOL_USE_SETTING_REFRESH_COOLDOWN_MS) {
+        return showToolUseDuringThinkingSetting;
+    }
+
+    lastToolUseSettingRefreshMs = now;
+    try {
+        const resp = await fetch('/settings/', { method: 'GET' });
+        if (!resp || !resp.ok) {
+            return showToolUseDuringThinkingSetting;
+        }
+        const data = await resp.json();
+        if (data && typeof data.show_tool_use_during_thinking !== 'undefined') {
+            showToolUseDuringThinkingSetting = !!data.show_tool_use_during_thinking;
+            if (!showToolUseDuringThinkingSetting && activeChatRequest) {
+                stopToolUseProgressPolling(activeChatRequest);
+                setLoadingIndicatorText(DEFAULT_THINKING_TEXT);
+            }
+        }
+    } catch (_) {
+        // Ignore.
+    }
+    return showToolUseDuringThinkingSetting;
+}
+
+function formatToolUseProgressText(progress) {
+    if (!progress || typeof progress !== 'object') {
+        return DEFAULT_THINKING_TEXT;
+    }
+
+    const status = typeof progress.status === 'string' ? progress.status : 'thinking';
+    const tool = typeof progress.tool === 'string' ? progress.tool : null;
+    const batchSize = Number.isFinite(progress.batch_size) ? Number(progress.batch_size) : null;
+    const done = Number.isFinite(progress.tool_calls_done) ? Number(progress.tool_calls_done) : null;
+    const cap = Number.isFinite(progress.tool_calls_cap) ? Number(progress.tool_calls_cap) : null;
+    const remaining = Number.isFinite(progress.tool_calls_remaining) ? Number(progress.tool_calls_remaining) : null;
+
+    const bits = [];
+
+    if (tool) {
+        bits.push(`tool: ${tool}`);
+    }
+
+    if (batchSize !== null) {
+        bits.push(`batch ${batchSize}`);
+    }
+
+    if (done !== null && cap !== null) {
+        bits.push(`${done}/${cap} used`);
+    }
+
+    if (remaining !== null) {
+        bits.push(`${remaining} remaining`);
+    }
+
+    if (status === 'tool_failed' || status === 'error') {
+        const error = typeof progress.error === 'string' ? progress.error.trim() : '';
+        if (error) {
+            bits.push(`error: ${error}`);
+        } else {
+            bits.push('error');
+        }
+    }
+
+    if (!bits.length) {
+        return DEFAULT_THINKING_TEXT;
+    }
+
+    return `${DEFAULT_THINKING_TEXT} (${bits.join(', ')})`;
+}
+
+function stopToolUseProgressPolling(request) {
+    if (!request) {
+        return;
+    }
+
+    const poll = request.toolUseProgressPoll;
+    if (!poll) {
+        return;
+    }
+
+    request.toolUseProgressPoll = null;
+
+    try {
+        if (poll.intervalId) {
+            clearInterval(poll.intervalId);
+        }
+    } catch (_) {
+        // Ignore.
+    }
+
+    try {
+        poll.abortController?.abort();
+    } catch (_) {
+        // Ignore.
+    }
+}
+
+function startToolUseProgressPolling(request) {
+    if (!request || request.aborted) {
+        return;
+    }
+
+    if (!showToolUseDuringThinkingSetting) {
+        return;
+    }
+
+    const requestId = request.clientRequestId;
+    if (!requestId) {
+        return;
+    }
+
+    stopToolUseProgressPolling(request);
+    const abortController = new AbortController();
+
+    const pollOnce = async () => {
+        if (request.aborted || activeChatRequest !== request) {
+            return;
+        }
+        try {
+            const resp = await fetch(`/von/progress/${encodeURIComponent(requestId)}`,
+                { method: 'GET', signal: abortController.signal });
+            if (!resp || !resp.ok) {
+                return;
+            }
+            const progress = await resp.json();
+            setLoadingIndicatorText(formatToolUseProgressText(progress));
+
+            const status = typeof progress?.status === 'string' ? progress.status : null;
+            if (status === 'completed' || status === 'error') {
+                stopToolUseProgressPolling(request);
+            }
+        } catch (err) {
+            if (err && err.name === 'AbortError') {
+                return;
+            }
+        }
+    };
+
+    request.toolUseProgressPoll = {
+        abortController,
+        intervalId: setInterval(() => { void pollOnce(); }, 350)
+    };
+
+    void pollOnce();
+}
+
 // Cool-down for failed history talk-track backfills so we do not spam the server.
 // Map<turnId, { at: number, error: string }>
 const historySpokenBackfillFailures = new Map();
@@ -2601,6 +2782,7 @@ export function initializeChatTab() {
 
     loadChatHistory();
     updateHistoryLength();
+    void refreshToolUseDuringThinkingSetting();
     console.log("Chat tab initialized successfully");
 }
 
@@ -2612,6 +2794,11 @@ function setThinkingState(isThinking) {
     if (loadingIndicator) {
         loadingIndicator.style.display = isThinking ? 'inline-flex' : 'none';
         loadingIndicator.setAttribute('aria-hidden', isThinking ? 'false' : 'true');
+        if (isThinking) {
+            setLoadingIndicatorText(DEFAULT_THINKING_TEXT);
+        } else {
+            setLoadingIndicatorText(DEFAULT_THINKING_TEXT);
+        }
     }
 
     if (sendButton) {
@@ -2656,6 +2843,8 @@ function abortActiveChatRequest() {
     const request = activeChatRequest;
     request.aborted = true;
     activeChatRequest = null;
+
+    stopToolUseProgressPolling(request);
 
     try {
         request.abortController?.abort();
@@ -2705,6 +2894,11 @@ async function handleSendPrompt() {
         return;
     }
 
+    // Refresh setting in the background; default is enabled.
+    void refreshToolUseDuringThinkingSetting();
+
+    const clientRequestId = createClientRequestId();
+
     // Show loading indicator and disable send button
     setThinkingState(true);
 
@@ -2737,9 +2931,13 @@ async function handleSendPrompt() {
             promptRaw,
             selectionStart,
             selectionEnd,
-            aborted: false
+            aborted: false,
+            clientRequestId
         };
         activeChatRequest = request;
+
+        // Start polling immediately while the request is in flight.
+        startToolUseProgressPolling(request);
 
         // Get user context from localStorage to send to backend
         const userContext = getUserContext();
@@ -2756,6 +2954,7 @@ async function handleSendPrompt() {
             signal: request.abortController.signal,
             body: JSON.stringify({
                 prompt: promptText,
+                client_request_id: request.clientRequestId,
                 user_id: userContext.user_id,
                 org_id: userContext.org_id,
                 language: userContext.language,
@@ -2841,6 +3040,7 @@ async function handleSendPrompt() {
         const isStillActive = activeChatRequest === request;
         if (isStillActive) {
             activeChatRequest = null;
+            stopToolUseProgressPolling(request);
             setThinkingState(false);
         }
         updateHistoryLength();

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -49,12 +49,24 @@ function setLoadingIndicatorText(text) {
 }
 
 function setLoadingIndicatorTooltip(text) {
-    const el = getLoadingIndicatorEl();
-    if (!el) {
-        return;
-    }
     const value = String(text ?? '').trim();
-    el.title = value;
+    const wrapper = getLoadingIndicatorEl();
+    if (wrapper) {
+        // Opt out of suppressTooltips.js for this element.
+        // Important: set before `title`, otherwise the MutationObserver may strip it.
+        wrapper.setAttribute('data-keep-title', 'true');
+        wrapper.title = value;
+        wrapper.setAttribute('aria-label', value);
+        wrapper.setAttribute('data-original-title', value);
+    }
+
+    const textEl = getLoadingIndicatorTextEl();
+    if (textEl) {
+        textEl.setAttribute('data-keep-title', 'true');
+        textEl.title = value;
+        textEl.setAttribute('aria-label', value);
+        textEl.setAttribute('data-original-title', value);
+    }
 }
 
 function createClientRequestId() {
@@ -76,7 +88,7 @@ async function refreshToolUseDuringThinkingSetting(force = false) {
 
     lastToolUseSettingRefreshMs = now;
     try {
-        const resp = await fetch('/settings/', { method: 'GET' });
+        const resp = await fetch('/api/settings/', { method: 'GET' });
         if (!resp || !resp.ok) {
             return showToolUseDuringThinkingSetting;
         }
@@ -168,16 +180,43 @@ function recordToolUseHistory(request, progress) {
     history.push({ tool, batchSize });
 }
 
-function formatToolUseHistoryTooltip(request) {
-    if (!request || !Array.isArray(request.toolUseProgressHistory)) {
-        return '';
+function formatThinkingDuration(elapsedMs) {
+    const ms = Number.isFinite(elapsedMs) ? Math.max(0, Number(elapsedMs)) : 0;
+    const totalSeconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+
+    if (minutes > 0) {
+        return `${minutes}m ${String(seconds).padStart(2, '0')}s`;
     }
-    const history = request.toolUseProgressHistory;
-    if (!history.length) {
+    return `${totalSeconds}s`;
+}
+
+function formatToolUseHistoryTooltip(request) {
+    if (!request) {
         return '';
     }
 
-    const lines = ['Tools this turn:'];
+    const thinkingStartedAtMs = Number.isFinite(request.thinkingStartedAtMs)
+        ? Number(request.thinkingStartedAtMs)
+        : null;
+    const elapsedMs = thinkingStartedAtMs === null ? null : Date.now() - thinkingStartedAtMs;
+
+    const history = Array.isArray(request.toolUseProgressHistory) ? request.toolUseProgressHistory : [];
+
+    if (!history.length) {
+        const lines = ['No tool use yet.'];
+        if (elapsedMs !== null) {
+            lines.push(`Thinking for ${formatThinkingDuration(elapsedMs)}.`);
+        }
+        return lines.join('\n');
+    }
+
+    const lines = [];
+    if (elapsedMs !== null) {
+        lines.push(`Thinking for ${formatThinkingDuration(elapsedMs)}`);
+    }
+    lines.push('Tools this turn:');
     for (const entry of history) {
         const tool = entry && typeof entry.tool === 'string' ? entry.tool : '';
         if (!tool) {
@@ -215,10 +254,52 @@ function stopToolUseProgressPolling(request) {
     }
 
     try {
+        if (poll.timeoutId) {
+            clearTimeout(poll.timeoutId);
+        }
+    } catch (_) {
+        // Ignore.
+    }
+
+    try {
         poll.abortController?.abort();
     } catch (_) {
         // Ignore.
     }
+}
+
+function stopThinkingTooltipTicker(request) {
+    if (!request) {
+        return;
+    }
+
+    try {
+        if (request.thinkingTooltipIntervalId) {
+            clearInterval(request.thinkingTooltipIntervalId);
+        }
+    } catch (_) {
+        // Ignore.
+    }
+
+    request.thinkingTooltipIntervalId = null;
+}
+
+function startThinkingTooltipTicker(request) {
+    if (!request || request.aborted) {
+        return;
+    }
+
+    stopThinkingTooltipTicker(request);
+
+    // Update once per second so the elapsed time in the tooltip stays current,
+    // even if tool-progress polling backs off (e.g., repeated 404s).
+    request.thinkingTooltipIntervalId = setInterval(() => {
+        if (request.aborted || activeChatRequest !== request) {
+            stopThinkingTooltipTicker(request);
+            return;
+        }
+        setLoadingIndicatorTooltip(formatToolUseHistoryTooltip(request));
+    }, 1000);
 }
 
 function startToolUseProgressPolling(request) {
@@ -238,17 +319,56 @@ function startToolUseProgressPolling(request) {
     stopToolUseProgressPolling(request);
     const abortController = new AbortController();
 
+    const poll = {
+        abortController,
+        timeoutId: null,
+        intervalId: null,
+        nextDelayMs: 350,
+        consecutiveNotFound: 0
+    };
+
+    const scheduleNextPoll = (delayMs) => {
+        if (request.aborted || activeChatRequest !== request) {
+            return;
+        }
+        poll.timeoutId = setTimeout(() => {
+            void pollOnce();
+        }, Math.max(0, Number(delayMs) || 0));
+    };
+
     const pollOnce = async () => {
         if (request.aborted || activeChatRequest !== request) {
             return;
         }
+
+        // Keep tooltip "alive" even before the server has any tool-progress state.
+        setLoadingIndicatorTooltip(formatToolUseHistoryTooltip(request));
+
         try {
             const resp = await fetch(`/von/progress/${encodeURIComponent(requestId)}`,
                 { method: 'GET', signal: abortController.signal });
-            if (!resp || !resp.ok) {
+            if (!resp) {
+                scheduleNextPoll(Math.min(5000, poll.nextDelayMs * 1.7));
+                poll.nextDelayMs = Math.min(5000, poll.nextDelayMs * 1.7);
+                return;
+            }
+
+            if (resp.status === 404) {
+                poll.consecutiveNotFound += 1;
+                poll.nextDelayMs = Math.min(5000, poll.nextDelayMs * 1.7);
+                scheduleNextPoll(poll.nextDelayMs);
+                return;
+            }
+
+            if (!resp.ok) {
+                poll.nextDelayMs = Math.min(5000, poll.nextDelayMs * 1.7);
+                scheduleNextPoll(poll.nextDelayMs);
                 return;
             }
             const progress = await resp.json();
+
+            poll.consecutiveNotFound = 0;
+            poll.nextDelayMs = 350;
             setLoadingIndicatorText(formatToolUseProgressText(progress));
             recordToolUseHistory(request, progress);
             setLoadingIndicatorTooltip(formatToolUseHistoryTooltip(request));
@@ -256,18 +376,21 @@ function startToolUseProgressPolling(request) {
             const status = typeof progress?.status === 'string' ? progress.status : null;
             if (status === 'completed' || status === 'error') {
                 stopToolUseProgressPolling(request);
+                return;
             }
+
+            scheduleNextPoll(poll.nextDelayMs);
         } catch (err) {
             if (err && err.name === 'AbortError') {
                 return;
             }
+
+            poll.nextDelayMs = Math.min(5000, poll.nextDelayMs * 1.7);
+            scheduleNextPoll(poll.nextDelayMs);
         }
     };
 
-    request.toolUseProgressPoll = {
-        abortController,
-        intervalId: setInterval(() => { void pollOnce(); }, 350)
-    };
+    request.toolUseProgressPoll = poll;
 
     void pollOnce();
 }
@@ -2916,6 +3039,7 @@ function abortActiveChatRequest() {
     activeChatRequest = null;
 
     stopToolUseProgressPolling(request);
+    stopThinkingTooltipTicker(request);
 
     try {
         request.abortController?.abort();
@@ -3004,9 +3128,14 @@ async function handleSendPrompt() {
             selectionEnd,
             aborted: false,
             clientRequestId,
+            thinkingStartedAtMs: Date.now(),
             toolUseProgressHistory: []
         };
         activeChatRequest = request;
+
+        setLoadingIndicatorTooltip(formatToolUseHistoryTooltip(request));
+
+        startThinkingTooltipTicker(request);
 
         // Start polling immediately while the request is in flight.
         startToolUseProgressPolling(request);
@@ -3113,6 +3242,7 @@ async function handleSendPrompt() {
         if (isStillActive) {
             activeChatRequest = null;
             stopToolUseProgressPolling(request);
+            stopThinkingTooltipTicker(request);
             setThinkingState(false);
         }
         updateHistoryLength();

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -36,12 +36,25 @@ function getLoadingIndicatorTextEl() {
     return loadingIndicator.querySelector('.loading-indicator-text');
 }
 
+function getLoadingIndicatorEl() {
+    return document.getElementById('loadingIndicator');
+}
+
 function setLoadingIndicatorText(text) {
     const el = getLoadingIndicatorTextEl();
     if (!el) {
         return;
     }
     el.textContent = String(text ?? '').trim() || DEFAULT_THINKING_TEXT;
+}
+
+function setLoadingIndicatorTooltip(text) {
+    const el = getLoadingIndicatorEl();
+    if (!el) {
+        return;
+    }
+    const value = String(text ?? '').trim();
+    el.title = value;
 }
 
 function createClientRequestId() {
@@ -127,6 +140,60 @@ function formatToolUseProgressText(progress) {
     return `${DEFAULT_THINKING_TEXT} (${bits.join(', ')})`;
 }
 
+function recordToolUseHistory(request, progress) {
+    if (!request || !progress || typeof progress !== 'object') {
+        return;
+    }
+
+    const tool = typeof progress.tool === 'string' ? progress.tool.trim() : '';
+    if (!tool) {
+        return;
+    }
+
+    const batchSize = Number.isFinite(progress.batch_size) ? Number(progress.batch_size) : null;
+
+    if (!Array.isArray(request.toolUseProgressHistory)) {
+        request.toolUseProgressHistory = [];
+    }
+
+    const history = request.toolUseProgressHistory;
+    const last = history.length ? history[history.length - 1] : null;
+    const lastTool = last && typeof last.tool === 'string' ? last.tool : null;
+    const lastBatch = last && Number.isFinite(last.batchSize) ? Number(last.batchSize) : null;
+
+    if (lastTool === tool && lastBatch === batchSize) {
+        return;
+    }
+
+    history.push({ tool, batchSize });
+}
+
+function formatToolUseHistoryTooltip(request) {
+    if (!request || !Array.isArray(request.toolUseProgressHistory)) {
+        return '';
+    }
+    const history = request.toolUseProgressHistory;
+    if (!history.length) {
+        return '';
+    }
+
+    const lines = ['Tools this turn:'];
+    for (const entry of history) {
+        const tool = entry && typeof entry.tool === 'string' ? entry.tool : '';
+        if (!tool) {
+            continue;
+        }
+        const batchSize = entry && Number.isFinite(entry.batchSize) ? Number(entry.batchSize) : null;
+        if (batchSize === null) {
+            lines.push(`- ${tool}`);
+        } else {
+            lines.push(`- ${tool} (batch ${batchSize})`);
+        }
+    }
+
+    return lines.length > 1 ? lines.join('\n') : '';
+}
+
 function stopToolUseProgressPolling(request) {
     if (!request) {
         return;
@@ -183,6 +250,8 @@ function startToolUseProgressPolling(request) {
             }
             const progress = await resp.json();
             setLoadingIndicatorText(formatToolUseProgressText(progress));
+            recordToolUseHistory(request, progress);
+            setLoadingIndicatorTooltip(formatToolUseHistoryTooltip(request));
 
             const status = typeof progress?.status === 'string' ? progress.status : null;
             if (status === 'completed' || status === 'error') {
@@ -2796,8 +2865,10 @@ function setThinkingState(isThinking) {
         loadingIndicator.setAttribute('aria-hidden', isThinking ? 'false' : 'true');
         if (isThinking) {
             setLoadingIndicatorText(DEFAULT_THINKING_TEXT);
+            setLoadingIndicatorTooltip('');
         } else {
             setLoadingIndicatorText(DEFAULT_THINKING_TEXT);
+            setLoadingIndicatorTooltip('');
         }
     }
 
@@ -2932,7 +3003,8 @@ async function handleSendPrompt() {
             selectionStart,
             selectionEnd,
             aborted: false,
-            clientRequestId
+            clientRequestId,
+            toolUseProgressHistory: []
         };
         activeChatRequest = request;
 

--- a/src/frontend/web/von_interface/static/js/settingsPage.js
+++ b/src/frontend/web/von_interface/static/js/settingsPage.js
@@ -1013,15 +1013,15 @@ async function loadAndDisplaySettings() {
       if (maxInvEl) {
         const raw = Object.prototype.hasOwnProperty.call(settings, 'internal_mcp_max_tool_invocations')
           ? settings.internal_mcp_max_tool_invocations
-          : 8;
-        maxInvEl.value = String(clampNumber(raw, 0, 50, 8));
+          : 30;
+        maxInvEl.value = String(clampNumber(raw, 0, 50, 30));
       }
       const batchCapEl = document.getElementById('internalMcpToolBatchCap');
       if (batchCapEl) {
         const raw = Object.prototype.hasOwnProperty.call(settings, 'internal_mcp_tool_batch_cap')
           ? settings.internal_mcp_tool_batch_cap
-          : 4;
-        batchCapEl.value = String(clampNumber(raw, 1, 50, 4));
+          : 10;
+        batchCapEl.value = String(clampNumber(raw, 1, 50, 10));
       }
     } catch { }
 
@@ -1225,13 +1225,13 @@ async function saveAllSettings(changedProvider = null) {
       document.getElementById('internalMcpMaxToolInvocations')?.value,
       0,
       50,
-      8,
+      30,
     ),
     internal_mcp_tool_batch_cap: clampNumber(
       document.getElementById('internalMcpToolBatchCap')?.value,
       1,
       50,
-      4,
+      10,
     ),
     show_tool_use_during_thinking: !!document.getElementById('showToolUseDuringThinkingToggle')?.checked,
   };

--- a/src/frontend/web/von_interface/static/js/settingsPage.js
+++ b/src/frontend/web/von_interface/static/js/settingsPage.js
@@ -1025,6 +1025,17 @@ async function loadAndDisplaySettings() {
       }
     } catch { }
 
+    // Populate tool-use during thinking toggle (JVNAUTOSCI-942)
+    try {
+      const toolUseToggleEl = document.getElementById('showToolUseDuringThinkingToggle');
+      if (toolUseToggleEl) {
+        const flag = Object.prototype.hasOwnProperty.call(settings, 'show_tool_use_during_thinking')
+          ? !!settings.show_tool_use_during_thinking
+          : true;
+        toolUseToggleEl.checked = !!flag;
+      }
+    } catch { }
+
     // Populate preferred language setting
     const languageSelect = document.getElementById('preferredLanguageSelect');
     if (languageSelect) {
@@ -1222,6 +1233,7 @@ async function saveAllSettings(changedProvider = null) {
       50,
       4,
     ),
+    show_tool_use_during_thinking: !!document.getElementById('showToolUseDuringThinkingToggle')?.checked,
   };
 
   try {

--- a/src/frontend/web/von_interface/templates/settings_tab.html
+++ b/src/frontend/web/von_interface/templates/settings_tab.html
@@ -160,13 +160,13 @@
 
             <div class="inline-form inline-form-tight">
                 <label for="internalMcpMaxToolInvocations" class="mr-1">Max tool invocations per turn:</label>
-                <input type="number" id="internalMcpMaxToolInvocations" min="0" max="50" step="1" value="8"
+                <input type="number" id="internalMcpMaxToolInvocations" min="0" max="50" step="1" value="30"
                     class="mr-2" />
 
                 <label for="internalMcpToolBatchCap" class="mr-1">Tool calls per batch:</label>
-                <input type="number" id="internalMcpToolBatchCap" min="1" max="50" step="1" value="4" />
+                <input type="number" id="internalMcpToolBatchCap" min="1" max="50" step="1" value="10" />
             </div>
-            <small class="settings-note">Defaults: 8 invocations, batch cap 4. Set invocations to 0 to disable tool
+            <small class="settings-note">Defaults: 30 invocations, batch cap 10. Set invocations to 0 to disable tool
                 calls (chat still works).</small>
 
             <div class="inline-form inline-form-tight mt-2">

--- a/src/frontend/web/von_interface/templates/settings_tab.html
+++ b/src/frontend/web/von_interface/templates/settings_tab.html
@@ -168,6 +168,16 @@
             </div>
             <small class="settings-note">Defaults: 8 invocations, batch cap 4. Set invocations to 0 to disable tool
                 calls (chat still works).</small>
+
+            <div class="inline-form inline-form-tight mt-2">
+                <input type="checkbox" id="showToolUseDuringThinkingToggle"
+                    aria-describedby="showToolUseDuringThinkingHelp" />
+                <label for="showToolUseDuringThinkingToggle" class="ml-1"
+                    title="When enabled, the Chat tab shows which internal MCP tool is being used while Von is thinking.">Show
+                    tool use during thinking</label>
+            </div>
+            <small id="showToolUseDuringThinkingHelp" class="settings-note">Default: enabled. Shows last tool name,
+                batch size, and remaining tool-call budget.</small>
         </section>
 
         <section id="current-user-settings">

--- a/src/utilities/index_chat_history.py
+++ b/src/utilities/index_chat_history.py
@@ -7,9 +7,9 @@ from datetime import datetime, timezone
 # Add src to path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from backend.db.mongo_client import get_db
-from backend.services.rag_service import get_rag_service
-from backend.models.chat_history_model import chat_history_collection_name
+from src.backend.db.mongo_client import get_db
+from src.backend.services.rag_service import get_rag_service
+from src.backend.models.chat_history_model import chat_history_collection_name
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/src/workflows/von/main.py
+++ b/src/workflows/von/main.py
@@ -19,11 +19,11 @@ import faulthandler
 import traceback
 import time
 import threading
-from backend.server.utils_flask import create_flask_app
-from backend.server.routes.von_routes import von_bp  # type: ignore
-from backend.server.routes.vontology_routes import vontology_bp  # type: ignore
-from backend.server.routes.settings_routes import settings_bp  # type: ignore
-from backend.languagemodels.llm_interface import OllamaClient  # type: ignore
+from src.backend.server.utils_flask import create_flask_app
+from src.backend.server.routes.von_routes import von_bp  # type: ignore
+from src.backend.server.routes.vontology_routes import vontology_bp  # type: ignore
+from src.backend.server.routes.settings_routes import settings_bp  # type: ignore
+from src.backend.languagemodels.llm_interface import OllamaClient  # type: ignore
 
 
 # Add src directory to Python path FIRST, before any backend imports
@@ -244,7 +244,7 @@ def main():
     # --- Instantiate the LLM Client ---
     # Use the unified LLM client factory that respects user settings
     try:
-        from backend.languagemodels.llm_interface import get_llm_client  # type: ignore
+        from src.backend.languagemodels.llm_interface import get_llm_client  # type: ignore
 
         llm_client = get_llm_client()
         logger.info(f"Using {type(llm_client).__name__} for LLM interactions.")

--- a/tests/backend/test_agent_gmail_token_store.py
+++ b/tests/backend/test_agent_gmail_token_store.py
@@ -16,7 +16,7 @@ def mock_db_env(monkeypatch):
     )
 
     # Ensure fresh module state after env var changes
-    import backend.db.mongo_client as mongo_client
+    import src.backend.db.mongo_client as mongo_client
 
     importlib.reload(mongo_client)
 
@@ -28,7 +28,7 @@ def mock_db_env(monkeypatch):
 
 
 def test_roundtrip_store_and_load(mock_db_env):
-    import backend.services.agent_gmail_token_store as store
+    import src.backend.services.agent_gmail_token_store as store
 
     importlib.reload(store)
 
@@ -54,7 +54,7 @@ def test_roundtrip_store_and_load(mock_db_env):
 
 
 def test_revoke_deletes_tokens(mock_db_env):
-    import backend.services.agent_gmail_token_store as store
+    import src.backend.services.agent_gmail_token_store as store
 
     importlib.reload(store)
 
@@ -72,11 +72,11 @@ def test_revoke_deletes_tokens(mock_db_env):
 def test_missing_key_raises(monkeypatch):
     monkeypatch.setenv("VON_USE_MOCK_DB", "1")
 
-    import backend.db.mongo_client as mongo_client
+    import src.backend.db.mongo_client as mongo_client
 
     importlib.reload(mongo_client)
 
-    import backend.services.agent_gmail_token_store as store
+    import src.backend.services.agent_gmail_token_store as store
 
     importlib.reload(store)
 

--- a/tests/backend/test_auto_names.py
+++ b/tests/backend/test_auto_names.py
@@ -1,15 +1,13 @@
-import sys
-import os
 import unittest
 from unittest.mock import MagicMock, patch
 
-from backend.services.concept_service import create_concept
-from backend.vontology.utils_vontology import import_ontology_nodes
+from src.backend.services.concept_service import create_concept
+from src.backend.vontology.utils_vontology import import_ontology_nodes
 
 
 class TestAutoNames(unittest.TestCase):
-    @patch("backend.services.concept_service.ConceptsRepository")
-    @patch("backend.services.text_value_service.upsert_text_for_concept")
+    @patch("src.backend.services.concept_service.ConceptsRepository")
+    @patch("src.backend.services.text_value_service.upsert_text_for_concept")
     def test_create_concept_auto_names(self, mock_upsert, mock_repo):
         print("Testing create_concept_auto_names...")
         # Setup mock
@@ -62,12 +60,12 @@ class TestAutoNames(unittest.TestCase):
         self.assertTrue(guid_call, "GUID not registered as CODE name")
 
     @patch(
-        "backend.vontology.utils_vontology.ConceptsRepository"
+        "src.backend.vontology.utils_vontology.ConceptsRepository"
     )  # Patch global import in utils_vontology
     @patch(
-        "backend.db.repositories.concepts_repository.ConceptsRepository"
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository"
     )  # Patch for local import
-    @patch("backend.services.text_value_service.upsert_text_for_concept")
+    @patch("src.backend.services.text_value_service.upsert_text_for_concept")
     def test_import_ontology_nodes_auto_names(
         self, mock_upsert, mock_repo_local, mock_repo_global
     ):

--- a/tests/backend/test_guid_migration.py
+++ b/tests/backend/test_guid_migration.py
@@ -1,15 +1,8 @@
-import sys
-import os
 import unittest
 import uuid
 from unittest.mock import MagicMock, patch
 
-# Add src to path
-sys.path.append(
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
-)
-
-from backend.services.concept_service import (
+from src.backend.services.concept_service import (
     create_concept,
     update_concept,
     InvalidConceptDataError,
@@ -18,8 +11,8 @@ from utilities.migrate_guids import migrate_guids
 
 
 class TestGuidMigration(unittest.TestCase):
-    @patch("backend.services.concept_service.ConceptsRepository")
-    @patch("backend.services.text_value_service.upsert_text_for_concept")
+    @patch("src.backend.services.concept_service.ConceptsRepository")
+    @patch("src.backend.services.text_value_service.upsert_text_for_concept")
     def test_create_concept_generates_guid(self, mock_upsert, mock_repo):
         print("Testing create_concept_generates_guid...")
         mock_collection = MagicMock()
@@ -68,7 +61,7 @@ class TestGuidMigration(unittest.TestCase):
         ]
         self.assertTrue(guid_call, "GUID not registered as CODE name")
 
-    @patch("backend.services.concept_service.ConceptsRepository")
+    @patch("src.backend.services.concept_service.ConceptsRepository")
     def test_update_concept_immutability(self, mock_repo):
         print("Testing update_concept_immutability...")
         mock_collection = MagicMock()

--- a/tests/backend/test_internal_mcp_cap_settings.py
+++ b/tests/backend/test_internal_mcp_cap_settings.py
@@ -23,10 +23,10 @@ class _StubGateway:
 @pytest.mark.parametrize(
     "raw, expected",
     [
-        (None, 8),
-        ("", 8),
-        ("not-a-number", 8),
-        (True, 8),
+        (None, 30),
+        ("", 30),
+        ("not-a-number", 30),
+        (True, 30),
         (-5, 0),
         (0, 0),
         (7, 7),
@@ -44,10 +44,10 @@ def test_get_internal_mcp_max_tool_invocations_clamps(
 @pytest.mark.parametrize(
     "raw, expected",
     [
-        (None, 4),
-        ("", 4),
-        ("not-a-number", 4),
-        (True, 4),
+        (None, 10),
+        ("", 10),
+        ("not-a-number", 10),
+        (True, 10),
         (0, 1),
         (1, 1),
         (7, 7),
@@ -96,8 +96,8 @@ def test_set_internal_mcp_tool_batch_cap_persists_clamped_value(monkeypatch):
 def test_orchestrator_configure_execution_caps_clamps():
     orchestrator = InternalMCPChatOrchestrator(
         gateway=cast(Any, _StubGateway()),
-        max_tool_invocations=8,
-        tool_batch_cap=4,
+        max_tool_invocations=30,
+        tool_batch_cap=10,
     )
 
     orchestrator.configure_execution_caps(max_tool_invocations=999, tool_batch_cap=0)

--- a/tests/backend/test_mcp_create_concepts_unknown_fields.py
+++ b/tests/backend/test_mcp_create_concepts_unknown_fields.py
@@ -6,7 +6,7 @@ when the MCP orchestrator or other callers included extra context fields.
 """
 
 import pytest
-from backend.integrations.internal_mcp.catalogue import _create_concepts
+from src.backend.integrations.internal_mcp.catalogue import _create_concepts
 
 
 def test_create_concepts_accepts_namespace_field():
@@ -87,4 +87,5 @@ def test_create_concepts_accepts_multiple_unknown_fields():
     assert result is not None
     assert result.get("total") == 1
     first_result = result["results"][0]
+    assert isinstance(first_result, dict)
     assert first_result.get("success") is True or "concept_id" in first_result

--- a/tests/backend/test_rag_service.py
+++ b/tests/backend/test_rag_service.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import MagicMock, patch
-from backend.services.rag_service import get_rag_service, RAGService
+from src.backend.services.rag_service import get_rag_service, RAGService
 
 
 # Mock LlamaIndex components to avoid real API calls and dependencies during unit tests

--- a/tests/backend/test_relation_elicitation_service.py
+++ b/tests/backend/test_relation_elicitation_service.py
@@ -2,13 +2,13 @@
 import unittest
 from unittest.mock import patch, MagicMock
 
-from backend.services.relation_elicitation_service import RelationElicitationService
+from src.backend.services.relation_elicitation_service import RelationElicitationService
 
 
 class TestRelationElicitationService(unittest.TestCase):
 
-    @patch("backend.services.concept_service.get_concept_by_concept_id")
-    @patch("backend.services.concept_service.get_concept_by_id")
+    @patch("src.backend.services.concept_service.get_concept_by_concept_id")
+    @patch("src.backend.services.concept_service.get_concept_by_id")
     def test_get_elicitation_opportunities(
         self, mock_get_by_id, mock_get_by_concept_id
     ):

--- a/tests/backend/test_workflow_trace_store.py
+++ b/tests/backend/test_workflow_trace_store.py
@@ -2,7 +2,9 @@ import importlib
 
 import pytest
 
-pytest.importorskip("mongomock", reason="mongomock is required for workflow trace tests")
+pytest.importorskip(
+    "mongomock", reason="mongomock is required for workflow trace tests"
+)
 
 
 @pytest.fixture()
@@ -10,7 +12,7 @@ def mock_db_env(monkeypatch):
     # Must be set before importing mongo_client so USE_MOCK_DB is computed correctly.
     monkeypatch.setenv("VON_USE_MOCK_DB", "1")
 
-    import backend.db.mongo_client as mongo_client
+    import src.backend.db.mongo_client as mongo_client
 
     importlib.reload(mongo_client)
 
@@ -20,8 +22,8 @@ def mock_db_env(monkeypatch):
 
 
 def test_trace_store_roundtrip_and_redaction(mock_db_env):
-    from backend.workflows.trace_model import WorkflowExecutionTrace
-    from backend.workflows.trace_store import (
+    from src.backend.workflows.trace_model import WorkflowExecutionTrace
+    from src.backend.workflows.trace_store import (
         get_workflow_execution_trace,
         insert_workflow_execution_trace,
         list_recent_workflow_execution_traces,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,16 @@ import os
 import sys
 from pathlib import Path
 
-# Ensure project root and src/ are on sys.path for test imports
+# Ensure project root is on sys.path for test imports.
+#
+# IMPORTANT: Do NOT add both the repo root and the src/ directory to sys.path.
+# Doing so makes both `src.backend...` and `backend...` importable and can lead to
+# modules being imported twice under different names, causing cross-test state
+# contamination (e.g., contextvars and cached DB clients).
 ROOT = Path(__file__).resolve().parents[1]
-SRC = ROOT / "src"
-for path in (ROOT, SRC):
-    path_str = str(path)
-    if path_str not in sys.path:
-        sys.path.insert(0, path_str)
+path_str = str(ROOT)
+if path_str not in sys.path:
+    sys.path.insert(0, path_str)
 
 
 # -----------------------------------------------------------------------------

--- a/tests/manual/test_rag_indexing.py
+++ b/tests/manual/test_rag_indexing.py
@@ -1,11 +1,6 @@
-import sys
-import os
 from datetime import datetime, timezone
 
-# Add src to path
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../src")))
-
-from backend.services.rag_service import get_rag_service
+from src.backend.services.rag_service import get_rag_service
 
 
 def test_rag():


### PR DESCRIPTION
Summary:
- Keep the “Thinking…” indicator tooltip visible (opt out of global title suppression) and refresh it once per second so elapsed time increments even when progress polling backs off.
- Make `/health` lightweight (no DB call) and add a short TTL cache to `/admin/rag_status` to reduce UI polling load.

Tests:
- npm run test:frontend
- pdm run pytest tests/backend -q (via test db task)