### PR TITLE
JVNAUTOSCI-1148: Add workflow view rendering with Von/Jira task links

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -10899,32 +10899,32 @@ class InternalMCPChatOrchestrator:
                 payloads.append((tool_name_raw.strip().lower(), payload))
             return payloads
 
+        def _first_text(*values: Any) -> str | None:
+            for value in values:
+                if not isinstance(value, str):
+                    continue
+                cleaned = value.strip()
+                if cleaned:
+                    return cleaned
+            return None
+
+        def _mapping_list(raw_value: Any, *, limit: int = 200) -> list[Mapping[str, Any]]:
+            if not isinstance(raw_value, list):
+                return []
+            rows: list[Mapping[str, Any]] = []
+            for item in raw_value:
+                if not isinstance(item, Mapping):
+                    continue
+                rows.append(item)
+                if len(rows) >= limit:
+                    break
+            return rows
+
         def _extract_renderer_screen_table_record_sets(
             *,
             tool_messages: Sequence[Mapping[str, Any]] = (),
         ) -> list[dict[str, Any]]:
             """Derive canonical record sets for screen tables from tool outputs."""
-
-            def _first_text(*values: Any) -> str | None:
-                for value in values:
-                    if not isinstance(value, str):
-                        continue
-                    cleaned = value.strip()
-                    if cleaned:
-                        return cleaned
-                return None
-
-            def _mapping_list(raw_value: Any, *, limit: int = 200) -> list[Mapping[str, Any]]:
-                if not isinstance(raw_value, list):
-                    return []
-                rows: list[Mapping[str, Any]] = []
-                for item in raw_value:
-                    if not isinstance(item, Mapping):
-                        continue
-                    rows.append(item)
-                    if len(rows) >= limit:
-                        break
-                return rows
 
             def _task_record_set() -> dict[str, Any] | None:
                 task_tool_names = {"task_list", "task_search", "list_my_tasks"}
@@ -11134,6 +11134,246 @@ class InternalMCPChatOrchestrator:
                 record_sets.append(predicate_records)
             return record_sets
 
+        def _extract_renderer_screen_workflow_elements(
+            *,
+            tool_messages: Sequence[Mapping[str, Any]] = (),
+        ) -> list[dict[str, Any]]:
+            """Derive workflow view payloads from workflow tool outputs.
+
+            The renderer may only have partial workflow graph data (for example,
+            status snapshots without edge topology). We therefore emit a
+            deterministic list-style workflow payload that still includes any
+            discoverable Von task concept links and Jira issue links.
+            """
+
+            tool_payloads = list(_iter_renderer_tool_result_payloads(tool_messages))
+            if not tool_payloads:
+                return []
+
+            workflow_detail_by_instance_id: dict[str, Mapping[str, Any]] = {}
+            workflow_list_payloads: list[Mapping[str, Any]] = []
+            source_tools: list[str] = []
+            seen_source_tools: set[str] = set()
+
+            for tool_name, payload in tool_payloads:
+                if tool_name in {"workflow_list_instances", "workflow_get_instance"}:
+                    if tool_name not in seen_source_tools:
+                        seen_source_tools.add(tool_name)
+                        source_tools.append(tool_name)
+
+                if tool_name == "workflow_get_instance":
+                    instance_id = _first_text(payload.get("instance_id"))
+                    if instance_id:
+                        workflow_detail_by_instance_id[instance_id] = payload
+                    continue
+                if tool_name == "workflow_list_instances":
+                    workflow_list_payloads.append(payload)
+
+            workflow_rows: list[Mapping[str, Any]] = []
+            for payload in workflow_list_payloads:
+                workflow_rows.extend(_mapping_list(payload.get("instances"), limit=200))
+
+            if not workflow_rows and workflow_detail_by_instance_id:
+                workflow_rows = list(workflow_detail_by_instance_id.values())
+
+            if not workflow_rows:
+                return []
+
+            concept_id_pattern = re.compile(r"^#V#[A-Za-z0-9._-]+$")
+            jira_issue_pattern = re.compile(r"^[A-Z][A-Z0-9]+-\d+$")
+
+            def _collect_task_links(*values: Any) -> list[dict[str, str]]:
+                links: list[dict[str, str]] = []
+                seen_targets: set[tuple[str, str]] = set()
+
+                def _add_link(link_type: str, target_id: str) -> None:
+                    target = target_id.strip()
+                    if not target:
+                        return
+                    key = (link_type, target)
+                    if key in seen_targets:
+                        return
+                    seen_targets.add(key)
+                    entry: dict[str, str] = {
+                        "link_type": link_type,
+                        "target_id": target,
+                        "label": target,
+                    }
+                    if link_type == "jira_issue":
+                        entry["href"] = (
+                            f"https://naoinstitute.atlassian.net/browse/{target}"
+                        )
+                    links.append(entry)
+
+                def _walk(value: Any, path: tuple[str, ...], depth: int) -> None:
+                    if depth > 4 or len(links) >= 12:
+                        return
+                    if isinstance(value, Mapping):
+                        for raw_key, nested in value.items():
+                            key_text = str(raw_key or "").strip().lower()
+                            if isinstance(nested, str):
+                                candidate = nested.strip()
+                                if not candidate:
+                                    continue
+                                path_tokens = " ".join(path + (key_text,))
+                                if concept_id_pattern.match(candidate) and (
+                                    "task" in path_tokens or "task" in candidate.lower()
+                                ):
+                                    _add_link("von_task", candidate)
+                                    continue
+                                if jira_issue_pattern.match(candidate):
+                                    _add_link("jira_issue", candidate)
+                                continue
+                            if isinstance(nested, (Mapping, list, tuple)):
+                                _walk(nested, path + (key_text,), depth + 1)
+                    elif isinstance(value, (list, tuple)):
+                        for nested in value:
+                            if isinstance(nested, (Mapping, list, tuple)):
+                                _walk(nested, path, depth + 1)
+                            elif isinstance(nested, str):
+                                candidate = nested.strip()
+                                if jira_issue_pattern.match(candidate):
+                                    _add_link("jira_issue", candidate)
+                                elif concept_id_pattern.match(candidate) and "task" in candidate.lower():
+                                    _add_link("von_task", candidate)
+
+                for value in values:
+                    _walk(value, tuple(), 0)
+
+                return links
+
+            nodes: list[dict[str, Any]] = []
+            seen_node_ids: set[str] = set()
+            for index, workflow_row in enumerate(workflow_rows, start=1):
+                detail = None
+                if isinstance(workflow_row, Mapping):
+                    instance_id = _first_text(workflow_row.get("instance_id"))
+                    if instance_id:
+                        detail = workflow_detail_by_instance_id.get(instance_id)
+                else:
+                    continue
+
+                instance_id = _first_text(
+                    workflow_row.get("instance_id"),
+                    detail.get("instance_id") if isinstance(detail, Mapping) else None,
+                )
+                workflow_id = _first_text(
+                    workflow_row.get("workflow_id"),
+                    detail.get("workflow_id") if isinstance(detail, Mapping) else None,
+                )
+                node_id = instance_id or workflow_id or f"workflow_node_{index}"
+                if node_id in seen_node_ids:
+                    continue
+                seen_node_ids.add(node_id)
+
+                status = (
+                    _first_text(
+                        workflow_row.get("status"),
+                        detail.get("status") if isinstance(detail, Mapping) else None,
+                    )
+                    or "unknown"
+                ).lower()
+                current_state = _first_text(
+                    workflow_row.get("current_state"),
+                    detail.get("current_state") if isinstance(detail, Mapping) else None,
+                ) or ""
+
+                progress_raw = workflow_row.get("progress")
+                if isinstance(progress_raw, Mapping):
+                    progress_map: Mapping[str, Any] = progress_raw
+                elif isinstance(detail, Mapping) and isinstance(
+                    detail.get("progress"), Mapping
+                ):
+                    progress_map = cast(Mapping[str, Any], detail.get("progress"))
+                else:
+                    progress_map = {}
+                progress_current = (
+                    progress_map.get("current")
+                    if isinstance(progress_map.get("current"), (int, float))
+                    else None
+                )
+                progress_total = (
+                    progress_map.get("total")
+                    if isinstance(progress_map.get("total"), (int, float))
+                    else None
+                )
+                progress_message = _first_text(progress_map.get("message"))
+                step_index = workflow_row.get("step_index")
+                if not isinstance(step_index, (int, float)):
+                    if isinstance(detail, Mapping) and isinstance(
+                        detail.get("step_index"), (int, float)
+                    ):
+                        step_index = detail.get("step_index")
+                    else:
+                        step_index = None
+
+                progress_bits: list[str] = []
+                if isinstance(progress_current, (int, float)) and isinstance(
+                    progress_total, (int, float)
+                ):
+                    progress_bits.append(
+                        f"Step {int(progress_current)}/{int(progress_total)}"
+                    )
+                elif isinstance(step_index, (int, float)):
+                    progress_bits.append(f"Step {int(step_index)}")
+                if progress_message:
+                    progress_bits.append(progress_message)
+                elif current_state:
+                    progress_bits.append(current_state)
+
+                task_links = _collect_task_links(
+                    workflow_row,
+                    detail if isinstance(detail, Mapping) else None,
+                    detail.get("inputs") if isinstance(detail, Mapping) else None,
+                    detail.get("outputs") if isinstance(detail, Mapping) else None,
+                    detail.get("workflow_data") if isinstance(detail, Mapping) else None,
+                )
+
+                label = workflow_id or instance_id or f"Workflow {index}"
+                node_payload: dict[str, Any] = {
+                    "node_id": node_id,
+                    "label": label,
+                    "status": status,
+                }
+                if workflow_id:
+                    node_payload["workflow_id"] = workflow_id
+                if instance_id:
+                    node_payload["instance_id"] = instance_id
+                if current_state:
+                    node_payload["state"] = current_state
+                if progress_bits:
+                    node_payload["progress_label"] = " · ".join(progress_bits)
+                if task_links:
+                    node_payload["task_links"] = task_links
+
+                nodes.append(node_payload)
+                if len(nodes) >= 50:
+                    break
+
+            if not nodes:
+                return []
+
+            return [
+                {
+                    "element_id": "screen_workflow_view",
+                    "intent": "structured_workflow_view",
+                    "payload": {
+                        "layout": "list",
+                        "nodes": nodes,
+                        "edges": [],
+                    },
+                    "constraints": {
+                        "supports_node_links": True,
+                        "supports_task_navigation": True,
+                    },
+                    "provenance": {
+                        "source": "tool_result_workflow_view",
+                        "source_tools": source_tools,
+                        "record_family": "workflow_instances",
+                    },
+                }
+            ]
+
         def _build_renderer_request_payload(
             screen_text: Any,
             *,
@@ -11241,6 +11481,14 @@ class InternalMCPChatOrchestrator:
                 decision["screen_table_record_sets"] = screen_table_record_sets
                 decision["screen_table_record_set_count"] = len(
                     screen_table_record_sets
+                )
+            screen_workflow_elements = _extract_renderer_screen_workflow_elements(
+                tool_messages=tool_messages
+            )
+            if screen_workflow_elements:
+                decision["screen_workflow_elements"] = screen_workflow_elements
+                decision["screen_workflow_element_count"] = len(
+                    screen_workflow_elements
                 )
             renderer_render_plan = decision
 

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -1994,6 +1994,33 @@ def _extract_screen_table_elements_from_render_plan(
     return table_elements
 
 
+def _extract_screen_workflow_elements_from_render_plan(
+    render_plan: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Extract display-contract workflow specs from renderer plan diagnostics."""
+    if not isinstance(render_plan, dict):
+        return []
+
+    workflow_elements: list[dict[str, Any]] = []
+
+    def _append_workflow_specs(raw_value: Any) -> None:
+        if isinstance(raw_value, list):
+            for item in raw_value:
+                if isinstance(item, dict):
+                    workflow_elements.append(dict(item))
+        elif isinstance(raw_value, dict):
+            workflow_elements.append(dict(raw_value))
+
+    _append_workflow_specs(render_plan.get("screen_workflow_elements"))
+    _append_workflow_specs(render_plan.get("screen_workflow_payloads"))
+
+    single_workflow = render_plan.get("screen_workflow_element")
+    if isinstance(single_workflow, dict):
+        workflow_elements.append(dict(single_workflow))
+
+    return workflow_elements
+
+
 def _ensure_required_screen_json_fence(
     screen_text: str | None,
     required_fence: str | None,
@@ -5010,12 +5037,16 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
         screen_table_elements = _extract_screen_table_elements_from_render_plan(
             render_plan_debug if isinstance(render_plan_debug, dict) else None
         )
+        screen_workflow_elements = _extract_screen_workflow_elements_from_render_plan(
+            render_plan_debug if isinstance(render_plan_debug, dict) else None
+        )
         display_elements_contract = build_turn_display_elements(
             response_text=response_text,
             presenter_channels=(
                 presenter_channels if isinstance(presenter_channels, dict) else None
             ),
             screen_table_elements=screen_table_elements,
+            screen_workflow_elements=screen_workflow_elements,
             required_screen_json_fence=required_screen_json_fence,
             screen_backfill_second_pass_attempted=screen_backfill_second_pass_attempted,
             screen_backfill_second_pass_reason=screen_backfill_second_pass_reason,

--- a/src/backend/services/display_elements_service.py
+++ b/src/backend/services/display_elements_service.py
@@ -468,6 +468,99 @@ def validate_turn_display_elements(
                     value_type = cell.get("value_type")
                     if not isinstance(value_type, str) or not value_type.strip():
                         errors.append(f"{cell_label}.value_type must be a non-empty string")
+        elif element_type == "workflow_view":
+            nodes = payload.get("nodes")
+            if not isinstance(nodes, list) or not nodes:
+                errors.append(f"{label}.payload.nodes must be a non-empty list")
+                nodes = []
+
+            valid_node_ids: set[str] = set()
+            for node_index, node in enumerate(nodes):
+                node_label = f"{label}.payload.nodes[{node_index}]"
+                if not isinstance(node, Mapping):
+                    errors.append(f"{node_label} must be a mapping")
+                    continue
+                node_id = node.get("node_id")
+                if not isinstance(node_id, str) or not node_id.strip():
+                    errors.append(f"{node_label}.node_id must be a non-empty string")
+                    continue
+                valid_node_ids.add(node_id)
+
+                display_label = node.get("label")
+                if not isinstance(display_label, str) or not display_label.strip():
+                    errors.append(f"{node_label}.label must be a non-empty string")
+
+                status = node.get("status")
+                if status is not None and (
+                    not isinstance(status, str) or not status.strip()
+                ):
+                    errors.append(f"{node_label}.status must be a non-empty string when provided")
+
+                task_links = node.get("task_links")
+                if task_links is None:
+                    continue
+                if not isinstance(task_links, list):
+                    errors.append(f"{node_label}.task_links must be a list when provided")
+                    continue
+
+                for link_index, link in enumerate(task_links):
+                    link_label = f"{node_label}.task_links[{link_index}]"
+                    if not isinstance(link, Mapping):
+                        errors.append(f"{link_label} must be a mapping")
+                        continue
+                    target_id = link.get("target_id")
+                    if not isinstance(target_id, str) or not target_id.strip():
+                        errors.append(f"{link_label}.target_id must be a non-empty string")
+                    label_value = link.get("label")
+                    if label_value is not None and (
+                        not isinstance(label_value, str) or not label_value.strip()
+                    ):
+                        errors.append(
+                            f"{link_label}.label must be a non-empty string when provided"
+                        )
+                    link_type = link.get("link_type")
+                    if link_type is not None and (
+                        not isinstance(link_type, str) or not link_type.strip()
+                    ):
+                        errors.append(
+                            f"{link_label}.link_type must be a non-empty string when provided"
+                        )
+                    href = link.get("href")
+                    if href is not None and (
+                        not isinstance(href, str) or not href.strip()
+                    ):
+                        errors.append(
+                            f"{link_label}.href must be a non-empty string when provided"
+                        )
+
+            edges = payload.get("edges")
+            if edges is not None and not isinstance(edges, list):
+                errors.append(f"{label}.payload.edges must be a list when provided")
+                edges = []
+            if isinstance(edges, list):
+                for edge_index, edge in enumerate(edges):
+                    edge_label = f"{label}.payload.edges[{edge_index}]"
+                    if not isinstance(edge, Mapping):
+                        errors.append(f"{edge_label} must be a mapping")
+                        continue
+                    source_node_id = edge.get("source_node_id")
+                    target_node_id = edge.get("target_node_id")
+                    if not isinstance(source_node_id, str) or not source_node_id.strip():
+                        errors.append(
+                            f"{edge_label}.source_node_id must be a non-empty string"
+                        )
+                    elif valid_node_ids and source_node_id not in valid_node_ids:
+                        errors.append(
+                            f"{edge_label}.source_node_id must reference a declared node"
+                        )
+                    if not isinstance(target_node_id, str) or not target_node_id.strip():
+                        errors.append(
+                            f"{edge_label}.target_node_id must be a non-empty string"
+                        )
+                    elif valid_node_ids and target_node_id not in valid_node_ids:
+                        errors.append(
+                            f"{edge_label}.target_node_id must reference a declared node"
+                        )
 
     return len(errors) == 0, errors
 
@@ -570,11 +663,94 @@ def _normalise_supplied_screen_tables(
     return normalised, dropped_count
 
 
+def _normalise_supplied_screen_workflows(
+    screen_workflow_elements: Sequence[Mapping[str, Any]] | None,
+) -> tuple[list[dict[str, Any]], int]:
+    """Normalise externally supplied screen workflow view specs."""
+    if (
+        not isinstance(screen_workflow_elements, Sequence)
+        or isinstance(screen_workflow_elements, (str, bytes, bytearray))
+    ):
+        return [], 0
+
+    normalised: list[dict[str, Any]] = []
+    dropped_count = 0
+
+    for index, raw_spec in enumerate(screen_workflow_elements, start=1):
+        if not isinstance(raw_spec, Mapping):
+            dropped_count += 1
+            continue
+
+        payload: Mapping[str, Any] | None = None
+        metadata = raw_spec
+        wrapped_payload = raw_spec.get("payload")
+        if isinstance(wrapped_payload, Mapping):
+            payload = wrapped_payload
+        elif "nodes" in raw_spec:
+            payload = raw_spec
+
+        if not isinstance(payload, Mapping):
+            dropped_count += 1
+            continue
+
+        intent = (
+            _normalise_text(metadata.get("intent"))
+            or "structured_workflow_view"
+        )
+        constraints = metadata.get("constraints")
+        if not isinstance(constraints, Mapping):
+            constraints = {
+                "supports_node_links": True,
+                "supports_task_navigation": True,
+            }
+        provenance = metadata.get("provenance")
+        if not isinstance(provenance, Mapping):
+            provenance = {}
+
+        is_valid, _errors = validate_turn_display_elements(
+            {
+                "schema_version": DISPLAY_ELEMENT_SCHEMA_VERSION,
+                "elements": [
+                    {
+                        "element_id": f"screen_structured_workflow_probe_{index}",
+                        "element_type": "workflow_view",
+                        "channel": "screen",
+                        "order": 26,
+                        "intent": intent,
+                        "payload": dict(payload),
+                        "constraints": dict(constraints),
+                        "provenance": dict(provenance),
+                    }
+                ],
+                "reason_codes": [],
+            }
+        )
+        if not is_valid:
+            dropped_count += 1
+            continue
+
+        normalised.append(
+            {
+                "element_id": _normalise_text(metadata.get("element_id")),
+                "order": metadata.get("order")
+                if isinstance(metadata.get("order"), int)
+                else None,
+                "intent": intent,
+                "payload": dict(payload),
+                "constraints": dict(constraints),
+                "provenance": dict(provenance),
+            }
+        )
+
+    return normalised, dropped_count
+
+
 def build_turn_display_elements(
     *,
     response_text: str | None,
     presenter_channels: Mapping[str, Any] | None,
     screen_table_elements: Sequence[Mapping[str, Any]] | None = None,
+    screen_workflow_elements: Sequence[Mapping[str, Any]] | None = None,
     required_screen_json_fence: str | None = None,
     screen_backfill_second_pass_attempted: bool = False,
     screen_backfill_second_pass_reason: str | None = None,
@@ -695,6 +871,14 @@ def build_turn_display_elements(
     if supplied_tables_dropped:
         reason_codes.append("screen_structured_tables_invalid_dropped")
 
+    supplied_screen_workflows, supplied_workflows_dropped = (
+        _normalise_supplied_screen_workflows(screen_workflow_elements)
+    )
+    if supplied_screen_workflows:
+        reason_codes.append("screen_structured_workflows_supplied")
+    if supplied_workflows_dropped:
+        reason_codes.append("screen_structured_workflows_invalid_dropped")
+
     table_specs: list[dict[str, Any]] = []
     for index, spec in enumerate(supplied_screen_tables, start=1):
         provenance = dict(spec.get("provenance") or {})
@@ -739,6 +923,27 @@ def build_turn_display_elements(
     if markdown_tables:
         reason_codes.append("screen_markdown_tables_detected")
 
+    workflow_specs: list[dict[str, Any]] = []
+    for index, spec in enumerate(supplied_screen_workflows, start=1):
+        provenance = dict(spec.get("provenance") or {})
+        provenance.setdefault("source", "screen_structured_workflow")
+        provenance.setdefault("workflow_index", index)
+        workflow_specs.append(
+            {
+                "element_id": spec.get("element_id")
+                or f"screen_structured_workflow_{index}",
+                "order": spec.get("order"),
+                "intent": spec.get("intent") or "structured_workflow_view",
+                "payload": spec.get("payload") or {},
+                "constraints": spec.get("constraints")
+                or {
+                    "supports_node_links": True,
+                    "supports_task_navigation": True,
+                },
+                "provenance": provenance,
+            }
+        )
+
     used_ids: set[str] = set()
     used_orders = {
         int(spec["order"])
@@ -760,6 +965,30 @@ def build_turn_display_elements(
             {
                 "element_id": element_id,
                 "element_type": "table",
+                "channel": "screen",
+                "order": int(order),
+                "intent": str(spec["intent"]),
+                "payload": dict(spec["payload"]),
+                "constraints": dict(spec["constraints"]),
+                "provenance": dict(spec["provenance"]),
+            }
+        )
+
+    next_workflow_order = 26
+    for spec in workflow_specs:
+        order = spec.get("order") if isinstance(spec.get("order"), int) else None
+        if order is None:
+            while next_workflow_order in used_orders:
+                next_workflow_order += 1
+            order = next_workflow_order
+            used_orders.add(order)
+            next_workflow_order += 1
+
+        element_id = _next_unique_element_id(str(spec["element_id"]), used_ids)
+        elements.append(
+            {
+                "element_id": element_id,
+                "element_type": "workflow_view",
                 "channel": "screen",
                 "order": int(order),
                 "intent": str(spec["intent"]),

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -1368,6 +1368,21 @@ function resolvePresenterChannels(rawPresenterChannels, displayElements) {
     });
 }
 
+function dispatchSelectConceptByIdEvent(conceptId, event = null) {
+    if (!conceptId || typeof conceptId !== 'string' || !conceptId.trim()) {
+        return;
+    }
+    document.dispatchEvent(new CustomEvent('von:selectConceptById', {
+        detail: {
+            conceptId: conceptId.trim(),
+            createConceptTab: true,
+            modifierKeys: {
+                shiftKey: !!(event && event.shiftKey)
+            }
+        }
+    }));
+}
+
 function resolveResponsePresenterState(responseData) {
     const debugData = (responseData && typeof responseData === 'object' && responseData.llm_debug && typeof responseData.llm_debug === 'object')
         ? responseData.llm_debug
@@ -1393,6 +1408,8 @@ function resolveResponsePresenterState(responseData) {
 const TABLE_NON_PAGINATED_ROW_LIMIT = 100;
 const TABLE_DEFAULT_PAGE_SIZE = 50;
 const TABLE_MAX_PAGE_SIZE = 200;
+const WORKFLOW_MAX_NODES = 100;
+const JIRA_ISSUE_KEY_PATTERN = /^[A-Z][A-Z0-9]+-\d+$/;
 
 function normaliseTableSortMetadata(value, columns) {
     if (!value || typeof value !== 'object') {
@@ -1660,6 +1677,164 @@ function resolveTableDisplayElements(debugData) {
     return tables;
 }
 
+function normaliseWorkflowTaskLink(rawLink) {
+    if (!rawLink || typeof rawLink !== 'object') {
+        return null;
+    }
+
+    const targetId = typeof rawLink.target_id === 'string'
+        ? rawLink.target_id.trim()
+        : '';
+    if (!targetId) {
+        return null;
+    }
+
+    const rawType = typeof rawLink.link_type === 'string'
+        ? rawLink.link_type.trim().toLowerCase()
+        : '';
+    let linkType = rawType;
+    if (!linkType) {
+        if (targetId.startsWith('#V#')) {
+            linkType = 'von_task';
+        } else if (JIRA_ISSUE_KEY_PATTERN.test(targetId)) {
+            linkType = 'jira_issue';
+        } else {
+            linkType = 'external';
+        }
+    }
+
+    const label = typeof rawLink.label === 'string' && rawLink.label.trim()
+        ? rawLink.label.trim()
+        : targetId;
+    const explicitHref = typeof rawLink.href === 'string' && rawLink.href.trim()
+        ? rawLink.href.trim()
+        : '';
+    const href = explicitHref || (linkType === 'jira_issue'
+        ? `https://naoinstitute.atlassian.net/browse/${targetId}`
+        : '');
+
+    return {
+        link_type: linkType,
+        target_id: targetId,
+        label,
+        href
+    };
+}
+
+function normaliseWorkflowDisplayElement(element) {
+    if (!element || typeof element !== 'object') {
+        return null;
+    }
+    if (String(element.element_type || '').trim() !== 'workflow_view') {
+        return null;
+    }
+
+    const payload = element.payload;
+    if (!payload || typeof payload !== 'object') {
+        return null;
+    }
+
+    const rawNodes = Array.isArray(payload.nodes) ? payload.nodes : [];
+    const nodes = rawNodes
+        .map((node, index) => {
+            if (!node || typeof node !== 'object') {
+                return null;
+            }
+            const nodeId = typeof node.node_id === 'string' && node.node_id.trim()
+                ? node.node_id.trim()
+                : `workflow_node_${index + 1}`;
+            const label = typeof node.label === 'string' && node.label.trim()
+                ? node.label.trim()
+                : (typeof node.workflow_id === 'string' && node.workflow_id.trim()
+                    ? node.workflow_id.trim()
+                    : nodeId);
+            const status = typeof node.status === 'string' && node.status.trim()
+                ? node.status.trim().toLowerCase()
+                : 'unknown';
+            const state = typeof node.state === 'string' ? node.state.trim() : '';
+            const progressLabel = typeof node.progress_label === 'string'
+                ? node.progress_label.trim()
+                : '';
+            const workflowId = typeof node.workflow_id === 'string' ? node.workflow_id.trim() : '';
+            const instanceId = typeof node.instance_id === 'string' ? node.instance_id.trim() : '';
+
+            const rawTaskLinks = Array.isArray(node.task_links) ? node.task_links : [];
+            const taskLinks = rawTaskLinks
+                .map((link) => normaliseWorkflowTaskLink(link))
+                .filter(Boolean);
+
+            return {
+                node_id: nodeId,
+                label,
+                status,
+                state,
+                progress_label: progressLabel,
+                workflow_id: workflowId,
+                instance_id: instanceId,
+                task_links: taskLinks
+            };
+        })
+        .filter(Boolean)
+        .slice(0, WORKFLOW_MAX_NODES);
+
+    if (!nodes.length) {
+        return null;
+    }
+
+    const nodeIdSet = new Set(nodes.map((node) => node.node_id));
+    const rawEdges = Array.isArray(payload.edges) ? payload.edges : [];
+    const edges = rawEdges
+        .map((edge) => {
+            if (!edge || typeof edge !== 'object') {
+                return null;
+            }
+            const sourceNodeId = typeof edge.source_node_id === 'string'
+                ? edge.source_node_id.trim()
+                : '';
+            const targetNodeId = typeof edge.target_node_id === 'string'
+                ? edge.target_node_id.trim()
+                : '';
+            if (!sourceNodeId || !targetNodeId) {
+                return null;
+            }
+            if (!nodeIdSet.has(sourceNodeId) || !nodeIdSet.has(targetNodeId)) {
+                return null;
+            }
+            return {
+                source_node_id: sourceNodeId,
+                target_node_id: targetNodeId,
+                label: typeof edge.label === 'string' ? edge.label.trim() : ''
+            };
+        })
+        .filter(Boolean);
+
+    return {
+        element_id: typeof element.element_id === 'string' ? element.element_id : null,
+        nodes,
+        edges,
+        layout: typeof payload.layout === 'string' && payload.layout.trim()
+            ? payload.layout.trim().toLowerCase()
+            : 'list'
+    };
+}
+
+function resolveWorkflowDisplayElements(debugData) {
+    const contract = normaliseDisplayElementsContract(debugData?.display_elements);
+    if (!contract) {
+        return [];
+    }
+
+    const workflows = [];
+    for (const element of contract.elements) {
+        const workflowElement = normaliseWorkflowDisplayElement(element);
+        if (!workflowElement) {
+            continue;
+        }
+        workflows.push(workflowElement);
+    }
+    return workflows;
+}
+
 function renderTableDisplayElementsIntoContainer(container, debugData) {
     if (!container || typeof container.querySelectorAll !== 'function') {
         return;
@@ -1679,13 +1854,30 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
     }
 
     const tableElements = resolveTableDisplayElements(debugData);
-    if (!tableElements.length) {
+    const workflowElements = resolveWorkflowDisplayElements(debugData);
+    if (!tableElements.length && !workflowElements.length) {
         return;
     }
 
     const root = document.createElement('div');
     root.className = 'chat-display-elements';
     root.style.cssText = 'margin-top: 10px; border: 1px solid #dce3ea; border-radius: 6px; background: #fff; padding: 8px;';
+    root.addEventListener('click', (event) => {
+        const target = event.target;
+        if (!target || !(target instanceof HTMLElement)) {
+            return;
+        }
+        const conceptButton = target.closest('.chat-display-elements-concept-link');
+        if (!conceptButton) {
+            return;
+        }
+        event.preventDefault();
+        const conceptId = conceptButton.dataset.conceptId;
+        if (!conceptId) {
+            return;
+        }
+        dispatchSelectConceptByIdEvent(conceptId, event);
+    });
 
     tableElements.forEach((tableElement, tableIndex) => {
         const section = document.createElement('section');
@@ -1801,6 +1993,121 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
             section.appendChild(truncationNotice);
         }
 
+        root.appendChild(section);
+    });
+
+    workflowElements.forEach((workflowElement, workflowIndex) => {
+        const section = document.createElement('section');
+        section.className = 'chat-display-elements-workflow-section';
+        section.style.cssText = (tableElements.length > 0 || workflowIndex > 0) ? 'margin-top: 10px;' : '';
+
+        const title = document.createElement('div');
+        title.className = 'chat-display-elements-workflow-title';
+        title.textContent = workflowElements.length > 1
+            ? `Workflow view ${workflowIndex + 1}`
+            : 'Workflow view';
+        title.style.cssText = 'font-weight: 600; font-size: 0.85em; color: #2f4f6f; margin-bottom: 6px;';
+        section.appendChild(title);
+
+        const summary = document.createElement('div');
+        summary.className = 'chat-display-elements-workflow-summary';
+        summary.textContent = `${workflowElement.nodes.length} node${workflowElement.nodes.length === 1 ? '' : 's'}`;
+        summary.style.cssText = 'font-size: 0.78em; color: #5a6b7b; margin-bottom: 6px;';
+        section.appendChild(summary);
+
+        const list = document.createElement('div');
+        list.className = 'chat-display-elements-workflow-list';
+        list.style.cssText = 'display: grid; gap: 8px;';
+
+        workflowElement.nodes.forEach((node) => {
+            const statusClass = String(node.status || 'unknown')
+                .toLowerCase()
+                .replace(/[^a-z0-9_-]+/g, '-');
+            const card = document.createElement('article');
+            card.className = `chat-display-elements-workflow-node status-${statusClass}`;
+            card.style.cssText = 'border: 1px solid #dce3ea; border-radius: 6px; padding: 8px; background: #f8fbff;';
+
+            const header = document.createElement('div');
+            header.style.cssText = 'display: flex; align-items: center; justify-content: space-between; gap: 8px;';
+
+            const name = document.createElement('div');
+            name.className = 'chat-display-elements-workflow-node-name';
+            name.textContent = node.label;
+            name.style.cssText = 'font-size: 0.83em; font-weight: 600; color: #1f3d5a;';
+            header.appendChild(name);
+
+            const badge = document.createElement('span');
+            badge.className = `workflow-status-badge status-${statusClass}`;
+            badge.textContent = formatWorkflowStatusLabel(node.status || 'unknown');
+            header.appendChild(badge);
+            card.appendChild(header);
+
+            const details = [];
+            if (node.workflow_id) {
+                details.push(`Workflow: ${node.workflow_id}`);
+            }
+            if (node.instance_id) {
+                details.push(`Instance: ${node.instance_id}`);
+            }
+            if (node.state) {
+                details.push(`State: ${node.state}`);
+            }
+            if (node.progress_label) {
+                details.push(node.progress_label);
+            }
+
+            if (details.length) {
+                const meta = document.createElement('div');
+                meta.className = 'chat-display-elements-workflow-node-meta';
+                meta.textContent = details.join(' · ');
+                meta.style.cssText = 'margin-top: 4px; font-size: 0.78em; color: #44576a;';
+                card.appendChild(meta);
+            }
+
+            if (Array.isArray(node.task_links) && node.task_links.length) {
+                const linksWrap = document.createElement('div');
+                linksWrap.className = 'chat-display-elements-workflow-node-links';
+                linksWrap.style.cssText = 'margin-top: 6px; display: flex; flex-wrap: wrap; gap: 6px;';
+
+                node.task_links.forEach((link) => {
+                    if (!link || typeof link !== 'object') {
+                        return;
+                    }
+                    if (link.link_type === 'von_task') {
+                        const conceptId = _normalisePotentialConceptId(link.target_id);
+                        if (!conceptId) {
+                            return;
+                        }
+                        const button = document.createElement('button');
+                        button.type = 'button';
+                        button.className = 'chat-display-elements-concept-link';
+                        button.dataset.conceptId = conceptId;
+                        button.textContent = link.label || conceptId;
+                        button.style.cssText = 'border: 1px solid #cad5df; background: #f4f8fc; border-radius: 999px; padding: 1px 8px; font-size: 0.75em; color: #1f4f7a; cursor: pointer;';
+                        linksWrap.appendChild(button);
+                        return;
+                    }
+                    if (link.link_type === 'jira_issue' && link.href) {
+                        const anchor = document.createElement('a');
+                        anchor.href = link.href;
+                        anchor.target = '_blank';
+                        anchor.rel = 'noopener noreferrer';
+                        anchor.textContent = link.label || link.target_id;
+                        anchor.style.cssText = 'border: 1px solid #cad5df; background: #f4f8fc; border-radius: 999px; padding: 1px 8px; font-size: 0.75em; color: #1f4f7a; text-decoration: none;';
+                        linksWrap.appendChild(anchor);
+                        return;
+                    }
+                });
+
+                if (linksWrap.childElementCount > 0) {
+                    card.appendChild(linksWrap);
+                }
+            }
+
+            list.appendChild(card);
+        });
+
+        section.appendChild(list);
         root.appendChild(section);
     });
 
@@ -9697,15 +10004,7 @@ function bindWorkflowStatusConceptLinks() {
         if (!conceptId) {
             return;
         }
-        document.dispatchEvent(new CustomEvent('von:selectConceptById', {
-            detail: {
-                conceptId,
-                createConceptTab: true,
-                modifierKeys: {
-                    shiftKey: event.shiftKey
-                }
-            }
-        }));
+        dispatchSelectConceptByIdEvent(conceptId, event);
     });
 
     body.dataset.conceptLinkBound = 'true';
@@ -11916,15 +12215,7 @@ async function showLlmDebugPopup(turnId, options = {}) {
             if (!conceptId) {
                 return;
             }
-            document.dispatchEvent(new CustomEvent('von:selectConceptById', {
-                detail: {
-                    conceptId,
-                    createConceptTab: true,
-                    modifierKeys: {
-                        shiftKey: event.shiftKey
-                    }
-                }
-            }));
+            dispatchSelectConceptByIdEvent(conceptId, event);
         });
         metaDiv.dataset.promptLinkBound = 'true';
     }

--- a/tests/backend/test_display_elements_service.py
+++ b/tests/backend/test_display_elements_service.py
@@ -242,6 +242,92 @@ def test_build_turn_display_elements_drops_invalid_supplied_tables() -> None:
     assert contract["validation"]["valid"] is True
 
 
+def test_build_turn_display_elements_includes_supplied_workflow_elements() -> None:
+    contract = build_turn_display_elements(
+        response_text="Workflow response",
+        presenter_channels={
+            "format": "tagged_blocks_v1",
+            "screen": "Workflow response",
+            "spoken": None,
+        },
+        screen_workflow_elements=[
+            {
+                "element_id": "screen_workflow_view",
+                "intent": "structured_workflow_view",
+                "payload": {
+                    "layout": "list",
+                    "nodes": [
+                        {
+                            "node_id": "inst_1",
+                            "label": "#V#salient_predicate_governance_workflow",
+                            "status": "running",
+                            "task_links": [
+                                {
+                                    "link_type": "von_task",
+                                    "target_id": "#V#task_alpha",
+                                    "label": "#V#task_alpha",
+                                },
+                                {
+                                    "link_type": "jira_issue",
+                                    "target_id": "JVNAUTOSCI-1148",
+                                    "label": "JVNAUTOSCI-1148",
+                                    "href": "https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-1148",
+                                },
+                            ],
+                        }
+                    ],
+                    "edges": [],
+                },
+            }
+        ],
+    )
+
+    workflow_elements = [
+        element
+        for element in contract["elements"]
+        if element["element_type"] == "workflow_view"
+    ]
+    assert len(workflow_elements) == 1
+    workflow_element = workflow_elements[0]
+    assert workflow_element["element_id"] == "screen_workflow_view"
+    assert workflow_element["payload"]["nodes"][0]["node_id"] == "inst_1"
+    assert (
+        workflow_element["payload"]["nodes"][0]["task_links"][0]["target_id"]
+        == "#V#task_alpha"
+    )
+    assert "screen_structured_workflows_supplied" in contract["reason_codes"]
+    assert contract["validation"]["valid"] is True
+
+
+def test_build_turn_display_elements_drops_invalid_supplied_workflows() -> None:
+    contract = build_turn_display_elements(
+        response_text="Workflow response",
+        presenter_channels={
+            "format": "tagged_blocks_v1",
+            "screen": "Workflow response",
+            "spoken": None,
+        },
+        screen_workflow_elements=[
+            {
+                "payload": {
+                    "layout": "list",
+                    "nodes": [],
+                    "edges": [],
+                }
+            }
+        ],
+    )
+
+    workflow_elements = [
+        element
+        for element in contract["elements"]
+        if element["element_type"] == "workflow_view"
+    ]
+    assert workflow_elements == []
+    assert "screen_structured_workflows_invalid_dropped" in contract["reason_codes"]
+    assert contract["validation"]["valid"] is True
+
+
 def test_validate_turn_display_elements_rejects_invalid_table_shape() -> None:
     valid, errors = validate_turn_display_elements(
         {
@@ -284,6 +370,43 @@ def test_validate_turn_display_elements_rejects_invalid_table_shape() -> None:
 
     assert valid is False
     assert any("must reference a declared column" in message for message in errors)
+
+
+def test_validate_turn_display_elements_rejects_invalid_workflow_links() -> None:
+    valid, errors = validate_turn_display_elements(
+        {
+            "schema_version": "turn_display_elements_v1",
+            "elements": [
+                {
+                    "element_id": "screen_workflow_view",
+                    "element_type": "workflow_view",
+                    "channel": "screen",
+                    "order": 26,
+                    "intent": "structured_workflow_view",
+                    "payload": {
+                        "nodes": [
+                            {
+                                "node_id": "workflow_1",
+                                "label": "Workflow 1",
+                                "status": "running",
+                            }
+                        ],
+                        "edges": [
+                            {
+                                "source_node_id": "workflow_1",
+                                "target_node_id": "missing_node",
+                            }
+                        ],
+                    },
+                    "provenance": {"source": "test"},
+                }
+            ],
+            "reason_codes": [],
+        }
+    )
+
+    assert valid is False
+    assert any("target_node_id must reference a declared node" in message for message in errors)
 
 
 def test_build_canonical_table_payload_from_records_preserves_row_provenance() -> None:

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -721,6 +721,132 @@ def test_renderer_render_plan_includes_table_record_sets_from_tool_messages(monk
     assert predicate_records[0]["object"] == "#V#task_beta"
 
 
+def test_renderer_render_plan_includes_workflow_view_from_tool_messages(monkeypatch):
+    """Render plan should carry workflow view payloads with Von/Jira task links."""
+    orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
+    monkeypatch.setenv("VON_RENDERER_APPLICABILITY_ROUTING_ENABLE", "1")
+    monkeypatch.setenv(
+        "VON_RENDERER_APPLICABILITY_DEFINITION_IDS",
+        "#V#workflow_renderer",
+    )
+
+    def _invoke(tool_name: str, _payload: Mapping[str, Any]):
+        if tool_name != "renderer_resolve_applicability":
+            raise AssertionError(f"Unexpected tool invocation: {tool_name}")
+        return _InvokeResult(
+            {
+                "success": True,
+                "selected_renderers": [
+                    {
+                        "renderer_id": "#V#workflow_renderer",
+                        "renderer_type": "workflow_view",
+                        "modalities": ["visual"],
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr(orchestrator._gateway, "invoke", _invoke)
+
+    class _WorkflowResult:
+        def __init__(self):
+            self.data = {
+                "final_response": "Workflow status summary.",
+                "tool_messages": [
+                    {
+                        "role": "tool",
+                        "content": json.dumps(
+                            {
+                                "tool": "workflow_list_instances",
+                                "status": "ok",
+                                "duration_ms": 3.1,
+                                "payload": {
+                                    "success": True,
+                                    "count": 1,
+                                    "instances": [
+                                        {
+                                            "instance_id": "inst_1",
+                                            "workflow_id": "#V#salient_predicate_governance_workflow",
+                                            "status": "running",
+                                            "current_state": "#V#salience_step_identify_type",
+                                            "progress": {
+                                                "current": 1,
+                                                "total": 3,
+                                                "message": "Processing",
+                                            },
+                                        }
+                                    ],
+                                },
+                            }
+                        ),
+                    },
+                    {
+                        "role": "tool",
+                        "content": json.dumps(
+                            {
+                                "tool": "workflow_get_instance",
+                                "status": "ok",
+                                "duration_ms": 2.6,
+                                "payload": {
+                                    "success": True,
+                                    "instance_id": "inst_1",
+                                    "workflow_id": "#V#salient_predicate_governance_workflow",
+                                    "status": "running",
+                                    "inputs": {
+                                        "task_concept_id": "#V#task_alpha",
+                                        "jira_issue_key": "JVNAUTOSCI-1148",
+                                    },
+                                    "outputs": {},
+                                },
+                            }
+                        ),
+                    },
+                ],
+                "invocations": [],
+                "iteration_count": 1,
+            }
+            self.final_state = "completed"
+            self.completed = True
+
+    def _execute_workflow(workflow_id: str, **_kwargs: Any):
+        if workflow_id != TOOL_CALLING_WORKFLOW_ID:
+            raise AssertionError(f"Unexpected workflow execution: {workflow_id}")
+        return _WorkflowResult()
+
+    monkeypatch.setattr(orchestrator, "execute_workflow", _execute_workflow)
+
+    llm = _CapturingLLM(["tool_seeking"])
+
+    result = orchestrator.run(
+        prompt="Show workflow progress",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+    )
+
+    assert result.response_text == "Workflow status summary."
+    assert isinstance(result.render_plan, dict)
+    assert result.render_plan.get("screen_workflow_element_count") == 1
+    workflow_elements = result.render_plan.get("screen_workflow_elements")
+    assert isinstance(workflow_elements, list)
+    assert len(workflow_elements) == 1
+
+    payload = workflow_elements[0].get("payload")
+    assert isinstance(payload, dict)
+    nodes = payload.get("nodes")
+    assert isinstance(nodes, list)
+    assert len(nodes) == 1
+
+    node = nodes[0]
+    assert node.get("node_id") == "inst_1"
+    task_links = node.get("task_links")
+    assert isinstance(task_links, list)
+    link_targets = {str(link.get("target_id")) for link in task_links}
+    assert "#V#task_alpha" in link_targets
+    assert "JVNAUTOSCI-1148" in link_targets
+
+
 def test_renderer_render_plan_skips_malformed_tool_messages_for_table_record_sets(
     monkeypatch,
 ):

--- a/tests/backend/test_von_generate_render_plan_debug.py
+++ b/tests/backend/test_von_generate_render_plan_debug.py
@@ -326,6 +326,80 @@ def test_generate_drops_invalid_tables_from_render_plan_record_sets(monkeypatch)
     assert not table_elements
 
 
+def test_generate_builds_workflow_view_from_render_plan_elements(monkeypatch):
+    from src.backend.integrations.internal_mcp.orchestrator import OrchestratorResult
+
+    render_plan = {
+        "enabled": True,
+        "reason": "resolved",
+        "render_mode": "screen_only",
+        "should_narrate": False,
+        "screen_workflow_elements": [
+            {
+                "element_id": "screen_workflow_view",
+                "intent": "structured_workflow_view",
+                "payload": {
+                    "layout": "list",
+                    "nodes": [
+                        {
+                            "node_id": "inst_1",
+                            "label": "#V#salient_predicate_governance_workflow",
+                            "status": "running",
+                            "state": "#V#salience_step_identify_type",
+                            "task_links": [
+                                {
+                                    "link_type": "von_task",
+                                    "target_id": "#V#task_alpha",
+                                },
+                                {
+                                    "link_type": "jira_issue",
+                                    "target_id": "JVNAUTOSCI-1148",
+                                    "href": "https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-1148",
+                                },
+                            ],
+                        }
+                    ],
+                    "edges": [],
+                },
+                "provenance": {"source": "test_render_plan"},
+            }
+        ],
+    }
+    orchestrator_result = OrchestratorResult(
+        response_text="Workflow summary",
+        extra_messages=(),
+        tool_invocations=(),
+        aux_llm_calls=(),
+        render_plan=render_plan,
+    )
+    app = _make_app(monkeypatch, _StubOrchestrator(orchestrator_result))
+
+    client = app.test_client()
+    response = client.post("/von/generate", json={"prompt": "Show workflow"})
+    assert response.status_code == 200
+    body = response.get_json()
+    assert isinstance(body, dict)
+    display_elements = body.get("display_elements")
+    assert isinstance(display_elements, dict)
+    assert display_elements.get("validation", {}).get("valid") is True
+    assert "screen_structured_workflows_supplied" in display_elements.get(
+        "reason_codes", []
+    )
+
+    workflow_elements = [
+        element
+        for element in display_elements.get("elements", [])
+        if isinstance(element, dict) and element.get("element_type") == "workflow_view"
+    ]
+    assert len(workflow_elements) == 1
+    workflow_element = workflow_elements[0]
+    assert workflow_element.get("element_id") == "screen_workflow_view"
+    nodes = workflow_element.get("payload", {}).get("nodes")
+    assert isinstance(nodes, list)
+    assert nodes[0]["node_id"] == "inst_1"
+    assert nodes[0]["task_links"][0]["target_id"] == "#V#task_alpha"
+
+
 def test_task_result_includes_render_plan_when_present(monkeypatch):
     from src.backend.integrations.internal_mcp.orchestrator import OrchestratorResult
 

--- a/tests/frontend/chatTabSpeechPlanning.test.js
+++ b/tests/frontend/chatTabSpeechPlanning.test.js
@@ -23,7 +23,12 @@ function advanceTimers(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function buildDisplayElementsContract({ screenText = null, spokenText = null, tablePayload = null } = {}) {
+function buildDisplayElementsContract({
+    screenText = null,
+    spokenText = null,
+    tablePayload = null,
+    workflowPayload = null
+} = {}) {
     const elements = [];
     if (typeof screenText === 'string') {
         elements.push({
@@ -55,6 +60,17 @@ function buildDisplayElementsContract({ screenText = null, spokenText = null, ta
             order: 16,
             intent: 'structured_tabular_view',
             payload: tablePayload,
+            provenance: { source: 'test' }
+        });
+    }
+    if (workflowPayload && typeof workflowPayload === 'object') {
+        elements.push({
+            element_id: 'screen_workflow_view',
+            element_type: 'workflow_view',
+            channel: 'screen',
+            order: 26,
+            intent: 'structured_workflow_view',
+            payload: workflowPayload,
             provenance: { source: 'test' }
         });
     }
@@ -484,6 +500,114 @@ describe('chat speech planning (presenter channels)', () => {
         expect(secondPageRows.length).toBe(1);
         expect(secondPageRows[0].querySelectorAll('td')[0].textContent).toBe('Alpha');
         expect(paginationStatus.textContent).toBe('Page 2 of 2');
+    });
+
+    test('renders workflow view display elements with Von/Jira task links', async () => {
+        const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        getUserContext.mockReturnValue({
+            user_id: 'user',
+            org_id: 'org',
+            language: 'en-NZ',
+            gmail_profile: null
+        });
+
+        const promptInput = document.getElementById('promptInput');
+        promptInput.value = 'show workflow status';
+
+        const displayElements = buildDisplayElementsContract({
+            screenText: 'Workflow summary',
+            spokenText: 'Here is the workflow summary.',
+            workflowPayload: {
+                layout: 'list',
+                nodes: [
+                    {
+                        node_id: 'inst_1',
+                        label: '#V#salient_predicate_governance_workflow',
+                        status: 'running',
+                        state: '#V#salience_step_identify_type',
+                        progress_label: 'Step 1/3 · Processing',
+                        task_links: [
+                            {
+                                link_type: 'von_task',
+                                target_id: '#V#task_alpha',
+                                label: '#V#task_alpha'
+                            },
+                            {
+                                link_type: 'jira_issue',
+                                target_id: 'JVNAUTOSCI-1148',
+                                label: 'JVNAUTOSCI-1148'
+                            }
+                        ]
+                    }
+                ],
+                edges: []
+            }
+        });
+
+        global.fetch = jest.fn((url, options) => {
+            if (typeof url === 'string' && url.startsWith('/von/api/render_markdown')) {
+                let text = '';
+                try {
+                    text = JSON.parse(options?.body ?? '{}')?.text ?? '';
+                } catch (_) {
+                    text = '';
+                }
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ html: String(text) })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ history_length: 0, authenticated: true })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/generate')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        response: 'Workflow summary',
+                        display_elements: displayElements,
+                        llm_debug: {
+                            model: 'gpt-5.2',
+                            response: 'Workflow summary',
+                            messages: [],
+                            display_elements: displayElements
+                        }
+                    })
+                });
+            }
+
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        const onSelect = jest.fn();
+        document.addEventListener('von:selectConceptById', onSelect);
+
+        await sendMessage();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        const workflowNode = document.querySelector('.chat-display-elements-workflow-node');
+        expect(workflowNode).toBeTruthy();
+        expect(workflowNode.textContent).toContain('#V#salient_predicate_governance_workflow');
+        expect(workflowNode.textContent).toContain('running');
+
+        const conceptLink = document.querySelector('.chat-display-elements-concept-link');
+        expect(conceptLink).toBeTruthy();
+        expect(conceptLink.dataset.conceptId).toBe('#V#task_alpha');
+
+        conceptLink.click();
+        expect(onSelect).toHaveBeenCalledTimes(1);
+        expect(onSelect.mock.calls[0][0].detail.conceptId).toBe('#V#task_alpha');
+
+        const jiraLink = document.querySelector('a[href*="JVNAUTOSCI-1148"]');
+        expect(jiraLink).toBeTruthy();
+        expect(jiraLink.getAttribute('href')).toContain('/browse/JVNAUTOSCI-1148');
+
+        document.removeEventListener('von:selectConceptById', onSelect);
     });
 
     test('Shift+click Speak uses screen channel (accessibility)', async () => {


### PR DESCRIPTION
## Summary
- add workflow-view render-plan extraction in the orchestrator from `workflow_list_instances`/`workflow_get_instance` tool outputs
- plumb `screen_workflow_elements` through `/von/generate` into the turn display-elements contract
- extend display-elements validation/building to support `workflow_view` elements with deterministic fallback handling
- extend chat display rendering to show workflow nodes in the existing display-elements framework and surface navigable Von concept + Jira issue links
- reuse a shared concept-link dispatch helper in workflow-status/debug metadata handlers

## Tests
- `pytest -q tests/backend/test_display_elements_service.py tests/backend/test_von_generate_render_plan_debug.py tests/backend/test_orchestrator_workflow_selector_routing.py`
- `npm test -- --runInBand tests/frontend/chatTabSpeechPlanning.test.js`
- `npm test -- --runInBand src/frontend/web/von_interface/static/js/test/chatTab.test.js`
- `pyright src/backend/integrations/internal_mcp/orchestrator.py src/backend/server/routes/von_routes.py src/backend/services/display_elements_service.py tests/backend/test_display_elements_service.py tests/backend/test_orchestrator_workflow_selector_routing.py tests/backend/test_von_generate_render_plan_debug.py`