### PR TITLE
JVNAUTOSCI-737: surface description provenance/confidence metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,15 +22,16 @@ All AI agents must read this file and `docs/engineering/security_considerations.
 16. When in doubt, run tests or re-run tests without requiring user confirmation, but start with a **targeted impacted set** (touched modules + real call-path tests) and only expand to broader suites when risk or failures indicate.
 17. In the case that multiple tests are failing, carefully consider the possibility that the tests are based on a design assumption that no longer holds. Tests are not definitional here, they are diagnostic, and should be changed (carefully) if they are not diagnostic for the current design. Do not allow tests to be a barrier to generality and good factoring.
 18. If you think you've finished implementing a Jira task, read the task and its epic and subtask context again and check.
-19. **DRY first**: Create central helpers FIRST, then replace all usages. See "DRY refactoring discipline" in Workflow section.
-20. **Comment for evolution**: Add comments that guide future modifications. See "Self-Documenting, Evolvable Code" section.
-21. **Proactive hygiene**: Periodically review touched files and their neighbours for inconsistency, duplication, and drift. Fix proactively.
-22. In docs/examples for secret env vars, use explicit placeholders like `<YOUR-CLIENT-SECRET-HERE>` and avoid token-like sample strings that can trigger secret scanners.
-23. **Workflow-first behaviours**: strongly prefer Vontology workflows (definitions, instances, event bindings, schedules) to drive Von behaviour instead of adding specialised orchestration code. Add bespoke code only when workflow primitives cannot express the behaviour, and document the gap in Jira.
-24. **Policy over task wording**: if a Jira issue suggests implementation in specialised orchestration code but the behaviour can be expressed as a Vontology workflow, enforce workflow-first policy and reinterpret/revise the task accordingly. In these cases, limit code changes to missing tools/validators/telemetry needed by the workflow, and add a Jira comment documenting the reinterpretation.
-25. If you are reasonably confident task implementation is complete, proactively merge and close the task (commit/push, create PR, merge to `main`, and transition Jira) unless the user explicitly asks to hold.
-26. **Definition of fully complete Jira task**: implementation committed and pushed, PR created, PR merged to `main`, and Jira transitioned/commented accordingly.
-27. **Fail closed when Vontology is unavailable for Vontology-governed behaviour**: do not silently fall back to in-code prompts, stale context reuse, or heuristic hacks. If required Vontology prompts/workflow data cannot be resolved, no-op that transformation and emit a clear user-visible and telemetry-visible reason.
+19. Before finalising a task, review nearby recent commits/issues for related progress and adjust scope to stay aligned; always run targeted regression checks for the touched behaviour so no avoidable regressions are introduced.
+20. **DRY first**: Create central helpers FIRST, then replace all usages. See "DRY refactoring discipline" in Workflow section.
+21. **Comment for evolution**: Add comments that guide future modifications. See "Self-Documenting, Evolvable Code" section.
+22. **Proactive hygiene**: Periodically review touched files and their neighbours for inconsistency, duplication, and drift. Fix proactively.
+23. In docs/examples for secret env vars, use explicit placeholders like `<YOUR-CLIENT-SECRET-HERE>` and avoid token-like sample strings that can trigger secret scanners.
+24. **Workflow-first behaviours**: strongly prefer Vontology workflows (definitions, instances, event bindings, schedules) to drive Von behaviour instead of adding specialised orchestration code. Add bespoke code only when workflow primitives cannot express the behaviour, and document the gap in Jira.
+25. **Policy over task wording**: if a Jira issue suggests implementation in specialised orchestration code but the behaviour can be expressed as a Vontology workflow, enforce workflow-first policy and reinterpret/revise the task accordingly. In these cases, limit code changes to missing tools/validators/telemetry needed by the workflow, and add a Jira comment documenting the reinterpretation.
+26. If you are reasonably confident task implementation is complete, proactively merge and close the task (commit/push, create PR, merge to `main`, and transition Jira) unless the user explicitly asks to hold.
+27. **Definition of fully complete Jira task**: implementation committed and pushed, PR created, PR merged to `main`, and Jira transitioned/commented accordingly.
+28. **Fail closed when Vontology is unavailable for Vontology-governed behaviour**: do not silently fall back to in-code prompts, stale context reuse, or heuristic hacks. If required Vontology prompts/workflow data cannot be resolved, no-op that transformation and emit a clear user-visible and telemetry-visible reason.
 
 ## Core AI-Focused Documents
 - `docs/AINotes.md`: short-term memory and tactical log.

--- a/src/backend/services/concept_service.py
+++ b/src/backend/services/concept_service.py
@@ -76,7 +76,8 @@ from ..security.access_control import (
     get_effective_user_concept_id,
     apply_concept_query_filter,
 )
-from .text_value_service import upsert_text_for_concept
+from .description_metadata_service import extract_inline_description_metadata
+from .text_value_service import get_texts_for_concept, upsert_text_for_concept
 from ..db.repositories.text_value_repository import TextRelationsRepository
 
 # Setup logger
@@ -3165,17 +3166,73 @@ def update_concept_description(concept_id: str, new_description: str) -> bool:
             )
             return False
 
+        existing_context: Dict[str, Any] = {}
+        existing_provenance: Dict[str, Any] = {}
+        cleaned_description, extracted_inline_metadata = (
+            extract_inline_description_metadata(new_description)
+        )
+        description_to_store = (
+            cleaned_description if cleaned_description.strip() else new_description
+        )
+
         try:
+            existing_descriptions = get_texts_for_concept(
+                subject_concept_id=concept_id, predicate="hasDescription", limit=1
+            )
+            if existing_descriptions:
+                first = existing_descriptions[0]
+                if isinstance(first.get("context"), dict):
+                    existing_context = dict(first["context"])
+                if isinstance(first.get("provenance"), dict):
+                    existing_provenance = dict(first["provenance"])
+        except Exception as e:  # pragma: no cover
+            logger.warning(
+                "update_concept_description: failed to read existing metadata for %s: %s",
+                concept_id,
+                e,
+            )
+
+        try:
+            now_iso = datetime.now(timezone.utc).isoformat()
+            provenance_payload: Dict[str, Any] = dict(existing_provenance)
+            context_payload: Dict[str, Any] = dict(existing_context)
+            if not provenance_payload:
+                provenance_payload["source"] = "update_concept_description"
+            provenance_payload["last_edited_at"] = now_iso
+            provenance_payload.setdefault("last_edited_by", "update_concept_description")
+            context_payload.setdefault("write_strategy", "relations_only_v2")
+
+            if extracted_inline_metadata:
+                if isinstance(extracted_inline_metadata.get("source"), str):
+                    provenance_payload.setdefault(
+                        "source_label", extracted_inline_metadata["source"]
+                    )
+                if isinstance(extracted_inline_metadata.get("attribution"), str):
+                    provenance_payload.setdefault(
+                        "attribution", extracted_inline_metadata["attribution"]
+                    )
+                if isinstance(extracted_inline_metadata.get("timestamp"), str):
+                    provenance_payload.setdefault(
+                        "upstream_timestamp", extracted_inline_metadata["timestamp"]
+                    )
+                if isinstance(extracted_inline_metadata.get("parent"), str):
+                    context_payload.setdefault(
+                        "parent_concept_id", extracted_inline_metadata["parent"]
+                    )
+                confidence_score = extracted_inline_metadata.get("confidence_score")
+                if isinstance(confidence_score, (int, float)):
+                    context_payload.setdefault(
+                        "confidence_score", float(confidence_score)
+                    )
+                context_payload["inline_metadata_migrated"] = True
+
             tv_payload = upsert_text_for_concept(
                 subject_concept_id=concept_id,
                 predicate="hasDescription",
-                text=new_description,
+                text=description_to_store,
                 lang="en",
-                provenance={
-                    "source": "update_concept_description",
-                    "ts": datetime.now(timezone.utc).isoformat(),
-                },
-                context={"write_strategy": "relations_only_v2"},
+                provenance=provenance_payload,
+                context=context_payload,
             )
             new_text_value_id = tv_payload.get("text_value_id")
             relation_id = tv_payload.get("relation_id")

--- a/src/backend/services/description_generation_service.py
+++ b/src/backend/services/description_generation_service.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from ..prompt.annotation_prompt import AnnotationPromptBuilder
+from .description_metadata_service import extract_inline_description_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -330,17 +331,52 @@ class DescriptionGenerationService:
         # Store if requested
         if store:
             try:
+                cleaned_description, extracted_metadata = (
+                    extract_inline_description_metadata(description)
+                )
+                if cleaned_description:
+                    description = cleaned_description
+                now_iso = datetime.now(timezone.utc).isoformat()
+                provenance_payload: Dict[str, Any] = {
+                    "source": "llm_generation",
+                    "service": "description_generation_service",
+                    "timestamp": now_iso,
+                }
+                context_payload: Dict[str, Any] = {
+                    "generated": True,
+                    "jira": "JVNAUTOSCI-1044",
+                }
+                if extracted_metadata:
+                    if isinstance(extracted_metadata.get("source"), str):
+                        provenance_payload.setdefault(
+                            "source_label", extracted_metadata["source"]
+                        )
+                    if isinstance(extracted_metadata.get("attribution"), str):
+                        provenance_payload.setdefault(
+                            "attribution", extracted_metadata["attribution"]
+                        )
+                    if isinstance(extracted_metadata.get("timestamp"), str):
+                        provenance_payload.setdefault(
+                            "upstream_timestamp", extracted_metadata["timestamp"]
+                        )
+                    if isinstance(extracted_metadata.get("parent"), str):
+                        context_payload.setdefault(
+                            "parent_concept_id", extracted_metadata["parent"]
+                        )
+                    confidence_score = extracted_metadata.get("confidence_score")
+                    if isinstance(confidence_score, (int, float)):
+                        context_payload.setdefault(
+                            "confidence_score", float(confidence_score)
+                        )
+                    context_payload["inline_metadata_migrated"] = True
+
                 upsert_text_for_concept(
                     subject_concept_id=concept_id,
                     predicate="hasDescription",
                     text=description,
                     lang="en-NZ",
-                    provenance={
-                        "source": "llm_generation",
-                        "service": "description_generation_service",
-                        "timestamp": datetime.now(timezone.utc).isoformat(),
-                    },
-                    context={"generated": True, "jira": "JVNAUTOSCI-1044"},
+                    provenance=provenance_payload,
+                    context=context_payload,
                 )
                 logger.info(f"Stored generated description for {concept_id}")
             except Exception as e:

--- a/src/backend/services/description_metadata_service.py
+++ b/src/backend/services/description_metadata_service.py
@@ -1,0 +1,107 @@
+"""Helpers for migrating legacy inline description metadata into structured fields."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Tuple
+
+
+_METADATA_LINE_RE = re.compile(
+    r"^(?:[-*]\s*)?(source|attribution|attributed\s+to|confidence|confidence\s+score|timestamp|generated\s+at|parent|parent\s+id)\s*[:=-]\s*(.+)$",
+    re.IGNORECASE,
+)
+
+
+def _coerce_confidence(raw_value: str) -> float | None:
+    token = raw_value.strip().rstrip("%").strip()
+    if not token:
+        return None
+    try:
+        value = float(token)
+    except ValueError:
+        return None
+    if value > 1 and value <= 100:
+        value = value / 100.0
+    if value < 0:
+        value = 0.0
+    if value > 1:
+        value = 1.0
+    return value
+
+
+def extract_inline_description_metadata(raw_text: str) -> Tuple[str, Dict[str, Any]]:
+    """Strip a leading metadata block from description text.
+
+    Legacy descriptions sometimes start with lines like:
+      Source: ...
+      Confidence: ...
+      Timestamp: ...
+
+    We treat that as metadata only when at least two recognised metadata lines
+    appear at the top of the text before the first blank line.
+    """
+
+    if not isinstance(raw_text, str):
+        return "", {}
+
+    text = raw_text.strip()
+    if not text:
+        return "", {}
+
+    lines = text.splitlines()
+    parsed: Dict[str, Any] = {}
+    consumed = 0
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            break
+        match = _METADATA_LINE_RE.match(stripped)
+        if not match:
+            break
+        key = match.group(1).strip().lower().replace(" ", "_")
+        value = match.group(2).strip()
+        if not value:
+            break
+        consumed += 1
+        if key == "attributed_to":
+            parsed["attribution"] = value
+        elif key == "generated_at":
+            parsed["timestamp"] = value
+        elif key == "parent_id":
+            parsed["parent"] = value
+        elif key == "confidence_score":
+            parsed["confidence"] = value
+        else:
+            parsed[key] = value
+
+    if consumed < 2:
+        return text, {}
+
+    remainder_lines = lines[consumed:]
+    while remainder_lines and not remainder_lines[0].strip():
+        remainder_lines.pop(0)
+    cleaned = "\n".join(remainder_lines).strip()
+    if not cleaned:
+        cleaned = text
+
+    confidence_raw = parsed.get("confidence")
+    confidence_score = None
+    if isinstance(confidence_raw, str):
+        confidence_score = _coerce_confidence(confidence_raw)
+
+    structured: Dict[str, Any] = {}
+    if isinstance(parsed.get("source"), str):
+        structured["source"] = parsed["source"]
+    if isinstance(parsed.get("attribution"), str):
+        structured["attribution"] = parsed["attribution"]
+    if isinstance(parsed.get("timestamp"), str):
+        structured["timestamp"] = parsed["timestamp"]
+    if isinstance(parsed.get("parent"), str):
+        structured["parent"] = parsed["parent"]
+    if confidence_score is not None:
+        structured["confidence_score"] = confidence_score
+    structured["migrated_from_inline_header"] = True
+    structured["raw_header_fields"] = parsed
+
+    return cleaned, structured

--- a/src/backend/services/text_value_service.py
+++ b/src/backend/services/text_value_service.py
@@ -29,6 +29,14 @@ def _now() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _iso_utc(value: Any) -> str | None:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def _invalidate_stats_for_predicate_change(predicate: str | None) -> None:
     """Best-effort stats invalidation for ontology predicate extent changes."""
 
@@ -370,6 +378,11 @@ def get_texts_for_concept(
                 "predicate": r.get("predicate"),
                 "relation_id": str(r.get("_id")) if r.get("_id") else None,
                 "context": r.get("context", {}),
+                "provenance": tv.get("provenance", {}),
+                "text_value_created_at": _iso_utc(tv.get("created_at")),
+                "text_value_updated_at": _iso_utc(tv.get("updated_at")),
+                "relation_created_at": _iso_utc(r.get("created_at")),
+                "relation_updated_at": _iso_utc(r.get("updated_at")),
             }
         )
         if len(results) >= limit:

--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -3420,6 +3420,70 @@ function escapeHtml(s) {
         .replace(/'/g, '&#039;');
 }
 
+function normaliseDescriptionConfidence(rawValue) {
+    const value = Number(rawValue);
+    if (!Number.isFinite(value)) return null;
+    if (value > 1 && value <= 100) return Math.max(0, Math.min(1, value / 100));
+    return Math.max(0, Math.min(1, value));
+}
+
+function normaliseDescriptionTimestamp(rawValue) {
+    if (typeof rawValue !== 'string') return null;
+    const token = rawValue.trim();
+    if (!token) return null;
+    const parsed = new Date(token);
+    if (Number.isNaN(parsed.getTime())) return token;
+    return parsed.toLocaleString();
+}
+
+export function buildDescriptionMetadataRows(record = {}) {
+    const context = (record && typeof record.context === 'object' && record.context)
+        ? record.context
+        : {};
+    const provenance = (record && typeof record.provenance === 'object' && record.provenance)
+        ? record.provenance
+        : {};
+
+    const rows = [];
+    const pushRow = (label, value) => {
+        const text = (value || '').toString().trim();
+        if (!text) return;
+        rows.push({ label, value: text });
+    };
+
+    const source = provenance.source || provenance.source_label || context.source || '';
+    pushRow('Source', source);
+    pushRow('Attribution', provenance.attribution || context.attribution || '');
+    pushRow('Parent', context.parent_concept_id || context.selected_parent || context.parent || '');
+
+    const confidence = normaliseDescriptionConfidence(
+        context.confidence_score
+            ?? context.confidence
+            ?? provenance.confidence_score
+            ?? provenance.confidence
+    );
+    if (typeof confidence === 'number') {
+        pushRow('Confidence', `${Math.round(confidence * 100)}%`);
+    }
+
+    const timestampCandidates = [
+        record.relation_updated_at,
+        record.text_value_updated_at,
+        provenance.last_edited_at,
+        provenance.timestamp,
+        provenance.upstream_timestamp,
+    ];
+    for (const candidate of timestampCandidates) {
+        const formatted = normaliseDescriptionTimestamp(candidate);
+        if (formatted) {
+            pushRow('Updated', formatted);
+            break;
+        }
+    }
+
+    return rows;
+}
+
 // Helper: show description for Type tabs and attach edit/save/cancel
 async function populateTypeDescription(conceptId, suffix) {
     try {
@@ -3438,6 +3502,35 @@ async function populateTypeDescription(conceptId, suffix) {
         const saveBtn = document.getElementById(`typeEditDescriptionSave_${suffix}`);
         const cancelBtn = document.getElementById(`typeEditDescriptionCancel_${suffix}`);
         const statusEl = document.getElementById(`typeDescriptionStatus_${suffix}`);
+        const ensureDescriptionMetadataContainer = () => {
+            let meta = document.getElementById(`typeDescriptionMetadata_${suffix}`);
+            if (meta) return meta;
+            if (!display || !display.parentNode) return null;
+            meta = document.createElement('div');
+            meta.id = `typeDescriptionMetadata_${suffix}`;
+            meta.className = 'description-metadata-panel hidden';
+            meta.setAttribute('aria-label', 'Description metadata');
+            if (display.nextSibling) {
+                display.parentNode.insertBefore(meta, display.nextSibling);
+            } else {
+                display.parentNode.appendChild(meta);
+            }
+            return meta;
+        };
+        const metadataEl = ensureDescriptionMetadataContainer();
+        const renderDescriptionMetadata = (record) => {
+            if (!metadataEl) return;
+            const rows = buildDescriptionMetadataRows(record);
+            if (!rows.length) {
+                metadataEl.classList.add('hidden');
+                metadataEl.innerHTML = '';
+                return;
+            }
+            metadataEl.classList.remove('hidden');
+            metadataEl.innerHTML = rows
+                .map((row) => `<span class="description-metadata-pill"><strong>${escapeHtml(row.label)}:</strong> ${escapeHtml(row.value)}</span>`)
+                .join('');
+        };
         // Capture missing buttons before potential reconstruction (so we can force rebind if we add them)
         const preMissingButtons = [];
         ['Copy', ...(annotationEnabled ? ['Annotate'] : []), 'Edit', 'Delete'].forEach(kind => {
@@ -3580,6 +3673,7 @@ async function populateTypeDescription(conceptId, suffix) {
                 relationId = null;
                 display.innerHTML = '<i>No description available.</i>';
                 textarea.value = '';
+                renderDescriptionMetadata(null);
             };
             try {
                 const primaryUrl = `/api/concepts/${encodedId}/texts?predicate=hasDescription&limit=1`;
@@ -3590,6 +3684,7 @@ async function populateTypeDescription(conceptId, suffix) {
                     relationId = desc.relation_id || null;
                     applyRawDescription(desc.text || '');
                     textarea.value = desc.text || '';
+                    renderDescriptionMetadata(desc);
                     console.debug('[dynamicTabs] Description loaded (primary API)', { conceptId, relationId });
                     return;
                 }
@@ -3606,6 +3701,7 @@ async function populateTypeDescription(conceptId, suffix) {
                         relationId = found.relation_id || null;
                         applyRawDescription(found.text || '');
                         textarea.value = found.text || '';
+                        renderDescriptionMetadata(found);
                         console.debug('[dynamicTabs] Description loaded (relations list fallback)', { conceptId, relationId });
                         return;
                     }
@@ -3621,6 +3717,7 @@ async function populateTypeDescription(conceptId, suffix) {
                         applyRawDescription(conceptDescription);
                         textarea.value = conceptDescription;
                         relationId = null;
+                        renderDescriptionMetadata(null);
                         console.debug('[dynamicTabs] Description loaded (concept endpoint canonical fallback)', { conceptId });
                         return;
                     }
@@ -3636,6 +3733,7 @@ async function populateTypeDescription(conceptId, suffix) {
                         applyRawDescription(legacyRaw);
                         textarea.value = legacyRaw || '';
                         relationId = null;
+                        renderDescriptionMetadata(null);
                         console.debug('[dynamicTabs] Description loaded (legacy node_content raw text)', { conceptId });
                         return;
                     }
@@ -3649,6 +3747,7 @@ async function populateTypeDescription(conceptId, suffix) {
                         applyRawDescription(plain);
                         textarea.value = plain;
                         relationId = null;
+                        renderDescriptionMetadata(null);
                         console.debug('[dynamicTabs] Description loaded (legacy node_content html->plain)', { conceptId });
                         return;
                     }
@@ -3773,8 +3872,7 @@ async function populateTypeDescription(conceptId, suffix) {
                 // JVNAUTOSCI-570 regression fix: use dedicated dual-write description endpoint
                 const ok = await updateConceptDescription(conceptId, rawText);
                 if (!ok) throw new Error('Failed to persist description');
-
-                applyRawDescription(rawText);
+                await loadDescription();
                 statusEl.textContent = 'Saved';
                 textarea.classList.add('hidden');
                 display.classList.remove('hidden');
@@ -3867,9 +3965,7 @@ async function populateTypeDescription(conceptId, suffix) {
                         throw new Error(data.error || data.message || `HTTP ${resp.status}`);
                     }
                     if (data.description) {
-                        applyRawDescription(data.description);
-                        textarea.value = data.description;
-                        relationId = null; // Relation ID will be updated on next load
+                        await loadDescription();
                         statusEl.textContent = data.was_generated ? 'Description generated!' : 'Description loaded';
                     } else {
                         statusEl.textContent = 'No description generated';

--- a/src/frontend/web/von_interface/static/js/test/dynamicTabsRelationshipsUncertainty.test.js
+++ b/src/frontend/web/von_interface/static/js/test/dynamicTabsRelationshipsUncertainty.test.js
@@ -1,4 +1,5 @@
 import {
+    buildDescriptionMetadataRows,
     deriveRelationshipExtentQuery,
     getRelationshipConfidenceScore,
     sortRelationshipExtentRows,
@@ -61,6 +62,25 @@ describe('dynamicTabs uncertain relationship helpers', () => {
         ];
         const sorted = sortRelationshipExtentRows(rows, 'confidence_desc');
         expect(sorted.map((row) => row.relation_id)).toEqual(['c', 'b', 'a']);
+    });
+
+    test('buildDescriptionMetadataRows surfaces structured provenance and confidence', () => {
+        const rows = buildDescriptionMetadataRows({
+            context: {
+                confidence_score: 0.83,
+                parent_concept_id: '#V#process'
+            },
+            provenance: {
+                source: 'relation_elicitation',
+                attribution: '#V#michael_witbrock',
+                timestamp: '2026-03-01T00:00:00Z'
+            },
+            relation_updated_at: '2026-03-01T01:00:00Z'
+        });
+        const labels = rows.map((row) => row.label);
+        expect(labels).toEqual(expect.arrayContaining(['Source', 'Attribution', 'Parent', 'Confidence', 'Updated']));
+        const confidenceRow = rows.find((row) => row.label === 'Confidence');
+        expect(confidenceRow?.value).toBe('83%');
     });
 });
 

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -8810,6 +8810,29 @@ html body .names-list-container .name-cartouche .name-delete-button:disabled:hov
     border-color: #106ebe;
 }
 
+.description-metadata-panel {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin: 6px 0 0 0;
+}
+
+.description-metadata-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-size: 0.75rem;
+    line-height: 1.2;
+    background: #eef2ff;
+    color: #312e81;
+}
+
+.description-metadata-pill strong {
+    font-weight: 600;
+}
+
 .text-relations-modal.anchored .raw-json-dialog {
     pointer-events: auto;
     width: min(640px, 70vw);

--- a/tests/backend/test_description_metadata_preservation.py
+++ b/tests/backend/test_description_metadata_preservation.py
@@ -1,0 +1,113 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from bson import ObjectId
+
+from src.backend.services.description_metadata_service import (
+    extract_inline_description_metadata,
+)
+from src.backend.services import concept_service, text_value_service
+
+
+def test_extract_inline_description_metadata_strips_header_block():
+    raw = (
+        "Source: relation_elicitation\n"
+        "Confidence: 78%\n"
+        "Timestamp: 2026-03-01T00:00:00Z\n\n"
+        "This is the canonical description body."
+    )
+    cleaned, metadata = extract_inline_description_metadata(raw)
+    assert cleaned == "This is the canonical description body."
+    assert metadata["source"] == "relation_elicitation"
+    assert metadata["confidence_score"] == 0.78
+    assert metadata["timestamp"] == "2026-03-01T00:00:00Z"
+    assert metadata["migrated_from_inline_header"] is True
+
+
+def test_update_concept_description_preserves_existing_structured_metadata(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        concept_service.ConceptsRepository,
+        "find_one",
+        lambda *args, **kwargs: {"_id": ObjectId()},
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "get_texts_for_concept",
+        lambda *args, **kwargs: [
+            {
+                "context": {"confidence_score": 0.91, "parent_concept_id": "#V#workflow"},
+                "provenance": {"source": "llm_generation", "attribution": "#V#agent"},
+            }
+        ],
+    )
+
+    def _fake_upsert(**kwargs):
+        captured.update(kwargs)
+        return {"text_value_id": "tv1", "relation_id": "rel1"}
+
+    monkeypatch.setattr(concept_service, "upsert_text_for_concept", _fake_upsert)
+    monkeypatch.setattr(
+        concept_service.TextRelationsRepository,
+        "delete_many",
+        lambda *args, **kwargs: SimpleNamespace(deleted_count=0),
+    )
+    monkeypatch.setattr(
+        concept_service.ConceptsRepository,
+        "update_one",
+        lambda *args, **kwargs: None,
+    )
+
+    ok = concept_service.update_concept_description(
+        "#V#desc_test",
+        "Source: inline_legacy\nConfidence: 20%\n\nUpdated description text.",
+    )
+    assert ok is True
+    assert captured["text"] == "Updated description text."
+    assert captured["provenance"]["source"] == "llm_generation"
+    assert captured["context"]["confidence_score"] == 0.91
+    assert captured["context"]["inline_metadata_migrated"] is True
+
+
+def test_get_texts_for_concept_returns_provenance_and_timestamps(monkeypatch):
+    relation_id = ObjectId()
+    text_value_id = ObjectId()
+    now = datetime(2026, 3, 1, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(text_value_service, "can_access_concept", lambda *_: True)
+    monkeypatch.setattr(
+        text_value_service.TextRelationsRepository,
+        "find",
+        lambda *args, **kwargs: [
+            {
+                "_id": relation_id,
+                "predicate": "hasDescription",
+                "object_text_id": text_value_id,
+                "context": {"confidence_score": 0.66},
+                "created_at": now,
+                "updated_at": now,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        text_value_service.TextValuesRepository,
+        "find",
+        lambda *args, **kwargs: [
+            {
+                "_id": text_value_id,
+                "text": "Body",
+                "lang": "en-NZ",
+                "provenance": {"source": "unit_test"},
+                "created_at": now,
+                "updated_at": now,
+            }
+        ],
+    )
+
+    rows = text_value_service.get_texts_for_concept("#V#desc_test", predicate="hasDescription")
+    assert len(rows) == 1
+    first = rows[0]
+    assert first["provenance"]["source"] == "unit_test"
+    assert first["relation_updated_at"] == now.isoformat()
+    assert first["text_value_updated_at"] == now.isoformat()


### PR DESCRIPTION
## Summary
- surface hasDescription provenance/confidence/timestamp metadata in Concept tab description UI
- preserve existing structured description metadata on description edits
- migrate legacy inline metadata headers into structured provenance/context and strip boilerplate from stored text
- add regression tests for metadata extraction/preservation and UI metadata row formatting
- add AGENTS guidance to align task implementation with recent related progress and run targeted regression checks

## Validation
- pytest tests/backend/test_description_metadata_preservation.py -q
- pytest tests/backend/test_preserved_fields_guardrails.py tests/backend/test_text_relations_summary_and_singleton.py -q
- npm test -- src/frontend/web/von_interface/static/js/test/dynamicTabsRelationshipsUncertainty.test.js --runInBand
- npm test -- tests/frontend/conceptTabTextRelationsRendering.test.js --runInBand
- pyright on all changed Python files