### PR TITLE
JVNAUTOSCI-952: Safe Jira write tools + Settings visibility

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -3000,6 +3000,74 @@ def _jira_transition_input_schema() -> Schema:
     )
 
 
+def _jira_create_issue_input_schema() -> Schema:
+    return Schema(
+        required={
+            "project_key": str,
+            "issue_type": str,
+            "summary": str,
+        },
+        optional={
+            "description": (str, type(None)),
+            "parent": (str, type(None)),
+            "assignee_account_id": (str, type(None)),
+            "labels": (list, type(None)),
+            "dry_run": (bool,),
+            "approved": (bool,),
+            "execute": (bool,),
+            "request_id": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "jira_create_issue input: project_key, issue_type, summary (required). "
+            "Optional description/parent/assignee_account_id/labels. "
+            "Guardrails: dry_run (default true), approved (per-write confirmation), execute (requires VON_INTERNAL_MCP_JIRA_EXECUTE_MODE=1)."
+        ),
+    )
+
+
+def _jira_update_issue_input_schema() -> Schema:
+    return Schema(
+        required={
+            "issue_key": str,
+            "update_fields": dict,
+        },
+        optional={
+            "dry_run": (bool,),
+            "approved": (bool,),
+            "execute": (bool,),
+            "request_id": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "jira_update_issue input: issue_key (required) and update_fields (dict of Jira fields to update). "
+            "Guardrails: dry_run (default true), approved (per-write confirmation), execute (requires VON_INTERNAL_MCP_JIRA_EXECUTE_MODE=1)."
+        ),
+    )
+
+
+def _jira_link_issue_input_schema() -> Schema:
+    return Schema(
+        required={
+            "inward_issue_key": str,
+            "outward_issue_key": str,
+            "link_type": str,
+        },
+        optional={
+            "comment": (str, type(None)),
+            "dry_run": (bool,),
+            "approved": (bool,),
+            "execute": (bool,),
+            "request_id": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "jira_link_issue input: inward_issue_key, outward_issue_key, link_type (required; e.g. 'Relates'). "
+            "Optional comment. Guardrails: dry_run (default true), approved, execute (requires VON_INTERNAL_MCP_JIRA_EXECUTE_MODE=1)."
+        ),
+    )
+
+
 def _jira_get_myself_input_schema() -> Schema:
     return Schema(
         required={},
@@ -3873,6 +3941,140 @@ def _gmail_modify_labels(**kwargs):
 
 
 # Jira MCP handlers
+
+_JIRA_WRITE_CACHE: dict[str, dict[str, Any]] = {}
+_JIRA_WRITE_CACHE_TTL_SEC = 3600.0
+_JIRA_WRITE_CACHE_MAX = 200
+
+
+def _jira_project_allow_list() -> list[str]:
+    import os
+
+    raw = (
+        os.getenv("VON_JIRA_PROJECT_ALLOW_LIST")
+        or os.getenv("VON_JIRA_PROJECT_ALLOWLIST")
+        or "JVNAUTOSCI"
+    )
+
+    projects: list[str] = []
+    for part in raw.split(","):
+        candidate = part.strip().upper()
+        if not candidate:
+            continue
+        if candidate not in projects:
+            projects.append(candidate)
+    return projects
+
+
+def _jira_project_from_issue_key(issue_key: str | None) -> str | None:
+    if not isinstance(issue_key, str):
+        return None
+    cleaned = issue_key.strip()
+    if not cleaned or "-" not in cleaned:
+        return None
+    return cleaned.split("-", 1)[0].upper() or None
+
+
+def _jira_execute_mode_enabled() -> bool:
+    import os
+
+    return os.getenv("VON_INTERNAL_MCP_JIRA_EXECUTE_MODE", "0").lower() in {
+        "1",
+        "true",
+    }
+
+
+def _jira_write_guardrails(
+    *,
+    action: str,
+    project_keys: list[str],
+    dry_run: bool,
+    approved: bool,
+    execute: bool,
+) -> dict[str, Any] | None:
+    allowed = _jira_project_allow_list()
+    if not allowed:
+        return {
+            "success": False,
+            "error": "Jira writes are blocked: project allow-list is empty",
+            "error_code": "allowlist_missing",
+        }
+
+    for project_key in project_keys:
+        if not project_key or project_key.upper() not in allowed:
+            return {
+                "success": False,
+                "error": f"Jira writes are blocked for project '{project_key}'. Allowed: {', '.join(allowed)}",
+                "error_code": "project_not_allowlisted",
+                "project_key": project_key,
+                "allowed_projects": allowed,
+                "action": action,
+            }
+
+    if dry_run:
+        return None
+
+    if execute and _jira_execute_mode_enabled():
+        return None
+
+    if approved:
+        return None
+
+    return {
+        "success": False,
+        "error": (
+            "Approval required for Jira write. Set approved=true to confirm this write, "
+            "or run in execute mode (set VON_INTERNAL_MCP_JIRA_EXECUTE_MODE=1 and pass execute=true)."
+        ),
+        "error_code": "approval_required",
+        "action": action,
+        "allowed_projects": allowed,
+    }
+
+
+def _jira_cache_get(tool: str, request_id: str) -> dict[str, Any] | None:
+    import time
+
+    key = f"{tool}:{request_id}"
+    record = _JIRA_WRITE_CACHE.get(key)
+    if not isinstance(record, dict):
+        return None
+    ts = record.get("timestamp")
+    if not isinstance(ts, (int, float)):
+        return None
+    if (time.time() - float(ts)) > _JIRA_WRITE_CACHE_TTL_SEC:
+        _JIRA_WRITE_CACHE.pop(key, None)
+        return None
+    cached_payload = record.get("payload")
+    if not isinstance(cached_payload, dict):
+        return None
+    return dict(cached_payload)
+
+
+def _jira_cache_set(tool: str, request_id: str, payload: dict[str, Any]) -> None:
+    import time
+
+    if len(_JIRA_WRITE_CACHE) >= _JIRA_WRITE_CACHE_MAX:
+        # Simple eviction: drop the oldest item.
+        oldest_key = None
+        oldest_ts = None
+        for k, v in _JIRA_WRITE_CACHE.items():
+            ts = v.get("timestamp") if isinstance(v, dict) else None
+            if not isinstance(ts, (int, float)):
+                continue
+            if oldest_ts is None or float(ts) < oldest_ts:
+                oldest_ts = float(ts)
+                oldest_key = k
+        if oldest_key:
+            _JIRA_WRITE_CACHE.pop(oldest_key, None)
+
+    key = f"{tool}:{request_id}"
+    _JIRA_WRITE_CACHE[key] = {
+        "timestamp": time.time(),
+        "payload": dict(payload),
+    }
+
+
 def _jira_search(**kwargs):
     import asyncio
     from .jira_proxy_mcp import get_jira_proxy, JiraProxyError
@@ -3957,6 +4159,314 @@ def _jira_transition_issue(**kwargs):
 
     try:
         return _run_async_compat(_async_transition)
+    except JiraProxyError as exc:
+        return {"error": str(exc), "success": False}
+
+
+def _jira_create_issue(**kwargs):
+    import asyncio
+    import logging
+    from .jira_proxy_mcp import get_jira_proxy, JiraProxyError
+
+    logger = logging.getLogger(__name__)
+
+    project_key = kwargs.get("project_key")
+    issue_type = kwargs.get("issue_type")
+    summary = kwargs.get("summary")
+
+    if not project_key or not issue_type or not summary:
+        return {
+            "success": False,
+            "error": "Missing required parameters: project_key, issue_type, summary",
+        }
+
+    project_key_norm = str(project_key).strip().upper()
+    dry_run = bool(kwargs.get("dry_run", True))
+    approved = bool(kwargs.get("approved", False))
+    execute = bool(kwargs.get("execute", False))
+    request_id = kwargs.get("request_id")
+
+    guardrail_error = _jira_write_guardrails(
+        action="create_issue",
+        project_keys=[project_key_norm],
+        dry_run=dry_run,
+        approved=approved,
+        execute=execute,
+    )
+    if guardrail_error is not None:
+        return guardrail_error
+
+    if isinstance(request_id, str) and request_id.strip() and not dry_run:
+        cached = _jira_cache_get("jira_create_issue", request_id.strip())
+        if cached is not None:
+            cached["reused"] = True
+            return cached
+
+    payload: dict[str, Any] = {
+        "fields": {
+            "project": {"key": project_key_norm},
+            "summary": str(summary),
+            "issuetype": {"name": str(issue_type)},
+        }
+    }
+
+    description = kwargs.get("description")
+    if isinstance(description, str) and description.strip():
+        payload["fields"]["description"] = description
+
+    parent = kwargs.get("parent")
+    if isinstance(parent, str) and parent.strip():
+        payload["fields"]["parent"] = {"key": parent.strip()}
+
+    assignee_account_id = kwargs.get("assignee_account_id")
+    if isinstance(assignee_account_id, str) and assignee_account_id.strip():
+        payload["fields"]["assignee"] = {"accountId": assignee_account_id.strip()}
+
+    labels = kwargs.get("labels")
+    if isinstance(labels, list):
+        payload["fields"]["labels"] = [str(l) for l in labels if str(l).strip()]
+
+    if dry_run:
+        return {
+            "success": True,
+            "dry_run": True,
+            "executed": False,
+            "action": "create_issue",
+            "project_key": project_key_norm,
+            "proposed_payload": payload,
+        }
+
+    async def _async_create():
+        proxy = await get_jira_proxy()
+        return await proxy.create_issue(payload=payload)
+
+    try:
+        logger.info(
+            "[jira_write] create_issue project=%s summary_preview=%r",
+            project_key_norm,
+            str(summary)[:120],
+        )
+        result = _run_async_compat(_async_create)
+        if isinstance(result, dict):
+            result = dict(result)
+            result.setdefault("success", True)
+            result["dry_run"] = False
+            result["executed"] = True
+            result["action"] = "create_issue"
+            if isinstance(request_id, str) and request_id.strip():
+                _jira_cache_set("jira_create_issue", request_id.strip(), result)
+            return result
+        return {
+            "success": True,
+            "dry_run": False,
+            "executed": True,
+            "action": "create_issue",
+            "result": result,
+        }
+    except JiraProxyError as exc:
+        return {"error": str(exc), "success": False}
+
+
+def _jira_update_issue(**kwargs):
+    import logging
+    from .jira_proxy_mcp import get_jira_proxy, JiraProxyError
+
+    logger = logging.getLogger(__name__)
+
+    issue_key = kwargs.get("issue_key")
+    update_fields = kwargs.get("update_fields")
+    if not issue_key or not isinstance(update_fields, dict):
+        return {
+            "success": False,
+            "error": "Missing required parameters: issue_key and update_fields (dict)",
+        }
+
+    issue_key_str = str(issue_key).strip()
+    project_key = _jira_project_from_issue_key(issue_key_str)
+    if not project_key:
+        return {
+            "success": False,
+            "error": "Invalid issue_key format; expected PROJECT-123",
+        }
+
+    dry_run = bool(kwargs.get("dry_run", True))
+    approved = bool(kwargs.get("approved", False))
+    execute = bool(kwargs.get("execute", False))
+    request_id = kwargs.get("request_id")
+
+    guardrail_error = _jira_write_guardrails(
+        action="update_issue",
+        project_keys=[project_key],
+        dry_run=dry_run,
+        approved=approved,
+        execute=execute,
+    )
+    if guardrail_error is not None:
+        return guardrail_error
+
+    if isinstance(request_id, str) and request_id.strip() and not dry_run:
+        cached = _jira_cache_get("jira_update_issue", request_id.strip())
+        if cached is not None:
+            cached["reused"] = True
+            return cached
+
+    # Guardrail: do not allow changing the project via this helper.
+    blocked_fields = {"project", "key", "id"}
+    safe_fields = {
+        str(k): v
+        for k, v in update_fields.items()
+        if isinstance(k, str) and k not in blocked_fields
+    }
+    if not safe_fields:
+        return {
+            "success": False,
+            "error": "No updatable fields provided (project/key/id are not allowed)",
+        }
+
+    payload: dict[str, Any] = {"fields": safe_fields}
+
+    if dry_run:
+        return {
+            "success": True,
+            "dry_run": True,
+            "executed": False,
+            "action": "update_issue",
+            "issue_key": issue_key_str,
+            "proposed_payload": payload,
+        }
+
+    async def _async_update():
+        proxy = await get_jira_proxy()
+        return await proxy.update_issue(issue_key=issue_key_str, payload=payload)
+
+    try:
+        logger.info(
+            "[jira_write] update_issue key=%s fields=%s",
+            issue_key_str,
+            sorted(safe_fields.keys())[:25],
+        )
+        result = _run_async_compat(_async_update)
+        if isinstance(result, dict):
+            result = dict(result)
+            result.setdefault("success", True)
+            result["dry_run"] = False
+            result["executed"] = True
+            result["action"] = "update_issue"
+            result["issue_key"] = issue_key_str
+            if isinstance(request_id, str) and request_id.strip():
+                _jira_cache_set("jira_update_issue", request_id.strip(), result)
+            return result
+        return {
+            "success": True,
+            "dry_run": False,
+            "executed": True,
+            "action": "update_issue",
+            "issue_key": issue_key_str,
+            "result": result,
+        }
+    except JiraProxyError as exc:
+        return {"error": str(exc), "success": False}
+
+
+def _jira_link_issue(**kwargs):
+    import logging
+    from .jira_proxy_mcp import get_jira_proxy, JiraProxyError
+
+    logger = logging.getLogger(__name__)
+
+    inward_issue_key = kwargs.get("inward_issue_key")
+    outward_issue_key = kwargs.get("outward_issue_key")
+    link_type = kwargs.get("link_type")
+    if not inward_issue_key or not outward_issue_key or not link_type:
+        return {
+            "success": False,
+            "error": "Missing required parameters: inward_issue_key, outward_issue_key, link_type",
+        }
+
+    inward_key = str(inward_issue_key).strip()
+    outward_key = str(outward_issue_key).strip()
+    inward_project = _jira_project_from_issue_key(inward_key)
+    outward_project = _jira_project_from_issue_key(outward_key)
+    if not inward_project or not outward_project:
+        return {
+            "success": False,
+            "error": "Invalid issue key format; expected PROJECT-123",
+        }
+
+    dry_run = bool(kwargs.get("dry_run", True))
+    approved = bool(kwargs.get("approved", False))
+    execute = bool(kwargs.get("execute", False))
+    request_id = kwargs.get("request_id")
+
+    guardrail_error = _jira_write_guardrails(
+        action="link_issue",
+        project_keys=[inward_project, outward_project],
+        dry_run=dry_run,
+        approved=approved,
+        execute=execute,
+    )
+    if guardrail_error is not None:
+        return guardrail_error
+
+    if isinstance(request_id, str) and request_id.strip() and not dry_run:
+        cached = _jira_cache_get("jira_link_issue", request_id.strip())
+        if cached is not None:
+            cached["reused"] = True
+            return cached
+
+    payload: dict[str, Any] = {
+        "type": {"name": str(link_type)},
+        "inwardIssue": {"key": inward_key},
+        "outwardIssue": {"key": outward_key},
+    }
+
+    comment = kwargs.get("comment")
+    if isinstance(comment, str) and comment.strip():
+        payload["comment"] = {"body": comment}
+
+    if dry_run:
+        return {
+            "success": True,
+            "dry_run": True,
+            "executed": False,
+            "action": "link_issue",
+            "inward_issue_key": inward_key,
+            "outward_issue_key": outward_key,
+            "link_type": str(link_type),
+            "proposed_payload": payload,
+        }
+
+    async def _async_link():
+        proxy = await get_jira_proxy()
+        return await proxy.link_issue(payload=payload)
+
+    try:
+        logger.info(
+            "[jira_write] link_issue %s -> %s (%s)",
+            outward_key,
+            inward_key,
+            str(link_type),
+        )
+        result = _run_async_compat(_async_link)
+        if isinstance(result, dict):
+            result = dict(result)
+            result.setdefault("success", True)
+            result["dry_run"] = False
+            result["executed"] = True
+            result["action"] = "link_issue"
+            result["inward_issue_key"] = inward_key
+            result["outward_issue_key"] = outward_key
+            result["link_type"] = str(link_type)
+            if isinstance(request_id, str) and request_id.strip():
+                _jira_cache_set("jira_link_issue", request_id.strip(), result)
+            return result
+        return {
+            "success": True,
+            "dry_run": False,
+            "executed": True,
+            "action": "link_issue",
+            "result": result,
+        }
     except JiraProxyError as exc:
         return {"error": str(exc), "success": False}
 
@@ -4374,6 +4884,9 @@ def build_default_catalogue() -> MethodCatalogue:
     jira_get_issue_output_schema = _jira_generic_output_schema("get_issue")
     jira_add_comment_output_schema = _jira_generic_output_schema("add_comment")
     jira_transition_output_schema = _jira_generic_output_schema("transition")
+    jira_create_issue_output_schema = _jira_generic_output_schema("create_issue")
+    jira_update_issue_output_schema = _jira_generic_output_schema("update_issue")
+    jira_link_issue_output_schema = _jira_generic_output_schema("link_issue")
     jira_get_myself_output_schema = _jira_generic_output_schema("get_myself")
     jira_get_auth_config_output_schema = _jira_get_auth_config_output_schema()
     gmail_list_messages_input_schema = Schema(
@@ -4969,6 +5482,45 @@ def build_default_catalogue() -> MethodCatalogue:
             category="write",
             timeout_sec=15.0,
             description="Add a comment to a Jira issue. Use to log investigation notes or status updates. Requires issue key and comment text.",
+        ),
+        MethodDefinition(
+            name="jira_create_issue",
+            handler=_jira_create_issue,
+            input_schema=_jira_create_issue_input_schema(),
+            output_schema=jira_create_issue_output_schema,
+            category="write",
+            timeout_sec=20.0,
+            description=(
+                "Create a Jira issue with safety guardrails. Default dry_run=true (no mutation). "
+                "Writes are allowed only for allow-listed projects (default JVNAUTOSCI). "
+                "To execute, pass dry_run=false and either approved=true (per write) or execute=true with VON_INTERNAL_MCP_JIRA_EXECUTE_MODE=1."
+            ),
+        ),
+        MethodDefinition(
+            name="jira_update_issue",
+            handler=_jira_update_issue,
+            input_schema=_jira_update_issue_input_schema(),
+            output_schema=jira_update_issue_output_schema,
+            category="write",
+            timeout_sec=20.0,
+            description=(
+                "Update a Jira issue with safety guardrails. Default dry_run=true (no mutation). "
+                "Writes are blocked unless the issue belongs to an allow-listed project. "
+                "To execute, pass dry_run=false and either approved=true or execute=true with VON_INTERNAL_MCP_JIRA_EXECUTE_MODE=1."
+            ),
+        ),
+        MethodDefinition(
+            name="jira_link_issue",
+            handler=_jira_link_issue,
+            input_schema=_jira_link_issue_input_schema(),
+            output_schema=jira_link_issue_output_schema,
+            category="write",
+            timeout_sec=20.0,
+            description=(
+                "Create a Jira issue link (e.g. Relates) with safety guardrails. Default dry_run=true (no mutation). "
+                "Both issue projects must be allow-listed. "
+                "To execute, pass dry_run=false and either approved=true or execute=true with VON_INTERNAL_MCP_JIRA_EXECUTE_MODE=1."
+            ),
         ),
         MethodDefinition(
             name="jira_transition",

--- a/src/backend/integrations/internal_mcp/jira_proxy_mcp.py
+++ b/src/backend/integrations/internal_mcp/jira_proxy_mcp.py
@@ -94,6 +94,19 @@ class JiraMCPProxy:
             "jira_transition", {"issue_key": issue_key, "transition_id": transition_id}
         )
 
+    async def create_issue(self, *, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return await self._call("jira_create_issue", {"payload": payload})
+
+    async def update_issue(
+        self, *, issue_key: str, payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        return await self._call(
+            "jira_update_issue", {"issue_key": issue_key, "payload": payload}
+        )
+
+    async def link_issue(self, *, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return await self._call("jira_link_issue", {"payload": payload})
+
     async def get_myself(self) -> Dict[str, Any]:
         return await self._call("jira_get_myself", {})
 

--- a/src/backend/mcp_server/mcp_server.py
+++ b/src/backend/mcp_server/mcp_server.py
@@ -1,6 +1,7 @@
 import os
 import base64
 import json
+import time
 from typing import Any, Dict, List, Sequence
 
 import anyio
@@ -85,37 +86,84 @@ def _request_json(
     params: Dict[str, Any] | None = None,
     payload: Dict[str, Any] | None = None,
 ) -> Dict[str, Any]:
-    try:
-        if method.upper() == "GET":
-            resp = requests.get(url, headers=HEADERS, params=params, timeout=30)
-        elif method.upper() == "POST":
-            resp = requests.post(url, headers=HEADERS, json=payload, timeout=30)
-        else:
-            return {"success": False, "error": f"Unsupported HTTP method: {method}"}
+    max_attempts = 3
+    delay_sec = 0.5
 
-        if resp.ok:
-            return resp.json()
-
-        hint = _jira_error_hint(resp.status_code, url=url)
-        response_text = None
+    for attempt in range(1, max_attempts + 1):
         try:
-            response_text = resp.text
-        except Exception:
-            response_text = None
+            resp = requests.request(
+                method.upper(),
+                url,
+                headers=HEADERS,
+                params=params,
+                json=payload,
+                timeout=30,
+            )
 
-        error: Dict[str, Any] = {
-            "success": False,
-            "status_code": resp.status_code,
-            "url": url,
-            "error": f"Jira API HTTP {resp.status_code}",
-        }
-        if response_text:
-            error["response"] = response_text[:2000]
-        if hint:
-            error["hint"] = hint
-        return error
-    except requests.exceptions.RequestException as exc:
-        return {"success": False, "error": f"Jira request failed: {exc}"}
+            if resp.ok:
+                # Jira sometimes returns 204/empty bodies for updates/links.
+                try:
+                    body_text = resp.text
+                except Exception:
+                    body_text = ""
+                if not body_text or not body_text.strip():
+                    return {
+                        "success": True,
+                        "status_code": resp.status_code,
+                        "url": url,
+                    }
+                try:
+                    return resp.json()
+                except Exception:
+                    return {
+                        "success": True,
+                        "status_code": resp.status_code,
+                        "url": url,
+                        "response": body_text[:2000],
+                    }
+
+            # Rate limiting: bounded retry/backoff.
+            if resp.status_code == 429 and attempt < max_attempts:
+                retry_after_header = resp.headers.get("Retry-After")
+                retry_after_sec: float | None = None
+                if retry_after_header:
+                    try:
+                        retry_after_sec = float(retry_after_header)
+                    except Exception:
+                        retry_after_sec = None
+                sleep_for = (
+                    retry_after_sec if retry_after_sec is not None else delay_sec
+                )
+                time.sleep(max(0.1, min(sleep_for, 10.0)))
+                delay_sec = min(delay_sec * 2.0, 8.0)
+                continue
+
+            hint = _jira_error_hint(resp.status_code, url=url)
+            response_text = None
+            try:
+                response_text = resp.text
+            except Exception:
+                response_text = None
+
+            error: Dict[str, Any] = {
+                "success": False,
+                "status_code": resp.status_code,
+                "url": url,
+                "error": f"Jira API HTTP {resp.status_code}",
+            }
+            if response_text:
+                error["response"] = response_text[:2000]
+            if hint:
+                error["hint"] = hint
+            return error
+        except requests.exceptions.RequestException as exc:
+            if attempt < max_attempts:
+                time.sleep(max(0.1, min(delay_sec, 8.0)))
+                delay_sec = min(delay_sec * 2.0, 8.0)
+                continue
+            return {"success": False, "error": f"Jira request failed: {exc}"}
+
+    return {"success": False, "error": "Jira request failed after retries"}
 
 
 def jira_get(endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
@@ -126,6 +174,11 @@ def jira_get(endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, A
 def jira_post(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     url = f"{JIRA_BASE_URL}/rest/api/3/{endpoint}"
     return _request_json("POST", url, payload=payload)
+
+
+def jira_put(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    url = f"{JIRA_BASE_URL}/rest/api/3/{endpoint}"
+    return _request_json("PUT", url, payload=payload)
 
 
 # ---------------------------------------------------------
@@ -219,6 +272,61 @@ async def list_tools() -> List[types.Tool]:
                 "properties": {},
             },
         ),
+        types.Tool(
+            name="jira_create_issue",
+            description=(
+                "Create a Jira issue via POST /rest/api/3/issue. "
+                "The caller must provide the exact Jira payload dict (fields, etc.)."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "payload": {
+                        "type": "object",
+                        "description": "Jira create issue payload to send as JSON body.",
+                    }
+                },
+                "required": ["payload"],
+            },
+        ),
+        types.Tool(
+            name="jira_update_issue",
+            description=(
+                "Update a Jira issue via PUT /rest/api/3/issue/{issue_key}. "
+                "The caller must provide the exact Jira payload dict (fields, update, etc.)."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "issue_key": {
+                        "type": "string",
+                        "description": "Issue key, e.g. JVNAUTOSCI-371",
+                    },
+                    "payload": {
+                        "type": "object",
+                        "description": "Jira update issue payload to send as JSON body.",
+                    },
+                },
+                "required": ["issue_key", "payload"],
+            },
+        ),
+        types.Tool(
+            name="jira_link_issue",
+            description=(
+                "Create an issue link via POST /rest/api/3/issueLink. "
+                "The caller must provide the exact Jira payload dict (type, inwardIssue, outwardIssue, etc.)."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "payload": {
+                        "type": "object",
+                        "description": "Jira issueLink payload to send as JSON body.",
+                    }
+                },
+                "required": ["payload"],
+            },
+        ),
     ]
 
 
@@ -288,6 +396,43 @@ async def call_tool(
 
     elif name == "jira_get_myself":
         result = jira_get("myself")
+        text = json.dumps(result, indent=2)
+        return [types.TextContent(type="text", text=text)]
+
+    elif name == "jira_create_issue":
+        payload = arguments["payload"]
+        if not isinstance(payload, dict):
+            error = {
+                "success": False,
+                "error": "payload must be an object",
+            }
+            return [types.TextContent(type="text", text=json.dumps(error, indent=2))]
+        result = jira_post("issue", payload)
+        text = json.dumps(result, indent=2)
+        return [types.TextContent(type="text", text=text)]
+
+    elif name == "jira_update_issue":
+        issue_key = arguments["issue_key"]
+        payload = arguments["payload"]
+        if not isinstance(payload, dict):
+            error = {
+                "success": False,
+                "error": "payload must be an object",
+            }
+            return [types.TextContent(type="text", text=json.dumps(error, indent=2))]
+        result = jira_put(f"issue/{issue_key}", payload)
+        text = json.dumps(result, indent=2)
+        return [types.TextContent(type="text", text=text)]
+
+    elif name == "jira_link_issue":
+        payload = arguments["payload"]
+        if not isinstance(payload, dict):
+            error = {
+                "success": False,
+                "error": "payload must be an object",
+            }
+            return [types.TextContent(type="text", text=json.dumps(error, indent=2))]
+        result = jira_post("issueLink", payload)
         text = json.dumps(result, indent=2)
         return [types.TextContent(type="text", text=text)]
 

--- a/src/backend/server/routes/settings_routes.py
+++ b/src/backend/server/routes/settings_routes.py
@@ -487,6 +487,25 @@ def _get_entity_with_fallback(
 def get_all_settings_data():
     """Get all settings (user/org/language now excluded - browser-local)."""
     try:
+        # Jira internal MCP guardrail environment settings (read-only; surfaced for visibility).
+        jira_allow_list_raw = os.getenv("VON_JIRA_PROJECT_ALLOW_LIST") or os.getenv(
+            "VON_JIRA_PROJECT_ALLOWLIST"
+        )
+        jira_allow_list_effective_raw = jira_allow_list_raw or "JVNAUTOSCI"
+        jira_allow_list_effective: list[str] = []
+        for part in jira_allow_list_effective_raw.split(","):
+            candidate = part.strip().upper()
+            if not candidate:
+                continue
+            if candidate not in jira_allow_list_effective:
+                jira_allow_list_effective.append(candidate)
+
+        jira_execute_mode_raw = os.getenv("VON_INTERNAL_MCP_JIRA_EXECUTE_MODE", "0")
+        jira_execute_mode_enabled = str(jira_execute_mode_raw).strip().lower() in {
+            "1",
+            "true",
+        }
+
         return {
             "active_llm": get_active_llm_setting(),
             "openai_api_key_env_var": get_openai_env_var(),
@@ -495,6 +514,10 @@ def get_all_settings_data():
             "internal_mcp_max_tool_invocations": get_internal_mcp_max_tool_invocations(),
             "internal_mcp_tool_batch_cap": get_internal_mcp_tool_batch_cap(),
             "show_tool_use_during_thinking": get_show_tool_use_during_thinking(),
+            "jira_project_allow_list_raw": jira_allow_list_raw,
+            "jira_project_allow_list_effective": jira_allow_list_effective,
+            "internal_mcp_jira_execute_mode_raw": jira_execute_mode_raw,
+            "internal_mcp_jira_execute_mode_enabled": jira_execute_mode_enabled,
         }
     except Exception as e:
         current_app.logger.error(f"Error retrieving settings data: {e}", exc_info=True)

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -7,7 +7,7 @@ import secrets
 import uuid
 from datetime import datetime, timezone
 from typing import Any
-from workflows.onboarding_workflow import run_onboarding_workflow  # fixed import path
+from src.workflows.onboarding_workflow import run_onboarding_workflow
 from ...languagemodels.llm_interface import get_llm_client, get_active_model_name
 from .settings_routes import get_all_settings_data
 from ...integrations.internal_mcp import ToolCallParsingError

--- a/src/frontend/web/von_interface/static/js/settingsPage.js
+++ b/src/frontend/web/von_interface/static/js/settingsPage.js
@@ -1076,6 +1076,21 @@ async function loadAndDisplaySettings() {
       }
     } catch { }
 
+    // Populate Jira tool guardrails (read-only env visibility)
+    try {
+      const { allowListText, executeModeText } = __testOnly_formatJiraGuardrailSettings(settings);
+
+      const allowEl = document.getElementById('settingsJiraProjectAllowListValue');
+      if (allowEl) {
+        allowEl.textContent = allowListText || 'JVNAUTOSCI';
+      }
+
+      const executeEl = document.getElementById('settingsJiraExecuteModeValue');
+      if (executeEl) {
+        executeEl.textContent = executeModeText || 'disabled (0)';
+      }
+    } catch { }
+
     // Populate preferred language setting
     const languageSelect = document.getElementById('preferredLanguageSelect');
     if (languageSelect) {
@@ -1467,6 +1482,34 @@ export async function saveSettings(settings) {
     console.error('Error saving settings:', error);
     throw error;
   }
+}
+
+export function __testOnly_formatJiraGuardrailSettings(settings) {
+  const rawAllow = typeof settings?.jira_project_allow_list_raw === 'string'
+    ? settings.jira_project_allow_list_raw
+    : null;
+
+  let effective = settings?.jira_project_allow_list_effective;
+  if (!Array.isArray(effective) || !effective.length) {
+    effective = ['JVNAUTOSCI'];
+  }
+  const allowListText = effective.map(x => String(x)).filter(Boolean).join(', ');
+
+  const rawExecute = (settings && Object.prototype.hasOwnProperty.call(settings, 'internal_mcp_jira_execute_mode_raw'))
+    ? String(settings.internal_mcp_jira_execute_mode_raw)
+    : '0';
+
+  const enabled = !!settings?.internal_mcp_jira_execute_mode_enabled;
+  const executeModeText = enabled
+    ? `enabled (${rawExecute})`
+    : `disabled (${rawExecute})`;
+
+  return {
+    allowListText,
+    rawAllow,
+    executeModeText,
+    executeModeEnabled: enabled
+  };
 }
 
 export function validateSettings() {

--- a/src/frontend/web/von_interface/templates/settings_tab.html
+++ b/src/frontend/web/von_interface/templates/settings_tab.html
@@ -178,6 +178,27 @@
             </div>
             <small id="showToolUseDuringThinkingHelp" class="settings-note">Default: enabled. Shows last tool name,
                 batch size, and remaining tool-call budget.</small>
+
+            <h3 class="mt-3">Jira Tool Guardrails</h3>
+            <p class="settings-note">Read-only visibility into the environment guardrails used by the internal MCP Jira
+                write tools. To change these values, update your environment and restart Von.</p>
+
+            <div class="inline-form inline-form-tight">
+                <span class="settings-note"><strong>Allowed Jira projects:</strong></span>
+                <button id="settingsJiraProjectAllowListValue" class="runtime-copy-button ml-2" type="button"
+                    title="Copy project allow-list">—</button>
+            </div>
+            <small class="settings-note">From <code>VON_JIRA_PROJECT_ALLOW_LIST</code>. Default:
+                <code>JVNAUTOSCI</code>.
+                Comma-separated project keys.</small>
+
+            <div class="inline-form inline-form-tight mt-2">
+                <span class="settings-note"><strong>Jira execute mode:</strong></span>
+                <button id="settingsJiraExecuteModeValue" class="runtime-copy-button ml-2" type="button"
+                    title="Copy execute-mode state">—</button>
+            </div>
+            <small class="settings-note">From <code>VON_INTERNAL_MCP_JIRA_EXECUTE_MODE</code>. When enabled, callers may
+                pass <code>execute=true</code> to run writes without per-call <code>approved=true</code>.</small>
         </section>
 
         <section id="current-user-settings">

--- a/tests/backend/test_internal_mcp_jira_tools.py
+++ b/tests/backend/test_internal_mcp_jira_tools.py
@@ -8,6 +8,9 @@ from src.backend.integrations.internal_mcp.catalogue import (
     _jira_search,
     _jira_get_issue,
     _jira_add_comment,
+    _jira_create_issue,
+    _jira_update_issue,
+    _jira_link_issue,
     _jira_transition_issue,
     build_default_catalogue,
 )
@@ -19,6 +22,9 @@ def test_jira_methods_registered_in_catalogue():
     assert "jira_search" in names
     assert "jira_get_issue" in names
     assert "jira_add_comment" in names
+    assert "jira_create_issue" in names
+    assert "jira_update_issue" in names
+    assert "jira_link_issue" in names
     assert "jira_transition" in names
     assert "jira_get_myself" in names
     assert "jira_get_auth_config" in names
@@ -43,3 +49,88 @@ def test_jira_handlers_require_minimum_fields():
     assert err_transition.get("success") is False
     err_msg = err_transition.get("error", "")
     assert "issue_key" in err_msg and "transition_id" in err_msg
+
+    err_create = _jira_create_issue(project_key=None, issue_type=None, summary=None)
+    assert err_create.get("success") is False
+    assert "project_key" in err_create.get("error", "")
+
+    err_update = _jira_update_issue(issue_key=None, update_fields=None)
+    assert err_update.get("success") is False
+    assert "issue_key" in err_update.get("error", "")
+
+    err_link = _jira_link_issue(
+        inward_issue_key=None, outward_issue_key=None, link_type=None
+    )
+    assert err_link.get("success") is False
+    assert "inward_issue_key" in err_link.get("error", "")
+
+
+def test_jira_write_tools_allowlist_and_dry_run_defaults():
+    # Default allow-list includes JVNAUTOSCI.
+    ok_create = _jira_create_issue(
+        project_key="JVNAUTOSCI",
+        issue_type="Task",
+        summary="Test create",
+    )
+    assert ok_create.get("success") is True
+    assert ok_create.get("dry_run") is True
+    assert ok_create.get("executed") is False
+    assert (
+        ok_create.get("proposed_payload", {})
+        .get("fields", {})
+        .get("project", {})
+        .get("key")
+        == "JVNAUTOSCI"
+    )
+
+    bad_create = _jira_create_issue(
+        project_key="OTHER",
+        issue_type="Task",
+        summary="Not allowed",
+    )
+    assert bad_create.get("success") is False
+    assert bad_create.get("error_code") == "project_not_allowlisted"
+
+    ok_update = _jira_update_issue(
+        issue_key="JVNAUTOSCI-123",
+        update_fields={"summary": "Updated"},
+    )
+    assert ok_update.get("success") is True
+    assert ok_update.get("dry_run") is True
+    assert ok_update.get("executed") is False
+
+    bad_update = _jira_update_issue(
+        issue_key="OTHER-1",
+        update_fields={"summary": "Updated"},
+    )
+    assert bad_update.get("success") is False
+    assert bad_update.get("error_code") == "project_not_allowlisted"
+
+    ok_link = _jira_link_issue(
+        inward_issue_key="JVNAUTOSCI-1",
+        outward_issue_key="JVNAUTOSCI-2",
+        link_type="Relates",
+    )
+    assert ok_link.get("success") is True
+    assert ok_link.get("dry_run") is True
+    assert ok_link.get("executed") is False
+
+    bad_link = _jira_link_issue(
+        inward_issue_key="JVNAUTOSCI-1",
+        outward_issue_key="OTHER-2",
+        link_type="Relates",
+    )
+    assert bad_link.get("success") is False
+    assert bad_link.get("error_code") == "project_not_allowlisted"
+
+
+def test_jira_write_tools_require_approval_when_not_dry_run():
+    # Should fail closed before any external call.
+    err = _jira_create_issue(
+        project_key="JVNAUTOSCI",
+        issue_type="Task",
+        summary="Real create",
+        dry_run=False,
+    )
+    assert err.get("success") is False
+    assert err.get("error_code") == "approval_required"

--- a/tests/frontend/settingsJiraGuardrails.test.js
+++ b/tests/frontend/settingsJiraGuardrails.test.js
@@ -1,0 +1,37 @@
+/** @jest-environment jsdom */
+
+const {
+    __testOnly_formatJiraGuardrailSettings
+} = require('../../src/frontend/web/von_interface/static/js/settingsPage.js');
+
+describe('Settings page Jira guardrails', () => {
+    test('defaults to JVNAUTOSCI allow-list when missing', () => {
+        const { allowListText } = __testOnly_formatJiraGuardrailSettings({});
+        expect(allowListText).toBe('JVNAUTOSCI');
+    });
+
+    test('formats allow-list and execute-mode enabled', () => {
+        const settings = {
+            jira_project_allow_list_raw: 'JVNAUTOSCI, KKAT',
+            jira_project_allow_list_effective: ['JVNAUTOSCI', 'KKAT'],
+            internal_mcp_jira_execute_mode_raw: '1',
+            internal_mcp_jira_execute_mode_enabled: true
+        };
+
+        const { allowListText, executeModeText, executeModeEnabled } = __testOnly_formatJiraGuardrailSettings(settings);
+        expect(allowListText).toBe('JVNAUTOSCI, KKAT');
+        expect(executeModeEnabled).toBe(true);
+        expect(executeModeText).toBe('enabled (1)');
+    });
+
+    test('formats execute-mode disabled when falsey', () => {
+        const settings = {
+            jira_project_allow_list_effective: ['JVNAUTOSCI'],
+            internal_mcp_jira_execute_mode_raw: '0',
+            internal_mcp_jira_execute_mode_enabled: false
+        };
+
+        const { executeModeText } = __testOnly_formatJiraGuardrailSettings(settings);
+        expect(executeModeText).toBe('disabled (0)');
+    });
+});


### PR DESCRIPTION
Implements safe-by-default Jira write tools in Von’s internal MCP gateway (create/update/link), with allow-list + approval gate + dry-run preview, and surfaces the guardrail env settings in the Settings UI.

Tests:
- pdm run pytest tests/backend/test_internal_mcp_jira_tools.py -q
- npm run test:frontend