### PR TITLE
JVNAUTOSCI-1313: canonical uncertain relationship lifecycle assertions

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -1388,6 +1388,200 @@ def _remove_relationship(**kwargs):
         )
 
 
+def _upsert_uncertain_relationship_assertion(**kwargs):
+    from ...services.uncertain_relationship_service import (
+        upsert_uncertain_relationship_assertion,
+    )
+
+    source_id = kwargs.get("source_id")
+    predicate = kwargs.get("predicate")
+    target = kwargs.get("target")
+    confidence_score = kwargs.get("confidence_score")
+
+    missing: list[str] = []
+    if not source_id:
+        missing.append("source_id")
+    if not predicate:
+        missing.append("predicate")
+    if not target:
+        missing.append("target")
+    if confidence_score is None:
+        missing.append("confidence_score")
+    if missing:
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameters for upsert_uncertain_relationship_assertion",
+            details={"missing": missing},
+        )
+
+    source_id_text = str(source_id)
+    predicate_text = str(predicate)
+    target_text = str(target)
+    if not isinstance(confidence_score, (int, float, str)):
+        return make_error_response(
+            "invalid_parameter",
+            "confidence_score must be numeric",
+            details={"confidence_score": confidence_score},
+        )
+    confidence_value = float(confidence_score)
+
+    try:
+        return upsert_uncertain_relationship_assertion(
+            source_id=source_id_text,
+            predicate=predicate_text,
+            target=target_text,
+            confidence_score=confidence_value,
+            provenance=kwargs.get("provenance"),
+            status=kwargs.get("status", "proposed"),
+            assertion_id=kwargs.get("assertion_id"),
+            evidence_count=kwargs.get("evidence_count"),
+        )
+    except Exception as e:
+        return make_error_response(
+            "exception",
+            f"Exception: {str(e)}",
+            details={"exception_type": type(e).__name__},
+        )
+
+
+def _list_uncertain_relationship_assertions(**kwargs):
+    from ...services.uncertain_relationship_service import (
+        list_uncertain_relationship_assertions,
+    )
+
+    source_id = kwargs.get("source_id")
+    if not source_id:
+        return make_error_response(
+            "missing_parameter",
+            "Missing 'source_id' parameter",
+            details={"missing": ["source_id"]},
+        )
+
+    try:
+        rows = list_uncertain_relationship_assertions(
+            source_id=source_id,
+            predicate=kwargs.get("predicate"),
+            statuses=kwargs.get("statuses"),
+            include_legacy=bool(kwargs.get("include_legacy", True)),
+        )
+        return {
+            "success": True,
+            "source_id": source_id,
+            "count": len(rows),
+            "assertions": rows,
+        }
+    except Exception as e:
+        return make_error_response(
+            "exception",
+            f"Exception: {str(e)}",
+            details={"exception_type": type(e).__name__},
+        )
+
+
+def _promote_uncertain_relationship_assertion(**kwargs):
+    from ...services.uncertain_relationship_service import (
+        promote_uncertain_relationship_assertion,
+    )
+
+    source_id = kwargs.get("source_id")
+    assertion_id = kwargs.get("assertion_id")
+    missing: list[str] = []
+    if not source_id:
+        missing.append("source_id")
+    if not assertion_id:
+        missing.append("assertion_id")
+    if missing:
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameters for promote_uncertain_relationship_assertion",
+            details={"missing": missing},
+        )
+
+    source_id_text = str(source_id)
+    assertion_id_text = str(assertion_id)
+
+    try:
+        return promote_uncertain_relationship_assertion(
+            source_id=source_id_text,
+            assertion_id=assertion_id_text,
+            operator=str(kwargs.get("operator") or "mcp"),
+        )
+    except Exception as e:
+        return make_error_response(
+            "exception",
+            f"Exception: {str(e)}",
+            details={"exception_type": type(e).__name__},
+        )
+
+
+def _reject_uncertain_relationship_assertion(**kwargs):
+    from ...services.uncertain_relationship_service import (
+        reject_uncertain_relationship_assertion,
+    )
+
+    source_id = kwargs.get("source_id")
+    assertion_id = kwargs.get("assertion_id")
+    reason = kwargs.get("reason")
+    missing: list[str] = []
+    if not source_id:
+        missing.append("source_id")
+    if not assertion_id:
+        missing.append("assertion_id")
+    if not reason:
+        missing.append("reason")
+    if missing:
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameters for reject_uncertain_relationship_assertion",
+            details={"missing": missing},
+        )
+
+    source_id_text = str(source_id)
+    assertion_id_text = str(assertion_id)
+    reason_text = str(reason)
+
+    try:
+        return reject_uncertain_relationship_assertion(
+            source_id=source_id_text,
+            assertion_id=assertion_id_text,
+            reason=reason_text,
+            operator=str(kwargs.get("operator") or "mcp"),
+        )
+    except Exception as e:
+        return make_error_response(
+            "exception",
+            f"Exception: {str(e)}",
+            details={"exception_type": type(e).__name__},
+        )
+
+
+def _migrate_legacy_hypothesized_relations(**kwargs):
+    from ...services.uncertain_relationship_service import (
+        migrate_legacy_hypothesized_relations,
+    )
+
+    source_id = kwargs.get("source_id")
+    if not source_id:
+        return make_error_response(
+            "missing_parameter",
+            "Missing 'source_id' parameter",
+            details={"missing": ["source_id"]},
+        )
+
+    try:
+        return migrate_legacy_hypothesized_relations(
+            source_id=source_id,
+            predicate=kwargs.get("predicate"),
+            dry_run=bool(kwargs.get("dry_run", True)),
+        )
+    except Exception as e:
+        return make_error_response(
+            "exception",
+            f"Exception: {str(e)}",
+            details={"exception_type": type(e).__name__},
+        )
+
+
 def _preview_remove_relationship(**kwargs):
     from ...services.relationship_removal_service import preview_remove_relationship
 
@@ -4928,6 +5122,105 @@ def _remove_relationship_input_schema() -> Schema:
         },
         allow_unknown=True,
         description="remove_relationship input: relation_id OR source_id+predicate+target. Optional mode/cascade/confirmation controls. Only concept-to-concept relationships are supported.",
+    )
+
+
+def _upsert_uncertain_relationship_assertion_input_schema() -> Schema:
+    return Schema(
+        required={
+            "source_id": str,
+            "predicate": str,
+            "target": str,
+            "confidence_score": (float, int),
+        },
+        optional={
+            "status": (str, type(None)),
+            "assertion_id": (str, type(None)),
+            "provenance": (dict, type(None)),
+            "evidence_count": (int, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "upsert_uncertain_relationship_assertion input: source_id, predicate, target, "
+            "confidence_score plus optional status/assertion_id/provenance/evidence_count."
+        ),
+    )
+
+
+def _uncertain_relationship_operation_output_schema() -> Schema:
+    return Schema(
+        required={"success": bool},
+        optional={
+            "created": (bool, type(None)),
+            "already_promoted": (bool, type(None)),
+            "already_rejected": (bool, type(None)),
+            "assertion": (dict, type(None)),
+            "assertions": (list, type(None)),
+            "count": (int, type(None)),
+            "source_id": (str, type(None)),
+            "dry_run": (bool, type(None)),
+            "migrated_count": (int, type(None)),
+            "migrated_assertion_ids": (list, type(None)),
+            "write_result": (dict, type(None)),
+            "error": (str, type(None)),
+            "error_code": (str, type(None)),
+            "error_details": (dict, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "uncertain relationship lifecycle output: success plus lifecycle payloads "
+            "(assertion/assertions/create/promote/reject/migrate metadata) and structured errors."
+        ),
+    )
+
+
+def _list_uncertain_relationship_assertions_input_schema() -> Schema:
+    return Schema(
+        required={"source_id": str},
+        optional={
+            "predicate": (str, type(None)),
+            "statuses": (list, type(None)),
+            "include_legacy": (bool, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "list_uncertain_relationship_assertions input: source_id with optional predicate/status "
+            "filters and include_legacy toggle."
+        ),
+    )
+
+
+def _promote_uncertain_relationship_assertion_input_schema() -> Schema:
+    return Schema(
+        required={"source_id": str, "assertion_id": str},
+        optional={"operator": (str, type(None))},
+        allow_unknown=True,
+        description=(
+            "promote_uncertain_relationship_assertion input: source_id + assertion_id, optional operator."
+        ),
+    )
+
+
+def _reject_uncertain_relationship_assertion_input_schema() -> Schema:
+    return Schema(
+        required={"source_id": str, "assertion_id": str, "reason": str},
+        optional={"operator": (str, type(None))},
+        allow_unknown=True,
+        description=(
+            "reject_uncertain_relationship_assertion input: source_id + assertion_id + rejection reason."
+        ),
+    )
+
+
+def _migrate_legacy_hypothesized_relations_input_schema() -> Schema:
+    return Schema(
+        required={"source_id": str},
+        optional={"predicate": (str, type(None)), "dry_run": (bool, type(None))},
+        allow_unknown=True,
+        description=(
+            "migrate_legacy_hypothesized_relations input: source_id with optional predicate filter "
+            "and dry_run (default true)."
+        ),
     )
 
 
@@ -15669,6 +15962,46 @@ def build_default_catalogue() -> MethodCatalogue:
             output_schema=_add_relationship_output_schema(),
             category="write",
             description="Add a relationship between two concepts or from a concept to a text value. Use to add instance_of/typeOf relationships (e.g., add '#V#professor' as instance_of for a person), custom predicates (e.g., '#V#hasAffiliation' → 'Auckland University'), or any binary relationship. Supports both concept-to-concept relations (target is concept ID) and text predicates (target is text value). Common predicates: 'instance_of'/'instanceOf' (maps to is_an_instance_of), 'typeOf' (maps to is_a_type_of), or custom predicates like '#V#hasAffiliation', '#V#founderOf', '#V#hasResearchInterest'. Examples: source_id='#V#nikola_k._kasabov', predicate='instance_of', target='#V#professor' OR source_id='#V#nikola_k._kasabov', predicate='#V#hasAffiliation', target='Auckland University of Technology'.",
+        ),
+        MethodDefinition(
+            name="upsert_uncertain_relationship_assertion",
+            handler=_upsert_uncertain_relationship_assertion,
+            input_schema=_upsert_uncertain_relationship_assertion_input_schema(),
+            output_schema=_uncertain_relationship_operation_output_schema(),
+            category="write",
+            description="Create or update a canonical uncertain relationship assertion (confidence + provenance + lifecycle status) for a source concept.",
+        ),
+        MethodDefinition(
+            name="list_uncertain_relationship_assertions",
+            handler=_list_uncertain_relationship_assertions,
+            input_schema=_list_uncertain_relationship_assertions_input_schema(),
+            output_schema=_uncertain_relationship_operation_output_schema(),
+            category="read",
+            description="List canonical uncertain relationship assertions for a concept, optionally filtered by predicate/status and optionally merged with legacy hypothesised relation mappings.",
+        ),
+        MethodDefinition(
+            name="promote_uncertain_relationship_assertion",
+            handler=_promote_uncertain_relationship_assertion,
+            input_schema=_promote_uncertain_relationship_assertion_input_schema(),
+            output_schema=_uncertain_relationship_operation_output_schema(),
+            category="write",
+            description="Promote an uncertain relationship assertion to an asserted relationship or text relation and persist promotion linkage metadata.",
+        ),
+        MethodDefinition(
+            name="reject_uncertain_relationship_assertion",
+            handler=_reject_uncertain_relationship_assertion,
+            input_schema=_reject_uncertain_relationship_assertion_input_schema(),
+            output_schema=_uncertain_relationship_operation_output_schema(),
+            category="write",
+            description="Reject/archive an uncertain relationship assertion with a required reason while preserving provenance and lifecycle history.",
+        ),
+        MethodDefinition(
+            name="migrate_legacy_hypothesized_relations",
+            handler=_migrate_legacy_hypothesized_relations,
+            input_schema=_migrate_legacy_hypothesized_relations_input_schema(),
+            output_schema=_uncertain_relationship_operation_output_schema(),
+            category="write",
+            description="Migrate legacy hypothesized_relations into canonical uncertain relationship assertions non-destructively, with dry-run support.",
         ),
         MethodDefinition(
             name="remove_relationship",

--- a/src/backend/services/relation_elicitation_service.py
+++ b/src/backend/services/relation_elicitation_service.py
@@ -2,6 +2,11 @@
 from typing import List, Dict, Any, Optional
 
 from ..services import concept_service
+from ..db.repositories.concepts_repository import ConceptsRepository
+from .uncertain_relationship_service import (
+    collect_uncertain_predicates,
+    upsert_uncertain_relationship_assertion,
+)
 
 
 class RelationElicitationService:
@@ -112,11 +117,22 @@ class RelationElicitationService:
         existing_hypothesized = set(
             (instance_concept.get("hypothesized_relations") or {}).keys()
         )
+        existing_uncertain = collect_uncertain_predicates(
+            source_id=instance_id,
+            source_doc=instance_concept,
+            include_legacy=True,
+        )
         return [
             c
             for c in candidate_predicates
             if c not in existing_relations
-            and (include_hypothesized or c not in existing_hypothesized)
+            and (
+                include_hypothesized
+                or (
+                    c not in existing_hypothesized
+                    and c not in existing_uncertain
+                )
+            )
         ]
 
     def generate_question_for_elicit(
@@ -171,8 +187,22 @@ class RelationElicitationService:
             "source": "llm_extraction",
             "evidence_count": 1,
         }
-        update_payload = {"hypothesized_relations": {predicate: [hypothesis]}}
-        concept_service.update_concept(instance_id, update_payload)
+        upsert_uncertain_relationship_assertion(
+            source_id=instance_id,
+            predicate=predicate,
+            target=hypothesis["value"],
+            confidence_score=float(hypothesis["confidence_score"]),
+            provenance={
+                "source": "relation_elicitation_service",
+                "source_interaction_id": hypothesis["source_interaction_id"],
+                "extraction_source": hypothesis["source"],
+            },
+            evidence_count=int(hypothesis.get("evidence_count", 1)),
+        )
+        ConceptsRepository.update_one(
+            {"concept_id": instance_id},
+            {"$push": {f"hypothesized_relations.{predicate}": hypothesis}},
+        )
         return hypothesis
 
     def elicit_relation(

--- a/src/backend/services/uncertain_relationship_service.py
+++ b/src/backend/services/uncertain_relationship_service.py
@@ -1,0 +1,658 @@
+"""Canonical uncertain relationship assertion lifecycle helpers.
+
+This module provides a first-class representation for uncertain relation
+assertions while preserving compatibility with legacy ``hypothesized_relations``
+payloads during migration.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+import uuid
+
+from ..db.repositories.concepts_repository import ConceptsRepository
+from .relationship_write_service import add_relationship
+from .text_value_service import upsert_text_for_concept
+
+UNCERTAIN_RELATIONSHIP_STATUSES: frozenset[str] = frozenset(
+    {"proposed", "promoted", "rejected", "archived"}
+)
+ACTIVE_UNCERTAIN_RELATIONSHIP_STATUSES: frozenset[str] = frozenset({"proposed"})
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _coerce_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _clamp_confidence(value: Any) -> float:
+    return max(0.0, min(1.0, _coerce_float(value, default=0.0)))
+
+
+def _normalise_status(value: Any, default: str = "proposed") -> str:
+    status = str(value or default).strip().lower() or default
+    if status not in UNCERTAIN_RELATIONSHIP_STATUSES:
+        return default
+    return status
+
+
+def _as_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    return ""
+
+
+def _resolve_target_kind(target: str) -> str:
+    return "concept" if isinstance(target, str) and target.startswith("#V#") else "text"
+
+
+def _build_legacy_assertion_id(
+    *,
+    source_id: str,
+    predicate: str,
+    target: str,
+    source_marker: str,
+    index: int,
+) -> str:
+    digest_seed = f"{source_id}|{predicate}|{target}|{source_marker}|{index}"
+    digest = hashlib.sha1(digest_seed.encode("utf-8")).hexdigest()[:18]
+    return f"legacy_hyp_{digest}"
+
+
+def _build_assertion_id() -> str:
+    return f"ura_{uuid.uuid4().hex}"
+
+
+def _normalise_assertion_record(
+    raw: Mapping[str, Any],
+    *,
+    source_id: str,
+) -> dict[str, Any]:
+    predicate = _as_text(raw.get("predicate"))
+    target = _as_text(raw.get("target"))
+    target_kind = _as_text(raw.get("target_kind")) or _resolve_target_kind(target)
+    assertion_id = _as_text(raw.get("assertion_id")) or _build_assertion_id()
+    status = _normalise_status(raw.get("status"))
+
+    created_at = _as_text(raw.get("created_at_utc")) or _now_iso()
+    updated_at = _as_text(raw.get("updated_at_utc")) or created_at
+    confidence_score = _clamp_confidence(raw.get("confidence_score"))
+
+    provenance_raw = raw.get("provenance")
+    provenance = dict(provenance_raw) if isinstance(provenance_raw, Mapping) else {}
+
+    assertion: dict[str, Any] = {
+        "assertion_id": assertion_id,
+        "source_id": source_id,
+        "predicate": predicate,
+        "target": target,
+        "target_kind": target_kind,
+        "confidence_score": confidence_score,
+        "status": status,
+        "provenance": provenance,
+        "created_at_utc": created_at,
+        "updated_at_utc": updated_at,
+    }
+
+    for field_name in (
+        "promoted_at_utc",
+        "rejected_at_utc",
+        "rejection_reason",
+        "promoted_relation_id",
+        "promoted_relation_kind",
+        "legacy_hypothesis_ref",
+    ):
+        if raw.get(field_name) is not None:
+            assertion[field_name] = raw.get(field_name)
+    return assertion
+
+
+def _validate_assertion_integrity(assertion: Mapping[str, Any]) -> Optional[str]:
+    status = _normalise_status(assertion.get("status"))
+    has_promoted = bool(assertion.get("promoted_at_utc"))
+    has_rejected = bool(assertion.get("rejected_at_utc")) or bool(
+        assertion.get("rejection_reason")
+    )
+    if has_promoted and has_rejected:
+        return "conflicting_terminal_state"
+    if status == "promoted" and not has_promoted:
+        return "missing_promotion_timestamp"
+    if status == "rejected" and not has_rejected:
+        return "missing_rejection_reason"
+    return None
+
+
+def _load_canonical_assertions(
+    source_doc: Mapping[str, Any],
+    *,
+    source_id: str,
+) -> list[dict[str, Any]]:
+    rows = source_doc.get("uncertain_relationship_assertions")
+    if not isinstance(rows, list):
+        return []
+    output: list[dict[str, Any]] = []
+    for item in rows:
+        if not isinstance(item, Mapping):
+            continue
+        record = _normalise_assertion_record(item, source_id=source_id)
+        if not record.get("predicate") or not record.get("target"):
+            continue
+        output.append(record)
+    return output
+
+
+def _extract_legacy_assertions(
+    source_doc: Mapping[str, Any],
+    *,
+    source_id: str,
+) -> list[dict[str, Any]]:
+    legacy = source_doc.get("hypothesized_relations")
+    if not isinstance(legacy, Mapping):
+        return []
+
+    assertions: list[dict[str, Any]] = []
+    for predicate, payload in legacy.items():
+        predicate_value = _as_text(predicate)
+        if not predicate_value:
+            continue
+        hypotheses: list[Any]
+        if isinstance(payload, list):
+            hypotheses = payload
+        elif isinstance(payload, Mapping):
+            hypotheses = [payload]
+        else:
+            continue
+
+        for index, hypothesis in enumerate(hypotheses):
+            if not isinstance(hypothesis, Mapping):
+                continue
+            target = _as_text(hypothesis.get("value"))
+            if not target:
+                continue
+
+            source_marker = _as_text(hypothesis.get("source_interaction_id")) or _as_text(
+                hypothesis.get("source")
+            )
+            assertion_id = (
+                _as_text(hypothesis.get("hypothesis_id"))
+                or _as_text(hypothesis.get("id"))
+                or _build_legacy_assertion_id(
+                    source_id=source_id,
+                    predicate=predicate_value,
+                    target=target,
+                    source_marker=source_marker or "unknown_source",
+                    index=index,
+                )
+            )
+            evidence_count = 1
+            if isinstance(hypothesis.get("evidence"), list):
+                evidence_count = len(hypothesis.get("evidence") or [])
+            if isinstance(hypothesis.get("evidence_count"), int):
+                evidence_count = int(hypothesis["evidence_count"])
+
+            provenance: dict[str, Any] = {"source": "legacy_hypothesized_relations"}
+            if source_marker:
+                provenance["source_interaction_id"] = source_marker
+            if _as_text(hypothesis.get("source")):
+                provenance["legacy_source"] = _as_text(hypothesis.get("source"))
+
+            assertions.append(
+                {
+                    "assertion_id": assertion_id,
+                    "source_id": source_id,
+                    "predicate": predicate_value,
+                    "target": target,
+                    "target_kind": _resolve_target_kind(target),
+                    "confidence_score": _clamp_confidence(
+                        hypothesis.get("confidence_score")
+                    ),
+                    "status": "proposed",
+                    "provenance": provenance,
+                    "created_at_utc": _now_iso(),
+                    "updated_at_utc": _now_iso(),
+                    "evidence_count": max(1, evidence_count),
+                    "legacy_hypothesis_ref": {
+                        "predicate": predicate_value,
+                        "index": index,
+                    },
+                    "legacy_only": True,
+                }
+            )
+    return assertions
+
+
+def list_uncertain_relationship_assertions(
+    *,
+    source_id: str,
+    predicate: Optional[str] = None,
+    statuses: Optional[Sequence[str]] = None,
+    include_legacy: bool = True,
+    source_doc: Optional[Mapping[str, Any]] = None,
+) -> list[dict[str, Any]]:
+    """List uncertain assertions for a concept, optionally including legacy-adapted rows."""
+    if not isinstance(source_id, str) or not source_id.strip():
+        return []
+    source_id = source_id.strip()
+    filter_predicate = _as_text(predicate)
+    status_filter = (
+        {_normalise_status(item) for item in statuses if isinstance(item, str)}
+        if statuses
+        else None
+    )
+
+    doc = source_doc
+    if doc is None:
+        doc = ConceptsRepository.find_one(
+            {"concept_id": source_id},
+            {
+                "concept_id": 1,
+                "uncertain_relationship_assertions": 1,
+                "hypothesized_relations": 1,
+            },
+        )
+    if not isinstance(doc, Mapping):
+        return []
+
+    canonical = _load_canonical_assertions(doc, source_id=source_id)
+    by_id: dict[str, dict[str, Any]] = {
+        str(item["assertion_id"]): dict(item) for item in canonical
+    }
+
+    if include_legacy:
+        for legacy_row in _extract_legacy_assertions(doc, source_id=source_id):
+            assertion_id = str(legacy_row["assertion_id"])
+            if assertion_id not in by_id:
+                by_id[assertion_id] = dict(legacy_row)
+
+    rows = list(by_id.values())
+    if filter_predicate:
+        rows = [r for r in rows if _as_text(r.get("predicate")) == filter_predicate]
+    if status_filter:
+        rows = [
+            r for r in rows if _normalise_status(r.get("status")) in status_filter
+        ]
+
+    rows.sort(
+        key=lambda item: (
+            str(item.get("updated_at_utc") or ""),
+            str(item.get("assertion_id") or ""),
+        ),
+        reverse=True,
+    )
+    return rows
+
+
+def collect_uncertain_predicates(
+    *,
+    source_id: str,
+    source_doc: Optional[Mapping[str, Any]] = None,
+    include_legacy: bool = True,
+) -> set[str]:
+    """Return predicate IDs that have uncertain assertions for a concept."""
+    assertions = list_uncertain_relationship_assertions(
+        source_id=source_id,
+        include_legacy=include_legacy,
+        source_doc=source_doc,
+    )
+    return {
+        _as_text(item.get("predicate"))
+        for item in assertions
+        if _as_text(item.get("predicate"))
+    }
+
+
+def upsert_uncertain_relationship_assertion(
+    *,
+    source_id: str,
+    predicate: str,
+    target: str,
+    confidence_score: float,
+    provenance: Optional[Mapping[str, Any]] = None,
+    status: str = "proposed",
+    assertion_id: Optional[str] = None,
+    evidence_count: Optional[int] = None,
+) -> dict[str, Any]:
+    """Create or update a canonical uncertain relation assertion."""
+    if not isinstance(source_id, str) or not source_id.strip():
+        return {"success": False, "error": "invalid_source_id"}
+
+    source_id = source_id.strip()
+    predicate_value = _as_text(predicate)
+    target_value = _as_text(target)
+    if not predicate_value:
+        return {"success": False, "error": "invalid_predicate"}
+    if not target_value:
+        return {"success": False, "error": "invalid_target"}
+
+    doc = ConceptsRepository.find_one(
+        {"concept_id": source_id},
+        {"concept_id": 1, "uncertain_relationship_assertions": 1},
+    )
+    if not doc:
+        return {"success": False, "error": "source_not_found"}
+
+    canonical = _load_canonical_assertions(doc, source_id=source_id)
+    resolved_status = _normalise_status(status)
+    now_iso = _now_iso()
+    target_kind = _resolve_target_kind(target_value)
+
+    incoming_assertion_id = _as_text(assertion_id)
+    existing_index = -1
+    if incoming_assertion_id:
+        for idx, item in enumerate(canonical):
+            if _as_text(item.get("assertion_id")) == incoming_assertion_id:
+                existing_index = idx
+                break
+    if existing_index < 0:
+        for idx, item in enumerate(canonical):
+            if (
+                _as_text(item.get("predicate")) == predicate_value
+                and _as_text(item.get("target")) == target_value
+                and _normalise_status(item.get("status")) in ACTIVE_UNCERTAIN_RELATIONSHIP_STATUSES
+            ):
+                existing_index = idx
+                break
+
+    if existing_index >= 0:
+        assertion = dict(canonical[existing_index])
+        assertion["confidence_score"] = _clamp_confidence(confidence_score)
+        assertion["status"] = resolved_status
+        assertion["updated_at_utc"] = now_iso
+        assertion["predicate"] = predicate_value
+        assertion["target"] = target_value
+        assertion["target_kind"] = target_kind
+        if isinstance(provenance, Mapping):
+            merged = dict(assertion.get("provenance") or {})
+            merged.update(dict(provenance))
+            assertion["provenance"] = merged
+        if isinstance(evidence_count, int):
+            assertion["evidence_count"] = max(1, int(evidence_count))
+        canonical[existing_index] = assertion
+        created = False
+    else:
+        assertion = {
+            "assertion_id": incoming_assertion_id or _build_assertion_id(),
+            "source_id": source_id,
+            "predicate": predicate_value,
+            "target": target_value,
+            "target_kind": target_kind,
+            "confidence_score": _clamp_confidence(confidence_score),
+            "status": resolved_status,
+            "provenance": dict(provenance or {}),
+            "created_at_utc": now_iso,
+            "updated_at_utc": now_iso,
+        }
+        if isinstance(evidence_count, int):
+            assertion["evidence_count"] = max(1, int(evidence_count))
+        canonical.append(assertion)
+        created = True
+
+    integrity_error = _validate_assertion_integrity(assertion)
+    if integrity_error:
+        return {"success": False, "error": integrity_error}
+
+    ConceptsRepository.update_one(
+        {"concept_id": source_id},
+        {"$set": {"uncertain_relationship_assertions": canonical}},
+    )
+    return {"success": True, "created": created, "assertion": assertion}
+
+
+def promote_uncertain_relationship_assertion(
+    *,
+    source_id: str,
+    assertion_id: str,
+    operator: str = "system",
+) -> dict[str, Any]:
+    """Promote an uncertain assertion into an asserted relationship/text relation."""
+    source_id = _as_text(source_id)
+    assertion_id = _as_text(assertion_id)
+    if not source_id:
+        return {"success": False, "error": "invalid_source_id"}
+    if not assertion_id:
+        return {"success": False, "error": "invalid_assertion_id"}
+
+    source_doc = ConceptsRepository.find_one(
+        {"concept_id": source_id},
+        {
+            "concept_id": 1,
+            "uncertain_relationship_assertions": 1,
+            "hypothesized_relations": 1,
+        },
+    )
+    if not source_doc:
+        return {"success": False, "error": "source_not_found"}
+
+    canonical = _load_canonical_assertions(source_doc, source_id=source_id)
+    idx = -1
+    for item_idx, item in enumerate(canonical):
+        if _as_text(item.get("assertion_id")) == assertion_id:
+            idx = item_idx
+            break
+
+    if idx < 0:
+        # Materialise a canonical row from legacy view on demand.
+        legacy_rows = _extract_legacy_assertions(source_doc, source_id=source_id)
+        legacy_row = next(
+            (item for item in legacy_rows if _as_text(item.get("assertion_id")) == assertion_id),
+            None,
+        )
+        if legacy_row is None:
+            return {"success": False, "error": "assertion_not_found"}
+        canonical.append(
+            _normalise_assertion_record(legacy_row, source_id=source_id)
+        )
+        idx = len(canonical) - 1
+
+    assertion = dict(canonical[idx])
+    status = _normalise_status(assertion.get("status"))
+    if status in {"rejected", "archived"}:
+        return {"success": False, "error": "assertion_not_promotable", "status": status}
+    if status == "promoted":
+        return {"success": True, "already_promoted": True, "assertion": assertion}
+
+    predicate = _as_text(assertion.get("predicate"))
+    target = _as_text(assertion.get("target"))
+    target_kind = _as_text(assertion.get("target_kind")) or _resolve_target_kind(target)
+
+    relation_result: dict[str, Any]
+    relation_kind = "concept_relationship"
+    if target_kind == "concept":
+        relation_result = add_relationship(source_id, predicate, target)
+        if not bool(relation_result.get("success")):
+            return {"success": False, "error": "promotion_write_failed", "result": relation_result}
+        promoted_relation_id = relation_result.get("relation_id")
+    else:
+        relation_kind = "text_relation"
+        text_result = upsert_text_for_concept(
+            subject_concept_id=source_id,
+            predicate=predicate,
+            text=target,
+            lang="en-NZ",
+            provenance={
+                "source": "uncertain_relationship_promotion",
+                "assertion_id": assertion_id,
+                "operator": operator,
+            },
+            context={
+                "assertion_id": assertion_id,
+                "source": "uncertain_relationship_service",
+            },
+        )
+        relation_result = dict(text_result)
+        promoted_relation_id = text_result.get("relation_id")
+
+    now_iso = _now_iso()
+    assertion["status"] = "promoted"
+    assertion["target_kind"] = target_kind
+    assertion["promoted_at_utc"] = now_iso
+    assertion["updated_at_utc"] = now_iso
+    assertion["promoted_relation_id"] = promoted_relation_id
+    assertion["promoted_relation_kind"] = relation_kind
+    assertion.pop("rejected_at_utc", None)
+    assertion.pop("rejection_reason", None)
+
+    integrity_error = _validate_assertion_integrity(assertion)
+    if integrity_error:
+        return {"success": False, "error": integrity_error}
+
+    canonical[idx] = assertion
+    ConceptsRepository.update_one(
+        {"concept_id": source_id},
+        {"$set": {"uncertain_relationship_assertions": canonical}},
+    )
+    return {
+        "success": True,
+        "assertion": assertion,
+        "write_result": relation_result,
+    }
+
+
+def reject_uncertain_relationship_assertion(
+    *,
+    source_id: str,
+    assertion_id: str,
+    reason: str,
+    operator: str = "system",
+) -> dict[str, Any]:
+    """Reject an uncertain assertion while preserving provenance and reason."""
+    source_id = _as_text(source_id)
+    assertion_id = _as_text(assertion_id)
+    rejection_reason = _as_text(reason)
+    if not source_id:
+        return {"success": False, "error": "invalid_source_id"}
+    if not assertion_id:
+        return {"success": False, "error": "invalid_assertion_id"}
+    if not rejection_reason:
+        return {"success": False, "error": "invalid_rejection_reason"}
+
+    source_doc = ConceptsRepository.find_one(
+        {"concept_id": source_id},
+        {
+            "concept_id": 1,
+            "uncertain_relationship_assertions": 1,
+            "hypothesized_relations": 1,
+        },
+    )
+    if not source_doc:
+        return {"success": False, "error": "source_not_found"}
+
+    canonical = _load_canonical_assertions(source_doc, source_id=source_id)
+    idx = -1
+    for item_idx, item in enumerate(canonical):
+        if _as_text(item.get("assertion_id")) == assertion_id:
+            idx = item_idx
+            break
+
+    if idx < 0:
+        legacy_rows = _extract_legacy_assertions(source_doc, source_id=source_id)
+        legacy_row = next(
+            (item for item in legacy_rows if _as_text(item.get("assertion_id")) == assertion_id),
+            None,
+        )
+        if legacy_row is None:
+            return {"success": False, "error": "assertion_not_found"}
+        canonical.append(
+            _normalise_assertion_record(legacy_row, source_id=source_id)
+        )
+        idx = len(canonical) - 1
+
+    assertion = dict(canonical[idx])
+    status = _normalise_status(assertion.get("status"))
+    if status == "promoted":
+        return {"success": False, "error": "assertion_already_promoted"}
+    if status == "rejected":
+        return {"success": True, "already_rejected": True, "assertion": assertion}
+
+    now_iso = _now_iso()
+    assertion["status"] = "rejected"
+    assertion["rejected_at_utc"] = now_iso
+    assertion["updated_at_utc"] = now_iso
+    assertion["rejection_reason"] = rejection_reason
+    prov = dict(assertion.get("provenance") or {})
+    prov["rejected_by"] = operator
+    assertion["provenance"] = prov
+    assertion.pop("promoted_at_utc", None)
+    assertion.pop("promoted_relation_id", None)
+    assertion.pop("promoted_relation_kind", None)
+
+    integrity_error = _validate_assertion_integrity(assertion)
+    if integrity_error:
+        return {"success": False, "error": integrity_error}
+
+    canonical[idx] = assertion
+    ConceptsRepository.update_one(
+        {"concept_id": source_id},
+        {"$set": {"uncertain_relationship_assertions": canonical}},
+    )
+    return {"success": True, "assertion": assertion}
+
+
+def migrate_legacy_hypothesized_relations(
+    *,
+    source_id: str,
+    predicate: Optional[str] = None,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    """Persist canonical assertion rows from legacy hypothesized relations."""
+    source_id = _as_text(source_id)
+    if not source_id:
+        return {"success": False, "error": "invalid_source_id"}
+    filter_predicate = _as_text(predicate)
+
+    source_doc = ConceptsRepository.find_one(
+        {"concept_id": source_id},
+        {
+            "concept_id": 1,
+            "uncertain_relationship_assertions": 1,
+            "hypothesized_relations": 1,
+        },
+    )
+    if not source_doc:
+        return {"success": False, "error": "source_not_found"}
+
+    canonical = _load_canonical_assertions(source_doc, source_id=source_id)
+    existing_ids = {_as_text(item.get("assertion_id")) for item in canonical}
+    legacy_rows = _extract_legacy_assertions(source_doc, source_id=source_id)
+    if filter_predicate:
+        legacy_rows = [
+            item
+            for item in legacy_rows
+            if _as_text(item.get("predicate")) == filter_predicate
+        ]
+
+    migrated_rows: list[dict[str, Any]] = []
+    for row in legacy_rows:
+        assertion_id = _as_text(row.get("assertion_id"))
+        if assertion_id and assertion_id in existing_ids:
+            continue
+        migrated = _normalise_assertion_record(row, source_id=source_id)
+        migrated["provenance"] = {
+            **dict(migrated.get("provenance") or {}),
+            "source": "legacy_hypothesized_relations_migration",
+        }
+        migrated_rows.append(migrated)
+        existing_ids.add(assertion_id)
+
+    if not dry_run and migrated_rows:
+        ConceptsRepository.update_one(
+            {"concept_id": source_id},
+            {"$set": {"uncertain_relationship_assertions": canonical + migrated_rows}},
+        )
+
+    return {
+        "success": True,
+        "dry_run": bool(dry_run),
+        "source_id": source_id,
+        "migrated_count": len(migrated_rows),
+        "migrated_assertion_ids": [row["assertion_id"] for row in migrated_rows],
+    }
+

--- a/src/backend/workflows/durable/rumination_workflow.py
+++ b/src/backend/workflows/durable/rumination_workflow.py
@@ -351,6 +351,7 @@ def _list_relation_gap_candidates(
         "names": 1,
         "relationships": 1,
         "hypothesized_relations": 1,
+        "uncertain_relationship_assertions": 1,
     }
     if candidate_concept_ids:
         concept_docs = ConceptsRepository.find(
@@ -437,10 +438,39 @@ def _resolve_relation_auto_apply_candidate(
     if isinstance(relationships, dict) and relationships.get(predicate):
         return {"status": "ineligible", "reason": "already_present"}
 
-    hypotheses = (instance_doc.get("hypothesized_relations") or {}).get(predicate)
-    if isinstance(hypotheses, dict):
-        hypotheses = [hypotheses]
-    if not isinstance(hypotheses, list) or not hypotheses:
+    from ...services.uncertain_relationship_service import (
+        ACTIVE_UNCERTAIN_RELATIONSHIP_STATUSES,
+        list_uncertain_relationship_assertions,
+    )
+
+    source_id = str(instance_doc.get("concept_id") or "").strip()
+    canonical_assertions = list_uncertain_relationship_assertions(
+        source_id=source_id,
+        predicate=predicate,
+        statuses=tuple(ACTIVE_UNCERTAIN_RELATIONSHIP_STATUSES),
+        include_legacy=True,
+        source_doc=instance_doc,
+    )
+    canonical_hypotheses: list[dict[str, Any]] = []
+    for assertion in canonical_assertions:
+        if not isinstance(assertion, dict):
+            continue
+        canonical_hypotheses.append(
+            {
+                "hypothesis_id": assertion.get("assertion_id"),
+                "id": assertion.get("assertion_id"),
+                "value": assertion.get("target"),
+                "confidence_score": assertion.get("confidence_score"),
+                "source": (assertion.get("provenance") or {}).get("source"),
+                "source_interaction_id": (assertion.get("provenance") or {}).get(
+                    "source_interaction_id"
+                ),
+                "evidence_count": assertion.get("evidence_count"),
+            }
+        )
+
+    hypotheses_list: list[Any] = list(canonical_hypotheses)
+    if not hypotheses_list:
         return {"status": "ineligible", "reason": "no_hypothesis"}
 
     policy = _resolve_relation_auto_apply_policy(
@@ -455,7 +485,7 @@ def _resolve_relation_auto_apply_candidate(
     candidates: list[dict[str, Any]] = []
     last_failure_reason = "no_eligible_hypothesis"
     last_failure_details: dict[str, Any] = {}
-    for idx, hypothesis in enumerate(hypotheses):
+    for idx, hypothesis in enumerate(hypotheses_list):
         if not isinstance(hypothesis, dict):
             last_failure_reason = "invalid_hypothesis_payload"
             continue
@@ -800,6 +830,7 @@ def _dispatch_relation_completion_task(
                 "names": 1,
                 "relationships": 1,
                 "hypothesized_relations": 1,
+                "uncertain_relationship_assertions": 1,
             },
         )
         if not instance_doc:

--- a/tests/backend/test_internal_mcp_uncertain_relationship_tools.py
+++ b/tests/backend/test_internal_mcp_uncertain_relationship_tools.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import pytest
+
+from src.backend.db.repositories.concepts_repository import ConceptsRepository
+from src.backend.integrations.internal_mcp import build_default_catalogue
+from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
+from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+
+
+@pytest.fixture(autouse=True)
+def reset_mock_db(monkeypatch):
+    monkeypatch.setenv("VON_USE_MOCK_DB", "1")
+    from src.backend.db.mongo_client import get_db
+
+    db = get_db()
+    if db is not None:
+        try:
+            db.drop_collection("concepts")
+            db.drop_collection("text_values")
+            db.drop_collection("text_relations")
+        except Exception:
+            pass
+    yield
+
+
+def _build_gateway() -> InternalMCPGateway:
+    return InternalMCPGateway(
+        catalogue=build_default_catalogue(),
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+
+
+def test_uncertain_relationship_tools_gateway_create_list_promote_flow() -> None:
+    gateway = _build_gateway()
+
+    ConceptsRepository.insert_one({"concept_id": "#V#alice", "relationships": {}})
+    ConceptsRepository.insert_one({"concept_id": "#V#strong_ai_lab", "relationships": {}})
+
+    upsert = gateway.invoke(
+        "upsert_uncertain_relationship_assertion",
+        {
+            "source_id": "#V#alice",
+            "predicate": "#V#related_to",
+            "target": "#V#strong_ai_lab",
+            "confidence_score": 0.96,
+            "provenance": {"source": "gateway_test"},
+            "evidence_count": 2,
+        },
+    ).payload
+    assert upsert.get("success") is True
+    assertion_id = (upsert.get("assertion") or {}).get("assertion_id")
+    assert isinstance(assertion_id, str) and assertion_id
+
+    listed = gateway.invoke(
+        "list_uncertain_relationship_assertions",
+        {"source_id": "#V#alice", "predicate": "#V#related_to"},
+    ).payload
+    assert listed.get("success") is True
+    assert listed.get("count") == 1
+
+    promoted = gateway.invoke(
+        "promote_uncertain_relationship_assertion",
+        {"source_id": "#V#alice", "assertion_id": assertion_id},
+    ).payload
+    assert promoted.get("success") is True
+    assert (promoted.get("assertion") or {}).get("status") == "promoted"
+
+    source_doc = ConceptsRepository.find_one({"concept_id": "#V#alice"})
+    relationships = (source_doc or {}).get("relationships") or {}
+    assert "#V#strong_ai_lab" in (relationships.get("related_to") or [])
+
+
+def test_uncertain_relationship_tools_gateway_reject_and_migrate_legacy() -> None:
+    gateway = _build_gateway()
+
+    ConceptsRepository.insert_one(
+        {
+            "concept_id": "#V#alice",
+            "relationships": {},
+            "hypothesized_relations": {
+                "#V#has_affiliation": [
+                    {"id": "legacy-1", "value": "#V#strong_ai_lab", "confidence_score": 0.8}
+                ]
+            },
+        }
+    )
+
+    migrated = gateway.invoke(
+        "migrate_legacy_hypothesized_relations",
+        {"source_id": "#V#alice", "dry_run": False},
+    ).payload
+    assert migrated.get("success") is True
+    assert migrated.get("migrated_count") == 1
+
+    rejected = gateway.invoke(
+        "reject_uncertain_relationship_assertion",
+        {
+            "source_id": "#V#alice",
+            "assertion_id": "legacy-1",
+            "reason": "not enough evidence",
+        },
+    ).payload
+    assert rejected.get("success") is True
+    assert (rejected.get("assertion") or {}).get("status") == "rejected"
+

--- a/tests/backend/test_uncertain_relationship_service.py
+++ b/tests/backend/test_uncertain_relationship_service.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_mock_db(monkeypatch):
+    monkeypatch.setenv("VON_USE_MOCK_DB", "1")
+    from src.backend.db.mongo_client import get_db
+
+    db = get_db()
+    if db is not None:
+        try:
+            db.drop_collection("concepts")
+            db.drop_collection("text_values")
+            db.drop_collection("text_relations")
+        except Exception:
+            pass
+    yield
+
+
+def test_list_uncertain_assertions_includes_legacy_mapping() -> None:
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.services.uncertain_relationship_service import (
+        list_uncertain_relationship_assertions,
+    )
+
+    ConceptsRepository.insert_one(
+        {
+            "concept_id": "#V#alice",
+            "relationships": {},
+            "hypothesized_relations": {
+                "#V#has_affiliation": [
+                    {
+                        "id": "legacy-1",
+                        "value": "#V#strong_ai_lab",
+                        "confidence_score": 0.88,
+                        "source": "llm_extraction",
+                        "source_interaction_id": "turn-1",
+                    }
+                ]
+            },
+        }
+    )
+
+    rows = list_uncertain_relationship_assertions(
+        source_id="#V#alice",
+        predicate="#V#has_affiliation",
+        include_legacy=True,
+    )
+    assert len(rows) == 1
+    assert rows[0]["assertion_id"] == "legacy-1"
+    assert rows[0]["target"] == "#V#strong_ai_lab"
+    assert rows[0]["status"] == "proposed"
+
+
+def test_upsert_uncertain_assertion_creates_then_updates() -> None:
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.services.uncertain_relationship_service import (
+        upsert_uncertain_relationship_assertion,
+    )
+
+    ConceptsRepository.insert_one({"concept_id": "#V#alice", "relationships": {}})
+
+    created = upsert_uncertain_relationship_assertion(
+        source_id="#V#alice",
+        predicate="#V#has_affiliation",
+        target="#V#strong_ai_lab",
+        confidence_score=0.9,
+        provenance={"source": "unit_test"},
+    )
+    assert created["success"] is True
+    assert created["created"] is True
+    assertion_id = created["assertion"]["assertion_id"]
+
+    updated = upsert_uncertain_relationship_assertion(
+        source_id="#V#alice",
+        predicate="#V#has_affiliation",
+        target="#V#strong_ai_lab",
+        confidence_score=0.97,
+        assertion_id=assertion_id,
+        provenance={"updated_by": "unit_test"},
+    )
+    assert updated["success"] is True
+    assert updated["created"] is False
+    assert updated["assertion"]["confidence_score"] == pytest.approx(0.97)
+    assert updated["assertion"]["provenance"]["updated_by"] == "unit_test"
+
+
+def test_promote_uncertain_assertion_writes_relationship_and_marks_promoted() -> None:
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.services.uncertain_relationship_service import (
+        promote_uncertain_relationship_assertion,
+        upsert_uncertain_relationship_assertion,
+    )
+
+    ConceptsRepository.insert_one({"concept_id": "#V#alice", "relationships": {}})
+    ConceptsRepository.insert_one(
+        {"concept_id": "#V#strong_ai_lab", "relationships": {}}
+    )
+
+    created = upsert_uncertain_relationship_assertion(
+        source_id="#V#alice",
+        predicate="#V#related_to",
+        target="#V#strong_ai_lab",
+        confidence_score=0.96,
+        provenance={"source": "unit_test"},
+    )
+    assertion_id = created["assertion"]["assertion_id"]
+
+    promoted = promote_uncertain_relationship_assertion(
+        source_id="#V#alice",
+        assertion_id=assertion_id,
+        operator="test",
+    )
+    assert promoted["success"] is True
+    assert promoted["assertion"]["status"] == "promoted"
+    assert promoted["assertion"]["promoted_relation_kind"] == "concept_relationship"
+
+    source_doc = ConceptsRepository.find_one({"concept_id": "#V#alice"})
+    relationships = (source_doc or {}).get("relationships") or {}
+    assert "#V#strong_ai_lab" in (relationships.get("related_to") or [])
+
+
+def test_reject_uncertain_assertion_records_reason_and_blocks_promotion() -> None:
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.services.uncertain_relationship_service import (
+        promote_uncertain_relationship_assertion,
+        reject_uncertain_relationship_assertion,
+        upsert_uncertain_relationship_assertion,
+    )
+
+    ConceptsRepository.insert_one({"concept_id": "#V#alice", "relationships": {}})
+
+    created = upsert_uncertain_relationship_assertion(
+        source_id="#V#alice",
+        predicate="#V#has_affiliation",
+        target="#V#strong_ai_lab",
+        confidence_score=0.45,
+        provenance={"source": "unit_test"},
+    )
+    assertion_id = created["assertion"]["assertion_id"]
+
+    rejected = reject_uncertain_relationship_assertion(
+        source_id="#V#alice",
+        assertion_id=assertion_id,
+        reason="insufficient evidence",
+        operator="test",
+    )
+    assert rejected["success"] is True
+    assert rejected["assertion"]["status"] == "rejected"
+    assert rejected["assertion"]["rejection_reason"] == "insufficient evidence"
+
+    promotion = promote_uncertain_relationship_assertion(
+        source_id="#V#alice",
+        assertion_id=assertion_id,
+    )
+    assert promotion["success"] is False
+    assert promotion["error"] == "assertion_not_promotable"
+
+
+def test_migrate_legacy_hypothesized_relations_persists_canonical_rows() -> None:
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.services.uncertain_relationship_service import (
+        migrate_legacy_hypothesized_relations,
+    )
+
+    ConceptsRepository.insert_one(
+        {
+            "concept_id": "#V#alice",
+            "relationships": {},
+            "hypothesized_relations": {
+                "#V#has_affiliation": [
+                    {"value": "#V#strong_ai_lab", "confidence_score": 0.91}
+                ]
+            },
+        }
+    )
+
+    dry = migrate_legacy_hypothesized_relations(
+        source_id="#V#alice",
+        dry_run=True,
+    )
+    assert dry["success"] is True
+    assert dry["migrated_count"] == 1
+
+    applied = migrate_legacy_hypothesized_relations(
+        source_id="#V#alice",
+        dry_run=False,
+    )
+    assert applied["success"] is True
+    assert applied["migrated_count"] == 1
+
+    source_doc = ConceptsRepository.find_one({"concept_id": "#V#alice"})
+    canonical = (source_doc or {}).get("uncertain_relationship_assertions") or []
+    assert len(canonical) == 1
+    assert canonical[0]["predicate"] == "#V#has_affiliation"
+


### PR DESCRIPTION
## Summary\n- add canonical uncertain relationship assertion model with confidence, provenance, lifecycle state and legacy adaptor\n- add lifecycle operations (upsert/list/promote/reject/migrate legacy) and expose them via internal MCP catalogue tools\n- wire relation elicitation + rumination relation auto-apply to consume canonical uncertain assertions\n- add unit and gateway-level tests covering lifecycle and migration flows\n\n## Validation\n- pdm run pyright src/backend/integrations/internal_mcp/catalogue.py src/backend/services/uncertain_relationship_service.py src/backend/services/relation_elicitation_service.py src/backend/workflows/durable/rumination_workflow.py tests/backend/test_uncertain_relationship_service.py tests/backend/test_internal_mcp_uncertain_relationship_tools.py tests/backend/test_relation_elicitation_service.py tests/backend/test_rumination_workflow.py\n- pdm run pytest tests/backend/test_uncertain_relationship_service.py tests/backend/test_internal_mcp_uncertain_relationship_tools.py tests/backend/test_internal_mcp_catalogue_builds.py tests/backend/test_relation_elicitation_service.py tests/backend/test_rumination_workflow.py -q