### PR TITLE
JVNAUTOSCI-1282: make task title and parent chips open concept view

### DIFF
--- a/src/frontend/web/von_interface/static/js/components/taskPanel.js
+++ b/src/frontend/web/von_interface/static/js/components/taskPanel.js
@@ -625,6 +625,70 @@ function getTaskId(task) {
     return task.task_concept_id || task.concept_id || '';
 }
 
+function normaliseTaskConceptId(value) {
+    if (typeof value !== 'string') return '';
+    const trimmed = value.trim();
+    if (!trimmed.startsWith('#V#') || trimmed.length <= 3) return '';
+    return trimmed;
+}
+
+function deriveConceptNameFromId(conceptId, fallbackName = '') {
+    const fallback = typeof fallbackName === 'string' ? fallbackName.trim() : '';
+    if (fallback) return fallback;
+    const normalised = normaliseTaskConceptId(conceptId);
+    if (!normalised) return '';
+    const raw = normalised.slice(3);
+    const pretty = raw
+        .split(/[_-]+/)
+        .map((part) => part.trim())
+        .filter(Boolean)
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+    return pretty || normalised;
+}
+
+function renderTaskConceptLink({
+    conceptId,
+    conceptName = '',
+    text,
+    className,
+    title,
+    ariaLabel,
+}) {
+    const safeText = escapeHtml(text);
+    const safeClass = escapeHtml(className || '');
+    const normalisedId = normaliseTaskConceptId(conceptId);
+    if (!normalisedId) {
+        return `<span class="${safeClass}">${safeText}</span>`;
+    }
+    const resolvedName = deriveConceptNameFromId(normalisedId, conceptName) || normalisedId;
+    const tooltip = title || 'Open concept';
+    const label = ariaLabel || tooltip;
+    return `
+        <button type="button"
+            class="${safeClass} task-concept-link"
+            data-concept-id="${escapeHtml(normalisedId)}"
+            data-concept-name="${escapeHtml(resolvedName)}"
+            title="${escapeHtml(tooltip)}"
+            aria-label="${escapeHtml(label)}">
+            ${safeText}
+        </button>
+    `;
+}
+
+function openTaskPanelConcept(conceptId, conceptName = '') {
+    const normalisedId = normaliseTaskConceptId(conceptId);
+    if (!normalisedId) return;
+    const resolvedName = deriveConceptNameFromId(normalisedId, conceptName) || normalisedId;
+    document.dispatchEvent(new CustomEvent('open-concept-tab', {
+        detail: {
+            conceptId: normalisedId,
+            conceptName: resolvedName,
+            activate: true,
+        },
+    }));
+}
+
 function renderTaskMetaChips(chips, cssClass) {
     if (!Array.isArray(chips) || chips.length === 0) return '';
     const display = chips.slice(0, 4).map((value) => `
@@ -853,11 +917,19 @@ function renderTaskItem(task) {
     const detailState = getTaskDetailState(taskId);
 
     // Escape HTML in title/description
-    const title = escapeHtml(task.title || 'Untitled Task');
+    const titleText = task.title || 'Untitled Task';
     const description = escapeHtml(task.description || '');
     const truncatedDescription = description.length > 120
         ? description.substring(0, 120) + '...'
         : description;
+    const titleHtml = renderTaskConceptLink({
+        conceptId: taskId,
+        conceptName: titleText,
+        text: titleText,
+        className: 'task-title task-title-link',
+        title: 'Open task concept',
+        ariaLabel: `Open task concept ${titleText}`,
+    });
 
     // Format dates if present
     let startDateHtml = '';
@@ -896,9 +968,18 @@ function renderTaskItem(task) {
 
     const labelsHtml = renderTaskMetaChips(task.labels, 'task-label-chip');
     const componentsHtml = renderTaskMetaChips(task.components, 'task-component-chip');
+    const parentChipHtml = task.parent_task_concept_id
+        ? renderTaskConceptLink({
+            conceptId: task.parent_task_concept_id,
+            text: `Parent: ${task.parent_task_concept_id}`,
+            className: 'task-hierarchy-chip',
+            title: 'Open parent concept',
+            ariaLabel: `Open parent concept ${task.parent_task_concept_id}`,
+        })
+        : '';
     const hierarchyHtml = `
         <div class="task-hierarchy-row">
-            ${task.parent_task_concept_id ? `<span class="task-hierarchy-chip">Parent: ${escapeHtml(task.parent_task_concept_id)}</span>` : ''}
+            ${parentChipHtml}
             ${task.epic_task_concept_id ? `<span class="task-hierarchy-chip">Epic: ${escapeHtml(task.epic_task_concept_id)}</span>` : ''}
         </div>
     `;
@@ -908,7 +989,7 @@ function renderTaskItem(task) {
         <div class="task-item" data-task-id="${taskId}">
             <div class="task-item-header">
                 <span class="task-priority" title="Priority: ${priorityInfo.label}">${priorityInfo.icon}</span>
-                <span class="task-title">${title}</span>
+                ${titleHtml}
                 <span class="task-status-badge" title="Status">${statusInfo.icon} ${escapeHtml(statusInfo.label)}</span>
             </div>
             <div class="task-item-body">
@@ -1108,6 +1189,22 @@ async function addTaskAttachment(taskId, panelEl) {
  */
 function attachTaskEventListeners() {
     if (!_taskListEl) return;
+
+    _taskListEl.querySelectorAll('.task-concept-link').forEach((btn) => {
+        btn.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            const conceptId = e.currentTarget.dataset.conceptId;
+            const conceptName = e.currentTarget.dataset.conceptName || '';
+            openTaskPanelConcept(conceptId, conceptName);
+        });
+        btn.addEventListener('keydown', (e) => {
+            if (e.key !== 'Enter' && e.key !== ' ') return;
+            e.preventDefault();
+            e.stopPropagation();
+            e.currentTarget.click();
+        });
+    });
 
     // Status change dropdowns
     _taskListEl.querySelectorAll('.task-status-select').forEach(select => {

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -1472,6 +1472,28 @@ body {
     max-width: 100%;
 }
 
+.task-title-link.task-concept-link {
+    appearance: none;
+    background: none;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    text-align: left;
+    cursor: pointer;
+}
+
+.task-title-link.task-concept-link:hover {
+    color: #1d4ed8;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.task-title-link.task-concept-link:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+    border-radius: 3px;
+}
+
 .task-status-badge {
     margin-left: auto;
     font-size: 0.72rem;
@@ -1534,6 +1556,22 @@ body {
     background: #f8fafc;
     border: 1px solid #cbd5e1;
     color: #334155;
+}
+
+.task-hierarchy-chip.task-concept-link {
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s, background-color 0.15s;
+}
+
+.task-hierarchy-chip.task-concept-link:hover {
+    border-color: #93c5fd;
+    color: #1d4ed8;
+    background: #eff6ff;
+}
+
+.task-hierarchy-chip.task-concept-link:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 1px;
 }
 
 .task-conversation-link {

--- a/tests/frontend/taskPanelConceptLinks.test.js
+++ b/tests/frontend/taskPanelConceptLinks.test.js
@@ -1,0 +1,173 @@
+/** @jest-environment jsdom */
+
+const taskPanelModulePath = '../../src/frontend/web/von_interface/static/js/components/taskPanel.js';
+const apiServiceModulePath = '../../src/frontend/web/von_interface/static/js/apiService.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    deleteJson: jest.fn(),
+    getJson: jest.fn(),
+    patchJson: jest.fn(),
+    postJson: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/tabNavigation.js', () => ({
+    activateTab: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/utils/toast.js', () => ({
+    showToast: jest.fn(),
+}));
+
+function flushMicrotasks() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('task panel concept links', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        document.body.innerHTML = `
+            <div id="globalTasksContainer"></div>
+            <span id="taskCountBadge" class="hidden"></span>
+            <span id="globalTaskCountBadge" class="hidden"></span>
+        `;
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('renders task title and parent as clickable concept links and dispatches concept navigation', async () => {
+        const { getJson } = require(apiServiceModulePath);
+        getJson.mockResolvedValue({
+            tasks: [
+                {
+                    task_concept_id: '#V#task_1282',
+                    title: 'Task card concept links',
+                    description: 'Make task card links clickable.',
+                    status: 'pending',
+                    priority: 'medium',
+                    parent_task_concept_id: '#V#task_programme',
+                },
+            ],
+        });
+
+        const { showGlobalTasks } = require(taskPanelModulePath);
+        await showGlobalTasks();
+
+        const seen = [];
+        const handler = (event) => seen.push(event.detail);
+        document.addEventListener('open-concept-tab', handler);
+
+        const titleButton = document.querySelector('.task-title.task-concept-link');
+        const parentButton = document.querySelector('.task-hierarchy-chip.task-concept-link');
+
+        expect(titleButton).toBeTruthy();
+        expect(parentButton).toBeTruthy();
+        expect(titleButton.getAttribute('title')).toBe('Open task concept');
+        expect(parentButton.getAttribute('title')).toBe('Open parent concept');
+        expect(titleButton.getAttribute('aria-label')).toContain('Open task concept');
+        expect(parentButton.getAttribute('aria-label')).toContain('Open parent concept');
+
+        titleButton.click();
+        parentButton.click();
+        parentButton.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        parentButton.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+
+        expect(seen).toHaveLength(4);
+        expect(seen[0]).toMatchObject({
+            conceptId: '#V#task_1282',
+            conceptName: 'Task card concept links',
+            activate: true,
+        });
+        expect(seen[1]).toMatchObject({
+            conceptId: '#V#task_programme',
+            activate: true,
+        });
+        expect(typeof seen[1].conceptName).toBe('string');
+        expect(seen[1].conceptName.length).toBeGreaterThan(0);
+        expect(seen[2]).toMatchObject({ conceptId: '#V#task_programme', activate: true });
+        expect(seen[3]).toMatchObject({ conceptId: '#V#task_programme', activate: true });
+
+        document.removeEventListener('open-concept-tab', handler);
+    });
+
+    test('renders non-clickable title and hierarchy text when concept IDs are missing or non-canonical', async () => {
+        const { getJson } = require(apiServiceModulePath);
+        getJson.mockResolvedValue({
+            tasks: [
+                {
+                    task_concept_id: 'legacy-task-id',
+                    title: 'Legacy task',
+                    description: '',
+                    status: 'pending',
+                    priority: 'low',
+                    parent_task_concept_id: 'parent-legacy',
+                },
+            ],
+        });
+
+        const { showGlobalTasks } = require(taskPanelModulePath);
+        await showGlobalTasks();
+
+        const seen = [];
+        const handler = (event) => seen.push(event.detail);
+        document.addEventListener('open-concept-tab', handler);
+
+        const titleText = document.querySelector('.task-title');
+        const parentChip = document.querySelector('.task-hierarchy-chip');
+
+        expect(titleText).toBeTruthy();
+        expect(parentChip).toBeTruthy();
+        expect(document.querySelector('.task-title.task-concept-link')).toBeNull();
+        expect(document.querySelector('.task-hierarchy-chip.task-concept-link')).toBeNull();
+
+        titleText.click();
+        parentChip.click();
+        expect(seen).toHaveLength(0);
+
+        document.removeEventListener('open-concept-tab', handler);
+    });
+
+    test('retains existing task controls without event conflicts', async () => {
+        const { getJson } = require(apiServiceModulePath);
+        const task = {
+            task_concept_id: '#V#task_1282',
+            title: 'Detail toggle check',
+            description: '',
+            status: 'pending',
+            priority: 'medium',
+            parent_task_concept_id: '#V#task_group',
+        };
+        getJson.mockImplementation((url) => {
+            if (url === '/api/tasks/my?include_created=true') {
+                return Promise.resolve({ tasks: [task] });
+            }
+            if (url === '/api/tasks/%23V%23task_1282') {
+                return Promise.resolve(task);
+            }
+            if (url === '/api/tasks/%23V%23task_1282/comments?limit=100') {
+                return Promise.resolve({ comments: [] });
+            }
+            if (url === '/api/tasks/%23V%23task_1282/attachments?limit=100') {
+                return Promise.resolve({ attachments: [] });
+            }
+            if (url === '/api/tasks/%23V%23task_1282/history?limit=200') {
+                return Promise.resolve({ history: [] });
+            }
+            return Promise.resolve({});
+        });
+
+        const { showGlobalTasks } = require(taskPanelModulePath);
+        await showGlobalTasks();
+
+        const detailButton = document.querySelector('.task-detail-toggle-btn');
+        expect(detailButton).toBeTruthy();
+        detailButton.click();
+
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        expect(getJson).toHaveBeenCalledWith('/api/tasks/%23V%23task_1282');
+        expect(document.querySelector('.task-detail-panel[data-task-id="#V#task_1282"]')).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## Summary
- make task-card titles clickable when they carry canonical task concept IDs
- make parent hierarchy chips clickable when they carry canonical parent concept IDs
- route both interactions through the existing `open-concept-tab` navigation path
- keep defensive non-clickable rendering for missing/non-canonical IDs
- add subtle hover/focus affordances and keyboard activation support
- add frontend regression tests for clickable rendering, navigation dispatch, and existing control compatibility

## 1283 Compatibility
- extracted reusable concept-link rendering/dispatch helpers in `taskPanel.js`
- wired links via class-based event handling so upcoming ontology-based task-group chips can reuse the same pattern without duplicate navigation logic

## Verification
- `npm test -- tests/frontend/taskPanelConceptLinks.test.js`