### PR TITLE
JVNAUTOSCI-1167 isolation hardening telemetry and diagnostics

### DIFF
--- a/docs/engineering/effective_namespace_contract.md
+++ b/docs/engineering/effective_namespace_contract.md
@@ -6,6 +6,7 @@ It is the canonical reference for namespace semantics across generate, persisten
 Status:
 - Normative contract approved for implementation and migration planning (JVNAUTOSCI-1168).
 - Current implementation alignment work landed in JVNAUTOSCI-1169.
+- Namespace-component telemetry and compact diagnostics reporting landed in JVNAUTOSCI-1167.
 
 ## 1) Scope and intent
 
@@ -150,14 +151,42 @@ Behaviour:
 4. Effective namespace used for retrieval must match namespace used for persistence/indexing within the same execution path.
 5. Namespace derivation must remain server-authoritative (do not trust raw client identity payloads).
 
-## 8) Non-goals
+## 8) Operational diagnostics (operator guidance)
+
+Runtime diagnostics surface (compact by default):
+- `/admin/rag_status` now includes `namespace_isolation_diagnostics`.
+- `/diag` now includes `namespace_isolation_diagnostics`.
+
+Canonical fields in diagnostics events:
+- `namespace`
+- `namespace_source`
+- `user_concept_id`
+- `organisation_concept_id`
+
+Counter meanings:
+- `namespace_mismatch_events`:
+  explicit-vs-derived or requested-vs-item namespace conflicts were observed.
+- `missing_component_events`:
+  at least one required component was absent for a user-scoped path.
+- `missing_namespace_events`:
+  no effective namespace was available for a namespace-governed path.
+- `org_scope_downgrade_events`:
+  an org component existed but the effective namespace was user-only.
+
+Interpretation guidance:
+1. Short spikes in mismatch counters can occur during migration or mixed legacy data.
+2. Sustained growth in mismatch/missing counters indicates resolver drift or caller propagation bugs and should be triaged before enabling stricter rejection modes.
+3. `org_scope_downgrade_events` should trend toward zero as user@org propagation becomes consistent across generate, RAG handlers, and sync/index flows.
+4. Use optional recent-event views only for active triage; default dashboards should rely on compact counters.
+
+## 9) Non-goals
 
 1. Enforcing strict mode on every endpoint immediately.
 2. Retrofitting every historical record before shipping incremental improvements.
 3. Encoding role semantics into namespace strings.
 4. Replacing broader access-control mechanisms with namespace alone.
 
-## 9) Migration path
+## 10) Migration path
 
 Phase A (completed):
 - Align generate/persistence/RAG handling around one effective namespace selection path (JVNAUTOSCI-1169).
@@ -167,19 +196,24 @@ Phase B (this contract, completed):
 - Publish this authoritative contract and link it from security/access-control docs (JVNAUTOSCI-1168).
 - Make enforcement modes and invariants explicit.
 
-Phase C (planned):
+Phase C (in progress):
+- Add namespace-component telemetry and compact operator diagnostics to generate, internal MCP RAG handlers, and sync/index paths (JVNAUTOSCI-1167).
+
+Phase D (planned):
 - Introduce one explicit policy switch for mode selection (experimental vs strict) across remaining namespace-sensitive entry points.
 - Expand strict mismatch rejection consistently where required by risk level.
 
-Phase D (planned):
+Phase E (planned):
 - Reduce legacy fallback behaviour where not needed.
 - Add targeted audits/backfills for legacy namespace inconsistencies.
 
-## 10) Primary implementation touchpoints
+## 11) Primary implementation touchpoints
 
 - `src/backend/services/namespace_service.py`
 - `src/backend/services/window_session_context_service.py`
 - `src/backend/server/routes/von_routes.py` (`_resolve_generate_namespace_context`)
 - `src/backend/services/chat_history_service.py` (`add_message_to_history`)
 - `src/backend/integrations/internal_mcp/catalogue.py` (`_resolve_rag_namespace_from_kwargs`, `_rag_namespace_resolution_error`)
+- `src/backend/services/namespace_isolation_diagnostics_service.py`
+- `src/backend/server/utils_flask.py` (`/admin/rag_status`, `/diag`)
 

--- a/docs/engineering/security_considerations.md
+++ b/docs/engineering/security_considerations.md
@@ -76,6 +76,7 @@ Authoritative contract:
 - Preserve org scope when present; do not silently degrade `#V#user@org` flows to user-only scope in downstream tool calls or persistence.
 - Carry component context alongside namespace where practical (`namespace`, `user_concept_id`, `organisation_concept_id`, `namespace_source`) for traceability and future policy enforcement.
 - Keep fail-closed behaviour for missing namespace on user-scoped operations (especially RAG).
+- Monitor compact namespace-isolation counters via `/admin/rag_status` (and `/diag`) to detect mismatch/missing-component regressions before enabling stricter rejection modes.
 
 **Tightening path (later)**:
 - During the current experimental phase, prefer visibility and diagnostics for non-critical mismatches over aggressive hard failures.

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -5200,81 +5200,146 @@ def _resolve_rag_namespace_from_kwargs(kwargs: dict) -> dict:
     if org_candidate is None:
         org_candidate = _normalise_concept_id(kwargs.get("org_id"))
 
-    derived_namespace: str | None = None
-    if user_candidate is not None:
-        user_slug = _namespace_slug_from_concept(user_candidate)
-        org_slug = _namespace_slug_from_concept(org_candidate)
-        if user_slug:
-            try:
-                from ...services.namespace_service import derive_namespace
+    def _derive_namespace_from_components(
+        user_component: str | None, organisation_component: str | None
+    ) -> str | None:
+        if user_component is None:
+            return None
+        user_slug = _namespace_slug_from_concept(user_component)
+        org_slug = _namespace_slug_from_concept(organisation_component)
+        if not user_slug:
+            return None
+        try:
+            from ...services.namespace_service import derive_namespace
 
-                derived_namespace = (
-                    derive_namespace(user_slug, org_slug)
-                    if org_slug
-                    else derive_namespace(user_slug)
-                )
-            except Exception:
-                derived_namespace = None
+            return (
+                derive_namespace(user_slug, org_slug)
+                if org_slug
+                else derive_namespace(user_slug)
+            )
+        except Exception:
+            return None
+
+    # If caller provides only namespace, derive component IDs for consistent
+    # provenance and cross-flow telemetry fields.
+    if explicit_namespace and (user_candidate is None or org_candidate is None):
+        try:
+            from ...services.namespace_service import parse_namespace
+
+            parsed = parse_namespace(explicit_namespace)
+            parsed_user = parsed.get("user_id")
+            parsed_org = parsed.get("org_id")
+            if user_candidate is None and isinstance(parsed_user, str):
+                user_candidate = _normalise_concept_id(parsed_user)
+            if org_candidate is None and isinstance(parsed_org, str):
+                org_candidate = _normalise_concept_id(parsed_org)
+        except Exception:
+            pass
+
+    derived_namespace: str | None = _derive_namespace_from_components(
+        user_candidate, org_candidate
+    )
+
+    def _finalise_report(report: dict[str, Any]) -> dict[str, Any]:
+        enriched = dict(report)
+        enriched["derived_user_concept_id"] = user_candidate
+        enriched["derived_organisation_concept_id"] = org_candidate
+        # Canonical aliases used by cross-flow telemetry/reporting.
+        enriched["user_concept_id"] = user_candidate
+        enriched["organisation_concept_id"] = org_candidate
+
+        try:
+            from ...services.namespace_isolation_diagnostics_service import (
+                record_namespace_context_observation,
+            )
+
+            record_namespace_context_observation(
+                flow="internal_mcp.rag.namespace_resolver",
+                namespace=enriched.get("namespace"),
+                namespace_source=enriched.get("namespace_source"),
+                user_concept_id=user_candidate,
+                organisation_concept_id=org_candidate,
+                mismatch_detected=bool(enriched.get("namespace_mismatch")),
+                details={
+                    "namespace_resolution_note": enriched.get(
+                        "namespace_resolution_note"
+                    ),
+                    "provided_namespace": enriched.get("provided_namespace"),
+                    "derived_namespace": enriched.get("derived_namespace"),
+                },
+            )
+        except Exception:
+            pass
+
+        if bool(enriched.get("namespace_mismatch")):
+            logger.warning(
+                "[NAMESPACE] RAG resolver mismatch provided=%s derived=%s user=%s org=%s",
+                enriched.get("provided_namespace"),
+                enriched.get("derived_namespace"),
+                user_candidate,
+                org_candidate,
+            )
+        return enriched
 
     if explicit_namespace and derived_namespace and explicit_namespace != derived_namespace:
-        return {
-            "namespace": None,
-            "namespace_source": "conflict",
-            "namespace_resolution_note": "namespace_mismatch",
-            "namespace_mismatch": True,
-            "provided_namespace": explicit_namespace,
-            "derived_namespace": derived_namespace,
-            "derived_user_concept_id": user_candidate,
-            "derived_organisation_concept_id": org_candidate,
-        }
+        return _finalise_report(
+            {
+                "namespace": None,
+                "namespace_source": "conflict",
+                "namespace_resolution_note": "namespace_mismatch",
+                "namespace_mismatch": True,
+                "provided_namespace": explicit_namespace,
+                "derived_namespace": derived_namespace,
+            }
+        )
 
     if explicit_namespace:
-        return {
-            "namespace": explicit_namespace,
-            "namespace_source": "request.namespace",
-            "namespace_resolution_note": None,
-            "namespace_mismatch": False,
-            "provided_namespace": explicit_namespace,
-            "derived_namespace": derived_namespace,
-            "derived_user_concept_id": user_candidate,
-            "derived_organisation_concept_id": org_candidate,
-        }
+        return _finalise_report(
+            {
+                "namespace": explicit_namespace,
+                "namespace_source": "request.namespace",
+                "namespace_resolution_note": None,
+                "namespace_mismatch": False,
+                "provided_namespace": explicit_namespace,
+                "derived_namespace": derived_namespace,
+            }
+        )
 
     if derived_namespace:
-        return {
-            "namespace": derived_namespace,
-            "namespace_source": "derived.user_org",
-            "namespace_resolution_note": "derived_from_user_org",
-            "namespace_mismatch": False,
-            "provided_namespace": None,
-            "derived_namespace": derived_namespace,
-            "derived_user_concept_id": user_candidate,
-            "derived_organisation_concept_id": org_candidate,
-        }
+        return _finalise_report(
+            {
+                "namespace": derived_namespace,
+                "namespace_source": "derived.user_org",
+                "namespace_resolution_note": "derived_from_user_org",
+                "namespace_mismatch": False,
+                "provided_namespace": None,
+                "derived_namespace": derived_namespace,
+            }
+        )
 
     env_ns = os.environ.get("VON_DEFAULT_NAMESPACE")
     if isinstance(env_ns, str) and env_ns.strip():
-        return {
-            "namespace": env_ns.strip(),
-            "namespace_source": "env.VON_DEFAULT_NAMESPACE",
-            "namespace_resolution_note": "fallback",
+        return _finalise_report(
+            {
+                "namespace": env_ns.strip(),
+                "namespace_source": "env.VON_DEFAULT_NAMESPACE",
+                "namespace_resolution_note": "fallback",
+                "namespace_mismatch": False,
+                "provided_namespace": None,
+                "derived_namespace": derived_namespace,
+            }
+        )
+
+    return _finalise_report(
+        {
+            "namespace": None,
+            "namespace_source": "missing",
+            "namespace_resolution_note": "namespace_required",
             "namespace_mismatch": False,
             "provided_namespace": None,
             "derived_namespace": derived_namespace,
-            "derived_user_concept_id": user_candidate,
-            "derived_organisation_concept_id": org_candidate,
         }
-
-    return {
-        "namespace": None,
-        "namespace_source": "missing",
-        "namespace_resolution_note": "namespace_required",
-        "namespace_mismatch": False,
-        "provided_namespace": None,
-        "derived_namespace": derived_namespace,
-        "derived_user_concept_id": user_candidate,
-        "derived_organisation_concept_id": org_candidate,
-    }
+    )
 
 
 def _rag_namespace_resolution_error(ns_report: dict[str, Any]) -> dict[str, Any] | None:
@@ -5303,11 +5368,20 @@ def _rag_namespace_resolution_error(ns_report: dict[str, Any]) -> dict[str, Any]
 
 def _with_rag_provenance(*, payload: dict, item_kind: str, source_system: str) -> dict:
     result = dict(payload)
+    user_concept_id = payload.get("user_concept_id")
+    if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+        user_concept_id = payload.get("derived_user_concept_id")
+    organisation_concept_id = payload.get("organisation_concept_id")
+    if not isinstance(organisation_concept_id, str) or not organisation_concept_id.strip():
+        organisation_concept_id = payload.get("derived_organisation_concept_id")
+
     provenance = {
         "item_kind": item_kind,
         "source_system": source_system,
         "namespace": payload.get("namespace"),
         "namespace_source": payload.get("namespace_source"),
+        "user_concept_id": user_concept_id,
+        "organisation_concept_id": organisation_concept_id,
     }
     existing = result.get("provenance")
     if isinstance(existing, dict):

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -3591,6 +3591,36 @@ def _namespace_is_org_scoped(namespace: str | None) -> bool:
     )
 
 
+def _record_namespace_isolation_observation(
+    *,
+    flow: str,
+    namespace: str | None,
+    namespace_source: str | None,
+    user_concept_id: str | None,
+    organisation_concept_id: str | None,
+    mismatch_detected: bool,
+    details: dict[str, Any] | None = None,
+) -> None:
+    """Best-effort namespace isolation telemetry for runtime diagnostics."""
+    try:
+        from ...services.namespace_isolation_diagnostics_service import (
+            record_namespace_context_observation,
+        )
+
+        record_namespace_context_observation(
+            flow=flow,
+            namespace=namespace,
+            namespace_source=namespace_source,
+            user_concept_id=user_concept_id,
+            organisation_concept_id=organisation_concept_id,
+            mismatch_detected=bool(mismatch_detected),
+            details=details,
+        )
+    except Exception:
+        # Diagnostics must never break request handling.
+        pass
+
+
 def _resolve_generate_namespace_context(
     *,
     user_concept_id: str | None,
@@ -4433,6 +4463,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
     namespace_report: dict[str, object] = {
         "authenticated": bool(user_concept_id),
         "user_concept_id": user_concept_id,
+        "organisation_concept_id": org_concept_id,
         "namespace": user_namespace,
         "namespace_source": namespace_source,
         "effective_context_source": namespace_resolution.get("effective_context_source"),
@@ -4454,6 +4485,25 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
         and user_namespace != namespace_resolution.get("effective_context_namespace")
     ):
         namespace_report["selected_namespace_differs_from_effective_context"] = True
+    _record_namespace_isolation_observation(
+        flow="/von/generate",
+        namespace=user_namespace if isinstance(user_namespace, str) else None,
+        namespace_source=(
+            namespace_source if isinstance(namespace_source, str) else "missing"
+        ),
+        user_concept_id=user_concept_id if isinstance(user_concept_id, str) else None,
+        organisation_concept_id=(
+            org_concept_id if isinstance(org_concept_id, str) else None
+        ),
+        mismatch_detected=bool(namespace_report.get("mismatch_detected")),
+        details={
+            "effective_context_source": namespace_report.get("effective_context_source"),
+            "effective_context_namespace": namespace_report.get(
+                "effective_context_namespace"
+            ),
+            "session_namespace": namespace_report.get("session_namespace"),
+        },
+    )
     if not user_namespace:
         current_app.logger.warning(
             "[NAMESPACE] No effective namespace resolved for user_concept_id=%s",
@@ -4904,10 +4954,11 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
 
         if isinstance(user_namespace, str) and user_namespace.strip():
             current_app.logger.info(
-                "[NAMESPACE] Resolved generate namespace=%s source=%s user_concept_id=%s",
+                "[NAMESPACE] Resolved generate namespace=%s source=%s user_concept_id=%s organisation_concept_id=%s",
                 user_namespace,
                 namespace_source,
                 user_concept_id,
+                org_concept_id,
             )
             if namespace_report.get("mismatch_detected"):
                 current_app.logger.warning(
@@ -4928,6 +4979,8 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             "authenticated": bool(user_concept_id),
             "namespace": user_namespace,
             "namespace_source": namespace_source,
+            "user_concept_id": user_concept_id,
+            "organisation_concept_id": org_concept_id,
             "retrieval_attempted": False,
             "retrieval_attempt_reason": (
                 None if user_concept_id else "not_authenticated"

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -754,7 +754,26 @@ def create_flask_app(
                 "yes",
                 "on",
             }
-            cache_key = (ns or "", bool(include_detail))
+            include_namespace_events = request.args.get(
+                "include_namespace_events", ""
+            ).lower() in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            }
+            try:
+                namespace_event_limit = int(
+                    request.args.get("namespace_event_limit", 20) or 20
+                )
+            except Exception:
+                namespace_event_limit = 20
+            cache_key = (
+                ns or "",
+                bool(include_detail),
+                bool(include_namespace_events),
+                int(namespace_event_limit),
+            )
             cache = app.config.setdefault("_RAG_STATUS_CACHE", {})
             lock = app.config.setdefault("_RAG_STATUS_CACHE_LOCK", threading.Lock())
 
@@ -1284,6 +1303,28 @@ def create_flask_app(
                     except Exception:
                         chat_summary["chat_history_backfill_available"] = False
                         chat_summary["chat_history_backfill_reason"] = "unavailable"
+
+            namespace_isolation_diagnostics = {"available": False}
+            try:
+                from ..services.namespace_isolation_diagnostics_service import (
+                    get_namespace_isolation_diagnostics_snapshot,
+                )
+
+                namespace_isolation_diagnostics = (
+                    get_namespace_isolation_diagnostics_snapshot(
+                        include_recent_events=include_namespace_events,
+                        recent_limit=namespace_event_limit,
+                    )
+                )
+                namespace_isolation_diagnostics["available"] = True
+                namespace_isolation_diagnostics["include_recent_events"] = bool(
+                    include_namespace_events
+                )
+            except Exception as exc:
+                namespace_isolation_diagnostics = {
+                    "available": False,
+                    "error": type(exc).__name__,
+                }
             base_payload = {
                 "total": total_sessions,
                 "scoped_sessions": scoped_sessions,
@@ -1303,6 +1344,7 @@ def create_flask_app(
                     session_ns_values[0] if session_ns_values else None
                 ),
                 "session_namespaces": session_ns_values,
+                "namespace_isolation_diagnostics": namespace_isolation_diagnostics,
                 **chat_summary,
             }
 
@@ -1794,8 +1836,14 @@ def create_flask_app(
 
         payload = request.get_json(silent=True) or {}
         namespace = payload.get("namespace")
+        user_concept_id = payload.get("user_concept_id")
+        organisation_concept_id = payload.get("organisation_concept_id")
         try:
-            result = sync_to_chat_store(namespace=namespace)
+            result = sync_to_chat_store(
+                namespace=namespace,
+                user_concept_id=user_concept_id,
+                organisation_concept_id=organisation_concept_id,
+            )
             return jsonify(result)
         except Exception as e:
             return jsonify({"success": False, "error": str(e)}), 500
@@ -2127,6 +2175,21 @@ def create_flask_app(
             "python_version": sys.version.split()[0],
         }
         diag["mongo"] = mongo_diag
+        try:
+            from ..services.namespace_isolation_diagnostics_service import (
+                get_namespace_isolation_diagnostics_snapshot,
+            )
+
+            diag["namespace_isolation_diagnostics"] = (
+                get_namespace_isolation_diagnostics_snapshot(
+                    include_recent_events=False
+                )
+            )
+        except Exception as exc:
+            diag["namespace_isolation_diagnostics"] = {
+                "available": False,
+                "error": type(exc).__name__,
+            }
         # Durable workflow system status (best-effort)
         try:
             from ..workflows.durable.startup import get_system_status

--- a/src/backend/services/namespace_isolation_diagnostics_service.py
+++ b/src/backend/services/namespace_isolation_diagnostics_service.py
@@ -1,0 +1,222 @@
+"""Lightweight runtime diagnostics for namespace isolation hardening.
+
+This module keeps in-memory counters and recent events for namespace
+provenance/mismatch monitoring. It is intentionally process-local and best
+effort, suitable for operator diagnostics rather than durable analytics.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, deque
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Any, Mapping
+
+_STATE_LOCK = Lock()
+_MAX_RECENT_EVENTS = 80
+
+_COUNTERS: dict[str, int] = {
+    "events_total": 0,
+    "namespace_mismatch_events": 0,
+    "missing_component_events": 0,
+    "missing_namespace_events": 0,
+    "org_scope_downgrade_events": 0,
+}
+_EVENT_TYPE_COUNTS: Counter[str] = Counter()
+_FLOW_COUNTS: Counter[str] = Counter()
+_RECENT_EVENTS: deque[dict[str, Any]] = deque(maxlen=_MAX_RECENT_EVENTS)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _normalise_optional_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _is_org_scoped_namespace(namespace: str | None) -> bool:
+    return isinstance(namespace, str) and namespace.strip().startswith("#V#") and (
+        "@" in namespace.strip()
+    )
+
+
+def _increment_counters_for_event_type(event_type: str) -> None:
+    _COUNTERS["events_total"] = int(_COUNTERS.get("events_total", 0)) + 1
+    if event_type == "namespace_mismatch":
+        _COUNTERS["namespace_mismatch_events"] = (
+            int(_COUNTERS.get("namespace_mismatch_events", 0)) + 1
+        )
+    if event_type.startswith("missing_component"):
+        _COUNTERS["missing_component_events"] = (
+            int(_COUNTERS.get("missing_component_events", 0)) + 1
+        )
+    if event_type == "missing_component.namespace":
+        _COUNTERS["missing_namespace_events"] = (
+            int(_COUNTERS.get("missing_namespace_events", 0)) + 1
+        )
+    if event_type == "org_scope_downgrade":
+        _COUNTERS["org_scope_downgrade_events"] = (
+            int(_COUNTERS.get("org_scope_downgrade_events", 0)) + 1
+        )
+
+
+def record_namespace_isolation_event(
+    *,
+    flow: str,
+    event_type: str,
+    namespace: str | None = None,
+    namespace_source: str | None = None,
+    user_concept_id: str | None = None,
+    organisation_concept_id: str | None = None,
+    details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Record one namespace-isolation diagnostic event."""
+    safe_flow = _normalise_optional_text(flow) or "unknown_flow"
+    safe_event_type = _normalise_optional_text(event_type) or "unknown_event"
+    safe_namespace = _normalise_optional_text(namespace)
+    safe_namespace_source = _normalise_optional_text(namespace_source)
+    safe_user_concept_id = _normalise_optional_text(user_concept_id)
+    safe_organisation_concept_id = _normalise_optional_text(organisation_concept_id)
+    event: dict[str, Any] = {
+        "timestamp_utc": _utc_now_iso(),
+        "flow": safe_flow,
+        "event_type": safe_event_type,
+        "namespace": safe_namespace,
+        "namespace_source": safe_namespace_source,
+        "user_concept_id": safe_user_concept_id,
+        "organisation_concept_id": safe_organisation_concept_id,
+    }
+    if isinstance(details, Mapping):
+        event["details"] = dict(details)
+
+    with _STATE_LOCK:
+        _increment_counters_for_event_type(safe_event_type)
+        _EVENT_TYPE_COUNTS[safe_event_type] += 1
+        _FLOW_COUNTS[safe_flow] += 1
+        _RECENT_EVENTS.append(event)
+
+    return event
+
+
+def record_namespace_context_observation(
+    *,
+    flow: str,
+    namespace: str | None,
+    namespace_source: str | None,
+    user_concept_id: str | None,
+    organisation_concept_id: str | None,
+    mismatch_detected: bool = False,
+    details: Mapping[str, Any] | None = None,
+) -> int:
+    """Record mismatch/missing-component events for one namespace decision."""
+    safe_namespace = _normalise_optional_text(namespace)
+    safe_namespace_source = _normalise_optional_text(namespace_source)
+    safe_user_concept_id = _normalise_optional_text(user_concept_id)
+    safe_organisation_concept_id = _normalise_optional_text(organisation_concept_id)
+
+    events_emitted = 0
+    if mismatch_detected:
+        record_namespace_isolation_event(
+            flow=flow,
+            event_type="namespace_mismatch",
+            namespace=safe_namespace,
+            namespace_source=safe_namespace_source,
+            user_concept_id=safe_user_concept_id,
+            organisation_concept_id=safe_organisation_concept_id,
+            details=details,
+        )
+        events_emitted += 1
+
+    if safe_namespace is None:
+        record_namespace_isolation_event(
+            flow=flow,
+            event_type="missing_component.namespace",
+            namespace=safe_namespace,
+            namespace_source=safe_namespace_source,
+            user_concept_id=safe_user_concept_id,
+            organisation_concept_id=safe_organisation_concept_id,
+            details=details,
+        )
+        events_emitted += 1
+
+    if safe_user_concept_id is None:
+        record_namespace_isolation_event(
+            flow=flow,
+            event_type="missing_component.user_concept_id",
+            namespace=safe_namespace,
+            namespace_source=safe_namespace_source,
+            user_concept_id=safe_user_concept_id,
+            organisation_concept_id=safe_organisation_concept_id,
+            details=details,
+        )
+        events_emitted += 1
+
+    if _is_org_scoped_namespace(safe_namespace) and safe_organisation_concept_id is None:
+        record_namespace_isolation_event(
+            flow=flow,
+            event_type="missing_component.organisation_concept_id",
+            namespace=safe_namespace,
+            namespace_source=safe_namespace_source,
+            user_concept_id=safe_user_concept_id,
+            organisation_concept_id=safe_organisation_concept_id,
+            details=details,
+        )
+        events_emitted += 1
+
+    if (
+        safe_organisation_concept_id is not None
+        and safe_namespace is not None
+        and not _is_org_scoped_namespace(safe_namespace)
+    ):
+        record_namespace_isolation_event(
+            flow=flow,
+            event_type="org_scope_downgrade",
+            namespace=safe_namespace,
+            namespace_source=safe_namespace_source,
+            user_concept_id=safe_user_concept_id,
+            organisation_concept_id=safe_organisation_concept_id,
+            details=details,
+        )
+        events_emitted += 1
+
+    return events_emitted
+
+
+def get_namespace_isolation_diagnostics_snapshot(
+    *, include_recent_events: bool = False, recent_limit: int = 20
+) -> dict[str, Any]:
+    """Return compact counters and optional recent event diagnostics."""
+    safe_recent_limit = max(1, int(recent_limit or 20))
+    with _STATE_LOCK:
+        counters = dict(_COUNTERS)
+        event_type_counts = dict(_EVENT_TYPE_COUNTS)
+        flow_counts = dict(_FLOW_COUNTS)
+        recent_events = list(_RECENT_EVENTS)
+        last_event_at_utc = (
+            recent_events[-1].get("timestamp_utc") if recent_events else None
+        )
+
+    payload: dict[str, Any] = {
+        "counters": counters,
+        "event_type_counts": event_type_counts,
+        "flow_counts": flow_counts,
+        "last_event_at_utc": last_event_at_utc,
+    }
+    if include_recent_events:
+        payload["recent_events"] = recent_events[-safe_recent_limit:]
+    return payload
+
+
+def reset_namespace_isolation_diagnostics() -> None:
+    """Reset in-memory diagnostics state (primarily for tests)."""
+    with _STATE_LOCK:
+        for key in list(_COUNTERS.keys()):
+            _COUNTERS[key] = 0
+        _EVENT_TYPE_COUNTS.clear()
+        _FLOW_COUNTS.clear()
+        _RECENT_EVENTS.clear()
+

--- a/src/backend/services/rag_sync_service.py
+++ b/src/backend/services/rag_sync_service.py
@@ -1,11 +1,136 @@
 from __future__ import annotations
 
-from typing import List, Optional
+import logging
+from typing import Any, List, Optional
+
 from bson import ObjectId
 
 from src.backend.db.connection_manager import get_db
-from src.backend.services.rag_service import get_rag_service, RAGBackendUnavailable
-from datetime import datetime
+from src.backend.services.rag_service import RAGBackendUnavailable, get_rag_service
+
+logger = logging.getLogger(__name__)
+
+
+def _normalise_namespace(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    if cleaned.startswith("#v#"):
+        return "#V#" + cleaned[3:]
+    if cleaned.startswith("#V#"):
+        return cleaned
+    return f"#V#{cleaned.lstrip('#')}"
+
+
+def _normalise_concept_id(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    if cleaned.startswith("#v#"):
+        return "#V#" + cleaned[3:]
+    if cleaned.startswith("#V#"):
+        return cleaned
+    return f"#V#{cleaned.lstrip('#')}"
+
+
+def _parse_namespace_components(namespace: str | None) -> tuple[str | None, str | None]:
+    if not isinstance(namespace, str) or not namespace.strip():
+        return None, None
+    try:
+        from src.backend.services.namespace_service import parse_namespace
+
+        parsed = parse_namespace(namespace)
+    except Exception:
+        return None, None
+
+    parsed_user = parsed.get("user_id")
+    parsed_org = parsed.get("org_id")
+    user_concept_id = _normalise_concept_id(parsed_user) if parsed_user else None
+    organisation_concept_id = _normalise_concept_id(parsed_org) if parsed_org else None
+    return user_concept_id, organisation_concept_id
+
+
+def _resolve_sync_namespace_provenance(
+    *,
+    requested_namespace: str | None,
+    requested_user_concept_id: str | None,
+    requested_organisation_concept_id: str | None,
+    item_namespace: str | None = None,
+    item_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    requested_ns = _normalise_namespace(requested_namespace)
+
+    item_ns = _normalise_namespace(item_namespace)
+    item_namespace_source = "item.namespace" if item_ns else None
+    if item_ns is None and isinstance(item_metadata, dict):
+        item_ns = _normalise_namespace(item_metadata.get("namespace"))
+        if item_ns is not None:
+            item_namespace_source = "item.metadata.namespace"
+
+    if requested_ns is not None:
+        namespace = requested_ns
+        namespace_source = "request.namespace"
+    elif item_ns is not None:
+        namespace = item_ns
+        namespace_source = item_namespace_source or "item.namespace"
+    else:
+        namespace = "chat_history"
+        namespace_source = "fallback.chat_history"
+
+    user_concept_id = _normalise_concept_id(requested_user_concept_id)
+    organisation_concept_id = _normalise_concept_id(requested_organisation_concept_id)
+    parsed_user, parsed_org = _parse_namespace_components(namespace)
+    if user_concept_id is None:
+        user_concept_id = parsed_user
+    if organisation_concept_id is None:
+        organisation_concept_id = parsed_org
+
+    namespace_mismatch = bool(
+        requested_ns is not None and item_ns is not None and requested_ns != item_ns
+    )
+
+    return {
+        "namespace": namespace,
+        "namespace_source": namespace_source,
+        "user_concept_id": user_concept_id,
+        "organisation_concept_id": organisation_concept_id,
+        "namespace_mismatch": namespace_mismatch,
+        "requested_namespace": requested_ns,
+        "item_namespace": item_ns,
+    }
+
+
+def _record_namespace_sync_observation(
+    *,
+    flow: str,
+    namespace: str | None,
+    namespace_source: str | None,
+    user_concept_id: str | None,
+    organisation_concept_id: str | None,
+    mismatch_detected: bool,
+    details: dict[str, Any] | None = None,
+) -> None:
+    try:
+        from src.backend.services.namespace_isolation_diagnostics_service import (
+            record_namespace_context_observation,
+        )
+
+        record_namespace_context_observation(
+            flow=flow,
+            namespace=namespace,
+            namespace_source=namespace_source,
+            user_concept_id=user_concept_id,
+            organisation_concept_id=organisation_concept_id,
+            mismatch_detected=mismatch_detected,
+            details=details,
+        )
+    except Exception:
+        # Diagnostics are best-effort and must not block RAG sync.
+        return
 
 
 def collect_indexed_sessions(limit: int = 1000) -> List[dict]:
@@ -40,7 +165,7 @@ def collect_indexed_sessions(limit: int = 1000) -> List[dict]:
                     text_parts.append(c)
         text = "\n\n".join(text_parts)
 
-        # Build metadata with organisation context if available
+        # Build metadata with organisation context if available.
         metadata = {
             "indexed_at": str(doc.get("indexed_at")) if doc.get("indexed_at") else None,
             "source": "interaction_session",
@@ -49,6 +174,7 @@ def collect_indexed_sessions(limit: int = 1000) -> List[dict]:
             metadata["namespace"] = doc["namespace"]
         if doc.get("user_id"):
             metadata["user_id"] = doc["user_id"]
+            metadata["user_concept_id"] = doc["user_id"]
         if doc.get("organisation_concept_id"):
             metadata["organisation_concept_id"] = doc["organisation_concept_id"]
         if doc.get("role_in_org"):
@@ -66,7 +192,12 @@ def collect_indexed_sessions(limit: int = 1000) -> List[dict]:
     return items
 
 
-def sync_to_chat_store(namespace: Optional[str] = None, limit: int = 1000) -> dict:
+def sync_to_chat_store(
+    namespace: Optional[str] = None,
+    limit: int = 1000,
+    user_concept_id: Optional[str] = None,
+    organisation_concept_id: Optional[str] = None,
+) -> dict:
     try:
         service = get_rag_service()
     except RAGBackendUnavailable as e:
@@ -75,17 +206,43 @@ def sync_to_chat_store(namespace: Optional[str] = None, limit: int = 1000) -> di
     indexed = collect_indexed_sessions(limit=limit)
     added = 0
     failed = 0
+    mismatch_count = 0
+    mismatch_session_ids: list[str] = []
+    target_namespaces: set[str] = set()
+
     for item in indexed:
-        target_namespace = (
-            namespace
-            or item.get("namespace")
-            or (item.get("metadata") or {}).get("namespace")
-            or "chat_history"
+        item_metadata = item.get("metadata")
+        if not isinstance(item_metadata, dict):
+            item_metadata = {}
+        provenance = _resolve_sync_namespace_provenance(
+            requested_namespace=namespace,
+            requested_user_concept_id=user_concept_id,
+            requested_organisation_concept_id=organisation_concept_id,
+            item_namespace=item.get("namespace"),
+            item_metadata=item_metadata,
         )
+
+        target_namespace = provenance.get("namespace") or "chat_history"
+        target_namespaces.add(str(target_namespace))
+        if provenance.get("namespace_mismatch"):
+            mismatch_count += 1
+            if len(mismatch_session_ids) < 20:
+                mismatch_session_ids.append(str(item.get("id")))
+
+        doc_metadata = dict(item_metadata)
+        doc_metadata["namespace"] = target_namespace
+        doc_metadata["namespace_source"] = provenance.get("namespace_source")
+        if provenance.get("user_concept_id"):
+            doc_metadata["user_concept_id"] = provenance.get("user_concept_id")
+        if provenance.get("organisation_concept_id"):
+            doc_metadata["organisation_concept_id"] = provenance.get(
+                "organisation_concept_id"
+            )
+
         doc = {
             "id": item.get("id"),
             "text": item.get("text", ""),
-            "metadata": item.get("metadata", {}),
+            "metadata": doc_metadata,
         }
         if item.get("embedding"):
             doc["embedding"] = item["embedding"]
@@ -95,7 +252,7 @@ def sync_to_chat_store(namespace: Optional[str] = None, limit: int = 1000) -> di
                 [doc], namespace=target_namespace
             )
         except Exception:
-            # Retry without embedding if backend rejects it
+            # Retry without embedding if backend rejects it.
             doc.pop("embedding", None)
             success_count, failure_count = service.upsert_documents(
                 [doc], namespace=target_namespace
@@ -104,22 +261,83 @@ def sync_to_chat_store(namespace: Optional[str] = None, limit: int = 1000) -> di
         added += success_count
         failed += failure_count
 
+    resolved_namespace = _normalise_namespace(namespace)
+    namespace_source = "request.namespace" if resolved_namespace else "mixed.item.namespace"
+    if resolved_namespace is None:
+        if len(target_namespaces) == 1:
+            resolved_namespace = next(iter(target_namespaces))
+            namespace_source = "item.namespace"
+        elif len(target_namespaces) == 0:
+            resolved_namespace = "chat_history"
+            namespace_source = "fallback.chat_history"
+
+    resolved_user = _normalise_concept_id(user_concept_id)
+    resolved_org = _normalise_concept_id(organisation_concept_id)
+    parsed_user, parsed_org = _parse_namespace_components(resolved_namespace)
+    if resolved_user is None:
+        resolved_user = parsed_user
+    if resolved_org is None:
+        resolved_org = parsed_org
+
+    if mismatch_count > 0:
+        logger.warning(
+            "[NAMESPACE] RAG sync mismatch_count=%s requested=%s sample_session_ids=%s",
+            mismatch_count,
+            _normalise_namespace(namespace),
+            mismatch_session_ids[:5],
+        )
+
+    _record_namespace_sync_observation(
+        flow="rag_sync.sync_to_chat_store",
+        namespace=resolved_namespace,
+        namespace_source=namespace_source,
+        user_concept_id=resolved_user,
+        organisation_concept_id=resolved_org,
+        mismatch_detected=mismatch_count > 0,
+        details={
+            "total_indexed": len(indexed),
+            "added": added,
+            "failed": failed,
+            "mismatch_count": mismatch_count,
+            "mismatch_session_ids": mismatch_session_ids[:5],
+            "indexed_namespaces": sorted(target_namespaces)[:20],
+        },
+    )
+
     return {
         "success": failed == 0,
         "added": added,
         "failed": failed,
         "total_indexed": len(indexed),
+        "namespace": resolved_namespace,
+        "namespace_source": namespace_source,
+        "user_concept_id": resolved_user,
+        "organisation_concept_id": resolved_org,
+        "namespace_mismatch": mismatch_count > 0,
+        "mismatch_count": mismatch_count,
+        "mismatch_session_ids": mismatch_session_ids,
     }
 
 
-def sync_one_session(session_id: str, namespace: Optional[str] = None) -> dict:
-    """Synchronise a single already-indexed interaction_session into the chat RAG store."""
+def sync_one_session(
+    session_id: str,
+    namespace: Optional[str] = None,
+    user_concept_id: Optional[str] = None,
+    organisation_concept_id: Optional[str] = None,
+) -> dict:
+    """Synchronise one already-indexed interaction_session into the chat RAG store."""
     db = get_db()
     if db is None:
         return {"success": False, "error": "DB unavailable"}
+
     coll = db["interaction_sessions"]
+    try:
+        query_id: ObjectId | str = ObjectId(session_id)
+    except Exception:
+        query_id = session_id
+
     doc = coll.find_one(
-        {"_id": ObjectId(session_id), "indexing_status": "indexed"},
+        {"_id": query_id, "indexing_status": "indexed"},
         {
             "_id": 1,
             "namespace": 1,
@@ -138,6 +356,7 @@ def sync_one_session(session_id: str, namespace: Optional[str] = None) -> dict:
             "error": "Session not found or not indexed",
             "session_id": session_id,
         }
+
     try:
         service = get_rag_service()
     except RAGBackendUnavailable as e:
@@ -158,7 +377,6 @@ def sync_one_session(session_id: str, namespace: Optional[str] = None) -> dict:
                 text_parts.append(c)
     text = "\n\n".join(text_parts)
 
-    # Build metadata with organisation context if available
     metadata = {
         "indexed_at": str(doc.get("indexed_at")) if doc.get("indexed_at") else None,
         "source": "interaction_session",
@@ -167,10 +385,27 @@ def sync_one_session(session_id: str, namespace: Optional[str] = None) -> dict:
         metadata["namespace"] = doc["namespace"]
     if doc.get("user_id"):
         metadata["user_id"] = doc["user_id"]
+        metadata["user_concept_id"] = doc["user_id"]
     if doc.get("organisation_concept_id"):
         metadata["organisation_concept_id"] = doc["organisation_concept_id"]
     if doc.get("role_in_org"):
         metadata["role_in_org"] = doc["role_in_org"]
+
+    provenance = _resolve_sync_namespace_provenance(
+        requested_namespace=namespace,
+        requested_user_concept_id=user_concept_id,
+        requested_organisation_concept_id=organisation_concept_id,
+        item_namespace=doc.get("namespace"),
+        item_metadata=metadata,
+    )
+    ns = provenance.get("namespace") or "chat_history"
+
+    metadata["namespace"] = ns
+    metadata["namespace_source"] = provenance.get("namespace_source")
+    if provenance.get("user_concept_id"):
+        metadata["user_concept_id"] = provenance.get("user_concept_id")
+    if provenance.get("organisation_concept_id"):
+        metadata["organisation_concept_id"] = provenance.get("organisation_concept_id")
 
     upsert_doc = {
         "id": str(doc["_id"]),
@@ -181,11 +416,8 @@ def sync_one_session(session_id: str, namespace: Optional[str] = None) -> dict:
     if isinstance(embedding, list) and embedding:
         upsert_doc["embedding"] = embedding
 
-    ns = namespace or doc.get("namespace") or "chat_history"
     try:
-        success_count, failure_count = service.upsert_documents(
-            [upsert_doc], namespace=ns
-        )
+        success_count, failure_count = service.upsert_documents([upsert_doc], namespace=ns)
     except Exception as e:
         if "embedding" in upsert_doc:
             upsert_doc.pop("embedding", None)
@@ -209,9 +441,35 @@ def sync_one_session(session_id: str, namespace: Optional[str] = None) -> dict:
     if failure_count > 0 or success_count == 0:
         return {"success": False, "error": "Upsert failed", "session_id": session_id}
 
+    if provenance.get("namespace_mismatch"):
+        logger.warning(
+            "[NAMESPACE] RAG sync one-session mismatch requested=%s session_namespace=%s session_id=%s",
+            provenance.get("requested_namespace"),
+            provenance.get("item_namespace"),
+            session_id,
+        )
+
+    _record_namespace_sync_observation(
+        flow="rag_sync.sync_one_session",
+        namespace=ns,
+        namespace_source=provenance.get("namespace_source"),
+        user_concept_id=provenance.get("user_concept_id"),
+        organisation_concept_id=provenance.get("organisation_concept_id"),
+        mismatch_detected=bool(provenance.get("namespace_mismatch")),
+        details={
+            "session_id": session_id,
+            "requested_namespace": provenance.get("requested_namespace"),
+            "item_namespace": provenance.get("item_namespace"),
+        },
+    )
+
     return {
         "success": True,
         "upserted": success_count,
         "namespace": ns,
+        "namespace_source": provenance.get("namespace_source"),
+        "user_concept_id": provenance.get("user_concept_id"),
+        "organisation_concept_id": provenance.get("organisation_concept_id"),
+        "namespace_mismatch": bool(provenance.get("namespace_mismatch")),
         "session_id": session_id,
     }

--- a/tests/backend/test_namespace_isolation_diagnostics_service.py
+++ b/tests/backend/test_namespace_isolation_diagnostics_service.py
@@ -1,0 +1,95 @@
+import pytest
+
+from src.backend.services import namespace_isolation_diagnostics_service as diagnostics
+
+
+@pytest.fixture(autouse=True)
+def _reset_namespace_isolation_state():
+    diagnostics.reset_namespace_isolation_diagnostics()
+    yield
+    diagnostics.reset_namespace_isolation_diagnostics()
+
+
+def test_record_namespace_context_observation_counts_mismatch_and_missing_components():
+    emitted = diagnostics.record_namespace_context_observation(
+        flow="test.generate",
+        namespace=None,
+        namespace_source="missing",
+        user_concept_id=None,
+        organisation_concept_id=None,
+        mismatch_detected=True,
+        details={"stage": "unit_test"},
+    )
+
+    assert emitted == 3
+
+    snapshot = diagnostics.get_namespace_isolation_diagnostics_snapshot(
+        include_recent_events=True
+    )
+    counters = snapshot["counters"]
+    assert counters["events_total"] == 3
+    assert counters["namespace_mismatch_events"] == 1
+    assert counters["missing_component_events"] == 2
+    assert counters["missing_namespace_events"] == 1
+    assert counters["org_scope_downgrade_events"] == 0
+
+    event_type_counts = snapshot["event_type_counts"]
+    assert event_type_counts["namespace_mismatch"] == 1
+    assert event_type_counts["missing_component.namespace"] == 1
+    assert event_type_counts["missing_component.user_concept_id"] == 1
+
+
+def test_record_namespace_context_observation_tracks_org_scope_events():
+    diagnostics.record_namespace_context_observation(
+        flow="test.rag",
+        namespace="#V#user@org",
+        namespace_source="request.namespace",
+        user_concept_id="#V#user",
+        organisation_concept_id=None,
+        mismatch_detected=False,
+    )
+    diagnostics.record_namespace_context_observation(
+        flow="test.rag",
+        namespace="#V#user",
+        namespace_source="request.namespace",
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        mismatch_detected=False,
+    )
+
+    snapshot = diagnostics.get_namespace_isolation_diagnostics_snapshot()
+    counters = snapshot["counters"]
+    assert counters["events_total"] == 2
+    assert counters["missing_component_events"] == 1
+    assert counters["org_scope_downgrade_events"] == 1
+
+    event_type_counts = snapshot["event_type_counts"]
+    assert event_type_counts["missing_component.organisation_concept_id"] == 1
+    assert event_type_counts["org_scope_downgrade"] == 1
+
+
+def test_namespace_isolation_snapshot_respects_recent_event_limit():
+    diagnostics.record_namespace_isolation_event(
+        flow="flow_a",
+        event_type="namespace_mismatch",
+        namespace="#V#a@b",
+    )
+    diagnostics.record_namespace_isolation_event(
+        flow="flow_b",
+        event_type="missing_component.namespace",
+        namespace=None,
+    )
+    diagnostics.record_namespace_isolation_event(
+        flow="flow_c",
+        event_type="org_scope_downgrade",
+        namespace="#V#a",
+    )
+
+    snapshot = diagnostics.get_namespace_isolation_diagnostics_snapshot(
+        include_recent_events=True,
+        recent_limit=2,
+    )
+
+    recent_events = snapshot["recent_events"]
+    assert len(recent_events) == 2
+    assert [event["flow"] for event in recent_events] == ["flow_b", "flow_c"]

--- a/tests/backend/test_rag_provenance_contract.py
+++ b/tests/backend/test_rag_provenance_contract.py
@@ -96,10 +96,14 @@ def test_rag_list_indexed_includes_provenance(monkeypatch):
 
     assert result["namespace"] == "#V#user@org"
     assert result["namespace_source"] == "request.namespace"
+    assert result["user_concept_id"] == "#V#user"
+    assert result["organisation_concept_id"] == "#V#org"
 
     assert "provenance" in result
     assert result["provenance"]["item_kind"] == "rag_indexed_session_list"
     assert result["provenance"]["source_system"] == "mongo.interaction_sessions"
+    assert result["provenance"]["user_concept_id"] == "#V#user"
+    assert result["provenance"]["organisation_concept_id"] == "#V#org"
 
     assert result["items"], "expected at least one item"
     item = result["items"][0]
@@ -134,6 +138,8 @@ def test_search_knowledge_base_stamps_result_metadata(monkeypatch):
     assert result["success"] is True
     assert result["namespace"] == "#V#user@org"
     assert result["namespace_source"] == "request.namespace"
+    assert result["user_concept_id"] == "#V#user"
+    assert result["organisation_concept_id"] == "#V#org"
 
     assert isinstance(result.get("elapsed_ms"), int)
     assert result["elapsed_ms"] >= 0
@@ -187,8 +193,12 @@ def test_rag_list_collections_includes_expected_collections():
     assert result["success"] is True
     assert result["namespace"] == "#V#user@org"
     assert result["namespace_source"] == "request.namespace"
+    assert result["user_concept_id"] == "#V#user"
+    assert result["organisation_concept_id"] == "#V#org"
 
     assert result["provenance"]["item_kind"] == "rag_collection_list"
+    assert result["provenance"]["user_concept_id"] == "#V#user"
+    assert result["provenance"]["organisation_concept_id"] == "#V#org"
     assert result["collections"]
     collections = {c["collection"] for c in result["collections"]}
     assert "ka_sessions" in collections
@@ -265,6 +275,8 @@ def test_rag_namespace_resolver_supports_user_only_path():
     assert report["namespace_source"] == "derived.user_org"
     assert report["namespace_resolution_note"] == "derived_from_user_org"
     assert report["namespace_mismatch"] is False
+    assert report["user_concept_id"] == "#V#user"
+    assert report["organisation_concept_id"] is None
 
 
 def test_rag_namespace_resolver_supports_user_org_path():
@@ -281,6 +293,20 @@ def test_rag_namespace_resolver_supports_user_org_path():
     assert report["namespace_source"] == "derived.user_org"
     assert report["namespace_resolution_note"] == "derived_from_user_org"
     assert report["namespace_mismatch"] is False
+    assert report["user_concept_id"] == "#V#user"
+    assert report["organisation_concept_id"] == "#V#org"
+
+
+def test_rag_namespace_resolver_derives_components_from_explicit_namespace():
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    report = cat._resolve_rag_namespace_from_kwargs({"namespace": "#V#user@org"})
+
+    assert report["namespace"] == "#V#user@org"
+    assert report["namespace_source"] == "request.namespace"
+    assert report["namespace_mismatch"] is False
+    assert report["user_concept_id"] == "#V#user"
+    assert report["organisation_concept_id"] == "#V#org"
 
 
 def test_rag_list_indexed_fails_closed_on_namespace_mismatch(monkeypatch):
@@ -302,3 +328,5 @@ def test_rag_list_indexed_fails_closed_on_namespace_mismatch(monkeypatch):
     assert result["namespace"] is None
     assert result["provided_namespace"] == "#V#user"
     assert result["derived_namespace"] == "#V#user@org"
+    assert result["user_concept_id"] == "#V#user"
+    assert result["organisation_concept_id"] == "#V#org"

--- a/tests/backend/test_rag_sync_service_provenance.py
+++ b/tests/backend/test_rag_sync_service_provenance.py
@@ -1,0 +1,106 @@
+class _StubRAGService:
+    def __init__(self):
+        self.upserts = []
+
+    def upsert_documents(self, docs, namespace):
+        self.upserts.append({"docs": docs, "namespace": namespace})
+        return len(docs), 0
+
+
+def test_sync_to_chat_store_emits_namespace_component_provenance(monkeypatch):
+    from src.backend.services import rag_sync_service
+
+    rag_stub = _StubRAGService()
+    observations = []
+
+    monkeypatch.setattr(
+        "src.backend.services.rag_sync_service.get_rag_service",
+        lambda: rag_stub,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_sync_service.collect_indexed_sessions",
+        lambda limit=1000: [
+            {
+                "id": "s1",
+                "namespace": "#V#user@org",
+                "text": "hello world",
+                "metadata": {"source": "interaction_session"},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_sync_service._record_namespace_sync_observation",
+        lambda **kwargs: observations.append(kwargs),
+    )
+
+    result = rag_sync_service.sync_to_chat_store(
+        namespace="#V#user@org",
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+    )
+
+    assert result["success"] is True
+    assert result["namespace"] == "#V#user@org"
+    assert result["namespace_source"] == "request.namespace"
+    assert result["user_concept_id"] == "#V#user"
+    assert result["organisation_concept_id"] == "#V#org"
+    assert result["namespace_mismatch"] is False
+    assert result["mismatch_count"] == 0
+
+    assert rag_stub.upserts
+    upsert = rag_stub.upserts[0]
+    assert upsert["namespace"] == "#V#user@org"
+    metadata = upsert["docs"][0]["metadata"]
+    assert metadata["namespace"] == "#V#user@org"
+    assert metadata["namespace_source"] == "request.namespace"
+    assert metadata["user_concept_id"] == "#V#user"
+    assert metadata["organisation_concept_id"] == "#V#org"
+
+    assert observations
+    assert observations[0]["mismatch_detected"] is False
+
+
+def test_sync_to_chat_store_reports_namespace_mismatch_without_failing(monkeypatch):
+    from src.backend.services import rag_sync_service
+
+    rag_stub = _StubRAGService()
+    observations = []
+
+    monkeypatch.setattr(
+        "src.backend.services.rag_sync_service.get_rag_service",
+        lambda: rag_stub,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_sync_service.collect_indexed_sessions",
+        lambda limit=1000: [
+            {
+                "id": "s-mismatch",
+                "namespace": "#V#user@other_org",
+                "text": "hello world",
+                "metadata": {"source": "interaction_session"},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_sync_service._record_namespace_sync_observation",
+        lambda **kwargs: observations.append(kwargs),
+    )
+
+    result = rag_sync_service.sync_to_chat_store(
+        namespace="#V#user@org",
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+    )
+
+    assert result["success"] is True
+    assert result["namespace"] == "#V#user@org"
+    assert result["namespace_source"] == "request.namespace"
+    assert result["namespace_mismatch"] is True
+    assert result["mismatch_count"] == 1
+    assert result["mismatch_session_ids"] == ["s-mismatch"]
+
+    assert rag_stub.upserts
+    assert rag_stub.upserts[0]["namespace"] == "#V#user@org"
+
+    assert observations
+    assert observations[0]["mismatch_detected"] is True

--- a/tests/backend/test_von_generate_rag_trace.py
+++ b/tests/backend/test_von_generate_rag_trace.py
@@ -106,12 +106,16 @@ def test_generate_includes_rag_trace_when_authenticated(app):
     assert rag_trace["authenticated"] is True
     assert rag_trace["namespace"] == "#V#user@org"
     assert rag_trace["namespace_source"] == "effective_context.namespace"
+    assert rag_trace["user_concept_id"] == "#V#user"
+    assert rag_trace["organisation_concept_id"] is None
     assert rag_trace["retrieval_attempted"] is True
     assert "search_knowledge_base" in rag_trace["tools_invoked"]
     assert rag_trace["tool_results_included_in_prompt"] is True
 
     assert "llm_debug" in body
     assert body["llm_debug"]["namespace_report"]["namespace"] == "#V#user@org"
+    assert body["llm_debug"]["namespace_report"]["user_concept_id"] == "#V#user"
+    assert body["llm_debug"]["namespace_report"]["organisation_concept_id"] is None
     assert (
         body["llm_debug"]["namespace_report"]["namespace_source"]
         == "effective_context.namespace"
@@ -163,6 +167,8 @@ def test_generate_prefers_window_effective_namespace_and_reports_mismatch(
     rag_trace = body["rag_trace"]
     assert rag_trace["namespace"] == "#V#user@window_org"
     assert rag_trace["namespace_source"] == "effective_context.namespace"
+    assert rag_trace["user_concept_id"] == "#V#user"
+    assert rag_trace["organisation_concept_id"] == "#V#window_org"
 
     namespace_report = body["llm_debug"]["namespace_report"]
     assert namespace_report["mismatch_detected"] is True
@@ -190,5 +196,7 @@ def test_generate_rag_trace_marks_unauthenticated(app):
     rag_trace = body["rag_trace"]
     assert rag_trace["authenticated"] is False
     assert rag_trace["namespace"] is None
+    assert rag_trace["user_concept_id"] is None
+    assert rag_trace["organisation_concept_id"] is None
     assert rag_trace["retrieval_attempted"] is False
     assert rag_trace["retrieval_attempt_reason"] == "not_authenticated"


### PR DESCRIPTION
## Summary
- add a new in-memory namespace-isolation diagnostics service with mismatch/missing-component counters and compact snapshot reporting
- instrument /von/generate, internal MCP RAG namespace resolution, and RAG sync/index paths with canonical provenance fields (namespace, namespace_source, user_concept_id, organisation_concept_id)
- expose compact namespace_isolation_diagnostics output on /admin/rag_status and /diag
- update effective-namespace/security docs with operator interpretation guidance
- add regression tests for diagnostics counters, RAG sync provenance telemetry, and expanded provenance assertions in existing RAG contract tests

## Verification
- pytest tests/backend/test_von_generate_rag_trace.py tests/backend/test_rag_provenance_contract.py tests/backend/test_namespace_isolation_diagnostics_service.py tests/backend/test_rag_sync_service_provenance.py
- pyright 