### PR TITLE
JVNAUTOSCI-1259: Stabilise false server-down states under load

### DIFF
--- a/src/backend/server/routes/settings_routes.py
+++ b/src/backend/server/routes/settings_routes.py
@@ -1,5 +1,7 @@
 import os
 import json
+import threading
+import time
 from datetime import datetime, timezone
 from flask import Blueprint, request, jsonify, current_app, send_file, session
 from werkzeug.utils import secure_filename
@@ -182,6 +184,60 @@ def _is_admin_or_owner_session() -> bool:
 # They remain empty until first relevant operation to avoid changing baseline /diag output.
 _IMPORT_METRICS: dict = {}
 _ORPHAN_SCAN_METRICS: dict = {}
+_OLLAMA_MODELS_CACHE_LOCK = threading.Lock()
+_OLLAMA_MODELS_CACHE: dict = {}
+_OLLAMA_MODELS_CACHE_TTL_SECONDS_DEFAULT = 20.0
+
+
+def _read_ollama_models_cache_ttl_seconds() -> float:
+    raw = os.getenv(
+        "VON_OLLAMA_MODELS_CACHE_TTL_SECONDS",
+        str(_OLLAMA_MODELS_CACHE_TTL_SECONDS_DEFAULT),
+    )
+    try:
+        ttl = float(raw)
+    except (TypeError, ValueError):
+        return _OLLAMA_MODELS_CACHE_TTL_SECONDS_DEFAULT
+    return max(0.0, ttl)
+
+
+def _read_cached_ollama_models(*, bypass_cache: bool) -> Optional[list]:
+    if bypass_cache:
+        return None
+
+    ttl_seconds = _read_ollama_models_cache_ttl_seconds()
+    if ttl_seconds <= 0.0:
+        return None
+
+    now_monotonic = time.monotonic()
+    with _OLLAMA_MODELS_CACHE_LOCK:
+        expires_at = _OLLAMA_MODELS_CACHE.get("expires_at_monotonic")
+        models = _OLLAMA_MODELS_CACHE.get("models")
+        if (
+            not isinstance(expires_at, (int, float))
+            or now_monotonic >= float(expires_at)
+            or not isinstance(models, list)
+        ):
+            _OLLAMA_MODELS_CACHE.clear()
+            return None
+        return models
+
+
+def _write_cached_ollama_models(models: list) -> None:
+    ttl_seconds = _read_ollama_models_cache_ttl_seconds()
+    if ttl_seconds <= 0.0:
+        return
+
+    now_monotonic = time.monotonic()
+    with _OLLAMA_MODELS_CACHE_LOCK:
+        _OLLAMA_MODELS_CACHE.clear()
+        _OLLAMA_MODELS_CACHE.update(
+            {
+                "models": models,
+                "stored_at_monotonic": now_monotonic,
+                "expires_at_monotonic": now_monotonic + ttl_seconds,
+            }
+        )
 
 
 def _utc_now_iso() -> str:
@@ -1259,11 +1315,23 @@ def set_ollama_hosts():
 @settings_bp.route("/ollama/models", methods=["GET"])
 def get_ollama_models_from_all_hosts():
     """API endpoint to get all Ollama models from all configured hosts."""
+    bypass_cache = request.args.get("nocache", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    cached_models = _read_cached_ollama_models(bypass_cache=bypass_cache)
+    if isinstance(cached_models, list):
+        return jsonify({"success": True, "models": cached_models}), 200
+
     try:
         from ...languagemodels.llm_interface import OllamaClient  # inline import
 
         # Get models from all hosts
         all_models = OllamaClient.list_models_from_all_hosts()
+        if isinstance(all_models, list):
+            _write_cached_ollama_models(all_models)
 
         current_app.logger.info(
             f"Retrieved {len(all_models)} Ollama models from all hosts"

--- a/src/backend/server/routes/workflows_routes.py
+++ b/src/backend/server/routes/workflows_routes.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import logging
+import os
+import threading
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
@@ -41,6 +44,84 @@ from ...workflows.workflow_definition_identity_service import (
 logger = logging.getLogger(__name__)
 
 workflows_bp = Blueprint("workflows", __name__)
+
+_WORKFLOW_DEFINITIONS_CACHE_LOCK = threading.Lock()
+_WORKFLOW_DEFINITIONS_CACHE: Dict[
+    Tuple[int, Optional[str], Optional[str], Optional[str]], Dict[str, Any]
+] = {}
+_WORKFLOW_DEFINITIONS_CACHE_MAX_ENTRIES = 32
+_WORKFLOW_DEFINITIONS_CACHE_TTL_SECONDS_DEFAULT = 8.0
+
+
+def _read_workflow_definitions_cache_ttl_seconds() -> float:
+    raw = os.getenv(
+        "VON_WORKFLOW_DEFINITIONS_CACHE_TTL_SECONDS",
+        str(_WORKFLOW_DEFINITIONS_CACHE_TTL_SECONDS_DEFAULT),
+    )
+    try:
+        ttl = float(raw)
+    except (TypeError, ValueError):
+        return _WORKFLOW_DEFINITIONS_CACHE_TTL_SECONDS_DEFAULT
+    return max(0.0, ttl)
+
+
+def _read_cached_workflow_definitions(
+    *,
+    cache_key: Tuple[int, Optional[str], Optional[str], Optional[str]],
+    bypass_cache: bool,
+) -> Optional[Dict[str, Any]]:
+    if bypass_cache:
+        return None
+
+    ttl_seconds = _read_workflow_definitions_cache_ttl_seconds()
+    if ttl_seconds <= 0.0:
+        return None
+
+    now_monotonic = time.monotonic()
+    with _WORKFLOW_DEFINITIONS_CACHE_LOCK:
+        entry = _WORKFLOW_DEFINITIONS_CACHE.get(cache_key)
+        if not isinstance(entry, dict):
+            return None
+        expires_at = entry.get("expires_at_monotonic")
+        payload = entry.get("payload")
+        if (
+            not isinstance(expires_at, (int, float))
+            or now_monotonic >= float(expires_at)
+            or not isinstance(payload, dict)
+        ):
+            _WORKFLOW_DEFINITIONS_CACHE.pop(cache_key, None)
+            return None
+        return payload
+
+
+def _write_cached_workflow_definitions(
+    *,
+    cache_key: Tuple[int, Optional[str], Optional[str], Optional[str]],
+    payload: Dict[str, Any],
+) -> None:
+    ttl_seconds = _read_workflow_definitions_cache_ttl_seconds()
+    if ttl_seconds <= 0.0:
+        return
+
+    now_monotonic = time.monotonic()
+    expires_at = now_monotonic + ttl_seconds
+    with _WORKFLOW_DEFINITIONS_CACHE_LOCK:
+        _WORKFLOW_DEFINITIONS_CACHE[cache_key] = {
+            "expires_at_monotonic": expires_at,
+            "stored_at_monotonic": now_monotonic,
+            "payload": payload,
+        }
+        if len(_WORKFLOW_DEFINITIONS_CACHE) <= _WORKFLOW_DEFINITIONS_CACHE_MAX_ENTRIES:
+            return
+        oldest_key = None
+        oldest_stamp = float("inf")
+        for key, value in _WORKFLOW_DEFINITIONS_CACHE.items():
+            stored_at = value.get("stored_at_monotonic")
+            if isinstance(stored_at, (int, float)) and float(stored_at) < oldest_stamp:
+                oldest_key = key
+                oldest_stamp = float(stored_at)
+        if oldest_key is not None:
+            _WORKFLOW_DEFINITIONS_CACHE.pop(oldest_key, None)
 
 
 @workflows_bp.get("/api/workflows/definitions/<path:workflow_id>")
@@ -100,6 +181,20 @@ def api_list_workflow_definitions():
     namespace = request.args.get("namespace")
     session_id = request.args.get("session_id")
     turn_id = request.args.get("turn_id")
+    bypass_cache = request.args.get("nocache", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    cache_key = (limit, namespace or None, session_id or None, turn_id or None)
+
+    cached_payload = _read_cached_workflow_definitions(
+        cache_key=cache_key,
+        bypass_cache=bypass_cache,
+    )
+    if isinstance(cached_payload, dict):
+        return jsonify(cached_payload)
 
     try:
         from ...workflows.durable.registry_factory import (
@@ -223,19 +318,19 @@ def api_list_workflow_definitions():
                 }
             )
 
-        return jsonify(
-            {
-                "items": items,
-                "count": len(items),
-                "total": len(workflow_ids),
-                "episodes_scope": {
-                    "namespace": namespace or None,
-                    "session_id": session_id or None,
-                    "turn_id": turn_id or None,
-                },
-                "parity_inventory": inventory_snapshot,
-            }
-        )
+        payload = {
+            "items": items,
+            "count": len(items),
+            "total": len(workflow_ids),
+            "episodes_scope": {
+                "namespace": namespace or None,
+                "session_id": session_id or None,
+                "turn_id": turn_id or None,
+            },
+            "parity_inventory": inventory_snapshot,
+        }
+        _write_cached_workflow_definitions(cache_key=cache_key, payload=payload)
+        return jsonify(payload)
     except Exception as exc:
         logger.exception("Failed to list workflow definitions via API")
         return jsonify({"error": "workflow_definitions_list_failed", "detail": str(exc)}), 500

--- a/src/frontend/web/von_interface/static/js/main.js
+++ b/src/frontend/web/von_interface/static/js/main.js
@@ -5,7 +5,7 @@ import { getLanguageDisplayName } from './languageConfig.js';
 import { escapeHtml } from './markdownUtils.js';
 import './suppressTooltips.js';
 import { activateTab, loadTabData, setupTabNavigation } from './tabNavigation.js';
-import { shouldMarkServerDown } from './utils/serverHealthState.js';
+import { evaluateServerHealthState } from './utils/serverHealthState.js';
 import { handleSelectConceptByIdDetail } from './utils/selectConceptByIdHandler.js';
 import {
   copyJsonTextWithButtonFeedback,
@@ -686,14 +686,76 @@ function startHealthPolling() {
   let lastIdentity = { pid: null, start: null };
   let reloadTriggered = false;
   let serverReachable = null;
+  let serverHealthUiState = 'waiting';
   let hasSeenSuccessfulHealthPoll = false;
+  let firstFailureAtMs = null;
+  let lastHealthSuccessAtMs = null;
+  let lastHealthErrorKind = null;
+  let lastHealthErrorDetail = null;
+  let latestHealthDiagnostics = null;
+
+  function publishHealthPollDiagnostics(diagnostics) {
+    if (!diagnostics || typeof diagnostics !== 'object') return;
+    latestHealthDiagnostics = diagnostics;
+    try {
+      window.__vonHealthPollDiagnostics = diagnostics;
+    } catch (_) {
+      // Ignore non-writable globals in constrained environments.
+    }
+    try {
+      document.dispatchEvent(new CustomEvent('von:healthPollDiagnostics', { detail: diagnostics }));
+    } catch (_) {
+      // Non-fatal diagnostic event.
+    }
+  }
 
   function setServerReachableState(isReachable) {
     serverReachable = (typeof isReachable === 'boolean') ? isReachable : null;
     setFooterServerReachability(serverReachable);
   }
 
-  setServerReachableState(null);
+  function setServerHealthUiState(nextState, diagnostics = null) {
+    const safeState = (nextState === 'healthy' || nextState === 'waiting' || nextState === 'degraded' || nextState === 'down')
+      ? nextState
+      : 'waiting';
+    serverHealthUiState = safeState;
+    if (safeState === 'down') {
+      setServerReachableState(false);
+    } else if (safeState === 'waiting') {
+      setServerReachableState(null);
+    } else {
+      setServerReachableState(true);
+    }
+    if (diagnostics && typeof diagnostics === 'object') {
+      publishHealthPollDiagnostics({ state: safeState, ...diagnostics });
+    }
+  }
+
+  function isThinkingActive() {
+    try {
+      const wrapper = document.getElementById('thinkingCardWrapper');
+      if (wrapper) {
+        return wrapper.getAttribute('aria-hidden') !== 'true';
+      }
+      const loadingIndicator = document.getElementById('loadingIndicator');
+      if (loadingIndicator) {
+        return loadingIndicator.style.display !== 'none';
+      }
+    } catch (_) {
+      // Ignore transient DOM read issues.
+    }
+    return false;
+  }
+
+  setServerHealthUiState('waiting', {
+    failureCount: 0,
+    failureWindowMs: 0,
+    downFailureThreshold: null,
+    downFailureWindowThresholdMs: null,
+    hasSeenSuccessfulHealthPoll: false,
+    isThinkingActive: false,
+    source: 'health_poll_initialise'
+  });
 
   function autoReloadEnabled() {
     try { return localStorage.getItem('von:autoReloadOnRestart') === '1'; } catch (_) { return false; }
@@ -712,13 +774,26 @@ function startHealthPolling() {
   function updateUptimeLoop() {
     if (uptimeSpan) {
       const uptimeContainer = uptimeSpan.parentElement;
-      if (serverReachable === false) {
+      if (serverHealthUiState === 'down') {
         uptimeSpan.textContent = 'server down';
         uptimeSpan.title = 'Von server is unreachable';
         if (uptimeContainer) uptimeContainer.classList.add('pid-error');
-      } else if (serverReachable === null) {
+      } else if (serverHealthUiState === 'waiting') {
         uptimeSpan.textContent = 'waiting for server';
         uptimeSpan.title = 'Waiting for initial server health response';
+        if (uptimeContainer) uptimeContainer.classList.remove('pid-error');
+      } else if (serverHealthUiState === 'degraded') {
+        const failureCountTitle = Number.isFinite(latestHealthDiagnostics?.failureCount)
+          ? `consecutive failures=${latestHealthDiagnostics.failureCount}`
+          : null;
+        const failureWindowTitle = Number.isFinite(latestHealthDiagnostics?.failureWindowMs)
+          ? `failure window=${Math.round(latestHealthDiagnostics.failureWindowMs / 1000)}s`
+          : null;
+        const detail = [failureCountTitle, failureWindowTitle].filter(Boolean).join(' | ');
+        uptimeSpan.textContent = 'degraded (retrying)';
+        uptimeSpan.title = detail
+          ? `Health probes are failing but below down threshold (${detail})`
+          : 'Health probes are failing but below down threshold';
         if (uptimeContainer) uptimeContainer.classList.remove('pid-error');
       } else if (startTimeIso) {
         const started = Date.parse(startTimeIso);
@@ -789,7 +864,24 @@ function startHealthPolling() {
       if (!res.ok) throw new Error('HTTP ' + res.status);
       const data = await res.json();
       hasSeenSuccessfulHealthPoll = true;
-      setServerReachableState(true);
+      firstFailureAtMs = null;
+      lastHealthSuccessAtMs = Date.now();
+      lastHealthErrorKind = null;
+      lastHealthErrorDetail = null;
+      const successState = evaluateServerHealthState({
+        hasSeenSuccessfulHealthPoll,
+        failureCount: 0,
+        firstFailureAtMs: null,
+        nowMs: lastHealthSuccessAtMs,
+        isThinkingActive: isThinkingActive(),
+      });
+      setServerHealthUiState('healthy', {
+        ...successState.diagnostics,
+        source: 'health_poll_success',
+        lastSuccessAgeMs: 0,
+        lastErrorKind: null,
+        lastErrorDetail: null,
+      });
       const newPid = (typeof data.pid !== 'undefined') ? data.pid : null;
       const newStart = data.start_time || null;
       const newLocalIp = data.local_ip || null;
@@ -1878,11 +1970,36 @@ function startHealthPolling() {
       failureCount = 0; // reset on success
     } catch (e) {
       failureCount++;
-      const markDown = shouldMarkServerDown({
+      if (!Number.isFinite(firstFailureAtMs)) {
+        firstFailureAtMs = Date.now();
+      }
+      const nowMs = Date.now();
+      const activeThinking = isThinkingActive();
+      const evaluation = evaluateServerHealthState({
         hasSeenSuccessfulHealthPoll,
-        failureCount
+        failureCount,
+        firstFailureAtMs,
+        nowMs,
+        isThinkingActive: activeThinking,
       });
-      setServerReachableState(markDown ? false : null);
+      const markDown = evaluation.markDown;
+      const isHttpError = typeof e?.message === 'string' && e.message.startsWith('HTTP ');
+      lastHealthErrorKind = e?.name === 'AbortError'
+        ? 'timeout'
+        : (isHttpError ? 'http' : 'network_or_unknown');
+      lastHealthErrorDetail = typeof e?.message === 'string'
+        ? e.message
+        : String(e || '');
+      const lastSuccessAgeMs = Number.isFinite(lastHealthSuccessAtMs)
+        ? Math.max(0, nowMs - lastHealthSuccessAtMs)
+        : null;
+      setServerHealthUiState(evaluation.state, {
+        ...evaluation.diagnostics,
+        source: 'health_poll_failure',
+        lastSuccessAgeMs,
+        lastErrorKind: lastHealthErrorKind,
+        lastErrorDetail: lastHealthErrorDetail,
+      });
       if (pidSpan) {
         if (markDown) {
           pidSpan.textContent = '-';

--- a/src/frontend/web/von_interface/static/js/test/serverHealthState.test.js
+++ b/src/frontend/web/von_interface/static/js/test/serverHealthState.test.js
@@ -1,32 +1,94 @@
 import {
+  FAILURES_BEFORE_DOWN_AFTER_SUCCESS,
+  FAILURE_WINDOW_MS_BEFORE_DOWN_AFTER_SUCCESS,
   INITIAL_FAILURES_BEFORE_DOWN,
+  INITIAL_FAILURE_WINDOW_MS_BEFORE_DOWN,
+  THINKING_EXTRA_FAILURES_BEFORE_DOWN,
+  THINKING_EXTRA_FAILURE_WINDOW_MS,
+  evaluateServerHealthState,
   shouldMarkServerDown
 } from '../utils/serverHealthState.js';
 
 describe('serverHealthState', () => {
-  test('keeps initial page-load failures in waiting state', () => {
+  test('keeps initial page-load failures in waiting state before both thresholds are met', () => {
     expect(INITIAL_FAILURES_BEFORE_DOWN).toBe(2);
+    expect(INITIAL_FAILURE_WINDOW_MS_BEFORE_DOWN).toBe(7000);
+    const waiting = evaluateServerHealthState({
+      hasSeenSuccessfulHealthPoll: false,
+      failureCount: 1,
+      firstFailureAtMs: 10_000,
+      nowMs: 15_000
+    });
+    expect(waiting.state).toBe('waiting');
+    expect(waiting.markDown).toBe(false);
     expect(shouldMarkServerDown({
       hasSeenSuccessfulHealthPoll: false,
-      failureCount: 0
-    })).toBe(false);
-    expect(shouldMarkServerDown({
-      hasSeenSuccessfulHealthPoll: false,
-      failureCount: 1
+      failureCount: 2,
+      firstFailureAtMs: 10_000,
+      nowMs: 16_000
     })).toBe(false);
   });
 
-  test('marks down after grace window before first success', () => {
+  test('marks down after initial thresholds are met before first success', () => {
     expect(shouldMarkServerDown({
       hasSeenSuccessfulHealthPoll: false,
-      failureCount: 2
+      failureCount: 2,
+      firstFailureAtMs: 10_000,
+      nowMs: 18_000
     })).toBe(true);
   });
 
-  test('marks down on first failure after seeing a healthy poll', () => {
+  test('uses degraded state after a single failure following successful polls', () => {
+    const result = evaluateServerHealthState({
+      hasSeenSuccessfulHealthPoll: true,
+      failureCount: 1,
+      firstFailureAtMs: 20_000,
+      nowMs: 24_000
+    });
+    expect(result.state).toBe('degraded');
+    expect(result.markDown).toBe(false);
+  });
+
+  test('requires both post-success thresholds before marking down', () => {
+    expect(FAILURES_BEFORE_DOWN_AFTER_SUCCESS).toBe(2);
+    expect(FAILURE_WINDOW_MS_BEFORE_DOWN_AFTER_SUCCESS).toBe(7000);
     expect(shouldMarkServerDown({
       hasSeenSuccessfulHealthPoll: true,
-      failureCount: 1
+      failureCount: 2,
+      firstFailureAtMs: 20_000,
+      nowMs: 26_000
+    })).toBe(false);
+    expect(shouldMarkServerDown({
+      hasSeenSuccessfulHealthPoll: true,
+      failureCount: 2,
+      firstFailureAtMs: 20_000,
+      nowMs: 28_000
+    })).toBe(true);
+  });
+
+  test('adds extra down hysteresis while thinking is active', () => {
+    expect(THINKING_EXTRA_FAILURES_BEFORE_DOWN).toBe(1);
+    expect(THINKING_EXTRA_FAILURE_WINDOW_MS).toBe(5000);
+    expect(shouldMarkServerDown({
+      hasSeenSuccessfulHealthPoll: true,
+      failureCount: 2,
+      firstFailureAtMs: 20_000,
+      nowMs: 35_000,
+      isThinkingActive: true
+    })).toBe(false);
+    expect(shouldMarkServerDown({
+      hasSeenSuccessfulHealthPoll: true,
+      failureCount: 3,
+      firstFailureAtMs: 20_000,
+      nowMs: 31_000,
+      isThinkingActive: true
+    })).toBe(false);
+    expect(shouldMarkServerDown({
+      hasSeenSuccessfulHealthPoll: true,
+      failureCount: 3,
+      firstFailureAtMs: 20_000,
+      nowMs: 33_000,
+      isThinkingActive: true
     })).toBe(true);
   });
 });

--- a/src/frontend/web/von_interface/static/js/utils/serverHealthState.js
+++ b/src/frontend/web/von_interface/static/js/utils/serverHealthState.js
@@ -1,19 +1,127 @@
 const INITIAL_FAILURES_BEFORE_DOWN = 2;
+const INITIAL_FAILURE_WINDOW_MS_BEFORE_DOWN = 7000;
+const FAILURES_BEFORE_DOWN_AFTER_SUCCESS = 2;
+const FAILURE_WINDOW_MS_BEFORE_DOWN_AFTER_SUCCESS = 7000;
+const THINKING_EXTRA_FAILURES_BEFORE_DOWN = 1;
+const THINKING_EXTRA_FAILURE_WINDOW_MS = 5000;
 
-export function shouldMarkServerDown({ hasSeenSuccessfulHealthPoll = false, failureCount = 0 } = {}) {
-  const safeFailureCount = Number.isFinite(failureCount)
-    ? Math.max(0, Math.trunc(failureCount))
-    : 0;
-
-  if (hasSeenSuccessfulHealthPoll) {
-    // Once we have seen the server healthy in this page lifecycle, a single
-    // failure is enough to treat it as down.
-    return safeFailureCount >= 1;
-  }
-
-  // On fresh page load, keep a brief grace window so startup/reload races show
-  // "waiting for server" instead of immediately showing "server down".
-  return safeFailureCount >= INITIAL_FAILURES_BEFORE_DOWN;
+function toSafeInteger(value, fallback = 0) {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.trunc(value));
 }
 
-export { INITIAL_FAILURES_BEFORE_DOWN };
+function toSafeTimestamp(value, fallback = null) {
+  if (!Number.isFinite(value)) return fallback;
+  return Number(value);
+}
+
+function toSafeWindowMs(nowMs, firstFailureAtMs) {
+  if (!Number.isFinite(nowMs) || !Number.isFinite(firstFailureAtMs)) return 0;
+  return Math.max(0, Math.trunc(nowMs - firstFailureAtMs));
+}
+
+function resolveThresholds({
+  hasSeenSuccessfulHealthPoll = false,
+  isThinkingActive = false,
+  downFailuresAfterSuccess = FAILURES_BEFORE_DOWN_AFTER_SUCCESS,
+  downFailureWindowMsAfterSuccess = FAILURE_WINDOW_MS_BEFORE_DOWN_AFTER_SUCCESS,
+  initialFailuresBeforeDown = INITIAL_FAILURES_BEFORE_DOWN,
+  initialFailureWindowMsBeforeDown = INITIAL_FAILURE_WINDOW_MS_BEFORE_DOWN,
+  thinkingExtraFailuresBeforeDown = THINKING_EXTRA_FAILURES_BEFORE_DOWN,
+  thinkingExtraFailureWindowMs = THINKING_EXTRA_FAILURE_WINDOW_MS,
+} = {}) {
+  const seenSuccess = !!hasSeenSuccessfulHealthPoll;
+  const baseFailureThreshold = seenSuccess
+    ? toSafeInteger(downFailuresAfterSuccess, FAILURES_BEFORE_DOWN_AFTER_SUCCESS)
+    : toSafeInteger(initialFailuresBeforeDown, INITIAL_FAILURES_BEFORE_DOWN);
+  const baseWindowThresholdMs = seenSuccess
+    ? toSafeInteger(
+      downFailureWindowMsAfterSuccess,
+      FAILURE_WINDOW_MS_BEFORE_DOWN_AFTER_SUCCESS
+    )
+    : toSafeInteger(
+      initialFailureWindowMsBeforeDown,
+      INITIAL_FAILURE_WINDOW_MS_BEFORE_DOWN
+    );
+
+  if (!isThinkingActive) {
+    return {
+      downFailureThreshold: Math.max(1, baseFailureThreshold),
+      downFailureWindowThresholdMs: Math.max(0, baseWindowThresholdMs),
+    };
+  }
+
+  return {
+    downFailureThreshold: Math.max(
+      1,
+      baseFailureThreshold + toSafeInteger(thinkingExtraFailuresBeforeDown, 0)
+    ),
+    downFailureWindowThresholdMs: Math.max(
+      0,
+      baseWindowThresholdMs + toSafeInteger(thinkingExtraFailureWindowMs, 0)
+    ),
+  };
+}
+
+export function evaluateServerHealthState({
+  hasSeenSuccessfulHealthPoll = false,
+  failureCount = 0,
+  firstFailureAtMs = null,
+  nowMs = Date.now(),
+  isThinkingActive = false,
+  thresholds = {},
+} = {}) {
+  const safeFailureCount = toSafeInteger(failureCount, 0);
+  const safeNowMs = toSafeTimestamp(nowMs, Date.now());
+  const safeFirstFailureAtMs = toSafeTimestamp(firstFailureAtMs, null);
+  const safeIsThinkingActive = !!isThinkingActive;
+  const safeSeenSuccess = !!hasSeenSuccessfulHealthPoll;
+
+  const { downFailureThreshold, downFailureWindowThresholdMs } = resolveThresholds({
+    ...thresholds,
+    hasSeenSuccessfulHealthPoll: safeSeenSuccess,
+    isThinkingActive: safeIsThinkingActive,
+  });
+
+  const failureWindowMs = toSafeWindowMs(safeNowMs, safeFirstFailureAtMs);
+  const meetsFailureThreshold = safeFailureCount >= downFailureThreshold;
+  const meetsFailureWindowThreshold =
+    failureWindowMs >= downFailureWindowThresholdMs;
+
+  let state = "healthy";
+  if (safeFailureCount <= 0) {
+    state = safeSeenSuccess ? "healthy" : "waiting";
+  } else if (meetsFailureThreshold && meetsFailureWindowThreshold) {
+    state = "down";
+  } else {
+    state = safeSeenSuccess ? "degraded" : "waiting";
+  }
+
+  return {
+    state,
+    markDown: state === "down",
+    diagnostics: {
+      hasSeenSuccessfulHealthPoll: safeSeenSuccess,
+      failureCount: safeFailureCount,
+      failureWindowMs,
+      downFailureThreshold,
+      downFailureWindowThresholdMs,
+      isThinkingActive: safeIsThinkingActive,
+      meetsFailureThreshold,
+      meetsFailureWindowThreshold,
+    },
+  };
+}
+
+export function shouldMarkServerDown(params = {}) {
+  return evaluateServerHealthState(params).markDown;
+}
+
+export {
+  INITIAL_FAILURES_BEFORE_DOWN,
+  INITIAL_FAILURE_WINDOW_MS_BEFORE_DOWN,
+  FAILURES_BEFORE_DOWN_AFTER_SUCCESS,
+  FAILURE_WINDOW_MS_BEFORE_DOWN_AFTER_SUCCESS,
+  THINKING_EXTRA_FAILURES_BEFORE_DOWN,
+  THINKING_EXTRA_FAILURE_WINDOW_MS,
+};

--- a/tests/backend/test_settings_ollama_models_cache.py
+++ b/tests/backend/test_settings_ollama_models_cache.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from flask import Flask
+
+from src.backend.server.routes.settings_routes import settings_bp
+
+
+def _make_settings_app() -> Flask:
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.config["TESTING"] = True
+    app.register_blueprint(settings_bp, url_prefix="/api/settings")
+    return app
+
+
+def test_ollama_models_route_uses_cache(monkeypatch):
+    import src.backend.server.routes.settings_routes as settings_routes
+
+    app = _make_settings_app()
+    monkeypatch.setenv("VON_OLLAMA_MODELS_CACHE_TTL_SECONDS", "60")
+
+    calls = {"count": 0}
+
+    def _fake_list_models_from_all_hosts():
+        calls["count"] += 1
+        return [{"host_url": "http://127.0.0.1:11434", "name": "llama3.2"}]
+
+    monkeypatch.setattr(
+        "src.backend.languagemodels.llm_interface.OllamaClient.list_models_from_all_hosts",
+        _fake_list_models_from_all_hosts,
+    )
+
+    with settings_routes._OLLAMA_MODELS_CACHE_LOCK:
+        settings_routes._OLLAMA_MODELS_CACHE.clear()
+
+    with app.test_client() as client:
+        first = client.get("/api/settings/ollama/models")
+        second = client.get("/api/settings/ollama/models")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert calls["count"] == 1
+    payload = second.get_json() or {}
+    assert payload.get("success") is True
+    assert len(payload.get("models") or []) == 1
+
+
+def test_ollama_models_route_nocache_bypasses_cache(monkeypatch):
+    import src.backend.server.routes.settings_routes as settings_routes
+
+    app = _make_settings_app()
+    monkeypatch.setenv("VON_OLLAMA_MODELS_CACHE_TTL_SECONDS", "60")
+
+    calls = {"count": 0}
+
+    def _fake_list_models_from_all_hosts():
+        calls["count"] += 1
+        return [{"host_url": "http://127.0.0.1:11434", "name": "llama3.2"}]
+
+    monkeypatch.setattr(
+        "src.backend.languagemodels.llm_interface.OllamaClient.list_models_from_all_hosts",
+        _fake_list_models_from_all_hosts,
+    )
+
+    with settings_routes._OLLAMA_MODELS_CACHE_LOCK:
+        settings_routes._OLLAMA_MODELS_CACHE.clear()
+
+    with app.test_client() as client:
+        first = client.get("/api/settings/ollama/models")
+        second = client.get("/api/settings/ollama/models?nocache=true")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert calls["count"] == 2

--- a/tests/backend/test_workflows_routes.py
+++ b/tests/backend/test_workflows_routes.py
@@ -11,6 +11,7 @@ import pytest
 def app_client(monkeypatch):
     # Must be set before importing mongo_client so USE_MOCK_DB is computed correctly.
     monkeypatch.setenv("VON_USE_MOCK_DB", "1")
+    monkeypatch.setenv("VON_WORKFLOW_DEFINITIONS_CACHE_TTL_SECONDS", "0")
 
     import src.backend.db.mongo_client as mongo_client
 
@@ -684,3 +685,148 @@ def test_trigger_workflow_schedule_route_rejects_unrunnable_workflow(
     assert "workflow_definition_not_registered" in payload["verification"]["preflight"][
         "errors"
     ]
+
+
+def test_workflow_definitions_list_uses_short_ttl_cache(monkeypatch, app_client):
+    import src.backend.server.routes.workflows_routes as workflows_routes
+    import src.backend.services.workflow_discovery_service as workflow_discovery_service
+    import src.backend.workflows.durable.registry_factory as registry_factory
+
+    class _FakeDefinition:
+        initial_state = "start"
+        purpose = "purpose"
+
+    class _FakeRegistration:
+        def __init__(self):
+            self.definition = _FakeDefinition()
+            self.purpose = "purpose"
+            self.source = "built_in"
+
+    class _FakeRegistry:
+        def all_workflow_ids(self):
+            return ["#V#cached_workflow"]
+
+        def get(self, workflow_id):
+            return _FakeDefinition()
+
+        def get_registration(self, workflow_id):
+            return _FakeRegistration()
+
+    calls = {"build_registry": 0}
+
+    def _fake_build_registry():
+        calls["build_registry"] += 1
+        return _FakeRegistry()
+
+    monkeypatch.setenv("VON_WORKFLOW_DEFINITIONS_CACHE_TTL_SECONDS", "60")
+    monkeypatch.setattr(
+        registry_factory,
+        "build_durable_workflow_registry_read_only",
+        _fake_build_registry,
+    )
+    monkeypatch.setattr(
+        registry_factory,
+        "get_workflow_registry_inventory_snapshot",
+        lambda: {"counts": {"registry": 1, "vontology_discovered": 1}},
+    )
+    monkeypatch.setattr(
+        workflows_routes,
+        "get_workflow_usage_aggregates_for_workflows",
+        lambda workflow_ids: {},
+    )
+    monkeypatch.setattr(
+        workflows_routes,
+        "get_workflow_episode_counts_for_workflows",
+        lambda workflow_ids, namespace=None, session_id=None, turn_id=None: {
+            "#V#cached_workflow": 0
+        },
+    )
+    monkeypatch.setattr(
+        workflow_discovery_service,
+        "classify_workflow_concept_executability",
+        lambda workflow_id: (True, "executable_now", None),
+    )
+
+    with workflows_routes._WORKFLOW_DEFINITIONS_CACHE_LOCK:
+        workflows_routes._WORKFLOW_DEFINITIONS_CACHE.clear()
+
+    resp1 = app_client.get("/api/workflows/definitions?limit=10")
+    assert resp1.status_code == 200
+    resp2 = app_client.get("/api/workflows/definitions?limit=10")
+    assert resp2.status_code == 200
+
+    assert calls["build_registry"] == 1
+    payload = resp2.get_json()
+    assert payload["count"] == 1
+    assert payload["items"][0]["workflow_id"] == "#V#cached_workflow"
+
+
+def test_workflow_definitions_list_nocache_bypasses_cache(monkeypatch, app_client):
+    import src.backend.server.routes.workflows_routes as workflows_routes
+    import src.backend.services.workflow_discovery_service as workflow_discovery_service
+    import src.backend.workflows.durable.registry_factory as registry_factory
+
+    class _FakeDefinition:
+        initial_state = "start"
+        purpose = "purpose"
+
+    class _FakeRegistration:
+        def __init__(self):
+            self.definition = _FakeDefinition()
+            self.purpose = "purpose"
+            self.source = "built_in"
+
+    class _FakeRegistry:
+        def all_workflow_ids(self):
+            return ["#V#cached_workflow"]
+
+        def get(self, workflow_id):
+            return _FakeDefinition()
+
+        def get_registration(self, workflow_id):
+            return _FakeRegistration()
+
+    calls = {"build_registry": 0}
+
+    def _fake_build_registry():
+        calls["build_registry"] += 1
+        return _FakeRegistry()
+
+    monkeypatch.setenv("VON_WORKFLOW_DEFINITIONS_CACHE_TTL_SECONDS", "60")
+    monkeypatch.setattr(
+        registry_factory,
+        "build_durable_workflow_registry_read_only",
+        _fake_build_registry,
+    )
+    monkeypatch.setattr(
+        registry_factory,
+        "get_workflow_registry_inventory_snapshot",
+        lambda: {"counts": {"registry": 1, "vontology_discovered": 1}},
+    )
+    monkeypatch.setattr(
+        workflows_routes,
+        "get_workflow_usage_aggregates_for_workflows",
+        lambda workflow_ids: {},
+    )
+    monkeypatch.setattr(
+        workflows_routes,
+        "get_workflow_episode_counts_for_workflows",
+        lambda workflow_ids, namespace=None, session_id=None, turn_id=None: {
+            "#V#cached_workflow": 0
+        },
+    )
+    monkeypatch.setattr(
+        workflow_discovery_service,
+        "classify_workflow_concept_executability",
+        lambda workflow_id: (True, "executable_now", None),
+    )
+
+    with workflows_routes._WORKFLOW_DEFINITIONS_CACHE_LOCK:
+        workflows_routes._WORKFLOW_DEFINITIONS_CACHE.clear()
+
+    resp1 = app_client.get("/api/workflows/definitions?limit=10")
+    assert resp1.status_code == 200
+    resp2 = app_client.get("/api/workflows/definitions?limit=10&nocache=true")
+    assert resp2.status_code == 200
+
+    assert calls["build_registry"] == 2


### PR DESCRIPTION
## Summary\n- harden frontend health-state transitions with explicit waiting/degraded/down evaluation\n- require both consecutive-failure and failure-window thresholds before down-state, with extra hysteresis while thinking is active\n- publish structured health poll diagnostics for UI introspection\n- add short-TTL bounded caching to /api/workflows/definitions and /api/settings/ollama/models with 
ocache bypass\n- add regression tests for health-state hysteresis and backend cache behaviour\n\n## Verification\n- npm test -- src/frontend/web/von_interface/static/js/test/serverHealthState.test.js\n- npm test -- tests/frontend/footerDbBadgeOutageStates.test.js\n- pdm run pytest tests/backend/test_workflows_routes.py tests/backend/test_settings_ollama_models_cache.py\n- pdm run pyright src/backend/server/routes/settings_routes.py src/backend/server/routes/workflows_routes.py tests/backend/test_workflows_routes.py tests/backend/test_settings_ollama_models_cache.py