### PR TITLE
JVNAUTOSCI-953 add narration playback telemetry logging

### DIFF
--- a/src/backend/server/routes/speech_routes.py
+++ b/src/backend/server/routes/speech_routes.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from flask import Blueprint, current_app, jsonify, request, session
+
+from ...services.chat_history_service import (
+    ChatHistoryServiceError,
+    update_llm_debug_data_for_request_id,
+)
+
+
+speech_bp = Blueprint("speech_bp", __name__, url_prefix="/api/speech")
+
+
+def _coerce_float(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except Exception:
+            return None
+    return None
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return int(value)
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(float(value.strip()))
+        except Exception:
+            return None
+    return None
+
+
+def _coerce_bool(value: Any) -> Optional[bool]:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return None
+
+
+def _coerce_text(value: Any, *, max_chars: int = 120) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    if len(cleaned) > max_chars:
+        return cleaned[:max_chars]
+    return cleaned
+
+
+def _normalise_timestamp(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        value = value.strip()
+        if value:
+            return value
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(float(value) / 1000.0, tz=timezone.utc).isoformat().replace(
+                "+00:00", "Z"
+            )
+        except Exception:
+            return None
+    return None
+
+
+def _sanitise_playback(payload: Dict[str, Any]) -> Dict[str, Any]:
+    playback = payload.get("speech_playback") or {}
+    if not isinstance(playback, dict):
+        return {}
+
+    settings = playback.get("tts_settings") or {}
+    settings = settings if isinstance(settings, dict) else {}
+
+    return {
+        "request_id": _coerce_text(payload.get("request_id") or playback.get("request_id")),
+        "turn_id": _coerce_text(payload.get("turn_id")),
+        "conversation_id": _coerce_text(payload.get("conversation_id")),
+        "started_at": _normalise_timestamp(playback.get("started_at")),
+        "ended_at": _normalise_timestamp(playback.get("ended_at")),
+        "actual_duration_ms": _coerce_int(playback.get("actual_duration_ms")),
+        "expected_duration_ms": _coerce_int(playback.get("expected_duration_ms")),
+        "estimate_method": _coerce_text(playback.get("estimate_method")),
+        "duration_threshold_sec": _coerce_float(playback.get("duration_threshold_sec")),
+        "duration_suspect_too_long": _coerce_bool(
+            playback.get("duration_suspect_too_long")
+        ),
+        "tts_source": _coerce_text(playback.get("tts_source")),
+        "tts_chars": _coerce_int(playback.get("tts_chars")),
+        "tts_words": _coerce_int(playback.get("tts_words")),
+        "stop_reason": _coerce_text(playback.get("stop_reason")),
+        "tts_settings": {
+            "language": _coerce_text(settings.get("language")),
+            "rate": _coerce_float(settings.get("rate")),
+            "pitch": _coerce_float(settings.get("pitch")),
+            "volume": _coerce_float(settings.get("volume")),
+            "voice_uri": _coerce_text(settings.get("voice_uri"), max_chars=200),
+            "voice_name": _coerce_text(settings.get("voice_name"), max_chars=200),
+        },
+    }
+
+
+@speech_bp.route("/telemetry", methods=["POST"])
+def record_speech_telemetry():
+    payload = request.get_json(silent=True) or {}
+
+    if not isinstance(payload, dict):
+        return jsonify({"success": False, "error": "payload_invalid"}), 400
+
+    playback = _sanitise_playback(payload)
+    if not playback:
+        return jsonify({"success": False, "error": "missing_speech_playback"}), 400
+
+    suspect = bool(playback.get("duration_suspect_too_long"))
+    log_fn = current_app.logger.warning if suspect else current_app.logger.info
+
+    try:
+        log_fn(
+            "[speech_telemetry] request_id=%s turn=%s duration_ms=%s expected_ms=%s threshold_sec=%s suspect=%s source=%s voice=%s rate=%s pitch=%s volume=%s start=%s end=%s",
+            playback.get("request_id"),
+            playback.get("turn_id"),
+            playback.get("actual_duration_ms"),
+            playback.get("expected_duration_ms"),
+            playback.get("duration_threshold_sec"),
+            playback.get("duration_suspect_too_long"),
+            playback.get("tts_source"),
+            (playback.get("tts_settings") or {}).get("voice_name"),
+            (playback.get("tts_settings") or {}).get("rate"),
+            (playback.get("tts_settings") or {}).get("pitch"),
+            (playback.get("tts_settings") or {}).get("volume"),
+            playback.get("started_at"),
+            playback.get("ended_at"),
+        )
+    except Exception:
+        pass
+
+    # Best-effort: attach telemetry to the stored llm_debug_data entry.
+    user_concept_id = session.get("user_concept_id")
+    session_id = session.get("session_id")
+    request_id = playback.get("request_id")
+
+    updated = False
+    update_reason = None
+    if (
+        isinstance(user_concept_id, str)
+        and user_concept_id.strip()
+        and isinstance(session_id, str)
+        and session_id.strip()
+        and isinstance(request_id, str)
+        and request_id.strip()
+    ):
+        try:
+            update_result = update_llm_debug_data_for_request_id(
+                user_id=user_concept_id.strip(),
+                session_id=session_id.strip(),
+                request_id=request_id.strip(),
+                updates={
+                    "speech_playback": playback,
+                    "speech_playback_updated_at": datetime.now(timezone.utc)
+                    .isoformat()
+                    .replace("+00:00", "Z"),
+                },
+            )
+            updated = bool(update_result.get("updated"))
+            update_reason = update_result.get("reason")
+        except ChatHistoryServiceError as exc:
+            update_reason = str(exc)
+        except Exception as exc:
+            update_reason = str(exc)
+
+    return jsonify(
+        {
+            "success": True,
+            "stored": playback,
+            "history_update": {"updated": updated, "reason": update_reason},
+        }
+    )

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -49,6 +49,7 @@ from .routes.predicate_routes import predicate_bp
 from .routes.workflows_routes import workflows_bp
 from .routes.room_device_routes import room_device_bp
 from .routes.client_capabilities_routes import client_capabilities_bp
+from .routes.speech_routes import speech_bp
 from ..db.connection_manager import (
     ensure_monitor_started,
     get_db,
@@ -196,6 +197,7 @@ def create_flask_app(
     app.register_blueprint(workflows_bp)  # /api/workflows/*
     app.register_blueprint(room_device_bp)
     app.register_blueprint(client_capabilities_bp)
+    app.register_blueprint(speech_bp)
     app.register_blueprint(admin_bp, url_prefix="/admin")
     app.register_blueprint(
         auth_bp, url_prefix="/von"

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -456,6 +456,62 @@ def upsert_presenter_channels_for_history_message(
         ) from e
 
 
+def update_llm_debug_data_for_request_id(
+    *,
+    user_id: str,
+    session_id: str,
+    request_id: str,
+    updates: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Update llm_debug_data fields for the assistant message matching request_id."""
+
+    if not isinstance(user_id, str) or not user_id:
+        raise ChatHistoryServiceError("user_id is required")
+    if not isinstance(session_id, str) or not session_id:
+        raise ChatHistoryServiceError("session_id is required")
+    if not isinstance(request_id, str) or not request_id:
+        raise ChatHistoryServiceError("request_id is required")
+    if not isinstance(updates, dict) or not updates:
+        return {"updated": False, "reason": "no_updates"}
+
+    chat_history_coll = get_chat_history_collection_service()
+    if chat_history_coll is None:
+        raise ChatHistoryServiceError("Could not connect to chat history collection.")
+
+    set_fields = {
+        f"history.$.llm_debug_data.{key}": value for key, value in updates.items()
+    }
+
+    try:
+        result = chat_history_coll.update_one(
+            {
+                "user_id": user_id,
+                "session_id": session_id,
+                "history": {
+                    "$elemMatch": {
+                        "role": "assistant",
+                        "llm_debug_data.request_id": request_id,
+                    }
+                },
+            },
+            {"$set": set_fields},
+        )
+        updated = bool(getattr(result, "modified_count", 0) > 0)
+        matched = bool(getattr(result, "matched_count", 0) > 0)
+        reason = None if matched else "request_id_not_found"
+        return {"updated": updated, "matched": matched, "reason": reason}
+    except PyMongoError as e:
+        logger.error(
+            "Error updating llm_debug_data for request_id=%s: %s",
+            request_id,
+            e,
+            exc_info=True,
+        )
+        raise ChatHistoryServiceError(
+            f"Could not update llm_debug_data for request_id {request_id}: {e}"
+        ) from e
+
+
 def add_message_to_history(
     user_id: str,
     session_id: str,

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -2130,6 +2130,36 @@ function deriveLlmDebugWarnings(debugData) {
         }
     }
 
+    const speechPlayback = debugData.speech_playback;
+    if (speechPlayback && typeof speechPlayback === 'object' && speechPlayback.duration_suspect_too_long) {
+        const actualMs = Number.isFinite(speechPlayback.actual_duration_ms)
+            ? speechPlayback.actual_duration_ms
+            : null;
+        const expectedMs = Number.isFinite(speechPlayback.expected_duration_ms)
+            ? speechPlayback.expected_duration_ms
+            : null;
+        const thresholdSec = Number.isFinite(speechPlayback.duration_threshold_sec)
+            ? speechPlayback.duration_threshold_sec
+            : null;
+
+        const actualSec = actualMs !== null ? (actualMs / 1000) : null;
+        const expectedSec = expectedMs !== null ? (expectedMs / 1000) : null;
+
+        const details = [];
+        if (actualSec !== null) {
+            details.push(`actual ${actualSec.toFixed(1)}s`);
+        } else if (expectedSec !== null) {
+            details.push(`expected ${expectedSec.toFixed(1)}s`);
+        }
+        if (thresholdSec !== null) {
+            details.push(`threshold ${thresholdSec}s`);
+        }
+
+        warnings.push(
+            `Narration playback duration exceeded long-duration threshold${details.length ? ` (${details.join(', ')})` : ''}.`
+        );
+    }
+
     return Array.from(new Set(warnings));
 }
 
@@ -2185,6 +2215,8 @@ const CHAT_TTS_LANGUAGE_STORAGE_KEY = 'chatTtsLanguage';
 const CHAT_TTS_RATE_STORAGE_KEY = 'chatTtsRate';
 const CHAT_TTS_PITCH_STORAGE_KEY = 'chatTtsPitch';
 const CHAT_TTS_VOLUME_STORAGE_KEY = 'chatTtsVolume';
+const CHAT_TTS_LONG_DURATION_THRESHOLD_KEY = 'chatTtsLongDurationThresholdSec';
+const DEFAULT_TTS_LONG_DURATION_THRESHOLD_SEC = 30;
 
 const CHAT_STT_LANGUAGE_STORAGE_KEY = 'chatSttLanguage';
 const CHAT_STT_CONTINUOUS_STORAGE_KEY = 'chatSttContinuous';
@@ -2195,6 +2227,7 @@ let dictationState = null;
 
 let activeTtsTurnId = null;
 let activeTtsButton = null;
+let activeTtsPlaybackState = null;
 
 function safeLocalStorageGet(key) {
     try {
@@ -2242,6 +2275,153 @@ function parseBoolSetting(value, fallbackValue) {
         return fallbackValue;
     }
     return String(value) === 'true';
+}
+
+function getTtsLongDurationThresholdSec() {
+    const raw = safeLocalStorageGet(CHAT_TTS_LONG_DURATION_THRESHOLD_KEY);
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+        return Math.min(Math.max(parsed, 5), 300);
+    }
+    return DEFAULT_TTS_LONG_DURATION_THRESHOLD_SEC;
+}
+
+function estimateSpeechDurationMs(text, rate) {
+    const cleaned = String(text ?? '').trim();
+    const chars = cleaned.length;
+    const words = cleaned ? cleaned.split(/\s+/).filter(Boolean).length : 0;
+    if (!chars) {
+        return { expectedMs: null, estimateMethod: null, words: 0, chars: 0 };
+    }
+
+    const safeRate = Number.isFinite(rate) && rate > 0 ? rate : 1;
+    const baseWpm = 180;
+    if (words > 0) {
+        const wpm = baseWpm * safeRate;
+        return {
+            expectedMs: Math.round((words / wpm) * 60 * 1000),
+            estimateMethod: 'words_per_minute',
+            words,
+            chars
+        };
+    }
+
+    const charsPerSec = 12 * safeRate;
+    return {
+        expectedMs: Math.round((chars / charsPerSec) * 1000),
+        estimateMethod: 'chars_per_sec',
+        words,
+        chars
+    };
+}
+
+function resolveSpeechVoiceInfo(voiceUri) {
+    const uri = String(voiceUri || '').trim();
+    if (!uri) {
+        return { voice_uri: null, voice_name: null };
+    }
+
+    const voices = getSpeechSynthesisVoices();
+    const match = voices.find((voice) => voice && String(voice.voiceURI || '') === uri) || null;
+    const voiceName = match && match.name ? String(match.name).trim() : null;
+
+    return {
+        voice_uri: uri,
+        voice_name: voiceName || null
+    };
+}
+
+function buildSpeechPlaybackTelemetry(state, stopReason) {
+    if (!state || typeof state !== 'object') {
+        return null;
+    }
+
+    const startedAtMs = Number.isFinite(state.startedAtMs) ? state.startedAtMs : null;
+    const endedAtMs = Number.isFinite(state.endedAtMs) ? state.endedAtMs : null;
+    const actualDurationMs = (startedAtMs !== null && endedAtMs !== null)
+        ? Math.max(0, endedAtMs - startedAtMs)
+        : null;
+
+    const expectedMs = Number.isFinite(state.expectedDurationMs) ? state.expectedDurationMs : null;
+    const thresholdSec = Number.isFinite(state.thresholdSec) ? state.thresholdSec : null;
+
+    const actualSec = actualDurationMs !== null ? actualDurationMs / 1000 : null;
+    const expectedSec = expectedMs !== null ? expectedMs / 1000 : null;
+
+    const durationTooLong = (actualSec !== null && thresholdSec !== null)
+        ? actualSec > thresholdSec
+        : (expectedSec !== null && thresholdSec !== null ? expectedSec > thresholdSec : false);
+
+    return {
+        request_id: state.requestId || null,
+        turn_id: state.turnId || null,
+        started_at: state.startedAt || null,
+        ended_at: state.endedAt || null,
+        actual_duration_ms: actualDurationMs,
+        expected_duration_ms: expectedMs,
+        estimate_method: state.estimateMethod || null,
+        duration_threshold_sec: thresholdSec,
+        duration_suspect_too_long: durationTooLong,
+        tts_source: state.ttsSource || null,
+        tts_chars: Number.isFinite(state.ttsChars) ? state.ttsChars : null,
+        tts_words: Number.isFinite(state.ttsWords) ? state.ttsWords : null,
+        stop_reason: stopReason || null,
+        tts_settings: {
+            language: state.ttsLanguage || null,
+            rate: state.ttsRate ?? null,
+            pitch: state.ttsPitch ?? null,
+            volume: state.ttsVolume ?? null,
+            voice_uri: state.voiceUri || null,
+            voice_name: state.voiceName || null
+        }
+    };
+}
+
+async function postSpeechPlaybackTelemetry(turnId, telemetry) {
+    if (!telemetry || typeof telemetry !== 'object') {
+        return;
+    }
+
+    const payload = {
+        conversation_id: elements.conversationId || 'local',
+        turn_id: turnId,
+        request_id: telemetry.request_id || null,
+        speech_playback: telemetry,
+        context: getUserContext()
+    };
+
+    try {
+        await fetch('/api/speech/telemetry', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+    } catch (err) {
+        console.warn('[speech] Telemetry post failed:', err);
+    }
+}
+
+function recordSpeechPlaybackTelemetry(turnId, telemetry) {
+    if (!telemetry || typeof telemetry !== 'object') {
+        return;
+    }
+
+    const debugData = turnId ? llmDebugData.get(turnId) : null;
+    if (debugData && typeof debugData === 'object') {
+        const updated = {
+            ...debugData,
+            speech_playback: telemetry
+        };
+        llmDebugData.set(turnId, updated);
+    }
+
+    if (telemetry.duration_suspect_too_long) {
+        console.warn('[speech] Long narration duration detected:', telemetry);
+    } else {
+        console.info('[speech] Narration playback telemetry:', telemetry);
+    }
+
+    void postSpeechPlaybackTelemetry(turnId, telemetry);
 }
 
 function getChatSpeechSettings() {
@@ -2360,6 +2540,9 @@ function toggleSpeakTurn(turnId, text, button) {
 
     const isAlreadyActive = activeTtsTurnId === turnId;
     if (isAlreadyActive) {
+        if (activeTtsPlaybackState && activeTtsPlaybackState.turnId === turnId) {
+            activeTtsPlaybackState.stopRequested = true;
+        }
         stopSpeaking();
         clearActiveTtsUi();
         return;
@@ -2379,6 +2562,34 @@ function toggleSpeakTurn(turnId, text, button) {
     let utterance = null;
     try {
         const settings = getChatSpeechSettings();
+        const debugData = llmDebugData.get(turnId);
+        const estimate = estimateSpeechDurationMs(trimmed, settings.tts.rate);
+        const voiceInfo = resolveSpeechVoiceInfo(settings.tts.voiceUri);
+        const thresholdSec = getTtsLongDurationThresholdSec();
+        const ttsSource = debugData?.speech_planning?.tts_source || null;
+
+        activeTtsPlaybackState = {
+            turnId,
+            requestId: debugData?.request_id || null,
+            expectedDurationMs: estimate.expectedMs,
+            estimateMethod: estimate.estimateMethod,
+            ttsChars: estimate.chars,
+            ttsWords: estimate.words,
+            thresholdSec,
+            ttsSource,
+            ttsLanguage: settings.tts.language,
+            ttsRate: settings.tts.rate,
+            ttsPitch: settings.tts.pitch,
+            ttsVolume: settings.tts.volume,
+            voiceUri: voiceInfo.voice_uri,
+            voiceName: voiceInfo.voice_name,
+            startedAtMs: null,
+            endedAtMs: null,
+            startedAt: null,
+            endedAt: null,
+            stopRequested: false
+        };
+
         utterance = speakText(trimmed, {
             language: settings.tts.language,
             rate: settings.tts.rate,
@@ -2392,15 +2603,29 @@ function toggleSpeakTurn(turnId, text, button) {
         return;
     }
 
-    const finish = () => {
+    const finish = (reason) => {
+        if (activeTtsPlaybackState && activeTtsPlaybackState.turnId === turnId) {
+            activeTtsPlaybackState.endedAtMs = Date.now();
+            activeTtsPlaybackState.endedAt = new Date(activeTtsPlaybackState.endedAtMs).toISOString();
+            const stopReason = activeTtsPlaybackState.stopRequested ? 'cancelled' : reason;
+            const telemetry = buildSpeechPlaybackTelemetry(activeTtsPlaybackState, stopReason);
+            recordSpeechPlaybackTelemetry(turnId, telemetry);
+            activeTtsPlaybackState = null;
+        }
         if (activeTtsTurnId === turnId) {
             clearActiveTtsUi();
         }
     };
 
     try {
-        utterance.onend = finish;
-        utterance.onerror = finish;
+        utterance.onstart = () => {
+            if (activeTtsPlaybackState && activeTtsPlaybackState.turnId === turnId) {
+                activeTtsPlaybackState.startedAtMs = Date.now();
+                activeTtsPlaybackState.startedAt = new Date(activeTtsPlaybackState.startedAtMs).toISOString();
+            }
+        };
+        utterance.onend = () => finish('ended');
+        utterance.onerror = () => finish('error');
     } catch (_) {
         // Ignore.
     }
@@ -4057,6 +4282,9 @@ function buildLlmDebugMetadata(debugData) {
         metadata.speech_planning = debugData.speech_planning || null;
         metadata.presenter_channels = debugData.presenter_channels || null;
     }
+    if (debugData?.speech_playback) {
+        metadata.speech_playback = debugData.speech_playback;
+    }
 
     // LLM interaction telemetry (JVNAUTOSCI-877)
     const llmInteraction = (debugData && typeof debugData === 'object') ? debugData.llm_interaction : null;
@@ -4464,6 +4692,11 @@ export function __testOnly_resetChatTtsState() {
     }
     try {
         clearActiveTtsUi();
+    } catch (_) {
+        // Ignore.
+    }
+    try {
+        activeTtsPlaybackState = null;
     } catch (_) {
         // Ignore.
     }

--- a/tests/frontend/chatTabSpeechPlaybackWarnings.test.js
+++ b/tests/frontend/chatTabSpeechPlaybackWarnings.test.js
@@ -1,0 +1,36 @@
+/** @jest-environment jsdom */
+
+const chatTabModulePath = '../../src/frontend/web/von_interface/static/js/chatTab.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    annotateTurn: jest.fn(),
+    getUserContext: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
+    elements: {},
+    renderSpanSuggestions: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/utils/textDecorator.js', () => ({
+    cartouchifyElementText: jest.fn(),
+    cartouchifyVontologyTokensInElement: jest.fn()
+}));
+
+describe('LLM debug warnings (speech playback)', () => {
+    test('flags long narration playback duration', () => {
+        const { __testOnly_deriveLlmDebugWarnings } = require(chatTabModulePath);
+
+        const warnings = __testOnly_deriveLlmDebugWarnings({
+            speech_playback: {
+                duration_suspect_too_long: true,
+                actual_duration_ms: 42000,
+                duration_threshold_sec: 30
+            }
+        });
+
+        expect(warnings).toContain(
+            'Narration playback duration exceeded long-duration threshold (actual 42.0s, threshold 30s).'
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- add speech playback telemetry endpoint for narration duration diagnostics
- capture playback duration estimates + send telemetry to backend
- surface long-duration warnings in LLM debug metadata
- add frontend test for playback warning

## Testing
- npm run test:frontend -- tests/frontend/chatTabSpeechPlaybackWarnings.test.js