### PR TITLE
JVNAUTOSCI-1315: UI uncertain relationships confidence/provenance and promotion controls

### DIFF
--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -3613,6 +3613,114 @@ def get_relationships_extent_route():
         )
 
 
+@vontology_bp.route("/relationships/uncertain/promote", methods=["POST"])
+def promote_uncertain_relationship_route():
+    """Promote an uncertain relationship assertion into an asserted relation."""
+    data = request.get_json(silent=True) or {}
+    source_id = str(data.get("source_id") or "").strip()
+    assertion_id = str(data.get("assertion_id") or "").strip()
+    operator = str(data.get("operator") or "ui").strip() or "ui"
+
+    if not source_id:
+        return jsonify({"success": False, "error": "Missing 'source_id'."}), 400
+    if not assertion_id:
+        return jsonify({"success": False, "error": "Missing 'assertion_id'."}), 400
+
+    try:
+        from ...services.uncertain_relationship_service import (
+            promote_uncertain_relationship_assertion,
+        )
+
+        result = promote_uncertain_relationship_assertion(
+            source_id=source_id,
+            assertion_id=assertion_id,
+            operator=operator,
+        )
+        if bool(result.get("success")):
+            return jsonify(result), 200
+
+        error = str(result.get("error") or "promotion_failed")
+        status_code = 400
+        if error in {"source_not_found", "assertion_not_found"}:
+            status_code = 404
+        elif error in {"assertion_not_promotable"}:
+            status_code = 409
+        return jsonify(result), status_code
+    except Exception as exc:
+        current_app.logger.error(
+            "Error promoting uncertain assertion source_id=%s assertion_id=%s: %s",
+            source_id,
+            assertion_id,
+            exc,
+            exc_info=True,
+        )
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "Failed to promote uncertain relationship due to an internal server error.",
+                }
+            ),
+            500,
+        )
+
+
+@vontology_bp.route("/relationships/uncertain/reject", methods=["POST"])
+def reject_uncertain_relationship_route():
+    """Reject an uncertain relationship assertion with an operator reason."""
+    data = request.get_json(silent=True) or {}
+    source_id = str(data.get("source_id") or "").strip()
+    assertion_id = str(data.get("assertion_id") or "").strip()
+    reason = str(data.get("reason") or "").strip()
+    operator = str(data.get("operator") or "ui").strip() or "ui"
+
+    if not source_id:
+        return jsonify({"success": False, "error": "Missing 'source_id'."}), 400
+    if not assertion_id:
+        return jsonify({"success": False, "error": "Missing 'assertion_id'."}), 400
+    if not reason:
+        return jsonify({"success": False, "error": "Missing 'reason'."}), 400
+
+    try:
+        from ...services.uncertain_relationship_service import (
+            reject_uncertain_relationship_assertion,
+        )
+
+        result = reject_uncertain_relationship_assertion(
+            source_id=source_id,
+            assertion_id=assertion_id,
+            reason=reason,
+            operator=operator,
+        )
+        if bool(result.get("success")):
+            return jsonify(result), 200
+
+        error = str(result.get("error") or "rejection_failed")
+        status_code = 400
+        if error in {"source_not_found", "assertion_not_found"}:
+            status_code = 404
+        elif error in {"assertion_already_promoted"}:
+            status_code = 409
+        return jsonify(result), status_code
+    except Exception as exc:
+        current_app.logger.error(
+            "Error rejecting uncertain assertion source_id=%s assertion_id=%s: %s",
+            source_id,
+            assertion_id,
+            exc,
+            exc_info=True,
+        )
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "Failed to reject uncertain relationship due to an internal server error.",
+                }
+            ),
+            500,
+        )
+
+
 @vontology_bp.route("/relationships/add", methods=["POST"])
 def add_relationship_route():
     """

--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -4769,6 +4769,187 @@ async function adaptTypeConceptTabUI(conceptId, suffix) {
     }
 }
 // --- Relationships UI ---
+const RELATIONSHIP_UNCERTAINTY_FILTERS = Object.freeze({
+    all: { uncertaintyMode: 'include_uncertain', includeUncertain: true },
+    asserted_only: { uncertaintyMode: 'asserted_only', includeUncertain: false },
+    uncertain_only: { uncertaintyMode: 'uncertain_only', includeUncertain: true }
+});
+const RELATIONSHIP_DEFAULT_UNCERTAIN_STATUSES = Object.freeze(['proposed']);
+const RELATIONSHIP_SORT_OPTIONS = Object.freeze(
+    new Set(['recency_desc', 'recency_asc', 'confidence_desc', 'confidence_asc'])
+);
+const relationshipExtentUiState = new Map();
+
+function getRelationshipExtentUiStateKey(conceptId, suffix) {
+    return `${String(conceptId || '')}::${String(suffix || '')}`;
+}
+
+function getRelationshipExtentUiState(conceptId, suffix) {
+    const key = getRelationshipExtentUiStateKey(conceptId, suffix);
+    const existing = relationshipExtentUiState.get(key);
+    if (existing) {
+        return existing;
+    }
+    const initial = { uncertaintyFilter: 'all', sortBy: 'recency_desc' };
+    relationshipExtentUiState.set(key, initial);
+    return initial;
+}
+
+function setRelationshipExtentUiState(conceptId, suffix, patch = {}) {
+    const state = getRelationshipExtentUiState(conceptId, suffix);
+    if (typeof patch.uncertaintyFilter === 'string' && RELATIONSHIP_UNCERTAINTY_FILTERS[patch.uncertaintyFilter]) {
+        state.uncertaintyFilter = patch.uncertaintyFilter;
+    }
+    if (typeof patch.sortBy === 'string' && RELATIONSHIP_SORT_OPTIONS.has(patch.sortBy)) {
+        state.sortBy = patch.sortBy;
+    }
+    relationshipExtentUiState.set(getRelationshipExtentUiStateKey(conceptId, suffix), state);
+    return state;
+}
+
+export function deriveRelationshipExtentQuery(uncertaintyFilter = 'all') {
+    const selected = RELATIONSHIP_UNCERTAINTY_FILTERS[String(uncertaintyFilter || 'all')] || RELATIONSHIP_UNCERTAINTY_FILTERS.all;
+    return {
+        uncertaintyMode: selected.uncertaintyMode,
+        includeUncertain: selected.includeUncertain,
+        uncertaintyStatuses: [...RELATIONSHIP_DEFAULT_UNCERTAIN_STATUSES]
+    };
+}
+
+function getRowUncertaintyPayload(row) {
+    if (!row || typeof row !== 'object') {
+        return {};
+    }
+    const uncertainty = row.uncertainty;
+    return (uncertainty && typeof uncertainty === 'object') ? uncertainty : {};
+}
+
+function normaliseConfidenceScore(rawValue) {
+    const value = Number(rawValue);
+    if (!Number.isFinite(value)) {
+        return null;
+    }
+    return Math.max(0, Math.min(1, value));
+}
+
+export function getRelationshipConfidenceScore(row) {
+    const uncertainty = getRowUncertaintyPayload(row);
+    return normaliseConfidenceScore(uncertainty.confidence_score);
+}
+
+function formatRelationshipConfidence(row) {
+    const confidence = getRelationshipConfidenceScore(row);
+    if (confidence === null) {
+        return 'N/A';
+    }
+    return `${Math.round(confidence * 100)}%`;
+}
+
+export function summariseRelationshipProvenance(row) {
+    const uncertainty = getRowUncertaintyPayload(row);
+    const provenance = (uncertainty.provenance && typeof uncertainty.provenance === 'object')
+        ? uncertainty.provenance
+        : {};
+    const source = String(provenance.source || '').trim();
+    const sourceInteraction = String(provenance.source_interaction_id || '').trim();
+    const rejectedBy = String(provenance.rejected_by || '').trim();
+    const segments = [];
+    if (source) segments.push(`source: ${source}`);
+    if (sourceInteraction) segments.push(`interaction: ${sourceInteraction}`);
+    if (rejectedBy) segments.push(`rejected by: ${rejectedBy}`);
+    return segments.join(' | ');
+}
+
+function getRelationshipSortTimestamp(row) {
+    const uncertainty = getRowUncertaintyPayload(row);
+    const candidates = [uncertainty.updated_at_utc, row?.updated_at, uncertainty.created_at_utc];
+    for (const candidate of candidates) {
+        if (!candidate) continue;
+        const timestamp = new Date(candidate).getTime();
+        if (Number.isFinite(timestamp)) {
+            return timestamp;
+        }
+    }
+    return 0;
+}
+
+export function sortRelationshipExtentRows(rows, sortBy = 'recency_desc') {
+    const mode = RELATIONSHIP_SORT_OPTIONS.has(sortBy) ? sortBy : 'recency_desc';
+    const working = Array.isArray(rows) ? [...rows] : [];
+    working.sort((a, b) => {
+        if (mode === 'confidence_desc' || mode === 'confidence_asc') {
+            const left = getRelationshipConfidenceScore(a);
+            const right = getRelationshipConfidenceScore(b);
+            const leftScore = left === null ? -1 : left;
+            const rightScore = right === null ? -1 : right;
+            if (leftScore !== rightScore) {
+                return mode === 'confidence_desc' ? rightScore - leftScore : leftScore - rightScore;
+            }
+            return getRelationshipSortTimestamp(b) - getRelationshipSortTimestamp(a);
+        }
+        const leftTs = getRelationshipSortTimestamp(a);
+        const rightTs = getRelationshipSortTimestamp(b);
+        if (leftTs !== rightTs) {
+            return mode === 'recency_asc' ? leftTs - rightTs : rightTs - leftTs;
+        }
+        return String(a?.relation_id || '').localeCompare(String(b?.relation_id || ''));
+    });
+    return working;
+}
+
+function ensureRelationshipsToolbar(container, conceptId, suffix, kind) {
+    if (!container) return;
+    const state = getRelationshipExtentUiState(conceptId, suffix);
+    let toolbar = container.querySelector('.relationships-toolbar');
+    if (!toolbar) {
+        toolbar = document.createElement('div');
+        toolbar.className = 'relationships-toolbar';
+        toolbar.innerHTML = `
+            <div class="relationships-toolbar-group">
+                <label for="relationshipUncertaintyFilter_${suffix || 'default'}">State</label>
+                <select id="relationshipUncertaintyFilter_${suffix || 'default'}" class="relationships-toolbar-select" aria-label="Relationship state filter">
+                    <option value="all">All</option>
+                    <option value="asserted_only">Asserted only</option>
+                    <option value="uncertain_only">Uncertain only</option>
+                </select>
+            </div>
+            <div class="relationships-toolbar-group">
+                <label for="relationshipSortBy_${suffix || 'default'}">Sort</label>
+                <select id="relationshipSortBy_${suffix || 'default'}" class="relationships-toolbar-select" aria-label="Relationship sort order">
+                    <option value="recency_desc">Recency (newest first)</option>
+                    <option value="recency_asc">Recency (oldest first)</option>
+                    <option value="confidence_desc">Confidence (highest first)</option>
+                    <option value="confidence_asc">Confidence (lowest first)</option>
+                </select>
+            </div>
+        `;
+        container.insertBefore(toolbar, container.firstChild);
+    }
+
+    const filterSelect = toolbar.querySelector(`#relationshipUncertaintyFilter_${suffix || 'default'}`);
+    const sortSelect = toolbar.querySelector(`#relationshipSortBy_${suffix || 'default'}`);
+    if (filterSelect) {
+        filterSelect.value = state.uncertaintyFilter;
+        if (filterSelect.dataset.bound !== 'true') {
+            filterSelect.addEventListener('change', async () => {
+                setRelationshipExtentUiState(conceptId, suffix, { uncertaintyFilter: filterSelect.value });
+                await renderRelationships(conceptId, suffix, kind);
+            });
+            filterSelect.dataset.bound = 'true';
+        }
+    }
+    if (sortSelect) {
+        sortSelect.value = state.sortBy;
+        if (sortSelect.dataset.bound !== 'true') {
+            sortSelect.addEventListener('change', async () => {
+                setRelationshipExtentUiState(conceptId, suffix, { sortBy: sortSelect.value });
+                await renderRelationships(conceptId, suffix, kind);
+            });
+            sortSelect.dataset.bound = 'true';
+        }
+    }
+}
+
 async function initializeRelationshipsUI(conceptId, suffix, kind) {
     try {
         // Show loading indicator immediately
@@ -4779,6 +4960,7 @@ async function initializeRelationshipsUI(conceptId, suffix, kind) {
 
         const container = document.getElementById(`relationshipsSection_${suffix}`) || document.getElementById('relationshipsSection');
         if (!container) return;
+        ensureRelationshipsToolbar(container, conceptId, suffix, kind);
 
         // Simple in-memory caches (module scope) – create if not already
         if (!window.__dynamicTabsCaches) {
@@ -5766,7 +5948,21 @@ async function renderRelationships(conceptId, suffix, kind) {
     if (!content) return;
     content.innerHTML = '<div>Loading relationships...</div>';
     try {
-        const resp = await fetch(`/vontology/api/vontology/relationships/extent?concept_id=${encodeURIComponent(conceptId)}&limit=500`);
+        const uiState = getRelationshipExtentUiState(conceptId, suffix);
+        const extentQuery = deriveRelationshipExtentQuery(uiState.uncertaintyFilter);
+        const params = new URLSearchParams();
+        params.set('concept_id', conceptId);
+        params.set('limit', '500');
+        if (extentQuery.uncertaintyMode) {
+            params.set('uncertainty_mode', extentQuery.uncertaintyMode);
+        }
+        if (extentQuery.includeUncertain) {
+            params.set('include_uncertain', 'true');
+        }
+        for (const status of extentQuery.uncertaintyStatuses || []) {
+            params.append('uncertainty_status', status);
+        }
+        const resp = await fetch(`/vontology/api/vontology/relationships/extent?${params.toString()}`);
         const data = await resp.json().catch(() => ({}));
         if (!resp.ok || !data.success) {
             throw new Error(data.error || `HTTP ${resp.status}`);
@@ -5791,6 +5987,7 @@ async function renderRelationships(conceptId, suffix, kind) {
             content.innerHTML = '<i>No relationships yet.</i>';
             return;
         }
+        rows = sortRelationshipExtentRows(rows, uiState.sortBy);
 
         const toPredicateConceptId = (predicateId) => {
             if (!predicateId || typeof predicateId !== 'string') {
@@ -5861,6 +6058,42 @@ async function renderRelationships(conceptId, suffix, kind) {
             return cell;
         };
 
+        const createRelationStateCell = (row) => {
+            const cell = document.createElement('td');
+            const state = String(row?.relation_state || (row?.is_asserted ? 'asserted' : 'uncertain')).trim().toLowerCase() || 'asserted';
+            const uncertainty = getRowUncertaintyPayload(row);
+            const uncertaintyStatus = String(uncertainty.status || '').trim().toLowerCase();
+            const badge = document.createElement('span');
+            badge.className = `relationship-state-badge state-${state}`;
+            badge.textContent = state === 'uncertain' ? 'Uncertain' : 'Asserted';
+            if (state === 'uncertain' && uncertaintyStatus) {
+                badge.textContent = `${badge.textContent} (${uncertaintyStatus})`;
+            }
+            badge.setAttribute('aria-label', `Relationship state ${badge.textContent}`);
+            cell.appendChild(badge);
+            return cell;
+        };
+
+        const createConfidenceCell = (row) => {
+            const cell = document.createElement('td');
+            const confidenceText = formatRelationshipConfidence(row);
+            cell.textContent = confidenceText;
+            cell.className = 'relationship-confidence-cell';
+            cell.setAttribute('aria-label', `Relationship confidence ${confidenceText}`);
+            return cell;
+        };
+
+        const createProvenanceCell = (row) => {
+            const cell = document.createElement('td');
+            const provenanceSummary = summariseRelationshipProvenance(row);
+            cell.textContent = provenanceSummary || 'N/A';
+            if (provenanceSummary) {
+                cell.title = provenanceSummary;
+            }
+            cell.className = 'relationship-provenance-cell';
+            return cell;
+        };
+
         const tableContainer = document.createElement('div');
         tableContainer.className = 'predicate-extent-table-container';
         const table = document.createElement('table');
@@ -5868,7 +6101,7 @@ async function renderRelationships(conceptId, suffix, kind) {
 
         const thead = document.createElement('thead');
         const headRow = document.createElement('tr');
-        ['Role', 'Predicate', 'Arg1', 'Arg2', 'Source', 'Updated', 'Actions'].forEach((label) => {
+        ['Role', 'Predicate', 'Arg1', 'Arg2', 'State', 'Confidence', 'Provenance', 'Source', 'Updated', 'Actions'].forEach((label) => {
             const th = document.createElement('th');
             th.textContent = label;
             headRow.appendChild(th);
@@ -5901,14 +6134,20 @@ async function renderRelationships(conceptId, suffix, kind) {
                 tr.appendChild(createTextCell(row.arg2_value || '', row.arg2_lang || ''));
             }
 
+            tr.appendChild(createRelationStateCell(row));
+            tr.appendChild(createConfidenceCell(row));
+            tr.appendChild(createProvenanceCell(row));
+
             const sourceCell = document.createElement('td');
             sourceCell.textContent = row.source || 'structured';
             sourceCell.className = `source-${row.source || 'structured'}`;
             tr.appendChild(sourceCell);
 
             const updatedCell = document.createElement('td');
-            if (row.updated_at) {
-                const date = new Date(row.updated_at);
+            const uncertaintyMeta = getRowUncertaintyPayload(row);
+            const updatedCandidate = uncertaintyMeta.updated_at_utc || row.updated_at || uncertaintyMeta.created_at_utc;
+            if (updatedCandidate) {
+                const date = new Date(updatedCandidate);
                 if (!Number.isNaN(date.getTime())) {
                     updatedCell.textContent = date.toLocaleString('en-NZ', {
                         year: 'numeric',
@@ -5919,7 +6158,7 @@ async function renderRelationships(conceptId, suffix, kind) {
                     });
                     updatedCell.title = date.toISOString();
                 } else {
-                    updatedCell.textContent = row.updated_at;
+                    updatedCell.textContent = String(updatedCandidate);
                 }
             } else {
                 updatedCell.textContent = 'N/A';
@@ -5927,46 +6166,125 @@ async function renderRelationships(conceptId, suffix, kind) {
             tr.appendChild(updatedCell);
 
             const actionCell = document.createElement('td');
-            const removeBtn = document.createElement('button');
-            removeBtn.type = 'button';
-            removeBtn.className = 'chip-remove';
-            removeBtn.textContent = '×';
-            removeBtn.title = 'Remove assertion';
-            removeBtn.addEventListener('click', async () => {
-                try {
-                    if (row.relation_kind === 'text') {
-                        const deleteResp = await fetch(`/api/concepts/${encodeURIComponent(row.arg1_value)}/texts`, {
-                            method: 'DELETE',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ predicate: row.predicate_id, text: row.arg2_value })
-                        });
-                        const payload = await deleteResp.json().catch(() => ({}));
-                        if (!deleteResp.ok || payload.error) {
-                            throw new Error(payload.error || `HTTP ${deleteResp.status}`);
-                        }
-                        dispatchConceptUpdated([conceptId], { reason: 'text_relation_removed', source: 'relationships_ui' });
-                    } else {
-                        const deleteResp = await fetch('/vontology/api/vontology/relationships/remove', {
+            const state = String(row?.relation_state || (row?.is_asserted ? 'asserted' : 'uncertain')).trim().toLowerCase() || 'asserted';
+            const uncertainty = getRowUncertaintyPayload(row);
+            const assertionId = String(uncertainty.assertion_id || '').trim();
+            const uncertaintyStatus = String(uncertainty.status || '').trim().toLowerCase();
+            const canReviewUncertain = state === 'uncertain' && assertionId && (!uncertaintyStatus || uncertaintyStatus === 'proposed');
+
+            if (canReviewUncertain) {
+                const confirmBtn = document.createElement('button');
+                confirmBtn.type = 'button';
+                confirmBtn.className = 'relationship-action-button relationship-action-confirm';
+                confirmBtn.textContent = 'Confirm';
+                confirmBtn.title = 'Promote uncertain relationship to asserted';
+                confirmBtn.setAttribute('aria-label', 'Confirm uncertain relationship');
+                confirmBtn.addEventListener('click', async () => {
+                    try {
+                        const promoteResp = await fetch('/vontology/api/vontology/relationships/uncertain/promote', {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
                             body: JSON.stringify({
-                                source_id: row.arg1_value,
-                                kind: row.predicate_id,
-                                target_id: row.arg2_value
+                                source_id: row.source_concept_id || row.arg1_value,
+                                assertion_id: assertionId,
+                                operator: 'ui'
                             })
                         });
-                        const payload = await deleteResp.json().catch(() => ({}));
-                        if (!deleteResp.ok || payload.error) {
-                            throw new Error(payload.error || `HTTP ${deleteResp.status}`);
+                        const payload = await promoteResp.json().catch(() => ({}));
+                        if (!promoteResp.ok || !payload.success) {
+                            throw new Error(payload.error || `HTTP ${promoteResp.status}`);
                         }
-                        dispatchConceptUpdated([row.arg1_value, row.arg2_value], { reason: 'relationship_removed', source: 'relationships_ui' });
+                        dispatchConceptUpdated([row.source_concept_id || row.arg1_value, row.arg2_value, conceptId], { reason: 'uncertain_relationship_promoted', source: 'relationships_ui' });
+                        await renderRelationships(conceptId, suffix, kind);
+                    } catch (err) {
+                        alert(`Failed to confirm relationship: ${err.message}`);
                     }
-                    await renderRelationships(conceptId, suffix, kind);
-                } catch (err) {
-                    alert(`Failed to remove relationship: ${err.message}`);
-                }
-            });
-            actionCell.appendChild(removeBtn);
+                });
+
+                const rejectBtn = document.createElement('button');
+                rejectBtn.type = 'button';
+                rejectBtn.className = 'relationship-action-button relationship-action-reject';
+                rejectBtn.textContent = 'Reject';
+                rejectBtn.title = 'Reject or defer uncertain relationship';
+                rejectBtn.setAttribute('aria-label', 'Reject uncertain relationship');
+                rejectBtn.addEventListener('click', async () => {
+                    const promptMessage = 'Optional reason for rejection/deferment (leave blank to use default):';
+                    const reasonInput = window.prompt(promptMessage, '');
+                    if (reasonInput === null) {
+                        return;
+                    }
+                    const reason = String(reasonInput || '').trim() || 'deferred_by_user';
+                    try {
+                        const rejectResp = await fetch('/vontology/api/vontology/relationships/uncertain/reject', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({
+                                source_id: row.source_concept_id || row.arg1_value,
+                                assertion_id: assertionId,
+                                reason,
+                                operator: 'ui'
+                            })
+                        });
+                        const payload = await rejectResp.json().catch(() => ({}));
+                        if (!rejectResp.ok || !payload.success) {
+                            throw new Error(payload.error || `HTTP ${rejectResp.status}`);
+                        }
+                        dispatchConceptUpdated([row.source_concept_id || row.arg1_value, conceptId], { reason: 'uncertain_relationship_rejected', source: 'relationships_ui' });
+                        await renderRelationships(conceptId, suffix, kind);
+                    } catch (err) {
+                        alert(`Failed to reject relationship: ${err.message}`);
+                    }
+                });
+
+                actionCell.appendChild(confirmBtn);
+                actionCell.appendChild(rejectBtn);
+            } else if (state === 'uncertain') {
+                const statusLabel = document.createElement('span');
+                statusLabel.className = 'relationship-action-readonly';
+                statusLabel.textContent = uncertaintyStatus ? `No actions (${uncertaintyStatus})` : 'No actions';
+                actionCell.appendChild(statusLabel);
+            } else {
+                const removeBtn = document.createElement('button');
+                removeBtn.type = 'button';
+                removeBtn.className = 'chip-remove';
+                removeBtn.textContent = '×';
+                removeBtn.title = 'Remove assertion';
+                removeBtn.addEventListener('click', async () => {
+                    try {
+                        if (row.relation_kind === 'text') {
+                            const deleteResp = await fetch(`/api/concepts/${encodeURIComponent(row.arg1_value)}/texts`, {
+                                method: 'DELETE',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ predicate: row.predicate_id, text: row.arg2_value })
+                            });
+                            const payload = await deleteResp.json().catch(() => ({}));
+                            if (!deleteResp.ok || payload.error) {
+                                throw new Error(payload.error || `HTTP ${deleteResp.status}`);
+                            }
+                            dispatchConceptUpdated([conceptId], { reason: 'text_relation_removed', source: 'relationships_ui' });
+                        } else {
+                            const deleteResp = await fetch('/vontology/api/vontology/relationships/remove', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({
+                                    source_id: row.arg1_value,
+                                    kind: row.predicate_id,
+                                    target_id: row.arg2_value
+                                })
+                            });
+                            const payload = await deleteResp.json().catch(() => ({}));
+                            if (!deleteResp.ok || payload.error) {
+                                throw new Error(payload.error || `HTTP ${deleteResp.status}`);
+                            }
+                            dispatchConceptUpdated([row.arg1_value, row.arg2_value], { reason: 'relationship_removed', source: 'relationships_ui' });
+                        }
+                        await renderRelationships(conceptId, suffix, kind);
+                    } catch (err) {
+                        alert(`Failed to remove relationship: ${err.message}`);
+                    }
+                });
+                actionCell.appendChild(removeBtn);
+            }
             tr.appendChild(actionCell);
 
             tbody.appendChild(tr);

--- a/src/frontend/web/von_interface/static/js/test/dynamicTabsRelationshipsUncertainty.test.js
+++ b/src/frontend/web/von_interface/static/js/test/dynamicTabsRelationshipsUncertainty.test.js
@@ -1,0 +1,66 @@
+import {
+    deriveRelationshipExtentQuery,
+    getRelationshipConfidenceScore,
+    sortRelationshipExtentRows,
+    summariseRelationshipProvenance
+} from '../dynamicTabs.js';
+
+describe('dynamicTabs uncertain relationship helpers', () => {
+    test('deriveRelationshipExtentQuery returns asserted-only mode', () => {
+        const query = deriveRelationshipExtentQuery('asserted_only');
+        expect(query.uncertaintyMode).toBe('asserted_only');
+        expect(query.includeUncertain).toBe(false);
+        expect(query.uncertaintyStatuses).toEqual(['proposed']);
+    });
+
+    test('deriveRelationshipExtentQuery defaults to include uncertain mode', () => {
+        const query = deriveRelationshipExtentQuery('unknown_filter');
+        expect(query.uncertaintyMode).toBe('include_uncertain');
+        expect(query.includeUncertain).toBe(true);
+    });
+
+    test('getRelationshipConfidenceScore clamps values into [0,1]', () => {
+        expect(getRelationshipConfidenceScore({ uncertainty: { confidence_score: 1.5 } })).toBe(1);
+        expect(getRelationshipConfidenceScore({ uncertainty: { confidence_score: -0.1 } })).toBe(0);
+        expect(getRelationshipConfidenceScore({ uncertainty: { confidence_score: '0.42' } })).toBeCloseTo(0.42);
+        expect(getRelationshipConfidenceScore({})).toBeNull();
+    });
+
+    test('summariseRelationshipProvenance builds compact provenance summary', () => {
+        const summary = summariseRelationshipProvenance({
+            uncertainty: {
+                provenance: {
+                    source: 'relation_elicitation',
+                    source_interaction_id: 'int-123',
+                    rejected_by: 'ui'
+                }
+            }
+        });
+        expect(summary).toContain('source: relation_elicitation');
+        expect(summary).toContain('interaction: int-123');
+        expect(summary).toContain('rejected by: ui');
+    });
+
+    test('sortRelationshipExtentRows sorts by confidence descending then recency', () => {
+        const rows = [
+            {
+                relation_id: 'a',
+                updated_at: '2026-02-01T10:00:00Z',
+                uncertainty: { confidence_score: 0.2, updated_at_utc: '2026-02-01T10:00:00Z' }
+            },
+            {
+                relation_id: 'b',
+                updated_at: '2026-02-02T10:00:00Z',
+                uncertainty: { confidence_score: 0.9, updated_at_utc: '2026-02-02T10:00:00Z' }
+            },
+            {
+                relation_id: 'c',
+                updated_at: '2026-02-03T10:00:00Z',
+                uncertainty: { confidence_score: 0.9, updated_at_utc: '2026-02-03T10:00:00Z' }
+            }
+        ];
+        const sorted = sortRelationshipExtentRows(rows, 'confidence_desc');
+        expect(sorted.map((row) => row.relation_id)).toEqual(['c', 'b', 'a']);
+    });
+});
+

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -10428,6 +10428,36 @@ body.settings-body {
     margin-bottom: 16px;
 }
 
+.relationships-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: flex-end;
+    margin-bottom: 10px;
+}
+
+.relationships-toolbar-group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 170px;
+}
+
+.relationships-toolbar-group label {
+    font-size: 0.85rem;
+    color: #334155;
+    font-weight: 600;
+}
+
+.relationships-toolbar-select {
+    min-height: 32px;
+    border: 1px solid #cbd5e1;
+    border-radius: 6px;
+    padding: 4px 8px;
+    font-size: 0.9rem;
+    background: #ffffff;
+}
+
 .predicate-extent-table {
     width: 100%;
     border-collapse: collapse;
@@ -10486,6 +10516,63 @@ body.settings-body {
 
 .predicate-extent-table td.source-structured {
     color: #28a745;
+}
+
+.relationship-state-badge {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1.2;
+}
+
+.relationship-state-badge.state-asserted {
+    background: #dcfce7;
+    color: #166534;
+}
+
+.relationship-state-badge.state-uncertain {
+    background: #fef3c7;
+    color: #92400e;
+}
+
+.relationship-confidence-cell,
+.relationship-provenance-cell {
+    font-size: 0.85rem;
+    color: #334155;
+}
+
+.relationship-action-button {
+    border: 1px solid #cbd5e1;
+    border-radius: 6px;
+    padding: 4px 8px;
+    font-size: 0.75rem;
+    line-height: 1.1;
+    cursor: pointer;
+    margin-right: 4px;
+}
+
+.relationship-action-confirm {
+    background: #e0f2fe;
+    color: #075985;
+}
+
+.relationship-action-reject {
+    background: #fee2e2;
+    color: #991b1b;
+}
+
+.relationship-action-readonly {
+    font-size: 0.75rem;
+    color: #64748b;
+}
+
+@media (max-width: 640px) {
+    .relationships-toolbar-group {
+        min-width: 100%;
+    }
 }
 
 .predicate-extent-add-row td {

--- a/tests/backend/test_virtual_code_predicate_concepts.py
+++ b/tests/backend/test_virtual_code_predicate_concepts.py
@@ -436,6 +436,43 @@ def test_relationship_extent_route_supports_uncertain_filters(app_client, monkey
     assert captured_kwargs.get("uncertainty_mode") == "uncertain_only"
 
 
+def test_uncertain_relationship_promote_route_returns_success_payload(
+    app_client, monkeypatch
+):
+    _, client = app_client
+
+    monkeypatch.setattr(
+        "src.backend.services.uncertain_relationship_service.promote_uncertain_relationship_assertion",
+        lambda **kwargs: {
+            "success": True,
+            "assertion": {"assertion_id": kwargs.get("assertion_id"), "status": "promoted"},
+            "write_result": {"success": True},
+        },
+    )
+
+    resp = client.post(
+        "/vontology/api/vontology/relationships/uncertain/promote",
+        json={"source_id": "#V#focus", "assertion_id": "u1", "operator": "unit_test"},
+    )
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload.get("success") is True
+    assert payload.get("assertion", {}).get("status") == "promoted"
+
+
+def test_uncertain_relationship_reject_route_requires_reason(app_client):
+    _, client = app_client
+
+    resp = client.post(
+        "/vontology/api/vontology/relationships/uncertain/reject",
+        json={"source_id": "#V#focus", "assertion_id": "u1"},
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload.get("success") is False
+    assert "reason" in (payload.get("error") or "").lower()
+
+
 def test_upsert_name_for_virtual_code_predicate_concept(app_client, monkeypatch):
     _, client = app_client
 


### PR DESCRIPTION
## Summary
- add uncertain relationship promote/reject routes for concept-tab UI actions
- extend dynamic relationship extent UI with uncertainty filter and sort controls
- render uncertainty state, confidence, provenance, and recency metadata in extent rows
- add confirm/reject actions for proposed uncertain assertions with immediate refresh
- style new controls and add helper-focused frontend tests

## Testing
- pytest tests/backend/test_virtual_code_predicate_concepts.py -q
- npx jest src/frontend/web/von_interface/static/js/test/dynamicTabsRelationshipsUncertainty.test.js --runInBand
- npx pyright src/backend/server/routes/vontology_routes.py tests/backend/test_virtual_code_predicate_concepts.py