### PR TITLE
JVNAUTOSCI-1287: tighten mutation completion-gate inference for no-op execution

### DIFF
--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -120,6 +120,91 @@ _KB_TERMS = (
     "relationships",
 )
 
+_WRITE_OBJECT_TERMS = (
+    "attachment",
+    "branch",
+    "comment",
+    "concept",
+    "file",
+    "issue",
+    "jira",
+    "predicate",
+    "pull request",
+    "relation",
+    "relationship",
+    "schedule",
+    "subtask",
+    "task",
+    "ticket",
+    "todo",
+    "to-do",
+    "to do",
+    "workflow",
+)
+
+_DIAGNOSTIC_ONLY_PHRASES = (
+    "didn't actually",
+    "did not actually",
+    "explain why",
+    "inspect the telemetry",
+    "what went wrong",
+    "why did not",
+    "why didn't",
+    "why was not",
+    "why wasn't",
+)
+
+_ACTION_REQUEST_MUTATION_PATTERN = re.compile(
+    r"\b(?:can you|could you|go ahead(?: and)?|please|would you)\s+"
+    r"(?:add|apply|attach|create|delete|link|modify|remove|rename|set|update)\b"
+)
+
+_NEGATED_MUTATION_PREFIX_PATTERN = re.compile(
+    r"(?:did(?:n't| not)|was(?:n't| not)|were(?:n't| not)|not)\s+(?:actually\s+)?$"
+)
+
+
+def _has_affirmative_mutation_term(prompt_text: str) -> bool:
+    if not prompt_text:
+        return False
+    for term in _MUTATION_INTENT_TERMS:
+        start = 0
+        while True:
+            index = prompt_text.find(term, start)
+            if index < 0:
+                break
+
+            before = prompt_text[index - 1] if index > 0 else " "
+            end_index = index + len(term)
+            after = prompt_text[end_index] if end_index < len(prompt_text) else " "
+            if (before.isalnum() or before == "_") or (after.isalnum() or after == "_"):
+                start = index + len(term)
+                continue
+
+            window_start = max(0, index - 48)
+            prefix = prompt_text[window_start:index]
+            if _NEGATED_MUTATION_PREFIX_PATTERN.search(prefix):
+                start = index + len(term)
+                continue
+
+            return True
+    return False
+
+
+def _looks_like_diagnostic_only_prompt(prompt_text: str) -> bool:
+    if not prompt_text:
+        return False
+    if not any(phrase in prompt_text for phrase in _DIAGNOSTIC_ONLY_PHRASES):
+        return False
+    if _ACTION_REQUEST_MUTATION_PATTERN.search(prompt_text):
+        return False
+    if re.match(
+        r"^\s*(?:add|apply|attach|create|delete|link|modify|remove|rename|set|update)\b",
+        prompt_text,
+    ):
+        return False
+    return True
+
 
 def _now_utc() -> datetime:
     return datetime.now(timezone.utc)
@@ -427,8 +512,10 @@ def _infer_mutation_required_effect(
     prompt_clean = prompt_text if isinstance(prompt_text, str) else ""
     lowered = prompt_clean.lower()
 
-    has_mutation_term = any(token in lowered for token in _MUTATION_INTENT_TERMS)
+    has_mutation_term = _has_affirmative_mutation_term(lowered)
     has_kb_term = any(token in lowered for token in _KB_TERMS)
+    has_write_object_term = any(token in lowered for token in _WRITE_OBJECT_TERMS)
+    diagnostic_only_prompt = _looks_like_diagnostic_only_prompt(lowered)
     explicit_missing_relation_phrase = any(
         phrase in lowered
         for phrase in (
@@ -441,8 +528,11 @@ def _infer_mutation_required_effect(
     )
 
     mutation_intent = explicit_missing_relation_phrase or (
-        has_mutation_term and has_kb_term
+        has_mutation_term and (has_kb_term or has_write_object_term)
     )
+    if diagnostic_only_prompt and not explicit_missing_relation_phrase:
+        mutation_intent = False
+
     if not mutation_intent and not successful_write_tools and not failed_tools and not blocked_tools:
         return None
 

--- a/tests/backend/test_orchestrator_turn_execution_gate.py
+++ b/tests/backend/test_orchestrator_turn_execution_gate.py
@@ -19,7 +19,13 @@ class _DummyGateway:
 
 
 def _build_orchestrator() -> InternalMCPChatOrchestrator:
-    return InternalMCPChatOrchestrator(gateway=cast(Any, _DummyGateway()))
+    # Avoid full orchestrator initialisation in unit tests.
+    # Constructor bootstrap can require external workflow registry state that is
+    # irrelevant for testing isolated turn-execution actions.
+    return cast(
+        InternalMCPChatOrchestrator,
+        object.__new__(InternalMCPChatOrchestrator),
+    )
 
 
 def _build_request(
@@ -150,3 +156,77 @@ def test_turn_completion_gate_appends_execution_status_for_unresolved_effect() -
         for entry in aux_llm_calls
         if isinstance(entry, dict)
     )
+
+
+def test_turn_execution_critic_flags_missing_non_kb_mutation_execution() -> None:
+    orchestrator = _build_orchestrator()
+    request = _build_request(
+        action_id="turn_execution.critic",
+        data={
+            "prompt": "Please create a Jira task for this regression and assign it to me.",
+            "final_response": "Done.",
+            "invocations": [],
+            "aux_llm_calls": [],
+            "turn_id": "req-turn-critic-2",
+            "conversation_session_id": "session-critic-2",
+            "workflow_discovery_result": None,
+            "workflow_routing": {
+                "workflow_id": "#V#tool_calling_workflow",
+                "verdict": "tool_seeking",
+            },
+        },
+    )
+
+    result = orchestrator._action_turn_execution_critic(request)
+    assert result.ok
+
+    record = result.outputs.get("turn_execution_record")
+    assert isinstance(record, dict)
+
+    required_effects = record.get("required_effects")
+    assert isinstance(required_effects, list)
+    assert len(required_effects) == 1
+    assert required_effects[0]["status"] == "not_executed"
+
+    completion_gate = record.get("completion_gate")
+    assert isinstance(completion_gate, dict)
+    assert completion_gate.get("decision") == "escalation_required"
+    assert completion_gate.get("safe_to_claim_completion") is False
+
+
+def test_turn_execution_critic_treats_diagnostic_prompt_as_non_mutating() -> None:
+    orchestrator = _build_orchestrator()
+    request = _build_request(
+        action_id="turn_execution.critic",
+        data={
+            "prompt": (
+                "You didn't actually create the task instance this time. "
+                "Inspect the telemetry and explain why."
+            ),
+            "final_response": "No mutation was attempted in this turn.",
+            "invocations": [],
+            "aux_llm_calls": [],
+            "turn_id": "req-turn-critic-3",
+            "conversation_session_id": "session-critic-3",
+            "workflow_discovery_result": None,
+            "workflow_routing": {
+                "workflow_id": "#V#tool_calling_workflow",
+                "verdict": "tool_seeking",
+            },
+        },
+    )
+
+    result = orchestrator._action_turn_execution_critic(request)
+    assert result.ok
+
+    record = result.outputs.get("turn_execution_record")
+    assert isinstance(record, dict)
+
+    required_effects = record.get("required_effects")
+    assert isinstance(required_effects, list)
+    assert required_effects == []
+
+    completion_gate = record.get("completion_gate")
+    assert isinstance(completion_gate, dict)
+    assert completion_gate.get("decision") == "completed"
+    assert completion_gate.get("safe_to_claim_completion") is True


### PR DESCRIPTION
## Summary
- broaden mutation-intent detection so non-KB write requests (for example Jira task creation) are treated as mutation-required effects
- keep diagnostic-only prompts ("why didn't you create...") from being misclassified as mutation requests
- preserve existing gate behaviour for unresolved writes (`escalation_required`) once mutation intent is inferred
- add regression tests for both the new positive case and the diagnostic guard case
- make the orchestrator gate unit tests constructor-light to avoid unrelated workflow bootstrap dependencies in action-level unit tests

## Test plan
- `pdm run pytest tests/backend/test_orchestrator_turn_execution_gate.py tests/backend/test_turn_execution_record_actor_identity.py -q`
- `pdm run pyright src/backend/services/turn_execution_record_service.py tests/backend/test_orchestrator_turn_execution_gate.py`

## Jira
- JVNAUTOSCI-1287
