### PR TITLE
JVNAUTOSCI-1317: comprehensive thinking-card activity timeline and icon toggle

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -1,0 +1,799 @@
+# Von Workflow Language (VWL) Manual
+
+Status: Draft (current implementation-aligned)
+Last updated: 2026-03-01 (Pacific/Auckland)
+Audience: Human engineers and AI agents
+
+## 1. Purpose and Scope
+
+Von Workflow Language (VWL) is the executable workflow language used by Von for LLM-era agent behaviour orchestration. VWL is not a standalone parser language. It is a graph-native language represented in Vontology concepts and predicates, then compiled into runtime workflow definitions.
+
+This manual documents:
+
+- the authoritative VWL vocabulary in Vontology,
+- compilation and runtime semantics in code,
+- durable execution semantics (instances, schedules, event bindings),
+- the MCP workflow control surface,
+- and a diagram appendix with tool-ready generation specifications.
+
+Normative keywords in this manual:
+
+- MUST: required for conformance with current VWL runtime.
+- SHOULD: strong recommendation.
+- MAY: optional.
+
+## 2. Authoritative Sources
+
+VWL is defined by the combination of:
+
+- Vontology concepts/predicates (source of meaning and graph data),
+- workflow loader/compiler/runtime in backend code,
+- durable runtime subsystem,
+- internal MCP workflow tools.
+
+Primary implementation anchors:
+
+- `src/backend/workflows/vontology_loader.py`
+- `src/backend/workflows/engine.py`
+- `src/backend/workflows/metadata_validation.py`
+- `src/backend/workflows/subworkflow_contracts.py`
+- `src/backend/workflows/workflow_definition_identity_service.py`
+- `src/backend/workflows/durable/models.py`
+- `src/backend/workflows/durable/worker.py`
+- `src/backend/workflows/durable/scheduler.py`
+- `src/backend/workflows/durable/workflow_instance_submission_service.py`
+- `src/backend/server/utils_flask.py`
+- `src/backend/integrations/internal_mcp/catalogue.py`
+
+## 3. VWL Ontology Vocabulary
+
+### 3.1 Core Type Concepts
+
+Canonical concepts (confirmed via Vontology MCP):
+
+- `#V#ai_workflow`: structured machine-interpretable workflow plan type.
+- `#V#durable_workflow`: workflow subtype with persistent execution/checkpointing semantics.
+- `#V#workflow_step`: type for workflow states/steps.
+- `#V#workflow_context_key`: type for deterministic context key symbols.
+- `#V#workflow_stage`: type for model-policy stage scoping.
+- `#V#workflow_model_policy`: type for stage-aware model selection policy.
+
+### 3.2 Core Predicate Concepts
+
+- `#V#workflow_step_invokes_tool`
+- `#V#workflow_step_uses_llm_prompt`
+- `#V#workflow_step_writes_context_key`
+- `#V#workflow_step_maps_context_key_to_tool_param`
+- `#V#workflow_step_maps_tool_output_field_to_context_key`
+- `#V#applies_to_workflow_stage`
+
+### 3.3 Graph Predicate Aliasing
+
+VWL accepts canonical and legacy aliases for graph links. Canonical names are preferred; aliases remain accepted for backward compatibility.
+
+Canonical graph families include:
+
+- `hasInitialStep`, `hasStep`
+- `invokesAction`, `invokesWorkflow`
+- `workflowStepInvokesTool`
+- `nextStep`
+- `onTrueNextStep`, `onFalseNextStep`, `onFailureNextStep`, `onUnknownNextStep`
+- `hasPrecondition`, `hasEffect`
+- `readsVariable`, `writesVariable`
+- `hasInputMap`
+- `workflowStepMapsContextKeyToToolParam`
+- `workflowStepWritesContextKey`
+- `workflowStepMapsToolOutputFieldToContextKey`
+
+## 4. VWL Program Model
+
+A VWL program is a workflow concept graph:
+
+- Workflow node (concept ID, usually an instance of `#V#ai_workflow` or `#V#durable_workflow`).
+- Step nodes linked via `hasStep`.
+- One initial step via `hasInitialStep` (or inferred first step if absent).
+- Per-step invocation target:
+  - tool/action (`invokesAction` or `workflow_step_invokes_tool`), or
+  - subworkflow (`invokesWorkflow`).
+- Per-step control flow links:
+  - `next`
+  - `on_true`, `on_false`
+  - `on_failure`, `on_unknown`.
+- Optional metadata and mapping contracts.
+
+## 5. Condition Language (Transition Expressions)
+
+Transition condition specs are JSON-like objects normalised by runtime code.
+
+Supported kinds:
+
+- `always`
+- `context_flag`
+- `context_value_equals`
+- `transition_result_truth`
+- `all`
+- `any`
+- `not`
+
+Canonical forms:
+
+```json
+{"kind":"always"}
+{"kind":"context_flag","key":"last_action_failed","expected":true}
+{"kind":"context_value_equals","key":"mode","value":"strict"}
+{"kind":"transition_result_truth","expected":false}
+{"kind":"all","conditions":[{"kind":"context_flag","key":"a"},{"kind":"context_flag","key":"b"}]}
+{"kind":"any","conditions":[...]}
+{"kind":"not","condition":{"kind":"context_flag","key":"disabled"}}
+```
+
+Invalid or malformed condition specs MUST fail workflow loading with deterministic error codes.
+
+## 6. Compilation Semantics (Ontology -> Executable Definition)
+
+Compilation flow:
+
+1. Resolve workflow concept and relationships.
+2. Build process graph (`build_workflow_process_graph`):
+   - collect steps,
+   - resolve invocation target,
+   - resolve control-flow edges,
+   - capture metadata and mapping references.
+3. Compile into runtime state machine (`load_workflow_definition_from_vontology`):
+   - create `WorkflowStateSpec` objects,
+   - create `WorkflowActionInvocation` records,
+   - compile transition condition specs,
+   - attach metadata contracts.
+
+Important deterministic ordering:
+
+- Generated branch precedence for implicit branch links is:
+  - `on_failure`
+  - `on_unknown`
+  - `on_true`/`on_false`
+  - `next_step`
+
+`on_failure` and `on_unknown` compile to context-flag conditions (`last_action_failed`, `last_action_unknown`).
+
+## 7. Execution Semantics
+
+Runtime execution model (`WorkflowExecutor`):
+
+1. Enter current state.
+2. Run pre-action metadata validation (unless validation mode disables enforcement).
+3. Execute actions in state order.
+4. Merge action outputs into context for non-failure outcomes.
+5. Apply tool-output-to-context mappings.
+6. Evaluate transitions in stored order and take first satisfied transition.
+7. If no valid transition and state terminal, complete.
+8. Abort on max transition count or unrecoverable errors.
+
+Action outcomes are normalised to:
+
+- success,
+- failure,
+- unknown.
+
+`last_action_failed` and `last_action_unknown` flags drive explicit failure/unknown routes.
+
+## 8. Metadata Contract Semantics
+
+Per-state metadata keys currently used:
+
+- `preconditions`
+- `effects`
+- `reads_variables`
+- `writes_variables`
+- `reads_context_keys`
+- `writes_context_keys`
+- `context_input_mappings`
+- `tool_output_context_mappings`
+- `subworkflow_contract`
+- `invokes_workflow`
+
+Validation phases:
+
+- pre-action: preconditions/reads checks,
+- post-action: effects/writes checks.
+
+Validation mode env var:
+
+- `VON_WORKFLOW_METADATA_VALIDATION_MODE`
+- values: `enforce`, `warn`, `off`
+
+Semantics:
+
+- `enforce`: metadata failures fail execution.
+- `warn`: metadata failures are recorded but non-blocking.
+- `off`: metadata validation is skipped (with explicit skip diagnostics).
+
+## 9. Context and Mapping Semantics
+
+### 9.1 Input Mapping
+
+Two mechanisms:
+
+- text mapping in `hasInputMap` (`key=value` or `key:value`),
+- semantic mapping via `workflow_step_maps_context_key_to_tool_param` concepts.
+
+Semantic mappings bind:
+
+- a workflow context key,
+- to a specific tool parameter name,
+- for the step invocation.
+
+### 9.2 Output Mapping
+
+`workflow_step_maps_tool_output_field_to_context_key` mappings bind:
+
+- a tool output field name,
+- to a target workflow context key.
+
+Runtime writes mapping events into context diagnostics for traceability.
+
+## 10. Subworkflow Semantics
+
+Subworkflow action ID:
+
+- `workflow_invoke_subworkflow`
+
+Contract schema:
+
+- `workflow_subworkflow_contract.v1`
+
+Failure modes:
+
+- `propagate_as_action_failure`
+- `capture_child_failure`
+
+Subworkflow contracts carry:
+
+- child workflow ID,
+- input mappings,
+- output mappings,
+- required/provided input-output lists,
+- failure mode.
+
+## 11. Durable Runtime Semantics
+
+### 11.1 Instance Model
+
+Durable instance statuses:
+
+- `pending`
+- `running`
+- `completed`
+- `failed`
+- `cancelled`
+- `paused`
+
+Terminal statuses:
+
+- `completed`, `failed`, `cancelled`
+
+Retry fields:
+
+- `retry_count`
+- `max_retries`
+
+### 11.2 Worker
+
+Background worker claims pending/resumable work, executes with checkpointing, heartbeat lock extension, and graceful shutdown.
+
+### 11.3 Scheduler
+
+Schedule types:
+
+- `once`
+- `interval`
+- `cron` (5-field)
+
+Scheduler creates workflow instances through the verified submission pathway (never bypassing runnability verification), updates `next_run_at`, and records polling telemetry.
+
+### 11.4 Event Binding
+
+Persistent event-to-workflow bindings include:
+
+- `event_type`
+- `workflow_id`
+- `input_mapping`
+- `enabled`
+- revision/actor metadata.
+
+## 12. Runnability and Safety Gates
+
+Instance creation uses the canonical verified pathway:
+
+- preflight runnable verification,
+- instance create,
+- postflight runnable verification,
+- fail-closed rejection or failure marking if checks do not pass.
+
+This prevents false "started/running" claims for non-runnable workflows.
+
+## 13. Automatic Background Operation
+
+Application startup (`utils_flask`) initialises durable workflows asynchronously by default:
+
+- gated by `VON_DURABLE_WORKFLOWS_ENABLE=1`,
+- starts worker and scheduler,
+- recovers orphaned instances,
+- records startup status in app config,
+- registers graceful shutdown hook,
+- bootstraps identity-resolution background schedule.
+
+Blocking startup can be enabled via:
+
+- `VON_DURABLE_WORKFLOWS_BLOCKING_STARTUP=1`
+
+Operational cadence controls include:
+
+- `VON_DURABLE_WORKER_POLL_INTERVAL`
+- `VON_DURABLE_SCHEDULER_CHECK_INTERVAL`
+
+## 14. VWL MCP Standard Library
+
+### 14.1 Discovery and Diagnostics
+
+- `workflow_list_definitions`
+- `workflow_mcp_health_check`
+- `workflow_list_event_bindings`
+
+### 14.2 Instance Control
+
+- `workflow_create_instance`
+- `workflow_list_instances`
+- `workflow_get_instance`
+- `workflow_cancel_instance`
+- `workflow_retry_instance`
+
+### 14.3 Event Binding Control
+
+- `workflow_bind_event`
+- `workflow_list_event_bindings`
+
+### 14.4 Schedule Control
+
+- `workflow_create_schedule`
+- `workflow_list_schedules`
+- `workflow_get_schedule`
+- `workflow_set_schedule_enabled`
+- `workflow_delete_schedule`
+- `workflow_trigger_schedule`
+
+These tools are the default operational control surface for VWL runtime behaviour.
+
+## 15. Conformance Checklist for Workflow Authors
+
+A VWL workflow is conformant when:
+
+- it has a resolvable workflow concept,
+- step graph is loadable and initial step is determinable,
+- step invocation targets are unambiguous,
+- transition conditions are valid,
+- metadata contracts are syntactically valid,
+- required mappings are parseable,
+- discovered actions are runnable in current registry,
+- submission verification passes preflight and postflight.
+
+---
+
+## Appendix A: Diagram Specification Pack (Tool-Ready)
+
+This appendix defines a complete diagram contract for tools that generate VWL diagrams.
+
+### A.1 Universal Diagram Envelope
+
+All VWL diagrams MUST conform to this envelope:
+
+```json
+{
+  "spec_version": "vwl.diagram.v1",
+  "diagram_type": "string",
+  "title": "string",
+  "purpose": "string",
+  "source": {
+    "workflow_id": "string|null",
+    "instance_id": "string|null",
+    "schedule_id": "string|null",
+    "generated_at_utc": "ISO-8601 string",
+    "source_artifacts": ["string"]
+  },
+  "nodes": [
+    {
+      "id": "string",
+      "kind": "string",
+      "label": "string",
+      "attrs": {}
+    }
+  ],
+  "edges": [
+    {
+      "id": "string",
+      "from": "node-id",
+      "to": "node-id",
+      "kind": "string",
+      "label": "string|null",
+      "attrs": {}
+    }
+  ],
+  "groups": [
+    {
+      "id": "string",
+      "label": "string",
+      "node_ids": ["node-id"]
+    }
+  ],
+  "legend": [
+    {
+      "kind": "string",
+      "visual": "string",
+      "meaning": "string"
+    }
+  ],
+  "layout": {
+    "engine": "dagre|dot|elk",
+    "direction": "LR|TB",
+    "rank_separation": "number",
+    "node_separation": "number"
+  },
+  "render": {
+    "target": "mermaid|graphviz|plantuml|svg-json",
+    "theme": "light|dark|auto",
+    "font_family": "string"
+  },
+  "validation": {
+    "errors": ["string"],
+    "warnings": ["string"]
+  }
+}
+```
+
+Hard requirements:
+
+- Node IDs MUST be unique.
+- Edge IDs MUST be unique.
+- Edges MUST reference existing node IDs.
+- `diagram_type` MUST be one of the types in A.2.
+
+### A.2 Diagram Types
+
+#### A.2.1 `workflow_topology`
+
+Purpose: static workflow graph structure.
+
+Required nodes:
+
+- `workflow`
+- `step`
+
+Required edges:
+
+- `hasInitialStep`
+- `hasStep`
+- `invokesAction` or `invokesWorkflow`
+- zero or more control-flow edges: `next`, `on_true`, `on_false`, `on_failure`, `on_unknown`
+
+Node attrs:
+
+- workflow: `workflow_id`, `source`, `initial_state`
+- step: `step_id`, `terminal` (bool), `action_id|null`, `invokes_workflow|null`
+
+Edge attrs:
+
+- control-flow edges: `reason`, `condition_kind`
+
+Layout:
+
+- direction `LR`
+- initial step pinned left-most.
+
+#### A.2.2 `transition_decision_graph`
+
+Purpose: transition precedence and condition logic per step.
+
+Required nodes:
+
+- `step`
+- `condition`
+- `target_step`
+
+Required edges:
+
+- `evaluates` (step -> condition)
+- `routes_to` (condition -> target_step)
+
+Condition attrs:
+
+- `kind`
+- `expected` (where applicable)
+- `key` (for `context_flag` and `context_value_equals`)
+- `value` (for `context_value_equals`)
+- `priority_index`
+
+Validation:
+
+- priority order MUST match compiled order.
+
+#### A.2.3 `context_dataflow`
+
+Purpose: flow from context keys to tool params and back to context keys.
+
+Required nodes:
+
+- `context_key`
+- `step`
+- `tool_param`
+- `tool_output_field`
+
+Required edges:
+
+- `context_to_param`
+- `param_to_step`
+- `step_to_output_field`
+- `output_to_context`
+
+Required attrs:
+
+- mapping concept IDs for semantic mappings.
+
+#### A.2.4 `action_sequence`
+
+Purpose: temporal sequence of action calls inside execution.
+
+Required nodes:
+
+- `state_entry`
+- `action_call`
+- `state_exit`
+
+Required edges:
+
+- `next_action`
+- `transition_taken`
+
+Action attrs:
+
+- `action_id`
+- `status`
+- `duration_ms`
+- `call_id|null`
+
+Layout:
+
+- direction `TB`
+- chronological order from top to bottom.
+
+#### A.2.5 `durable_instance_lifecycle`
+
+Purpose: status machine for durable instances.
+
+Required nodes:
+
+- `pending`, `running`, `paused`, `completed`, `failed`, `cancelled`
+
+Required edges:
+
+- `claim` (`pending|paused` -> `running`)
+- `complete` (`running` -> `completed`)
+- `fail` (`running` -> `failed`)
+- `cancel` (`pending|running|paused` -> `cancelled`)
+- `retry_reset` (`failed` -> `pending`)
+- optional lock-expiry recovery (`running` -> `paused`)
+
+Validation:
+
+- terminal states MUST be marked (`completed`, `failed`, `cancelled`).
+
+#### A.2.6 `schedule_timeline`
+
+Purpose: schedule trigger cadence and next-run logic.
+
+Required nodes:
+
+- `schedule`
+- `run_event`
+- `instance`
+
+Required edges:
+
+- `triggers`
+- `creates_instance`
+- `reschedules_to_next_run`
+
+Required attrs:
+
+- `schedule_type`
+- `cron_expression|null`
+- `interval_seconds|null`
+- `run_at|null`
+- `next_run_at|null`
+- `last_run_at|null`
+
+#### A.2.7 `event_binding_pipeline`
+
+Purpose: event-driven workflow launch path.
+
+Required nodes:
+
+- `event_type`
+- `binding`
+- `input_mapping`
+- `workflow`
+- `instance_submission`
+
+Required edges:
+
+- `matched_by_event_type`
+- `maps_inputs`
+- `submits_workflow`
+
+Validation:
+
+- binding node MUST include `enabled` and `revision`.
+
+#### A.2.8 `runnability_gate_pipeline`
+
+Purpose: verified submission safety gates.
+
+Required nodes:
+
+- `preflight_verification`
+- `instance_create`
+- `postflight_verification`
+- `accept_pending`
+- `reject_preflight`
+- `reject_postflight_mark_failed`
+
+Required edges:
+
+- `preflight_pass`
+- `preflight_fail`
+- `postflight_pass`
+- `postflight_fail`
+
+Required attrs:
+
+- `conceptual_representation_success`
+- `executable_registration_success`
+- `runnable_verification_success`
+- `error_code|null`
+
+#### A.2.9 `metadata_validation_matrix`
+
+Purpose: per-state metadata obligations and outcomes.
+
+Required nodes:
+
+- `state`
+- `metadata_key`
+- `validation_result`
+
+Required edges:
+
+- `requires`
+- `validated_as`
+
+Validation result attrs:
+
+- `phase` (`pre_action|post_action`)
+- `mode` (`enforce|warn|off`)
+- `ok`
+- `reason_code|null`
+
+#### A.2.10 `runtime_deployment_view`
+
+Purpose: long-term background operation topology.
+
+Required nodes:
+
+- `flask_app_startup`
+- `durable_startup`
+- `worker`
+- `scheduler`
+- `mongo_instance_store`
+- `mongo_schedule_store`
+- `action_registry`
+- `definition_loader`
+
+Required edges:
+
+- `starts`
+- `polls`
+- `claims`
+- `executes`
+- `reads_writes`
+
+Required attrs:
+
+- startup gating env vars:
+  - `VON_DURABLE_WORKFLOWS_ENABLE`
+  - `VON_DURABLE_WORKFLOWS_BLOCKING_STARTUP`
+  - `VON_DURABLE_WORKER_POLL_INTERVAL`
+  - `VON_DURABLE_SCHEDULER_CHECK_INTERVAL`
+
+### A.3 Rendering Conventions
+
+Default style conventions:
+
+- workflow nodes: rounded rectangle.
+- step/state nodes: rectangle.
+- condition nodes: diamond.
+- terminal states: double-border.
+- failures/errors: red edge or red node accent.
+- unknown routes: amber edge.
+- success routes: green edge.
+- neutral control-flow: blue/grey edge.
+
+Label conventions:
+
+- Always render canonical IDs in attrs.
+- Use human label for node text where available.
+- Keep edge labels short (`on_failure`, `writes`, `maps`).
+
+### A.4 Output Targets and Determinism
+
+Diagram tools SHOULD support at least one of:
+
+- Mermaid
+- Graphviz DOT
+- PlantUML
+- SVG with explicit coordinates (`svg-json`)
+
+Determinism requirements:
+
+- stable node order sorted by semantic key (`step_id`, then `action_id`),
+- stable edge ordering by `(from, kind, to)`,
+- stable layout direction per diagram type default.
+
+### A.5 Diagram Validation Rules
+
+Before rendering, tool MUST run:
+
+- schema validation of envelope,
+- reference integrity checks (`edge.from`, `edge.to`),
+- required node/edge kind presence checks per diagram type,
+- conformance checks for mandatory attrs listed above.
+
+If checks fail:
+
+- output MUST include `validation.errors`,
+- renderer MAY still emit partial diagram if explicitly requested.
+
+### A.6 Minimal Example Payload (`workflow_topology`)
+
+```json
+{
+  "spec_version": "vwl.diagram.v1",
+  "diagram_type": "workflow_topology",
+  "title": "Example VWL Topology",
+  "purpose": "Show workflow and control flow",
+  "source": {
+    "workflow_id": "#V#example_workflow",
+    "instance_id": null,
+    "schedule_id": null,
+    "generated_at_utc": "2026-03-01T00:00:00Z",
+    "source_artifacts": ["vontology_loader.build_workflow_process_graph"]
+  },
+  "nodes": [
+    {"id": "w1", "kind": "workflow", "label": "Example Workflow", "attrs": {"workflow_id": "#V#example_workflow", "initial_state": "#V#step_a", "source": "vontology"}},
+    {"id": "sA", "kind": "step", "label": "Step A", "attrs": {"step_id": "#V#step_a", "action_id": "todo_refresh.fetch_gmail", "terminal": false}},
+    {"id": "sB", "kind": "step", "label": "Step B", "attrs": {"step_id": "#V#step_b", "action_id": null, "terminal": true}}
+  ],
+  "edges": [
+    {"id": "e1", "from": "w1", "to": "sA", "kind": "hasInitialStep", "label": null, "attrs": {}},
+    {"id": "e2", "from": "w1", "to": "sA", "kind": "hasStep", "label": null, "attrs": {}},
+    {"id": "e3", "from": "w1", "to": "sB", "kind": "hasStep", "label": null, "attrs": {}},
+    {"id": "e4", "from": "sA", "to": "sB", "kind": "next", "label": "next_step", "attrs": {"reason": "next_step", "condition_kind": "always"}}
+  ],
+  "groups": [],
+  "legend": [],
+  "layout": {"engine": "dagre", "direction": "LR", "rank_separation": 120, "node_separation": 60},
+  "render": {"target": "mermaid", "theme": "light", "font_family": "ui-sans-serif"},
+  "validation": {"errors": [], "warnings": []}
+}
+```
+
+---
+
+End of VWL manual (implementation-aligned snapshot).

--- a/src/backend/services/file_copy_interpretation_service.py
+++ b/src/backend/services/file_copy_interpretation_service.py
@@ -69,12 +69,17 @@ def extract_image_metadata(data_bytes: bytes) -> dict[str, Any]:
             image_for_palette = image.convert("RGB")
             # Quantise to keep palette extraction fast and deterministic.
             palette_image = image_for_palette.quantize(colors=8, method=2)
-            palette_data = [int(pixel) for pixel in palette_image.getdata()]
+            palette_data: list[int] = []
+            for pixel in palette_image.getdata():
+                if isinstance(pixel, (int, float)):
+                    palette_data.append(int(pixel))
             palette_counts = Counter(palette_data)
             palette = palette_image.getpalette() or []
             dominant_colours: list[list[int]] = []
-            for index, _count in palette_counts.most_common(3):
-                base = int(index) * 3
+            for index_raw, _count in palette_counts.most_common(3):
+                if not isinstance(index_raw, (int, float)):
+                    continue
+                base = int(index_raw) * 3
                 if base + 2 < len(palette):
                     dominant_colours.append(
                         [int(palette[base]), int(palette[base + 1]), int(palette[base + 2])]

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -578,8 +578,9 @@ const TOOL_USE_SETTING_REFRESH_COOLDOWN_MS = 30_000;
 const THINKING_STATUS_ACTIVE = 'active';
 const THINKING_STATUS_WAITING = 'waiting';
 const THINKING_STATUS_STALLED = 'stalled';
-const THINKING_CARD_TOGGLE_LABEL_EXPANDED = 'Collapse';
-const THINKING_CARD_TOGGLE_LABEL_COLLAPSED = 'Expand';
+const THINKING_CARD_TOGGLE_ARIA_LABEL_EXPANDED = 'Collapse thinking details';
+const THINKING_CARD_TOGGLE_ARIA_LABEL_COLLAPSED = 'Expand thinking details';
+const THINKING_ACTIVITY_LOW_LEVEL_EVENT_KINDS = new Set(['llm_call_chunk', 'heartbeat']);
 const THINKING_TERMINAL_PROGRESS_STATUSES = new Set([
     'completed',
     'done',
@@ -816,13 +817,11 @@ function syncThinkingCardExpandedStateToDom(request = getThinkingCardDisplayRequ
     if (toggleButton) {
         toggleButton.setAttribute('aria-expanded', expanded ? 'true' : 'false');
         if (expanded) {
-            toggleButton.textContent = THINKING_CARD_TOGGLE_LABEL_EXPANDED;
-            toggleButton.setAttribute('aria-label', 'Collapse thinking details');
-            toggleButton.title = 'Collapse thinking details';
+            toggleButton.setAttribute('aria-label', THINKING_CARD_TOGGLE_ARIA_LABEL_EXPANDED);
+            toggleButton.title = THINKING_CARD_TOGGLE_ARIA_LABEL_EXPANDED;
         } else {
-            toggleButton.textContent = THINKING_CARD_TOGGLE_LABEL_COLLAPSED;
-            toggleButton.setAttribute('aria-label', 'Expand thinking details');
-            toggleButton.title = 'Expand thinking details';
+            toggleButton.setAttribute('aria-label', THINKING_CARD_TOGGLE_ARIA_LABEL_COLLAPSED);
+            toggleButton.title = THINKING_CARD_TOGGLE_ARIA_LABEL_COLLAPSED;
         }
     }
 }
@@ -868,6 +867,9 @@ function createThinkingCardHistorySnapshot(request) {
     const latestProgress = (request.latestProgress && typeof request.latestProgress === 'object')
         ? { ...request.latestProgress }
         : null;
+    const activityHistory = Array.isArray(request.activityHistory)
+        ? request.activityHistory.map((entry) => ({ ...entry }))
+        : [];
     const toolHistory = Array.isArray(request.toolUseProgressHistory)
         ? request.toolUseProgressHistory.map((entry) => ({ ...entry }))
         : [];
@@ -887,6 +889,7 @@ function createThinkingCardHistorySnapshot(request) {
     );
 
     return {
+        activityHistory,
         toolUseProgressHistory: toolHistory,
         workflowDiscovery,
         latestProgress,
@@ -1191,6 +1194,14 @@ export function __testOnly_setUnambiguousTimestampTooltip(element, value, prefix
     setUnambiguousTimestampTooltip(element, value, prefix);
 }
 
+export function __testOnly_normaliseThinkingActivityHistory(diagnosticEvents = []) {
+    return normaliseThinkingActivityHistory(diagnosticEvents);
+}
+
+export function __testOnly_renderThinkingCardBodyHTML(request = null) {
+    return renderThinkingCardBodyHTML(request);
+}
+
 function updateThinkingCardStatusBadge(progress) {
     const badgeEl = document.getElementById('thinkingCardStatusBadge');
     if (!badgeEl) {
@@ -1332,6 +1343,268 @@ function recordToolUseHistory(request, progress) {
     history.push({ tool, workflowTask, batchSize, phase, resultSummary, success: isSuccess ? true : (isFail ? false : null) });
 }
 
+function normaliseThinkingActivityString(value) {
+    return (typeof value === 'string') ? value.trim() : '';
+}
+
+function formatThinkingActivityFallbackLabel(value) {
+    const raw = normaliseThinkingActivityString(value);
+    if (!raw) {
+        return '';
+    }
+    return raw
+        .replace(/_/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .replace(/^\w/, (c) => c.toUpperCase());
+}
+
+function deriveThinkingActivityState(status, eventKind) {
+    const statusLower = normaliseThinkingActivityString(status).toLowerCase();
+    const kindLower = normaliseThinkingActivityString(eventKind).toLowerCase();
+
+    if (statusLower === 'error' || statusLower === 'failed' || statusLower === 'tool_failed' || statusLower === 'tool_blocked' || kindLower === 'error') {
+        return 'failure';
+    }
+
+    if (
+        statusLower === 'completed'
+        || statusLower === 'done'
+        || statusLower === 'tool_invoked'
+        || statusLower === 'workflow_discovery_complete'
+        || statusLower === 'llm_call_end'
+        || statusLower === 'retry_end'
+        || statusLower === 'orchestrator_end'
+    ) {
+        return 'success';
+    }
+
+    return 'pending';
+}
+
+function buildThinkingActivityLabelAndDetail(entry) {
+    const status = normaliseThinkingActivityString(entry.status).toLowerCase();
+    const stageLabel = normaliseThinkingActivityString(entry.stage_label) || normaliseThinkingActivityString(entry.phase_label);
+    const stage = normaliseThinkingActivityString(entry.stage) || normaliseThinkingActivityString(entry.phase);
+    const tool = normaliseThinkingActivityString(entry.tool);
+    const workflowTask = normaliseThinkingActivityString(entry.workflow_task);
+    const subtask = normaliseThinkingActivityString(entry.subtask);
+    const model = normaliseThinkingActivityString(entry.model);
+    const provider = normaliseThinkingActivityString(entry.provider);
+    const resultSummary = normaliseThinkingActivityString(entry.result_summary);
+    const error = normaliseThinkingActivityString(entry.error);
+    const batchSize = Number.isFinite(entry.batch_size) ? Number(entry.batch_size) : null;
+
+    const stageText = stageLabel || formatThinkingActivityFallbackLabel(stage);
+    const toolName = tool || workflowTask || subtask;
+    const modelText = [model, provider].filter(Boolean).join(' · ');
+    const detailParts = [];
+    let label = '';
+
+    if (status === 'phase_transition') {
+        label = stageText || 'Phase transition';
+        if (stage && stageText.toLowerCase() !== stage.toLowerCase()) {
+            detailParts.push(formatThinkingActivityFallbackLabel(stage));
+        }
+    } else if (status === 'workflow_discovery') {
+        label = 'Searching workflows';
+    } else if (status === 'workflow_discovery_complete') {
+        label = 'Found workflows';
+    } else if (status === 'orchestrator_start') {
+        label = 'Starting orchestrator';
+    } else if (status === 'orchestrator_end') {
+        label = 'Finished orchestrator';
+    } else if (status === 'llm_call_start') {
+        label = 'Starting LLM call';
+        if (modelText) {
+            detailParts.push(modelText);
+        }
+    } else if (status === 'llm_call_chunk') {
+        label = 'Streaming LLM output';
+        if (modelText) {
+            detailParts.push(modelText);
+        }
+    } else if (status === 'llm_call_end') {
+        label = 'Completed LLM call';
+        if (modelText) {
+            detailParts.push(modelText);
+        }
+    } else if (status === 'tool_call_start') {
+        label = toolName ? `Starting ${toolName}` : 'Starting tool call';
+    } else if (status === 'tool_invoked') {
+        label = toolName ? `${toolName} completed` : 'Tool call completed';
+    } else if (status === 'tool_failed') {
+        label = toolName ? `${toolName} failed` : 'Tool call failed';
+    } else if (status === 'tool_blocked') {
+        label = toolName ? `${toolName} blocked` : 'Tool call blocked';
+    } else if (status === 'retry_start') {
+        label = 'Retrying step';
+        if (subtask) {
+            detailParts.push(subtask);
+        }
+    } else if (status === 'retry_end') {
+        label = 'Retry completed';
+        if (subtask) {
+            detailParts.push(subtask);
+        }
+    } else if (status === 'heartbeat') {
+        label = 'Waiting for updates';
+        if (stageText) {
+            detailParts.push(stageText);
+        }
+    } else if (status === 'completed' || status === 'done') {
+        label = 'Turn completed';
+    } else if (status === 'error' || status === 'failed') {
+        label = 'Turn failed';
+    } else if (toolName) {
+        label = toolName;
+    } else if (stageText) {
+        label = stageText;
+    } else if (stage) {
+        label = formatThinkingActivityFallbackLabel(stage);
+    } else if (entry.status) {
+        label = formatThinkingActivityFallbackLabel(entry.status);
+    } else if (entry.event_kind) {
+        label = formatThinkingActivityFallbackLabel(entry.event_kind);
+    } else {
+        label = 'Activity update';
+    }
+
+    if (batchSize !== null) {
+        detailParts.push(`batch ${batchSize}`);
+    }
+    if (resultSummary) {
+        detailParts.push(resultSummary);
+    } else if (error) {
+        detailParts.push(error);
+    }
+
+    return {
+        label,
+        detail: detailParts.join(' · ')
+    };
+}
+
+function buildThinkingActivityGroupingKey(entry) {
+    const status = normaliseThinkingActivityString(entry.status).toLowerCase();
+    const eventKind = normaliseThinkingActivityString(entry.eventKind).toLowerCase();
+    const stage = normaliseThinkingActivityString(entry.stage).toLowerCase();
+    const subtask = normaliseThinkingActivityString(entry.subtask).toLowerCase();
+    const model = normaliseThinkingActivityString(entry.model).toLowerCase();
+    return `${status}::${eventKind}::${stage}::${subtask}::${model}`;
+}
+
+function normaliseThinkingActivityHistory(diagnosticEvents) {
+    if (!Array.isArray(diagnosticEvents) || diagnosticEvents.length === 0) {
+        return [];
+    }
+
+    const normalised = [];
+
+    for (const rawEntry of diagnosticEvents) {
+        if (!rawEntry || typeof rawEntry !== 'object') {
+            continue;
+        }
+
+        const status = normaliseThinkingActivityString(rawEntry.status);
+        const eventKind = normaliseThinkingActivityString(rawEntry.event_kind);
+        const stage = normaliseThinkingActivityString(rawEntry.stage) || normaliseThinkingActivityString(rawEntry.phase);
+        const subtask = normaliseThinkingActivityString(rawEntry.subtask)
+            || normaliseThinkingActivityString(rawEntry.tool)
+            || normaliseThinkingActivityString(rawEntry.workflow_task);
+        const model = normaliseThinkingActivityString(rawEntry.model);
+        const sequenceNo = Number.isFinite(rawEntry.sequence_no) ? Number(rawEntry.sequence_no) : null;
+        const atUtc = normaliseThinkingActivityString(rawEntry.at_utc);
+        const state = deriveThinkingActivityState(status, eventKind);
+        const isLowLevel = THINKING_ACTIVITY_LOW_LEVEL_EVENT_KINDS.has(eventKind.toLowerCase()) || status.toLowerCase() === 'heartbeat';
+        const labelAndDetail = buildThinkingActivityLabelAndDetail(rawEntry);
+
+        const entry = {
+            sequenceNo,
+            atUtc,
+            stage,
+            status,
+            eventKind,
+            label: labelAndDetail.label,
+            detail: labelAndDetail.detail,
+            state,
+            isLowLevel,
+            groupCount: 1,
+            subtask,
+            model
+        };
+
+        if (isLowLevel && normalised.length > 0) {
+            const previous = normalised[normalised.length - 1];
+            const groupingKey = buildThinkingActivityGroupingKey(entry);
+            if (previous.isLowLevel && previous.groupingKey === groupingKey) {
+                previous.groupCount = Number(previous.groupCount || 1) + 1;
+                if (sequenceNo !== null) {
+                    previous.sequenceNo = sequenceNo;
+                }
+                if (atUtc) {
+                    previous.atUtc = atUtc;
+                }
+                if (entry.detail) {
+                    previous.detail = entry.detail;
+                }
+                continue;
+            }
+            entry.groupingKey = groupingKey;
+        } else if (isLowLevel) {
+            entry.groupingKey = buildThinkingActivityGroupingKey(entry);
+        }
+
+        normalised.push(entry);
+    }
+
+    return normalised.map(({ groupingKey: _groupingKey, ...entry }) => entry);
+}
+
+function renderThinkingActivityHistoryHTML(request) {
+    if (!request || typeof request !== 'object') {
+        return '';
+    }
+
+    const activityHistory = Array.isArray(request.activityHistory) ? request.activityHistory : [];
+    if (activityHistory.length === 0) {
+        return '';
+    }
+
+    const items = [];
+    for (const entry of activityHistory) {
+        if (!entry || typeof entry !== 'object') {
+            continue;
+        }
+
+        const label = normaliseThinkingActivityString(entry.label);
+        if (!label) {
+            continue;
+        }
+
+        const statusClass = (entry.state === 'success' || entry.state === 'failure') ? entry.state : 'pending';
+        const statusIcon = statusClass === 'success' ? '✓' : (statusClass === 'failure' ? '✗' : '');
+        const detailParts = [];
+        if (Number.isFinite(entry.groupCount) && Number(entry.groupCount) > 1) {
+            detailParts.push(`${Number(entry.groupCount)} updates`);
+        }
+        if (normaliseThinkingActivityString(entry.detail)) {
+            detailParts.push(normaliseThinkingActivityString(entry.detail));
+        }
+        const detailLabel = detailParts.length > 0
+            ? `<span class="thinking-card-tool-result">${escapeHtml(detailParts.join(' · '))}</span>`
+            : '';
+
+        const rowClass = entry.isLowLevel ? 'thinking-card-tool thinking-card-activity is-low-level' : 'thinking-card-tool thinking-card-activity';
+        items.push(`<div class="${rowClass}">
+            <span class="thinking-card-tool-status ${statusClass}">${statusIcon}</span>
+            <span class="thinking-card-tool-name">${escapeHtml(label)}</span>${detailLabel}
+        </div>`);
+    }
+
+    return items.join('');
+}
+
 function formatThinkingDuration(elapsedMs) {
     const ms = Number.isFinite(elapsedMs) ? Math.max(0, Number(elapsedMs)) : 0;
     const totalSeconds = Math.floor(ms / 1000);
@@ -1428,7 +1701,8 @@ function renderWorkflowDiscoveryHTML(workflows) {
  * JVNAUTOSCI-1076: Combines tool history with workflow suggestions.
  */
 function renderThinkingCardBodyHTML(request) {
-    const toolHistoryHtml = renderToolHistoryHTML(request);
+    const activityHistoryHtml = renderThinkingActivityHistoryHTML(request);
+    const toolHistoryHtml = activityHistoryHtml || renderToolHistoryHTML(request);
     const workflowHtml = request?.workflowDiscovery?.matches
         ? renderWorkflowDiscoveryHTML(request.workflowDiscovery.matches)
         : '';
@@ -1638,6 +1912,10 @@ function startToolUseProgressPolling(request) {
             setLoadingIndicatorText(formatToolUseProgressText(progress, request));
             updateThinkingCardMeta(request, progress);
             recordToolUseHistory(request, progress);
+            request.activityHistory = normaliseThinkingActivityHistory(progress?.diagnostic_events);
+            if (request.activityHistory.length > 80) {
+                request.activityHistory = request.activityHistory.slice(-80);
+            }
 
             // JVNAUTOSCI-1076: Capture workflow discovery from progress
             if (progress.workflow_discovery && progress.workflow_discovery.matches) {
@@ -14888,6 +15166,7 @@ function buildThinkingDiagnosticsPayload(request) {
         elapsed_ms: elapsedMs,
         prompt_preview: typeof request.promptRaw === 'string' ? request.promptRaw.slice(0, 1000) : null,
         latest_progress: request.latestProgress || null,
+        activity_history: Array.isArray(request.activityHistory) ? request.activityHistory.slice(-40) : [],
         progress_events: Array.isArray(request.progressEvents) ? request.progressEvents.slice(-40) : [],
         phase_history: Array.isArray(request.phaseHistory) ? request.phaseHistory.slice(-40) : [],
         tool_history: Array.isArray(request.toolUseProgressHistory) ? request.toolUseProgressHistory.slice(-40) : [],
@@ -15424,6 +15703,7 @@ async function handleSendPrompt(options = {}) {
         aborted: false,
         clientRequestId,
         thinkingStartedAtMs: Date.now(),
+        activityHistory: [],
         toolUseProgressHistory: [],
         latestProgress: null,
         progressEvents: [],

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -26,6 +26,8 @@ import {
     __testOnly_showNewSharedMessagesIndicator,
     __testOnly_updateScrollToEndButtonVisibility,
     __testOnly_reduceThinkingCardDisplayState,
+    __testOnly_normaliseThinkingActivityHistory,
+    __testOnly_renderThinkingCardBodyHTML,
     __testOnly_resetChatConceptMetaCaches,
     formatChatTimestamp,
     sendMessage
@@ -77,7 +79,7 @@ jest.mock('../utils/textDecorator.js', () => ({
         if (/^[Vv]#/.test(raw)) raw = `#${raw}`;
         if (raw.startsWith('#v#')) raw = `#V#${raw.slice(3)}`;
         if (!raw.startsWith('#V#')) return '';
-        raw = raw.replace(/[.,:;!?\)\]\}…]+$/g, '');
+        raw = raw.replace(/[.,:;!?)}\]…]+$/g, '');
         return raw.startsWith('#V#') && raw.length > 3 ? raw : '';
     }),
     linkifyVontologyTokensInElement: jest.fn()
@@ -619,6 +621,131 @@ describe('thinking card display state reducer', () => {
     });
 });
 
+describe('thinking activity history normalisation', () => {
+    test('captures non-tool orchestration and workflow activity rows', () => {
+        const rows = __testOnly_normaliseThinkingActivityHistory([
+            {
+                sequence_no: 1,
+                status: 'phase_transition',
+                stage: 'context_build',
+                stage_label: 'Building context'
+            },
+            {
+                sequence_no: 2,
+                status: 'workflow_discovery',
+                stage: 'workflow_discovery'
+            },
+            {
+                sequence_no: 3,
+                status: 'workflow_discovery_complete',
+                stage: 'workflow_discovery_complete'
+            },
+            {
+                sequence_no: 4,
+                status: 'orchestrator_start',
+                stage: 'tool_plan'
+            },
+            {
+                sequence_no: 5,
+                status: 'llm_call_start',
+                stage: 'tool_plan',
+                model: 'gpt-test'
+            },
+            {
+                sequence_no: 6,
+                status: 'tool_call_start',
+                stage: 'tool_execute',
+                tool: 'fetch_concept'
+            },
+            {
+                sequence_no: 7,
+                status: 'tool_failed',
+                stage: 'tool_execute',
+                tool: 'fetch_concept',
+                error: 'Timeout while fetching'
+            },
+            {
+                sequence_no: 8,
+                status: 'completed',
+                stage: 'completed',
+                result_summary: 'Response generated'
+            }
+        ]);
+
+        expect(rows.map((row) => row.label)).toEqual(expect.arrayContaining([
+            'Building context',
+            'Searching workflows',
+            'Found workflows',
+            'Starting orchestrator',
+            'Starting LLM call',
+            'Starting fetch_concept',
+            'fetch_concept failed',
+            'Turn completed'
+        ]));
+        const failureRow = rows.find((row) => row.label === 'fetch_concept failed');
+        expect(failureRow?.state).toBe('failure');
+    });
+
+    test('groups contiguous low-level updates', () => {
+        const rows = __testOnly_normaliseThinkingActivityHistory([
+            {
+                sequence_no: 1,
+                status: 'llm_call_chunk',
+                event_kind: 'llm_call_chunk',
+                stage: 'tool_plan',
+                model: 'gpt-test'
+            },
+            {
+                sequence_no: 2,
+                status: 'llm_call_chunk',
+                event_kind: 'llm_call_chunk',
+                stage: 'tool_plan',
+                model: 'gpt-test'
+            },
+            {
+                sequence_no: 3,
+                status: 'heartbeat',
+                event_kind: 'heartbeat',
+                stage: 'tool_plan'
+            }
+        ]);
+
+        expect(rows).toHaveLength(2);
+        expect(rows[0].label).toBe('Streaming LLM output');
+        expect(rows[0].groupCount).toBe(2);
+        expect(rows[0].isLowLevel).toBe(true);
+        expect(rows[1].label).toBe('Waiting for updates');
+    });
+
+    test('prefers activity history rendering and falls back to tool history', () => {
+        const activityHtml = __testOnly_renderThinkingCardBodyHTML({
+            activityHistory: [{
+                label: 'Starting orchestrator',
+                detail: '',
+                state: 'pending',
+                isLowLevel: false,
+                groupCount: 1
+            }],
+            toolUseProgressHistory: [{
+                tool: 'fetch_concept',
+                resultSummary: 'Fetched'
+            }]
+        });
+        expect(activityHtml).toContain('Starting orchestrator');
+        expect(activityHtml).not.toContain('fetch_concept');
+
+        const fallbackHtml = __testOnly_renderThinkingCardBodyHTML({
+            toolUseProgressHistory: [{
+                tool: 'fetch_concept',
+                resultSummary: 'Fetched',
+                success: true
+            }]
+        });
+        expect(fallbackHtml).toContain('fetch_concept');
+        expect(fallbackHtml).toContain('Fetched');
+    });
+});
+
 describe('thinking card toggle accessibility', () => {
     beforeEach(() => {
         document.body.innerHTML = `
@@ -629,7 +756,10 @@ describe('thinking card toggle accessibility', () => {
                         <span class="thinking-card-phase loading-indicator-text">Thinking...</span>
                         <span id="thinkingCardStatusBadge" class="thinking-card-status active" aria-hidden="true">Active</span>
                         <span class="thinking-card-meta" id="thinkingCardMeta"></span>
-                        <button id="thinkingCardToggleButton" type="button" aria-hidden="true" aria-expanded="true" aria-controls="loadingIndicatorDetail">Collapse</button>
+                        <button id="thinkingCardToggleButton" type="button" aria-hidden="true" aria-expanded="true" aria-controls="loadingIndicatorDetail" aria-label="Collapse thinking details" title="Collapse thinking details">
+                            <span class="thinking-card-toggle-icon" aria-hidden="true">⌄</span>
+                            <span class="visually-hidden">Toggle thinking details</span>
+                        </button>
                         <button id="retryThinkingButton" type="button" aria-hidden="true">Retry</button>
                         <button id="copyThinkingDiagnosticsButton" type="button" aria-hidden="true">Copy diagnostics</button>
                         <button id="abortButton" type="button" aria-hidden="true"></button>
@@ -706,11 +836,15 @@ describe('thinking card toggle accessibility', () => {
 
         expect(toggleButton.getAttribute('aria-hidden')).toBe('false');
         expect(toggleButton.getAttribute('aria-expanded')).toBe('true');
+        expect(toggleButton.getAttribute('aria-label')).toBe('Collapse thinking details');
+        expect(toggleButton.getAttribute('title')).toBe('Collapse thinking details');
         expect(toggleButton.disabled).toBe(true);
 
         toggleButton.click();
 
         expect(toggleButton.getAttribute('aria-expanded')).toBe('true');
+        expect(toggleButton.getAttribute('aria-label')).toBe('Collapse thinking details');
+        expect(toggleButton.getAttribute('title')).toBe('Collapse thinking details');
         expect(wrapper.classList.contains('is-collapsed')).toBe(false);
         expect(detail.getAttribute('aria-hidden')).toBe('true');
 
@@ -786,12 +920,16 @@ describe('thinking card toggle accessibility', () => {
         expect(toggleButton.getAttribute('aria-hidden')).toBe('false');
         expect(toggleButton.disabled).toBe(false);
         expect(toggleButton.getAttribute('aria-expanded')).toBe('false');
+        expect(toggleButton.getAttribute('aria-label')).toBe('Expand thinking details');
+        expect(toggleButton.getAttribute('title')).toBe('Expand thinking details');
         expect(detail.getAttribute('aria-hidden')).toBe('true');
         expect(detail.innerHTML).toContain('search_knowledge_base');
 
         toggleButton.click();
 
         expect(toggleButton.getAttribute('aria-expanded')).toBe('true');
+        expect(toggleButton.getAttribute('aria-label')).toBe('Collapse thinking details');
+        expect(toggleButton.getAttribute('title')).toBe('Collapse thinking details');
         expect(detail.getAttribute('aria-hidden')).toBe('false');
     });
 });

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -6452,7 +6452,32 @@ footer {
 }
 
 .thinking-card-toggle {
-    min-width: 72px;
+    width: 22px;
+    height: 22px;
+    min-width: 22px;
+    padding: 0;
+}
+
+.thinking-card-toggle-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.2s ease;
+}
+
+.thinking-card-toggle-icon svg {
+    width: 12px;
+    height: 12px;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    pointer-events: none;
+}
+
+.thinking-card-toggle[aria-expanded="false"] .thinking-card-toggle-icon {
+    transform: rotate(-90deg);
 }
 
 .thinking-card-stop {
@@ -6569,6 +6594,10 @@ footer {
 .thinking-card-tool-result::before {
     content: '→ ';
     opacity: 0.5;
+}
+
+.thinking-card-activity.is-low-level .thinking-card-tool-name {
+    color: #64748b;
 }
 
 /* Workflow discovery results in thinking card (JVNAUTOSCI-1076) */

--- a/src/frontend/web/von_interface/templates/chat_tab.html
+++ b/src/frontend/web/von_interface/templates/chat_tab.html
@@ -78,7 +78,14 @@
           <span class="thinking-card-meta" id="thinkingCardMeta"></span>
           <button id="thinkingCardToggleButton" class="btn thinking-card-action thinking-card-toggle" type="button"
             aria-hidden="true" aria-expanded="true" aria-controls="loadingIndicatorDetail"
-            aria-label="Collapse thinking details" title="Collapse thinking details">Collapse</button>
+            aria-label="Collapse thinking details" title="Collapse thinking details">
+            <span class="thinking-card-toggle-icon" aria-hidden="true">
+              <svg viewBox="0 0 16 16" focusable="false">
+                <path d="M4 6l4 4 4-4"></path>
+              </svg>
+            </span>
+            <span class="visually-hidden">Toggle thinking details</span>
+          </button>
           <button id="retryThinkingButton" class="btn thinking-card-action" type="button" aria-hidden="true"
             aria-label="Retry request" title="Retry request">Retry</button>
           <button id="copyThinkingDiagnosticsButton" class="btn thinking-card-action" type="button" aria-hidden="true"


### PR DESCRIPTION
## Summary
- render thinking-card details from comprehensive /von/progress diagnostic_events activity history (workflow/orchestrator/LLM/tool/retry/terminal)
- group high-frequency low-level events (llm_call_chunk, heartbeat) into compact rows while preserving major events
- keep backwards-compatible fallback to legacy tool history when diagnostic events are missing
- switch thinking-card expand/collapse control to icon-only chevron while preserving aria-label/title and aria-expanded
- include activity_history in copied diagnostics payload
- add/extend chat tab tests for activity normalisation/grouping/fallback and toggle accessibility
- include docs/engineering/von_workflow_language_manual.md in this commit as requested

## Additional cleanup
- resolve pre-existing pyright type issue in file_copy_interpretation_service.py palette metadata extraction

## Validation
- npx eslint src/frontend/web/von_interface/static/js/chatTab.js src/frontend/web/von_interface/static/js/test/chatTab.test.js
- npx pyright
- npm test -- src/frontend/web/von_interface/static/js/test/chatTab.test.js tests/frontend/chatTabDiagnosticExportShortcut.test.js tests/frontend/chatTabLlmDebugWorkflowExecution.test.js