### PR TITLE
JVNAUTOSCI-999: complete Phase II messaging safety hardening

### DIFF
--- a/src/backend/server/routes/message_routes.py
+++ b/src/backend/server/routes/message_routes.py
@@ -29,6 +29,32 @@ _log = logging.getLogger(__name__)
 message_bp = Blueprint("messages", __name__)
 
 
+def _normalise_concept_id(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    return cleaned if cleaned.startswith("#V#") else f"#V#{cleaned}"
+
+
+def _normalise_recipient_ids(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        concept_id = _normalise_concept_id(item)
+        if not isinstance(concept_id, str):
+            continue
+        lowered = concept_id.casefold()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        result.append(concept_id)
+    return result
+
+
 def _get_current_user_concept_id() -> Optional[str]:
     """Get the current user's concept_id from session or access control."""
     try:
@@ -48,9 +74,54 @@ def _get_current_user_concept_id() -> Optional[str]:
     return None
 
 
-def _get_current_org_concept_id() -> Optional[str]:
-    """Get the current organisation's concept ID from the session."""
-    return session.get("organisation_concept_id")
+def _get_current_org_concept_id(user_concept_id: Optional[str]) -> Optional[str]:
+    """Get the current organisation's concept ID from effective window/session context."""
+    if isinstance(user_concept_id, str) and user_concept_id.strip():
+        try:
+            from ...services.window_session_context_service import get_effective_context
+
+            window_session_id = request.headers.get("X-Von-Window-Session")
+            effective = get_effective_context(
+                window_session_id,
+                dict(session),
+                user_concept_id.strip(),
+            )
+            org_id = _normalise_concept_id(effective.get("organisation_id"))
+            if org_id:
+                return org_id
+        except Exception:
+            pass
+
+    return _normalise_concept_id(session.get("organisation_concept_id"))
+
+
+def _authorise_sender_and_recipients_for_org(
+    *,
+    sender_id: str,
+    recipient_ids: list[str],
+    organisation_concept_id: str,
+) -> tuple[bool, list[str]]:
+    from ...services.organisation_membership_service import get_organisation_members
+
+    members = get_organisation_members(organisation_concept_id)
+    org_member_ids = {
+        normalised
+        for normalised in (
+            _normalise_concept_id(member.get("user_concept_id"))
+            for member in members.get("members", [])
+            if isinstance(member, dict)
+        )
+        if isinstance(normalised, str)
+    }
+
+    invalid_ids: list[str] = []
+    if sender_id not in org_member_ids:
+        invalid_ids.append(sender_id)
+    for recipient_id in recipient_ids:
+        if recipient_id not in org_member_ids:
+            invalid_ids.append(recipient_id)
+
+    return (len(invalid_ids) == 0, invalid_ids)
 
 
 @message_bp.route("/", methods=["POST"])
@@ -71,13 +142,16 @@ def send_message() -> ResponseReturnValue:
     if not sender_id:
         return jsonify({"error": "Authentication required"}), 401
 
-    org_id = _get_current_org_concept_id()
+    sender_id = sender_id.strip()
+    org_id = _get_current_org_concept_id(sender_id)
+    if not isinstance(org_id, str) or not org_id:
+        return jsonify({"error": "No organisation context"}), 400
 
-    data = request.get_json()
-    if not data:
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
         return jsonify({"error": "Request body required"}), 400
 
-    recipient_ids = data.get("recipient_ids", [])
+    recipient_ids = _normalise_recipient_ids(data.get("recipient_ids"))
     content = data.get("content", "").strip()
 
     if not recipient_ids:
@@ -86,6 +160,32 @@ def send_message() -> ResponseReturnValue:
         return jsonify({"error": "Message content is required"}), 400
 
     try:
+        is_authorised, invalid_ids = _authorise_sender_and_recipients_for_org(
+            sender_id=sender_id,
+            recipient_ids=recipient_ids,
+            organisation_concept_id=org_id,
+        )
+        if not is_authorised:
+            return (
+                jsonify(
+                    {
+                        "error": "Sender/recipient must share the current organisation",
+                        "invalid_concept_ids": invalid_ids,
+                    }
+                ),
+                403,
+            )
+
+        metadata = data.get("metadata")
+        metadata_payload = metadata if isinstance(metadata, dict) else {}
+        metadata_payload = dict(metadata_payload)
+        metadata_payload.setdefault("delivery_channel", "interuser_message")
+        metadata_payload.setdefault("intent", "info")
+        metadata_payload.setdefault(
+            "attribution",
+            f"Sent by Von on behalf of {sender_id}",
+        )
+
         message = create_message(
             sender_id=sender_id,
             recipient_ids=recipient_ids,
@@ -94,7 +194,23 @@ def send_message() -> ResponseReturnValue:
             thread_id=data.get("thread_id"),
             reply_to_id=data.get("reply_to_id"),
             org_id=org_id,
-            metadata=data.get("metadata"),
+            metadata=metadata_payload,
+        )
+
+        from ...services.episode_logging_service import log_episode
+
+        log_episode(
+            episode_type="interuser_message_sent",
+            actor_user_id=sender_id,
+            organisation_concept_id=org_id,
+            payload={
+                "message_id": message.get("concept_id"),
+                "recipient_ids": recipient_ids,
+                "intent": metadata_payload.get("intent"),
+                "thread_id": data.get("thread_id"),
+                "reply_to_id": data.get("reply_to_id"),
+            },
+            status="sent",
         )
 
         # Return sanitised response
@@ -104,6 +220,7 @@ def send_message() -> ResponseReturnValue:
                     "success": True,
                     "message_id": message.get("concept_id"),
                     "sent_at": message.get("concept_data", {}).get("sent_at"),
+                    "attribution": metadata_payload.get("attribution"),
                 }
             ),
             201,

--- a/src/backend/services/message_service.py
+++ b/src/backend/services/message_service.py
@@ -110,6 +110,14 @@ def create_message(
     if org_id:
         relationships["specific_to_org"] = [org_id.strip()]
 
+    metadata_payload = metadata if isinstance(metadata, dict) else {}
+    metadata_payload = {str(k): v for k, v in metadata_payload.items() if isinstance(k, str)}
+    attribution = metadata_payload.get("attribution")
+    if not isinstance(attribution, str) or not attribution.strip():
+        attribution = f"Sent by Von on behalf of {sender_id}"
+    else:
+        attribution = attribution.strip()
+
     # Build concept document
     concept_doc: Dict[str, Any] = {
         "concept_id": concept_id,
@@ -119,6 +127,9 @@ def create_message(
             "message_status": MESSAGE_STATUS_SENT,
             "sent_at": timestamp.isoformat(),
             "read_by": [],  # Track which recipients have read it
+            # Keep a canonical copy for UI/search paths that do not resolve text relations.
+            "content_fallback": content,
+            "attribution": attribution,
         },
         "created_at": timestamp,
         "updated_at": timestamp,
@@ -129,8 +140,8 @@ def create_message(
         concept_doc["concept_data"]["subject"] = subject.strip()
 
     # Add custom metadata
-    if metadata:
-        concept_doc["concept_data"]["metadata"] = metadata
+    if metadata_payload:
+        concept_doc["concept_data"]["metadata"] = metadata_payload
 
     # Insert into MongoDB
     coll = get_concepts_collection()
@@ -149,8 +160,6 @@ def create_message(
         )
     except Exception as e:
         _log.warning(f"Failed to store message content as text relation: {e}")
-        # Fall back to storing in concept_data
-        concept_doc["concept_data"]["content_fallback"] = content
 
     # Event-driven workflow launch is best-effort and must not block messaging.
     try:

--- a/tests/backend/test_message_routes.py
+++ b/tests/backend/test_message_routes.py
@@ -1,0 +1,157 @@
+"""Route tests for inter-user messaging safety and attribution."""
+
+from __future__ import annotations
+
+from flask import Flask
+import pytest
+
+import src.backend.server.routes.message_routes as message_routes
+
+
+@pytest.fixture
+def app_client():
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.config["TESTING"] = True
+    app.register_blueprint(message_routes.message_bp, url_prefix="/api/messages")
+
+    with app.test_client() as client:
+        yield app, client
+
+
+def test_send_message_requires_authentication(monkeypatch, app_client):
+    _, client = app_client
+    monkeypatch.setattr(message_routes, "_get_current_user_concept_id", lambda: None)
+
+    response = client.post(
+        "/api/messages/",
+        json={"recipient_ids": ["#V#user_bob"], "content": "Kia ora"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "Authentication required"
+
+
+def test_send_message_rejects_recipient_outside_organisation(monkeypatch, app_client):
+    _, client = app_client
+    monkeypatch.setattr(
+        message_routes,
+        "_get_current_user_concept_id",
+        lambda: "#V#user_alice",
+    )
+    monkeypatch.setattr(
+        message_routes,
+        "_get_current_org_concept_id",
+        lambda _user_id: "#V#org_test",
+    )
+
+    import src.backend.services.organisation_membership_service as membership_service
+
+    monkeypatch.setattr(
+        membership_service,
+        "get_organisation_members",
+        lambda _org_id: {
+            "members": [
+                {"user_concept_id": "#V#user_alice"},
+                {"user_concept_id": "#V#user_charlie"},
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        message_routes,
+        "create_message",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("create_message should not be called")
+        ),
+    )
+
+    response = client.post(
+        "/api/messages/",
+        json={"recipient_ids": ["#V#user_bob"], "content": "Review this please"},
+    )
+
+    assert response.status_code == 403
+    payload = response.get_json()
+    assert payload["error"] == "Sender/recipient must share the current organisation"
+    assert "#V#user_bob" in payload["invalid_concept_ids"]
+
+
+def test_send_message_success_logs_episode_and_returns_attribution(
+    monkeypatch, app_client
+):
+    _, client = app_client
+    monkeypatch.setattr(
+        message_routes,
+        "_get_current_user_concept_id",
+        lambda: "#V#user_alice",
+    )
+    monkeypatch.setattr(
+        message_routes,
+        "_get_current_org_concept_id",
+        lambda _user_id: "#V#org_test",
+    )
+
+    import src.backend.services.organisation_membership_service as membership_service
+
+    monkeypatch.setattr(
+        membership_service,
+        "get_organisation_members",
+        lambda _org_id: {
+            "members": [
+                {"user_concept_id": "#V#user_alice"},
+                {"user_concept_id": "#V#user_bob"},
+            ]
+        },
+    )
+
+    captured_create_args: dict[str, object] = {}
+
+    def _fake_create_message(**kwargs):
+        captured_create_args.update(kwargs)
+        return {
+            "concept_id": "#V#message_test_1",
+            "concept_data": {"sent_at": "2026-02-24T10:00:00+00:00"},
+        }
+
+    monkeypatch.setattr(message_routes, "create_message", _fake_create_message)
+
+    import src.backend.services.episode_logging_service as episode_logging_service
+
+    episode_calls: list[dict] = []
+
+    def _fake_log_episode(**kwargs):
+        episode_calls.append(dict(kwargs))
+        return "episode-1"
+
+    monkeypatch.setattr(episode_logging_service, "log_episode", _fake_log_episode)
+
+    response = client.post(
+        "/api/messages/",
+        json={
+            "recipient_ids": ["#V#user_bob"],
+            "content": "Please review the workflow output.",
+            "metadata": {"intent": "review_request"},
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["message_id"] == "#V#message_test_1"
+    assert payload["attribution"] == "Sent by Von on behalf of #V#user_alice"
+
+    assert captured_create_args["sender_id"] == "#V#user_alice"
+    assert captured_create_args["recipient_ids"] == ["#V#user_bob"]
+    assert captured_create_args["org_id"] == "#V#org_test"
+    metadata = captured_create_args["metadata"]
+    assert isinstance(metadata, dict)
+    assert metadata["intent"] == "review_request"
+    assert metadata["delivery_channel"] == "interuser_message"
+    assert metadata["attribution"] == "Sent by Von on behalf of #V#user_alice"
+
+    assert len(episode_calls) == 1
+    assert episode_calls[0]["episode_type"] == "interuser_message_sent"
+    assert episode_calls[0]["actor_user_id"] == "#V#user_alice"
+    assert episode_calls[0]["organisation_concept_id"] == "#V#org_test"
+    assert episode_calls[0]["payload"]["message_id"] == "#V#message_test_1"
+

--- a/tests/backend/test_message_service.py
+++ b/tests/backend/test_message_service.py
@@ -75,6 +75,11 @@ class TestCreateMessage:
         assert "#V#user_bob" in result["relationships"]["specific_to_user"]
         assert result["relationships"][PREDICATE_SENDER] == ["#V#user_alice"]
         assert result["relationships"][PREDICATE_RECIPIENT] == ["#V#user_bob"]
+        assert result["concept_data"]["content_fallback"] == "Hello Bob!"
+        assert (
+            result["concept_data"]["attribution"]
+            == "Sent by Von on behalf of #V#user_alice"
+        )
         mock_launch_workflow.assert_called_once()
 
     @patch("src.backend.services.message_service.get_concepts_collection")
@@ -152,6 +157,34 @@ class TestCreateMessage:
         )
 
         assert result["concept_data"]["subject"] == "Important Update"
+        mock_launch_workflow.assert_called_once()
+
+    @patch("src.backend.services.message_service.get_concepts_collection")
+    @patch("src.backend.services.message_service.ConceptsRepository")
+    @patch("src.backend.services.message_service.upsert_text_for_concept")
+    @patch("src.backend.services.message_service.maybe_launch_direct_message_workflow")
+    def test_create_message_uses_metadata_attribution_when_provided(
+        self,
+        mock_launch_workflow: MagicMock,
+        mock_upsert: MagicMock,
+        mock_repo: MagicMock,
+        mock_get_coll: MagicMock,
+    ) -> None:
+        """create_message() should keep explicit attribution metadata."""
+        mock_get_coll.return_value = MagicMock()
+        mock_repo.insert_one.return_value = None
+
+        result = create_message(
+            sender_id="#V#user_alice",
+            recipient_ids=["#V#user_bob"],
+            content="Attribution override",
+            metadata={"attribution": "Sent by Von on behalf of Alice"},
+        )
+
+        assert result["concept_data"]["attribution"] == "Sent by Von on behalf of Alice"
+        assert result["concept_data"]["metadata"]["attribution"] == (
+            "Sent by Von on behalf of Alice"
+        )
         mock_launch_workflow.assert_called_once()
 
     def test_create_message_empty_sender(self) -> None:


### PR DESCRIPTION
## Summary\n- enforce server-side same-organisation checks for interuser message send (/api/messages/)\n- resolve organisation context from window-session effective context (with session fallback)\n- add explicit attribution metadata (Sent by Von on behalf of <user>) and include it in send response\n- add interuser message episode logging (interuser_message_sent) for auditability\n- persist concept_data.content_fallback and concept_data.attribution in message concepts to keep thread preview/search/read paths reliable\n- add focused route tests for auth, organisation membership enforcement, attribution, and episode logging\n\n## Validation\n- pdm run pytest tests/backend/test_message_service.py tests/backend/test_message_routes.py -q\n- pdm run pyright src/backend/server/routes/message_routes.py src/backend/services/message_service.py tests/backend/test_message_service.py tests/backend/test_message_routes.py\n