### PR TITLE
JVNAUTOSCI-1285: Queue follow-up chat tasks with edit/delete

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -7479,6 +7479,13 @@ function createChatDebugWarningIndicator(warnings) {
 }
 
 let activeChatRequest = null;
+let queuedChatPrompts = [];
+let queuedChatPromptCounter = 0;
+let queuedChatPromptDrainTimer = null;
+
+const CHAT_TASK_QUEUE_PANEL_ID = 'chatTaskQueuePanel';
+const CHAT_TASK_QUEUE_LIST_ID = 'chatTaskQueueList';
+const CHAT_TASK_QUEUE_COUNT_ID = 'chatTaskQueueCount';
 
 const CHAT_TTS_STORAGE_KEY = 'chatTtsEnabled';
 
@@ -13981,6 +13988,7 @@ export function initializeChatTab() {
     resetButton.addEventListener('click', handleResetContext);
 
     ensureAbortButtonBound();
+    renderChatTaskQueuePanel();
 
     // Add Enter key support for prompt input
     promptInput.addEventListener('keypress', function (event) {
@@ -14065,7 +14073,8 @@ function setThinkingState(isThinking) {
     }
 
     if (sendButton) {
-        sendButton.disabled = !!isThinking;
+        sendButton.disabled = false;
+        sendButton.textContent = isThinking ? 'Queue Prompt' : 'Send Prompt';
     }
 
     if (abortButton) {
@@ -14469,23 +14478,215 @@ function ensureAbortButtonBound() {
     }
 }
 
-async function handleSendPrompt() {
+function createQueuedChatPromptId() {
+    queuedChatPromptCounter += 1;
+    return `queued-${Date.now()}-${queuedChatPromptCounter}`;
+}
+
+function ensureChatTaskQueuePanel() {
     const promptInput = document.getElementById('promptInput');
+    if (!promptInput || !promptInput.parentElement) {
+        return null;
+    }
+
+    let panel = document.getElementById(CHAT_TASK_QUEUE_PANEL_ID);
+    if (!panel) {
+        panel = document.createElement('section');
+        panel.id = CHAT_TASK_QUEUE_PANEL_ID;
+        panel.className = 'chat-task-queue-panel hidden';
+        panel.setAttribute('aria-live', 'polite');
+        panel.setAttribute('aria-label', 'Queued tasks');
+        panel.innerHTML = `
+            <div class="chat-task-queue-header">
+                <span class="chat-task-queue-title">Queued tasks</span>
+                <span id="${CHAT_TASK_QUEUE_COUNT_ID}" class="chat-task-queue-count">0 queued</span>
+            </div>
+            <div id="${CHAT_TASK_QUEUE_LIST_ID}" class="chat-task-queue-list"></div>
+        `;
+        promptInput.insertAdjacentElement('afterend', panel);
+    }
+
+    if (panel.dataset.bound !== '1') {
+        panel.dataset.bound = '1';
+
+        panel.addEventListener('input', (event) => {
+            const target = event.target;
+            if (!(target instanceof HTMLTextAreaElement)) {
+                return;
+            }
+            if (!target.classList.contains('chat-task-queue-edit')) {
+                return;
+            }
+            const queueId = String(target.dataset.queueId || '').trim();
+            if (!queueId) {
+                return;
+            }
+            const queued = queuedChatPrompts.find((entry) => entry.id === queueId);
+            if (!queued) {
+                return;
+            }
+            queued.promptRaw = target.value;
+        });
+
+        panel.addEventListener('click', (event) => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+            const deleteButton = target.closest('.chat-task-queue-delete');
+            if (!deleteButton) {
+                return;
+            }
+            const queueId = String(deleteButton.getAttribute('data-queue-id') || '').trim();
+            if (!queueId) {
+                return;
+            }
+            queuedChatPrompts = queuedChatPrompts.filter((entry) => entry.id !== queueId);
+            renderChatTaskQueuePanel();
+        });
+    }
+
+    const list = panel.querySelector(`#${CHAT_TASK_QUEUE_LIST_ID}`);
+    const count = panel.querySelector(`#${CHAT_TASK_QUEUE_COUNT_ID}`);
+    if (!(list instanceof HTMLElement) || !(count instanceof HTMLElement)) {
+        return null;
+    }
+
+    return { panel, list, count };
+}
+
+function renderChatTaskQueuePanel() {
+    const elements = ensureChatTaskQueuePanel();
+    if (!elements) {
+        return;
+    }
+
+    const { panel, list, count } = elements;
+    const queueSize = queuedChatPrompts.length;
+
+    count.textContent = queueSize === 1 ? '1 queued' : `${queueSize} queued`;
+    list.innerHTML = '';
+
+    if (queueSize === 0) {
+        panel.classList.add('hidden');
+        return;
+    }
+
+    panel.classList.remove('hidden');
+
+    queuedChatPrompts.forEach((entry, index) => {
+        const item = document.createElement('div');
+        item.className = 'chat-task-queue-item';
+        item.setAttribute('data-queue-id', entry.id);
+
+        const label = document.createElement('div');
+        label.className = 'chat-task-queue-item-label';
+        label.textContent = index === 0 ? 'Next up' : `Queue #${index + 1}`;
+
+        const editor = document.createElement('textarea');
+        editor.className = 'chat-task-queue-edit';
+        editor.rows = 2;
+        editor.value = entry.promptRaw;
+        editor.setAttribute('data-queue-id', entry.id);
+        editor.setAttribute('aria-label', `Queued task ${index + 1}`);
+
+        const actions = document.createElement('div');
+        actions.className = 'chat-task-queue-actions';
+
+        const deleteButton = document.createElement('button');
+        deleteButton.type = 'button';
+        deleteButton.className = 'btn-mini chat-task-queue-delete';
+        deleteButton.textContent = 'Delete';
+        deleteButton.setAttribute('data-queue-id', entry.id);
+        deleteButton.setAttribute('aria-label', `Delete queued task ${index + 1}`);
+
+        actions.appendChild(deleteButton);
+        item.appendChild(label);
+        item.appendChild(editor);
+        item.appendChild(actions);
+        list.appendChild(item);
+    });
+}
+
+function queuePromptForLater(promptRaw) {
+    const value = String(promptRaw ?? '');
+    queuedChatPrompts.push({
+        id: createQueuedChatPromptId(),
+        promptRaw: value,
+    });
+    renderChatTaskQueuePanel();
+}
+
+function drainQueuedChatPromptIfIdle() {
+    if (activeChatRequest || queuedChatPrompts.length === 0) {
+        return;
+    }
+
+    const nextEntry = queuedChatPrompts[0];
+    if (!nextEntry || typeof nextEntry.promptRaw !== 'string' || !nextEntry.promptRaw.trim()) {
+        queuedChatPrompts = queuedChatPrompts.slice(1);
+        renderChatTaskQueuePanel();
+        scheduleQueuedChatPromptDrain();
+        return;
+    }
+
+    queuedChatPrompts = queuedChatPrompts.slice(1);
+    renderChatTaskQueuePanel();
+
+    void handleSendPrompt({
+        promptOverride: nextEntry.promptRaw,
+        fromQueue: true,
+    });
+}
+
+function scheduleQueuedChatPromptDrain() {
+    if (queuedChatPromptDrainTimer !== null) {
+        return;
+    }
+    queuedChatPromptDrainTimer = setTimeout(() => {
+        queuedChatPromptDrainTimer = null;
+        drainQueuedChatPromptIfIdle();
+    }, 0);
+}
+
+async function handleSendPrompt(options = {}) {
+    const promptInput = document.getElementById('promptInput');
+    if (!promptInput) {
+        return;
+    }
+
+    const fromQueue = options && options.fromQueue === true;
+    const hasPromptOverride = options && typeof options.promptOverride === 'string';
+    const promptRaw = hasPromptOverride ? options.promptOverride : promptInput.value;
+    const selectionStart = hasPromptOverride
+        ? null
+        : (typeof promptInput.selectionStart === 'number' ? promptInput.selectionStart : null);
+    const selectionEnd = hasPromptOverride
+        ? null
+        : (typeof promptInput.selectionEnd === 'number' ? promptInput.selectionEnd : null);
+    const promptForSend = normaliseVontologyIdsForBackend(promptRaw);
+    const promptText = promptForSend.trim();
 
     if (activeChatRequest) {
+        if (fromQueue) {
+            scheduleQueuedChatPromptDrain();
+            return;
+        }
+        if (!promptText) {
+            return;
+        }
+        queuePromptForLater(promptRaw);
+        promptInput.value = '';
+        promptInput.dispatchEvent(new Event('input', { bubbles: true }));
         return;
     }
 
     ensureAbortButtonBound();
 
-    const promptRaw = promptInput.value;
-    const selectionStart = typeof promptInput.selectionStart === 'number' ? promptInput.selectionStart : null;
-    const selectionEnd = typeof promptInput.selectionEnd === 'number' ? promptInput.selectionEnd : null;
-    const promptForSend = normaliseVontologyIdsForBackend(promptRaw);
-    const promptText = promptForSend.trim();
-
     if (!promptText) {
-        alert('Please enter a prompt.');
+        if (!fromQueue) {
+            alert('Please enter a prompt.');
+        }
         return;
     }
 
@@ -14516,9 +14717,11 @@ async function handleSendPrompt() {
         } catch (e) { console.info('[annotations] annotate user failed', e); }
     }
 
-    // Clear input
-    promptInput.value = '';
-    promptInput.dispatchEvent(new Event('input', { bubbles: true }));
+    if (!fromQueue) {
+        // Clear input only for direct sends; queued execution should preserve current draft text.
+        promptInput.value = '';
+        promptInput.dispatchEvent(new Event('input', { bubbles: true }));
+    }
     let request = null;
     try {
         request = {
@@ -14656,6 +14859,7 @@ async function handleSendPrompt() {
             setThinkingState(false);
         }
         updateHistoryLength();
+        scheduleQueuedChatPromptDrain();
     }
 }
 

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -6725,6 +6725,91 @@ footer {
     margin-bottom: 8px;
 }
 
+.chat-task-queue-panel {
+    margin: 2px 0 10px;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    background: #f8fafc;
+    padding: 8px;
+}
+
+.chat-task-queue-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 6px;
+}
+
+.chat-task-queue-title {
+    font-size: 12px;
+    font-weight: 700;
+    color: #334155;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+}
+
+.chat-task-queue-count {
+    font-size: 12px;
+    color: #64748b;
+    font-variant-numeric: tabular-nums;
+}
+
+.chat-task-queue-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.chat-task-queue-item {
+    border: 1px solid #dbe3ee;
+    border-radius: 6px;
+    background: #ffffff;
+    padding: 6px;
+}
+
+.chat-task-queue-item-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: #475569;
+    margin-bottom: 4px;
+}
+
+.chat-task-queue-edit {
+    width: 100%;
+    min-height: 52px;
+    border: 1px solid #cbd5e1;
+    border-radius: 6px;
+    padding: 6px 8px;
+    font-size: 13px;
+    line-height: 1.3;
+    resize: vertical;
+    background: #fff;
+    color: #0f172a;
+}
+
+.chat-task-queue-edit:focus {
+    outline: none;
+    border-color: #93c5fd;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+.chat-task-queue-actions {
+    margin-top: 6px;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.chat-task-queue-delete {
+    border: 1px solid #fca5a5;
+    background: #fff5f5;
+    color: #b91c1c;
+}
+
+.chat-task-queue-delete:hover {
+    background: #ffe4e6;
+}
+
 @media (max-height: 700px) {
 
     .scrollable-field,

--- a/src/frontend/web/von_interface/templates/chat_tab.html
+++ b/src/frontend/web/von_interface/templates/chat_tab.html
@@ -92,6 +92,13 @@
 
     <!-- Textarea for user prompt -->
     <textarea id="promptInput" rows="6" class="prompt-input" placeholder="Talk with Von here..."></textarea>
+    <section id="chatTaskQueuePanel" class="chat-task-queue-panel hidden" aria-live="polite" aria-label="Queued tasks">
+      <div class="chat-task-queue-header">
+        <span class="chat-task-queue-title">Queued tasks</span>
+        <span id="chatTaskQueueCount" class="chat-task-queue-count">0 queued</span>
+      </div>
+      <div id="chatTaskQueueList" class="chat-task-queue-list"></div>
+    </section>
 
     <!-- Buttons for sending prompt and resetting context -->
     <div class="button-row">

--- a/tests/frontend/chatTabAbort.test.js
+++ b/tests/frontend/chatTabAbort.test.js
@@ -134,7 +134,7 @@ describe('chat abort behaviour', () => {
 
         const sendPromise = sendMessage();
 
-        expect(document.getElementById('sendButton').disabled).toBe(true);
+        expect(document.getElementById('sendButton').disabled).toBe(false);
         expect(document.getElementById('abortButton').getAttribute('aria-hidden')).toBe('false');
 
         document.getElementById('abortButton').click();

--- a/tests/frontend/chatTaskQueue.test.js
+++ b/tests/frontend/chatTaskQueue.test.js
@@ -1,0 +1,222 @@
+/** @jest-environment jsdom */
+
+const chatTabModulePath = '../../src/frontend/web/von_interface/static/js/chatTab.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    annotateTurn: jest.fn(),
+    getUserContext: jest.fn(),
+    getWindowSessionId: jest.fn(() => 'mock-window-session-id')
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
+    elements: {},
+    renderSpanSuggestions: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/utils/textDecorator.js', () => ({
+    applyCartoucheAppearance: jest.fn(),
+    cartouchifyElementText: jest.fn(),
+    cartouchifyVontologyTokensInElement: jest.fn(),
+    createVontologyCartouche: jest.fn(),
+    getCartoucheAppearanceSettings: jest.fn(() => ({})),
+    linkifyVontologyTokensInElement: jest.fn(),
+    normalisePotentialConceptId: jest.fn((value) => value)
+}));
+
+function flushMicrotasks() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('chat task queue', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="scrollableField"></div>
+            <div class="thinking-card-wrapper" id="thinkingCardWrapper" aria-hidden="true">
+                <div class="thinking-card">
+                    <div class="thinking-card-header" id="loadingIndicator">
+                        <span class="thinking-card-phase loading-indicator-text">Thinking...</span>
+                        <span class="thinking-card-meta" id="thinkingCardMeta"></span>
+                        <button id="abortButton" aria-hidden="true"></button>
+                    </div>
+                    <div class="thinking-card-body" id="loadingIndicatorDetail"></div>
+                </div>
+            </div>
+            <button id="sendButton"></button>
+            <textarea id="promptInput"></textarea>
+            <input type="checkbox" id="annotationToggle" />
+        `;
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        delete global.fetch;
+    });
+
+    test('queues while thinking and executes edited queued prompt after current turn', async () => {
+        const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        const { sendMessage } = require(chatTabModulePath);
+
+        getUserContext.mockReturnValue({
+            user_id: 'user',
+            org_id: 'org',
+            language: 'en-NZ',
+            gmail_profile: null
+        });
+
+        const generateBodies = [];
+        let resolveFirstGenerate = null;
+
+        global.fetch = jest.fn((url, options = {}) => {
+            if (typeof url === 'string' && url.startsWith('/von/api/render_markdown')) {
+                const body = JSON.parse(options.body || '{}');
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ html: String(body.text || '') })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ history_length: 0, authenticated: true })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/generate')) {
+                const parsed = JSON.parse(options.body || '{}');
+                generateBodies.push(parsed);
+
+                if (generateBodies.length === 1) {
+                    return new Promise((resolve) => {
+                        resolveFirstGenerate = () => resolve({
+                            ok: true,
+                            json: async () => ({
+                                response: 'First response',
+                                llm_debug: { model: 'gpt-5.2' }
+                            })
+                        });
+                    });
+                }
+
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        response: 'Second response',
+                        llm_debug: { model: 'gpt-5.2' }
+                    })
+                });
+            }
+
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        const promptInput = document.getElementById('promptInput');
+        promptInput.value = 'First request';
+        const firstRequestPromise = sendMessage();
+
+        await flushMicrotasks();
+        expect(generateBodies).toHaveLength(1);
+        expect(document.getElementById('sendButton').textContent).toBe('Queue Prompt');
+
+        promptInput.value = 'Second draft';
+        await sendMessage();
+
+        const queuedEditor = document.querySelector('.chat-task-queue-edit');
+        expect(queuedEditor).toBeTruthy();
+        queuedEditor.value = 'Second edited';
+        queuedEditor.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(resolveFirstGenerate).toBeTruthy();
+        resolveFirstGenerate();
+
+        await firstRequestPromise;
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        expect(generateBodies).toHaveLength(2);
+        expect(generateBodies[1].prompt).toBe('Second edited');
+        expect(document.querySelector('.chat-task-queue-item')).toBeNull();
+    }, 15000);
+
+    test('deleting a queued prompt prevents queued execution', async () => {
+        const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        const { sendMessage } = require(chatTabModulePath);
+
+        getUserContext.mockReturnValue({
+            user_id: 'user',
+            org_id: 'org',
+            language: 'en-NZ',
+            gmail_profile: null
+        });
+
+        const generateBodies = [];
+        let resolveFirstGenerate = null;
+
+        global.fetch = jest.fn((url, options = {}) => {
+            if (typeof url === 'string' && url.startsWith('/von/api/render_markdown')) {
+                const body = JSON.parse(options.body || '{}');
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ html: String(body.text || '') })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ history_length: 0, authenticated: true })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/generate')) {
+                const parsed = JSON.parse(options.body || '{}');
+                generateBodies.push(parsed);
+
+                if (generateBodies.length === 1) {
+                    return new Promise((resolve) => {
+                        resolveFirstGenerate = () => resolve({
+                            ok: true,
+                            json: async () => ({
+                                response: 'First response',
+                                llm_debug: { model: 'gpt-5.2' }
+                            })
+                        });
+                    });
+                }
+
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        response: 'Second response',
+                        llm_debug: { model: 'gpt-5.2' }
+                    })
+                });
+            }
+
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        const promptInput = document.getElementById('promptInput');
+        promptInput.value = 'First request';
+        const firstRequestPromise = sendMessage();
+        await flushMicrotasks();
+
+        promptInput.value = 'Second queued';
+        await sendMessage();
+
+        const deleteButton = document.querySelector('.chat-task-queue-delete');
+        expect(deleteButton).toBeTruthy();
+        deleteButton.click();
+
+        expect(resolveFirstGenerate).toBeTruthy();
+        resolveFirstGenerate();
+
+        await firstRequestPromise;
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        expect(generateBodies).toHaveLength(1);
+        expect(document.querySelector('.chat-task-queue-item')).toBeNull();
+        expect(document.getElementById('chatTaskQueuePanel')?.classList.contains('hidden')).toBe(true);
+    }, 15000);
+});


### PR DESCRIPTION
## Summary
- allow sending new prompts while a turn is in-flight by queueing them instead of dropping/ignoring input
- add an inline queued-task panel with per-item editable text and delete controls
- automatically execute queued prompts FIFO after each active turn finalises
- keep normal immediate send behaviour when idle and preserve draft text while queued items execute

## Files
- `src/frontend/web/von_interface/static/js/chatTab.js`
- `src/frontend/web/von_interface/static/styles.css`
- `src/frontend/web/von_interface/templates/chat_tab.html`
- `tests/frontend/chatTaskQueue.test.js`
- `tests/frontend/chatTabAbort.test.js`

## Validation
- `npm run test:frontend -- tests/frontend/chatTaskQueue.test.js tests/frontend/chatTabAbort.test.js`
- `npx pyright`