### PR TITLE
JVNAUTOSCI-955: Set automation profile to PowerShell

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,12 @@
   "terminal.integrated.shellIntegration.suggestEnabled": true,
   "terminal.integrated.environmentChangesRelaunch": false,
   "terminal.integrated.showEnvironmentContributions": false,
+  "terminal.integrated.automationProfile.windows": {
+    "path": "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+    "args": [
+      "-NoLogo"
+    ]
+  },
   "terminal.integrated.profiles.windows": {
     "PowerShell": {
       "path": "C:\\Program Files\\PowerShell\\7\\pwsh.exe",


### PR DESCRIPTION
Fixes the VS Code Testing/Jest provider failing with: spawn C:\\WINDOWS\\system32\\cmd.exe ENOENT by setting 	erminal.integrated.automationProfile.windows to PowerShell in the workspace settings.

After merging, run Developer: Reload Window and retry the Jest Test Provider run.
