### PR TITLE
Fix Settings user concept session identity

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -3011,6 +3011,67 @@ def reset_context():
 
 
 # Phase 2: Organisation and Role Selection Endpoints
+@von_bp.route("/api/session/set_user_concept", methods=["POST"])
+def set_user_concept():
+    """Set the current user concept in the session.
+
+    This aligns the authenticated session identity with the user selected in Settings.
+
+    Request body: {user_concept_id: str}
+    Returns: {user_id, organisation_id, role, namespace, status: 'updated'}
+    """
+    try:
+        from ...services.namespace_service import derive_namespace
+
+        authenticated_id = (
+            session.get("user_id")
+            or session.get("user_concept_id")
+            or session.get("user_email")
+        )
+        if not authenticated_id:
+            return jsonify({"error": "Not authenticated"}), 401
+
+        data = request.get_json(silent=True) or {}
+        user_concept_id = data.get("user_concept_id")
+        if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+            return jsonify({"error": "user_concept_id required"}), 400
+
+        user_concept_id = user_concept_id.strip()
+        if not user_concept_id.startswith("#V#"):
+            user_concept_id = f"#V#{user_concept_id}"
+
+        user_slug = user_concept_id[3:]
+        user_slug = re.sub(r"[^a-z0-9]+", "_", user_slug.strip().lower()).strip("_")
+        namespace = derive_namespace(user_slug)
+
+        # Store the concept id for authoritative identity.
+        session["user_concept_id"] = user_concept_id
+        # Keep backward compatibility with code that still reads session['user_id'].
+        session["user_id"] = user_concept_id
+
+        # Clear org-scoped context when switching user.
+        session.pop("organisation_concept_id", None)
+        session.pop("role_in_org", None)
+        session["namespace"] = namespace
+        session.modified = True
+
+        return (
+            jsonify(
+                {
+                    "status": "updated",
+                    "user_id": user_concept_id,
+                    "organisation_id": None,
+                    "role": None,
+                    "namespace": namespace,
+                }
+            ),
+            200,
+        )
+    except Exception as e:
+        print(f"Error setting user concept: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
 @von_bp.route("/api/session/set_organisation", methods=["POST"])
 def set_organisation():
     """
@@ -3026,8 +3087,8 @@ def set_organisation():
         from ...security.role_resolver import get_user_role
 
         user_id = (
-            session.get("user_id")
-            or session.get("user_concept_id")
+            session.get("user_concept_id")
+            or session.get("user_id")
             or session.get("user_email")
         )
         if not user_id:
@@ -3041,8 +3102,10 @@ def set_organisation():
         if user_slug.startswith("#V#"):
             user_slug = user_slug[3:]
         if "@" in user_slug:
-            user_slug = user_slug.split("@")[0]
-        user_slug = user_slug.strip().lower().replace(" ", "_")
+            user_slug = user_slug.split("@", 1)[0]
+        if "+" in user_slug:
+            user_slug = user_slug.split("+", 1)[0]
+        user_slug = re.sub(r"[^a-z0-9]+", "_", user_slug.strip().lower()).strip("_")
 
         # Check if this is a clear request (empty dict or explicit null/empty string)
         is_clear_request = "organisation_concept_id" in data and not org_id
@@ -3130,8 +3193,8 @@ def get_session_context():
         from ...security.role_resolver import get_user_role
 
         user_id = (
-            session.get("user_id")
-            or session.get("user_concept_id")
+            session.get("user_concept_id")
+            or session.get("user_id")
             or session.get("user_email")
         )
         if not user_id:
@@ -3158,8 +3221,10 @@ def get_session_context():
             if user_slug.startswith("#V#"):
                 user_slug = user_slug[3:]
             if "@" in user_slug:
-                user_slug = user_slug.split("@")[0]
-            user_slug = user_slug.strip().lower().replace(" ", "_")
+                user_slug = user_slug.split("@", 1)[0]
+            if "+" in user_slug:
+                user_slug = user_slug.split("+", 1)[0]
+            user_slug = re.sub(r"[^a-z0-9]+", "_", user_slug.strip().lower()).strip("_")
             if org_id:
                 # Get role if not in session
                 if not role_in_org:

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -3285,7 +3285,9 @@ def get_my_organisations():
         if not user_id:
             return jsonify({"error": "Not authenticated"}), 401
 
-        user_concept_id = session.get("user_concept_id")
+        requested_user_concept_id = request.args.get("user_concept_id")
+        user_concept_id = requested_user_concept_id or session.get("user_concept_id")
+        user_email = session.get("user_email")
 
         def _normalise_relationships(rel):
             if not isinstance(rel, (dict, list)):
@@ -3310,21 +3312,33 @@ def get_my_organisations():
         def _prettify_concept_id(concept_id: str) -> str:
             return concept_id.replace("#V#", "").replace("_", " ").title()
 
-        # Derive a slug for stub role resolution
-        user_slug = str(user_id)
+        # Derive a slug for stub role resolution.
+        # Prefer identifiers that are stable/meaningful (concept ID or email) over
+        # opaque auth subjects.
+        slug_source = user_concept_id or user_email or user_id
+
+        user_slug = str(slug_source)
         if user_slug.startswith("#V#"):
             user_slug = user_slug[3:]
         if "@" in user_slug:
-            user_slug = user_slug.split("@")[0]
-        user_slug = user_slug.strip().lower().replace(" ", "_")
+            user_slug = user_slug.split("@", 1)[0]
+        if "+" in user_slug:
+            user_slug = user_slug.split("+", 1)[0]
+
+        import re
+
+        user_slug = re.sub(r"[^a-z0-9]+", "_", user_slug.strip().lower()).strip("_")
 
         USER_PREF_ORG_PREDICATE = "#V#member_of_organisation"
 
         organisations = []
 
-        # Prefer memberships stored on the authenticated user concept.
+        # Prefer memberships stored on the selected/authenticated user concept.
         if isinstance(user_concept_id, str) and user_concept_id.strip():
-            user_concept = get_concept_by_concept_id(concept_id=user_concept_id)
+            try:
+                user_concept = get_concept_by_concept_id(concept_id=user_concept_id)
+            except Exception:
+                user_concept = None
             if isinstance(user_concept, dict):
                 rel = _normalise_relationships(user_concept.get("relationships", {}))
                 org_raw = rel.get(USER_PREF_ORG_PREDICATE)

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -3042,26 +3042,67 @@ def set_user_concept():
 
         user_slug = user_concept_id[3:]
         user_slug = re.sub(r"[^a-z0-9]+", "_", user_slug.strip().lower()).strip("_")
-        namespace = derive_namespace(user_slug)
+
+        existing_user_concept_id = session.get("user_concept_id")
+        if isinstance(existing_user_concept_id, str):
+            existing_user_concept_id = existing_user_concept_id.strip()
+            if existing_user_concept_id and not existing_user_concept_id.startswith(
+                "#V#"
+            ):
+                existing_user_concept_id = f"#V#{existing_user_concept_id}"
+        else:
+            existing_user_concept_id = None
+
+        organisation_concept_id = session.get("organisation_concept_id")
+        role_in_org = session.get("role_in_org")
+        org_slug = None
+        if isinstance(organisation_concept_id, str) and organisation_concept_id.strip():
+            org_slug_raw = organisation_concept_id.strip()
+            if org_slug_raw.startswith("#V#"):
+                org_slug_raw = org_slug_raw[3:]
+            if "@" in org_slug_raw:
+                org_slug_raw = org_slug_raw.split("@", 1)[0]
+            if "+" in org_slug_raw:
+                org_slug_raw = org_slug_raw.split("+", 1)[0]
+            org_slug = re.sub(r"[^a-z0-9]+", "_", org_slug_raw.strip().lower()).strip(
+                "_"
+            )
+
+        namespace = derive_namespace(user_slug, org_slug, role_in_org)
 
         # Store the concept id for authoritative identity.
         session["user_concept_id"] = user_concept_id
         # Keep backward compatibility with code that still reads session['user_id'].
         session["user_id"] = user_concept_id
 
-        # Clear org-scoped context when switching user.
-        session.pop("organisation_concept_id", None)
-        session.pop("role_in_org", None)
+        # Clear org-scoped context only when switching between different user concepts.
+        # If we are simply backfilling user_concept_id for an already-authenticated session,
+        # keep any existing org selection and recompute namespace accordingly.
+        if existing_user_concept_id and existing_user_concept_id != user_concept_id:
+            organisation_concept_id = None
+            role_in_org = None
+            session.pop("organisation_concept_id", None)
+            session.pop("role_in_org", None)
         session["namespace"] = namespace
         session.modified = True
+
+        organisation_id_response = None
+        if isinstance(organisation_concept_id, str) and organisation_concept_id.strip():
+            organisation_id_response = organisation_concept_id.strip()
+            if not organisation_id_response.startswith("#V#"):
+                organisation_id_response = f"#V#{organisation_id_response}"
 
         return (
             jsonify(
                 {
-                    "status": "updated",
+                    "status": (
+                        "updated"
+                        if existing_user_concept_id != user_concept_id
+                        else "unchanged"
+                    ),
                     "user_id": user_concept_id,
-                    "organisation_id": None,
-                    "role": None,
+                    "organisation_id": organisation_id_response,
+                    "role": role_in_org,
                     "namespace": namespace,
                 }
             ),
@@ -3236,12 +3277,18 @@ def get_session_context():
             else:
                 namespace = derive_namespace(user_slug)
 
+        organisation_id_response = None
+        if isinstance(org_id, str) and org_id.strip():
+            organisation_id_response = org_id.strip()
+            if not organisation_id_response.startswith("#V#"):
+                organisation_id_response = f"#V#{organisation_id_response}"
+
         return (
             jsonify(
                 {
                     "authenticated": True,
                     "user_id": user_id,
-                    "organisation_id": org_id,
+                    "organisation_id": organisation_id_response,
                     "role": role_in_org,
                     "namespace": namespace,
                 }

--- a/src/frontend/web/von_interface/static/js/components/orgSelector.js
+++ b/src/frontend/web/von_interface/static/js/components/orgSelector.js
@@ -5,7 +5,7 @@
  * Integrates with session management to switch RAG namespace on org change.
  */
 
-import { getJson, postJson } from '../apiService.js';
+import { getJson, getUserContext, postJson } from '../apiService.js';
 
 const LS_ORG_CONTEXT = 'von_org_context';
 const LS_ORG_ROLE = 'von_org_role';
@@ -15,7 +15,13 @@ const LS_ORG_ROLE = 'von_org_role';
  */
 export async function loadMyOrganisations() {
     try {
-        const response = await getJson('/von/api/organisations/my_organisations');
+        const ctx = getUserContext();
+        const userConceptId = ctx?.user_id;
+        const url = userConceptId
+            ? `/von/api/organisations/my_organisations?user_concept_id=${encodeURIComponent(userConceptId)}`
+            : '/von/api/organisations/my_organisations';
+
+        const response = await getJson(url);
         return response.organisations || [];
     } catch (err) {
         console.error('Error loading organisations:', err);

--- a/src/frontend/web/von_interface/static/js/settingsPage.js
+++ b/src/frontend/web/von_interface/static/js/settingsPage.js
@@ -955,6 +955,23 @@ async function loadAndDisplaySettings() {
     // Override with stored local selection if present
     applyStoredSelection('currentUserSelect', getStoredJson(LS_USER_KEY));
 
+    // Align server session identity with the selected user concept on initial load.
+    // Without this, the UI can show #V#lu_yunli while the server session remains email-derived,
+    // causing org/namespace inconsistencies.
+    try {
+      const userSelect = document.getElementById('currentUserSelect');
+      const selected = userSelect?.selectedOptions?.[0];
+      const selectedConceptId = selected?.dataset?.conceptId;
+      if (selectedConceptId) {
+        const resp = await postJson('/von/api/session/set_user_concept', { user_concept_id: selectedConceptId });
+        if (resp?.namespace) {
+          try { localStorage.setItem('current_user_namespace', resp.namespace); } catch { }
+        }
+      }
+    } catch (e) {
+      console.warn('Failed to sync server session user concept (initial load)', e);
+    }
+
     // Populate Organisations and select the saved one
     await populateOrganisationsDropdown('currentOrganisationSelect', settings.current_organisation_id);
     // If we have concept_id too, attempt to match based on data attribute
@@ -988,6 +1005,17 @@ async function loadAndDisplaySettings() {
             localStorage.setItem('current_user_namespace', namespace);
           }
         } catch { }
+
+        // Keep footer/user-visible org display in sync with Phase 2 org selection.
+        try {
+          if (orgId) {
+            setStoredJson(LS_ORG_KEY, { id: null, concept_id: orgId, name: null });
+          } else {
+            setStoredJson(LS_ORG_KEY, null);
+          }
+        } catch { }
+        if (window.parent?.updateModelInfoFooterDisplay) { window.parent.updateModelInfoFooterDisplay(); }
+
         renderActiveNamespace();
         void loadRagStatus(null);
       });

--- a/src/frontend/web/von_interface/static/js/settingsPage.js
+++ b/src/frontend/web/von_interface/static/js/settingsPage.js
@@ -726,6 +726,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (opt) {
       setStoredJson(LS_USER_KEY, { id: opt.dataset.id || null, concept_id: opt.dataset.conceptId || null, name: opt.textContent || null });
       if (window.parent?.updateModelInfoFooterDisplay) { window.parent.updateModelInfoFooterDisplay(); }
+      // Keep the authenticated server session aligned with the selected user concept.
+      if (opt.dataset.conceptId) {
+        try {
+          await postJson('/von/api/session/set_user_concept', { user_concept_id: opt.dataset.conceptId });
+        } catch (e) {
+          console.warn('Failed to update server session user concept', e);
+        }
+      }
       // When user changes, attempt to load stored server-side prefs (language/org)
       if (opt.dataset.conceptId) {
         await loadUserConceptPreferences(opt.dataset.conceptId);

--- a/tests/backend/test_session_org_routes.py
+++ b/tests/backend/test_session_org_routes.py
@@ -208,6 +208,44 @@ def test_get_my_organisations_returns_stubbed_memberships(app_client):
     assert org["name"] == "University Of Auckland Strong Ai Lab"
 
 
+def test_get_my_organisations_uses_user_email_for_stub_memberships(app_client):
+    _, client = app_client
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = "opaque-oauth-subject"
+        sess["user_email"] = "lu.yunli@example.com"
+
+    resp = client.get("/von/api/organisations/my_organisations")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total_count"] == 1
+    org = data["organisations"][0]
+    assert org["concept_id"] == "#V#the_lu_witbrock_household"
+    assert org["role"] == "member"
+    assert org["name"] == "The Lu Witbrock Household"
+
+
+def test_get_my_organisations_allows_selected_user_concept_id_override(app_client):
+    _, client = app_client
+
+    # Authenticated session identity does not match stub mapping.
+    with client.session_transaction() as sess:
+        sess["user_id"] = "jeremyluyunli123@gmail.com"
+
+    resp = client.get(
+        "/von/api/organisations/my_organisations?user_concept_id=%23V%23lu_yunli"
+    )
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total_count"] == 1
+    org = data["organisations"][0]
+    assert org["concept_id"] == "#V#the_lu_witbrock_household"
+    assert org["role"] == "member"
+    assert org["name"] == "The Lu Witbrock Household"
+
+
 def test_get_my_organisations_prefers_memberships_from_user_concept_relationships(
     app_client, monkeypatch
 ):

--- a/tests/backend/test_session_org_routes.py
+++ b/tests/backend/test_session_org_routes.py
@@ -182,6 +182,36 @@ def test_get_session_context_derives_role_and_namespace_with_org(app_client):
     )
 
 
+def test_set_user_concept_updates_session_context_and_org_listing(app_client):
+    _, client = app_client
+
+    with client.session_transaction() as sess:
+        sess["user_email"] = "jeremyluyunli123@gmail.com"
+
+    resp = client.post(
+        "/von/api/session/set_user_concept", json={"user_concept_id": "#V#lu_yunli"}
+    )
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["user_id"] == "#V#lu_yunli"
+    assert data["organisation_id"] is None
+    assert data["role"] is None
+    assert data["namespace"] == "#V#lu_yunli"
+
+    ctx = client.get("/von/api/session/context")
+    assert ctx.status_code == 200
+    ctx_data = ctx.get_json()
+    assert ctx_data["user_id"] == "#V#lu_yunli"
+    assert ctx_data["namespace"] == "#V#lu_yunli"
+
+    orgs = client.get("/von/api/organisations/my_organisations")
+    assert orgs.status_code == 200
+    orgs_data = orgs.get_json()
+    assert orgs_data["total_count"] == 1
+    assert orgs_data["organisations"][0]["concept_id"] == "#V#the_lu_witbrock_household"
+
+
 def test_get_my_organisations_requires_authentication(app_client):
     _, client = app_client
 


### PR DESCRIPTION
Fixes missing organisations in Settings for users whose login email does not match their Vontology user concept.

Changes:
- Add POST /von/api/session/set_user_concept to align server session identity with selected Settings user.
- Prefer session.user_concept_id when deriving namespace and roles.
- Update Settings page to call the new endpoint when Current User changes.
- Add backend regression test covering set_user_concept + org listing.

Tests:
- pdm run pytest tests/backend/test_session_org_routes.py
- npm run test:frontend (already green in local runs)