### PR TITLE
Dev UX: stabilise VS Code Jest settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -94,7 +94,7 @@
   "jest.rootPath": "${workspaceFolder}",
   "workbench.tree.expandMode": "singleClick",
   "files.eol": "\n",
-  "jest.runMode": "deferred",
+  "jest.runMode": "on-demand",
   "github.copilot.nextEditSuggestions.enabled": true,
   "chat.instructionsFilesLocations": {
     ".github/instructions": true,
@@ -105,7 +105,7 @@
   "editor.formatOnSaveMode": "file",
   "editor.trimAutoWhitespace": true,
   "chat.edits2.enabled": true,
-  "jest.jestCommandLine": "node --unhandled-rejections=strict node_modules/jest/bin/jest.js",
+  "jest.jestCommandLine": "npm run test:frontend --",
   "git.pruneOnFetch": true,
   "editor.renderWhitespace": "selection",
   "typescript.inlayHints.enumMemberValues.enabled": true,
@@ -119,7 +119,6 @@
     "**/logs": true
   },
   "chat.editing.confirmEditRequestRemoval": false,
-  "jest.shell": "",
   "git.autofetch": true,
   "jest.enableInlineErrorMessages": true,
   "jupyter.askForKernelRestart": false,


### PR DESCRIPTION
Configure the VS Code Jest provider to run via npm script (npm run test:frontend --), set runMode to on-demand, and remove an empty jest.shell setting.