### PR TITLE
JVNAUTOSCI-1286 Fix cartouchify suggestion replacement range

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,9 @@ All AI agents must read this file and `docs/engineering/security_considerations.
 22. In docs/examples for secret env vars, use explicit placeholders like `<YOUR-CLIENT-SECRET-HERE>` and avoid token-like sample strings that can trigger secret scanners.
 23. **Workflow-first behaviours**: strongly prefer Vontology workflows (definitions, instances, event bindings, schedules) to drive Von behaviour instead of adding specialised orchestration code. Add bespoke code only when workflow primitives cannot express the behaviour, and document the gap in Jira.
 24. **Policy over task wording**: if a Jira issue suggests implementation in specialised orchestration code but the behaviour can be expressed as a Vontology workflow, enforce workflow-first policy and reinterpret/revise the task accordingly. In these cases, limit code changes to missing tools/validators/telemetry needed by the workflow, and add a Jira comment documenting the reinterpretation.
-25. If you are reasonably confident task implementation is complete, proactively merge and close the task (commit/push, merge to `main`, and transition Jira) unless the user explicitly asks to hold.
-26. **Fail closed when Vontology is unavailable for Vontology-governed behaviour**: do not silently fall back to in-code prompts, stale context reuse, or heuristic hacks. If required Vontology prompts/workflow data cannot be resolved, no-op that transformation and emit a clear user-visible and telemetry-visible reason.
+25. If you are reasonably confident task implementation is complete, proactively merge and close the task (commit/push, create PR, merge to `main`, and transition Jira) unless the user explicitly asks to hold.
+26. **Definition of fully complete Jira task**: implementation committed and pushed, PR created, PR merged to `main`, and Jira transitioned/commented accordingly.
+27. **Fail closed when Vontology is unavailable for Vontology-governed behaviour**: do not silently fall back to in-code prompts, stale context reuse, or heuristic hacks. If required Vontology prompts/workflow data cannot be resolved, no-op that transformation and emit a clear user-visible and telemetry-visible reason.
 
 ## Core AI-Focused Documents
 - `docs/AINotes.md`: short-term memory and tactical log.

--- a/src/frontend/web/von_interface/static/js/components/conceptAutocomplete.js
+++ b/src/frontend/web/von_interface/static/js/components/conceptAutocomplete.js
@@ -35,6 +35,7 @@ function getOrCreateState(textarea) {
             selectedIndex: -1,
             results: [],
             triggerPos: null,
+            triggerEndPos: null,
             searchTimeout: null,
             dropdownPointerDown: false,
         });
@@ -94,6 +95,8 @@ export function closeAutocomplete() {
         state.isOpen = false;
         state.selectedIndex = -1;
         state.results = [];
+        state.triggerPos = null;
+        state.triggerEndPos = null;
     }
 }
 
@@ -189,6 +192,40 @@ export function getTriggerSearchText(text, cursorPos, maxLookback = 200) {
 
     const searchText = input.substring(lastTriggerIdx + 3, safeCursorPos);
     return { triggerIdx: lastTriggerIdx, searchText };
+}
+
+function isVontologyTriggerAt(text, index) {
+    if (typeof index !== 'number' || index < 0 || index + 2 >= text.length) {
+        return false;
+    }
+    return (
+        text[index] === '#' &&
+        (text[index + 1] === 'V' || text[index + 1] === 'v') &&
+        text[index + 2] === '#'
+    );
+}
+
+function getStoredTriggerRange(text, state) {
+    if (!state) {
+        return null;
+    }
+
+    const start = Number.isInteger(state.triggerPos) ? state.triggerPos : null;
+    const end = Number.isInteger(state.triggerEndPos) ? state.triggerEndPos : null;
+    if (start === null || end === null || start < 0 || end < start || end > text.length) {
+        return null;
+    }
+    if (!isVontologyTriggerAt(text, start)) {
+        return null;
+    }
+
+    // Stored ranges are only valid for the active token fragment (no whitespace).
+    const tokenFragment = text.substring(start + 3, end);
+    if (/\s/.test(tokenFragment)) {
+        return null;
+    }
+
+    return { start, end };
 }
 
 /**
@@ -320,35 +357,24 @@ function insertConcept(conceptId) {
     }
 
     const insertedId = makeNonTriggerVontologyId(conceptId);
+    const state = getOrCreateState(ta);
 
     const text = ta.value;
     const cursorPos = ta.selectionStart;
+    const storedRange = getStoredTriggerRange(text, state);
+    const fallbackTrigger = getTriggerSearchText(text, cursorPos, 100);
 
-    // Find the #V# or #v# trigger position (search backwards for the pattern)
-    let triggerIdx = -1;
-    let searchStart = Math.max(0, cursorPos - 100);
-    let substring = text.substring(searchStart, cursorPos);
+    const triggerIdx = storedRange ? storedRange.start : fallbackTrigger?.triggerIdx;
+    const replaceEnd = storedRange ? storedRange.end : cursorPos;
 
-    // Search backwards for #V# or #v#
-    for (let i = substring.length - 3; i >= 0; i--) {
-        if (
-            substring[i] === '#' &&
-            (substring[i + 1] === 'V' || substring[i + 1] === 'v') &&
-            substring[i + 2] === '#'
-        ) {
-            triggerIdx = searchStart + i;
-            break;
-        }
-    }
-
-    if (triggerIdx === -1) {
+    if (typeof triggerIdx !== 'number' || triggerIdx < 0) {
         console.warn('[conceptAutocomplete] No #V# trigger found when inserting concept');
         return;
     }
 
-    // Replace from trigger to cursor position
+    // Replace from trigger start to the captured end-of-token position.
     const before = text.substring(0, triggerIdx);
-    const after = text.substring(cursorPos);
+    const after = text.substring(replaceEnd);
 
     // Ensure a separator after the inserted concept token, otherwise subsequent typing can
     // accidentally extend the hidden token (e.g., #V\u200B#personabc), which breaks hydration.
@@ -369,6 +395,8 @@ function insertConcept(conceptId) {
     ta.focus();
 
     console.log(`[conceptAutocomplete] Inserted ${insertedId} at position ${triggerIdx}`);
+    state.triggerPos = null;
+    state.triggerEndPos = null;
 
     // Trigger input event for any listeners
     ta.dispatchEvent(new Event('input', { bubbles: true }));
@@ -456,6 +484,11 @@ function handleInput(event) {
         closeAutocomplete();
         return;
     }
+
+    // Persist the replacement range so selecting from the dropdown can replace the
+    // original typed token even if the caret has moved elsewhere.
+    state.triggerPos = lastTriggerIdx;
+    state.triggerEndPos = cursorPos;
 
     // Debounce search - capture the textarea for race condition protection
     clearTimeout(state.searchTimeout);

--- a/tests/frontend/conceptAutocomplete.test.js
+++ b/tests/frontend/conceptAutocomplete.test.js
@@ -167,4 +167,42 @@ describe('conceptAutocomplete', () => {
             done();
         }, 300);
     });
+
+    test('selecting a concept replaces the original trigger even when caret moves', (done) => {
+        initializeConceptAutocomplete(textarea);
+
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                ok: true,
+                json: () =>
+                    Promise.resolve({
+                        results: [{ id: '#V#person', name: 'Person', kind: 'type' }],
+                    }),
+            })
+        );
+
+        textarea.value = 'Plan #V#pe and more';
+        const triggerEnd = textarea.value.indexOf(' and more');
+        textarea.selectionStart = triggerEnd;
+        textarea.selectionEnd = triggerEnd;
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+
+        setTimeout(() => {
+            const dropdown = document.querySelector('.concept-autocomplete-dropdown');
+            const first = dropdown
+                ? dropdown.querySelector('.concept-autocomplete-item[data-concept-id="#V#person"]')
+                : null;
+            expect(first).toBeTruthy();
+
+            // Simulate the user moving the caret elsewhere before choosing.
+            textarea.selectionStart = textarea.value.length;
+            textarea.selectionEnd = textarea.value.length;
+
+            first.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+            const ZWSP = '\u200B';
+            expect(textarea.value).toBe(`Plan #V${ZWSP}#person and more`);
+            done();
+        }, 300);
+    });
 });


### PR DESCRIPTION
## Summary
- fix concept autocomplete insertion to replace the stored trigger span instead of recomputing from the current caret
- preserve fallback behaviour when no stored trigger range is available
- add a regression test for selecting a suggestion after moving the caret
- update AGENTS.md to explicitly define fully complete Jira work as commit/push + PR + merge

## Testing
- npm test -- tests/frontend/conceptAutocomplete.test.js --runInBand
- npx pyright