### PR TITLE
JVNAUTOSCI-1250: Enable Vontology-defined MCP tool registration into runtime

### DIFF
--- a/docs/engineering/mcp_tools_best_practices.md
+++ b/docs/engineering/mcp_tools_best_practices.md
@@ -225,6 +225,52 @@ result = create_vontology_concept(
 
 ---
 
+### 1.6 Dynamic MCP Tool Registration from Vontology (Runtime-Safe Path)
+
+Use this when you need a Vontology concept to expose a new MCP tool **without**
+adding a bespoke Python `MethodDefinition`.
+
+Current runtime behaviour (JVNAUTOSCI-1250):
+- Only `#V#mcp_tool` instances are considered.
+- Dynamic registration is **fail-closed** and requires explicit activation markers.
+- Dynamic tools can proxy **existing built-in internal MCP tools only**.
+- Dynamic tool names cannot override protected built-in names.
+- Load outcomes are inspectable via gateway diagnostics (`dynamic_tool_registration`).
+
+Required concept attributes for activation:
+- `mcp_tool_name` (string): dynamic method name to expose.
+- `dynamic_target_tool_name` (string): existing built-in method name to proxy.
+- `dynamic_registration_enabled` (bool): must be `true`.
+- `dynamic_registration_approved` (bool): must be `true`.
+
+Optional attributes:
+- `dynamic_fixed_payload` (object): fixed arguments enforced at runtime.
+- `dynamic_timeout_sec` (number > 0): override timeout for this proxy.
+- `dynamic_description` (string): human-readable description.
+
+Example attributes payload:
+```json
+{
+  "mcp_tool_name": "jira_get_issue_safe",
+  "dynamic_target_tool_name": "jira_get_issue",
+  "dynamic_registration_enabled": true,
+  "dynamic_registration_approved": true,
+  "dynamic_fixed_payload": {
+    "fields": ["summary", "status", "assignee"]
+  },
+  "dynamic_timeout_sec": 20,
+  "dynamic_description": "Safe Jira issue lookup with constrained fields."
+}
+```
+
+Guardrails to preserve:
+- Do not point `dynamic_target_tool_name` at non-existent methods.
+- Do not reuse built-in method names in `mcp_tool_name`.
+- Keep fixed payload keys schema-compatible with the target tool.
+- Keep approval explicit; avoid implicit activation from metadata-only concepts.
+
+---
+
 ## Category 2: When to Write Custom Python Scripts
 
 ### 2.1 Bulk Operations with Conditional Logic

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -25,17 +25,21 @@ See JVNAUTOSCI-1044 for an example of namespace rejection breaking tool calls.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 from datetime import datetime
 from typing import Any, List, Mapping, Sequence
 
+from .dynamic_tool_loader import load_dynamic_method_definitions
 from .gateway import MethodCatalogue, MethodDefinition
 from .schemas import Schema, make_error_response
 from .workflow_surface_capabilities import (
     build_workflow_surface_capability_matrix,
 )
 from src.backend.services.prompt_template_service import PromptTemplateService
+
+logger = logging.getLogger(__name__)
 
 _JIRA_ISSUE_KEY_PATTERN = re.compile(
     r"\b([A-Z][A-Z0-9]{1,24})-(\d+)\b",
@@ -15823,5 +15827,19 @@ def build_default_catalogue() -> MethodCatalogue:
 
     for definition in definitions:
         catalogue.register(definition)
+
+    try:
+        built_in_definitions = {definition.name: definition for definition in definitions}
+        dynamic_result = load_dynamic_method_definitions(
+            base_definitions=built_in_definitions,
+            protected_method_names=built_in_definitions.keys(),
+        )
+        for dynamic_definition in dynamic_result.definitions:
+            catalogue.register(dynamic_definition)
+    except Exception as exc:
+        # Fail closed: keep baseline built-ins available even if dynamic loading fails.
+        logger.warning(
+            "[internal_mcp_catalogue] Dynamic MCP tool registration failed: %s", exc
+        )
 
     return catalogue

--- a/src/backend/integrations/internal_mcp/dynamic_tool_loader.py
+++ b/src/backend/integrations/internal_mcp/dynamic_tool_loader.py
@@ -1,0 +1,492 @@
+"""Dynamic MCP tool registration backed by Vontology concept metadata.
+
+The runtime loads a constrained subset of ``#V#mcp_tool`` instances and turns
+them into proxy ``MethodDefinition`` entries. The current implementation
+intentionally fails closed:
+
+- only explicitly enabled + approved concepts are considered;
+- dynamic tools can proxy existing built-in handlers only;
+- dynamic names cannot override protected built-in method names;
+- malformed specs are rejected with structured diagnostics.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import re
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable, Mapping
+
+from .gateway import MethodDefinition
+from .schemas import Schema, validate_payload
+
+logger = logging.getLogger(__name__)
+
+_DYNAMIC_TOOL_INSTANCE_OF = "#V#mcp_tool"
+_DYNAMIC_TOOL_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]{2,127}$")
+_DYNAMIC_SPEC_CACHE_TTL_SECONDS = 60.0
+
+_spec_cache_lock = threading.Lock()
+_spec_cache_loaded = False
+_spec_cache_timestamp = 0.0
+_spec_cache_documents: list[dict[str, Any]] = []
+_spec_cache_error: str | None = None
+
+_status_lock = threading.Lock()
+_last_registration_status: dict[str, Any] = {
+    "loaded_at_utc": None,
+    "source": "vontology:#V#mcp_tool",
+    "total_concepts_scanned": 0,
+    "candidate_count": 0,
+    "loaded_count": 0,
+    "failed_count": 0,
+    "skipped_disabled_count": 0,
+    "loaded": [],
+    "failed": [],
+    "source_load_error": None,
+}
+
+
+@dataclass(frozen=True)
+class DynamicMethodLoadResult:
+    """Result object for dynamic MCP method registration."""
+
+    definitions: tuple[MethodDefinition, ...]
+    status: dict[str, Any]
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _is_truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "on", "enabled"}
+    return False
+
+
+def _set_last_registration_status(status: Mapping[str, Any]) -> None:
+    with _status_lock:
+        global _last_registration_status
+        _last_registration_status = copy.deepcopy(dict(status))
+
+
+def get_dynamic_tool_registration_status() -> dict[str, Any]:
+    """Return a safe snapshot of the most recent dynamic load attempt."""
+
+    with _status_lock:
+        return copy.deepcopy(_last_registration_status)
+
+
+def reset_dynamic_tool_registration_status() -> None:
+    """Reset dynamic registration diagnostics (test helper)."""
+
+    _set_last_registration_status(
+        {
+            "loaded_at_utc": None,
+            "source": "vontology:#V#mcp_tool",
+            "total_concepts_scanned": 0,
+            "candidate_count": 0,
+            "loaded_count": 0,
+            "failed_count": 0,
+            "skipped_disabled_count": 0,
+            "loaded": [],
+            "failed": [],
+            "source_load_error": None,
+        }
+    )
+
+
+def invalidate_dynamic_tool_spec_cache() -> None:
+    """Force refresh of Vontology-backed dynamic tool specs on next load."""
+
+    with _spec_cache_lock:
+        global _spec_cache_loaded
+        global _spec_cache_timestamp
+        global _spec_cache_documents
+        global _spec_cache_error
+        _spec_cache_loaded = False
+        _spec_cache_timestamp = 0.0
+        _spec_cache_documents = []
+        _spec_cache_error = None
+
+
+def _load_dynamic_tool_documents(
+    *, force_refresh: bool = False
+) -> tuple[list[dict[str, Any]], str | None]:
+    global _spec_cache_loaded
+    global _spec_cache_timestamp
+    global _spec_cache_documents
+    global _spec_cache_error
+
+    now = time.time()
+    with _spec_cache_lock:
+        cache_fresh = (
+            _spec_cache_loaded
+            and not force_refresh
+            and (now - _spec_cache_timestamp) < _DYNAMIC_SPEC_CACHE_TTL_SECONDS
+        )
+        if cache_fresh:
+            return copy.deepcopy(_spec_cache_documents), _spec_cache_error
+
+    documents: list[dict[str, Any]] = []
+    load_error: str | None = None
+    try:
+        from ...db.repositories.concepts_repository import ConceptsRepository
+
+        cursor = ConceptsRepository.find(
+            {"relationships.is_an_instance_of": _DYNAMIC_TOOL_INSTANCE_OF},
+            {"concept_id": 1, "attributes": 1},
+        )
+        for raw_doc in cursor:
+            if isinstance(raw_doc, Mapping):
+                documents.append(dict(raw_doc))
+    except Exception as exc:
+        load_error = str(exc)
+        logger.warning(
+            "[dynamic_tool_loader] Failed loading Vontology tool specs: %s", exc
+        )
+
+    with _spec_cache_lock:
+        _spec_cache_loaded = True
+        _spec_cache_timestamp = time.time()
+        _spec_cache_documents = copy.deepcopy(documents)
+        _spec_cache_error = load_error
+
+    return documents, load_error
+
+
+def _build_dynamic_input_schema(
+    *,
+    target_schema: Schema,
+    fixed_payload_keys: set[str],
+    tool_name: str,
+    target_tool_name: str,
+) -> Schema:
+    required = {
+        key: expected
+        for key, expected in target_schema.required.items()
+        if key not in fixed_payload_keys
+    }
+    optional = {
+        key: expected
+        for key, expected in target_schema.optional.items()
+        if key not in fixed_payload_keys
+    }
+    description = (
+        f"Dynamic tool '{tool_name}' proxying '{target_tool_name}'. "
+        "Caller-provided values for fixed payload keys are not accepted."
+    )
+    return Schema(
+        required=required,
+        optional=optional,
+        allow_unknown=target_schema.allow_unknown,
+        description=description,
+    )
+
+
+def _build_proxy_handler(
+    *, target_handler: Callable[..., Any], fixed_payload: Mapping[str, Any]
+) -> Callable[..., Any]:
+    frozen_fixed_payload = dict(fixed_payload)
+
+    def _dynamic_proxy_handler(**kwargs):
+        merged_payload = dict(kwargs)
+        # Fixed payload values always win so policy markers cannot be overridden.
+        merged_payload.update(frozen_fixed_payload)
+        return target_handler(**merged_payload)
+
+    return _dynamic_proxy_handler
+
+
+def _validate_fixed_payload(
+    *,
+    fixed_payload: Mapping[str, Any],
+    target_tool_name: str,
+    target_schema: Schema,
+) -> list[str]:
+    errors: list[str] = []
+
+    for key in fixed_payload.keys():
+        if not isinstance(key, str) or not key.strip():
+            errors.append("dynamic_fixed_payload keys must be non-empty strings.")
+
+    target_known_keys = set(target_schema.required.keys()) | set(
+        target_schema.optional.keys()
+    )
+    if not target_schema.allow_unknown:
+        unknown_keys = sorted(
+            key for key in fixed_payload.keys() if key not in target_known_keys
+        )
+        if unknown_keys:
+            errors.append(
+                f"dynamic_fixed_payload contains unknown keys for '{target_tool_name}': {unknown_keys}"
+            )
+
+    typed_optional: dict[str, Any] = {}
+    for key in fixed_payload.keys():
+        expected = target_schema.expect(key)
+        if expected is not None:
+            typed_optional[key] = expected
+
+    if typed_optional:
+        ok, validation_errors = validate_payload(
+            Schema(
+                required={},
+                optional=typed_optional,
+                allow_unknown=target_schema.allow_unknown,
+                description=(
+                    f"dynamic_fixed_payload for tool '{target_tool_name}'"
+                ),
+            ),
+            fixed_payload,
+        )
+        if not ok:
+            errors.extend(validation_errors)
+
+    return errors
+
+
+def load_dynamic_method_definitions(
+    *,
+    base_definitions: Mapping[str, MethodDefinition],
+    protected_method_names: Iterable[str] | None = None,
+    force_refresh: bool = False,
+) -> DynamicMethodLoadResult:
+    """Resolve and validate dynamic method definitions from Vontology specs."""
+
+    protected_names = {
+        name.strip()
+        for name in (protected_method_names or ())
+        if isinstance(name, str) and name.strip()
+    }
+    protected_names.update(base_definitions.keys())
+
+    documents, source_load_error = _load_dynamic_tool_documents(
+        force_refresh=force_refresh
+    )
+    status: dict[str, Any] = {
+        "loaded_at_utc": _utc_now_iso(),
+        "source": "vontology:#V#mcp_tool",
+        "total_concepts_scanned": len(documents),
+        "candidate_count": 0,
+        "loaded_count": 0,
+        "failed_count": 0,
+        "skipped_disabled_count": 0,
+        "loaded": [],
+        "failed": [],
+        "source_load_error": source_load_error,
+    }
+
+    resolved: list[MethodDefinition] = []
+    dynamic_name_guard: set[str] = set()
+
+    for doc in documents:
+        concept_id = str(doc.get("concept_id") or "").strip() or None
+        attributes = doc.get("attributes")
+        if not isinstance(attributes, Mapping):
+            status["skipped_disabled_count"] += 1
+            continue
+
+        if not _is_truthy(attributes.get("dynamic_registration_enabled")):
+            status["skipped_disabled_count"] += 1
+            continue
+
+        status["candidate_count"] += 1
+
+        if not _is_truthy(attributes.get("dynamic_registration_approved")):
+            status["failed"].append(
+                {
+                    "concept_id": concept_id,
+                    "reason": "missing_approval_marker",
+                    "message": (
+                        "dynamic_registration_approved must be true for activation."
+                    ),
+                }
+            )
+            continue
+
+        tool_name_raw = attributes.get("mcp_tool_name")
+        tool_name = str(tool_name_raw or "").strip()
+        if not tool_name:
+            status["failed"].append(
+                {
+                    "concept_id": concept_id,
+                    "reason": "missing_tool_name",
+                    "message": "Missing attributes.mcp_tool_name",
+                }
+            )
+            continue
+
+        if not _DYNAMIC_TOOL_NAME_PATTERN.fullmatch(tool_name):
+            status["failed"].append(
+                {
+                    "concept_id": concept_id,
+                    "tool_name": tool_name,
+                    "reason": "invalid_tool_name",
+                    "message": (
+                        "Tool name must match ^[a-z][a-z0-9_]{2,127}$."
+                    ),
+                }
+            )
+            continue
+
+        if tool_name in protected_names:
+            status["failed"].append(
+                {
+                    "concept_id": concept_id,
+                    "tool_name": tool_name,
+                    "reason": "protected_name_conflict",
+                    "message": "Dynamic tool name conflicts with a protected method.",
+                }
+            )
+            continue
+
+        if tool_name in dynamic_name_guard:
+            status["failed"].append(
+                {
+                    "concept_id": concept_id,
+                    "tool_name": tool_name,
+                    "reason": "duplicate_dynamic_name",
+                    "message": (
+                        "Another dynamic concept already registered this tool name."
+                    ),
+                }
+            )
+            continue
+
+        target_tool_name = str(attributes.get("dynamic_target_tool_name") or "").strip()
+        if not target_tool_name:
+            status["failed"].append(
+                {
+                    "concept_id": concept_id,
+                    "tool_name": tool_name,
+                    "reason": "missing_target_tool_name",
+                    "message": "Missing attributes.dynamic_target_tool_name",
+                }
+            )
+            continue
+
+        target_definition = base_definitions.get(target_tool_name)
+        if target_definition is None:
+            status["failed"].append(
+                {
+                    "concept_id": concept_id,
+                    "tool_name": tool_name,
+                    "target_tool_name": target_tool_name,
+                    "reason": "target_not_registered",
+                    "message": (
+                        "dynamic_target_tool_name must reference an existing built-in method."
+                    ),
+                }
+            )
+            continue
+
+        fixed_payload_raw = attributes.get("dynamic_fixed_payload")
+        if fixed_payload_raw in (None, ""):
+            fixed_payload: dict[str, Any] = {}
+        elif isinstance(fixed_payload_raw, Mapping):
+            fixed_payload = dict(fixed_payload_raw)
+        else:
+            status["failed"].append(
+                {
+                    "concept_id": concept_id,
+                    "tool_name": tool_name,
+                    "reason": "invalid_fixed_payload",
+                    "message": "dynamic_fixed_payload must be a mapping when provided.",
+                }
+            )
+            continue
+
+        fixed_payload_errors = _validate_fixed_payload(
+            fixed_payload=fixed_payload,
+            target_tool_name=target_tool_name,
+            target_schema=target_definition.input_schema,
+        )
+        if fixed_payload_errors:
+            status["failed"].append(
+                {
+                    "concept_id": concept_id,
+                    "tool_name": tool_name,
+                    "target_tool_name": target_tool_name,
+                    "reason": "invalid_fixed_payload",
+                    "message": "; ".join(fixed_payload_errors),
+                }
+            )
+            continue
+
+        timeout_sec = target_definition.timeout_sec
+        timeout_override = attributes.get("dynamic_timeout_sec")
+        if timeout_override not in (None, ""):
+            if (
+                isinstance(timeout_override, (int, float))
+                and not isinstance(timeout_override, bool)
+                and float(timeout_override) > 0.0
+            ):
+                timeout_sec = float(timeout_override)
+            else:
+                status["failed"].append(
+                    {
+                        "concept_id": concept_id,
+                        "tool_name": tool_name,
+                        "reason": "invalid_timeout",
+                        "message": "dynamic_timeout_sec must be a positive number.",
+                    }
+                )
+                continue
+
+        fixed_payload_keys = {str(key) for key in fixed_payload.keys()}
+        dynamic_input_schema = _build_dynamic_input_schema(
+            target_schema=target_definition.input_schema,
+            fixed_payload_keys=fixed_payload_keys,
+            tool_name=tool_name,
+            target_tool_name=target_tool_name,
+        )
+        dynamic_description_raw = attributes.get("dynamic_description")
+        dynamic_description = (
+            dynamic_description_raw.strip()
+            if isinstance(dynamic_description_raw, str)
+            and dynamic_description_raw.strip()
+            else None
+        )
+        description = dynamic_description or (
+            f"Dynamic Vontology proxy for '{target_tool_name}'."
+        )
+
+        dynamic_definition = MethodDefinition(
+            name=tool_name,
+            handler=_build_proxy_handler(
+                target_handler=target_definition.handler,
+                fixed_payload=fixed_payload,
+            ),
+            input_schema=dynamic_input_schema,
+            output_schema=target_definition.output_schema,
+            category=target_definition.category,
+            timeout_sec=timeout_sec,
+            description=description,
+        )
+        resolved.append(dynamic_definition)
+        dynamic_name_guard.add(tool_name)
+        status["loaded"].append(
+            {
+                "concept_id": concept_id,
+                "tool_name": tool_name,
+                "target_tool_name": target_tool_name,
+                "category": target_definition.category,
+                "fixed_payload_keys": sorted(fixed_payload_keys),
+            }
+        )
+
+    status["loaded_count"] = len(resolved)
+    status["failed_count"] = len(status["failed"])
+    _set_last_registration_status(status)
+
+    return DynamicMethodLoadResult(definitions=tuple(resolved), status=status)

--- a/src/backend/integrations/internal_mcp/gateway.py
+++ b/src/backend/integrations/internal_mcp/gateway.py
@@ -209,7 +209,7 @@ class InternalMCPGateway:
         metrics.last_error = error_message
 
     def get_diagnostics(self) -> Dict[str, Any]:
-        return {
+        diagnostics = {
             "enabled": self._enabled,
             "registered_methods": self._catalogue.list_methods(),
             "total_calls": self._total_calls,
@@ -219,6 +219,19 @@ class InternalMCPGateway:
                 for name, metrics in self._method_metrics.items()
             },
         }
+        try:
+            from .dynamic_tool_loader import get_dynamic_tool_registration_status
+
+            diagnostics["dynamic_tool_registration"] = (
+                get_dynamic_tool_registration_status()
+            )
+        except Exception as exc:
+            diagnostics["dynamic_tool_registration"] = {
+                "loaded_at_utc": None,
+                "source": "vontology:#V#mcp_tool",
+                "error": str(exc),
+            }
+        return diagnostics
 
     def describe_methods(self) -> Dict[str, Dict[str, Any]]:
         """Return descriptive metadata for registered methods."""

--- a/tests/backend/test_internal_mcp_dynamic_tool_registration.py
+++ b/tests/backend/test_internal_mcp_dynamic_tool_registration.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from src.backend.integrations.internal_mcp import build_default_catalogue
+from src.backend.integrations.internal_mcp.dynamic_tool_loader import (
+    get_dynamic_tool_registration_status,
+    invalidate_dynamic_tool_spec_cache,
+    load_dynamic_method_definitions,
+    reset_dynamic_tool_registration_status,
+)
+from src.backend.integrations.internal_mcp.gateway import (
+    InternalMCPGateway,
+    MethodCatalogue,
+    MethodDefinition,
+)
+from src.backend.integrations.internal_mcp.schemas import Schema, SchemaValidationError
+from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+
+
+def _set_dynamic_tool_docs(monkeypatch, docs):
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find",
+        lambda *_args, **_kwargs: docs,
+    )
+    invalidate_dynamic_tool_spec_cache()
+    reset_dynamic_tool_registration_status()
+
+
+def test_dynamic_loader_supports_fixed_payload_with_gateway_invoke(monkeypatch):
+    _set_dynamic_tool_docs(
+        monkeypatch,
+        [
+            {
+                "concept_id": "#V#dynamic_echo_proxy",
+                "attributes": {
+                    "mcp_tool_name": "echo_proxy",
+                    "dynamic_registration_enabled": True,
+                    "dynamic_registration_approved": True,
+                    "dynamic_target_tool_name": "echo_base",
+                    "dynamic_fixed_payload": {
+                        "name": "fixed-name",
+                        "fixed": "forced",
+                    },
+                },
+            }
+        ],
+    )
+
+    def _echo_handler(**kwargs):
+        return {
+            "success": True,
+            "name": kwargs.get("name"),
+            "value": kwargs.get("value"),
+            "fixed": kwargs.get("fixed"),
+        }
+
+    base_definition = MethodDefinition(
+        name="echo_base",
+        handler=_echo_handler,
+        input_schema=Schema(
+            required={"name": str},
+            optional={"value": str, "fixed": str},
+            allow_unknown=False,
+            description="Echo payload for dynamic proxy tests.",
+        ),
+        output_schema=Schema(
+            required={"success": bool},
+            optional={"name": (str, type(None)), "value": (str, type(None)), "fixed": (str, type(None))},
+            allow_unknown=False,
+            description="Echo output.",
+        ),
+        category="read",
+        description="Echo base tool.",
+    )
+
+    load_result = load_dynamic_method_definitions(
+        base_definitions={"echo_base": base_definition},
+        protected_method_names={"echo_base"},
+    )
+    assert len(load_result.definitions) == 1
+    dynamic_definition = load_result.definitions[0]
+    assert dynamic_definition.name == "echo_proxy"
+    assert dynamic_definition.input_schema.required == {}
+    assert "name" not in dynamic_definition.input_schema.optional
+
+    catalogue = MethodCatalogue()
+    catalogue.register(base_definition)
+    catalogue.register(dynamic_definition)
+    gateway = InternalMCPGateway(
+        catalogue=catalogue,
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+
+    result = gateway.invoke("echo_proxy", {"value": "hello"})
+    assert result.payload["success"] is True
+    assert result.payload["name"] == "fixed-name"
+    assert result.payload["fixed"] == "forced"
+    assert result.payload["value"] == "hello"
+
+    try:
+        gateway.invoke("echo_proxy", {"value": "hello", "name": "attempted-override"})
+        assert False, "Expected SchemaValidationError for fixed key override attempt."
+    except SchemaValidationError:
+        pass
+
+
+def test_build_default_catalogue_registers_enabled_dynamic_tool(monkeypatch):
+    _set_dynamic_tool_docs(
+        monkeypatch,
+        [
+            {
+                "concept_id": "#V#dynamic_get_context_alias",
+                "attributes": {
+                    "mcp_tool_name": "get_context_dynamic",
+                    "dynamic_registration_enabled": True,
+                    "dynamic_registration_approved": True,
+                    "dynamic_target_tool_name": "get_context",
+                },
+            }
+        ],
+    )
+
+    catalogue = build_default_catalogue()
+    assert "get_context_dynamic" in set(catalogue.list_methods())
+
+    gateway = InternalMCPGateway(
+        catalogue=catalogue,
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+    result = gateway.invoke("get_context_dynamic", {})
+    assert result.payload.get("language")
+
+    diagnostics = gateway.get_diagnostics()
+    registration = diagnostics.get("dynamic_tool_registration") or {}
+    assert registration.get("loaded_count") == 1
+    assert registration.get("failed_count") == 0
+    loaded_entries = registration.get("loaded")
+    assert isinstance(loaded_entries, list)
+    assert loaded_entries
+    assert loaded_entries[0].get("tool_name") == "get_context_dynamic"
+
+
+def test_dynamic_tool_with_invalid_spec_is_rejected_and_reported(monkeypatch):
+    _set_dynamic_tool_docs(
+        monkeypatch,
+        [
+            {
+                "concept_id": "#V#dynamic_invalid_missing_target",
+                "attributes": {
+                    "mcp_tool_name": "invalid_dynamic_tool",
+                    "dynamic_registration_enabled": True,
+                    "dynamic_registration_approved": True,
+                },
+            }
+        ],
+    )
+
+    catalogue = build_default_catalogue()
+    assert "invalid_dynamic_tool" not in set(catalogue.list_methods())
+
+    status = get_dynamic_tool_registration_status()
+    assert status.get("failed_count") == 1
+    failed_entries = status.get("failed")
+    assert isinstance(failed_entries, list)
+    assert failed_entries
+    assert failed_entries[0].get("reason") == "missing_target_tool_name"
+
+
+def test_dynamic_tool_cannot_override_builtin_name(monkeypatch):
+    _set_dynamic_tool_docs(
+        monkeypatch,
+        [
+            {
+                "concept_id": "#V#dynamic_conflict_get_context",
+                "attributes": {
+                    "mcp_tool_name": "get_context",
+                    "dynamic_registration_enabled": True,
+                    "dynamic_registration_approved": True,
+                    "dynamic_target_tool_name": "get_context",
+                },
+            }
+        ],
+    )
+
+    catalogue = build_default_catalogue()
+    methods = set(catalogue.list_methods())
+    assert "get_context" in methods
+
+    status = get_dynamic_tool_registration_status()
+    assert status.get("loaded_count") == 0
+    assert status.get("failed_count") == 1
+    failed_entries = status.get("failed")
+    assert isinstance(failed_entries, list)
+    assert failed_entries
+    assert failed_entries[0].get("reason") == "protected_name_conflict"


### PR DESCRIPTION
## Summary
- add dynamic_tool_loader to discover and validate Vontology #V#mcp_tool dynamic specs
- enforce fail-closed activation (dynamic_registration_enabled + dynamic_registration_approved) and protected-name conflict rejection
- register validated dynamic proxy MethodDefinitions after built-ins in build_default_catalogue()
- expose dynamic registration diagnostics in InternalMCPGateway.get_diagnostics()
- document Vontology authoring format and guardrails for dynamic registration

## Testing
- pdm run pyright src/backend/integrations/internal_mcp/dynamic_tool_loader.py src/backend/integrations/internal_mcp/catalogue.py src/backend/integrations/internal_mcp/gateway.py tests/backend/test_internal_mcp_dynamic_tool_registration.py
- ='test_von_db'; pdm run pytest tests/backend/test_internal_mcp_dynamic_tool_registration.py tests/backend/test_internal_mcp_catalogue_builds.py tests/backend/test_mcp_tool_contract_registry.py tests/backend/test_mcp_manifest_parity.py -q

## Notes
- Dynamic tool specs proxy existing built-in handlers only (no arbitrary runtime handler registration).
- Load status includes loaded/failed entries and reason codes for inspectability.