### PR TITLE
JVNAUTOSCI-879: complete blob artefact metadata, import, and indexing flow

### DIFF
--- a/docs/engineering/blob_store_artefact_source_strategy.md
+++ b/docs/engineering/blob_store_artefact_source_strategy.md
@@ -1,0 +1,43 @@
+# Blob Store Artefact Source Strategy
+
+## Purpose
+
+Define a single approach for onboarding artefacts into Von's durable blob layer and
+for indexing/retrieval workflows that consume those artefacts.
+
+This document covers `JVNAUTOSCI-883` follow-on scope from `JVNAUTOSCI-879`.
+
+## Decisions
+
+1. Blob store is authoritative for durable artefact bytes.
+2. A canonical artefact record is carried as `artifact_record` metadata (concept ID,
+   blob reference, content type, size, and provenance timestamps/source fields).
+3. Retrieval/indexing paths should operate on blob references, not stable local paths.
+4. Filesystem import is supported as a first-class path via `import_local_file_copy`.
+5. Google Drive/Docs ingestion remains optional and is deferred until auth/session
+   lifecycle and export-format policy are fully stabilised.
+
+## Filesystem Import Path
+
+`import_local_file_copy` performs:
+
+1. Workspace-root bounded local file read.
+2. Durable upload to configured blob backend (local or Swift).
+3. Registration of a `#V#computer_file_copy` concept with blob metadata.
+4. Emission of canonical `artifact_record` metadata for downstream indexing/retrieval.
+
+This provides a stable way to ingest pre-existing local files without relying on
+ephemeral cache paths.
+
+## Google Drive/Docs Strategy
+
+Google Drive/Docs ingestion is intentionally staged:
+
+1. Reuse existing Google auth/integration primitives.
+2. Export bytes to normalised durable artefacts in blob store.
+3. Emit the same `artifact_record` shape used by filesystem/arXiv paths.
+4. Route retrieval and indexing through the same blob-backed pathways.
+
+Until this is implemented, filesystem import plus existing upload/arXiv flows remain
+the supported production path for durable artefact onboarding.
+

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -3039,6 +3039,258 @@ def _read_file_copy(**kwargs):
     return _run_read()
 
 
+def _index_file_copy(**kwargs):
+    from ...services.rag_service import RAGBackendUnavailable, get_rag_service
+
+    concept_id = kwargs.get("concept_id") or kwargs.get("file_copy_concept_id")
+    if not isinstance(concept_id, str) or not concept_id.strip():
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameter: concept_id",
+            details={"missing": ["concept_id"]},
+            suggestions=["Provide the concept ID of a #V#computer_file_copy instance"],
+        )
+    concept_id = concept_id.strip()
+
+    ns_report = _resolve_rag_namespace_from_kwargs(kwargs)
+    ns_error = _rag_namespace_resolution_error(ns_report)
+    if ns_error is not None:
+        return ns_error
+    ns = ns_report.get("namespace")
+    if not isinstance(ns, str) or not ns.strip():
+        return make_error_response(
+            "namespace_required",
+            "File-copy indexing requires authenticated user context (namespace)",
+            details={"namespace_report": ns_report},
+        )
+    ns = ns.strip()
+
+    max_bytes = kwargs.get("max_bytes")
+    if max_bytes is None:
+        max_bytes = 10_000_000
+    allow_large = bool(kwargs.get("allow_large", False))
+
+    read_payload = _read_file_copy(
+        concept_id=concept_id,
+        max_bytes=max_bytes,
+        allow_large=allow_large,
+        as_text=True,
+        namespace=ns,
+    )
+    if not isinstance(read_payload, dict):
+        return make_error_response(
+            "read_file_copy_failed",
+            "Unexpected read_file_copy response shape",
+            details={"response_type": type(read_payload).__name__},
+        )
+    if read_payload.get("success") is not True:
+        return {
+            "success": False,
+            "error": read_payload.get("error") or read_payload.get("error_code"),
+            "message": read_payload.get("message")
+            or "Failed to read file-copy bytes for indexing",
+            "concept_id": concept_id,
+            "namespace": ns,
+            **ns_report,
+            "read_result": read_payload,
+        }
+
+    text_payload = read_payload.get("text")
+    text = text_payload if isinstance(text_payload, str) else ""
+    if not text.strip():
+        return {
+            "success": False,
+            "error": "unsupported_or_empty_content",
+            "message": (
+                "File-copy content could not be extracted into indexable text."
+            ),
+            "concept_id": concept_id,
+            "namespace": ns,
+            **ns_report,
+            "read_result": read_payload,
+        }
+
+    try:
+        from ...services.computer_file_copy_service import build_file_copy_artifact_record
+
+        artifact_record = build_file_copy_artifact_record(file_copy_concept_id=concept_id)
+    except Exception:
+        artifact_record = None
+
+    doc_id_raw = kwargs.get("document_id")
+    if isinstance(doc_id_raw, str) and doc_id_raw.strip():
+        doc_id = doc_id_raw.strip()
+    else:
+        doc_id = f"file_copy:{concept_id}"
+
+    metadata: dict[str, Any] = {
+        "source": "file_copy_blob",
+        "concept_id": concept_id,
+        "namespace": ns,
+        "namespace_source": ns_report.get("namespace_source"),
+        "content_type": read_payload.get("content_type"),
+        "original_filename": read_payload.get("original_filename"),
+        "size_bytes": read_payload.get("size_bytes"),
+        "blob": read_payload.get("blob"),
+    }
+    if isinstance(artifact_record, dict):
+        metadata["artifact_record"] = artifact_record
+        provenance = artifact_record.get("provenance")
+        if isinstance(provenance, dict):
+            metadata["artifact_provenance"] = provenance
+
+    doc = {
+        "id": doc_id,
+        "text": text,
+        "metadata": metadata,
+    }
+
+    try:
+        rag = get_rag_service()
+    except RAGBackendUnavailable as exc:
+        return make_error_response(
+            "rag_backend_unavailable",
+            f"RAG backend unavailable: {exc}",
+            details={"exception_type": "RAGBackendUnavailable"},
+        )
+
+    try:
+        indexed_count, failed_count = rag.upsert_documents([doc], namespace=ns)
+    except Exception as exc:
+        return make_error_response(
+            "rag_upsert_failed",
+            f"RAG upsert failed: {exc}",
+            details={
+                "exception_type": type(exc).__name__,
+                "concept_id": concept_id,
+                "document_id": doc_id,
+                "namespace": ns,
+            },
+            suggestions=[
+                "Verify RAG backend configuration and embedding model availability",
+                "Retry with a smaller max_bytes if the file is very large",
+            ],
+        )
+
+    payload = {
+        "success": indexed_count > 0 and failed_count == 0,
+        "concept_id": concept_id,
+        "document_id": doc_id,
+        "indexed_count": int(indexed_count or 0),
+        "failed_count": int(failed_count or 0),
+        "namespace": ns,
+        **ns_report,
+        "text_length": len(text),
+        "content_type": read_payload.get("content_type"),
+        "original_filename": read_payload.get("original_filename"),
+    }
+    if isinstance(artifact_record, dict):
+        payload["artifact_record"] = artifact_record
+    return payload
+
+
+def _import_local_file_copy(**kwargs):
+    from pathlib import Path
+    from ...security.access_control import (
+        get_effective_user_concept_id,
+        override_current_organisation,
+        override_current_user,
+    )
+    from ...services.computer_file_copy_service import import_local_file_copy
+
+    local_path = kwargs.get("local_path")
+    if not isinstance(local_path, str) or not local_path.strip():
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameter: local_path",
+            details={"missing": ["local_path"]},
+            suggestions=[
+                "Provide a local filesystem path within the current workspace"
+            ],
+        )
+    local_path = local_path.strip()
+
+    ns_report = _resolve_rag_namespace_from_kwargs(kwargs)
+    ns_error = _rag_namespace_resolution_error(ns_report)
+    if ns_error is not None:
+        return ns_error
+    ns = ns_report.get("namespace")
+    if not isinstance(ns, str) or not ns.strip():
+        return make_error_response(
+            "namespace_required",
+            "Local file import requires authenticated user context (namespace)",
+            details={"namespace_report": ns_report},
+        )
+    ns = ns.strip()
+
+    type_concept_id_raw = kwargs.get("type_concept_id")
+    type_concept_id = (
+        type_concept_id_raw.strip()
+        if isinstance(type_concept_id_raw, str) and type_concept_id_raw.strip()
+        else "#V#computer_file_copy"
+    )
+    source_system_raw = kwargs.get("source_system")
+    source_system = (
+        source_system_raw.strip()
+        if isinstance(source_system_raw, str) and source_system_raw.strip()
+        else "filesystem_import"
+    )
+    source_identifier = kwargs.get("source_identifier")
+    source_uri = kwargs.get("source_uri")
+    source_identifier = (
+        source_identifier.strip()
+        if isinstance(source_identifier, str) and source_identifier.strip()
+        else None
+    )
+    source_uri = (
+        source_uri.strip()
+        if isinstance(source_uri, str) and source_uri.strip()
+        else None
+    )
+
+    workspace_root = Path(__file__).resolve().parents[4]
+    user_part: str | None = None
+    org_part: str | None = None
+    if "@" in ns:
+        user_raw, org_raw = ns.split("@", 1)
+        user_part = user_raw.strip() or None
+        org_part = org_raw.strip() or None
+        if org_part and not org_part.startswith("#V#"):
+            org_part = f"#V#{org_part}"
+    else:
+        user_part = ns
+
+    def _run_import():
+        user_concept_id = get_effective_user_concept_id()
+        if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+            return make_error_response(
+                "authentication_required",
+                "User authentication required to import local files",
+                suggestions=["Ensure user context is set before calling this tool"],
+            )
+
+        result = import_local_file_copy(
+            local_path=local_path,
+            user_concept_id=user_concept_id.strip(),
+            type_concept_id=type_concept_id,
+            allowed_root=workspace_root,
+            source_system=source_system,
+            source_identifier=source_identifier,
+            source_uri=source_uri,
+        )
+        if isinstance(result, dict):
+            result = dict(result)
+            result.setdefault("namespace", ns)
+            result.update(ns_report)
+            result["allowed_root"] = str(workspace_root)
+        return result
+
+    if user_part or org_part:
+        with override_current_user(user_part), override_current_organisation(org_part):
+            return _run_import()
+    return _run_import()
+
+
 def _get_predicate_extent(**kwargs):
     from ...server.routes.predicate_routes import get_predicate_extent_data
 
@@ -4653,6 +4905,96 @@ def _read_file_copy_output_schema() -> Schema:
             "text (str, when as_text=true) or bytes_base64 (str, when as_text=false), "
             "encoding (str, when as_text=true), text_extraction (str, optional), "
             "or error (str) if failed."
+        ),
+    )
+
+
+def _index_file_copy_input_schema() -> Schema:
+    return Schema(
+        required={
+            "concept_id": str,
+        },
+        optional={
+            "namespace": (str, type(None)),
+            "document_id": (str, type(None)),
+            "max_bytes": (int, type(None)),
+            "allow_large": (bool, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "index_file_copy input: concept_id (str for a #V#computer_file_copy instance), "
+            "namespace (required user@org context), optional document_id override, optional "
+            "max_bytes and allow_large controls forwarded to read_file_copy."
+        ),
+    )
+
+
+def _index_file_copy_output_schema() -> Schema:
+    return Schema(
+        required={},
+        optional={
+            "success": (bool, type(None)),
+            "error": (str, type(None)),
+            "message": (str, type(None)),
+            "concept_id": (str, type(None)),
+            "document_id": (str, type(None)),
+            "indexed_count": (int, type(None)),
+            "failed_count": (int, type(None)),
+            "namespace": (str, type(None)),
+            "text_length": (int, type(None)),
+            "content_type": (str, type(None)),
+            "original_filename": (str, type(None)),
+            "artifact_record": (dict, type(None)),
+            "read_result": (dict, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "index_file_copy output: success flag plus indexing counts/document_id for a "
+            "blob-backed file-copy ingestion into RAG."
+        ),
+    )
+
+
+def _import_local_file_copy_input_schema() -> Schema:
+    return Schema(
+        required={
+            "local_path": str,
+        },
+        optional={
+            "namespace": (str, type(None)),
+            "type_concept_id": (str, type(None)),
+            "source_system": (str, type(None)),
+            "source_identifier": (str, type(None)),
+            "source_uri": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "import_local_file_copy input: local_path (workspace file path) plus namespace "
+            "user@org context; optional file-copy type and provenance source fields."
+        ),
+    )
+
+
+def _import_local_file_copy_output_schema() -> Schema:
+    return Schema(
+        required={},
+        optional={
+            "success": (bool, type(None)),
+            "error": (str, type(None)),
+            "message": (str, type(None)),
+            "concept_id": (str, type(None)),
+            "type_concept_id": (str, type(None)),
+            "uploaded_at": (str, type(None)),
+            "local_path": (str, type(None)),
+            "storage": (dict, type(None)),
+            "artifact_record": (dict, type(None)),
+            "namespace": (str, type(None)),
+            "allowed_root": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "import_local_file_copy output: blob-store registration result with created "
+            "#V#computer_file_copy concept and canonical artifact_record."
         ),
     )
 
@@ -9134,6 +9476,17 @@ def _build_rag_file_copy_item(
         preview_parts.append(content_type)
     preview = " | ".join(preview_parts)
 
+    artifact_record: dict[str, Any] | None = None
+    try:
+        from ...services.computer_file_copy_service import build_file_copy_artifact_record
+
+        artifact_record = build_file_copy_artifact_record(
+            file_copy_concept_id=concept_id,
+            concept_doc=doc,
+        )
+    except Exception:
+        artifact_record = None
+
     return {
         "collection": collection,
         "session_id": concept_id,
@@ -9152,6 +9505,7 @@ def _build_rag_file_copy_item(
         "namespace": namespace,
         "preview": preview[:4000],
         "preview_length": len(preview),
+        "artifact_record": artifact_record,
         "item_kind": "file_copy_concept",
         "source_system": "mongo.concepts",
         "namespace_source": namespace_source,
@@ -14808,6 +15162,30 @@ def build_default_catalogue() -> MethodCatalogue:
                 "Use when the user asks to read, summarise, analyse, or extract information from "
                 "a file they uploaded or an artefact stored as a #V#computer_file_copy. "
                 "Requires authenticated user context and the file-copy concept_id."
+            ),
+        ),
+        MethodDefinition(
+            name="index_file_copy",
+            handler=_index_file_copy,
+            input_schema=_index_file_copy_input_schema(),
+            output_schema=_index_file_copy_output_schema(),
+            category="write",
+            timeout_sec=30.0,
+            description=(
+                "Read a blob-backed #V#computer_file_copy and index its extracted text into RAG "
+                "for the effective namespace. Supports PDFs and other file types handled by read_file_copy."
+            ),
+        ),
+        MethodDefinition(
+            name="import_local_file_copy",
+            handler=_import_local_file_copy,
+            input_schema=_import_local_file_copy_input_schema(),
+            output_schema=_import_local_file_copy_output_schema(),
+            category="write",
+            timeout_sec=30.0,
+            description=(
+                "Import a local workspace file into the configured blob store and register a "
+                "#V#computer_file_copy concept with canonical provenance metadata."
             ),
         ),
         # LinkedIn Data Dump MCP tools (local external server)

--- a/src/backend/integrations/internal_mcp/tool_contract_registry.py
+++ b/src/backend/integrations/internal_mcp/tool_contract_registry.py
@@ -285,8 +285,11 @@ def _infer_tool_family(tool_name: str) -> str:
         "list_papers",
         "read_paper",
         "read_file_copy",
+        "import_local_file_copy",
     }:
         return "arxiv"
+    if tool_name in {"index_file_copy"}:
+        return "rag"
     if tool_name.startswith("linkedin_"):
         return "linkedin"
     if tool_name.startswith("task_") or tool_name in {

--- a/src/backend/services/computer_file_copy_service.py
+++ b/src/backend/services/computer_file_copy_service.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import hashlib
+import mimetypes
+import re
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Mapping
 
 
@@ -433,4 +437,273 @@ def fetch_file_copy_bytes(
         "success": True,
         "info": info,
         "data": bytes(data_bytes),
+    }
+
+
+def _normalise_optional_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _normalise_type_concept_ids(relationships: Mapping[str, Any]) -> list[str]:
+    raw = relationships.get("is_an_instance_of")
+    if isinstance(raw, list):
+        return [str(v) for v in raw if isinstance(v, str) and v.strip()]
+    if isinstance(raw, str) and raw.strip():
+        return [raw.strip()]
+    return []
+
+
+def build_file_copy_artifact_record(
+    *,
+    file_copy_concept_id: str | None = None,
+    concept_doc: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Build a canonical artefact record for a blob-backed file-copy concept.
+
+    This record is the shared metadata shape used across retrieval and indexing
+    paths so callers can pass one stable reference instead of ad-hoc field sets.
+    """
+
+    concept_id: str | None = None
+    if isinstance(file_copy_concept_id, str) and file_copy_concept_id.strip():
+        concept_id = file_copy_concept_id.strip()
+    elif isinstance(concept_doc, Mapping):
+        raw_concept_id = concept_doc.get("concept_id")
+        if isinstance(raw_concept_id, str) and raw_concept_id.strip():
+            concept_id = raw_concept_id.strip()
+    if concept_id is None:
+        return None
+
+    doc: Mapping[str, Any] | None = concept_doc
+    if not isinstance(doc, Mapping):
+        try:
+            from ..db.repositories.concepts_repository import ConceptsRepository
+
+            resolved = ConceptsRepository.find_one(
+                {"concept_id": concept_id},
+                {
+                    "concept_id": 1,
+                    "name": 1,
+                    "attributes": 1,
+                    "relationships.is_an_instance_of": 1,
+                    "created_at": 1,
+                    "updated_at": 1,
+                },
+            )
+        except Exception:
+            resolved = None
+        if not isinstance(resolved, Mapping):
+            return None
+        doc = resolved
+
+    attributes_raw = doc.get("attributes")
+    attributes: Mapping[str, Any] = (
+        attributes_raw if isinstance(attributes_raw, Mapping) else {}
+    )
+    relationships_raw = doc.get("relationships")
+    relationships: Mapping[str, Any] = (
+        relationships_raw if isinstance(relationships_raw, Mapping) else {}
+    )
+
+    info = resolve_file_copy_blob_info(file_copy_concept_id=concept_id)
+    if info is None:
+        return None
+
+    original_filename = _normalise_optional_text(info.original_filename) or _normalise_optional_text(
+        doc.get("name")
+    )
+    source_system = (
+        _normalise_optional_text(attributes.get("source_system"))
+        or _normalise_optional_text(attributes.get("source"))
+    )
+    source_identifier = (
+        _normalise_optional_text(attributes.get("source_identifier"))
+        or _normalise_optional_text(attributes.get("original_identifier"))
+    )
+    source_uri = (
+        _normalise_optional_text(attributes.get("source_uri"))
+        or _normalise_optional_text(attributes.get("source_url"))
+    )
+    sha256 = _first_text_value(concept_id, "#V#has_sha256") or _normalise_optional_text(
+        attributes.get("sha256")
+    )
+    uploaded_at = _first_text_value(
+        concept_id, "#V#has_upload_timestamp"
+    ) or _normalise_optional_text(attributes.get("uploaded_at"))
+    ingested_at = _normalise_optional_text(attributes.get("ingested_at"))
+    created_at = _normalise_optional_text(doc.get("created_at"))
+    updated_at = _normalise_optional_text(doc.get("updated_at"))
+    type_concept_ids = _normalise_type_concept_ids(relationships)
+
+    return {
+        "artifact_id": concept_id,
+        "concept_id": concept_id,
+        "name": original_filename,
+        "content_type": _normalise_optional_text(info.content_type),
+        "size_bytes": info.size_bytes,
+        "sha256": sha256,
+        "blob": {
+            "backend": _normalise_optional_text(info.blob_backend),
+            "key": info.blob_key,
+            "uri": _normalise_optional_text(info.blob_uri),
+        },
+        "type_concept_ids": type_concept_ids,
+        "provenance": {
+            "source": source_system,
+            "source_identifier": source_identifier,
+            "source_uri": source_uri,
+            "uploaded_at": uploaded_at,
+            "ingested_at": ingested_at,
+            "created_at": created_at,
+            "updated_at": updated_at,
+        },
+    }
+
+
+def _slugify_concept_id_for_blob_key(concept_id: str) -> str:
+    cleaned = (concept_id or "").strip()
+    if cleaned.startswith("#V#"):
+        cleaned = cleaned[3:]
+    cleaned = cleaned.strip().lower()
+    cleaned = re.sub(r"[^a-z0-9]+", "_", cleaned).strip("_")
+    return cleaned or "unknown"
+
+
+def import_local_file_copy(
+    *,
+    local_path: str,
+    user_concept_id: str,
+    type_concept_id: str = "#V#computer_file_copy",
+    allowed_root: str | Path | None = None,
+    source_system: str = "filesystem_import",
+    source_identifier: str | None = None,
+    source_uri: str | None = None,
+) -> dict[str, Any]:
+    """Import a local file into blob storage and register a file-copy concept."""
+
+    if not isinstance(local_path, str) or not local_path.strip():
+        return {"success": False, "error": "missing_local_path"}
+    if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+        return {"success": False, "error": "missing_user_concept_id"}
+
+    path = Path(local_path.strip()).expanduser()
+    try:
+        resolved = path.resolve(strict=True)
+    except Exception:
+        return {"success": False, "error": "local_path_not_found", "local_path": local_path}
+    if not resolved.is_file():
+        return {"success": False, "error": "local_path_not_file", "local_path": str(resolved)}
+
+    if allowed_root is not None:
+        try:
+            root = Path(allowed_root).expanduser().resolve(strict=True)
+        except Exception:
+            return {"success": False, "error": "invalid_allowed_root"}
+        if resolved != root and root not in resolved.parents:
+            return {
+                "success": False,
+                "error": "path_outside_allowed_root",
+                "local_path": str(resolved),
+                "allowed_root": str(root),
+            }
+
+    try:
+        data = resolved.read_bytes()
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": "local_file_read_failed",
+            "message": str(exc),
+            "local_path": str(resolved),
+        }
+    if not data:
+        return {"success": False, "error": "empty_file", "local_path": str(resolved)}
+
+    sha256 = hashlib.sha256(data).hexdigest()
+    size_bytes = len(data)
+    original_filename = resolved.name
+    content_type, _encoding = mimetypes.guess_type(original_filename)
+    user_slug = _slugify_concept_id_for_blob_key(user_concept_id)
+    safe_filename = re.sub(r"[^A-Za-z0-9._-]+", "_", original_filename).strip("._")
+    safe_filename = safe_filename or "file.bin"
+    uploaded_at = _now_utc_iso()
+
+    try:
+        resolved_uri = resolved.as_uri()
+    except Exception:
+        resolved_uri = None
+
+    metadata: dict[str, Any] = {
+        "original_filename": original_filename,
+        "user_concept_id": user_concept_id.strip(),
+        "uploaded_at": uploaded_at,
+        "source_system": source_system,
+        "source_identifier": source_identifier or str(resolved),
+        "source_uri": source_uri or resolved_uri,
+        "ingested_at": uploaded_at,
+    }
+
+    blob_key = f"imports/{user_slug}/{sha256}/{safe_filename}"
+    try:
+        from .blob_uploads import BlobUploadError, put_bytes_durable
+
+        stored = put_bytes_durable(
+            key=blob_key,
+            data=data,
+            content_type=content_type,
+            metadata=metadata,
+            sha256=sha256,
+            size_bytes=size_bytes,
+        )
+    except BlobUploadError as exc:
+        return {
+            "success": False,
+            "error": "blob_store_upload_failed",
+            "message": str(exc),
+            "local_path": str(resolved),
+            "blob_key": blob_key,
+        }
+
+    try:
+        created = create_computer_file_copy_instance(
+            type_concept_id=type_concept_id,
+            user_concept_id=user_concept_id,
+            name=original_filename,
+            sha256=sha256,
+            size_bytes=size_bytes,
+            content_type=content_type,
+            blob_backend=stored.ref.backend,
+            blob_key=stored.ref.key,
+            blob_uri=stored.ref.uri,
+            metadata=metadata,
+        )
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": "file_copy_register_failed",
+            "message": str(exc),
+            "local_path": str(resolved),
+            "blob_key": blob_key,
+        }
+
+    artifact_record = build_file_copy_artifact_record(file_copy_concept_id=created.concept_id)
+
+    return {
+        "success": True,
+        "concept_id": created.concept_id,
+        "type_concept_id": created.type_concept_id,
+        "uploaded_at": created.uploaded_at,
+        "local_path": str(resolved),
+        "storage": {
+            "backend": stored.ref.backend,
+            "key": stored.ref.key,
+            "uri": stored.ref.uri,
+            "content_type": stored.ref.content_type,
+            "size_bytes": stored.ref.size_bytes,
+            "metadata": stored.ref.metadata,
+        },
+        "artifact_record": artifact_record,
     }

--- a/src/backend/services/tool_metadata_service.py
+++ b/src/backend/services/tool_metadata_service.py
@@ -383,6 +383,16 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
         "category": "vontology",
         "display_template": "Read: {filename}",
     },
+    "index_file_copy": {
+        "salience": "medium",
+        "category": "vontology",
+        "display_template": "Indexed file copy",
+    },
+    "import_local_file_copy": {
+        "salience": "medium",
+        "category": "vontology",
+        "display_template": "Imported local file",
+    },
     "generate_concept_description": {
         "salience": "medium",
         "category": "vontology",

--- a/tests/backend/test_computer_file_copy_artifact_ingestion.py
+++ b/tests/backend/test_computer_file_copy_artifact_ingestion.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+
+def test_build_file_copy_artifact_record_includes_provenance(monkeypatch):
+    from src.backend.services import computer_file_copy_service as svc
+
+    info = svc.FileCopyBlobInfo(
+        concept_id="#V#file_copy_test",
+        blob_key="uploads/user/hash/notes.txt",
+        blob_backend="swift",
+        blob_uri="swift://bucket/uploads/user/hash/notes.txt",
+        content_type="text/plain",
+        original_filename="notes.txt",
+        size_bytes=42,
+    )
+
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.resolve_file_copy_blob_info",
+        lambda **_kwargs: info,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service._first_text_value",
+        lambda concept_id, predicate: {
+            "#V#has_sha256": "deadbeef",
+            "#V#has_upload_timestamp": "2026-01-01T00:00:00+00:00",
+        }.get(predicate),
+    )
+
+    record = svc.build_file_copy_artifact_record(
+        concept_doc={
+            "concept_id": "#V#file_copy_test",
+            "name": "notes.txt",
+            "attributes": {
+                "source_system": "filesystem_import",
+                "source_identifier": "C:/repo/notes.txt",
+                "source_uri": "file:///C:/repo/notes.txt",
+                "ingested_at": "2026-01-01T00:00:01+00:00",
+            },
+            "relationships": {"is_an_instance_of": ["#V#computer_file_copy"]},
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-01T00:01:00+00:00",
+        }
+    )
+
+    assert record is not None
+    assert record["artifact_id"] == "#V#file_copy_test"
+    assert record["blob"]["key"] == "uploads/user/hash/notes.txt"
+    assert record["sha256"] == "deadbeef"
+    assert record["provenance"]["source"] == "filesystem_import"
+    assert record["provenance"]["source_uri"] == "file:///C:/repo/notes.txt"
+    assert record["provenance"]["uploaded_at"] == "2026-01-01T00:00:00+00:00"
+    assert record["type_concept_ids"] == ["#V#computer_file_copy"]
+
+
+def test_import_local_file_copy_registers_blob_and_concept(monkeypatch, tmp_path):
+    from src.backend.services import computer_file_copy_service as svc
+    from src.backend.services.blob_store import BlobRef
+    from src.backend.services.blob_uploads import StoredBytes
+
+    local_file = tmp_path / "notes.txt"
+    local_file.write_text("hello world", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "src.backend.services.blob_uploads.put_bytes_durable",
+        lambda **kwargs: StoredBytes(
+            ref=BlobRef(
+                backend="local",
+                key=str(kwargs["key"]),
+                uri=f"local://{kwargs['key']}",
+                content_type=kwargs.get("content_type"),
+                size_bytes=len(kwargs["data"]),
+                metadata=dict(kwargs.get("metadata") or {}),
+            ),
+            sha256="abc123",
+            size_bytes=len(kwargs["data"]),
+        ),
+    )
+
+    class _Record:
+        concept_id = "#V#imported_file_copy"
+        type_concept_id = "#V#computer_file_copy"
+        uploaded_at = "2026-01-01T00:00:00+00:00"
+
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.create_computer_file_copy_instance",
+        lambda **_kwargs: _Record(),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.build_file_copy_artifact_record",
+        lambda **_kwargs: {"artifact_id": "#V#imported_file_copy"},
+    )
+
+    result = svc.import_local_file_copy(
+        local_path=str(local_file),
+        user_concept_id="#V#user",
+        allowed_root=tmp_path,
+    )
+
+    assert result["success"] is True
+    assert result["concept_id"] == "#V#imported_file_copy"
+    assert result["artifact_record"]["artifact_id"] == "#V#imported_file_copy"
+    assert result["storage"]["key"].startswith("imports/user/")
+
+
+def test_import_local_file_copy_rejects_path_outside_allowed_root(tmp_path):
+    from src.backend.services import computer_file_copy_service as svc
+
+    allowed_root = tmp_path / "allowed"
+    outside_root = tmp_path / "outside"
+    allowed_root.mkdir()
+    outside_root.mkdir()
+
+    local_file = outside_root / "private.txt"
+    local_file.write_text("nope", encoding="utf-8")
+
+    result = svc.import_local_file_copy(
+        local_path=str(local_file),
+        user_concept_id="#V#user",
+        allowed_root=allowed_root,
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "path_outside_allowed_root"

--- a/tests/backend/test_file_copy_ingestion_mcp_tools.py
+++ b/tests/backend/test_file_copy_ingestion_mcp_tools.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+
+def test_index_file_copy_indexes_blob_backed_text(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue._read_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "text": "Indexed text content",
+            "content_type": "text/plain",
+            "original_filename": "notes.txt",
+            "size_bytes": 21,
+            "blob": {"backend": "swift", "key": "uploads/user/hash/notes.txt"},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.build_file_copy_artifact_record",
+        lambda **_kwargs: {"artifact_id": "#V#file_copy_test"},
+    )
+
+    class _StubRAG:
+        def __init__(self):
+            self.docs = []
+            self.namespace = None
+
+        def upsert_documents(
+            self, docs, *, namespace=None, allow_partial_failures=True
+        ):
+            self.docs = list(docs)
+            self.namespace = namespace
+            return 1, 0
+
+    rag = _StubRAG()
+    monkeypatch.setattr(
+        "src.backend.services.rag_service.get_rag_service",
+        lambda *_args, **_kwargs: rag,
+    )
+
+    result = cat._index_file_copy(
+        concept_id="#V#file_copy_test",
+        namespace="#V#user@org",
+    )
+
+    assert result["success"] is True
+    assert result["document_id"] == "file_copy:#V#file_copy_test"
+    assert result["indexed_count"] == 1
+    assert rag.namespace == "#V#user@org"
+    assert rag.docs[0]["metadata"]["artifact_record"]["artifact_id"] == "#V#file_copy_test"
+
+
+def test_index_file_copy_requires_namespace(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    monkeypatch.delenv("VON_DEFAULT_NAMESPACE", raising=False)
+    result = cat._index_file_copy(concept_id="#V#file_copy_test")
+    assert result["success"] is False
+    assert result["error"] == "namespace_required"
+
+
+def test_import_local_file_copy_uses_authenticated_context(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#user",
+    )
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.import_local_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "concept_id": "#V#imported_file",
+            "artifact_record": {"artifact_id": "#V#imported_file"},
+            "storage": {"backend": "local", "key": "imports/user/hash/file.txt"},
+        },
+    )
+
+    result = cat._import_local_file_copy(
+        local_path="README.md",
+        namespace="#V#user@org",
+    )
+
+    assert result["success"] is True
+    assert result["concept_id"] == "#V#imported_file"
+    assert result["namespace"] == "#V#user@org"

--- a/tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py
+++ b/tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py
@@ -1,0 +1,74 @@
+"""Gateway-level coverage for file-copy import/index MCP tools."""
+
+from __future__ import annotations
+
+from src.backend.integrations.internal_mcp import build_default_catalogue
+from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
+from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+
+
+def _build_gateway() -> InternalMCPGateway:
+    return InternalMCPGateway(
+        catalogue=build_default_catalogue(),
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+
+
+def test_file_copy_ingestion_tools_gateway_invoke(monkeypatch):
+    gateway = _build_gateway()
+
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#user",
+    )
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.import_local_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "concept_id": "#V#imported_file_gateway",
+            "type_concept_id": "#V#computer_file_copy",
+            "artifact_record": {"artifact_id": "#V#imported_file_gateway"},
+            "storage": {"backend": "local", "key": "imports/user/hash/file.txt"},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue._read_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "text": "gateway indexed text",
+            "content_type": "text/plain",
+            "original_filename": "gateway.txt",
+            "size_bytes": 19,
+            "blob": {"backend": "local", "key": "imports/user/hash/file.txt"},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.build_file_copy_artifact_record",
+        lambda **_kwargs: {"artifact_id": "#V#imported_file_gateway"},
+    )
+
+    class _StubRAG:
+        def upsert_documents(
+            self, docs, *, namespace=None, allow_partial_failures=True
+        ):
+            return 1, 0
+
+    monkeypatch.setattr(
+        "src.backend.services.rag_service.get_rag_service",
+        lambda *_args, **_kwargs: _StubRAG(),
+    )
+
+    imported = gateway.invoke(
+        "import_local_file_copy",
+        {"local_path": "README.md", "namespace": "#V#user@org"},
+    ).payload
+    assert imported.get("success") is True
+    assert imported.get("concept_id") == "#V#imported_file_gateway"
+
+    indexed = gateway.invoke(
+        "index_file_copy",
+        {"concept_id": "#V#imported_file_gateway", "namespace": "#V#user@org"},
+    ).payload
+    assert indexed.get("success") is True
+    assert indexed.get("indexed_count") == 1


### PR DESCRIPTION
## Summary
- add a canonical file-copy `artifact_record` model with provenance fields in `computer_file_copy_service`
- add `import_local_file_copy` ingestion path (workspace-bounded local file -> durable blob store -> `#V#computer_file_copy` registration)
- add `index_file_copy` MCP write tool to ingest blob-backed file-copy content into RAG without local-cache dependency
- surface canonical `artifact_record` from `rag_list_indexed`/`rag_get_item` file-copy collection items
- add blob-store artefact source strategy doc (filesystem now supported, Google Drive/Docs staged)

## Validation
- `pdm run pytest tests/backend/test_computer_file_copy_artifact_ingestion.py tests/backend/test_file_copy_ingestion_mcp_tools.py tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py tests/backend/test_rag_file_copy_mcp_read_tools.py tests/backend/test_rag_provenance_contract.py`
- `pdm run pytest tests/backend/test_mcp_tool_contract_registry.py tests/backend/test_mcp_stdio_tool_list_fallback.py tests/backend/test_mcp_manifest_parity.py`
- `pdm run pyright src/backend/integrations/internal_mcp/catalogue.py src/backend/integrations/internal_mcp/tool_contract_registry.py src/backend/services/computer_file_copy_service.py src/backend/services/tool_metadata_service.py tests/backend/test_computer_file_copy_artifact_ingestion.py tests/backend/test_file_copy_ingestion_mcp_tools.py tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py tests/backend/test_rag_file_copy_mcp_read_tools.py tests/backend/test_rag_provenance_contract.py`
