### PR TITLE
JVNAUTOSCI-1296: Stabilise health status detection and diagnostics

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -112,6 +112,8 @@ const INCOMING_INVITE_POLL_INTERVAL_MS = 60_000;
 let incomingInvitePollTimerId = null;
 let incomingInviteLoadInFlight = false;
 let incomingInviteAbortController = null;
+const SHARED_SESSION_BADGE_POLL_INTERVAL_MS = 60_000;
+let sharedSessionBadgePollTimerId = null;
 
 // JVNAUTOSCI-1002: SSE streaming for shared conversation turn updates
 const sharedConversationStreams = new Map();
@@ -147,6 +149,11 @@ const workflowDefinitionsState = {
     lastRequestQuery: '',
     showDesigns: false
 };
+const WORKFLOW_DEFINITIONS_SILENT_REFRESH_COOLDOWN_MS = 15_000;
+const WORKFLOW_DEFINITIONS_FETCH_TIMEOUT_MS = 20_000;
+let workflowStatusPanelInitialised = false;
+let chatTabInitialised = false;
+const REALTIME_CONNECTION_TELEMETRY_SCHEMA_VERSION = 1;
 const workflowEpisodesState = {
     open: false,
     workflowId: '',
@@ -158,6 +165,97 @@ const workflowEpisodesState = {
     lastRequestQuery: '',
     lastFetchedAt: 0
 };
+
+function isDocumentVisibleForRealtimeConnections() {
+    try {
+        if (typeof document === 'undefined') return true;
+        if (typeof document.visibilityState === 'string') {
+            return document.visibilityState !== 'hidden';
+        }
+        return !document.hidden;
+    } catch (_) {
+        return true;
+    }
+}
+
+function shouldRunSharedSessionBadgePollingForInputs({
+    isVisible
+} = {}) {
+    return !!isVisible;
+}
+
+function shouldRunSharedSessionBadgePolling() {
+    return shouldRunSharedSessionBadgePollingForInputs({
+        isVisible: isDocumentVisibleForRealtimeConnections()
+    });
+}
+
+function shouldMaintainSharedConversationStreamForInputs({
+    sessionId,
+    activeSessionId,
+    isVisible,
+    isSharedSession
+} = {}) {
+    const sid = String(sessionId || '').trim();
+    if (!sid) return false;
+    if (!isVisible) return false;
+    if (String(activeSessionId || '').trim() !== sid) return false;
+    return !!isSharedSession;
+}
+
+function shouldMaintainSharedConversationStream(sessionId) {
+    const sid = String(sessionId || '').trim();
+    return shouldMaintainSharedConversationStreamForInputs({
+        sessionId: sid,
+        activeSessionId: activeChatSessionId,
+        isVisible: isDocumentVisibleForRealtimeConnections(),
+        isSharedSession: isSharedConversationSession(sid)
+    });
+}
+
+function shouldMaintainWorkflowStatusStream() {
+    const { panel } = getWorkflowStatusElements();
+    if (!panel || typeof EventSource === 'undefined') return false;
+    return isDocumentVisibleForRealtimeConnections();
+}
+
+function buildRealtimeConnectionTelemetrySnapshot(source = 'unknown') {
+    const eventSource = (typeof source === 'string' && source.trim()) ? source.trim() : 'unknown';
+    const visibilityState = (typeof document !== 'undefined' && typeof document.visibilityState === 'string')
+        ? document.visibilityState
+        : null;
+    return {
+        schemaVersion: REALTIME_CONNECTION_TELEMETRY_SCHEMA_VERSION,
+        generatedAtMs: Date.now(),
+        generatedAtIso: new Date().toISOString(),
+        eventSource,
+        visibilityState,
+        documentVisible: isDocumentVisibleForRealtimeConnections(),
+        activeChatSessionId: activeChatSessionId || null,
+        sharedStreamCount: sharedConversationStreams.size,
+        sharedStreamSessionIds: Array.from(sharedConversationStreams.keys()),
+        sharedReconnectTrackedCount: sharedConversationReconnectAttempts.size,
+        workflowStreamConnected: !!workflowStatusStreamState.eventSource,
+        workflowReconnectScheduled: !!workflowStatusStreamState.reconnectTimeoutId,
+        incomingInvitePollingActive: !!incomingInvitePollTimerId,
+        sharedSessionBadgePollingActive: !!sharedSessionBadgePollTimerId,
+    };
+}
+
+function publishRealtimeConnectionTelemetry(source = 'unknown') {
+    const snapshot = buildRealtimeConnectionTelemetrySnapshot(source);
+    try {
+        window.__vonRealtimeConnectionTelemetry = snapshot;
+    } catch (_) {
+        // Ignore non-writable globals in constrained environments.
+    }
+    try {
+        document.dispatchEvent(new CustomEvent('von:realtimeConnectionTelemetryUpdated', { detail: snapshot }));
+    } catch (_) {
+        // Telemetry dispatch should not block normal flow.
+    }
+    return snapshot;
+}
 
 // Lightweight client-side telemetry for chat session tab loading (elapsed + ETA).
 // Stored locally only; intended to feed future introspection.
@@ -12008,6 +12106,7 @@ function closeSharedConversationStream(sessionId = null) {
         }
         sharedConversationStreams.delete(sessionId);
         sharedConversationReconnectAttempts.delete(sessionId);
+        publishRealtimeConnectionTelemetry('shared_stream_closed');
         return;
     }
 
@@ -12021,21 +12120,14 @@ function closeSharedConversationStream(sessionId = null) {
     });
     sharedConversationStreams.clear();
     sharedConversationReconnectAttempts.clear();
+    publishRealtimeConnectionTelemetry('shared_streams_closed_all');
 }
 
 function syncSharedConversationStreams() {
+    // Keep a single shared-conversation stream per tab to avoid exhausting
+    // browser/server connection slots under multi-tab usage.
     const desiredSessions = new Set();
-    if (Array.isArray(sessionTabsCache)) {
-        sessionTabsCache.forEach((session) => {
-            const sid = (typeof session?.session_id === 'string') ? session.session_id.trim() : '';
-            if (!sid) return;
-            if (isSharedConversationSession(sid)) {
-                desiredSessions.add(sid);
-            }
-        });
-    }
-
-    if (activeChatSessionId && isSharedConversationSession(activeChatSessionId)) {
+    if (shouldMaintainSharedConversationStream(activeChatSessionId)) {
         desiredSessions.add(activeChatSessionId);
     }
 
@@ -12048,6 +12140,7 @@ function syncSharedConversationStreams() {
     desiredSessions.forEach((sid) => {
         void startSharedConversationStream(sid);
     });
+    publishRealtimeConnectionTelemetry('shared_stream_sync');
 }
 
 /**
@@ -12058,7 +12151,7 @@ async function startSharedConversationStream(sessionId) {
     const sid = String(sessionId || '').trim();
     if (!sid) return;
 
-    if (!isSharedConversationSession(sid)) {
+    if (!shouldMaintainSharedConversationStream(sid)) {
         closeSharedConversationStream(sid);
         return;
     }
@@ -12075,10 +12168,12 @@ async function startSharedConversationStream(sessionId) {
     const url = `/von/api/shared_conversations/stream?session_id=${encodeURIComponent(sid)}`;
     const eventSource = new EventSource(url);
     sharedConversationStreams.set(sid, eventSource);
+    publishRealtimeConnectionTelemetry('shared_stream_started');
 
     eventSource.onopen = () => {
         console.log('[chatTab] SSE stream connected', { sessionId: sid });
         sharedConversationReconnectAttempts.set(sid, 0);
+        publishRealtimeConnectionTelemetry('shared_stream_open');
     };
 
     eventSource.onerror = () => {
@@ -12090,8 +12185,9 @@ async function startSharedConversationStream(sessionId) {
         if (eventSource.readyState === EventSource.CLOSED) {
             eventSource.close();
             sharedConversationStreams.delete(sid);
+            publishRealtimeConnectionTelemetry('shared_stream_closed_remote');
 
-            if (isSharedConversationSession(sid) || activeChatSessionId === sid) {
+            if (shouldMaintainSharedConversationStream(sid)) {
                 const attempts = (sharedConversationReconnectAttempts.get(sid) || 0) + 1;
                 sharedConversationReconnectAttempts.set(sid, attempts);
                 const delay = Math.min(
@@ -12100,10 +12196,13 @@ async function startSharedConversationStream(sessionId) {
                 );
                 console.log('[chatTab] SSE reconnecting in', delay, 'ms, attempt', attempts);
                 setTimeout(() => {
-                    if ((activeChatSessionId === sid || isSharedConversationSession(sid)) && !sharedConversationStreams.has(sid)) {
+                    if (shouldMaintainSharedConversationStream(sid) && !sharedConversationStreams.has(sid)) {
                         void startSharedConversationStream(sid);
                     }
                 }, delay);
+            } else {
+                sharedConversationReconnectAttempts.delete(sid);
+                publishRealtimeConnectionTelemetry('shared_stream_reconnect_skipped');
             }
         }
     };
@@ -13343,6 +13442,17 @@ async function refreshWorkflowStatusSnapshot({ silent = false } = {}) {
 async function refreshAvailableWorkflowDefinitions({ silent = false } = {}) {
     const { panel } = getWorkflowStatusElements();
     if (!panel) return;
+    if (workflowDefinitionsState.loading) return;
+
+    const now = Date.now();
+    if (
+        silent
+        && Number.isFinite(workflowDefinitionsState.lastFetchedAt)
+        && workflowDefinitionsState.lastFetchedAt > 0
+        && (now - workflowDefinitionsState.lastFetchedAt) < WORKFLOW_DEFINITIONS_SILENT_REFRESH_COOLDOWN_MS
+    ) {
+        return;
+    }
 
     workflowDefinitionsState.loading = true;
     workflowDefinitionsState.error = '';
@@ -13354,11 +13464,16 @@ async function refreshAvailableWorkflowDefinitions({ silent = false } = {}) {
     params.set('limit', '200');
     workflowDefinitionsState.lastRequestQuery = params.toString();
 
+    let timeoutId = null;
     try {
+        const controller = new AbortController();
+        timeoutId = setTimeout(() => controller.abort(), WORKFLOW_DEFINITIONS_FETCH_TIMEOUT_MS);
         const resp = await fetch(
             `/api/workflows/definitions?${params.toString()}`,
-            { method: 'GET', headers: buildChatFetchHeaders() }
+            { method: 'GET', headers: buildChatFetchHeaders(), signal: controller.signal }
         );
+        clearTimeout(timeoutId);
+        timeoutId = null;
         if (!resp.ok) {
             throw new Error(`HTTP ${resp.status}`);
         }
@@ -13368,16 +13483,22 @@ async function refreshAvailableWorkflowDefinitions({ silent = false } = {}) {
         workflowDefinitionsState.lastFetchedAt = Date.now();
         workflowDefinitionsState.error = '';
     } catch (err) {
+        const isAbortError = err && typeof err === 'object' && err.name === 'AbortError';
         workflowDefinitionsState.error = 'Could not load available workflows';
         workflowDefinitionsState.lastPayload = {
             error: 'workflow_definitions_fetch_failed',
-            detail: err instanceof Error ? err.message : String(err || 'unknown_error'),
+            detail: isAbortError
+                ? `Request timed out after ${Math.round(WORKFLOW_DEFINITIONS_FETCH_TIMEOUT_MS / 1000)}s`
+                : (err instanceof Error ? err.message : String(err || 'unknown_error')),
             request_query: workflowDefinitionsState.lastRequestQuery || null
         };
         if (!silent) {
             console.warn('[workflowStatus] Available workflow fetch failed', err);
         }
     } finally {
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+        }
         workflowDefinitionsState.loading = false;
         if (workflowDefinitionsState.visible) {
             renderWorkflowStatusBody();
@@ -13385,7 +13506,7 @@ async function refreshAvailableWorkflowDefinitions({ silent = false } = {}) {
     }
 }
 
-function stopWorkflowStatusStream() {
+function stopWorkflowStatusStream(source = 'workflow_stream_stopped') {
     if (workflowStatusStreamState.reconnectTimeoutId) {
         clearTimeout(workflowStatusStreamState.reconnectTimeoutId);
         workflowStatusStreamState.reconnectTimeoutId = null;
@@ -13394,9 +13515,15 @@ function stopWorkflowStatusStream() {
         workflowStatusStreamState.eventSource.close();
         workflowStatusStreamState.eventSource = null;
     }
+    publishRealtimeConnectionTelemetry(source);
 }
 
 function scheduleWorkflowStatusReconnect() {
+    if (!shouldMaintainWorkflowStatusStream()) {
+        workflowStatusStreamState.reconnectAttempts = 0;
+        publishRealtimeConnectionTelemetry('workflow_stream_reconnect_skipped');
+        return;
+    }
     if (workflowStatusStreamState.reconnectTimeoutId) return;
     workflowStatusStreamState.reconnectAttempts += 1;
     const delay = Math.min(
@@ -13407,21 +13534,26 @@ function scheduleWorkflowStatusReconnect() {
         workflowStatusStreamState.reconnectTimeoutId = null;
         startWorkflowStatusStream();
     }, delay);
+    publishRealtimeConnectionTelemetry('workflow_stream_reconnect_scheduled');
 }
 
 function startWorkflowStatusStream() {
-    const { panel } = getWorkflowStatusElements();
-    if (!panel || typeof EventSource === 'undefined') return;
+    if (!shouldMaintainWorkflowStatusStream()) {
+        stopWorkflowStatusStream('workflow_stream_not_started_visibility');
+        return;
+    }
 
-    stopWorkflowStatusStream();
+    stopWorkflowStatusStream('workflow_stream_restart');
 
     const params = buildWorkflowStatusStreamQuery();
     const url = `/api/workflows/instances/stream?${params.toString()}`;
     const eventSource = new EventSource(url);
     workflowStatusStreamState.eventSource = eventSource;
+    publishRealtimeConnectionTelemetry('workflow_stream_started');
 
     eventSource.onopen = () => {
         workflowStatusStreamState.reconnectAttempts = 0;
+        publishRealtimeConnectionTelemetry('workflow_stream_open');
     };
 
     eventSource.onerror = () => {
@@ -13429,6 +13561,7 @@ function startWorkflowStatusStream() {
         if (eventSource.readyState === EventSource.CLOSED) {
             eventSource.close();
             workflowStatusStreamState.eventSource = null;
+            publishRealtimeConnectionTelemetry('workflow_stream_closed_remote');
             scheduleWorkflowStatusReconnect();
         }
     };
@@ -13448,6 +13581,8 @@ function startWorkflowStatusStream() {
 function initializeWorkflowStatusPanel() {
     const { panel, refreshButton, toggleAvailableButton, showDesignsCheckbox, copyJsonButton } = getWorkflowStatusElements();
     if (!panel) return;
+    if (workflowStatusPanelInitialised) return;
+    workflowStatusPanelInitialised = true;
     const {
         closeButton: closeEpisodesButton,
         copyJsonButton: copyEpisodesJsonButton
@@ -13482,7 +13617,7 @@ function initializeWorkflowStatusPanel() {
         copyEpisodesJsonButton.dataset.bound = 'true';
     }
 
-    if (refreshButton) {
+    if (refreshButton && refreshButton.dataset.bound !== 'true') {
         refreshButton.addEventListener('click', () => {
             if (workflowDefinitionsState.visible) {
                 void refreshAvailableWorkflowDefinitions();
@@ -13490,6 +13625,7 @@ function initializeWorkflowStatusPanel() {
             }
             void refreshWorkflowStatusSnapshot();
         });
+        refreshButton.dataset.bound = 'true';
     }
 
     if (copyJsonButton) {
@@ -13502,7 +13638,7 @@ function initializeWorkflowStatusPanel() {
         }
     }
 
-    if (toggleAvailableButton) {
+    if (toggleAvailableButton && toggleAvailableButton.dataset.bound !== 'true') {
         toggleAvailableButton.addEventListener('click', () => {
             workflowDefinitionsState.visible = !workflowDefinitionsState.visible;
             updateWorkflowStatusActionButtons();
@@ -13513,18 +13649,78 @@ function initializeWorkflowStatusPanel() {
                 renderWorkflowStatusBody();
             }
         });
+        toggleAvailableButton.dataset.bound = 'true';
     }
 
     startWorkflowStatusStream();
     void refreshWorkflowStatusSnapshot({ silent: true });
-    void refreshAvailableWorkflowDefinitions({ silent: true });
 }
 
 function startIncomingInvitePolling() {
+    if (!isDocumentVisibleForRealtimeConnections()) {
+        return;
+    }
     if (incomingInvitePollTimerId) return;
     incomingInvitePollTimerId = window.setInterval(() => {
         void loadIncomingInvites({ silent: true });
     }, INCOMING_INVITE_POLL_INTERVAL_MS);
+    publishRealtimeConnectionTelemetry('incoming_invite_polling_started');
+}
+
+function stopIncomingInvitePolling() {
+    if (!incomingInvitePollTimerId) return;
+    clearInterval(incomingInvitePollTimerId);
+    incomingInvitePollTimerId = null;
+    publishRealtimeConnectionTelemetry('incoming_invite_polling_stopped');
+}
+
+function startSharedSessionBadgePolling() {
+    if (!shouldRunSharedSessionBadgePolling()) {
+        return;
+    }
+    if (sharedSessionBadgePollTimerId) return;
+    sharedSessionBadgePollTimerId = window.setInterval(() => {
+        if (!shouldRunSharedSessionBadgePolling()) {
+            return;
+        }
+        // Keep shared conversation unread badges eventually consistent even when
+        // SSE is paused for inactive/hidden sessions.
+        scheduleChatSessionTabsRefresh();
+    }, SHARED_SESSION_BADGE_POLL_INTERVAL_MS);
+    publishRealtimeConnectionTelemetry('shared_session_badge_polling_started');
+}
+
+function stopSharedSessionBadgePolling() {
+    if (!sharedSessionBadgePollTimerId) return;
+    clearInterval(sharedSessionBadgePollTimerId);
+    sharedSessionBadgePollTimerId = null;
+    publishRealtimeConnectionTelemetry('shared_session_badge_polling_stopped');
+}
+
+function handleRealtimeConnectionsVisibilityChange() {
+    const visible = isDocumentVisibleForRealtimeConnections();
+    if (!visible) {
+        closeSharedConversationStream();
+        stopWorkflowStatusStream('workflow_stream_stopped_visibility_hidden');
+        stopIncomingInvitePolling();
+        stopSharedSessionBadgePolling();
+        try {
+            incomingInviteAbortController?.abort();
+        } catch (_) {
+            // Ignore abort race.
+        }
+        publishRealtimeConnectionTelemetry('document_hidden');
+        return;
+    }
+
+    syncSharedConversationStreams();
+    startWorkflowStatusStream();
+    startIncomingInvitePolling();
+    startSharedSessionBadgePolling();
+    scheduleChatSessionTabsRefresh(true);
+    void loadIncomingInvites({ silent: true });
+    void refreshWorkflowStatusSnapshot({ silent: true });
+    publishRealtimeConnectionTelemetry('document_visible');
 }
 
 async function handleOrgSwitchForChatTab(_detail) {
@@ -13549,7 +13745,7 @@ async function handleOrgSwitchForChatTab(_detail) {
     }
 
     closeSharedConversationStream();
-    stopWorkflowStatusStream();
+    stopWorkflowStatusStream('workflow_stream_stopped_org_switch');
     workflowStatusStreamState.items.clear();
     renderWorkflowStatusBody();
 
@@ -13588,6 +13784,8 @@ async function handleOrgSwitchForChatTab(_detail) {
     void loadIncomingInvites({ silent: true });
     startWorkflowStatusStream();
     void refreshWorkflowStatusSnapshot({ silent: true });
+    syncSharedConversationStreams();
+    publishRealtimeConnectionTelemetry('org_switch_completed');
 }
 
 try {
@@ -13615,20 +13813,32 @@ function handleAuthStatusChangeForChatTab(detail) {
         container.hidden = false;
     }
 
-    stopWorkflowStatusStream();
+    closeSharedConversationStream();
+    stopWorkflowStatusStream('workflow_stream_stopped_auth_change');
     workflowStatusStreamState.items.clear();
     renderWorkflowStatusBody();
 
     if (detail?.authenticated !== false) {
         startWorkflowStatusStream();
         void refreshWorkflowStatusSnapshot({ silent: true });
+        startIncomingInvitePolling();
+        startSharedSessionBadgePolling();
+    } else {
+        stopIncomingInvitePolling();
+        stopSharedSessionBadgePolling();
     }
 
     scheduleChatSessionTabsRefresh(true);
     void loadIncomingInvites({ silent: true });
+    publishRealtimeConnectionTelemetry('auth_status_changed');
 }
 
 export function initializeChatTab() {
+    if (chatTabInitialised) {
+        console.warn('[chatTab] initializeChatTab called more than once; skipping duplicate initialisation.');
+        return;
+    }
+    chatTabInitialised = true;
     console.log("Initializing chat tab...");
 
     // JVNAUTOSCI-1014: Load hidden session IDs from localStorage (user-scoped)
@@ -13694,6 +13904,7 @@ export function initializeChatTab() {
 
     if (!sendButton || !resetButton || !promptInput) {
         console.error("Chat tab elements not found");
+        chatTabInitialised = false;
         return;
     }
 
@@ -13865,6 +14076,13 @@ export function initializeChatTab() {
 
     void loadIncomingInvites({ silent: true });
     startIncomingInvitePolling();
+    document.addEventListener('visibilitychange', handleRealtimeConnectionsVisibilityChange);
+    window.addEventListener('beforeunload', () => {
+        closeSharedConversationStream();
+        stopWorkflowStatusStream('workflow_stream_stopped_unload');
+        stopIncomingInvitePolling();
+        stopSharedSessionBadgePolling();
+    }, { once: true });
 
     // JVNAUTOSCI-1040: Initialize task panel
     initializeTaskPanel();
@@ -13887,6 +14105,7 @@ export function initializeChatTab() {
 
     // Phase 5: Workflow monitor panel
     initializeWorkflowStatusPanel();
+    handleRealtimeConnectionsVisibilityChange();
 
     // Load annotation toggle state from localStorage (default: false)
     const savedState = localStorage.getItem('annotationToggleEnabled');
@@ -16242,6 +16461,12 @@ export function __testOnly_setWorkflowShowDesigns(enabled) {
 }
 export function __testOnly_buildWorkflowMonitorExportPayload() {
     return buildWorkflowMonitorExportPayload();
+}
+export function __testOnly_shouldMaintainSharedConversationStreamForInputs(inputs = {}) {
+    return shouldMaintainSharedConversationStreamForInputs(inputs);
+}
+export function __testOnly_shouldRunSharedSessionBadgePollingForInputs(inputs = {}) {
+    return shouldRunSharedSessionBadgePollingForInputs(inputs);
 }
 export function __testOnly_renderDisplayElementsIntoContainer(container, debugData) {
     renderTableDisplayElementsIntoContainer(container, debugData);

--- a/src/frontend/web/von_interface/static/js/main.js
+++ b/src/frontend/web/von_interface/static/js/main.js
@@ -10,10 +10,12 @@ import { handleSelectConceptByIdDetail } from './utils/selectConceptByIdHandler.
 import { formatBackgroundTaskSummary, formatBackgroundTaskTooltip, subscribeBackgroundTaskUpdates } from './backgroundTaskTracker.js';
 import {
   copyJsonTextWithButtonFeedback,
+  copyTextWithClipboardFallback,
   initialiseCopyJsonButtonPreCopyState,
   resetCopyJsonButtonPreCopyState
 } from './utils/copyJsonButtonState.js';
 import { getSessionScopedNamespace, hasSessionOrgContext, syncNamespaceFromLocalStorage, syncOrgContextFromLocalStorage } from './utils/sessionScopedStorage.js';
+import { buildHealthTelemetryCopyPayload, buildHealthTelemetrySnapshot } from './utils/healthTelemetrySnapshot.js';
 import { isVontologyBusy, loadKeyConceptsForUser, preloadVontologyData, selectVontologyNodeByIdentifier, setupVontologySearchUI } from './vontology.js';
 
 // JVNAUTOSCI-1011: getCurrentNamespace is now provided by sessionScopedStorage.js
@@ -662,6 +664,21 @@ function startHealthPolling() {
       } catch (err) { console.warn('PID copy failed', err); }
     });
   }
+  if (uptimeSpan && uptimeSpan.dataset.healthTelemetryCopyBound !== 'true') {
+    uptimeSpan.dataset.healthTelemetryCopyBound = 'true';
+    uptimeSpan.setAttribute('role', 'button');
+    uptimeSpan.setAttribute('tabindex', '0');
+    uptimeSpan.addEventListener('click', () => {
+      if (!canCopyHealthTelemetryFromUptime()) return;
+      void copyCurrentHealthTelemetry('uptime_badge_click');
+    });
+    uptimeSpan.addEventListener('keydown', (event) => {
+      if (!canCopyHealthTelemetryFromUptime()) return;
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      event.preventDefault();
+      void copyCurrentHealthTelemetry('uptime_badge_keypress');
+    });
+  }
   const HEALTH_START_TIME_CACHE_KEY = 'von_server_start_time_iso';
   const healthLoopStartedAtMs = Date.now();
   function readCachedStartTimeIso() {
@@ -689,12 +706,25 @@ function startHealthPolling() {
   let reloadTriggered = false;
   let serverReachable = null;
   let serverHealthUiState = 'waiting';
+  let failureCount = 0;
+  let healthPollInFlight = false;
+  let healthPollQueuedImmediate = false;
+  let healthPollTimerId = null;
+  let nextScheduledHealthPollAtMs = null;
+  let lastHealthCheckCompletedAtMs = null;
   let hasSeenSuccessfulHealthPoll = false;
   let firstFailureAtMs = null;
   let lastHealthSuccessAtMs = null;
   let lastHealthErrorKind = null;
   let lastHealthErrorDetail = null;
+  let lastHealthSuccessPid = null;
+  let lastHealthStateSource = 'health_poll_initialise';
   let latestHealthDiagnostics = null;
+  let latestHealthTelemetry = null;
+  let lastHealthTelemetryCopyAttempt = null;
+  let lastBusyState = null;
+  let unsubscribeBackgroundTaskUpdates = null;
+  let uptimeTelemetryCopyFeedbackTimerId = null;
 
   function publishHealthPollDiagnostics(diagnostics) {
     if (!diagnostics || typeof diagnostics !== 'object') return;
@@ -729,8 +759,13 @@ function startHealthPolling() {
       setServerReachableState(true);
     }
     if (diagnostics && typeof diagnostics === 'object') {
-      publishHealthPollDiagnostics({ state: safeState, ...diagnostics });
+      const diagnosticsPayload = { state: safeState, ...diagnostics };
+      if (typeof diagnosticsPayload.source === 'string' && diagnosticsPayload.source.trim()) {
+        lastHealthStateSource = diagnosticsPayload.source.trim();
+      }
+      publishHealthPollDiagnostics(diagnosticsPayload);
     }
+    publishHealthTelemetry('health_state_transition');
   }
 
   function isThinkingActive() {
@@ -773,16 +808,166 @@ function startHealthPolling() {
     if (m > 0) return `${m}m ${s}s`;
     return `${s}s`;
   }
+
+  function getBrowserOnlineState() {
+    try {
+      return (typeof navigator !== 'undefined' && typeof navigator.onLine === 'boolean')
+        ? navigator.onLine
+        : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function publishHealthTelemetry(eventSource = null) {
+    const locationHref = (typeof window !== 'undefined' && window.location)
+      ? (window.location.href || null)
+      : null;
+    const locationOrigin = (typeof window !== 'undefined' && window.location)
+      ? (window.location.origin || null)
+      : null;
+    const locationPathname = (typeof window !== 'undefined' && window.location)
+      ? (window.location.pathname || null)
+      : null;
+    const locationPort = (typeof window !== 'undefined' && window.location)
+      ? (window.location.port || null)
+      : null;
+    const realtimeConnectionTelemetry = (typeof window !== 'undefined' && window.__vonRealtimeConnectionTelemetry && typeof window.__vonRealtimeConnectionTelemetry === 'object')
+      ? window.__vonRealtimeConnectionTelemetry
+      : null;
+    const snapshot = buildHealthTelemetrySnapshot({
+      state: serverHealthUiState,
+      eventSource,
+      stateSource: lastHealthStateSource,
+      nowMs: Date.now(),
+      serverReachable,
+      hasSeenSuccessfulHealthPoll,
+      failureCount,
+      firstFailureAtMs,
+      lastHealthCheckCompletedAtMs,
+      lastHealthSuccessAtMs,
+      lastHealthSuccessPid,
+      lastErrorKind: lastHealthErrorKind,
+      lastErrorDetail: lastHealthErrorDetail,
+      diagnostics: latestHealthDiagnostics,
+      pollInFlight: healthPollInFlight,
+      pollQueuedImmediate: healthPollQueuedImmediate,
+      nextPollAtMs: nextScheduledHealthPollAtMs,
+      browserOnline: getBrowserOnlineState(),
+      isVontologyBusy: !!lastBusyState,
+      healthLoopStartedAtMs,
+      lastCopyAttempt: lastHealthTelemetryCopyAttempt,
+      realtimeConnectionTelemetry,
+      locationHref,
+      locationOrigin,
+      locationPathname,
+      locationPort,
+    });
+    latestHealthTelemetry = snapshot;
+    try {
+      window.__vonHealthTelemetry = snapshot;
+    } catch (_) {
+      // Ignore non-writable globals in constrained environments.
+    }
+    try {
+      document.dispatchEvent(new CustomEvent('von:healthTelemetryUpdated', { detail: snapshot }));
+    } catch (_) {
+      // Non-fatal telemetry event.
+    }
+    return snapshot;
+  }
+  function formatSecondsAgo(ms) {
+    if (!Number.isFinite(ms) || ms < 0) return null;
+    return `${Math.max(0, Math.floor(ms / 1000))}s ago`;
+  }
+
+  function canCopyHealthTelemetryFromUptime() {
+    return serverHealthUiState === 'down' || serverHealthUiState === 'degraded' || serverHealthUiState === 'waiting';
+  }
+
+  function updateUptimeCopyFeedbackClass(copied) {
+    if (!uptimeSpan) return;
+    uptimeSpan.classList.remove('health-telemetry-copy-success', 'health-telemetry-copy-error');
+    uptimeSpan.classList.add(copied ? 'health-telemetry-copy-success' : 'health-telemetry-copy-error');
+    if (uptimeTelemetryCopyFeedbackTimerId) {
+      clearTimeout(uptimeTelemetryCopyFeedbackTimerId);
+    }
+    uptimeTelemetryCopyFeedbackTimerId = setTimeout(() => {
+      uptimeTelemetryCopyFeedbackTimerId = null;
+      if (uptimeSpan) {
+        uptimeSpan.classList.remove('health-telemetry-copy-success', 'health-telemetry-copy-error');
+      }
+    }, 1800);
+  }
+
+  async function copyCurrentHealthTelemetry(copySource = 'uptime_badge_click') {
+    const attemptStartedAtMs = Date.now();
+    lastHealthTelemetryCopyAttempt = {
+      copySource,
+      attemptedAtMs: attemptStartedAtMs,
+      attemptedAtIso: new Date(attemptStartedAtMs).toISOString(),
+      copied: null,
+    };
+    const snapshot = publishHealthTelemetry('health_telemetry_copy_attempted');
+    const snapshotForCopy = (latestHealthTelemetry && typeof latestHealthTelemetry === 'object')
+      ? latestHealthTelemetry
+      : snapshot;
+    const payload = buildHealthTelemetryCopyPayload(snapshotForCopy, {
+      copySource,
+      nowMs: attemptStartedAtMs,
+    });
+    const payloadText = JSON.stringify(payload, null, 2);
+    try {
+      window.__vonLastHealthTelemetryCopyPayload = payload;
+    } catch (_) {
+      // Ignore non-writable globals.
+    }
+    let copied = false;
+    try {
+      copied = await copyTextWithClipboardFallback(payloadText);
+    } catch (_) {
+      copied = false;
+    }
+    const attemptCompletedAtMs = Date.now();
+    lastHealthTelemetryCopyAttempt = {
+      ...lastHealthTelemetryCopyAttempt,
+      copied,
+      completedAtMs: attemptCompletedAtMs,
+      completedAtIso: new Date(attemptCompletedAtMs).toISOString(),
+      copyPayloadBytes: payloadText.length,
+    };
+    publishHealthTelemetry(copied ? 'health_telemetry_copy_succeeded' : 'health_telemetry_copy_failed');
+    updateUptimeCopyFeedbackClass(copied);
+    return copied;
+  }
+
   function updateUptimeLoop() {
     if (uptimeSpan) {
       const uptimeContainer = uptimeSpan.parentElement;
+      const telemetryCopyEnabled = canCopyHealthTelemetryFromUptime();
+      const copyHint = telemetryCopyEnabled ? 'Click to copy health telemetry JSON' : null;
+      uptimeSpan.classList.toggle('health-telemetry-copyable', telemetryCopyEnabled);
+      uptimeSpan.setAttribute('aria-disabled', telemetryCopyEnabled ? 'false' : 'true');
       if (serverHealthUiState === 'down') {
-        uptimeSpan.textContent = 'server down';
-        uptimeSpan.title = 'Von server is unreachable';
+        const lastCheckAgeMs = Number.isFinite(lastHealthCheckCompletedAtMs)
+          ? Math.max(0, Date.now() - lastHealthCheckCompletedAtMs)
+          : null;
+        const lastCheckLabel = formatSecondsAgo(lastCheckAgeMs);
+        const lastSuccessLabel = Number.isFinite(lastHealthSuccessAtMs)
+          ? formatUptime(Math.max(0, Date.now() - lastHealthSuccessAtMs))
+          : null;
+        uptimeSpan.textContent = lastCheckLabel
+          ? `server down (checked ${lastCheckLabel})`
+          : 'server down';
+        const baseTitle = lastSuccessLabel
+          ? `Von server is unreachable | Last healthy response ${lastSuccessLabel} ago`
+          : 'Von server is unreachable';
+        uptimeSpan.title = copyHint ? `${baseTitle} | ${copyHint}` : baseTitle;
         if (uptimeContainer) uptimeContainer.classList.add('pid-error');
       } else if (serverHealthUiState === 'waiting') {
         uptimeSpan.textContent = 'waiting for server';
-        uptimeSpan.title = 'Waiting for initial server health response';
+        const baseTitle = 'Waiting for initial server health response';
+        uptimeSpan.title = copyHint ? `${baseTitle} | ${copyHint}` : baseTitle;
         if (uptimeContainer) uptimeContainer.classList.remove('pid-error');
       } else if (serverHealthUiState === 'degraded') {
         const failureCountTitle = Number.isFinite(latestHealthDiagnostics?.failureCount)
@@ -793,9 +978,10 @@ function startHealthPolling() {
           : null;
         const detail = [failureCountTitle, failureWindowTitle].filter(Boolean).join(' | ');
         uptimeSpan.textContent = 'degraded (retrying)';
-        uptimeSpan.title = detail
+        const baseTitle = detail
           ? `Health probes are failing but below down threshold (${detail})`
           : 'Health probes are failing but below down threshold';
+        uptimeSpan.title = copyHint ? `${baseTitle} | ${copyHint}` : baseTitle;
         if (uptimeContainer) uptimeContainer.classList.remove('pid-error');
       } else if (startTimeIso) {
         const started = Date.parse(startTimeIso);
@@ -814,12 +1000,6 @@ function startHealthPolling() {
     }
     requestAnimationFrame(() => setTimeout(updateUptimeLoop, 1000));
   }
-  let failureCount = 0;
-  let healthPollInFlight = false;
-  let healthPollQueuedImmediate = false;
-  let healthPollTimerId = null;
-  let lastBusyState = null;
-  let unsubscribeBackgroundTaskUpdates = null;
 
   function updateBackgroundTaskFooter(snapshot) {
     if (!backgroundTaskEl) return;
@@ -851,6 +1031,7 @@ function startHealthPolling() {
       if (lastBusyState !== busy) {
         lastBusyState = busy;
         document.dispatchEvent(new CustomEvent('von:vontologyBusyChange', { detail: { busy } }));
+        publishHealthTelemetry('vontology_busy_changed');
       }
     } catch (_) { }
   }
@@ -877,24 +1058,37 @@ function startHealthPolling() {
   } catch (_) { }
 
   function scheduleHealthPoll(delayMs) {
+    const safeDelayMs = Number.isFinite(delayMs) ? Math.max(0, Math.trunc(delayMs)) : 0;
     if (healthPollTimerId) {
       clearTimeout(healthPollTimerId);
     }
+    nextScheduledHealthPollAtMs = Date.now() + safeDelayMs;
+    publishHealthTelemetry('health_poll_scheduled');
     healthPollTimerId = setTimeout(() => {
       healthPollTimerId = null;
+      nextScheduledHealthPollAtMs = null;
+      publishHealthTelemetry('health_poll_schedule_fired');
       void poll();
-    }, delayMs);
+    }, safeDelayMs);
   }
 
   async function poll() {
     if (healthPollInFlight) {
       healthPollQueuedImmediate = true;
+      publishHealthTelemetry('health_poll_queued_immediate');
       return;
     }
 
     healthPollInFlight = true;
-    updateBusyIndicator();
-    const busy = isVontologyBusy();
+    nextScheduledHealthPollAtMs = null;
+    publishHealthTelemetry('health_poll_started');
+    let busy = false;
+    try {
+      updateBusyIndicator();
+      busy = isVontologyBusy();
+    } catch (_) {
+      busy = false;
+    }
     let nextDelay = 5000; // base
     try {
       const controller = new AbortController();
@@ -903,6 +1097,7 @@ function startHealthPolling() {
       clearTimeout(timeout);
       if (!res.ok) throw new Error('HTTP ' + res.status);
       const data = await res.json();
+      lastHealthCheckCompletedAtMs = Date.now();
       hasSeenSuccessfulHealthPoll = true;
       firstFailureAtMs = null;
       lastHealthSuccessAtMs = Date.now();
@@ -923,6 +1118,7 @@ function startHealthPolling() {
         lastErrorDetail: null,
       });
       const newPid = (typeof data.pid !== 'undefined') ? data.pid : null;
+      lastHealthSuccessPid = Number.isFinite(Number(newPid)) ? Number(newPid) : null;
       const newStart = data.start_time || null;
       const newLocalIp = data.local_ip || null;
       const newPublicIp = data.public_ip || null;
@@ -2009,11 +2205,21 @@ function startHealthPolling() {
       if (newStart !== null) lastIdentity.start = newStart;
       failureCount = 0; // reset on success
     } catch (e) {
+      lastHealthCheckCompletedAtMs = Date.now();
       failureCount++;
       if (!Number.isFinite(firstFailureAtMs)) {
         firstFailureAtMs = Date.now();
       }
       const nowMs = Date.now();
+      const isHttpError = typeof e?.message === 'string' && e.message.startsWith('HTTP ');
+      const errorKind = e?.name === 'AbortError'
+        ? 'timeout'
+        : (isHttpError ? 'http' : 'network_or_unknown');
+      const errorDetail = typeof e?.message === 'string'
+        ? e.message
+        : String(e || '');
+      lastHealthErrorKind = errorKind;
+      lastHealthErrorDetail = errorDetail;
       const activeThinking = isThinkingActive();
       const evaluation = evaluateServerHealthState({
         hasSeenSuccessfulHealthPoll,
@@ -2021,15 +2227,9 @@ function startHealthPolling() {
         firstFailureAtMs,
         nowMs,
         isThinkingActive: activeThinking,
+        latestErrorKind: lastHealthErrorKind,
       });
       const markDown = evaluation.markDown;
-      const isHttpError = typeof e?.message === 'string' && e.message.startsWith('HTTP ');
-      lastHealthErrorKind = e?.name === 'AbortError'
-        ? 'timeout'
-        : (isHttpError ? 'http' : 'network_or_unknown');
-      lastHealthErrorDetail = typeof e?.message === 'string'
-        ? e.message
-        : String(e || '');
       const lastSuccessAgeMs = Number.isFinite(lastHealthSuccessAtMs)
         ? Math.max(0, nowMs - lastHealthSuccessAtMs)
         : null;
@@ -2049,14 +2249,20 @@ function startHealthPolling() {
           pidSpan.parentElement.classList.remove('pid-error');
         }
       }
-      // Exponential backoff on failures (5s,10s,20s,30s cap)
-      nextDelay = Math.min(30000, 5000 * Math.pow(2, Math.min(failureCount - 1, 3)));
+      // Exponential backoff on failures. Timeouts retry sooner so status can recover quickly
+      // after transient saturation (while still backing off to avoid request pileups).
+      const failureBackoffCapMs = (lastHealthErrorKind === 'timeout') ? 15000 : 30000;
+      const effectiveBackoffCapMs = (lastHealthErrorKind === 'network_or_unknown')
+        ? 15000
+        : failureBackoffCapMs;
+      nextDelay = Math.min(effectiveBackoffCapMs, 5000 * Math.pow(2, Math.min(failureCount - 1, 3)));
     }
     // If ontology is busy, stretch the delay (but keep success shorter than failure backoff)
     if (busy) {
       nextDelay = Math.min(15000, Math.max(nextDelay, 10000));
     }
     healthPollInFlight = false;
+    publishHealthTelemetry('health_poll_finished');
     if (healthPollQueuedImmediate) {
       healthPollQueuedImmediate = false;
       scheduleHealthPoll(250);

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -16,6 +16,8 @@ import {
     __testOnly_deriveLlmDebugWarnings,
     __testOnly_hydrateChatConceptCartouches,
     __testOnly_jumpToLatestUnreadBoundary,
+    __testOnly_shouldMaintainSharedConversationStreamForInputs,
+    __testOnly_shouldRunSharedSessionBadgePollingForInputs,
     __testOnly_renderDisplayElementsIntoContainer,
     __testOnly_ensureScrollToEndButton,
     __testOnly_scrollConversationToEnd,
@@ -217,6 +219,46 @@ describe('workflow status query scoping', () => {
 
         expect(params.get('namespace')).toBe('#V#michael_witbrock');
         expect(params.has('status')).toBe(false);
+    });
+});
+
+describe('shared conversation stream eligibility', () => {
+    test('requires active session, visible document, and shared session status', () => {
+        expect(__testOnly_shouldMaintainSharedConversationStreamForInputs({
+            sessionId: 'session-a',
+            activeSessionId: 'session-a',
+            isVisible: true,
+            isSharedSession: true
+        })).toBe(true);
+    });
+
+    test('rejects reconnect for non-active shared sessions', () => {
+        expect(__testOnly_shouldMaintainSharedConversationStreamForInputs({
+            sessionId: 'session-a',
+            activeSessionId: 'session-b',
+            isVisible: true,
+            isSharedSession: true
+        })).toBe(false);
+    });
+
+    test('rejects reconnect when tab is hidden', () => {
+        expect(__testOnly_shouldMaintainSharedConversationStreamForInputs({
+            sessionId: 'session-a',
+            activeSessionId: 'session-a',
+            isVisible: false,
+            isSharedSession: true
+        })).toBe(false);
+    });
+});
+
+describe('shared session badge polling eligibility', () => {
+    test('runs polling only when visible', () => {
+        expect(__testOnly_shouldRunSharedSessionBadgePollingForInputs({
+            isVisible: true
+        })).toBe(true);
+        expect(__testOnly_shouldRunSharedSessionBadgePollingForInputs({
+            isVisible: false
+        })).toBe(false);
     });
 });
 

--- a/src/frontend/web/von_interface/static/js/test/healthTelemetrySnapshot.test.js
+++ b/src/frontend/web/von_interface/static/js/test/healthTelemetrySnapshot.test.js
@@ -1,0 +1,96 @@
+import {
+  buildHealthTelemetryCopyPayload,
+  buildHealthTelemetrySnapshot
+} from '../utils/healthTelemetrySnapshot.js';
+
+describe('healthTelemetrySnapshot', () => {
+  test('builds a structured snapshot with computed ages and next poll delay', () => {
+    const snapshot = buildHealthTelemetrySnapshot({
+      state: 'down',
+      eventSource: 'health_poll_failure',
+      stateSource: 'health_poll_failure',
+      nowMs: 50_000,
+      serverReachable: false,
+      hasSeenSuccessfulHealthPoll: true,
+      failureCount: 3,
+      firstFailureAtMs: 40_000,
+      lastHealthCheckCompletedAtMs: 49_000,
+      lastHealthSuccessAtMs: 39_000,
+      lastHealthSuccessPid: 12345,
+      lastErrorKind: 'timeout',
+      lastErrorDetail: 'AbortError',
+      diagnostics: { downFailureThreshold: 2 },
+      pollInFlight: false,
+      pollQueuedImmediate: true,
+      nextPollAtMs: 55_000,
+      browserOnline: true,
+      isVontologyBusy: true,
+      healthLoopStartedAtMs: 10_000,
+      lastCopyAttempt: { copied: true, attemptedAtMs: 49_500 },
+      realtimeConnectionTelemetry: {
+        sharedStreamCount: 1,
+        workflowStreamConnected: true,
+      },
+      locationHref: 'http://localhost:5000/von/',
+      locationOrigin: 'http://localhost:5000',
+      locationPathname: '/von/',
+      locationPort: '5000'
+    });
+
+    expect(snapshot.state).toBe('down');
+    expect(snapshot.eventSource).toBe('health_poll_failure');
+    expect(snapshot.serverReachable).toBe(false);
+    expect(snapshot.failureCount).toBe(3);
+    expect(snapshot.firstFailureAgeMs).toBe(10_000);
+    expect(snapshot.lastHealthCheckAgeMs).toBe(1_000);
+    expect(snapshot.lastHealthSuccessAgeMs).toBe(11_000);
+    expect(snapshot.lastHealthSuccessPid).toBe(12345);
+    expect(snapshot.nextPollDueInMs).toBe(5_000);
+    expect(snapshot.healthLoopAgeMs).toBe(40_000);
+    expect(snapshot.diagnostics).toEqual({ downFailureThreshold: 2 });
+    expect(snapshot.lastCopyAttempt).toEqual({ copied: true, attemptedAtMs: 49_500 });
+    expect(snapshot.realtimeConnectionTelemetry).toEqual({
+      sharedStreamCount: 1,
+      workflowStreamConnected: true,
+    });
+    expect(snapshot.locationOrigin).toBe('http://localhost:5000');
+    expect(snapshot.locationPathname).toBe('/von/');
+  });
+
+  test('normalises invalid values safely', () => {
+    const snapshot = buildHealthTelemetrySnapshot({
+      state: 'invalid_state',
+      nowMs: Number.NaN,
+      failureCount: -3,
+      serverReachable: 'nope',
+      browserOnline: 'offline',
+      nextPollAtMs: 'later',
+      lastErrorDetail: 'x'.repeat(900)
+    });
+
+    expect(snapshot.state).toBe('waiting');
+    expect(snapshot.failureCount).toBe(0);
+    expect(snapshot.serverReachable).toBeNull();
+    expect(snapshot.browserOnline).toBeNull();
+    expect(snapshot.nextPollAtMs).toBeNull();
+    expect(snapshot.nextPollDueInMs).toBeNull();
+    expect(snapshot.lastErrorDetail.endsWith('…')).toBe(true);
+    expect(snapshot.lastErrorDetail.length).toBe(801);
+  });
+
+  test('builds copy payload wrapper with timestamp and snapshot', () => {
+    const snapshot = buildHealthTelemetrySnapshot({
+      state: 'degraded',
+      nowMs: 25_000
+    });
+    const payload = buildHealthTelemetryCopyPayload(snapshot, {
+      copySource: 'uptime_badge_click',
+      nowMs: 26_000
+    });
+
+    expect(payload.type).toBe('von_health_poll_telemetry');
+    expect(payload.copySource).toBe('uptime_badge_click');
+    expect(payload.copiedAtMs).toBe(26_000);
+    expect(payload.snapshot).toEqual(snapshot);
+  });
+});

--- a/src/frontend/web/von_interface/static/js/test/serverHealthState.test.js
+++ b/src/frontend/web/von_interface/static/js/test/serverHealthState.test.js
@@ -5,6 +5,10 @@ import {
   INITIAL_FAILURE_WINDOW_MS_BEFORE_DOWN,
   THINKING_EXTRA_FAILURES_BEFORE_DOWN,
   THINKING_EXTRA_FAILURE_WINDOW_MS,
+  TIMEOUT_EXTRA_FAILURES_BEFORE_DOWN,
+  TIMEOUT_EXTRA_FAILURE_WINDOW_MS,
+  NETWORK_EXTRA_FAILURES_BEFORE_DOWN,
+  NETWORK_EXTRA_FAILURE_WINDOW_MS,
   evaluateServerHealthState,
   shouldMarkServerDown
 } from '../utils/serverHealthState.js';
@@ -90,5 +94,62 @@ describe('serverHealthState', () => {
       nowMs: 33_000,
       isThinkingActive: true
     })).toBe(true);
+  });
+
+  test('adds additional hysteresis for timeout failures', () => {
+    expect(TIMEOUT_EXTRA_FAILURES_BEFORE_DOWN).toBe(4);
+    expect(TIMEOUT_EXTRA_FAILURE_WINDOW_MS).toBe(60000);
+
+    const timeoutDegraded = evaluateServerHealthState({
+      hasSeenSuccessfulHealthPoll: true,
+      failureCount: 5,
+      firstFailureAtMs: 20_000,
+      nowMs: 90_000,
+      latestErrorKind: 'timeout'
+    });
+    expect(timeoutDegraded.state).toBe('degraded');
+    expect(timeoutDegraded.markDown).toBe(false);
+    expect(timeoutDegraded.diagnostics.downFailureThreshold).toBe(
+      FAILURES_BEFORE_DOWN_AFTER_SUCCESS + TIMEOUT_EXTRA_FAILURES_BEFORE_DOWN
+    );
+    expect(timeoutDegraded.diagnostics.downFailureWindowThresholdMs).toBe(
+      FAILURE_WINDOW_MS_BEFORE_DOWN_AFTER_SUCCESS + TIMEOUT_EXTRA_FAILURE_WINDOW_MS
+    );
+
+    const timeoutDown = evaluateServerHealthState({
+      hasSeenSuccessfulHealthPoll: true,
+      failureCount: 6,
+      firstFailureAtMs: 20_000,
+      nowMs: 90_000,
+      latestErrorKind: 'timeout'
+    });
+    expect(timeoutDown.state).toBe('down');
+    expect(timeoutDown.markDown).toBe(true);
+  });
+
+  test('adds additional hysteresis for network failures', () => {
+    expect(NETWORK_EXTRA_FAILURES_BEFORE_DOWN).toBe(2);
+    expect(NETWORK_EXTRA_FAILURE_WINDOW_MS).toBe(20000);
+
+    const networkDegraded = evaluateServerHealthState({
+      hasSeenSuccessfulHealthPoll: true,
+      failureCount: 3,
+      firstFailureAtMs: 20_000,
+      nowMs: 40_000,
+      latestErrorKind: 'network_or_unknown'
+    });
+    expect(networkDegraded.state).toBe('degraded');
+    expect(networkDegraded.markDown).toBe(false);
+    expect(networkDegraded.diagnostics.isNetworkFailure).toBe(true);
+
+    const networkDown = evaluateServerHealthState({
+      hasSeenSuccessfulHealthPoll: true,
+      failureCount: 4,
+      firstFailureAtMs: 20_000,
+      nowMs: 50_000,
+      latestErrorKind: 'network_or_unknown'
+    });
+    expect(networkDown.state).toBe('down');
+    expect(networkDown.markDown).toBe(true);
   });
 });

--- a/src/frontend/web/von_interface/static/js/utils/healthTelemetrySnapshot.js
+++ b/src/frontend/web/von_interface/static/js/utils/healthTelemetrySnapshot.js
@@ -1,0 +1,154 @@
+function toTimestampOrNull(value) {
+  if (!Number.isFinite(value)) return null;
+  return Number(value);
+}
+
+function toIsoOrNull(timestampMs) {
+  const safeTimestamp = toTimestampOrNull(timestampMs);
+  if (!Number.isFinite(safeTimestamp)) return null;
+  return new Date(safeTimestamp).toISOString();
+}
+
+function toAgeMsOrNull(nowMs, timestampMs) {
+  if (!Number.isFinite(nowMs) || !Number.isFinite(timestampMs)) return null;
+  return Math.max(0, Math.trunc(nowMs - timestampMs));
+}
+
+function toDueMsOrNull(nowMs, nextPollAtMs) {
+  if (!Number.isFinite(nowMs) || !Number.isFinite(nextPollAtMs)) return null;
+  return Math.max(0, Math.trunc(nextPollAtMs - nowMs));
+}
+
+function normaliseString(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function normaliseErrorDetail(value, maxLength = 800) {
+  const raw = normaliseString(typeof value === 'string' ? value : String(value || ''));
+  if (!raw) return null;
+  if (raw.length <= maxLength) return raw;
+  return `${raw.slice(0, maxLength)}…`;
+}
+
+function normaliseBooleanOrNull(value) {
+  return typeof value === 'boolean' ? value : null;
+}
+
+function cloneDiagnostics(value) {
+  if (!value || typeof value !== 'object') return null;
+  try {
+    if (typeof structuredClone === 'function') {
+      return structuredClone(value);
+    }
+  } catch (_) {
+    // Fallback to JSON clone below.
+  }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (_) {
+    return null;
+  }
+}
+
+function normaliseHealthState(value) {
+  return (value === 'healthy' || value === 'waiting' || value === 'degraded' || value === 'down')
+    ? value
+    : 'waiting';
+}
+
+export function buildHealthTelemetrySnapshot({
+  state = 'waiting',
+  eventSource = null,
+  stateSource = null,
+  nowMs = Date.now(),
+  serverReachable = null,
+  hasSeenSuccessfulHealthPoll = false,
+  failureCount = 0,
+  firstFailureAtMs = null,
+  lastHealthCheckCompletedAtMs = null,
+  lastHealthSuccessAtMs = null,
+  lastHealthSuccessPid = null,
+  lastErrorKind = null,
+  lastErrorDetail = null,
+  diagnostics = null,
+  pollInFlight = false,
+  pollQueuedImmediate = false,
+  nextPollAtMs = null,
+  browserOnline = null,
+  isVontologyBusy = false,
+  healthLoopStartedAtMs = null,
+  lastCopyAttempt = null,
+  realtimeConnectionTelemetry = null,
+  locationHref = null,
+  locationOrigin = null,
+  locationPathname = null,
+  locationPort = null,
+} = {}) {
+  const safeNowMs = Number.isFinite(nowMs) ? Number(nowMs) : Date.now();
+  const safeFirstFailureAtMs = toTimestampOrNull(firstFailureAtMs);
+  const safeLastHealthCheckCompletedAtMs = toTimestampOrNull(lastHealthCheckCompletedAtMs);
+  const safeLastHealthSuccessAtMs = toTimestampOrNull(lastHealthSuccessAtMs);
+  const safeNextPollAtMs = toTimestampOrNull(nextPollAtMs);
+  const safeHealthLoopStartedAtMs = toTimestampOrNull(healthLoopStartedAtMs);
+  const safeFailureCount = Number.isFinite(failureCount)
+    ? Math.max(0, Math.trunc(failureCount))
+    : 0;
+
+  return {
+    schemaVersion: 1,
+    generatedAtMs: safeNowMs,
+    generatedAtIso: new Date(safeNowMs).toISOString(),
+    state: normaliseHealthState(state),
+    eventSource: normaliseString(eventSource),
+    stateSource: normaliseString(stateSource),
+    serverReachable: normaliseBooleanOrNull(serverReachable),
+    browserOnline: normaliseBooleanOrNull(browserOnline),
+    isVontologyBusy: !!isVontologyBusy,
+    hasSeenSuccessfulHealthPoll: !!hasSeenSuccessfulHealthPoll,
+    failureCount: safeFailureCount,
+    firstFailureAtMs: safeFirstFailureAtMs,
+    firstFailureAtIso: toIsoOrNull(safeFirstFailureAtMs),
+    firstFailureAgeMs: toAgeMsOrNull(safeNowMs, safeFirstFailureAtMs),
+    lastHealthCheckCompletedAtMs: safeLastHealthCheckCompletedAtMs,
+    lastHealthCheckCompletedAtIso: toIsoOrNull(safeLastHealthCheckCompletedAtMs),
+    lastHealthCheckAgeMs: toAgeMsOrNull(safeNowMs, safeLastHealthCheckCompletedAtMs),
+    lastHealthSuccessAtMs: safeLastHealthSuccessAtMs,
+    lastHealthSuccessAtIso: toIsoOrNull(safeLastHealthSuccessAtMs),
+    lastHealthSuccessAgeMs: toAgeMsOrNull(safeNowMs, safeLastHealthSuccessAtMs),
+    lastHealthSuccessPid: Number.isFinite(Number(lastHealthSuccessPid))
+      ? Number(lastHealthSuccessPid)
+      : null,
+    lastErrorKind: normaliseString(lastErrorKind),
+    lastErrorDetail: normaliseErrorDetail(lastErrorDetail),
+    pollInFlight: !!pollInFlight,
+    pollQueuedImmediate: !!pollQueuedImmediate,
+    nextPollAtMs: safeNextPollAtMs,
+    nextPollDueInMs: toDueMsOrNull(safeNowMs, safeNextPollAtMs),
+    healthLoopStartedAtMs: safeHealthLoopStartedAtMs,
+    healthLoopStartedAtIso: toIsoOrNull(safeHealthLoopStartedAtMs),
+    healthLoopAgeMs: toAgeMsOrNull(safeNowMs, safeHealthLoopStartedAtMs),
+    diagnostics: cloneDiagnostics(diagnostics),
+    lastCopyAttempt: cloneDiagnostics(lastCopyAttempt),
+    realtimeConnectionTelemetry: cloneDiagnostics(realtimeConnectionTelemetry),
+    locationHref: normaliseString(locationHref),
+    locationOrigin: normaliseString(locationOrigin),
+    locationPathname: normaliseString(locationPathname),
+    locationPort: normaliseString(locationPort),
+  };
+}
+
+export function buildHealthTelemetryCopyPayload(snapshot, {
+  copySource = 'manual',
+  nowMs = Date.now(),
+} = {}) {
+  const safeNowMs = Number.isFinite(nowMs) ? Number(nowMs) : Date.now();
+  return {
+    type: 'von_health_poll_telemetry',
+    copiedAtMs: safeNowMs,
+    copiedAtIso: new Date(safeNowMs).toISOString(),
+    copySource: normaliseString(copySource) || 'manual',
+    snapshot: snapshot && typeof snapshot === 'object' ? snapshot : null,
+  };
+}

--- a/src/frontend/web/von_interface/static/js/utils/serverHealthState.js
+++ b/src/frontend/web/von_interface/static/js/utils/serverHealthState.js
@@ -4,6 +4,10 @@ const FAILURES_BEFORE_DOWN_AFTER_SUCCESS = 2;
 const FAILURE_WINDOW_MS_BEFORE_DOWN_AFTER_SUCCESS = 7000;
 const THINKING_EXTRA_FAILURES_BEFORE_DOWN = 1;
 const THINKING_EXTRA_FAILURE_WINDOW_MS = 5000;
+const TIMEOUT_EXTRA_FAILURES_BEFORE_DOWN = 4;
+const TIMEOUT_EXTRA_FAILURE_WINDOW_MS = 60000;
+const NETWORK_EXTRA_FAILURES_BEFORE_DOWN = 2;
+const NETWORK_EXTRA_FAILURE_WINDOW_MS = 20000;
 
 function toSafeInteger(value, fallback = 0) {
   if (!Number.isFinite(value)) return fallback;
@@ -23,12 +27,17 @@ function toSafeWindowMs(nowMs, firstFailureAtMs) {
 function resolveThresholds({
   hasSeenSuccessfulHealthPoll = false,
   isThinkingActive = false,
+  latestErrorKind = null,
   downFailuresAfterSuccess = FAILURES_BEFORE_DOWN_AFTER_SUCCESS,
   downFailureWindowMsAfterSuccess = FAILURE_WINDOW_MS_BEFORE_DOWN_AFTER_SUCCESS,
   initialFailuresBeforeDown = INITIAL_FAILURES_BEFORE_DOWN,
   initialFailureWindowMsBeforeDown = INITIAL_FAILURE_WINDOW_MS_BEFORE_DOWN,
   thinkingExtraFailuresBeforeDown = THINKING_EXTRA_FAILURES_BEFORE_DOWN,
   thinkingExtraFailureWindowMs = THINKING_EXTRA_FAILURE_WINDOW_MS,
+  timeoutExtraFailuresBeforeDown = TIMEOUT_EXTRA_FAILURES_BEFORE_DOWN,
+  timeoutExtraFailureWindowMs = TIMEOUT_EXTRA_FAILURE_WINDOW_MS,
+  networkExtraFailuresBeforeDown = NETWORK_EXTRA_FAILURES_BEFORE_DOWN,
+  networkExtraFailureWindowMs = NETWORK_EXTRA_FAILURE_WINDOW_MS,
 } = {}) {
   const seenSuccess = !!hasSeenSuccessfulHealthPoll;
   const baseFailureThreshold = seenSuccess
@@ -44,22 +53,45 @@ function resolveThresholds({
       INITIAL_FAILURE_WINDOW_MS_BEFORE_DOWN
     );
 
+  const isTimeoutFailure = latestErrorKind === "timeout";
+  const timeoutFailureThresholdBoost = isTimeoutFailure
+    ? toSafeInteger(timeoutExtraFailuresBeforeDown, TIMEOUT_EXTRA_FAILURES_BEFORE_DOWN)
+    : 0;
+  const timeoutWindowThresholdBoostMs = isTimeoutFailure
+    ? toSafeInteger(timeoutExtraFailureWindowMs, TIMEOUT_EXTRA_FAILURE_WINDOW_MS)
+    : 0;
+  const isNetworkFailure = latestErrorKind === "network_or_unknown";
+  const networkFailureThresholdBoost = isNetworkFailure
+    ? toSafeInteger(networkExtraFailuresBeforeDown, NETWORK_EXTRA_FAILURES_BEFORE_DOWN)
+    : 0;
+  const networkWindowThresholdBoostMs = isNetworkFailure
+    ? toSafeInteger(networkExtraFailureWindowMs, NETWORK_EXTRA_FAILURE_WINDOW_MS)
+    : 0;
+  const failureThresholdWithTimeoutBoost =
+    baseFailureThreshold + timeoutFailureThresholdBoost + networkFailureThresholdBoost;
+  const windowThresholdWithTimeoutBoostMs =
+    baseWindowThresholdMs + timeoutWindowThresholdBoostMs + networkWindowThresholdBoostMs;
+
   if (!isThinkingActive) {
     return {
-      downFailureThreshold: Math.max(1, baseFailureThreshold),
-      downFailureWindowThresholdMs: Math.max(0, baseWindowThresholdMs),
+      downFailureThreshold: Math.max(1, failureThresholdWithTimeoutBoost),
+      downFailureWindowThresholdMs: Math.max(0, windowThresholdWithTimeoutBoostMs),
+      isTimeoutFailure,
+      isNetworkFailure,
     };
   }
 
   return {
     downFailureThreshold: Math.max(
       1,
-      baseFailureThreshold + toSafeInteger(thinkingExtraFailuresBeforeDown, 0)
+      failureThresholdWithTimeoutBoost + toSafeInteger(thinkingExtraFailuresBeforeDown, 0)
     ),
     downFailureWindowThresholdMs: Math.max(
       0,
-      baseWindowThresholdMs + toSafeInteger(thinkingExtraFailureWindowMs, 0)
+      windowThresholdWithTimeoutBoostMs + toSafeInteger(thinkingExtraFailureWindowMs, 0)
     ),
+    isTimeoutFailure,
+    isNetworkFailure,
   };
 }
 
@@ -69,6 +101,7 @@ export function evaluateServerHealthState({
   firstFailureAtMs = null,
   nowMs = Date.now(),
   isThinkingActive = false,
+  latestErrorKind = null,
   thresholds = {},
 } = {}) {
   const safeFailureCount = toSafeInteger(failureCount, 0);
@@ -77,10 +110,11 @@ export function evaluateServerHealthState({
   const safeIsThinkingActive = !!isThinkingActive;
   const safeSeenSuccess = !!hasSeenSuccessfulHealthPoll;
 
-  const { downFailureThreshold, downFailureWindowThresholdMs } = resolveThresholds({
+  const { downFailureThreshold, downFailureWindowThresholdMs, isTimeoutFailure, isNetworkFailure } = resolveThresholds({
     ...thresholds,
     hasSeenSuccessfulHealthPoll: safeSeenSuccess,
     isThinkingActive: safeIsThinkingActive,
+    latestErrorKind,
   });
 
   const failureWindowMs = toSafeWindowMs(safeNowMs, safeFirstFailureAtMs);
@@ -107,6 +141,11 @@ export function evaluateServerHealthState({
       downFailureThreshold,
       downFailureWindowThresholdMs,
       isThinkingActive: safeIsThinkingActive,
+      latestErrorKind: (typeof latestErrorKind === "string" && latestErrorKind.trim())
+        ? latestErrorKind.trim()
+        : null,
+      isTimeoutFailure,
+      isNetworkFailure,
       meetsFailureThreshold,
       meetsFailureWindowThreshold,
     },
@@ -124,4 +163,8 @@ export {
   FAILURE_WINDOW_MS_BEFORE_DOWN_AFTER_SUCCESS,
   THINKING_EXTRA_FAILURES_BEFORE_DOWN,
   THINKING_EXTRA_FAILURE_WINDOW_MS,
+  TIMEOUT_EXTRA_FAILURES_BEFORE_DOWN,
+  TIMEOUT_EXTRA_FAILURE_WINDOW_MS,
+  NETWORK_EXTRA_FAILURES_BEFORE_DOWN,
+  NETWORK_EXTRA_FAILURE_WINDOW_MS,
 };

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -7396,6 +7396,25 @@ button.prompt-vontology-cartouche {
     border-color: #f5c2c7;
 }
 
+#serverUptimeValue.health-telemetry-copyable {
+    cursor: pointer;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+}
+
+#serverUptimeValue.health-telemetry-copyable:focus {
+    outline: 1px solid #93c5fd;
+    border-radius: 4px;
+}
+
+#serverUptimeValue.health-telemetry-copy-success {
+    color: #065f46;
+}
+
+#serverUptimeValue.health-telemetry-copy-error {
+    color: #991b1b;
+}
+
 .footer-separator {
     margin: 0 4px;
     opacity: 0.5;


### PR DESCRIPTION
## Summary
- harden health state transitions with timeout/network-aware hysteresis and improved failure diagnostics
- add copyable health telemetry payloads, including location metadata and realtime connection telemetry
- gate shared/workflow realtime streams by tab visibility and active shared session to avoid connection-slot starvation
- add visible-only low-rate shared session badge polling to keep unread indicators eventually consistent

## Validation
- npx pyright src/backend/server/routes/workflows_routes.py tests/backend/test_workflows_routes.py
- node --check src/frontend/web/von_interface/static/js/main.js
- node --check src/frontend/web/von_interface/static/js/chatTab.js
- npx jest src/frontend/web/von_interface/static/js/test/serverHealthState.test.js src/frontend/web/von_interface/static/js/test/healthTelemetrySnapshot.test.js --runInBand
- npx jest src/frontend/web/von_interface/static/js/test/chatTab.test.js -t "shared conversation stream eligibility|shared session badge polling eligibility" --runInBand

## Notes
- existing unrelated local changes were left untouched (.vscode and backend workflow route/test files).