### PR TITLE
JVNAUTOSCI-1321: polish cartouche kind-marker edge alignment

### DIFF
--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -7527,7 +7527,8 @@ button.prompt-vontology-cartouche {
     display: inline-block;
     font-size: 0.8em;
     padding: 1px 6px;
-    border-radius: 999px;
+    border-radius: 8px;
+    margin-right: -3px;
     border: 1px solid transparent;
 }
 


### PR DESCRIPTION
## Summary
- reduce cartouche kind-marker end radius so it is visually subordinate to cartouche ends
- move kind markers closer to the cartouche right edge without changing label-to-marker spacing

## Changes
- update \\.vontology-cartouche-kind in src/frontend/web/von_interface/static/styles.css
  - border-radius: 999px -> 8px
  - add margin-right: -3px

## Validation
- no Python files changed for this task
- manual UI polish change only (CSS)

## Jira
- JVNAUTOSCI-1321