### PR TITLE
JVNAUTOSCI-1258 Fix stale running workflow monitor cards

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -12961,6 +12961,14 @@ function buildWorkflowStatusQuery({ includeStatusFilter } = {}) {
     return params;
 }
 
+function buildWorkflowStatusStreamQuery() {
+    const params = buildWorkflowStatusQuery();
+    // Subscribe to all status transitions for the scoped namespace/user/org so
+    // terminal updates (completed/failed/cancelled) can remove active cards.
+    // Filtering to active-only statuses here causes stale "running" rows.
+    return params;
+}
+
 function buildWorkflowMonitorExportPayload() {
     const namespace = getSessionScopedNamespace();
     const orgContext = getSessionScopedOrgContext();
@@ -13398,7 +13406,7 @@ function startWorkflowStatusStream() {
 
     stopWorkflowStatusStream();
 
-    const params = buildWorkflowStatusQuery({ includeStatusFilter: true });
+    const params = buildWorkflowStatusStreamQuery();
     const url = `/api/workflows/instances/stream?${params.toString()}`;
     const eventSource = new EventSource(url);
     workflowStatusStreamState.eventSource = eventSource;
@@ -16012,6 +16020,9 @@ export const __test_only__rehydrateHistory = rehydrateHistory;
 export const __test_only__renderChatSessionMetadataPanel = _renderChatSessionMetadataPanel;
 export function __testOnly_buildWorkflowStatusQuery(opts = {}) {
     return buildWorkflowStatusQuery(opts).toString();
+}
+export function __testOnly_buildWorkflowStatusStreamQuery() {
+    return buildWorkflowStatusStreamQuery().toString();
 }
 export function __testOnly_renderWorkflowDefinitionsBody(items = []) {
     workflowDefinitionsState.visible = true;

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -6,6 +6,7 @@ import {
     __testOnly_setUnambiguousTimestampTooltip,
     __testOnly_setWorkflowShowDesigns,
     __testOnly_buildWorkflowStatusQuery,
+    __testOnly_buildWorkflowStatusStreamQuery,
     __testOnly_buildLlmDebugMetadata,
     __testOnly_convertInlineQuotedStrongSegmentsToButtons,
     __testOnly_convertQuotedInstructionBlockquotesToButtons,
@@ -196,6 +197,26 @@ describe('workflow status query scoping', () => {
         expect(params.has('namespace')).toBe(false);
         expect(params.get('org_id')).toBe('#V#university_of_auckland_strong_ai_lab');
         expect(params.get('user_id')).toBe('#V#michael_witbrock');
+    });
+
+    test('workflow status stream query does not filter out terminal statuses', () => {
+        const { getCurrentUserConceptId } = require('../domUtils.js');
+        const {
+            getSessionScopedNamespace,
+            getSessionScopedOrgContext
+        } = require('../utils/sessionScopedStorage.js');
+
+        getSessionScopedNamespace.mockReturnValue('#V#michael_witbrock');
+        getSessionScopedOrgContext.mockReturnValue({
+            concept_id: '#V#university_of_auckland_strong_ai_lab'
+        });
+        getCurrentUserConceptId.mockReturnValue('#V#michael_witbrock');
+
+        const query = __testOnly_buildWorkflowStatusStreamQuery();
+        const params = new URLSearchParams(query);
+
+        expect(params.get('namespace')).toBe('#V#michael_witbrock');
+        expect(params.has('status')).toBe(false);
     });
 });
 


### PR DESCRIPTION
## Summary
- include terminal workflow status transitions in Workflow Monitor SSE subscription
- prevent stale RUNNING cards after completion/failure/cancellation
- add regression test to keep stream query free of active-status filtering

## Validation
- npx jest --runInBand src/frontend/web/von_interface/static/js/test/chatTab.test.js

## Jira
- JVNAUTOSCI-1258