### PR TITLE
JVNAUTOSCI-1314: expose uncertain relationships in retrieval APIs and MCP

### DIFF
--- a/docs/engineering/uncertain_relationship_retrieval_contract.md
+++ b/docs/engineering/uncertain_relationship_retrieval_contract.md
@@ -1,0 +1,52 @@
+# Uncertain Relationship Retrieval Contract (JVNAUTOSCI-1314)
+
+## Scope
+- Relationship retrieval surfaces now support asserted-only, uncertain-only, and combined retrieval without breaking existing callers.
+- Uncertainty metadata is returned in stable fields for APIs and MCP tools.
+
+## Retrieval Controls
+- `uncertainty_mode`: `asserted_only` | `uncertain_only` | `include_uncertain`
+- `include_uncertain`: boolean convenience flag (equivalent to `uncertainty_mode=include_uncertain` when mode is omitted)
+- `uncertainty_statuses`: optional list of assertion statuses to keep (for uncertain rows)
+
+Defaults:
+- Existing callers are unchanged (`asserted_only`).
+
+## API: `/api/vontology/relationships/extent`
+New query parameters:
+- `uncertainty_mode`
+- `include_uncertain`
+- `uncertainty_status` (repeatable query param)
+
+New source filter value:
+- `source=uncertain_assertions`
+
+Returned row additions:
+- `is_asserted`: boolean
+- `relation_state`: `asserted` | `uncertain`
+- `uncertainty`: object or `null` with:
+  - `assertion_id`
+  - `status`
+  - `confidence_score`
+  - `provenance`
+  - `created_at_utc`
+  - `updated_at_utc`
+  - `target_kind`
+
+## MCP: `fetch_concept` / `find_relations_with_argument`
+New input fields:
+- `include_uncertain`
+- `uncertainty_mode`
+- `uncertainty_statuses`
+
+New output section:
+- `uncertainty_diagnostics` with:
+  - `mode`
+  - `include_uncertain`
+  - `statuses`
+
+Relation/hit additions:
+- `is_asserted`
+- `relation_state`
+- `uncertainty` (for uncertain rows/hits)
+

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -121,6 +121,9 @@ def _get_concept_by_concept_id(**kwargs):
     limit = kwargs.get("limit")
     offset = kwargs.get("offset")
     include_concept_preview = kwargs.get("include_concept_preview", True)
+    include_uncertain = bool(kwargs.get("include_uncertain", False))
+    uncertainty_mode = kwargs.get("uncertainty_mode")
+    uncertainty_statuses = kwargs.get("uncertainty_statuses")
 
     if any(
         [include_relations_arg1, include_relations_any_arg, include_text_relations_arg1]
@@ -134,6 +137,9 @@ def _get_concept_by_concept_id(**kwargs):
             limit=limit,
             offset=offset,
             include_concept_preview=include_concept_preview,
+            include_uncertain=include_uncertain,
+            uncertainty_mode=uncertainty_mode,
+            uncertainty_statuses=uncertainty_statuses,
         )
         concept["relations"] = relations_payload
 
@@ -158,6 +164,9 @@ def _find_relations_with_argument(**kwargs):
         limit=kwargs.get("limit"),
         offset=kwargs.get("offset"),
         sort_by=kwargs.get("sort_by"),
+        include_uncertain=bool(kwargs.get("include_uncertain", False)),
+        uncertainty_mode=kwargs.get("uncertainty_mode"),
+        uncertainty_statuses=kwargs.get("uncertainty_statuses"),
     )
 
 
@@ -4538,13 +4547,18 @@ def _concept_fetch_input_schema() -> Schema:
             "limit": (int,),
             "offset": (int,),
             "include_concept_preview": (bool,),
+            "include_uncertain": (bool, type(None)),
+            "uncertainty_mode": (str, type(None)),
+            "uncertainty_statuses": (list, type(None)),
         },
         allow_unknown=True,
         description=(
             "get_concept_by_concept_id input: concept_id (required), plus optional"
             " flags to include structural/text relations (include_relations_arg1,"
             " include_relations_any_arg, include_text_relations_arg1), predicate"
-            " filtering, paging (limit/offset), and concept preview toggling."
+            " filtering, paging (limit/offset), concept preview toggling, and"
+            " uncertainty retrieval controls (include_uncertain, uncertainty_mode,"
+            " uncertainty_statuses)."
         ),
     )
 
@@ -4923,6 +4937,9 @@ def _find_relations_with_argument_input_schema() -> Schema:
             "limit": (int, type(None)),
             "offset": (int, type(None)),
             "sort_by": (str, type(None)),
+            "include_uncertain": (bool, type(None)),
+            "uncertainty_mode": (str, type(None)),
+            "uncertainty_statuses": (list, type(None)),
             "namespace": (str, type(None)),
         },
         allow_unknown=True,
@@ -4931,7 +4948,8 @@ def _find_relations_with_argument_input_schema() -> Schema:
             "(int or 'any'), predicate_filter (list of predicate IDs or substrings), "
             "relation_kind ('any'|'binary'|'text'), scope (optional), include_text_snippets "
             "(bool), include_concept_preview (bool), paging (limit/offset), sort_by, "
-            "and optional namespace passthrough."
+            "uncertainty retrieval controls (include_uncertain, uncertainty_mode,"
+            " uncertainty_statuses), and optional namespace passthrough."
         ),
     )
 
@@ -4950,7 +4968,7 @@ def _find_relations_with_argument_output_schema() -> Schema:
             "find_relations_with_argument output: concept_id, total_hits, hits[] "
             "(source_concept_id, predicate_concept_id, relation_kind, argument_indexes, "
             "target_value, optional previews/snippets, relation_metadata, access_granted, "
-            "follow_up_actions, score), and paging metadata."
+            "follow_up_actions, score, optional uncertainty metadata), and paging metadata."
         ),
     )
 

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -1323,6 +1323,9 @@ async def _handle_fetch_concept(arguments: dict[str, Any]) -> list[TextContent]:
         limit = arguments.get("limit")
         offset = arguments.get("offset")
         include_concept_preview = arguments.get("include_concept_preview", True)
+        include_uncertain = bool(arguments.get("include_uncertain", False))
+        uncertainty_mode = arguments.get("uncertainty_mode")
+        uncertainty_statuses = arguments.get("uncertainty_statuses")
 
         if predicate_filter is not None and not isinstance(predicate_filter, list):
             if isinstance(predicate_filter, (tuple, set)):
@@ -1346,6 +1349,9 @@ async def _handle_fetch_concept(arguments: dict[str, Any]) -> list[TextContent]:
                 limit=limit,
                 offset=offset,
                 include_concept_preview=include_concept_preview,
+                include_uncertain=include_uncertain,
+                uncertainty_mode=uncertainty_mode,
+                uncertainty_statuses=uncertainty_statuses,
             )
             concept["relations"] = relations_payload
         return [_json_text(concept)]
@@ -1388,6 +1394,9 @@ async def _handle_find_relations_with_argument(
             limit=arguments.get("limit"),
             offset=arguments.get("offset"),
             sort_by=arguments.get("sort_by"),
+            include_uncertain=bool(arguments.get("include_uncertain", False)),
+            uncertainty_mode=arguments.get("uncertainty_mode"),
+            uncertainty_statuses=arguments.get("uncertainty_statuses"),
         )
         return [_json_text(payload)]
     except Exception as exc:

--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -194,6 +194,12 @@ def _expand_relation_payload_entry_for_extent(
         return []
 
     relation_kind = str(relation.get("relation_kind") or "binary").strip().lower()
+    is_asserted = bool(relation.get("is_asserted", True))
+    relation_state = str(
+        relation.get("relation_state") or ("asserted" if is_asserted else "uncertain")
+    ).strip().lower()
+    raw_uncertainty = relation.get("uncertainty")
+    uncertainty_payload = dict(raw_uncertainty) if isinstance(raw_uncertainty, dict) else None
     source_preview = relation.get("source_preview")
     updated_at = None
     if isinstance(source_preview, dict):
@@ -202,6 +208,7 @@ def _expand_relation_payload_entry_for_extent(
             updated_at = candidate.strip()
 
     rows: list[dict[str, Any]] = []
+    row_source = "uncertain_assertions" if relation_state == "uncertain" else None
     if relation_kind == "text":
         text_payload = relation.get("text_value")
         text_value = None
@@ -226,7 +233,7 @@ def _expand_relation_payload_entry_for_extent(
                     relation.get("relation_id")
                     or f"text::{source_concept_id}::{predicate_id}"
                 ),
-                "source": "text_relations",
+                "source": row_source or "text_relations",
                 "relation_kind": "text",
                 "role": "arg1",
                 "predicate_id": predicate_id,
@@ -238,7 +245,9 @@ def _expand_relation_payload_entry_for_extent(
                 "source_concept_id": source_concept_id,
                 "target_value": text_value,
                 "updated_at": updated_at,
-                "is_asserted": True,
+                "is_asserted": is_asserted,
+                "relation_state": relation_state,
+                "uncertainty": uncertainty_payload,
             }
         )
         return rows
@@ -259,7 +268,7 @@ def _expand_relation_payload_entry_for_extent(
         rows.append(
             {
                 "relation_id": f"{relation.get('relation_id') or 'struct'}::{target_index}",
-                "source": "structured",
+                "source": row_source or "structured",
                 "relation_kind": "binary",
                 "role": role,
                 "predicate_id": predicate_id,
@@ -271,7 +280,9 @@ def _expand_relation_payload_entry_for_extent(
                 "source_concept_id": source_concept_id,
                 "target_value": target_value,
                 "updated_at": updated_at,
-                "is_asserted": True,
+                "is_asserted": is_asserted,
+                "relation_state": relation_state,
+                "uncertainty": uncertainty_payload,
             }
         )
     return rows
@@ -3339,16 +3350,47 @@ def get_relationships_extent_route():
         )
 
     source_filter = str(request.args.get("source") or "").strip().lower()
-    if source_filter and source_filter not in {"structured", "text_relations"}:
+    if source_filter and source_filter not in {
+        "structured",
+        "text_relations",
+        "uncertain_assertions",
+    }:
         return (
             jsonify(
                 {
                     "success": False,
-                    "error": "Invalid source filter. Use one of: structured, text_relations.",
+                    "error": "Invalid source filter. Use one of: structured, text_relations, uncertain_assertions.",
                 }
             ),
             400,
         )
+
+    uncertainty_mode = (
+        str(request.args.get("uncertainty_mode") or "").strip().lower() or None
+    )
+    if uncertainty_mode and uncertainty_mode not in {
+        "asserted_only",
+        "uncertain_only",
+        "include_uncertain",
+    }:
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "Invalid uncertainty_mode. Use one of: asserted_only, uncertain_only, include_uncertain.",
+                }
+            ),
+            400,
+        )
+    include_uncertain_raw = (
+        str(request.args.get("include_uncertain") or "").strip().lower()
+    )
+    include_uncertain = include_uncertain_raw in {"1", "true", "yes", "on"}
+    uncertainty_statuses: list[str] = []
+    for raw in request.args.getlist("uncertainty_status"):
+        token = str(raw or "").strip().lower()
+        if token:
+            uncertainty_statuses.append(token)
 
     requested_predicate = _canonicalise_relationship_predicate(
         request.args.get("predicate")
@@ -3416,6 +3458,9 @@ def get_relationships_extent_route():
             limit=_RELATIONSHIP_EXTENT_MAX_LIMIT,
             offset=0,
             include_concept_preview=True,
+            include_uncertain=include_uncertain,
+            uncertainty_mode=uncertainty_mode,
+            uncertainty_statuses=uncertainty_statuses or None,
         )
         for relation in base_payload.get("relations", []):
             rows.extend(
@@ -3493,6 +3538,7 @@ def get_relationships_extent_route():
                         "target_value": target_value,
                         "updated_at": updated_at,
                         "is_asserted": True,
+                        "relation_state": "asserted",
                     }
                 )
 

--- a/src/backend/services/concept_relation_service.py
+++ b/src/backend/services/concept_relation_service.py
@@ -25,6 +25,19 @@ _ARG_INDEX_SUBJECT = 1  # Align with example payloads (1-based indexing)
 _ARG_INDEX_FIRST_OBJECT = 2
 _DEFAULT_LIMIT = 200
 _MAX_LIMIT = 500
+_UNCERTAINTY_MODE_ASSERTED_ONLY = "asserted_only"
+_UNCERTAINTY_MODE_UNCERTAIN_ONLY = "uncertain_only"
+_UNCERTAINTY_MODE_INCLUDE_UNCERTAIN = "include_uncertain"
+
+_UNCERTAINTY_RETRIEVAL_STATS: Dict[str, int] = {
+    "payload_calls_total": 0,
+    "find_calls_total": 0,
+    "asserted_only_calls": 0,
+    "uncertain_only_calls": 0,
+    "include_uncertain_calls": 0,
+    "uncertain_rows_returned": 0,
+    "uncertainty_mode_errors": 0,
+}
 
 
 @dataclass
@@ -36,6 +49,9 @@ class RelationOptions:
     limit: Optional[int] = None
     offset: Optional[int] = None
     include_concept_preview: bool = True
+    include_uncertain: bool = False
+    uncertainty_mode: Optional[str] = None
+    uncertainty_statuses: Optional[Sequence[str]] = None
 
 
 def build_concept_relations_payload(
@@ -48,6 +64,9 @@ def build_concept_relations_payload(
     limit: Optional[int] = None,
     offset: Optional[int] = None,
     include_concept_preview: bool = True,
+    include_uncertain: bool = False,
+    uncertainty_mode: Optional[str] = None,
+    uncertainty_statuses: Optional[Sequence[str]] = None,
 ) -> Dict[str, Any]:
     """Return a structured payload capturing relations connected to ``concept``.
 
@@ -84,6 +103,12 @@ def build_concept_relations_payload(
             key for key in predicate_allow_list if isinstance(key, str)
         )
     include_text_relations = bool(include_text_relations_arg1)
+    mode_value, include_asserted_rows, include_uncertain_rows = _resolve_uncertainty_mode(
+        uncertainty_mode=uncertainty_mode,
+        include_uncertain=include_uncertain,
+    )
+    status_filter = _normalise_uncertainty_statuses(uncertainty_statuses)
+    _record_uncertainty_mode_usage(mode_value)
     snippet_mode = (
         str(include_text_relations_arg1).strip().lower()
         if isinstance(include_text_relations_arg1, str)
@@ -113,7 +138,7 @@ def build_concept_relations_payload(
             return
         results.append(entry)
 
-    if include_relations_arg1:
+    if include_asserted_rows and include_relations_arg1:
         relationships = (concept.get("relationships") or {}) if concept else {}
         _collect_structural_relations_for_subject(
             concept_id=concept_id,
@@ -124,7 +149,7 @@ def build_concept_relations_payload(
             consumer=_record,
         )
 
-    if include_relations_any_arg:
+    if include_asserted_rows and include_relations_any_arg:
         _collect_structural_relations_for_targets(
             concept_id=concept_id,
             predicate_allowed=_predicate_allowed,
@@ -134,7 +159,7 @@ def build_concept_relations_payload(
             consumer=_record,
         )
 
-    if include_text_relations:
+    if include_asserted_rows and include_text_relations:
         _collect_text_relations_for_subject(
             concept_id=concept_id,
             predicate_allowed=_predicate_allowed,
@@ -142,6 +167,28 @@ def build_concept_relations_payload(
             preview_cache=preview_cache,
             snippet_mode=snippet_mode,
             consumer=_record,
+        )
+
+    if include_uncertain_rows:
+        uncertain_total = _collect_uncertain_relations_for_subject(
+            concept_id=concept_id,
+            predicate_allowed=_predicate_allowed,
+            include_preview=include_concept_preview,
+            preview_cache=preview_cache,
+            consumer=_record,
+            status_filter=status_filter,
+        )
+        if include_relations_any_arg:
+            uncertain_total += _collect_uncertain_relations_for_targets(
+                concept_id=concept_id,
+                predicate_allowed=_predicate_allowed,
+                include_preview=include_concept_preview,
+                preview_cache=preview_cache,
+                consumer=_record,
+                status_filter=status_filter,
+            )
+        _UNCERTAINTY_RETRIEVAL_STATS["uncertain_rows_returned"] += max(
+            0, int(uncertain_total)
         )
 
     paging = {
@@ -155,6 +202,11 @@ def build_concept_relations_payload(
         "relations_found": total_matches,
         "relations": results,
         "paging": paging,
+        "uncertainty_diagnostics": {
+            "mode": mode_value,
+            "include_uncertain": include_uncertain_rows,
+            "statuses": status_filter or None,
+        },
     }
 
 
@@ -170,6 +222,9 @@ def find_relations_with_argument(
     limit: Optional[int] = None,
     offset: Optional[int] = None,
     sort_by: Optional[str] = None,
+    include_uncertain: bool = False,
+    uncertainty_mode: Optional[str] = None,
+    uncertainty_statuses: Optional[Sequence[str]] = None,
 ) -> Dict[str, Any]:
     """Find relation hits where ``concept_id`` appears in any argument position.
 
@@ -195,6 +250,13 @@ def find_relations_with_argument(
 
     include_structural = relation_filter in {"any", "binary"}
     include_text = relation_filter in {"any", "text"}
+    mode_value, include_asserted_rows, include_uncertain_rows = _resolve_uncertainty_mode(
+        uncertainty_mode=uncertainty_mode,
+        include_uncertain=include_uncertain,
+    )
+    status_filter = _normalise_uncertainty_statuses(uncertainty_statuses)
+    _record_uncertainty_mode_usage(mode_value)
+    _UNCERTAINTY_RETRIEVAL_STATS["find_calls_total"] += 1
     include_arg1 = argument_filter in (None, _ARG_INDEX_SUBJECT)
     include_arg2_or_later = argument_filter is None or argument_filter >= _ARG_INDEX_FIRST_OBJECT
 
@@ -206,7 +268,7 @@ def find_relations_with_argument(
         {"concept_id": 1, "name": 1, "relationships": 1, "updated_at": 1},
     )
 
-    if include_structural and subject_doc:
+    if include_asserted_rows and include_structural and subject_doc:
         relationships = (subject_doc.get("relationships") or {}) if subject_doc else {}
         source_updated_at = _isoformat(subject_doc.get("updated_at")) if subject_doc else None
         for predicate_id, raw_targets in relationships.items():
@@ -253,10 +315,12 @@ def find_relations_with_argument(
                             exclude={resolved_concept_id},
                         ),
                         "score": 1.0,
+                        "is_asserted": True,
+                        "relation_state": "asserted",
                     }
                 )
 
-    if include_structural and include_arg2_or_later:
+    if include_asserted_rows and include_structural and include_arg2_or_later:
         incoming_pipeline = [
             {"$match": {"relationships": {"$type": "object"}}},
             {
@@ -327,10 +391,12 @@ def find_relations_with_argument(
                             exclude={resolved_concept_id},
                         ),
                         "score": 1.0,
+                        "is_asserted": True,
+                        "relation_state": "asserted",
                     }
                 )
 
-    if include_text and include_arg1:
+    if include_asserted_rows and include_text and include_arg1:
         source_preview = _resolve_concept_preview(
             resolved_concept_id,
             include_concept_preview,
@@ -362,6 +428,8 @@ def find_relations_with_argument(
                 "access_granted": source_preview is not None or not include_concept_preview,
                 "follow_up_actions": [],
                 "score": 1.0,
+                "is_asserted": True,
+                "relation_state": "asserted",
             }
             snippet = _make_argument_match_snippet(
                 text=text_value,
@@ -372,7 +440,7 @@ def find_relations_with_argument(
                 hit["text_snippet"] = snippet
             hits.append(hit)
 
-    if include_text and include_arg2_or_later:
+    if include_asserted_rows and include_text and include_arg2_or_later:
         escaped = re.escape(resolved_concept_id)
         text_values = list(
             TextValuesRepository.find(
@@ -434,6 +502,8 @@ def find_relations_with_argument(
                         exclude={resolved_concept_id},
                     ),
                     "score": _compute_text_match_score(text_value, resolved_concept_id),
+                    "is_asserted": True,
+                    "relation_state": "asserted",
                 }
                 if include_concept_preview:
                     hit["target_concept_preview"] = _resolve_concept_preview(
@@ -444,6 +514,31 @@ def find_relations_with_argument(
                 if snippet:
                     hit["text_snippet"] = snippet
                 hits.append(hit)
+
+    if include_uncertain_rows:
+        hits.extend(
+            _collect_uncertain_argument_hits_for_subject(
+                concept_id=resolved_concept_id,
+                argument_filter=argument_filter,
+                relation_filter=relation_filter,
+                predicate_terms=predicate_terms,
+                include_concept_preview=include_concept_preview,
+                preview_cache=preview_cache,
+                status_filter=status_filter,
+            )
+        )
+        if include_arg2_or_later:
+            hits.extend(
+                _collect_uncertain_argument_hits_for_targets(
+                    concept_id=resolved_concept_id,
+                    argument_filter=argument_filter,
+                    relation_filter=relation_filter,
+                    predicate_terms=predicate_terms,
+                    include_concept_preview=include_concept_preview,
+                    preview_cache=preview_cache,
+                    status_filter=status_filter,
+                )
+            )
 
     deduped_hits = _dedupe_argument_hits(hits)
     sorted_hits = _sort_argument_hits(deduped_hits, sort_by)
@@ -459,6 +554,11 @@ def find_relations_with_argument(
             "offset": resolved_offset,
             "returned": len(paged_hits),
             "total_available": len(sorted_hits),
+        },
+        "uncertainty_diagnostics": {
+            "mode": mode_value,
+            "include_uncertain": include_uncertain_rows,
+            "statuses": status_filter or None,
         },
     }
 
@@ -603,6 +703,8 @@ def _collect_text_relations_for_subject(
             },
             "follow_up_actions": [],
             "access_granted": True,
+            "is_asserted": True,
+            "relation_state": "asserted",
         }
         if include_preview:
             entry["source_preview"] = _resolve_concept_preview(
@@ -636,6 +738,8 @@ def _make_structural_entry(
         "target_values": targets,
         "follow_up_actions": [],
         "access_granted": True,
+        "is_asserted": True,
+        "relation_state": "asserted",
     }
     if include_preview and source_id:
         entry["source_preview"] = _resolve_concept_preview(
@@ -760,6 +864,368 @@ def _normalise_relation_kind_filter(raw: Optional[str]) -> str:
     if value == "text":
         return "text"
     raise ValueError("relation_kind must be one of: any, binary, text")
+
+
+def _resolve_uncertainty_mode(
+    *,
+    uncertainty_mode: Optional[str],
+    include_uncertain: bool,
+) -> Tuple[str, bool, bool]:
+    if uncertainty_mode is None:
+        mode = (
+            _UNCERTAINTY_MODE_INCLUDE_UNCERTAIN
+            if include_uncertain
+            else _UNCERTAINTY_MODE_ASSERTED_ONLY
+        )
+    else:
+        mode = str(uncertainty_mode).strip().lower()
+        if mode in {"combined", "all"}:
+            mode = _UNCERTAINTY_MODE_INCLUDE_UNCERTAIN
+    if mode not in {
+        _UNCERTAINTY_MODE_ASSERTED_ONLY,
+        _UNCERTAINTY_MODE_UNCERTAIN_ONLY,
+        _UNCERTAINTY_MODE_INCLUDE_UNCERTAIN,
+    }:
+        _UNCERTAINTY_RETRIEVAL_STATS["uncertainty_mode_errors"] += 1
+        raise ValueError(
+            "uncertainty_mode must be one of: asserted_only, uncertain_only, include_uncertain"
+        )
+    if mode == _UNCERTAINTY_MODE_ASSERTED_ONLY:
+        return mode, True, False
+    if mode == _UNCERTAINTY_MODE_UNCERTAIN_ONLY:
+        return mode, False, True
+    return mode, True, True
+
+
+def _normalise_uncertainty_statuses(
+    raw_statuses: Optional[Sequence[str]],
+) -> List[str]:
+    if raw_statuses is None:
+        return []
+    if isinstance(raw_statuses, str):
+        candidates: Sequence[Any] = [raw_statuses]
+    else:
+        candidates = raw_statuses
+    out: List[str] = []
+    for item in candidates:
+        token = str(item or "").strip().lower()
+        if not token:
+            continue
+        out.append(token)
+    # stable dedupe
+    return list(dict.fromkeys(out))
+
+
+def _record_uncertainty_mode_usage(mode: str) -> None:
+    _UNCERTAINTY_RETRIEVAL_STATS["payload_calls_total"] += 1
+    if mode == _UNCERTAINTY_MODE_ASSERTED_ONLY:
+        _UNCERTAINTY_RETRIEVAL_STATS["asserted_only_calls"] += 1
+    elif mode == _UNCERTAINTY_MODE_UNCERTAIN_ONLY:
+        _UNCERTAINTY_RETRIEVAL_STATS["uncertain_only_calls"] += 1
+    elif mode == _UNCERTAINTY_MODE_INCLUDE_UNCERTAIN:
+        _UNCERTAINTY_RETRIEVAL_STATS["include_uncertain_calls"] += 1
+
+
+def _coerce_uncertainty_entry(assertion: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "assertion_id": assertion.get("assertion_id"),
+        "status": assertion.get("status"),
+        "confidence_score": assertion.get("confidence_score"),
+        "provenance": assertion.get("provenance") or {},
+        "created_at_utc": assertion.get("created_at_utc"),
+        "updated_at_utc": assertion.get("updated_at_utc"),
+        "target_kind": assertion.get("target_kind"),
+    }
+
+
+def _collect_uncertain_relations_for_subject(
+    *,
+    concept_id: str,
+    predicate_allowed,
+    include_preview: bool,
+    preview_cache: Dict[str, Optional[Dict[str, Any]]],
+    consumer,
+    status_filter: Sequence[str],
+) -> int:
+    from .uncertain_relationship_service import list_uncertain_relationship_assertions
+
+    assertions = list_uncertain_relationship_assertions(
+        source_id=concept_id,
+        statuses=status_filter or None,
+        include_legacy=True,
+    )
+    emitted = 0
+    source_preview = (
+        _resolve_concept_preview(concept_id, include_preview, preview_cache)
+        if include_preview
+        else None
+    )
+    for assertion in assertions:
+        predicate_id = assertion.get("predicate")
+        if not predicate_allowed(predicate_id):
+            continue
+        target_value = assertion.get("target")
+        if target_value is None:
+            continue
+        target_text = str(target_value)
+        target_kind = str(assertion.get("target_kind") or "")
+        is_text = target_kind == "text" or not target_text.startswith("#V#")
+        entry: RelationValue = {
+            "relation_id": f"uncertain::{concept_id}::{assertion.get('assertion_id')}",
+            "source_concept_id": concept_id,
+            "predicate_id": predicate_id,
+            "relation_kind": "text" if is_text else "binary",
+            "matched_argument_indexes": [_ARG_INDEX_SUBJECT],
+            "target_values": [target_text],
+            "follow_up_actions": _build_follow_up_actions(
+                [target_text] if target_text.startswith("#V#") else [],
+                exclude={concept_id},
+            ),
+            "access_granted": source_preview is not None or not include_preview,
+            "is_asserted": False,
+            "relation_state": "uncertain",
+            "uncertainty": _coerce_uncertainty_entry(assertion),
+        }
+        if include_preview:
+            entry["source_preview"] = source_preview
+            if target_text.startswith("#V#"):
+                preview = _resolve_concept_preview(target_text, True, preview_cache)
+                if preview is not None:
+                    entry["target_previews"] = {target_text: preview}
+        if is_text:
+            entry["text_value"] = {
+                "text": target_text,
+                "lang": None,
+                "text_value_id": None,
+                "context": {
+                    "uncertainty_assertion_id": assertion.get("assertion_id"),
+                    "uncertainty_status": assertion.get("status"),
+                },
+            }
+        consumer(entry)
+        emitted += 1
+    return emitted
+
+
+def _collect_uncertain_relations_for_targets(
+    *,
+    concept_id: str,
+    predicate_allowed,
+    include_preview: bool,
+    preview_cache: Dict[str, Optional[Dict[str, Any]]],
+    consumer,
+    status_filter: Sequence[str],
+) -> int:
+    query: Dict[str, Any] = {"uncertain_relationship_assertions.target": concept_id}
+    if status_filter:
+        query["uncertain_relationship_assertions.status"] = {"$in": list(status_filter)}
+    cursor = ConceptsRepository.find(
+        query,
+        projection={
+            "concept_id": 1,
+            "uncertain_relationship_assertions": 1,
+        },
+    )
+    emitted = 0
+    target_preview = (
+        _resolve_concept_preview(concept_id, include_preview, preview_cache)
+        if include_preview
+        else None
+    )
+    for source_doc in cursor:
+        source_id = source_doc.get("concept_id")
+        if not isinstance(source_id, str) or not source_id.strip():
+            continue
+        source_id = source_id.strip()
+        assertions = source_doc.get("uncertain_relationship_assertions")
+        if not isinstance(assertions, list):
+            continue
+        source_preview = (
+            _resolve_concept_preview(source_id, include_preview, preview_cache)
+            if include_preview
+            else None
+        )
+        for assertion in assertions:
+            if not isinstance(assertion, dict):
+                continue
+            if str(assertion.get("target") or "") != concept_id:
+                continue
+            status_value = str(assertion.get("status") or "").strip().lower()
+            if status_filter and status_value not in status_filter:
+                continue
+            predicate_id = assertion.get("predicate")
+            if not predicate_allowed(predicate_id):
+                continue
+            entry: RelationValue = {
+                "relation_id": f"uncertain::{source_id}::{assertion.get('assertion_id')}::incoming",
+                "source_concept_id": source_id,
+                "predicate_id": predicate_id,
+                "relation_kind": "binary",
+                "matched_argument_indexes": [_ARG_INDEX_FIRST_OBJECT],
+                "target_values": [concept_id],
+                "follow_up_actions": _build_follow_up_actions(
+                    [source_id], exclude={concept_id}
+                ),
+                "access_granted": source_preview is not None or not include_preview,
+                "is_asserted": False,
+                "relation_state": "uncertain",
+                "uncertainty": _coerce_uncertainty_entry(assertion),
+            }
+            if include_preview:
+                entry["source_preview"] = source_preview
+                if target_preview is not None:
+                    entry["target_previews"] = {concept_id: target_preview}
+            consumer(entry)
+            emitted += 1
+    return emitted
+
+
+def _collect_uncertain_argument_hits_for_subject(
+    *,
+    concept_id: str,
+    argument_filter: Optional[int],
+    relation_filter: str,
+    predicate_terms: Sequence[str],
+    include_concept_preview: bool,
+    preview_cache: Dict[str, Optional[Dict[str, Any]]],
+    status_filter: Sequence[str],
+) -> List[Dict[str, Any]]:
+    from .uncertain_relationship_service import list_uncertain_relationship_assertions
+
+    assertions = list_uncertain_relationship_assertions(
+        source_id=concept_id,
+        statuses=status_filter or None,
+        include_legacy=True,
+    )
+    source_preview = _resolve_concept_preview(
+        concept_id,
+        include_concept_preview,
+        preview_cache,
+    )
+    hits: List[Dict[str, Any]] = []
+    for assertion in assertions:
+        predicate_id = assertion.get("predicate")
+        if not _predicate_matches_terms(predicate_id, predicate_terms):
+            continue
+        target_value = str(assertion.get("target") or "")
+        if not target_value:
+            continue
+        target_kind = str(assertion.get("target_kind") or "")
+        is_text = target_kind == "text" or not target_value.startswith("#V#")
+        if relation_filter == "binary" and is_text:
+            continue
+        if relation_filter == "text" and not is_text:
+            continue
+        matched_indexes = [_ARG_INDEX_SUBJECT]
+        if target_value == concept_id and not is_text:
+            matched_indexes.append(_ARG_INDEX_FIRST_OBJECT)
+        if not _argument_indexes_match(matched_indexes, argument_filter):
+            continue
+        hit: Dict[str, Any] = {
+            "source_concept_id": concept_id,
+            "predicate_concept_id": predicate_id,
+            "relation_kind": "text" if is_text else "binary",
+            "argument_indexes": matched_indexes,
+            "target_value": target_value,
+            "relation_metadata": {
+                "relation_id": f"uncertain::{concept_id}::{assertion.get('assertion_id')}",
+                "updated_at": assertion.get("updated_at_utc"),
+                "match_type": "uncertain_assertion",
+            },
+            "access_granted": source_preview is not None or not include_concept_preview,
+            "follow_up_actions": _build_follow_up_actions(
+                [target_value] if target_value.startswith("#V#") else [],
+                exclude={concept_id},
+            ),
+            "score": float(assertion.get("confidence_score") or 0.0),
+            "is_asserted": False,
+            "relation_state": "uncertain",
+            "uncertainty": _coerce_uncertainty_entry(assertion),
+        }
+        if include_concept_preview and target_value.startswith("#V#"):
+            hit["target_concept_preview"] = _resolve_concept_preview(
+                target_value,
+                True,
+                preview_cache,
+            )
+        hits.append(hit)
+    return hits
+
+
+def _collect_uncertain_argument_hits_for_targets(
+    *,
+    concept_id: str,
+    argument_filter: Optional[int],
+    relation_filter: str,
+    predicate_terms: Sequence[str],
+    include_concept_preview: bool,
+    preview_cache: Dict[str, Optional[Dict[str, Any]]],
+    status_filter: Sequence[str],
+) -> List[Dict[str, Any]]:
+    if relation_filter == "text":
+        return []
+    if not _argument_indexes_match([_ARG_INDEX_FIRST_OBJECT], argument_filter):
+        return []
+    query: Dict[str, Any] = {"uncertain_relationship_assertions.target": concept_id}
+    if status_filter:
+        query["uncertain_relationship_assertions.status"] = {"$in": list(status_filter)}
+    cursor = ConceptsRepository.find(
+        query,
+        projection={"concept_id": 1, "uncertain_relationship_assertions": 1},
+    )
+    target_preview = _resolve_concept_preview(
+        concept_id,
+        include_concept_preview,
+        preview_cache,
+    )
+    hits: List[Dict[str, Any]] = []
+    for doc in cursor:
+        source_id = doc.get("concept_id")
+        if not isinstance(source_id, str) or not source_id.strip():
+            continue
+        source_id = source_id.strip()
+        assertions = doc.get("uncertain_relationship_assertions")
+        if not isinstance(assertions, list):
+            continue
+        source_preview = _resolve_concept_preview(
+            source_id, include_concept_preview, preview_cache
+        )
+        for assertion in assertions:
+            if not isinstance(assertion, dict):
+                continue
+            if str(assertion.get("target") or "") != concept_id:
+                continue
+            if status_filter:
+                token = str(assertion.get("status") or "").strip().lower()
+                if token not in status_filter:
+                    continue
+            predicate_id = assertion.get("predicate")
+            if not _predicate_matches_terms(predicate_id, predicate_terms):
+                continue
+            hit: Dict[str, Any] = {
+                "source_concept_id": source_id,
+                "predicate_concept_id": predicate_id,
+                "relation_kind": "binary",
+                "argument_indexes": [_ARG_INDEX_FIRST_OBJECT],
+                "target_value": concept_id,
+                "relation_metadata": {
+                    "relation_id": f"uncertain::{source_id}::{assertion.get('assertion_id')}::incoming",
+                    "updated_at": assertion.get("updated_at_utc"),
+                    "match_type": "uncertain_assertion",
+                },
+                "access_granted": source_preview is not None or not include_concept_preview,
+                "follow_up_actions": _build_follow_up_actions(
+                    [source_id], exclude={concept_id}
+                ),
+                "score": float(assertion.get("confidence_score") or 0.0),
+                "is_asserted": False,
+                "relation_state": "uncertain",
+                "uncertainty": _coerce_uncertainty_entry(assertion),
+            }
+            if include_concept_preview:
+                hit["target_concept_preview"] = target_preview
+            hits.append(hit)
+    return hits
 
 
 def _normalise_predicate_terms(

--- a/tests/backend/test_concept_relation_service_uncertainty.py
+++ b/tests/backend/test_concept_relation_service_uncertainty.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_mock_db(monkeypatch):
+    monkeypatch.setenv("VON_USE_MOCK_DB", "1")
+    from src.backend.db.mongo_client import get_db
+
+    db = get_db()
+    if db is not None:
+        try:
+            db.drop_collection("concepts")
+        except Exception:
+            pass
+    yield
+
+
+def test_build_concept_relations_payload_defaults_to_asserted_only() -> None:
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.services.concept_relation_service import (
+        build_concept_relations_payload,
+    )
+
+    ConceptsRepository.insert_one(
+        {
+            "concept_id": "#V#alice",
+            "relationships": {"related_to": ["#V#bob"]},
+            "uncertain_relationship_assertions": [
+                {
+                    "assertion_id": "u1",
+                    "source_id": "#V#alice",
+                    "predicate": "related_to",
+                    "target": "#V#charlie",
+                    "target_kind": "concept",
+                    "confidence_score": 0.74,
+                    "status": "proposed",
+                    "provenance": {"source": "unit_test"},
+                    "created_at_utc": "2026-02-01T00:00:00Z",
+                    "updated_at_utc": "2026-02-02T00:00:00Z",
+                }
+            ],
+        }
+    )
+    ConceptsRepository.insert_one({"concept_id": "#V#bob", "relationships": {}})
+    ConceptsRepository.insert_one({"concept_id": "#V#charlie", "relationships": {}})
+
+    concept_doc = ConceptsRepository.find_one({"concept_id": "#V#alice"})
+    payload = build_concept_relations_payload(
+        concept_doc,
+        include_relations_arg1=True,
+        include_text_relations_arg1=False,
+        include_concept_preview=False,
+    )
+    relations = payload.get("relations") or []
+    assert any(r.get("relation_state") == "asserted" for r in relations)
+    assert not any(r.get("relation_state") == "uncertain" for r in relations)
+    assert payload["uncertainty_diagnostics"]["mode"] == "asserted_only"
+
+
+def test_build_concept_relations_payload_includes_uncertain_rows_when_requested() -> None:
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.services.concept_relation_service import (
+        build_concept_relations_payload,
+    )
+
+    ConceptsRepository.insert_one(
+        {
+            "concept_id": "#V#alice",
+            "relationships": {"related_to": ["#V#bob"]},
+            "uncertain_relationship_assertions": [
+                {
+                    "assertion_id": "u1",
+                    "source_id": "#V#alice",
+                    "predicate": "related_to",
+                    "target": "#V#charlie",
+                    "target_kind": "concept",
+                    "confidence_score": 0.74,
+                    "status": "proposed",
+                    "provenance": {"source": "unit_test"},
+                    "created_at_utc": "2026-02-01T00:00:00Z",
+                    "updated_at_utc": "2026-02-02T00:00:00Z",
+                }
+            ],
+        }
+    )
+    ConceptsRepository.insert_one({"concept_id": "#V#bob", "relationships": {}})
+    ConceptsRepository.insert_one({"concept_id": "#V#charlie", "relationships": {}})
+
+    concept_doc = ConceptsRepository.find_one({"concept_id": "#V#alice"})
+    payload = build_concept_relations_payload(
+        concept_doc,
+        include_relations_arg1=True,
+        include_text_relations_arg1=False,
+        include_concept_preview=False,
+        include_uncertain=True,
+        uncertainty_mode="include_uncertain",
+    )
+    relations = payload.get("relations") or []
+    uncertain_rows = [r for r in relations if r.get("relation_state") == "uncertain"]
+    assert uncertain_rows
+    assert uncertain_rows[0]["is_asserted"] is False
+    assert uncertain_rows[0]["uncertainty"]["assertion_id"] == "u1"
+    assert payload["uncertainty_diagnostics"]["mode"] == "include_uncertain"
+
+
+def test_find_relations_with_argument_uncertain_only_returns_uncertain_hits() -> None:
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.services.concept_relation_service import (
+        find_relations_with_argument,
+    )
+
+    ConceptsRepository.insert_one(
+        {
+            "concept_id": "#V#alice",
+            "relationships": {"related_to": ["#V#bob"]},
+            "uncertain_relationship_assertions": [
+                {
+                    "assertion_id": "u1",
+                    "source_id": "#V#alice",
+                    "predicate": "related_to",
+                    "target": "#V#bob",
+                    "target_kind": "concept",
+                    "confidence_score": 0.81,
+                    "status": "proposed",
+                    "provenance": {"source": "unit_test"},
+                    "created_at_utc": "2026-02-01T00:00:00Z",
+                    "updated_at_utc": "2026-02-02T00:00:00Z",
+                }
+            ],
+        }
+    )
+    ConceptsRepository.insert_one({"concept_id": "#V#bob", "relationships": {}})
+
+    payload = find_relations_with_argument(
+        "#V#bob",
+        include_uncertain=True,
+        uncertainty_mode="uncertain_only",
+        include_concept_preview=False,
+    )
+    hits = payload.get("hits") or []
+    assert hits
+    assert all(hit.get("relation_state") == "uncertain" for hit in hits)
+    assert all(hit.get("is_asserted") is False for hit in hits)
+    assert payload["uncertainty_diagnostics"]["mode"] == "uncertain_only"
+

--- a/tests/backend/test_internal_mcp_uncertain_relation_retrieval_contracts.py
+++ b/tests/backend/test_internal_mcp_uncertain_relation_retrieval_contracts.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import pytest
+
+from src.backend.db.repositories.concepts_repository import ConceptsRepository
+from src.backend.integrations.internal_mcp import build_default_catalogue
+from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
+from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+
+
+@pytest.fixture(autouse=True)
+def reset_mock_db(monkeypatch):
+    monkeypatch.setenv("VON_USE_MOCK_DB", "1")
+    from src.backend.db.mongo_client import get_db
+
+    db = get_db()
+    if db is not None:
+        try:
+            db.drop_collection("concepts")
+        except Exception:
+            pass
+    yield
+
+
+def _gateway() -> InternalMCPGateway:
+    return InternalMCPGateway(
+        catalogue=build_default_catalogue(),
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+
+
+def test_fetch_concept_relations_exposes_uncertainty_metadata() -> None:
+    gateway = _gateway()
+    ConceptsRepository.insert_one(
+        {
+            "concept_id": "#V#alice",
+            "relationships": {"related_to": ["#V#bob"]},
+            "uncertain_relationship_assertions": [
+                {
+                    "assertion_id": "u1",
+                    "source_id": "#V#alice",
+                    "predicate": "related_to",
+                    "target": "#V#charlie",
+                    "target_kind": "concept",
+                    "confidence_score": 0.66,
+                    "status": "proposed",
+                    "provenance": {"source": "gateway_test"},
+                    "created_at_utc": "2026-02-01T00:00:00Z",
+                    "updated_at_utc": "2026-02-02T00:00:00Z",
+                }
+            ],
+        }
+    )
+    ConceptsRepository.insert_one({"concept_id": "#V#bob", "relationships": {}})
+    ConceptsRepository.insert_one({"concept_id": "#V#charlie", "relationships": {}})
+
+    payload = gateway.invoke(
+        "fetch_concept",
+        {
+            "concept_id": "#V#alice",
+            "include_relations_arg1": True,
+            "include_uncertain": True,
+            "uncertainty_mode": "include_uncertain",
+            "include_concept_preview": False,
+        },
+    ).payload
+
+    relations = ((payload or {}).get("relations") or {}).get("relations") or []
+    uncertain_rows = [row for row in relations if row.get("relation_state") == "uncertain"]
+    assert uncertain_rows
+    assert uncertain_rows[0]["uncertainty"]["assertion_id"] == "u1"
+    assert uncertain_rows[0]["is_asserted"] is False
+
+
+def test_find_relations_with_argument_supports_uncertain_only_mode() -> None:
+    gateway = _gateway()
+    ConceptsRepository.insert_one(
+        {
+            "concept_id": "#V#alice",
+            "relationships": {"related_to": ["#V#bob"]},
+            "uncertain_relationship_assertions": [
+                {
+                    "assertion_id": "u2",
+                    "source_id": "#V#alice",
+                    "predicate": "related_to",
+                    "target": "#V#bob",
+                    "target_kind": "concept",
+                    "confidence_score": 0.72,
+                    "status": "proposed",
+                    "provenance": {"source": "gateway_test"},
+                    "created_at_utc": "2026-02-01T00:00:00Z",
+                    "updated_at_utc": "2026-02-02T00:00:00Z",
+                }
+            ],
+        }
+    )
+    ConceptsRepository.insert_one({"concept_id": "#V#bob", "relationships": {}})
+
+    payload = gateway.invoke(
+        "find_relations_with_argument",
+        {
+            "concept_id": "#V#bob",
+            "uncertainty_mode": "uncertain_only",
+            "include_uncertain": True,
+            "include_concept_preview": False,
+        },
+    ).payload
+    hits = payload.get("hits") or []
+    assert hits
+    assert all(hit.get("relation_state") == "uncertain" for hit in hits)
+    assert all(hit.get("is_asserted") is False for hit in hits)
+

--- a/tests/backend/test_virtual_code_predicate_concepts.py
+++ b/tests/backend/test_virtual_code_predicate_concepts.py
@@ -379,6 +379,63 @@ def test_relationship_extent_route_includes_incoming_dynamic_arg2_rows(
     assert rows[0]["arg2_value"] == "#V#focus"
 
 
+def test_relationship_extent_route_supports_uncertain_filters(app_client, monkeypatch):
+    _, client = app_client
+
+    captured_kwargs = {}
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.ConceptsRepository.find_one",
+        lambda *a, **k: {"concept_id": "#V#focus", "relationships": {}},
+    )
+
+    def _fake_build_payload(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return {
+            "relations": [
+                {
+                    "relation_id": "uncertain::#V#focus::u1",
+                    "source_concept_id": "#V#focus",
+                    "predicate_id": "#V#related_to",
+                    "relation_kind": "binary",
+                    "target_values": ["#V#candidate"],
+                    "matched_argument_indexes": [1],
+                    "is_asserted": False,
+                    "relation_state": "uncertain",
+                    "uncertainty": {
+                        "assertion_id": "u1",
+                        "status": "proposed",
+                        "confidence_score": 0.77,
+                        "provenance": {"source": "unit_test"},
+                    },
+                }
+            ]
+        }
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.build_concept_relations_payload",
+        _fake_build_payload,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.ConceptsRepository.aggregate",
+        lambda *a, **k: [],
+    )
+
+    resp = client.get(
+        "/vontology/api/vontology/relationships/extent?"
+        "concept_id=%23V%23focus&uncertainty_mode=uncertain_only&source=uncertain_assertions"
+    )
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    rows = payload.get("rows") or []
+    assert len(rows) == 1
+    assert rows[0]["source"] == "uncertain_assertions"
+    assert rows[0]["relation_state"] == "uncertain"
+    assert rows[0]["is_asserted"] is False
+    assert rows[0]["uncertainty"]["assertion_id"] == "u1"
+    assert captured_kwargs.get("uncertainty_mode") == "uncertain_only"
+
+
 def test_upsert_name_for_virtual_code_predicate_concept(app_client, monkeypatch):
     _, client = app_client
 


### PR DESCRIPTION
## Summary
- extend concept relation retrieval surfaces with uncertainty retrieval modes: asserted_only, uncertain_only, include_uncertain
- expose stable uncertainty metadata fields (relation_state, is_asserted, uncertainty) in relation payloads, hits, and extent rows
- add uncertain source filtering in /api/vontology/relationships/extent with non-breaking defaults
- thread new controls through internal MCP and stdio fetch/find handlers and schemas
- add diagnostics payload (uncertainty_diagnostics) and retrieval mode usage counters
- add regression tests and contract documentation

## Validation
- pdm run pyright src/backend/services/concept_relation_service.py src/backend/server/routes/vontology_routes.py src/backend/integrations/internal_mcp/catalogue.py src/backend/mcp_server/mcp_stdio_server.py tests/backend/test_concept_relation_service_uncertainty.py tests/backend/test_internal_mcp_uncertain_relation_retrieval_contracts.py tests/backend/test_virtual_code_predicate_concepts.py
- pdm run pytest tests/backend/test_concept_relation_service_uncertainty.py tests/backend/test_internal_mcp_uncertain_relation_retrieval_contracts.py tests/backend/test_virtual_code_predicate_concepts.py tests/backend/test_internal_mcp_catalogue_builds.py -q
