### PR TITLE
JVNAUTOSCI-954: Safe client capability introspection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,51 @@ This is not hypothetical. The Atlassian MCP server can and does fail intermitten
 - Do not change scope (“I’ll do code changes instead”) without explicit user agreement.
 - Do not fabricate a Jira state update (if we didn’t get a success response, assume it did not happen).
 
+### Atlassian MCP broken (Copilot Agent Mode) — checklist
+
+Ordered by fastest → most invasive.
+
+1. First thing to try (often fixes it)
+  - `Ctrl + Shift + P` → **Developer: Reload Window**
+  - This restarts the extension host and often re-injects OAuth correctly.
+
+2. If it still 401s or says `invalid_token`
+  - `Ctrl + Shift + P` → **Atlassian: Open Settings**
+  - Sign out → sign in again if prompted
+
+3. If logs show `Canceled: Canceled` during token fetch
+  - Retry the action and watch the Notifications bell
+  - Explicitly **Allow / Open external website** if prompted
+  - Missing this can silently cancel OAuth → MCP connects without a token.
+
+4. If MCP keeps failing immediately
+  - Close VS Code, then in PowerShell:
+    ```powershell
+    taskkill /IM atlassian_cli_rovodev.exe /F
+    ```
+  - Optionally free the port:
+    ```powershell
+    netstat -ano | findstr 40000
+    taskkill /PID <pid> /F
+    ```
+  - Reopen VS Code → **Developer: Reload Window**
+
+5. If it’s still wedged (rare)
+  - Close VS Code and delete:
+    - `%APPDATA%\Code - Insiders\User\globalStorage\atlassian.atlascode`
+    - `%APPDATA%\Code - Insiders\User\workspaceStorage\*\atlassian.atlascode`
+  - Reopen VS Code → **Atlassian: Open Settings**
+
+6. Hardening (prevents recurrence)
+  - Keep in PowerShell profile:
+    ```powershell
+    $env:ATLASSIAN_CLOUD_ID = "b2b12142-9002-4b11-b421-83f073678fd3"
+    ```
+  - Disable Atlassian Rovo / AI features unless you actually need them.
+
+One-line memory hook:
+**Atlassian MCP 401? Reload Window → Atlassian: Open Settings.**
+
 **If the failure smells like config rather than flakiness:**
 - If the error is consistently “cloudId missing/invalid”, use the Cloud ID fast path below.
 - Cache/Data Structure Sensitivity: Never reorder or shrink tuple/dict cache structures relied upon by diagnostics (append only; update summariser accordingly).

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -123,6 +123,20 @@ def _get_context(**kwargs):
     return context
 
 
+def _get_client_capabilities(**kwargs):
+    """Return the current client-reported capabilities snapshot (if any).
+
+    Notes:
+    - Stored per server-side session.
+    - Client-reported and non-authoritative.
+    - May be None if the client has not reported yet or no request context.
+    """
+
+    from ...services.client_capabilities_service import get_client_capabilities_snapshot
+
+    return {"success": True, "capabilities": get_client_capabilities_snapshot()}
+
+
 def _get_paper_metadata(**kwargs):
     import asyncio
     from .arxiv_proxy_mcp import get_arxiv_proxy, ArxivProxyError
@@ -4955,6 +4969,34 @@ def build_default_catalogue() -> MethodCatalogue:
             ),
             category="read",
             description="Get current server-side context: active LLM model (string), provider, language preference, and runtime settings. NOTE: User and organisation information is managed client-side (localStorage) per JVNAUTOSCI-628 and may not be available here. Use when you need to know what model/language is configured.",
+        ),
+        MethodDefinition(
+            name="get_client_capabilities",
+            handler=_get_client_capabilities,
+            input_schema=Schema(
+                required={},
+                optional={},
+                allow_unknown=False,
+                description="Return the current session's last reported client capabilities snapshot (no input parameters).",
+            ),
+            output_schema=Schema(
+                required={
+                    "success": bool,
+                    "capabilities": (dict, type(None)),
+                },
+                optional={},
+                allow_unknown=True,
+                description=(
+                    "Client capability snapshot as last reported by the browser (bounded, non-authoritative). "
+                    "Returns capabilities=null if not available."
+                ),
+            ),
+            category="read",
+            description=(
+                "Get the browser-reported client capability snapshot for the current session (speech synthesis, "
+                "speech recognition, and basic audio hints). Use for debugging speech/narration behaviours without "
+                "collecting high-fidelity fingerprinting data."
+            ),
         ),
         MethodDefinition(
             name="chat_get_prompt_context",

--- a/src/backend/server/routes/client_capabilities_routes.py
+++ b/src/backend/server/routes/client_capabilities_routes.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from src.backend.services.client_capabilities_service import (
+    get_client_capabilities_snapshot,
+    sanitise_client_capabilities,
+    set_client_capabilities_snapshot,
+)
+
+
+client_capabilities_bp = Blueprint(
+    "client_capabilities_bp", __name__, url_prefix="/api/client_capabilities"
+)
+
+
+@client_capabilities_bp.route("", methods=["GET"])
+def get_client_capabilities():
+    snapshot = get_client_capabilities_snapshot()
+    return jsonify({"success": True, "capabilities": snapshot})
+
+
+@client_capabilities_bp.route("", methods=["POST"])
+def set_client_capabilities():
+    raw_payload = request.get_json(silent=True)
+
+    snapshot = sanitise_client_capabilities(
+        raw_payload,
+        user_agent=request.headers.get("User-Agent"),
+    )
+
+    set_client_capabilities_snapshot(snapshot)
+
+    return jsonify({"success": True, "stored": snapshot})

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -48,6 +48,7 @@ from .routes.agent_gmail_oauth_routes import agent_gmail_oauth_bp
 from .routes.predicate_routes import predicate_bp
 from .routes.workflows_routes import workflows_bp
 from .routes.room_device_routes import room_device_bp
+from .routes.client_capabilities_routes import client_capabilities_bp
 from ..db.connection_manager import (
     ensure_monitor_started,
     get_db,
@@ -194,6 +195,7 @@ def create_flask_app(
     app.register_blueprint(predicate_bp)  # Already has /api/predicates prefix
     app.register_blueprint(workflows_bp)  # /api/workflows/*
     app.register_blueprint(room_device_bp)
+    app.register_blueprint(client_capabilities_bp)
     app.register_blueprint(admin_bp, url_prefix="/admin")
     app.register_blueprint(
         auth_bp, url_prefix="/von"

--- a/src/backend/services/client_capabilities_service.py
+++ b/src/backend/services/client_capabilities_service.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+
+_SESSION_KEY = "client_capabilities_snapshot"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _clamp_int(value: Any, *, minimum: int = 0, maximum: int = 10_000) -> int:
+    try:
+        parsed = int(value)
+    except Exception:
+        return minimum
+
+    if parsed < minimum:
+        return minimum
+    if parsed > maximum:
+        return maximum
+    return parsed
+
+
+def _normalise_bool(value: Any) -> bool:
+    return bool(value)
+
+
+def _truncate_str(value: Any, *, max_chars: int) -> str:
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        value = str(value)
+    value = value.strip()
+    if max_chars <= 0 or len(value) <= max_chars:
+        return value
+    return value[:max_chars]
+
+
+def _normalise_lang(value: Any) -> str | None:
+    text = _truncate_str(value, max_chars=32)
+    if not text:
+        return None
+    # Keep it permissive: BCP 47-ish; don't over-validate.
+    if not re.match(r"^[A-Za-z]{2,3}([\-][A-Za-z0-9]{2,8})*$", text):
+        return None
+    return text
+
+
+def _summarise_user_agent(user_agent: str | None) -> dict[str, str | int | None]:
+    ua = (user_agent or "").strip()
+
+    def _major(pattern: str) -> int | None:
+        match = re.search(pattern, ua)
+        if not match:
+            return None
+        try:
+            return int(match.group(1))
+        except Exception:
+            return None
+
+    # Order matters.
+    if "Edg/" in ua:
+        return {"browser_family": "Edge", "major_version": _major(r"Edg/(\d+)")}
+    if "Chrome/" in ua and "Chromium" not in ua:
+        return {"browser_family": "Chrome", "major_version": _major(r"Chrome/(\d+)")}
+    if "Firefox/" in ua:
+        return {"browser_family": "Firefox", "major_version": _major(r"Firefox/(\d+)")}
+    if "Safari/" in ua and "Chrome/" not in ua:
+        return {"browser_family": "Safari", "major_version": _major(r"Version/(\d+)")}
+
+    return {"browser_family": "Other", "major_version": None}
+
+
+def sanitise_client_capabilities(
+    raw: Any,
+    *,
+    user_agent: str | None = None,
+    received_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Return a safe, bounded snapshot of client-reported capabilities.
+
+    Security notes:
+    - Treat everything as client-reported and non-authoritative.
+    - Never store or return secrets.
+    - Cap list sizes and string lengths to prevent session bloat.
+    """
+
+    payload: dict[str, Any] = raw if isinstance(raw, dict) else {}
+
+    snapshot: dict[str, Any] = {
+        "kind": "client_capabilities",
+        "client_reported": True,
+        "received_at_utc": received_at_utc or _utc_now_iso(),
+        "client_reported_timestamp": _truncate_str(
+            payload.get("client_reported_timestamp"), max_chars=64
+        )
+        or None,
+        "user_agent_summary": _summarise_user_agent(user_agent),
+    }
+
+    speech_raw = payload.get("speech_synthesis")
+    speech: dict[str, Any] = speech_raw if isinstance(speech_raw, dict) else {}
+
+    voices_sample_raw = speech.get("voices_sample")
+    voices_sample_in = voices_sample_raw if isinstance(voices_sample_raw, list) else []
+    voices_sample_out: list[dict[str, Any]] = []
+
+    for item in voices_sample_in[:8]:
+        voice = item if isinstance(item, dict) else {}
+        name = _truncate_str(voice.get("name"), max_chars=120)
+        lang = _normalise_lang(voice.get("lang"))
+        local_service = voice.get("localService")
+
+        voices_sample_out.append(
+            {
+                "name": name or None,
+                "lang": lang,
+                "localService": _normalise_bool(local_service),
+            }
+        )
+
+    default_voice_lang = _normalise_lang(speech.get("default_voice_lang"))
+
+    snapshot["speech_synthesis"] = {
+        "supported": _normalise_bool(speech.get("supported")),
+        "voices_count": _clamp_int(speech.get("voices_count"), minimum=0, maximum=5000),
+        "voices_sample": voices_sample_out,
+        "default_voice_lang": default_voice_lang,
+        "last_error": _truncate_str(speech.get("last_error"), max_chars=200) or None,
+        "settings": {
+            "rate": (
+                float(speech.get("settings", {}).get("rate"))
+                if isinstance(speech.get("settings"), dict)
+                and isinstance(speech.get("settings", {}).get("rate"), (int, float))
+                else None
+            ),
+            "pitch": (
+                float(speech.get("settings", {}).get("pitch"))
+                if isinstance(speech.get("settings"), dict)
+                and isinstance(speech.get("settings", {}).get("pitch"), (int, float))
+                else None
+            ),
+            "volume": (
+                float(speech.get("settings", {}).get("volume"))
+                if isinstance(speech.get("settings"), dict)
+                and isinstance(speech.get("settings", {}).get("volume"), (int, float))
+                else None
+            ),
+            "voice_name": _truncate_str(
+                (
+                    speech.get("settings", {})
+                    if isinstance(speech.get("settings"), dict)
+                    else {}
+                ).get("voice_name"),
+                max_chars=120,
+            )
+            or None,
+        },
+    }
+
+    audio_raw = payload.get("audio_output")
+    audio: dict[str, Any] = audio_raw if isinstance(audio_raw, dict) else {}
+    snapshot["audio_output"] = {
+        "document_muted": (
+            bool(audio.get("document_muted"))
+            if audio.get("document_muted") is not None
+            else None
+        ),
+        "autoplay_policy_hint": _truncate_str(
+            audio.get("autoplay_policy_hint"), max_chars=40
+        )
+        or None,
+        "user_activation": (
+            bool(audio.get("user_activation"))
+            if audio.get("user_activation") is not None
+            else None
+        ),
+    }
+
+    other_raw = payload.get("other")
+    other: dict[str, Any] = other_raw if isinstance(other_raw, dict) else {}
+    snapshot["other"] = {
+        "speech_recognition_supported": (
+            bool(other.get("speech_recognition_supported"))
+            if other.get("speech_recognition_supported") is not None
+            else None
+        ),
+        "visibility_state": _truncate_str(other.get("visibility_state"), max_chars=30)
+        or None,
+    }
+
+    return snapshot
+
+
+def set_client_capabilities_snapshot(snapshot: dict[str, Any]) -> None:
+    from flask import has_request_context, session
+
+    if not has_request_context():
+        raise RuntimeError("No request context available")
+
+    session[_SESSION_KEY] = snapshot
+
+
+def get_client_capabilities_snapshot() -> dict[str, Any] | None:
+    from flask import has_request_context, session
+
+    if not has_request_context():
+        return None
+
+    value = session.get(_SESSION_KEY)
+    return value if isinstance(value, dict) else None

--- a/src/frontend/web/von_interface/static/js/clientCapabilitiesReporter.js
+++ b/src/frontend/web/von_interface/static/js/clientCapabilitiesReporter.js
@@ -1,0 +1,250 @@
+// Client capability reporting (browser-only)
+//
+// JVNAUTOSCI-954: Safely report bounded, non-authoritative client capability hints
+// (primarily for speech synthesis / audio debugging) to the backend.
+//
+// Keep this module safe to import in test environments (no top-level browser-only refs).
+
+import { getSpeechSynthesisVoices, isSpeechRecognitionSupported, isTextToSpeechSupported } from './speech.js';
+
+const DEFAULT_REPORT_COOLDOWN_MS = 30_000;
+const DEFAULT_DEBOUNCE_MS = 400;
+
+function getRoot() {
+    return typeof globalThis !== 'undefined' ? globalThis : null;
+}
+
+function safeIsoNow() {
+    try {
+        return new Date().toISOString();
+    } catch (_) {
+        return null;
+    }
+}
+
+function safeLocalStorageGet(key) {
+    try {
+        return getRoot()?.localStorage?.getItem?.(key);
+    } catch (_) {
+        return null;
+    }
+}
+
+function parseNumber(value) {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+}
+
+function clampNumber(value, min, max) {
+    const n = parseNumber(value);
+    if (n == null) {
+        return null;
+    }
+    return Math.min(max, Math.max(min, n));
+}
+
+function summariseVoicesSample(voices, maxItems = 8) {
+    const list = Array.isArray(voices) ? voices : [];
+    const out = [];
+
+    for (const voice of list.slice(0, maxItems)) {
+        if (!voice) {
+            continue;
+        }
+
+        const name = (typeof voice.name === 'string' && voice.name.trim()) ? voice.name.trim() : null;
+        const lang = (typeof voice.lang === 'string' && voice.lang.trim()) ? voice.lang.trim() : null;
+        const localService = !!voice.localService;
+
+        out.push({ name, lang, localService });
+    }
+
+    return out;
+}
+
+function findSelectedVoiceName(voices) {
+    const uri = String(safeLocalStorageGet('chatTtsVoiceUri') || '').trim();
+    if (!uri) {
+        return null;
+    }
+
+    const list = Array.isArray(voices) ? voices : [];
+    const match = list.find((v) => v && String(v.voiceURI || '') === uri);
+    if (!match) {
+        return null;
+    }
+
+    const name = (typeof match.name === 'string' && match.name.trim()) ? match.name.trim() : null;
+    return name;
+}
+
+function findDefaultVoiceLang(voices) {
+    const list = Array.isArray(voices) ? voices : [];
+    const def = list.find((v) => v && v.default);
+    const lang = (def && typeof def.lang === 'string' && def.lang.trim()) ? def.lang.trim() : null;
+    return lang;
+}
+
+export function __testOnly_buildClientCapabilitiesPayload() {
+    const root = getRoot();
+    const documentEl = root?.document || null;
+
+    const ttsSupported = isTextToSpeechSupported();
+    const voices = ttsSupported ? getSpeechSynthesisVoices() : [];
+
+    const voiceName = findSelectedVoiceName(voices);
+
+    return {
+        client_reported_timestamp: safeIsoNow(),
+        speech_synthesis: {
+            supported: ttsSupported,
+            voices_count: Array.isArray(voices) ? voices.length : 0,
+            voices_sample: summariseVoicesSample(voices, 8),
+            default_voice_lang: findDefaultVoiceLang(voices),
+            last_error: null,
+            settings: {
+                rate: clampNumber(safeLocalStorageGet('chatTtsRate'), 0.5, 2),
+                pitch: clampNumber(safeLocalStorageGet('chatTtsPitch'), 0, 2),
+                volume: clampNumber(safeLocalStorageGet('chatTtsVolume'), 0, 1),
+                voice_name: voiceName
+            }
+        },
+        audio_output: {
+            document_muted: null,
+            autoplay_policy_hint: null,
+            user_activation: (typeof root?.navigator?.userActivation?.hasBeenActive === 'boolean')
+                ? root.navigator.userActivation.hasBeenActive
+                : null
+        },
+        other: {
+            speech_recognition_supported: isSpeechRecognitionSupported(),
+            visibility_state: (typeof documentEl?.visibilityState === 'string') ? documentEl.visibilityState : null
+        }
+    };
+}
+
+async function postCapabilities(payload) {
+    const root = getRoot();
+    if (!root || typeof root.fetch !== 'function') {
+        return { ok: false, skipped: true, error: 'fetch_unavailable' };
+    }
+
+    try {
+        const res = await root.fetch('/api/client_capabilities', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+
+        if (!res || !res.ok) {
+            return { ok: false, status: res?.status ?? null };
+        }
+
+        return { ok: true };
+    } catch (err) {
+        return { ok: false, error: err && err.message ? String(err.message) : 'request_failed' };
+    }
+}
+
+export function startClientCapabilitiesReporting(options = {}) {
+    const root = getRoot();
+    const cooldownMs = Number.isFinite(options.cooldownMs) ? Math.max(0, options.cooldownMs) : DEFAULT_REPORT_COOLDOWN_MS;
+    const debounceMs = Number.isFinite(options.debounceMs) ? Math.max(0, options.debounceMs) : DEFAULT_DEBOUNCE_MS;
+
+    if (!root) {
+        return { stop: () => { } };
+    }
+
+    const state = {
+        stopped: false,
+        lastReportAtMs: 0,
+        debounceTimerId: null,
+        boundVoicesHandler: null
+    };
+
+    const scheduleReport = (reason) => {
+        if (state.stopped) {
+            return;
+        }
+
+        const now = Date.now();
+        if (cooldownMs > 0 && state.lastReportAtMs && now - state.lastReportAtMs < cooldownMs) {
+            return;
+        }
+
+        if (state.debounceTimerId) {
+            try { root.clearTimeout?.(state.debounceTimerId); } catch (_) { }
+        }
+
+        state.debounceTimerId = root.setTimeout?.(async () => {
+            state.debounceTimerId = null;
+            if (state.stopped) {
+                return;
+            }
+
+            const payload = __testOnly_buildClientCapabilitiesPayload();
+            // Store the send timestamp even if POST fails, to avoid tight retry loops.
+            state.lastReportAtMs = Date.now();
+
+            const resp = await postCapabilities(payload);
+            if (!resp.ok && options?.debug) {
+                // eslint-disable-next-line no-console
+                console.debug('[clientCapabilitiesReporter] report failed', { reason, resp });
+            }
+        }, debounceMs);
+    };
+
+    // Initial report.
+    scheduleReport('initial');
+
+    // Re-report when speech synthesis voices become available.
+    try {
+        if (root.speechSynthesis) {
+            const handler = () => scheduleReport('voices_changed');
+            state.boundVoicesHandler = handler;
+            root.speechSynthesis.addEventListener?.('voiceschanged', handler);
+
+            // Some browsers use the onvoiceschanged property.
+            if (typeof root.speechSynthesis.onvoiceschanged !== 'function') {
+                root.speechSynthesis.onvoiceschanged = handler;
+            }
+        }
+    } catch (_) {
+        // Ignore.
+    }
+
+    // Re-report when tab becomes visible (user might grant permissions / enable audio).
+    try {
+        const doc = root.document;
+        if (doc && typeof doc.addEventListener === 'function') {
+            doc.addEventListener('visibilitychange', () => {
+                if (doc.visibilityState === 'visible') {
+                    scheduleReport('visibilitychange');
+                }
+            });
+        }
+    } catch (_) {
+        // Ignore.
+    }
+
+    return {
+        stop: () => {
+            state.stopped = true;
+            try {
+                if (state.debounceTimerId) {
+                    root.clearTimeout?.(state.debounceTimerId);
+                }
+            } catch (_) {
+                // Ignore.
+            }
+
+            try {
+                if (root?.speechSynthesis && state.boundVoicesHandler) {
+                    root.speechSynthesis.removeEventListener?.('voiceschanged', state.boundVoicesHandler);
+                }
+            } catch (_) {
+                // Ignore.
+            }
+        }
+    };
+}

--- a/src/frontend/web/von_interface/static/js/main.js
+++ b/src/frontend/web/von_interface/static/js/main.js
@@ -25,6 +25,17 @@ document.addEventListener('DOMContentLoaded', async () => {
   // where chat history loads with null user_id
   await ensureUserContext();
 
+  // JVNAUTOSCI-954: report bounded, client-reported capability hints (speech/audio)
+  import('./clientCapabilitiesReporter.js').then(module => {
+    if (module.startClientCapabilitiesReporting) {
+      try {
+        window.__vonClientCapabilitiesReporter = module.startClientCapabilitiesReporting();
+      } catch (e) {
+        console.warn('[main] Client capability reporter failed to start:', e);
+      }
+    }
+  }).catch(err => console.error('Error loading client capability reporter:', err));
+
   // Initialize chat tab since it's embedded and active by default
   console.log("Initializing chat tab...");
   import('./chatTab.js').then(module => {

--- a/tests/backend/test_client_capabilities_routes.py
+++ b/tests/backend/test_client_capabilities_routes.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from flask import Flask
+
+from src.backend.server.routes.client_capabilities_routes import client_capabilities_bp
+
+
+def test_client_capabilities_get_defaults_to_none():
+    app = Flask(__name__)
+    app.config.update(SECRET_KEY="test")
+    app.register_blueprint(client_capabilities_bp)
+
+    with app.test_client() as client:
+        res = client.get("/api/client_capabilities")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["success"] is True
+        assert data["capabilities"] is None
+
+
+def test_client_capabilities_post_sanitises_and_persists_in_session():
+    app = Flask(__name__)
+    app.config.update(SECRET_KEY="test")
+    app.register_blueprint(client_capabilities_bp)
+
+    payload = {
+        "client_reported_timestamp": " 2026-01-01T00:00:00Z ",
+        "speech_synthesis": {
+            "supported": True,
+            "voices_count": 999_999,
+            "voices_sample": [
+                {
+                    "name": "n" * 250,
+                    "lang": "en-NZ",
+                    "localService": "notbool",
+                    "extra": "ignored",
+                }
+            ]
+            * 20,
+            "default_voice_lang": "not-a-lang!",
+            "last_error": "e" * 500,
+            "settings": {
+                "rate": "fast",
+                "pitch": 1.2,
+                "volume": 0.8,
+                "voice_name": "v" * 250,
+                "voice_uri": "uri-ignored",
+            },
+        },
+        "audio_output": {
+            "document_muted": "yes",
+            "autoplay_policy_hint": "a" * 100,
+            "user_activation": 1,
+        },
+        "other": {
+            "speech_recognition_supported": "true",
+            "visibility_state": "visible" * 20,
+        },
+        "unknown_top_level": {"secret": "nope"},
+    }
+
+    with app.test_client() as client:
+        res = client.post("/api/client_capabilities", json=payload)
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["success"] is True
+        stored = data["stored"]
+        assert stored["kind"] == "client_capabilities"
+        assert stored["client_reported"] is True
+
+        speech = stored["speech_synthesis"]
+        assert speech["supported"] is True
+        assert speech["voices_count"] == 5000
+        assert isinstance(speech["voices_sample"], list)
+        assert len(speech["voices_sample"]) == 8
+        assert speech["voices_sample"][0]["lang"] == "en-NZ"
+        assert speech["voices_sample"][0]["name"] is not None
+        assert len(speech["voices_sample"][0]["name"]) <= 120
+        assert speech["default_voice_lang"] is None
+        assert speech["last_error"] is not None
+        assert len(speech["last_error"]) <= 200
+        assert speech["settings"]["rate"] is None
+        assert speech["settings"]["pitch"] == 1.2
+        assert speech["settings"]["volume"] == 0.8
+        assert speech["settings"]["voice_name"] is not None
+        assert len(speech["settings"]["voice_name"]) <= 120
+
+        audio = stored["audio_output"]
+        assert audio["autoplay_policy_hint"] is not None
+        assert len(audio["autoplay_policy_hint"]) <= 40
+        assert audio["user_activation"] is True
+
+        other = stored["other"]
+        assert other["speech_recognition_supported"] is True
+        assert other["visibility_state"] is not None
+        assert len(other["visibility_state"]) <= 30
+
+        res2 = client.get("/api/client_capabilities")
+        assert res2.status_code == 200
+        data2 = res2.get_json()
+        assert data2["success"] is True
+        assert data2["capabilities"] == stored


### PR DESCRIPTION
Implements safe client capability introspection (JVNAUTOSCI-954).

- Adds `/api/client_capabilities` (GET/POST) storing a sanitised snapshot in the Flask session.
- Adds a lightweight browser reporter (speech synthesis + minimal audio hints) and starts it on app load.
- Exposes `get_client_capabilities` via the internal MCP catalogue for agent read access.
- Adds backend route/sanitisation tests.

Tests:
- `pytest tests/backend -q` (test db)
- `npm run test:frontend`
- `pytest -q` (test db)