### PR TITLE
JVNAUTOSCI-1074: add shortcut-driven diagnostics export

### DIFF
--- a/docs/engineering/coding_agent_diagnostics_export.md
+++ b/docs/engineering/coding_agent_diagnostics_export.md
@@ -1,0 +1,29 @@
+# Coding Agent Diagnostics Export
+
+`JVNAUTOSCI-1074` adds an opt-in diagnostics export path for local coding-agent troubleshooting.
+
+## How to Export
+
+1. Open the Chat tab in Von.
+2. Press `Ctrl+Shift+D`.
+3. Von writes a sanitised snapshot to `data/diagnostic_latest.json`.
+
+## What Is Included
+
+- Tool invocation summaries (method/status/duration/argument keys)
+- Error metadata and warning summaries
+- Turn execution timing/progress diagnostics when available
+- LLM call metadata summaries
+
+## What Is Removed
+
+- Message bodies and `messages` payloads
+- Prompt text fields (`prompt`, `prompt_preview`, `user_prompt`)
+- Response text fields
+- Token/secret/password/cookie-style fields
+- Raw nested tool payload bodies (replaced with shape summaries)
+
+## Notes
+
+- Export is explicit and user-triggered by shortcut.
+- Each export overwrites `data/diagnostic_latest.json` with the newest snapshot.

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -13,6 +13,8 @@ import time
 import threading
 import secrets
 import uuid
+import json
+from pathlib import Path
 from dataclasses import asdict, is_dataclass
 from datetime import datetime, timezone
 from typing import Any, Mapping, cast
@@ -88,6 +90,51 @@ _TOOL_PROGRESS_TERMINAL_STATUSES = {"completed", "error", "cancelled"}
 _TOOL_PROGRESS_DIAGNOSTIC_EVENT_LIMIT = 80
 _TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT = 40
 _TURN_EXECUTION_DIAGNOSTICS_PROMPT_PREVIEW_LIMIT = 1000
+_DIAGNOSTIC_EXPORT_STRING_LIMIT = 2000
+_DIAGNOSTIC_EXPORT_COLLECTION_LIMIT = 80
+_DIAGNOSTIC_EXPORT_MAX_DEPTH = 8
+_DIAGNOSTIC_EXPORT_REDACTED_VALUE = "[redacted]"
+_DIAGNOSTIC_EXPORT_SUMMARISED_VALUE = "[summarised]"
+_DIAGNOSTIC_EXPORT_REPO_ROOT = Path(__file__).resolve().parents[4]
+_DIAGNOSTIC_EXPORT_RELATIVE_PATH = Path("data") / "diagnostic_latest.json"
+_DIAGNOSTIC_EXPORT_FILE_PATH = (
+    _DIAGNOSTIC_EXPORT_REPO_ROOT / _DIAGNOSTIC_EXPORT_RELATIVE_PATH
+)
+_DIAGNOSTIC_EXPORT_EXACT_SENSITIVE_KEYS = {
+    "message",
+    "messages",
+    "content",
+    "raw_content",
+    "prompt",
+    "prompt_raw",
+    "prompt_preview",
+    "user_prompt",
+    "response",
+    "screen",
+    "spoken",
+    "screen_text",
+    "spoken_text",
+    "authorization",
+    "api_key",
+    "apikey",
+    "secret",
+    "password",
+    "cookie",
+    "cookies",
+    "set_cookie",
+    "id_token",
+    "access_token",
+    "refresh_token",
+}
+_DIAGNOSTIC_EXPORT_STRUCTURAL_ONLY_KEYS = {
+    "arguments",
+    "args",
+    "payload",
+    "request_payload",
+    "response_payload",
+    "raw_payload",
+    "tool_payload",
+}
 
 
 def get_buttonify_heuristic_preflight_enabled() -> bool:
@@ -759,6 +806,110 @@ def _build_turn_execution_diagnostics(
         "workflow_stage_path": workflow_stage_path,
         "timing_breakdown": timing_breakdown,
     }
+
+
+def _truncate_diagnostic_export_string(value: str) -> str:
+    if len(value) <= _DIAGNOSTIC_EXPORT_STRING_LIMIT:
+        return value
+    truncated_chars = len(value) - _DIAGNOSTIC_EXPORT_STRING_LIMIT
+    return (
+        f"{value[:_DIAGNOSTIC_EXPORT_STRING_LIMIT]}"
+        f"... [truncated {truncated_chars} chars]"
+    )
+
+
+def _is_sensitive_diagnostic_export_key(key: str) -> bool:
+    lowered = key.strip().lower()
+    if not lowered:
+        return False
+    if lowered in _DIAGNOSTIC_EXPORT_EXACT_SENSITIVE_KEYS:
+        return True
+    if "token" in lowered and "count" not in lowered and "tokens_" not in lowered:
+        return True
+    for marker in ("secret", "password", "authorization", "cookie"):
+        if marker in lowered:
+            return True
+    return False
+
+
+def _summarise_diagnostic_export_collection_shape(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        keys = [str(item) for item in value.keys()][: _DIAGNOSTIC_EXPORT_COLLECTION_LIMIT]
+        return {
+            "summary": _DIAGNOSTIC_EXPORT_SUMMARISED_VALUE,
+            "type": "object",
+            "key_count": len(value),
+            "keys": keys,
+        }
+    if isinstance(value, list):
+        return {
+            "summary": _DIAGNOSTIC_EXPORT_SUMMARISED_VALUE,
+            "type": "array",
+            "item_count": len(value),
+        }
+    return {"summary": _DIAGNOSTIC_EXPORT_SUMMARISED_VALUE, "type": type(value).__name__}
+
+
+def _sanitise_diagnostic_export_payload(
+    value: Any,
+    *,
+    depth: int = 0,
+    parent_key: str | None = None,
+) -> Any:
+    if depth >= _DIAGNOSTIC_EXPORT_MAX_DEPTH:
+        return {"summary": _DIAGNOSTIC_EXPORT_SUMMARISED_VALUE, "depth_limited": True}
+
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+
+    if isinstance(value, str):
+        return _truncate_diagnostic_export_string(value)
+
+    if isinstance(value, Mapping):
+        sanitised: dict[str, Any] = {}
+        for index, (raw_key, raw_item) in enumerate(value.items()):
+            if index >= _DIAGNOSTIC_EXPORT_COLLECTION_LIMIT:
+                sanitised["truncated_keys"] = len(value) - _DIAGNOSTIC_EXPORT_COLLECTION_LIMIT
+                break
+
+            key = str(raw_key)
+            if _is_sensitive_diagnostic_export_key(key):
+                sanitised[key] = _DIAGNOSTIC_EXPORT_REDACTED_VALUE
+                continue
+
+            lowered_key = key.strip().lower()
+            if lowered_key in _DIAGNOSTIC_EXPORT_STRUCTURAL_ONLY_KEYS:
+                sanitised[key] = _summarise_diagnostic_export_collection_shape(raw_item)
+                continue
+
+            sanitised[key] = _sanitise_diagnostic_export_payload(
+                raw_item,
+                depth=depth + 1,
+                parent_key=key,
+            )
+        return sanitised
+
+    if isinstance(value, list):
+        sanitised_items = []
+        for index, raw_item in enumerate(value):
+            if index >= _DIAGNOSTIC_EXPORT_COLLECTION_LIMIT:
+                sanitised_items.append(
+                    {"summary": _DIAGNOSTIC_EXPORT_SUMMARISED_VALUE, "truncated_items": len(value) - _DIAGNOSTIC_EXPORT_COLLECTION_LIMIT}
+                )
+                break
+            sanitised_items.append(
+                _sanitise_diagnostic_export_payload(
+                    raw_item,
+                    depth=depth + 1,
+                    parent_key=parent_key,
+                )
+            )
+        return sanitised_items
+
+    try:
+        return _truncate_diagnostic_export_string(str(value))
+    except Exception:
+        return f"<{type(value).__name__}>"
 
 
 def _start_tool_progress_heartbeat(
@@ -7336,6 +7487,67 @@ def history_debug():
     except Exception as e:
         print(f"Error retrieving history debug data: {e}")
         return jsonify({"error": str(e)}), 500
+
+
+@von_bp.route("/diagnostics/export", methods=["POST"])
+def export_diagnostics_snapshot():
+    """Write a sanitised diagnostics snapshot to data/diagnostic_latest.json.
+
+    This route is intentionally opt-in and user-triggered (keyboard shortcut in
+    the chat UI). It keeps troubleshooting friction low for external coding
+    agents while removing message bodies, prompts, and token-like fields.
+    """
+
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "invalid_payload",
+                    "message": "Expected a JSON object payload.",
+                }
+            ),
+            400,
+        )
+
+    sanitised_payload = _sanitise_diagnostic_export_payload(payload)
+    exported_at_utc = _now_utc_iso()
+    file_payload = {
+        "schema_version": "von_diagnostic_export.v1",
+        "exported_at_utc": exported_at_utc,
+        "source": "chat_shortcut",
+        "sanitised": True,
+        "diagnostics": sanitised_payload,
+    }
+
+    try:
+        _DIAGNOSTIC_EXPORT_FILE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _DIAGNOSTIC_EXPORT_FILE_PATH.write_text(
+            json.dumps(file_payload, indent=2, ensure_ascii=True, default=str) + "\n",
+            encoding="utf-8",
+        )
+        return jsonify(
+            {
+                "success": True,
+                "path": str(_DIAGNOSTIC_EXPORT_RELATIVE_PATH).replace("\\", "/"),
+                "written_at_utc": exported_at_utc,
+            }
+        )
+    except Exception as exc:
+        current_app.logger.error(
+            "Failed to write diagnostic snapshot export: %s", exc, exc_info=True
+        )
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "write_failed",
+                    "message": "Could not write diagnostic export file.",
+                }
+            ),
+            500,
+        )
 
 
 @von_bp.route("/history/backfill_spoken", methods=["POST"])

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -461,6 +461,7 @@ async function deleteConversation(sessionId) {
 
 let orgSwitchListenerBound = false;
 let authStatusListenerBound = false;
+let diagnosticsExportShortcutBound = false;
 
 // JVNAUTOSCI-942: Tool-use progress while "Thinking..."
 const DEFAULT_THINKING_TEXT = 'Thinking...';
@@ -470,6 +471,8 @@ const TOOL_USE_SETTING_REFRESH_COOLDOWN_MS = 30_000;
 const THINKING_STATUS_ACTIVE = 'active';
 const THINKING_STATUS_WAITING = 'waiting';
 const THINKING_STATUS_STALLED = 'stalled';
+const DIAGNOSTICS_EXPORT_ENDPOINT = '/von/diagnostics/export';
+const DIAGNOSTICS_EXPORT_SHORTCUT_HINT = 'Ctrl+Shift+D';
 
 function getLoadingIndicatorTextEl() {
     const loadingIndicator = document.getElementById('loadingIndicator');
@@ -13676,6 +13679,7 @@ export function initializeChatTab() {
 
     // Initialize LLM debug popup handlers
     initializeLlmDebugPopup();
+    bindDiagnosticsExportShortcut();
     initializeHistoryControls();
     updateHistoryBanner();
     setupChatTabContextMenu();
@@ -14045,6 +14049,233 @@ function buildThinkingDiagnosticsPayload(request) {
         tool_history: Array.isArray(request.toolUseProgressHistory) ? request.toolUseProgressHistory.slice(-40) : [],
         workflow_discovery: request.workflowDiscovery || null
     };
+}
+
+function getLatestLlmDebugEntryForExport() {
+    if (llmDebugData.size === 0) {
+        return null;
+    }
+
+    const getTurnTimestamp = (turnId) => {
+        if (typeof turnId !== 'string') {
+            return 0;
+        }
+        const parts = turnId.split('-');
+        const tail = parts.length > 1 ? Number.parseInt(parts[parts.length - 1], 10) : 0;
+        return Number.isFinite(tail) ? tail : 0;
+    };
+
+    let latest = null;
+    for (const [turnId, debugData] of llmDebugData.entries()) {
+        if (!latest) {
+            latest = { turnId, debugData, timestamp: getTurnTimestamp(turnId) };
+            continue;
+        }
+        const nextTimestamp = getTurnTimestamp(turnId);
+        if (nextTimestamp >= latest.timestamp) {
+            latest = { turnId, debugData, timestamp: nextTimestamp };
+        }
+    }
+    return latest;
+}
+
+function summariseDiagnosticToolInvocation(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const method = entry.method || entry.tool || entry.name || null;
+    const argumentsPayload = (entry.arguments && typeof entry.arguments === 'object') ? entry.arguments : null;
+    return {
+        method,
+        status: entry.status || null,
+        success: (typeof entry.success === 'boolean') ? entry.success : null,
+        duration_ms: (typeof entry.duration_ms === 'number' && Number.isFinite(entry.duration_ms))
+            ? Math.max(0, Math.round(entry.duration_ms))
+            : null,
+        error: entry.error || null,
+        error_type: entry.error_type || null,
+        argument_keys: argumentsPayload ? Object.keys(argumentsPayload).slice(0, 50) : []
+    };
+}
+
+function summariseAuxLlmCallForExport(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+    return {
+        type: entry.type || null,
+        model: entry.model || null,
+        provider: entry.provider || null,
+        status: entry.status || null,
+        duration_ms: (typeof entry.duration_ms === 'number' && Number.isFinite(entry.duration_ms))
+            ? Math.max(0, Math.round(entry.duration_ms))
+            : null,
+        error: entry.error || null
+    };
+}
+
+function summariseTurnDiagnosticsForExport(rawTurnDiagnostics) {
+    const turnDiagnostics = (rawTurnDiagnostics && typeof rawTurnDiagnostics === 'object')
+        ? rawTurnDiagnostics
+        : null;
+    if (!turnDiagnostics) {
+        return null;
+    }
+    const events = Array.isArray(turnDiagnostics.events)
+        ? turnDiagnostics.events.filter(event => event && typeof event === 'object')
+        : [];
+    const categories = Array.from(new Set(events
+        .map(event => (typeof (event.type || event.category) === 'string') ? String(event.type || event.category) : '')
+        .filter(Boolean)));
+
+    return {
+        event_count: events.length,
+        categories,
+        latest_event_type: categories.length ? categories[categories.length - 1] : null
+    };
+}
+
+function buildSanitisedLlmDebugExportPayload(debugData) {
+    if (!debugData || typeof debugData !== 'object') {
+        return null;
+    }
+
+    if (debugData.turn_execution_diagnostics && typeof debugData.turn_execution_diagnostics === 'object') {
+        return {
+            type: 'turn_execution_diagnostics',
+            ...debugData.turn_execution_diagnostics,
+            prompt_preview: undefined
+        };
+    }
+
+    const toolInvocations = Array.isArray(debugData.tool_invocations)
+        ? debugData.tool_invocations
+            .map(summariseDiagnosticToolInvocation)
+            .filter(Boolean)
+            .slice(0, 80)
+        : [];
+
+    const auxLlmCalls = Array.isArray(debugData.aux_llm_calls)
+        ? debugData.aux_llm_calls
+            .map(summariseAuxLlmCallForExport)
+            .filter(Boolean)
+            .slice(0, 80)
+        : [];
+
+    return {
+        type: 'llm_debug_summary',
+        request_id: debugData.request_id || null,
+        model: debugData.model || null,
+        error: debugData.error || null,
+        warnings: Array.isArray(debugData.warnings) ? debugData.warnings.slice(0, 40) : [],
+        llm_interaction: (debugData.llm_interaction && typeof debugData.llm_interaction === 'object') ? {
+            requested_model: debugData.llm_interaction.requested_model || null,
+            orchestrator_used: debugData.llm_interaction.orchestrator_used || null,
+            duration_ms: debugData.llm_interaction.duration_ms || null,
+            server_elapsed_ms: debugData.llm_interaction.server_elapsed_ms || null,
+            call_count: Array.isArray(debugData.llm_interaction.calls) ? debugData.llm_interaction.calls.length : 0
+        } : null,
+        tool_invocations: toolInvocations,
+        aux_llm_calls: auxLlmCalls,
+        turn_diagnostics: summariseTurnDiagnosticsForExport(debugData.turn_diagnostics),
+        workflow_discovery: (debugData.workflow_discovery && typeof debugData.workflow_discovery === 'object')
+            ? debugData.workflow_discovery
+            : null,
+        internal_mcp: (debugData.internal_mcp && typeof debugData.internal_mcp === 'object')
+            ? debugData.internal_mcp
+            : null
+    };
+}
+
+function buildDiagnosticsExportRequestPayload() {
+    const activeThinkingRaw = buildThinkingDiagnosticsPayload(activeChatRequest);
+    const activeThinking = activeThinkingRaw ? {
+        ...activeThinkingRaw,
+        prompt_preview: undefined
+    } : null;
+
+    const latestEntry = getLatestLlmDebugEntryForExport();
+    const latestDebug = latestEntry ? buildSanitisedLlmDebugExportPayload(latestEntry.debugData) : null;
+
+    return {
+        schema_version: 'diagnostic_export_request.v1',
+        generated_at_utc: new Date().toISOString(),
+        trigger: 'keyboard_shortcut',
+        shortcut: DIAGNOSTICS_EXPORT_SHORTCUT_HINT,
+        session_id: activeChatSessionId || null,
+        diagnostics: {
+            active_thinking: activeThinking,
+            latest_turn_id: latestEntry ? latestEntry.turnId : null,
+            latest_turn_debug: latestDebug
+        },
+        telemetry: {
+            llm_debug_turn_count: llmDebugData.size,
+            transcript_turn_count: Array.isArray(transcriptTurns) ? transcriptTurns.length : 0
+        }
+    };
+}
+
+function shouldHandleDiagnosticsExportShortcut(event) {
+    if (!event || event.defaultPrevented) {
+        return false;
+    }
+    if (!(event.ctrlKey || event.metaKey) || !event.shiftKey || event.altKey) {
+        return false;
+    }
+    return String(event.key || '').toLowerCase() === 'd';
+}
+
+async function exportDiagnosticsSnapshotFromShortcut() {
+    const payload = buildDiagnosticsExportRequestPayload();
+    const hasDiagnostics = !!(
+        payload.diagnostics.active_thinking
+        || payload.diagnostics.latest_turn_debug
+    );
+    if (!hasDiagnostics) {
+        showToast('No diagnostics available to export.', 'info');
+        return false;
+    }
+
+    try {
+        const response = await fetch(DIAGNOSTICS_EXPORT_ENDPOINT, {
+            method: 'POST',
+            headers: buildChatFetchHeaders({
+                'Content-Type': 'application/json',
+            }),
+            body: JSON.stringify(payload),
+        });
+        const body = await response.json();
+        if (!response.ok || !body?.success) {
+            throw new Error(body?.error || `HTTP ${response.status}`);
+        }
+        const savedPath = body.path || 'data/diagnostic_latest.json';
+        showToast(`Diagnostics exported to ${savedPath}`, 'success');
+        return true;
+    } catch (error) {
+        console.error('[chatTab] Failed to export diagnostics snapshot:', error);
+        showToast('Failed to export diagnostics snapshot.', 'error');
+        return false;
+    }
+}
+
+function bindDiagnosticsExportShortcut() {
+    if (diagnosticsExportShortcutBound) {
+        return;
+    }
+
+    diagnosticsExportShortcutBound = true;
+    document.addEventListener('keydown', (event) => {
+        if (!shouldHandleDiagnosticsExportShortcut(event)) {
+            return;
+        }
+        const chatTab = document.getElementById('chatTab');
+        if (!chatTab || !chatTab.classList.contains('active')) {
+            return;
+        }
+        event.preventDefault();
+        void exportDiagnosticsSnapshotFromShortcut();
+    });
 }
 
 function retryActiveChatRequest() {
@@ -15700,6 +15931,15 @@ export function __testOnly_resetChatTtsState() {
     } catch (_) {
         // Ignore.
     }
+}
+export function __testOnly_shouldHandleDiagnosticsExportShortcut(event) {
+    return shouldHandleDiagnosticsExportShortcut(event);
+}
+export function __testOnly_buildDiagnosticsExportRequestPayload() {
+    return buildDiagnosticsExportRequestPayload();
+}
+export function __testOnly_buildSanitisedLlmDebugExportPayload(debugData) {
+    return buildSanitisedLlmDebugExportPayload(debugData);
 }
 export { formatChatTimestamp, showLlmDebugPopup, switchToChatSession, updateHistoryLength };
 

--- a/tests/backend/test_von_diagnostics_export_endpoint.py
+++ b/tests/backend/test_von_diagnostics_export_endpoint.py
@@ -1,0 +1,87 @@
+import json
+
+from flask import Flask
+
+
+def _build_test_client(monkeypatch, tmp_path):
+    from src.backend.server.routes import von_routes
+
+    export_path = tmp_path / "diagnostic_latest.json"
+    monkeypatch.setattr(von_routes, "_DIAGNOSTIC_EXPORT_FILE_PATH", export_path)
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.register_blueprint(von_routes.von_bp, url_prefix="/von")
+    return app.test_client(), export_path
+
+
+def test_diagnostics_export_writes_sanitised_file(monkeypatch, tmp_path):
+    client, export_path = _build_test_client(monkeypatch, tmp_path)
+
+    response = client.post(
+        "/von/diagnostics/export",
+        json={
+            "schema_version": "diagnostic_export_request.v1",
+            "diagnostics": {
+                "active_thinking": {
+                    "request_id": "req-1",
+                    "prompt_preview": "This should be redacted",
+                    "progress_events": [{"status": "thinking", "message": "event body"}],
+                },
+                "latest_turn_debug": {
+                    "model": "gpt-5",
+                    "messages": [{"role": "user", "content": "raw message body"}],
+                    "tool_invocations": [
+                        {
+                            "method": "search_knowledge_base",
+                            "arguments": {"query": "very sensitive text", "limit": 5},
+                        }
+                    ],
+                    "api_token": "abc123",
+                    "llm_interaction": {"token_count": 42},
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert isinstance(body, dict)
+    assert body.get("success") is True
+    assert body.get("path") == "data/diagnostic_latest.json"
+    assert export_path.exists() is True
+
+    file_payload = json.loads(export_path.read_text(encoding="utf-8"))
+    diagnostics = file_payload.get("diagnostics")
+    assert isinstance(diagnostics, dict)
+
+    active = diagnostics.get("diagnostics", {}).get("active_thinking")
+    assert active.get("prompt_preview") == "[redacted]"
+
+    latest = diagnostics.get("diagnostics", {}).get("latest_turn_debug")
+    assert latest.get("messages") == "[redacted]"
+    assert latest.get("api_token") == "[redacted]"
+    assert latest.get("llm_interaction", {}).get("token_count") == 42
+
+    tool_invocations = latest.get("tool_invocations")
+    assert isinstance(tool_invocations, list)
+    arguments_summary = tool_invocations[0].get("arguments")
+    assert arguments_summary == {
+        "summary": "[summarised]",
+        "type": "object",
+        "key_count": 2,
+        "keys": ["limit", "query"],
+    }
+
+
+def test_diagnostics_export_rejects_non_object_payload(monkeypatch, tmp_path):
+    client, export_path = _build_test_client(monkeypatch, tmp_path)
+
+    response = client.post("/von/diagnostics/export", json=["not", "an", "object"])
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert isinstance(body, dict)
+    assert body.get("success") is False
+    assert body.get("error") == "invalid_payload"
+    assert export_path.exists() is False

--- a/tests/frontend/chatTabDiagnosticExportShortcut.test.js
+++ b/tests/frontend/chatTabDiagnosticExportShortcut.test.js
@@ -1,0 +1,114 @@
+/** @jest-environment jsdom */
+
+const chatTabModulePath = '../../src/frontend/web/von_interface/static/js/chatTab.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    annotateTurn: jest.fn(),
+    getUserContext: jest.fn(),
+    getWindowSessionId: jest.fn(() => 'test-window-session'),
+    postJson: jest.fn(),
+    WINDOW_SESSION_HEADER: 'X-Von-Window-Session'
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
+    elements: {},
+    getCurrentUserConceptId: jest.fn(),
+    renderSpanSuggestions: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/utils/textDecorator.js', () => ({
+    annotateElementText: jest.fn(),
+    applyCartoucheAppearance: jest.fn(),
+    cartouchifyElementText: jest.fn(),
+    cartouchifyVontologyTokensInElement: jest.fn(),
+    createVontologyCartouche: jest.fn(),
+    getCartoucheAppearanceSettings: jest.fn(() => ({
+        useShortestName: false,
+        showName: true,
+        showId: true,
+        showKind: true,
+        kindAsBackground: false
+    })),
+    linkifyVontologyTokensInElement: jest.fn(),
+    normalisePotentialConceptId: jest.fn(() => '')
+}));
+
+describe('chat diagnostics export shortcut', () => {
+    test('recognises Ctrl+Shift+D as the export shortcut', () => {
+        const { __testOnly_shouldHandleDiagnosticsExportShortcut } = require(chatTabModulePath);
+
+        expect(__testOnly_shouldHandleDiagnosticsExportShortcut({
+            key: 'd',
+            ctrlKey: true,
+            shiftKey: true,
+            metaKey: false,
+            altKey: false,
+            defaultPrevented: false
+        })).toBe(true);
+
+        expect(__testOnly_shouldHandleDiagnosticsExportShortcut({
+            key: 'd',
+            ctrlKey: true,
+            shiftKey: false,
+            metaKey: false,
+            altKey: false,
+            defaultPrevented: false
+        })).toBe(false);
+    });
+
+    test('sanitises tool arguments and omits message bodies in export payload', () => {
+        const {
+            setLlmDebugDataForTurn,
+            __testOnly_buildDiagnosticsExportRequestPayload
+        } = require(chatTabModulePath);
+
+        setLlmDebugDataForTurn('a-9999999999999', {
+            request_id: 'req-export-1',
+            model: 'gpt-test',
+            messages: [{ role: 'user', content: 'private content' }],
+            tool_invocations: [
+                {
+                    method: 'search_knowledge_base',
+                    arguments: {
+                        query: 'sensitive query text',
+                        namespace: '#V#test_user'
+                    },
+                    success: true
+                }
+            ],
+            aux_llm_calls: [
+                { type: 'workflow_discovery', model: 'gpt-test', duration_ms: 21 }
+            ]
+        });
+
+        const payload = __testOnly_buildDiagnosticsExportRequestPayload();
+        const latest = payload?.diagnostics?.latest_turn_debug;
+
+        expect(payload.shortcut).toBe('Ctrl+Shift+D');
+        expect(latest.type).toBe('llm_debug_summary');
+        expect(latest.messages).toBeUndefined();
+        expect(latest.tool_invocations).toEqual([
+            expect.objectContaining({
+                method: 'search_knowledge_base',
+                argument_keys: ['query', 'namespace']
+            })
+        ]);
+    });
+
+    test('removes prompt preview when turn execution diagnostics are exported', () => {
+        const { __testOnly_buildSanitisedLlmDebugExportPayload } = require(chatTabModulePath);
+
+        const payload = __testOnly_buildSanitisedLlmDebugExportPayload({
+            turn_execution_diagnostics: {
+                request_id: 'req-turn-1',
+                prompt_preview: 'should not be exported',
+                elapsed_ms: 123
+            }
+        });
+
+        expect(payload.type).toBe('turn_execution_diagnostics');
+        expect(payload.request_id).toBe('req-turn-1');
+        expect(payload.elapsed_ms).toBe(123);
+        expect(payload.prompt_preview).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary
- add a new `/von/diagnostics/export` endpoint that writes a sanitised diagnostics snapshot to `data/diagnostic_latest.json`
- add `Ctrl+Shift+D` chat shortcut to export current diagnostics context for coding-agent troubleshooting
- add backend/frontend regression tests and usage docs

## Testing
- $env:VON_DB_NAME='test_von_db'; pytest tests/backend/test_von_diagnostics_export_endpoint.py tests/backend/test_von_history_debug_endpoint.py -q
- npm test -- tests/frontend/chatTabDiagnosticExportShortcut.test.js tests/frontend/chatTabLlmDebugWorkflowExecution.test.js --runInBand
- npx pyright src/backend/server/routes/von_routes.py tests/backend/test_von_diagnostics_export_endpoint.py