### PR TITLE
JVNAUTOSCI-1297: Thinking card default-unfurl with one-time terminal auto-furl

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -572,6 +572,17 @@ const TOOL_USE_SETTING_REFRESH_COOLDOWN_MS = 30_000;
 const THINKING_STATUS_ACTIVE = 'active';
 const THINKING_STATUS_WAITING = 'waiting';
 const THINKING_STATUS_STALLED = 'stalled';
+const THINKING_CARD_TOGGLE_LABEL_EXPANDED = 'Collapse';
+const THINKING_CARD_TOGGLE_LABEL_COLLAPSED = 'Expand';
+const THINKING_TERMINAL_PROGRESS_STATUSES = new Set([
+    'completed',
+    'done',
+    'error',
+    'cancelled',
+    'canceled',
+    'aborted',
+    'failed'
+]);
 const DIAGNOSTICS_EXPORT_ENDPOINT = '/von/diagnostics/export';
 const DIAGNOSTICS_EXPORT_SHORTCUT_HINT = 'Ctrl+Shift+D';
 
@@ -645,6 +656,8 @@ function setLoadingIndicatorDetailHtml(html) {
             wrapper.classList.remove('has-tools');
         }
     }
+
+    syncThinkingCardExpandedStateToDom();
 }
 
 /**
@@ -672,6 +685,152 @@ function _setLoadingIndicatorDetailText(text) {
             wrapper.classList.remove('has-tools');
         }
     }
+
+    syncThinkingCardExpandedStateToDom();
+}
+
+function createThinkingCardDisplayState() {
+    return {
+        expanded: true,
+        autoFurlApplied: false
+    };
+}
+
+function normaliseThinkingCardDisplayState(state) {
+    if (!state || typeof state !== 'object') {
+        return createThinkingCardDisplayState();
+    }
+    return {
+        expanded: state.expanded !== false,
+        autoFurlApplied: state.autoFurlApplied === true
+    };
+}
+
+function normaliseThinkingProgressStatus(progress) {
+    const status = (progress && typeof progress.status === 'string')
+        ? progress.status.trim().toLowerCase()
+        : '';
+    return status;
+}
+
+function isTerminalThinkingProgress(progress) {
+    const status = normaliseThinkingProgressStatus(progress);
+    if (!status) {
+        return false;
+    }
+    return THINKING_TERMINAL_PROGRESS_STATUSES.has(status);
+}
+
+function reduceThinkingCardDisplayState(state, event = {}) {
+    const current = normaliseThinkingCardDisplayState(state);
+    const type = (event && typeof event.type === 'string') ? event.type.trim() : '';
+
+    if (type === 'reset_for_active') {
+        return createThinkingCardDisplayState();
+    }
+
+    if (type === 'manual_toggle') {
+        return {
+            ...current,
+            expanded: !current.expanded
+        };
+    }
+
+    if (type === 'manual_set') {
+        if (typeof event.expanded !== 'boolean') {
+            return current;
+        }
+        return {
+            ...current,
+            expanded: event.expanded
+        };
+    }
+
+    if (type === 'progress_update') {
+        if (!current.autoFurlApplied && isTerminalThinkingProgress(event.progress)) {
+            return {
+                expanded: false,
+                autoFurlApplied: true
+            };
+        }
+        return current;
+    }
+
+    return current;
+}
+
+export function __testOnly_reduceThinkingCardDisplayState(state, event = {}) {
+    return reduceThinkingCardDisplayState(state, event);
+}
+
+function getThinkingCardToggleButtonEl() {
+    return document.getElementById('thinkingCardToggleButton');
+}
+
+function ensureThinkingCardDisplayState(request) {
+    if (!request || typeof request !== 'object') {
+        return null;
+    }
+
+    request.thinkingCardDisplayState = normaliseThinkingCardDisplayState(request.thinkingCardDisplayState);
+    return request.thinkingCardDisplayState;
+}
+
+function syncThinkingCardExpandedStateToDom(request = activeChatRequest) {
+    const wrapper = document.getElementById('thinkingCardWrapper');
+    const detailEl = getLoadingIndicatorDetailEl();
+    const toggleButton = getThinkingCardToggleButtonEl();
+    if (!wrapper) {
+        return;
+    }
+
+    const state = ensureThinkingCardDisplayState(request) || createThinkingCardDisplayState();
+    const hasTools = wrapper.classList.contains('has-tools');
+    const expanded = state.expanded !== false;
+
+    wrapper.classList.toggle('is-collapsed', !expanded);
+    wrapper.classList.toggle('is-expanded', expanded);
+
+    if (detailEl) {
+        const showBody = expanded && hasTools;
+        detailEl.setAttribute('aria-hidden', showBody ? 'false' : 'true');
+    }
+
+    if (toggleButton) {
+        toggleButton.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        if (expanded) {
+            toggleButton.textContent = THINKING_CARD_TOGGLE_LABEL_EXPANDED;
+            toggleButton.setAttribute('aria-label', 'Collapse thinking details');
+            toggleButton.title = 'Collapse thinking details';
+        } else {
+            toggleButton.textContent = THINKING_CARD_TOGGLE_LABEL_COLLAPSED;
+            toggleButton.setAttribute('aria-label', 'Expand thinking details');
+            toggleButton.title = 'Expand thinking details';
+        }
+    }
+}
+
+function applyThinkingCardDisplayStateUpdate(request, event = {}) {
+    if (!request || typeof request !== 'object') {
+        return null;
+    }
+
+    const previous = normaliseThinkingCardDisplayState(request.thinkingCardDisplayState);
+    const next = reduceThinkingCardDisplayState(previous, event);
+    request.thinkingCardDisplayState = next;
+
+    if (previous.expanded !== next.expanded || previous.autoFurlApplied !== next.autoFurlApplied) {
+        syncThinkingCardExpandedStateToDom(request);
+    }
+
+    return next;
+}
+
+function toggleThinkingCardExpanded(request = activeChatRequest) {
+    if (!request || typeof request !== 'object') {
+        return;
+    }
+    applyThinkingCardDisplayStateUpdate(request, { type: 'manual_toggle' });
 }
 
 function createClientRequestId() {
@@ -1331,6 +1490,10 @@ function startToolUseProgressPolling(request) {
                     phase_label: 'Waiting for status',
                     liveness_state: THINKING_STATUS_WAITING
                 };
+                applyThinkingCardDisplayStateUpdate(request, {
+                    type: 'progress_update',
+                    progress: request.latestProgress
+                });
                 setLoadingIndicatorText(formatToolUseProgressText(request.latestProgress, request));
                 updateThinkingCardMeta(request, request.latestProgress);
                 poll.nextDelayMs = Math.min(10_000, poll.nextDelayMs * 1.7);
@@ -1346,6 +1509,10 @@ function startToolUseProgressPolling(request) {
                     phase_label: 'Waiting for status',
                     liveness_state: THINKING_STATUS_WAITING
                 };
+                applyThinkingCardDisplayStateUpdate(request, {
+                    type: 'progress_update',
+                    progress: request.latestProgress
+                });
                 setLoadingIndicatorText(formatToolUseProgressText(request.latestProgress, request));
                 updateThinkingCardMeta(request, request.latestProgress);
                 poll.nextDelayMs = Math.min(5000, poll.nextDelayMs * 1.4);
@@ -1360,6 +1527,10 @@ function startToolUseProgressPolling(request) {
             }
             const progress = await resp.json();
             request.latestProgress = progress;
+            applyThinkingCardDisplayStateUpdate(request, {
+                type: 'progress_update',
+                progress
+            });
             if (!Array.isArray(request.progressEvents)) {
                 request.progressEvents = [];
             }
@@ -14262,10 +14433,11 @@ export function initializeChatTab() {
     console.log("Chat tab initialized successfully");
 }
 
-function setThinkingState(isThinking) {
+function setThinkingState(isThinking, request = activeChatRequest) {
     const wrapper = document.getElementById('thinkingCardWrapper');
     const loadingIndicator = document.getElementById('loadingIndicator');
     const loadingDetail = document.getElementById('loadingIndicatorDetail');
+    const toggleButton = getThinkingCardToggleButtonEl();
     const abortButton = document.getElementById('abortButton');
     const retryButton = document.getElementById('retryThinkingButton');
     const copyDiagnosticsButton = document.getElementById('copyThinkingDiagnosticsButton');
@@ -14273,11 +14445,20 @@ function setThinkingState(isThinking) {
     const sendButton = document.getElementById('sendButton');
     const metaEl = document.getElementById('thinkingCardMeta');
 
+    if (isThinking && request) {
+        request.thinkingCardDisplayState = reduceThinkingCardDisplayState(
+            request.thinkingCardDisplayState,
+            { type: 'reset_for_active' }
+        );
+    }
+
     // Toggle wrapper visibility (controls the entire card)
     if (wrapper) {
         wrapper.setAttribute('aria-hidden', isThinking ? 'false' : 'true');
         if (!isThinking) {
             wrapper.classList.remove('has-tools');
+            wrapper.classList.remove('is-collapsed');
+            wrapper.classList.remove('is-expanded');
         }
     }
 
@@ -14292,6 +14473,7 @@ function setThinkingState(isThinking) {
     if (loadingDetail) {
         if (!isThinking) {
             loadingDetail.innerHTML = '';
+            loadingDetail.setAttribute('aria-hidden', 'true');
         }
     }
 
@@ -14317,6 +14499,10 @@ function setThinkingState(isThinking) {
         sendButton.textContent = isThinking ? 'Queue Prompt' : 'Send Prompt';
     }
 
+    if (toggleButton) {
+        toggleButton.setAttribute('aria-hidden', isThinking ? 'false' : 'true');
+    }
+
     if (abortButton) {
         abortButton.setAttribute('aria-hidden', isThinking ? 'false' : 'true');
     }
@@ -14329,6 +14515,10 @@ function setThinkingState(isThinking) {
             copyDiagnosticsButton.textContent = 'Copy diagnostics';
             copyDiagnosticsButton.classList.remove('success-feedback', 'error-feedback');
         }
+    }
+
+    if (isThinking) {
+        syncThinkingCardExpandedStateToDom(request);
     }
 }
 
@@ -14369,7 +14559,6 @@ function abortActiveChatRequest() {
 
     const request = activeChatRequest;
     request.aborted = true;
-    activeChatRequest = null;
 
     stopToolUseProgressPolling(request);
     stopThinkingTooltipTicker(request);
@@ -14380,7 +14569,8 @@ function abortActiveChatRequest() {
         // Ignore abort errors.
     }
 
-    setThinkingState(false);
+    setThinkingState(false, request);
+    activeChatRequest = null;
     restorePromptEditingState(request);
 }
 
@@ -14692,9 +14882,17 @@ async function copyActiveThinkingDiagnostics(button = null) {
 }
 
 function ensureAbortButtonBound() {
+    const toggleButton = getThinkingCardToggleButtonEl();
     const abortButton = document.getElementById('abortButton');
     const retryButton = document.getElementById('retryThinkingButton');
     const copyDiagnosticsButton = document.getElementById('copyThinkingDiagnosticsButton');
+
+    if (toggleButton && toggleButton.dataset.bound !== '1') {
+        toggleButton.dataset.bound = '1';
+        toggleButton.addEventListener('click', () => {
+            toggleThinkingCardExpanded();
+        });
+    }
 
     if (abortButton && abortButton.dataset.bound !== '1') {
         abortButton.dataset.bound = '1';
@@ -14934,9 +15132,23 @@ async function handleSendPrompt(options = {}) {
     void refreshToolUseDuringThinkingSetting();
 
     const clientRequestId = createClientRequestId();
+    const request = {
+        abortController: new AbortController(),
+        promptRaw,
+        selectionStart,
+        selectionEnd,
+        aborted: false,
+        clientRequestId,
+        thinkingStartedAtMs: Date.now(),
+        toolUseProgressHistory: [],
+        latestProgress: null,
+        progressEvents: [],
+        thinkingCardDisplayState: reduceThinkingCardDisplayState(null, { type: 'reset_for_active' })
+    };
+    activeChatRequest = request;
 
     // Show loading indicator and disable send button
-    setThinkingState(true);
+    setThinkingState(true, request);
 
     // Create turn IDs for user and assistant
     const userTurnId = `u-${Date.now()}`;
@@ -14962,22 +15174,8 @@ async function handleSendPrompt(options = {}) {
         promptInput.value = '';
         promptInput.dispatchEvent(new Event('input', { bubbles: true }));
     }
-    let request = null;
-    try {
-        request = {
-            abortController: new AbortController(),
-            promptRaw,
-            selectionStart,
-            selectionEnd,
-            aborted: false,
-            clientRequestId,
-            thinkingStartedAtMs: Date.now(),
-            toolUseProgressHistory: [],
-            latestProgress: null,
-            progressEvents: []
-        };
-        activeChatRequest = request;
 
+    try {
         setLoadingIndicatorTooltip(formatToolUseHistoryTooltip(request));
 
         startThinkingTooltipTicker(request);
@@ -15093,10 +15291,10 @@ async function handleSendPrompt(options = {}) {
     } finally {
         const isStillActive = activeChatRequest === request;
         if (isStillActive) {
-            activeChatRequest = null;
             stopToolUseProgressPolling(request);
             stopThinkingTooltipTicker(request);
-            setThinkingState(false);
+            setThinkingState(false, request);
+            activeChatRequest = null;
         }
         updateHistoryLength();
         scheduleQueuedChatPromptDrain();

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -24,6 +24,7 @@ import {
     __testOnly_setLatestUnreadBoundary,
     __testOnly_showNewSharedMessagesIndicator,
     __testOnly_updateScrollToEndButtonVisibility,
+    __testOnly_reduceThinkingCardDisplayState,
     __testOnly_resetChatConceptMetaCaches,
     formatChatTimestamp,
     sendMessage
@@ -499,6 +500,148 @@ describe('thinking liveness presentation', () => {
     });
 });
 
+describe('thinking card display state reducer', () => {
+    test('auto-furls once on first terminal progress update', () => {
+        let state = __testOnly_reduceThinkingCardDisplayState(null, { type: 'reset_for_active' });
+        expect(state.expanded).toBe(true);
+        expect(state.autoFurlApplied).toBe(false);
+
+        state = __testOnly_reduceThinkingCardDisplayState(state, {
+            type: 'progress_update',
+            progress: { status: 'completed' }
+        });
+        expect(state.expanded).toBe(false);
+        expect(state.autoFurlApplied).toBe(true);
+    });
+
+    test('manual reopen after terminal state is preserved', () => {
+        let state = __testOnly_reduceThinkingCardDisplayState(null, { type: 'reset_for_active' });
+        state = __testOnly_reduceThinkingCardDisplayState(state, {
+            type: 'progress_update',
+            progress: { status: 'error' }
+        });
+        expect(state.expanded).toBe(false);
+
+        state = __testOnly_reduceThinkingCardDisplayState(state, {
+            type: 'manual_set',
+            expanded: true
+        });
+        expect(state.expanded).toBe(true);
+
+        state = __testOnly_reduceThinkingCardDisplayState(state, {
+            type: 'progress_update',
+            progress: { status: 'completed' }
+        });
+        expect(state.expanded).toBe(true);
+        expect(state.autoFurlApplied).toBe(true);
+    });
+});
+
+describe('thinking card toggle accessibility', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="scrollableField"></div>
+            <div class="thinking-card-wrapper" id="thinkingCardWrapper" aria-hidden="true">
+                <div class="thinking-card" role="status" aria-live="polite">
+                    <div class="thinking-card-header" id="loadingIndicator">
+                        <span class="thinking-card-phase loading-indicator-text">Thinking...</span>
+                        <span id="thinkingCardStatusBadge" class="thinking-card-status active" aria-hidden="true">Active</span>
+                        <span class="thinking-card-meta" id="thinkingCardMeta"></span>
+                        <button id="thinkingCardToggleButton" type="button" aria-hidden="true" aria-expanded="true" aria-controls="loadingIndicatorDetail">Collapse</button>
+                        <button id="retryThinkingButton" type="button" aria-hidden="true">Retry</button>
+                        <button id="copyThinkingDiagnosticsButton" type="button" aria-hidden="true">Copy diagnostics</button>
+                        <button id="abortButton" type="button" aria-hidden="true"></button>
+                    </div>
+                    <div class="thinking-card-body" id="loadingIndicatorDetail" aria-live="polite"></div>
+                </div>
+            </div>
+            <button id="sendButton"></button>
+            <textarea id="promptInput"></textarea>
+            <input type="checkbox" id="annotationToggle" />
+        `;
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        delete global.fetch;
+    });
+
+    test('sets aria-expanded while active and allows manual toggle', async () => {
+        const { getUserContext } = require('../apiService.js');
+        getUserContext.mockReturnValue({
+            user_id: 'user',
+            org_id: 'org',
+            language: 'en-NZ',
+            gmail_profile: null
+        });
+
+        document.getElementById('promptInput').value = 'test prompt';
+
+        let generateSignal = null;
+        global.fetch = jest.fn((url, options = {}) => {
+            if (typeof url === 'string' && url.startsWith('/api/settings/')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ show_tool_use_during_thinking: true })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/progress/')) {
+                return Promise.resolve({
+                    ok: true,
+                    status: 202,
+                    json: async () => ({})
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ history_length: 0, authenticated: true })
+                });
+            }
+
+            if (typeof url === 'string' && url.startsWith('/von/generate')) {
+                generateSignal = options.signal;
+                return new Promise((resolve, reject) => {
+                    if (generateSignal) {
+                        generateSignal.addEventListener('abort', () => {
+                            const err = new Error('aborted');
+                            err.name = 'AbortError';
+                            reject(err);
+                        });
+                    }
+                });
+            }
+
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        const sendPromise = sendMessage();
+        const toggleButton = document.getElementById('thinkingCardToggleButton');
+        const wrapper = document.getElementById('thinkingCardWrapper');
+        const detail = document.getElementById('loadingIndicatorDetail');
+
+        expect(toggleButton.getAttribute('aria-hidden')).toBe('false');
+        expect(toggleButton.getAttribute('aria-expanded')).toBe('true');
+
+        toggleButton.click();
+
+        expect(toggleButton.getAttribute('aria-expanded')).toBe('false');
+        expect(wrapper.classList.contains('is-collapsed')).toBe(true);
+        expect(detail.getAttribute('aria-hidden')).toBe('true');
+
+        document.getElementById('abortButton').click();
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(generateSignal).not.toBeNull();
+        expect(generateSignal.aborted).toBe(true);
+        expect(toggleButton.getAttribute('aria-hidden')).toBe('true');
+
+        await expect(sendPromise).resolves.toBeUndefined();
+    });
+});
+
 describe('chat abort behaviour', () => {
     beforeEach(() => {
         document.body.innerHTML = `
@@ -562,7 +705,8 @@ describe('chat abort behaviour', () => {
 
         const sendPromise = sendMessage();
 
-        expect(document.getElementById('sendButton').disabled).toBe(true);
+        expect(document.getElementById('sendButton').disabled).toBe(false);
+        expect(document.getElementById('sendButton').textContent).toBe('Queue Prompt');
         expect(document.getElementById('abortButton').getAttribute('aria-hidden')).toBe('false');
 
         document.getElementById('abortButton').click();

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -6231,7 +6231,7 @@ footer {
     border-bottom: 1px solid transparent;
 }
 
-.thinking-card-wrapper.has-tools .thinking-card-header {
+.thinking-card-wrapper.has-tools.is-expanded .thinking-card-header {
     border-bottom-color: #e2e8f0;
 }
 
@@ -6351,6 +6351,10 @@ footer {
     background: #fee2e2;
 }
 
+.thinking-card-toggle {
+    min-width: 72px;
+}
+
 .thinking-card-stop {
     display: none;
     align-items: center;
@@ -6390,22 +6394,29 @@ footer {
 }
 
 .thinking-card-body {
-    display: none;
-    padding: 10px 14px;
+    padding: 0 14px;
     font-size: 0.78rem;
     color: #475569;
     line-height: 1.45;
-    max-height: 180px;
-    overflow-y: auto;
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
     background-color: #fff;
+    transition: max-height 0.22s ease, opacity 0.16s ease, padding 0.22s ease;
 }
 
-.thinking-card-wrapper.has-tools .thinking-card-body {
-    display: block;
+.thinking-card-wrapper.has-tools.is-expanded .thinking-card-body {
+    max-height: 180px;
+    opacity: 1;
+    padding: 10px 14px;
+    overflow-y: auto;
 }
 
 .thinking-card-body:empty {
-    display: none;
+    max-height: 0;
+    opacity: 0;
+    padding: 0 14px;
+    overflow: hidden;
 }
 
 /* Tool item styling within thinking card */
@@ -6523,6 +6534,13 @@ footer {
 
     .thinking-card-meta {
         margin-left: 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .thinking-card-wrapper,
+    .thinking-card-body {
+        transition: none;
     }
 }
 

--- a/src/frontend/web/von_interface/templates/chat_tab.html
+++ b/src/frontend/web/von_interface/templates/chat_tab.html
@@ -76,6 +76,9 @@
           <span class="thinking-card-phase loading-indicator-text">Thinking...</span>
           <span id="thinkingCardStatusBadge" class="thinking-card-status active" aria-hidden="true">Active</span>
           <span class="thinking-card-meta" id="thinkingCardMeta"></span>
+          <button id="thinkingCardToggleButton" class="btn thinking-card-action thinking-card-toggle" type="button"
+            aria-hidden="true" aria-expanded="true" aria-controls="loadingIndicatorDetail"
+            aria-label="Collapse thinking details" title="Collapse thinking details">Collapse</button>
           <button id="retryThinkingButton" class="btn thinking-card-action" type="button" aria-hidden="true"
             aria-label="Retry request" title="Retry request">Retry</button>
           <button id="copyThinkingDiagnosticsButton" class="btn thinking-card-action" type="button" aria-hidden="true"


### PR DESCRIPTION
## Summary
- add explicit per-turn thinking-card display state in chatTab.js
- default card to expanded while active and auto-furl once on first terminal progress state
- add manual header toggle control (aria-expanded + keyboard operable button)
- preserve manual re-open state after terminal auto-furl and keep state stable across incremental updates
- update template/styles for expanded/collapsed transitions with reduced-motion support
- add regression tests for reducer logic and toggle accessibility

## Validation
- npm test -- src/frontend/web/von_interface/static/js/test/chatTab.test.js tests/frontend/chatTaskQueue.test.js tests/frontend/chatTabAbort.test.js
- npx eslint src/frontend/web/von_interface/static/js/chatTab.js src/frontend/web/von_interface/static/js/test/chatTab.test.js