### PR TITLE
Fix missing concept cartouches: show ID with pink/red border and tooltip

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -4586,9 +4586,13 @@ def history_debug():
         owner_user_id = user_concept_id
         shared_invite = None
 
-        if not chat_history_service.has_chat_history_session(
+        has_session = chat_history_service.has_chat_history_session(
             user_concept_id, session_id, namespace=namespace
-        ):
+        )
+        print(
+            f"[history/debug] user={user_concept_id}, session={session_id}, namespace={namespace}, has_session={has_session}, history_index={history_index}"
+        )
+        if not has_session:
             owner_user_id, shared_invite = _resolve_shared_conversation_owner(
                 user_concept_id=user_concept_id, session_id=session_id
             )
@@ -4599,12 +4603,26 @@ def history_debug():
             owner_user_id,
             shared_invite.get("organisation_concept_id") if shared_invite else None,
         ) or chat_history_service.resolve_chat_history_namespace(owner_user_id)
+        print(
+            f"[history/debug] owner_user_id={owner_user_id}, owner_namespace={owner_namespace}"
+        )
         debug_data = chat_history_service.get_chat_history_debug_entry(
             user_id=owner_user_id,
             session_id=session_id,
             history_index=history_index,
             namespace=owner_namespace,
         )
+        # Fallback: if namespace mismatch (e.g. org session accessed without org context),
+        # retry without namespace restriction since we've already verified access above.
+        if not debug_data:
+            print(f"[history/debug] Retrying without namespace restriction")
+            debug_data = chat_history_service.get_chat_history_debug_entry(
+                user_id=owner_user_id,
+                session_id=session_id,
+                history_index=history_index,
+                namespace=None,
+            )
+        print(f"[history/debug] debug_data={bool(debug_data)}")
         if not debug_data:
             return jsonify(
                 {

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -2281,7 +2281,17 @@ function scheduleChatConceptMetaRetry(fullId) {
 function updateCartoucheElement(cartoucheEl, meta) {
     if (!cartoucheEl) return;
     if (!meta) {
-        cartoucheEl.classList.add('unresolved');
+        // Concept not found: mark as missing and show only the concept ID.
+        cartoucheEl.classList.add('vontology-cartouche-missing');
+        cartoucheEl.classList.remove('unresolved', 'cartouche-hide-id', 'cartouche-hide-name', 'cartouche-hide-kind', 'cartouche-kind-as-bg');
+        cartoucheEl.dataset.kind = '';
+        const nameEl = cartoucheEl.querySelector('.vontology-cartouche-name');
+        if (nameEl) nameEl.textContent = '';
+        const kindEl = cartoucheEl.querySelector('.vontology-cartouche-kind');
+        if (kindEl) {
+            kindEl.className = 'vontology-cartouche-kind';
+            kindEl.textContent = '';
+        }
         return;
     }
     const prefs = getCartoucheAppearanceSettings();

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -2280,11 +2280,15 @@ function scheduleChatConceptMetaRetry(fullId) {
 
 function updateCartoucheElement(cartoucheEl, meta) {
     if (!cartoucheEl) return;
+    const fullId = cartoucheEl?.dataset?.fullConceptId;
+    console.log('[chatTab] updateCartoucheElement', { fullId, hasMeta: !!meta, meta });
     if (!meta) {
         // Concept not found: mark as missing and show only the concept ID.
+        console.log('[chatTab] Marking cartouche as missing:', fullId);
         cartoucheEl.classList.add('vontology-cartouche-missing');
         cartoucheEl.classList.remove('unresolved', 'cartouche-hide-id', 'cartouche-hide-name', 'cartouche-hide-kind', 'cartouche-kind-as-bg');
         cartoucheEl.dataset.kind = '';
+        cartoucheEl.title = "This concept doesn't exist yet — click to create";
         const nameEl = cartoucheEl.querySelector('.vontology-cartouche-name');
         if (nameEl) nameEl.textContent = '';
         const kindEl = cartoucheEl.querySelector('.vontology-cartouche-kind');
@@ -8553,6 +8557,7 @@ async function loadLlmDebugDataForTurn(turnId, options = {}) {
                 session_id: historyLocation.session_id,
                 history_index: String(historyLocation.history_index)
             });
+            console.log('[chatTab] loadLlmDebugDataForTurn request:', { turnId, session_id: historyLocation.session_id, history_index: historyLocation.history_index });
             const response = await fetch(`/von/history/debug?${params.toString()}`, { cache: 'no-store' });
             let data = null;
             try {
@@ -8560,6 +8565,7 @@ async function loadLlmDebugDataForTurn(turnId, options = {}) {
             } catch (_) {
                 data = null;
             }
+            console.log('[chatTab] loadLlmDebugDataForTurn response:', { status: response.status, ok: response.ok, success: data?.success, error: data?.error, hasLlmDebugData: !!data?.llm_debug_data });
             if (!response.ok) {
                 if (response.status === 404 && data?.error === 'debug_not_available') {
                     showToast('No LLM debug data stored for this turn.');

--- a/src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js
+++ b/src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js
@@ -200,6 +200,9 @@ function updateCartouchesForMissingConcept(conceptId) {
             if (el?.dataset?.fullConceptId !== id) continue;
 
             el.classList.add('vontology-cartouche-missing');
+            // Remove hide classes so CSS for missing cartouches can control visibility.
+            // The ID must be visible; CSS hides name and kind for missing cartouches.
+            el.classList.remove('cartouche-hide-id', 'cartouche-hide-name', 'cartouche-hide-kind', 'cartouche-kind-as-bg');
             el.dataset.kind = '';
 
             const nameEl = el.querySelector('.vontology-cartouche-name');

--- a/src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js
+++ b/src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js
@@ -204,6 +204,7 @@ function updateCartouchesForMissingConcept(conceptId) {
             // The ID must be visible; CSS hides name and kind for missing cartouches.
             el.classList.remove('cartouche-hide-id', 'cartouche-hide-name', 'cartouche-hide-kind', 'cartouche-kind-as-bg');
             el.dataset.kind = '';
+            el.title = "This concept doesn't exist yet — click to create";
 
             const nameEl = el.querySelector('.vontology-cartouche-name');
             if (nameEl) nameEl.textContent = '';

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -4440,12 +4440,41 @@ footer {
 
 .vontology-cartouche.vontology-cartouche-missing {
     background: #ffffff;
-    border-color: #ef4444;
+    border: 2px solid #fecaca !important;
     color: #991b1b;
+    position: relative;
 }
 
 .vontology-cartouche.vontology-cartouche-missing:hover {
-    background: #ffffff;
+    background: #fff5f5;
+    border-color: #ef4444 !important;
+}
+
+/* CSS tooltip for missing cartouches */
+.vontology-cartouche.vontology-cartouche-missing::after {
+    content: "This concept doesn't exist yet — click to create";
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-bottom: 6px;
+    padding: 6px 10px;
+    background: #1e293b;
+    color: #f8fafc;
+    font-size: 12px;
+    font-weight: 400;
+    white-space: nowrap;
+    border-radius: 6px;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.15s ease, visibility 0.15s ease;
+    pointer-events: none;
+    z-index: 9999;
+}
+
+.vontology-cartouche.vontology-cartouche-missing:hover::after {
+    opacity: 1;
+    visibility: visible;
 }
 
 .vontology-cartouche.vontology-cartouche-missing .vontology-cartouche-name,


### PR DESCRIPTION
## Summary
Fixes non-existent concepts rendering as empty cartouches. Now they display the concept ID with visual distinction (pink/red border) and a tooltip explaining the missing state.

## Changes
- **chatTab.js**: Mark missing concepts with `vontology-cartouche-missing` class, remove hide classes so the concept ID is visible
- **selectConceptByIdHandler.js**: Same fix for cartouches updated when clicking reveals the concept doesn't exist
- **von_routes.py**: Added namespace fallback for LLM debug button when org session is accessed without org context
- **styles.css**: Light pink border (#fecaca) normally, red (#ef4444) on hover, plus CSS tooltip "This concept doesn't exist yet — click to create"

Fixes JVNAUTOSCI-1009