### PR TITLE
JVNAUTOSCI-1319: Add hierarchy_view renderer pipeline and UI

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -18612,6 +18612,236 @@ class InternalMCPChatOrchestrator:
                 }
             ]
 
+        def _extract_renderer_screen_hierarchy_elements(
+            *,
+            tool_messages: Sequence[Mapping[str, Any]] = (),
+            focus_concept_id: Any = None,
+        ) -> list[dict[str, Any]]:
+            """Derive hierarchy payloads from relation graph tool outputs."""
+
+            relation_graph_elements = _extract_renderer_screen_relation_graph_elements(
+                tool_messages=tool_messages,
+                focus_concept_id=focus_concept_id,
+            )
+            if not relation_graph_elements:
+                return []
+
+            graph_element = relation_graph_elements[0]
+            payload = (
+                cast(Mapping[str, Any], graph_element.get("payload"))
+                if isinstance(graph_element.get("payload"), Mapping)
+                else {}
+            )
+            raw_nodes = _mapping_list(payload.get("nodes"), limit=360)
+            raw_edges = _mapping_list(payload.get("edges"), limit=720)
+            if not raw_nodes or not raw_edges:
+                return []
+
+            def _coerce_text(value: Any) -> str | None:
+                if isinstance(value, str):
+                    cleaned = value.strip()
+                    return cleaned or None
+                if value is None:
+                    return None
+                cleaned = str(value).strip()
+                return cleaned or None
+
+            node_by_id: dict[str, dict[str, Any]] = {}
+            for raw_node in raw_nodes:
+                node_id = _coerce_text(
+                    _first_text(
+                        raw_node.get("node_id"),
+                        raw_node.get("concept_id"),
+                        raw_node.get("id"),
+                    )
+                )
+                if not node_id or node_id in node_by_id:
+                    continue
+                label = _coerce_text(
+                    _first_text(raw_node.get("label"), raw_node.get("name"), node_id)
+                ) or node_id
+                node_kind = _coerce_text(
+                    _first_text(raw_node.get("node_kind"), raw_node.get("kind"))
+                )
+                node_entry: dict[str, Any] = {"node_id": node_id, "label": label}
+                if node_kind:
+                    node_entry["node_kind"] = node_kind.lower()
+                node_by_id[node_id] = node_entry
+
+            if len(node_by_id) < 2:
+                return []
+
+            def _classify_branch_kind(predicate_value: str) -> tuple[str, bool]:
+                predicate = predicate_value.strip().lower()
+                compact_predicate = re.sub(r"[^a-z0-9]+", "_", predicate).strip("_")
+                if compact_predicate in {
+                    "is_a_type_of",
+                    "isa_type_of",
+                    "type_of",
+                    "isatypeof",
+                }:
+                    return "type_hierarchy", True
+                if compact_predicate in {
+                    "is_an_instance_of",
+                    "instance_of",
+                    "isaninstanceof",
+                }:
+                    return "instance_hierarchy", True
+                if "organis" in compact_predicate or "organiz" in compact_predicate:
+                    return "organisational_hierarchy", False
+                return "custom", False
+
+            hierarchy_edges: list[dict[str, Any]] = []
+            seen_edge_keys: set[tuple[str, str, str]] = set()
+            parent_counts: dict[str, int] = {}
+            child_counts: dict[str, int] = {}
+            has_explicit_hierarchy_predicates = False
+
+            for raw_edge in raw_edges:
+                source_id = _coerce_text(
+                    _first_text(
+                        raw_edge.get("source"),
+                        raw_edge.get("source_node_id"),
+                        raw_edge.get("from"),
+                    )
+                )
+                target_id = _coerce_text(
+                    _first_text(
+                        raw_edge.get("target"),
+                        raw_edge.get("target_node_id"),
+                        raw_edge.get("to"),
+                    )
+                )
+                predicate = _coerce_text(
+                    _first_text(raw_edge.get("predicate"), raw_edge.get("label"))
+                )
+                if not source_id or not target_id or not predicate:
+                    continue
+                if source_id not in node_by_id or target_id not in node_by_id:
+                    continue
+
+                branch_kind, parent_is_target = _classify_branch_kind(predicate)
+                if branch_kind in {"type_hierarchy", "instance_hierarchy"}:
+                    has_explicit_hierarchy_predicates = True
+
+                parent_node_id = target_id if parent_is_target else source_id
+                child_node_id = source_id if parent_is_target else target_id
+                if parent_node_id == child_node_id:
+                    continue
+
+                edge_key = (parent_node_id, child_node_id, predicate)
+                if edge_key in seen_edge_keys:
+                    continue
+                seen_edge_keys.add(edge_key)
+
+                hierarchy_edges.append(
+                    {
+                        "edge_id": f"hierarchy_edge_{len(hierarchy_edges) + 1}",
+                        "parent_node_id": parent_node_id,
+                        "child_node_id": child_node_id,
+                        "predicate": predicate,
+                        "branch_kind": branch_kind,
+                    }
+                )
+                parent_counts[child_node_id] = parent_counts.get(child_node_id, 0) + 1
+                child_counts[parent_node_id] = child_counts.get(parent_node_id, 0) + 1
+
+            if not hierarchy_edges:
+                return []
+
+            focus_node_id = _coerce_text(payload.get("focus_node_id"))
+            if focus_node_id not in node_by_id:
+                focus_node_id = None
+
+            parent_nodes = {edge["parent_node_id"] for edge in hierarchy_edges}
+            child_nodes = {edge["child_node_id"] for edge in hierarchy_edges}
+            root_node_ids = sorted(parent_nodes - child_nodes)
+            if not root_node_ids and focus_node_id:
+                root_node_ids = [focus_node_id]
+            elif not root_node_ids:
+                root_node_ids = [sorted(node_by_id.keys())[0]]
+
+            ordered_node_ids = sorted(node_by_id.keys())
+            if focus_node_id:
+                ordered_node_ids = [focus_node_id] + [
+                    node_id for node_id in ordered_node_ids if node_id != focus_node_id
+                ]
+
+            ordered_nodes: list[dict[str, Any]] = []
+            for node_id in ordered_node_ids:
+                node_entry = dict(node_by_id[node_id])
+                if parent_counts.get(node_id):
+                    node_entry["parent_count"] = int(parent_counts[node_id])
+                if child_counts.get(node_id):
+                    node_entry["child_count"] = int(child_counts[node_id])
+                ordered_nodes.append(node_entry)
+
+            ordered_edges = sorted(
+                hierarchy_edges,
+                key=lambda edge: (
+                    str(edge.get("parent_node_id") or ""),
+                    str(edge.get("child_node_id") or ""),
+                    str(edge.get("predicate") or ""),
+                ),
+            )
+            for index, edge in enumerate(ordered_edges, start=1):
+                edge["edge_id"] = f"hierarchy_edge_{index}"
+
+            hierarchy_payload: dict[str, Any] = {
+                "nodes": ordered_nodes,
+                "edges": ordered_edges,
+                "root_node_ids": root_node_ids[:40],
+                "expansion": {
+                    "show_parents": True,
+                    "show_children": True,
+                    "show_siblings": True,
+                    "max_depth": 4,
+                },
+            }
+            if focus_node_id:
+                hierarchy_payload["focus_node_id"] = focus_node_id
+
+            relation_graph_title = _coerce_text(payload.get("title"))
+            if relation_graph_title:
+                if "hierarchy" in relation_graph_title.lower():
+                    hierarchy_payload["title"] = relation_graph_title
+                else:
+                    hierarchy_payload["title"] = f"{relation_graph_title} hierarchy"
+
+            relation_graph_provenance = (
+                cast(Mapping[str, Any], graph_element.get("provenance"))
+                if isinstance(graph_element.get("provenance"), Mapping)
+                else {}
+            )
+            provenance: dict[str, Any] = {
+                "source": "tool_result_hierarchy_view",
+                "record_family": "hierarchy",
+                "derived_from": "relation_graph",
+                "has_explicit_hierarchy_predicates": has_explicit_hierarchy_predicates,
+            }
+            source_tools = relation_graph_provenance.get("source_tools")
+            if isinstance(source_tools, list):
+                provenance["source_tools"] = [
+                    str(item).strip()
+                    for item in source_tools
+                    if isinstance(item, str) and item.strip()
+                ]
+            provenance["node_count"] = len(ordered_nodes)
+            provenance["edge_count"] = len(ordered_edges)
+
+            return [
+                {
+                    "element_id": "screen_hierarchy_view",
+                    "intent": "hierarchy_view",
+                    "payload": hierarchy_payload,
+                    "constraints": {
+                        "supports_neighbourhood_toggle": True,
+                        "supports_focus_navigation": True,
+                    },
+                    "provenance": provenance,
+                }
+            ]
+
         def _build_renderer_request_payload(
             screen_text: Any,
             *,
@@ -18695,11 +18925,14 @@ class InternalMCPChatOrchestrator:
             "citation": ("document_view",),
             "document": ("document_view",),
             "document_view": ("document_view",),
+            "hierarchy": ("hierarchy_view",),
+            "hierarchy_view": ("hierarchy_view",),
             "kanban": ("kanban_view",),
             "kanban_view": ("kanban_view",),
             "graph": ("relation_graph_view",),
             "relation_graph": ("relation_graph_view",),
             "relation_graph_view": ("relation_graph_view",),
+            "tree": ("hierarchy_view",),
             "task": ("task_view",),
             "task_view": ("task_view",),
             "timeline": ("timeline",),
@@ -18777,6 +19010,7 @@ class InternalMCPChatOrchestrator:
             include_document_elements = "document_view" in selected_families
             include_kanban_elements = "kanban_view" in selected_families
             include_timeline_elements = "timeline" in selected_families
+            include_hierarchy_elements = "hierarchy_view" in selected_families
             include_relation_graph_elements = "relation_graph_view" in selected_families
             decision["screen_element_mapping_mode"] = mapping_mode
             decision["screen_element_reason_codes"] = list(reason_codes)
@@ -18789,6 +19023,7 @@ class InternalMCPChatOrchestrator:
                 "document_view": include_document_elements,
                 "kanban_view": include_kanban_elements,
                 "timeline": include_timeline_elements,
+                "hierarchy_view": include_hierarchy_elements,
                 "relation_graph_view": include_relation_graph_elements,
             }
             if unsupported_renderer_types:
@@ -18868,6 +19103,19 @@ class InternalMCPChatOrchestrator:
                     decision["screen_timeline_elements"] = screen_timeline_elements
                     decision["screen_timeline_element_count"] = len(
                         screen_timeline_elements
+                    )
+
+            if include_hierarchy_elements:
+                screen_hierarchy_elements = _extract_renderer_screen_hierarchy_elements(
+                    tool_messages=tool_messages,
+                    focus_concept_id=decision.get(
+                        "request_payload_selected_concept_id"
+                    ),
+                )
+                if screen_hierarchy_elements:
+                    decision["screen_hierarchy_elements"] = screen_hierarchy_elements
+                    decision["screen_hierarchy_element_count"] = len(
+                        screen_hierarchy_elements
                     )
 
             if include_relation_graph_elements:

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -3008,6 +3008,39 @@ def _extract_screen_relation_graph_elements_from_render_plan(
     return relation_graph_elements
 
 
+def _extract_screen_hierarchy_elements_from_render_plan(
+    render_plan: dict[str, Any] | None,
+    *,
+    screen_element_targets: dict[str, bool] | None = None,
+) -> list[dict[str, Any]]:
+    """Extract display-contract hierarchy specs from renderer plan diagnostics."""
+    if not isinstance(render_plan, dict):
+        return []
+    if isinstance(screen_element_targets, dict) and not bool(
+        screen_element_targets.get("hierarchy_view", True)
+    ):
+        return []
+
+    hierarchy_elements: list[dict[str, Any]] = []
+
+    def _append_hierarchy_specs(raw_value: Any) -> None:
+        if isinstance(raw_value, list):
+            for item in raw_value:
+                if isinstance(item, dict):
+                    hierarchy_elements.append(dict(item))
+        elif isinstance(raw_value, dict):
+            hierarchy_elements.append(dict(raw_value))
+
+    _append_hierarchy_specs(render_plan.get("screen_hierarchy_elements"))
+    _append_hierarchy_specs(render_plan.get("screen_hierarchy_payloads"))
+
+    single_hierarchy = render_plan.get("screen_hierarchy_element")
+    if isinstance(single_hierarchy, dict):
+        hierarchy_elements.append(dict(single_hierarchy))
+
+    return hierarchy_elements
+
+
 def _extract_screen_relation_truth_state_elements_from_render_plan(
     render_plan: dict[str, Any] | None,
     *,
@@ -3057,6 +3090,7 @@ def _extract_screen_element_targets_from_render_plan(
         "document_view": True,
         "kanban_view": True,
         "timeline": True,
+        "hierarchy_view": True,
         "relation_graph_view": True,
         "relation_truth_state": True,
     }
@@ -3075,6 +3109,7 @@ def _extract_screen_element_targets_from_render_plan(
         "document_view": bool(raw_targets.get("document_view", True)),
         "kanban_view": bool(raw_targets.get("kanban_view", True)),
         "timeline": bool(raw_targets.get("timeline", True)),
+        "hierarchy_view": bool(raw_targets.get("hierarchy_view", True)),
         "relation_graph_view": bool(
             raw_targets.get("relation_graph_view", True)
         ),
@@ -6926,6 +6961,10 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             render_plan_for_display,
             screen_element_targets=screen_element_targets,
         )
+        screen_hierarchy_elements = _extract_screen_hierarchy_elements_from_render_plan(
+            render_plan_for_display,
+            screen_element_targets=screen_element_targets,
+        )
         screen_relation_graph_elements = (
             _extract_screen_relation_graph_elements_from_render_plan(
                 render_plan_for_display,
@@ -6950,6 +6989,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             screen_document_elements=screen_document_elements,
             screen_kanban_elements=screen_kanban_elements,
             screen_timeline_elements=screen_timeline_elements,
+            screen_hierarchy_elements=screen_hierarchy_elements,
             screen_relation_graph_elements=screen_relation_graph_elements,
             screen_relation_truth_state_elements=screen_relation_truth_state_elements,
             supplemental_reason_codes=screen_element_reason_codes,

--- a/src/backend/services/display_elements_service.py
+++ b/src/backend/services/display_elements_service.py
@@ -17,6 +17,7 @@ ALLOWED_DISPLAY_ELEMENT_TYPES = frozenset(
     {
         "calendar_view",
         "document_view",
+        "hierarchy_view",
         "text_block",
         "json_block",
         "kanban_view",
@@ -32,6 +33,7 @@ OPTIONAL_PAYLOAD_TITLE_ELEMENT_TYPES = frozenset(
     {
         "calendar_view",
         "document_view",
+        "hierarchy_view",
         "kanban_view",
         "relation_graph_view",
         "table",
@@ -46,6 +48,12 @@ RELATION_TRUTH_STATE_GROUP_STATUSES = frozenset(
 RELATION_GRAPH_ALLOWED_DIRECTIONS = frozenset({"directed", "undirected"})
 RELATION_GRAPH_MAX_NODES = 200
 RELATION_GRAPH_MAX_EDGES = 400
+HIERARCHY_MAX_NODES = 200
+HIERARCHY_MAX_EDGES = 400
+HIERARCHY_EDGE_BRANCH_KINDS = frozenset(
+    {"type_hierarchy", "instance_hierarchy", "organisational_hierarchy", "custom"}
+)
+HIERARCHY_MAX_DEPTH = 12
 CALENDAR_ALLOWED_GRANULARITIES = frozenset({"month", "week", "day"})
 DOCUMENT_SECTION_EXCERPT_MAX_CHARS = 700
 DOCUMENT_SECTION_DIFF_SUMMARY_MAX_CHARS = 280
@@ -1050,6 +1058,173 @@ def validate_turn_display_elements(
                     errors.append(
                         f"{label}.payload.focus_node_id must reference a declared node"
                     )
+        elif element_type == "hierarchy_view":
+            nodes = payload.get("nodes")
+            if not isinstance(nodes, list) or not nodes:
+                errors.append(f"{label}.payload.nodes must be a non-empty list")
+                nodes = []
+            if isinstance(nodes, list) and len(nodes) > HIERARCHY_MAX_NODES:
+                errors.append(
+                    f"{label}.payload.nodes exceeds max size {HIERARCHY_MAX_NODES}"
+                )
+
+            valid_node_ids: set[str] = set()
+            for node_index, node in enumerate(nodes):
+                node_label = f"{label}.payload.nodes[{node_index}]"
+                if not isinstance(node, Mapping):
+                    errors.append(f"{node_label} must be a mapping")
+                    continue
+
+                node_id = node.get("node_id")
+                if not isinstance(node_id, str) or not node_id.strip():
+                    errors.append(f"{node_label}.node_id must be a non-empty string")
+                    continue
+                if node_id in valid_node_ids:
+                    errors.append(f"{node_label}.node_id must be unique")
+                    continue
+                valid_node_ids.add(node_id)
+
+                display_label = node.get("label")
+                if not isinstance(display_label, str) or not display_label.strip():
+                    errors.append(f"{node_label}.label must be a non-empty string")
+
+                node_kind = node.get("node_kind")
+                if node_kind is not None and (
+                    not isinstance(node_kind, str) or not node_kind.strip()
+                ):
+                    errors.append(
+                        f"{node_label}.node_kind must be a non-empty string when provided"
+                    )
+
+                for count_key in ("parent_count", "child_count"):
+                    count_value = node.get(count_key)
+                    if count_value is None:
+                        continue
+                    if isinstance(count_value, bool) or not isinstance(count_value, int):
+                        errors.append(
+                            f"{node_label}.{count_key} must be a non-negative integer when provided"
+                        )
+                        continue
+                    if count_value < 0:
+                        errors.append(
+                            f"{node_label}.{count_key} must be a non-negative integer when provided"
+                        )
+
+            edges = payload.get("edges")
+            if not isinstance(edges, list):
+                errors.append(f"{label}.payload.edges must be a list")
+                edges = []
+            if isinstance(edges, list) and len(edges) > HIERARCHY_MAX_EDGES:
+                errors.append(
+                    f"{label}.payload.edges exceeds max size {HIERARCHY_MAX_EDGES}"
+                )
+
+            seen_edge_ids: set[str] = set()
+            for edge_index, edge in enumerate(edges):
+                edge_label = f"{label}.payload.edges[{edge_index}]"
+                if not isinstance(edge, Mapping):
+                    errors.append(f"{edge_label} must be a mapping")
+                    continue
+
+                edge_id = edge.get("edge_id")
+                if not isinstance(edge_id, str) or not edge_id.strip():
+                    errors.append(f"{edge_label}.edge_id must be a non-empty string")
+                elif edge_id in seen_edge_ids:
+                    errors.append(f"{edge_label}.edge_id must be unique")
+                else:
+                    seen_edge_ids.add(edge_id)
+
+                parent_node_id = edge.get("parent_node_id")
+                if not isinstance(parent_node_id, str) or not parent_node_id.strip():
+                    errors.append(
+                        f"{edge_label}.parent_node_id must be a non-empty string"
+                    )
+                elif valid_node_ids and parent_node_id not in valid_node_ids:
+                    errors.append(
+                        f"{edge_label}.parent_node_id must reference a declared node"
+                    )
+
+                child_node_id = edge.get("child_node_id")
+                if not isinstance(child_node_id, str) or not child_node_id.strip():
+                    errors.append(
+                        f"{edge_label}.child_node_id must be a non-empty string"
+                    )
+                elif valid_node_ids and child_node_id not in valid_node_ids:
+                    errors.append(
+                        f"{edge_label}.child_node_id must reference a declared node"
+                    )
+
+                predicate = edge.get("predicate")
+                if predicate is not None and (
+                    not isinstance(predicate, str) or not predicate.strip()
+                ):
+                    errors.append(
+                        f"{edge_label}.predicate must be a non-empty string when provided"
+                    )
+
+                branch_kind = edge.get("branch_kind")
+                if branch_kind is not None:
+                    if (
+                        not isinstance(branch_kind, str)
+                        or branch_kind.strip() not in HIERARCHY_EDGE_BRANCH_KINDS
+                    ):
+                        errors.append(
+                            f"{edge_label}.branch_kind must be one of {sorted(HIERARCHY_EDGE_BRANCH_KINDS)} when provided"
+                        )
+
+            focus_node_id = payload.get("focus_node_id")
+            if focus_node_id is not None:
+                if not isinstance(focus_node_id, str) or not focus_node_id.strip():
+                    errors.append(
+                        f"{label}.payload.focus_node_id must be a non-empty string when provided"
+                    )
+                elif valid_node_ids and focus_node_id not in valid_node_ids:
+                    errors.append(
+                        f"{label}.payload.focus_node_id must reference a declared node"
+                    )
+
+            root_node_ids = payload.get("root_node_ids")
+            if root_node_ids is not None:
+                if not isinstance(root_node_ids, list):
+                    errors.append(f"{label}.payload.root_node_ids must be a list")
+                else:
+                    for root_index, root_node_id in enumerate(root_node_ids):
+                        root_label = f"{label}.payload.root_node_ids[{root_index}]"
+                        if (
+                            not isinstance(root_node_id, str)
+                            or not root_node_id.strip()
+                        ):
+                            errors.append(
+                                f"{root_label} must be a non-empty string"
+                            )
+                            continue
+                        if valid_node_ids and root_node_id not in valid_node_ids:
+                            errors.append(
+                                f"{root_label} must reference a declared node"
+                            )
+
+            expansion = payload.get("expansion")
+            if expansion is not None:
+                if not isinstance(expansion, Mapping):
+                    errors.append(f"{label}.payload.expansion must be a mapping")
+                else:
+                    for key in ("show_parents", "show_children", "show_siblings"):
+                        flag = expansion.get(key)
+                        if flag is not None and not isinstance(flag, bool):
+                            errors.append(
+                                f"{label}.payload.expansion.{key} must be a boolean when provided"
+                            )
+
+                    max_depth = expansion.get("max_depth")
+                    if max_depth is not None:
+                        if isinstance(max_depth, bool) or not isinstance(max_depth, int):
+                            errors.append(
+                                f"{label}.payload.expansion.max_depth must be an integer between 1 and {HIERARCHY_MAX_DEPTH} when provided"
+                            )
+                        elif max_depth < 1 or max_depth > HIERARCHY_MAX_DEPTH:
+                            errors.append(
+                                f"{label}.payload.expansion.max_depth must be an integer between 1 and {HIERARCHY_MAX_DEPTH} when provided"
+                            )
         elif element_type == "timeline":
             items = payload.get("items")
             if not isinstance(items, list) or not items:
@@ -2353,6 +2528,86 @@ def _normalise_supplied_screen_relation_graph_views(
     return normalised, dropped_count
 
 
+def _normalise_supplied_screen_hierarchy_views(
+    screen_hierarchy_elements: Sequence[Mapping[str, Any]] | None,
+) -> tuple[list[dict[str, Any]], int]:
+    """Normalise externally supplied screen hierarchy specs."""
+    if (
+        not isinstance(screen_hierarchy_elements, Sequence)
+        or isinstance(screen_hierarchy_elements, (str, bytes, bytearray))
+    ):
+        return [], 0
+
+    normalised: list[dict[str, Any]] = []
+    dropped_count = 0
+
+    for index, raw_spec in enumerate(screen_hierarchy_elements, start=1):
+        if not isinstance(raw_spec, Mapping):
+            dropped_count += 1
+            continue
+
+        payload: Mapping[str, Any] | None = None
+        metadata = raw_spec
+        wrapped_payload = raw_spec.get("payload")
+        if isinstance(wrapped_payload, Mapping):
+            payload = wrapped_payload
+        elif "nodes" in raw_spec and "edges" in raw_spec:
+            payload = raw_spec
+
+        if not isinstance(payload, Mapping):
+            dropped_count += 1
+            continue
+
+        intent = _normalise_text(metadata.get("intent")) or "hierarchy_view"
+        constraints = metadata.get("constraints")
+        if not isinstance(constraints, Mapping):
+            constraints = {
+                "supports_neighbourhood_toggle": True,
+                "supports_focus_navigation": True,
+            }
+        provenance = metadata.get("provenance")
+        if not isinstance(provenance, Mapping):
+            provenance = {}
+        canonical_payload = _with_optional_payload_title(payload, metadata=metadata)
+
+        is_valid, _errors = validate_turn_display_elements(
+            {
+                "schema_version": DISPLAY_ELEMENT_SCHEMA_VERSION,
+                "elements": [
+                    {
+                        "element_id": f"screen_structured_hierarchy_view_probe_{index}",
+                        "element_type": "hierarchy_view",
+                        "channel": "screen",
+                        "order": 42,
+                        "intent": intent,
+                        "payload": dict(canonical_payload),
+                        "constraints": dict(constraints),
+                        "provenance": dict(provenance),
+                    }
+                ],
+                "reason_codes": [],
+            }
+        )
+        if not is_valid:
+            dropped_count += 1
+            continue
+
+        normalised.append(
+            {
+                "element_id": _normalise_text(metadata.get("element_id")),
+                "order": metadata.get("order")
+                if isinstance(metadata.get("order"), int)
+                else None,
+                "intent": intent,
+                "payload": dict(canonical_payload),
+                "constraints": dict(constraints),
+                "provenance": dict(provenance),
+            }
+        )
+
+    return normalised, dropped_count
+
+
 def _normalise_supplied_screen_relation_truth_states(
     screen_relation_truth_state_elements: Sequence[Mapping[str, Any]] | None,
 ) -> tuple[list[dict[str, Any]], int]:
@@ -2447,6 +2702,7 @@ def build_turn_display_elements(
     screen_document_elements: Sequence[Mapping[str, Any]] | None = None,
     screen_kanban_elements: Sequence[Mapping[str, Any]] | None = None,
     screen_timeline_elements: Sequence[Mapping[str, Any]] | None = None,
+    screen_hierarchy_elements: Sequence[Mapping[str, Any]] | None = None,
     screen_relation_graph_elements: Sequence[Mapping[str, Any]] | None = None,
     screen_relation_truth_state_elements: Sequence[Mapping[str, Any]] | None = None,
     supplemental_reason_codes: Sequence[str] | None = None,
@@ -2625,6 +2881,14 @@ def build_turn_display_elements(
         reason_codes.append("screen_structured_timelines_supplied")
     if supplied_timelines_dropped:
         reason_codes.append("screen_structured_timelines_invalid_dropped")
+
+    supplied_screen_hierarchy_views, supplied_hierarchy_views_dropped = (
+        _normalise_supplied_screen_hierarchy_views(screen_hierarchy_elements)
+    )
+    if supplied_screen_hierarchy_views:
+        reason_codes.append("screen_structured_hierarchy_views_supplied")
+    if supplied_hierarchy_views_dropped:
+        reason_codes.append("screen_structured_hierarchy_views_invalid_dropped")
 
     supplied_screen_relation_graph_views, supplied_relation_graph_views_dropped = (
         _normalise_supplied_screen_relation_graph_views(
@@ -2817,6 +3081,27 @@ def build_turn_display_elements(
             }
         )
 
+    hierarchy_specs: list[dict[str, Any]] = []
+    for index, spec in enumerate(supplied_screen_hierarchy_views, start=1):
+        provenance = dict(spec.get("provenance") or {})
+        provenance.setdefault("source", "screen_structured_hierarchy_view")
+        provenance.setdefault("hierarchy_index", index)
+        hierarchy_specs.append(
+            {
+                "element_id": spec.get("element_id")
+                or f"screen_structured_hierarchy_view_{index}",
+                "order": spec.get("order"),
+                "intent": spec.get("intent") or "hierarchy_view",
+                "payload": spec.get("payload") or {},
+                "constraints": spec.get("constraints")
+                or {
+                    "supports_neighbourhood_toggle": True,
+                    "supports_focus_navigation": True,
+                },
+                "provenance": provenance,
+            }
+        )
+
     relation_graph_specs: list[dict[str, Any]] = []
     for index, spec in enumerate(supplied_screen_relation_graph_views, start=1):
         provenance = dict(spec.get("provenance") or {})
@@ -2870,6 +3155,7 @@ def build_turn_display_elements(
             *document_specs,
             *kanban_specs,
             *timeline_specs,
+            *hierarchy_specs,
             *relation_graph_specs,
             *relation_truth_state_specs,
         ]
@@ -3058,6 +3344,30 @@ def build_turn_display_elements(
             {
                 "element_id": element_id,
                 "element_type": "relation_graph_view",
+                "channel": "screen",
+                "order": int(order),
+                "intent": str(spec["intent"]),
+                "payload": dict(spec["payload"]),
+                "constraints": dict(spec["constraints"]),
+                "provenance": dict(spec["provenance"]),
+            }
+        )
+
+    next_hierarchy_order = 42
+    for spec in hierarchy_specs:
+        order = spec.get("order") if isinstance(spec.get("order"), int) else None
+        if order is None:
+            while next_hierarchy_order in used_orders:
+                next_hierarchy_order += 1
+            order = next_hierarchy_order
+            used_orders.add(order)
+            next_hierarchy_order += 1
+
+        element_id = _next_unique_element_id(str(spec["element_id"]), used_ids)
+        elements.append(
+            {
+                "element_id": element_id,
+                "element_type": "hierarchy_view",
                 "channel": "screen",
                 "order": int(order),
                 "intent": str(spec["intent"]),

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -2210,6 +2210,9 @@ const DOCUMENT_SECTION_DIFF_SUMMARY_MAX_CHARS = 280;
 const DOCUMENT_EXCERPT_TRUNCATION_MARKER = ' ... [truncated]';
 const RELATION_GRAPH_MAX_NODES = 120;
 const RELATION_GRAPH_MAX_EDGES = 240;
+const HIERARCHY_MAX_NODES = 180;
+const HIERARCHY_MAX_EDGES = 360;
+const HIERARCHY_MAX_DEPTH = 10;
 const RELATION_TRUTH_STATE_MAX_GROUPS = 50;
 const RELATION_TRUTH_STATE_MAX_ASSERTIONS_PER_GROUP = 200;
 const RELATION_TRUTH_STATE_FALLBACK_MAX_LINES = 300;
@@ -3663,6 +3666,221 @@ function resolveRelationGraphDisplayElements(debugData) {
     return relationGraphs;
 }
 
+function normaliseHierarchyBranchKind(value) {
+    const branchKind = typeof value === 'string' ? value.trim().toLowerCase() : '';
+    if (
+        branchKind === 'type_hierarchy'
+        || branchKind === 'instance_hierarchy'
+        || branchKind === 'organisational_hierarchy'
+    ) {
+        return branchKind;
+    }
+    return 'custom';
+}
+
+function normaliseHierarchyDisplayElement(element) {
+    if (!element || typeof element !== 'object') {
+        return null;
+    }
+    if (String(element.element_type || '').trim() !== 'hierarchy_view') {
+        return null;
+    }
+
+    const payload = element.payload;
+    if (!payload || typeof payload !== 'object') {
+        return null;
+    }
+
+    const rawNodes = Array.isArray(payload.nodes) ? payload.nodes : [];
+    const nodeMap = new Map();
+    for (const rawNode of rawNodes) {
+        if (!rawNode || typeof rawNode !== 'object') {
+            continue;
+        }
+        const nodeId = typeof rawNode.node_id === 'string' ? rawNode.node_id.trim() : '';
+        if (!nodeId || nodeMap.has(nodeId)) {
+            continue;
+        }
+        const label = typeof rawNode.label === 'string' && rawNode.label.trim()
+            ? rawNode.label.trim()
+            : nodeId;
+        const nodeKind = normaliseRelationGraphNodeKind(rawNode.node_kind || rawNode.kind);
+        const parentCountRaw = Number(rawNode.parent_count);
+        const childCountRaw = Number(rawNode.child_count);
+        nodeMap.set(nodeId, {
+            node_id: nodeId,
+            label,
+            node_kind: nodeKind,
+            parent_count: Number.isInteger(parentCountRaw) && parentCountRaw >= 0
+                ? parentCountRaw
+                : null,
+            child_count: Number.isInteger(childCountRaw) && childCountRaw >= 0
+                ? childCountRaw
+                : null
+        });
+        if (nodeMap.size >= HIERARCHY_MAX_NODES) {
+            break;
+        }
+    }
+
+    if (!nodeMap.size) {
+        return null;
+    }
+
+    const classifyPredicateBranchKind = (predicate) => {
+        const cleaned = typeof predicate === 'string'
+            ? predicate.trim().toLowerCase()
+            : '';
+        if (!cleaned) {
+            return 'custom';
+        }
+        const compact = cleaned.replace(/[^a-z0-9]+/g, '_');
+        if (
+            compact.includes('is_a_type_of')
+            || compact.includes('type_of')
+            || compact.includes('isatypeof')
+        ) {
+            return 'type_hierarchy';
+        }
+        if (compact.includes('instance_of') || compact.includes('is_an_instance_of')) {
+            return 'instance_hierarchy';
+        }
+        if (compact.includes('organis') || compact.includes('organiz')) {
+            return 'organisational_hierarchy';
+        }
+        return 'custom';
+    };
+
+    const rawEdges = Array.isArray(payload.edges) ? payload.edges : [];
+    const edges = [];
+    const seenEdgeKeys = new Set();
+    for (let index = 0; index < rawEdges.length; index += 1) {
+        const rawEdge = rawEdges[index];
+        if (!rawEdge || typeof rawEdge !== 'object') {
+            continue;
+        }
+        const parentNodeId = typeof rawEdge.parent_node_id === 'string'
+            ? rawEdge.parent_node_id.trim()
+            : (typeof rawEdge.source === 'string' ? rawEdge.source.trim() : '');
+        const childNodeId = typeof rawEdge.child_node_id === 'string'
+            ? rawEdge.child_node_id.trim()
+            : (typeof rawEdge.target === 'string' ? rawEdge.target.trim() : '');
+        if (!parentNodeId || !childNodeId || parentNodeId === childNodeId) {
+            continue;
+        }
+        if (!nodeMap.has(parentNodeId) || !nodeMap.has(childNodeId)) {
+            continue;
+        }
+
+        const predicate = typeof rawEdge.predicate === 'string' && rawEdge.predicate.trim()
+            ? rawEdge.predicate.trim()
+            : '';
+        const branchKind = rawEdge.branch_kind
+            ? normaliseHierarchyBranchKind(rawEdge.branch_kind)
+            : classifyPredicateBranchKind(predicate);
+        const edgeKey = `${parentNodeId}|${childNodeId}|${predicate}|${branchKind}`;
+        if (seenEdgeKeys.has(edgeKey)) {
+            continue;
+        }
+        seenEdgeKeys.add(edgeKey);
+
+        edges.push({
+            edge_id: typeof rawEdge.edge_id === 'string' && rawEdge.edge_id.trim()
+                ? rawEdge.edge_id.trim()
+                : `hierarchy_edge_${edges.length + 1}`,
+            parent_node_id: parentNodeId,
+            child_node_id: childNodeId,
+            predicate,
+            branch_kind: branchKind
+        });
+        if (edges.length >= HIERARCHY_MAX_EDGES) {
+            break;
+        }
+    }
+
+    if (!edges.length && nodeMap.size > 1) {
+        return null;
+    }
+
+    const focusNodeId = typeof payload.focus_node_id === 'string' && payload.focus_node_id.trim() && nodeMap.has(payload.focus_node_id.trim())
+        ? payload.focus_node_id.trim()
+        : '';
+
+    const rootNodeIds = [];
+    const seenRootNodeIds = new Set();
+    const rawRootNodeIds = Array.isArray(payload.root_node_ids) ? payload.root_node_ids : [];
+    for (const rawRootNodeId of rawRootNodeIds) {
+        const rootNodeId = typeof rawRootNodeId === 'string' ? rawRootNodeId.trim() : '';
+        if (!rootNodeId || seenRootNodeIds.has(rootNodeId) || !nodeMap.has(rootNodeId)) {
+            continue;
+        }
+        seenRootNodeIds.add(rootNodeId);
+        rootNodeIds.push(rootNodeId);
+    }
+    if (!rootNodeIds.length && edges.length > 0) {
+        const parentIds = new Set(edges.map((edge) => edge.parent_node_id));
+        const childIds = new Set(edges.map((edge) => edge.child_node_id));
+        const derivedRoots = Array.from(parentIds).filter((nodeId) => !childIds.has(nodeId));
+        derivedRoots.sort((left, right) => String(left).localeCompare(String(right)));
+        for (const rootNodeId of derivedRoots) {
+            if (seenRootNodeIds.has(rootNodeId)) {
+                continue;
+            }
+            seenRootNodeIds.add(rootNodeId);
+            rootNodeIds.push(rootNodeId);
+        }
+    }
+    if (!rootNodeIds.length && focusNodeId) {
+        rootNodeIds.push(focusNodeId);
+    }
+
+    const rawExpansion = payload.expansion;
+    const expansion = {
+        show_parents: typeof rawExpansion?.show_parents === 'boolean'
+            ? rawExpansion.show_parents
+            : true,
+        show_children: typeof rawExpansion?.show_children === 'boolean'
+            ? rawExpansion.show_children
+            : true,
+        show_siblings: typeof rawExpansion?.show_siblings === 'boolean'
+            ? rawExpansion.show_siblings
+            : true,
+        max_depth: Number.isInteger(Number(rawExpansion?.max_depth))
+            && Number(rawExpansion.max_depth) >= 1
+            && Number(rawExpansion.max_depth) <= HIERARCHY_MAX_DEPTH
+            ? Number(rawExpansion.max_depth)
+            : 4
+    };
+
+    return {
+        element_id: typeof element.element_id === 'string' ? element.element_id.trim() : null,
+        title: normaliseOptionalDisplayElementTitle(payload.title),
+        nodes: Array.from(nodeMap.values()),
+        edges,
+        focus_node_id: focusNodeId,
+        root_node_ids: rootNodeIds,
+        expansion,
+        truncated: rawNodes.length > nodeMap.size || rawEdges.length > edges.length
+    };
+}
+
+function resolveHierarchyDisplayElements(debugData) {
+    const contract = normaliseDisplayElementsContract(debugData?.display_elements);
+    if (!contract) {
+        return [];
+    }
+
+    const hierarchyElements = [];
+    for (const element of contract.elements) {
+        const hierarchyElement = normaliseHierarchyDisplayElement(element);
+        if (!hierarchyElement) {
+            continue;
+        }
+        hierarchyElements.push(hierarchyElement);
+    }
+    return hierarchyElements;
+}
+
 function normaliseRelationTruthStateStatus(value) {
     const status = typeof value === 'string' ? value.trim().toLowerCase() : '';
     if (status === 'asserted' || status === 'missing_expected' || status === 'uncertain') {
@@ -4201,6 +4419,416 @@ function buildRelationGraphScene(graphElement) {
     return section;
 }
 
+function buildHierarchyNodeElement(node) {
+    if (!node || typeof node !== 'object') {
+        return null;
+    }
+    const nodeId = typeof node.node_id === 'string' ? node.node_id.trim() : '';
+    if (!nodeId) {
+        return null;
+    }
+    const label = typeof node.label === 'string' && node.label.trim()
+        ? node.label.trim()
+        : nodeId;
+
+    const conceptId = _normalisePotentialConceptId(nodeId);
+    if (conceptId) {
+        const cartouche = createVontologyCartouche(conceptId, {
+            title: 'Open concept tab',
+            name: label,
+            kind: node.node_kind
+        });
+        cartouche.classList.add('chat-display-elements-hierarchy-node-cartouche');
+        cartouche.title = `${label} (${nodeId})`;
+        return cartouche;
+    }
+
+    const textNode = document.createElement('span');
+    textNode.className = 'chat-display-elements-hierarchy-node-text';
+    textNode.textContent = label;
+    textNode.title = nodeId;
+    return textNode;
+}
+
+function buildHierarchyScene(hierarchyElement) {
+    const section = document.createElement('div');
+    section.className = 'chat-display-elements-hierarchy-scene-wrap';
+
+    const nodeById = new Map();
+    for (const node of hierarchyElement.nodes) {
+        if (!node || typeof node !== 'object') {
+            continue;
+        }
+        const nodeId = typeof node.node_id === 'string' ? node.node_id.trim() : '';
+        if (!nodeId || nodeById.has(nodeId)) {
+            continue;
+        }
+        nodeById.set(nodeId, node);
+    }
+
+    const childrenByParent = new Map();
+    const parentsByChild = new Map();
+    const predicateByPair = new Map();
+    for (const edge of hierarchyElement.edges) {
+        if (!edge || typeof edge !== 'object') {
+            continue;
+        }
+        const parentNodeId = typeof edge.parent_node_id === 'string'
+            ? edge.parent_node_id.trim()
+            : '';
+        const childNodeId = typeof edge.child_node_id === 'string'
+            ? edge.child_node_id.trim()
+            : '';
+        if (!parentNodeId || !childNodeId || !nodeById.has(parentNodeId) || !nodeById.has(childNodeId)) {
+            continue;
+        }
+
+        if (!childrenByParent.has(parentNodeId)) {
+            childrenByParent.set(parentNodeId, new Set());
+        }
+        childrenByParent.get(parentNodeId).add(childNodeId);
+
+        if (!parentsByChild.has(childNodeId)) {
+            parentsByChild.set(childNodeId, new Set());
+        }
+        parentsByChild.get(childNodeId).add(parentNodeId);
+
+        const pairKey = `${parentNodeId}|${childNodeId}`;
+        if (!predicateByPair.has(pairKey)) {
+            predicateByPair.set(pairKey, new Set());
+        }
+        const predicate = typeof edge.predicate === 'string' ? edge.predicate.trim() : '';
+        if (predicate) {
+            predicateByPair.get(pairKey).add(predicate);
+        }
+    }
+
+    const sortNodeIds = (nodeIds) => {
+        return [...nodeIds].sort((left, right) => {
+            const leftNode = nodeById.get(left);
+            const rightNode = nodeById.get(right);
+            const leftLabel = typeof leftNode?.label === 'string' && leftNode.label.trim()
+                ? leftNode.label.trim()
+                : left;
+            const rightLabel = typeof rightNode?.label === 'string' && rightNode.label.trim()
+                ? rightNode.label.trim()
+                : right;
+            return `${leftLabel}|${left}`.localeCompare(`${rightLabel}|${right}`);
+        });
+    };
+
+    const focusNodeId = (
+        typeof hierarchyElement.focus_node_id === 'string'
+        && hierarchyElement.focus_node_id.trim()
+        && nodeById.has(hierarchyElement.focus_node_id.trim())
+    )
+        ? hierarchyElement.focus_node_id.trim()
+        : (
+            Array.isArray(hierarchyElement.root_node_ids)
+            && hierarchyElement.root_node_ids.length
+            && nodeById.has(hierarchyElement.root_node_ids[0])
+        )
+            ? hierarchyElement.root_node_ids[0]
+            : (hierarchyElement.nodes[0]?.node_id || '');
+
+    const rootNodeIds = [];
+    const seenRoots = new Set();
+    const explicitRoots = Array.isArray(hierarchyElement.root_node_ids)
+        ? hierarchyElement.root_node_ids
+        : [];
+    for (const rootNodeId of explicitRoots) {
+        const candidateRoot = typeof rootNodeId === 'string' ? rootNodeId.trim() : '';
+        if (!candidateRoot || seenRoots.has(candidateRoot) || !nodeById.has(candidateRoot)) {
+            continue;
+        }
+        seenRoots.add(candidateRoot);
+        rootNodeIds.push(candidateRoot);
+    }
+    if (!rootNodeIds.length) {
+        const parentIds = new Set();
+        const childIds = new Set();
+        for (const edge of hierarchyElement.edges) {
+            parentIds.add(edge.parent_node_id);
+            childIds.add(edge.child_node_id);
+        }
+        for (const parentNodeId of sortNodeIds(parentIds)) {
+            if (childIds.has(parentNodeId) || !nodeById.has(parentNodeId)) {
+                continue;
+            }
+            rootNodeIds.push(parentNodeId);
+        }
+    }
+    if (!rootNodeIds.length && focusNodeId) {
+        rootNodeIds.push(focusNodeId);
+    }
+
+    const focusAncestors = new Set();
+    if (focusNodeId) {
+        const queue = [focusNodeId];
+        while (queue.length > 0) {
+            const currentNodeId = queue.shift();
+            if (focusAncestors.has(currentNodeId)) {
+                continue;
+            }
+            focusAncestors.add(currentNodeId);
+            const parents = parentsByChild.get(currentNodeId);
+            if (!parents) {
+                continue;
+            }
+            for (const parentNodeId of parents) {
+                if (!focusAncestors.has(parentNodeId)) {
+                    queue.push(parentNodeId);
+                }
+            }
+        }
+    }
+
+    const renderNodeBadge = (node) => {
+        const badges = [];
+        if (Number.isInteger(node?.parent_count) && node.parent_count > 0) {
+            badges.push(`${node.parent_count} parent${node.parent_count === 1 ? '' : 's'}`);
+        }
+        if (Number.isInteger(node?.child_count) && node.child_count > 0) {
+            badges.push(`${node.child_count} child${node.child_count === 1 ? '' : 'ren'}`);
+        }
+        if (!badges.length) {
+            return null;
+        }
+        const badge = document.createElement('span');
+        badge.className = 'chat-display-elements-hierarchy-node-badge';
+        badge.textContent = badges.join(' · ');
+        return badge;
+    };
+
+    const renderNodeRow = (nodeId, { isFocus = false, relationHint = '' } = {}) => {
+        const node = nodeById.get(nodeId);
+        if (!node) {
+            return null;
+        }
+
+        const row = document.createElement('div');
+        row.className = `chat-display-elements-hierarchy-node-row${isFocus ? ' is-focus' : ''}`;
+
+        const nodeElement = buildHierarchyNodeElement(node);
+        if (!nodeElement) {
+            return null;
+        }
+        row.appendChild(nodeElement);
+
+        const badge = renderNodeBadge(node);
+        if (badge) {
+            row.appendChild(badge);
+        }
+
+        if (relationHint) {
+            const relation = document.createElement('span');
+            relation.className = 'chat-display-elements-hierarchy-relation-hint';
+            relation.textContent = relationHint;
+            row.appendChild(relation);
+        }
+
+        if (isFocus) {
+            const focusTag = document.createElement('span');
+            focusTag.className = 'chat-display-elements-hierarchy-focus-tag';
+            focusTag.textContent = 'Focus';
+            row.appendChild(focusTag);
+        }
+        return row;
+    };
+
+    const expansion = hierarchyElement.expansion || {};
+    const expansionMaxDepth = Number.isInteger(expansion.max_depth)
+        ? Math.max(1, Math.min(expansion.max_depth, HIERARCHY_MAX_DEPTH))
+        : 4;
+    const showParents = expansion.show_parents !== false;
+    const showChildren = expansion.show_children !== false;
+    const showSiblings = expansion.show_siblings !== false;
+
+    const neighbourhood = document.createElement('div');
+    neighbourhood.className = 'chat-display-elements-hierarchy-neighbourhood';
+
+    const buildNeighbourhoodPanel = (title, nodeIds, openByDefault, relationHintFactory = null) => {
+        if (!nodeIds.length) {
+            return null;
+        }
+        const details = document.createElement('details');
+        details.className = 'chat-display-elements-hierarchy-neighbourhood-panel';
+        details.open = openByDefault;
+
+        const summary = document.createElement('summary');
+        summary.className = 'chat-display-elements-hierarchy-neighbourhood-summary';
+        summary.textContent = `${title} (${nodeIds.length})`;
+        details.appendChild(summary);
+
+        const list = document.createElement('div');
+        list.className = 'chat-display-elements-hierarchy-neighbourhood-list';
+        for (const nodeId of nodeIds) {
+            const relationHint = typeof relationHintFactory === 'function'
+                ? relationHintFactory(nodeId)
+                : '';
+            const row = renderNodeRow(nodeId, { relationHint });
+            if (row) {
+                list.appendChild(row);
+            }
+        }
+        details.appendChild(list);
+        return details;
+    };
+
+    if (focusNodeId && nodeById.has(focusNodeId)) {
+        const focusHeader = document.createElement('div');
+        focusHeader.className = 'chat-display-elements-hierarchy-focus';
+        const focusRow = renderNodeRow(focusNodeId, { isFocus: true });
+        if (focusRow) {
+            focusHeader.appendChild(focusRow);
+            neighbourhood.appendChild(focusHeader);
+        }
+
+        const parentNodeIds = sortNodeIds(parentsByChild.get(focusNodeId) || []);
+        const childNodeIds = sortNodeIds(childrenByParent.get(focusNodeId) || []);
+        const siblingIdSet = new Set();
+        for (const parentNodeId of parentNodeIds) {
+            const siblingCandidates = childrenByParent.get(parentNodeId);
+            if (!siblingCandidates) {
+                continue;
+            }
+            for (const siblingNodeId of siblingCandidates) {
+                if (siblingNodeId !== focusNodeId) {
+                    siblingIdSet.add(siblingNodeId);
+                }
+            }
+        }
+        const siblingNodeIds = sortNodeIds(siblingIdSet);
+
+        const parentsPanel = buildNeighbourhoodPanel(
+            'Parents',
+            parentNodeIds,
+            showParents,
+            (nodeId) => {
+                const predicates = predicateByPair.get(`${nodeId}|${focusNodeId}`) || [];
+                return [...predicates].join(', ');
+            }
+        );
+        if (parentsPanel) {
+            neighbourhood.appendChild(parentsPanel);
+        }
+
+        const siblingsPanel = buildNeighbourhoodPanel(
+            'Siblings',
+            siblingNodeIds,
+            showSiblings
+        );
+        if (siblingsPanel) {
+            neighbourhood.appendChild(siblingsPanel);
+        }
+
+        const childrenPanel = buildNeighbourhoodPanel(
+            'Children',
+            childNodeIds,
+            showChildren,
+            (nodeId) => {
+                const predicates = predicateByPair.get(`${focusNodeId}|${nodeId}`) || [];
+                return [...predicates].join(', ');
+            }
+        );
+        if (childrenPanel) {
+            neighbourhood.appendChild(childrenPanel);
+        }
+    }
+
+    if (neighbourhood.childElementCount > 0) {
+        section.appendChild(neighbourhood);
+    }
+
+    const treeWrap = document.createElement('div');
+    treeWrap.className = 'chat-display-elements-hierarchy-tree-wrap';
+
+    const treeHeading = document.createElement('div');
+    treeHeading.className = 'chat-display-elements-hierarchy-tree-heading';
+    treeHeading.textContent = 'Hierarchy tree';
+    treeWrap.appendChild(treeHeading);
+
+    const renderTreeList = (nodeIds, depth, ancestry = new Set()) => {
+        if (!nodeIds.length || depth > expansionMaxDepth) {
+            return null;
+        }
+        const list = document.createElement('ul');
+        list.className = 'chat-display-elements-hierarchy-tree-list';
+
+        const sortedNodeIds = sortNodeIds(nodeIds);
+        for (const nodeId of sortedNodeIds) {
+            if (!nodeById.has(nodeId)) {
+                continue;
+            }
+            const item = document.createElement('li');
+            item.className = 'chat-display-elements-hierarchy-tree-item';
+
+            const row = renderNodeRow(nodeId, {
+                isFocus: !!focusNodeId && nodeId === focusNodeId
+            });
+            if (row) {
+                item.appendChild(row);
+            }
+
+            const childCandidates = childrenByParent.get(nodeId) || new Set();
+            const childNodeIds = [];
+            for (const childNodeId of childCandidates) {
+                if (ancestry.has(childNodeId)) {
+                    continue;
+                }
+                childNodeIds.push(childNodeId);
+            }
+
+            if (childNodeIds.length > 0 && depth < expansionMaxDepth) {
+                const childDetails = document.createElement('details');
+                childDetails.className = 'chat-display-elements-hierarchy-tree-subtree';
+                childDetails.open = (
+                    showChildren
+                    && (depth < 1 || nodeId === focusNodeId || focusAncestors.has(nodeId))
+                );
+
+                const childSummary = document.createElement('summary');
+                childSummary.className = 'chat-display-elements-hierarchy-tree-subtree-summary';
+                childSummary.textContent = `Children (${childNodeIds.length})`;
+                childDetails.appendChild(childSummary);
+
+                const nextAncestry = new Set(ancestry);
+                nextAncestry.add(nodeId);
+                const childList = renderTreeList(childNodeIds, depth + 1, nextAncestry);
+                if (childList) {
+                    childDetails.appendChild(childList);
+                }
+
+                item.appendChild(childDetails);
+            } else if (childNodeIds.length > 0 && depth >= expansionMaxDepth) {
+                const capNotice = document.createElement('div');
+                capNotice.className = 'chat-display-elements-hierarchy-depth-cap';
+                capNotice.textContent = `Depth limit reached (${expansionMaxDepth})`;
+                item.appendChild(capNotice);
+            }
+
+            list.appendChild(item);
+        }
+        return list;
+    };
+
+    const treeRoots = rootNodeIds.length > 0 ? rootNodeIds : sortNodeIds(nodeById.keys());
+    const treeList = renderTreeList(treeRoots, 0, new Set());
+    if (treeList) {
+        treeWrap.appendChild(treeList);
+    }
+    section.appendChild(treeWrap);
+
+    if (hierarchyElement.truncated) {
+        const truncationNotice = document.createElement('div');
+        truncationNotice.className = 'chat-display-elements-hierarchy-truncation';
+        truncationNotice.textContent = 'Hierarchy truncated to keep rendering responsive.';
+        section.appendChild(truncationNotice);
+    }
+
+    return section;
+}
+
 function renderTableDisplayElementsIntoContainer(container, debugData) {
     if (!container || typeof container.querySelectorAll !== 'function') {
         return;
@@ -4226,6 +4854,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
     const timelineElements = resolveTimelineDisplayElements(debugData);
     const calendarElements = resolveCalendarDisplayElements(debugData);
     const documentElements = resolveDocumentDisplayElements(debugData);
+    const hierarchyElements = resolveHierarchyDisplayElements(debugData);
     const relationGraphElements = resolveRelationGraphDisplayElements(debugData);
     let relationTruthStateElements = resolveRelationTruthStateDisplayElements(debugData);
     let relationTruthStateSource = relationTruthStateElements.length ? 'structured' : 'none';
@@ -4255,6 +4884,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
         && !timelineElements.length
         && !calendarElements.length
         && !documentElements.length
+        && !hierarchyElements.length
         && !relationGraphElements.length
         && !relationTruthStateElements.length
     ) {
@@ -5154,6 +5784,44 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
         root.appendChild(section);
     });
 
+    hierarchyElements.forEach((hierarchyElement, hierarchyIndex) => {
+        const section = document.createElement('section');
+        section.className = 'chat-display-elements-hierarchy-section';
+        section.style.cssText = (
+            tableElements.length > 0
+            || workflowElements.length > 0
+            || taskViewElements.length > 0
+            || kanbanElements.length > 0
+            || timelineElements.length > 0
+            || calendarElements.length > 0
+            || documentElements.length > 0
+            || hierarchyIndex > 0
+        ) ? 'margin-top: 10px;' : '';
+
+        const title = document.createElement('div');
+        title.className = 'chat-display-elements-hierarchy-title';
+        title.textContent = resolveDisplayElementSectionTitle(
+            hierarchyElement.title,
+            'Hierarchy view',
+            hierarchyIndex,
+            hierarchyElements.length
+        );
+        title.style.cssText = 'font-weight: 600; font-size: 0.85em; color: #2f4f6f; margin-bottom: 6px;';
+        section.appendChild(title);
+
+        const summary = document.createElement('div');
+        summary.className = 'chat-display-elements-hierarchy-summary';
+        summary.textContent = `${hierarchyElement.nodes.length} node${hierarchyElement.nodes.length === 1 ? '' : 's'}, ${hierarchyElement.edges.length} relation${hierarchyElement.edges.length === 1 ? '' : 's'}`;
+        if (hierarchyElement.truncated) {
+            summary.textContent += ' (truncated)';
+        }
+        summary.style.cssText = 'font-size: 0.78em; color: #5a6b7b; margin-bottom: 6px;';
+        section.appendChild(summary);
+
+        section.appendChild(buildHierarchyScene(hierarchyElement));
+        root.appendChild(section);
+    });
+
     relationGraphElements.forEach((relationGraphElement, relationGraphIndex) => {
         const section = document.createElement('section');
         section.className = 'chat-display-elements-relation-graph-section';
@@ -5165,6 +5833,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
             || timelineElements.length > 0
             || calendarElements.length > 0
             || documentElements.length > 0
+            || hierarchyElements.length > 0
             || relationGraphIndex > 0
         ) ? 'margin-top: 10px;' : '';
 
@@ -5201,6 +5870,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
             || taskViewElements.length > 0
             || kanbanElements.length > 0
             || timelineElements.length > 0
+            || hierarchyElements.length > 0
             || relationGraphElements.length > 0
             || calendarElements.length > 0
             || documentElements.length > 0
@@ -5450,6 +6120,7 @@ function extractRenderPlanSourceSummary(
     screenTimelineElements,
     screenCalendarElements,
     screenDocumentElements,
+    screenHierarchyElements,
     screenRelationGraphElements
 ) {
     const sourceTools = [];
@@ -5535,6 +6206,12 @@ function extractRenderPlanSourceSummary(
         }
         addProvenance(documentElement.provenance);
     }
+    for (const hierarchyElement of screenHierarchyElements) {
+        if (!hierarchyElement || typeof hierarchyElement !== 'object') {
+            continue;
+        }
+        addProvenance(hierarchyElement.provenance);
+    }
     for (const relationGraphElement of screenRelationGraphElements) {
         if (!relationGraphElement || typeof relationGraphElement !== 'object') {
             continue;
@@ -5588,6 +6265,9 @@ function buildRenderPlanMetadataSummary(renderPlan) {
     const screenDocumentElements = Array.isArray(renderPlan.screen_document_elements)
         ? renderPlan.screen_document_elements.filter(item => item && typeof item === 'object')
         : [];
+    const screenHierarchyElements = Array.isArray(renderPlan.screen_hierarchy_elements)
+        ? renderPlan.screen_hierarchy_elements.filter(item => item && typeof item === 'object')
+        : [];
     const screenRelationGraphElements = Array.isArray(renderPlan.screen_relation_graph_elements)
         ? renderPlan.screen_relation_graph_elements.filter(item => item && typeof item === 'object')
         : [];
@@ -5600,6 +6280,7 @@ function buildRenderPlanMetadataSummary(renderPlan) {
         screenTimelineElements,
         screenCalendarElements,
         screenDocumentElements,
+        screenHierarchyElements,
         screenRelationGraphElements
     );
 
@@ -5632,6 +6313,7 @@ function buildRenderPlanMetadataSummary(renderPlan) {
         screen_timeline_element_count: screenTimelineElements.length,
         screen_calendar_element_count: screenCalendarElements.length,
         screen_document_element_count: screenDocumentElements.length,
+        screen_hierarchy_element_count: screenHierarchyElements.length,
         screen_relation_graph_element_count: screenRelationGraphElements.length,
         unsupported_selected_renderer_types: unsupportedRendererTypes,
         resolver_suggestions: resolverSuggestions
@@ -5699,6 +6381,7 @@ function buildRenderPlanSummaryHtml(renderPlanSummary) {
     addScalar('Screen timeline elements', renderPlanSummary.screen_timeline_element_count);
     addScalar('Screen calendar elements', renderPlanSummary.screen_calendar_element_count);
     addScalar('Screen document elements', renderPlanSummary.screen_document_element_count);
+    addScalar('Screen hierarchy elements', renderPlanSummary.screen_hierarchy_element_count);
     addScalar('Screen relation graph elements', renderPlanSummary.screen_relation_graph_element_count);
     addList('Source tools', renderPlanSummary.source_tools);
     addList('Record families', renderPlanSummary.record_families);

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -1500,6 +1500,93 @@ describe('relation graph display elements', () => {
     });
 });
 
+describe('hierarchy display elements', () => {
+    beforeEach(() => {
+        const { createVontologyCartouche } = require('../utils/textDecorator.js');
+        createVontologyCartouche.mockClear();
+    });
+
+    test('renders hierarchy with focus neighbourhood panels for parents, siblings and children', () => {
+        const container = document.createElement('div');
+        const debugData = {
+            display_elements: {
+                schema_version: 'turn_display_elements_v1',
+                elements: [
+                    {
+                        element_id: 'screen_hierarchy_view',
+                        element_type: 'hierarchy_view',
+                        channel: 'screen',
+                        order: 42,
+                        intent: 'hierarchy_view',
+                        payload: {
+                            title: 'Meeting hierarchy',
+                            nodes: [
+                                { node_id: '#V#meeting', label: 'Meeting', node_kind: 'type' },
+                                { node_id: '#V#reading_group_meeting', label: 'Reading group meeting', node_kind: 'type' },
+                                { node_id: '#V#naoi_reading_group_meeting', label: 'NAOI reading group meeting', node_kind: 'type' },
+                                { node_id: '#V#sail_reading_group_meeting', label: 'SAIL reading group meeting', node_kind: 'type' },
+                                { node_id: '#V#other_reading_group_meeting', label: 'Other reading group meeting', node_kind: 'type' }
+                            ],
+                            edges: [
+                                {
+                                    edge_id: 'hierarchy_edge_1',
+                                    parent_node_id: '#V#meeting',
+                                    child_node_id: '#V#reading_group_meeting',
+                                    predicate: '#V#is_a_type_of',
+                                    branch_kind: 'type_hierarchy'
+                                },
+                                {
+                                    edge_id: 'hierarchy_edge_2',
+                                    parent_node_id: '#V#reading_group_meeting',
+                                    child_node_id: '#V#naoi_reading_group_meeting',
+                                    predicate: '#V#is_a_type_of',
+                                    branch_kind: 'type_hierarchy'
+                                },
+                                {
+                                    edge_id: 'hierarchy_edge_3',
+                                    parent_node_id: '#V#reading_group_meeting',
+                                    child_node_id: '#V#other_reading_group_meeting',
+                                    predicate: '#V#is_a_type_of',
+                                    branch_kind: 'type_hierarchy'
+                                },
+                                {
+                                    edge_id: 'hierarchy_edge_4',
+                                    parent_node_id: '#V#naoi_reading_group_meeting',
+                                    child_node_id: '#V#sail_reading_group_meeting',
+                                    predicate: '#V#is_a_type_of',
+                                    branch_kind: 'type_hierarchy'
+                                }
+                            ],
+                            focus_node_id: '#V#naoi_reading_group_meeting',
+                            root_node_ids: ['#V#meeting'],
+                            expansion: {
+                                show_parents: true,
+                                show_children: true,
+                                show_siblings: true,
+                                max_depth: 4
+                            }
+                        },
+                        provenance: { source: 'test' }
+                    }
+                ]
+            }
+        };
+
+        __testOnly_renderDisplayElementsIntoContainer(container, debugData);
+
+        const section = container.querySelector('.chat-display-elements-hierarchy-section');
+        expect(section).not.toBeNull();
+        expect(section.textContent).toContain('Meeting hierarchy');
+        expect(section.textContent).toContain('Parents (1)');
+        expect(section.textContent).toContain('Siblings (1)');
+        expect(section.textContent).toContain('Children (1)');
+        expect(section.textContent).toContain('Hierarchy tree');
+
+        const { createVontologyCartouche } = require('../utils/textDecorator.js');
+        expect(createVontologyCartouche).toHaveBeenCalled();
+    });
+});
+
 describe('chat insert prompt button behaviour', () => {
     beforeEach(() => {
         document.body.innerHTML = `
@@ -2109,6 +2196,39 @@ describe('LLM debug popup metadata (internal MCP caps + usage)', () => {
             screen_relation_graph_element_count: 1,
             source_tools: ['get_predicate_extent'],
             record_families: ['relation_graph']
+        });
+    });
+
+    test('includes hierarchy render plan provenance counts when present', () => {
+        const metadata = __testOnly_buildLlmDebugMetadata({
+            model: 'gpt-test',
+            messages: [],
+            render_plan: {
+                enabled: true,
+                attempted: true,
+                success: true,
+                reason: 'resolved',
+                selected_renderer_ids: ['#V#renderer_hierarchy'],
+                selected_renderer_types: ['hierarchy'],
+                screen_element_families: ['hierarchy_view'],
+                screen_hierarchy_elements: [
+                    {
+                        element_id: 'screen_hierarchy_view',
+                        provenance: {
+                            source_tools: ['fetch_concept'],
+                            record_family: 'hierarchy'
+                        }
+                    }
+                ]
+            }
+        });
+
+        expect(metadata.render_plan).toMatchObject({
+            selected_renderer_types: ['hierarchy'],
+            screen_element_families: ['hierarchy_view'],
+            screen_hierarchy_element_count: 1,
+            source_tools: ['fetch_concept'],
+            record_families: ['hierarchy']
         });
     });
 

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -5388,7 +5388,7 @@ footer {
 }
 
 .chat-session-current-title {
-    font-size: 14px;
+    font-size: 21px;
     font-weight: 700;
     line-height: 1.25;
     color: #0f172a;
@@ -5633,6 +5633,157 @@ footer {
 .workflow-status-badge.status-cancelled {
     background: #fee2e2;
     color: #991b1b;
+}
+
+.chat-display-elements-hierarchy-scene-wrap {
+    border: 1px solid #dce3ea;
+    border-radius: 8px;
+    background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+    padding: 8px;
+    display: grid;
+    gap: 8px;
+}
+
+.chat-display-elements-hierarchy-neighbourhood {
+    display: grid;
+    gap: 6px;
+}
+
+.chat-display-elements-hierarchy-focus {
+    padding: 6px 8px;
+    border: 1px solid #dce3ea;
+    border-radius: 8px;
+    background: #f8fbff;
+}
+
+.chat-display-elements-hierarchy-neighbourhood-panel {
+    border: 1px solid #dce3ea;
+    border-radius: 8px;
+    background: #ffffff;
+}
+
+.chat-display-elements-hierarchy-neighbourhood-summary {
+    cursor: pointer;
+    padding: 6px 8px;
+    font-size: 0.8em;
+    font-weight: 600;
+    color: #1f3d5a;
+}
+
+.chat-display-elements-hierarchy-neighbourhood-list {
+    display: grid;
+    gap: 6px;
+    padding: 0 8px 8px;
+}
+
+.chat-display-elements-hierarchy-node-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.chat-display-elements-hierarchy-node-row.is-focus {
+    padding: 2px 0;
+}
+
+.chat-display-elements-hierarchy-node-cartouche {
+    min-height: 22px;
+    font-size: 12px;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.chat-display-elements-hierarchy-node-text {
+    display: inline-flex;
+    align-items: center;
+    max-width: 180px;
+    border-radius: 999px;
+    border: 1px solid #cfd9e3;
+    background: #ffffff;
+    color: #0f172a;
+    font-size: 12px;
+    line-height: 1.2;
+    padding: 2px 8px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.chat-display-elements-hierarchy-node-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 7px;
+    border-radius: 999px;
+    background: #e2e8f0;
+    color: #334155;
+    font-size: 11px;
+    line-height: 1.2;
+}
+
+.chat-display-elements-hierarchy-focus-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 7px;
+    border-radius: 999px;
+    background: #dbeafe;
+    color: #1d4ed8;
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.chat-display-elements-hierarchy-relation-hint {
+    font-size: 11px;
+    color: #475569;
+}
+
+.chat-display-elements-hierarchy-tree-wrap {
+    border: 1px solid #dce3ea;
+    border-radius: 8px;
+    background: #f8fbff;
+    padding: 8px;
+}
+
+.chat-display-elements-hierarchy-tree-heading {
+    font-size: 0.79em;
+    font-weight: 600;
+    color: #334155;
+    margin-bottom: 6px;
+}
+
+.chat-display-elements-hierarchy-tree-list {
+    margin: 0;
+    padding: 0 0 0 14px;
+    list-style: none;
+    display: grid;
+    gap: 6px;
+}
+
+.chat-display-elements-hierarchy-tree-item {
+    display: grid;
+    gap: 4px;
+}
+
+.chat-display-elements-hierarchy-tree-subtree {
+    border: 1px dashed #d6dee7;
+    border-radius: 8px;
+    background: #ffffff;
+    padding: 4px 6px;
+}
+
+.chat-display-elements-hierarchy-tree-subtree-summary {
+    cursor: pointer;
+    font-size: 11px;
+    color: #475569;
+}
+
+.chat-display-elements-hierarchy-depth-cap {
+    font-size: 11px;
+    color: #92400e;
+}
+
+.chat-display-elements-hierarchy-truncation {
+    font-size: 0.74em;
+    color: #92400e;
 }
 
 .chat-display-elements-relation-graph-scene-wrap {

--- a/tests/backend/test_display_elements_service.py
+++ b/tests/backend/test_display_elements_service.py
@@ -897,6 +897,123 @@ def test_build_turn_display_elements_drops_invalid_relation_graph_elements() -> 
     assert contract["validation"]["valid"] is True
 
 
+def test_build_turn_display_elements_includes_supplied_hierarchy_elements() -> None:
+    contract = build_turn_display_elements(
+        response_text="Hierarchy response",
+        presenter_channels={
+            "format": "tagged_blocks_v1",
+            "screen": "Hierarchy response",
+            "spoken": None,
+        },
+        screen_hierarchy_elements=[
+            {
+                "element_id": "screen_hierarchy_view",
+                "intent": "hierarchy_view",
+                "payload": {
+                    "title": "Meeting hierarchy",
+                    "nodes": [
+                        {
+                            "node_id": "#V#meeting",
+                            "label": "Meeting",
+                            "node_kind": "type",
+                        },
+                        {
+                            "node_id": "#V#reading_group_meeting",
+                            "label": "Reading group meeting",
+                            "node_kind": "type",
+                        },
+                        {
+                            "node_id": "#V#sail_reading_group_meeting",
+                            "label": "SAIL reading group meeting",
+                            "node_kind": "type",
+                        },
+                    ],
+                    "edges": [
+                        {
+                            "edge_id": "hierarchy_edge_1",
+                            "parent_node_id": "#V#meeting",
+                            "child_node_id": "#V#reading_group_meeting",
+                            "predicate": "#V#is_a_type_of",
+                            "branch_kind": "type_hierarchy",
+                        },
+                        {
+                            "edge_id": "hierarchy_edge_2",
+                            "parent_node_id": "#V#reading_group_meeting",
+                            "child_node_id": "#V#sail_reading_group_meeting",
+                            "predicate": "#V#is_a_type_of",
+                            "branch_kind": "type_hierarchy",
+                        },
+                    ],
+                    "focus_node_id": "#V#sail_reading_group_meeting",
+                    "root_node_ids": ["#V#meeting"],
+                    "expansion": {
+                        "show_parents": True,
+                        "show_children": True,
+                        "show_siblings": True,
+                        "max_depth": 4,
+                    },
+                },
+            }
+        ],
+    )
+
+    hierarchy_elements = [
+        element
+        for element in contract["elements"]
+        if element["element_type"] == "hierarchy_view"
+    ]
+    assert len(hierarchy_elements) == 1
+    hierarchy_element = hierarchy_elements[0]
+    assert hierarchy_element["element_id"] == "screen_hierarchy_view"
+    assert hierarchy_element["payload"]["nodes"][0]["node_id"] == "#V#meeting"
+    assert (
+        hierarchy_element["payload"]["edges"][0]["parent_node_id"] == "#V#meeting"
+    )
+    assert "screen_structured_hierarchy_views_supplied" in contract["reason_codes"]
+    assert contract["validation"]["valid"] is True
+
+
+def test_build_turn_display_elements_drops_invalid_hierarchy_elements() -> None:
+    contract = build_turn_display_elements(
+        response_text="Hierarchy response",
+        presenter_channels={
+            "format": "tagged_blocks_v1",
+            "screen": "Hierarchy response",
+            "spoken": None,
+        },
+        screen_hierarchy_elements=[
+            {
+                "payload": {
+                    "nodes": [
+                        {
+                            "node_id": "#V#meeting",
+                            "label": "Meeting",
+                            "node_kind": "type",
+                        }
+                    ],
+                    "edges": [
+                        {
+                            "edge_id": "hierarchy_edge_1",
+                            "parent_node_id": "#V#meeting",
+                            "child_node_id": "#V#missing_node",
+                            "predicate": "#V#is_a_type_of",
+                        }
+                    ],
+                }
+            }
+        ],
+    )
+
+    hierarchy_elements = [
+        element
+        for element in contract["elements"]
+        if element["element_type"] == "hierarchy_view"
+    ]
+    assert hierarchy_elements == []
+    assert "screen_structured_hierarchy_views_invalid_dropped" in contract["reason_codes"]
+    assert contract["validation"]["valid"] is True
+
+
 def test_build_turn_display_elements_includes_supplied_relation_truth_state_elements() -> None:
     contract = build_turn_display_elements(
         response_text="Truth state summary",
@@ -1289,6 +1406,54 @@ def test_validate_turn_display_elements_rejects_invalid_relation_graph_shape() -
     assert any("target must reference a declared node" in message for message in errors)
     assert any("direction must be one of" in message for message in errors)
     assert any("focus_node_id must reference a declared node" in message for message in errors)
+
+
+def test_validate_turn_display_elements_rejects_invalid_hierarchy_shape() -> None:
+    valid, errors = validate_turn_display_elements(
+        {
+            "schema_version": "turn_display_elements_v1",
+            "elements": [
+                {
+                    "element_id": "screen_hierarchy_view",
+                    "element_type": "hierarchy_view",
+                    "channel": "screen",
+                    "order": 42,
+                    "intent": "hierarchy_view",
+                    "payload": {
+                        "nodes": [
+                            {
+                                "node_id": "#V#reading_group_meeting",
+                                "label": "Reading group meeting",
+                            }
+                        ],
+                        "edges": [
+                            {
+                                "edge_id": "hierarchy_edge_1",
+                                "parent_node_id": "#V#missing_parent",
+                                "child_node_id": "#V#reading_group_meeting",
+                                "predicate": "#V#is_a_type_of",
+                                "branch_kind": "unknown_branch",
+                            }
+                        ],
+                        "focus_node_id": "#V#missing_focus",
+                        "expansion": {
+                            "show_children": "yes",
+                            "max_depth": 999,
+                        },
+                    },
+                    "provenance": {"source": "test"},
+                }
+            ],
+            "reason_codes": [],
+        }
+    )
+
+    assert valid is False
+    assert any("parent_node_id must reference a declared node" in message for message in errors)
+    assert any("branch_kind must be one of" in message for message in errors)
+    assert any("focus_node_id must reference a declared node" in message for message in errors)
+    assert any("show_children must be a boolean" in message for message in errors)
+    assert any("max_depth must be an integer between 1 and 12" in message for message in errors)
 
 
 def test_validate_turn_display_elements_rejects_invalid_relation_truth_state_shape() -> None:
@@ -1706,6 +1871,33 @@ def test_build_turn_display_elements_preserves_optional_payload_titles() -> None
                 }
             }
         ],
+        screen_hierarchy_elements=[
+            {
+                "payload": {
+                    "title": "Meeting hierarchy",
+                    "nodes": [
+                        {
+                            "node_id": "#V#meeting",
+                            "label": "Meeting",
+                            "node_kind": "type",
+                        },
+                        {
+                            "node_id": "#V#reading_group_meeting",
+                            "label": "Reading group meeting",
+                            "node_kind": "type",
+                        },
+                    ],
+                    "edges": [
+                        {
+                            "edge_id": "hierarchy_edge_1",
+                            "parent_node_id": "#V#meeting",
+                            "child_node_id": "#V#reading_group_meeting",
+                            "predicate": "#V#is_a_type_of",
+                        }
+                    ],
+                }
+            }
+        ],
         screen_relation_graph_elements=[
             {
                 "payload": {
@@ -1746,6 +1938,7 @@ def test_build_turn_display_elements_preserves_optional_payload_titles() -> None
             "timeline",
             "calendar_view",
             "document_view",
+            "hierarchy_view",
             "relation_graph_view",
         }
     }
@@ -1757,6 +1950,7 @@ def test_build_turn_display_elements_preserves_optional_payload_titles() -> None
     assert payload_title_by_type["timeline"] == "Timeline of changes"
     assert payload_title_by_type["calendar_view"] == "Calendar schedule"
     assert payload_title_by_type["document_view"] == "Document excerpts"
+    assert payload_title_by_type["hierarchy_view"] == "Meeting hierarchy"
     assert payload_title_by_type["relation_graph_view"] == "Relation network"
     assert contract["validation"]["valid"] is True
 


### PR DESCRIPTION
## Summary
- add first-class hierarchy_view support to the turn display-elements contract
- wire hierarchy extraction through route/render-plan mapping and renderer family routing
- add a specialised hierarchy UI renderer with cartouched concepts and neighbourhood/tree exploration
- extend render-plan debug metadata summaries and CSS styling for hierarchy sections
- add backend + frontend regression coverage for hierarchy acceptance, validation, rendering, and metadata counts

## Validation
- pytest tests/backend/test_display_elements_service.py
- npx jest src/frontend/web/von_interface/static/js/test/chatTab.test.js --runInBand
- npx pyright src/backend/integrations/internal_mcp/orchestrator.py src/backend/server/routes/von_routes.py src/backend/services/display_elements_service.py tests/backend/test_display_elements_service.py
- npx eslint src/frontend/web/von_interface/static/js/chatTab.js src/frontend/web/von_interface/static/js/test/chatTab.test.js