### PR TITLE
JVNAUTOSCI-996: Harden tool-call recovery/validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ All AI agents must read this file and `docs/engineering/security_considerations.
 11. Enable pre-commit guardrails: `git config core.hooksPath .githooks`.
 12. **STOP**: Never run backend tests against `VON_DB_NAME=von_db`. Always use the test DB (`VON_DB_NAME=test_von_db`) or the `pytest:backend (test db)` task.
 13. Requiring a user choice is almost always dispreferred; prefer LLM reasoning to achieve reliability and only ask the user when ambiguity cannot be resolved safely.
+14. When in doubt, run tests or re-run tests without requiring user confirmation.
+15. In the case that multiple tests are faiing, carefully consider the possibility that the tests are based on a design assumption that no longer holds. Tests are not definitional here, they are diagnostic, and should be changed (carefully) if they are not diagnostic for the current design. Do not allow tests to be a barrier to generality and good factoring.
 
 ## Core AI-Focused Documents
 - `docs/AINotes.md`: short-term memory and tactical log.
@@ -29,6 +31,9 @@ All AI agents must read this file and `docs/engineering/security_considerations.
 - Users may update this file; retain any user changes.
 - Add a regression test for every state/format-loss bug (load -> edit -> save -> re-edit).
 - Prefer lightweight telemetry where practical (timings, counters, and error summaries) to support UX and future introspection.
+- When fixing reliability issues, prefer **systemic, general fixes** over point fixes: update shared pipelines, validators, and policies so that behaviour remains stable across model changes and configuration drift.
+- Changes must be **modification-tolerant**: switching underlying models should not silently remove or change capabilities; differences must be explicit and detectable (telemetry, validation, or policy).
+- **Vontology-first prompt pattern**: any new or modified LLM prompt should be stored as Vontology text relations (hasContent/hasDescription, primary en-NZ), with a code fallback only when the concept is missing or tools are unavailable. Include prompt IDs in diagnostics for introspection and multilingual support.
 - For high-risk state changes (auth/org handling, DB writes, Vontology mutations), use a single authoritative pathway and reuse it consistently.
 - Strong rule: treat canonical predicate concepts (e.g. #V#is_a_type_of) as the authoritative ontology relations. Do not introduce or rely on structural relationship fields when predicate concepts exist; kind/classification should be derived from canonical predicate usage.
 - **Predicate concepts must be instances of `#V#predicate` (or a specialisation such as `#V#binary_predicate`) and must not keep `is_a_type_of` links that would force kind=`type`.** This ensures `is_predicate()` and the computed kind behave correctly.

--- a/src/backend/integrations/internal_mcp/gateway.py
+++ b/src/backend/integrations/internal_mcp/gateway.py
@@ -221,6 +221,14 @@ class InternalMCPGateway:
 
         return self._catalogue.snapshot()
 
+    def get_method_definition(self, method_name: str) -> MethodDefinition | None:
+        """Return the full method definition if registered."""
+
+        try:
+            return self._catalogue.get(method_name)
+        except Exception:
+            return None
+
     def extend_catalogue(self, definitions: Iterable[MethodDefinition]) -> None:
         for definition in definitions:
             self._catalogue.register(definition)

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -2883,6 +2883,12 @@ class InternalMCPChatOrchestrator:
             tool_name = candidate.get(self._TOOL_FIELD)
             payload_value = candidate.get(self._PAYLOAD_FIELD)
             action_value = candidate.get(self._ACTION_FIELD)
+            if not isinstance(payload_value, MutableMapping):
+                for alt_key in ("params", "arguments", "args"):
+                    alt_value = candidate.get(alt_key)
+                    if isinstance(alt_value, MutableMapping):
+                        payload_value = alt_value
+                        break
 
             has_tool = isinstance(tool_name, str)
             has_payload = isinstance(payload_value, MutableMapping)
@@ -2892,6 +2898,9 @@ class InternalMCPChatOrchestrator:
             strict_shape = set(candidate.keys()) <= {
                 self._TOOL_FIELD,
                 self._PAYLOAD_FIELD,
+                "params",
+                "arguments",
+                "args",
             }
 
             if missing_action and has_tool and has_payload and strict_shape:
@@ -2902,7 +2911,7 @@ class InternalMCPChatOrchestrator:
                 if isinstance(catalogue, Mapping) and tool_name in catalogue:
                     has_action = True
                 else:
-                    return None
+                    has_action = True
 
             if not (has_action and has_tool and has_payload):
                 return None
@@ -5451,7 +5460,7 @@ class InternalMCPChatOrchestrator:
                     pass
             if preflight.errors:
                 repaired_calls = None
-                if not preflight.tool_unavailable:
+                if method_catalogue:
                     repaired_calls = self._attempt_tool_call_repair(
                         current_response=(
                             current_response

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -24,7 +24,8 @@ from typing import (
     TypedDict,
 )
 
-from .gateway import InternalMCPGateway
+from .gateway import InternalMCPGateway, MethodDefinition
+from .schemas import Schema as McpSchema, coerce_payload_types, validate_payload
 
 # Structured tool calling support (JVNAUTOSCI-799 Phase 3)
 from ...languagemodels.structured_tool_calling import (
@@ -118,6 +119,14 @@ class _MissingToolCallAssessment:
 
 
 @dataclass(frozen=True)
+class _ToolCallPreflightResult:
+    tool_calls: list[_ToolCallRequest] | None
+    errors: list[str]
+    warnings: list[str]
+    tool_unavailable: list[str]
+
+
+@dataclass(frozen=True)
 class _MissingToolCallDetectorSpec:
     """Declarative definition of the missing-tool-call detector."""
 
@@ -171,6 +180,24 @@ class InternalMCPChatOrchestrator:
     _MISSING_TOOL_CALL_ACTION_ID = "#V#detect_missing_tool_call_action"
     _PREFLIGHT_PREDICATE_TYPE_ID = "#V#conversation_preflight_predicate"
     _PREFLIGHT_CACHE_TTL_SECONDS = 120
+    _TOOL_CALL_REPAIR_PROMPT = (
+        "You are a strict tool-call repairer for an MCP agent.\n"
+        "Return ONLY a JSON object or JSON array of tool-call objects.\n"
+        "Do NOT include prose, markdown fences, or explanations.\n\n"
+        "Each tool call must follow:\n"
+        '{{"action": "call_tool", "tool": "tool_name", "payload": {{"param": "value"}}}}\n\n'
+        "Constraints:\n"
+        "- Use only tools that appear in the available tool list.\n"
+        "- Ensure payload types match the schema (e.g. integers are integers).\n"
+        "- If you cannot produce a valid tool call, return an empty JSON array [].\n\n"
+        "Available tools:\n"
+        "{tool_list}\n\n"
+        "Validation errors to fix:\n"
+        "{errors}\n\n"
+        "Original tool-call JSON:\n"
+        "{raw_tool_call}\n"
+    )
+    _TOOL_CALL_REPAIR_PROMPTS = ("#V#tool_call_repair_prompt",)
     _FALLBACK_MISSING_TOOL_CALL_PROMPT = (
         "You are a strict classifier for an agent system that can call tools via JSON.\n"
         "Your job: decide whether the assistant response *promises* to call tools (or says it is about to do so) "
@@ -3056,6 +3083,236 @@ class InternalMCPChatOrchestrator:
 
         return tool_calls
 
+    def _tool_schema_for_name(
+        self,
+        tool_name: str,
+        method_catalogue: Mapping[str, Any],
+    ) -> McpSchema | None:
+        get_definition = getattr(self._gateway, "get_method_definition", None)
+        if callable(get_definition):
+            definition = get_definition(tool_name)
+            if isinstance(definition, MethodDefinition) and isinstance(
+                definition.input_schema, McpSchema
+            ):
+                return definition.input_schema
+
+        metadata = method_catalogue.get(tool_name)
+        if not isinstance(metadata, Mapping):
+            return None
+
+        raw_schema = metadata.get("input_schema")
+        if isinstance(raw_schema, McpSchema):
+            return raw_schema
+        if not isinstance(raw_schema, Mapping):
+            return None
+
+        def _coerce_fields(value: Any) -> Dict[str, Any]:
+            if isinstance(value, Mapping):
+                return dict(value)
+            if isinstance(value, list):
+                return {
+                    item: object for item in value if isinstance(item, str) and item
+                }
+            return {}
+
+        return McpSchema(
+            required=_coerce_fields(raw_schema.get("required") or {}),
+            optional=_coerce_fields(raw_schema.get("optional") or {}),
+            allow_unknown=bool(raw_schema.get("allow_unknown")),
+            description=(
+                raw_schema.get("description")
+                if isinstance(raw_schema.get("description"), str)
+                else None
+            ),
+        )
+
+    def _preflight_tool_calls(
+        self,
+        tool_calls: list[_ToolCallRequest],
+        method_catalogue: Mapping[str, Any],
+        *,
+        user_namespace: str | None,
+        selected_gmail_profile: str | None,
+    ) -> _ToolCallPreflightResult:
+        errors: list[str] = []
+        warnings: list[str] = []
+        tool_unavailable: list[str] = []
+
+        if not tool_calls:
+            return _ToolCallPreflightResult(None, errors, warnings, tool_unavailable)
+
+        available_tools = set(method_catalogue.keys())
+        enforce_availability = bool(available_tools)
+
+        for tool_call in tool_calls:
+            tool_name = tool_call.get(self._TOOL_FIELD)
+            payload = tool_call.get(self._PAYLOAD_FIELD)
+
+            if not isinstance(tool_name, str):
+                errors.append("Tool name must be a string.")
+                continue
+
+            if enforce_availability and tool_name not in available_tools:
+                tool_unavailable.append(tool_name)
+                errors.append(f"Tool '{tool_name}' is not available.")
+                continue
+
+            if not isinstance(payload, MutableMapping):
+                errors.append(f"Tool '{tool_name}' payload must be a JSON object.")
+                continue
+
+            schema = self._tool_schema_for_name(tool_name, method_catalogue)
+
+            self._apply_payload_defaults(
+                tool_name,
+                payload,
+                schema=schema,
+                user_namespace=user_namespace,
+                selected_gmail_profile=selected_gmail_profile,
+            )
+            if schema is None:
+                continue
+
+            _, coercion_warnings = coerce_payload_types(schema, payload)
+            warnings.extend(
+                [f"{tool_name}: {warning}" for warning in coercion_warnings]
+            )
+
+            validation_payload = payload
+            if (
+                not schema.allow_unknown
+                and "namespace" in payload
+                and "namespace" not in schema.required
+                and "namespace" not in schema.optional
+            ):
+                validation_payload = dict(payload)
+                validation_payload.pop("namespace", None)
+
+            ok, validation_errors = validate_payload(schema, validation_payload)
+            if not ok:
+                errors.extend([f"{tool_name}: {error}" for error in validation_errors])
+
+        return _ToolCallPreflightResult(tool_calls, errors, warnings, tool_unavailable)
+
+    def _apply_payload_defaults(
+        self,
+        tool_name: str,
+        payload: MutableMapping[str, Any],
+        *,
+        schema: McpSchema | None,
+        user_namespace: str | None,
+        selected_gmail_profile: str | None,
+    ) -> None:
+        if tool_name.startswith("gmail_"):
+            if not payload.get("profile") and selected_gmail_profile:
+                payload["profile"] = selected_gmail_profile
+            if "namespace" in payload:
+                payload.pop("namespace", None)
+            return
+
+        if user_namespace and "namespace" not in payload:
+            payload["namespace"] = user_namespace
+
+    def _tool_call_repair_enabled(self) -> bool:
+        return os.getenv("VON_TOOL_CALL_REPAIR_ENABLE", "1").lower() in {
+            "1",
+            "true",
+        }
+
+    def _attempt_tool_call_repair(
+        self,
+        *,
+        current_response: str,
+        errors: Sequence[str],
+        tool_list: Sequence[str],
+        llm_client: Any,
+        policy_state: _WorkflowModelPolicyState,
+        default_model: str | None,
+        registry_snapshot: Mapping[str, Any] | None,
+        user_concept_id: str | None,
+        org_concept_id: str | None,
+        aux_llm_calls: list[Mapping[str, Any]],
+        llm_calls_log: list[dict[str, Any]],
+        record_llm_call: Callable[..., None] | None,
+    ) -> list[_ToolCallRequest] | None:
+        if not self._tool_call_repair_enabled():
+            return None
+
+        variables = {
+            "tool_list": "\n".join(f"- {name}" for name in tool_list),
+            "errors": "\n".join(f"- {err}" for err in errors),
+            "raw_tool_call": (current_response[:4000] if current_response else ""),
+        }
+        rendered_prompt = self._prompt_templates.render_prompt(
+            self._TOOL_CALL_REPAIR_PROMPTS,
+            variables=variables,
+            fallback=self._TOOL_CALL_REPAIR_PROMPT.format(**variables),
+            max_chars=4000,
+        )
+        prompt_text = (
+            rendered_prompt.text
+            if rendered_prompt is not None
+            else self._TOOL_CALL_REPAIR_PROMPT.format(**variables)
+        )
+
+        try:
+            aux_llm_calls.append(
+                {
+                    "type": "tool_call_repair",
+                    "stage": "prompt",
+                    "prompt_preview": prompt_text[:800],
+                }
+            )
+        except Exception:
+            pass
+
+        repaired_response = None
+        if isinstance(policy_state, _WorkflowModelPolicyState) and callable(
+            record_llm_call
+        ):
+            repaired_response, _, _ = self._run_llm_with_fallbacks(
+                stage="tool_recovery",
+                prompt=prompt_text,
+                context=[],
+                default_client=llm_client,
+                default_model=default_model,
+                policy_state=policy_state,
+                registry_snapshot=registry_snapshot,
+                user_concept_id=user_concept_id,
+                org_concept_id=org_concept_id,
+                llm_calls_log=llm_calls_log,
+                aux_log=aux_llm_calls,
+                record_llm_call=record_llm_call,
+            )
+        else:
+            repaired_response = llm_client.generate(
+                prompt_text, context=[], model=default_model
+            )
+
+        try:
+            aux_llm_calls.append(
+                {
+                    "type": "tool_call_repair",
+                    "stage": "response",
+                    "response_preview": (
+                        repaired_response[:800]
+                        if isinstance(repaired_response, str)
+                        else str(repaired_response)[:800]
+                    ),
+                }
+            )
+        except Exception:
+            pass
+
+        try:
+            return self._extract_tool_calls(
+                repaired_response
+                if isinstance(repaired_response, str)
+                else str(repaired_response)
+            )
+        except ToolCallParsingError:
+            return None
+
     @staticmethod
     def _repair_truncated_json(raw: str) -> str | None:
         """Attempt to close unterminated JSON when it looks safely truncated."""
@@ -4373,6 +4630,57 @@ class InternalMCPChatOrchestrator:
                 aux_llm_calls=tuple(aux_llm_calls),
             )
 
+        def _build_tool_call_validation_error_result(
+            errors: Sequence[str],
+            warnings: Sequence[str],
+            tool_unavailable: Sequence[str],
+            *,
+            raw_tool_call: str | None,
+            invocations_override: Sequence[Mapping[str, Any]] = (),
+            tool_messages_override: Sequence[Mapping[str, Any]] = (),
+        ) -> OrchestratorResult:
+            payload: dict[str, Any] = {
+                "errors": list(errors),
+                "warnings": list(warnings),
+                "tool_unavailable": list(tool_unavailable),
+            }
+            if raw_tool_call:
+                payload["raw_tool_call"] = raw_tool_call[:8000]
+
+            tool_invocations = list(invocations_override)
+            tool_invocations.append(
+                {
+                    "tool": "__tool_call_validation_error__",
+                    "payload": payload,
+                    "error": "; ".join(errors) if errors else "validation_failed",
+                }
+            )
+
+            message_lines = [
+                "Tool call was not executed due to a validation error.",
+            ]
+            if tool_unavailable:
+                message_lines.append(
+                    "Unavailable tools: " + ", ".join(sorted(set(tool_unavailable)))
+                )
+            if errors:
+                message_lines.append("Errors:")
+                message_lines.extend([f"- {err}" for err in errors])
+            if warnings:
+                message_lines.append("Warnings:")
+                message_lines.extend([f"- {warning}" for warning in warnings])
+
+            message_lines.append(
+                "\nPlease retry. If this keeps happening, share the debug output so we can reproduce it."
+            )
+
+            return OrchestratorResult(
+                response_text="\n".join(message_lines),
+                extra_messages=tuple(tool_messages_override),
+                tool_invocations=tuple(tool_invocations),
+                aux_llm_calls=tuple(aux_llm_calls),
+            )
+
         trace_enabled = os.getenv("VON_WORKFLOWS_TRACE_ENABLED", "0").lower() in {
             "1",
             "true",
@@ -5125,6 +5433,70 @@ class InternalMCPChatOrchestrator:
             if not tool_calls:
                 break
 
+            preflight = self._preflight_tool_calls(
+                cast(list[_ToolCallRequest], tool_calls),
+                method_catalogue,
+                user_namespace=user_namespace,
+                selected_gmail_profile=selected_gmail_profile,
+            )
+            if preflight.warnings:
+                try:
+                    aux_llm_calls.append(
+                        {
+                            "type": "tool_call_coercions",
+                            "warnings": list(preflight.warnings),
+                        }
+                    )
+                except Exception:
+                    pass
+            if preflight.errors:
+                repaired_calls = None
+                if not preflight.tool_unavailable:
+                    repaired_calls = self._attempt_tool_call_repair(
+                        current_response=(
+                            current_response
+                            if isinstance(current_response, str)
+                            else str(current_response)
+                        ),
+                        errors=preflight.errors,
+                        tool_list=sorted(method_catalogue.keys()),
+                        llm_client=llm_client,
+                        policy_state=policy_state,
+                        default_model=tool_call_model,
+                        registry_snapshot=registry_snapshot,
+                        user_concept_id=user_concept_id,
+                        org_concept_id=org_concept_id,
+                        aux_llm_calls=aux_llm_calls,
+                        llm_calls_log=llm_calls,
+                        record_llm_call=_record_llm_call,
+                    )
+
+                if repaired_calls:
+                    preflight = self._preflight_tool_calls(
+                        repaired_calls,
+                        method_catalogue,
+                        user_namespace=user_namespace,
+                        selected_gmail_profile=selected_gmail_profile,
+                    )
+                    if not preflight.errors:
+                        tool_calls = repaired_calls
+
+            if preflight.errors:
+                result = _build_tool_call_validation_error_result(
+                    preflight.errors,
+                    preflight.warnings,
+                    preflight.tool_unavailable,
+                    raw_tool_call=(
+                        current_response
+                        if isinstance(current_response, str)
+                        else str(current_response)
+                    ),
+                    invocations_override=tuple(invocations),
+                    tool_messages_override=tuple(tool_messages),
+                )
+                _persist_trace(status="completed")
+                return result
+
             # Enforce invocation limit across batched calls.
             remaining = self._max_tool_invocations - iteration_count
             if remaining <= 0:
@@ -5191,6 +5563,11 @@ class InternalMCPChatOrchestrator:
                             else str(current_response)
                         ),
                     )
+                if not isinstance(payload, dict):
+                    payload = dict(payload)
+                else:
+                    payload = dict(payload)
+                tool_request[self._PAYLOAD_FIELD] = payload
 
                 # Safety: block write-category tools unless user explicitly requested a Vontology mutation.
                 # This is intentionally enforced at execution time so it applies to both legacy and
@@ -5258,46 +5635,37 @@ class InternalMCPChatOrchestrator:
                     continue
 
                 try:
+                    schema = self._tool_schema_for_name(tool_name, method_catalogue)
+                    self._apply_payload_defaults(
+                        tool_name,
+                        payload,
+                        schema=schema,
+                        user_namespace=user_namespace,
+                        selected_gmail_profile=selected_gmail_profile,
+                    )
+
                     if tool_name.startswith("gmail_"):
-                        if not payload.get("profile") and selected_gmail_profile:
-                            payload["profile"] = selected_gmail_profile
+                        if payload.get("profile"):
                             self._logger.info(
-                                "[mcp_orchestrator] Injected gmail_profile=%s into tool=%s payload",
-                                selected_gmail_profile,
+                                "[mcp_orchestrator] Using gmail_profile=%s for tool=%s",
+                                payload.get("profile"),
                                 tool_name,
                             )
-                        elif not payload.get("profile"):
+                        else:
                             self._logger.warning(
                                 "[mcp_orchestrator] Gmail tool=%s invoked without profile and no default configured",
                                 tool_name,
                             )
-
-                    # Inject user_namespace into payload for non-Gmail tools only; Gmail MCP rejects unexpected fields
-                    if not tool_name.startswith("gmail_"):
-                        if user_namespace and "namespace" not in payload:
-                            payload["namespace"] = user_namespace
+                    else:
+                        if user_namespace and "namespace" in payload:
                             self._logger.info(
-                                "[mcp_orchestrator] Injected namespace=%s into tool=%s payload",
-                                user_namespace,
+                                "[mcp_orchestrator] Using namespace=%s for tool=%s",
+                                payload.get("namespace"),
                                 tool_name,
                             )
                         elif user_namespace:
-                            self._logger.info(
-                                "[mcp_orchestrator] Tool=%s already has namespace=%s in payload",
-                                tool_name,
-                                payload.get("namespace"),
-                            )
-                        else:
                             self._logger.warning(
                                 "[mcp_orchestrator] No user_namespace available for tool=%s (unauthenticated request)",
-                                tool_name,
-                            )
-                    else:
-                        # Gmail tools must not receive namespace; profile is sufficient for routing
-                        if "namespace" in payload:
-                            payload.pop("namespace", None)
-                            self._logger.info(
-                                "[mcp_orchestrator] Removed namespace from Gmail tool=%s payload to satisfy MCP schema",
                                 tool_name,
                             )
 

--- a/src/backend/integrations/internal_mcp/schemas.py
+++ b/src/backend/integrations/internal_mcp/schemas.py
@@ -124,3 +124,60 @@ def coerce_payload(
 
     ok, errors = validate_payload(schema, payload)
     return payload, errors
+
+
+def coerce_payload_types(
+    schema: Schema, payload: MutableMapping[str, Any]
+) -> Tuple[MutableMapping[str, Any], list[str]]:
+    """Coerce payload fields to expected primitive types when safe.
+
+    This intentionally applies only narrow, predictable coercions to avoid
+    unexpected behaviour changes. It is used as a pre-validation step to
+    recover from common LLM output mismatches (e.g., numeric strings).
+    """
+
+    warnings: list[str] = []
+
+    def _coerce_value(key: str, value: Any, expected: JsonCompatibleType) -> Any:
+        allowed = _normalise_expected(expected)
+
+        if value is None:
+            return value
+
+        if isinstance(value, str):
+            raw = value.strip()
+            if not raw:
+                return value
+
+            if int in allowed and raw.isdigit():
+                warnings.append(f"Coerced field '{key}' from string to int.")
+                return int(raw)
+
+            if float in allowed:
+                try:
+                    coerced = float(raw)
+                except ValueError:
+                    coerced = None
+                if coerced is not None:
+                    warnings.append(f"Coerced field '{key}' from string to float.")
+                    return coerced
+
+            if bool in allowed:
+                lowered = raw.lower()
+                if lowered in {"true", "false"}:
+                    warnings.append(f"Coerced field '{key}' from string to bool.")
+                    return lowered == "true"
+
+        return value
+
+    for key, expected in schema.required.items():
+        if key not in payload:
+            continue
+        payload[key] = _coerce_value(key, payload[key], expected)
+
+    for key, expected in schema.optional.items():
+        if key not in payload:
+            continue
+        payload[key] = _coerce_value(key, payload[key], expected)
+
+    return payload, warnings

--- a/src/backend/services/prompt_template_service.py
+++ b/src/backend/services/prompt_template_service.py
@@ -42,16 +42,15 @@ def _detect_variables(template: str) -> List[str]:
 
 
 def _render_template(template: str, variables: Mapping[str, Any]) -> str:
-    missing: List[str] = []
-    for key in _detect_variables(template):
-        if key not in variables:
-            missing.append(key)
+    detected = _detect_variables(template)
+    missing = [key for key in detected if key not in variables]
     if missing:
         raise ValueError(f"Missing template variables: {', '.join(missing)}")
-    try:
-        return template.format(**variables)
-    except Exception as exc:
-        raise ValueError(f"Failed to render prompt template: {exc}") from exc
+
+    rendered = template
+    for key in detected:
+        rendered = rendered.replace("{" + key + "}", str(variables.get(key, "")))
+    return rendered
 
 
 def _best_effort_text_for_concept(concept_id: str) -> Optional[str]:
@@ -116,11 +115,7 @@ class PromptTemplateService:
             return fragment.prompt_id, fragment.text
         if isinstance(fallback, str) and fallback.strip():
             text = fallback.strip()
-            if (
-                isinstance(max_chars, int)
-                and max_chars > 0
-                and len(text) > max_chars
-            ):
+            if isinstance(max_chars, int) and max_chars > 0 and len(text) > max_chars:
                 text = (
                     text[:max_chars]
                     + f"\n... [truncated {len(text) - max_chars} chars]"
@@ -148,11 +143,13 @@ class PromptTemplateService:
         limit = max_chars or self._default_max_chars
         if len(rendered) > limit:
             rendered = (
-                rendered[:limit]
-                + f"\n... [truncated {len(rendered) - limit} chars]"
+                rendered[:limit] + f"\n... [truncated {len(rendered) - limit} chars]"
             )
             truncated = True
 
         return RenderedPrompt(
-            prompt_id=prompt_id, text=rendered, variables=dict(variables), truncated=truncated
+            prompt_id=prompt_id,
+            text=rendered,
+            variables=dict(variables),
+            truncated=truncated,
         )

--- a/tests/backend/test_orchestrator_tool_call_repair_integration.py
+++ b/tests/backend/test_orchestrator_tool_call_repair_integration.py
@@ -106,3 +106,33 @@ def test_tool_call_repair_recovers_invalid_payload(
     assert gateway.invocations
     assert gateway.invocations[0]["payload"]["top_k"] == 20
     assert "validation error" not in result.response_text.lower()
+
+
+def test_tool_call_repair_recovers_unknown_tool_with_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VON_TOOL_CALL_REPAIR_ENABLE", "1")
+
+    gateway = _Gateway()
+    orchestrator = InternalMCPChatOrchestrator(gateway=cast(Any, gateway))
+
+    llm = _SequencedLLM(
+        [
+            '[{"tool":"#V_concept_search","params":{"query":"test"}}]',
+            '{"action":"call_tool","tool":"search_knowledge_base","payload":{"query":"test","top_k":5}}',
+            "All done.",
+        ]
+    )
+
+    result = orchestrator.run(
+        prompt="Search the knowledge base",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+    )
+
+    assert gateway.invocations
+    assert gateway.invocations[0]["tool"] == "search_knowledge_base"
+    assert gateway.invocations[0]["payload"]["top_k"] == 5
+    assert "validation error" not in result.response_text.lower()

--- a/tests/backend/test_orchestrator_tool_call_repair_integration.py
+++ b/tests/backend/test_orchestrator_tool_call_repair_integration.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Sequence, cast
+
+import pytest
+
+from src.backend.integrations.internal_mcp.gateway import MethodDefinition
+from src.backend.integrations.internal_mcp.orchestrator import (
+    InternalMCPChatOrchestrator,
+)
+from src.backend.integrations.internal_mcp.schemas import Schema
+
+
+@dataclass(frozen=True)
+class _TransportResult:
+    payload: Any
+    duration_ms: float
+
+
+class _Gateway:
+    enabled = True
+
+    def __init__(self) -> None:
+        self.invocations: list[dict[str, Any]] = []
+        self._definition = MethodDefinition(
+            name="search_knowledge_base",
+            handler=lambda **_kwargs: None,
+            input_schema=Schema(
+                required={"query": str},
+                optional={"top_k": int},
+                allow_unknown=False,
+                description="search params",
+            ),
+            category="read",
+            description="Search the knowledge base",
+        )
+
+    def describe_methods(self) -> dict[str, Any]:
+        return {
+            "search_knowledge_base": {
+                "category": "read",
+                "description": "Search the knowledge base",
+                "input_schema": {
+                    "required": {"query": str},
+                    "optional": {"top_k": int},
+                    "allow_unknown": False,
+                    "description": "search params",
+                },
+            }
+        }
+
+    def get_method_definition(self, method_name: str) -> MethodDefinition | None:
+        if method_name == "search_knowledge_base":
+            return self._definition
+        return None
+
+    def invoke(self, tool_name: str, payload: Mapping[str, Any]) -> _TransportResult:
+        self.invocations.append({"tool": tool_name, "payload": dict(payload)})
+        return _TransportResult(payload={"ok": True}, duration_ms=1.0)
+
+
+class _SequencedLLM:
+    def __init__(self, responses: Sequence[str]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    def generate(
+        self,
+        prompt: str,
+        context: Optional[Sequence[Mapping[str, Any]]] = None,
+        model=None,
+    ) -> str:
+        self.calls.append(
+            {"prompt": prompt, "context": list(context or []), "model": model}
+        )
+        if not self._responses:
+            raise AssertionError("LLM called more times than expected")
+        return self._responses.pop(0)
+
+
+def test_tool_call_repair_recovers_invalid_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VON_TOOL_CALL_REPAIR_ENABLE", "1")
+
+    gateway = _Gateway()
+    orchestrator = InternalMCPChatOrchestrator(gateway=cast(Any, gateway))
+
+    llm = _SequencedLLM(
+        [
+            '{"action":"call_tool","tool":"search_knowledge_base","payload":{"query":"test","top_k":"bad"}}',
+            '{"action":"call_tool","tool":"search_knowledge_base","payload":{"query":"test","top_k":20}}',
+            "All done.",
+        ]
+    )
+
+    result = orchestrator.run(
+        prompt="Search the knowledge base",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+    )
+
+    assert gateway.invocations
+    assert gateway.invocations[0]["payload"]["top_k"] == 20
+    assert "validation error" not in result.response_text.lower()

--- a/tests/backend/test_orchestrator_tool_call_validation.py
+++ b/tests/backend/test_orchestrator_tool_call_validation.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Sequence, cast
+
+from src.backend.integrations.internal_mcp.gateway import MethodDefinition
+from src.backend.integrations.internal_mcp.orchestrator import (
+    InternalMCPChatOrchestrator,
+)
+from src.backend.integrations.internal_mcp.schemas import Schema
+
+
+@dataclass(frozen=True)
+class _TransportResult:
+    payload: Any
+    duration_ms: float
+
+
+class _Gateway:
+    enabled = True
+
+    def __init__(self) -> None:
+        self.invocations: list[dict[str, Any]] = []
+        self._definition = MethodDefinition(
+            name="search_knowledge_base",
+            handler=lambda **_kwargs: None,
+            input_schema=Schema(
+                required={"query": str},
+                optional={"top_k": int},
+                allow_unknown=False,
+                description="search params",
+            ),
+            category="read",
+            description="Search the knowledge base",
+        )
+
+    def describe_methods(self) -> dict[str, Any]:
+        return {
+            "search_knowledge_base": {
+                "category": "read",
+                "description": "Search the knowledge base",
+                "input_schema": {
+                    "required": {"query": str},
+                    "optional": {"top_k": int},
+                    "allow_unknown": False,
+                    "description": "search params",
+                },
+            }
+        }
+
+    def get_method_definition(self, method_name: str) -> MethodDefinition | None:
+        if method_name == "search_knowledge_base":
+            return self._definition
+        return None
+
+    def invoke(self, tool_name: str, payload: Mapping[str, Any]) -> _TransportResult:
+        self.invocations.append({"tool": tool_name, "payload": dict(payload)})
+        return _TransportResult(payload={"ok": True}, duration_ms=1.0)
+
+
+class _LLM:
+    def __init__(self, response: str):
+        self._response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def generate(
+        self,
+        prompt: str,
+        context: Optional[Sequence[Mapping[str, Any]]] = None,
+        model=None,
+    ) -> str:
+        self.calls.append(
+            {"prompt": prompt, "context": list(context or []), "model": model}
+        )
+        return self._response
+
+
+def test_tool_call_payload_coercion_allows_numeric_string() -> None:
+    gateway = _Gateway()
+    orchestrator = InternalMCPChatOrchestrator(gateway=cast(Any, gateway))
+
+    llm = _LLM(
+        '{"action":"call_tool","tool":"search_knowledge_base","payload":{"query":"test","top_k":"20"}}'
+    )
+
+    result = orchestrator.run(
+        prompt="Search the knowledge base",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+    )
+
+    assert result.tool_invocations
+    assert gateway.invocations
+    payload = gateway.invocations[0]["payload"]
+    assert payload["top_k"] == 20
+
+
+def test_tool_unavailable_returns_validation_error() -> None:
+    gateway = _Gateway()
+    orchestrator = InternalMCPChatOrchestrator(gateway=cast(Any, gateway))
+
+    llm = _LLM(
+        '{"action":"call_tool","tool":"missing_tool","payload":{"query":"test"}}'
+    )
+
+    result = orchestrator.run(
+        prompt="Try an unavailable tool",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+    )
+
+    assert not gateway.invocations
+    assert result.tool_invocations
+    assert result.tool_invocations[-1]["tool"] == "__tool_call_validation_error__"
+    assert "Unavailable tools" in result.response_text


### PR DESCRIPTION
## Summary
- Accept payload aliases (params/arguments/args) in tool-call normalisation.
- Allow repair when tool names are unavailable so recovery can select a valid tool.
- Add regression coverage for unknown tool + params recovery.

## Testing
- pytest tests/backend/test_orchestrator_tool_call_repair_integration.py -q