### PR TITLE
JVNAUTOSCI-941: Stabilise resolver instance_of filtering

### DIFF
--- a/src/backend/services/concept_resolution_service.py
+++ b/src/backend/services/concept_resolution_service.py
@@ -266,28 +266,40 @@ def resolve_concept_by_name(
         # Be robust to incomplete type-hierarchy data: if descendant expansion fails to
         # locate the start node, still treat instance_of as a valid direct filter.
         if not descendant_ids:
-            if ConceptsRepository.find_one({"concept_id": instance_of}, {"_id": 1}):
-                descendant_ids = [instance_of]
+            descendant_ids = [instance_of]
             audit.append(
                 {
                     "stage": "filter",
                     "method": "instance_of_descendants_fallback",
                     "instance_of": instance_of,
-                    "descendants": len(descendant_ids),
+                    "descendants": 1,
                 }
             )
 
+        descendant_set = {str(cid) for cid in descendant_ids if cid}
+
         filtered: set[str] = set()
+        # Filter in Python rather than relying on nested $in queries. This is robust
+        # across Mongo backends and avoids subtle driver/mongomock incompatibilities.
         cursor = ConceptsRepository.find(
-            {
-                "concept_id": {"$in": list(candidate_ids)},
-                "relationships.is_an_instance_of": {"$in": descendant_ids},
-            },
-            {"concept_id": 1},
+            {"concept_id": {"$in": list(candidate_ids)}},
+            {"concept_id": 1, "relationships": 1},
         )
         for doc in cursor:
             cid = doc.get("concept_id")
-            if cid:
+            rels = doc.get("relationships") or {}
+            raw_instances = (
+                rels.get("is_an_instance_of") if isinstance(rels, dict) else None
+            )
+
+            if isinstance(raw_instances, str):
+                instance_ids = [raw_instances]
+            elif isinstance(raw_instances, list):
+                instance_ids = [x for x in raw_instances if isinstance(x, str)]
+            else:
+                instance_ids = []
+
+            if cid and any(inst in descendant_set for inst in instance_ids):
                 filtered.add(cid)
 
         audit.append(

--- a/src/backend/vontology/utils_vontology.py
+++ b/src/backend/vontology/utils_vontology.py
@@ -1601,16 +1601,41 @@ def get_vontology_node_and_descendant_ids(
     except bson_errors.InvalidId:
         start_node_query = {"name": identifier}
 
+    def _manual_descendants(start_concept_id: str) -> list[str]:
+        if not include_descendants:
+            return [start_concept_id]
+        visited: set[str] = {start_concept_id}
+        queue: list[str] = [start_concept_id]
+
+        while queue:
+            current = queue.pop(0)
+            cursor = ConceptsRepository.find(
+                {"relationships.is_a_type_of": current},
+                {"concept_id": 1},
+            )
+            for doc in cursor:
+                cid = doc.get("concept_id")
+                if isinstance(cid, str) and cid and cid not in visited:
+                    visited.add(cid)
+                    queue.append(cid)
+
+        return list(visited)
+
+    start_doc = ConceptsRepository.find_one(start_node_query, {"concept_id": 1})
+    if not start_doc or not isinstance(start_doc.get("concept_id"), str):
+        return []
+    start_concept_id = str(start_doc.get("concept_id"))
+
     # Phase 3: Updated pipeline to work with unified concepts collection
-    # and relationships.is_a_type_of structure using concept_id strings
+    # and relationships.is_a_type_of structure using concept_id strings.
     pipeline = [
-        {"$match": start_node_query},
+        {"$match": {"concept_id": start_concept_id}},
         {
             "$graphLookup": {
-                "from": CONCEPTS_COLLECTION_NAME,  # Updated to use concepts collection
-                "startWith": "$concept_id",  # Start with the concept_id string
-                "connectFromField": "concept_id",  # Connect from concept_id string
-                "connectToField": "relationships.is_a_type_of",  # Connect to Phase 3 relationship structure
+                "from": CONCEPTS_COLLECTION_NAME,
+                "startWith": "$concept_id",
+                "connectFromField": "concept_id",
+                "connectToField": "relationships.is_a_type_of",
                 "as": "descendants",
             }
         },
@@ -1618,8 +1643,8 @@ def get_vontology_node_and_descendant_ids(
             "$project": {
                 "all_concept_ids": {
                     "$concatArrays": [
-                        ["$concept_id"],  # Include the starting node's concept_id
-                        "$descendants.concept_id",  # Include descendant concept_ids
+                        ["$concept_id"],
+                        "$descendants.concept_id",
                     ]
                 }
             }
@@ -1629,22 +1654,32 @@ def get_vontology_node_and_descendant_ids(
     try:
         result = list(ConceptsRepository.aggregate(pipeline))
         if not result:
-            return []
+            return _manual_descendants(start_concept_id)
 
-        # The result is a list containing one document with an "all_concept_ids" field
-        # Return concept_id strings and remove duplicates
-        all_concept_ids = []
-        for concept_id in result[0].get("all_concept_ids", []):
-            if concept_id:  # Skip None/empty values
-                all_concept_ids.append(str(concept_id))
+        raw_ids = result[0].get("all_concept_ids", [])
+        all_concept_ids: list[str] = []
+        for concept_id in raw_ids:
+            if not concept_id:
+                continue
+            all_concept_ids.append(str(concept_id))
 
-        return list(set(all_concept_ids))  # Remove duplicates
+        # Mongomock (and some other test doubles) can incorrectly return literal
+        # field-path strings like "$concept_id" instead of actual values.
+        valid = [
+            cid
+            for cid in all_concept_ids
+            if isinstance(cid, str) and cid.startswith("#V#")
+        ]
+        if not valid:
+            return _manual_descendants(start_concept_id)
 
-    except PyMongoError as e:
+        return list(set(valid))
+
+    except Exception as e:
         logger.error(
             f"MongoDB error during get_vontology_node_and_descendant_ids for identifier '{identifier}': {e}"
         )
-        return []
+        return _manual_descendants(start_concept_id)
 
 
 def get_vontology_node_and_ancestor_instance_ids(


### PR DESCRIPTION
Fixes inconsistent behaviour in `resolve_concept_by_name` when running under mock DB / editor runners.

- Make `instance_of` filtering robust when descendant expansion is unavailable or returns invalid IDs.
- Add fallback logic for descendant discovery so tests behave consistently across real Mongo and mongomock.

Tests:
- `tests/backend/test_resolve_concept_by_name.py::test_resolve_concept_by_name_honours_instance_of_filter`