### PR TITLE
JVNAUTOSCI-1303: canonical conversation session view-model normalisation

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -29,6 +29,10 @@ import {
     parseIsoTimestampMs,
     selectConversationHistorySessions
 } from './utils/conversationHistoryPreferences.js';
+import {
+    normaliseConversationSessionViewModel,
+    normaliseConversationSessionViewModels
+} from './utils/chatSessionViewModel.js';
 import { getSessionScopedNamespace, getSessionScopedOrgContext } from './utils/sessionScopedStorage.js';
 import {
     applyCartoucheAppearance,
@@ -534,7 +538,9 @@ async function deleteConversation(sessionId) {
             return false;
         }
         // Remove from cache and re-render
-        sessionTabsCache = sessionTabsCache.filter(s => s?.session_id !== sessionId);
+        sessionTabsCache = normaliseConversationSessionViewModels(
+            sessionTabsCache.filter(s => s?.session_id !== sessionId)
+        );
         // Also remove from hidden set if present
         hiddenChatSessionIds.delete(sessionId);
         pinnedChatSessionIds.delete(sessionId);
@@ -8635,12 +8641,14 @@ async function assignChatSessionToCurrentOrg(sessionId) {
         const resp = await postJson('/von/api/session/assign_chat_session_org', { session_id: sid });
         const updatedNamespace = resp?.namespace;
         if (updatedNamespace) {
-            sessionTabsCache = sessionTabsCache.map((session) => {
-                if (String(session?.session_id || '') === sid) {
-                    return { ...session, namespace: updatedNamespace };
-                }
-                return session;
-            });
+            sessionTabsCache = normaliseConversationSessionViewModels(
+                sessionTabsCache.map((session) => {
+                    if (String(session?.session_id || '') === sid) {
+                        return { ...session, namespace: updatedNamespace };
+                    }
+                    return session;
+                })
+            );
         }
         showToast('Conversation updated to current organisation.', 'success');
         _renderChatSessionMetadataPanel({
@@ -8761,7 +8769,9 @@ async function promptMoveToOrganisation(sessionId) {
             const revokedCount = resp.invites_revoked || 0;
 
             // Remove conversation from current view since it now belongs to a different namespace
-            sessionTabsCache = sessionTabsCache.filter((s) => String(s?.session_id || '') !== sid);
+            sessionTabsCache = normaliseConversationSessionViewModels(
+                sessionTabsCache.filter((s) => String(s?.session_id || '') !== sid)
+            );
 
             // If moved the active session, switch to first available or null
             if (activeChatSessionId === sid) {
@@ -10067,9 +10077,11 @@ async function refreshChatSessionTabs() {
             });
         }
 
+        const normalisedSessions = normaliseConversationSessionViewModels(sessions);
+
         // If the server temporarily reports no sessions (e.g. after creating a new chat
         // while history is still updating), keep the existing UI rather than hiding it.
-        if (sessions.length === 0) {
+        if (normalisedSessions.length === 0) {
             if (hasCachedTabs) {
                 console.warn('[chatTab] Session list empty during refresh; keeping existing tabs');
                 setTimeout(() => scheduleChatSessionTabsRefresh(true), 2000);
@@ -10103,13 +10115,13 @@ async function refreshChatSessionTabs() {
             _stopChatTabsLoadingTicker();
         }
 
-        sessionTabsCache = sessions;
+        sessionTabsCache = normalisedSessions;
         const activeSessionId = (typeof data?.active_session_id === 'string' && data.active_session_id.trim())
             ? data.active_session_id.trim()
             : null;
 
         if (activeSessionId) {
-            const activeSession = sessions.find(
+            const activeSession = normalisedSessions.find(
                 s => (typeof s?.session_id === 'string') && s.session_id === activeSessionId
             );
             activeChatSessionOwnerId = activeSession?.shared_owner_user_id || null;
@@ -10119,13 +10131,13 @@ async function refreshChatSessionTabs() {
         // This prevents race conditions where the user clicks a tab but the server response
         // from a concurrent refresh overwrites their selection.
         if (activeSessionId && !activeChatSessionId) {
-            const activeSession = sessions.find(
+            const activeSession = normalisedSessions.find(
                 s => (typeof s?.session_id === 'string') && s.session_id === activeSessionId
             );
             setActiveChatSession(activeSessionId, activeSession?.session_name);
         }
 
-        renderChatSessionTabs(sessions, activeChatSessionId || activeSessionId);
+        renderChatSessionTabs(normalisedSessions, activeChatSessionId || activeSessionId);
         syncSharedConversationStreams();
 
         const sidForMeta = activeChatSessionId || activeSessionId;
@@ -10156,7 +10168,8 @@ function renderChatSessionTabs(sessions, activeSessionId) {
         return;
     }
 
-    if (!Array.isArray(sessions) || sessions.length === 0) {
+    const canonicalSessions = normaliseConversationSessionViewModels(sessions);
+    if (canonicalSessions.length === 0) {
         renderChatSessionTabsPlaceholder('empty');
         lastRenderedSessionCount = 0;
         setChatSessionCount(0);
@@ -10165,11 +10178,12 @@ function renderChatSessionTabs(sessions, activeSessionId) {
         _clearChatSessionMetadata();
         return;
     }
+    sessionTabsCache = canonicalSessions;
 
     // JVNAUTOSCI-1014: Filter hidden sessions unless showHiddenSessions is enabled.
     const sessionsAfterHiddenFilter = showHiddenSessions
-        ? sessions
-        : sessions.filter(s => !isConversationHidden(s?.session_id));
+        ? canonicalSessions
+        : canonicalSessions.filter(s => !isConversationHidden(s?.session_id));
 
     const conversationHistorySettings = loadConversationHistorySettings((key) => safeLocalStorageGet(key));
     const filteredResult = selectConversationHistorySessions({
@@ -10716,7 +10730,7 @@ async function createChatSession(sessionName) {
             : '';
 
     if (effectiveSessionId) {
-        const newSession = {
+        const newSession = normaliseConversationSessionViewModel({
             session_id: effectiveSessionId,
             session_name: effectiveName || null,
             message_count: 0,
@@ -10724,11 +10738,11 @@ async function createChatSession(sessionName) {
             created_at: nowIso,
             is_completed: false,
             completed_at: null
-        };
-        sessionTabsCache = [
+        });
+        sessionTabsCache = normaliseConversationSessionViewModels([
             newSession,
             ...sessionTabsCache.filter(s => String(s?.session_id || '') !== effectiveSessionId)
-        ];
+        ]);
         renderChatSessionTabs(sessionTabsCache, effectiveSessionId);
     }
 
@@ -10800,15 +10814,17 @@ async function renameChatSession(sessionId, sessionName) {
         const updatedName = (typeof data?.session_name === 'string' && data.session_name.trim())
             ? data.session_name.trim()
             : name;
-        sessionTabsCache = sessionTabsCache.map((session) => {
-            if (String(session?.session_id || '') !== sid) {
-                return session;
-            }
-            return {
-                ...session,
-                session_name: updatedName
-            };
-        });
+        sessionTabsCache = normaliseConversationSessionViewModels(
+            sessionTabsCache.map((session) => {
+                if (String(session?.session_id || '') !== sid) {
+                    return session;
+                }
+                return {
+                    ...session,
+                    session_name: updatedName
+                };
+            })
+        );
         renderChatSessionTabs(sessionTabsCache, activeChatSessionId || sid);
     }
 
@@ -12423,20 +12439,30 @@ function updateChatSessionTabUnreadBadge(sessionId, unreadCount) {
 function updateSharedSessionCache(sessionId, payload) {
     const sid = String(sessionId || '').trim();
     if (!sid || !Array.isArray(sessionTabsCache)) return null;
-    const session = sessionTabsCache.find(
+    const sessionIndex = sessionTabsCache.findIndex(
         s => String(s?.session_id || '') === sid
     );
-    if (!session) return null;
+    if (sessionIndex < 0) return null;
+    const session = sessionTabsCache[sessionIndex];
+    const updatedSession = { ...session };
     const createdAt = payload?.created_at;
     const content = payload?.content;
     if (typeof createdAt === 'string' && createdAt.trim()) {
-        session.last_message_at = createdAt;
+        updatedSession.last_message_at = createdAt;
     }
     if (typeof content === 'string' && content.trim()) {
-        session.preview = content.trim();
-        updateChatSessionTabPreview(sid, session.preview);
+        updatedSession.preview = content.trim();
     }
-    return session;
+    const normalised = normaliseConversationSessionViewModel(updatedSession) || updatedSession;
+    sessionTabsCache = [
+        ...sessionTabsCache.slice(0, sessionIndex),
+        normalised,
+        ...sessionTabsCache.slice(sessionIndex + 1)
+    ];
+    if (typeof content === 'string' && content.trim()) {
+        updateChatSessionTabPreview(sid, normalised.preview);
+    }
+    return normalised;
 }
 
 function markSharedSessionUnread(sessionId) {

--- a/src/frontend/web/von_interface/static/js/test/chatSessionViewModel.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatSessionViewModel.test.js
@@ -1,0 +1,96 @@
+import {
+    normaliseConversationSessionViewModel,
+    normaliseConversationSessionViewModels
+} from '../utils/chatSessionViewModel.js';
+
+describe('chatSessionViewModel', () => {
+    test('normalises legacy private conversation rows with stable defaults', () => {
+        const session = normaliseConversationSessionViewModel({
+            session_id: '  s-private  ',
+            session_name: '   ',
+            created_at: '2026-02-26T10:00:00Z',
+            message_count: '6',
+            namespace: '#V#alice'
+        });
+
+        expect(session).toMatchObject({
+            session_id: 's-private',
+            session_name: null,
+            message_count: 6,
+            shared_with_me: false,
+            conversation_kind: 'direct',
+            lifecycle_state: 'open',
+            visibility_scope: 'user',
+            ownership_state: 'owner_private',
+            has_topic_context: false,
+            recency_timestamp: '2026-02-26T10:00:00Z'
+        });
+    });
+
+    test('marks inbound shared conversations and derives shared visibility when namespace is absent', () => {
+        const session = normaliseConversationSessionViewModel({
+            session_id: 'shared-1',
+            shared_from_user_id: '#V#owner',
+            invite_id: 'invite-123',
+            last_message_at: '2026-02-26T11:30:00Z',
+            shared_unread_count: '4'
+        });
+
+        expect(session).toMatchObject({
+            session_id: 'shared-1',
+            shared_with_me: true,
+            conversation_kind: 'shared',
+            lifecycle_state: 'open',
+            visibility_scope: 'shared',
+            ownership_state: 'participant',
+            shared_unread_count: 4,
+            recency_timestamp: '2026-02-26T11:30:00Z'
+        });
+    });
+
+    test('keeps completed collaborative owner sessions in a canonical lifecycle state', () => {
+        const session = normaliseConversationSessionViewModel({
+            session_id: 'shared-owner',
+            namespace: '#V#alice@lab',
+            has_shared_participants: true,
+            is_completed: true,
+            completed_at: '2026-02-26T11:40:00Z'
+        });
+
+        expect(session).toMatchObject({
+            session_id: 'shared-owner',
+            conversation_kind: 'collaborative',
+            lifecycle_state: 'completed',
+            visibility_scope: 'organisation',
+            ownership_state: 'owner_shared',
+            is_completed: true,
+            completed_at: '2026-02-26T11:40:00Z'
+        });
+    });
+
+    test('normalises topic context fields and de-duplicates rows by session id', () => {
+        const sessions = normaliseConversationSessionViewModels([
+            {
+                session_id: 'topic-1',
+                topic_concept_id: '#V#alignment_workstream',
+                topic_member_count: '12'
+            },
+            {
+                session_id: 'topic-1',
+                topic_concept_id: '#V#overridden_duplicate'
+            },
+            {
+                session_id: '',
+                session_name: 'Invalid'
+            }
+        ]);
+
+        expect(sessions).toHaveLength(1);
+        expect(sessions[0]).toMatchObject({
+            session_id: 'topic-1',
+            topic_group_id: '#V#alignment_workstream',
+            has_topic_context: true,
+            topic_member_count: 12
+        });
+    });
+});

--- a/src/frontend/web/von_interface/static/js/utils/chatSessionViewModel.js
+++ b/src/frontend/web/von_interface/static/js/utils/chatSessionViewModel.js
@@ -1,0 +1,167 @@
+function normaliseString(value) {
+    if (typeof value !== 'string') {
+        return '';
+    }
+    return value.trim();
+}
+
+function normaliseNullableString(value) {
+    const trimmed = normaliseString(value);
+    return trimmed || null;
+}
+
+function normaliseIsoTimestamp(value) {
+    const trimmed = normaliseString(value);
+    if (!trimmed) {
+        return null;
+    }
+    return Number.isFinite(Date.parse(trimmed)) ? trimmed : null;
+}
+
+function normaliseNonNegativeNumber(value, { fallback = null } = {}) {
+    if (!Number.isFinite(value)) {
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed)) {
+            return fallback;
+        }
+        return Math.max(0, Math.trunc(parsed));
+    }
+    return Math.max(0, Math.trunc(value));
+}
+
+function deriveVisibilityScope(namespace, isSharedConversation) {
+    const trimmedNamespace = normaliseString(namespace);
+    if (!trimmedNamespace) {
+        return isSharedConversation ? 'shared' : 'unspecified';
+    }
+    return trimmedNamespace.includes('@') ? 'organisation' : 'user';
+}
+
+function deriveOwnershipState(isSharedConversation, hasSharedParticipants) {
+    if (isSharedConversation) {
+        return 'participant';
+    }
+    if (hasSharedParticipants) {
+        return 'owner_shared';
+    }
+    return 'owner_private';
+}
+
+function deriveConversationKind(isSharedConversation, hasSharedParticipants) {
+    if (isSharedConversation) {
+        return 'shared';
+    }
+    if (hasSharedParticipants) {
+        return 'collaborative';
+    }
+    return 'direct';
+}
+
+function deriveRecencyTimestamp({
+    lastMessageAt,
+    createdAt,
+    sharedAcceptedAt
+}) {
+    return lastMessageAt || createdAt || sharedAcceptedAt || null;
+}
+
+function deriveTopicGroupId(session) {
+    const candidates = [
+        session?.topic_group_id,
+        session?.topic_concept_id,
+        session?.group_id,
+        session?.topic_id
+    ];
+    for (const value of candidates) {
+        const normalised = normaliseNullableString(value);
+        if (normalised) {
+            return normalised;
+        }
+    }
+    return null;
+}
+
+export function normaliseConversationSessionViewModel(rawSession) {
+    const session = (rawSession && typeof rawSession === 'object') ? rawSession : null;
+    const sessionId = normaliseString(session?.session_id);
+    if (!sessionId) {
+        return null;
+    }
+
+    const sessionName = normaliseNullableString(session?.session_name);
+    const namespace = normaliseNullableString(session?.namespace);
+    const sharedFromUserId = normaliseNullableString(session?.shared_from_user_id);
+    const sharedOwnerUserId = normaliseNullableString(session?.shared_owner_user_id);
+    const inviteId = normaliseNullableString(session?.invite_id);
+    const sharedAcceptedAt = normaliseIsoTimestamp(session?.shared_accepted_at);
+    const isSharedConversation = Boolean(
+        session?.shared_with_me
+        || sharedFromUserId
+        || inviteId
+    );
+    const hasSharedParticipants = Boolean(session?.has_shared_participants);
+    const isCompleted = session?.is_completed === true;
+    const lifecycleState = isCompleted ? 'completed' : 'open';
+    const topicGroupId = deriveTopicGroupId(session);
+    const topicMemberCount = normaliseNonNegativeNumber(session?.topic_member_count, { fallback: null });
+    const messageCount = normaliseNonNegativeNumber(session?.message_count, { fallback: null });
+    const sharedUnreadCount = normaliseNonNegativeNumber(session?.shared_unread_count, { fallback: 0 });
+    const createdAt = normaliseIsoTimestamp(session?.created_at);
+    const lastMessageAt = normaliseIsoTimestamp(session?.last_message_at);
+    const completedAt = normaliseIsoTimestamp(session?.completed_at);
+    const recencyTimestamp = deriveRecencyTimestamp({
+        lastMessageAt,
+        createdAt,
+        sharedAcceptedAt
+    });
+
+    return {
+        ...session,
+        session_id: sessionId,
+        session_name: sessionName,
+        namespace,
+        message_count: messageCount,
+        created_at: createdAt,
+        last_message_at: lastMessageAt,
+        shared_accepted_at: sharedAcceptedAt,
+        is_completed: isCompleted,
+        completed_at: completedAt,
+        shared_with_me: isSharedConversation,
+        shared_from_user_id: sharedFromUserId,
+        shared_owner_user_id: sharedOwnerUserId,
+        invite_id: inviteId,
+        has_shared_participants: hasSharedParticipants,
+        shared_unread_count: sharedUnreadCount,
+        conversation_kind: deriveConversationKind(
+            isSharedConversation,
+            hasSharedParticipants
+        ),
+        lifecycle_state: lifecycleState,
+        visibility_scope: deriveVisibilityScope(namespace, isSharedConversation),
+        ownership_state: deriveOwnershipState(
+            isSharedConversation,
+            hasSharedParticipants
+        ),
+        topic_group_id: topicGroupId,
+        topic_member_count: topicMemberCount,
+        has_topic_context: Boolean(topicGroupId),
+        recency_timestamp: recencyTimestamp
+    };
+}
+
+export function normaliseConversationSessionViewModels(rawSessions) {
+    if (!Array.isArray(rawSessions) || rawSessions.length === 0) {
+        return [];
+    }
+    const dedupedBySessionId = new Map();
+    rawSessions.forEach((rawSession) => {
+        const normalised = normaliseConversationSessionViewModel(rawSession);
+        if (!normalised) {
+            return;
+        }
+        if (!dedupedBySessionId.has(normalised.session_id)) {
+            dedupedBySessionId.set(normalised.session_id, normalised);
+        }
+    });
+    return Array.from(dedupedBySessionId.values());
+}


### PR DESCRIPTION
## Summary
- add a central chatSessionViewModel normaliser for conversation-session rows
- route chat session list ingestion and mutations in chatTab.js through canonical normalisation
- preserve existing UI behaviour while adding stable derived semantics (conversation_kind, lifecycle_state, visibility_scope, topic context fields, and recency_timestamp)
- add focused unit tests for legacy/shared/completed/topic session rows

## Testing
- npx jest src/frontend/web/von_interface/static/js/test/chatSessionViewModel.test.js
- npx jest tests/frontend/chatSessionPinning.test.js tests/frontend/chatSessionMetadataLabelLinks.test.js
- npx jest tests/frontend/orgSwitchRefreshChatTabs.test.js
- npx pyright

## Jira
- JVNAUTOSCI-1303
- Parent: JVNAUTOSCI-1277