### PR TITLE
JVNAUTOSCI-956 allow recent write intent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ All AI agents must read this file and `docs/engineering/security_considerations.
 - For high-risk state changes (auth/org handling, DB writes, Vontology mutations), use a single authoritative pathway and reuse it consistently.
 - When uncertain, ask succinctly; do not guess or fabricate behaviour.
 - When working on a task that may involve changes, you may open a branch based on the Jira task name (e.g. `JVNAUTOSCI-956-short-title`).
+- When you start work on a task (including restarting from Done or other closed states), transition it to In Progress.
 
 ## Tooling and Automation
 - Activate required external tool categories (Jira, Vontology, MongoDB, GitHub) without asking, when clearly needed.

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -439,14 +439,20 @@ class InternalMCPChatOrchestrator:
     def _action_write_policy_decide(self, request: Any) -> WorkflowActionResult:
         prompt = request.data.get("prompt")
         requested_tools = request.data.get("requested_write_tools")
+        recent_user_prompts = request.data.get("recent_user_prompts")
         if not isinstance(prompt, str):
             prompt = ""
         if not isinstance(requested_tools, list):
             requested_tools = []
+        if not isinstance(recent_user_prompts, list):
+            recent_user_prompts = []
 
         decision = compute_allowed_write_tools(
             prompt=prompt,
             requested_tools=[str(tool) for tool in requested_tools if tool],
+            recent_user_prompts=[
+                str(item) for item in recent_user_prompts if isinstance(item, str)
+            ],
         )
 
         return WorkflowActionResult(
@@ -2017,6 +2023,30 @@ class InternalMCPChatOrchestrator:
         return self._limit_context_for_llm(base)
 
     @staticmethod
+    def _extract_recent_user_prompts(
+        context: Optional[Sequence[Mapping[str, Any]]],
+        *,
+        max_count: int = 5,
+    ) -> list[str]:
+        if not context:
+            return []
+        prompts: list[str] = []
+        for msg in context:
+            if not isinstance(msg, Mapping):
+                continue
+            if msg.get("role") != "user":
+                continue
+            content = msg.get("content")
+            if not isinstance(content, str):
+                continue
+            cleaned = content.strip()
+            if cleaned:
+                prompts.append(cleaned)
+        if max_count > 0 and len(prompts) > max_count:
+            return prompts[-max_count:]
+        return prompts
+
+    @staticmethod
     def _prompt_requests_tts_voice(prompt: str) -> bool:
         if not isinstance(prompt, str):
             return False
@@ -2271,6 +2301,7 @@ class InternalMCPChatOrchestrator:
         *,
         prompt: str,
         requested_write_tools: list[str],
+        recent_user_prompts: list[str] | None,
         llm_client: Any,
         model: str | None,
         user_namespace: str | None,
@@ -2282,6 +2313,7 @@ class InternalMCPChatOrchestrator:
             data={
                 "prompt": prompt,
                 "requested_write_tools": list(requested_write_tools),
+                "recent_user_prompts": list(recent_user_prompts or []),
             },
             llm_client=llm_client,
             model=model,
@@ -2344,6 +2376,7 @@ class InternalMCPChatOrchestrator:
         aux_llm_calls: List[Mapping[str, Any]] = []
         llm_calls: list[dict[str, Any]] = []
         orchestrator_start = time.perf_counter()
+        recent_user_prompts = self._extract_recent_user_prompts(context, max_count=5)
 
         def _record_llm_call(
             *,
@@ -3025,6 +3058,7 @@ class InternalMCPChatOrchestrator:
                             self._resolve_allowed_write_tools(
                                 prompt=prompt,
                                 requested_write_tools=[tool_name],
+                                recent_user_prompts=recent_user_prompts,
                                 llm_client=llm_client,
                                 model=model,
                                 user_namespace=user_namespace,

--- a/src/backend/workflows/write_tool_policy.py
+++ b/src/backend/workflows/write_tool_policy.py
@@ -19,7 +19,7 @@ class WriteToolPolicyDecision:
 
 
 def compute_allowed_write_tools(
-    *, prompt: str, requested_tools: list[str]
+    *, prompt: str, requested_tools: list[str], recent_user_prompts: list[str] | None = None
 ) -> WriteToolPolicyDecision:
     """Compute which write tools are allowed for this user prompt.
 
@@ -29,20 +29,44 @@ def compute_allowed_write_tools(
 
     allowed: set[str] = set()
     requested = [tool for tool in requested_tools if isinstance(tool, str) and tool]
+    recent_prompts = [
+        str(item).strip()
+        for item in (recent_user_prompts or [])
+        if isinstance(item, str) and str(item).strip()
+    ]
 
-    if _prompt_allows_vontology_mutation(prompt):
+    explicit_vontology_intent = _prompt_allows_vontology_mutation(prompt)
+    explicit_artefact_intent = _prompt_allows_artefact_download(prompt)
+    recent_vontology_intent = any(
+        _prompt_allows_vontology_mutation(item) for item in recent_prompts
+    )
+    recent_artefact_intent = any(
+        _prompt_allows_artefact_download(item) for item in recent_prompts
+    )
+
+    if explicit_vontology_intent or recent_vontology_intent:
         allowed.update(requested)
         return WriteToolPolicyDecision(
             allowed_tools=frozenset(allowed),
-            reason="explicit_vontology_mutation_request",
+            reason=(
+                "explicit_vontology_mutation_request"
+                if explicit_vontology_intent
+                else "recent_vontology_mutation_request"
+            ),
         )
 
     # Side-effect writes (artefact storage) are allowed when explicitly requested.
-    if "download_paper" in requested and _prompt_allows_artefact_download(prompt):
+    if "download_paper" in requested and (
+        explicit_artefact_intent or recent_artefact_intent
+    ):
         allowed.add("download_paper")
         return WriteToolPolicyDecision(
             allowed_tools=frozenset(allowed),
-            reason="explicit_artefact_download_request",
+            reason=(
+                "explicit_artefact_download_request"
+                if explicit_artefact_intent
+                else "recent_artefact_download_request"
+            ),
         )
 
     return WriteToolPolicyDecision(

--- a/tests/backend/test_write_tool_policy.py
+++ b/tests/backend/test_write_tool_policy.py
@@ -1,0 +1,44 @@
+"""Tests for write-tool policy decisions."""
+
+from __future__ import annotations
+
+
+def test_recent_prompt_allows_vontology_write():
+    from src.backend.workflows.write_tool_policy import compute_allowed_write_tools
+
+    decision = compute_allowed_write_tools(
+        prompt="These predicates are just instances of #V#nearly_functional_binary_predicate.",
+        requested_tools=["create_concepts"],
+        recent_user_prompts=[
+            "Please create the predicate has_blob_key in the ontology.",
+        ],
+    )
+
+    assert "create_concepts" in decision.allowed_tools
+    assert decision.reason == "recent_vontology_mutation_request"
+
+
+def test_recent_prompt_allows_artefact_download():
+    from src.backend.workflows.write_tool_policy import compute_allowed_write_tools
+
+    decision = compute_allowed_write_tools(
+        prompt="What is arxiv 1234.5678 about?",
+        requested_tools=["download_paper"],
+        recent_user_prompts=["Download and store the arxiv 1234.5678 PDF."],
+    )
+
+    assert "download_paper" in decision.allowed_tools
+    assert decision.reason == "recent_artefact_download_request"
+
+
+def test_no_recent_write_intent_blocks():
+    from src.backend.workflows.write_tool_policy import compute_allowed_write_tools
+
+    decision = compute_allowed_write_tools(
+        prompt="These predicates are just instances of #V#nearly_functional_binary_predicate.",
+        requested_tools=["create_concepts"],
+        recent_user_prompts=["Explain how predicates relate to instances."],
+    )
+
+    assert "create_concepts" not in decision.allowed_tools
+    assert decision.reason == "no_explicit_write_intent_detected"


### PR DESCRIPTION
## Summary
- allow write-tool gating when a recent user prompt requested a write
- pass recent user prompts into write policy workflow and enforce consistently
- add regression tests for recent write intent handling

## Testing
- pdm run pytest tests\backend\test_write_tool_policy.py -q