### PR TITLE
JVNAUTOSCI-1284: Move PINNED/RECENT labels above first tabs

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -9739,26 +9739,17 @@ function renderChatSessionTabs(sessions, activeSessionId) {
         fragment.appendChild(placeholder);
     }
 
-    if (pinnedSessions.length > 0) {
-        const pinnedGroupLabel = document.createElement('div');
-        pinnedGroupLabel.className = 'chat-session-tabs-group-label';
-        pinnedGroupLabel.textContent = `Pinned (${pinnedSessions.length})`;
-        fragment.appendChild(pinnedGroupLabel);
-    }
-
     orderedVisibleSessions.forEach((session, index) => {
         const sid = (typeof session?.session_id === 'string') ? session.session_id.trim() : '';
         if (!sid) {
             return;
         }
         const isPinned = isConversationPinned(sid);
-
-        if (pinnedSessions.length > 0 && unpinnedSessions.length > 0 && index === pinnedSessions.length) {
-            const recentGroupLabel = document.createElement('div');
-            recentGroupLabel.className = 'chat-session-tabs-group-label';
-            recentGroupLabel.textContent = 'Recent';
-            fragment.appendChild(recentGroupLabel);
-        }
+        const isFirstPinnedTab = pinnedSessions.length > 0 && index === 0 && isPinned;
+        const isFirstRecentTab = pinnedSessions.length > 0 && unpinnedSessions.length > 0 && index === pinnedSessions.length;
+        const groupLabelText = isFirstPinnedTab
+            ? `Pinned (${pinnedSessions.length})`
+            : (isFirstRecentTab ? 'Recent' : '');
 
         const displayName = getSessionDisplayName(session);
         const timestampSource = (typeof session?.last_message_at === 'string' && session.last_message_at.trim())
@@ -9779,6 +9770,21 @@ function renderChatSessionTabs(sessions, activeSessionId) {
 
         if (sid === activeSessionId) {
             tab.classList.add('is-active');
+        }
+
+        if (groupLabelText) {
+            tab.classList.add('chat-session-tab-group-start');
+            const groupBadge = document.createElement('span');
+            groupBadge.className = 'chat-session-tab-group-badge';
+            if (isFirstRecentTab) {
+                tab.classList.add('chat-session-tab-group-start-recent');
+                groupBadge.classList.add('chat-session-tab-group-badge-recent');
+            } else {
+                groupBadge.classList.add('chat-session-tab-group-badge-pinned');
+            }
+            groupBadge.textContent = groupLabelText;
+            groupBadge.setAttribute('aria-hidden', 'true');
+            tab.appendChild(groupBadge);
         }
 
         if (sid === loadingChatSessionId) {

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -4949,10 +4949,10 @@ footer {
 
 .chat-session-tabs {
     display: flex;
-    align-items: center;
+    align-items: flex-end;
     gap: 6px;
     margin-bottom: 0;
-    padding: 6px 0 10px;
+    padding: 18px 0 10px;
     border-bottom: 1px solid #e5e7eb;
     overflow-x: auto;
 }
@@ -4964,18 +4964,38 @@ footer {
     margin-bottom: 12px;
 }
 
-.chat-session-tabs-group-label {
-    flex: 0 0 auto;
+.chat-session-tab-group-start {
+    overflow: visible;
+}
+
+.chat-session-tab-group-badge {
+    position: absolute;
+    top: -16px;
+    left: 8px;
+    display: inline-flex;
+    align-items: center;
     font-size: 10px;
     font-weight: 700;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.04em;
     text-transform: uppercase;
-    color: #64748b;
-    background: #f8fafc;
-    border: 1px dashed #cbd5e1;
     border-radius: 999px;
-    padding: 3px 8px;
+    padding: 2px 7px;
+    line-height: 1.1;
     user-select: none;
+    pointer-events: none;
+    white-space: nowrap;
+}
+
+.chat-session-tab-group-badge-pinned {
+    color: #92400e;
+    border: 1px dashed #fbbf24;
+    background: #fff7ed;
+}
+
+.chat-session-tab-group-badge-recent {
+    color: #475569;
+    border: 1px dashed #cbd5e1;
+    background: #f8fafc;
 }
 
 .chat-session-count {

--- a/tests/frontend/chatSessionPinning.test.js
+++ b/tests/frontend/chatSessionPinning.test.js
@@ -92,15 +92,22 @@ describe('chat session pinning', () => {
         const storedPins = JSON.parse(localStorage.getItem(storageKey) || '[]');
         expect(storedPins).toContain('s2');
 
-        const groupLabels = Array.from(
-            document.querySelectorAll('#chatSessionTabs .chat-session-tabs-group-label')
-        ).map((el) => el.textContent || '');
-        expect(groupLabels.some((label) => label.includes('Pinned'))).toBe(true);
-
         const reordered = Array.from(
             document.querySelectorAll('#chatSessionTabs .chat-session-tab[data-session-id]')
         ).map((el) => el.dataset.sessionId);
         expect(reordered[0]).toBe('s2');
+
+        const pinnedTab = document.querySelector(
+            '#chatSessionTabs .chat-session-tab[data-session-id="s2"]'
+        );
+        const pinnedBadge = pinnedTab?.querySelector('.chat-session-tab-group-badge-pinned');
+        expect(pinnedBadge?.textContent || '').toContain('Pinned (1)');
+
+        const recentTab = document.querySelector(
+            '#chatSessionTabs .chat-session-tab[data-session-id="s1"]'
+        );
+        const recentBadge = recentTab?.querySelector('.chat-session-tab-group-badge-recent');
+        expect(recentBadge?.textContent || '').toBe('Recent');
 
         const pinnedButton = document.querySelector(
             '#chatSessionTabs .chat-session-tab[data-session-id="s2"] .chat-session-tab-pin-toggle'
@@ -126,9 +133,6 @@ describe('chat session pinning', () => {
         const storedPins = JSON.parse(localStorage.getItem(storageKey) || '[]');
         expect(storedPins).toEqual([]);
 
-        const groupLabels = Array.from(
-            document.querySelectorAll('#chatSessionTabs .chat-session-tabs-group-label')
-        ).map((el) => el.textContent || '');
-        expect(groupLabels.some((label) => label.includes('Pinned'))).toBe(false);
+        expect(document.querySelector('#chatSessionTabs .chat-session-tab-group-badge')).toBeNull();
     });
 });


### PR DESCRIPTION
## Summary
- move PINNED and RECENT group labels from standalone inline pills into compact badges anchored on the first tab of each group
- preserve tab ordering logic while removing horizontal slots consumed by standalone group labels
- update pinning tests to assert badge placement on first pinned and first recent tabs

## Validation
- `npm run test:frontend -- tests/frontend/chatSessionPinning.test.js`
- `npx pyright`