### PR TITLE
JVNAUTOSCI-1302: workflow-driven screenshot/image interpretation + paste uploads

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+from contextlib import contextmanager
 from datetime import datetime
 from typing import Any, List, Mapping, Sequence
 
@@ -2001,14 +2002,62 @@ def _read_paper(**kwargs):
     return _run_async_compat(_async_read)
 
 
+def _normalise_namespace_override(namespace: Any) -> str | None:
+    if not isinstance(namespace, str):
+        return None
+    cleaned = namespace.strip()
+    return cleaned or None
+
+
+def _namespace_actor_overrides_from_namespace(
+    namespace: str | None,
+) -> tuple[str | None, str | None]:
+    """Resolve optional user/org auth overrides from namespace payload."""
+
+    namespace_clean = _normalise_namespace_override(namespace)
+    if namespace_clean is None:
+        return None, None
+
+    user_part: str | None
+    org_part: str | None
+    if "@" in namespace_clean:
+        user_raw, org_raw = namespace_clean.split("@", 1)
+        user_part = user_raw.strip() or None
+        org_part = org_raw.strip() or None
+    elif "/" in namespace_clean:
+        user_raw, org_raw = namespace_clean.split("/", 1)
+        user_part = user_raw.strip() or None
+        org_part = org_raw.strip() or None
+    else:
+        user_part = namespace_clean
+        org_part = None
+
+    if org_part and not org_part.startswith("#V#"):
+        org_part = f"#V#{org_part}"
+    return user_part, org_part
+
+
+@contextmanager
+def _with_namespace_actor_override(namespace: str | None):
+    """Apply best-effort auth context override for namespace-driven tool calls."""
+
+    from ...security.access_control import (
+        override_current_organisation,
+        override_current_user,
+    )
+
+    user_part, org_part = _namespace_actor_overrides_from_namespace(namespace)
+    if user_part or org_part:
+        with override_current_user(user_part), override_current_organisation(org_part):
+            yield
+        return
+    yield
+
+
 # Blob/file-copy retrieval
 def _read_file_copy(**kwargs):
     import os
-    from ...security.access_control import (
-        get_effective_user_concept_id,
-        override_current_user,
-        override_current_organisation,
-    )
+    from ...security.access_control import get_effective_user_concept_id
     from ...services.computer_file_copy_service import fetch_file_copy_bytes
 
     concept_id = kwargs.get("concept_id") or kwargs.get("file_copy_concept_id")
@@ -2059,17 +2108,7 @@ def _read_file_copy(**kwargs):
         if max_bytes is None or max_bytes > max_override:
             max_bytes = max_override
 
-    namespace = kwargs.get("namespace")
-    user_part = None
-    org_part = None
-    if isinstance(namespace, str) and "@" in namespace:
-        user_part, org_part = namespace.split("@", 1)
-        user_part = (user_part or "").strip() or None
-        org_part = (org_part or "").strip() or None
-        if org_part and not org_part.startswith("#V#"):
-            org_part = f"#V#{org_part}"
-    elif isinstance(namespace, str) and namespace.strip():
-        user_part = namespace.strip()
+    namespace = _normalise_namespace_override(kwargs.get("namespace"))
 
     def _run_read():
         user_concept_id = get_effective_user_concept_id()
@@ -2925,11 +2964,316 @@ def _read_file_copy(**kwargs):
 
         return payload
 
-    if user_part or org_part:
-        with override_current_user(user_part), override_current_organisation(org_part):
-            return _run_read()
+    with _with_namespace_actor_override(namespace):
+        return _run_read()
 
-    return _run_read()
+
+def _interpret_file_copy(**kwargs):
+    import json
+
+    from ...services.computer_file_copy_service import fetch_file_copy_bytes
+    from ...services.file_copy_interpretation_service import (
+        build_document_interpretation,
+        build_image_interpretation,
+        is_image_file,
+    )
+    from ...services.rag_text_relation_change_hook_service import (
+        maybe_sync_concept_text_relations_to_rag,
+    )
+    from ...services.text_value_service import upsert_singleton_text_relation
+
+    concept_id = kwargs.get("concept_id") or kwargs.get("file_copy_concept_id")
+    if not isinstance(concept_id, str) or not concept_id.strip():
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameter: concept_id",
+            details={"missing": ["concept_id"]},
+            suggestions=[
+                "Provide concept_id for a blob-backed #V#computer_file_copy instance"
+            ],
+        )
+    concept_id = concept_id.strip()
+
+    max_bytes = kwargs.get("max_bytes")
+    if max_bytes is None:
+        max_bytes = 10_000_000
+    else:
+        try:
+            max_bytes = int(max_bytes)
+        except (TypeError, ValueError):
+            return make_error_response(
+                "invalid_parameter",
+                "Invalid max_bytes: must be an integer",
+                details={"max_bytes": max_bytes},
+            )
+        if max_bytes <= 0:
+            return make_error_response(
+                "invalid_parameter",
+                "max_bytes must be positive",
+                details={"max_bytes": max_bytes},
+            )
+
+    max_persist_content_chars_raw = kwargs.get("max_persist_content_chars")
+    if max_persist_content_chars_raw is None:
+        max_persist_content_chars = 20_000
+    else:
+        try:
+            max_persist_content_chars = int(max_persist_content_chars_raw)
+        except (TypeError, ValueError):
+            return make_error_response(
+                "invalid_parameter",
+                "Invalid max_persist_content_chars: must be an integer",
+                details={"max_persist_content_chars": max_persist_content_chars_raw},
+            )
+        if max_persist_content_chars < 0:
+            return make_error_response(
+                "invalid_parameter",
+                "max_persist_content_chars must be zero or positive",
+                details={"max_persist_content_chars": max_persist_content_chars},
+            )
+
+    allow_large = bool(kwargs.get("allow_large", False))
+    persist = bool(kwargs.get("persist", True))
+    persist_description = bool(kwargs.get("persist_description", True))
+    persist_content = bool(kwargs.get("persist_content", True))
+    persist_interpretation_json = bool(kwargs.get("persist_interpretation_json", True))
+    include_semantic_description = bool(kwargs.get("include_semantic_description", True))
+    include_text = bool(kwargs.get("include_text", False))
+    model_override = (
+        kwargs.get("vision_model")
+        if isinstance(kwargs.get("vision_model"), str)
+        else None
+    )
+    prompt_override = (
+        kwargs.get("semantic_prompt")
+        if isinstance(kwargs.get("semantic_prompt"), str)
+        else None
+    )
+
+    namespace = _normalise_namespace_override(kwargs.get("namespace"))
+    ns_report = _resolve_rag_namespace_from_kwargs(kwargs)
+    if bool(ns_report.get("namespace_mismatch")):
+        return {
+            "success": False,
+            "error": "namespace_mismatch",
+            "message": (
+                "Explicit namespace conflicts with derived user/org namespace; "
+                "interpretation was not executed."
+            ),
+            **ns_report,
+        }
+    effective_namespace = namespace
+    if effective_namespace is None:
+        derived_ns = ns_report.get("namespace")
+        if isinstance(derived_ns, str) and derived_ns.strip():
+            effective_namespace = derived_ns.strip()
+
+    read_payload = _read_file_copy(
+        concept_id=concept_id,
+        max_bytes=max_bytes,
+        allow_large=allow_large,
+        as_text=True,
+        namespace=effective_namespace,
+    )
+    if not isinstance(read_payload, dict):
+        return make_error_response(
+            "read_file_copy_failed",
+            "Unexpected read_file_copy response shape",
+            details={"response_type": type(read_payload).__name__},
+        )
+    if read_payload.get("success") is not True:
+        return {
+            "success": False,
+            "error": read_payload.get("error") or read_payload.get("error_code"),
+            "message": read_payload.get("message")
+            or "Failed to read file-copy bytes for interpretation",
+            "concept_id": concept_id,
+            "namespace": effective_namespace,
+            **ns_report,
+            "read_result": read_payload,
+        }
+
+    content_type = read_payload.get("content_type")
+    original_filename = read_payload.get("original_filename")
+    extracted_text_raw = read_payload.get("text")
+    extracted_text = (
+        extracted_text_raw if isinstance(extracted_text_raw, str) else None
+    )
+    file_kind = (
+        "image"
+        if is_image_file(
+            content_type=content_type if isinstance(content_type, str) else None,
+            filename=(
+                original_filename if isinstance(original_filename, str) else None
+            ),
+        )
+        else "document"
+    )
+
+    interpretation: dict[str, Any]
+    image_fetch_error: str | None = None
+    if file_kind == "image":
+        with _with_namespace_actor_override(effective_namespace):
+            image_fetch = fetch_file_copy_bytes(
+                file_copy_concept_id=concept_id,
+                max_bytes=max_bytes,
+                allow_large=allow_large,
+            )
+        if not isinstance(image_fetch, dict) or image_fetch.get("success") is not True:
+            image_fetch_error = str(
+                image_fetch.get("error") if isinstance(image_fetch, dict) else "unknown"
+            )
+            interpretation = {
+                "kind": "image",
+                "description": (
+                    "Image uploaded but byte-level visual interpretation could not be completed."
+                ),
+                "content_text": extracted_text,
+                "content_length": len(extracted_text) if extracted_text else 0,
+                "subject_tags": ["image"],
+                "image_fetch_error": image_fetch_error,
+            }
+        else:
+            image_bytes = image_fetch.get("data") or b""
+            interpretation = build_image_interpretation(
+                data_bytes=bytes(image_bytes),
+                content_type=content_type if isinstance(content_type, str) else None,
+                original_filename=(
+                    original_filename if isinstance(original_filename, str) else None
+                ),
+                include_semantic_description=include_semantic_description,
+                model_override=model_override,
+                prompt_override=prompt_override,
+            )
+            interpreted_content = interpretation.get("content_text")
+            if (
+                isinstance(interpreted_content, str)
+                and interpreted_content.strip()
+                and (
+                    not isinstance(extracted_text, str)
+                    or len(interpreted_content.strip()) > len(extracted_text.strip())
+                )
+            ):
+                extracted_text = interpreted_content.strip()
+    else:
+        interpretation = build_document_interpretation(
+            extracted_text=extracted_text,
+            content_type=content_type if isinstance(content_type, str) else None,
+            original_filename=(
+                original_filename if isinstance(original_filename, str) else None
+            ),
+        )
+
+    description_text = interpretation.get("description")
+    description = description_text if isinstance(description_text, str) else None
+    content_for_persist = extracted_text if isinstance(extracted_text, str) else None
+    content_truncated = False
+    if (
+        isinstance(content_for_persist, str)
+        and max_persist_content_chars > 0
+        and len(content_for_persist) > max_persist_content_chars
+    ):
+        content_for_persist = content_for_persist[:max_persist_content_chars]
+        content_truncated = True
+    if max_persist_content_chars == 0:
+        content_for_persist = None
+
+    persisted_relations: list[dict[str, Any]] = []
+    persist_errors: list[dict[str, Any]] = []
+    if persist:
+        writes: list[tuple[str, str | None]] = []
+        if persist_description and isinstance(description, str) and description.strip():
+            writes.append(("hasDescription", description.strip()))
+        if (
+            persist_content
+            and isinstance(content_for_persist, str)
+            and content_for_persist.strip()
+        ):
+            writes.append(("hasContent", content_for_persist.strip()))
+        if persist_interpretation_json:
+            writes.append(
+                (
+                    "#V#has_file_copy_interpretation_json",
+                    json.dumps(interpretation, ensure_ascii=False),
+                )
+            )
+
+        with _with_namespace_actor_override(effective_namespace):
+            for predicate, text_value in writes:
+                if not isinstance(text_value, str) or not text_value.strip():
+                    continue
+                try:
+                    relation = upsert_singleton_text_relation(
+                        subject_concept_id=concept_id,
+                        predicate=predicate,
+                        text=text_value,
+                        lang="en-NZ",
+                        garbage_collect=True,
+                        context={
+                            "source": "interpret_file_copy",
+                            "file_kind": file_kind,
+                        },
+                    )
+                    relation_id = (
+                        relation.get("relation_id")
+                        if isinstance(relation, dict)
+                        else None
+                    )
+                    persisted_relations.append(
+                        {
+                            "predicate": predicate,
+                            "relation_id": relation_id,
+                            "text_length": len(text_value),
+                        }
+                    )
+                    maybe_sync_concept_text_relations_to_rag(
+                        namespace=effective_namespace,
+                        concept_id=concept_id,
+                        predicate=predicate,
+                    )
+                except Exception as exc:
+                    persist_errors.append(
+                        {
+                            "predicate": predicate,
+                            "error": str(exc),
+                        }
+                    )
+
+    content_text = extracted_text if isinstance(extracted_text, str) else None
+    text_preview = None
+    if isinstance(content_text, str):
+        text_preview = (
+            content_text[:4000] + "..."
+            if len(content_text) > 4000
+            else content_text
+        )
+
+    return {
+        "success": len(persist_errors) == 0,
+        "concept_id": concept_id,
+        "file_kind": file_kind,
+        "description": description,
+        "content_type": content_type,
+        "original_filename": original_filename,
+        "text_length": len(content_text) if isinstance(content_text, str) else 0,
+        "text_preview": text_preview,
+        "text": content_text if include_text else None,
+        "content_truncated_for_persist": content_truncated,
+        "interpretation": interpretation,
+        "persisted": persist and len(persist_errors) == 0,
+        "persisted_relations": persisted_relations,
+        "persist_errors": persist_errors,
+        "namespace": effective_namespace,
+        **ns_report,
+        "read_result": {
+            "text_extraction": read_payload.get("text_extraction"),
+            "text_extraction_error": read_payload.get("text_extraction_error"),
+            "size_bytes": read_payload.get("size_bytes"),
+            "byte_length": read_payload.get("byte_length"),
+            "blob": read_payload.get("blob"),
+        },
+        "image_fetch_error": image_fetch_error,
+    }
 
 
 def _index_file_copy(**kwargs):
@@ -3084,11 +3428,7 @@ def _index_file_copy(**kwargs):
 
 def _import_local_file_copy(**kwargs):
     from pathlib import Path
-    from ...security.access_control import (
-        get_effective_user_concept_id,
-        override_current_organisation,
-        override_current_user,
-    )
+    from ...security.access_control import get_effective_user_concept_id
     from ...services.computer_file_copy_service import import_local_file_copy
 
     local_path = kwargs.get("local_path")
@@ -3142,16 +3482,6 @@ def _import_local_file_copy(**kwargs):
     )
 
     workspace_root = Path(__file__).resolve().parents[4]
-    user_part: str | None = None
-    org_part: str | None = None
-    if "@" in ns:
-        user_raw, org_raw = ns.split("@", 1)
-        user_part = user_raw.strip() or None
-        org_part = org_raw.strip() or None
-        if org_part and not org_part.startswith("#V#"):
-            org_part = f"#V#{org_part}"
-    else:
-        user_part = ns
 
     def _run_import():
         user_concept_id = get_effective_user_concept_id()
@@ -3178,10 +3508,8 @@ def _import_local_file_copy(**kwargs):
             result["allowed_root"] = str(workspace_root)
         return result
 
-    if user_part or org_part:
-        with override_current_user(user_part), override_current_organisation(org_part):
-            return _run_import()
-    return _run_import()
+    with _with_namespace_actor_override(ns):
+        return _run_import()
 
 
 def _get_predicate_extent(**kwargs):
@@ -5026,6 +5354,68 @@ def _index_file_copy_output_schema() -> Schema:
         description=(
             "index_file_copy output: success flag plus indexing counts/document_id for a "
             "blob-backed file-copy ingestion into RAG."
+        ),
+    )
+
+
+def _interpret_file_copy_input_schema() -> Schema:
+    return Schema(
+        required={
+            "concept_id": str,
+        },
+        optional={
+            "namespace": (str, type(None)),
+            "max_bytes": (int, type(None)),
+            "allow_large": (bool, type(None)),
+            "persist": (bool, type(None)),
+            "persist_description": (bool, type(None)),
+            "persist_content": (bool, type(None)),
+            "persist_interpretation_json": (bool, type(None)),
+            "include_semantic_description": (bool, type(None)),
+            "vision_model": (str, type(None)),
+            "semantic_prompt": (str, type(None)),
+            "include_text": (bool, type(None)),
+            "max_persist_content_chars": (int, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "interpret_file_copy input: concept_id for a #V#computer_file_copy instance. "
+            "Optionally pass namespace, max_bytes/allow_large, and persistence controls. "
+            "For image files (including screenshots, faces, and building photos), this tool "
+            "extracts OCR and semantic descriptions and persists canonical hasDescription/"
+            "hasContent plus structured interpretation metadata."
+        ),
+    )
+
+
+def _interpret_file_copy_output_schema() -> Schema:
+    return Schema(
+        required={},
+        optional={
+            "success": (bool, type(None)),
+            "error": (str, type(None)),
+            "message": (str, type(None)),
+            "concept_id": (str, type(None)),
+            "file_kind": (str, type(None)),
+            "description": (str, type(None)),
+            "content_type": (str, type(None)),
+            "original_filename": (str, type(None)),
+            "text_length": (int, type(None)),
+            "text_preview": (str, type(None)),
+            "text": (str, type(None)),
+            "content_truncated_for_persist": (bool, type(None)),
+            "interpretation": (dict, type(None)),
+            "persisted": (bool, type(None)),
+            "persisted_relations": (list, type(None)),
+            "persist_errors": (list, type(None)),
+            "namespace": (str, type(None)),
+            "read_result": (dict, type(None)),
+            "image_fetch_error": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "interpret_file_copy output: interpretation summary and persistence status "
+            "for a blob-backed file-copy concept."
         ),
     )
 
@@ -15430,6 +15820,20 @@ def build_default_catalogue() -> MethodCatalogue:
             description=(
                 "Read a blob-backed #V#computer_file_copy and index its extracted text into RAG "
                 "for the effective namespace. Supports PDFs and other file types handled by read_file_copy."
+            ),
+        ),
+        MethodDefinition(
+            name="interpret_file_copy",
+            handler=_interpret_file_copy,
+            input_schema=_interpret_file_copy_input_schema(),
+            output_schema=_interpret_file_copy_output_schema(),
+            category="write",
+            timeout_sec=45.0,
+            description=(
+                "Interpret an uploaded #V#computer_file_copy and persist rich concept text relations. "
+                "For screenshots and other images (including face/building photos), this runs OCR plus "
+                "semantic image description where available, then writes hasDescription/hasContent and "
+                "structured interpretation metadata."
             ),
         ),
         MethodDefinition(

--- a/src/backend/integrations/internal_mcp/tool_contract_registry.py
+++ b/src/backend/integrations/internal_mcp/tool_contract_registry.py
@@ -289,6 +289,7 @@ def _infer_tool_family(tool_name: str) -> str:
         "list_papers",
         "read_paper",
         "read_file_copy",
+        "interpret_file_copy",
         "import_local_file_copy",
     }:
         return "arxiv"

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -1262,6 +1262,43 @@ def upload_file_to_blob_store_and_vontology():
         file_copy_concept_id=instance_concept_id,
     )
 
+    organisation_concept_id = session.get("organisation_concept_id")
+    if not isinstance(organisation_concept_id, str) or not organisation_concept_id.strip():
+        organisation_concept_id = None
+    else:
+        organisation_concept_id = organisation_concept_id.strip()
+
+    try:
+        from ...services.workflow_event_integration_service import (
+            maybe_launch_file_copy_uploaded_workflow,
+        )
+
+        workflow_event_launch = maybe_launch_file_copy_uploaded_workflow(
+            file_copy_concept_id=instance_concept_id,
+            uploaded_by_concept_id=user_concept_id.strip(),
+            organisation_concept_id=organisation_concept_id,
+            content_type=content_type,
+            original_filename=original_filename,
+            size_bytes=size_bytes,
+            sha256=sha256,
+            blob_uri=str(blob_ref.uri),
+            uploaded_at_iso=uploaded_at,
+            index_in_rag=True,
+        )
+    except Exception as exc:
+        current_app.logger.warning(
+            "[files/upload] Failed to launch file-copy upload workflow event: %s",
+            exc,
+        )
+        workflow_event_launch = {
+            "success": False,
+            "triggered": False,
+            "outcome": "not_triggered",
+            "event_type": "file_copy.uploaded",
+            "reason": "workflow_event_launch_failed",
+            "error": str(exc),
+        }
+
     return (
         jsonify(
             {
@@ -1283,6 +1320,7 @@ def upload_file_to_blob_store_and_vontology():
                     "metadata": blob_ref.metadata,
                 },
                 "chat_history_recorded": bool(chat_history_recorded),
+                "workflow_event_launch": workflow_event_launch,
             }
         ),
         200,

--- a/src/backend/services/file_copy_interpretation_service.py
+++ b/src/backend/services/file_copy_interpretation_service.py
@@ -1,0 +1,498 @@
+"""Helpers for interpreting uploaded file-copy content (JVNAUTOSCI-1302).
+
+This module keeps image/document interpretation logic out of MCP handlers so
+the same behaviour can be reused by workflow-driven ingestion paths.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import os
+import re
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalise_optional_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def is_image_file(*, content_type: str | None, filename: str | None) -> bool:
+    content_type_clean = _normalise_optional_text(content_type)
+    if isinstance(content_type_clean, str) and content_type_clean.lower().startswith(
+        "image/"
+    ):
+        return True
+
+    filename_clean = _normalise_optional_text(filename)
+    if not filename_clean:
+        return False
+    lowered = filename_clean.lower()
+    return lowered.endswith(
+        (
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".gif",
+            ".webp",
+            ".bmp",
+            ".tif",
+            ".tiff",
+            ".heic",
+            ".heif",
+        )
+    )
+
+
+def extract_image_metadata(data_bytes: bytes) -> dict[str, Any]:
+    """Return lightweight technical metadata for an image byte payload."""
+
+    try:
+        from PIL import Image  # type: ignore[import-not-found]
+    except Exception as exc:
+        return {"available": False, "error": f"pillow_unavailable:{exc}"}
+
+    try:
+        with Image.open(io.BytesIO(bytes(data_bytes))) as image:
+            image_for_palette = image.convert("RGB")
+            # Quantise to keep palette extraction fast and deterministic.
+            palette_image = image_for_palette.quantize(colors=8, method=2)
+            palette_data = [int(pixel) for pixel in palette_image.getdata()]
+            palette_counts = Counter(palette_data)
+            palette = palette_image.getpalette() or []
+            dominant_colours: list[list[int]] = []
+            for index, _count in palette_counts.most_common(3):
+                base = int(index) * 3
+                if base + 2 < len(palette):
+                    dominant_colours.append(
+                        [int(palette[base]), int(palette[base + 1]), int(palette[base + 2])]
+                    )
+
+            exif_available = False
+            exif_tag_count = 0
+            try:
+                exif_payload = image.getexif()
+                if exif_payload:
+                    exif_available = True
+                    exif_tag_count = len(exif_payload)
+            except Exception:
+                exif_available = False
+                exif_tag_count = 0
+
+            return {
+                "available": True,
+                "width": int(image.width),
+                "height": int(image.height),
+                "mode": str(image.mode),
+                "format": str(image.format or "").upper() or None,
+                "dominant_colours_rgb": dominant_colours,
+                "exif_available": exif_available,
+                "exif_tag_count": int(exif_tag_count),
+            }
+    except Exception as exc:
+        return {"available": False, "error": f"image_metadata_failed:{exc}"}
+
+
+def extract_image_ocr_text(data_bytes: bytes) -> dict[str, Any]:
+    """Extract OCR text from image bytes using pytesseract when available."""
+
+    try:
+        import pytesseract  # type: ignore[import-not-found]
+        from PIL import Image  # type: ignore[import-not-found]
+    except Exception as exc:
+        return {
+            "text": None,
+            "method": "image_ocr_unavailable",
+            "error": str(exc),
+        }
+
+    try:
+        with Image.open(io.BytesIO(bytes(data_bytes))) as image:
+            text = pytesseract.image_to_string(image).strip()
+        return {
+            "text": text or None,
+            "method": "image_ocr",
+            "error": None,
+        }
+    except Exception as exc:
+        return {
+            "text": None,
+            "method": "image_ocr_failed",
+            "error": str(exc),
+        }
+
+
+def _resolve_active_provider_and_model(
+    *,
+    model_override: str | None,
+) -> tuple[str | None, str | None]:
+    """Resolve active provider/model from settings with optional override."""
+
+    try:
+        from .settings_service import resolve_llm_setting
+        from ..languagemodels.llm_interface import (
+            resolve_openai_model_name,
+            resolve_provider_from_model_concept,
+        )
+
+        active = resolve_llm_setting()
+    except Exception:
+        active = None
+        resolve_openai_model_name = None  # type: ignore[assignment]
+        resolve_provider_from_model_concept = None  # type: ignore[assignment]
+
+    provider: str | None = None
+    model: str | None = None
+    if isinstance(active, dict):
+        provider_raw = active.get("provider")
+        if isinstance(provider_raw, str) and provider_raw.strip():
+            provider = provider_raw.strip().lower()
+        model_raw = active.get("model")
+        if isinstance(model_raw, str) and model_raw.strip():
+            model = model_raw.strip()
+            if model.startswith("#V#") and callable(resolve_provider_from_model_concept):
+                resolved = resolve_provider_from_model_concept(model)
+                if isinstance(resolved, str) and resolved.strip():
+                    provider = resolved.strip().lower()
+            if provider == "openai" and callable(resolve_openai_model_name):
+                resolved_model = resolve_openai_model_name(model)
+                if isinstance(resolved_model, str) and resolved_model.strip():
+                    model = resolved_model.strip()
+
+    if isinstance(model_override, str) and model_override.strip():
+        model = model_override.strip()
+
+    return provider, model
+
+
+def _describe_image_with_openai(
+    *,
+    data_bytes: bytes,
+    content_type: str | None,
+    model: str | None,
+    prompt: str,
+) -> dict[str, Any]:
+    try:
+        from openai import OpenAI
+    except Exception as exc:
+        return {
+            "description": None,
+            "method": "openai_vision_unavailable",
+            "error": str(exc),
+            "provider": "openai",
+            "model": model,
+        }
+
+    api_key: str | None = None
+    try:
+        from .settings_service import get_openai_env_var
+
+        env_var = get_openai_env_var()
+        if isinstance(env_var, str) and env_var.strip():
+            api_key = os.getenv(env_var.strip())
+    except Exception:
+        api_key = None
+
+    if not api_key:
+        api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return {
+            "description": None,
+            "method": "openai_vision_unavailable",
+            "error": "missing_openai_api_key",
+            "provider": "openai",
+            "model": model,
+        }
+
+    target_model = model or "gpt-4.1-mini"
+    mime = _normalise_optional_text(content_type) or "image/png"
+    image_b64 = base64.b64encode(bytes(data_bytes)).decode("ascii")
+    data_url = f"data:{mime};base64,{image_b64}"
+
+    try:
+        client = OpenAI(api_key=api_key)
+        response = client.chat.completions.create(
+            model=target_model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": prompt},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": data_url},
+                        },
+                    ],
+                }
+            ],
+            max_tokens=500,
+            temperature=0.2,
+        )
+        content = response.choices[0].message.content
+        description = content.strip() if isinstance(content, str) else None
+        if not description:
+            return {
+                "description": None,
+                "method": "openai_vision_failed",
+                "error": "empty_response",
+                "provider": "openai",
+                "model": target_model,
+            }
+        return {
+            "description": description,
+            "method": "openai_vision",
+            "error": None,
+            "provider": "openai",
+            "model": target_model,
+        }
+    except Exception as exc:
+        return {
+            "description": None,
+            "method": "openai_vision_failed",
+            "error": str(exc),
+            "provider": "openai",
+            "model": target_model,
+        }
+
+
+def _describe_image_with_gemini(
+    *,
+    data_bytes: bytes,
+    content_type: str | None,
+    model: str | None,
+    prompt: str,
+) -> dict[str, Any]:
+    try:
+        from google import genai  # type: ignore
+    except Exception as exc:
+        return {
+            "description": None,
+            "method": "gemini_vision_unavailable",
+            "error": str(exc),
+            "provider": "gemini",
+            "model": model,
+        }
+
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        return {
+            "description": None,
+            "method": "gemini_vision_unavailable",
+            "error": "missing_gemini_api_key",
+            "provider": "gemini",
+            "model": model,
+        }
+
+    target_model = model or "gemini-2.0-flash"
+    mime = _normalise_optional_text(content_type) or "image/png"
+    try:
+        genai.configure(api_key=api_key)  # type: ignore[attr-defined]
+        model_instance = genai.GenerativeModel(target_model)  # type: ignore[attr-defined]
+        response = model_instance.generate_content(
+            [prompt, {"mime_type": mime, "data": bytes(data_bytes)}]
+        )
+        response_text = getattr(response, "text", None)
+        description = response_text.strip() if isinstance(response_text, str) else None
+        if not description:
+            return {
+                "description": None,
+                "method": "gemini_vision_failed",
+                "error": "empty_response",
+                "provider": "gemini",
+                "model": target_model,
+            }
+        return {
+            "description": description,
+            "method": "gemini_vision",
+            "error": None,
+            "provider": "gemini",
+            "model": target_model,
+        }
+    except Exception as exc:
+        return {
+            "description": None,
+            "method": "gemini_vision_failed",
+            "error": str(exc),
+            "provider": "gemini",
+            "model": target_model,
+        }
+
+
+def describe_image_semantics(
+    *,
+    data_bytes: bytes,
+    content_type: str | None,
+    model_override: str | None = None,
+    prompt_override: str | None = None,
+) -> dict[str, Any]:
+    """Describe image semantics using the active multimodal-capable provider."""
+
+    provider, model = _resolve_active_provider_and_model(model_override=model_override)
+    prompt = (
+        _normalise_optional_text(prompt_override)
+        or (
+            "Describe this image in 2-5 concise sentences using New Zealand English. "
+            "Include salient entities, likely setting, visible text, and whether people "
+            "or buildings are present. Do not identify real people."
+        )
+    )
+
+    if provider == "openai":
+        return _describe_image_with_openai(
+            data_bytes=data_bytes,
+            content_type=content_type,
+            model=model,
+            prompt=prompt,
+        )
+    if provider == "gemini":
+        return _describe_image_with_gemini(
+            data_bytes=data_bytes,
+            content_type=content_type,
+            model=model,
+            prompt=prompt,
+        )
+
+    return {
+        "description": None,
+        "method": "semantic_vision_not_configured",
+        "error": (
+            f"active_provider_not_supported:{provider}"
+            if provider
+            else "active_provider_not_configured"
+        ),
+        "provider": provider,
+        "model": model,
+    }
+
+
+def _infer_subject_tags(*, semantic_description: str | None, ocr_text: str | None) -> list[str]:
+    haystack_parts = []
+    if isinstance(semantic_description, str) and semantic_description.strip():
+        haystack_parts.append(semantic_description.strip().lower())
+    if isinstance(ocr_text, str) and ocr_text.strip():
+        haystack_parts.append(ocr_text.strip().lower())
+    haystack = "\n".join(haystack_parts)
+    if not haystack:
+        return []
+
+    tags: list[str] = []
+    if re.search(r"\b(face|person|portrait|selfie|people)\b", haystack):
+        tags.append("face_or_person")
+    if re.search(
+        r"\b(building|architecture|office|tower|house|campus|street|facade|fa[cç]ade)\b",
+        haystack,
+    ):
+        tags.append("building_or_structure")
+    if re.search(r"\b(screenshot|ui|interface|menu|window|table|form)\b", haystack):
+        tags.append("screenshot_or_interface")
+    if len(re.findall(r"[A-Za-z0-9]", haystack)) > 80:
+        tags.append("text_heavy")
+    return tags
+
+
+def build_image_interpretation(
+    *,
+    data_bytes: bytes,
+    content_type: str | None,
+    original_filename: str | None,
+    include_semantic_description: bool,
+    model_override: str | None = None,
+    prompt_override: str | None = None,
+) -> dict[str, Any]:
+    metadata = extract_image_metadata(data_bytes)
+    ocr = extract_image_ocr_text(data_bytes)
+    semantic = (
+        describe_image_semantics(
+            data_bytes=data_bytes,
+            content_type=content_type,
+            model_override=model_override,
+            prompt_override=prompt_override,
+        )
+        if include_semantic_description
+        else {
+            "description": None,
+            "method": "semantic_disabled",
+            "error": None,
+            "provider": None,
+            "model": model_override,
+        }
+    )
+
+    ocr_text = _normalise_optional_text(ocr.get("text"))
+    semantic_description = _normalise_optional_text(semantic.get("description"))
+
+    width = metadata.get("width")
+    height = metadata.get("height")
+    format_name = metadata.get("format")
+    metadata_bits = []
+    if isinstance(width, int) and isinstance(height, int):
+        metadata_bits.append(f"{width}x{height}")
+    if isinstance(format_name, str) and format_name.strip():
+        metadata_bits.append(format_name.strip())
+    metadata_suffix = f" ({', '.join(metadata_bits)})" if metadata_bits else ""
+
+    if semantic_description:
+        description = semantic_description
+    elif ocr_text:
+        preview = ocr_text[:220] + ("..." if len(ocr_text) > 220 else "")
+        description = f"Image with readable text{metadata_suffix}: {preview}"
+    else:
+        filename_clean = _normalise_optional_text(original_filename) or "uploaded image"
+        description = f"{filename_clean.capitalize()}{metadata_suffix}"
+
+    subject_tags = _infer_subject_tags(
+        semantic_description=semantic_description,
+        ocr_text=ocr_text,
+    )
+
+    return {
+        "kind": "image",
+        "interpreted_at": _utc_now_iso(),
+        "description": description,
+        "subject_tags": subject_tags,
+        "content_text": ocr_text,
+        "content_length": len(ocr_text) if isinstance(ocr_text, str) else 0,
+        "image_metadata": metadata,
+        "ocr": ocr,
+        "semantic": semantic,
+    }
+
+
+def build_document_interpretation(
+    *,
+    extracted_text: str | None,
+    content_type: str | None,
+    original_filename: str | None,
+) -> dict[str, Any]:
+    text = _normalise_optional_text(extracted_text)
+    if text:
+        preview = text[:260] + ("..." if len(text) > 260 else "")
+        description = f"Document text extracted: {preview}"
+    else:
+        filename_clean = _normalise_optional_text(original_filename) or "uploaded file"
+        content_type_clean = _normalise_optional_text(content_type)
+        if content_type_clean:
+            description = f"{filename_clean} ({content_type_clean}) uploaded"
+        else:
+            description = f"{filename_clean} uploaded"
+
+    return {
+        "kind": "document",
+        "interpreted_at": _utc_now_iso(),
+        "description": description,
+        "subject_tags": ["document"],
+        "content_text": text,
+        "content_length": len(text) if isinstance(text, str) else 0,
+    }

--- a/src/backend/services/workflow_event_integration_service.py
+++ b/src/backend/services/workflow_event_integration_service.py
@@ -37,6 +37,7 @@ EVENT_TYPE_TEXT_RELATION_UPSERTED = "text_relation.upserted"
 EVENT_TYPE_TEXT_RELATION_UPDATED = "text_relation.updated"
 EVENT_TYPE_TEXT_RELATION_DELETED = "text_relation.deleted"
 EVENT_TYPE_VONTOLOGY_MUTATED = "vontology.mutated"
+EVENT_TYPE_FILE_COPY_UPLOADED = "file_copy.uploaded"
 
 # Backward-compatible environment wiring (legacy/system bootstrap).
 EVENT_WORKFLOW_ID_ENV_MAP: dict[str, str] = {
@@ -45,6 +46,7 @@ EVENT_WORKFLOW_ID_ENV_MAP: dict[str, str] = {
     EVENT_TYPE_EFFORT_UNIT_COMPLETED: "VON_EVENT_EFFORT_UNIT_COMPLETED_WORKFLOW_ID",
     EVENT_TYPE_DIRECT_MESSAGE_CREATED: "VON_EVENT_DIRECT_MESSAGE_WORKFLOW_ID",
     EVENT_TYPE_TYPE_CREATED: "VON_EVENT_TYPE_CREATED_WORKFLOW_ID",
+    EVENT_TYPE_FILE_COPY_UPLOADED: "VON_EVENT_FILE_COPY_UPLOADED_WORKFLOW_ID",
 }
 
 _DEFAULT_EVENT_BINDINGS: tuple[dict[str, Any], ...] = (
@@ -52,6 +54,21 @@ _DEFAULT_EVENT_BINDINGS: tuple[dict[str, Any], ...] = (
         "event_type": EVENT_TYPE_TYPE_CREATED,
         "workflow_id": "#V#salient_predicate_governance_workflow",
         "input_mapping": {"type_concept_id": "event.concept_id"},
+        "enabled": True,
+    },
+    {
+        "event_type": EVENT_TYPE_FILE_COPY_UPLOADED,
+        "workflow_id": "#V#file_copy_interpretation_workflow",
+        "input_mapping": {
+            "concept_id": "event.file_copy_concept_id",
+            "file_copy_concept_id": "event.file_copy_concept_id",
+            "content_type": "event.content_type",
+            "original_filename": "event.original_filename",
+            "size_bytes": "event.size_bytes",
+            "sha256": "event.sha256",
+            "blob_uri": "event.blob_uri",
+            "index_in_rag": "event.index_in_rag",
+        },
         "enabled": True,
     },
 )
@@ -1303,3 +1320,65 @@ def maybe_launch_vontology_mutation_workflow(
         "specific_triggered": bool(specific_result.get("triggered")),
         "catch_all_triggered": bool(catch_all_result.get("triggered")),
     }
+
+
+def maybe_launch_file_copy_uploaded_workflow(
+    *,
+    file_copy_concept_id: str,
+    uploaded_by_concept_id: str | None,
+    organisation_concept_id: str | None,
+    namespace: str | None = None,
+    content_type: str | None = None,
+    original_filename: str | None = None,
+    size_bytes: int | None = None,
+    sha256: str | None = None,
+    blob_uri: str | None = None,
+    uploaded_at_iso: str | None = None,
+    index_in_rag: bool = True,
+) -> dict[str, Any]:
+    """Launch interpretation workflow(s) for a newly uploaded file copy."""
+
+    concept_id = str(file_copy_concept_id or "").strip()
+    if not concept_id:
+        return {
+            "success": False,
+            "triggered": False,
+            "outcome": "not_triggered",
+            "event_type": EVENT_TYPE_FILE_COPY_UPLOADED,
+            "reason": "missing_file_copy_concept_id",
+            "hint": "Provide file_copy_concept_id for upload-event workflow launch.",
+        }
+
+    ensure_report = ensure_default_event_bindings()
+    launch_result = launch_event_workflow(
+        event_type=EVENT_TYPE_FILE_COPY_UPLOADED,
+        event_id=concept_id,
+        user_id=uploaded_by_concept_id,
+        org_id=organisation_concept_id,
+        namespace=namespace,
+        event_payload={
+            "concept_id": concept_id,
+            "file_copy_concept_id": concept_id,
+            "content_type": content_type,
+            "original_filename": original_filename,
+            "size_bytes": size_bytes,
+            "sha256": sha256,
+            "blob_uri": blob_uri,
+            "uploaded_at": uploaded_at_iso,
+            "index_in_rag": bool(index_in_rag),
+        },
+        inputs={
+            "concept_id": concept_id,
+            "file_copy_concept_id": concept_id,
+            "content_type": content_type,
+            "original_filename": original_filename,
+            "size_bytes": size_bytes,
+            "sha256": sha256,
+            "blob_uri": blob_uri,
+            "uploaded_at": uploaded_at_iso,
+            "index_in_rag": bool(index_in_rag),
+        },
+    )
+    if isinstance(launch_result, dict):
+        launch_result["default_binding_bootstrap"] = ensure_report
+    return launch_result

--- a/src/backend/workflows/durable/file_copy_interpretation_workflow.py
+++ b/src/backend/workflows/durable/file_copy_interpretation_workflow.py
@@ -1,0 +1,99 @@
+"""Durable workflow for uploaded file-copy interpretation (JVNAUTOSCI-1302).
+
+This workflow is intentionally MCP-tool driven so behaviour can evolve through
+Vontology-bound tool orchestration without adding specialised Python handlers.
+"""
+
+from __future__ import annotations
+
+from ..action_registry import ActionRegistry
+from ..engine import (
+    WorkflowActionInvocation,
+    WorkflowDefinition,
+    WorkflowStateSpec,
+    WorkflowTransitionSpec,
+)
+from ..workflow_registry import WorkflowRegistration
+
+FILE_COPY_INTERPRETATION_WORKFLOW_ID = "#V#file_copy_interpretation_workflow"
+
+
+def build_file_copy_interpretation_workflow() -> WorkflowDefinition:
+    interpret = WorkflowStateSpec(
+        state_id="interpret",
+        actions=(
+            WorkflowActionInvocation(
+                action_id="interpret_file_copy",
+                description=(
+                    "Extract structured interpretation from a blob-backed "
+                    "#V#computer_file_copy and persist canonical text relations."
+                ),
+            ),
+        ),
+        transitions=(
+            WorkflowTransitionSpec(
+                to_state="index",
+                condition=lambda ctx: bool(ctx.get("index_in_rag", True)),
+                reason="index_enabled",
+            ),
+            WorkflowTransitionSpec(
+                to_state="complete",
+                condition=lambda _ctx: True,
+                reason="index_skipped",
+            ),
+        ),
+    )
+
+    index = WorkflowStateSpec(
+        state_id="index",
+        actions=(
+            WorkflowActionInvocation(
+                action_id="index_file_copy",
+                description="Index extracted file-copy text into RAG for the namespace.",
+            ),
+        ),
+        transitions=(
+            WorkflowTransitionSpec(
+                to_state="complete",
+                condition=lambda _ctx: True,
+                reason="index_finished",
+            ),
+        ),
+    )
+
+    complete = WorkflowStateSpec(state_id="complete", terminal=True)
+    failed = WorkflowStateSpec(state_id="failed", terminal=True)
+
+    return WorkflowDefinition(
+        workflow_id=FILE_COPY_INTERPRETATION_WORKFLOW_ID,
+        initial_state="interpret",
+        states={
+            "interpret": interpret,
+            "index": index,
+            "complete": complete,
+            "failed": failed,
+        },
+        termination_states=("complete", "failed"),
+        purpose=(
+            "Interpret newly uploaded file-copy content (including screenshots/"
+            "images) and persist rich concept descriptions, then index in RAG."
+        ),
+    )
+
+
+def get_file_copy_interpretation_workflow_registration() -> WorkflowRegistration:
+    return WorkflowRegistration(
+        workflow_id=FILE_COPY_INTERPRETATION_WORKFLOW_ID,
+        definition=build_file_copy_interpretation_workflow(),
+        purpose=(
+            "Interpret uploaded file copies with image/document extraction and "
+            "persisted concept enrichment."
+        ),
+        source="built_in",
+    )
+
+
+def register_file_copy_interpretation_actions(_registry: ActionRegistry) -> None:
+    """No-op: this workflow intentionally relies on MCP fallback actions."""
+
+    return None

--- a/src/backend/workflows/durable/registry_factory.py
+++ b/src/backend/workflows/durable/registry_factory.py
@@ -39,6 +39,10 @@ from .workflow_introspection_maintenance_workflow import (
     get_workflow_introspection_maintenance_registration,
     register_workflow_introspection_maintenance_actions,
 )
+from .file_copy_interpretation_workflow import (
+    get_file_copy_interpretation_workflow_registration,
+    register_file_copy_interpretation_actions,
+)
 from ..vontology_loader import (
     build_workflow_process_graph,
     discover_workflow_ids,
@@ -402,6 +406,7 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
     registry.register(get_rumination_workflow_registration())
     registry.register(get_planning_workflow_registration())
     registry.register(get_workflow_introspection_maintenance_registration())
+    registry.register(get_file_copy_interpretation_workflow_registration())
 
     # 3. Vontology-discovered workflows
     discovered_workflow_ids: List[str] = []
@@ -534,6 +539,7 @@ def build_durable_action_registry() -> ActionRegistry:
     register_rumination_actions(registry)
     register_planning_actions(registry)
     register_workflow_introspection_maintenance_actions(registry)
+    register_file_copy_interpretation_actions(registry)
     # Keep durable action routing aligned with orchestrator routing: if an
     # action ID is not explicitly registered, treat it as an MCP tool name.
     registry.set_fallback_handler(_durable_mcp_fallback_action)

--- a/src/backend/workflows/workflow_concept_authority_service.py
+++ b/src/backend/workflows/workflow_concept_authority_service.py
@@ -36,6 +36,9 @@ from .workflow_definition_identity_service import (
     validate_workflow_definition_contract,
 )
 from .workflow_registry import WorkflowRegistry
+from .durable.file_copy_interpretation_workflow import (
+    FILE_COPY_INTERPRETATION_WORKFLOW_ID,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +62,11 @@ CANONICAL_CHAT_WORKFLOW_IDS: tuple[str, ...] = (
     CONCEPT_SUGGESTION_PREFLIGHT_WORKFLOW_ID,
     TOOL_CALLING_WORKFLOW_ID,
     CONVERSATION_TURN_EXECUTION_WORKFLOW_ID,
+)
+
+# Additional built-in workflows that should be published when registered.
+CANONICAL_DURABLE_WORKFLOW_IDS: tuple[str, ...] = (
+    FILE_COPY_INTERPRETATION_WORKFLOW_ID,
 )
 
 _CANONICAL_GRAPH_PREDICATES: Dict[str, str] = {
@@ -246,7 +254,9 @@ _CANONICAL_WORKFLOW_PUBLICATION_SPECS: Dict[str, _CanonicalWorkflowPublicationSp
             _CanonicalStepPublicationSpec(
                 state_id="completion_gate",
                 action_id="turn_execution.completion_gate",
-                on_true_state="completed",
+                # Built-in workflow allows completion-gate retries by
+                # transitioning back to plan when repeat_iteration is set.
+                on_true_state="plan",
                 on_false_state="completed",
             ),
             _CanonicalStepPublicationSpec(state_id="completed"),
@@ -267,6 +277,24 @@ _CANONICAL_WORKFLOW_PUBLICATION_SPECS: Dict[str, _CanonicalWorkflowPublicationSp
                 next_state="completed",
             ),
             _CanonicalStepPublicationSpec(state_id="completed"),
+        ),
+    ),
+    FILE_COPY_INTERPRETATION_WORKFLOW_ID: _CanonicalWorkflowPublicationSpec(
+        initial_state="interpret",
+        steps=(
+            _CanonicalStepPublicationSpec(
+                state_id="interpret",
+                action_id="interpret_file_copy",
+                on_true_state="index",
+                on_false_state="complete",
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="index",
+                action_id="index_file_copy",
+                next_state="complete",
+            ),
+            _CanonicalStepPublicationSpec(state_id="complete"),
+            _CanonicalStepPublicationSpec(state_id="failed"),
         ),
     ),
 }
@@ -364,7 +392,12 @@ def publish_canonical_chat_workflow_graphs(
     workflow_type_ids = list(resolve_available_workflow_type_ids())
     preferred_workflow_type = workflow_type_ids[0] if workflow_type_ids else None
 
-    for workflow_id in CANONICAL_CHAT_WORKFLOW_IDS:
+    target_workflow_ids = list(CANONICAL_CHAT_WORKFLOW_IDS)
+    for workflow_id in CANONICAL_DURABLE_WORKFLOW_IDS:
+        if registry.get_registration(workflow_id) is not None:
+            target_workflow_ids.append(workflow_id)
+
+    for workflow_id in target_workflow_ids:
         spec = _CANONICAL_WORKFLOW_PUBLICATION_SPECS.get(workflow_id)
         registration = registry.get_registration(workflow_id)
         if spec is None or registration is None:
@@ -569,7 +602,7 @@ def publish_canonical_chat_workflow_graphs(
 
     return {
         "counts": {
-            "workflows_targeted": len(CANONICAL_CHAT_WORKFLOW_IDS),
+            "workflows_targeted": len(target_workflow_ids),
             "workflows_published": len(published),
             "workflows_skipped_missing_registration": len(skipped_missing_registration),
             "workflows_skipped_missing_concept": len(skipped_missing_concept),

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -5771,6 +5771,107 @@ function isFileDragEvent(event) {
     }
 }
 
+const CLIPBOARD_IMAGE_EXTENSION_BY_MIME = Object.freeze({
+    'image/png': 'png',
+    'image/jpeg': 'jpg',
+    'image/jpg': 'jpg',
+    'image/webp': 'webp',
+    'image/gif': 'gif',
+    'image/bmp': 'bmp',
+    'image/tiff': 'tiff',
+    'image/heic': 'heic',
+    'image/heif': 'heif'
+});
+
+function getClipboardImageExtension(contentType) {
+    const mime = String(contentType || '').trim().toLowerCase();
+    return CLIPBOARD_IMAGE_EXTENSION_BY_MIME[mime] || 'png';
+}
+
+function normaliseClipboardImageFile(file, index = 0, timestampMs = Date.now()) {
+    if (!(file instanceof Blob)) {
+        return null;
+    }
+
+    const contentType = String(file.type || '').trim().toLowerCase();
+    if (!contentType.startsWith('image/')) {
+        return null;
+    }
+
+    const existingName = typeof file?.name === 'string' ? file.name.trim() : '';
+    if (file instanceof File && existingName) {
+        return file;
+    }
+
+    const extension = getClipboardImageExtension(contentType);
+    const generatedName = `pasted-image-${timestampMs}-${index + 1}.${extension}`;
+
+    try {
+        if (typeof File === 'function') {
+            return new File([file], generatedName, {
+                type: contentType || 'image/png',
+                lastModified:
+                    Number.isFinite(file?.lastModified) && Number(file.lastModified) > 0
+                        ? Number(file.lastModified)
+                        : timestampMs
+            });
+        }
+    } catch (_) {
+        // Ignore and fall back to a best-effort Blob object.
+    }
+
+    return file;
+}
+
+function extractImageFilesFromClipboardEvent(event) {
+    const clipboardData = event?.clipboardData;
+    if (!clipboardData) return [];
+
+    const timestampMs = Date.now();
+    const collectedFiles = [];
+    const seenCandidates = new Set();
+    const appendCandidate = (candidate) => {
+        if (!candidate || seenCandidates.has(candidate)) return;
+        seenCandidates.add(candidate);
+        const normalised = normaliseClipboardImageFile(
+            candidate,
+            collectedFiles.length,
+            timestampMs
+        );
+        if (normalised) {
+            collectedFiles.push(normalised);
+        }
+    };
+
+    try {
+        const items = Array.from(clipboardData.items || []);
+        for (const item of items) {
+            const kind = String(item?.kind || '').trim().toLowerCase();
+            const itemType = String(item?.type || '').trim().toLowerCase();
+            if (kind !== 'file' || !itemType.startsWith('image/')) continue;
+            if (typeof item.getAsFile !== 'function') continue;
+            appendCandidate(item.getAsFile());
+        }
+    } catch (_) {
+        // Ignore and continue with clipboardData.files fallback.
+    }
+
+    if (collectedFiles.length > 0) {
+        return collectedFiles;
+    }
+
+    try {
+        const files = Array.from(clipboardData.files || []);
+        for (const file of files) {
+            appendCandidate(file);
+        }
+    } catch (_) {
+        return collectedFiles;
+    }
+
+    return collectedFiles;
+}
+
 async function uploadSingleFileToVon(file) {
     if (!file) {
         throw new Error('No file provided');
@@ -14283,6 +14384,21 @@ export function initializeChatTab() {
         document.addEventListener('dragover', preventIfFiles);
         document.addEventListener('drop', preventIfFiles);
 
+        const handleClipboardImagePaste = (event) => {
+            const pastedImageFiles = extractImageFilesFromClipboardEvent(event);
+            if (!pastedImageFiles.length) return;
+
+            event.preventDefault();
+            event.stopPropagation();
+
+            // Route clipboard images through the same upload path used for
+            // drag/drop and file-picker uploads so workflow handling is
+            // consistent across all attachment entry points.
+            void uploadFilesToVon(pastedImageFiles);
+        };
+
+        chatTab.addEventListener('paste', handleClipboardImagePaste);
+
         // Local UI + drop handling
         const applyDragOverState = () => {
             scrollableField.classList.add('drag-over');
@@ -16873,6 +16989,9 @@ export function __testOnly_buildDiagnosticsExportRequestPayload() {
 }
 export function __testOnly_buildSanitisedLlmDebugExportPayload(debugData) {
     return buildSanitisedLlmDebugExportPayload(debugData);
+}
+export function __testOnly_extractImageFilesFromClipboardEvent(event) {
+    return extractImageFilesFromClipboardEvent(event);
 }
 export { formatChatTimestamp, showLlmDebugPopup, switchToChatSession, updateHistoryLength };
 

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -8,6 +8,7 @@ import {
     __testOnly_buildWorkflowStatusQuery,
     __testOnly_buildWorkflowStatusStreamQuery,
     __testOnly_buildLlmDebugMetadata,
+    __testOnly_extractImageFilesFromClipboardEvent,
     __testOnly_convertInlineQuotedStrongSegmentsToButtons,
     __testOnly_convertQuotedInstructionBlockquotesToButtons,
     __testOnly_convertQuotedInstructionListItemsToButtons,
@@ -124,6 +125,71 @@ describe('formatChatTimestamp', () => {
         expect(result).not.toContain('Yesterday');
         const month = tenDaysAgo.toLocaleString([], { month: 'short' });
         expect(result).toContain(month);
+    });
+});
+
+describe('clipboard image extraction for uploads', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('normalises unnamed clipboard image files into uploadable files', () => {
+        jest.spyOn(Date, 'now').mockReturnValue(1735689600000);
+        const rawClipboardFile = new File(['pixels'], '', { type: 'image/png' });
+        const event = {
+            clipboardData: {
+                items: [
+                    {
+                        kind: 'file',
+                        type: 'image/png',
+                        getAsFile: () => rawClipboardFile
+                    }
+                ]
+            }
+        };
+
+        const files = __testOnly_extractImageFilesFromClipboardEvent(event);
+        expect(files).toHaveLength(1);
+        expect(files[0].type).toBe('image/png');
+        expect(files[0].name).toBe('pasted-image-1735689600000-1.png');
+    });
+
+    test('ignores non-image clipboard entries', () => {
+        const event = {
+            clipboardData: {
+                items: [
+                    {
+                        kind: 'string',
+                        type: 'text/plain',
+                        getAsFile: () => null
+                    },
+                    {
+                        kind: 'file',
+                        type: 'application/pdf',
+                        getAsFile: () => new File(['pdf'], 'doc.pdf', { type: 'application/pdf' })
+                    }
+                ]
+            }
+        };
+
+        const files = __testOnly_extractImageFilesFromClipboardEvent(event);
+        expect(files).toEqual([]);
+    });
+
+    test('falls back to clipboardData.files when clipboardData.items is unavailable', () => {
+        const event = {
+            clipboardData: {
+                files: [
+                    new File(['img'], 'clipboard-face.jpg', { type: 'image/jpeg' }),
+                    new File(['txt'], 'notes.txt', { type: 'text/plain' })
+                ]
+            }
+        };
+
+        const files = __testOnly_extractImageFilesFromClipboardEvent(event);
+        expect(files).toHaveLength(1);
+        expect(files[0].name).toBe('clipboard-face.jpg');
+        expect(files[0].type).toBe('image/jpeg');
     });
 });
 

--- a/src/frontend/web/von_interface/templates/chat_tab.html
+++ b/src/frontend/web/von_interface/templates/chat_tab.html
@@ -114,7 +114,7 @@
         conversation</button>
 
       <button id="uploadFileButton" class="btn btn-secondary" type="button"
-        title="Upload a file (or drag and drop onto the conversation)">Upload File</button>
+        title="Upload a file, drag and drop onto the conversation, or paste an image">Upload File</button>
       <span id="uploadFileStatus" class="upload-file-status" aria-live="polite"></span>
       <input id="uploadFileInput" class="visually-hidden" type="file" aria-label="Upload file" />
 

--- a/tests/backend/test_file_copy_ingestion_mcp_tools.py
+++ b/tests/backend/test_file_copy_ingestion_mcp_tools.py
@@ -84,3 +84,106 @@ def test_import_local_file_copy_uses_authenticated_context(monkeypatch):
     assert result["success"] is True
     assert result["concept_id"] == "#V#imported_file"
     assert result["namespace"] == "#V#user@org"
+
+
+def test_interpret_file_copy_persists_image_interpretation(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue._read_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "text": "OCR text from screenshot",
+            "content_type": "image/png",
+            "original_filename": "screenshot.png",
+            "size_bytes": 1280,
+            "byte_length": 1280,
+            "blob": {"backend": "local", "key": "uploads/user/hash/screenshot.png"},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.fetch_file_copy_bytes",
+        lambda **_kwargs: {"success": True, "data": b"\x89PNG..."},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.file_copy_interpretation_service.build_image_interpretation",
+        lambda **_kwargs: {
+            "kind": "image",
+            "description": "University enrolment screenshot with tabular student details.",
+            "subject_tags": ["screenshot_or_interface", "text_heavy"],
+            "content_text": "OCR text from screenshot",
+            "content_length": 24,
+        },
+    )
+
+    writes: list[dict[str, object]] = []
+
+    def _fake_upsert_singleton_text_relation(**kwargs):
+        writes.append(dict(kwargs))
+        return {"relation_id": f"rel-{len(writes)}"}
+
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.upsert_singleton_text_relation",
+        _fake_upsert_singleton_text_relation,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_text_relation_change_hook_service.maybe_sync_concept_text_relations_to_rag",
+        lambda **_kwargs: None,
+    )
+
+    result = cat._interpret_file_copy(
+        concept_id="#V#file_copy_image_test",
+        namespace="#V#user@org",
+    )
+
+    assert result["success"] is True
+    assert result["file_kind"] == "image"
+    assert result["description"].startswith("University enrolment screenshot")
+    assert result["persisted"] is True
+    assert len(result["persisted_relations"]) == 3
+    written_predicates = [row["predicate"] for row in writes]
+    assert "hasDescription" in written_predicates
+    assert "hasContent" in written_predicates
+    assert "#V#has_file_copy_interpretation_json" in written_predicates
+
+
+def test_interpret_file_copy_supports_non_persist_mode(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue._read_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "text": "Document body text",
+            "content_type": "text/plain",
+            "original_filename": "notes.txt",
+            "size_bytes": 64,
+            "byte_length": 64,
+            "blob": {"backend": "local", "key": "uploads/user/hash/notes.txt"},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.file_copy_interpretation_service.build_document_interpretation",
+        lambda **_kwargs: {
+            "kind": "document",
+            "description": "Document text extracted: Document body text",
+            "subject_tags": ["document"],
+            "content_text": "Document body text",
+            "content_length": 18,
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.upsert_singleton_text_relation",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("should_not_write")),
+    )
+
+    result = cat._interpret_file_copy(
+        concept_id="#V#file_copy_doc_test",
+        namespace="#V#user@org",
+        persist=False,
+    )
+
+    assert result["success"] is True
+    assert result["file_kind"] == "document"
+    assert result["persisted"] is False
+    assert result["persisted_relations"] == []

--- a/tests/backend/test_file_copy_interpretation_workflow.py
+++ b/tests/backend/test_file_copy_interpretation_workflow.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from src.backend.workflows.action_registry import ActionRegistry
+from src.backend.workflows.durable.file_copy_interpretation_workflow import (
+    FILE_COPY_INTERPRETATION_WORKFLOW_ID,
+    build_file_copy_interpretation_workflow,
+    get_file_copy_interpretation_workflow_registration,
+    register_file_copy_interpretation_actions,
+)
+
+
+def test_build_file_copy_interpretation_workflow_definition_shape() -> None:
+    workflow = build_file_copy_interpretation_workflow()
+
+    assert workflow.workflow_id == FILE_COPY_INTERPRETATION_WORKFLOW_ID
+    assert workflow.initial_state == "interpret"
+    assert set(workflow.states.keys()) == {"interpret", "index", "complete", "failed"}
+    assert workflow.termination_states == ("complete", "failed")
+
+    interpret_actions = [action.action_id for action in workflow.states["interpret"].actions]
+    assert interpret_actions == ["interpret_file_copy"]
+    index_actions = [action.action_id for action in workflow.states["index"].actions]
+    assert index_actions == ["index_file_copy"]
+
+
+def test_get_file_copy_interpretation_workflow_registration() -> None:
+    registration = get_file_copy_interpretation_workflow_registration()
+
+    assert registration.workflow_id == FILE_COPY_INTERPRETATION_WORKFLOW_ID
+    assert registration.source == "built_in"
+    assert registration.definition.workflow_id == FILE_COPY_INTERPRETATION_WORKFLOW_ID
+
+
+def test_register_file_copy_interpretation_actions_is_noop() -> None:
+    registry = ActionRegistry()
+    register_file_copy_interpretation_actions(registry)
+    assert registry.all_action_ids() == []

--- a/tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py
+++ b/tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py
@@ -47,6 +47,28 @@ def test_file_copy_ingestion_tools_gateway_invoke(monkeypatch):
         "src.backend.services.computer_file_copy_service.build_file_copy_artifact_record",
         lambda **_kwargs: {"artifact_id": "#V#imported_file_gateway"},
     )
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.fetch_file_copy_bytes",
+        lambda **_kwargs: {"success": True, "data": b"\x89PNG..."},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.file_copy_interpretation_service.build_image_interpretation",
+        lambda **_kwargs: {
+            "kind": "image",
+            "description": "Campus building exterior photo with visible signage.",
+            "subject_tags": ["building_or_structure"],
+            "content_text": "",
+            "content_length": 0,
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.upsert_singleton_text_relation",
+        lambda **_kwargs: {"relation_id": "rel-test"},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_text_relation_change_hook_service.maybe_sync_concept_text_relations_to_rag",
+        lambda **_kwargs: None,
+    )
 
     class _StubRAG:
         def upsert_documents(
@@ -72,3 +94,10 @@ def test_file_copy_ingestion_tools_gateway_invoke(monkeypatch):
     ).payload
     assert indexed.get("success") is True
     assert indexed.get("indexed_count") == 1
+
+    interpreted = gateway.invoke(
+        "interpret_file_copy",
+        {"concept_id": "#V#imported_file_gateway", "namespace": "#V#user@org"},
+    ).payload
+    assert interpreted.get("success") is True
+    assert interpreted.get("file_kind") == "document"

--- a/tests/backend/test_internal_mcp_workflow_tools.py
+++ b/tests/backend/test_internal_mcp_workflow_tools.py
@@ -458,7 +458,9 @@ def test_workflow_list_definitions_exists_and_returns_data():
     assert "workflow_list_definitions" in methods
 
     handler = catalogue.get("workflow_list_definitions").handler
-    result = handler(limit=10)
+    # Keep the sample wide enough that newly-registered durable workflows do
+    # not get paged out and cause false negatives.
+    result = handler(limit=200)
 
     assert result.get("success") is True
     assert "definitions" in result
@@ -475,6 +477,7 @@ def test_workflow_list_definitions_exists_and_returns_data():
     assert "#V#rag_text_relation_sync_workflow" in def_ids
     assert "#V#enrichment_workflow" in def_ids
     assert "#V#planning_workflow" in def_ids
+    assert "#V#file_copy_interpretation_workflow" in def_ids
     assert any("description_source" in d for d in result["definitions"])
     assert any("definition_identity" in d for d in result["definitions"])
     assert any("background_launch_policy_source" in d for d in result["definitions"])

--- a/tests/backend/test_von_file_upload_endpoint.py
+++ b/tests/backend/test_von_file_upload_endpoint.py
@@ -183,11 +183,30 @@ def app(monkeypatch):
         fake_add_message_to_history,
     )
 
+    workflow_launch_calls = []
+
+    def fake_maybe_launch_file_copy_uploaded_workflow(**kwargs):
+        workflow_launch_calls.append(kwargs)
+        return {
+            "success": True,
+            "triggered": True,
+            "event_type": "file_copy.uploaded",
+            "workflow_id": "#V#file_copy_interpretation_workflow",
+            "reason": "created_new_instance",
+            "instance_id": "test-instance-1",
+        }
+
+    monkeypatch.setattr(
+        "src.backend.services.workflow_event_integration_service.maybe_launch_file_copy_uploaded_workflow",
+        fake_maybe_launch_file_copy_uploaded_workflow,
+    )
+
     flask_app.config["TEST_FAKE_STORE"] = fake_store
     flask_app.config["TEST_CREATED"] = created
     flask_app.config["TEST_UPSERTS"] = upserts
     flask_app.config["TEST_UPDATES"] = updates
     flask_app.config["TEST_HISTORY_CALLS"] = history_calls
+    flask_app.config["TEST_WORKFLOW_LAUNCH_CALLS"] = workflow_launch_calls
     flask_app.config["TEST_CONCEPT_DOCS"] = concept_docs
     return flask_app
 
@@ -226,6 +245,8 @@ def test_upload_stores_bytes_and_registers_concept(app):
     body = resp.get_json()
     assert body["success"] is True
     assert body["chat_history_recorded"] is True
+    assert body["workflow_event_launch"]["success"] is True
+    assert body["workflow_event_launch"]["event_type"] == "file_copy.uploaded"
     assert body["uploaded"]["type_concept_id"] == "#V#computer_file_copy"
     assert body["uploaded"]["sha256"] == expected_sha256
     assert body["uploaded"]["original_filename"] == "notes.txt"
@@ -264,6 +285,11 @@ def test_upload_stores_bytes_and_registers_concept(app):
     assert "Blob URI:" in assistant_text
     assert "local://" in assistant_text
     assert expected_sha256 in assistant_text
+
+    workflow_calls = app.config["TEST_WORKFLOW_LAUNCH_CALLS"]
+    assert len(workflow_calls) == 1
+    assert workflow_calls[0]["file_copy_concept_id"] == body["uploaded"]["concept_id"]
+    assert workflow_calls[0]["uploaded_by_concept_id"] == "#V#user"
 
 
 def test_download_round_trip_and_access_control(app):
@@ -326,3 +352,5 @@ def test_upload_returns_error_when_blob_store_fails(app, monkeypatch):
 
     created = app.config["TEST_CREATED"]
     assert created == []
+    workflow_calls = app.config["TEST_WORKFLOW_LAUNCH_CALLS"]
+    assert workflow_calls == []

--- a/tests/backend/test_workflow_event_integration_service.py
+++ b/tests/backend/test_workflow_event_integration_service.py
@@ -10,10 +10,12 @@ from src.backend.workflows.durable.models import EventWorkflowBinding
 from src.backend.services.workflow_event_integration_service import (
     EVENT_TYPE_CONCEPT_UPDATED,
     EVENT_TYPE_EFFORT_UNIT_COMPLETED,
+    EVENT_TYPE_FILE_COPY_UPLOADED,
     EVENT_TYPE_TASK_CREATED,
     EVENT_TYPE_VONTOLOGY_MUTATED,
     launch_event_workflow,
     maybe_launch_effort_unit_completed_workflow,
+    maybe_launch_file_copy_uploaded_workflow,
     maybe_launch_vontology_mutation_workflow,
     maybe_launch_task_status_workflow,
 )
@@ -476,6 +478,43 @@ def test_maybe_launch_effort_unit_completed_workflow_emits_completion_event(
     assert called_args.kwargs["event_payload"]["successor_effort_unit_type_ids"] == [
         "#V#conference_presentation"
     ]
+
+
+@patch("src.backend.services.workflow_event_integration_service.launch_event_workflow")
+@patch(
+    "src.backend.services.workflow_event_integration_service.ensure_default_event_bindings"
+)
+def test_maybe_launch_file_copy_uploaded_workflow_emits_upload_event(
+    mock_ensure_default_event_bindings: MagicMock,
+    mock_launch_event_workflow: MagicMock,
+) -> None:
+    mock_ensure_default_event_bindings.return_value = {"success": True, "ensured": True}
+    mock_launch_event_workflow.return_value = {"success": True, "triggered": True}
+
+    result = maybe_launch_file_copy_uploaded_workflow(
+        file_copy_concept_id="#V#uploaded_file_copy_123",
+        uploaded_by_concept_id="#V#user_alice",
+        organisation_concept_id="#V#org_nao",
+        content_type="image/png",
+        original_filename="screenshot.png",
+        size_bytes=1024,
+        sha256="abc123",
+        blob_uri="local://uploads/user/abc/screenshot.png",
+        uploaded_at_iso="2026-02-27T09:00:00+00:00",
+        index_in_rag=True,
+    )
+
+    assert result["success"] is True
+    assert result["triggered"] is True
+    assert result["default_binding_bootstrap"]["ensured"] is True
+    mock_ensure_default_event_bindings.assert_called_once()
+
+    called_args = mock_launch_event_workflow.call_args
+    assert called_args is not None
+    assert called_args.kwargs["event_type"] == EVENT_TYPE_FILE_COPY_UPLOADED
+    assert called_args.kwargs["event_id"] == "#V#uploaded_file_copy_123"
+    assert called_args.kwargs["inputs"]["file_copy_concept_id"] == "#V#uploaded_file_copy_123"
+    assert called_args.kwargs["inputs"]["index_in_rag"] is True
 
 
 @patch("src.backend.services.workflow_event_integration_service.launch_event_workflow")


### PR DESCRIPTION
## Summary
- add a durable `#V#file_copy_interpretation_workflow` and bind `file_copy.uploaded` events to launch it after uploads
- add internal MCP `interpret_file_copy` to interpret images/documents, persist canonical interpretation text relations, and optionally index in RAG
- add image interpretation helpers (metadata, OCR, semantic description + face/building/screenshot tagging)
- add chat clipboard image paste support routed through the same upload endpoint/workflow path as button and drag/drop uploads
- publish durable workflow graph authority and include it in workflow definition surfaces

## Verification
- `pdm run pyright <all changed python files>`
- `pdm run pytest tests/backend/test_workflow_event_integration_service.py tests/backend/test_von_file_upload_endpoint.py tests/backend/test_file_copy_ingestion_mcp_tools.py tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py tests/backend/test_internal_mcp_workflow_tools.py tests/backend/test_file_copy_interpretation_workflow.py tests/backend/test_workflow_registry_factory_parity.py tests/backend/test_workflow_concept_authority_service.py`
- `npm test -- src/frontend/web/von_interface/static/js/test/chatTab.test.js --runInBand`