### PR TITLE
JVNAUTOSCI-760: expose blob-store file-copy concepts in RAG MCP tools

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -8595,6 +8595,15 @@ def _resolve_rag_collection_from_kwargs(kwargs: dict) -> dict[str, object]:
         "chat_history": "chat_history_sessions",
         "chat_history_session": "chat_history_sessions",
         "chat_history_sessions": "chat_history_sessions",
+        "file_copy": "file_copy_concepts",
+        "file_copies": "file_copy_concepts",
+        "file_copy_concept": "file_copy_concepts",
+        "file_copy_concepts": "file_copy_concepts",
+        "blob_store": "file_copy_concepts",
+        "blob_store_file": "file_copy_concepts",
+        "blob_store_files": "file_copy_concepts",
+        "uploaded_file": "file_copy_concepts",
+        "uploaded_files": "file_copy_concepts",
         "text_relations": "vontology_text_relations",
         "text_relation": "vontology_text_relations",
         "text": "vontology_text_relations",
@@ -8665,6 +8674,24 @@ def _rag_list_collections(**kwargs):
             "get_supported_reason": None,
             "item_kind": "chat_history_session",
             "source_system": "mongo.chat_history",
+        },
+        {
+            "collection": "file_copy_concepts",
+            "label": "Blob-store file-copy concepts",
+            "description": (
+                "User-visible file-copy concepts stored in MongoDB (concepts collection) with blob metadata. "
+                "Use this to inspect uploaded/object-store files discoverable by namespace-scoped retrieval."
+            ),
+            "list_tool": "rag_list_indexed",
+            "get_tool": "rag_get_item",
+            "search_tool": "search_knowledge_base",
+            "list_supported": True,
+            "get_supported": True,
+            "search_supported": True,
+            "list_supported_reason": None,
+            "get_supported_reason": None,
+            "item_kind": "file_copy_concept",
+            "source_system": "mongo.concepts",
         },
         {
             "collection": "turn_execution_records",
@@ -8981,6 +9008,156 @@ def _summarise_turn_execution_rag_indexing_states(
     return counts
 
 
+def _resolve_rag_actor_scope_ids(
+    ns_report: Mapping[str, Any],
+) -> tuple[str | None, str | None]:
+    """Extract user/org scope IDs from a namespace resolution report."""
+
+    user_concept_id = ns_report.get("user_concept_id")
+    if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+        user_concept_id = ns_report.get("derived_user_concept_id")
+    if isinstance(user_concept_id, str):
+        user_concept_id = user_concept_id.strip() or None
+    else:
+        user_concept_id = None
+
+    organisation_concept_id = ns_report.get("organisation_concept_id")
+    if not isinstance(organisation_concept_id, str) or not organisation_concept_id.strip():
+        organisation_concept_id = ns_report.get("derived_organisation_concept_id")
+    if isinstance(organisation_concept_id, str):
+        organisation_concept_id = organisation_concept_id.strip() or None
+    else:
+        organisation_concept_id = None
+
+    return user_concept_id, organisation_concept_id
+
+
+def _build_rag_file_copy_visibility_query(
+    *,
+    ns_report: Mapping[str, Any],
+    extra_filters: Sequence[Mapping[str, Any]] | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    user_concept_id, organisation_concept_id = _resolve_rag_actor_scope_ids(ns_report)
+    visibility_filters: list[dict[str, Any]] = []
+
+    if user_concept_id:
+        visibility_filters.append(
+            {"relationships.specific_to_user": {"$in": [user_concept_id]}}
+        )
+        visibility_filters.append(
+            {"relationships.#V#specific_to_user": {"$in": [user_concept_id]}}
+        )
+    if organisation_concept_id:
+        visibility_filters.append(
+            {"relationships.specific_to_org": {"$in": [organisation_concept_id]}}
+        )
+
+    if not visibility_filters:
+        return None, "namespace_user_required"
+
+    and_filters: list[dict[str, Any]] = [
+        {"attributes.blob_key": {"$exists": True, "$nin": [None, ""]}},
+        {"$or": visibility_filters},
+    ]
+    if extra_filters:
+        for row in extra_filters:
+            if isinstance(row, Mapping):
+                and_filters.append(dict(row))
+
+    return {"$and": and_filters}, None
+
+
+def _coerce_int_or_none(value: Any) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _build_rag_file_copy_item(
+    *,
+    collection: str,
+    doc: Mapping[str, Any],
+    namespace: str,
+    namespace_source: Any,
+) -> dict[str, Any]:
+    attributes = doc.get("attributes")
+    attrs = attributes if isinstance(attributes, Mapping) else {}
+    relationships = doc.get("relationships")
+    rels = relationships if isinstance(relationships, Mapping) else {}
+
+    instance_types_raw = rels.get("is_an_instance_of")
+    if isinstance(instance_types_raw, list):
+        instance_types = [str(v) for v in instance_types_raw if isinstance(v, str)]
+    elif isinstance(instance_types_raw, str):
+        instance_types = [instance_types_raw]
+    else:
+        instance_types = []
+
+    concept_id_raw = doc.get("concept_id")
+    concept_id = (
+        concept_id_raw
+        if isinstance(concept_id_raw, str) and concept_id_raw.strip()
+        else str(doc.get("_id"))
+    )
+    concept_id = concept_id.strip()
+
+    original_filename = attrs.get("original_filename")
+    if not isinstance(original_filename, str) or not original_filename.strip():
+        fallback_name = doc.get("name")
+        original_filename = (
+            fallback_name.strip()
+            if isinstance(fallback_name, str) and fallback_name.strip()
+            else None
+        )
+    else:
+        original_filename = original_filename.strip()
+
+    size_bytes = _coerce_int_or_none(attrs.get("size_bytes"))
+    content_type = attrs.get("content_type")
+    content_type = (
+        content_type.strip()
+        if isinstance(content_type, str) and content_type.strip()
+        else None
+    )
+
+    preview_parts: list[str] = []
+    if original_filename:
+        preview_parts.append(original_filename)
+    if isinstance(size_bytes, int):
+        preview_parts.append(f"{size_bytes} bytes")
+    if content_type:
+        preview_parts.append(content_type)
+    preview = " | ".join(preview_parts)
+
+    return {
+        "collection": collection,
+        "session_id": concept_id,
+        "concept_id": concept_id,
+        "name": original_filename,
+        "content_type": content_type,
+        "size_bytes": size_bytes,
+        "blob": {
+            "backend": attrs.get("blob_backend"),
+            "key": attrs.get("blob_key"),
+            "uri": attrs.get("blob_uri"),
+        },
+        "instance_types": instance_types,
+        "updated_at": doc.get("updated_at"),
+        "created_at": doc.get("created_at"),
+        "namespace": namespace,
+        "preview": preview[:4000],
+        "preview_length": len(preview),
+        "item_kind": "file_copy_concept",
+        "source_system": "mongo.concepts",
+        "namespace_source": namespace_source,
+    }
+
+
 def _rag_list_indexed(**kwargs):
     from ...db.connection_manager import get_db
 
@@ -9146,6 +9323,72 @@ def _rag_list_indexed(**kwargs):
             payload=payload,
             item_kind="rag_chat_session_list",
             source_system="mongo.chat_history",
+        )
+
+    if collection == "file_copy_concepts":
+        coll = db["concepts"]
+        file_copy_query, query_error = _build_rag_file_copy_visibility_query(
+            ns_report=ns_report
+        )
+        if file_copy_query is None:
+            return {
+                "error": str(query_error or "namespace_user_required"),
+                "message": (
+                    "File-copy retrieval requires namespace-derived user or organisation context."
+                ),
+                "collection": collection,
+                **collection_report,
+                "effective_namespace": ns,
+                "effective_namespace_source": ns_report.get("namespace_source"),
+                **ns_report,
+                "success": False,
+            }
+        assert file_copy_query is not None
+
+        cursor = (
+            coll.find(
+                file_copy_query,
+                {
+                    "concept_id": 1,
+                    "name": 1,
+                    "attributes": 1,
+                    "relationships.is_an_instance_of": 1,
+                    "created_at": 1,
+                    "updated_at": 1,
+                },
+            )
+            .skip(offset)
+            .limit(limit)
+        )
+        items: list[dict[str, Any]] = []
+        for doc in cursor:
+            if not isinstance(doc, dict):
+                continue
+            items.append(
+                _build_rag_file_copy_item(
+                    collection=collection,
+                    doc=doc,
+                    namespace=ns,
+                    namespace_source=ns_report.get("namespace_source"),
+                )
+            )
+
+        payload = {
+            "collection": collection,
+            **collection_report,
+            "items": items,
+            "total": coll.count_documents(file_copy_query),
+            "limit": limit,
+            "offset": offset,
+            "effective_namespace": ns,
+            "effective_namespace_source": ns_report.get("namespace_source"),
+            **ns_report,
+            "success": True,
+        }
+        return _with_rag_provenance(
+            payload=payload,
+            item_kind="rag_file_copy_list",
+            source_system="mongo.concepts",
         )
 
     if collection == "turn_execution_records":
@@ -9600,6 +9843,67 @@ def _rag_get_item(**kwargs):
             payload=payload,
             item_kind="rag_chat_session_item",
             source_system="mongo.chat_history",
+        )
+
+    if collection == "file_copy_concepts":
+        coll = db["concepts"]
+        file_copy_query, query_error = _build_rag_file_copy_visibility_query(
+            ns_report=ns_report,
+            extra_filters=[{"concept_id": str(session_id).strip()}],
+        )
+        if file_copy_query is None:
+            return {
+                "error": str(query_error or "namespace_user_required"),
+                "message": (
+                    "File-copy retrieval requires namespace-derived user or organisation context."
+                ),
+                "collection": collection,
+                **collection_report,
+                "effective_namespace": ns,
+                "effective_namespace_source": ns_report.get("namespace_source"),
+                **ns_report,
+                "success": False,
+            }
+        assert file_copy_query is not None
+
+        doc = coll.find_one(
+            file_copy_query,
+            {
+                "concept_id": 1,
+                "name": 1,
+                "attributes": 1,
+                "relationships.is_an_instance_of": 1,
+                "created_at": 1,
+                "updated_at": 1,
+            },
+        )
+        if not isinstance(doc, dict):
+            return make_error_response(
+                "not_found",
+                f"File-copy concept {session_id} not found",
+                details={"session_id": session_id, "namespace": ns},
+                suggestions=["Check the concept_id and namespace"],
+            )
+
+        item = _build_rag_file_copy_item(
+            collection=collection,
+            doc=doc,
+            namespace=ns,
+            namespace_source=ns_report.get("namespace_source"),
+        )
+        payload = {
+            "collection": collection,
+            **collection_report,
+            **item,
+            "effective_namespace": ns,
+            "effective_namespace_source": ns_report.get("namespace_source"),
+            **ns_report,
+            "success": True,
+        }
+        return _with_rag_provenance(
+            payload=payload,
+            item_kind="rag_file_copy_item",
+            source_system="mongo.concepts",
         )
 
     if collection == "turn_execution_records":
@@ -14972,7 +15276,8 @@ def build_default_catalogue() -> MethodCatalogue:
             category="read",
             description=(
                 "List available RAG collections/sources for the current user/namespace. "
-                "Use when user asks 'what is in my RAG store?' or needs to disambiguate KA sessions vs chat sessions vs vector chunks."
+                "Use when user asks 'what is in my RAG store?' or needs to disambiguate KA sessions, "
+                "chat sessions, blob-store file copies, and vector chunks."
             ),
         ),
         MethodDefinition(
@@ -14987,11 +15292,11 @@ def build_default_catalogue() -> MethodCatalogue:
                     "namespace": (str, type(None)),
                 },
                 allow_unknown=True,
-                description="List indexed sessions with optional namespace filter",
+                description="List namespace-scoped RAG collections (sessions, text relations, file copies)",
             ),
             output_schema=None,
             category="read",
-            description="List all RAG-indexed interaction sessions (KA sessions) for the current user. Returns total count and session metadata. Use this to answer 'how many KA sessions are indexed'. Namespace filtered automatically.",
+            description="List namespace-scoped RAG items for the selected collection (KA sessions, chat sessions, file-copy concepts, turn execution records, text relations).",
         ),
         MethodDefinition(
             name="rag_get_item",
@@ -15003,11 +15308,11 @@ def build_default_catalogue() -> MethodCatalogue:
                     "collection": (str, type(None)),
                 },
                 allow_unknown=True,
-                description="Fetch one indexed session with optional namespace filter",
+                description="Fetch one namespace-scoped RAG item with optional collection selector",
             ),
             output_schema=None,
             category="read",
-            description="Get one indexed item (session) with a safe text preview. Respects namespace isolation.",
+            description="Get one namespace-scoped RAG item (session/relation/file copy/turn record) with a safe preview. Respects namespace isolation.",
         ),
         MethodDefinition(
             name="turn_execution_list",

--- a/tests/backend/test_internal_mcp_rag_file_copy_gateway.py
+++ b/tests/backend/test_internal_mcp_rag_file_copy_gateway.py
@@ -1,0 +1,158 @@
+"""Gateway-level tests for file-copy RAG read tools."""
+
+from __future__ import annotations
+
+from src.backend.integrations.internal_mcp import build_default_catalogue
+from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
+from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+
+
+_MISSING = object()
+
+
+def _get_nested_value(doc: dict, path: str):
+    value = doc
+    for part in path.split("."):
+        if not isinstance(value, dict) or part not in value:
+            return _MISSING
+        value = value[part]
+    return value
+
+
+def _matches_query(doc: dict, query: dict) -> bool:
+    for key, condition in query.items():
+        if key == "$and":
+            if not all(_matches_query(doc, clause) for clause in condition):
+                return False
+            continue
+        if key == "$or":
+            if not any(_matches_query(doc, clause) for clause in condition):
+                return False
+            continue
+
+        value = _get_nested_value(doc, key)
+        if isinstance(condition, dict):
+            for operator, expected in condition.items():
+                if operator == "$exists":
+                    if bool(expected) != (value is not _MISSING):
+                        return False
+                elif operator == "$in":
+                    if value is _MISSING:
+                        return False
+                    if isinstance(value, list):
+                        if not any(item in expected for item in value):
+                            return False
+                    elif value not in expected:
+                        return False
+                elif operator == "$nin":
+                    if value is _MISSING:
+                        continue
+                    if isinstance(value, list):
+                        if any(item in expected for item in value):
+                            return False
+                    elif value in expected:
+                        return False
+                else:
+                    return False
+            continue
+        if value is _MISSING or value != condition:
+            return False
+    return True
+
+
+class _Cursor:
+    def __init__(self, docs):
+        self._docs = list(docs)
+
+    def skip(self, n):
+        self._docs = self._docs[int(n) :]
+        return self
+
+    def limit(self, n):
+        self._docs = self._docs[: int(n)]
+        return self
+
+    def __iter__(self):
+        return iter(self._docs)
+
+
+class _ConceptCollection:
+    def __init__(self, docs):
+        self._docs = list(docs)
+
+    def find(self, query, _projection=None):
+        return _Cursor([doc for doc in self._docs if _matches_query(doc, query)])
+
+    def find_one(self, query, _projection=None):
+        for doc in self._docs:
+            if _matches_query(doc, query):
+                return doc
+        return None
+
+    def count_documents(self, query):
+        return sum(1 for doc in self._docs if _matches_query(doc, query))
+
+
+class _DB:
+    def __init__(self, collections):
+        self._collections = dict(collections)
+
+    def __getitem__(self, key):
+        return self._collections[key]
+
+
+def _build_gateway() -> InternalMCPGateway:
+    return InternalMCPGateway(
+        catalogue=build_default_catalogue(),
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+
+
+def test_rag_file_copy_collection_gateway_reads(monkeypatch):
+    gateway = _build_gateway()
+    docs = [
+        {
+            "concept_id": "#V#uploaded_file_copy_gateway",
+            "name": "gateway.txt",
+            "attributes": {
+                "blob_key": "uploads/user/hash/gateway.txt",
+                "blob_backend": "swift",
+                "blob_uri": "swift://bucket/uploads/user/hash/gateway.txt",
+                "content_type": "text/plain",
+                "size_bytes": 12,
+            },
+            "relationships": {"specific_to_user": ["#V#user"]},
+            "updated_at": "2026-01-01T00:00:00Z",
+        }
+    ]
+    concepts = _ConceptCollection(docs)
+
+    monkeypatch.setattr(
+        "src.backend.db.connection_manager.get_db",
+        lambda: _DB({"concepts": concepts}),
+    )
+
+    listed = gateway.invoke(
+        "rag_list_indexed",
+        {
+            "namespace": "#V#user@org",
+            "collection": "file_copy_concepts",
+            "limit": 10,
+            "offset": 0,
+        },
+    ).payload
+    assert listed.get("success") is True
+    assert listed.get("collection") == "file_copy_concepts"
+    assert listed.get("total") == 1
+
+    got = gateway.invoke(
+        "rag_get_item",
+        {
+            "namespace": "#V#user@org",
+            "collection": "file_copy_concepts",
+            "session_id": "#V#uploaded_file_copy_gateway",
+        },
+    ).payload
+    assert got.get("success") is True
+    assert got.get("concept_id") == "#V#uploaded_file_copy_gateway"

--- a/tests/backend/test_rag_file_copy_mcp_read_tools.py
+++ b/tests/backend/test_rag_file_copy_mcp_read_tools.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+
+_MISSING = object()
+
+
+def _get_nested_value(doc: dict, path: str):
+    value = doc
+    for part in path.split("."):
+        if not isinstance(value, dict) or part not in value:
+            return _MISSING
+        value = value[part]
+    return value
+
+
+def _matches_operator(value, operator: str, expected) -> bool:
+    if operator == "$exists":
+        return bool(expected) == (value is not _MISSING)
+    if operator == "$in":
+        if value is _MISSING:
+            return False
+        if isinstance(value, list):
+            return any(item in expected for item in value)
+        return value in expected
+    if operator == "$nin":
+        if value is _MISSING:
+            return True
+        if isinstance(value, list):
+            return all(item not in expected for item in value)
+        return value not in expected
+    return False
+
+
+def _matches_query(doc: dict, query: dict) -> bool:
+    for key, condition in query.items():
+        if key == "$and":
+            if not all(_matches_query(doc, clause) for clause in condition):
+                return False
+            continue
+        if key == "$or":
+            if not any(_matches_query(doc, clause) for clause in condition):
+                return False
+            continue
+
+        value = _get_nested_value(doc, key)
+        if isinstance(condition, dict):
+            if not all(
+                _matches_operator(value, operator, expected)
+                for operator, expected in condition.items()
+            ):
+                return False
+            continue
+        if value is _MISSING or value != condition:
+            return False
+    return True
+
+
+class _Cursor:
+    def __init__(self, docs):
+        self._docs = list(docs)
+
+    def skip(self, n):
+        self._docs = self._docs[int(n) :]
+        return self
+
+    def limit(self, n):
+        self._docs = self._docs[: int(n)]
+        return self
+
+    def __iter__(self):
+        return iter(self._docs)
+
+
+class _ConceptCollection:
+    def __init__(self, docs):
+        self._docs = list(docs)
+        self.last_find_query = None
+        self.last_find_one_query = None
+
+    def find(self, query, _projection=None):
+        self.last_find_query = dict(query)
+        return _Cursor([doc for doc in self._docs if _matches_query(doc, query)])
+
+    def find_one(self, query, _projection=None):
+        self.last_find_one_query = dict(query)
+        for doc in self._docs:
+            if _matches_query(doc, query):
+                return doc
+        return None
+
+    def count_documents(self, query):
+        return sum(1 for doc in self._docs if _matches_query(doc, query))
+
+
+class _DB:
+    def __init__(self, collections):
+        self._collections = dict(collections)
+
+    def __getitem__(self, key):
+        return self._collections[key]
+
+
+def test_rag_list_indexed_supports_file_copy_concepts(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    docs = [
+        {
+            "concept_id": "#V#uploaded_file_copy_visible",
+            "name": "notes.txt",
+            "attributes": {
+                "blob_key": "uploads/user/hash/notes.txt",
+                "blob_backend": "swift",
+                "blob_uri": "swift://bucket/uploads/user/hash/notes.txt",
+                "content_type": "text/plain",
+                "size_bytes": 42,
+            },
+            "relationships": {"specific_to_user": ["#V#user"]},
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T01:00:00Z",
+        },
+        {
+            "concept_id": "#V#uploaded_file_copy_hidden",
+            "name": "secret.txt",
+            "attributes": {
+                "blob_key": "uploads/other/hash/secret.txt",
+                "blob_backend": "swift",
+            },
+            "relationships": {"specific_to_user": ["#V#other_user"]},
+        },
+        {
+            "concept_id": "#V#uploaded_file_copy_missing_blob",
+            "name": "broken.txt",
+            "attributes": {},
+            "relationships": {"specific_to_user": ["#V#user"]},
+        },
+    ]
+    concepts = _ConceptCollection(docs)
+
+    monkeypatch.setattr(
+        "src.backend.db.connection_manager.get_db",
+        lambda: _DB({"concepts": concepts}),
+    )
+
+    result = cat._rag_list_indexed(
+        namespace="#V#user@org",
+        collection="blob_store_files",
+        limit=10,
+        offset=0,
+    )
+
+    assert result["success"] is True
+    assert result["collection"] == "file_copy_concepts"
+    assert result["requested_collection"] == "blob_store_files"
+    assert result["effective_collection"] == "file_copy_concepts"
+    assert result["provenance"]["item_kind"] == "rag_file_copy_list"
+    assert result["provenance"]["source_system"] == "mongo.concepts"
+    assert result["total"] == 1
+    assert len(result["items"]) == 1
+    item = result["items"][0]
+    assert item["concept_id"] == "#V#uploaded_file_copy_visible"
+    assert item["item_kind"] == "file_copy_concept"
+    assert item["blob"]["key"] == "uploads/user/hash/notes.txt"
+
+
+def test_rag_get_item_supports_file_copy_concepts(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    docs = [
+        {
+            "concept_id": "#V#uploaded_file_copy_visible",
+            "name": "paper.pdf",
+            "attributes": {
+                "blob_key": "uploads/user/hash/paper.pdf",
+                "blob_backend": "swift",
+                "blob_uri": "swift://bucket/uploads/user/hash/paper.pdf",
+                "content_type": "application/pdf",
+                "size_bytes": 5120,
+            },
+            "relationships": {"specific_to_user": ["#V#user"]},
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T02:00:00Z",
+        }
+    ]
+    concepts = _ConceptCollection(docs)
+
+    monkeypatch.setattr(
+        "src.backend.db.connection_manager.get_db",
+        lambda: _DB({"concepts": concepts}),
+    )
+
+    result = cat._rag_get_item(
+        namespace="#V#user@org",
+        collection="file_copy_concepts",
+        session_id="#V#uploaded_file_copy_visible",
+    )
+
+    assert result["success"] is True
+    assert result["collection"] == "file_copy_concepts"
+    assert result["provenance"]["item_kind"] == "rag_file_copy_item"
+    assert result["concept_id"] == "#V#uploaded_file_copy_visible"
+    assert result["blob"]["backend"] == "swift"
+    assert "paper.pdf" in result["preview"]
+
+
+def test_rag_get_item_file_copy_respects_visibility_scope(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    docs = [
+        {
+            "concept_id": "#V#uploaded_file_copy_hidden",
+            "name": "private.pdf",
+            "attributes": {
+                "blob_key": "uploads/other/hash/private.pdf",
+                "content_type": "application/pdf",
+            },
+            "relationships": {"specific_to_user": ["#V#other_user"]},
+        }
+    ]
+    concepts = _ConceptCollection(docs)
+
+    monkeypatch.setattr(
+        "src.backend.db.connection_manager.get_db",
+        lambda: _DB({"concepts": concepts}),
+    )
+
+    result = cat._rag_get_item(
+        namespace="#V#user@org",
+        collection="file_copy_concepts",
+        session_id="#V#uploaded_file_copy_hidden",
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "not_found"

--- a/tests/backend/test_rag_provenance_contract.py
+++ b/tests/backend/test_rag_provenance_contract.py
@@ -203,6 +203,7 @@ def test_rag_list_collections_includes_expected_collections():
     collections = {c["collection"] for c in result["collections"]}
     assert "ka_sessions" in collections
     assert "chat_history_sessions" in collections
+    assert "file_copy_concepts" in collections
     assert "turn_execution_records" in collections
     assert "rag_documents" in collections
     assert "vontology_text_relations" in collections
@@ -211,6 +212,8 @@ def test_rag_list_collections_includes_expected_collections():
     by_name = {c["collection"]: c for c in result["collections"]}
     assert by_name["ka_sessions"]["list_supported"] is True
     assert by_name["ka_sessions"]["get_supported"] is True
+    assert by_name["file_copy_concepts"]["list_supported"] is True
+    assert by_name["file_copy_concepts"]["get_supported"] is True
     assert by_name["turn_execution_records"]["list_supported"] is True
     assert by_name["turn_execution_records"]["get_supported"] is True
     assert by_name["rag_documents"]["list_supported"] is False


### PR DESCRIPTION
## Summary
- add `file_copy_concepts` as a first-class RAG collection in internal MCP discovery
- extend `rag_list_indexed` and `rag_get_item` to list/get namespace-scoped blob-store file-copy concepts
- add collection aliases (`blob_store_files`, `uploaded_files`, etc.) and richer tool descriptions
- add direct and gateway-level tests for the new collection path

## Validation
- `pdm run pytest tests/backend/test_rag_provenance_contract.py tests/backend/test_rag_file_copy_mcp_read_tools.py tests/backend/test_internal_mcp_rag_file_copy_gateway.py`
- `pdm run pyright src/backend/integrations/internal_mcp/catalogue.py tests/backend/test_rag_provenance_contract.py tests/backend/test_internal_mcp_rag_file_copy_gateway.py tests/backend/test_rag_file_copy_mcp_read_tools.py`
