### PR TITLE
JVNAUTOSCI-1248: Canonicalise visibility predicate handling

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -1344,6 +1344,9 @@ def _remove_relationship(**kwargs):
     try:
         repo = ConceptsRepository
 
+        from ...services.relationship_write_service import (
+            normalise_structural_predicate,
+        )
         from ...vontology.code_concepts_registry import (
             build_virtual_concept_doc,
             is_code_concept_id,
@@ -1384,16 +1387,8 @@ def _remove_relationship(**kwargs):
                 suggestions=["Use delete_text_relation to remove text relations"],
             )
 
-        # Map common predicate aliases to stored field names
-        predicate_map = {
-            "instance_of": "is_an_instance_of",
-            "instanceOf": "is_an_instance_of",
-            "type_of": "is_a_type_of",
-            "typeOf": "is_a_type_of",
-            "subtype": "has_subtype",
-            "instance": "has_instance",
-        }
-        rel_kind = predicate_map.get(predicate, predicate)
+        # Canonical predicate normalisation is shared with add_relationship.
+        rel_kind = normalise_structural_predicate(predicate_str)
 
         # Determine if this is a text predicate (binary_text_predicate instance)
         if isinstance(rel_kind, str) and rel_kind.startswith("#V#"):

--- a/src/backend/security/access_control.py
+++ b/src/backend/security/access_control.py
@@ -12,6 +12,11 @@ import logging
 _log = logging.getLogger(__name__)
 
 from ..db.mongo_client import get_concepts_collection
+from .visibility_predicates import (
+    SPECIFIC_TO_ORG_PREDICATES_READ,
+    SPECIFIC_TO_USER_PREDICATES,
+    get_specific_to_user_values,
+)
 
 # ---------------------------------------------------------------------------
 # Context state
@@ -24,9 +29,6 @@ _EVALUATOR: ContextVar["AccessEvaluator | None"] = ContextVar(
 )
 
 _REMOVE = object()
-
-# Both legacy and predicate-style specific_to_user fields should be checked
-_SPECIFIC_TO_USER_PREDICATES = ("specific_to_user", "#V#specific_to_user")
 
 
 def _normalise_concept_id(value: Any) -> Optional[str]:
@@ -58,17 +60,8 @@ def _specific_allows_user(spec: Any, user_id: Optional[str]) -> bool:
 
 
 def _get_specific_to_user_values(relationships: Dict[str, Any]) -> List[Any]:
-    """Collect specific_to_user values from all predicate variants."""
-    values: List[Any] = []
-    for predicate in _SPECIFIC_TO_USER_PREDICATES:
-        val = relationships.get(predicate)
-        if val is None:
-            continue
-        if isinstance(val, list):
-            values.extend(val)
-        else:
-            values.append(val)
-    return values
+    """Compatibility wrapper used by routes/services importing this private helper."""
+    return list(get_specific_to_user_values(relationships))
 
 
 def _document_visible_to_user(doc: Dict[str, Any], user_id: Optional[str]) -> bool:
@@ -129,7 +122,7 @@ class AccessEvaluator:
         else:
             doc = coll.find_one(
                 {"concept_id": normalised},
-                {f"relationships.{p}": 1 for p in _SPECIFIC_TO_USER_PREDICATES},
+                {f"relationships.{p}": 1 for p in SPECIFIC_TO_USER_PREDICATES},
             )
             if doc:
                 rels = doc.get("relationships", {})
@@ -302,7 +295,7 @@ def build_visibility_filter() -> Optional[Dict[str, Any]]:
     # OR if any of them includes the current user.
     # Build "no restriction" clauses for ALL predicate variants
     no_restriction_clauses: List[Dict[str, Any]] = []
-    for predicate in _SPECIFIC_TO_USER_PREDICATES:
+    for predicate in SPECIFIC_TO_USER_PREDICATES:
         field = f"relationships.{predicate}"
         no_restriction_clauses.extend(
             [
@@ -319,7 +312,7 @@ def build_visibility_filter() -> Optional[Dict[str, Any]]:
 
     # User-specific visibility: user appears in ANY of the predicate variants
     if user_id:
-        for predicate in _SPECIFIC_TO_USER_PREDICATES:
+        for predicate in SPECIFIC_TO_USER_PREDICATES:
             clauses.append({f"relationships.{predicate}": {"$in": [user_id]}})
         _log.info(
             f"[access_filter] Including user-specific concepts for user={user_id}"
@@ -340,7 +333,8 @@ def build_visibility_filter() -> Optional[Dict[str, Any]]:
 
     # Organisation-specific visibility (Phase 1)
     if user_org_id:
-        clauses.append({"relationships.specific_to_org": {"$in": [user_org_id]}})
+        for predicate in SPECIFIC_TO_ORG_PREDICATES_READ:
+            clauses.append({f"relationships.{predicate}": {"$in": [user_org_id]}})
         _log.info(
             f"[access_filter] Including org-specific concepts for org={user_org_id}"
         )

--- a/src/backend/security/visibility_predicates.py
+++ b/src/backend/security/visibility_predicates.py
@@ -1,0 +1,124 @@
+"""Visibility predicate helpers.
+
+This module centralises legacy/canonical visibility predicate aliases so write
+paths can mirror values consistently and read paths can tolerate historical
+storage variants.
+
+Why this exists:
+- Legacy records use ``specific_to_user`` / ``specific_to_org`` fields.
+- Newer ontology usage expects predicate-concept IDs (for example
+  ``#V#specific_to_user`` and ``#V#specific_to_organisation``).
+- Without a shared helper, call paths drift and debugging predicate state
+  becomes brittle (for example fetches for one variant while data is stored in
+  another).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Sequence
+
+# Keep read aliases broad for backwards compatibility.
+SPECIFIC_TO_USER_PREDICATES: tuple[str, ...] = (
+    "specific_to_user",
+    "#V#specific_to_user",
+)
+
+SPECIFIC_TO_ORG_PREDICATES_READ: tuple[str, ...] = (
+    "specific_to_org",
+    "specific_to_organisation",
+    "#V#specific_to_org",
+    "#V#specific_to_organisation",
+)
+
+# Writes should favour currently supported canonical/legacy keys and avoid
+# introducing new non-canonical variants unless explicitly required.
+SPECIFIC_TO_ORG_PREDICATES_WRITE: tuple[str, ...] = (
+    "specific_to_org",
+    "specific_to_organisation",
+    "#V#specific_to_organisation",
+)
+
+
+def _normalise_concept_ids(values: Any) -> List[str]:
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, list):
+        return []
+
+    ordered: List[str] = []
+    seen: set[str] = set()
+    for item in values:
+        if not isinstance(item, str):
+            continue
+        candidate = item.strip()
+        if not candidate.startswith("#V#"):
+            continue
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        ordered.append(candidate)
+    return ordered
+
+
+def collect_visibility_values(
+    relationships: Dict[str, Any] | None,
+    predicates: Sequence[str],
+) -> List[str]:
+    if not isinstance(relationships, dict):
+        return []
+
+    gathered: List[str] = []
+    seen: set[str] = set()
+    for predicate in predicates:
+        raw = relationships.get(predicate)
+        for candidate in _normalise_concept_ids(raw):
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            gathered.append(candidate)
+    return gathered
+
+
+def _set_visibility_values(
+    relationships: Dict[str, Any] | None,
+    predicates: Sequence[str],
+    values: Iterable[str],
+) -> Dict[str, Any]:
+    updated = dict(relationships) if isinstance(relationships, dict) else {}
+    normalised = _normalise_concept_ids(list(values))
+
+    for predicate in predicates:
+        if normalised:
+            updated[predicate] = list(normalised)
+        else:
+            updated.pop(predicate, None)
+    return updated
+
+
+def get_specific_to_user_values(relationships: Dict[str, Any] | None) -> List[str]:
+    return collect_visibility_values(relationships, SPECIFIC_TO_USER_PREDICATES)
+
+
+def get_specific_to_org_values(relationships: Dict[str, Any] | None) -> List[str]:
+    return collect_visibility_values(relationships, SPECIFIC_TO_ORG_PREDICATES_READ)
+
+
+def set_specific_to_user_values(
+    relationships: Dict[str, Any] | None,
+    values: Iterable[str],
+) -> Dict[str, Any]:
+    return _set_visibility_values(relationships, SPECIFIC_TO_USER_PREDICATES, values)
+
+
+def set_specific_to_org_values(
+    relationships: Dict[str, Any] | None,
+    values: Iterable[str],
+) -> Dict[str, Any]:
+    return _set_visibility_values(
+        relationships,
+        SPECIFIC_TO_ORG_PREDICATES_WRITE,
+        values,
+    )
+

--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -4740,17 +4740,17 @@ def toggle_organization_relation():
             force = raw_force.strip().lower() in ("1", "true", "yes", "y", "force")
 
         from ...db.repositories.concepts_repository import ConceptsRepository
+        from ...security.visibility_predicates import (
+            get_specific_to_org_values,
+            set_specific_to_org_values,
+        )
 
         concept = ConceptsRepository.find_one({"concept_id": concept_id})
         if not concept:
             return jsonify({"success": False, "error": "Concept not found"}), 404
 
         relationships = concept.get("relationships") or {}
-        org_relations = relationships.get("specific_to_organisation") or []
-        if isinstance(org_relations, str):
-            org_relations = [org_relations]
-        elif not isinstance(org_relations, list):
-            org_relations = []
+        org_relations = get_specific_to_org_values(relationships)
 
         changed = False
         if action == "add":
@@ -4778,7 +4778,7 @@ def toggle_organization_relation():
                     org_relations.remove(organisation_concept_id)
                     changed = True
 
-        relationships["specific_to_organisation"] = org_relations
+        relationships = set_specific_to_org_values(relationships, org_relations)
         ConceptsRepository.update_one(
             {"concept_id": concept_id}, {"$set": {"relationships": relationships}}
         )

--- a/src/backend/services/concept_service.py
+++ b/src/backend/services/concept_service.py
@@ -164,6 +164,10 @@ def _resolve_creation_visibility_scope(
     """Resolve concept visibility restrictions and diagnostics for create_concept."""
 
     from .workflow_event_integration_service import resolve_event_actor_context
+    from ..security.visibility_predicates import (
+        set_specific_to_org_values,
+        set_specific_to_user_values,
+    )
 
     warnings: List[str] = []
     requested_scope_mode = _normalise_creation_scope_mode(visibility_scope_mode)
@@ -199,7 +203,10 @@ def _resolve_creation_visibility_scope(
 
         if mode_for_resolution == CONCEPT_SCOPE_ORGANISATION_GENERAL:
             if actor_org_id:
-                relationships["specific_to_org"] = [actor_org_id]
+                relationships = set_specific_to_org_values(
+                    relationships,
+                    [actor_org_id],
+                )
                 effective_scope_mode = CONCEPT_SCOPE_ORGANISATION_GENERAL
                 scope_source = "request.scope_mode"
             else:
@@ -207,9 +214,15 @@ def _resolve_creation_visibility_scope(
                 effective_scope_mode = CONCEPT_SCOPE_GLOBAL_GENERAL
                 scope_source = "missing_authenticated_context"
         elif actor_user_id:
-            relationships["specific_to_user"] = [actor_user_id]
+            relationships = set_specific_to_user_values(
+                relationships,
+                [actor_user_id],
+            )
             if actor_org_id:
-                relationships["specific_to_org"] = [actor_org_id]
+                relationships = set_specific_to_org_values(
+                    relationships,
+                    [actor_org_id],
+                )
                 effective_scope_mode = CONCEPT_SCOPE_USER_ORG_DEFAULT
             else:
                 effective_scope_mode = CONCEPT_SCOPE_USER_ONLY_DEFAULT
@@ -805,6 +818,35 @@ def get_concept_by_concept_id(concept_id: str) -> Optional[Dict[str, Any]]:
                 return get_concept_by_concept_id(resolved_id)
         except Exception as alias_err:
             logger.debug("Alias resolution for '%s' failed: %s", concept_id, alias_err)
+
+        # Fallback: deterministic name/code resolution for known legacy variants.
+        # This keeps fetch_concept robust when callers use legacy IDs that are now
+        # preserved as hasName aliases instead of first-class concept_ids.
+        try:
+            from .concept_resolution_service import resolve_concept_by_name
+
+            resolution = resolve_concept_by_name(
+                name=concept_id,
+                match_code_strings=True,
+                max_results=3,
+            )
+            resolved_id = (
+                resolution.get("resolved_concept_id")
+                if isinstance(resolution, dict)
+                else None
+            )
+            if (
+                isinstance(resolved_id, str)
+                and resolved_id.startswith("#V#")
+                and resolved_id != concept_id
+            ):
+                return get_concept_by_concept_id(resolved_id)
+        except Exception as resolve_err:
+            logger.debug(
+                "Name-based resolution for '%s' failed: %s",
+                concept_id,
+                resolve_err,
+            )
 
         # Virtual fallback for code-handled concepts (read-only).
         try:

--- a/src/backend/services/message_service.py
+++ b/src/backend/services/message_service.py
@@ -23,6 +23,10 @@ from ..security.access_control import (
     get_effective_user_concept_id,
     bypass_access_control,
 )
+from ..security.visibility_predicates import (
+    set_specific_to_org_values,
+    set_specific_to_user_values,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -96,9 +100,12 @@ def create_message(
         "is_an_instance_of": [MESSAGE_TYPE_CONCEPT_ID],
         PREDICATE_SENDER: [sender_id],
         PREDICATE_RECIPIENT: recipient_ids,
-        # Visibility: both sender and all recipients can see the message
-        "specific_to_user": [sender_id] + recipient_ids,
     }
+    # Visibility: both sender and all recipients can see the message.
+    relationships = set_specific_to_user_values(
+        relationships,
+        [sender_id] + recipient_ids,
+    )
 
     # Optional thread/reply relationships
     if thread_id:
@@ -108,7 +115,7 @@ def create_message(
 
     # Organisation scoping if provided
     if org_id:
-        relationships["specific_to_org"] = [org_id.strip()]
+        relationships = set_specific_to_org_values(relationships, [org_id.strip()])
 
     metadata_payload = metadata if isinstance(metadata, dict) else {}
     metadata_payload = {str(k): v for k, v in metadata_payload.items() if isinstance(k, str)}

--- a/src/backend/services/relationship_write_service.py
+++ b/src/backend/services/relationship_write_service.py
@@ -62,6 +62,14 @@ PREDICATE_NAME_ALIASES: Dict[str, str] = {
     "typeOf": "is_a_type_of",
     "subtype": "has_subtype",
     "instance": "has_instance",
+    # Visibility predicate aliases:
+    # Route legacy field-style predicates to canonical predicate concept IDs so
+    # agents can write relationships using historic terms without creating
+    # orphan predicate references.
+    "specific_to_user": "#V#specific_to_user",
+    "specific_to_org": "#V#specific_to_organisation",
+    "specific_to_organisation": "#V#specific_to_organisation",
+    "#V#specific_to_org": "#V#specific_to_organisation",
 }
 
 # Blocked parent types that defeat the purpose of the ontology (JVNAUTOSCI-1072).

--- a/src/backend/services/task_management_service.py
+++ b/src/backend/services/task_management_service.py
@@ -21,6 +21,12 @@ from ..services.text_value_service import (
 from ..utils.concept_id_utils import (
     ensure_v_concept_prefix,
 )
+from ..security.visibility_predicates import (
+    SPECIFIC_TO_ORG_PREDICATES_WRITE,
+    SPECIFIC_TO_USER_PREDICATES,
+    set_specific_to_org_values,
+    set_specific_to_user_values,
+)
 from .effort_unit_ontology_service import (
     ensure_effort_unit_ontology,
     extract_effort_unit_type_ids,
@@ -732,11 +738,14 @@ def create_task(
     if assignee_concept_id and assignee_concept_id not in visible_to_users:
         visible_to_users.append(assignee_concept_id)
     if visible_to_users:
-        relationships["specific_to_user"] = visible_to_users
+        relationships = set_specific_to_user_values(relationships, visible_to_users)
 
     # Organisation scoping
     if organisation_concept_id:
-        relationships["specific_to_org"] = [organisation_concept_id]
+        relationships = set_specific_to_org_values(
+            relationships,
+            [organisation_concept_id],
+        )
 
     # Handle conversation linkage (lazy creation)
     conversation_concept_id = None
@@ -1279,13 +1288,14 @@ def assign_task(task_concept_id: str, assignee_concept_id: str) -> Dict[str, Any
         action="add",
     )
 
-    # Also add new assignee to specific_to_user for visibility
-    ConceptsRepository.mutate_relationship_edge(
-        source_id=task_concept_id,
-        kind="specific_to_user",
-        target_id=assignee_concept_id,
-        action="add",
-    )
+    # Also add new assignee to all specific_to_user predicate variants for visibility.
+    for predicate in SPECIFIC_TO_USER_PREDICATES:
+        ConceptsRepository.mutate_relationship_edge(
+            source_id=task_concept_id,
+            kind=predicate,
+            target_id=assignee_concept_id,
+            action="add",
+        )
 
     # Update timestamp
     now = _now()
@@ -2744,15 +2754,13 @@ def update_task_fields(
             metadata_key=TASK_METADATA_KEY_ORGANISATION,
             value=organisation_concept_id,
         )
+        relationship_updates: Dict[str, Any] = {}
+        org_targets = [organisation_concept_id] if organisation_concept_id else []
+        for predicate in SPECIFIC_TO_ORG_PREDICATES_WRITE:
+            relationship_updates[f"relationships.{predicate}"] = list(org_targets)
         ConceptsRepository.update_one(
             {"concept_id": task_concept_id},
-            {
-                "$set": {
-                    "relationships.specific_to_org": (
-                        [organisation_concept_id] if organisation_concept_id else []
-                    )
-                }
-            },
+            {"$set": relationship_updates},
         )
         changed_fields.append("organisation_concept_id")
 

--- a/tests/backend/test_concept_service_name_resolution_fallback.py
+++ b/tests/backend/test_concept_service_name_resolution_fallback.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+
+def test_get_concept_by_concept_id_falls_back_to_name_resolution(monkeypatch) -> None:
+    from src.backend.services import concept_rename_service
+    from src.backend.services import concept_resolution_service
+    from src.backend.services import concept_service
+
+    class _FakeCollection:
+        def find_one(self, query):
+            concept_id = query.get("concept_id")
+            if concept_id == "#V#specific_to_organisation":
+                return {
+                    "_id": "fake-id",
+                    "concept_id": "#V#specific_to_organisation",
+                    "relationships": {"is_an_instance_of": ["#V#predicate"]},
+                }
+            return None
+
+    monkeypatch.setattr(
+        concept_service.ConceptsRepository,
+        "collection",
+        staticmethod(lambda: _FakeCollection()),
+    )
+    monkeypatch.setattr(
+        concept_rename_service,
+        "resolve_concept_by_alias",
+        lambda _alias: None,
+    )
+    monkeypatch.setattr(
+        concept_resolution_service,
+        "resolve_concept_by_name",
+        lambda **_kwargs: {
+            "success": True,
+            "status": "resolved",
+            "resolved_concept_id": "#V#specific_to_organisation",
+        },
+    )
+
+    result = concept_service.get_concept_by_concept_id("#V#specific_to_org")
+    assert result is not None
+    assert result["concept_id"] == "#V#specific_to_organisation"
+

--- a/tests/backend/test_structural_canonical_consistency.py
+++ b/tests/backend/test_structural_canonical_consistency.py
@@ -98,6 +98,20 @@ class TestStructuralFieldNormalisation:
         assert normalise_structural_predicate("#V#has_author") == "#V#has_author"
         assert normalise_structural_predicate("custom_relation") == "custom_relation"
 
+    def test_visibility_aliases_normalise_to_predicate_concepts(self):
+        """Legacy visibility keys should map to canonical predicate concept IDs."""
+        from src.backend.services.relationship_write_service import (
+            normalise_structural_predicate,
+        )
+
+        assert normalise_structural_predicate("specific_to_user") == "#V#specific_to_user"
+        assert normalise_structural_predicate("specific_to_org") == "#V#specific_to_organisation"
+        assert (
+            normalise_structural_predicate("specific_to_organisation")
+            == "#V#specific_to_organisation"
+        )
+        assert normalise_structural_predicate("#V#specific_to_org") == "#V#specific_to_organisation"
+
 
 class TestDriftDetection:
     """Test that drift between structural and canonical representations is detected."""

--- a/tests/backend/test_visibility_predicates.py
+++ b/tests/backend/test_visibility_predicates.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from src.backend.security.visibility_predicates import (
+    get_specific_to_org_values,
+    get_specific_to_user_values,
+    set_specific_to_org_values,
+    set_specific_to_user_values,
+)
+
+
+def test_collect_visibility_values_reads_legacy_and_canonical_variants() -> None:
+    relationships = {
+        "specific_to_org": ["#V#org_a"],
+        "#V#specific_to_organisation": ["#V#org_b"],
+        "specific_to_user": ["#V#user_a"],
+        "#V#specific_to_user": ["#V#user_b"],
+    }
+
+    assert get_specific_to_org_values(relationships) == ["#V#org_a", "#V#org_b"]
+    assert get_specific_to_user_values(relationships) == ["#V#user_a", "#V#user_b"]
+
+
+def test_set_visibility_values_mirrors_across_supported_write_predicates() -> None:
+    relationships = {"other_predicate": ["#V#value"]}
+
+    updated = set_specific_to_org_values(relationships, ["#V#org_a"])
+    updated = set_specific_to_user_values(updated, ["#V#user_a"])
+
+    assert updated["specific_to_org"] == ["#V#org_a"]
+    assert updated["specific_to_organisation"] == ["#V#org_a"]
+    assert updated["#V#specific_to_organisation"] == ["#V#org_a"]
+    assert updated["specific_to_user"] == ["#V#user_a"]
+    assert updated["#V#specific_to_user"] == ["#V#user_a"]
+    assert updated["other_predicate"] == ["#V#value"]
+


### PR DESCRIPTION
## Summary
- centralise visibility predicate alias handling in a shared security helper
- apply shared helpers across access control, concept/task/message write paths, and organisation toggling route
- normalise remove-relationship predicate aliases through shared structural normaliser
- add regression coverage for visibility predicate normalisation and name-based concept-id fallback

## Verification
- pyright on all changed Python files
- pytest tests/backend/test_structural_canonical_consistency.py tests/backend/test_concept_service_name_resolution_fallback.py tests/backend/test_visibility_predicates.py