### PR TITLE
JVNAUTOSCI-1169 Align effective namespace usage across generate, persistence, and RAG

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -5146,13 +5146,110 @@ def _resolve_rag_namespace_from_kwargs(kwargs: dict) -> dict:
     """
 
     import os
+    import re
 
-    raw = kwargs.get("namespace")
-    if isinstance(raw, str) and raw.strip():
+    def _normalise_concept_id(value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        if cleaned.startswith("#v#"):
+            return "#V#" + cleaned[3:]
+        if cleaned.startswith("#V#"):
+            return cleaned
+        return f"#V#{cleaned.lstrip('#')}"
+
+    def _namespace_slug_from_concept(value: str | None) -> str | None:
+        if not isinstance(value, str):
+            return None
+        slug = value.strip()
+        if not slug:
+            return None
+        if slug.startswith("#V#"):
+            slug = slug[3:]
+        if "@" in slug:
+            slug = slug.split("@", 1)[0]
+        if "+" in slug:
+            slug = slug.split("+", 1)[0]
+        slug = re.sub(r"[^a-z0-9]+", "_", slug.strip().lower()).strip("_")
+        return slug or None
+
+    raw_namespace = kwargs.get("namespace")
+    explicit_namespace: str | None = None
+    if isinstance(raw_namespace, str) and raw_namespace.strip():
+        explicit_namespace = raw_namespace.strip()
+        if explicit_namespace.startswith("#v#"):
+            explicit_namespace = "#V#" + explicit_namespace[3:]
+        elif not explicit_namespace.startswith("#V#"):
+            explicit_namespace = f"#V#{explicit_namespace.lstrip('#')}"
+
+    user_candidate = _normalise_concept_id(kwargs.get("user_concept_id"))
+    if user_candidate is None:
+        user_candidate = _normalise_concept_id(kwargs.get("user_id"))
+    if user_candidate is None:
+        user_candidate = _normalise_concept_id(kwargs.get("actor_concept_id"))
+    if user_candidate is None:
+        user_candidate = _normalise_concept_id(kwargs.get("created_by_concept_id"))
+    if user_candidate is None:
+        user_payload = kwargs.get("user")
+        if isinstance(user_payload, dict):
+            user_candidate = _normalise_concept_id(user_payload.get("id"))
+
+    org_candidate = _normalise_concept_id(kwargs.get("organisation_concept_id"))
+    if org_candidate is None:
+        org_candidate = _normalise_concept_id(kwargs.get("org_id"))
+
+    derived_namespace: str | None = None
+    if user_candidate is not None:
+        user_slug = _namespace_slug_from_concept(user_candidate)
+        org_slug = _namespace_slug_from_concept(org_candidate)
+        if user_slug:
+            try:
+                from ...services.namespace_service import derive_namespace
+
+                derived_namespace = (
+                    derive_namespace(user_slug, org_slug)
+                    if org_slug
+                    else derive_namespace(user_slug)
+                )
+            except Exception:
+                derived_namespace = None
+
+    if explicit_namespace and derived_namespace and explicit_namespace != derived_namespace:
         return {
-            "namespace": raw.strip(),
+            "namespace": None,
+            "namespace_source": "conflict",
+            "namespace_resolution_note": "namespace_mismatch",
+            "namespace_mismatch": True,
+            "provided_namespace": explicit_namespace,
+            "derived_namespace": derived_namespace,
+            "derived_user_concept_id": user_candidate,
+            "derived_organisation_concept_id": org_candidate,
+        }
+
+    if explicit_namespace:
+        return {
+            "namespace": explicit_namespace,
             "namespace_source": "request.namespace",
             "namespace_resolution_note": None,
+            "namespace_mismatch": False,
+            "provided_namespace": explicit_namespace,
+            "derived_namespace": derived_namespace,
+            "derived_user_concept_id": user_candidate,
+            "derived_organisation_concept_id": org_candidate,
+        }
+
+    if derived_namespace:
+        return {
+            "namespace": derived_namespace,
+            "namespace_source": "derived.user_org",
+            "namespace_resolution_note": "derived_from_user_org",
+            "namespace_mismatch": False,
+            "provided_namespace": None,
+            "derived_namespace": derived_namespace,
+            "derived_user_concept_id": user_candidate,
+            "derived_organisation_concept_id": org_candidate,
         }
 
     env_ns = os.environ.get("VON_DEFAULT_NAMESPACE")
@@ -5161,12 +5258,46 @@ def _resolve_rag_namespace_from_kwargs(kwargs: dict) -> dict:
             "namespace": env_ns.strip(),
             "namespace_source": "env.VON_DEFAULT_NAMESPACE",
             "namespace_resolution_note": "fallback",
+            "namespace_mismatch": False,
+            "provided_namespace": None,
+            "derived_namespace": derived_namespace,
+            "derived_user_concept_id": user_candidate,
+            "derived_organisation_concept_id": org_candidate,
         }
 
     return {
         "namespace": None,
         "namespace_source": "missing",
         "namespace_resolution_note": "namespace_required",
+        "namespace_mismatch": False,
+        "provided_namespace": None,
+        "derived_namespace": derived_namespace,
+        "derived_user_concept_id": user_candidate,
+        "derived_organisation_concept_id": org_candidate,
+    }
+
+
+def _rag_namespace_resolution_error(ns_report: dict[str, Any]) -> dict[str, Any] | None:
+    namespace = ns_report.get("namespace")
+    if isinstance(namespace, str) and namespace.strip():
+        return None
+
+    if ns_report.get("namespace_resolution_note") == "namespace_mismatch":
+        return {
+            "error": "namespace_mismatch",
+            "message": (
+                "Explicit namespace conflicts with derived user/org namespace; "
+                "request was not executed."
+            ),
+            **ns_report,
+            "success": False,
+        }
+
+    return {
+        "error": "namespace_required",
+        "message": "RAG access requires authenticated user context (namespace)",
+        **ns_report,
+        "success": False,
     }
 
 
@@ -6121,13 +6252,13 @@ def _search_knowledge_base(**kwargs):
         ns = ns_report.get("namespace")
 
         # SECURITY: Require namespace for RAG search - prevents cross-user data leakage
-        if not ns:
-            return {
-                "error": "namespace_required",
-                "message": "RAG search requires authenticated user context (namespace)",
-                **ns_report,
-                "success": False,
-            }
+        ns_error = _rag_namespace_resolution_error(ns_report)
+        if ns_error is not None:
+            if ns_error.get("error") == "namespace_required":
+                ns_error["message"] = (
+                    "RAG search requires authenticated user context (namespace)"
+                )
+            return ns_error
 
         # Build permissions context from Flask session for org-scoped RAG filtering.
         # IMPORTANT: Use concept IDs (e.g. #V#user) rather than email/usernames.
@@ -6331,13 +6462,20 @@ def _index_concept_text(**kwargs):
 
     ns_report = _resolve_rag_namespace_from_kwargs(kwargs)
     ns = ns_report.get("namespace")
-    if not ns:
-        return {
-            "error": "namespace_required",
-            "message": "RAG indexing requires authenticated user context (namespace)",
-            **ns_report,
-            "success": False,
-        }
+    ns_error = _rag_namespace_resolution_error(ns_report)
+    if ns_error is not None:
+        if ns_error.get("error") == "namespace_required":
+            ns_error["message"] = (
+                "RAG indexing requires authenticated user context (namespace)"
+            )
+        return ns_error
+    if not isinstance(ns, str) or not ns.strip():
+        return make_error_response(
+            "namespace_required",
+            "RAG indexing requires authenticated user context (namespace)",
+            details={"namespace_report": ns_report},
+        )
+    ns = ns.strip()
 
     from ...services.rag_text_relation_sync_service import sync_text_relations_to_rag
 
@@ -7529,13 +7667,13 @@ def _get_related_concepts(**kwargs):
 
     ns_report = _resolve_rag_namespace_from_kwargs(kwargs)
     ns = ns_report.get("namespace")
-    if not ns:
-        return {
-            "error": "namespace_required",
-            "message": "RAG search requires authenticated user context (namespace)",
-            **ns_report,
-            "success": False,
-        }
+    ns_error = _rag_namespace_resolution_error(ns_report)
+    if ns_error is not None:
+        if ns_error.get("error") == "namespace_required":
+            ns_error["message"] = (
+                "RAG search requires authenticated user context (namespace)"
+            )
+        return ns_error
 
     # Attempt to seed the similarity query from the concept description text.
     # We scope access by (user, org) implied by the namespace to avoid cross-namespace reads.
@@ -8291,6 +8429,10 @@ def _rag_get_status(**kwargs):
 
     try:
         ns_report = _resolve_rag_namespace_from_kwargs(kwargs)
+        ns_error = _rag_namespace_resolution_error(ns_report)
+        if ns_error is not None and ns_error.get("error") == "namespace_mismatch":
+            return ns_error
+
         ns = ns_report.get("namespace") or os.environ.get("VON_DEFAULT_NAMESPACE")
         detail = kwargs.get("detail")
         base_url = (
@@ -8405,13 +8547,9 @@ def _rag_list_collections(**kwargs):
     ns = ns_report.get("namespace")
 
     # SECURITY: Require namespace for RAG access - prevents cross-user data leakage
-    if not ns:
-        return {
-            "error": "namespace_required",
-            "message": "RAG access requires authenticated user context (namespace)",
-            **ns_report,
-            "success": False,
-        }
+    ns_error = _rag_namespace_resolution_error(ns_report)
+    if ns_error is not None:
+        return ns_error
 
     collections = [
         {
@@ -8784,13 +8922,16 @@ def _rag_list_indexed(**kwargs):
     ns = ns_report.get("namespace")
 
     # SECURITY: Require namespace for RAG access - prevents cross-user data leakage
-    if not ns:
-        return {
-            "error": "namespace_required",
-            "message": "RAG access requires authenticated user context (namespace)",
-            **ns_report,
-            "success": False,
-        }
+    ns_error = _rag_namespace_resolution_error(ns_report)
+    if ns_error is not None:
+        return ns_error
+    if not isinstance(ns, str) or not ns.strip():
+        return make_error_response(
+            "namespace_required",
+            "RAG access requires authenticated user context (namespace)",
+            details={"namespace_report": ns_report},
+        )
+    ns = ns.strip()
 
     if not isinstance(collection, str) or not collection:
         collection = "ka_sessions"
@@ -9272,13 +9413,16 @@ def _rag_get_item(**kwargs):
     ns = ns_report.get("namespace")
 
     # SECURITY: Require namespace for RAG access - prevents cross-user data leakage
-    if not ns:
-        return {
-            "error": "namespace_required",
-            "message": "RAG access requires authenticated user context (namespace)",
-            **ns_report,
-            "success": False,
-        }
+    ns_error = _rag_namespace_resolution_error(ns_report)
+    if ns_error is not None:
+        return ns_error
+    if not isinstance(ns, str) or not ns.strip():
+        return make_error_response(
+            "namespace_required",
+            "RAG access requires authenticated user context (namespace)",
+            details={"namespace_report": ns_report},
+        )
+    ns = ns.strip()
 
     if not isinstance(collection, str) or not collection:
         collection = "ka_sessions"
@@ -9523,13 +9667,20 @@ def _rag_sync_text_relations(**kwargs):
     ns = ns_report.get("namespace")
 
     # SECURITY: Require namespace for RAG access - prevents cross-user data leakage
-    if not ns:
-        return {
-            "error": "namespace_required",
-            "message": "RAG sync requires an explicit namespace (e.g. #V#user@org)",
-            **ns_report,
-            "success": False,
-        }
+    ns_error = _rag_namespace_resolution_error(ns_report)
+    if ns_error is not None:
+        if ns_error.get("error") == "namespace_required":
+            ns_error["message"] = (
+                "RAG sync requires an explicit namespace (e.g. #V#user@org)"
+            )
+        return ns_error
+    if not isinstance(ns, str) or not ns.strip():
+        return make_error_response(
+            "namespace_required",
+            "RAG sync requires an explicit namespace (e.g. #V#user@org)",
+            details={"namespace_report": ns_report},
+        )
+    ns = ns.strip()
 
     predicates = kwargs.get("predicates")
     if predicates is not None and not isinstance(predicates, list):

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -3542,10 +3542,166 @@ def _deterministic_introspection_enabled() -> bool:
         return False
 
 
+def _build_chat_history_context_kwargs(
+    *,
+    namespace: str | None,
+    organisation_concept_id: str | None,
+    role_in_org: str | None,
+) -> dict[str, Any]:
+    context_kwargs: dict[str, Any] = {}
+    if isinstance(namespace, str) and namespace.strip():
+        context_kwargs["namespace"] = namespace.strip()
+    if (
+        isinstance(organisation_concept_id, str)
+        and organisation_concept_id.strip()
+    ):
+        context_kwargs["organisation_concept_id"] = organisation_concept_id.strip()
+    if isinstance(role_in_org, str) and role_in_org.strip():
+        context_kwargs["role_in_org"] = role_in_org.strip()
+    return context_kwargs
+
+
+def _add_chat_history_message(
+    *,
+    user_id: str,
+    session_id: str,
+    message: dict[str, Any],
+    llm_debug_data: dict[str, Any] | None = None,
+    namespace: str | None = None,
+    organisation_concept_id: str | None = None,
+    role_in_org: str | None = None,
+) -> None:
+    context_kwargs = _build_chat_history_context_kwargs(
+        namespace=namespace,
+        organisation_concept_id=organisation_concept_id,
+        role_in_org=role_in_org,
+    )
+    chat_history_service.add_message_to_history(
+        user_id,
+        session_id,
+        message,
+        llm_debug_data=llm_debug_data,
+        **context_kwargs,
+    )
+
+
+def _namespace_is_org_scoped(namespace: str | None) -> bool:
+    return isinstance(namespace, str) and namespace.strip().startswith("#V#") and (
+        "@" in namespace.strip()
+    )
+
+
+def _resolve_generate_namespace_context(
+    *,
+    user_concept_id: str | None,
+    effective_context: dict[str, Any] | None,
+    flask_session_snapshot: dict[str, Any],
+) -> dict[str, Any]:
+    """Resolve generate-time namespace with provenance and mismatch diagnostics.
+
+    Ordering strategy:
+    1. Preserve effective window/flask context namespace.
+    2. Prefer an org-scoped namespace when any org context is present.
+    3. Fall back to user-only namespace derivation.
+    """
+
+    candidates: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    def _add_candidate(source: str, namespace_value: Any) -> None:
+        if not isinstance(namespace_value, str):
+            return
+        cleaned = namespace_value.strip()
+        if not cleaned:
+            return
+        if cleaned.startswith("#v#"):
+            cleaned = "#V#" + cleaned[3:]
+        elif not cleaned.startswith("#V#"):
+            cleaned = f"#V#{cleaned.lstrip('#')}"
+        if cleaned in seen:
+            return
+        seen.add(cleaned)
+        candidates.append(
+            {
+                "namespace": cleaned,
+                "source": source,
+                "org_scoped": _namespace_is_org_scoped(cleaned),
+            }
+        )
+
+    effective = effective_context if isinstance(effective_context, dict) else {}
+    effective_namespace = effective.get("namespace")
+    effective_org = effective.get("organisation_id")
+    effective_source = effective.get("source")
+
+    _add_candidate("effective_context.namespace", effective_namespace)
+    if isinstance(effective_org, str) and effective_org.strip():
+        _add_candidate(
+            "derived_from_effective_context.org",
+            _derive_namespace_for_user_org(user_concept_id, effective_org),
+        )
+
+    session_namespace = flask_session_snapshot.get("namespace")
+    session_org = flask_session_snapshot.get("organisation_concept_id") or (
+        flask_session_snapshot.get("org_id")
+    )
+
+    _add_candidate("flask_session.namespace", session_namespace)
+    if isinstance(session_org, str) and session_org.strip():
+        _add_candidate(
+            "derived_from_flask_session.org",
+            _derive_namespace_for_user_org(user_concept_id, session_org),
+        )
+    _add_candidate(
+        "derived_from_user_concept_id",
+        _derive_namespace_for_user_org(user_concept_id, None),
+    )
+
+    org_candidates = [c for c in candidates if c.get("org_scoped")]
+    selected = org_candidates[0] if org_candidates else (candidates[0] if candidates else None)
+
+    comparable_candidates = [
+        c
+        for c in candidates
+        if c.get("source") != "derived_from_user_concept_id"
+    ]
+    distinct_namespaces = {
+        c.get("namespace")
+        for c in (comparable_candidates or candidates)
+        if c.get("namespace")
+    }
+    mismatch_detected = len(distinct_namespaces) > 1
+
+    report = {
+        "namespace": selected.get("namespace") if isinstance(selected, dict) else None,
+        "namespace_source": selected.get("source") if isinstance(selected, dict) else "missing",
+        "effective_context_source": effective_source if isinstance(effective_source, str) else None,
+        "effective_context_namespace": (
+            effective_namespace.strip()
+            if isinstance(effective_namespace, str) and effective_namespace.strip()
+            else None
+        ),
+        "session_namespace": (
+            session_namespace.strip()
+            if isinstance(session_namespace, str) and session_namespace.strip()
+            else None
+        ),
+        "candidates": candidates,
+        "mismatch_detected": mismatch_detected,
+        "org_scope_preferred": bool(org_candidates),
+    }
+    if mismatch_detected:
+        report["mismatch_reason"] = "multiple_namespace_candidates"
+    return report
+
+
 def _maybe_handle_prompt_introspection_fastpath(
     *,
     prompt_text: str,
     user_concept_id: str,
+    user_namespace: str | None,
+    org_concept_id: str | None,
+    role_in_org: str | None,
     history_user_id: str | None,
     session_id: str,
     auxiliary_system_prompt: str | None,
@@ -3559,6 +3715,7 @@ def _maybe_handle_prompt_introspection_fastpath(
 ):
     gateway = current_app.config.get("INTERNAL_MCP_GATEWAY")
     import json as _json
+    prompt_namespace = user_namespace or user_concept_id
 
     tool_messages: list[dict] = []
     tool_invocations: list[dict] = []
@@ -3571,7 +3728,7 @@ def _maybe_handle_prompt_introspection_fastpath(
             tool_result = gateway.invoke(
                 "chat_get_prompt_context",
                 {
-                    "namespace": user_concept_id,
+                    "namespace": prompt_namespace,
                     "include_content": True,
                     "max_chars": 5000,
                 },
@@ -3597,7 +3754,7 @@ def _maybe_handle_prompt_introspection_fastpath(
                 {
                     "tool": "chat_get_prompt_context",
                     "payload": {
-                        "namespace": user_concept_id,
+                        "namespace": prompt_namespace,
                         "include_content": True,
                         "max_chars": 5000,
                     },
@@ -3659,21 +3816,29 @@ def _maybe_handle_prompt_introspection_fastpath(
 
     # Store messages in history/context, matching the direct-tool-call pattern.
     if history_user_id:
-        chat_history_service.add_message_to_history(
-            history_user_id,
-            session_id,
-            {
+        _add_chat_history_message(
+            user_id=history_user_id,
+            session_id=session_id,
+            message={
                 "role": "user",
                 "content": prompt_text,
                 "author_user_id": user_concept_id,
             },
+            namespace=prompt_namespace,
+            organisation_concept_id=org_concept_id,
+            role_in_org=role_in_org,
         )
     for tool_msg in _truncate_large_tool_results(
         tool_messages, max_tool_content_chars=5000
     ):
         if history_user_id:
-            chat_history_service.add_message_to_history(
-                history_user_id, session_id, tool_msg
+            _add_chat_history_message(
+                user_id=history_user_id,
+                session_id=session_id,
+                message=tool_msg,
+                namespace=prompt_namespace,
+                organisation_concept_id=org_concept_id,
+                role_in_org=role_in_org,
             )
 
     current_app.config["CONTEXT"] = _limit_context_size(
@@ -3729,17 +3894,20 @@ def _maybe_handle_prompt_introspection_fastpath(
         prompt_text=prompt_text,
         response_text=response_text,
         session_id=session_id,
-        namespace=user_concept_id,
+        namespace=prompt_namespace,
         user_id=history_user_id or user_concept_id,
-        org_id=None,
+        org_id=org_concept_id,
     )
 
     if history_user_id:
-        chat_history_service.add_message_to_history(
-            history_user_id,
-            session_id,
-            {"role": "assistant", "content": response_text},
+        _add_chat_history_message(
+            user_id=history_user_id,
+            session_id=session_id,
+            message={"role": "assistant", "content": response_text},
             llm_debug_data=llm_debug_info,
+            namespace=prompt_namespace,
+            organisation_concept_id=org_concept_id,
+            role_in_org=role_in_org,
         )
 
     return jsonify(
@@ -3759,6 +3927,9 @@ def _maybe_handle_tool_inventory_fastpath(
     *,
     prompt_text: str,
     user_concept_id: str | None,
+    user_namespace: str | None,
+    org_concept_id: str | None,
+    role_in_org: str | None,
     history_user_id: str | None,
     session_id: str,
     context: list[dict],
@@ -3770,6 +3941,7 @@ def _maybe_handle_tool_inventory_fastpath(
     progress_scope_key: str | None = None,
 ):
     gateway = current_app.config.get("INTERNAL_MCP_GATEWAY")
+    prompt_namespace = user_namespace or user_concept_id
 
     response_text = None
     used_tool = False
@@ -3850,26 +4022,32 @@ def _maybe_handle_tool_inventory_fastpath(
             response_text if isinstance(response_text, str) else str(response_text)
         ),
         session_id=session_id,
-        namespace=user_concept_id,
+        namespace=prompt_namespace,
         user_id=history_user_id or user_concept_id,
-        org_id=None,
+        org_id=org_concept_id,
     )
 
     if history_user_id:
-        chat_history_service.add_message_to_history(
-            history_user_id,
-            session_id,
-            {
+        _add_chat_history_message(
+            user_id=history_user_id,
+            session_id=session_id,
+            message={
                 "role": "user",
                 "content": prompt_text,
                 "author_user_id": user_concept_id,
             },
+            namespace=prompt_namespace,
+            organisation_concept_id=org_concept_id,
+            role_in_org=role_in_org,
         )
-        chat_history_service.add_message_to_history(
-            history_user_id,
-            session_id,
-            {"role": "assistant", "content": response_text},
+        _add_chat_history_message(
+            user_id=history_user_id,
+            session_id=session_id,
+            message={"role": "assistant", "content": response_text},
             llm_debug_data=llm_debug_info,
+            namespace=prompt_namespace,
+            organisation_concept_id=org_concept_id,
+            role_in_org=role_in_org,
         )
     else:
         stored_context = current_app.config.get("CONTEXT", [])
@@ -3900,6 +4078,9 @@ def _maybe_handle_rag_status_fastpath(
     *,
     prompt_text: str,
     user_concept_id: str,
+    user_namespace: str | None,
+    org_concept_id: str | None,
+    role_in_org: str | None,
     history_user_id: str | None,
     session_id: str,
     context: list[dict],
@@ -3912,6 +4093,7 @@ def _maybe_handle_rag_status_fastpath(
 ):
     gateway = current_app.config.get("INTERNAL_MCP_GATEWAY")
     import json as _json
+    rag_namespace = user_namespace or user_concept_id
 
     tool_messages: list[dict] = []
     tool_invocations: list[dict] = []
@@ -3922,7 +4104,7 @@ def _maybe_handle_rag_status_fastpath(
         try:
             tool_result = gateway.invoke(
                 "rag_get_status",
-                {"namespace": user_concept_id},
+                {"namespace": rag_namespace},
             )
             payload = tool_result.payload
             duration_ms = getattr(tool_result, "duration_ms", None)
@@ -3945,7 +4127,7 @@ def _maybe_handle_rag_status_fastpath(
             tool_invocations = [
                 {
                     "tool": "rag_get_status",
-                    "payload": {"namespace": user_concept_id},
+                    "payload": {"namespace": rag_namespace},
                     "duration_ms": duration_ms,
                     "direct_user_call": False,
                 }
@@ -3962,21 +4144,29 @@ def _maybe_handle_rag_status_fastpath(
 
     # Persist messages in history/context.
     if history_user_id:
-        chat_history_service.add_message_to_history(
-            history_user_id,
-            session_id,
-            {
+        _add_chat_history_message(
+            user_id=history_user_id,
+            session_id=session_id,
+            message={
                 "role": "user",
                 "content": prompt_text,
                 "author_user_id": user_concept_id,
             },
+            namespace=rag_namespace,
+            organisation_concept_id=org_concept_id,
+            role_in_org=role_in_org,
         )
     for tool_msg in _truncate_large_tool_results(
         tool_messages, max_tool_content_chars=5000
     ):
         if history_user_id:
-            chat_history_service.add_message_to_history(
-                history_user_id, session_id, tool_msg
+            _add_chat_history_message(
+                user_id=history_user_id,
+                session_id=session_id,
+                message=tool_msg,
+                namespace=rag_namespace,
+                organisation_concept_id=org_concept_id,
+                role_in_org=role_in_org,
             )
 
     current_app.config["CONTEXT"] = _limit_context_size(
@@ -4031,17 +4221,20 @@ def _maybe_handle_rag_status_fastpath(
         prompt_text=prompt_text,
         response_text=response_text,
         session_id=session_id,
-        namespace=user_concept_id,
+        namespace=rag_namespace,
         user_id=history_user_id or user_concept_id,
-        org_id=None,
+        org_id=org_concept_id,
     )
 
     if history_user_id:
-        chat_history_service.add_message_to_history(
-            history_user_id,
-            session_id,
-            {"role": "assistant", "content": response_text},
+        _add_chat_history_message(
+            user_id=history_user_id,
+            session_id=session_id,
+            message={"role": "assistant", "content": response_text},
             llm_debug_data=llm_debug_info,
+            namespace=rag_namespace,
+            organisation_concept_id=org_concept_id,
+            role_in_org=role_in_org,
         )
 
     return jsonify(
@@ -4228,6 +4421,44 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
         user_concept_id=user_concept_id, session_id=session_id
     )
     history_user_id = history_owner_user_id or user_concept_id
+    role_in_org = effective.get("role") if isinstance(effective, dict) else None
+
+    namespace_resolution = _resolve_generate_namespace_context(
+        user_concept_id=user_concept_id,
+        effective_context=effective if isinstance(effective, dict) else {},
+        flask_session_snapshot=dict(session),
+    )
+    user_namespace = namespace_resolution.get("namespace")
+    namespace_source = namespace_resolution.get("namespace_source") or "missing"
+    namespace_report: dict[str, object] = {
+        "authenticated": bool(user_concept_id),
+        "user_concept_id": user_concept_id,
+        "namespace": user_namespace,
+        "namespace_source": namespace_source,
+        "effective_context_source": namespace_resolution.get("effective_context_source"),
+        "effective_context_namespace": namespace_resolution.get(
+            "effective_context_namespace"
+        ),
+        "session_namespace": namespace_resolution.get("session_namespace"),
+        "candidates": namespace_resolution.get("candidates") or [],
+        "mismatch_detected": bool(namespace_resolution.get("mismatch_detected")),
+        "org_scope_preferred": bool(namespace_resolution.get("org_scope_preferred")),
+    }
+    if isinstance(namespace_resolution.get("mismatch_reason"), str):
+        namespace_report["mismatch_reason"] = namespace_resolution.get(
+            "mismatch_reason"
+        )
+    if (
+        isinstance(user_namespace, str)
+        and user_namespace.strip()
+        and user_namespace != namespace_resolution.get("effective_context_namespace")
+    ):
+        namespace_report["selected_namespace_differs_from_effective_context"] = True
+    if not user_namespace:
+        current_app.logger.warning(
+            "[NAMESPACE] No effective namespace resolved for user_concept_id=%s",
+            user_concept_id,
+        )
 
     if history_user_id:
         if (
@@ -4439,6 +4670,9 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                 return _maybe_handle_prompt_introspection_fastpath(
                     prompt_text=prompt_text,
                     user_concept_id=user_concept_id,
+                    user_namespace=user_namespace,
+                    org_concept_id=org_concept_id,
+                    role_in_org=role_in_org,
                     history_user_id=history_user_id,
                     session_id=session_id,
                     auxiliary_system_prompt=auxiliary_system_prompt,
@@ -4455,6 +4689,9 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                 return _maybe_handle_rag_status_fastpath(
                     prompt_text=prompt_text,
                     user_concept_id=user_concept_id,
+                    user_namespace=user_namespace,
+                    org_concept_id=org_concept_id,
+                    role_in_org=role_in_org,
                     history_user_id=history_user_id,
                     session_id=session_id,
                     context=context,
@@ -4472,6 +4709,9 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             return _maybe_handle_tool_inventory_fastpath(
                 prompt_text=prompt_text,
                 user_concept_id=user_concept_id,
+                user_namespace=user_namespace,
+                org_concept_id=org_concept_id,
+                role_in_org=role_in_org,
                 history_user_id=history_user_id,
                 session_id=session_id,
                 context=context,
@@ -4662,58 +4902,27 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
         gateway = current_app.config.get("INTERNAL_MCP_GATEWAY")
         tool_messages: list[dict[str, str]] = []
 
-        # Derive user namespace for MCP tool isolation (JVNAUTOSCI-760)
-        user_namespace = None
-        namespace_source = "missing"
-        namespace_report: dict[str, object] = {
-            "authenticated": bool(user_concept_id),
-            "user_concept_id": user_concept_id,
-            "session_namespace": session.get("namespace"),
-            "namespace": None,
-            "namespace_source": None,
-        }
-        if user_concept_id:
-            session_namespace = session.get("namespace")
-            if (
-                isinstance(session_namespace, str)
-                and session_namespace.strip()
-                and session_namespace.startswith("#V#")
-            ):
-                user_namespace = session_namespace.strip()
-                namespace_source = "session.namespace"
-                current_app.logger.info(
-                    "[NAMESPACE] Using session namespace=%s for user_concept_id=%s",
-                    user_namespace,
-                    user_concept_id,
+        if isinstance(user_namespace, str) and user_namespace.strip():
+            current_app.logger.info(
+                "[NAMESPACE] Resolved generate namespace=%s source=%s user_concept_id=%s",
+                user_namespace,
+                namespace_source,
+                user_concept_id,
+            )
+            if namespace_report.get("mismatch_detected"):
+                current_app.logger.warning(
+                    "[NAMESPACE] Mismatch detected during resolution candidates=%s",
+                    namespace_report.get("candidates"),
                 )
-            else:
-                # Convert concept ID to namespace format (#V#michael_witbrock)
-                # Handle both full concept ID and person ID formats
-                if user_concept_id.startswith("#V#"):
-                    user_namespace = user_concept_id
-                    namespace_source = "user_concept_id"
-                else:
-                    # Normalize to namespace format
-                    user_id_normalized = (
-                        user_concept_id.lower()
-                        .replace(" ", "_")
-                        .replace("#v#", "")
-                        .replace("#", "")
-                    )
-                    user_namespace = f"#V#{user_id_normalized}"
-                    namespace_source = "derived_from_user_concept_id"
-                current_app.logger.info(
-                    "[NAMESPACE] Derived user_namespace=%s from user_concept_id=%s",
-                    user_namespace,
-                    user_concept_id,
-                )
-        else:
+        elif not user_concept_id:
             current_app.logger.warning(
                 "[NAMESPACE] No user_concept_id - user_namespace=None (RAG unavailable)"
             )
-
-        namespace_report["namespace"] = user_namespace
-        namespace_report["namespace_source"] = namespace_source
+        else:
+            current_app.logger.warning(
+                "[NAMESPACE] No effective namespace resolved for user_concept_id=%s",
+                user_concept_id,
+            )
 
         rag_trace: dict[str, object] = {
             "authenticated": bool(user_concept_id),
@@ -4929,21 +5138,29 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
 
             # Persist messages in history/context.
             if user_id_for_history:
-                chat_history_service.add_message_to_history(
-                    user_id_for_history,
-                    session_id,
-                    {
+                _add_chat_history_message(
+                    user_id=user_id_for_history,
+                    session_id=session_id,
+                    message={
                         "role": "user",
                         "content": prompt_text,
                         "author_user_id": user_concept_id,
                     },
+                    namespace=user_namespace,
+                    organisation_concept_id=org_concept_id,
+                    role_in_org=role_in_org,
                 )
             for tool_msg in _truncate_large_tool_results(
                 tool_messages, max_tool_content_chars=5000
             ):
                 if user_id_for_history:
-                    chat_history_service.add_message_to_history(
-                        user_id_for_history, session_id, tool_msg
+                    _add_chat_history_message(
+                        user_id=user_id_for_history,
+                        session_id=session_id,
+                        message=tool_msg,
+                        namespace=user_namespace,
+                        organisation_concept_id=org_concept_id,
+                        role_in_org=role_in_org,
                     )
             current_app.config["CONTEXT"] = _limit_context_size(
                 current_app.config["CONTEXT"], max_messages=20
@@ -5007,11 +5224,14 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             )
 
             if user_id_for_history:
-                chat_history_service.add_message_to_history(
-                    user_id_for_history,
-                    session_id,
-                    {"role": "assistant", "content": response_text},
+                _add_chat_history_message(
+                    user_id=user_id_for_history,
+                    session_id=session_id,
+                    message={"role": "assistant", "content": response_text},
                     llm_debug_data=llm_debug_info,
+                    namespace=user_namespace,
+                    organisation_concept_id=org_concept_id,
+                    role_in_org=role_in_org,
                 )
 
             return jsonify(
@@ -5100,20 +5320,28 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
 
                     # Skip LLM generation for direct tool calls
                     if history_user_id:
-                        chat_history_service.add_message_to_history(
-                            history_user_id,
-                            session_id,
-                            {
+                        _add_chat_history_message(
+                            user_id=history_user_id,
+                            session_id=session_id,
+                            message={
                                 "role": "user",
                                 "content": prompt_text,
                                 "author_user_id": user_concept_id,
                             },
+                            namespace=user_namespace,
+                            organisation_concept_id=org_concept_id,
+                            role_in_org=role_in_org,
                         )
                         for tool_msg in _truncate_large_tool_results(
                             tool_messages, max_tool_content_chars=5000
                         ):
-                            chat_history_service.add_message_to_history(
-                                history_user_id, session_id, tool_msg
+                            _add_chat_history_message(
+                                user_id=history_user_id,
+                                session_id=session_id,
+                                message=tool_msg,
+                                namespace=user_namespace,
+                                organisation_concept_id=org_concept_id,
+                                role_in_org=role_in_org,
                             )
                     else:
                         current_app.config["CONTEXT"].append(
@@ -5196,11 +5424,14 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                     )
 
                     if history_user_id:
-                        chat_history_service.add_message_to_history(
-                            history_user_id,
-                            session_id,
-                            {"role": "assistant", "content": response_text},
+                        _add_chat_history_message(
+                            user_id=history_user_id,
+                            session_id=session_id,
+                            message={"role": "assistant", "content": response_text},
                             llm_debug_data=llm_debug_info,
+                            namespace=user_namespace,
+                            organisation_concept_id=org_concept_id,
+                            role_in_org=role_in_org,
                         )
 
                     rag_trace["tools_invoked"] = [
@@ -5348,6 +5579,9 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                     bg_history_user_id = history_user_id
                     bg_session_id = session_id
                     bg_user_concept_id = user_concept_id
+                    bg_user_namespace = user_namespace
+                    bg_org_concept_id = org_concept_id
+                    bg_role_in_org = role_in_org
 
                     def _run_in_background() -> Any:
                         """Execute orchestrator.run() in background with app context.
@@ -5374,15 +5608,18 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                             if bg_history_user_id:
                                 try:
                                     # Store user message
-                                    chat_history_service.add_message_to_history(
-                                        bg_history_user_id,
-                                        bg_session_id,
-                                        {
+                                    _add_chat_history_message(
+                                        user_id=bg_history_user_id,
+                                        session_id=bg_session_id,
+                                        message={
                                             "role": "user",
                                             "content": prompt_text,
                                             "author_user_id": bg_user_concept_id,
                                             "background_task_id": request_id,
                                         },
+                                        namespace=bg_user_namespace,
+                                        organisation_concept_id=bg_org_concept_id,
+                                        role_in_org=bg_role_in_org,
                                     )
                                     # Store tool messages
                                     tool_messages = [
@@ -5391,20 +5628,26 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                                     for tool_msg in _truncate_large_tool_results(
                                         tool_messages, max_tool_content_chars=5000
                                     ):
-                                        chat_history_service.add_message_to_history(
-                                            bg_history_user_id,
-                                            bg_session_id,
-                                            tool_msg,
+                                        _add_chat_history_message(
+                                            user_id=bg_history_user_id,
+                                            session_id=bg_session_id,
+                                            message=tool_msg,
+                                            namespace=bg_user_namespace,
+                                            organisation_concept_id=bg_org_concept_id,
+                                            role_in_org=bg_role_in_org,
                                         )
                                     # Store assistant response
-                                    chat_history_service.add_message_to_history(
-                                        bg_history_user_id,
-                                        bg_session_id,
-                                        {
+                                    _add_chat_history_message(
+                                        user_id=bg_history_user_id,
+                                        session_id=bg_session_id,
+                                        message={
                                             "role": "assistant",
                                             "content": result.response_text,
                                             "background_task_id": request_id,
                                         },
+                                        namespace=bg_user_namespace,
+                                        organisation_concept_id=bg_org_concept_id,
+                                        role_in_org=bg_role_in_org,
                                     )
                                 except Exception as hist_exc:
                                     _logger.warning(
@@ -7026,25 +7269,36 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
         )
 
         if history_user_id:
-            chat_history_service.add_message_to_history(
-                history_user_id,
-                session_id,
-                {
+            _add_chat_history_message(
+                user_id=history_user_id,
+                session_id=session_id,
+                message={
                     "role": "user",
                     "content": prompt_text,
                     "author_user_id": user_concept_id,
                 },
+                namespace=user_namespace,
+                organisation_concept_id=org_concept_id,
+                role_in_org=role_in_org,
             )
             for tool_msg in truncated_tool_messages:
-                chat_history_service.add_message_to_history(
-                    history_user_id, session_id, tool_msg
+                _add_chat_history_message(
+                    user_id=history_user_id,
+                    session_id=session_id,
+                    message=tool_msg,
+                    namespace=user_namespace,
+                    organisation_concept_id=org_concept_id,
+                    role_in_org=role_in_org,
                 )
             # Save assistant message WITH debug data
-            chat_history_service.add_message_to_history(
-                history_user_id,
-                session_id,
-                {"role": "assistant", "content": response_text},
+            _add_chat_history_message(
+                user_id=history_user_id,
+                session_id=session_id,
+                message={"role": "assistant", "content": response_text},
                 llm_debug_data=llm_debug_info,
+                namespace=user_namespace,
+                organisation_concept_id=org_concept_id,
+                role_in_org=role_in_org,
             )
         else:
             current_app.config["CONTEXT"].append(

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -1051,6 +1051,9 @@ def add_message_to_history(
     *,
     broadcast_to_shared: Optional[bool] = None,
     exclude_user_from_broadcast: Optional[str] = None,
+    namespace: Optional[str] = None,
+    organisation_concept_id: Optional[str] = None,
+    role_in_org: Optional[str] = None,
 ) -> None:
     """
     Adds a message to the chat history for a specific user and session.
@@ -1075,13 +1078,30 @@ def add_message_to_history(
         raise ChatHistoryServiceError("Could not connect to chat history collection.")
 
     try:
-        # Get session context for organisation/role/namespace (best effort).
+        # Get session context for organisation/role/namespace (best effort), then
+        # apply any explicit call-site overrides so write and index paths stay aligned
+        # with the request's effective namespace resolution.
         session_context = get_session_context()
+        effective_session_context = dict(session_context)
+
+        if isinstance(namespace, str) and namespace.strip():
+            effective_session_context["namespace"] = namespace.strip()
+        if (
+            isinstance(organisation_concept_id, str)
+            and organisation_concept_id.strip()
+        ):
+            org_value = organisation_concept_id.strip()
+            effective_session_context["organisation_concept_id"] = org_value
+            effective_session_context["org_id"] = org_value
+        if isinstance(role_in_org, str) and role_in_org.strip():
+            effective_session_context["role_in_org"] = role_in_org.strip()
 
         # Determine namespace used for both persistence and RAG indexing.
-        ns = _derive_rag_namespace(session_context=session_context, user_id=user_id)
+        ns = _derive_rag_namespace(
+            session_context=effective_session_context, user_id=user_id
+        )
 
-        org_concept_id = session_context.get("organisation_concept_id")
+        org_concept_id = effective_session_context.get("organisation_concept_id")
         org_id_value = (
             org_concept_id.strip()
             if isinstance(org_concept_id, str) and org_concept_id.strip()
@@ -1127,9 +1147,9 @@ def add_message_to_history(
             set_on_insert["session_name"] = session_name
         if isinstance(org_concept_id, str) and org_concept_id.strip():
             set_on_insert["organisation_concept_id"] = org_concept_id.strip()
-        role_in_org = session_context.get("role_in_org")
-        if isinstance(role_in_org, str) and role_in_org.strip():
-            set_on_insert["role_in_org"] = role_in_org.strip()
+        role_value = effective_session_context.get("role_in_org")
+        if isinstance(role_value, str) and role_value.strip():
+            set_on_insert["role_in_org"] = role_value.strip()
 
         # Update or insert the session document
         result = chat_history_coll.update_one(
@@ -1171,7 +1191,7 @@ def add_message_to_history(
                         "id": str(uuid.uuid4()),
                         "text": content,
                         "metadata": _build_rag_metadata(
-                            session_context=session_context,
+                            session_context=effective_session_context,
                             user_id=user_id,
                             session_id=session_id,
                             role=role,
@@ -1194,7 +1214,7 @@ def add_message_to_history(
                                         "id": str(uuid.uuid4()),
                                         "text": _truncate_for_rag(spoken_txt),
                                         "metadata": _build_rag_metadata(
-                                            session_context=session_context,
+                                            session_context=effective_session_context,
                                             user_id=user_id,
                                             session_id=session_id,
                                             role=role,

--- a/tests/backend/test_chat_history_rag_namespace.py
+++ b/tests/backend/test_chat_history_rag_namespace.py
@@ -97,3 +97,48 @@ def test_add_message_to_history_indexes_spoken_presenter_channel_to_rag():
     spoken_docs = spoken_call.args[0]
     assert spoken_docs[0]["text"] == "Spoken answer."
     assert spoken_docs[0]["metadata"]["channel"] == "spoken"
+
+
+def test_add_message_to_history_explicit_namespace_override_controls_write_and_rag():
+    mock_coll = MagicMock()
+    mock_rag = MagicMock()
+    mock_rag.upsert_documents.return_value = (1, 0)
+
+    target_namespace = "#V#michael_witbrock@university_of_auckland_strong_ai_lab"
+    target_org = "#V#university_of_auckland_strong_ai_lab"
+
+    with (
+        patch(
+            "src.backend.services.chat_history_service.get_chat_history_collection_service",
+            return_value=mock_coll,
+        ),
+        patch(
+            "src.backend.services.chat_history_service.get_session_context",
+            return_value={
+                "org_id": None,
+                "role_in_org": None,
+                "namespace": "#V#michael_witbrock",
+            },
+        ),
+        patch(
+            "src.backend.services.chat_history_service.get_rag_service",
+            return_value=mock_rag,
+        ),
+    ):
+        chat_history_service.add_message_to_history(
+            user_id="#V#michael_witbrock",
+            session_id="session-override",
+            message={"role": "user", "content": "hello"},
+            namespace=target_namespace,
+            organisation_concept_id=target_org,
+            role_in_org="member",
+        )
+
+    _, rag_kwargs = mock_rag.upsert_documents.call_args
+    assert rag_kwargs.get("namespace") == target_namespace
+
+    update_args, _ = mock_coll.update_one.call_args_list[0]
+    set_on_insert = update_args[1]["$setOnInsert"]
+    assert set_on_insert["namespace"] == target_namespace
+    assert set_on_insert["organisation_concept_id"] == target_org
+    assert set_on_insert["role_in_org"] == "member"

--- a/tests/backend/test_rag_provenance_contract.py
+++ b/tests/backend/test_rag_provenance_contract.py
@@ -254,3 +254,51 @@ def test_rag_list_indexed_supports_chat_history_sessions(monkeypatch):
     item = result["items"][0]
     assert item["item_kind"] == "chat_history_session"
     assert item["source_system"] == "mongo.chat_history"
+
+
+def test_rag_namespace_resolver_supports_user_only_path():
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    report = cat._resolve_rag_namespace_from_kwargs({"user": {"id": "#V#user"}})
+
+    assert report["namespace"] == "#V#user"
+    assert report["namespace_source"] == "derived.user_org"
+    assert report["namespace_resolution_note"] == "derived_from_user_org"
+    assert report["namespace_mismatch"] is False
+
+
+def test_rag_namespace_resolver_supports_user_org_path():
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    report = cat._resolve_rag_namespace_from_kwargs(
+        {
+            "user": {"id": "#V#user"},
+            "organisation_concept_id": "#V#org",
+        }
+    )
+
+    assert report["namespace"] == "#V#user@org"
+    assert report["namespace_source"] == "derived.user_org"
+    assert report["namespace_resolution_note"] == "derived_from_user_org"
+    assert report["namespace_mismatch"] is False
+
+
+def test_rag_list_indexed_fails_closed_on_namespace_mismatch(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    monkeypatch.setattr(
+        "src.backend.db.connection_manager.get_db",
+        lambda: _DB({"interaction_sessions": _Collection([])}),
+    )
+
+    result = cat._rag_list_indexed(
+        namespace="#V#user",
+        user={"id": "#V#user"},
+        organisation_concept_id="#V#org",
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "namespace_mismatch"
+    assert result["namespace"] is None
+    assert result["provided_namespace"] == "#V#user"
+    assert result["derived_namespace"] == "#V#user@org"

--- a/tests/backend/test_von_generate_rag_trace.py
+++ b/tests/backend/test_von_generate_rag_trace.py
@@ -105,13 +105,73 @@ def test_generate_includes_rag_trace_when_authenticated(app):
     rag_trace = body["rag_trace"]
     assert rag_trace["authenticated"] is True
     assert rag_trace["namespace"] == "#V#user@org"
-    assert rag_trace["namespace_source"] == "session.namespace"
+    assert rag_trace["namespace_source"] == "effective_context.namespace"
     assert rag_trace["retrieval_attempted"] is True
     assert "search_knowledge_base" in rag_trace["tools_invoked"]
     assert rag_trace["tool_results_included_in_prompt"] is True
 
     assert "llm_debug" in body
     assert body["llm_debug"]["namespace_report"]["namespace"] == "#V#user@org"
+    assert (
+        body["llm_debug"]["namespace_report"]["namespace_source"]
+        == "effective_context.namespace"
+    )
+    assert body["llm_debug"]["namespace_report"]["mismatch_detected"] is False
+
+
+def test_generate_prefers_window_effective_namespace_and_reports_mismatch(
+    app, monkeypatch
+):
+    client = app.test_client()
+
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#user"
+        sess["namespace"] = "#V#user@flask_org"
+        sess["session_id"] = "test-session"
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_effective_context",
+        lambda *_args, **_kwargs: {
+            "user_id": "#V#user",
+            "organisation_id": "#V#window_org",
+            "role": "member",
+            "namespace": "#V#user@window_org",
+            "chat_session_id": "test-session",
+            "source": "window_session",
+        },
+    )
+
+    captured_namespaces = []
+
+    def _capture_add_message(_user_id, _session_id, _message, llm_debug_data=None, **kwargs):
+        captured_namespaces.append(kwargs.get("namespace"))
+        return None
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.chat_history_service.add_message_to_history",
+        _capture_add_message,
+    )
+
+    resp = client.post(
+        "/von/generate",
+        json={"prompt": "What is in my RAG store?"},
+        headers={"X-Von-Window-Session": "ws-test"},
+    )
+    assert resp.status_code == 200
+
+    body = resp.get_json()
+    rag_trace = body["rag_trace"]
+    assert rag_trace["namespace"] == "#V#user@window_org"
+    assert rag_trace["namespace_source"] == "effective_context.namespace"
+
+    namespace_report = body["llm_debug"]["namespace_report"]
+    assert namespace_report["mismatch_detected"] is True
+    assert namespace_report["effective_context_source"] == "window_session"
+    assert namespace_report["session_namespace"] == "#V#user@flask_org"
+    assert namespace_report["namespace"] == "#V#user@window_org"
+
+    assert captured_namespaces
+    assert all(ns == "#V#user@window_org" for ns in captured_namespaces if ns is not None)
 
 
 def test_generate_rag_trace_marks_unauthenticated(app):


### PR DESCRIPTION
## Summary
- align `/von/generate` namespace resolution to effective context first, with mismatch diagnostics in `llm_debug.namespace_report`
- pass resolved namespace/org/role context into all generate-path chat history writes so persistence and RAG metadata/indexing use the same namespace
- harden RAG namespace resolution in internal MCP catalogue to derive from user/org hints, fail closed on explicit-vs-derived mismatch, and use shared namespace error handling across list/get/search/sync paths
- add regression coverage for effective-context namespace precedence and mismatch reporting, explicit history namespace overrides, user/org namespace derivation, and mismatch fail-closed behaviour

## Verification
- `pdm run pyright src/backend/integrations/internal_mcp/catalogue.py src/backend/server/routes/von_routes.py src/backend/services/chat_history_service.py tests/backend/test_chat_history_rag_namespace.py tests/backend/test_rag_provenance_contract.py tests/backend/test_von_generate_rag_trace.py`
- `pdm run pytest tests/backend/test_von_generate_rag_trace.py tests/backend/test_chat_history_rag_namespace.py tests/backend/test_rag_provenance_contract.py -q`

## Jira
- JVNAUTOSCI-1169