### PR TITLE
JVNAUTOSCI-1178: add location_view renderer pipeline and map fallback

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -17811,6 +17811,271 @@ class InternalMCPChatOrchestrator:
                 }
             ]
 
+        def _extract_renderer_screen_location_elements(
+            *,
+            tool_messages: Sequence[Mapping[str, Any]] = (),
+        ) -> list[dict[str, Any]]:
+            """Derive location-view payloads from tool outputs with map fallback metadata."""
+
+            max_points = 200
+            latitude_min = -90.0
+            latitude_max = 90.0
+            longitude_min = -180.0
+            longitude_max = 180.0
+
+            source_tools: list[str] = []
+            seen_source_tools: set[str] = set()
+            points: list[dict[str, Any]] = []
+            seen_point_ids: set[str] = set()
+
+            def _register_source_tool(tool_name: str) -> None:
+                if tool_name in seen_source_tools:
+                    return
+                seen_source_tools.add(tool_name)
+                source_tools.append(tool_name)
+
+            def _normalise_number(value: Any) -> float | None:
+                if isinstance(value, bool):
+                    return None
+                if isinstance(value, (int, float)):
+                    number = float(value)
+                elif isinstance(value, str):
+                    cleaned = value.strip()
+                    if not cleaned:
+                        return None
+                    try:
+                        number = float(cleaned)
+                    except ValueError:
+                        return None
+                else:
+                    return None
+                if number != number or number in (float("inf"), float("-inf")):
+                    return None
+                return number
+
+            def _extract_lat_lon(row: Mapping[str, Any]) -> tuple[float, float] | None:
+                candidate_pairs: list[tuple[Any, Any]] = [
+                    (row.get("latitude"), row.get("longitude")),
+                    (row.get("lat"), row.get("lon")),
+                    (row.get("lat"), row.get("lng")),
+                    (row.get("lat"), row.get("long")),
+                    (row.get("y"), row.get("x")),
+                ]
+
+                for nested_key in ("location", "geo", "geolocation", "coordinates", "coord", "position"):
+                    nested = row.get(nested_key)
+                    if isinstance(nested, Mapping):
+                        candidate_pairs.extend(
+                            [
+                                (nested.get("latitude"), nested.get("longitude")),
+                                (nested.get("lat"), nested.get("lon")),
+                                (nested.get("lat"), nested.get("lng")),
+                                (nested.get("lat"), nested.get("long")),
+                            ]
+                        )
+
+                for raw_lat, raw_lon in candidate_pairs:
+                    latitude = _normalise_number(raw_lat)
+                    longitude = _normalise_number(raw_lon)
+                    if latitude is None or longitude is None:
+                        continue
+                    if latitude < latitude_min or latitude > latitude_max:
+                        continue
+                    if longitude < longitude_min or longitude > longitude_max:
+                        continue
+                    return (round(latitude, 6), round(longitude, 6))
+                return None
+
+            def _extract_address_text(value: Any) -> str | None:
+                if isinstance(value, str):
+                    cleaned = value.strip()
+                    return cleaned or None
+                if isinstance(value, Mapping):
+                    parts = [
+                        _first_text(
+                            value.get("line1"),
+                            value.get("address_line_1"),
+                            value.get("street"),
+                        ),
+                        _first_text(value.get("line2"), value.get("address_line_2")),
+                        _first_text(value.get("city"), value.get("suburb"), value.get("town")),
+                        _first_text(value.get("state"), value.get("region")),
+                        _first_text(value.get("postcode"), value.get("postal_code"), value.get("zip")),
+                        _first_text(value.get("country")),
+                    ]
+                    joined = ", ".join(part for part in parts if isinstance(part, str) and part)
+                    return joined or None
+                return None
+
+            def _extract_address(row: Mapping[str, Any]) -> str | None:
+                direct_fields = (
+                    row.get("address"),
+                    row.get("formatted_address"),
+                    row.get("location_name"),
+                    row.get("venue"),
+                    row.get("place"),
+                )
+                for field in direct_fields:
+                    address = _extract_address_text(field)
+                    if address:
+                        return address
+
+                for nested_key in ("location", "geo", "details"):
+                    nested = row.get(nested_key)
+                    if not isinstance(nested, Mapping):
+                        continue
+                    for nested_field in (
+                        nested.get("address"),
+                        nested.get("formatted_address"),
+                        nested.get("location_name"),
+                        nested.get("venue"),
+                        nested.get("place"),
+                    ):
+                        address = _extract_address_text(nested_field)
+                        if address:
+                            return address
+                return None
+
+            def _iter_candidate_rows(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+                rows: list[Mapping[str, Any]] = []
+                for key in ("locations", "results", "tasks", "items", "records"):
+                    rows.extend(_mapping_list(payload.get(key), limit=max_points * 3))
+
+                contains_location_fields = any(
+                    key in payload
+                    for key in (
+                        "latitude",
+                        "longitude",
+                        "lat",
+                        "lon",
+                        "lng",
+                        "long",
+                        "address",
+                        "formatted_address",
+                        "location",
+                        "coordinates",
+                    )
+                )
+                if contains_location_fields:
+                    rows.append(payload)
+                return rows[: max_points * 4]
+
+            for tool_name, payload in _iter_renderer_tool_result_payloads(tool_messages):
+                candidate_rows = _iter_candidate_rows(payload)
+                if not candidate_rows:
+                    continue
+                _register_source_tool(tool_name)
+
+                for row_index, row in enumerate(candidate_rows, start=1):
+                    if len(points) >= max_points:
+                        break
+
+                    lat_lon = _extract_lat_lon(row)
+                    address = _extract_address(row)
+                    if lat_lon is None and not address:
+                        continue
+
+                    point_id = _first_text(
+                        row.get("point_id"),
+                        row.get("location_id"),
+                        row.get("id"),
+                        row.get("task_concept_id"),
+                        row.get("task_id"),
+                        row.get("concept_id"),
+                    ) or f"{tool_name}_location_{row_index}"
+
+                    if point_id in seen_point_ids:
+                        continue
+                    seen_point_ids.add(point_id)
+
+                    label = _first_text(
+                        row.get("label"),
+                        row.get("title"),
+                        row.get("name"),
+                        row.get("task_title"),
+                        row.get("location_name"),
+                        row.get("venue"),
+                        row.get("place"),
+                    ) or point_id
+
+                    point: dict[str, Any] = {
+                        "point_id": point_id,
+                        "label": label,
+                    }
+                    if lat_lon is not None:
+                        point["latitude"] = lat_lon[0]
+                        point["longitude"] = lat_lon[1]
+                    if address:
+                        point["address"] = address
+
+                    description = _first_text(
+                        row.get("description"),
+                        row.get("summary"),
+                        row.get("details"),
+                        row.get("comment"),
+                        row.get("message"),
+                    )
+                    if description:
+                        point["description"] = description
+
+                    confidence = _normalise_number(
+                        row.get("confidence") if row.get("confidence") is not None else row.get("score")
+                    )
+                    if confidence is not None and 0.0 <= confidence <= 1.0:
+                        point["confidence"] = round(confidence, 4)
+
+                    task_links = _collect_renderer_task_links(row)
+                    if task_links:
+                        point["task_links"] = task_links
+
+                    points.append(point)
+                if len(points) >= max_points:
+                    break
+
+            if not points:
+                return []
+
+            location_payload: dict[str, Any] = {
+                "points": points[:max_points],
+                "map_provider_hint": "openstreetmap_fallback",
+            }
+
+            coordinates: list[tuple[float, float]] = []
+            for point in points:
+                raw_latitude = point.get("latitude")
+                raw_longitude = point.get("longitude")
+                if not isinstance(raw_latitude, (int, float)) or not isinstance(
+                    raw_longitude, (int, float)
+                ):
+                    continue
+                coordinates.append((float(raw_latitude), float(raw_longitude)))
+            if coordinates:
+                centre_lat = sum(lat for lat, _ in coordinates) / len(coordinates)
+                centre_lon = sum(lon for _, lon in coordinates) / len(coordinates)
+                location_payload["viewport"] = {
+                    "centre_lat": round(centre_lat, 6),
+                    "centre_lon": round(centre_lon, 6),
+                    "zoom": 12 if len(coordinates) == 1 else (9 if len(coordinates) <= 3 else 6),
+                }
+
+            return [
+                {
+                    "element_id": "screen_location_view",
+                    "intent": "structured_location_view",
+                    "payload": location_payload,
+                    "constraints": {
+                        "supports_geospatial_plot": True,
+                        "supports_address_fallback": True,
+                        "supports_external_map_links": True,
+                    },
+                    "provenance": {
+                        "source": "tool_result_location_view",
+                        "source_tools": source_tools,
+                        "record_family": "location_points",
+                    },
+                }
+            ]
+
         def _extract_renderer_screen_document_elements(
             *,
             tool_messages: Sequence[Mapping[str, Any]] = (),
@@ -18925,10 +19190,14 @@ class InternalMCPChatOrchestrator:
             "citation": ("document_view",),
             "document": ("document_view",),
             "document_view": ("document_view",),
+            "geo": ("location_view",),
             "hierarchy": ("hierarchy_view",),
             "hierarchy_view": ("hierarchy_view",),
             "kanban": ("kanban_view",),
             "kanban_view": ("kanban_view",),
+            "location": ("location_view",),
+            "location_view": ("location_view",),
+            "map": ("location_view",),
             "graph": ("relation_graph_view",),
             "relation_graph": ("relation_graph_view",),
             "relation_graph_view": ("relation_graph_view",),
@@ -19007,6 +19276,7 @@ class InternalMCPChatOrchestrator:
             include_workflow_elements = "workflow_view" in selected_families
             include_task_view_elements = "task_view" in selected_families
             include_calendar_elements = "calendar_view" in selected_families
+            include_location_elements = "location_view" in selected_families
             include_document_elements = "document_view" in selected_families
             include_kanban_elements = "kanban_view" in selected_families
             include_timeline_elements = "timeline" in selected_families
@@ -19020,6 +19290,7 @@ class InternalMCPChatOrchestrator:
                 "workflow_view": include_workflow_elements,
                 "task_view": include_task_view_elements,
                 "calendar_view": include_calendar_elements,
+                "location_view": include_location_elements,
                 "document_view": include_document_elements,
                 "kanban_view": include_kanban_elements,
                 "timeline": include_timeline_elements,
@@ -19071,6 +19342,16 @@ class InternalMCPChatOrchestrator:
                     decision["screen_calendar_elements"] = screen_calendar_elements
                     decision["screen_calendar_element_count"] = len(
                         screen_calendar_elements
+                    )
+
+            if include_location_elements:
+                screen_location_elements = _extract_renderer_screen_location_elements(
+                    tool_messages=tool_messages
+                )
+                if screen_location_elements:
+                    decision["screen_location_elements"] = screen_location_elements
+                    decision["screen_location_element_count"] = len(
+                        screen_location_elements
                     )
 
             if include_document_elements:

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -2909,6 +2909,39 @@ def _extract_screen_document_elements_from_render_plan(
     return document_elements
 
 
+def _extract_screen_location_elements_from_render_plan(
+    render_plan: dict[str, Any] | None,
+    *,
+    screen_element_targets: dict[str, bool] | None = None,
+) -> list[dict[str, Any]]:
+    """Extract display-contract location_view specs from renderer plan diagnostics."""
+    if not isinstance(render_plan, dict):
+        return []
+    if isinstance(screen_element_targets, dict) and not bool(
+        screen_element_targets.get("location_view", True)
+    ):
+        return []
+
+    location_elements: list[dict[str, Any]] = []
+
+    def _append_location_specs(raw_value: Any) -> None:
+        if isinstance(raw_value, list):
+            for item in raw_value:
+                if isinstance(item, dict):
+                    location_elements.append(dict(item))
+        elif isinstance(raw_value, dict):
+            location_elements.append(dict(raw_value))
+
+    _append_location_specs(render_plan.get("screen_location_elements"))
+    _append_location_specs(render_plan.get("screen_location_payloads"))
+
+    single_location = render_plan.get("screen_location_element")
+    if isinstance(single_location, dict):
+        location_elements.append(dict(single_location))
+
+    return location_elements
+
+
 def _extract_screen_kanban_elements_from_render_plan(
     render_plan: dict[str, Any] | None,
     *,
@@ -3087,6 +3120,7 @@ def _extract_screen_element_targets_from_render_plan(
         "workflow_view": True,
         "task_view": True,
         "calendar_view": True,
+        "location_view": True,
         "document_view": True,
         "kanban_view": True,
         "timeline": True,
@@ -3106,6 +3140,7 @@ def _extract_screen_element_targets_from_render_plan(
         "workflow_view": bool(raw_targets.get("workflow_view", True)),
         "task_view": bool(raw_targets.get("task_view", True)),
         "calendar_view": bool(raw_targets.get("calendar_view", True)),
+        "location_view": bool(raw_targets.get("location_view", True)),
         "document_view": bool(raw_targets.get("document_view", True)),
         "kanban_view": bool(raw_targets.get("kanban_view", True)),
         "timeline": bool(raw_targets.get("timeline", True)),
@@ -6949,6 +6984,10 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             render_plan_for_display,
             screen_element_targets=screen_element_targets,
         )
+        screen_location_elements = _extract_screen_location_elements_from_render_plan(
+            render_plan_for_display,
+            screen_element_targets=screen_element_targets,
+        )
         screen_document_elements = _extract_screen_document_elements_from_render_plan(
             render_plan_for_display,
             screen_element_targets=screen_element_targets,
@@ -6986,6 +7025,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             screen_workflow_elements=screen_workflow_elements,
             screen_task_view_elements=screen_task_view_elements,
             screen_calendar_elements=screen_calendar_elements,
+            screen_location_elements=screen_location_elements,
             screen_document_elements=screen_document_elements,
             screen_kanban_elements=screen_kanban_elements,
             screen_timeline_elements=screen_timeline_elements,

--- a/src/backend/services/display_elements_service.py
+++ b/src/backend/services/display_elements_service.py
@@ -6,6 +6,7 @@ display elements so rendering decisions are explicit and inspectable.
 
 from __future__ import annotations
 
+import math
 from typing import Any, Mapping, Sequence
 import re
 
@@ -18,6 +19,7 @@ ALLOWED_DISPLAY_ELEMENT_TYPES = frozenset(
         "calendar_view",
         "document_view",
         "hierarchy_view",
+        "location_view",
         "text_block",
         "json_block",
         "kanban_view",
@@ -34,6 +36,7 @@ OPTIONAL_PAYLOAD_TITLE_ELEMENT_TYPES = frozenset(
         "calendar_view",
         "document_view",
         "hierarchy_view",
+        "location_view",
         "kanban_view",
         "relation_graph_view",
         "table",
@@ -55,6 +58,13 @@ HIERARCHY_EDGE_BRANCH_KINDS = frozenset(
 )
 HIERARCHY_MAX_DEPTH = 12
 CALENDAR_ALLOWED_GRANULARITIES = frozenset({"month", "week", "day"})
+LOCATION_MAX_POINTS = 240
+LOCATION_LATITUDE_MIN = -90.0
+LOCATION_LATITUDE_MAX = 90.0
+LOCATION_LONGITUDE_MIN = -180.0
+LOCATION_LONGITUDE_MAX = 180.0
+LOCATION_VIEWPORT_MIN_ZOOM = 1
+LOCATION_VIEWPORT_MAX_ZOOM = 20
 DOCUMENT_SECTION_EXCERPT_MAX_CHARS = 700
 DOCUMENT_SECTION_DIFF_SUMMARY_MAX_CHARS = 280
 DOCUMENT_EXCERPT_TRUNCATION_MARKER = " ... [truncated]"
@@ -93,6 +103,26 @@ def _normalise_relation_extent_column_token(value: object) -> str:
     if not text:
         return ""
     return re.sub(r"[^a-z0-9]+", "", text.lower())
+
+
+def _normalise_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+    elif isinstance(value, str):
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        try:
+            number = float(cleaned)
+        except ValueError:
+            return None
+    else:
+        return None
+    if not math.isfinite(number):
+        return None
+    return number
 
 
 def _resolve_optional_payload_title(
@@ -1225,6 +1255,163 @@ def validate_turn_display_elements(
                             errors.append(
                                 f"{label}.payload.expansion.max_depth must be an integer between 1 and {HIERARCHY_MAX_DEPTH} when provided"
                             )
+        elif element_type == "location_view":
+            points = payload.get("points")
+            if not isinstance(points, list) or not points:
+                errors.append(f"{label}.payload.points must be a non-empty list")
+                points = []
+            if isinstance(points, list) and len(points) > LOCATION_MAX_POINTS:
+                errors.append(
+                    f"{label}.payload.points exceeds max size {LOCATION_MAX_POINTS}"
+                )
+
+            seen_point_ids: set[str] = set()
+            for point_index, point in enumerate(points):
+                point_label = f"{label}.payload.points[{point_index}]"
+                if not isinstance(point, Mapping):
+                    errors.append(f"{point_label} must be a mapping")
+                    continue
+
+                point_id = point.get("point_id")
+                if not isinstance(point_id, str) or not point_id.strip():
+                    errors.append(f"{point_label}.point_id must be a non-empty string")
+                elif point_id in seen_point_ids:
+                    errors.append(f"{point_label}.point_id must be unique")
+                else:
+                    seen_point_ids.add(point_id)
+
+                display_label = point.get("label")
+                if not isinstance(display_label, str) or not display_label.strip():
+                    errors.append(f"{point_label}.label must be a non-empty string")
+
+                latitude = _normalise_float(point.get("latitude"))
+                longitude = _normalise_float(point.get("longitude"))
+                has_coordinates = latitude is not None and longitude is not None
+                has_partial_coordinates = (latitude is None) != (longitude is None)
+                if has_partial_coordinates:
+                    errors.append(
+                        f"{point_label} must provide both latitude and longitude when either coordinate is present"
+                    )
+                if latitude is not None and (
+                    latitude < LOCATION_LATITUDE_MIN
+                    or latitude > LOCATION_LATITUDE_MAX
+                ):
+                    errors.append(
+                        f"{point_label}.latitude must be between {LOCATION_LATITUDE_MIN:g} and {LOCATION_LATITUDE_MAX:g}"
+                    )
+                if longitude is not None and (
+                    longitude < LOCATION_LONGITUDE_MIN
+                    or longitude > LOCATION_LONGITUDE_MAX
+                ):
+                    errors.append(
+                        f"{point_label}.longitude must be between {LOCATION_LONGITUDE_MIN:g} and {LOCATION_LONGITUDE_MAX:g}"
+                    )
+
+                address = point.get("address")
+                has_address = isinstance(address, str) and bool(address.strip())
+                if address is not None and not has_address:
+                    errors.append(
+                        f"{point_label}.address must be a non-empty string when provided"
+                    )
+                if not has_coordinates and not has_address:
+                    errors.append(
+                        f"{point_label} must provide at least one spatial anchor (coordinates or address)"
+                    )
+
+                description = point.get("description")
+                if description is not None and (
+                    not isinstance(description, str) or not description.strip()
+                ):
+                    errors.append(
+                        f"{point_label}.description must be a non-empty string when provided"
+                    )
+
+                confidence = point.get("confidence")
+                if confidence is not None:
+                    confidence_value = _normalise_float(confidence)
+                    if confidence_value is None:
+                        errors.append(
+                            f"{point_label}.confidence must be numeric when provided"
+                        )
+                    elif confidence_value < 0.0 or confidence_value > 1.0:
+                        errors.append(
+                            f"{point_label}.confidence must be between 0 and 1 when provided"
+                        )
+
+                _validate_task_links(
+                    links=point.get("task_links"),
+                    label=f"{point_label}.task_links",
+                    errors=errors,
+                )
+
+            viewport = payload.get("viewport")
+            if viewport is not None:
+                if not isinstance(viewport, Mapping):
+                    errors.append(f"{label}.payload.viewport must be a mapping")
+                else:
+                    centre_lat_raw = (
+                        viewport.get("centre_lat")
+                        if "centre_lat" in viewport
+                        else viewport.get("center_lat")
+                    )
+                    centre_lon_raw = (
+                        viewport.get("centre_lon")
+                        if "centre_lon" in viewport
+                        else viewport.get("center_lon")
+                    )
+                    centre_lat = _normalise_float(centre_lat_raw)
+                    centre_lon = _normalise_float(centre_lon_raw)
+                    has_centre_lat = centre_lat_raw is not None
+                    has_centre_lon = centre_lon_raw is not None
+                    has_partial_centre = has_centre_lat != has_centre_lon
+                    if has_partial_centre:
+                        errors.append(
+                            f"{label}.payload.viewport must provide both centre_lat and centre_lon when either is present"
+                        )
+                    if has_centre_lat and centre_lat is None:
+                        errors.append(
+                            f"{label}.payload.viewport.centre_lat must be numeric when provided"
+                        )
+                    if has_centre_lon and centre_lon is None:
+                        errors.append(
+                            f"{label}.payload.viewport.centre_lon must be numeric when provided"
+                        )
+                    if centre_lat is not None and (
+                        centre_lat < LOCATION_LATITUDE_MIN
+                        or centre_lat > LOCATION_LATITUDE_MAX
+                    ):
+                        errors.append(
+                            f"{label}.payload.viewport.centre_lat must be between {LOCATION_LATITUDE_MIN:g} and {LOCATION_LATITUDE_MAX:g} when provided"
+                        )
+                    if centre_lon is not None and (
+                        centre_lon < LOCATION_LONGITUDE_MIN
+                        or centre_lon > LOCATION_LONGITUDE_MAX
+                    ):
+                        errors.append(
+                            f"{label}.payload.viewport.centre_lon must be between {LOCATION_LONGITUDE_MIN:g} and {LOCATION_LONGITUDE_MAX:g} when provided"
+                        )
+
+                    zoom = viewport.get("zoom")
+                    if zoom is not None:
+                        if isinstance(zoom, bool) or not isinstance(zoom, int):
+                            errors.append(
+                                f"{label}.payload.viewport.zoom must be an integer between {LOCATION_VIEWPORT_MIN_ZOOM} and {LOCATION_VIEWPORT_MAX_ZOOM} when provided"
+                            )
+                        elif (
+                            zoom < LOCATION_VIEWPORT_MIN_ZOOM
+                            or zoom > LOCATION_VIEWPORT_MAX_ZOOM
+                        ):
+                            errors.append(
+                                f"{label}.payload.viewport.zoom must be an integer between {LOCATION_VIEWPORT_MIN_ZOOM} and {LOCATION_VIEWPORT_MAX_ZOOM} when provided"
+                            )
+
+            map_provider_hint = payload.get("map_provider_hint")
+            if map_provider_hint is not None and (
+                not isinstance(map_provider_hint, str) or not map_provider_hint.strip()
+            ):
+                errors.append(
+                    f"{label}.payload.map_provider_hint must be a non-empty string when provided"
+                )
         elif element_type == "timeline":
             items = payload.get("items")
             if not isinstance(items, list) or not items:
@@ -2066,6 +2253,90 @@ def _normalise_supplied_screen_calendar_views(
     return normalised, dropped_count
 
 
+def _normalise_supplied_screen_location_views(
+    screen_location_elements: Sequence[Mapping[str, Any]] | None,
+) -> tuple[list[dict[str, Any]], int]:
+    """Normalise externally supplied screen location-view specs."""
+    if (
+        not isinstance(screen_location_elements, Sequence)
+        or isinstance(screen_location_elements, (str, bytes, bytearray))
+    ):
+        return [], 0
+
+    normalised: list[dict[str, Any]] = []
+    dropped_count = 0
+
+    for index, raw_spec in enumerate(screen_location_elements, start=1):
+        if not isinstance(raw_spec, Mapping):
+            dropped_count += 1
+            continue
+
+        payload: Mapping[str, Any] | None = None
+        metadata = raw_spec
+        wrapped_payload = raw_spec.get("payload")
+        if isinstance(wrapped_payload, Mapping):
+            payload = wrapped_payload
+        elif "points" in raw_spec:
+            payload = raw_spec
+
+        if not isinstance(payload, Mapping):
+            dropped_count += 1
+            continue
+
+        intent = (
+            _normalise_text(metadata.get("intent"))
+            or "structured_location_view"
+        )
+        constraints = metadata.get("constraints")
+        if not isinstance(constraints, Mapping):
+            constraints = {
+                "supports_geospatial_plot": True,
+                "supports_address_fallback": True,
+                "supports_external_map_links": True,
+            }
+        provenance = metadata.get("provenance")
+        if not isinstance(provenance, Mapping):
+            provenance = {}
+        canonical_payload = _with_optional_payload_title(payload, metadata=metadata)
+
+        is_valid, _errors = validate_turn_display_elements(
+            {
+                "schema_version": DISPLAY_ELEMENT_SCHEMA_VERSION,
+                "elements": [
+                    {
+                        "element_id": f"screen_structured_location_view_probe_{index}",
+                        "element_type": "location_view",
+                        "channel": "screen",
+                        "order": 39,
+                        "intent": intent,
+                        "payload": dict(canonical_payload),
+                        "constraints": dict(constraints),
+                        "provenance": dict(provenance),
+                    }
+                ],
+                "reason_codes": [],
+            }
+        )
+        if not is_valid:
+            dropped_count += 1
+            continue
+
+        normalised.append(
+            {
+                "element_id": _normalise_text(metadata.get("element_id")),
+                "order": metadata.get("order")
+                if isinstance(metadata.get("order"), int)
+                else None,
+                "intent": intent,
+                "payload": dict(canonical_payload),
+                "constraints": dict(constraints),
+                "provenance": dict(provenance),
+            }
+        )
+
+    return normalised, dropped_count
+
+
 def _normalise_supplied_screen_document_views(
     screen_document_elements: Sequence[Mapping[str, Any]] | None,
 ) -> tuple[list[dict[str, Any]], int]:
@@ -2699,6 +2970,7 @@ def build_turn_display_elements(
     screen_workflow_elements: Sequence[Mapping[str, Any]] | None = None,
     screen_task_view_elements: Sequence[Mapping[str, Any]] | None = None,
     screen_calendar_elements: Sequence[Mapping[str, Any]] | None = None,
+    screen_location_elements: Sequence[Mapping[str, Any]] | None = None,
     screen_document_elements: Sequence[Mapping[str, Any]] | None = None,
     screen_kanban_elements: Sequence[Mapping[str, Any]] | None = None,
     screen_timeline_elements: Sequence[Mapping[str, Any]] | None = None,
@@ -2857,6 +3129,14 @@ def build_turn_display_elements(
         reason_codes.append("screen_structured_calendar_views_supplied")
     if supplied_calendar_views_dropped:
         reason_codes.append("screen_structured_calendar_views_invalid_dropped")
+
+    supplied_screen_location_views, supplied_location_views_dropped = (
+        _normalise_supplied_screen_location_views(screen_location_elements)
+    )
+    if supplied_screen_location_views:
+        reason_codes.append("screen_structured_location_views_supplied")
+    if supplied_location_views_dropped:
+        reason_codes.append("screen_structured_location_views_invalid_dropped")
 
     supplied_screen_document_views, supplied_document_views_dropped = (
         _normalise_supplied_screen_document_views(screen_document_elements)
@@ -3017,6 +3297,28 @@ def build_turn_display_elements(
             }
         )
 
+    location_specs: list[dict[str, Any]] = []
+    for index, spec in enumerate(supplied_screen_location_views, start=1):
+        provenance = dict(spec.get("provenance") or {})
+        provenance.setdefault("source", "screen_structured_location_view")
+        provenance.setdefault("location_view_index", index)
+        location_specs.append(
+            {
+                "element_id": spec.get("element_id")
+                or f"screen_structured_location_view_{index}",
+                "order": spec.get("order"),
+                "intent": spec.get("intent") or "structured_location_view",
+                "payload": spec.get("payload") or {},
+                "constraints": spec.get("constraints")
+                or {
+                    "supports_geospatial_plot": True,
+                    "supports_address_fallback": True,
+                    "supports_external_map_links": True,
+                },
+                "provenance": provenance,
+            }
+        )
+
     document_specs: list[dict[str, Any]] = []
     for index, spec in enumerate(supplied_screen_document_views, start=1):
         provenance = dict(spec.get("provenance") or {})
@@ -3152,6 +3454,7 @@ def build_turn_display_elements(
             *workflow_specs,
             *task_view_specs,
             *calendar_specs,
+            *location_specs,
             *document_specs,
             *kanban_specs,
             *timeline_specs,
@@ -3224,6 +3527,30 @@ def build_turn_display_elements(
             {
                 "element_id": element_id,
                 "element_type": "calendar_view",
+                "channel": "screen",
+                "order": int(order),
+                "intent": str(spec["intent"]),
+                "payload": dict(spec["payload"]),
+                "constraints": dict(spec["constraints"]),
+                "provenance": dict(spec["provenance"]),
+            }
+        )
+
+    next_location_order = 39
+    for spec in location_specs:
+        order = spec.get("order") if isinstance(spec.get("order"), int) else None
+        if order is None:
+            while next_location_order in used_orders:
+                next_location_order += 1
+            order = next_location_order
+            used_orders.add(order)
+            next_location_order += 1
+
+        element_id = _next_unique_element_id(str(spec["element_id"]), used_ids)
+        elements.append(
+            {
+                "element_id": element_id,
+                "element_type": "location_view",
                 "channel": "screen",
                 "order": int(order),
                 "intent": str(spec["intent"]),

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -2203,6 +2203,13 @@ const KANBAN_MAX_COLUMNS = 30;
 const KANBAN_MAX_CARDS = 200;
 const TIMELINE_MAX_ITEMS = 200;
 const CALENDAR_MAX_ITEMS = 240;
+const LOCATION_MAX_POINTS = 200;
+const LOCATION_LATITUDE_MIN = -90;
+const LOCATION_LATITUDE_MAX = 90;
+const LOCATION_LONGITUDE_MIN = -180;
+const LOCATION_LONGITUDE_MAX = 180;
+const LOCATION_VIEWPORT_MIN_ZOOM = 1;
+const LOCATION_VIEWPORT_MAX_ZOOM = 20;
 const DOCUMENT_MAX_DOCUMENTS = 12;
 const DOCUMENT_MAX_SECTIONS_PER_DOCUMENT = 12;
 const DOCUMENT_SECTION_EXCERPT_MAX_CHARS = 700;
@@ -3317,6 +3324,205 @@ function resolveCalendarDisplayElements(debugData) {
         calendarViews.push(calendarElement);
     }
     return calendarViews;
+}
+
+function normaliseLocationCoordinate(value, minValue, maxValue) {
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) {
+            return null;
+        }
+        if (value < minValue || value > maxValue) {
+            return null;
+        }
+        return value;
+    }
+    if (typeof value === 'string') {
+        const cleaned = value.trim();
+        if (!cleaned) {
+            return null;
+        }
+        const parsed = Number(cleaned);
+        if (!Number.isFinite(parsed)) {
+            return null;
+        }
+        if (parsed < minValue || parsed > maxValue) {
+            return null;
+        }
+        return parsed;
+    }
+    return null;
+}
+
+function formatLocationCoordinate(value) {
+    if (!Number.isFinite(value)) {
+        return '';
+    }
+    return Number(value).toFixed(5);
+}
+
+function buildExternalLocationMapHref(point) {
+    if (!point || typeof point !== 'object') {
+        return '';
+    }
+    const latitude = Number(point.latitude);
+    const longitude = Number(point.longitude);
+    if (Number.isFinite(latitude) && Number.isFinite(longitude)) {
+        const zoom = Number.isInteger(point.zoom) ? point.zoom : 13;
+        return `https://www.openstreetmap.org/?mlat=${encodeURIComponent(String(latitude))}&mlon=${encodeURIComponent(String(longitude))}#map=${encodeURIComponent(String(zoom))}/${encodeURIComponent(String(latitude))}/${encodeURIComponent(String(longitude))}`;
+    }
+    const address = typeof point.address === 'string' ? point.address.trim() : '';
+    if (address) {
+        return `https://www.openstreetmap.org/search?query=${encodeURIComponent(address)}`;
+    }
+    return '';
+}
+
+function normaliseLocationDisplayElement(element) {
+    if (!element || typeof element !== 'object') {
+        return null;
+    }
+    if (String(element.element_type || '').trim() !== 'location_view') {
+        return null;
+    }
+
+    const payload = element.payload;
+    if (!payload || typeof payload !== 'object') {
+        return null;
+    }
+
+    const rawPoints = Array.isArray(payload.points) ? payload.points : [];
+    const points = [];
+    const seenPointIds = new Set();
+    for (let index = 0; index < rawPoints.length; index += 1) {
+        const point = rawPoints[index];
+        if (!point || typeof point !== 'object') {
+            continue;
+        }
+        const pointIdRaw = typeof point.point_id === 'string' && point.point_id.trim()
+            ? point.point_id.trim()
+            : `location_point_${index + 1}`;
+        if (seenPointIds.has(pointIdRaw)) {
+            continue;
+        }
+
+        const label = typeof point.label === 'string' && point.label.trim()
+            ? point.label.trim()
+            : pointIdRaw;
+
+        const latitude = normaliseLocationCoordinate(
+            point.latitude,
+            LOCATION_LATITUDE_MIN,
+            LOCATION_LATITUDE_MAX
+        );
+        const longitude = normaliseLocationCoordinate(
+            point.longitude,
+            LOCATION_LONGITUDE_MIN,
+            LOCATION_LONGITUDE_MAX
+        );
+        const hasCoordinates = latitude !== null && longitude !== null;
+        if ((latitude === null) !== (longitude === null)) {
+            continue;
+        }
+
+        const address = typeof point.address === 'string' && point.address.trim()
+            ? point.address.trim()
+            : '';
+        if (!hasCoordinates && !address) {
+            continue;
+        }
+
+        const description = typeof point.description === 'string' && point.description.trim()
+            ? point.description.trim()
+            : '';
+        const confidenceRaw = Number(point.confidence);
+        const confidence = Number.isFinite(confidenceRaw) && confidenceRaw >= 0 && confidenceRaw <= 1
+            ? confidenceRaw
+            : null;
+        const rawTaskLinks = Array.isArray(point.task_links) ? point.task_links : [];
+        const taskLinks = rawTaskLinks
+            .map((link) => normaliseWorkflowTaskLink(link))
+            .filter(Boolean);
+
+        const normalisedPoint = {
+            point_id: pointIdRaw,
+            label,
+            latitude,
+            longitude,
+            address,
+            description,
+            confidence,
+            task_links: taskLinks
+        };
+        normalisedPoint.map_href = buildExternalLocationMapHref(normalisedPoint);
+        seenPointIds.add(pointIdRaw);
+        points.push(normalisedPoint);
+        if (points.length >= LOCATION_MAX_POINTS) {
+            break;
+        }
+    }
+
+    if (!points.length) {
+        return null;
+    }
+
+    const rawViewport = payload.viewport && typeof payload.viewport === 'object'
+        ? payload.viewport
+        : null;
+    let viewport = null;
+    if (rawViewport) {
+        const centreLat = normaliseLocationCoordinate(
+            rawViewport.centre_lat ?? rawViewport.center_lat,
+            LOCATION_LATITUDE_MIN,
+            LOCATION_LATITUDE_MAX
+        );
+        const centreLon = normaliseLocationCoordinate(
+            rawViewport.centre_lon ?? rawViewport.center_lon,
+            LOCATION_LONGITUDE_MIN,
+            LOCATION_LONGITUDE_MAX
+        );
+        const zoomRaw = Number(rawViewport.zoom);
+        const zoom = Number.isInteger(zoomRaw)
+            && zoomRaw >= LOCATION_VIEWPORT_MIN_ZOOM
+            && zoomRaw <= LOCATION_VIEWPORT_MAX_ZOOM
+            ? zoomRaw
+            : null;
+        if (centreLat !== null && centreLon !== null) {
+            viewport = {
+                centre_lat: centreLat,
+                centre_lon: centreLon,
+                zoom: zoom ?? 12
+            };
+        }
+    }
+
+    const mapProviderHint = typeof payload.map_provider_hint === 'string' && payload.map_provider_hint.trim()
+        ? payload.map_provider_hint.trim()
+        : '';
+
+    return {
+        element_id: typeof element.element_id === 'string' ? element.element_id.trim() : null,
+        title: normaliseOptionalDisplayElementTitle(payload.title),
+        map_provider_hint: mapProviderHint,
+        viewport,
+        points
+    };
+}
+
+function resolveLocationDisplayElements(debugData) {
+    const contract = normaliseDisplayElementsContract(debugData?.display_elements);
+    if (!contract) {
+        return [];
+    }
+
+    const locationViews = [];
+    for (const element of contract.elements) {
+        const locationElement = normaliseLocationDisplayElement(element);
+        if (!locationElement) {
+            continue;
+        }
+        locationViews.push(locationElement);
+    }
+    return locationViews;
 }
 
 function truncateDocumentSectionText(value, maxChars) {
@@ -4853,6 +5059,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
     const kanbanElements = resolveKanbanDisplayElements(debugData);
     const timelineElements = resolveTimelineDisplayElements(debugData);
     const calendarElements = resolveCalendarDisplayElements(debugData);
+    const locationElements = resolveLocationDisplayElements(debugData);
     const documentElements = resolveDocumentDisplayElements(debugData);
     const hierarchyElements = resolveHierarchyDisplayElements(debugData);
     const relationGraphElements = resolveRelationGraphDisplayElements(debugData);
@@ -4883,6 +5090,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
         && !kanbanElements.length
         && !timelineElements.length
         && !calendarElements.length
+        && !locationElements.length
         && !documentElements.length
         && !hierarchyElements.length
         && !relationGraphElements.length
@@ -5634,6 +5842,141 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
         root.appendChild(section);
     });
 
+    locationElements.forEach((locationElement, locationIndex) => {
+        const section = document.createElement('section');
+        section.className = 'chat-display-elements-location-section';
+        section.style.cssText = (
+            tableElements.length > 0
+            || workflowElements.length > 0
+            || taskViewElements.length > 0
+            || kanbanElements.length > 0
+            || timelineElements.length > 0
+            || calendarElements.length > 0
+            || locationIndex > 0
+        ) ? 'margin-top: 10px;' : '';
+
+        const title = document.createElement('div');
+        title.className = 'chat-display-elements-location-title';
+        title.textContent = resolveDisplayElementSectionTitle(
+            locationElement.title,
+            'Location view',
+            locationIndex,
+            locationElements.length
+        );
+        title.style.cssText = 'font-weight: 600; font-size: 0.85em; color: #2f4f6f; margin-bottom: 6px;';
+        section.appendChild(title);
+
+        const pointsWithCoordinates = locationElement.points.filter((point) => (
+            Number.isFinite(point.latitude) && Number.isFinite(point.longitude)
+        ));
+        const summary = document.createElement('div');
+        summary.className = 'chat-display-elements-location-summary';
+        summary.textContent = `${locationElement.points.length} location${locationElement.points.length === 1 ? '' : 's'} · ${pointsWithCoordinates.length} with coordinates`;
+        summary.style.cssText = 'font-size: 0.78em; color: #5a6b7b; margin-bottom: 6px;';
+        section.appendChild(summary);
+
+        const mapPanel = document.createElement('div');
+        mapPanel.className = 'chat-display-elements-location-map';
+        mapPanel.style.cssText = 'position: relative; min-height: 180px; border: 1px solid #dce3ea; border-radius: 6px; background: linear-gradient(180deg, #f8fbff 0%, #eef5fb 100%); overflow: hidden; margin-bottom: 8px;';
+
+        if (pointsWithCoordinates.length > 0) {
+            let latMin = Number.POSITIVE_INFINITY;
+            let latMax = Number.NEGATIVE_INFINITY;
+            let lonMin = Number.POSITIVE_INFINITY;
+            let lonMax = Number.NEGATIVE_INFINITY;
+            pointsWithCoordinates.forEach((point) => {
+                latMin = Math.min(latMin, Number(point.latitude));
+                latMax = Math.max(latMax, Number(point.latitude));
+                lonMin = Math.min(lonMin, Number(point.longitude));
+                lonMax = Math.max(lonMax, Number(point.longitude));
+            });
+            const latSpan = Math.max(0.001, latMax - latMin);
+            const lonSpan = Math.max(0.001, lonMax - lonMin);
+
+            const markerCap = Math.min(pointsWithCoordinates.length, 80);
+            for (let index = 0; index < markerCap; index += 1) {
+                const point = pointsWithCoordinates[index];
+                const lat = Number(point.latitude);
+                const lon = Number(point.longitude);
+                const marker = document.createElement('div');
+                marker.className = 'chat-display-elements-location-map-marker';
+                const x = ((lon - lonMin) / lonSpan) * 100;
+                const y = ((latMax - lat) / latSpan) * 100;
+                marker.style.cssText = `position: absolute; left: ${Math.max(2, Math.min(98, x)).toFixed(2)}%; top: ${Math.max(4, Math.min(96, y)).toFixed(2)}%; transform: translate(-50%, -50%); background: #1f4f7a; color: #fff; border-radius: 999px; min-width: 18px; height: 18px; padding: 0 5px; display: inline-flex; align-items: center; justify-content: center; font-size: 0.68em; font-weight: 600; box-shadow: 0 1px 3px rgba(18, 40, 66, 0.25);`;
+                marker.textContent = String(index + 1);
+                marker.title = `${point.label} (${formatLocationCoordinate(lat)}, ${formatLocationCoordinate(lon)})`;
+                mapPanel.appendChild(marker);
+            }
+        } else {
+            const fallback = document.createElement('div');
+            fallback.className = 'chat-display-elements-location-map-fallback';
+            fallback.style.cssText = 'padding: 10px; font-size: 0.78em; color: #5a6b7b;';
+            fallback.textContent = 'No coordinates available; showing address-based list.';
+            mapPanel.appendChild(fallback);
+        }
+        section.appendChild(mapPanel);
+
+        const list = document.createElement('div');
+        list.className = 'chat-display-elements-location-list';
+        list.style.cssText = 'display: grid; gap: 8px;';
+
+        locationElement.points.forEach((point) => {
+            const card = document.createElement('article');
+            card.className = 'chat-display-elements-location-point';
+            card.style.cssText = 'border: 1px solid #dce3ea; border-radius: 6px; background: #f8fbff; padding: 8px;';
+
+            const name = document.createElement('div');
+            name.className = 'chat-display-elements-location-point-title';
+            name.textContent = point.label;
+            name.style.cssText = 'font-size: 0.82em; font-weight: 600; color: #1f3d5a;';
+            card.appendChild(name);
+
+            const details = [];
+            if (Number.isFinite(point.latitude) && Number.isFinite(point.longitude)) {
+                details.push(`Lat/Lon: ${formatLocationCoordinate(point.latitude)}, ${formatLocationCoordinate(point.longitude)}`);
+            }
+            if (point.address) {
+                details.push(point.address);
+            }
+            if (point.description) {
+                details.push(point.description);
+            }
+            if (Number.isFinite(point.confidence)) {
+                details.push(`Confidence: ${(Number(point.confidence) * 100).toFixed(0)}%`);
+            }
+            if (details.length) {
+                const meta = document.createElement('div');
+                meta.className = 'chat-display-elements-location-point-meta';
+                meta.textContent = details.join(' · ');
+                meta.style.cssText = 'margin-top: 4px; font-size: 0.78em; color: #44576a;';
+                card.appendChild(meta);
+            }
+
+            const mapHref = typeof point.map_href === 'string' ? point.map_href.trim() : '';
+            if (mapHref) {
+                const mapLink = document.createElement('a');
+                mapLink.href = mapHref;
+                mapLink.target = '_blank';
+                mapLink.rel = 'noopener noreferrer';
+                mapLink.className = 'chat-display-elements-location-map-link';
+                mapLink.textContent = 'Open map';
+                mapLink.style.cssText = 'display: inline-block; margin-top: 6px; font-size: 0.76em; color: #1f4f7a;';
+                card.appendChild(mapLink);
+            }
+
+            appendTaskLinksToCard(
+                card,
+                point.task_links,
+                'chat-display-elements-location-point-links'
+            );
+
+            list.appendChild(card);
+        });
+
+        section.appendChild(list);
+        root.appendChild(section);
+    });
+
     documentElements.forEach((documentElement, documentIndex) => {
         const section = document.createElement('section');
         section.className = 'chat-display-elements-document-section';
@@ -5644,6 +5987,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
             || kanbanElements.length > 0
             || timelineElements.length > 0
             || calendarElements.length > 0
+            || locationElements.length > 0
             || documentIndex > 0
         ) ? 'margin-top: 10px;' : '';
 
@@ -5794,6 +6138,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
             || kanbanElements.length > 0
             || timelineElements.length > 0
             || calendarElements.length > 0
+            || locationElements.length > 0
             || documentElements.length > 0
             || hierarchyIndex > 0
         ) ? 'margin-top: 10px;' : '';
@@ -5832,6 +6177,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
             || kanbanElements.length > 0
             || timelineElements.length > 0
             || calendarElements.length > 0
+            || locationElements.length > 0
             || documentElements.length > 0
             || hierarchyElements.length > 0
             || relationGraphIndex > 0
@@ -5873,6 +6219,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
             || hierarchyElements.length > 0
             || relationGraphElements.length > 0
             || calendarElements.length > 0
+            || locationElements.length > 0
             || documentElements.length > 0
             || relationIndex > 0
         ) ? 'margin-top: 10px;' : '';
@@ -6119,6 +6466,7 @@ function extractRenderPlanSourceSummary(
     screenKanbanElements,
     screenTimelineElements,
     screenCalendarElements,
+    screenLocationElements,
     screenDocumentElements,
     screenHierarchyElements,
     screenRelationGraphElements
@@ -6200,6 +6548,12 @@ function extractRenderPlanSourceSummary(
         }
         addProvenance(calendarElement.provenance);
     }
+    for (const locationElement of screenLocationElements) {
+        if (!locationElement || typeof locationElement !== 'object') {
+            continue;
+        }
+        addProvenance(locationElement.provenance);
+    }
     for (const documentElement of screenDocumentElements) {
         if (!documentElement || typeof documentElement !== 'object') {
             continue;
@@ -6262,6 +6616,9 @@ function buildRenderPlanMetadataSummary(renderPlan) {
     const screenCalendarElements = Array.isArray(renderPlan.screen_calendar_elements)
         ? renderPlan.screen_calendar_elements.filter(item => item && typeof item === 'object')
         : [];
+    const screenLocationElements = Array.isArray(renderPlan.screen_location_elements)
+        ? renderPlan.screen_location_elements.filter(item => item && typeof item === 'object')
+        : [];
     const screenDocumentElements = Array.isArray(renderPlan.screen_document_elements)
         ? renderPlan.screen_document_elements.filter(item => item && typeof item === 'object')
         : [];
@@ -6279,6 +6636,7 @@ function buildRenderPlanMetadataSummary(renderPlan) {
         screenKanbanElements,
         screenTimelineElements,
         screenCalendarElements,
+        screenLocationElements,
         screenDocumentElements,
         screenHierarchyElements,
         screenRelationGraphElements
@@ -6312,6 +6670,7 @@ function buildRenderPlanMetadataSummary(renderPlan) {
         screen_kanban_element_count: screenKanbanElements.length,
         screen_timeline_element_count: screenTimelineElements.length,
         screen_calendar_element_count: screenCalendarElements.length,
+        screen_location_element_count: screenLocationElements.length,
         screen_document_element_count: screenDocumentElements.length,
         screen_hierarchy_element_count: screenHierarchyElements.length,
         screen_relation_graph_element_count: screenRelationGraphElements.length,
@@ -6380,6 +6739,7 @@ function buildRenderPlanSummaryHtml(renderPlanSummary) {
     addScalar('Screen kanban elements', renderPlanSummary.screen_kanban_element_count);
     addScalar('Screen timeline elements', renderPlanSummary.screen_timeline_element_count);
     addScalar('Screen calendar elements', renderPlanSummary.screen_calendar_element_count);
+    addScalar('Screen location elements', renderPlanSummary.screen_location_element_count);
     addScalar('Screen document elements', renderPlanSummary.screen_document_element_count);
     addScalar('Screen hierarchy elements', renderPlanSummary.screen_hierarchy_element_count);
     addScalar('Screen relation graph elements', renderPlanSummary.screen_relation_graph_element_count);

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -1366,6 +1366,70 @@ describe('calendar display elements', () => {
     });
 });
 
+describe('location display elements', () => {
+    test('renders location map markers with address fallback and task links', () => {
+        const container = document.createElement('div');
+        const debugData = {
+            display_elements: {
+                schema_version: 'turn_display_elements_v1',
+                elements: [
+                    {
+                        element_id: 'screen_location_view',
+                        element_type: 'location_view',
+                        channel: 'screen',
+                        order: 39,
+                        intent: 'structured_location_view',
+                        payload: {
+                            title: 'Meeting locations',
+                            points: [
+                                {
+                                    point_id: '#V#task_alpha',
+                                    label: 'AUT city campus',
+                                    latitude: -36.8509,
+                                    longitude: 174.7676,
+                                    address: '55 Wellesley Street East, Auckland',
+                                    task_links: [
+                                        {
+                                            link_type: 'von_task',
+                                            target_id: '#V#task_alpha',
+                                            label: '#V#task_alpha'
+                                        }
+                                    ]
+                                },
+                                {
+                                    point_id: '#V#task_beta',
+                                    label: 'Remote participant',
+                                    address: 'Wellington, New Zealand'
+                                }
+                            ]
+                        },
+                        provenance: { source: 'test' }
+                    }
+                ]
+            }
+        };
+
+        __testOnly_renderDisplayElementsIntoContainer(container, debugData);
+
+        const section = container.querySelector('.chat-display-elements-location-section');
+        expect(section).not.toBeNull();
+        expect(section.textContent).toContain('Meeting locations');
+        expect(section.textContent).toContain('AUT city campus');
+        expect(section.textContent).toContain('Wellington, New Zealand');
+
+        const markers = container.querySelectorAll('.chat-display-elements-location-map-marker');
+        expect(markers.length).toBe(1);
+
+        const mapLinks = section.querySelectorAll('.chat-display-elements-location-map-link');
+        expect(mapLinks.length).toBeGreaterThanOrEqual(1);
+        expect(mapLinks[0].href).toContain('openstreetmap.org');
+
+        const conceptButton = section.querySelector('.chat-display-elements-concept-link');
+        expect(conceptButton).not.toBeNull();
+        expect(conceptButton.dataset.conceptId).toBe('#V#task_alpha');
+    });
+});
+
 describe('document display elements', () => {
     test('renders collapsible document cards with section excerpts and citations', () => {
         const container = document.createElement('div');
@@ -2130,6 +2194,39 @@ describe('LLM debug popup metadata (internal MCP caps + usage)', () => {
             screen_calendar_element_count: 1,
             source_tools: ['task_list', 'workflow_list_instances'],
             record_families: ['calendar_items']
+        });
+    });
+
+    test('includes location render plan provenance counts when present', () => {
+        const metadata = __testOnly_buildLlmDebugMetadata({
+            model: 'gpt-test',
+            messages: [],
+            render_plan: {
+                enabled: true,
+                attempted: true,
+                success: true,
+                reason: 'resolved',
+                selected_renderer_ids: ['#V#renderer_location'],
+                selected_renderer_types: ['location'],
+                screen_element_families: ['location_view'],
+                screen_location_elements: [
+                    {
+                        element_id: 'screen_location_view',
+                        provenance: {
+                            source_tools: ['task_list'],
+                            record_family: 'location_points'
+                        }
+                    }
+                ]
+            }
+        });
+
+        expect(metadata.render_plan).toMatchObject({
+            selected_renderer_types: ['location'],
+            screen_element_families: ['location_view'],
+            screen_location_element_count: 1,
+            source_tools: ['task_list'],
+            record_families: ['location_points']
         });
     });
 

--- a/tests/backend/test_display_elements_service.py
+++ b/tests/backend/test_display_elements_service.py
@@ -670,6 +670,91 @@ def test_build_turn_display_elements_drops_invalid_supplied_calendar_views() -> 
     assert contract["validation"]["valid"] is True
 
 
+def test_build_turn_display_elements_includes_supplied_location_views() -> None:
+    contract = build_turn_display_elements(
+        response_text="Location response",
+        presenter_channels={
+            "format": "tagged_blocks_v1",
+            "screen": "Location response",
+            "spoken": None,
+        },
+        screen_location_elements=[
+            {
+                "element_id": "screen_location_view",
+                "intent": "structured_location_view",
+                "payload": {
+                    "title": "Meeting locations",
+                    "points": [
+                        {
+                            "point_id": "#V#meeting_location_1",
+                            "label": "AUT city campus",
+                            "latitude": -36.8509,
+                            "longitude": 174.7676,
+                            "address": "55 Wellesley Street East, Auckland",
+                        },
+                        {
+                            "point_id": "#V#meeting_location_2",
+                            "label": "Remote participant",
+                            "address": "Wellington, New Zealand",
+                        },
+                    ],
+                    "viewport": {
+                        "centre_lat": -36.8509,
+                        "centre_lon": 174.7676,
+                        "zoom": 11,
+                    },
+                },
+            }
+        ],
+    )
+
+    location_elements = [
+        element
+        for element in contract["elements"]
+        if element["element_type"] == "location_view"
+    ]
+    assert len(location_elements) == 1
+    location_element = location_elements[0]
+    assert location_element["element_id"] == "screen_location_view"
+    assert location_element["payload"]["points"][0]["latitude"] == -36.8509
+    assert location_element["payload"]["points"][1]["address"] == "Wellington, New Zealand"
+    assert "screen_structured_location_views_supplied" in contract["reason_codes"]
+    assert contract["validation"]["valid"] is True
+
+
+def test_build_turn_display_elements_drops_invalid_supplied_location_views() -> None:
+    contract = build_turn_display_elements(
+        response_text="Location response",
+        presenter_channels={
+            "format": "tagged_blocks_v1",
+            "screen": "Location response",
+            "spoken": None,
+        },
+        screen_location_elements=[
+            {
+                "payload": {
+                    "points": [
+                        {
+                            "point_id": "bad_point",
+                            "label": "Missing anchors",
+                            "latitude": -36.85,
+                        }
+                    ]
+                }
+            }
+        ],
+    )
+
+    location_elements = [
+        element
+        for element in contract["elements"]
+        if element["element_type"] == "location_view"
+    ]
+    assert location_elements == []
+    assert "screen_structured_location_views_invalid_dropped" in contract["reason_codes"]
+    assert contract["validation"]["valid"] is True
+
+
 def test_build_turn_display_elements_includes_supplied_document_views() -> None:
     contract = build_turn_display_elements(
         response_text="Document response",
@@ -1264,6 +1349,49 @@ def test_validate_turn_display_elements_rejects_calendar_item_without_title() ->
     assert any("default_granularity must be one of" in message for message in errors)
 
 
+def test_validate_turn_display_elements_rejects_invalid_location_view_shape() -> None:
+    valid, errors = validate_turn_display_elements(
+        {
+            "schema_version": "turn_display_elements_v1",
+            "elements": [
+                {
+                    "element_id": "screen_location_view",
+                    "element_type": "location_view",
+                    "channel": "screen",
+                    "order": 39,
+                    "intent": "structured_location_view",
+                    "payload": {
+                        "points": [
+                            {
+                                "point_id": "point_1",
+                                "label": "Invalid coordinate",
+                                "latitude": 123.0,
+                                "longitude": 174.7,
+                            },
+                            {
+                                "point_id": "point_2",
+                                "label": "Missing anchors",
+                            },
+                        ],
+                        "viewport": {
+                            "centre_lat": -36.8,
+                            "zoom": 99,
+                        },
+                    },
+                    "provenance": {"source": "test"},
+                }
+            ],
+            "reason_codes": [],
+        }
+    )
+
+    assert valid is False
+    assert any(".latitude must be between -90 and 90" in message for message in errors)
+    assert any("must provide at least one spatial anchor" in message for message in errors)
+    assert any("must provide both centre_lat and centre_lon" in message for message in errors)
+    assert any(".viewport.zoom must be an integer between 1 and 20" in message for message in errors)
+
+
 def test_validate_turn_display_elements_rejects_invalid_document_view_shape() -> None:
     valid, errors = validate_turn_display_elements(
         {
@@ -1850,6 +1978,21 @@ def test_build_turn_display_elements_preserves_optional_payload_titles() -> None
                 }
             }
         ],
+        screen_location_elements=[
+            {
+                "payload": {
+                    "title": "Location markers",
+                    "points": [
+                        {
+                            "point_id": "location_1",
+                            "label": "Auckland office",
+                            "latitude": -36.8509,
+                            "longitude": 174.7676,
+                        }
+                    ],
+                }
+            }
+        ],
         screen_document_elements=[
             {
                 "payload": {
@@ -1937,6 +2080,7 @@ def test_build_turn_display_elements_preserves_optional_payload_titles() -> None
             "kanban_view",
             "timeline",
             "calendar_view",
+            "location_view",
             "document_view",
             "hierarchy_view",
             "relation_graph_view",
@@ -1949,6 +2093,7 @@ def test_build_turn_display_elements_preserves_optional_payload_titles() -> None
     assert payload_title_by_type["kanban_view"] == "Kanban backlog"
     assert payload_title_by_type["timeline"] == "Timeline of changes"
     assert payload_title_by_type["calendar_view"] == "Calendar schedule"
+    assert payload_title_by_type["location_view"] == "Location markers"
     assert payload_title_by_type["document_view"] == "Document excerpts"
     assert payload_title_by_type["hierarchy_view"] == "Meeting hierarchy"
     assert payload_title_by_type["relation_graph_view"] == "Relation network"

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -948,9 +948,11 @@ def test_renderer_selection_gates_screen_element_families(monkeypatch):
         "workflow_view": True,
         "task_view": False,
         "calendar_view": False,
+        "location_view": False,
         "document_view": False,
         "kanban_view": False,
         "timeline": False,
+        "hierarchy_view": False,
         "relation_graph_view": False,
     }
     assert "screen_table_record_sets" not in result.render_plan
@@ -1047,9 +1049,11 @@ def test_renderer_selection_emits_timeline_elements_for_timeline_renderer(monkey
         "workflow_view": False,
         "task_view": False,
         "calendar_view": False,
+        "location_view": False,
         "document_view": False,
         "kanban_view": False,
         "timeline": True,
+        "hierarchy_view": False,
         "relation_graph_view": False,
     }
     assert "screen_table_record_sets" not in result.render_plan
@@ -1148,9 +1152,11 @@ def test_renderer_selection_emits_calendar_elements_for_calendar_renderer(monkey
         "workflow_view": False,
         "task_view": False,
         "calendar_view": True,
+        "location_view": False,
         "document_view": False,
         "kanban_view": False,
         "timeline": False,
+        "hierarchy_view": False,
         "relation_graph_view": False,
     }
     assert "screen_table_record_sets" not in result.render_plan
@@ -1169,6 +1175,125 @@ def test_renderer_selection_emits_calendar_elements_for_calendar_renderer(monkey
     assert items[0]["title"] == "Alpha task"
     assert items[0]["all_day"] is True
     assert items[0]["task_links"][0]["target_id"] == "#V#task_alpha"
+
+
+def test_renderer_selection_emits_location_elements_for_location_renderer(monkeypatch):
+    """Location renderer selection should emit location display elements only."""
+    orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
+    monkeypatch.setenv("VON_RENDERER_APPLICABILITY_ROUTING_ENABLE", "1")
+    monkeypatch.setenv(
+        "VON_RENDERER_APPLICABILITY_DEFINITION_IDS",
+        "#V#location_renderer,#V#workflow_renderer,#V#table_renderer",
+    )
+
+    def _invoke(tool_name: str, _payload: Mapping[str, Any]):
+        if tool_name != "renderer_resolve_applicability":
+            raise AssertionError(f"Unexpected tool invocation: {tool_name}")
+        return _InvokeResult(
+            {
+                "success": True,
+                "selected_renderers": [
+                    {
+                        "renderer_id": "#V#location_renderer",
+                        "renderer_type": "location",
+                        "modalities": ["visual"],
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr(orchestrator._gateway, "invoke", _invoke)
+
+    class _WorkflowResult:
+        def __init__(self):
+            self.data = {
+                "final_response": "Location summary.",
+                "tool_messages": [
+                    {
+                        "role": "tool",
+                        "content": json.dumps(
+                            {
+                                "tool": "task_list",
+                                "status": "ok",
+                                "duration_ms": 2.1,
+                                "payload": {
+                                    "tasks": [
+                                        {
+                                            "task_concept_id": "#V#task_alpha",
+                                            "title": "Alpha task",
+                                            "location": {
+                                                "lat": -36.8485,
+                                                "lng": 174.7633,
+                                                "address": "Auckland, New Zealand",
+                                            },
+                                            "jira_issue_key": "JVNAUTOSCI-1178",
+                                        },
+                                        {
+                                            "task_concept_id": "#V#task_beta",
+                                            "title": "Beta task",
+                                            "address": "Wellington, New Zealand",
+                                        },
+                                    ]
+                                },
+                            }
+                        ),
+                    }
+                ],
+                "invocations": [],
+                "iteration_count": 1,
+            }
+            self.final_state = "completed"
+            self.completed = True
+
+    def _execute_workflow(workflow_id: str, **_kwargs: Any):
+        if workflow_id != TOOL_CALLING_WORKFLOW_ID:
+            raise AssertionError(f"Unexpected workflow execution: {workflow_id}")
+        return _WorkflowResult()
+
+    monkeypatch.setattr(orchestrator, "execute_workflow", _execute_workflow)
+
+    llm = _CapturingLLM(["tool_seeking"])
+    result = orchestrator.run(
+        prompt="Show locations",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+    )
+
+    assert isinstance(result.render_plan, dict)
+    assert result.render_plan.get("screen_element_mapping_mode") == "selected_renderer_types"
+    assert result.render_plan.get("screen_element_targets") == {
+        "table": False,
+        "workflow_view": False,
+        "task_view": False,
+        "calendar_view": False,
+        "location_view": True,
+        "document_view": False,
+        "kanban_view": False,
+        "timeline": False,
+        "hierarchy_view": False,
+        "relation_graph_view": False,
+    }
+    assert "screen_table_record_sets" not in result.render_plan
+    assert "screen_workflow_elements" not in result.render_plan
+    assert "screen_task_view_elements" not in result.render_plan
+    assert "screen_timeline_elements" not in result.render_plan
+    assert result.render_plan.get("screen_location_element_count") == 1
+
+    location_elements = result.render_plan.get("screen_location_elements")
+    assert isinstance(location_elements, list)
+    assert len(location_elements) == 1
+    payload = location_elements[0].get("payload", {})
+    points = payload.get("points")
+    assert isinstance(points, list)
+    assert len(points) == 2
+    assert points[0]["point_id"] == "#V#task_alpha"
+    assert points[0]["latitude"] == -36.8485
+    assert points[0]["longitude"] == 174.7633
+    assert points[0]["address"] == "Auckland, New Zealand"
+    assert points[0]["task_links"][0]["target_id"] == "#V#task_alpha"
+    assert payload.get("viewport", {}).get("centre_lat") is not None
 
 
 def test_renderer_selection_emits_document_elements_for_document_renderer(monkeypatch):
@@ -1254,9 +1379,11 @@ def test_renderer_selection_emits_document_elements_for_document_renderer(monkey
         "workflow_view": False,
         "task_view": False,
         "calendar_view": False,
+        "location_view": False,
         "document_view": True,
         "kanban_view": False,
         "timeline": False,
+        "hierarchy_view": False,
         "relation_graph_view": False,
     }
     assert "screen_table_record_sets" not in result.render_plan
@@ -1359,9 +1486,11 @@ def test_renderer_selection_emits_task_view_elements_for_task_renderer(monkeypat
         "workflow_view": False,
         "task_view": True,
         "calendar_view": False,
+        "location_view": False,
         "document_view": False,
         "kanban_view": False,
         "timeline": False,
+        "hierarchy_view": False,
         "relation_graph_view": False,
     }
     assert "screen_table_record_sets" not in result.render_plan
@@ -1472,9 +1601,11 @@ def test_renderer_selection_emits_kanban_elements_for_kanban_renderer(monkeypatc
         "workflow_view": False,
         "task_view": False,
         "calendar_view": False,
+        "location_view": False,
         "document_view": False,
         "kanban_view": True,
         "timeline": False,
+        "hierarchy_view": False,
         "relation_graph_view": False,
     }
     assert "screen_table_record_sets" not in result.render_plan
@@ -1585,9 +1716,11 @@ def test_renderer_selection_emits_relation_graph_elements_for_graph_renderer(mon
         "workflow_view": False,
         "task_view": False,
         "calendar_view": False,
+        "location_view": False,
         "document_view": False,
         "kanban_view": False,
         "timeline": False,
+        "hierarchy_view": False,
         "relation_graph_view": True,
     }
     assert "screen_table_record_sets" not in result.render_plan
@@ -1688,9 +1821,11 @@ def test_renderer_selection_fallback_when_no_types_selected(monkeypatch):
         "workflow_view": True,
         "task_view": False,
         "calendar_view": False,
+        "location_view": False,
         "document_view": False,
         "kanban_view": False,
         "timeline": False,
+        "hierarchy_view": False,
         "relation_graph_view": False,
     }
     assert result.render_plan.get("screen_table_record_set_count") == 1
@@ -2612,3 +2747,4 @@ def test_no_routing_info_when_selector_disabled(monkeypatch):
     )
 
     assert result.workflow_routing is None
+

--- a/tests/backend/test_von_generate_render_plan_debug.py
+++ b/tests/backend/test_von_generate_render_plan_debug.py
@@ -545,6 +545,84 @@ def test_generate_builds_calendar_from_render_plan_elements(monkeypatch):
     assert calendar_item["all_day"] is True
 
 
+def test_generate_builds_location_view_from_render_plan_elements(monkeypatch):
+    from src.backend.integrations.internal_mcp.orchestrator import OrchestratorResult
+
+    render_plan = {
+        "enabled": True,
+        "reason": "resolved",
+        "render_mode": "screen_only",
+        "should_narrate": False,
+        "screen_location_elements": [
+            {
+                "element_id": "screen_location_view",
+                "intent": "structured_location_view",
+                "payload": {
+                    "points": [
+                        {
+                            "point_id": "#V#task_alpha",
+                            "label": "Alpha task",
+                            "latitude": -36.8485,
+                            "longitude": 174.7633,
+                            "address": "Auckland, New Zealand",
+                            "task_links": [
+                                {
+                                    "link_type": "von_task",
+                                    "target_id": "#V#task_alpha",
+                                }
+                            ],
+                        },
+                        {
+                            "point_id": "#V#task_beta",
+                            "label": "Beta task",
+                            "address": "Wellington, New Zealand",
+                        },
+                    ],
+                    "viewport": {
+                        "centre_lat": -41.2865,
+                        "centre_lon": 174.7762,
+                        "zoom": 7,
+                    },
+                },
+                "provenance": {"source": "test_render_plan"},
+            }
+        ],
+    }
+    orchestrator_result = OrchestratorResult(
+        response_text="Location summary",
+        extra_messages=(),
+        tool_invocations=(),
+        aux_llm_calls=(),
+        render_plan=render_plan,
+    )
+    app = _make_app(monkeypatch, _StubOrchestrator(orchestrator_result))
+
+    client = app.test_client()
+    response = client.post("/von/generate", json={"prompt": "Show locations"})
+    assert response.status_code == 200
+    body = response.get_json()
+    assert isinstance(body, dict)
+    display_elements = body.get("display_elements")
+    assert isinstance(display_elements, dict)
+    assert display_elements.get("validation", {}).get("valid") is True
+    assert "screen_structured_location_views_supplied" in display_elements.get(
+        "reason_codes", []
+    )
+
+    location_elements = [
+        element
+        for element in display_elements.get("elements", [])
+        if isinstance(element, dict) and element.get("element_type") == "location_view"
+    ]
+    assert len(location_elements) == 1
+    points = location_elements[0].get("payload", {}).get("points", [])
+    assert isinstance(points, list)
+    assert points[0]["point_id"] == "#V#task_alpha"
+    assert points[0]["latitude"] == -36.8485
+    assert points[0]["longitude"] == 174.7633
+    assert points[1]["address"] == "Wellington, New Zealand"
+
+
 def test_generate_builds_document_view_from_render_plan_elements(monkeypatch):
     from src.backend.integrations.internal_mcp.orchestrator import OrchestratorResult
 
@@ -918,9 +996,11 @@ def test_generate_respects_renderer_screen_element_targets(monkeypatch):
             "workflow_view": True,
             "task_view": False,
             "calendar_view": False,
+            "location_view": False,
             "document_view": False,
             "kanban_view": False,
             "timeline": False,
+            "hierarchy_view": False,
             "relation_graph_view": False,
         },
         "screen_element_reason_codes": [


### PR DESCRIPTION
## Summary
- add `location_view` as a first-class display element type in the canonical display-elements contract
- add renderer mapping/extraction for `location`/`map` families and emit `screen_location_elements` from tool payloads
- wire `/von/generate` render-plan extraction and screen target handling for `location_view`
- add frontend normalisation + rendering for location cards with geospatial marker panel and address/map-link fallback
- include location counts/provenance in LLM debug render-plan metadata summary
- add backend and frontend tests for location view contract validation, routing, render-plan extraction, and UI rendering

## Validation
- `pytest tests/backend/test_display_elements_service.py -q`
- `pytest tests/backend/test_von_generate_render_plan_debug.py -q`
- `pytest tests/backend/test_orchestrator_workflow_selector_routing.py -q`
- `npm test -- src/frontend/web/von_interface/static/js/test/chatTab.test.js --runInBand`
- `pdm run pyright src/backend/integrations/internal_mcp/orchestrator.py src/backend/server/routes/von_routes.py src/backend/services/display_elements_service.py tests/backend/test_display_elements_service.py tests/backend/test_orchestrator_workflow_selector_routing.py tests/backend/test_von_generate_render_plan_debug.py`