### PR TITLE
refactor(dependencies): move geospatial libs to optional geo group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ dependencies = [
     "decorator>=5.1.1",
     "docutils>=0.21.2",
     "executing>=2.1.0",
-    "geopandas>=1.0.1",
     "ipython>=8.31.0",
     "jedi>=0.19.2",
     "jupyter_client>=8.6.3",
@@ -112,15 +111,12 @@ dependencies = [
     "pybtex-docutils>=1.0.3",
     "pydantic_core>=2.27.2",
     "Pygments>=2.18.0",
-    "pyogrio>=0.10.0",
-    "pyproj>=3.7.0",
     "pytz>=2024.2",
     "pywin32>=308; platform_system == 'Windows'",
     "PyYAML>=6.0.2",
     "pyzmq>=26.2.0",
     "rdflib>=7.1.1",
     "setuptools>=75.6.0",
-    "shapely>=2.0.6",
     "stack-data>=0.6.3",
     "tokenize_rt>=6.1.0",
     "tornado>=6.4.2",
@@ -170,6 +166,12 @@ dev = [
     "annotated-types>=0.7.0",
     "anyio>=4.10.0",
     "pytest-asyncio>=1.3.0",
+]
+geo = [
+    "geopandas>=1.0.1",
+    "pyogrio>=0.10.0",
+    "pyproj>=3.7.0",
+    "shapely>=2.0.6",
 ]
 
 [tool.pyright]


### PR DESCRIPTION
## Summary
- remove `geopandas`, `pyogrio`, `pyproj`, and `shapely` from the default dependency list
- add a new optional dependency group `geo` containing those packages

## Why
- keeps base installs lighter while preserving geospatial support for environments that need it