### PR TITLE
JVNAUTOSCI-941: Harden tool-call parsing + surface tool failures

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -1659,13 +1659,21 @@ class InternalMCPChatOrchestrator:
                 )
             return None
 
-        # Reject concatenated JSON values.
+        # Reject concatenated JSON values, but tolerate non-JSON markers like
+        # "[json]" that some models append after a valid tool call.
         if trailing:
             if trailing.startswith("{") or trailing.startswith("["):
-                raise ToolCallParsingError(
-                    "Tool call was not executed: multiple JSON values were emitted in one response.",
-                    raw_response=text,
-                )
+                try:
+                    # Only treat the remainder as a second value if it is itself
+                    # valid JSON.
+                    decoder.raw_decode(trailing)
+                except json.JSONDecodeError:
+                    pass
+                else:
+                    raise ToolCallParsingError(
+                        "Tool call was not executed: multiple JSON values were emitted in one response.",
+                        raw_response=text,
+                    )
 
             snippet = trailing
             if len(snippet) > 120:
@@ -1680,10 +1688,15 @@ class InternalMCPChatOrchestrator:
             if post_fence_trailing.startswith("{") or post_fence_trailing.startswith(
                 "["
             ):
-                raise ToolCallParsingError(
-                    "Tool call was not executed: multiple JSON values were emitted in one response.",
-                    raw_response=text,
-                )
+                try:
+                    decoder.raw_decode(post_fence_trailing)
+                except json.JSONDecodeError:
+                    pass
+                else:
+                    raise ToolCallParsingError(
+                        "Tool call was not executed: multiple JSON values were emitted in one response.",
+                        raw_response=text,
+                    )
             snippet = post_fence_trailing
             if len(snippet) > 120:
                 snippet = snippet[:117] + "..."
@@ -1803,10 +1816,15 @@ class InternalMCPChatOrchestrator:
         trailing = raw[end:].strip()
         if trailing and is_tool_call:
             if trailing.startswith("{") or trailing.startswith("["):
-                raise ToolCallParsingError(
-                    "Tool call was not executed: multiple tool calls were emitted in one response.",
-                    raw_response=text,
-                )
+                try:
+                    decoder.raw_decode(trailing)
+                except json.JSONDecodeError:
+                    pass
+                else:
+                    raise ToolCallParsingError(
+                        "Tool call was not executed: multiple tool calls were emitted in one response.",
+                        raw_response=text,
+                    )
 
             # Some models append explanatory prose after a valid JSON tool call.
             # Prefer a safe recovery that preserves the single-tool-call contract
@@ -1825,10 +1843,15 @@ class InternalMCPChatOrchestrator:
             if post_fence_trailing.startswith("{") or post_fence_trailing.startswith(
                 "["
             ):
-                raise ToolCallParsingError(
-                    "Tool call was not executed: multiple tool calls were emitted in one response.",
-                    raw_response=text,
-                )
+                try:
+                    decoder.raw_decode(post_fence_trailing)
+                except json.JSONDecodeError:
+                    pass
+                else:
+                    raise ToolCallParsingError(
+                        "Tool call was not executed: multiple tool calls were emitted in one response.",
+                        raw_response=text,
+                    )
             snippet = post_fence_trailing
             if len(snippet) > 120:
                 snippet = snippet[:117] + "..."

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -351,6 +351,62 @@ def _derive_llm_debug_warnings(debug_info: dict) -> list[str]:
             if isinstance(call.get("error"), str) and call.get("error", "").strip():
                 warnings.append(call["error"].strip())
 
+    # Tool invocation failures / parse errors
+    tool_invocations = debug_info.get("tool_invocations", [])
+    if isinstance(tool_invocations, list):
+        for inv in tool_invocations:
+            if not isinstance(inv, dict):
+                continue
+            method = inv.get("method")
+            if not isinstance(method, str):
+                method = (
+                    inv.get("tool") if isinstance(inv.get("tool"), str) else "unknown"
+                )
+            error = inv.get("error")
+            error_text = error.strip() if isinstance(error, str) else ""
+            if not error_text:
+                continue
+
+            # Surface parse errors directly so it is obvious tools were not executed.
+            if method == "__tool_call_parse_error__":
+                warnings.append(error_text)
+            else:
+                warnings.append(f"Tool {method} failed: {error_text}")
+
+    # Max tool invocation cap reached (LLM still wants tools)
+    try:
+        internal_mcp = debug_info.get("internal_mcp")
+        caps = (
+            internal_mcp.get("execution_caps")
+            if isinstance(internal_mcp, dict)
+            else None
+        )
+        max_invocations = (
+            caps.get("max_tool_invocations") if isinstance(caps, dict) else None
+        )
+        max_invocations = int(max_invocations) if max_invocations is not None else None
+    except Exception:
+        max_invocations = None
+
+    response_text = debug_info.get("response")
+    if (
+        isinstance(response_text, str)
+        and isinstance(max_invocations, int)
+        and max_invocations > 0
+        and isinstance(tool_invocations, list)
+        and len(tool_invocations) >= max_invocations
+    ):
+        trimmed = response_text.strip()
+        looks_like_tool_call = (
+            (trimmed.startswith("{") or trimmed.startswith("["))
+            and '"call_tool"' in trimmed
+            and '"tool"' in trimmed
+        )
+        if looks_like_tool_call:
+            warnings.append(
+                f"Reached max tool invocation limit ({max_invocations}); additional tool calls were not executed."
+            )
+
     # Check presenter channel health (screen/spoken routes)
     presenter_channels = debug_info.get("presenter_channels")
     if isinstance(presenter_channels, dict):

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -1906,6 +1906,47 @@ function deriveLlmDebugWarnings(debugData) {
         : null;
     const executedToolCount = toolInvocations.length || (toolStatsCount ?? 0);
 
+    // Surface tool invocation failures / parse errors so it is obvious when tool
+    // use was intended but did not execute.
+    for (const inv of toolInvocations) {
+        if (!inv || typeof inv !== 'object') {
+            continue;
+        }
+
+        const method = (typeof inv.method === 'string')
+            ? inv.method
+            : ((typeof inv.tool === 'string') ? inv.tool : 'unknown');
+
+        const errorText = (typeof inv.error === 'string') ? inv.error.trim() : '';
+        if (!errorText) {
+            continue;
+        }
+
+        if (method === '__tool_call_parse_error__') {
+            warnings.push(errorText);
+        } else {
+            warnings.push(`Tool ${method} failed: ${errorText}`);
+        }
+    }
+
+    // Detect when we reached the max tool invocation cap but the response still
+    // looks like a tool call (i.e., the LLM wanted more tools than we executed).
+    const maxToolInvocations = (debugData.internal_mcp && debugData.internal_mcp.execution_caps && Number.isFinite(debugData.internal_mcp.execution_caps.max_tool_invocations))
+        ? Number(debugData.internal_mcp.execution_caps.max_tool_invocations)
+        : null;
+
+    if (maxToolInvocations != null && maxToolInvocations > 0 && toolInvocations.length >= maxToolInvocations) {
+        const trimmed = String(responseText || '').trim();
+        const looksLikeToolCall = (trimmed.startsWith('{') || trimmed.startsWith('['))
+            && trimmed.includes('"call_tool"')
+            && trimmed.includes('"tool"');
+        if (looksLikeToolCall) {
+            warnings.push(
+                `Reached max tool invocation limit (${maxToolInvocations}); additional tool calls were not executed.`
+            );
+        }
+    }
+
     // Heuristic: detect when the assistant claims it performed N operations but we
     // only executed M tool calls. This often indicates tool truncation/early stop.
     // (e.g., “Done — 9 links” but tool_invocations contains 4 items).

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -528,6 +528,39 @@ describe('LLM debug warnings (presenter channel health)', () => {
             'Response claims 9 operations, but only 4 tool invocations were recorded.'
         );
     });
+
+    test('surfaces tool-call parse errors from tool invocations', () => {
+        const warnings = __testOnly_deriveLlmDebugWarnings({
+            response: 'Tool call was not executed due to an MCP serialisation error.',
+            tool_invocations: [
+                {
+                    method: '__tool_call_parse_error__',
+                    error: 'Tool call was not executed: multiple JSON values were emitted in one response.'
+                }
+            ]
+        });
+
+        expect(warnings).toContain(
+            'Tool call was not executed: multiple JSON values were emitted in one response.'
+        );
+    });
+
+    test('flags when max tool invocation cap is hit but response still looks tool-shaped', () => {
+        const warnings = __testOnly_deriveLlmDebugWarnings({
+            response: '{"action":"call_tool","tool":"test","payload":{}}',
+            tool_invocations: [{ method: 'a' }, { method: 'b' }],
+            internal_mcp: {
+                execution_caps: {
+                    max_tool_invocations: 2,
+                    tool_batch_cap: 1
+                }
+            }
+        });
+
+        expect(warnings).toContain(
+            'Reached max tool invocation limit (2); additional tool calls were not executed.'
+        );
+    });
 });
 
 describe('LLM debug popup metadata (internal MCP caps + usage)', () => {

--- a/tests/backend/test_orchestrator_extraction.py
+++ b/tests/backend/test_orchestrator_extraction.py
@@ -61,6 +61,32 @@ def test_extract_tool_calls_accepts_single_tool_call():
     assert calls == [{"action": "call_tool", "tool": "test", "payload": {}}]
 
 
+def test_extract_tool_calls_tolerates_trailing_json_marker_suffix():
+    """Regression test: tolerate trailing markers like "[json]".
+
+    Some models append a non-JSON suffix such as "[json]" after emitting a valid
+    tool-call JSON payload. This should not be treated as a second JSON value.
+    """
+
+    text = '{"action":"call_tool","tool":"test","payload":{}}[json]'
+    orchestrator = InternalMCPChatOrchestrator(gateway=_DummyGateway())  # type: ignore[arg-type]
+    calls = orchestrator._extract_tool_calls(text)
+    assert calls == [{"action": "call_tool", "tool": "test", "payload": {}}]
+
+
+def test_extract_tool_calls_rejects_concatenated_json_values():
+    """Still reject truly concatenated JSON values."""
+
+    text = (
+        '{"action":"call_tool","tool":"test","payload":{}}'
+        '{"action":"call_tool","tool":"test","payload":{}}'
+    )
+    orchestrator = InternalMCPChatOrchestrator(gateway=_DummyGateway())  # type: ignore[arg-type]
+    with pytest.raises(ToolCallParsingError) as excinfo:
+        orchestrator._extract_tool_calls(text)
+    assert "multiple JSON values" in str(excinfo.value)
+
+
 def test_extract_tool_calls_accepts_json_array_batch():
     text = (
         '[{"action":"call_tool","tool":"test","payload":{}},'

--- a/tests/backend/test_von_generate_llm_debug_parse_error.py
+++ b/tests/backend/test_von_generate_llm_debug_parse_error.py
@@ -63,3 +63,10 @@ def test_llm_debug_contains_rejected_tool_payload(app):
         == '{"action":"call_tool"} trailing'
     )
     assert "invalid JSON in tool call response" in invocation["error"]
+
+    warnings = llm_debug.get("warnings")
+    assert isinstance(warnings, list)
+    assert any(
+        "Tool call was not executed" in str(w) or "invalid JSON" in str(w)
+        for w in warnings
+    )


### PR DESCRIPTION
Summary:
- Tolerate harmless trailing markers (e.g. [json]) after tool-call JSON while still rejecting truly concatenated JSON values.
- Surface tool invocation failures/parse errors and max tool-invocation-cap hits as warnings in LLM debug data.
- Add backend + frontend regression tests.

Tests:
- pytest tests/backend (test DB)
- npm run test:frontend