### PR TITLE
JVNAUTOSCI-371: proactive relation-filling in rumination workflow

### DIFF
--- a/src/backend/services/relation_elicitation_service.py
+++ b/src/backend/services/relation_elicitation_service.py
@@ -24,7 +24,12 @@ class RelationElicitationService:
             self.llm_client = None
             self._llm_initialisation_error = exc
 
-    def get_elicitation_opportunities(self, instance_id: str) -> List[str]:
+    def get_elicitation_opportunities(
+        self,
+        instance_id: str,
+        *,
+        include_reverse_subtypes: bool = True,
+    ) -> List[str]:
         """Return unfilled suggested or salient predicates for an individual.
 
         Traverses direct and ancestor types (forward is_a_type_of + reverse has_subtype) and
@@ -79,20 +84,22 @@ class RelationElicitationService:
                             and p not in queue
                         ):
                             queue.append(p)
-            try:
-                reverse_cursor = repo.find(
-                    {"relationships.has_subtype": {"$in": [t_id]}}, {"concept_id": 1}
-                )
-                for d in reverse_cursor:
-                    cid = d.get("concept_id")
-                    if (
-                        isinstance(cid, str)
-                        and cid not in visited_types
-                        and cid not in queue
-                    ):
-                        queue.append(cid)
-            except Exception:
-                pass
+            if include_reverse_subtypes:
+                try:
+                    reverse_cursor = repo.find(
+                        {"relationships.has_subtype": {"$in": [t_id]}},
+                        {"concept_id": 1},
+                    )
+                    for d in reverse_cursor:
+                        cid = d.get("concept_id")
+                        if (
+                            isinstance(cid, str)
+                            and cid not in visited_types
+                            and cid not in queue
+                        ):
+                            queue.append(cid)
+                except Exception:
+                    pass
 
         if not candidate_predicates:
             return []

--- a/src/backend/workflows/durable/rumination_workflow.py
+++ b/src/backend/workflows/durable/rumination_workflow.py
@@ -10,9 +10,10 @@ predicate for a batch of concepts), the rumination orchestrator decides
 
 1. **Missing descriptions** — concepts without ``hasDescription``
 2. **Missing considerations** — concepts without ``hasConsiderationsForUse``
-3. **Isolated concepts** — concepts with no outgoing relationships beyond
+3. **Missing relations** — individuals missing high-value suggested/salient
+   relation predicates (with safe auto-apply from high-confidence hypotheses)
+4. **Isolated concepts** — concepts with no outgoing relationships beyond
    type hierarchy
-4. **Stale embeddings** — concepts with ``embedding_status == 'stale'``
 
 The orchestrator is budget-aware: it tracks how many LLM calls / items
 have been processed and stops when the budget is exhausted, deferring
@@ -49,19 +50,47 @@ RUMINATION_WORKFLOW_ID = "#V#rumination_workflow"
 # Default budget: max items to enrich per orchestrator run
 DEFAULT_BUDGET = 30
 
+RELATION_COMPLETION_PREDICATE = "__relation_completion__"
+DEFAULT_RELATION_SCAN_LIMIT = 120
+DEFAULT_RELATION_MAX_PREDICATES_PER_CONCEPT = 4
+DEFAULT_RELATION_AUTO_APPLY_CONFIDENCE_THRESHOLD = 0.95
+DEFAULT_RELATION_DETAIL_LIMIT = 80
+DEFAULT_RELATION_QUESTION_LIMIT = 50
+RELATION_PRIORITY_KEYWORDS: tuple[str, ...] = (
+    "owner",
+    "affiliation",
+    "project",
+    "deadline",
+    "milestone",
+    "paper",
+    "supervis",
+    "depend",
+    "task",
+    "member",
+)
+
 # Gap dimensions the orchestrator checks, in priority order.
 # Each entry: (gap_name, predicate_to_check, enrichment_predicate, prompt_concept_id_or_none)
 DEFAULT_GAP_DIMENSIONS: List[Dict[str, Any]] = [
     {
+        "gap_name": "missing_relations",
+        "predicate": RELATION_COMPLETION_PREDICATE,
+        "priority": 1,
+        "dispatch_mode": "relation_completion",
+        "scan_limit": DEFAULT_RELATION_SCAN_LIMIT,
+        "max_predicates_per_concept": DEFAULT_RELATION_MAX_PREDICATES_PER_CONCEPT,
+        "auto_apply_confidence_threshold": DEFAULT_RELATION_AUTO_APPLY_CONFIDENCE_THRESHOLD,
+    },
+    {
         "gap_name": "missing_descriptions",
         "predicate": "hasDescription",
-        "priority": 1,
+        "priority": 2,
         "prompt_concept_id": "#V#generate_concept_description_prompt",
     },
     {
         "gap_name": "missing_considerations",
         "predicate": "#V#has_considerations_for_use",
-        "priority": 2,
+        "priority": 3,
         "prompt_concept_id": None,  # Uses default enrichment prompt
     },
 ]
@@ -79,6 +108,9 @@ def build_rumination_workflow() -> WorkflowDefinition:
         - gap_assessment: Dict mapping gap_name → count of concepts with that gap
         - enrichment_plan: Ordered list of enrichment tasks to run
         - dispatched_tasks: Results from dispatched enrichments
+        - relation_metrics: proposed/applied/deferred/confirmed relation counts
+        - relation_changes: detailed proposed/applied relation assertions
+        - relation_questions: deferred clarification questions
         - rumination_result: Final summary
     """
 
@@ -261,6 +293,338 @@ def _count_isolated_concepts(limit: int = 500) -> int:
         return 0
 
 
+def _coerce_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _compute_relation_priority(predicate: str) -> tuple[int, list[str]]:
+    if not isinstance(predicate, str):
+        return 0, []
+    lowered = predicate.lower()
+    matched = [kw for kw in RELATION_PRIORITY_KEYWORDS if kw in lowered]
+    return len(matched), matched
+
+
+def _list_relation_gap_candidates(
+    *,
+    scan_limit: int,
+    max_predicates_per_concept: int,
+    candidate_concept_ids: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Scan individual concepts and list missing relation opportunities.
+
+    This intentionally uses bounded scans to keep rumination predictable.
+    """
+    from ...db.repositories.concepts_repository import ConceptsRepository
+    from ...services.relation_elicitation_service import RelationElicitationService
+    from ...vontology.utils_vontology import get_concept_display_name_with_names_fallback
+
+    service = RelationElicitationService(llm_client=False)
+    projection = {
+        "concept_id": 1,
+        "name": 1,
+        "names": 1,
+        "relationships": 1,
+        "hypothesized_relations": 1,
+    }
+    if candidate_concept_ids:
+        concept_docs = ConceptsRepository.find(
+            {"concept_id": {"$in": [cid for cid in candidate_concept_ids if isinstance(cid, str)]}},
+            projection=projection,
+            limit=scan_limit,
+        )
+    else:
+        concept_docs = ConceptsRepository.find(
+            {"relationships.is_an_instance_of": {"$exists": True, "$ne": []}},
+            projection=projection,
+            limit=scan_limit,
+        )
+
+    candidates: list[dict[str, Any]] = []
+    for concept_doc in concept_docs:
+        concept_id = concept_doc.get("concept_id")
+        if not isinstance(concept_id, str) or not concept_id:
+            continue
+
+        missing_predicates = service.get_elicitation_opportunities(
+            concept_id,
+            include_reverse_subtypes=False,
+        )
+        if not missing_predicates:
+            continue
+
+        scored: list[tuple[str, int, list[str]]] = []
+        for predicate in missing_predicates:
+            score, matched = _compute_relation_priority(predicate)
+            scored.append((predicate, score, matched))
+
+        scored.sort(key=lambda item: (-item[1], item[0]))
+        selected = scored[: max(1, max_predicates_per_concept)]
+        selected_predicates = [item[0] for item in selected]
+
+        matched_keywords: set[str] = set()
+        priority_score = 0
+        for _, score, matched in selected:
+            priority_score += score
+            matched_keywords.update(matched)
+
+        try:
+            concept_name = get_concept_display_name_with_names_fallback(concept_doc)
+        except Exception:
+            concept_name = concept_doc.get("name") or concept_id
+
+        candidates.append(
+            {
+                "concept_id": concept_id,
+                "concept_name": concept_name or concept_id,
+                "missing_predicates": selected_predicates,
+                "total_missing_predicates": len(missing_predicates),
+                "priority_score": priority_score,
+                "matched_priority_keywords": sorted(matched_keywords),
+            }
+        )
+
+    # Highest-priority and highest-coverage concepts first.
+    candidates.sort(
+        key=lambda item: (
+            -int(item.get("priority_score", 0)),
+            -int(item.get("total_missing_predicates", 0)),
+            str(item.get("concept_id", "")),
+        )
+    )
+    return candidates
+
+
+def _resolve_relation_auto_apply_candidate(
+    *,
+    instance_doc: dict[str, Any],
+    predicate: str,
+    confidence_threshold: float,
+) -> dict[str, Any] | None:
+    """Resolve a safe auto-apply target from hypothesised relations."""
+    if not isinstance(predicate, str) or not predicate.startswith("#V#"):
+        return None
+
+    relationships = instance_doc.get("relationships") or {}
+    if isinstance(relationships, dict) and relationships.get(predicate):
+        return None
+
+    hypotheses = (instance_doc.get("hypothesized_relations") or {}).get(predicate)
+    if isinstance(hypotheses, dict):
+        hypotheses = [hypotheses]
+    if not isinstance(hypotheses, list) or not hypotheses:
+        return None
+
+    candidates: list[tuple[float, str]] = []
+    for hypothesis in hypotheses:
+        if not isinstance(hypothesis, dict):
+            continue
+        target_id = hypothesis.get("value")
+        if not isinstance(target_id, str) or not target_id.startswith("#V#"):
+            continue
+        confidence = _coerce_float(hypothesis.get("confidence_score"), default=0.0)
+        if confidence < confidence_threshold:
+            continue
+        candidates.append((confidence, target_id))
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda item: (-item[0], item[1]))
+    confidence, target_id = candidates[0]
+
+    from ...db.repositories.concepts_repository import ConceptsRepository
+
+    target_exists = ConceptsRepository.find_one(
+        {"concept_id": target_id}, projection={"concept_id": 1}
+    )
+    if not target_exists:
+        return None
+
+    return {
+        "target_id": target_id,
+        "confidence_score": confidence,
+        "source": "hypothesized_relation",
+    }
+
+
+def _build_relation_completion_question(
+    *,
+    service: Any,
+    instance_doc: dict[str, Any],
+    predicate: str,
+) -> str:
+    concept_id = str(instance_doc.get("concept_id") or "")
+    question = None
+    try:
+        question = service.generate_question_for_elicit(concept_id, predicate)
+    except Exception:
+        question = None
+    if isinstance(question, str) and question.strip():
+        return question.strip()
+
+    from ...vontology.utils_vontology import get_concept_display_name_with_names_fallback
+
+    try:
+        concept_name = get_concept_display_name_with_names_fallback(instance_doc)
+    except Exception:
+        concept_name = instance_doc.get("name") or concept_id or "this concept"
+    predicate_label = predicate.replace("#V#", "").replace("_", " ").strip()
+    if not predicate_label:
+        predicate_label = "relation"
+    return f"What should the '{predicate_label}' relation be for {concept_name}?"
+
+
+def _dispatch_relation_completion_task(
+    *,
+    task: dict[str, Any],
+    ctx: dict[str, Any],
+) -> dict[str, Any]:
+    """Process relation completion for one rumination plan task."""
+    from ...db.repositories.concepts_repository import ConceptsRepository
+    from ...services.relation_elicitation_service import RelationElicitationService
+    from ...services.relationship_write_service import add_relationship
+
+    dry_run = bool(ctx.get("dry_run", False))
+    allocation = max(0, int(task.get("allocation", 0)))
+    confidence_threshold = _coerce_float(
+        task.get(
+            "auto_apply_confidence_threshold",
+            ctx.get(
+                "relation_auto_apply_confidence_threshold",
+                DEFAULT_RELATION_AUTO_APPLY_CONFIDENCE_THRESHOLD,
+            ),
+        ),
+        default=DEFAULT_RELATION_AUTO_APPLY_CONFIDENCE_THRESHOLD,
+    )
+    detail_limit = int(
+        ctx.get("relation_detail_limit", DEFAULT_RELATION_DETAIL_LIMIT)
+    )
+    question_limit = int(
+        ctx.get("relation_question_limit", DEFAULT_RELATION_QUESTION_LIMIT)
+    )
+
+    candidates = list(ctx.get("relation_gap_candidates") or [])
+    selected_candidates = candidates[:allocation] if allocation > 0 else []
+    service = RelationElicitationService(llm_client=False)
+
+    proposed_relations = 0
+    auto_applied_relations = 0
+    would_apply_relations = 0
+    deferred_relations = 0
+    confirmed_relations = 0
+    failed_relations = 0
+    proposal_details: list[dict[str, Any]] = []
+    deferred_questions: list[dict[str, Any]] = []
+
+    for candidate in selected_candidates:
+        concept_id = candidate.get("concept_id")
+        if not isinstance(concept_id, str) or not concept_id:
+            continue
+
+        instance_doc = ConceptsRepository.find_one(
+            {"concept_id": concept_id},
+            projection={
+                "concept_id": 1,
+                "name": 1,
+                "names": 1,
+                "relationships": 1,
+                "hypothesized_relations": 1,
+            },
+        )
+        if not instance_doc:
+            continue
+
+        missing_predicates = list(candidate.get("missing_predicates") or [])
+        for predicate in missing_predicates:
+            if not isinstance(predicate, str) or not predicate:
+                continue
+            proposed_relations += 1
+
+            detail: dict[str, Any] = {
+                "source_id": concept_id,
+                "predicate": predicate,
+                "dry_run": dry_run,
+            }
+
+            auto_candidate = _resolve_relation_auto_apply_candidate(
+                instance_doc=instance_doc,
+                predicate=predicate,
+                confidence_threshold=confidence_threshold,
+            )
+            if auto_candidate:
+                detail["target_id"] = auto_candidate["target_id"]
+                detail["confidence_score"] = auto_candidate["confidence_score"]
+                detail["candidate_source"] = auto_candidate["source"]
+
+                if dry_run:
+                    detail["action"] = "would_auto_apply"
+                    would_apply_relations += 1
+                else:
+                    try:
+                        result = add_relationship(
+                            concept_id,
+                            predicate,
+                            auto_candidate["target_id"],
+                        )
+                        if bool(result.get("success")):
+                            detail["action"] = "auto_applied"
+                            auto_applied_relations += 1
+                            confirmed_relations += 1
+                        else:
+                            detail["action"] = "deferred_after_apply_failure"
+                            detail["error"] = result.get("error")
+                            deferred_relations += 1
+                            failed_relations += 1
+                    except Exception as exc:
+                        detail["action"] = "deferred_after_apply_exception"
+                        detail["error"] = str(exc)
+                        deferred_relations += 1
+                        failed_relations += 1
+            else:
+                detail["action"] = "deferred_question"
+                deferred_relations += 1
+                if len(deferred_questions) < question_limit:
+                    deferred_questions.append(
+                        {
+                            "source_id": concept_id,
+                            "predicate": predicate,
+                            "question": _build_relation_completion_question(
+                                service=service,
+                                instance_doc=instance_doc,
+                                predicate=predicate,
+                            ),
+                        }
+                    )
+
+            if len(proposal_details) < detail_limit:
+                proposal_details.append(detail)
+
+    relation_metrics = {
+        "concepts_considered": len(selected_candidates),
+        "proposed_relations": proposed_relations,
+        "auto_applied_relations": auto_applied_relations,
+        "would_apply_relations": would_apply_relations,
+        "deferred_relations": deferred_relations,
+        "confirmed_relations": confirmed_relations,
+        "failed_relations": failed_relations,
+    }
+
+    task_result = {
+        "gap_name": task.get("gap_name"),
+        "predicate": task.get("predicate"),
+        "dispatch_mode": "relation_completion",
+        "allocation": allocation,
+        "dry_run": dry_run,
+        "metrics": relation_metrics,
+        "proposal_details": proposal_details,
+        "deferred_questions": deferred_questions,
+    }
+    return task_result
+
+
 def _handle_assess_gaps(request: WorkflowActionRequest) -> WorkflowActionResult:
     """Scan the ontology for quality gaps across multiple dimensions."""
     try:
@@ -268,10 +632,66 @@ def _handle_assess_gaps(request: WorkflowActionRequest) -> WorkflowActionResult:
         dimensions = ctx.get("gap_dimensions") or DEFAULT_GAP_DIMENSIONS
 
         gap_assessment: Dict[str, int] = {}
+        relation_gap_candidates: list[dict[str, Any]] = []
+        relation_gap_summary: dict[str, Any] = {}
 
         for dim in dimensions:
             gap_name = dim["gap_name"]
             predicate = dim["predicate"]
+            dispatch_mode = dim.get("dispatch_mode")
+            if (
+                dispatch_mode == "relation_completion"
+                or predicate == RELATION_COMPLETION_PREDICATE
+            ):
+                try:
+                    scan_limit = int(
+                        dim.get(
+                            "scan_limit",
+                            ctx.get("relation_scan_limit", DEFAULT_RELATION_SCAN_LIMIT),
+                        )
+                    )
+                    max_predicates_per_concept = int(
+                        dim.get(
+                            "max_predicates_per_concept",
+                            ctx.get(
+                                "relation_max_predicates_per_concept",
+                                DEFAULT_RELATION_MAX_PREDICATES_PER_CONCEPT,
+                            ),
+                        )
+                    )
+                    candidate_concept_ids = dim.get("candidate_concept_ids")
+                    if not isinstance(candidate_concept_ids, list):
+                        candidate_concept_ids = ctx.get("relation_candidate_concept_ids")
+                    if not isinstance(candidate_concept_ids, list):
+                        candidate_concept_ids = None
+                    relation_gap_candidates = _list_relation_gap_candidates(
+                        scan_limit=max(1, scan_limit),
+                        max_predicates_per_concept=max(1, max_predicates_per_concept),
+                        candidate_concept_ids=candidate_concept_ids,
+                    )
+                    gap_assessment[gap_name] = len(relation_gap_candidates)
+                    relation_gap_summary[gap_name] = {
+                        "scan_limit": scan_limit,
+                        "concepts_with_missing_relations": len(relation_gap_candidates),
+                        "opportunity_count": sum(
+                            len(item.get("missing_predicates") or [])
+                            for item in relation_gap_candidates
+                        ),
+                    }
+                    logger.info(
+                        "[rumination] Gap '%s' (relation_completion): %d concepts",
+                        gap_name,
+                        gap_assessment[gap_name],
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "[rumination] Failed to assess relation gap '%s': %s",
+                        gap_name,
+                        e,
+                    )
+                    gap_assessment[gap_name] = -1
+                    relation_gap_summary[gap_name] = {"error": str(e)}
+                continue
             try:
                 count = _count_concepts_missing_predicate(predicate)
                 gap_assessment[gap_name] = count
@@ -306,6 +726,8 @@ def _handle_assess_gaps(request: WorkflowActionRequest) -> WorkflowActionResult:
             outputs={
                 "gap_assessment": gap_assessment,
                 "gap_dimensions": dimensions,
+                "relation_gap_candidates": relation_gap_candidates,
+                "relation_gap_summary": relation_gap_summary,
             }
         )
     except Exception as e:
@@ -342,12 +764,27 @@ def _handle_plan_enrichment(request: WorkflowActionRequest) -> WorkflowActionRes
             # Allocate: min(remaining, count, budget_per_gap)
             allocation = min(remaining_budget, count)
 
+            dispatch_mode = dim.get("dispatch_mode")
+            if not isinstance(dispatch_mode, str) or not dispatch_mode:
+                dispatch_mode = (
+                    "relation_completion"
+                    if dim.get("predicate") == RELATION_COMPLETION_PREDICATE
+                    else "text_enrichment"
+                )
+
             enrichment_plan.append(
                 {
                     "gap_name": gap_name,
                     "predicate": dim["predicate"],
+                    "dispatch_mode": dispatch_mode,
                     "prompt_concept_id": dim.get("prompt_concept_id"),
                     "allocation": allocation,
+                    "scan_limit": dim.get("scan_limit"),
+                    "max_predicates_per_concept": dim.get("max_predicates_per_concept"),
+                    "auto_apply_confidence_threshold": dim.get(
+                        "auto_apply_confidence_threshold",
+                        DEFAULT_RELATION_AUTO_APPLY_CONFIDENCE_THRESHOLD,
+                    ),
                 }
             )
             remaining_budget -= allocation
@@ -366,6 +803,17 @@ def _handle_plan_enrichment(request: WorkflowActionRequest) -> WorkflowActionRes
                 "dispatched_tasks": [],
                 "total_processed": 0,
                 "total_failed": 0,
+                "relation_metrics": {
+                    "concepts_considered": 0,
+                    "proposed_relations": 0,
+                    "auto_applied_relations": 0,
+                    "would_apply_relations": 0,
+                    "deferred_relations": 0,
+                    "confirmed_relations": 0,
+                    "failed_relations": 0,
+                },
+                "relation_changes": [],
+                "relation_questions": [],
             }
         )
     except Exception as e:
@@ -387,6 +835,9 @@ def _handle_dispatch_enrichment(request: WorkflowActionRequest) -> WorkflowActio
         dispatched = ctx.get("dispatched_tasks", [])
         total_processed = ctx.get("total_processed", 0)
         total_failed = ctx.get("total_failed", 0)
+        relation_metrics = dict(ctx.get("relation_metrics") or {})
+        relation_changes = list(ctx.get("relation_changes") or [])
+        relation_questions = list(ctx.get("relation_questions") or [])
 
         if plan_index >= len(plan):
             return WorkflowActionResult(
@@ -395,6 +846,9 @@ def _handle_dispatch_enrichment(request: WorkflowActionRequest) -> WorkflowActio
                     "dispatched_tasks": dispatched,
                     "total_processed": total_processed,
                     "total_failed": total_failed,
+                    "relation_metrics": relation_metrics,
+                    "relation_changes": relation_changes,
+                    "relation_questions": relation_questions,
                 }
             )
 
@@ -403,6 +857,50 @@ def _handle_dispatch_enrichment(request: WorkflowActionRequest) -> WorkflowActio
         allocation = task["allocation"]
         prompt_concept_id = task.get("prompt_concept_id")
         gap_name = task["gap_name"]
+        dispatch_mode = task.get("dispatch_mode", "text_enrichment")
+
+        if dispatch_mode == "relation_completion":
+            logger.info(
+                "[rumination] Dispatching relation completion for '%s' (allocation=%d)",
+                gap_name,
+                allocation,
+            )
+            relation_task_result = _dispatch_relation_completion_task(task=task, ctx=ctx)
+            dispatched.append(relation_task_result)
+
+            task_metrics = dict(relation_task_result.get("metrics") or {})
+            for metric_key in (
+                "concepts_considered",
+                "proposed_relations",
+                "auto_applied_relations",
+                "would_apply_relations",
+                "deferred_relations",
+                "confirmed_relations",
+                "failed_relations",
+            ):
+                relation_metrics[metric_key] = int(relation_metrics.get(metric_key, 0)) + int(
+                    task_metrics.get(metric_key, 0)
+                )
+
+            relation_changes.extend(relation_task_result.get("proposal_details") or [])
+            relation_questions.extend(
+                relation_task_result.get("deferred_questions") or []
+            )
+
+            return WorkflowActionResult(
+                outputs={
+                    "plan_index": plan_index + 1,
+                    "has_more_tasks": plan_index + 1 < len(plan),
+                    "dispatched_tasks": dispatched,
+                    "total_processed": total_processed
+                    + int(task_metrics.get("auto_applied_relations", 0)),
+                    "total_failed": total_failed
+                    + int(task_metrics.get("failed_relations", 0)),
+                    "relation_metrics": relation_metrics,
+                    "relation_changes": relation_changes,
+                    "relation_questions": relation_questions,
+                }
+            )
 
         logger.info(
             "[rumination] Dispatching enrichment for '%s' (predicate=%s, allocation=%d)",
@@ -439,6 +937,9 @@ def _handle_dispatch_enrichment(request: WorkflowActionRequest) -> WorkflowActio
                     "dispatched_tasks": dispatched,
                     "total_processed": total_processed,
                     "total_failed": total_failed,
+                    "relation_metrics": relation_metrics,
+                    "relation_changes": relation_changes,
+                    "relation_questions": relation_questions,
                 }
             )
 
@@ -511,6 +1012,9 @@ def _handle_dispatch_enrichment(request: WorkflowActionRequest) -> WorkflowActio
                 "dispatched_tasks": dispatched,
                 "total_processed": total_processed + task_processed,
                 "total_failed": total_failed + task_failed,
+                "relation_metrics": relation_metrics,
+                "relation_changes": relation_changes,
+                "relation_questions": relation_questions,
             }
         )
     except Exception as e:
@@ -525,6 +1029,9 @@ def _handle_finalise(request: WorkflowActionRequest) -> WorkflowActionResult:
     dispatched = ctx.get("dispatched_tasks", [])
     total_processed = ctx.get("total_processed", 0)
     total_failed = ctx.get("total_failed", 0)
+    relation_metrics = dict(ctx.get("relation_metrics") or {})
+    relation_changes = list(ctx.get("relation_changes") or [])
+    relation_questions = list(ctx.get("relation_questions") or [])
 
     rumination_result = {
         "success": total_failed == 0,
@@ -533,6 +1040,11 @@ def _handle_finalise(request: WorkflowActionRequest) -> WorkflowActionResult:
         "total_processed": total_processed,
         "total_failed": total_failed,
         "task_details": dispatched,
+        "relation_metrics": relation_metrics,
+        "relation_changes_count": len(relation_changes),
+        "relation_questions_count": len(relation_questions),
+        "relation_changes": relation_changes,
+        "relation_questions": relation_questions,
     }
 
     logger.info(

--- a/tests/backend/test_rumination_workflow.py
+++ b/tests/backend/test_rumination_workflow.py
@@ -153,6 +153,55 @@ class TestRuminationAssessGaps:
             assessment = result.outputs["gap_assessment"]
             assert all(v == 0 for v in assessment.values())
 
+    def test_assess_includes_relation_gap_candidates(self) -> None:
+        from src.backend.workflows.action_registry import (
+            WorkflowActionRequest,
+            WorkflowEnvironment,
+        )
+        from src.backend.workflows.durable.rumination_workflow import (
+            _handle_assess_gaps,
+        )
+
+        with (
+            patch(
+                "src.backend.workflows.durable.rumination_workflow."
+                "_count_concepts_missing_predicate",
+                return_value=0,
+            ),
+            patch(
+                "src.backend.workflows.durable.rumination_workflow."
+                "_count_isolated_concepts",
+                return_value=0,
+            ),
+            patch(
+                "src.backend.workflows.durable.rumination_workflow."
+                "_list_relation_gap_candidates",
+                return_value=[
+                    {
+                        "concept_id": "#V#alice",
+                        "missing_predicates": ["#V#has_affiliation"],
+                    },
+                    {
+                        "concept_id": "#V#bob",
+                        "missing_predicates": ["#V#depends_on"],
+                    },
+                ],
+            ),
+        ):
+            env = WorkflowEnvironment(llm_client=None)
+            req = WorkflowActionRequest(
+                action_id="rumination.assess_gaps",
+                inputs={},
+                environment=env,
+                data={},
+            )
+
+            result = _handle_assess_gaps(req)
+            assert result.ok
+            assessment = result.outputs["gap_assessment"]
+            assert assessment["missing_relations"] == 2
+            assert len(result.outputs["relation_gap_candidates"]) == 2
+
 
 class TestRuminationPlanEnrichment:
     """Test the budget-aware planning handler."""
@@ -394,6 +443,79 @@ class TestRuminationDispatch:
         assert result.ok
         assert result.outputs["has_more_tasks"] is False
 
+    def test_dispatch_relation_completion_dry_run(self) -> None:
+        from src.backend.workflows.action_registry import (
+            WorkflowActionRequest,
+            WorkflowEnvironment,
+        )
+        from src.backend.workflows.durable.rumination_workflow import (
+            _handle_dispatch_enrichment,
+        )
+
+        with patch(
+            "src.backend.workflows.durable.rumination_workflow."
+            "_dispatch_relation_completion_task",
+            return_value={
+                "metrics": {
+                    "concepts_considered": 1,
+                    "proposed_relations": 2,
+                    "auto_applied_relations": 0,
+                    "would_apply_relations": 1,
+                    "deferred_relations": 1,
+                    "confirmed_relations": 0,
+                    "failed_relations": 0,
+                },
+                "proposal_details": [
+                    {
+                        "source_id": "#V#alice",
+                        "predicate": "#V#has_affiliation",
+                        "action": "would_auto_apply",
+                    }
+                ],
+                "deferred_questions": [
+                    {
+                        "source_id": "#V#alice",
+                        "predicate": "#V#depends_on",
+                        "question": "What should the dependency relation be?",
+                    }
+                ],
+            },
+        ):
+            env = WorkflowEnvironment(llm_client=None)
+            req = WorkflowActionRequest(
+                action_id="rumination.dispatch_enrichment",
+                inputs={},
+                environment=env,
+                data={
+                    "dry_run": True,
+                    "enrichment_plan": [
+                        {
+                            "gap_name": "missing_relations",
+                            "predicate": "__relation_completion__",
+                            "dispatch_mode": "relation_completion",
+                            "allocation": 1,
+                        }
+                    ],
+                    "plan_index": 0,
+                    "dispatched_tasks": [],
+                    "total_processed": 0,
+                    "total_failed": 0,
+                    "relation_metrics": {},
+                    "relation_changes": [],
+                    "relation_questions": [],
+                },
+            )
+
+            result = _handle_dispatch_enrichment(req)
+            assert result.ok
+            assert result.outputs["has_more_tasks"] is False
+            metrics = result.outputs["relation_metrics"]
+            assert metrics["proposed_relations"] == 2
+            assert metrics["would_apply_relations"] == 1
+            assert metrics["deferred_relations"] == 1
+            assert len(result.outputs["relation_changes"]) == 1
+            assert len(result.outputs["relation_questions"]) == 1
+
 
 class TestRuminationFinalise:
     """Test the finalise handler."""
@@ -429,6 +551,106 @@ class TestRuminationFinalise:
         assert summary["total_failed"] == 2
         assert summary["success"] is False  # failed > 0
         assert summary["tasks_dispatched"] == 1
+
+    def test_finalise_includes_relation_metrics(self) -> None:
+        from src.backend.workflows.action_registry import (
+            WorkflowActionRequest,
+            WorkflowEnvironment,
+        )
+        from src.backend.workflows.durable.rumination_workflow import (
+            _handle_finalise,
+        )
+
+        env = WorkflowEnvironment(llm_client=None)
+        req = WorkflowActionRequest(
+            action_id="rumination.finalise",
+            inputs={},
+            environment=env,
+            data={
+                "gap_assessment": {"missing_relations": 1},
+                "dispatched_tasks": [{"gap_name": "missing_relations"}],
+                "total_processed": 0,
+                "total_failed": 0,
+                "relation_metrics": {"proposed_relations": 3, "deferred_relations": 2},
+                "relation_changes": [{"source_id": "#V#alice"}],
+                "relation_questions": [{"source_id": "#V#alice"}],
+            },
+        )
+
+        result = _handle_finalise(req)
+        assert result.ok
+        summary = result.outputs["rumination_result"]
+        assert summary["relation_metrics"]["proposed_relations"] == 3
+        assert summary["relation_changes_count"] == 1
+        assert summary["relation_questions_count"] == 1
+
+
+class TestRuminationRelationCompletionHelpers:
+    def test_dispatch_relation_completion_auto_apply_dry_run(self) -> None:
+        from src.backend.workflows.durable.rumination_workflow import (
+            _dispatch_relation_completion_task,
+        )
+
+        instance_doc = {
+            "concept_id": "#V#alice",
+            "relationships": {},
+            "hypothesized_relations": {
+                "#V#has_affiliation": [
+                    {"value": "#V#strong_ai_lab", "confidence_score": 0.99}
+                ]
+            },
+            "name": "Alice",
+        }
+
+        def _fake_find_one(query, projection=None):
+            cid = (query or {}).get("concept_id")
+            if cid == "#V#alice":
+                return instance_doc
+            if cid == "#V#strong_ai_lab":
+                return {"concept_id": "#V#strong_ai_lab"}
+            return None
+
+        with (
+            patch(
+                "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+                side_effect=_fake_find_one,
+            ),
+            patch(
+                "src.backend.services.relation_elicitation_service."
+                "RelationElicitationService.generate_question_for_elicit",
+                return_value="What is Alice's affiliation?",
+            ),
+            patch(
+                "src.backend.services.relationship_write_service.add_relationship"
+            ) as mock_add_relationship,
+        ):
+            result = _dispatch_relation_completion_task(
+                task={
+                    "gap_name": "missing_relations",
+                    "predicate": "__relation_completion__",
+                    "allocation": 1,
+                    "auto_apply_confidence_threshold": 0.95,
+                },
+                ctx={
+                    "dry_run": True,
+                    "relation_gap_candidates": [
+                        {
+                            "concept_id": "#V#alice",
+                            "missing_predicates": ["#V#has_affiliation"],
+                        }
+                    ],
+                },
+            )
+
+        metrics = result["metrics"]
+        assert metrics["concepts_considered"] == 1
+        assert metrics["proposed_relations"] == 1
+        assert metrics["would_apply_relations"] == 1
+        assert metrics["auto_applied_relations"] == 0
+        assert metrics["deferred_relations"] == 0
+        assert len(result["proposal_details"]) == 1
+        assert result["proposal_details"][0]["action"] == "would_auto_apply"
+        mock_add_relationship.assert_not_called()
 
 
 class TestRuminationRegistration:


### PR DESCRIPTION
## Summary
- add `missing_relations` as a first-class rumination gap dimension
- add bounded relation-gap candidate discovery with priority scoring
- add relation-completion dispatch path with dry-run support and safe auto-apply gating from high-confidence hypothesised relations
- include relation telemetry (`relation_metrics`, `relation_changes`, `relation_questions`) in plan/dispatch/finalise outputs
- allow relation elicitation traversal to disable reverse-subtype expansion for bounded rumination scans
- add regression tests for relation assessment, relation dispatch dry-run behaviour, relation finalise summary, and auto-apply dry-run helper logic

## Validation
- `pdm run pytest tests/backend/test_rumination_workflow.py tests/backend/test_relation_elicitation_service.py -q`
- `pdm run pyright src/backend/workflows/durable/rumination_workflow.py src/backend/services/relation_elicitation_service.py tests/backend/test_rumination_workflow.py`

## Notes
- local dry-run of the new relation path was executed via `_handle_assess_gaps -> _handle_plan_enrichment -> _handle_dispatch_enrichment -> _handle_finalise` with `dry_run=true` and relation-only dimensions.