### PR TITLE
JVNAUTOSCI-549: add footer LLM server settings link

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -39,6 +39,7 @@ import {
     linkifyVontologyTokensInElement,
     normalisePotentialConceptId
 } from './utils/textDecorator.js';
+import { openSettingsTabAndFocus } from './utils/settingsNavigation.js';
 import { showToast } from './utils/toast.js';
 
 // Helper to build fetch headers with window session context (JVNAUTOSCI-1011)
@@ -9359,35 +9360,9 @@ function _startChatTabsLoadingTicker() {
 }
 
 function openSettingsToLogin() {
-    try {
-        const settingsTabButton = document.querySelector('.tab-button[data-tab="settingsTab"]');
-        if (settingsTabButton) {
-            settingsTabButton.click();
-        }
-
-        const sendFocusMessage = (attempt = 0) => {
-            const frame = document.getElementById('settingsFrame');
-            const targetWindow = frame?.contentWindow;
-            if (targetWindow) {
-                try {
-                    targetWindow.postMessage({ type: 'von:focus-current-user-settings' }, window.location.origin);
-                } catch (_) {
-                    // Best-effort
-                }
-
-                if (attempt < 8) {
-                    setTimeout(() => sendFocusMessage(attempt + 1), 250);
-                }
-                return;
-            }
-
-            if (attempt < 8) {
-                setTimeout(() => sendFocusMessage(attempt + 1), 250);
-            }
-        };
-
-        sendFocusMessage(0);
-    } catch (err) {
+    const opened = openSettingsTabAndFocus('von:focus-current-user-settings');
+    if (!opened) {
+        const err = new Error('Failed to open settings tab');
         console.warn('[chatTab] Failed to open Settings for login:', err);
         try { showToast('Unable to open Settings for login.', true); } catch (_) { }
     }

--- a/src/frontend/web/von_interface/static/js/domUtils.js
+++ b/src/frontend/web/von_interface/static/js/domUtils.js
@@ -1,3 +1,5 @@
+import { openSettingsTabAndFocus } from './utils/settingsNavigation.js';
+
 export const elements = {};
 
 export function initializeDomElements() {
@@ -748,6 +750,11 @@ function attachFooterDbBadge(footer, dbInfo) {
   footer.appendChild(badge);
 }
 
+// Export for testing.
+export function openSettingsForModelControls() {
+  return openSettingsTabAndFocus('von:focus-model-settings');
+}
+
 export async function setModelInfoFooterText() {
   const footer = document.getElementById('modelInfoFooter');
   if (!footer) return;
@@ -851,6 +858,7 @@ export async function setModelInfoFooterText() {
   // Determine LLM status styles
   const status = llmInfo?.status || 'unknown';
   const errorMsg = llmInfo?.error || '';
+  const llmHost = typeof llmInfo?.details?.host === 'string' ? llmInfo.details.host : '';
   let llmClass = '';
   let llmTooltipSuffix = '';
 
@@ -962,6 +970,50 @@ export async function setModelInfoFooterText() {
     }
     span.appendChild(btn);
     return span;
+  }
+
+  function makeActionButton(labelPrefix, displayName, onClick, options = {}) {
+    const span = document.createElement('span');
+    span.className = 'footer-segment';
+    const prefix = document.createElement('span');
+    prefix.className = 'footer-label-inline';
+    prefix.textContent = labelPrefix + ': ';
+    span.appendChild(prefix);
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'concept-footer-button';
+    btn.textContent = displayName;
+    if (options.title) btn.title = options.title;
+    if (options.ariaLabel) btn.setAttribute('aria-label', options.ariaLabel);
+    if (typeof onClick === 'function') {
+      btn.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        onClick();
+      });
+    }
+    span.appendChild(btn);
+    return span;
+  }
+
+  // LLM settings link button: keep it parallel to footer concept controls.
+  {
+    const titleParts = ['Open language model settings'];
+    titleParts.push(`Status: ${status}`);
+    if (activeLlm?.provider) titleParts.push(`Provider: ${activeLlm.provider}`);
+    if (activeLlm?.model) titleParts.push(`Model: ${activeLlm.model}`);
+    if (llmHost) titleParts.push(`Host: ${llmHost}`);
+    if (errorMsg) titleParts.push(`Error: ${errorMsg}`);
+    const llmSettingsSegment = makeActionButton(
+      'LLM',
+      llmHost ? 'Server' : 'Settings',
+      () => { openSettingsForModelControls(); },
+      {
+        ariaLabel: 'Open language model settings',
+        title: titleParts.join('\n')
+      }
+    );
+    if (llmClass) llmSettingsSegment.classList.add('llm-status-badge', llmClass);
+    segments.push(llmSettingsSegment);
   }
 
   // User segment

--- a/src/frontend/web/von_interface/static/js/settingsPage.js
+++ b/src/frontend/web/von_interface/static/js/settingsPage.js
@@ -94,6 +94,27 @@ function _focusCurrentUserSettingsSection() {
   } catch { }
 }
 
+function _focusModelSettingsSection() {
+  try {
+    const section = document.getElementById('premium-model-settings') || document.getElementById('ollima-settings');
+    if (section) {
+      section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+
+    setTimeout(() => {
+      try {
+        const focusTarget =
+          document.getElementById('globalModelSelect')
+          || document.getElementById('openaiModelSelect')
+          || section?.querySelector('select, input, button');
+        if (focusTarget && typeof focusTarget.focus === 'function') {
+          focusTarget.focus();
+        }
+      } catch { }
+    }, 250);
+  } catch { }
+}
+
 // Allow parent (main app) to request focus on the login area from elsewhere (e.g. chat tabs placeholder).
 try {
   window.addEventListener('message', (event) => {
@@ -102,6 +123,8 @@ try {
       const type = event?.data?.type;
       if (type === 'von:focus-current-user-settings') {
         _focusCurrentUserSettingsSection();
+      } else if (type === 'von:focus-model-settings') {
+        _focusModelSettingsSection();
       }
     } catch { }
   });

--- a/src/frontend/web/von_interface/static/js/utils/settingsNavigation.js
+++ b/src/frontend/web/von_interface/static/js/utils/settingsNavigation.js
@@ -1,0 +1,37 @@
+export function openSettingsTabAndFocus(focusMessageType, options = {}) {
+  const retries = Number.isFinite(Number(options?.retries)) ? Math.max(0, Number(options.retries)) : 8;
+  const retryDelayMs = Number.isFinite(Number(options?.retryDelayMs)) ? Math.max(50, Number(options.retryDelayMs)) : 250;
+  const messageType = typeof focusMessageType === 'string' ? focusMessageType.trim() : '';
+
+  try {
+    const settingsTabButton = document.querySelector('.tab-button[data-tab="settingsTab"]');
+    if (settingsTabButton) {
+      settingsTabButton.click();
+    }
+
+    if (!messageType) {
+      return !!settingsTabButton;
+    }
+
+    const sendFocusMessage = (attempt = 0) => {
+      const frame = document.getElementById('settingsFrame');
+      const targetWindow = frame?.contentWindow;
+      if (targetWindow) {
+        try {
+          targetWindow.postMessage({ type: messageType }, window.location.origin);
+        } catch (_) {
+          // Best-effort focus handoff.
+        }
+        return;
+      }
+      if (attempt < retries) {
+        setTimeout(() => sendFocusMessage(attempt + 1), retryDelayMs);
+      }
+    };
+
+    sendFocusMessage(0);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}

--- a/tests/frontend/footerLlmServerLink.test.js
+++ b/tests/frontend/footerLlmServerLink.test.js
@@ -1,0 +1,77 @@
+/** @jest-environment jsdom */
+
+const domUtilsPath = '../../src/frontend/web/von_interface/static/js/domUtils.js';
+
+describe('footer LLM settings link button', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        document.body.innerHTML = `
+            <button class="tab-button" data-tab="settingsTab" type="button">Settings</button>
+            <iframe id="settingsFrame"></iframe>
+            <div class="footer-container"><p id="modelInfoFooter"></p></div>
+        `;
+        localStorage.clear();
+        sessionStorage.clear();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        localStorage.clear();
+        sessionStorage.clear();
+    });
+
+    test('renders LLM footer button and opens model settings focus target', async () => {
+        const settingsTabButton = document.querySelector('.tab-button[data-tab="settingsTab"]');
+        const settingsFrame = document.getElementById('settingsFrame');
+        const frameWindow = settingsFrame.contentWindow;
+        const postMessageMock = jest.spyOn(frameWindow, 'postMessage').mockImplementation(() => { });
+
+        const settingsClickSpy = jest.spyOn(settingsTabButton, 'click');
+        global.fetch = jest.fn(async (url) => {
+            const rawUrl = typeof url === 'string' ? url : (url?.url || String(url));
+            const parsed = new URL(rawUrl, 'http://localhost');
+            const path = parsed.pathname;
+            if (path === '/api/settings/' || path === '/api/settings') {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        active_llm: { provider: 'ollama', model: 'llama3.1:8b' }
+                    })
+                };
+            }
+            if (path === '/api/settings/llm/info') {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        provider: 'ollama',
+                        model: 'llama3.1:8b',
+                        status: 'ready',
+                        details: { host: 'http://127.0.0.1:11434' }
+                    })
+                };
+            }
+            if (path === '/api/settings/db/info') {
+                return { ok: true, json: async () => ({}) };
+            }
+            if (path === '/von/api/auth/status' || path === '/api/auth/status') {
+                return { ok: true, json: async () => ({ authenticated: true, email: 'm.witbrock@auckland.ac.nz' }) };
+            }
+            return { ok: true, json: async () => ({}) };
+        });
+
+        const { setModelInfoFooterText } = require(domUtilsPath);
+        await setModelInfoFooterText();
+
+        const llmSegment = Array.from(document.querySelectorAll('.footer-segment'))
+            .find((seg) => seg.querySelector('.footer-label-inline')?.textContent?.trim() === 'LLM:');
+        expect(llmSegment).toBeTruthy();
+        const llmButton = llmSegment.querySelector('.concept-footer-button');
+        expect(llmButton).toBeTruthy();
+        expect(llmButton.textContent.trim()).toBe('Server');
+        expect(llmButton.getAttribute('aria-label')).toBe('Open language model settings');
+
+        llmButton.click();
+        expect(settingsClickSpy).toHaveBeenCalledTimes(1);
+        expect(postMessageMock).toHaveBeenCalledWith({ type: 'von:focus-model-settings' }, window.location.origin);
+    });
+});


### PR DESCRIPTION
## Summary\n- add a dedicated footer LLM button styled like existing footer controls\n- wire the button to open Settings and focus the model/provider configuration area\n- extract reusable settings-tab focus helper (openSettingsTabAndFocus) and reuse it in chat login redirect path\n- add settings iframe message handling for on:focus-model-settings\n- add frontend regression test for LLM footer button rendering and click behaviour\n\n## Validation\n- npm run test:frontend\n- npx pyright\n