### PR TITLE
JVNAUTOSCI-1283: Add Vontology-backed task group salience filters

### DIFF
--- a/src/frontend/web/von_interface/static/js/components/taskPanel.js
+++ b/src/frontend/web/von_interface/static/js/components/taskPanel.js
@@ -5,9 +5,10 @@
  * Tasks are stored as Vontology concepts and accessed via REST API.
  */
 
-import { deleteJson, getJson, patchJson, postJson } from '../apiService.js';
+import { deleteJson, getJson, patchJson, postJson, getUserContext } from '../apiService.js';
 import { activateTab } from '../tabNavigation.js';
 import { showToast } from '../utils/toast.js';
+import { selectBestNameForContext } from '../utils/nameSelection.js';
 
 // Task panel state
 let _panelEl = null;
@@ -23,6 +24,13 @@ let _queryFilter = '';
 let _viewMode = 'board';
 let _isGlobalTabMode = false;  // True when rendering into global tasks tab
 let _taskDetailState = {};  // taskId -> detail panel state
+let _taskGroupStorageKey = null;
+let _selectedTaskGroupIds = new Set();  // Selected ontology-backed task groups.
+let _taskGroupOptions = [];
+const _taskGroupDisplayNameCache = new Map();
+const _taskGroupNameFetchInFlight = new Set();
+
+const TASK_GROUP_STORAGE_KEY_PREFIX = 'von_task_group_filter_v1';
 
 // Constants
 const TASK_STATUS_OPTIONS = [
@@ -135,6 +143,8 @@ export function initializeTaskPanel() {
         console.warn('[taskPanel] Panel elements not found in DOM');
         return;
     }
+    loadTaskGroupSelectionFromStorage();
+    renderTaskGroupFilterControls();
 
     // Set up close button
     const closeBtn = document.getElementById('closeTaskPanel');
@@ -195,6 +205,7 @@ export function initializeTaskPanel() {
  */
 export function showTaskPanel() {
     if (_panelEl) {
+        loadTaskGroupSelectionFromStorage();
         _isGlobalTabMode = false;
         _taskListEl = document.getElementById('taskList') || _taskListEl;
         _panelEl.classList.remove('hidden');
@@ -232,6 +243,7 @@ export function toggleTaskPanel() {
  * Renders into the globalTasksContainer instead of the overlay panel.
  */
 export async function showGlobalTasks() {
+    loadTaskGroupSelectionFromStorage();
     _currentSessionId = null;  // Clear session filter
     _isGlobalTabMode = true;
 
@@ -285,6 +297,7 @@ function renderGlobalTasksTabContent() {
                 <button id="refreshGlobalTasksBtn" class="task-refresh-btn" title="Refresh tasks">🔄</button>
             </div>
         </div>
+        <div id="globalTaskGroupFilterRow" class="task-group-filter-row hidden" aria-label="Task groups"></div>
         <div class="global-tasks-create">
             <input type="text" id="globalNewTaskTitle" class="task-input" placeholder="Task title...">
             <textarea id="globalNewTaskDescription" class="task-textarea" placeholder="Task description..." rows="2"></textarea>
@@ -350,6 +363,7 @@ function renderGlobalTasksTabContent() {
 
     // Update the task list element reference for global mode
     _taskListEl = _globalTasksContainer.querySelector('#globalTaskList');
+    renderTaskGroupFilterControls();
 }
 
 /**
@@ -423,6 +437,7 @@ export function getTaskCount() {
 export async function loadTasks(sessionId = null) {
     if (_isLoading) return;
 
+    loadTaskGroupSelectionFromStorage();
     _isLoading = true;
     updateLoadingState(true);
 
@@ -447,6 +462,7 @@ export async function loadTasks(sessionId = null) {
         const response = await getJson(url);
         _tasks = response.tasks || [];
         pruneTaskDetailState();
+        refreshTaskGroupOptions();
         renderTaskList();
         updateTaskCountBadge();
 
@@ -465,6 +481,7 @@ export async function loadTasks(sessionId = null) {
 export async function loadMyTasks(statusFilter = null) {
     if (_isLoading) return;
 
+    loadTaskGroupSelectionFromStorage();
     _isLoading = true;
     updateLoadingState(true);
 
@@ -484,6 +501,7 @@ export async function loadMyTasks(statusFilter = null) {
         const response = await getJson(url);
         _tasks = response.tasks || [];
         pruneTaskDetailState();
+        refreshTaskGroupOptions();
         renderTaskList();
         updateTaskCountBadge();
 
@@ -529,15 +547,22 @@ function renderTaskList() {
                 return false;
             }
         }
+        if (_selectedTaskGroupIds.size > 0) {
+            const taskGroupId = deriveTaskGroupConceptId(task);
+            if (!taskGroupId || !_selectedTaskGroupIds.has(taskGroupId)) {
+                return false;
+            }
+        }
         return true;
     });
 
     if (filteredTasks.length === 0) {
+        const hasGroupFilter = _selectedTaskGroupIds.size > 0;
         _taskListEl.innerHTML = `
             <div class="task-empty-state">
                 <span class="task-empty-icon">📋</span>
                 <p>No tasks match the active filters</p>
-                <p class="task-empty-hint">Create a task using the form above</p>
+                <p class="task-empty-hint">${hasGroupFilter ? 'Adjust selected task groups to broaden the list' : 'Create a task using the form above'}</p>
             </div>
         `;
         return;
@@ -630,6 +655,235 @@ function normaliseTaskConceptId(value) {
     const trimmed = value.trim();
     if (!trimmed.startsWith('#V#') || trimmed.length <= 3) return '';
     return trimmed;
+}
+
+function deriveTaskGroupConceptId(task) {
+    if (!task || typeof task !== 'object') return '';
+    const candidates = [
+        task.task_group_concept_id,
+        task.group_concept_id,
+        task.parent_task_concept_id,
+        task.epic_task_concept_id,
+    ];
+    for (const candidate of candidates) {
+        const normalised = normaliseTaskConceptId(candidate);
+        if (normalised) {
+            return normalised;
+        }
+    }
+    return '';
+}
+
+function deriveGroupLabelFromConceptId(conceptId) {
+    const normalised = normaliseTaskConceptId(conceptId);
+    if (!normalised) return 'Unknown group';
+    const slug = normalised.slice(3);
+    const label = slug
+        .split(/[_-]+/)
+        .map((part) => part.trim())
+        .filter(Boolean)
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+    return label || normalised;
+}
+
+function getTaskGroupStorageKey() {
+    let userId = 'anonymous';
+    let orgId = 'none';
+    try {
+        const ctx = getUserContext ? getUserContext() : {};
+        const normalisedUser = normaliseTaskConceptId(ctx?.user_id);
+        const normalisedOrg = normaliseTaskConceptId(ctx?.org_id);
+        if (normalisedUser) userId = normalisedUser;
+        if (normalisedOrg) orgId = normalisedOrg;
+    } catch (_) {
+        // Ignore local/session storage lookup errors.
+    }
+    return `${TASK_GROUP_STORAGE_KEY_PREFIX}:${userId}:${orgId}`;
+}
+
+function loadTaskGroupSelectionFromStorage() {
+    const nextStorageKey = getTaskGroupStorageKey();
+    if (_taskGroupStorageKey === nextStorageKey) return;
+    _taskGroupStorageKey = nextStorageKey;
+    _selectedTaskGroupIds = new Set();
+    try {
+        const raw = localStorage.getItem(_taskGroupStorageKey);
+        if (!raw) return;
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return;
+        parsed.forEach((item) => {
+            const normalised = normaliseTaskConceptId(item);
+            if (normalised) {
+                _selectedTaskGroupIds.add(normalised);
+            }
+        });
+    } catch (err) {
+        console.warn('[taskPanel] Failed to read task group filter selection:', err);
+    }
+}
+
+function persistTaskGroupSelectionToStorage() {
+    if (!_taskGroupStorageKey) {
+        _taskGroupStorageKey = getTaskGroupStorageKey();
+    }
+    try {
+        localStorage.setItem(
+            _taskGroupStorageKey,
+            JSON.stringify([..._selectedTaskGroupIds]),
+        );
+    } catch (err) {
+        console.warn('[taskPanel] Failed to persist task group filter selection:', err);
+    }
+}
+
+function compareTaskGroupOptions(left, right) {
+    const leftName = String(left?.displayName || '');
+    const rightName = String(right?.displayName || '');
+    return leftName.localeCompare(rightName, undefined, { sensitivity: 'base' });
+}
+
+function resolveTaskGroupDisplayName(conceptId) {
+    return (
+        _taskGroupDisplayNameCache.get(conceptId)
+        || deriveGroupLabelFromConceptId(conceptId)
+    );
+}
+
+function renderTaskGroupFilterControls() {
+    const rows = [
+        document.getElementById('taskGroupFilterRow'),
+        _globalTasksContainer?.querySelector('#globalTaskGroupFilterRow'),
+    ].filter(Boolean);
+
+    rows.forEach((row) => {
+        if (!row) return;
+        if (_taskGroupOptions.length === 0) {
+            row.classList.add('hidden');
+            row.innerHTML = '';
+            return;
+        }
+
+        row.classList.remove('hidden');
+        const allActive = _selectedTaskGroupIds.size === 0;
+        const chips = _taskGroupOptions.map((group) => {
+            const isActive = _selectedTaskGroupIds.has(group.conceptId);
+            return `
+                <button type="button"
+                    class="task-group-filter-btn ${isActive ? 'active' : ''}"
+                    data-group-id="${escapeHtml(group.conceptId)}"
+                    aria-pressed="${isActive ? 'true' : 'false'}"
+                    title="Toggle task group ${escapeHtml(group.displayName)}">
+                    ${escapeHtml(group.displayName)}
+                    <span class="task-group-filter-count">${group.count}</span>
+                </button>
+            `;
+        }).join('');
+
+        row.innerHTML = `
+            <span class="task-group-filter-label">Groups:</span>
+            <button type="button"
+                class="task-group-filter-btn task-group-filter-all ${allActive ? 'active' : ''}"
+                data-group-id=""
+                aria-pressed="${allActive ? 'true' : 'false'}"
+                title="Show all task groups">
+                All groups
+            </button>
+            ${chips}
+        `;
+
+        row.querySelectorAll('.task-group-filter-btn').forEach((btn) => {
+            btn.addEventListener('click', (event) => {
+                const groupId = normaliseTaskConceptId(
+                    event.currentTarget?.dataset?.groupId || '',
+                );
+                if (!groupId) {
+                    _selectedTaskGroupIds.clear();
+                } else if (_selectedTaskGroupIds.has(groupId)) {
+                    _selectedTaskGroupIds.delete(groupId);
+                } else {
+                    _selectedTaskGroupIds.add(groupId);
+                }
+                persistTaskGroupSelectionToStorage();
+                renderTaskGroupFilterControls();
+                renderTaskList();
+            });
+        });
+    });
+}
+
+async function ensureTaskGroupDisplayName(conceptId) {
+    const normalised = normaliseTaskConceptId(conceptId);
+    if (!normalised) return;
+    if (_taskGroupDisplayNameCache.has(normalised)) return;
+    if (_taskGroupNameFetchInFlight.has(normalised)) return;
+
+    _taskGroupNameFetchInFlight.add(normalised);
+    try {
+        const encoded = encodeURIComponent(normalised);
+        const payload = await getJson(
+            `/vontology/api/vontology/node_content?identifier=${encoded}&raw_only=1&soft=1`,
+        );
+        const fromNames = selectBestNameForContext(payload?.raw_doc?.names);
+        const displayName = (
+            (typeof fromNames === 'string' && fromNames.trim())
+            || (typeof payload?.display_name === 'string' && payload.display_name.trim())
+            || deriveGroupLabelFromConceptId(normalised)
+        );
+        _taskGroupDisplayNameCache.set(normalised, displayName);
+        let didUpdate = false;
+        _taskGroupOptions = _taskGroupOptions.map((group) => {
+            if (group.conceptId !== normalised) return group;
+            if (group.displayName === displayName) return group;
+            didUpdate = true;
+            return {
+                ...group,
+                displayName,
+            };
+        });
+        if (didUpdate) {
+            _taskGroupOptions.sort(compareTaskGroupOptions);
+            renderTaskGroupFilterControls();
+        }
+    } catch (err) {
+        // Keep fallback labels when ontology lookups fail.
+        console.debug('[taskPanel] Failed to resolve task group name:', normalised, err);
+    } finally {
+        _taskGroupNameFetchInFlight.delete(normalised);
+    }
+}
+
+function refreshTaskGroupOptions() {
+    const counts = new Map();
+    _tasks.forEach((task) => {
+        const groupId = deriveTaskGroupConceptId(task);
+        if (!groupId) return;
+        counts.set(groupId, (counts.get(groupId) || 0) + 1);
+    });
+
+    _taskGroupOptions = Array.from(counts.entries()).map(([conceptId, count]) => ({
+        conceptId,
+        count,
+        displayName: resolveTaskGroupDisplayName(conceptId),
+    }));
+    _taskGroupOptions.sort(compareTaskGroupOptions);
+
+    const availableGroupIds = new Set(_taskGroupOptions.map((group) => group.conceptId));
+    let didPruneSelection = false;
+    [..._selectedTaskGroupIds].forEach((groupId) => {
+        if (!availableGroupIds.has(groupId)) {
+            _selectedTaskGroupIds.delete(groupId);
+            didPruneSelection = true;
+        }
+    });
+    if (didPruneSelection) {
+        persistTaskGroupSelectionToStorage();
+    }
+
+    renderTaskGroupFilterControls();
+    _taskGroupOptions.forEach((group) => {
+        void ensureTaskGroupDisplayName(group.conceptId);
+    });
 }
 
 function deriveConceptNameFromId(conceptId, fallbackName = '') {
@@ -1046,6 +1300,7 @@ function replaceCachedTask(updatedTask) {
     const existingIndex = _tasks.findIndex((item) => getTaskId(item) === updatedTaskId);
     if (existingIndex >= 0) {
         _tasks[existingIndex] = updatedTask;
+        refreshTaskGroupOptions();
     }
 }
 
@@ -1403,6 +1658,7 @@ async function deleteTask(taskId) {
 
         // Remove from local cache and re-render
         _tasks = _tasks.filter(t => getTaskId(t) !== taskId);
+        refreshTaskGroupOptions();
         renderTaskList();
         updateTaskCountBadge();
 

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -1367,6 +1367,64 @@ body {
     flex: 1 1 180px;
 }
 
+.task-group-filter-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 2px 0 4px;
+}
+
+.task-group-filter-row.hidden {
+    display: none;
+}
+
+.task-group-filter-label {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #64748b;
+}
+
+.task-group-filter-btn {
+    appearance: none;
+    border: 1px solid #cbd5e1;
+    background: #f8fafc;
+    color: #334155;
+    border-radius: 999px;
+    font-size: 0.74rem;
+    line-height: 1.3;
+    padding: 3px 9px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.task-group-filter-btn:hover {
+    border-color: #94a3b8;
+    background: #f1f5f9;
+}
+
+.task-group-filter-btn:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 1px;
+}
+
+.task-group-filter-btn.active {
+    border-color: #1d4ed8;
+    background: #eff6ff;
+    color: #1e40af;
+}
+
+.task-group-filter-count {
+    font-size: 0.7rem;
+    line-height: 1;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.35);
+    color: inherit;
+    padding: 2px 6px;
+}
+
 /* Task list */
 .task-list {
     display: flex;

--- a/src/frontend/web/von_interface/templates/chat_tab.html
+++ b/src/frontend/web/von_interface/templates/chat_tab.html
@@ -270,6 +270,7 @@
         <input id="taskQueryFilter" type="search" class="task-filter-query"
           placeholder="Search tasks…" aria-label="Search tasks" />
       </div>
+      <div id="taskGroupFilterRow" class="task-group-filter-row hidden" aria-label="Task groups"></div>
 
       <!-- Task list -->
       <div id="taskList" class="task-list" role="list" aria-label="Task list">

--- a/tests/frontend/taskPanelConceptLinks.test.js
+++ b/tests/frontend/taskPanelConceptLinks.test.js
@@ -6,6 +6,7 @@ const apiServiceModulePath = '../../src/frontend/web/von_interface/static/js/api
 jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
     deleteJson: jest.fn(),
     getJson: jest.fn(),
+    getUserContext: jest.fn(() => ({ user_id: '#V#test_user', org_id: '#V#test_org' })),
     patchJson: jest.fn(),
     postJson: jest.fn(),
 }));

--- a/tests/frontend/taskPanelGroupFilters.test.js
+++ b/tests/frontend/taskPanelGroupFilters.test.js
@@ -1,0 +1,183 @@
+/** @jest-environment jsdom */
+
+const taskPanelModulePath = '../../src/frontend/web/von_interface/static/js/components/taskPanel.js';
+const apiServiceModulePath = '../../src/frontend/web/von_interface/static/js/apiService.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    deleteJson: jest.fn(),
+    getJson: jest.fn(),
+    getUserContext: jest.fn(() => ({ user_id: '#V#group_user', org_id: '#V#group_org' })),
+    patchJson: jest.fn(),
+    postJson: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/tabNavigation.js', () => ({
+    activateTab: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/utils/toast.js', () => ({
+    showToast: jest.fn(),
+}));
+
+async function flushRenderQueue() {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('task panel ontology-backed groups', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        localStorage.clear();
+        document.body.innerHTML = `
+            <div id="globalTasksContainer"></div>
+            <span id="taskCountBadge" class="hidden"></span>
+            <span id="globalTaskCountBadge" class="hidden"></span>
+        `;
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('derives groups from ontology-linked task parents and filters visible tasks', async () => {
+        const { getJson } = require(apiServiceModulePath);
+        getJson.mockImplementation((url) => {
+            if (url === '/api/tasks/my?include_created=true') {
+                return Promise.resolve({
+                    tasks: [
+                        {
+                            task_concept_id: '#V#task_a',
+                            title: 'Task A',
+                            description: '',
+                            status: 'pending',
+                            priority: 'medium',
+                            parent_task_concept_id: '#V#activity_alpha',
+                        },
+                        {
+                            task_concept_id: '#V#task_b',
+                            title: 'Task B',
+                            description: '',
+                            status: 'pending',
+                            priority: 'medium',
+                            parent_task_concept_id: '#V#activity_beta',
+                        },
+                        {
+                            task_concept_id: '#V#task_c',
+                            title: 'Task C',
+                            description: '',
+                            status: 'pending',
+                            priority: 'medium',
+                        },
+                    ],
+                });
+            }
+            if (typeof url === 'string' && url.includes('identifier=%23V%23activity_alpha')) {
+                return Promise.resolve({
+                    raw_doc: {
+                        names: [{ name: 'Activity Alpha', language: 'en-NZ', type: 'NL' }],
+                    },
+                });
+            }
+            if (typeof url === 'string' && url.includes('identifier=%23V%23activity_beta')) {
+                return Promise.resolve({
+                    raw_doc: {
+                        names: [{ name: 'Activity Beta', language: 'en-NZ', type: 'NL' }],
+                    },
+                });
+            }
+            return Promise.resolve({});
+        });
+
+        const { showGlobalTasks } = require(taskPanelModulePath);
+        await showGlobalTasks();
+        await flushRenderQueue();
+
+        const groupRow = document.querySelector('#globalTaskGroupFilterRow');
+        expect(groupRow).toBeTruthy();
+        expect(groupRow.classList.contains('hidden')).toBe(false);
+        expect(groupRow.textContent).toContain('Activity Alpha');
+        expect(groupRow.textContent).toContain('Activity Beta');
+
+        const groupAlphaButton = groupRow.querySelector('[data-group-id="#V#activity_alpha"]');
+        expect(groupAlphaButton).toBeTruthy();
+        groupAlphaButton.click();
+        await flushRenderQueue();
+
+        const visibleTitlesAfterFilter = Array.from(
+            document.querySelectorAll('.task-item .task-title'),
+        ).map((el) => (el.textContent || '').trim());
+        expect(visibleTitlesAfterFilter).toEqual(['Task A']);
+
+        const allGroupsButton = groupRow.querySelector('[data-group-id=""]');
+        expect(allGroupsButton).toBeTruthy();
+        allGroupsButton.click();
+        await flushRenderQueue();
+
+        const visibleTitlesAfterReset = Array.from(
+            document.querySelectorAll('.task-item .task-title'),
+        ).map((el) => (el.textContent || '').trim());
+        expect(visibleTitlesAfterReset).toEqual(expect.arrayContaining(['Task A', 'Task B', 'Task C']));
+    });
+
+    test('restores persisted group selection between sessions', async () => {
+        const { getJson } = require(apiServiceModulePath);
+        localStorage.setItem(
+            'von_task_group_filter_v1:#V#group_user:#V#group_org',
+            JSON.stringify(['#V#activity_beta']),
+        );
+
+        getJson.mockImplementation((url) => {
+            if (url === '/api/tasks/my?include_created=true') {
+                return Promise.resolve({
+                    tasks: [
+                        {
+                            task_concept_id: '#V#task_a',
+                            title: 'Task A',
+                            description: '',
+                            status: 'pending',
+                            priority: 'medium',
+                            parent_task_concept_id: '#V#activity_alpha',
+                        },
+                        {
+                            task_concept_id: '#V#task_b',
+                            title: 'Task B',
+                            description: '',
+                            status: 'pending',
+                            priority: 'medium',
+                            parent_task_concept_id: '#V#activity_beta',
+                        },
+                    ],
+                });
+            }
+            if (typeof url === 'string' && url.includes('identifier=%23V%23activity_alpha')) {
+                return Promise.resolve({
+                    raw_doc: {
+                        names: [{ name: 'Activity Alpha', language: 'en-NZ', type: 'NL' }],
+                    },
+                });
+            }
+            if (typeof url === 'string' && url.includes('identifier=%23V%23activity_beta')) {
+                return Promise.resolve({
+                    raw_doc: {
+                        names: [{ name: 'Activity Beta', language: 'en-NZ', type: 'NL' }],
+                    },
+                });
+            }
+            return Promise.resolve({});
+        });
+
+        const { showGlobalTasks } = require(taskPanelModulePath);
+        await showGlobalTasks();
+        await flushRenderQueue();
+
+        const visibleTitles = Array.from(
+            document.querySelectorAll('.task-item .task-title'),
+        ).map((el) => (el.textContent || '').trim());
+        expect(visibleTitles).toEqual(['Task B']);
+
+        const selectedButton = document.querySelector(
+            '#globalTaskGroupFilterRow .task-group-filter-btn.active[data-group-id="#V#activity_beta"]',
+        );
+        expect(selectedButton).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## Summary
- add ontology-backed task grouping in task panel by deriving group concepts from task hierarchy links (`parent_task_concept_id`, fallback `epic_task_concept_id`)
- populate group labels from Vontology concept names (`node_content`), with deterministic fallback labels
- add salience controls to both overlay and global task views using reusable group-chip filters
- persist selected group concepts across sessions in user+organisation-scoped localStorage keys
- keep defensive behaviour: tasks with missing/non-canonical group concepts are excluded only when explicit group filters are active

## UX
- new `Groups` filter chip row in task panel and global tasks tab
- `All groups` reset chip
- per-group counts and active-state affordance

## Verification
- `npm test -- tests/frontend/taskPanelConceptLinks.test.js tests/frontend/taskPanelGroupFilters.test.js`
- `pyright`