### PR TITLE
JVNAUTOSCI-982: chat session links + conversation counts UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@ All AI agents must read this file and `docs/engineering/security_considerations.
 - Add a regression test for every state/format-loss bug (load -> edit -> save -> re-edit).
 - Prefer lightweight telemetry where practical (timings, counters, and error summaries) to support UX and future introspection.
 - For high-risk state changes (auth/org handling, DB writes, Vontology mutations), use a single authoritative pathway and reuse it consistently.
+- Do a quick factoring review whenever you touch write paths: search for existing canonical helpers/endpoints (especially for deletes/merges) and route through them rather than adding parallel pathways.
+- Treat ontology/predicate investigation as a normal first step for Vontology work: resolve candidate concepts by name (including spelling variants like programme/program), search for existing predicates/types before inventing new ones, and record the findings (and chosen canonical IDs) in the related Jira issue.
 - When uncertain, ask succinctly; do not guess or fabricate behaviour.
 - When working on a task that may involve changes, you may open a branch based on the Jira task name (e.g. `JVNAUTOSCI-956-short-title`).
 - When you start work on a task (including restarting from Done or other closed states), transition it to In Progress.

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -4395,6 +4395,147 @@ def rename_chat_session():
         return jsonify({"error": str(e)}), 500
 
 
+@von_bp.route("/api/session/chat_session_links", methods=["GET", "POST"])
+def chat_session_links():
+    """Get or set concept links for a chat session.
+
+    Stored on the chat_history session document as `session_links`.
+    Links are many-to-many lists of concept_ids:
+      - programmes
+      - projects
+      - activities
+      - modalities
+    """
+    try:
+        user_concept_id = session.get("user_concept_id")
+        if not user_concept_id:
+            return jsonify({"error": "Not authenticated"}), 401
+
+        requested_session_id = (
+            request.args.get("session_id")
+            if request.method == "GET"
+            else (request.get_json(silent=True) or {}).get("session_id")
+        )
+        session_id = None
+        if isinstance(requested_session_id, str) and requested_session_id.strip():
+            session_id = requested_session_id.strip()
+        else:
+            session_id = session.get("session_id")
+
+        if not isinstance(session_id, str) or not session_id.strip():
+            return jsonify({"error": "session_id required"}), 400
+        session_id = session_id.strip()
+
+        namespace = chat_history_service.resolve_chat_history_namespace(user_concept_id)
+
+        # Best-effort: ensure modality concepts exist so the UI can attach them.
+        try:
+            from ...vontology.utils_vontology import (
+                ensure_conversation_modality_concepts,
+            )
+
+            ensure_conversation_modality_concepts()
+        except Exception:
+            pass
+
+        if request.method == "GET":
+            links = chat_history_service.get_chat_session_links(
+                user_id=user_concept_id,
+                session_id=session_id,
+                namespace=namespace,
+            )
+            return (
+                jsonify(
+                    {
+                        "status": "ok",
+                        "session_id": session_id,
+                        "session_links": links,
+                    }
+                ),
+                200,
+            )
+
+        data = request.get_json(silent=True) or {}
+        raw_links = data.get("session_links")
+        if not isinstance(raw_links, dict):
+            # Allow top-level key alternatives for callers.
+            raw_links = {
+                "programmes": data.get("programmes") or data.get("programme_ids"),
+                "projects": data.get("projects") or data.get("project_ids"),
+                "activities": data.get("activities") or data.get("activity_ids"),
+                "modalities": data.get("modalities") or data.get("modality_ids"),
+            }
+
+        # Filter out unknown concept IDs (best-effort) so we don't persist stale references.
+        try:
+            from ...db.repositories.concepts_repository import ConceptsRepository
+
+            def _flatten(values):
+                if values is None:
+                    return []
+                if isinstance(values, str):
+                    return [values]
+                if isinstance(values, list):
+                    return values
+                return []
+
+            all_ids = []
+            for key in ("programmes", "projects", "activities", "modalities"):
+                all_ids.extend(_flatten(raw_links.get(key)))
+
+            all_ids = [
+                v.strip()
+                for v in all_ids
+                if isinstance(v, str) and v.strip().startswith("#V#")
+            ]
+            if all_ids:
+                found = set(
+                    doc.get("concept_id")
+                    for doc in ConceptsRepository.find(
+                        {"concept_id": {"$in": list(set(all_ids))}},
+                        {"concept_id": 1},
+                    )
+                    if isinstance(doc, dict) and isinstance(doc.get("concept_id"), str)
+                )
+            else:
+                found = set()
+
+            missing = sorted({cid for cid in set(all_ids) if cid not in found})
+            if found:
+                for key in ("programmes", "projects", "activities", "modalities"):
+                    raw_links[key] = [
+                        v.strip()
+                        for v in _flatten(raw_links.get(key))
+                        if isinstance(v, str)
+                        and v.strip().startswith("#V#")
+                        and v.strip() in found
+                    ]
+        except Exception:
+            missing = []
+
+        result = chat_history_service.set_chat_session_links(
+            user_id=user_concept_id,
+            session_id=session_id,
+            session_links=raw_links,
+            namespace=namespace,
+        )
+
+        if not result.get("matched"):
+            return jsonify({"error": "Session not found"}), 404
+
+        body = {
+            "status": "updated" if result.get("updated") else "ok",
+            "session_id": session_id,
+            "session_links": result.get("session_links") or {},
+        }
+        if missing:
+            body["missing_concepts"] = missing
+        return jsonify(body), 200
+    except Exception as e:
+        print(f"Error updating chat session links: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
 @von_bp.route("/api/organisations/my_organisations", methods=["GET"])
 def get_my_organisations():
     """

--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -495,7 +495,8 @@ def tree_build_progress(job_id: str):
     return jsonify(response), 200
 
 
-## Legacy route /delete_node removed (Phase 5 deprecation). Use unified DELETE /api/vontology/node instead.
+## Canonical ontology delete endpoint: use DELETE /api/vontology/node.
+## The legacy /api/vontology/delete_node route remains for backwards compatibility and is deprecated.
 @vontology_bp.route("/node", methods=["DELETE"])
 def unified_delete_node():
     """Unified ontology deletion endpoint.
@@ -1976,10 +1977,7 @@ def delete_node():
         )
 
     try:
-        repo = ConceptsRepository
-
-        # Check if node exists
-        existing_node = repo.find_one({"concept_id": concept_id})
+        existing_node = ConceptsRepository.find_one({"concept_id": concept_id})
         if not existing_node:
             return (
                 jsonify(
@@ -1991,32 +1989,38 @@ def delete_node():
                 404,
             )
 
-        # Delete the node
-        result = repo.delete_one({"concept_id": concept_id})
+        from ...vontology.utils_vontology import simulate_or_delete_concept
 
-        if result.deleted_count > 0:
+        report = simulate_or_delete_concept(concept_id, execute=True)
+        if report.get("success") is True:
             current_app.logger.info(f"Successfully deleted node: {concept_id}")
             return (
                 jsonify(
                     {
                         "success": True,
+                        "deprecated": True,
+                        "use_endpoint": "/api/vontology/node",
                         "message": f"Node '{existing_node.get('name', concept_id)}' deleted successfully.",
                         "deleted_concept_id": concept_id,
                         "deleted_name": existing_node.get("name"),
+                        "report": report,
                     }
                 ),
                 200,
             )
-        else:
-            return (
-                jsonify(
-                    {
-                        "success": False,
-                        "message": f"Failed to delete node '{concept_id}'.",
-                    }
-                ),
-                500,
-            )
+
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "deprecated": True,
+                    "use_endpoint": "/api/vontology/node",
+                    "message": f"Failed to delete node '{concept_id}'.",
+                    "report": report,
+                }
+            ),
+            500,
+        )
 
     except Exception as e:
         current_app.logger.error(

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -1408,6 +1408,166 @@ def rename_chat_session(
         raise ChatHistoryServiceError(f"Could not rename chat session: {e}") from e
 
 
+def _normalise_concept_id_list(values: Any) -> List[str]:
+    """Normalise a user-provided value into a de-duplicated list of concept IDs."""
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, list):
+        return []
+
+    seen: set[str] = set()
+    result: List[str] = []
+    for raw in values:
+        if not isinstance(raw, str):
+            continue
+        item = raw.strip()
+        if not item:
+            continue
+        if not item.startswith("#V#"):
+            continue
+        if item in seen:
+            continue
+        seen.add(item)
+        result.append(item)
+    return result
+
+
+def get_chat_session_links(
+    *,
+    user_id: str,
+    session_id: str,
+    namespace: Optional[str] = None,
+    include_legacy: bool = True,
+) -> Dict[str, List[str]]:
+    """Fetch persisted concept links for a chat session.
+
+    Returns a dict of lists keyed by: programmes, projects, activities, modalities.
+    Missing/invalid stored values are normalised away.
+    """
+    if not isinstance(user_id, str) or not user_id:
+        raise ChatHistoryServiceError("user_id is required.")
+    if not isinstance(session_id, str) or not session_id:
+        raise ChatHistoryServiceError("session_id is required.")
+
+    chat_history_coll = get_chat_history_collection_service()
+    if chat_history_coll is None:
+        raise ChatHistoryServiceError("Could not connect to chat history collection.")
+
+    query = build_chat_history_query(
+        user_id=user_id,
+        session_id=session_id,
+        namespace=namespace,
+        include_legacy=include_legacy,
+    )
+
+    try:
+        doc = chat_history_coll.find_one(query, {"session_links": 1}) or {}
+    except PyMongoError as e:
+        logger.error(f"Error fetching chat session links: {e}", exc_info=True)
+        raise ChatHistoryServiceError(f"Could not fetch session links: {e}") from e
+
+    raw_links = doc.get("session_links")
+    links = raw_links if isinstance(raw_links, dict) else {}
+    return {
+        "programmes": _normalise_concept_id_list(
+            links.get("programmes")
+            or links.get("programme_ids")
+            or links.get("programme_concept_ids")
+        ),
+        "projects": _normalise_concept_id_list(
+            links.get("projects")
+            or links.get("project_ids")
+            or links.get("project_concept_ids")
+        ),
+        "activities": _normalise_concept_id_list(
+            links.get("activities")
+            or links.get("activity_ids")
+            or links.get("activity_concept_ids")
+        ),
+        "modalities": _normalise_concept_id_list(
+            links.get("modalities")
+            or links.get("modality_ids")
+            or links.get("modality_concept_ids")
+        ),
+    }
+
+
+def set_chat_session_links(
+    *,
+    user_id: str,
+    session_id: str,
+    session_links: Dict[str, Any],
+    namespace: Optional[str] = None,
+    include_legacy: bool = True,
+) -> Dict[str, Any]:
+    """Persist concept links for a chat session.
+
+    Important: does NOT update session `updated_at` so recency ordering is stable.
+    """
+    if not isinstance(user_id, str) or not user_id:
+        raise ChatHistoryServiceError("user_id is required.")
+    if not isinstance(session_id, str) or not session_id:
+        raise ChatHistoryServiceError("session_id is required.")
+
+    if not isinstance(session_links, dict):
+        session_links = {}
+
+    chat_history_coll = get_chat_history_collection_service()
+    if chat_history_coll is None:
+        raise ChatHistoryServiceError("Could not connect to chat history collection.")
+
+    query = build_chat_history_query(
+        user_id=user_id,
+        session_id=session_id,
+        namespace=namespace,
+        include_legacy=include_legacy,
+    )
+
+    normalised = {
+        "programmes": _normalise_concept_id_list(
+            session_links.get("programmes")
+            or session_links.get("programme_ids")
+            or session_links.get("programme_concept_ids")
+        ),
+        "projects": _normalise_concept_id_list(
+            session_links.get("projects")
+            or session_links.get("project_ids")
+            or session_links.get("project_concept_ids")
+        ),
+        "activities": _normalise_concept_id_list(
+            session_links.get("activities")
+            or session_links.get("activity_ids")
+            or session_links.get("activity_concept_ids")
+        ),
+        "modalities": _normalise_concept_id_list(
+            session_links.get("modalities")
+            or session_links.get("modality_ids")
+            or session_links.get("modality_concept_ids")
+        ),
+    }
+
+    try:
+        result = chat_history_coll.update_one(
+            query,
+            {
+                "$set": {
+                    "session_links": normalised,
+                    "session_links_updated_at": datetime.now(timezone.utc),
+                }
+            },
+        )
+        return {
+            "updated": bool(getattr(result, "modified_count", 0) > 0),
+            "matched": bool(getattr(result, "matched_count", 0) > 0),
+            "session_links": normalised,
+        }
+    except PyMongoError as e:
+        logger.error(f"Error setting chat session links: {e}", exc_info=True)
+        raise ChatHistoryServiceError(f"Could not set session links: {e}") from e
+
+
 def backfill_chat_history_for_user(
     *,
     user_concept_id: str,
@@ -1885,7 +2045,9 @@ def reindex_chat_history_session_chunk(
     history_len = len(history)
     indexable_total, signature = _compute_rag_history_signature(history)
 
-    if safe_chunk_start == 0 and _should_skip_rag_reindex(doc, signature, indexable_total):
+    if safe_chunk_start == 0 and _should_skip_rag_reindex(
+        doc, signature, indexable_total
+    ):
         return {
             "status": "ok",
             "user_concept_id": user_concept_id,
@@ -2035,7 +2197,10 @@ def reindex_chat_history_session_chunk(
                 previous_failed = int(doc.get("rag_indexed_failed") or 0)
             except (TypeError, ValueError):
                 previous_failed = 0
-        if previous_failed == 0 and (previous_success + messages_indexed_success) >= indexable_total:
+        if (
+            previous_failed == 0
+            and (previous_success + messages_indexed_success) >= indexable_total
+        ):
             _update_rag_history_signature(
                 chat_history_coll,
                 doc.get("_id"),

--- a/src/backend/services/concept_merge_service.py
+++ b/src/backend/services/concept_merge_service.py
@@ -6,7 +6,7 @@ from pymongo.errors import DuplicateKeyError
 
 from ..db.repositories.concepts_repository import ConceptsRepository
 from ..db.repositories.text_value_repository import TextRelationsRepository
-from ..services.concept_service import get_concept_by_id
+from ..services.concept_service import get_concept_by_id, delete_concept
 
 logger = logging.getLogger(__name__)
 
@@ -441,8 +441,8 @@ def merge_concepts(
                 # If another process created the relation on target between fetch and update.
                 TextRelationsRepository.delete_one({"_id": rel_id})
 
-        # 5. Delete Source
-        ConceptsRepository.delete_one({"concept_id": source_id})
+        # 5. Delete Source (use canonical delete helper for consistent cleanup semantics)
+        delete_concept(source_id)
 
         report["success"] = True
         report["executed"] = True

--- a/src/backend/services/concept_resolution_service.py
+++ b/src/backend/services/concept_resolution_service.py
@@ -249,6 +249,41 @@ def resolve_concept_by_name(
             "audit": audit,
         }
 
+    # Filter out stale text relations pointing at non-existent concepts.
+    # This can happen if a concept is deleted but its text_relations (e.g. hasName) remain.
+    # Also keep virtual/code concepts, which intentionally have no DB row.
+    existing: set[str] = set()
+    try:
+        cursor = ConceptsRepository.find(
+            {"concept_id": {"$in": list(candidate_ids)}},
+            {"concept_id": 1},
+        )
+        for doc in cursor:
+            cid = doc.get("concept_id")
+            if isinstance(cid, str) and cid:
+                existing.add(cid)
+    except Exception as exc:  # pragma: no cover
+        audit.append(
+            {
+                "stage": "filter",
+                "method": "existing_concepts_error",
+                "error": str(exc),
+            }
+        )
+
+    existing.update({cid for cid in candidate_ids if is_code_concept_id(cid)})
+
+    if len(existing) != len(candidate_ids):
+        audit.append(
+            {
+                "stage": "filter",
+                "method": "existing_concepts",
+                "before": len(candidate_ids),
+                "after": len(existing),
+            }
+        )
+        candidate_ids = existing
+
     # Optional instance_of filter (recursive, includes descendants).
     if instance_of:
         try:

--- a/src/backend/services/concept_service.py
+++ b/src/backend/services/concept_service.py
@@ -950,55 +950,102 @@ def delete_concept(concept_id: str) -> bool:
     if concepts_coll is None:  # MODIFIED
         raise ConceptServiceError("Database collection 'concepts' not available.")
 
-    obj_id = None
-    try:
-        obj_id = ObjectId(concept_id)
-    except Exception:
-        logger.debug(
-            f"delete_concept: '{concept_id}' is not a valid ObjectId; will try string _id."
-        )
+    if not isinstance(concept_id, str) or not concept_id.strip():
+        raise InvalidConceptDataError("concept_id must be a non-empty string")
 
+    # Resolve identifier to a concrete concept document and canonical concept_id.
+    # Callers may provide either:
+    # - a MongoDB _id (ObjectId hex string or string-stored _id)
+    # - an ontological concept_id (e.g. '#V#person')
     try:
-        delete_filter: Dict[str, Any]
-        if obj_id is not None:
-            delete_filter = {"$or": [{"_id": obj_id}, {"_id": concept_id}]}
+        doc = None
+
+        if concept_id.startswith("#V#"):
+            doc = ConceptsRepository.find_one(
+                {"concept_id": concept_id}, {"concept_id": 1, "_id": 1}
+            )
         else:
-            delete_filter = {"_id": concept_id}
-        # Fetch prior doc to obtain ontological concept_id variant for cascade purposes
-        prior_doc = concepts_coll.find_one(delete_filter, {"concept_id": 1, "_id": 1})
-        result: DeleteResult = concepts_coll.delete_one(delete_filter)
+            obj_id = None
+            try:
+                obj_id = ObjectId(concept_id)
+            except Exception:
+                obj_id = None
 
-        if result.deleted_count == 0:
+            if obj_id is not None:
+                doc = ConceptsRepository.find_one(
+                    {"_id": obj_id}, {"concept_id": 1, "_id": 1}
+                )
+            if doc is None:
+                doc = ConceptsRepository.find_one(
+                    {"_id": concept_id}, {"concept_id": 1, "_id": 1}
+                )
+            if doc is None:
+                # Fallback: treat as a concept_id-like identifier even if it doesn't start with '#V#'.
+                doc = ConceptsRepository.find_one(
+                    {"concept_id": concept_id}, {"concept_id": 1, "_id": 1}
+                )
+
+        if not doc:
             raise ConceptNotFoundError(
                 f"concept with ID '{concept_id}' not found for deletion."
             )
 
-        ok = result.acknowledged and result.deleted_count > 0
-        if ok:
+        canonical_concept_id = doc.get("concept_id")
+        if not isinstance(canonical_concept_id, str) or not canonical_concept_id:
+            # Extremely defensive: if the document lacks a concept_id, fall back to deleting by _id.
+            delete_filter: Dict[str, Any] = {"_id": doc.get("_id")}
+            result: DeleteResult = concepts_coll.delete_one(delete_filter)
+            if result.deleted_count == 0:
+                raise ConceptNotFoundError(
+                    f"concept with ID '{concept_id}' not found for deletion."
+                )
             try:
                 invalidate_phrase_cache()
             except Exception:
                 pass
-            cascade_ids = {concept_id}
-            if prior_doc:
-                doc_cid = prior_doc.get("concept_id")
-                if isinstance(doc_cid, str) and doc_cid:
-                    cascade_ids.add(doc_cid)
-            total_rel = 0
-            total_tv = 0
-            for sid in cascade_ids:
-                try:
-                    rel_removed, tv_removed = _cascade_delete_text_relations(sid)
-                    total_rel += rel_removed
-                    total_tv += tv_removed
-                except Exception as e:  # pragma: no cover - defensive
-                    logger.warning(
-                        f"[cascade_delete] Failed for subject variant {sid}: {e}"
-                    )
-            logger.info(
-                f"[cascade_delete] concept={concept_id} subject_variants={len(cascade_ids)} removed_relations={total_rel} gc_text_values={total_tv}"
+            return bool(result.acknowledged and result.deleted_count > 0)
+
+        # Best-effort: remove text relations (and GC orphaned text_values) before deleting.
+        # This keeps behaviour consistent even if the lower-level delete helper changes.
+        cascade_ids = {canonical_concept_id}
+        if concept_id != canonical_concept_id:
+            cascade_ids.add(concept_id)
+
+        total_rel = 0
+        total_tv = 0
+        for sid in cascade_ids:
+            try:
+                rel_removed, tv_removed = _cascade_delete_text_relations(sid)
+                total_rel += rel_removed
+                total_tv += tv_removed
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning(
+                    f"[cascade_delete] Failed for subject variant {sid}: {e}"
+                )
+
+        # Canonical delete path: use vontology delete helper so rewiring/protection is consistent.
+        from ..vontology.utils_vontology import simulate_or_delete_concept
+
+        delete_report = simulate_or_delete_concept(canonical_concept_id, execute=True)
+
+        if not delete_report.get("success"):
+            if delete_report.get("protected"):
+                raise ConceptServiceError(
+                    f"Concept '{canonical_concept_id}' is protected and cannot be deleted."
+                )
+            raise ConceptServiceError(
+                f"Delete failed for concept '{canonical_concept_id}': {delete_report.get('error') or delete_report.get('message') or delete_report}"
             )
-        return ok
+
+        try:
+            invalidate_phrase_cache()
+        except Exception:
+            pass
+
+        logger.info(
+            f"[cascade_delete] concept={canonical_concept_id} subject_variants={len(cascade_ids)} removed_relations={total_rel} gc_text_values={total_tv}"
+        )
+        return True
     except ConceptNotFoundError:  # Re-raise specific error
         raise
     except Exception as e:

--- a/src/backend/vontology/utils_vontology.py
+++ b/src/backend/vontology/utils_vontology.py
@@ -193,6 +193,8 @@ from ..db.repositories.concepts_repository import (
     ConceptsRepository,
 )  # Added repository import
 
+from ..db.repositories.text_value_repository import TextRelationsRepository
+
 # --- Cached preferred language to avoid repeated DB calls ---
 _cached_preferred_language = None
 _cache_timestamp = 0
@@ -2407,6 +2409,16 @@ def delete_vontology_concept(concept_id: str) -> dict:
                 "message": f"Concept with id '{concept_id}' was not deleted.",
             }
 
+        # Remove associated text relations (names/descriptions/etc.) so deleted concepts
+        # cannot re-surface via stale text-value edges.
+        try:
+            rel_delete = TextRelationsRepository.delete_many(
+                {"subject_concept_id": concept_id}
+            )
+            text_relations_deleted = int(getattr(rel_delete, "deleted_count", 0) or 0)
+        except Exception:
+            text_relations_deleted = 0
+
         logger.info(
             f"Deleted concept '{concept_id}'. Reparented {children_reparented} children and re-typed {instances_retyped} instances."
         )
@@ -2432,6 +2444,7 @@ def delete_vontology_concept(concept_id: str) -> dict:
             "deleted_count": getattr(delete_result, "deleted_count", 0),
             "children_updated": children_reparented,
             "instances_updated": instances_retyped,
+            "text_relations_deleted": text_relations_deleted,
         }
 
     except PyMongoError as e:
@@ -2472,11 +2485,24 @@ def simulate_or_delete_concept(concept_id: str, execute: bool = False) -> dict:
     try:
         concept_doc = ConceptsRepository.find_one({"concept_id": concept_id})
         if not concept_doc:
+            # Simulation must be read-only; only attempt cleanup when actually executing.
+            if execute:
+                try:
+                    rel_del = TextRelationsRepository.delete_many(
+                        {"subject_concept_id": concept_id}
+                    )
+                    cleaned = int(getattr(rel_del, "deleted_count", 0) or 0)
+                except Exception:
+                    cleaned = 0
+            else:
+                cleaned = 0
+
             # Return dict only (avoid tuple) to satisfy declared return type
             return {
                 "success": False,
                 "error": f"Concept '{concept_id}' not found",
                 "simulate": not execute,
+                "text_relations_deleted": cleaned,
             }
 
         warnings: list[str] = []
@@ -2635,6 +2661,16 @@ def simulate_or_delete_concept(concept_id: str, execute: bool = False) -> dict:
             )
 
         del_result = ConceptsRepository.delete_one({"concept_id": concept_id})
+
+        # Remove associated text relations (names/descriptions/etc.) so deleted concepts
+        # cannot re-surface via stale text-value edges.
+        try:
+            rel_delete = TextRelationsRepository.delete_many(
+                {"subject_concept_id": concept_id}
+            )
+            text_relations_deleted = int(getattr(rel_delete, "deleted_count", 0) or 0)
+        except Exception:
+            text_relations_deleted = 0
         return {
             "success": getattr(del_result, "deleted_count", 0) == 1,
             "simulate": False,
@@ -2647,6 +2683,7 @@ def simulate_or_delete_concept(concept_id: str, execute: bool = False) -> dict:
             "instances": instances,
             "warnings": warnings,
             "transactional": False,
+            "text_relations_deleted": text_relations_deleted,
         }
     except Exception as e:  # pragma: no cover
         logger.error("simulate_or_delete_concept error: %s", e, exc_info=True)
@@ -3729,6 +3766,84 @@ def ensure_thing_exists_and_link_orphans() -> Dict[str, Any]:
         "orphans_linked": orphans_linked,
         "orphan_ids": orphan_ids,
     }
+
+
+def ensure_conversation_modality_concepts() -> Dict[str, Any]:
+    """Ensure core meeting/conversation modality concepts exist.
+
+    Creates (if missing):
+    - Type: Conversation Modality (#V#conversation_modality)
+    - Instances: Zoom, Microsoft Teams, Google Meet
+
+    Returns summary dict with created/exists counts.
+    """
+    from ..services.concept_service import create_concept
+    from ..utils.concept_id_utils import canonicalise_vontology_concept_id
+
+    summary: Dict[str, Any] = {
+        "type_created": False,
+        "instances_created": [],
+        "instances_skipped": [],
+        "errors": [],
+    }
+
+    try:
+        if not ConceptsRepository.find_one({"concept_id": THING_PRIMARY_ID}):
+            ensure_thing_exists_and_link_orphans()
+    except Exception:
+        pass
+
+    modality_type_id = "#V#conversation_modality"
+    try:
+        if not ConceptsRepository.find_one({"concept_id": modality_type_id}):
+            created = create_vontology_concept(
+                parent_id=THING_PRIMARY_ID,
+                new_concept_name="Conversation Modality",
+                create_as_instance=False,
+                description=(
+                    "A conversation modality is the medium/platform through which a conversation or meeting occurs, "
+                    "such as Zoom, Microsoft Teams, or Google Meet."
+                ),
+                notes=(
+                    "Used to tag conversations/meetings with the platform they occurred on. "
+                    "This is a non-exclusive (many-to-many) categorisation; sessions may have multiple modalities."
+                ),
+            )
+            summary["type_created"] = bool(created.get("success"))
+    except Exception as exc:
+        summary["errors"].append(f"type_create_failed: {exc}")
+
+    instances = [
+        ("Zoom", "Video meeting platform."),
+        ("Microsoft Teams", "Video meeting and collaboration platform."),
+        ("Google Meet", "Video meeting platform (Google)."),
+    ]
+
+    for display_name, description in instances:
+        try:
+            concept_id = canonicalise_vontology_concept_id(display_name)
+            if not concept_id:
+                summary["errors"].append(f"invalid_name: {display_name}")
+                continue
+
+            if ConceptsRepository.find_one({"concept_id": concept_id}):
+                summary["instances_skipped"].append(concept_id)
+                continue
+
+            create_concept(
+                name=display_name,
+                concept_id=concept_id,
+                parent_concept_ids=[modality_type_id],
+                create_as_instance=True,
+                description=description,
+                notes="Created by Von to support conversation metadata.",
+                system_tags=["conversation", "modality", "meeting"],
+            )
+            summary["instances_created"].append(concept_id)
+        except Exception as exc:
+            summary["errors"].append(f"instance_create_failed:{display_name}:{exc}")
+
+    return summary
 
 
 # Note: add_upward_closure_nodes defined later (duplicate removed - keeping complete implementation at line 2949)

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -1,9 +1,9 @@
 // Chat Tab Module
 import { annotateTurn, getUserContext } from './apiService.js';
-import { isAnnotationEnabled } from './featureFlags.js';
 import { initializeConceptAutocomplete } from './components/conceptAutocomplete.js';
 import { initializePromptCartoucheOverlay, normaliseVontologyIdsForBackend } from './components/promptCartoucheOverlay.js';
 import { elements, renderSpanSuggestions } from './domUtils.js';
+import { isAnnotationEnabled } from './featureFlags.js';
 import { detectMarkdown, renderMarkdownViaServer } from './markdownUtils.js';
 import {
     getSpeechSynthesisVoices,
@@ -2829,6 +2829,28 @@ function getChatSessionTabsContainer() {
     return document.getElementById('chatSessionTabs');
 }
 
+function getChatSessionCountEl() {
+    return document.getElementById('chatSessionCount');
+}
+
+function setChatSessionCount(count) {
+    const el = getChatSessionCountEl();
+    if (!el) {
+        return;
+    }
+
+    if (Number.isFinite(count)) {
+        const value = Math.max(0, Number(count));
+        el.textContent = String(value);
+        el.title = `Conversations (${value})`;
+        el.setAttribute('aria-label', `Conversation count: ${value}`);
+    } else {
+        el.textContent = '—';
+        el.title = 'Conversations';
+        el.setAttribute('aria-label', 'Conversation count');
+    }
+}
+
 function getChatTabButton() {
     return document.querySelector('.tab-button[data-tab="chatTab"]');
 }
@@ -3128,6 +3150,8 @@ function renderChatSessionTabsPlaceholder(mode = 'loading') {
     container.hidden = false;
     container.innerHTML = '';
 
+    setChatSessionCount(null);
+
     const fragment = document.createDocumentFragment();
 
     const allowNewChat = mode !== 'unauthenticated';
@@ -3336,6 +3360,7 @@ function renderChatSessionTabs(sessions, activeSessionId) {
     if (!Array.isArray(sessions) || sessions.length === 0) {
         renderChatSessionTabsPlaceholder('empty');
         lastRenderedSessionCount = 0;
+        setChatSessionCount(0);
         sessionTabsCache = [];
         return;
     }
@@ -3343,6 +3368,7 @@ function renderChatSessionTabs(sessions, activeSessionId) {
     container.hidden = false;
     container.innerHTML = '';
     lastRenderedSessionCount = sessions.length;
+    setChatSessionCount(sessions.length);
 
     const fragment = document.createDocumentFragment();
     const hasMultiple = sessions.length > 1;
@@ -3400,15 +3426,31 @@ function renderChatSessionTabs(sessions, activeSessionId) {
             tab.title = `${displayName} • ${timestampLabel}`;
         }
 
+        const header = document.createElement('span');
+        header.className = 'chat-session-tab-header';
+
         const label = document.createElement('span');
         label.className = 'chat-session-tab-label';
         label.textContent = displayName;
+        header.appendChild(label);
+
+        const messageCount = Number.isFinite(session?.message_count) ? Number(session.message_count) : null;
+        const turnCount = messageCount === null ? null : Math.max(0, Math.ceil(messageCount / 2));
+        if (turnCount !== null && turnCount > 0) {
+            const suffix = turnCount === 1 ? 'turn' : 'turns';
+            tab.title = `${tab.title} • ${turnCount} ${suffix}`;
+
+            const count = document.createElement('span');
+            count.className = 'chat-session-tab-count';
+            count.textContent = String(turnCount);
+            header.appendChild(count);
+        }
 
         const meta = document.createElement('span');
         meta.className = 'chat-session-tab-meta';
         meta.textContent = timestampLabel;
 
-        tab.appendChild(label);
+        tab.appendChild(header);
         tab.appendChild(meta);
         tab.addEventListener('click', () => {
             if (sid === activeChatSessionId) {

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -13,7 +13,7 @@ import {
     startSpeechRecognition,
     stopSpeaking
 } from './speech.js';
-import { selectBestNameForContext } from './utils/nameSelection.js';
+import { getPreferredLanguage, selectBestNameForContext } from './utils/nameSelection.js';
 import { cartouchifyElementText, cartouchifyVontologyTokensInElement } from './utils/textDecorator.js';
 import { showToast } from './utils/toast.js';
 
@@ -33,6 +33,25 @@ const SESSION_TABS_REFRESH_COOLDOWN_MS = 15_000;
 let lastSessionTabsRefreshMs = 0;
 let pendingSessionTabsRefresh = null;
 let lastRenderedSessionCount = 0;
+
+// JVNAUTOSCI-982: Per-session metadata (programme/project/activity/modality links)
+const CHAT_SESSION_LINK_KEYS = [
+    { key: 'programmes', label: 'Programmes', placeholder: 'Add a programme…' },
+    { key: 'projects', label: 'Projects', placeholder: 'Add a project…' },
+    { key: 'activities', label: 'Activities', placeholder: 'Add an activity…' },
+    { key: 'modalities', label: 'Modalities', placeholder: 'Add a modality…' }
+];
+const chatSessionLinksCache = new Map();
+let activeChatSessionLinks = null;
+let chatSessionLinksLoadInFlight = null;
+let chatSessionLinksSaveInFlight = null;
+let chatSessionLinksSaveDebounceId = null;
+let chatSessionLinksDirtySessionId = null;
+let chatSessionLinksDirtyPayload = null;
+let chatSessionMetadataOpenKey = null;
+
+const chatSessionConceptMetaCache = new Map();
+const chatSessionConceptMetaInFlight = new Map();
 
 // Lightweight client-side telemetry for chat session tab loading (elapsed + ETA).
 // Stored locally only; intended to feed future introspection.
@@ -2851,6 +2870,670 @@ function setChatSessionCount(count) {
     }
 }
 
+function getChatSessionMetadataEl() {
+    return document.getElementById('chatSessionMetadata');
+}
+
+function _normaliseChatSessionLinks(links) {
+    const raw = (links && typeof links === 'object') ? links : {};
+    const out = {};
+    for (const { key } of CHAT_SESSION_LINK_KEYS) {
+        const values = raw[key];
+        const arr = Array.isArray(values) ? values : (typeof values === 'string' ? [values] : []);
+        const cleaned = [];
+        const seen = new Set();
+        for (const item of arr) {
+            if (typeof item !== 'string') continue;
+            const trimmed = item.trim();
+            if (!trimmed) continue;
+            if (!trimmed.startsWith('#V#')) continue;
+            if (seen.has(trimmed)) continue;
+            seen.add(trimmed);
+            cleaned.push(trimmed);
+        }
+        out[key] = cleaned;
+    }
+    return out;
+}
+
+function _normalisePotentialConceptId(text) {
+    const raw = String(text ?? '').trim();
+    if (!raw) return '';
+
+    let id = raw;
+    if (id.startsWith('#v#')) id = `#V#${id.slice(3)}`;
+    if (!id.startsWith('#V#')) return '';
+
+    // Strip common trailing punctuation.
+    const trailingJunk = new Set(['.', ',', ':', ';', '!', '?', ')', ']', '}', '…']);
+    while (id.length > 3 && trailingJunk.has(id[id.length - 1])) {
+        id = id.slice(0, -1);
+    }
+
+    return id.trim();
+}
+
+function _deriveNameFromConceptId(conceptId) {
+    const slug = String(conceptId || '').replace(/^#V#/, '');
+    if (!slug) return '';
+    return slug.replace(/_/g, ' ');
+}
+
+async function _getConceptMetaForChatSession(conceptId) {
+    const id = String(conceptId || '').trim();
+    if (!id || !id.startsWith('#V#')) return null;
+
+    if (chatSessionConceptMetaCache.has(id)) {
+        return chatSessionConceptMetaCache.get(id);
+    }
+
+    if (chatSessionConceptMetaInFlight.has(id)) {
+        return chatSessionConceptMetaInFlight.get(id);
+    }
+
+    const request = (async () => {
+        try {
+            const url = `/vontology/api/vontology/node_content?identifier=${encodeURIComponent(id)}&raw_only=1`;
+            const resp = await fetch(url, { method: 'GET', headers: { 'Accept': 'application/json' } });
+            if (!resp.ok) {
+                return null;
+            }
+            const json = await resp.json();
+            const preferredLanguage = getPreferredLanguage();
+            const bestName = selectBestNameForContext(json?.raw_doc?.names, preferredLanguage);
+            const meta = {
+                displayName: bestName || json?.display_name || null,
+                kind: json?.kind || json?.computed_kind || null
+            };
+            chatSessionConceptMetaCache.set(id, meta);
+            return meta;
+        } catch (_) {
+            return null;
+        } finally {
+            chatSessionConceptMetaInFlight.delete(id);
+        }
+    })();
+
+    chatSessionConceptMetaInFlight.set(id, request);
+    return request;
+}
+
+function _clearChatSessionMetadata() {
+    const el = getChatSessionMetadataEl();
+    if (!el) return;
+    el.innerHTML = '';
+    el.classList.add('is-hidden');
+}
+
+function _renderChatSessionMetadataMessage(message) {
+    const el = getChatSessionMetadataEl();
+    if (!el) return;
+    el.classList.remove('is-hidden');
+    el.innerHTML = '';
+
+    const row = document.createElement('div');
+    row.className = 'chat-session-metadata-row';
+    const label = document.createElement('div');
+    label.className = 'chat-session-metadata-label';
+    label.textContent = 'Metadata';
+    const values = document.createElement('div');
+    values.className = 'chat-session-metadata-values';
+
+    const msg = document.createElement('span');
+    msg.style.fontSize = '13px';
+    msg.style.color = '#475569';
+    msg.textContent = String(message || '').trim() || '—';
+    values.appendChild(msg);
+    row.appendChild(label);
+    row.appendChild(values);
+    el.appendChild(row);
+}
+
+function _buildChatSessionMetadataSuggestions({ inputEl, suggestionsEl, onPick, includeIndividuals = true }) {
+    const state = { items: [], activeIndex: -1, abortController: null };
+    let pointerDown = false;
+
+    suggestionsEl.addEventListener('pointerdown', () => {
+        pointerDown = true;
+    });
+    suggestionsEl.addEventListener('pointerup', () => {
+        setTimeout(() => {
+            pointerDown = false;
+        }, 0);
+    });
+
+    const clearSuggestions = () => {
+        state.items = [];
+        state.activeIndex = -1;
+        suggestionsEl.classList.remove('open');
+        suggestionsEl.innerHTML = '';
+    };
+
+    const setActive = (idx) => {
+        state.activeIndex = idx;
+        suggestionsEl.querySelectorAll('.chat-session-metadata-suggestion').forEach((el, i) => {
+            if (i === idx) {
+                el.classList.add('active');
+            } else {
+                el.classList.remove('active');
+            }
+        });
+    };
+
+    const render = (items) => {
+        suggestionsEl.innerHTML = '';
+        if (!items.length) {
+            suggestionsEl.classList.remove('open');
+            return;
+        }
+
+        items.forEach((it, idx) => {
+            const row = document.createElement('div');
+            row.className = 'chat-session-metadata-suggestion';
+            row.setAttribute('role', 'option');
+
+            const name = document.createElement('span');
+            name.textContent = it.name || it.id;
+            name.title = `${it.name || it.id} — ${it.id}`;
+
+            const kind = document.createElement('span');
+            kind.className = 'chat-session-metadata-suggestion-kind';
+            kind.textContent = it.kind === 'predicate' ? 'Predicate' : (it.kind === 'individual' ? 'Individual' : 'Type');
+
+            row.appendChild(name);
+            row.appendChild(kind);
+
+            row.addEventListener('mouseenter', () => setActive(idx));
+            row.addEventListener('mouseleave', () => setActive(-1));
+            row.addEventListener('click', () => {
+                onPick(it);
+                clearSuggestions();
+            });
+
+            suggestionsEl.appendChild(row);
+        });
+
+        suggestionsEl.classList.add('open');
+    };
+
+    const performSearch = async (query) => {
+        const q = String(query || '').trim();
+        if (!q) {
+            clearSuggestions();
+            return;
+        }
+
+        try {
+            state.abortController?.abort?.();
+        } catch (_) { /* ignore */ }
+        const ac = new AbortController();
+        state.abortController = ac;
+
+        const url = `/vontology/api/vontology/search?q=${encodeURIComponent(q)}&limit=12&fallback_substring=true${includeIndividuals ? '&include_individuals=true' : ''}`;
+        try {
+            const resp = await fetch(url, { signal: ac.signal });
+            if (!resp.ok) {
+                clearSuggestions();
+                return;
+            }
+            const data = await resp.json();
+            const items = Array.isArray(data?.results) ? data.results : [];
+            state.items = items;
+            state.activeIndex = -1;
+            render(items);
+        } catch (err) {
+            if (err?.name === 'AbortError') return;
+            clearSuggestions();
+        }
+    };
+
+    const debounce = (fn, wait) => {
+        let t;
+        return (...args) => {
+            clearTimeout(t);
+            t = setTimeout(() => fn(...args), wait);
+        };
+    };
+
+    const debouncedSearch = debounce(() => performSearch(inputEl.value), 200);
+
+    inputEl.addEventListener('input', () => debouncedSearch());
+    inputEl.addEventListener('focus', () => {
+        if (state.items.length) {
+            suggestionsEl.classList.add('open');
+        }
+    });
+
+    inputEl.addEventListener('blur', () => {
+        // Allow click selection to run first.
+        setTimeout(() => {
+            if (!pointerDown) {
+                clearSuggestions();
+            }
+        }, 0);
+    });
+
+    inputEl.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+            clearSuggestions();
+            inputEl.blur();
+            return;
+        }
+
+        if (!state.items.length) {
+            if (e.key === 'Enter') {
+                const maybeId = _normalisePotentialConceptId(inputEl.value);
+                if (maybeId) {
+                    e.preventDefault();
+                    onPick({ id: maybeId, name: null, kind: 'individual' });
+                    inputEl.value = '';
+                    clearSuggestions();
+                }
+            }
+            return;
+        }
+
+        if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            setActive(Math.min(state.activeIndex + 1, state.items.length - 1));
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            setActive(Math.max(state.activeIndex - 1, 0));
+        } else if (e.key === 'Enter') {
+            e.preventDefault();
+            const idx = (state.activeIndex >= 0) ? state.activeIndex : 0;
+            const chosen = state.items[idx];
+            if (chosen) {
+                onPick(chosen);
+                inputEl.value = '';
+                clearSuggestions();
+            }
+        }
+    });
+
+    return { clearSuggestions };
+}
+
+function _escapeCssValue(value) {
+    const raw = String(value ?? '');
+    if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+        return CSS.escape(raw);
+    }
+    return raw.replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+function _renderChatSessionMetadataPanel({ sessionId, links, statusText, statusTone, disabled }) {
+    const el = getChatSessionMetadataEl();
+    if (!el) return;
+
+    const sid = String(sessionId || '').trim();
+    if (!sid) {
+        _clearChatSessionMetadata();
+        return;
+    }
+
+    el.classList.remove('is-hidden');
+    el.innerHTML = '';
+
+    if (statusText) {
+        const statusRow = document.createElement('div');
+        statusRow.className = 'chat-session-metadata-row';
+        const label = document.createElement('div');
+        label.className = 'chat-session-metadata-label';
+        label.textContent = 'Status';
+        const values = document.createElement('div');
+        values.className = 'chat-session-metadata-values';
+        const status = document.createElement('span');
+        status.style.fontSize = '12px';
+        status.style.color = statusTone === 'error' ? '#b91c1c' : '#64748b';
+        status.textContent = statusText;
+        values.appendChild(status);
+        statusRow.appendChild(label);
+        statusRow.appendChild(values);
+        el.appendChild(statusRow);
+    }
+
+    const safeLinks = _normaliseChatSessionLinks(links);
+
+    for (const group of CHAT_SESSION_LINK_KEYS) {
+        const row = document.createElement('div');
+        row.className = 'chat-session-metadata-row';
+
+        const label = document.createElement('div');
+        label.className = 'chat-session-metadata-label';
+        label.textContent = group.label;
+
+        const values = document.createElement('div');
+        values.className = 'chat-session-metadata-values';
+
+        const ids = Array.isArray(safeLinks[group.key]) ? safeLinks[group.key] : [];
+        ids.forEach((conceptId) => {
+            const chip = document.createElement('span');
+            chip.className = 'chat-session-metadata-chip';
+
+            const link = document.createElement('a');
+            link.href = '#';
+            const cached = chatSessionConceptMetaCache.get(conceptId);
+            link.textContent = cached?.displayName || _deriveNameFromConceptId(conceptId) || conceptId;
+            link.title = `${cached?.displayName || conceptId} — ${conceptId}`;
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                document.dispatchEvent(new CustomEvent('von:selectConceptById', {
+                    detail: { conceptId, createConceptTab: true }
+                }));
+            });
+            chip.appendChild(link);
+
+            const removeBtn = document.createElement('button');
+            removeBtn.type = 'button';
+            removeBtn.className = 'chat-session-metadata-chip-remove';
+            removeBtn.textContent = '×';
+            removeBtn.title = `Remove ${conceptId}`;
+            removeBtn.disabled = !!disabled;
+            removeBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                removeChatSessionLink(group.key, conceptId);
+            });
+            chip.appendChild(removeBtn);
+
+            values.appendChild(chip);
+
+            if (!cached && !chatSessionConceptMetaInFlight.has(conceptId)) {
+                void _getConceptMetaForChatSession(conceptId).then(() => {
+                    if (activeChatSessionLinks?.sessionId === sid) {
+                        _renderChatSessionMetadataPanel({
+                            sessionId: sid,
+                            links: activeChatSessionLinks?.links,
+                            statusText: activeChatSessionLinks?.statusText,
+                            statusTone: activeChatSessionLinks?.statusTone,
+                            disabled: activeChatSessionLinks?.disabled
+                        });
+                    }
+                });
+            }
+        });
+
+        const actions = document.createElement('div');
+        actions.className = 'chat-session-metadata-actions';
+
+        const addBtn = document.createElement('button');
+        addBtn.type = 'button';
+        addBtn.className = 'chat-session-metadata-add';
+        addBtn.textContent = '+';
+        addBtn.title = `Add ${group.label}`;
+        addBtn.disabled = !!disabled;
+
+        const inputWrap = document.createElement('div');
+        inputWrap.className = 'chat-session-metadata-inputwrap';
+        inputWrap.dataset.linkKey = group.key;
+        inputWrap.style.display = (chatSessionMetadataOpenKey === group.key) ? 'block' : 'none';
+
+        const input = document.createElement('input');
+        input.className = 'chat-session-metadata-input';
+        input.type = 'text';
+        input.placeholder = group.placeholder;
+        input.disabled = !!disabled;
+
+        const suggestions = document.createElement('div');
+        suggestions.className = 'chat-session-metadata-suggestions';
+        suggestions.setAttribute('role', 'listbox');
+
+        inputWrap.appendChild(input);
+        inputWrap.appendChild(suggestions);
+
+        addBtn.addEventListener('click', () => {
+            if (chatSessionMetadataOpenKey === group.key) {
+                chatSessionMetadataOpenKey = null;
+                _renderChatSessionMetadataPanel({
+                    sessionId: sid,
+                    links: activeChatSessionLinks?.links,
+                    statusText: activeChatSessionLinks?.statusText,
+                    statusTone: activeChatSessionLinks?.statusTone,
+                    disabled: activeChatSessionLinks?.disabled
+                });
+                return;
+            }
+            chatSessionMetadataOpenKey = group.key;
+            _renderChatSessionMetadataPanel({
+                sessionId: sid,
+                links: activeChatSessionLinks?.links,
+                statusText: activeChatSessionLinks?.statusText,
+                statusTone: activeChatSessionLinks?.statusTone,
+                disabled: activeChatSessionLinks?.disabled
+            });
+
+            setTimeout(() => {
+                const container = getChatSessionMetadataEl();
+                if (!container) return;
+                const escapedKey = _escapeCssValue(group.key);
+                const target = container.querySelector(`.chat-session-metadata-inputwrap[data-link-key="${escapedKey}"] .chat-session-metadata-input`);
+                try { target?.focus?.(); } catch (_) { /* ignore */ }
+            }, 0);
+        });
+
+        actions.appendChild(addBtn);
+        actions.appendChild(inputWrap);
+        values.appendChild(actions);
+
+        row.appendChild(label);
+        row.appendChild(values);
+        el.appendChild(row);
+
+        if (chatSessionMetadataOpenKey === group.key && !disabled) {
+            // Wire autocomplete + focus.
+            _buildChatSessionMetadataSuggestions({
+                inputEl: input,
+                suggestionsEl: suggestions,
+                includeIndividuals: true,
+                onPick: (it) => {
+                    const picked = _normalisePotentialConceptId(it?.id) || (typeof it?.id === 'string' ? it.id.trim() : '');
+                    if (!picked) {
+                        showToast('Select a valid concept.', 'error');
+                        return;
+                    }
+                    addChatSessionLink(group.key, picked);
+                }
+            });
+            setTimeout(() => {
+                try { input.focus(); } catch (_) { /* ignore */ }
+            }, 0);
+        }
+    }
+}
+
+function _setActiveChatSessionLinksState(state) {
+    activeChatSessionLinks = state;
+    _renderChatSessionMetadataPanel({
+        sessionId: state?.sessionId,
+        links: state?.links,
+        statusText: state?.statusText,
+        statusTone: state?.statusTone,
+        disabled: state?.disabled
+    });
+}
+
+function _scheduleSaveChatSessionLinks(sessionId, links) {
+    const sid = String(sessionId || '').trim();
+    if (!sid) return;
+    chatSessionLinksDirtySessionId = sid;
+    chatSessionLinksDirtyPayload = links;
+
+    if (chatSessionLinksSaveDebounceId) {
+        clearTimeout(chatSessionLinksSaveDebounceId);
+        chatSessionLinksSaveDebounceId = null;
+    }
+
+    chatSessionLinksSaveDebounceId = setTimeout(() => {
+        chatSessionLinksSaveDebounceId = null;
+        void saveChatSessionLinks(sid, chatSessionLinksDirtyPayload);
+    }, 650);
+}
+
+async function _flushPendingChatSessionLinksSave(sessionId) {
+    const sid = String(sessionId || '').trim();
+    if (!sid) return;
+    if (!chatSessionLinksDirtySessionId || chatSessionLinksDirtySessionId !== sid) return;
+    if (chatSessionLinksSaveDebounceId) {
+        clearTimeout(chatSessionLinksSaveDebounceId);
+        chatSessionLinksSaveDebounceId = null;
+    }
+    await saveChatSessionLinks(sid, chatSessionLinksDirtyPayload);
+}
+
+function addChatSessionLink(key, conceptId) {
+    const sid = activeChatSessionLinks?.sessionId;
+    if (!sid || sid !== activeChatSessionId) return;
+    const safeKey = String(key || '').trim();
+    const id = _normalisePotentialConceptId(conceptId);
+    if (!safeKey || !id) return;
+
+    const current = _normaliseChatSessionLinks(activeChatSessionLinks?.links);
+    const list = Array.isArray(current[safeKey]) ? current[safeKey].slice() : [];
+    if (list.includes(id)) {
+        showToast('Already added.', 'info');
+        return;
+    }
+    list.push(id);
+    current[safeKey] = list;
+
+    chatSessionLinksCache.set(sid, current);
+    _setActiveChatSessionLinksState({
+        sessionId: sid,
+        links: current,
+        statusText: 'Saving…',
+        statusTone: 'info',
+        disabled: false
+    });
+    _scheduleSaveChatSessionLinks(sid, current);
+}
+
+function removeChatSessionLink(key, conceptId) {
+    const sid = activeChatSessionLinks?.sessionId;
+    if (!sid || sid !== activeChatSessionId) return;
+    const safeKey = String(key || '').trim();
+    const id = String(conceptId || '').trim();
+    if (!safeKey || !id) return;
+
+    const current = _normaliseChatSessionLinks(activeChatSessionLinks?.links);
+    const list = Array.isArray(current[safeKey]) ? current[safeKey].slice() : [];
+    const next = list.filter(v => v !== id);
+    current[safeKey] = next;
+
+    chatSessionLinksCache.set(sid, current);
+    _setActiveChatSessionLinksState({
+        sessionId: sid,
+        links: current,
+        statusText: 'Saving…',
+        statusTone: 'info',
+        disabled: false
+    });
+    _scheduleSaveChatSessionLinks(sid, current);
+}
+
+async function loadChatSessionLinks(sessionId, options = {}) {
+    const sid = String(sessionId || '').trim();
+    if (!sid) {
+        _clearChatSessionMetadata();
+        return;
+    }
+
+    const force = options.force === true;
+    const cached = chatSessionLinksCache.get(sid);
+    if (!force && cached) {
+        _setActiveChatSessionLinksState({ sessionId: sid, links: cached, statusText: '', statusTone: 'info', disabled: false });
+        return;
+    }
+
+    try {
+        chatSessionLinksLoadInFlight?.abortController?.abort?.();
+    } catch (_) { /* ignore */ }
+    const abortController = new AbortController();
+    chatSessionLinksLoadInFlight = { sessionId: sid, abortController };
+
+    _setActiveChatSessionLinksState({ sessionId: sid, links: cached || {}, statusText: 'Loading…', statusTone: 'info', disabled: true });
+
+    try {
+        const resp = await fetch(`/von/api/session/chat_session_links?session_id=${encodeURIComponent(sid)}`, {
+            method: 'GET',
+            headers: { 'Accept': 'application/json' },
+            cache: 'no-store',
+            signal: abortController.signal
+        });
+        const data = await resp.json().catch(() => ({}));
+
+        if (abortController.signal.aborted) return;
+        if (activeChatSessionId !== sid) return;
+
+        if (resp.status === 401 || data?.error === 'Not authenticated') {
+            chatSessionMetadataOpenKey = null;
+            _renderChatSessionMetadataMessage('Log in to view/edit conversation metadata.');
+            return;
+        }
+
+        if (!resp.ok) {
+            _setActiveChatSessionLinksState({ sessionId: sid, links: cached || {}, statusText: 'Unable to load metadata.', statusTone: 'error', disabled: false });
+            return;
+        }
+
+        const links = _normaliseChatSessionLinks(data?.session_links);
+        chatSessionLinksCache.set(sid, links);
+        _setActiveChatSessionLinksState({ sessionId: sid, links, statusText: '', statusTone: 'info', disabled: false });
+    } catch (err) {
+        if (err?.name === 'AbortError') return;
+        _setActiveChatSessionLinksState({ sessionId: sid, links: cached || {}, statusText: 'Unable to load metadata.', statusTone: 'error', disabled: false });
+    }
+}
+
+async function saveChatSessionLinks(sessionId, links) {
+    const sid = String(sessionId || '').trim();
+    if (!sid) return;
+    const payload = _normaliseChatSessionLinks(links);
+
+    // Avoid parallel saves; last write wins.
+    try {
+        chatSessionLinksSaveInFlight?.abortController?.abort?.();
+    } catch (_) { /* ignore */ }
+    const abortController = new AbortController();
+    chatSessionLinksSaveInFlight = { sessionId: sid, abortController };
+
+    try {
+        const resp = await fetch('/von/api/session/chat_session_links', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+            body: JSON.stringify({ session_id: sid, session_links: payload }),
+            signal: abortController.signal
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (abortController.signal.aborted) return;
+        if (activeChatSessionId !== sid) return;
+
+        if (resp.status === 401 || data?.error === 'Not authenticated') {
+            _renderChatSessionMetadataMessage('Log in to view/edit conversation metadata.');
+            return;
+        }
+
+        if (!resp.ok) {
+            _setActiveChatSessionLinksState({ sessionId: sid, links: payload, statusText: 'Save failed.', statusTone: 'error', disabled: false });
+            return;
+        }
+
+        const saved = _normaliseChatSessionLinks(data?.session_links || payload);
+        chatSessionLinksCache.set(sid, saved);
+        chatSessionLinksDirtySessionId = null;
+        chatSessionLinksDirtyPayload = null;
+        _setActiveChatSessionLinksState({ sessionId: sid, links: saved, statusText: 'Saved', statusTone: 'info', disabled: false });
+        setTimeout(() => {
+            if (activeChatSessionLinks?.sessionId === sid && activeChatSessionLinks?.statusText === 'Saved') {
+                _setActiveChatSessionLinksState({ sessionId: sid, links: saved, statusText: '', statusTone: 'info', disabled: false });
+            }
+        }, 1200);
+    } catch (err) {
+        if (err?.name === 'AbortError') return;
+        _setActiveChatSessionLinksState({ sessionId: sid, links: payload, statusText: 'Save failed.', statusTone: 'error', disabled: false });
+    }
+}
+
 function getChatTabButton() {
     return document.querySelector('.tab-button[data-tab="chatTab"]');
 }
@@ -3264,6 +3947,8 @@ async function refreshChatSessionTabs() {
             renderChatSessionTabsPlaceholder('unauthenticated');
             lastRenderedSessionCount = 0;
             sessionTabsCache = [];
+            chatSessionMetadataOpenKey = null;
+            _clearChatSessionMetadata();
             return;
         }
 
@@ -3333,6 +4018,11 @@ async function refreshChatSessionTabs() {
         }
 
         renderChatSessionTabs(sessions, activeChatSessionId || activeSessionId);
+
+        const sidForMeta = activeChatSessionId || activeSessionId;
+        if (sidForMeta) {
+            void loadChatSessionLinks(sidForMeta, { force: false });
+        }
     } catch (err) {
         console.error('Failed to load chat sessions:', err);
 
@@ -3362,6 +4052,8 @@ function renderChatSessionTabs(sessions, activeSessionId) {
         lastRenderedSessionCount = 0;
         setChatSessionCount(0);
         sessionTabsCache = [];
+        chatSessionMetadataOpenKey = null;
+        _clearChatSessionMetadata();
         return;
     }
 
@@ -3659,6 +4351,12 @@ async function createChatSession(sessionName) {
         renderChatSessionTabs(sessionTabsCache, effectiveSessionId);
     }
 
+    // Metadata editor: start with a fresh load for the new session.
+    chatSessionMetadataOpenKey = null;
+    if (effectiveSessionId) {
+        void loadChatSessionLinks(effectiveSessionId, { force: true });
+    }
+
     const history = Array.isArray(data?.history) ? data.history : [];
     const scrollableField = document.getElementById('scrollableField');
     if (scrollableField) {
@@ -3742,6 +4440,11 @@ async function switchToChatSession(sessionId) {
 
     const previousSessionId = activeChatSessionId;
     const previousSessionName = activeChatSessionName;
+
+    // Best-effort: flush any pending metadata save before switching away.
+    if (previousSessionId) {
+        void _flushPendingChatSessionLinksSave(previousSessionId);
+    }
     const cachedSession = sessionTabsCache.find(
         session => String(session?.session_id || '') === sid
     );
@@ -3761,6 +4464,10 @@ async function switchToChatSession(sessionId) {
         renderChatSessionTabs(sessionTabsCache, sid);
     }
     setChatSessionTabLoading(sid, true);
+
+    // Render metadata panel immediately (cached if available).
+    chatSessionMetadataOpenKey = null;
+    void loadChatSessionLinks(sid, { force: false });
 
     abortActiveHistoryRequest();
     abortActiveChatRequest();
@@ -3798,6 +4505,14 @@ async function switchToChatSession(sessionId) {
             if (sessionTabsCache.length > 0) {
                 renderChatSessionTabs(sessionTabsCache, previousSessionId || sid);
             }
+
+            chatSessionMetadataOpenKey = null;
+            if (previousSessionId) {
+                void loadChatSessionLinks(previousSessionId, { force: false });
+            } else {
+                _clearChatSessionMetadata();
+            }
+
             setChatSessionTabLoading(sid, false);
             scrollableField.innerHTML = `<div class="chat-session-loading">${escapeHtml(msg)}</div>`;
             void loadChatHistory({
@@ -3810,6 +4525,13 @@ async function switchToChatSession(sessionId) {
         }
 
         setActiveChatSession(data?.session_id, data?.session_name);
+
+        // Refresh metadata (server-side session may have changed).
+        const effectiveMetaSessionId = (typeof data?.session_id === 'string' && data.session_id.trim())
+            ? data.session_id.trim()
+            : sid;
+        chatSessionMetadataOpenKey = null;
+        void loadChatSessionLinks(effectiveMetaSessionId, { force: true });
 
         if (shouldReuseCachedHistory) {
             const cached = getSessionHistoryCache(sid);
@@ -3882,6 +4604,14 @@ async function switchToChatSession(sessionId) {
         if (sessionTabsCache.length > 0) {
             renderChatSessionTabs(sessionTabsCache, previousSessionId || sid);
         }
+
+        chatSessionMetadataOpenKey = null;
+        if (previousSessionId) {
+            void loadChatSessionLinks(previousSessionId, { force: false });
+        } else {
+            _clearChatSessionMetadata();
+        }
+
         setChatSessionTabLoading(sid, false);
         scrollableField.innerHTML = '<div class="chat-session-loading">Unable to switch session.</div>';
         void loadChatHistory({

--- a/src/frontend/web/von_interface/static/js/domUtils.js
+++ b/src/frontend/web/von_interface/static/js/domUtils.js
@@ -380,22 +380,7 @@ export async function setModelInfoFooterText() {
   }
 
   // Build footer content: segments first (auth highlight depends on DOM order)
-  // Preserve chat history element if it exists (must remove before clearing innerHTML)
-  const historyElement = footer.querySelector('#chat-history-length');
-  if (historyElement) {
-    historyElement.remove(); // Remove from DOM before clearing
-  }
-
   footer.innerHTML = '';
-
-  // Re-append history element first (left-most position)
-  if (historyElement) {
-    footer.appendChild(historyElement);
-    const sep = document.createElement('span');
-    sep.className = 'footer-separator';
-    sep.textContent = ' | ';
-    footer.appendChild(sep);
-  }
 
   segments.forEach((seg, idx) => {
     if (typeof seg === 'string') {

--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -803,10 +803,14 @@ function createTabContent(tabId, conceptId, kind) {
 function insertTabButton(tabButton) {
     const tabContainer = document.getElementById('tabContainer');
     const importExportTab = document.querySelector('.tab-button[data-tab="importExportTab"]');
+    const settingsTab = document.querySelector('.tab-button[data-tab="settingsTab"]');
 
     if (tabContainer && importExportTab) {
         // Insert before import/export tab
         tabContainer.insertBefore(tabButton, importExportTab);
+    } else if (tabContainer && settingsTab) {
+        // Non-expert mode: keep dynamic concept tabs immediately after Conversations (before Settings).
+        tabContainer.insertBefore(tabButton, settingsTab);
     } else if (tabContainer) {
         // Fallback: append to end
         tabContainer.appendChild(tabButton);
@@ -821,9 +825,14 @@ function insertTabButton(tabButton) {
  */
 function insertTabContent(tabContent) {
     const tabContentArea = document.querySelector('.tab-content-area');
+    const settingsTabContent = document.getElementById('settingsTab');
 
     if (tabContentArea) {
-        tabContentArea.appendChild(tabContent);
+        if (settingsTabContent && settingsTabContent.parentNode === tabContentArea) {
+            tabContentArea.insertBefore(tabContent, settingsTabContent);
+        } else {
+            tabContentArea.appendChild(tabContent);
+        }
     } else {
         console.error('[dynamicTabs] Tab content area not found');
     }

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -3451,6 +3451,10 @@ footer {
     background: #f8fafc;
 }
 
+.chat-session-metadata-suggestion.active {
+    background: #f8fafc;
+}
+
 .chat-session-metadata-suggestion:last-child {
     border-bottom: none;
 }

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -2440,12 +2440,6 @@ footer {
     color: #666;
 }
 
-#chat-history-length {
-    font-size: 0.8rem;
-    color: #666;
-    padding: 4px 8px;
-}
-
 /* Footer segments & concept buttons */
 .footer-segment {
     display: inline-flex;
@@ -3131,10 +3125,30 @@ footer {
     display: flex;
     align-items: center;
     gap: 6px;
-    margin-bottom: 12px;
+    margin-bottom: 0;
     padding: 6px 0 10px;
     border-bottom: 1px solid #e5e7eb;
     overflow-x: auto;
+}
+
+.chat-session-tabs-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 12px;
+}
+
+.chat-session-count {
+    flex: 0 0 auto;
+    font-size: 12px;
+    color: #64748b;
+    padding: 0;
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    font-variant-numeric: tabular-nums;
+    -webkit-user-select: none;
+    user-select: none;
 }
 
 .chat-session-tabs::-webkit-scrollbar {
@@ -3162,7 +3176,7 @@ footer {
     white-space: nowrap;
     display: inline-flex;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: stretch;
     gap: 2px;
     flex: 0 0 auto;
     max-width: 160px;
@@ -3217,12 +3231,21 @@ footer {
     justify-content: center;
 }
 
+.chat-session-tab-header {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    min-width: 0;
+}
+
 .chat-session-tab-label {
     font-weight: 600;
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
     display: block;
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 .chat-session-tab-meta {
@@ -3231,6 +3254,20 @@ footer {
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.chat-session-tab-count {
+    font-size: 11px;
+    line-height: 1.1;
+    color: #64748b;
+    background: transparent;
+    border: none;
+    border-radius: 0;
+    padding: 0;
+    margin-left: auto;
+    font-variant-numeric: tabular-nums;
+    -webkit-user-select: none;
+    user-select: none;
 }
 
 .chat-session-tabs-placeholder {
@@ -3268,6 +3305,160 @@ footer {
     padding: 16px;
     color: #475569;
     font-weight: 600;
+}
+
+.chat-session-metadata {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 0 12px;
+    margin-bottom: 10px;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.chat-session-metadata.is-hidden {
+    display: none;
+}
+
+.chat-session-metadata-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+}
+
+.chat-session-metadata-label {
+    min-width: 92px;
+    font-weight: 600;
+    color: #334155;
+    font-size: 13px;
+    padding-top: 3px;
+}
+
+.chat-session-metadata-values {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    flex: 1;
+    min-width: 0;
+}
+
+.chat-session-metadata-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: #f1f5f9;
+    border: 1px solid #cbd5e1;
+    font-size: 12px;
+    color: #0f172a;
+    max-width: 100%;
+}
+
+.chat-session-metadata-chip a {
+    color: inherit;
+    text-decoration: none;
+    max-width: 220px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.chat-session-metadata-chip a:hover {
+    text-decoration: underline;
+}
+
+.chat-session-metadata-chip-remove {
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: #64748b;
+    font-weight: 700;
+    line-height: 1;
+    padding: 0 2px;
+}
+
+.chat-session-metadata-chip-remove:hover {
+    color: #b91c1c;
+}
+
+.chat-session-metadata-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.chat-session-metadata-add {
+    border: 1px solid #cbd5e1;
+    background: #ffffff;
+    color: #1f2937;
+    border-radius: 6px;
+    padding: 3px 8px;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.chat-session-metadata-add:hover {
+    border-color: #94a3b8;
+    background: #f8fafc;
+}
+
+.chat-session-metadata-inputwrap {
+    position: relative;
+    min-width: 240px;
+    max-width: 420px;
+    flex: 1;
+}
+
+.chat-session-metadata-input {
+    width: 100%;
+    border: 1px solid #cbd5e1;
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 13px;
+}
+
+.chat-session-metadata-suggestions {
+    position: absolute;
+    z-index: 1001;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    background: #ffffff;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+    max-height: 240px;
+    overflow: auto;
+    display: none;
+}
+
+.chat-session-metadata-suggestions.open {
+    display: block;
+}
+
+.chat-session-metadata-suggestion {
+    padding: 8px 10px;
+    cursor: pointer;
+    border-bottom: 1px solid #eef2f7;
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    font-size: 13px;
+}
+
+.chat-session-metadata-suggestion:hover {
+    background: #f8fafc;
+}
+
+.chat-session-metadata-suggestion:last-child {
+    border-bottom: none;
+}
+
+.chat-session-metadata-suggestion-kind {
+    font-size: 11px;
+    color: #64748b;
+    white-space: nowrap;
 }
 
 @keyframes chatSessionLoadingBar {

--- a/src/frontend/web/von_interface/templates/chat_tab.html
+++ b/src/frontend/web/von_interface/templates/chat_tab.html
@@ -16,7 +16,13 @@
       </div>
     </div>
 
-    <div id="chatSessionTabs" class="chat-session-tabs" role="tablist" aria-label="Conversation sessions"></div>
+    <div class="chat-session-tabs-row" aria-label="Conversation sessions">
+      <div id="chatSessionTabs" class="chat-session-tabs" role="tablist" aria-label="Conversation sessions"></div>
+      <div id="chatSessionCount" class="chat-session-count" aria-label="Conversation count" title="Conversations">—
+      </div>
+    </div>
+
+    <div id="chatSessionMetadata" class="chat-session-metadata" aria-label="Conversation metadata"></div>
 
     <div id="historyBanner" class="history-banner hidden" role="status" aria-live="polite">
       <span id="historyBannerText" class="history-banner-text">Older conversation available</span>
@@ -53,7 +59,8 @@
         Dictate
       </button>
       <button id="resetButton" class="btn btn-secondary" type="button"
-        title="End this conversation (resets Von's context while keeping the conversation view)">End conversation</button>
+        title="End this conversation (resets Von's context while keeping the conversation view)">End
+        conversation</button>
 
       <button id="uploadFileButton" class="btn btn-secondary" type="button"
         title="Upload a file (or drag and drop onto the conversation)">Upload File</button>

--- a/src/frontend/web/von_interface/templates/von_interface.html
+++ b/src/frontend/web/von_interface/templates/von_interface.html
@@ -13,7 +13,7 @@
   <script>
     window.__VON_FEATURE_FLAGS__ = {
       expertTabsEnabled: {{ 'true' if expert_tabs_enabled else 'false' }},
-      expertFooterEnabled: {{ 'true' if expert_footer_enabled else 'false' }}
+    expertFooterEnabled: { { 'true' if expert_footer_enabled else 'false' } }
     };
   </script>
 
@@ -132,7 +132,7 @@
   <!-- Footer for Model Info -->
   <div class="footer-container">
     <p id="modelInfoFooter" class="footer-info">
-      <span id="chat-history-length"></span>
+
     </p>
     <p id="languageIndicator" class="language-indicator">🌐 en-NZ</p>
     <p id="serverUptimeFooter" class="pid-indicator" title="Process uptime">
@@ -174,19 +174,6 @@
     </div>
   </div>
   {% endif %}
-
-  <!-- History Status Modal -->
-  <div id="historyStatusModal" class="modal" aria-hidden="true" role="dialog" aria-labelledby="historyStatusTitle">
-    <div class="modal-content">
-      <h2 id="historyStatusTitle">Conversation history</h2>
-      <div id="historyStatusBody">
-        <p>Loading…</p>
-      </div>
-      <div class="modal-actions">
-        <button id="historyStatusClose" type="button">Close</button>
-      </div>
-    </div>
-  </div>
 
   <!-- Link to external JavaScript (fixed endpoint spacing) -->
   <script type='module' src="{{ url_for('static', filename='js/main.js') }}"></script>

--- a/tests/backend/test_chat_history_session_links_service.py
+++ b/tests/backend/test_chat_history_session_links_service.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.backend.services import chat_history_service
+
+
+def test_get_chat_session_links_normalises_and_deduplicates():
+    coll = MagicMock()
+    coll.find_one.return_value = {
+        "session_links": {
+            "programmes": ["#V#programme", "  #V#programme  ", "not-a-concept"],
+            "project_ids": ["#V#project_a", "#V#project_a", ""],
+            "activity_concept_ids": ["#V#activity_1", None, 123],
+            "modalities": "#V#zoom",
+        }
+    }
+
+    with (
+        patch(
+            "src.backend.services.chat_history_service.get_chat_history_collection_service",
+            return_value=coll,
+        ),
+        patch(
+            "src.backend.services.chat_history_service.build_chat_history_query",
+            return_value={"user_id": "#V#u", "session_id": "s"},
+        ),
+    ):
+        links = chat_history_service.get_chat_session_links(
+            user_id="#V#u",
+            session_id="s",
+            namespace="#V#u",
+        )
+
+    assert links == {
+        "programmes": ["#V#programme"],
+        "projects": ["#V#project_a"],
+        "activities": ["#V#activity_1"],
+        "modalities": ["#V#zoom"],
+    }
+
+
+def test_set_chat_session_links_normalises_and_does_not_touch_updated_at():
+    coll = MagicMock()
+    coll.update_one.return_value = SimpleNamespace(modified_count=1, matched_count=1)
+
+    session_links = {
+        "programme_ids": ["#V#programme", "#V#programme"],
+        "projects": ["#V#project_a", "not-a-concept"],
+        "activities": "#V#activity_1",
+        "modalities": ["  #V#teams  ", "#V#teams"],
+    }
+
+    with (
+        patch(
+            "src.backend.services.chat_history_service.get_chat_history_collection_service",
+            return_value=coll,
+        ),
+        patch(
+            "src.backend.services.chat_history_service.build_chat_history_query",
+            return_value={"user_id": "#V#u", "session_id": "s"},
+        ),
+    ):
+        result = chat_history_service.set_chat_session_links(
+            user_id="#V#u",
+            session_id="s",
+            session_links=session_links,
+            namespace="#V#u",
+        )
+
+    assert result["matched"] is True
+    assert result["updated"] is True
+    assert result["session_links"] == {
+        "programmes": ["#V#programme"],
+        "projects": ["#V#project_a"],
+        "activities": ["#V#activity_1"],
+        "modalities": ["#V#teams"],
+    }
+
+    # Ensure we only update the session_links fields and *not* the session recency.
+    args, kwargs = coll.update_one.call_args
+    assert kwargs == {}
+    update_doc = args[1]
+
+    assert "$set" in update_doc
+    set_doc = update_doc["$set"]
+    assert "session_links" in set_doc
+    assert "session_links_updated_at" in set_doc
+    assert "updated_at" not in set_doc
+
+
+def test_set_chat_session_links_returns_not_matched_when_session_missing():
+    coll = MagicMock()
+    coll.update_one.return_value = SimpleNamespace(modified_count=0, matched_count=0)
+
+    with (
+        patch(
+            "src.backend.services.chat_history_service.get_chat_history_collection_service",
+            return_value=coll,
+        ),
+        patch(
+            "src.backend.services.chat_history_service.build_chat_history_query",
+            return_value={"user_id": "#V#u", "session_id": "s"},
+        ),
+    ):
+        result = chat_history_service.set_chat_session_links(
+            user_id="#V#u",
+            session_id="s",
+            session_links={},
+            namespace="#V#u",
+        )
+
+    assert result["matched"] is False
+    assert result["updated"] is False

--- a/tests/backend/test_chat_session_links_routes.py
+++ b/tests/backend/test_chat_session_links_routes.py
@@ -1,0 +1,239 @@
+"""Tests for the /von/api/session/chat_session_links endpoint.
+
+These tests focus on authentication behaviour and payload normalisation without
+requiring a real MongoDB instance.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def app_client(monkeypatch):
+    """Provide a Flask test client with side effects stubbed out."""
+
+    # Stub Google auth dependencies pulled in by utils_flask -> auth_routes imports.
+    fake_flow_module = types.ModuleType("google_auth_oauthlib.flow")
+
+    class _DummyFlow:
+        def __init__(self, *args, **kwargs):
+            self.credentials = types.SimpleNamespace(id_token="dummy-token")
+            self.redirect_uri = kwargs.get("redirect_uri")
+            self.client_config = {"web": {"redirect_uris": [self.redirect_uri]}}
+
+        @classmethod
+        def from_client_config(cls, *args, **kwargs):
+            return cls(**kwargs)
+
+        def authorization_url(self, *args, **kwargs):
+            return "https://auth.example", "state-token"
+
+        def fetch_token(self, *args, **kwargs):
+            return None
+
+    fake_flow_module.Flow = _DummyFlow  # type: ignore[attr-defined]
+    sys.modules["google_auth_oauthlib"] = types.ModuleType("google_auth_oauthlib")
+    sys.modules["google_auth_oauthlib"].flow = fake_flow_module  # type: ignore[attr-defined]
+    sys.modules["google_auth_oauthlib.flow"] = fake_flow_module
+
+    fake_id_token_module = types.ModuleType("google.oauth2.id_token")
+    fake_id_token_module.verify_oauth2_token = lambda *args, **kwargs: {  # type: ignore[attr-defined]
+        "sub": "dummy-user"
+    }
+
+    fake_credentials_module = types.ModuleType("google.oauth2.credentials")
+
+    class _DummyCredentials:
+        def __init__(self, id_token: str = "dummy-token"):
+            self.id_token = id_token
+
+    fake_credentials_module.Credentials = _DummyCredentials  # type: ignore[attr-defined]
+
+    fake_service_account_module = types.ModuleType("google.oauth2.service_account")
+
+    class _DummyServiceAccountCredentials:
+        def __init__(self, *args, **kwargs):
+            self.project_id = kwargs.get("project_id")
+
+    fake_service_account_module.Credentials = _DummyServiceAccountCredentials  # type: ignore[attr-defined]
+
+    fake_oauth2_package = types.ModuleType("google.oauth2")
+    fake_oauth2_package.id_token = fake_id_token_module  # type: ignore[attr-defined]
+    fake_oauth2_package.credentials = fake_credentials_module  # type: ignore[attr-defined]
+    fake_oauth2_package.service_account = fake_service_account_module  # type: ignore[attr-defined]
+
+    sys.modules["google.oauth2"] = fake_oauth2_package
+    sys.modules["google.oauth2.id_token"] = fake_id_token_module
+    sys.modules["google.oauth2.credentials"] = fake_credentials_module
+    sys.modules["google.oauth2.service_account"] = fake_service_account_module
+
+    import src.backend.server.utils_flask as utils_flask
+
+    # Avoid starting the DB monitor thread or touching Mongo during tests.
+    monkeypatch.setattr(utils_flask, "ensure_monitor_started", lambda: None)
+    # Keep prompt concept health check lightweight.
+    monkeypatch.setattr(
+        utils_flask,
+        "prompt_concept_health_status",
+        lambda: {"available": True, "source_field": "stub"},
+    )
+
+    app = utils_flask.create_flask_app(
+        list_models_func=lambda: ["dummy-model"],
+        generate_func=lambda prompt, context, model: "ok",
+    )
+    app.config["TESTING"] = True
+
+    with app.test_client() as client:
+        yield app, client
+
+
+def test_chat_session_links_requires_authentication(app_client):
+    _, client = app_client
+
+    resp = client.get("/von/api/session/chat_session_links?session_id=abc")
+
+    assert resp.status_code == 401
+    assert resp.get_json()["error"] == "Not authenticated"
+
+
+def test_chat_session_links_get_returns_links(app_client):
+    _, client = app_client
+
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#test_user"
+        sess["session_id"] = "sess-default"
+
+    expected = {
+        "programmes": ["#V#programme_a"],
+        "projects": [],
+        "activities": ["#V#activity_b"],
+        "modalities": ["#V#zoom"],
+    }
+
+    with (
+        patch(
+            "src.backend.services.chat_history_service.resolve_chat_history_namespace",
+            return_value="#V#test_user",
+        ),
+        patch(
+            "src.backend.services.chat_history_service.get_chat_session_links",
+            return_value=expected,
+        ) as mock_get,
+        patch(
+            "src.backend.vontology.utils_vontology.ensure_conversation_modality_concepts",
+            return_value={},
+        ),
+    ):
+        resp = client.get("/von/api/session/chat_session_links?session_id=sess-1")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "ok"
+    assert data["session_id"] == "sess-1"
+    assert data["session_links"] == expected
+
+    mock_get.assert_called_once()
+
+
+def test_chat_session_links_post_filters_missing_concepts(app_client):
+    _, client = app_client
+
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#test_user"
+        sess["session_id"] = "sess-default"
+
+    payload = {
+        "session_id": "sess-2",
+        "session_links": {
+            "programmes": ["#V#programme_a", "#V#missing_programme"],
+            "projects": ["#V#project_x"],
+            "activities": [],
+            "modalities": ["#V#zoom"],
+        },
+    }
+
+    def fake_find(query: Dict[str, Any], projection: Dict[str, Any]):
+        # Only return a subset as "existing".
+        wanted = set(query.get("concept_id", {}).get("$in", []))
+        existing = wanted.intersection({"#V#programme_a", "#V#project_x", "#V#zoom"})
+        return [{"concept_id": cid} for cid in existing]
+
+    mock_set = MagicMock(
+        return_value={
+            "updated": True,
+            "matched": True,
+            "session_links": {
+                "programmes": ["#V#programme_a"],
+                "projects": ["#V#project_x"],
+                "activities": [],
+                "modalities": ["#V#zoom"],
+            },
+        }
+    )
+
+    with (
+        patch(
+            "src.backend.services.chat_history_service.resolve_chat_history_namespace",
+            return_value="#V#test_user",
+        ),
+        patch(
+            "src.backend.db.repositories.concepts_repository.ConceptsRepository.find",
+            side_effect=fake_find,
+        ),
+        patch(
+            "src.backend.services.chat_history_service.set_chat_session_links",
+            mock_set,
+        ),
+        patch(
+            "src.backend.vontology.utils_vontology.ensure_conversation_modality_concepts",
+            return_value={},
+        ),
+    ):
+        resp = client.post("/von/api/session/chat_session_links", json=payload)
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "updated"
+    assert data["session_id"] == "sess-2"
+    assert data["session_links"]["programmes"] == ["#V#programme_a"]
+    assert data["missing_concepts"] == ["#V#missing_programme"]
+
+    # Ensure the service only receives filtered concepts.
+    called_links = mock_set.call_args.kwargs["session_links"]
+    assert called_links["programmes"] == ["#V#programme_a"]
+
+
+def test_chat_session_links_post_404_when_session_missing(app_client):
+    _, client = app_client
+
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#test_user"
+
+    with (
+        patch(
+            "src.backend.services.chat_history_service.resolve_chat_history_namespace",
+            return_value="#V#test_user",
+        ),
+        patch(
+            "src.backend.services.chat_history_service.set_chat_session_links",
+            return_value={"updated": False, "matched": False, "session_links": {}},
+        ),
+        patch(
+            "src.backend.vontology.utils_vontology.ensure_conversation_modality_concepts",
+            return_value={},
+        ),
+    ):
+        resp = client.post(
+            "/von/api/session/chat_session_links",
+            json={"session_id": "sess-missing", "session_links": {}},
+        )
+
+    assert resp.status_code == 404
+    assert resp.get_json()["error"] == "Session not found"

--- a/tests/backend/test_concept_merge_service_text_relations.py
+++ b/tests/backend/test_concept_merge_service_text_relations.py
@@ -114,6 +114,10 @@ def test_merge_concepts_apply_updates_text_relations_and_deletes_source() -> Non
             side_effect=fake_get,
         ),
         patch(
+            "src.backend.services.concept_merge_service.delete_concept",
+            return_value=True,
+        ) as mock_delete_concept,
+        patch(
             "src.backend.services.concept_merge_service.ConceptsRepository"
         ) as mock_concepts_repo,
         patch(
@@ -139,4 +143,4 @@ def test_merge_concepts_apply_updates_text_relations_and_deletes_source() -> Non
 
     assert report["success"] is True
     mock_text_rel_repo.update_one.assert_called()
-    mock_concepts_repo.delete_one.assert_called_with({"concept_id": source_id})
+    mock_delete_concept.assert_called_with(source_id)

--- a/tests/backend/test_resolve_concept_by_name.py
+++ b/tests/backend/test_resolve_concept_by_name.py
@@ -164,3 +164,36 @@ def test_resolve_concept_by_name_can_resolve_code_style_identifier():
     assert result["success"] is True
     assert result["status"] == "resolved"
     assert result["resolved_concept_id"] == concept_id
+
+
+def test_resolve_concept_by_name_does_not_resolve_deleted_concepts_from_stale_text_relations():
+    if TextValuesRepository.db() is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concepts = ConceptsRepository.collection()
+    if concepts is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concept_id = "#V#stale_deleted_concept"
+    concepts.insert_one({"concept_id": concept_id, "relationships": {}})
+
+    # Add a hasName relation that matches a code-style identifier exactly.
+    # This reproduces the historical failure mode where name resolution could
+    # return a deleted concept due to stale text_relations.
+    with bypass_access_control():
+        upsert_text_for_concept(
+            subject_concept_id=concept_id,
+            predicate="hasName",
+            text=concept_id,
+            lang="en-NZ",
+            context={"name_type": "CODE"},
+        )
+
+    # Simulate partial deletion: concept doc gone, text_relations remain.
+    ConceptsRepository.delete_one({"concept_id": concept_id})
+
+    result = resolve_concept_by_name(name=concept_id, match_code_strings=False)
+
+    assert result["success"] is True
+    assert result["status"] == "not_found"
+    assert result["resolved_concept_id"] is None


### PR DESCRIPTION
## Summary
- Adds per-session `session_links` support (programmes/projects/activities + modalities) with API routes + service helpers.
- Adds lightweight conversation UI counts: total conversations by the session scroller and per-session turn count.

## Jira / Tracking
- Jira: JVNAUTOSCI-982

## Key Changes
- Backend:
  - New `/von/api/session/chat_session_links` read/write route for session link metadata.
  - Chat history service helpers to get/set `session_links` while preserving `updated_at` ordering.
  - Best-effort ontology bootstrap for Conversation Modality concepts.
- Frontend:
  - Session count indicator next to the session scroller.
  - Per-session turn count rendered inline with the session name (no bubble styling).
  - Removed footer “History” UI handling from footer composition.
- Vontology / Knowledge:
  - Ensures `#V#conversation_modality` type and common instances (Zoom / Microsoft Teams / Google Meet).
- Docs:
  - Minor workflow guidance updates.

## Testing
- [x] Backend tests (note DB): `VON_DB_NAME=test_von_db` used
  - Command/task: `pdm run pytest tests/backend -q`
- [x] Frontend tests:
  - Command/task: `npm run test:frontend -- --runInBand`
- [ ] Manual checks (if relevant):
  - Verify session scroller loads and counts align correctly.

## Vontology / MCP (complete if applicable)
- Details:
  - Concepts/predicates added/updated: Conversation Modality type + instances via bootstrap.
  - Tooling changes: N/A

## Risk & Rollback
- Risk level: Low
- Rollback plan:
  - Revert this PR; session history data remains intact (new fields are additive).

## Screenshots / UI Notes (if applicable)
- Conversation session tabs now show a plain numeric turn count; conversation count shows next to scroller.

## Checklist
- [x] No secrets or runtime data committed (check `data/`, `logs/`, etc.)
- [x] Changes are scoped to the issue
