### PR TITLE
JVNAUTOSCI-949: Settings org selection + prefs refactor

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -2145,9 +2145,74 @@ class InternalMCPChatOrchestrator:
         return (
             "Your previous message described an action that requires MCP tools, but you did not emit a tool call. "
             "NOW respond with ONLY a tool-call JSON object or a JSON array of tool-call objects. "
+            "Choose a tool that matches the user's request; do NOT call write tools unless the user explicitly asked to create/update/delete Vontology data. "
             "No prose. No Markdown. Do NOT wrap the JSON in ``` fences (including ```json). "
             "The first character MUST be an opening curly brace or an opening square bracket, and the response must contain only valid JSON."
         )
+
+    @staticmethod
+    def _prompt_allows_write_tools(prompt: str) -> bool:
+        """Return True when the user explicitly requests a Vontology mutation.
+
+        This guard prevents accidental writes when the model emits an unrelated
+        write tool call (often after a missing-tool-call retry).
+
+        Keep this conservative: require both a write verb and an ontology/concept
+        reference so unrelated "create" requests (e.g., "create a file") do not
+        enable write-category tools.
+        """
+
+        if not isinstance(prompt, str):
+            return False
+
+        lowered = prompt.lower()
+
+        mentions_vontology = any(
+            token in lowered
+            for token in (
+                "#v#",
+                "vontology",
+                "ontology",
+                "concept",
+                "relationship",
+                "predicate",
+                "text relation",
+            )
+        )
+        if not mentions_vontology:
+            return False
+
+        import re
+
+        verbs = (
+            "create",
+            "add",
+            "insert",
+            "upsert",
+            "update",
+            "edit",
+            "change",
+            "delete",
+            "remove",
+            "rename",
+            "merge",
+            "link",
+            "unlink",
+            "set",
+        )
+
+        negated = {
+            match.group(1)
+            for match in re.finditer(
+                r"\b(?:do not|don't|dont|never)\s+(create|add|insert|upsert|update|edit|change|delete|remove|rename|merge|link|unlink|set)\b",
+                lowered,
+            )
+        }
+
+        for verb in verbs:
+            if re.search(rf"\b{re.escape(verb)}\b", lowered) and verb not in negated:
+                return True
+        return False
 
     def execute_workflow(
         self,
@@ -2705,6 +2770,17 @@ class InternalMCPChatOrchestrator:
         tool_messages: List[Mapping[str, Any]] = []
         selected_gmail_profile = gmail_profile or self._default_gmail_profile
 
+        method_catalogue = self._gateway.describe_methods()
+        tool_categories: dict[str, str] = {}
+        for name, meta in method_catalogue.items():
+            if not isinstance(meta, Mapping):
+                continue
+            category = meta.get("category")
+            if isinstance(category, str):
+                tool_categories[name] = category
+
+        write_allowed = self._prompt_allows_write_tools(prompt)
+
         # Support chained tool calls up to max_tool_invocations limit (JVNAUTOSCI-699)
         iteration_count = 0
         current_response = response
@@ -2841,6 +2917,54 @@ class InternalMCPChatOrchestrator:
                             else str(current_response)
                         ),
                     )
+
+                # Safety: block write-category tools unless user explicitly requested a Vontology mutation.
+                # This is intentionally enforced at execution time so it applies to both legacy and
+                # structured tool-calling paths, including retry flows.
+                tool_category = tool_categories.get(tool_name)
+                if tool_category == "write" and not write_allowed:
+                    message = (
+                        f"Blocked write tool {tool_name!r}: the user request appears read-only. "
+                        "If you intended to modify the Vontology, restate the request explicitly."
+                    )
+                    tool_payload = self._format_tool_result(
+                        tool_name, None, None, "error", message
+                    )
+
+                    blocked_record: dict[str, Any] = {
+                        "tool": tool_name,
+                        "payload": dict(payload),
+                        "error": message,
+                        "blocked": True,
+                    }
+                    if call_id:
+                        blocked_record["call_id"] = call_id
+                    invocations.append(blocked_record)
+
+                    if tool_step is not None:
+                        try:
+                            tool_step.finish_failed(message)
+                        except Exception:
+                            pass
+
+                    self._emit_progress(
+                        {
+                            "status": "tool_blocked",
+                            "tool": tool_name,
+                            "batch_size": current_batch_size,
+                            "tool_calls_done": iteration_count,
+                            "tool_calls_cap": int(self._max_tool_invocations),
+                            "tool_calls_remaining": max(
+                                0, int(self._max_tool_invocations) - iteration_count
+                            ),
+                            "call_id": call_id,
+                            "error": message,
+                        }
+                    )
+
+                    augmented_context.append({"role": "tool", "content": tool_payload})
+                    tool_messages.append({"role": "tool", "content": tool_payload})
+                    continue
 
                 try:
                     if tool_name.startswith("gmail_"):

--- a/src/backend/security/access_control.py
+++ b/src/backend/security/access_control.py
@@ -90,7 +90,6 @@ class AccessEvaluator:
                 self._cache[normalised] = True
                 return True
         except Exception:
-            # Best-effort: fall through to Mongo lookup.
             pass
 
         if normalised == self.user_id:

--- a/src/backend/security/role_resolver.py
+++ b/src/backend/security/role_resolver.py
@@ -29,6 +29,9 @@ STUB_ROLE_MAPPINGS = {
     "von_archivist": {
         "university_of_auckland_strong_ai_lab": "member",
     },
+    "lu_yunli": {
+        "the_lu_witbrock_household": "member",
+    },
 }
 
 # Default role for new members

--- a/src/backend/server/routes/settings_routes.py
+++ b/src/backend/server/routes/settings_routes.py
@@ -816,7 +816,9 @@ def get_user_prefs(user_concept_id: str):
     try:
         if not user_concept_id:
             return jsonify({"error": "Missing user_concept_id"}), 400
-        concept = ConceptsRepository.find_one({"concept_id": user_concept_id})
+        from ...services.concept_service import get_concept_by_concept_id
+
+        concept = get_concept_by_concept_id(concept_id=user_concept_id)
         if not concept:
             return jsonify({"error": "User concept not found"}), 404
         rel = _normalize_relationships(concept.get("relationships", {}))
@@ -857,7 +859,12 @@ def set_user_prefs(user_concept_id: str):
         data = request.get_json(silent=True) or {}
         preferred_language = data.get("preferred_language")
         organisation_concept_id = data.get("organisation_concept_id")
-        concept = ConceptsRepository.find_one({"concept_id": user_concept_id})
+        from ...services.concept_service import (
+            get_concept_by_concept_id,
+            update_concept,
+        )
+
+        concept = get_concept_by_concept_id(concept_id=user_concept_id)
         if not concept:
             return jsonify({"error": "User concept not found"}), 404
         rel = _normalize_relationships(concept.get("relationships", {}))
@@ -876,42 +883,7 @@ def set_user_prefs(user_concept_id: str):
         )
         desired_lang = desired_lang or None
 
-        for current_lang in list(existing_lang):
-            if desired_lang and current_lang == desired_lang:
-                continue
-            try:
-                ConceptsRepository.mutate_relationship_edge(
-                    user_concept_id,
-                    USER_PREF_LANG_PREDICATE,
-                    current_lang,
-                    action="remove",
-                    maintain_inverse=False,
-                )
-            except ValueError:
-                current_app.logger.debug(
-                    f"preferred_language remove skipped for {user_concept_id}: missing concept",
-                    exc_info=False,
-                )
-            existing_lang.remove(current_lang)
-
-        if desired_lang:
-            if desired_lang not in existing_lang:
-                try:
-                    ConceptsRepository.mutate_relationship_edge(
-                        user_concept_id,
-                        USER_PREF_LANG_PREDICATE,
-                        desired_lang,
-                        action="add",
-                        maintain_inverse=False,
-                    )
-                    existing_lang.append(desired_lang)
-                except ValueError:
-                    current_app.logger.warning(
-                        f"Failed to set preferred_language for {user_concept_id}"
-                    )
-        else:
-            rel.pop(USER_PREF_LANG_PREDICATE, None)
-
+        existing_lang = [desired_lang] if desired_lang else []
         if existing_lang:
             rel[USER_PREF_LANG_PREDICATE] = existing_lang
         else:
@@ -926,46 +898,14 @@ def set_user_prefs(user_concept_id: str):
         )
         desired_org = desired_org or None
 
-        for current_org in list(existing_org):
-            if desired_org and current_org == desired_org:
-                continue
-            try:
-                ConceptsRepository.mutate_relationship_edge(
-                    user_concept_id,
-                    USER_PREF_ORG_PREDICATE,
-                    current_org,
-                    action="remove",
-                    maintain_inverse=False,
-                )
-            except ValueError:
-                current_app.logger.debug(
-                    f"organisation remove skipped for {user_concept_id}: missing concept",
-                    exc_info=False,
-                )
-            existing_org.remove(current_org)
-
-        if desired_org:
-            if desired_org not in existing_org:
-                try:
-                    ConceptsRepository.mutate_relationship_edge(
-                        user_concept_id,
-                        USER_PREF_ORG_PREDICATE,
-                        desired_org,
-                        action="add",
-                        maintain_inverse=False,
-                    )
-                    existing_org.append(desired_org)
-                except ValueError:
-                    current_app.logger.warning(
-                        f"Failed to set organisation preference for {user_concept_id}"
-                    )
-        else:
-            rel.pop(USER_PREF_ORG_PREDICATE, None)
-
+        existing_org = [desired_org] if desired_org else []
         if existing_org:
             rel[USER_PREF_ORG_PREDICATE] = existing_org
         else:
             rel.pop(USER_PREF_ORG_PREDICATE, None)
+
+        # Persist updated relationships via the normal concept service update path.
+        update_concept(user_concept_id, {"relationships": rel})
 
         return (
             jsonify(

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -3274,7 +3274,8 @@ def get_my_organisations():
     Returns: {organisations: [{concept_id, name, role}, ...], total_count}
     """
     try:
-        from ...security.role_resolver import get_all_user_organisations
+        from ...security.role_resolver import get_all_user_organisations, get_user_role
+        from ...services.concept_service import get_concept_by_concept_id
 
         user_id = (
             session.get("user_id")
@@ -3284,6 +3285,31 @@ def get_my_organisations():
         if not user_id:
             return jsonify({"error": "Not authenticated"}), 401
 
+        user_concept_id = session.get("user_concept_id")
+
+        def _normalise_relationships(rel):
+            if not isinstance(rel, (dict, list)):
+                return {}
+            if isinstance(rel, list):
+                out = {}
+                for item in rel:
+                    if not isinstance(item, dict):
+                        continue
+                    pred = item.get("predicate")
+                    tgt = item.get("target")
+                    if not pred or not tgt:
+                        continue
+                    out.setdefault(pred, [])
+                    if isinstance(tgt, list):
+                        out[pred].extend(tgt)
+                    else:
+                        out[pred].append(tgt)
+                return out
+            return rel or {}
+
+        def _prettify_concept_id(concept_id: str) -> str:
+            return concept_id.replace("#V#", "").replace("_", " ").title()
+
         # Derive a slug for stub role resolution
         user_slug = str(user_id)
         if user_slug.startswith("#V#"):
@@ -3292,22 +3318,52 @@ def get_my_organisations():
             user_slug = user_slug.split("@")[0]
         user_slug = user_slug.strip().lower().replace(" ", "_")
 
-        # Get orgs from role resolver (Phase 1 hardcoded mappings)
-        # Returns dict: {org_id: role_name}
-        org_roles = get_all_user_organisations(user_slug)
+        USER_PREF_ORG_PREDICATE = "#V#member_of_organisation"
 
-        # TODO: Once organisation concepts exist in Vontology, fetch their names
-        # For now, use concept_id as name
         organisations = []
-        for org_id, role in org_roles.items():
-            concept_id = org_id if org_id.startswith("#V#") else f"#V#{org_id}"
-            organisations.append(
-                {
-                    "concept_id": concept_id,
-                    "name": concept_id.replace("#V#", "").replace("_", " ").title(),
-                    "role": role,
-                }
-            )
+
+        # Prefer memberships stored on the authenticated user concept.
+        if isinstance(user_concept_id, str) and user_concept_id.strip():
+            user_concept = get_concept_by_concept_id(concept_id=user_concept_id)
+            if isinstance(user_concept, dict):
+                rel = _normalise_relationships(user_concept.get("relationships", {}))
+                org_raw = rel.get(USER_PREF_ORG_PREDICATE)
+
+                org_targets: list[str] = []
+                if isinstance(org_raw, str) and org_raw:
+                    org_targets = [org_raw]
+                elif isinstance(org_raw, list):
+                    org_targets = [t for t in org_raw if isinstance(t, str) and t]
+
+                for org_cid in org_targets:
+                    org_cid = org_cid if org_cid.startswith("#V#") else f"#V#{org_cid}"
+                    org_slug = org_cid[3:] if org_cid.startswith("#V#") else org_cid
+                    org_slug = org_slug.strip().lower().replace(" ", "_")
+                    try:
+                        role = get_user_role(user_slug, org_slug)
+                    except Exception:
+                        role = "member"
+
+                    organisations.append(
+                        {
+                            "concept_id": org_cid,
+                            "name": _prettify_concept_id(org_cid),
+                            "role": role,
+                        }
+                    )
+
+        # Fallback: stub role resolver mappings (Phase 1 hardcoded)
+        if not organisations:
+            org_roles = get_all_user_organisations(user_slug)
+            for org_id, role in org_roles.items():
+                concept_id = org_id if org_id.startswith("#V#") else f"#V#{org_id}"
+                organisations.append(
+                    {
+                        "concept_id": concept_id,
+                        "name": _prettify_concept_id(concept_id),
+                        "role": role,
+                    }
+                )
 
         return (
             jsonify(

--- a/src/frontend/web/von_interface/static/js/settingsPage.js
+++ b/src/frontend/web/von_interface/static/js/settingsPage.js
@@ -720,7 +720,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     saveAllSettings('ollama');
   });
   document.getElementById('openaiModelSelect')?.addEventListener('change', () => saveAllSettings('openai'));
-  document.getElementById('currentUserSelect')?.addEventListener('change', () => {
+  document.getElementById('currentUserSelect')?.addEventListener('change', async () => {
     const sel = document.getElementById('currentUserSelect');
     const opt = sel?.selectedOptions?.[0];
     if (opt) {
@@ -728,7 +728,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (window.parent?.updateModelInfoFooterDisplay) { window.parent.updateModelInfoFooterDisplay(); }
       // When user changes, attempt to load stored server-side prefs (language/org)
       if (opt.dataset.conceptId) {
-        loadUserConceptPreferences(opt.dataset.conceptId);
+        await loadUserConceptPreferences(opt.dataset.conceptId);
+        // Refresh organisation selector so memberships reflect the selected user.
+        if (window.refreshOrgSelector) {
+          try { await window.refreshOrgSelector(); } catch (e) { console.warn('Org selector refresh failed', e); }
+        }
       }
     } else { setStoredJson(LS_USER_KEY, null); }
   });

--- a/tests/backend/test_orchestrator_write_tool_guard.py
+++ b/tests/backend/test_orchestrator_write_tool_guard.py
@@ -1,0 +1,93 @@
+"""Regression tests for guarding write-category tools in the internal orchestrator."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional, Sequence, cast
+
+from src.backend.integrations.internal_mcp.orchestrator import (
+    InternalMCPChatOrchestrator,
+)
+
+
+class _StubGateway:
+    def __init__(self) -> None:
+        self.enabled = True
+        self.invoked: list[tuple[str, Mapping[str, Any]]] = []
+
+    def describe_methods(self) -> dict[str, Any]:
+        # Match InternalMCPGateway.describe_methods() shape closely enough for
+        # _tool_listing() and the write-guard category lookup.
+        return {
+            "create_concepts": {
+                "category": "write",
+                "description": "Create one or more Vontology concepts.",
+                "input_schema": {
+                    "required": ["parent_id", "concepts"],
+                    "optional": [],
+                    "allow_unknown": False,
+                    "description": None,
+                },
+                "output_schema": None,
+            },
+            "search_concepts": {
+                "category": "read",
+                "description": "Search concepts by name.",
+                "input_schema": {
+                    "required": ["name"],
+                    "optional": [],
+                    "allow_unknown": False,
+                    "description": None,
+                },
+                "output_schema": None,
+            },
+        }
+
+    def invoke(self, tool_name: str, payload: Mapping[str, Any]):
+        self.invoked.append((tool_name, dict(payload)))
+        raise AssertionError("Gateway should not be invoked for blocked tools")
+
+
+class _CapturingLLM:
+    def __init__(self, responses: Sequence[str]):
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    def generate(
+        self,
+        prompt: str,
+        context: Optional[Sequence[Mapping[str, Any]]] = None,
+        model=None,
+    ):
+        self.calls.append(
+            {"prompt": prompt, "context": list(context or []), "model": model}
+        )
+        if not self._responses:
+            raise AssertionError("LLM called more times than expected")
+        return self._responses.pop(0)
+
+
+def test_read_only_prompt_blocks_write_tool_call() -> None:
+    gateway = cast(Any, _StubGateway())
+    orchestrator = InternalMCPChatOrchestrator(gateway=gateway, max_tool_invocations=1)
+
+    llm = _CapturingLLM(
+        [
+            '{"action": "call_tool", "tool": "create_concepts", "payload": {"parent_id": "#V#thing", "concepts": [{"name": "qiming"}]}}',
+            "OK, I won't create anything. What name should I search for?",
+        ]
+    )
+
+    result = orchestrator.run(
+        prompt="Search for Qiming in the Vontology (do not create anything)",
+        context=None,
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+    )
+
+    assert gateway.invoked == []
+    assert any(
+        inv.get("tool") == "create_concepts" and inv.get("blocked") is True
+        for inv in result.tool_invocations
+        if isinstance(inv, Mapping)
+    )

--- a/tests/backend/test_session_org_routes.py
+++ b/tests/backend/test_session_org_routes.py
@@ -206,3 +206,40 @@ def test_get_my_organisations_returns_stubbed_memberships(app_client):
     assert org["concept_id"] == "#V#university_of_auckland_strong_ai_lab"
     assert org["role"] == "admin"
     assert org["name"] == "University Of Auckland Strong Ai Lab"
+
+
+def test_get_my_organisations_prefers_memberships_from_user_concept_relationships(
+    app_client, monkeypatch
+):
+    _, client = app_client
+
+    # Stub concept lookup via the normal concept service path.
+    import src.backend.services.concept_service as concept_service
+
+    def _fake_get_concept_by_concept_id(concept_id: str, **_kwargs):
+        if concept_id == "#V#lu_yunli":
+            return {
+                "concept_id": "#V#lu_yunli",
+                "relationships": {
+                    "#V#member_of_organisation": ["#V#the_lu_witbrock_household"]
+                },
+            }
+        return None
+
+    monkeypatch.setattr(
+        concept_service, "get_concept_by_concept_id", _fake_get_concept_by_concept_id
+    )
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = "lu_yunli"
+        sess["user_concept_id"] = "#V#lu_yunli"
+
+    resp = client.get("/von/api/organisations/my_organisations")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total_count"] == 1
+    org = data["organisations"][0]
+    assert org["concept_id"] == "#V#the_lu_witbrock_household"
+    assert org["role"] == "member"
+    assert org["name"] == "The Lu Witbrock Household"

--- a/tests/backend/test_user_prefs_routes.py
+++ b/tests/backend/test_user_prefs_routes.py
@@ -1,0 +1,182 @@
+"""Tests for per-user preference (language & organisation) routes.
+
+Covers /api/settings/user_prefs/<user_concept_id> GET/POST behaviour while
+stubbing out DB access. These preferences are stored as relationships on the
+user concept.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def app_client(monkeypatch):
+    """Provide a Flask test client with side effects stubbed out."""
+
+    # Stub Google auth dependencies pulled in by utils_flask -> auth_routes imports.
+    import sys
+    import types
+
+    fake_flow_module = types.ModuleType("google_auth_oauthlib.flow")
+
+    class _DummyFlow:
+        def __init__(self, *args, **kwargs):
+            self.credentials = types.SimpleNamespace(id_token="dummy-token")
+            self.redirect_uri = kwargs.get("redirect_uri")
+            self.client_config = {"web": {"redirect_uris": [self.redirect_uri]}}
+
+        @classmethod
+        def from_client_config(cls, *args, **kwargs):
+            return cls(**kwargs)
+
+        def authorization_url(self, *args, **kwargs):
+            return "https://auth.example", "state-token"
+
+        def fetch_token(self, *args, **kwargs):
+            return None
+
+    fake_flow_module.Flow = _DummyFlow  # type: ignore[attr-defined]
+    sys.modules["google_auth_oauthlib"] = types.ModuleType("google_auth_oauthlib")
+    sys.modules["google_auth_oauthlib"].flow = fake_flow_module  # type: ignore[attr-defined]
+    sys.modules["google_auth_oauthlib.flow"] = fake_flow_module
+
+    fake_id_token_module = types.ModuleType("google.oauth2.id_token")
+    fake_id_token_module.verify_oauth2_token = lambda *args, **kwargs: {  # type: ignore[attr-defined]
+        "sub": "dummy-user"
+    }
+
+    fake_credentials_module = types.ModuleType("google.oauth2.credentials")
+
+    class _DummyCredentials:
+        def __init__(self, id_token: str = "dummy-token"):
+            self.id_token = id_token
+
+    fake_credentials_module.Credentials = _DummyCredentials  # type: ignore[attr-defined]
+
+    fake_service_account_module = types.ModuleType("google.oauth2.service_account")
+
+    class _DummyServiceAccountCredentials:
+        def __init__(self, *args, **kwargs):
+            self.project_id = kwargs.get("project_id")
+
+    fake_service_account_module.Credentials = _DummyServiceAccountCredentials  # type: ignore[attr-defined]
+
+    fake_oauth2_package = types.ModuleType("google.oauth2")
+    fake_oauth2_package.id_token = fake_id_token_module  # type: ignore[attr-defined]
+    fake_oauth2_package.credentials = fake_credentials_module  # type: ignore[attr-defined]
+    fake_oauth2_package.service_account = fake_service_account_module  # type: ignore[attr-defined]
+
+    sys.modules["google.oauth2"] = fake_oauth2_package
+    sys.modules["google.oauth2.id_token"] = fake_id_token_module
+    sys.modules["google.oauth2.credentials"] = fake_credentials_module
+    sys.modules["google.oauth2.service_account"] = fake_service_account_module
+
+    import src.backend.server.utils_flask as utils_flask
+
+    # Avoid starting the DB monitor thread or touching Mongo during tests.
+    monkeypatch.setattr(utils_flask, "ensure_monitor_started", lambda: None)
+    monkeypatch.setattr(
+        utils_flask,
+        "prompt_concept_health_status",
+        lambda: {"available": True, "source_field": "stub"},
+    )
+
+    app = utils_flask.create_flask_app(
+        list_models_func=lambda: ["dummy-model"],
+        generate_func=lambda prompt, context, model: "ok",
+    )
+    app.config["TESTING"] = True
+
+    with app.test_client() as client:
+        yield app, client
+
+
+def test_get_user_prefs_returns_404_when_user_concept_missing(app_client, monkeypatch):
+    _, client = app_client
+
+    import src.backend.services.concept_service as concept_service
+
+    monkeypatch.setattr(concept_service, "get_concept_by_concept_id", lambda **_: None)
+
+    resp = client.get("/api/settings/user_prefs/%23V%23missing_user")
+
+    assert resp.status_code == 404
+    assert resp.get_json()["error"] == "User concept not found"
+
+
+def test_get_user_prefs_reads_relationship_values(app_client, monkeypatch):
+    _, client = app_client
+
+    import src.backend.services.concept_service as concept_service
+
+    def _fake_get_concept_by_concept_id(*, concept_id: str, **_kwargs):
+        assert concept_id == "#V#lu_yunli"
+        return {
+            "concept_id": concept_id,
+            "relationships": {
+                "#V#preferred_language": ["en-NZ"],
+                "#V#member_of_organisation": ["#V#the_lu_witbrock_household"],
+            },
+        }
+
+    monkeypatch.setattr(
+        concept_service, "get_concept_by_concept_id", _fake_get_concept_by_concept_id
+    )
+
+    resp = client.get("/api/settings/user_prefs/%23V%23lu_yunli")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["preferred_language"] == "en-NZ"
+    assert data["organisation_concept_id"] == "#V#the_lu_witbrock_household"
+
+
+def test_set_user_prefs_updates_relationships_via_concept_service(
+    app_client, monkeypatch
+):
+    _, client = app_client
+
+    import src.backend.services.concept_service as concept_service
+
+    def _fake_get_concept_by_concept_id(*, concept_id: str, **_kwargs):
+        return {
+            "concept_id": concept_id,
+            "relationships": {
+                "#V#some_other_predicate": ["#V#untouched"],
+                "#V#preferred_language": ["en"],
+                "#V#member_of_organisation": ["#V#old_org"],
+            },
+        }
+
+    captured = {}
+
+    def _fake_update_concept(concept_id: str, update_data):
+        captured["concept_id"] = concept_id
+        captured["update_data"] = update_data
+        return {"concept_id": concept_id}
+
+    monkeypatch.setattr(
+        concept_service, "get_concept_by_concept_id", _fake_get_concept_by_concept_id
+    )
+    monkeypatch.setattr(concept_service, "update_concept", _fake_update_concept)
+
+    resp = client.post(
+        "/api/settings/user_prefs/%23V%23lu_yunli",
+        json={
+            "preferred_language": "en-NZ",
+            "organisation_concept_id": "#V#the_lu_witbrock_household",
+        },
+    )
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "success"
+    assert data["preferred_language"] == "en-NZ"
+    assert data["organisation_concept_id"] == "#V#the_lu_witbrock_household"
+
+    assert captured["concept_id"] == "#V#lu_yunli"
+    rel = captured["update_data"]["relationships"]
+    assert rel["#V#some_other_predicate"] == ["#V#untouched"]
+    assert rel["#V#preferred_language"] == ["en-NZ"]
+    assert rel["#V#member_of_organisation"] == ["#V#the_lu_witbrock_household"]


### PR DESCRIPTION
Implements the Settings/org membership work split out of JVNAUTOSCI-948:
- Settings UI refreshes organisation selector immediately on user change
- `my_organisations` prefers `#V#member_of_organisation` relationships via the concept service (fallback retained)
- User prefs routes refactored to use concept service read/update
- Adds regression tests, including a safety guard blocking accidental write-category tool calls

Tests:
- `pytest:backend (test db)` (targeted tests run)