### PR TITLE
JVNAUTOSCI-1209 Conversation UX scroll-to-end affordance

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -120,6 +120,8 @@ const sharedConversationUnreadSessions = new Set();
 const sharedConversationLastHistoryIndex = new Map();
 const sharedConversationResyncInFlight = new Set();
 let latestUnreadBoundaryElement = null;
+const CHAT_SCROLL_BOTTOM_THRESHOLD_PX = 56;
+const CHAT_SCROLL_TO_END_BUTTON_ID = 'chatScrollToEndButton';
 const SSE_RECONNECT_BASE_DELAY_MS = 1000;
 const SSE_RECONNECT_MAX_DELAY_MS = 30000;
 
@@ -11131,6 +11133,7 @@ function rehydrateHistory(scrollableField, historyMessages, options = {}) {
         }
         // Update history display to reflect new context count
         updateHistoryLength();
+        updateScrollToEndButtonVisibility(scrollableField);
     });
 }
 
@@ -12221,6 +12224,137 @@ function appendSharedTurnToTranscript(message) {
         // Show "new messages" indicator
         showNewSharedMessagesIndicator();
     }
+
+    updateScrollToEndButtonVisibility(scrollableField);
+}
+
+function ensureScrollableFieldShell(scrollableField) {
+    if (!(scrollableField instanceof HTMLElement)) {
+        return null;
+    }
+
+    const parent = scrollableField.parentElement;
+    if (parent && parent.classList.contains('scrollable-field-shell')) {
+        return parent;
+    }
+
+    if (!parent) {
+        return null;
+    }
+
+    const shell = document.createElement('div');
+    shell.className = 'scrollable-field-shell';
+    parent.insertBefore(shell, scrollableField);
+    shell.appendChild(scrollableField);
+    return shell;
+}
+
+function ensureScrollToEndButton(scrollableField = null) {
+    const targetField = scrollableField || document.getElementById('scrollableField');
+    if (!(targetField instanceof HTMLElement)) {
+        return null;
+    }
+
+    const shell = ensureScrollableFieldShell(targetField);
+    if (!(shell instanceof HTMLElement)) {
+        return null;
+    }
+
+    let button = document.getElementById(CHAT_SCROLL_TO_END_BUTTON_ID);
+    if (button instanceof HTMLButtonElement && button.parentElement !== shell) {
+        button.remove();
+        button = null;
+    }
+
+    if (!(button instanceof HTMLButtonElement)) {
+        button = document.createElement('button');
+        button.type = 'button';
+        button.id = CHAT_SCROLL_TO_END_BUTTON_ID;
+        button.className = 'chat-scroll-to-end-btn';
+        button.setAttribute('aria-label', 'Scroll to latest message');
+        button.title = 'Scroll to latest message';
+        button.innerHTML = '<span aria-hidden="true">↓</span><span class="sr-only">Scroll to latest message</span>';
+        button.setAttribute('aria-hidden', 'true');
+        button.tabIndex = -1;
+        button.addEventListener('click', () => {
+            void scrollConversationToEnd(targetField, { smooth: true });
+        });
+        shell.appendChild(button);
+    }
+
+    return button;
+}
+
+function isScrollableFieldNearBottom(scrollableField, thresholdPx = CHAT_SCROLL_BOTTOM_THRESHOLD_PX) {
+    if (!(scrollableField instanceof HTMLElement)) {
+        return true;
+    }
+    const clientHeight = Number(scrollableField.clientHeight) || 0;
+    const scrollHeight = Number(scrollableField.scrollHeight) || 0;
+    const scrollTop = Number(scrollableField.scrollTop) || 0;
+    const distanceToBottom = scrollHeight - (scrollTop + clientHeight);
+    return distanceToBottom <= Math.max(0, Number(thresholdPx) || 0);
+}
+
+function scrollConversationToEnd(scrollableField, options = {}) {
+    if (!(scrollableField instanceof HTMLElement)) {
+        return false;
+    }
+
+    const smooth = options?.smooth !== false;
+    const top = scrollableField.scrollHeight;
+    try {
+        scrollableField.scrollTo({ top, behavior: smooth ? 'smooth' : 'auto' });
+    } catch (_err) {
+        scrollableField.scrollTop = top;
+    }
+
+    const schedule = (typeof window !== 'undefined' && typeof window.setTimeout === 'function')
+        ? window.setTimeout.bind(window)
+        : setTimeout;
+
+    schedule(() => {
+        if (isScrollableFieldNearBottom(scrollableField)) {
+            clearLatestUnreadBoundary();
+            hideNewSharedMessagesIndicator();
+        }
+        updateScrollToEndButtonVisibility(scrollableField);
+    }, smooth ? 220 : 0);
+
+    return true;
+}
+
+function updateScrollToEndButtonVisibility(scrollableField = null) {
+    const targetField = scrollableField || document.getElementById('scrollableField');
+    if (!(targetField instanceof HTMLElement)) {
+        return;
+    }
+
+    const button = ensureScrollToEndButton(targetField);
+    if (!(button instanceof HTMLButtonElement)) {
+        return;
+    }
+
+    const hasOverflow = (targetField.scrollHeight - targetField.clientHeight) > 1;
+    const nearBottom = isScrollableFieldNearBottom(targetField);
+    const shouldShow = hasOverflow && !nearBottom;
+
+    button.classList.toggle('visible', shouldShow);
+    button.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+    button.tabIndex = shouldShow ? 0 : -1;
+}
+
+function handleConversationScrollPositionChange(scrollableField) {
+    if (!(scrollableField instanceof HTMLElement)) {
+        return;
+    }
+
+    if (isScrollableFieldNearBottom(scrollableField)) {
+        clearLatestUnreadBoundary();
+        hideNewSharedMessagesIndicator();
+    }
+
+    updateScrollToEndButtonVisibility(scrollableField);
 }
 
 function setLatestUnreadBoundary(messageElement) {
@@ -13594,15 +13728,12 @@ export function initializeChatTab() {
     }
 
     if (chatTab && scrollableField) {
+        ensureScrollToEndButton(scrollableField);
+
         if (!scrollableField._sharedIndicatorWired) {
             scrollableField._sharedIndicatorWired = true;
             scrollableField.addEventListener('scroll', () => {
-                const isAtBottom = scrollableField.scrollHeight - scrollableField.scrollTop
-                    <= scrollableField.clientHeight + 50;
-                if (isAtBottom) {
-                    clearLatestUnreadBoundary();
-                    hideNewSharedMessagesIndicator();
-                }
+                handleConversationScrollPositionChange(scrollableField);
             });
         }
 
@@ -13886,7 +14017,9 @@ export function initializeChatTab() {
         scrollToBottom: false,
         preserveScroll: true,
         showResetNotice: false
-    })).catch(() => { });
+    })).then(() => {
+        updateScrollToEndButtonVisibility();
+    }).catch(() => { });
     void refreshChatSessionTabs();
     void refreshToolUseDuringThinkingSetting();
     console.log("Chat tab initialized successfully");
@@ -15177,6 +15310,7 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
         if (!isHistory) {
             scrollableField.scrollTop = scrollableField.scrollHeight;
         }
+        updateScrollToEndButtonVisibility(scrollableField);
     } catch (err) {
         console.error('[chatTab] appendMessage crashed:', err);
     }
@@ -15907,6 +16041,15 @@ export function __testOnly_jumpToLatestUnreadBoundary() {
 export function __testOnly_clearLatestUnreadJumpState() {
     clearLatestUnreadBoundary();
     hideNewSharedMessagesIndicator();
+}
+export function __testOnly_ensureScrollToEndButton(scrollableField = null) {
+    return ensureScrollToEndButton(scrollableField);
+}
+export function __testOnly_updateScrollToEndButtonVisibility(scrollableField = null) {
+    updateScrollToEndButtonVisibility(scrollableField);
+}
+export function __testOnly_scrollConversationToEnd(scrollableField, options = {}) {
+    return scrollConversationToEnd(scrollableField, options);
 }
 
 // Export for testing.

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -16,8 +16,11 @@ import {
     __testOnly_hydrateChatConceptCartouches,
     __testOnly_jumpToLatestUnreadBoundary,
     __testOnly_renderDisplayElementsIntoContainer,
+    __testOnly_ensureScrollToEndButton,
+    __testOnly_scrollConversationToEnd,
     __testOnly_setLatestUnreadBoundary,
     __testOnly_showNewSharedMessagesIndicator,
+    __testOnly_updateScrollToEndButtonVisibility,
     __testOnly_resetChatConceptMetaCaches,
     formatChatTimestamp,
     sendMessage
@@ -1707,5 +1710,63 @@ describe('latest unread jump affordance', () => {
         expect(__testOnly_jumpToLatestUnreadBoundary()).toBe(true);
         expect(boundary.scrollIntoView).toHaveBeenCalled();
         expect(boundary.focus).toHaveBeenCalled();
+    });
+});
+
+describe('scroll to latest message affordance', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="chatTab">
+                <div class="content-wrapper">
+                    <div id="scrollableField"></div>
+                </div>
+            </div>
+        `;
+    });
+
+    test('shows floating control only when conversation is away from the end', () => {
+        const scrollableField = document.getElementById('scrollableField');
+        Object.defineProperty(scrollableField, 'clientHeight', { value: 200, configurable: true });
+        Object.defineProperty(scrollableField, 'scrollHeight', { value: 600, configurable: true });
+
+        scrollableField.scrollTop = 20;
+        __testOnly_updateScrollToEndButtonVisibility(scrollableField);
+        const button = __testOnly_ensureScrollToEndButton(scrollableField);
+        expect(button).toBeTruthy();
+        expect(button.classList.contains('visible')).toBe(true);
+        expect(button.getAttribute('aria-hidden')).toBe('false');
+
+        scrollableField.scrollTop = 410;
+        __testOnly_updateScrollToEndButtonVisibility(scrollableField);
+        expect(button.classList.contains('visible')).toBe(false);
+        expect(button.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    test('clicking floating control scrolls to the latest message', () => {
+        jest.useFakeTimers();
+
+        const scrollableField = document.getElementById('scrollableField');
+        Object.defineProperty(scrollableField, 'clientHeight', { value: 180, configurable: true });
+        Object.defineProperty(scrollableField, 'scrollHeight', { value: 500, configurable: true });
+        scrollableField.scrollTop = 0;
+        scrollableField.scrollTo = jest.fn(({ top }) => {
+            scrollableField.scrollTop = top;
+        });
+
+        const button = __testOnly_ensureScrollToEndButton(scrollableField);
+        __testOnly_updateScrollToEndButtonVisibility(scrollableField);
+        expect(button.classList.contains('visible')).toBe(true);
+
+        button.click();
+
+        expect(scrollableField.scrollTo).toHaveBeenCalledWith({
+            top: 500,
+            behavior: 'smooth'
+        });
+
+        jest.runOnlyPendingTimers();
+        expect(__testOnly_scrollConversationToEnd(scrollableField, { smooth: false })).toBe(true);
+
+        jest.useRealTimers();
     });
 });

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -3132,6 +3132,57 @@ h1 {
     opacity: 0.6;
 }
 
+.scrollable-field-shell {
+    position: relative;
+    width: 100%;
+}
+
+.chat-scroll-to-end-btn {
+    position: absolute;
+    right: 14px;
+    bottom: 14px;
+    z-index: 12;
+    width: 40px;
+    height: 40px;
+    border: none;
+    border-radius: 999px;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #2563eb, #1d4ed8);
+    color: #ffffff;
+    font-size: 1.2rem;
+    line-height: 1;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.24);
+    transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.chat-scroll-to-end-btn.visible {
+    display: inline-flex;
+}
+
+.chat-scroll-to-end-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 14px rgba(15, 23, 42, 0.3);
+}
+
+.chat-scroll-to-end-btn:focus-visible {
+    outline: 2px solid #ffffff;
+    outline-offset: 2px;
+    box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.35);
+}
+
+@media (max-width: 768px) {
+    .chat-scroll-to-end-btn {
+        right: 10px;
+        bottom: 10px;
+        width: 44px;
+        height: 44px;
+        font-size: 1.3rem;
+    }
+}
+
 /* Dropdown */
 select {
     background-color: #fff;


### PR DESCRIPTION
## Summary
- add a floating "scroll to latest message" control in chat when the user is not near the end
- integrate button visibility updates with existing scroll, history rehydrate, and message append pathways
- keep unread-boundary/new-message indicator behaviour aligned when scrolling back to latest
- add unit tests for visibility and click-to-scroll behaviour

## Testing
- npx jest --runInBand src/frontend/web/von_interface/static/js/test/chatTab.test.js tests/frontend/chatTabLlmDebugWorkflowExecution.test.js --verbose

## Jira
- https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-1209