### PR TITLE
JVNAUTOSCI-948: Deterministic concept resolver tool

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -1405,6 +1405,7 @@ def _resilient_extract_url(**kwargs):
     def _truncate(text: str) -> str:
         if max_chars <= 0:
             return text
+
         if len(text) <= max_chars:
             return text
         return text[:max_chars]
@@ -1989,6 +1990,73 @@ def _add_names_output_schema() -> Schema:
         },
         allow_unknown=True,
         description="add_names output: success (bool), concept_id (str), added_count (int), error_count (int), results (list of {index, name, language, name_type, text_value_id, relation_id}), errors (list of {index, name?, error})",
+    )
+
+
+def _resolve_concept_by_name(**kwargs):
+    from ...services.concept_resolution_service import resolve_concept_by_name
+
+    name = kwargs.get("name")
+    if name is None or not str(name).strip():
+        return {
+            "success": False,
+            "status": "not_found",
+            "error": "Missing 'name' parameter",
+            "resolved_concept_id": None,
+            "candidates": [],
+            "audit": [],
+        }
+
+    return resolve_concept_by_name(
+        name=str(name),
+        preferred_languages=kwargs.get("preferred_languages"),
+        allowed_languages=kwargs.get("allowed_languages"),
+        instance_of=kwargs.get("instance_of"),
+        match_code_strings=bool(kwargs.get("match_code_strings", True)),
+        normalisation_level=str(kwargs.get("normalisation_level", "default")),
+        max_results=int(kwargs.get("max_results", 5)),
+    )
+
+
+def _resolve_concept_by_name_input_schema() -> Schema:
+    return Schema(
+        required={
+            "name": str,
+        },
+        optional={
+            "preferred_languages": (list, type(None)),
+            "allowed_languages": (list, type(None)),
+            "instance_of": (str, type(None)),
+            "match_code_strings": (bool, type(None)),
+            "normalisation_level": (str, type(None)),
+            "max_results": (int, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "resolve_concept_by_name input: name (str) plus optional language preferences/constraints, "
+            "instance_of restriction, code-string matching toggle, normalisation_level, max_results"
+        ),
+    )
+
+
+def _resolve_concept_by_name_output_schema() -> Schema:
+    return Schema(
+        required={
+            "success": bool,
+            "status": str,
+            "resolved_concept_id": (str, type(None)),
+            "candidates": list,
+            "audit": list,
+        },
+        optional={
+            "match": (dict, type(None)),
+            "error": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "resolve_concept_by_name output: status in {resolved, ambiguous, not_found} with "
+            "resolved_concept_id, optional match info, candidates (for ambiguous), and audit steps"
+        ),
     )
 
 
@@ -4537,6 +4605,18 @@ def build_default_catalogue() -> MethodCatalogue:
             output_schema=concept_search_output_schema,
             category="read",
             description="Namespaced alias for concept search used by the MCP orchestrator. Same parameters as search_concepts (query required; pass empty string when using instance_of filters).",
+        ),
+        MethodDefinition(
+            name="resolve_concept_by_name",
+            handler=_resolve_concept_by_name,
+            input_schema=_resolve_concept_by_name_input_schema(),
+            output_schema=_resolve_concept_by_name_output_schema(),
+            category="read",
+            description=(
+                "Resolve a Vontology concept deterministically from a user-provided surface form. "
+                "Read-only: does not mutate concepts. Returns resolved/ambiguous/not_found with an audit trail. "
+                "Supports language preferences, instance_of restriction, and optional code-string matching."
+            ),
         ),
         MethodDefinition(
             name="upsert_text_relation",

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -704,6 +704,49 @@ async def list_tools() -> list[Tool]:
             },
         ),
         Tool(
+            name="resolve_concept_by_name",
+            description="Resolve a Vontology concept deterministically from a user-provided surface form. Read-only (no mutation). Returns resolved/ambiguous/not_found with an audit trail.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The surface form / name to resolve",
+                    },
+                    "preferred_languages": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Preferred languages (ordered) used as a tie-breaker",
+                    },
+                    "allowed_languages": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Restrict candidate name matching to these languages",
+                    },
+                    "instance_of": {
+                        "type": "string",
+                        "description": "Restrict matches to concepts that are instances of this type (includes descendants)",
+                    },
+                    "match_code_strings": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "If true, allow resolving '#V#...' and code-style identifiers",
+                    },
+                    "normalisation_level": {
+                        "type": "string",
+                        "default": "default",
+                        "description": "Normalisation aggressiveness (currently informational)",
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "default": 5,
+                        "description": "Maximum candidates returned when ambiguous",
+                    },
+                },
+                "required": ["name"],
+            },
+        ),
+        Tool(
             name="vontology_concept_search",
             description="Namespaced alias for concept search used by the MCP orchestrator. Same behaviour as search_concepts (query required; use empty string when combining with instance_of filters).",
             inputSchema={
@@ -1993,6 +2036,31 @@ async def _handle_search_concepts(arguments: dict[str, Any]) -> list[TextContent
     return [_json_text(search_result)]
 
 
+async def _handle_resolve_concept_by_name(
+    arguments: dict[str, Any],
+) -> list[TextContent]:
+    from src.backend.services.concept_resolution_service import resolve_concept_by_name
+
+    name = arguments.get("name")
+    if name is None or not str(name).strip():
+        return [
+            _json_text(
+                {"success": False, "status": "not_found", "error": "Missing 'name'"}
+            )
+        ]
+
+    payload = resolve_concept_by_name(
+        name=str(name),
+        preferred_languages=arguments.get("preferred_languages"),
+        allowed_languages=arguments.get("allowed_languages"),
+        instance_of=arguments.get("instance_of"),
+        match_code_strings=bool(arguments.get("match_code_strings", True)),
+        normalisation_level=str(arguments.get("normalisation_level", "default")),
+        max_results=int(arguments.get("max_results", 5)),
+    )
+    return [_json_text(payload)]
+
+
 async def _handle_extract_annotations(arguments: dict[str, Any]) -> list[TextContent]:
     input_text = arguments.get("input_text")
     context_concept_id = arguments.get("context_concept_id")
@@ -2416,6 +2484,7 @@ _TOOL_HANDLERS: dict[str, Callable[[dict[str, Any]], Awaitable[list[TextContent]
     "concept_exists": _handle_concept_exists,
     "search_concepts": _handle_search_concepts,
     "vontology_concept_search": _handle_search_concepts,
+    "resolve_concept_by_name": _handle_resolve_concept_by_name,
     "extract_annotations": _handle_extract_annotations,
     "search_arxiv": _handle_search_arxiv,
     "get_paper_metadata": _handle_get_paper_metadata,

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -512,6 +512,55 @@
             }
         },
         {
+            "name": "resolve_concept_by_name",
+            "description": "Resolve a Vontology concept deterministically from a user-provided surface form. Read-only (no mutation). Returns resolved/ambiguous/not_found with an audit trail.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The surface form / name to resolve"
+                    },
+                    "preferred_languages": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Preferred languages (ordered) used as a tie-breaker"
+                    },
+                    "allowed_languages": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Restrict candidate name matching to these languages"
+                    },
+                    "instance_of": {
+                        "type": "string",
+                        "description": "Restrict matches to concepts that are instances of this type (includes descendants)"
+                    },
+                    "match_code_strings": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "If true, allow resolving '#V#...' and code-style identifiers"
+                    },
+                    "normalisation_level": {
+                        "type": "string",
+                        "default": "default",
+                        "description": "Normalisation aggressiveness (currently informational)"
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "default": 5,
+                        "description": "Maximum candidates returned when ambiguous"
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            }
+        },
+        {
             "name": "vontology_concept_search",
             "description": "Namespaced alias for concept search used by the MCP orchestrator. Same behaviour as search_concepts (query required; use empty string when combining with instance_of filters).",
             "inputSchema": {

--- a/src/backend/services/concept_resolution_service.py
+++ b/src/backend/services/concept_resolution_service.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from .concept_search_service import _search_text_relations
+from .text_value_service import get_texts_for_concept
+from ..db.repositories.concepts_repository import ConceptsRepository
+from ..vontology.code_concepts_registry import is_code_concept_id
+from ..vontology.utils_vontology import get_vontology_node_and_descendant_ids
+
+
+_CODE_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9._-]*$")
+
+
+def _collapse_whitespace(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip())
+
+
+def _strip_diacritics(text: str) -> str:
+    return "".join(
+        ch
+        for ch in unicodedata.normalize("NFKD", text)
+        if not unicodedata.combining(ch)
+    )
+
+
+def _alnum_tokens(text: str) -> list[str]:
+    return [t for t in re.split(r"[^A-Za-z0-9]+", text) if t]
+
+
+def _person_signature(tokens: Sequence[str]) -> Optional[Tuple[str, str, str]]:
+    if len(tokens) < 2:
+        return None
+    first = tokens[0]
+    last = tokens[-1]
+    middle_initials = "".join(t[0] for t in tokens[1:-1] if t)
+    return (first, last, middle_initials)
+
+
+def _slug_to_concept_id(value: str) -> Optional[str]:
+    raw = value.strip()
+    if not raw or " " in raw:
+        return None
+    if raw.startswith("#V#"):
+        return raw
+    if not _CODE_IDENTIFIER_RE.match(raw):
+        return None
+    return f"#V#{raw}"
+
+
+@dataclass(frozen=True)
+class _CandidateMatch:
+    concept_id: str
+    score: int
+    stage: str
+    matched_name: str
+    language: Optional[str]
+    name_type: Optional[str]
+
+
+def resolve_concept_by_name(
+    *,
+    name: str,
+    preferred_languages: Optional[Sequence[str]] = None,
+    allowed_languages: Optional[Sequence[str]] = None,
+    instance_of: Optional[str] = None,
+    match_code_strings: bool = True,
+    normalisation_level: str = "default",
+    max_results: int = 5,
+) -> Dict[str, Any]:
+    """Resolve a Vontology concept deterministically from a user-provided surface form.
+
+    This is a read-only helper intended for MCP tooling. It does not mutate the Vontology.
+
+    Returns a dict with:
+    - success: bool
+    - status: 'resolved' | 'ambiguous' | 'not_found'
+    - resolved_concept_id: str | None
+    - candidates: list (for ambiguous)
+    - audit: list of steps
+    """
+
+    raw = _collapse_whitespace(name)
+    if not raw:
+        return {
+            "success": False,
+            "status": "not_found",
+            "error": "Missing 'name' parameter",
+            "resolved_concept_id": None,
+            "candidates": [],
+            "audit": [],
+        }
+
+    audit: list[dict[str, Any]] = []
+    preferred = [str(l) for l in (preferred_languages or []) if str(l).strip()]
+    allowed = [str(l) for l in (allowed_languages or []) if str(l).strip()]
+    allowed_set = set(allowed) if allowed else None
+
+    # Stage 0: direct concept-id/code identifier resolution.
+    if match_code_strings:
+        maybe_id = _slug_to_concept_id(raw)
+        if maybe_id:
+            audit.append({"stage": "code_string", "candidate": maybe_id})
+            doc = ConceptsRepository.find_one({"concept_id": maybe_id}, {"_id": 1})
+            if doc or is_code_concept_id(maybe_id):
+                return {
+                    "success": True,
+                    "status": "resolved",
+                    "resolved_concept_id": maybe_id,
+                    "match": {"stage": "code_string", "score": 1000},
+                    "candidates": [],
+                    "audit": audit,
+                }
+
+    query_variants: list[tuple[str, str]] = [(raw, "raw")]
+    stripped = _strip_diacritics(raw)
+    if stripped != raw:
+        query_variants.append((stripped, "diacritics_stripped"))
+
+    candidate_ids: set[str] = set()
+
+    # Stage 1: exact name match via text relations.
+    for query_text, variant in query_variants:
+        hits = _search_text_relations(query_text, exact=True)
+        if hits:
+            audit.append(
+                {
+                    "stage": "candidate_generation",
+                    "method": "text_relations_exact",
+                    "variant": variant,
+                    "query": query_text,
+                    "hits": len(hits),
+                }
+            )
+            candidate_ids.update(hits)
+
+    # Stage 2+: broaden if nothing found.
+    if not candidate_ids:
+        hits = _search_text_relations(raw, prefix=True)
+        audit.append(
+            {
+                "stage": "candidate_generation",
+                "method": "text_relations_prefix",
+                "query": raw,
+                "hits": len(hits),
+            }
+        )
+        candidate_ids.update(hits)
+
+    if not candidate_ids:
+        hits = _search_text_relations(raw)
+        audit.append(
+            {
+                "stage": "candidate_generation",
+                "method": "text_relations_substring",
+                "query": raw,
+                "hits": len(hits),
+            }
+        )
+        candidate_ids.update(hits)
+
+    # Deterministic cap to avoid pathological scans.
+    candidate_pool_cap = max(50, min(500, max_results * 50))
+    if len(candidate_ids) > candidate_pool_cap:
+        candidate_ids = set(sorted(candidate_ids)[:candidate_pool_cap])
+        audit.append(
+            {
+                "stage": "candidate_generation",
+                "method": "cap",
+                "cap": candidate_pool_cap,
+                "note": "Deterministic cap applied to candidate pool",
+            }
+        )
+
+    if not candidate_ids:
+        return {
+            "success": True,
+            "status": "not_found",
+            "resolved_concept_id": None,
+            "candidates": [],
+            "audit": audit,
+        }
+
+    # Optional instance_of filter (recursive, includes descendants).
+    if instance_of:
+        try:
+            descendant_ids = get_vontology_node_and_descendant_ids(instance_of)
+        except Exception as exc:
+            return {
+                "success": False,
+                "status": "not_found",
+                "error": f"Failed to expand instance_of descendants: {exc}",
+                "resolved_concept_id": None,
+                "candidates": [],
+                "audit": audit,
+            }
+
+        filtered: set[str] = set()
+        cursor = ConceptsRepository.find(
+            {
+                "concept_id": {"$in": list(candidate_ids)},
+                "relationships.is_an_instance_of": {"$in": descendant_ids},
+            },
+            {"concept_id": 1},
+        )
+        for doc in cursor:
+            cid = doc.get("concept_id")
+            if cid:
+                filtered.add(cid)
+
+        audit.append(
+            {
+                "stage": "filter",
+                "method": "instance_of",
+                "instance_of": instance_of,
+                "before": len(candidate_ids),
+                "after": len(filtered),
+            }
+        )
+        candidate_ids = filtered
+
+    if not candidate_ids:
+        return {
+            "success": True,
+            "status": "not_found",
+            "resolved_concept_id": None,
+            "candidates": [],
+            "audit": audit,
+        }
+
+    query_casefold = raw.casefold()
+    query_casefold_stripped = _strip_diacritics(query_casefold)
+    query_tokens = [t.casefold() for t in _alnum_tokens(raw)]
+    query_signature = _person_signature(query_tokens)
+
+    preferred_rank: dict[str, int] = {
+        lang: (len(preferred) - idx) for idx, lang in enumerate(preferred)
+    }
+
+    matches: list[_CandidateMatch] = []
+
+    for concept_id in sorted(candidate_ids):
+        names = get_texts_for_concept(
+            concept_id,
+            predicate="hasName",
+            limit=200,
+        )
+
+        best: Optional[_CandidateMatch] = None
+        for name_doc in names:
+            candidate_text = name_doc.get("text")
+            if not candidate_text:
+                continue
+
+            lang = name_doc.get("lang")
+            if allowed_set is not None and lang not in allowed_set:
+                continue
+
+            context = name_doc.get("context") or {}
+            name_type = context.get("name_type") if isinstance(context, dict) else None
+
+            candidate_norm = _collapse_whitespace(str(candidate_text))
+            candidate_cf = candidate_norm.casefold()
+            candidate_cf_stripped = _strip_diacritics(candidate_cf)
+
+            stage = None
+            score = 0
+
+            if candidate_norm == raw:
+                stage = "exact"
+                score = 400
+            elif candidate_cf == query_casefold:
+                stage = "casefold_exact"
+                score = 390
+            elif candidate_cf_stripped == query_casefold_stripped:
+                stage = "diacritic_insensitive"
+                score = 380
+            else:
+                candidate_tokens = [t.casefold() for t in _alnum_tokens(candidate_norm)]
+                if candidate_tokens == query_tokens and candidate_tokens:
+                    stage = "token_exact"
+                    score = 360
+                else:
+                    cand_signature = _person_signature(candidate_tokens)
+                    if (
+                        query_signature
+                        and cand_signature
+                        and cand_signature == query_signature
+                    ):
+                        stage = "person_signature"
+                        score = 340
+
+            if stage is None or score <= 0:
+                continue
+
+            if lang and lang in preferred_rank:
+                score += preferred_rank[lang]
+
+            candidate_match = _CandidateMatch(
+                concept_id=concept_id,
+                score=score,
+                stage=stage,
+                matched_name=candidate_norm,
+                language=lang,
+                name_type=name_type,
+            )
+
+            if best is None or candidate_match.score > best.score:
+                best = candidate_match
+            elif (
+                candidate_match.score == best.score
+                and candidate_match.matched_name < best.matched_name
+            ):
+                # Deterministic tiebreak within a concept.
+                best = candidate_match
+
+        if best is not None:
+            matches.append(best)
+
+    if not matches:
+        return {
+            "success": True,
+            "status": "not_found",
+            "resolved_concept_id": None,
+            "candidates": [],
+            "audit": audit,
+        }
+
+    matches.sort(key=lambda m: (-m.score, m.concept_id))
+
+    top_score = matches[0].score
+    top = [m for m in matches if m.score == top_score]
+
+    if len(top) == 1:
+        winner = matches[0]
+        return {
+            "success": True,
+            "status": "resolved",
+            "resolved_concept_id": winner.concept_id,
+            "match": {
+                "score": winner.score,
+                "stage": winner.stage,
+                "matched_name": winner.matched_name,
+                "language": winner.language,
+                "name_type": winner.name_type,
+            },
+            "candidates": [],
+            "audit": audit,
+        }
+
+    # Ambiguous: return a deterministic top-N of the tied results.
+    tied = sorted(top, key=lambda m: (m.concept_id, m.matched_name))
+    return {
+        "success": True,
+        "status": "ambiguous",
+        "resolved_concept_id": None,
+        "candidates": [
+            {
+                "concept_id": m.concept_id,
+                "score": m.score,
+                "stage": m.stage,
+                "matched_name": m.matched_name,
+                "language": m.language,
+                "name_type": m.name_type,
+            }
+            for m in tied[:max_results]
+        ],
+        "audit": audit,
+    }

--- a/src/backend/services/concept_resolution_service.py
+++ b/src/backend/services/concept_resolution_service.py
@@ -5,9 +5,15 @@ import unicodedata
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
+from bson import ObjectId
+
 from .concept_search_service import _search_text_relations
 from .text_value_service import get_texts_for_concept
 from ..db.repositories.concepts_repository import ConceptsRepository
+from ..db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
 from ..vontology.code_concepts_registry import is_code_concept_id
 from ..vontology.utils_vontology import get_vontology_node_and_descendant_ids
 
@@ -162,6 +168,65 @@ def resolve_concept_by_name(
         )
         candidate_ids.update(hits)
 
+    # Stage 3b: diacritic-insensitive fallback.
+    # If the user types ASCII (e.g. 'Gael') but the stored name contains diacritics
+    # (e.g. 'Gaël'), Mongo text/regex matching may not find it. Do a bounded scan of
+    # hasName text relations and compare with diacritics stripped.
+    if not candidate_ids:
+        query_cf_stripped = _strip_diacritics(raw.casefold())
+        if query_cf_stripped:
+            relations = list(
+                TextRelationsRepository.find(
+                    {"predicate": "hasName"},
+                    limit=10000,
+                )
+            )
+
+            # Map text_value_id -> subject_concept_ids
+            tv_to_subjects: dict[str, set[str]] = {}
+            tv_object_ids: list[ObjectId] = []
+            for rel in relations:
+                subj = rel.get("subject_concept_id")
+                obj = rel.get("object_text_id")
+                if not isinstance(subj, str) or not subj:
+                    continue
+                obj_str = str(obj) if obj is not None else ""
+                if not obj_str:
+                    continue
+                tv_to_subjects.setdefault(obj_str, set()).add(subj)
+                if ObjectId.is_valid(obj_str):
+                    tv_object_ids.append(ObjectId(obj_str))
+
+            if tv_object_ids:
+                text_value_docs = list(
+                    TextValuesRepository.find(
+                        {"_id": {"$in": tv_object_ids}},
+                        limit=5000,
+                    )
+                )
+            else:
+                text_value_docs = []
+
+            diacritic_hits: set[str] = set()
+            for tv in text_value_docs:
+                tv_id = str(tv.get("_id"))
+                text = tv.get("text")
+                if not isinstance(text, str) or not text:
+                    continue
+                if _strip_diacritics(text.casefold()) == query_cf_stripped:
+                    diacritic_hits.update(tv_to_subjects.get(tv_id, set()))
+
+            audit.append(
+                {
+                    "stage": "candidate_generation",
+                    "method": "text_relations_diacritic_scan",
+                    "query": raw,
+                    "hits": len(diacritic_hits),
+                    "relation_scan_cap": 10000,
+                }
+            )
+            candidate_ids.update(diacritic_hits)
+
     # Deterministic cap to avoid pathological scans.
     candidate_pool_cap = max(50, min(500, max_results * 50))
     if len(candidate_ids) > candidate_pool_cap:
@@ -197,6 +262,20 @@ def resolve_concept_by_name(
                 "candidates": [],
                 "audit": audit,
             }
+
+        # Be robust to incomplete type-hierarchy data: if descendant expansion fails to
+        # locate the start node, still treat instance_of as a valid direct filter.
+        if not descendant_ids:
+            if ConceptsRepository.find_one({"concept_id": instance_of}, {"_id": 1}):
+                descendant_ids = [instance_of]
+            audit.append(
+                {
+                    "stage": "filter",
+                    "method": "instance_of_descendants_fallback",
+                    "instance_of": instance_of,
+                    "descendants": len(descendant_ids),
+                }
+            )
 
         filtered: set[str] = set()
         cursor = ConceptsRepository.find(

--- a/tests/backend/test_resolve_concept_by_name.py
+++ b/tests/backend/test_resolve_concept_by_name.py
@@ -1,0 +1,166 @@
+import pytest
+
+from src.backend.db.repositories.concepts_repository import ConceptsRepository
+from src.backend.db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
+from src.backend.security.access_control import bypass_access_control
+from src.backend.services.concept_resolution_service import resolve_concept_by_name
+from src.backend.services.text_value_service import upsert_text_for_concept
+
+
+@pytest.fixture(autouse=True)
+def clean_collections():
+    db = TextValuesRepository.db()
+    if db is None:
+        yield
+        return
+
+    concepts = ConceptsRepository.collection()
+    relations = TextRelationsRepository.collection()
+    text_values = TextValuesRepository.collection()
+
+    if concepts is None or relations is None or text_values is None:
+        yield
+        return
+
+    concepts.delete_many({})
+    relations.delete_many({})
+    text_values.delete_many({})
+    yield
+    concepts.delete_many({})
+    relations.delete_many({})
+    text_values.delete_many({})
+
+
+def test_resolve_concept_by_name_matches_diacritics_insensitively():
+    if TextValuesRepository.db() is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concept_id = "#V#gael_test"
+    concepts = ConceptsRepository.collection()
+    if concepts is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concepts.insert_one({"concept_id": concept_id, "relationships": {}})
+
+    with bypass_access_control():
+        upsert_text_for_concept(
+            subject_concept_id=concept_id,
+            predicate="hasName",
+            text="Gaël",
+            lang="fr",
+            context={"name_type": "NL"},
+        )
+
+    result = resolve_concept_by_name(name="Gael", preferred_languages=["fr"])
+
+    assert result["success"] is True
+    assert result["status"] == "resolved"
+    assert result["resolved_concept_id"] == concept_id
+    assert result["match"]["stage"] in {
+        "diacritic_insensitive",
+        "casefold_exact",
+        "exact",
+    }
+
+
+def test_resolve_concept_by_name_returns_ambiguous_on_tie():
+    if TextValuesRepository.db() is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concepts = ConceptsRepository.collection()
+    if concepts is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concept_a = "#V#michael_witbrock_a"
+    concept_b = "#V#michael_witbrock_b"
+    concepts.insert_one({"concept_id": concept_a, "relationships": {}})
+    concepts.insert_one({"concept_id": concept_b, "relationships": {}})
+
+    with bypass_access_control():
+        upsert_text_for_concept(
+            subject_concept_id=concept_a,
+            predicate="hasName",
+            text="Michael Witbrock",
+            lang="en-NZ",
+            context={"name_type": "NL"},
+        )
+        upsert_text_for_concept(
+            subject_concept_id=concept_b,
+            predicate="hasName",
+            text="Michael Witbrock",
+            lang="en-NZ",
+            context={"name_type": "NL"},
+        )
+
+    result = resolve_concept_by_name(name="Michael Witbrock")
+
+    assert result["success"] is True
+    assert result["status"] == "ambiguous"
+    assert result["resolved_concept_id"] is None
+    assert {c["concept_id"] for c in result["candidates"]} == {concept_a, concept_b}
+
+
+def test_resolve_concept_by_name_honours_instance_of_filter():
+    if TextValuesRepository.db() is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concepts = ConceptsRepository.collection()
+    if concepts is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    researcher_type = "#V#researcher"
+    concepts.insert_one({"concept_id": researcher_type, "relationships": {}})
+
+    good = "#V#alex_researcher"
+    bad = "#V#alex_not_researcher"
+
+    concepts.insert_one(
+        {
+            "concept_id": good,
+            "relationships": {"is_an_instance_of": [researcher_type]},
+        }
+    )
+    concepts.insert_one({"concept_id": bad, "relationships": {}})
+
+    with bypass_access_control():
+        upsert_text_for_concept(
+            subject_concept_id=good,
+            predicate="hasName",
+            text="Alex Example",
+            lang="en-NZ",
+            context={"name_type": "NL"},
+        )
+        upsert_text_for_concept(
+            subject_concept_id=bad,
+            predicate="hasName",
+            text="Alex Example",
+            lang="en-NZ",
+            context={"name_type": "NL"},
+        )
+
+    result = resolve_concept_by_name(name="Alex Example", instance_of=researcher_type)
+
+    assert result["success"] is True
+    assert result["status"] == "resolved"
+    assert result["resolved_concept_id"] == good
+
+
+def test_resolve_concept_by_name_can_resolve_code_style_identifier():
+    if TextValuesRepository.db() is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concepts = ConceptsRepository.collection()
+    if concepts is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concept_id = "#V#michael_witbrock"
+    concepts.insert_one({"concept_id": concept_id, "relationships": {}})
+
+    result = resolve_concept_by_name(name="michael_witbrock", match_code_strings=True)
+
+    assert result["success"] is True
+    assert result["status"] == "resolved"
+    assert result["resolved_concept_id"] == concept_id

--- a/tests/backend/test_resolve_concept_by_name.py
+++ b/tests/backend/test_resolve_concept_by_name.py
@@ -144,7 +144,7 @@ def test_resolve_concept_by_name_honours_instance_of_filter():
     result = resolve_concept_by_name(name="Alex Example", instance_of=researcher_type)
 
     assert result["success"] is True
-    assert result["status"] == "resolved"
+    assert result["status"] == "resolved", result
     assert result["resolved_concept_id"] == good
 
 


### PR DESCRIPTION
Adds a deterministic concept-name resolver tool (MCP) and hardens matching:
- Diacritic-insensitive fallback (e.g., Gaël vs Gael)
- More robust instance_of filtering when the hierarchy lookup is incomplete

Notes:
- This PR contains only JVNAUTOSCI-948 work; unrelated Settings/organisation changes are kept out.