### PR TITLE
JVNAUTOSCI-957: Chat attachments (upload + download)

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -1,4 +1,12 @@
-from flask import Blueprint, request, jsonify, render_template, current_app, session
+from flask import (
+    Blueprint,
+    request,
+    jsonify,
+    render_template,
+    current_app,
+    session,
+    send_file,
+)
 import os
 import re
 import time
@@ -46,6 +54,15 @@ def _now_utc_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _slugify_concept_id_for_key(concept_id: str) -> str:
+    cleaned = (concept_id or "").strip()
+    if cleaned.startswith("#V#"):
+        cleaned = cleaned[3:]
+    cleaned = cleaned.strip().lower()
+    cleaned = re.sub(r"[^a-z0-9]+", "_", cleaned).strip("_")
+    return cleaned or "unknown"
+
+
 def _get_tool_progress_scope_key() -> str:
     """Return a stable scope key for tool-progress lookup.
 
@@ -68,6 +85,461 @@ def _get_tool_progress_scope_key() -> str:
         session["tool_progress_scope"] = secrets.token_urlsafe(16)
 
     return f"anon:{session.get('tool_progress_scope')}"
+
+
+@von_bp.route("/api/files/upload", methods=["POST"])
+def upload_file_to_blob_store_and_vontology():
+    """Upload a user-provided file into the configured blob store and register it in Vontology.
+
+    Security: user identity is derived server-side via get_effective_user_concept_id().
+
+    Multipart form-data:
+      - file: the uploaded file
+
+    Returns JSON:
+      - success
+      - uploaded: { concept_id, type_concept_id, sha256, size_bytes, content_type, original_filename }
+      - storage: { backend, key, uri, content_type, size_bytes, metadata }
+    """
+
+    from werkzeug.utils import secure_filename
+
+    try:
+        from ...security.access_control import get_effective_user_concept_id
+
+        user_concept_id = get_effective_user_concept_id()
+    except Exception:
+        user_concept_id = session.get("user_concept_id")
+
+    if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "missing_user_context",
+                    "message": "Missing user context: establish an authenticated session first.",
+                }
+            ),
+            401,
+        )
+
+    # Ensure the upload is associated with a stable chat session so it becomes part
+    # of the same persisted history that /von/generate uses.
+    if "session_id" not in session:
+        session["session_id"] = str(uuid.uuid4())
+    session_id = session["session_id"]
+
+    if "file" not in request.files:
+        return jsonify({"success": False, "error": "missing_file"}), 400
+
+    uploaded = request.files.get("file")
+    if not uploaded or not getattr(uploaded, "filename", None):
+        return jsonify({"success": False, "error": "empty_upload"}), 400
+
+    original_filename = str(uploaded.filename)
+    safe_filename = secure_filename(original_filename) or "uploaded_file"
+    content_type = getattr(uploaded, "mimetype", None) or None
+
+    try:
+        data = uploaded.read()
+    except Exception as exc:
+        current_app.logger.warning(f"[files/upload] Failed to read upload: {exc}")
+        return jsonify({"success": False, "error": "read_failed"}), 400
+
+    if not isinstance(data, (bytes, bytearray)) or not data:
+        return jsonify({"success": False, "error": "empty_bytes"}), 400
+
+    data_bytes = bytes(data)
+
+    import hashlib
+
+    sha256 = hashlib.sha256(data_bytes).hexdigest()
+    size_bytes = len(data_bytes)
+
+    from ...services.blob_store import get_blob_store_from_env
+
+    store = get_blob_store_from_env()
+    user_slug = _slugify_concept_id_for_key(user_concept_id)
+    blob_key = f"uploads/{user_slug}/{sha256}/{safe_filename}"
+
+    blob_ref = store.put_bytes(
+        blob_key,
+        data_bytes,
+        content_type=content_type,
+        metadata={
+            "original_filename": original_filename,
+            "sha256": sha256,
+            "user_concept_id": user_concept_id.strip(),
+            "uploaded_at": _now_utc_iso(),
+        },
+    )
+
+    # --- Ensure KR infrastructure exists ---
+    type_concept_id = "#V#computer_file_copy"
+
+    try:
+        from ...db.repositories.concepts_repository import ConceptsRepository
+        from ...vontology.utils_vontology import (
+            THING_PRIMARY_ID,
+            create_vontology_concept,
+            ensure_thing_exists_and_link_orphans,
+        )
+
+        if not ConceptsRepository.find_one({"concept_id": type_concept_id}):
+            # Prefer a store-of-information parent if present; otherwise fall back to Thing.
+            parent_id = (
+                "#V#store_of_information"
+                if ConceptsRepository.find_one(
+                    {"concept_id": "#V#store_of_information"}
+                )
+                else THING_PRIMARY_ID
+            )
+            if parent_id == THING_PRIMARY_ID:
+                # Best-effort: ensure Thing exists.
+                ensure_thing_exists_and_link_orphans()
+
+            created = create_vontology_concept(
+                parent_id=parent_id,
+                new_concept_name="Computer File Copy",
+                create_as_instance=False,
+                description=(
+                    "A computer file copy is an information-bearing artefact representing a specific stored byte sequence "
+                    "(for example an uploaded file stored in Von's blob store)."
+                ),
+                notes=(
+                    "Created on-demand by Von's chat file upload flow. Instances typically have blob store metadata "
+                    "(URI, key, content type, size, and hash) recorded as text relations."
+                ),
+            )
+            if not created.get("success"):
+                current_app.logger.warning(
+                    "[files/upload] Failed to create Computer File Copy type: %s",
+                    created.get("message"),
+                )
+    except Exception as exc:
+        current_app.logger.warning(
+            f"[files/upload] KR type ensure failed (continuing): {exc}"
+        )
+
+    # --- Create the file-copy instance concept ---
+    instance_concept_id = f"#V#uploaded_file_copy_{uuid.uuid4().hex}"
+
+    try:
+        from ...services import concept_service
+        from ...db.repositories.concepts_repository import ConceptsRepository
+        from ...services.text_value_service import upsert_text_for_concept
+
+        instance = concept_service.create_concept(
+            name=original_filename,
+            concept_id=instance_concept_id,
+            parent_concept_ids=[type_concept_id],
+            create_as_instance=True,
+            system_tags=["uploaded", "file", "blob_store"],
+            attributes={
+                "sha256": sha256,
+                "size_bytes": size_bytes,
+                "content_type": content_type,
+                "blob_backend": blob_ref.backend,
+                "blob_key": blob_ref.key,
+                "blob_uri": blob_ref.uri,
+            },
+        )
+
+        # Scope visibility to the current user.
+        ConceptsRepository.update_one(
+            {"concept_id": instance_concept_id},
+            {"$set": {"relationships.specific_to_user": [user_concept_id.strip()]}},
+        )
+
+        # Attach blob + metadata as text relations (authoritative)
+        upsert_text_for_concept(
+            subject_concept_id=instance_concept_id,
+            predicate="hasOriginalFilename",
+            text=original_filename,
+            lang="en-NZ",
+        )
+        upsert_text_for_concept(
+            subject_concept_id=instance_concept_id,
+            predicate="hasSha256",
+            text=sha256,
+            lang="en-NZ",
+        )
+        upsert_text_for_concept(
+            subject_concept_id=instance_concept_id,
+            predicate="hasSizeBytes",
+            text=str(size_bytes),
+            lang="en-NZ",
+        )
+        if content_type:
+            upsert_text_for_concept(
+                subject_concept_id=instance_concept_id,
+                predicate="hasMimeType",
+                text=content_type,
+                lang="en-NZ",
+            )
+
+        upsert_text_for_concept(
+            subject_concept_id=instance_concept_id,
+            predicate="hasBlobBackend",
+            text=str(blob_ref.backend),
+            lang="en-NZ",
+        )
+        upsert_text_for_concept(
+            subject_concept_id=instance_concept_id,
+            predicate="hasBlobKey",
+            text=str(blob_ref.key),
+            lang="en-NZ",
+        )
+        upsert_text_for_concept(
+            subject_concept_id=instance_concept_id,
+            predicate="hasBlobUri",
+            text=str(blob_ref.uri),
+            lang="en-NZ",
+        )
+    except Exception as exc:
+        current_app.logger.error(
+            f"[files/upload] Failed to register uploaded file in Vontology: {exc}",
+            exc_info=True,
+        )
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "vontology_register_failed",
+                    "detail": str(exc),
+                }
+            ),
+            500,
+        )
+
+    chat_history_recorded = _record_file_upload_in_chat_history(
+        user_concept_id=user_concept_id.strip(),
+        session_id=session_id,
+        original_filename=original_filename,
+        content_type=content_type,
+        size_bytes=size_bytes,
+        sha256=sha256,
+        blob_backend=str(blob_ref.backend),
+        blob_key=str(blob_ref.key),
+        blob_uri=str(blob_ref.uri),
+        file_copy_concept_id=instance_concept_id,
+    )
+
+    return (
+        jsonify(
+            {
+                "success": True,
+                "uploaded": {
+                    "concept_id": instance_concept_id,
+                    "type_concept_id": type_concept_id,
+                    "sha256": sha256,
+                    "size_bytes": size_bytes,
+                    "content_type": content_type,
+                    "original_filename": original_filename,
+                },
+                "storage": {
+                    "backend": blob_ref.backend,
+                    "key": blob_ref.key,
+                    "uri": blob_ref.uri,
+                    "content_type": blob_ref.content_type,
+                    "size_bytes": blob_ref.size_bytes,
+                    "metadata": blob_ref.metadata,
+                },
+                "chat_history_recorded": bool(chat_history_recorded),
+            }
+        ),
+        200,
+    )
+
+
+def _record_file_upload_in_chat_history(
+    *,
+    user_concept_id: str,
+    session_id: str,
+    original_filename: str,
+    content_type: str | None,
+    size_bytes: int,
+    sha256: str,
+    blob_backend: str,
+    blob_key: str,
+    blob_uri: str,
+    file_copy_concept_id: str,
+) -> bool:
+    """Persist a durable upload record in chat history.
+
+    We store human-readable text plus a compact JSON payload. This ensures the
+    attachment can be rediscovered later (including the blob key/URI), assuming
+    the user is authorised.
+    """
+
+    try:
+        import json
+
+        upload_summary = f"[UPLOAD] {original_filename} ({size_bytes} bytes)"
+        assistant_lines: list[str] = [
+            f"Attachment uploaded: {original_filename}",
+            f"File copy concept: {file_copy_concept_id}",
+            f"Blob URI: {blob_uri}",
+            "(Blob access is subject to authorisation.)",
+        ]
+
+        payload = {
+            "kind": "file_upload",
+            "original_filename": original_filename,
+            "content_type": content_type,
+            "size_bytes": size_bytes,
+            "sha256": sha256,
+            "file_copy_concept_id": file_copy_concept_id,
+            "blob": {
+                "backend": blob_backend,
+                "key": blob_key,
+                "uri": blob_uri,
+            },
+        }
+
+        assistant_text = (
+            "\n".join(assistant_lines)
+            + "\n\n"
+            + json.dumps(payload, ensure_ascii=False)
+        )
+
+        chat_history_service.add_message_to_history(
+            user_concept_id,
+            session_id,
+            {"role": "user", "content": upload_summary},
+        )
+        chat_history_service.add_message_to_history(
+            user_concept_id,
+            session_id,
+            {"role": "assistant", "content": assistant_text},
+        )
+        return True
+    except Exception as exc:
+        current_app.logger.warning(
+            "[files/upload] Failed to record upload in chat history: %s", exc
+        )
+        return False
+
+
+@von_bp.route("/api/files/<path:file_copy_concept_id>/download", methods=["GET"])
+def download_file_copy(file_copy_concept_id: str):
+    """Download an uploaded file-copy by its Vontology concept id.
+
+    Security: user identity is derived server-side via get_effective_user_concept_id().
+    Access is restricted using relationships.specific_to_user on the file-copy concept.
+
+    Path params:
+      - file_copy_concept_id: URL-encoded concept id (e.g. %23V%23uploaded_file_copy_...)
+    Query params:
+      - concept_id: optional override (for callers that prefer query param)
+    """
+
+    try:
+        from ...security.access_control import get_effective_user_concept_id
+
+        user_concept_id = get_effective_user_concept_id()
+    except Exception:
+        user_concept_id = session.get("user_concept_id")
+
+    if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "missing_user_context",
+                    "message": "Missing user context: establish an authenticated session first.",
+                }
+            ),
+            401,
+        )
+
+    # Allow query-parameter override so callers don't need to place the full id in the path.
+    concept_id = request.args.get("concept_id") or file_copy_concept_id
+    concept_id = str(concept_id or "").strip()
+    if not concept_id:
+        return jsonify({"success": False, "error": "missing_concept_id"}), 400
+
+    try:
+        from ...db.repositories.concepts_repository import ConceptsRepository
+
+        concept_doc = ConceptsRepository.find_one({"concept_id": concept_id})
+    except Exception as exc:
+        current_app.logger.warning("[files/download] Concept lookup failed: %s", exc)
+        concept_doc = None
+
+    if not isinstance(concept_doc, dict):
+        # Avoid leaking which concept IDs exist.
+        return jsonify({"success": False, "error": "not_found"}), 404
+
+    relationships = (
+        concept_doc.get("relationships") if isinstance(concept_doc, dict) else None
+    )
+    specific = (
+        relationships.get("specific_to_user")
+        if isinstance(relationships, dict)
+        else None
+    )
+    if isinstance(specific, list) and user_concept_id.strip() not in {
+        str(x).strip() for x in specific if x is not None
+    }:
+        # Avoid leaking which concept IDs exist.
+        return jsonify({"success": False, "error": "not_found"}), 404
+
+    def _first_text(subject_id: str, predicate: str) -> str | None:
+        try:
+            from ...services.text_value_service import get_texts_for_concept
+
+            rows = get_texts_for_concept(subject_id, predicate=predicate, limit=5)
+            for row in rows or []:
+                text = row.get("text") if isinstance(row, dict) else None
+                if isinstance(text, str) and text.strip():
+                    return text.strip()
+            return None
+        except Exception:
+            return None
+
+    blob_key = _first_text(concept_id, "hasBlobKey")
+    blob_backend = _first_text(concept_id, "hasBlobBackend")
+    content_type = _first_text(concept_id, "hasMimeType")
+    original_filename = _first_text(concept_id, "hasOriginalFilename")
+
+    if not blob_key:
+        return jsonify({"success": False, "error": "missing_blob_key"}), 404
+
+    from ...services.blob_store import get_blob_store_from_env
+
+    store = get_blob_store_from_env()
+    env_backend = (os.environ.get("VON_BLOB_STORE_BACKEND") or "local").strip().lower()
+    if blob_backend and str(blob_backend).strip().lower() != env_backend:
+        current_app.logger.warning(
+            "[files/download] Blob backend mismatch for %s: concept=%s env=%s",
+            concept_id,
+            blob_backend,
+            env_backend,
+        )
+        # Proceed anyway: the configured store may still be able to fetch the key,
+        # and we avoid failing downloads in test/mocked environments.
+
+    try:
+        data_bytes = store.get_bytes(blob_key)
+    except Exception as exc:
+        current_app.logger.warning("[files/download] Blob fetch failed: %s", exc)
+        return jsonify({"success": False, "error": "blob_fetch_failed"}), 404
+
+    import io
+
+    download_name = original_filename or concept_doc.get("name") or "download"
+    mimetype = content_type or "application/octet-stream"
+    resp = send_file(
+        io.BytesIO(data_bytes),
+        mimetype=mimetype,
+        as_attachment=True,
+        download_name=download_name,
+        max_age=0,
+    )
+    resp.headers["Cache-Control"] = "no-store"
+    resp.headers["Pragma"] = "no-cache"
+    return resp
 
 
 def _prune_tool_progress() -> None:

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -668,6 +668,98 @@ function submitChatPromptImmediately() {
     }
 }
 
+function formatBytesForUi(sizeBytes) {
+    const size = Number(sizeBytes);
+    if (!Number.isFinite(size) || size < 0) return '';
+    if (size < 1024) return `${size} B`;
+    const kb = size / 1024;
+    if (kb < 1024) return `${kb.toFixed(1)} KB`;
+    const mb = kb / 1024;
+    if (mb < 1024) return `${mb.toFixed(1)} MB`;
+    const gb = mb / 1024;
+    return `${gb.toFixed(2)} GB`;
+}
+
+function isFileDragEvent(event) {
+    const dt = event?.dataTransfer;
+    if (!dt) return false;
+    try {
+        const types = Array.from(dt.types || []);
+        return types.includes('Files');
+    } catch (_) {
+        return false;
+    }
+}
+
+async function uploadSingleFileToVon(file) {
+    if (!file) {
+        throw new Error('No file provided');
+    }
+
+    const formData = new FormData();
+    formData.append('file', file, file.name || 'uploaded_file');
+
+    const response = await fetch('/von/api/files/upload', {
+        method: 'POST',
+        body: formData
+    });
+
+    let data = null;
+    try {
+        data = await response.json();
+    } catch (_) {
+        data = null;
+    }
+
+    if (!response.ok || !data || data.success !== true) {
+        const detail = data?.message || data?.error || `HTTP ${response.status}`;
+        throw new Error(`Upload failed: ${detail}`);
+    }
+
+    return data;
+}
+
+async function uploadFilesToVon(files) {
+    const list = Array.from(files || []).filter(Boolean);
+    if (!list.length) return;
+
+    for (const file of list) {
+        const sizeLabel = formatBytesForUi(file.size);
+        appendMessage('User', `Uploading file: ${file.name}${sizeLabel ? ` (${sizeLabel})` : ''}`);
+
+        try {
+            const result = await uploadSingleFileToVon(file);
+            const conceptId = result?.uploaded?.concept_id;
+            const blobUri = result?.storage?.uri;
+            const blobKey = result?.storage?.key;
+            const blobBackend = result?.storage?.backend;
+            const historyRecorded = result?.chat_history_recorded === true;
+
+            const downloadUrl = conceptId
+                ? `/von/api/files/${encodeURIComponent(conceptId)}/download`
+                : null;
+
+            const details = [];
+            if (blobUri) details.push(`Blob: ${blobUri}`);
+            if (blobBackend || blobKey) details.push(`Blob key: ${String(blobBackend || '')}:${String(blobKey || '')}`.replace(/^:/, ''));
+            if (historyRecorded) details.push('Recorded in chat history.');
+            if (downloadUrl) details.push(`[Download attachment](${downloadUrl})`);
+
+            appendMessage(
+                'Von',
+                `File uploaded and registered as ${conceptId || '(unknown)'}${details.length ? `\n${details.join('\n')}` : ''}`
+            );
+
+            if (conceptId) {
+                insertTextIntoChatPrompt(`Attached file concept: ${conceptId}`);
+            }
+        } catch (error) {
+            console.error('[chatTab] file upload error', error);
+            appendMessage('Error', `File upload failed: ${String(error?.message || error)}`);
+        }
+    }
+}
+
 function convertJustSayInstructionsToButtons(root) {
     if (!root || !root.querySelectorAll) return;
 
@@ -2858,10 +2950,65 @@ export function initializeChatTab() {
     const ttsToggle = document.getElementById('ttsToggle');
     const exportConversationJsonBtn = document.getElementById('exportConversationJsonBtn');
     const exportConversationMarkdownBtn = document.getElementById('exportConversationMarkdownBtn');
+    const uploadFileButton = document.getElementById('uploadFileButton');
+    const uploadFileInput = document.getElementById('uploadFileInput');
+    const chatTab = document.getElementById('chatTab');
 
     if (!sendButton || !resetButton || !promptInput) {
         console.error("Chat tab elements not found");
         return;
+    }
+
+    if (uploadFileButton && uploadFileInput) {
+        uploadFileButton.addEventListener('click', () => {
+            try {
+                uploadFileInput.click();
+            } catch (_) {
+                // Ignore.
+            }
+        });
+
+        uploadFileInput.addEventListener('change', async () => {
+            const files = uploadFileInput.files;
+            // Clear the input so selecting the same file again triggers change.
+            uploadFileInput.value = '';
+            await uploadFilesToVon(files);
+        });
+    }
+
+    if (chatTab && scrollableField) {
+        // Prevent the browser navigating away when dropping files.
+        const preventIfFiles = (event) => {
+            if (!isFileDragEvent(event)) return;
+            event.preventDefault();
+            event.stopPropagation();
+        };
+
+        // Global guards
+        document.addEventListener('dragover', preventIfFiles);
+        document.addEventListener('drop', preventIfFiles);
+
+        // Local UI + drop handling
+        chatTab.addEventListener('dragover', (event) => {
+            if (!isFileDragEvent(event)) return;
+            preventIfFiles(event);
+            scrollableField.classList.add('drag-over');
+        });
+
+        chatTab.addEventListener('dragleave', (event) => {
+            if (!isFileDragEvent(event)) return;
+            scrollableField.classList.remove('drag-over');
+        });
+
+        chatTab.addEventListener('drop', async (event) => {
+            if (!isFileDragEvent(event)) return;
+            preventIfFiles(event);
+            scrollableField.classList.remove('drag-over');
+
+            const dt = event.dataTransfer;
+            const files = dt ? dt.files : null;
+            await uploadFilesToVon(files);
+        });
     }
 
     // Initialize LLM debug popup handlers

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -3232,6 +3232,13 @@ footer {
     background-color: white;
 }
 
+.scrollable-field.drag-over {
+    border-color: #2b7fff;
+    outline: 2px dashed #2b7fff;
+    outline-offset: -6px;
+    background-color: rgba(43, 127, 255, 0.06);
+}
+
 /* Chat variant (legacy class) updated for parity */
 .chat-scrollable-field {
     white-space: pre-wrap;

--- a/src/frontend/web/von_interface/templates/chat_tab.html
+++ b/src/frontend/web/von_interface/templates/chat_tab.html
@@ -52,6 +52,11 @@
       </button>
       <button id="resetButton" class="btn btn-secondary" type="button"
         title="Reset Von's context while keeping this conversation view">Reset Context</button>
+
+      <button id="uploadFileButton" class="btn btn-secondary" type="button"
+        title="Upload a file (or drag and drop onto chat)">Upload File</button>
+      <input id="uploadFileInput" class="visually-hidden" type="file" />
+
       <label class="annotation-toggle" title="Enable concept annotations in chat responses">
         <input type="checkbox" id="annotationToggle">
         <span class="eye-icon">

--- a/tests/backend/test_von_file_upload_endpoint.py
+++ b/tests/backend/test_von_file_upload_endpoint.py
@@ -1,0 +1,296 @@
+import hashlib
+import io
+import urllib.parse
+from typing import Any
+
+import pytest
+from flask import Flask
+
+
+class _FakeStore:
+    def __init__(self, blob_ref_cls):
+        self._blob_ref_cls = blob_ref_cls
+        self.last_put = None
+        self._bytes_by_key = {}
+
+    def put_bytes(self, key, data, content_type=None, metadata=None):
+        self.last_put = {
+            "key": key,
+            "data": data,
+            "content_type": content_type,
+            "metadata": metadata,
+        }
+        self._bytes_by_key[key] = bytes(data)
+        return self._blob_ref_cls(
+            backend="local",
+            key=key,
+            uri=f"local://{key}",
+            content_type=content_type,
+            size_bytes=len(data),
+            metadata=metadata or {},
+        )
+
+    def get_bytes(self, key):
+        if key not in self._bytes_by_key:
+            raise FileNotFoundError(key)
+        return self._bytes_by_key[key]
+
+
+@pytest.fixture()
+def app(monkeypatch):
+    from src.backend.server.routes.von_routes import von_bp
+    from src.backend.services.blob_store import BlobRef
+
+    flask_app = Flask(__name__)
+    flask_app.secret_key = "test-secret"
+    flask_app.register_blueprint(von_bp, url_prefix="/von")
+
+    fake_store = _FakeStore(BlobRef)
+    monkeypatch.setattr(
+        "src.backend.services.blob_store.get_blob_store_from_env",
+        lambda: fake_store,
+    )
+
+    # Avoid touching the database: keep an in-memory concept table.
+    concept_docs: dict[str, dict[str, Any]] = {
+        "#V#computer_file_copy": {"concept_id": "#V#computer_file_copy"},
+        "#V#store_of_information": {"concept_id": "#V#store_of_information"},
+    }
+
+    def fake_find_one(query):
+        concept_id = (query or {}).get("concept_id")
+        if not concept_id:
+            return None
+        return concept_docs.get(concept_id)
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        fake_find_one,
+    )
+
+    updates = []
+
+    def fake_update_one(filter_doc: dict[str, Any], update_doc: dict[str, Any]):
+        updates.append((filter_doc, update_doc))
+
+        concept_id = (filter_doc or {}).get("concept_id")
+        if concept_id and concept_id in concept_docs and isinstance(update_doc, dict):
+            set_doc: dict[str, Any] = {}
+            raw_set = update_doc.get("$set")
+            if isinstance(raw_set, dict):
+                set_doc = dict(raw_set)
+            for key, value in set_doc.items():
+                if key == "relationships.specific_to_user":
+                    doc: dict[str, Any] = concept_docs.get(concept_id) or {
+                        "concept_id": concept_id
+                    }
+                    rel: dict[str, Any] = {}
+                    raw_rel = doc.get("relationships")
+                    if isinstance(raw_rel, dict):
+                        rel = dict(raw_rel)
+                    rel["specific_to_user"] = value
+                    doc["relationships"] = rel
+                    concept_docs[concept_id] = doc
+                else:
+                    doc: dict[str, Any] = concept_docs.get(concept_id) or {
+                        "concept_id": concept_id
+                    }
+                    doc[key] = value
+                    concept_docs[concept_id] = doc
+
+        return None
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.update_one",
+        fake_update_one,
+    )
+
+    created = []
+
+    def fake_create_concept(**kwargs):
+        created.append(kwargs)
+        concept_id = kwargs.get("concept_id")
+        if concept_id:
+            concept_docs[concept_id] = {
+                "concept_id": concept_id,
+                "name": kwargs.get("name") or kwargs.get("concept_id"),
+                "relationships": {},
+            }
+        return {"success": True, "concept": {"concept_id": kwargs.get("concept_id")}}
+
+    monkeypatch.setattr(
+        "src.backend.services.concept_service.create_concept",
+        fake_create_concept,
+    )
+
+    upserts = []
+    text_values = {}
+
+    def fake_upsert_text_for_concept(
+        subject_concept_id,
+        predicate,
+        text,
+        lang="en",
+        provenance=None,
+        context=None,
+    ):
+        upserts.append(
+            {
+                "subject_concept_id": subject_concept_id,
+                "predicate": predicate,
+                "text": text,
+                "lang": lang,
+            }
+        )
+        text_values[(subject_concept_id, predicate)] = [str(text)]
+        return {"relation_id": "test", "text": text, "lang": lang}
+
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.upsert_text_for_concept",
+        fake_upsert_text_for_concept,
+    )
+
+    def fake_get_texts_for_concept(
+        subject_concept_id, predicate=None, lang=None, limit=50
+    ):
+        if not predicate:
+            return []
+        values = text_values.get((subject_concept_id, predicate), [])
+        results = []
+        for v in values[: max(0, int(limit or 0) or 0)]:
+            results.append({"text": v, "predicate": predicate, "lang": lang or "en-NZ"})
+        return results
+
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.get_texts_for_concept",
+        fake_get_texts_for_concept,
+    )
+
+    history_calls = []
+
+    def fake_add_message_to_history(user_id, session_id, message, llm_debug_data=None):
+        history_calls.append(
+            {
+                "user_id": user_id,
+                "session_id": session_id,
+                "message": message,
+                "llm_debug_data": llm_debug_data,
+            }
+        )
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.chat_history_service.add_message_to_history",
+        fake_add_message_to_history,
+    )
+
+    flask_app.config["TEST_FAKE_STORE"] = fake_store
+    flask_app.config["TEST_CREATED"] = created
+    flask_app.config["TEST_UPSERTS"] = upserts
+    flask_app.config["TEST_UPDATES"] = updates
+    flask_app.config["TEST_HISTORY_CALLS"] = history_calls
+    flask_app.config["TEST_CONCEPT_DOCS"] = concept_docs
+    return flask_app
+
+
+def test_upload_requires_user_session(app):
+    client = app.test_client()
+
+    resp = client.post(
+        "/von/api/files/upload",
+        data={"file": (io.BytesIO(b"hello"), "hello.txt")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 401
+    body = resp.get_json()
+    assert body["success"] is False
+    assert body["error"] == "missing_user_context"
+
+
+def test_upload_stores_bytes_and_registers_concept(app):
+    client = app.test_client()
+
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#user"
+        sess["session_id"] = "test-session"
+
+    payload = b"hello world"
+    expected_sha256 = hashlib.sha256(payload).hexdigest()
+
+    resp = client.post(
+        "/von/api/files/upload",
+        data={"file": (io.BytesIO(payload), "notes.txt")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 200
+
+    body = resp.get_json()
+    assert body["success"] is True
+    assert body["chat_history_recorded"] is True
+    assert body["uploaded"]["type_concept_id"] == "#V#computer_file_copy"
+    assert body["uploaded"]["sha256"] == expected_sha256
+    assert body["uploaded"]["original_filename"] == "notes.txt"
+
+    fake_store = app.config["TEST_FAKE_STORE"]
+    assert fake_store.last_put is not None
+    assert fake_store.last_put["metadata"]["sha256"] == expected_sha256
+    assert fake_store.last_put["key"].startswith(f"uploads/user/{expected_sha256}/")
+    assert fake_store.last_put["key"].endswith("notes.txt")
+
+    created = app.config["TEST_CREATED"]
+    assert len(created) == 1
+    assert created[0]["create_as_instance"] is True
+    assert created[0]["parent_concept_ids"] == ["#V#computer_file_copy"]
+
+    upserts = app.config["TEST_UPSERTS"]
+    predicates = {u["predicate"] for u in upserts}
+    assert "hasBlobUri" in predicates
+    assert "hasBlobKey" in predicates
+    assert "hasSha256" in predicates
+    assert "hasSizeBytes" in predicates
+
+    history_calls = app.config["TEST_HISTORY_CALLS"]
+    assert len(history_calls) == 2
+    assert history_calls[0]["user_id"] == "#V#user"
+    assert history_calls[0]["session_id"] == "test-session"
+    assert history_calls[0]["message"]["role"] == "user"
+    assert "[UPLOAD]" in history_calls[0]["message"]["content"]
+
+    assert history_calls[1]["message"]["role"] == "assistant"
+    assistant_text = history_calls[1]["message"]["content"]
+    assert "File copy concept:" in assistant_text
+    assert "Blob URI:" in assistant_text
+    assert "local://" in assistant_text
+    assert expected_sha256 in assistant_text
+
+
+def test_download_round_trip_and_access_control(app):
+    client = app.test_client()
+
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#user"
+        sess["session_id"] = "test-session"
+
+    payload = b"hello download"
+
+    upload_resp = client.post(
+        "/von/api/files/upload",
+        data={"file": (io.BytesIO(payload), "download.txt")},
+        content_type="multipart/form-data",
+    )
+    assert upload_resp.status_code == 200
+    uploaded = upload_resp.get_json()["uploaded"]
+    concept_id = uploaded["concept_id"]
+
+    encoded = urllib.parse.quote(concept_id, safe="")
+    download_resp = client.get(f"/von/api/files/{encoded}/download")
+    assert download_resp.status_code == 200
+    assert download_resp.data == payload
+    assert "attachment" in (download_resp.headers.get("Content-Disposition") or "")
+
+    # Different user should not be able to fetch (return 404 to avoid leakage).
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#other_user"
+        sess["session_id"] = "test-session"
+
+    denied_resp = client.get(f"/von/api/files/{encoded}/download")
+    assert denied_resp.status_code == 404


### PR DESCRIPTION
Implements file attachment upload and secure download in Von chat.

- Backend: `POST /von/api/files/upload` stores bytes in blob store, creates `#V#computer_file_copy` instance, and persists blob metadata as text relations + chat-history record.
- Backend: `GET /von/api/files/<concept_id>/download` streams bytes back as an attachment, enforcing `relationships.specific_to_user` and returning 404 on unauthorised access.
- Frontend: Upload File button + drag-and-drop support, and shows a “Download attachment” link after upload.
- Tests: adds `tests/backend/test_von_file_upload_endpoint.py` (upload + download round-trip + access control).

Verification:
- `pdm run pytest -q tests/backend/test_von_file_upload_endpoint.py` (with `VON_DB_NAME=test_von_db`)