### PR TITLE
JVNAUTOSCI-610: add footer visibility and settings log for background tasks

### DIFF
--- a/src/frontend/web/von_interface/static/js/backgroundTaskTracker.js
+++ b/src/frontend/web/von_interface/static/js/backgroundTaskTracker.js
@@ -1,0 +1,320 @@
+const ACTIVE_STORAGE_KEY = 'von_background_tasks_active_v1';
+const HISTORY_STORAGE_KEY = 'von_background_tasks_history_v1';
+const MAX_HISTORY_ITEMS = 60;
+const ACTIVE_TASK_STALE_MS = 15 * 60 * 1000;
+
+export const BACKGROUND_TASKS_CHANGED_EVENT = 'von:backgroundTasksChanged';
+
+let taskSequence = 0;
+
+function resolveStorage(kind) {
+  try {
+    if (kind === 'session') {
+      return typeof sessionStorage !== 'undefined' ? sessionStorage : null;
+    }
+    return typeof localStorage !== 'undefined' ? localStorage : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function asString(value) {
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return '';
+}
+
+function normaliseTaskType(taskType) {
+  const raw = asString(taskType) || 'background_task';
+  return raw.replace(/\s+/g, '_').toLowerCase();
+}
+
+function normaliseLabel(taskType, explicitLabel) {
+  const raw = asString(explicitLabel);
+  if (raw) return raw;
+  return normaliseTaskType(taskType)
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function readJsonArray(storage, key) {
+  if (!storage) return [];
+  try {
+    const raw = storage.getItem(key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (_) {
+    return [];
+  }
+}
+
+function writeJsonArray(storage, key, value) {
+  if (!storage) return;
+  try {
+    storage.setItem(key, JSON.stringify(value));
+  } catch (_) {
+    // Ignore quota and serialization failures for diagnostics-only data.
+  }
+}
+
+function safeDurationMs(startedAtMs, finishedAtMs) {
+  const startMs = Number(startedAtMs);
+  const finishMs = Number(finishedAtMs);
+  if (!Number.isFinite(startMs) || !Number.isFinite(finishMs)) return null;
+  return Math.max(0, Math.round(finishMs - startMs));
+}
+
+function normaliseStatus(rawStatus) {
+  const value = asString(rawStatus).toLowerCase();
+  if (value === 'error' || value === 'failed' || value === 'failure') return 'error';
+  if (value === 'cancelled' || value === 'canceled') return 'cancelled';
+  return 'success';
+}
+
+function normaliseActiveEntry(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const id = asString(raw.id);
+  if (!id) return null;
+  const startedAtMs = Number(raw.startedAtMs);
+  const safeStartedAtMs = Number.isFinite(startedAtMs) ? startedAtMs : Date.now();
+  const taskType = normaliseTaskType(raw.taskType);
+  return {
+    id,
+    taskType,
+    label: normaliseLabel(taskType, raw.label),
+    detail: asString(raw.detail),
+    startedAtMs: safeStartedAtMs,
+    startedAtIso: asString(raw.startedAtIso) || new Date(safeStartedAtMs).toISOString(),
+  };
+}
+
+function normaliseHistoryEntry(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const id = asString(raw.id);
+  if (!id) return null;
+  const startedAtMs = Number(raw.startedAtMs);
+  const finishedAtMs = Number(raw.finishedAtMs);
+  const safeStartedAtMs = Number.isFinite(startedAtMs) ? startedAtMs : Date.now();
+  const safeFinishedAtMs = Number.isFinite(finishedAtMs) ? finishedAtMs : safeStartedAtMs;
+  const taskType = normaliseTaskType(raw.taskType);
+  return {
+    id,
+    taskType,
+    label: normaliseLabel(taskType, raw.label),
+    detail: asString(raw.detail),
+    status: normaliseStatus(raw.status),
+    errorMessage: asString(raw.errorMessage),
+    startedAtMs: safeStartedAtMs,
+    startedAtIso: asString(raw.startedAtIso) || new Date(safeStartedAtMs).toISOString(),
+    finishedAtMs: safeFinishedAtMs,
+    finishedAtIso: asString(raw.finishedAtIso) || new Date(safeFinishedAtMs).toISOString(),
+    durationMs: safeDurationMs(safeStartedAtMs, safeFinishedAtMs),
+  };
+}
+
+function writeActiveTasks(entries) {
+  const storage = resolveStorage('session');
+  if (!storage) return;
+  const normalised = Array.isArray(entries)
+    ? entries.map(normaliseActiveEntry).filter(Boolean)
+    : [];
+  writeJsonArray(storage, ACTIVE_STORAGE_KEY, normalised);
+}
+
+function readActiveTasks() {
+  const storage = resolveStorage('session');
+  const parsed = readJsonArray(storage, ACTIVE_STORAGE_KEY)
+    .map(normaliseActiveEntry)
+    .filter(Boolean);
+  const cutoff = Date.now() - ACTIVE_TASK_STALE_MS;
+  const pruned = parsed.filter((entry) => entry.startedAtMs >= cutoff);
+  if (pruned.length !== parsed.length) {
+    writeActiveTasks(pruned);
+  }
+  return pruned;
+}
+
+function writeHistory(entries) {
+  const storage = resolveStorage('local');
+  if (!storage) return;
+  const normalised = Array.isArray(entries)
+    ? entries.map(normaliseHistoryEntry).filter(Boolean).slice(0, MAX_HISTORY_ITEMS)
+    : [];
+  writeJsonArray(storage, HISTORY_STORAGE_KEY, normalised);
+}
+
+function readHistory() {
+  return readJsonArray(resolveStorage('local'), HISTORY_STORAGE_KEY)
+    .map(normaliseHistoryEntry)
+    .filter(Boolean);
+}
+
+function emitBackgroundTaskChange() {
+  try {
+    const detail = getBackgroundTaskState();
+    document.dispatchEvent(new CustomEvent(BACKGROUND_TASKS_CHANGED_EVENT, { detail }));
+  } catch (_) {
+    // Ignore dispatch errors in constrained test runners.
+  }
+}
+
+export function getBackgroundTaskState(options = {}) {
+  const historyLimitRaw = Number(options?.historyLimit);
+  const historyLimit = Number.isFinite(historyLimitRaw) && historyLimitRaw > 0
+    ? Math.min(Math.round(historyLimitRaw), MAX_HISTORY_ITEMS)
+    : Math.min(20, MAX_HISTORY_ITEMS);
+  return {
+    active: readActiveTasks(),
+    history: readHistory().slice(0, historyLimit),
+  };
+}
+
+export function clearBackgroundTaskHistory() {
+  writeHistory([]);
+  emitBackgroundTaskChange();
+}
+
+export function startBackgroundTask(taskType, options = {}) {
+  const type = normaliseTaskType(taskType);
+  taskSequence += 1;
+  const startedAtMs = Date.now();
+  const entry = normaliseActiveEntry({
+    id: `${type}:${startedAtMs}:${taskSequence}`,
+    taskType: type,
+    label: options?.label,
+    detail: options?.detail,
+    startedAtMs,
+    startedAtIso: new Date(startedAtMs).toISOString(),
+  });
+  const activeTasks = readActiveTasks();
+  activeTasks.push(entry);
+  writeActiveTasks(activeTasks);
+  emitBackgroundTaskChange();
+  return {
+    id: entry.id,
+    taskType: entry.taskType,
+    label: entry.label,
+    detail: entry.detail,
+    startedAtMs: entry.startedAtMs,
+    startedAtIso: entry.startedAtIso,
+  };
+}
+
+export function finishBackgroundTask(handle, options = {}) {
+  const id = asString(typeof handle === 'string' ? handle : handle?.id);
+  if (!id) return null;
+
+  const activeTasks = readActiveTasks();
+  const taskIndex = activeTasks.findIndex((entry) => entry.id === id);
+  const activeEntry = taskIndex >= 0 ? activeTasks[taskIndex] : null;
+  if (taskIndex >= 0) {
+    activeTasks.splice(taskIndex, 1);
+    writeActiveTasks(activeTasks);
+  }
+
+  const finishedAtMs = Date.now();
+  const fallbackStartMs = Number((typeof handle === 'object' && handle) ? handle.startedAtMs : null);
+  const startedAtMs = Number.isFinite(activeEntry?.startedAtMs)
+    ? activeEntry.startedAtMs
+    : (Number.isFinite(fallbackStartMs) ? fallbackStartMs : finishedAtMs);
+  const taskType = normaliseTaskType(activeEntry?.taskType || handle?.taskType || 'background_task');
+  const historyEntry = normaliseHistoryEntry({
+    id,
+    taskType,
+    label: options?.label || activeEntry?.label || handle?.label,
+    detail: options?.detail || activeEntry?.detail || handle?.detail,
+    status: options?.status,
+    errorMessage: options?.error ? String(options.error?.message || options.error) : '',
+    startedAtMs,
+    startedAtIso: activeEntry?.startedAtIso || handle?.startedAtIso || new Date(startedAtMs).toISOString(),
+    finishedAtMs,
+    finishedAtIso: new Date(finishedAtMs).toISOString(),
+  });
+
+  const history = readHistory();
+  history.unshift(historyEntry);
+  writeHistory(history);
+  emitBackgroundTaskChange();
+  return historyEntry;
+}
+
+export function formatBackgroundTaskSummary(activeTasks, options = {}) {
+  const tasks = Array.isArray(activeTasks) ? activeTasks.filter(Boolean) : [];
+  if (!tasks.length) return '';
+  const maxLabelsRaw = Number(options?.maxLabels);
+  const maxLabels = Number.isFinite(maxLabelsRaw) && maxLabelsRaw > 0 ? Math.round(maxLabelsRaw) : 1;
+  const labels = tasks.map((task) => normaliseLabel(task.taskType, task.label));
+  const shown = labels.slice(0, maxLabels);
+  const hiddenCount = Math.max(0, labels.length - shown.length);
+  if (hiddenCount > 0) {
+    return `BG: ${shown.join(', ')} +${hiddenCount}`;
+  }
+  return `BG: ${shown.join(', ')}`;
+}
+
+export function formatBackgroundTaskTooltip(activeTasks) {
+  const tasks = Array.isArray(activeTasks) ? activeTasks.filter(Boolean) : [];
+  if (!tasks.length) return '';
+  const nowMs = Date.now();
+  return tasks
+    .map((task) => {
+      const label = normaliseLabel(task.taskType, task.label);
+      const ageMs = Math.max(0, Math.round(nowMs - Number(task.startedAtMs || nowMs)));
+      const detail = asString(task.detail);
+      if (detail) {
+        return `${label} (${ageMs}ms) - ${detail}`;
+      }
+      return `${label} (${ageMs}ms)`;
+    })
+    .join('\n');
+}
+
+export function subscribeBackgroundTaskUpdates(listener, options = {}) {
+  if (typeof listener !== 'function') {
+    return () => { };
+  }
+
+  const onTaskChange = (event) => {
+    const detail = event?.detail || getBackgroundTaskState();
+    listener(detail);
+  };
+  const onStorage = (event) => {
+    if (!event) return;
+    if (event.key && event.key !== ACTIVE_STORAGE_KEY && event.key !== HISTORY_STORAGE_KEY) return;
+    listener(getBackgroundTaskState());
+  };
+
+  try {
+    document.addEventListener(BACKGROUND_TASKS_CHANGED_EVENT, onTaskChange);
+  } catch (_) { }
+  try {
+    window.addEventListener('storage', onStorage);
+  } catch (_) { }
+
+  if (options?.emitInitial !== false) {
+    listener(getBackgroundTaskState());
+  }
+
+  return () => {
+    try {
+      document.removeEventListener(BACKGROUND_TASKS_CHANGED_EVENT, onTaskChange);
+    } catch (_) { }
+    try {
+      window.removeEventListener('storage', onStorage);
+    } catch (_) { }
+  };
+}
+
+export function __testOnly_resetBackgroundTaskTracker() {
+  taskSequence = 0;
+  try {
+    resolveStorage('session')?.removeItem(ACTIVE_STORAGE_KEY);
+  } catch (_) { }
+  try {
+    resolveStorage('local')?.removeItem(HISTORY_STORAGE_KEY);
+  } catch (_) { }
+  emitBackgroundTaskChange();
+}

--- a/src/frontend/web/von_interface/static/js/main.js
+++ b/src/frontend/web/von_interface/static/js/main.js
@@ -7,6 +7,7 @@ import './suppressTooltips.js';
 import { activateTab, loadTabData, setupTabNavigation } from './tabNavigation.js';
 import { evaluateServerHealthState } from './utils/serverHealthState.js';
 import { handleSelectConceptByIdDetail } from './utils/selectConceptByIdHandler.js';
+import { formatBackgroundTaskSummary, formatBackgroundTaskTooltip, subscribeBackgroundTaskUpdates } from './backgroundTaskTracker.js';
 import {
   copyJsonTextWithButtonFeedback,
   initialiseCopyJsonButtonPreCopyState,
@@ -615,7 +616,8 @@ function startHealthPolling() {
   const ragChatBackfillBtn = ragModal ? document.getElementById('ragChatBackfill') : null;
   const busyEl = document.getElementById('vontologyBusyIndicator');
   const busySr = document.getElementById('vontologyBusySrStatus');
-  if (!localIpSpan && !publicIpSpan && !pidSpan && !uptimeSpan && !ragSpan && !ragModal && !busyEl) {
+  const backgroundTaskEl = document.getElementById('backgroundTaskFooterStatus');
+  if (!localIpSpan && !publicIpSpan && !pidSpan && !uptimeSpan && !ragSpan && !ragModal && !busyEl && !backgroundTaskEl) {
     return;
   }
   // Copy-to-clipboard behavior for local IP address
@@ -817,6 +819,22 @@ function startHealthPolling() {
   let healthPollQueuedImmediate = false;
   let healthPollTimerId = null;
   let lastBusyState = null;
+  let unsubscribeBackgroundTaskUpdates = null;
+
+  function updateBackgroundTaskFooter(snapshot) {
+    if (!backgroundTaskEl) return;
+    const activeTasks = Array.isArray(snapshot?.active) ? snapshot.active : [];
+    if (!activeTasks.length) {
+      backgroundTaskEl.classList.remove('active');
+      backgroundTaskEl.textContent = '';
+      backgroundTaskEl.title = '';
+      return;
+    }
+    backgroundTaskEl.textContent = formatBackgroundTaskSummary(activeTasks, { maxLabels: 1 });
+    backgroundTaskEl.title = formatBackgroundTaskTooltip(activeTasks);
+    backgroundTaskEl.classList.add('active');
+  }
+
   function updateBusyIndicator() {
     if (!busyEl) return;
     try {
@@ -836,6 +854,28 @@ function startHealthPolling() {
       }
     } catch (_) { }
   }
+
+  if (backgroundTaskEl) {
+    try {
+      unsubscribeBackgroundTaskUpdates = subscribeBackgroundTaskUpdates((snapshot) => {
+        updateBackgroundTaskFooter(snapshot);
+      });
+    } catch (_) {
+      updateBackgroundTaskFooter(null);
+    }
+  }
+
+  try {
+    window.addEventListener('beforeunload', () => {
+      try {
+        if (unsubscribeBackgroundTaskUpdates) {
+          unsubscribeBackgroundTaskUpdates();
+          unsubscribeBackgroundTaskUpdates = null;
+        }
+      } catch (_) { }
+    }, { once: true });
+  } catch (_) { }
+
   function scheduleHealthPoll(delayMs) {
     if (healthPollTimerId) {
       clearTimeout(healthPollTimerId);

--- a/src/frontend/web/von_interface/static/js/settingsPage.js
+++ b/src/frontend/web/von_interface/static/js/settingsPage.js
@@ -1,4 +1,10 @@
 import { getWindowSessionId, postJson, WINDOW_SESSION_HEADER } from './apiService.js';
+import {
+  clearBackgroundTaskHistory,
+  formatBackgroundTaskSummary,
+  getBackgroundTaskState,
+  subscribeBackgroundTaskUpdates
+} from './backgroundTaskTracker.js';
 import { renderOrgSelector, setupOrgSwitchListener, switchOrganisation } from './components/orgSelector.js';
 import { populateLanguageSelect } from './languageConfig.js';
 import {
@@ -62,6 +68,7 @@ const RUNTIME_REFRESH_MS = 12000;
 let runtimeIntervalId = null;
 let runtimeAbortController = null;
 let runtimeStatusInFlight = false;
+let backgroundTaskUnsubscribe = null;
 let gmailProfileStatusInFlight = false;
 
 let __vonIsAdminOrOwner = false;
@@ -139,6 +146,134 @@ function formatUptime(ms) {
   if (h > 0) return `${h}h ${m}m ${s}s`;
   if (m > 0) return `${m}m ${s}s`;
   return `${s}s`;
+}
+
+function normaliseBackgroundTaskStatus(rawStatus) {
+  const status = String(rawStatus || '').trim().toLowerCase();
+  if (status === 'error' || status === 'failed' || status === 'failure') return 'error';
+  if (status === 'cancelled' || status === 'canceled') return 'cancelled';
+  return 'success';
+}
+
+function formatBackgroundTaskTimestamp(isoValue) {
+  const value = String(isoValue || '').trim();
+  if (!value) return 'unknown time';
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) return value;
+  return new Date(parsed).toLocaleString();
+}
+
+function formatBackgroundTaskDuration(durationMs) {
+  const ms = Number(durationMs);
+  if (!Number.isFinite(ms) || ms < 0) return 'duration unknown';
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  return `${Math.round(ms)}ms`;
+}
+
+export function __testOnly_formatBackgroundTaskActivity(snapshot) {
+  const active = Array.isArray(snapshot?.active) ? snapshot.active.filter(Boolean) : [];
+  const history = Array.isArray(snapshot?.history) ? snapshot.history.filter(Boolean) : [];
+  const activeText = active.length
+    ? `${formatBackgroundTaskSummary(active, { maxLabels: 2 })} (${active.length} running)`
+    : 'No background tasks running.';
+  const historyRows = history.slice(0, 20).map((entry) => {
+    const status = normaliseBackgroundTaskStatus(entry.status);
+    const label = String(entry.label || entry.taskType || 'Background task').trim();
+    const detail = String(entry.detail || '').trim();
+    const duration = formatBackgroundTaskDuration(entry.durationMs);
+    const completedAt = formatBackgroundTaskTimestamp(entry.finishedAtIso);
+    const parts = [`${label}`, `status=${status}`, `duration=${duration}`, `finished=${completedAt}`];
+    if (detail) parts.push(`detail=${detail}`);
+    if (status === 'error' && entry.errorMessage) parts.push(`error=${String(entry.errorMessage).trim()}`);
+    return parts.join(' | ');
+  });
+  return { activeText, historyRows };
+}
+
+function renderBackgroundTaskActivity(snapshot = getBackgroundTaskState({ historyLimit: 20 })) {
+  const statusEl = document.getElementById('settingsBackgroundTaskStatus');
+  const historyEl = document.getElementById('settingsBackgroundTaskHistory');
+  if (!statusEl && !historyEl) return;
+
+  const active = Array.isArray(snapshot?.active) ? snapshot.active.filter(Boolean) : [];
+  const history = Array.isArray(snapshot?.history) ? snapshot.history.filter(Boolean) : [];
+  const { activeText } = __testOnly_formatBackgroundTaskActivity({ active, history });
+
+  if (statusEl) {
+    statusEl.textContent = activeText;
+    statusEl.classList.toggle('is-active', active.length > 0);
+  }
+
+  if (!historyEl) return;
+  historyEl.textContent = '';
+  if (!history.length) {
+    const empty = document.createElement('p');
+    empty.className = 'background-task-history-empty';
+    empty.textContent = 'No background tasks recorded yet.';
+    historyEl.appendChild(empty);
+    return;
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'background-task-history-list';
+  history.slice(0, 20).forEach((entry) => {
+    const status = normaliseBackgroundTaskStatus(entry.status);
+    const item = document.createElement('li');
+    item.className = `background-task-history-item status-${status}`;
+
+    const title = document.createElement('div');
+    title.className = 'background-task-history-title';
+    const label = String(entry.label || entry.taskType || 'Background task').trim();
+    const detail = String(entry.detail || '').trim();
+    title.textContent = detail ? `${label}: ${detail}` : label;
+    item.appendChild(title);
+
+    const meta = document.createElement('div');
+    meta.className = 'background-task-history-meta';
+    const finishedAt = formatBackgroundTaskTimestamp(entry.finishedAtIso);
+    const duration = formatBackgroundTaskDuration(entry.durationMs);
+    const metaParts = [`Completed ${finishedAt}`, `status ${status}`, duration];
+    if (status === 'error' && entry.errorMessage) {
+      metaParts.push(`error ${String(entry.errorMessage).trim()}`);
+    }
+    meta.textContent = metaParts.join(' | ');
+    item.appendChild(meta);
+
+    list.appendChild(item);
+  });
+  historyEl.appendChild(list);
+}
+
+function setupBackgroundTaskSection() {
+  const statusEl = document.getElementById('settingsBackgroundTaskStatus');
+  const historyEl = document.getElementById('settingsBackgroundTaskHistory');
+  const clearBtn = document.getElementById('settingsClearBackgroundTaskHistoryButton');
+
+  if (!statusEl && !historyEl && !clearBtn) return;
+
+  try {
+    if (backgroundTaskUnsubscribe) {
+      backgroundTaskUnsubscribe();
+      backgroundTaskUnsubscribe = null;
+    }
+  } catch (_) { }
+
+  try {
+    backgroundTaskUnsubscribe = subscribeBackgroundTaskUpdates((snapshot) => {
+      renderBackgroundTaskActivity(snapshot);
+    });
+  } catch (_) {
+    renderBackgroundTaskActivity();
+  }
+
+  if (clearBtn && !clearBtn.dataset.backgroundTaskBound) {
+    clearBtn.dataset.backgroundTaskBound = '1';
+    clearBtn.addEventListener('click', () => {
+      clearBackgroundTaskHistory();
+      renderBackgroundTaskActivity(getBackgroundTaskState({ historyLimit: 20 }));
+      showStatusMessage('vontologyPerformanceStatus', 'Background task history cleared.', false);
+    });
+  }
 }
 
 function wireCopyButton(btn) {
@@ -1165,6 +1300,12 @@ window.addEventListener('beforeunload', () => {
     }
   } catch { }
   try { runtimeAbortController?.abort(); } catch { }
+  try {
+    if (backgroundTaskUnsubscribe) {
+      backgroundTaskUnsubscribe();
+      backgroundTaskUnsubscribe = null;
+    }
+  } catch { }
 });
 
 function getStoredJson(key) {
@@ -1245,6 +1386,7 @@ function applyStoredSelection(selectId, stored, fallbackSelected = true) {
 
 document.addEventListener('DOMContentLoaded', async () => {
   setupRuntimeSection();
+  setupBackgroundTaskSection();
   // Initialize all settings sections
   await loadAndDisplaySettings();
   setupConversationHistorySettingsSection();

--- a/src/frontend/web/von_interface/static/js/vontology.js
+++ b/src/frontend/web/von_interface/static/js/vontology.js
@@ -13,6 +13,7 @@ import {
   setVontologyTreeData,
   vontologyTreeData
 } from './state.js';
+import { finishBackgroundTask, startBackgroundTask } from './backgroundTaskTracker.js';
 import { createAnnotatedFragment } from './utils/textDecorator.js';
 
 // Search configuration constants
@@ -3140,6 +3141,7 @@ const __idToElement = new Map(); // concept_id -> span.vontology-node-name
 export async function chooseBestTypeForIndividual(candidateTypeIds = []) {
   const __perfStart = (typeof window !== 'undefined' && window.performance ? performance.now() : Date.now());
   if (!candidateTypeIds || !candidateTypeIds.length) return null;
+  let countFetchTask = null;
 
   try {
     const idsParam = candidateTypeIds.join(',');
@@ -3157,11 +3159,22 @@ export async function chooseBestTypeForIndividual(candidateTypeIds = []) {
       }
       return chosenCached;
     }
+    countFetchTask = startBackgroundTask('instance_counts', {
+      label: 'Instance counts',
+      detail: `${candidateTypeIds.length} candidate types`
+    });
     const resp = await fetch(`/api/vontology/instance_counts?ids=${encodeURIComponent(idsParam)}`);
     if (!resp.ok) {
       console.warn('Failed to fetch instance counts for candidate types');
       // Ensure no stale negative/empty cache persists for this key
       try { __instanceCountsCache.delete(idsParam); } catch (_) { }
+      if (countFetchTask) {
+        finishBackgroundTask(countFetchTask, {
+          status: 'error',
+          detail: `HTTP ${resp.status}`
+        });
+        countFetchTask = null;
+      }
       return candidateTypeIds[0];
     }
     const data = await resp.json();
@@ -3191,12 +3204,26 @@ export async function chooseBestTypeForIndividual(candidateTypeIds = []) {
     // If tie in total, keep the first (stable). Optionally, we could prefer deeper nodes if depth info is available.
     const chosen = scored[0] && scored[0].id;
     console.debug('[chooseBestTypeForIndividual] chosen best type:', chosen);
+    if (countFetchTask) {
+      finishBackgroundTask(countFetchTask, {
+        status: 'success',
+        detail: `${candidateTypeIds.length} candidate types`
+      });
+      countFetchTask = null;
+    }
     if (typeof window !== 'undefined' && window.VON_PERF_LOG) {
       const dur = (window.performance ? performance.now() : Date.now()) - __perfStart;
       console.log('[perf] chooseBestTypeForIndividual duration(ms)=', dur.toFixed(2), 'candidates=', candidateTypeIds.length, 'cacheMiss=1');
     }
     return chosen;
   } catch (e) {
+    if (countFetchTask) {
+      finishBackgroundTask(countFetchTask, {
+        status: 'error',
+        error: e
+      });
+      countFetchTask = null;
+    }
     console.error('Error choosing best type for individual:', e);
     // Defensive: clear any partial cache entry that may have been set just before error
     try { /* error stage cleanup */ } catch (_) { }
@@ -4201,6 +4228,7 @@ export function preloadVontologyData() {
   }
   console.log('[preloadVontologyData] Checking whether to preload Vontology tree...');
   __vontologyPreloadInFlight = (async () => {
+    let preloadTask = null;
     try {
       // Fetch settings to determine if counts should be fetched on load
       let fetchCountsOnLoad = true;
@@ -4233,6 +4261,10 @@ export function preloadVontologyData() {
       }
 
       console.log('[preloadVontologyData] Starting background preload of Vontology tree (and counts if enabled)...');
+      preloadTask = startBackgroundTask('preload_vontology_tree', {
+        label: 'Preload Vontology tree',
+        detail: fetchCountsOnLoad ? 'Tree + entity counts' : 'Tree only'
+      });
       try { if (typeof window !== 'undefined') window.__VONTOLOGY_BUSY = true; } catch (_) { }
 
       const treePromise = fetch('/vontology/api/vontology/tree').then(r => r.ok ? r.json() : Promise.reject(`HTTP error! status: ${r.status}`));
@@ -4250,7 +4282,21 @@ export function preloadVontologyData() {
       // Also seed the global state so helpers that rely on stored tree can function sooner
       try { setVontologyTreeData(tree); } catch (_) { }
       console.log('[preloadVontologyData] Preload complete. counts_on_load=', fetchCountsOnLoad);
+      if (preloadTask) {
+        finishBackgroundTask(preloadTask, {
+          status: 'success',
+          detail: fetchCountsOnLoad ? 'Tree + counts preloaded' : 'Tree preloaded'
+        });
+        preloadTask = null;
+      }
     } catch (err) {
+      if (preloadTask) {
+        finishBackgroundTask(preloadTask, {
+          status: 'error',
+          error: err
+        });
+        preloadTask = null;
+      }
       console.warn('[preloadVontologyData] Preload failed:', err);
     }
   })().finally(() => {

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -51,6 +51,25 @@ body {
     animation: vontology-spin 1.2s linear infinite;
 }
 
+.background-task-footer-status {
+    display: none;
+    margin-left: 8px;
+    padding: 1px 8px;
+    border-radius: 999px;
+    border: 1px solid #bfdbfe;
+    background: #eff6ff;
+    color: #1d4ed8;
+    font-size: 0.72rem;
+    font-weight: 600;
+    line-height: 1.4;
+    cursor: default;
+}
+
+.background-task-footer-status.active {
+    display: inline-flex;
+    align-items: center;
+}
+
 @keyframes vontology-spin {
     0% {
         filter: brightness(1);
@@ -8852,6 +8871,69 @@ body.settings-body {
 .runtime-hint {
     margin-top: 4px;
     font-size: 0.85rem;
+    color: #6b7280;
+}
+
+.background-task-status {
+    margin-top: 8px;
+    font-size: 0.95rem;
+    color: #4b5563;
+}
+
+.background-task-status.is-active {
+    color: #1d4ed8;
+    font-weight: 600;
+}
+
+.background-task-history {
+    margin-top: 8px;
+}
+
+.background-task-history-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 240px;
+    overflow-y: auto;
+}
+
+.background-task-history-item {
+    border: 1px solid #e5e7eb;
+    border-left: 4px solid #94a3b8;
+    border-radius: 8px;
+    padding: 8px 10px;
+    background: #f8fafc;
+}
+
+.background-task-history-item.status-success {
+    border-left-color: #16a34a;
+}
+
+.background-task-history-item.status-error {
+    border-left-color: #dc2626;
+}
+
+.background-task-history-item.status-cancelled {
+    border-left-color: #d97706;
+}
+
+.background-task-history-title {
+    font-weight: 600;
+    color: #111827;
+}
+
+.background-task-history-meta {
+    margin-top: 4px;
+    font-size: 0.82rem;
+    color: #6b7280;
+}
+
+.background-task-history-empty {
+    margin: 0;
+    font-size: 0.9rem;
     color: #6b7280;
 }
 

--- a/src/frontend/web/von_interface/templates/settings_tab.html
+++ b/src/frontend/web/von_interface/templates/settings_tab.html
@@ -304,6 +304,17 @@
                     faster; counts will still appear shortly after as they are loaded lazily.</small>
             </div>
 
+            <h3 class="mt-3">Background Task Activity</h3>
+            <p class="settings-note">Recent background operations such as instance-count fetches.</p>
+            <div id="settingsBackgroundTaskStatus" class="background-task-status">No background tasks running.</div>
+            <div id="settingsBackgroundTaskHistory" class="background-task-history">
+                <p class="background-task-history-empty">No background tasks recorded yet.</p>
+            </div>
+            <div class="inline-form inline-form-tight mt-2">
+                <button id="settingsClearBackgroundTaskHistoryButton" type="button" class="btn-secondary">Clear
+                    background task history</button>
+            </div>
+
             <h3 class="mt-3">Vontology Concept Appearance</h3>
             <p class="settings-note">Controls how #V# concept cartouches render across chat, prompt overlay, and
                 Vontology

--- a/src/frontend/web/von_interface/templates/von_interface.html
+++ b/src/frontend/web/von_interface/templates/von_interface.html
@@ -167,6 +167,7 @@
         title="Click to copy PID">?</button>
       <span id="vontologyBusyIndicator" aria-hidden="true" title="Vontology operations in progress">⏳</span>
       <span id="vontologyBusySrStatus" class="visually-hidden" aria-live="polite"></span>
+      <span id="backgroundTaskFooterStatus" class="background-task-footer-status" aria-live="polite"></span>
       <span class="footer-separator">|</span>
       <span class="footer-label">RAG:</span> <span id="ragIndexingValue" class="concept-footer-button"
         title="Click for detailed RAG status">—</span>

--- a/tests/frontend/backgroundTaskTracker.test.js
+++ b/tests/frontend/backgroundTaskTracker.test.js
@@ -1,0 +1,65 @@
+/** @jest-environment jsdom */
+
+const trackerPath = '../../src/frontend/web/von_interface/static/js/backgroundTaskTracker.js';
+
+describe('backgroundTaskTracker', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        localStorage.clear();
+        sessionStorage.clear();
+    });
+
+    afterEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+    });
+
+    test('tracks active background tasks and writes completion history', () => {
+        const {
+            __testOnly_resetBackgroundTaskTracker,
+            finishBackgroundTask,
+            formatBackgroundTaskSummary,
+            getBackgroundTaskState,
+            startBackgroundTask
+        } = require(trackerPath);
+
+        __testOnly_resetBackgroundTaskTracker();
+        const handle = startBackgroundTask('instance_counts', {
+            label: 'Instance counts',
+            detail: '3 candidate types'
+        });
+
+        const duringRun = getBackgroundTaskState({ historyLimit: 10 });
+        expect(duringRun.active).toHaveLength(1);
+        expect(duringRun.active[0].taskType).toBe('instance_counts');
+        expect(duringRun.active[0].detail).toBe('3 candidate types');
+        expect(formatBackgroundTaskSummary(duringRun.active)).toBe('BG: Instance counts');
+
+        finishBackgroundTask(handle, { status: 'success' });
+
+        const afterRun = getBackgroundTaskState({ historyLimit: 10 });
+        expect(afterRun.active).toHaveLength(0);
+        expect(afterRun.history).toHaveLength(1);
+        expect(afterRun.history[0].taskType).toBe('instance_counts');
+        expect(afterRun.history[0].status).toBe('success');
+        expect(afterRun.history[0].durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    test('clears persisted history entries', () => {
+        const {
+            __testOnly_resetBackgroundTaskTracker,
+            clearBackgroundTaskHistory,
+            finishBackgroundTask,
+            getBackgroundTaskState,
+            startBackgroundTask
+        } = require(trackerPath);
+
+        __testOnly_resetBackgroundTaskTracker();
+        const handle = startBackgroundTask('preload_vontology_tree', { label: 'Preload Vontology tree' });
+        finishBackgroundTask(handle, { status: 'error', error: 'timeout' });
+
+        expect(getBackgroundTaskState({ historyLimit: 5 }).history).toHaveLength(1);
+        clearBackgroundTaskHistory();
+        expect(getBackgroundTaskState({ historyLimit: 5 }).history).toHaveLength(0);
+    });
+});

--- a/tests/frontend/settingsBackgroundTaskActivity.test.js
+++ b/tests/frontend/settingsBackgroundTaskActivity.test.js
@@ -1,0 +1,45 @@
+/** @jest-environment jsdom */
+
+const {
+    __testOnly_formatBackgroundTaskActivity
+} = require('../../src/frontend/web/von_interface/static/js/settingsPage.js');
+
+describe('Settings background task activity formatting', () => {
+    test('shows idle message with no rows when empty', () => {
+        const formatted = __testOnly_formatBackgroundTaskActivity({ active: [], history: [] });
+        expect(formatted.activeText).toBe('No background tasks running.');
+        expect(formatted.historyRows).toEqual([]);
+    });
+
+    test('formats active and history rows with status metadata', () => {
+        const snapshot = {
+            active: [
+                {
+                    taskType: 'instance_counts',
+                    label: 'Instance counts',
+                    detail: '5 candidate types'
+                }
+            ],
+            history: [
+                {
+                    taskType: 'preload_vontology_tree',
+                    label: 'Preload Vontology tree',
+                    detail: 'Tree + counts',
+                    status: 'error',
+                    durationMs: 1834,
+                    finishedAtIso: '2026-02-24T10:11:12.000Z',
+                    errorMessage: 'timeout'
+                }
+            ]
+        };
+
+        const formatted = __testOnly_formatBackgroundTaskActivity(snapshot);
+        expect(formatted.activeText).toContain('BG: Instance counts');
+        expect(formatted.activeText).toContain('(1 running)');
+        expect(formatted.historyRows).toHaveLength(1);
+        expect(formatted.historyRows[0]).toContain('status=error');
+        expect(formatted.historyRows[0]).toContain('duration=1.83s');
+        expect(formatted.historyRows[0]).toContain('detail=Tree + counts');
+        expect(formatted.historyRows[0]).toContain('error=timeout');
+    });
+});


### PR DESCRIPTION
## Summary\n- add shared ackgroundTaskTracker helper for active + recent background task lifecycle tracking\n- instrument chooseBestTypeForIndividual and Vontology preload with task start/finish events\n- add footer background-task status badge beside existing Vontology busy indicator\n- add Settings > Vontology UI & Performance panel for active/recent background task activity with clear-history action\n- add focused frontend tests for tracker behaviour and settings formatting\n\n## Validation\n- npm run test:frontend -- tests/frontend/backgroundTaskTracker.test.js tests/frontend/settingsBackgroundTaskActivity.test.js tests/frontend/footerDbBadgeOutageStates.test.js tests/frontend/footerOrgContextFallback.test.js\n- npx pyright\n