### PR TITLE
JVNAUTOSCI-1179: Add chart renderer and ontology-driven screen family routing

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -17811,6 +17811,445 @@ class InternalMCPChatOrchestrator:
                 }
             ]
 
+        def _extract_renderer_screen_chart_elements(
+            *,
+            tool_messages: Sequence[Mapping[str, Any]] = (),
+        ) -> list[dict[str, Any]]:
+            """Derive chart-view payloads from explicit series and distribution-style tool outputs."""
+
+            max_series = 20
+            max_points_per_series = 240
+            max_total_points = 1200
+            allowed_chart_types = {"line", "bar", "area", "scatter"}
+
+            source_tools: list[str] = []
+            seen_source_tools: set[str] = set()
+
+            def _register_source_tool(tool_name: str) -> None:
+                if tool_name in seen_source_tools:
+                    return
+                seen_source_tools.add(tool_name)
+                source_tools.append(tool_name)
+
+            def _normalise_number(value: Any) -> float | None:
+                if isinstance(value, bool):
+                    return None
+                if isinstance(value, (int, float)):
+                    number = float(value)
+                elif isinstance(value, str):
+                    cleaned = value.strip()
+                    if not cleaned:
+                        return None
+                    try:
+                        number = float(cleaned)
+                    except ValueError:
+                        return None
+                else:
+                    return None
+                if number != number or number in (float("inf"), float("-inf")):
+                    return None
+                return number
+
+            def _normalise_x_value(value: Any) -> str | float | int | None:
+                if isinstance(value, bool):
+                    return None
+                if isinstance(value, int):
+                    return value
+                if isinstance(value, float):
+                    if value != value or value in (float("inf"), float("-inf")):
+                        return None
+                    return round(value, 6)
+                if isinstance(value, str):
+                    cleaned = value.strip()
+                    return cleaned or None
+                return None
+
+            def _normalise_chart_type(value: Any) -> str | None:
+                candidate = _first_text(value)
+                if not candidate:
+                    return None
+                token = candidate.strip().lower()
+                alias_map = {
+                    "timeseries": "line",
+                    "time_series": "line",
+                    "trend": "line",
+                    "histogram": "bar",
+                    "distribution": "bar",
+                }
+                token = alias_map.get(token, token)
+                return token if token in allowed_chart_types else None
+
+            def _normalise_point(raw_point: Any) -> dict[str, Any] | None:
+                point_mapping: Mapping[str, Any] | None = (
+                    cast(Mapping[str, Any], raw_point)
+                    if isinstance(raw_point, Mapping)
+                    else None
+                )
+
+                x_raw: Any = None
+                y_raw: Any = None
+                point_meta: Mapping[str, Any] | None = None
+
+                if point_mapping is not None:
+                    x_raw = (
+                        point_mapping.get("x")
+                        if point_mapping.get("x") is not None
+                        else _first_text(
+                            point_mapping.get("timestamp"),
+                            point_mapping.get("date"),
+                            point_mapping.get("bucket"),
+                            point_mapping.get("label"),
+                            point_mapping.get("name"),
+                            point_mapping.get("category"),
+                        )
+                    )
+                    y_raw = (
+                        point_mapping.get("y")
+                        if point_mapping.get("y") is not None
+                        else (
+                            point_mapping.get("value")
+                            if point_mapping.get("value") is not None
+                            else (
+                                point_mapping.get("count")
+                                if point_mapping.get("count") is not None
+                                else point_mapping.get("total")
+                            )
+                        )
+                    )
+                    if isinstance(point_mapping.get("meta"), Mapping):
+                        point_meta = cast(Mapping[str, Any], point_mapping.get("meta"))
+                elif isinstance(raw_point, Sequence) and not isinstance(
+                    raw_point, (str, bytes, bytearray)
+                ):
+                    if len(raw_point) >= 2:
+                        x_raw = raw_point[0]
+                        y_raw = raw_point[1]
+                else:
+                    return None
+
+                x_value = _normalise_x_value(x_raw)
+                y_value = _normalise_number(y_raw)
+                if x_value is None or y_value is None:
+                    return None
+
+                point: dict[str, Any] = {
+                    "x": x_value,
+                    "y": round(y_value, 6),
+                }
+                if point_meta is not None:
+                    point["meta"] = dict(point_meta)
+                if point_mapping is not None:
+                    task_links = _collect_renderer_task_links(point_mapping)
+                    if task_links:
+                        point["task_links"] = task_links
+                return point
+
+            def _normalise_series_entries(
+                raw_series: Any,
+                *,
+                source_tool: str,
+            ) -> tuple[list[dict[str, Any]], str | None, dict[str, Any]]:
+                if isinstance(raw_series, Sequence) and not isinstance(
+                    raw_series, (str, bytes, bytearray)
+                ):
+                    series_candidates = list(raw_series)
+                elif isinstance(raw_series, Mapping):
+                    series_candidates = [raw_series]
+                else:
+                    return [], None, {}
+
+                series_entries: list[dict[str, Any]] = []
+                seen_series_ids: set[str] = set()
+                total_points = 0
+                chart_type: str | None = None
+                axis_metadata: dict[str, Any] = {}
+
+                for index, raw_series_entry in enumerate(series_candidates, start=1):
+                    if len(series_entries) >= max_series:
+                        break
+                    if not isinstance(raw_series_entry, Mapping):
+                        continue
+
+                    if chart_type is None:
+                        chart_type = _normalise_chart_type(
+                            raw_series_entry.get("chart_type")
+                        )
+                    if not axis_metadata:
+                        axis_metadata = {
+                            "x_axis": _first_text(
+                                raw_series_entry.get("x_axis"),
+                                raw_series_entry.get("x_label"),
+                            ),
+                            "y_axis": _first_text(
+                                raw_series_entry.get("y_axis"),
+                                raw_series_entry.get("y_label"),
+                            ),
+                            "units": _first_text(
+                                raw_series_entry.get("units"),
+                                raw_series_entry.get("unit"),
+                            ),
+                            "stacked": (
+                                raw_series_entry.get("stacked")
+                                if isinstance(raw_series_entry.get("stacked"), bool)
+                                else None
+                            ),
+                            "legend": (
+                                raw_series_entry.get("legend")
+                                if isinstance(raw_series_entry.get("legend"), bool)
+                                else None
+                            ),
+                        }
+
+                    series_id = _first_text(
+                        raw_series_entry.get("series_id"),
+                        raw_series_entry.get("id"),
+                        raw_series_entry.get("key"),
+                        raw_series_entry.get("metric"),
+                        raw_series_entry.get("name"),
+                    ) or f"{source_tool}_series_{index}"
+                    if series_id in seen_series_ids:
+                        continue
+
+                    series_label = _first_text(
+                        raw_series_entry.get("label"),
+                        raw_series_entry.get("name"),
+                        raw_series_entry.get("metric"),
+                    ) or series_id
+
+                    raw_points = raw_series_entry.get("points")
+                    if not isinstance(raw_points, Sequence) or isinstance(
+                        raw_points, (str, bytes, bytearray)
+                    ):
+                        raw_points = raw_series_entry.get("data")
+                    if not isinstance(raw_points, Sequence) or isinstance(
+                        raw_points, (str, bytes, bytearray)
+                    ):
+                        raw_points = raw_series_entry.get("values")
+                    if not isinstance(raw_points, Sequence) or isinstance(
+                        raw_points, (str, bytes, bytearray)
+                    ):
+                        raw_points = []
+
+                    points: list[dict[str, Any]] = []
+                    for raw_point in raw_points:
+                        if total_points >= max_total_points:
+                            break
+                        if len(points) >= max_points_per_series:
+                            break
+                        point = _normalise_point(raw_point)
+                        if not point:
+                            continue
+                        points.append(point)
+                        total_points += 1
+
+                    if not points:
+                        continue
+
+                    series_entry: dict[str, Any] = {
+                        "series_id": series_id,
+                        "label": series_label,
+                        "points": points,
+                    }
+                    task_links = _collect_renderer_task_links(raw_series_entry)
+                    if task_links:
+                        series_entry["task_links"] = task_links
+
+                    seen_series_ids.add(series_id)
+                    series_entries.append(series_entry)
+
+                return series_entries, chart_type, axis_metadata
+
+            def _build_distribution_series(
+                *,
+                source_tool: str,
+                distribution: Mapping[str, Any],
+                series_label: str = "Count",
+            ) -> list[dict[str, Any]]:
+                points: list[dict[str, Any]] = []
+                for bucket, raw_value in distribution.items():
+                    bucket_label = _first_text(bucket)
+                    bucket_value = _normalise_number(raw_value)
+                    if not bucket_label or bucket_value is None:
+                        continue
+                    points.append({"x": bucket_label, "y": round(bucket_value, 6)})
+                    if len(points) >= max_points_per_series:
+                        break
+                if not points:
+                    return []
+                return [
+                    {
+                        "series_id": f"{source_tool}_distribution",
+                        "label": series_label,
+                        "points": points,
+                    }
+                ]
+
+            tool_payloads = list(_iter_renderer_tool_result_payloads(tool_messages))
+            if not tool_payloads:
+                return []
+
+            extracted_payload: dict[str, Any] | None = None
+            for tool_name, payload in tool_payloads:
+                candidate_series_collections: list[Any] = []
+                if isinstance(payload.get("series"), Mapping):
+                    candidate_series_collections.append(payload.get("series"))
+                elif isinstance(payload.get("series"), Sequence) and not isinstance(
+                    payload.get("series"),
+                    (str, bytes, bytearray),
+                ):
+                    candidate_series_collections.append(payload.get("series"))
+                for collection_key in ("charts", "chart_series", "timeseries", "time_series"):
+                    collection = payload.get(collection_key)
+                    if isinstance(collection, Mapping):
+                        candidate_series_collections.append(collection)
+                    elif isinstance(collection, Sequence) and not isinstance(
+                        collection, (str, bytes, bytearray)
+                    ):
+                        candidate_series_collections.append(collection)
+                if isinstance(payload.get("points"), Sequence) and not isinstance(
+                    payload.get("points"),
+                    (str, bytes, bytearray),
+                ):
+                    candidate_series_collections.append([payload])
+                if isinstance(payload.get("data"), Sequence) and not isinstance(
+                    payload.get("data"),
+                    (str, bytes, bytearray),
+                ):
+                    candidate_series_collections.append([payload])
+
+                for candidate_collection in candidate_series_collections:
+                    series_entries, chart_type, axis_metadata = _normalise_series_entries(
+                        candidate_collection,
+                        source_tool=tool_name,
+                    )
+                    if not series_entries:
+                        continue
+
+                    resolved_chart_type = (
+                        chart_type
+                        or _normalise_chart_type(payload.get("chart_type"))
+                        or "line"
+                    )
+                    extracted_payload = {
+                        "chart_type": resolved_chart_type,
+                        "series": series_entries,
+                        "legend": True if len(series_entries) > 1 else False,
+                    }
+                    resolved_x_axis = axis_metadata.get("x_axis") or _first_text(
+                        payload.get("x_axis"),
+                        payload.get("x_label"),
+                    )
+                    if resolved_x_axis:
+                        extracted_payload["x_axis"] = resolved_x_axis
+                    resolved_y_axis = axis_metadata.get("y_axis") or _first_text(
+                        payload.get("y_axis"),
+                        payload.get("y_label"),
+                    )
+                    if resolved_y_axis:
+                        extracted_payload["y_axis"] = resolved_y_axis
+                    resolved_units = axis_metadata.get("units") or _first_text(
+                        payload.get("units"),
+                        payload.get("unit"),
+                    )
+                    if resolved_units:
+                        extracted_payload["units"] = resolved_units
+                    if isinstance(axis_metadata.get("stacked"), bool):
+                        extracted_payload["stacked"] = axis_metadata["stacked"]
+                    elif isinstance(payload.get("stacked"), bool):
+                        extracted_payload["stacked"] = payload.get("stacked")
+                    if isinstance(axis_metadata.get("legend"), bool):
+                        extracted_payload["legend"] = axis_metadata["legend"]
+                    elif isinstance(payload.get("legend"), bool):
+                        extracted_payload["legend"] = payload.get("legend")
+
+                    _register_source_tool(tool_name)
+                    break
+                if extracted_payload is not None:
+                    break
+
+            if extracted_payload is None:
+                for tool_name, payload in tool_payloads:
+                    distribution_mapping: Mapping[str, Any] | None = None
+                    if isinstance(payload.get("status_counts"), Mapping):
+                        distribution_mapping = cast(
+                            Mapping[str, Any], payload.get("status_counts")
+                        )
+                    elif isinstance(payload.get("counts"), Mapping):
+                        distribution_mapping = cast(
+                            Mapping[str, Any], payload.get("counts")
+                        )
+                    elif isinstance(payload.get("distribution"), Mapping):
+                        distribution_mapping = cast(
+                            Mapping[str, Any], payload.get("distribution")
+                        )
+                    if distribution_mapping is None:
+                        continue
+
+                    series_entries = _build_distribution_series(
+                        source_tool=tool_name,
+                        distribution=distribution_mapping,
+                    )
+                    if not series_entries:
+                        continue
+                    extracted_payload = {
+                        "chart_type": "bar",
+                        "x_axis": "Category",
+                        "y_axis": "Count",
+                        "series": series_entries,
+                        "legend": False,
+                    }
+                    _register_source_tool(tool_name)
+                    break
+
+            if extracted_payload is None:
+                task_entries, task_source_tools = _extract_renderer_task_entries(
+                    tool_messages=tool_messages,
+                    limit=max_total_points,
+                )
+                status_counts: dict[str, int] = {}
+                for task_entry in task_entries:
+                    status = _first_text(task_entry.get("status")) or "unknown"
+                    status_counts[status] = status_counts.get(status, 0) + 1
+                if status_counts:
+                    extracted_payload = {
+                        "chart_type": "bar",
+                        "x_axis": "Task status",
+                        "y_axis": "Count",
+                        "series": [
+                            {
+                                "series_id": "task_status_counts",
+                                "label": "Tasks",
+                                "points": [
+                                    {"x": status, "y": count}
+                                    for status, count in sorted(status_counts.items())
+                                ],
+                            }
+                        ],
+                        "legend": False,
+                    }
+                    for source_tool in task_source_tools:
+                        _register_source_tool(source_tool)
+
+            if extracted_payload is None:
+                return []
+
+            return [
+                {
+                    "element_id": "screen_chart_view",
+                    "intent": "structured_chart_view",
+                    "payload": extracted_payload,
+                    "constraints": {
+                        "supports_legend_toggle": True,
+                        "supports_series_comparison": True,
+                    },
+                    "provenance": {
+                        "source": "tool_result_chart_view",
+                        "source_tools": source_tools,
+                        "record_family": "chart_series",
+                    },
+                }
+            ]
+
         def _extract_renderer_screen_location_elements(
             *,
             tool_messages: Sequence[Mapping[str, Any]] = (),
@@ -19182,11 +19621,17 @@ class InternalMCPChatOrchestrator:
             }
             return request_payload, diagnostics
 
-        _RENDERER_SCREEN_ELEMENT_FAMILY_MAP: dict[str, tuple[str, ...]] = {
+        # Legacy renderer-type mapping fallback retained for profiles that do
+        # not yet publish explicit screen-element families in Vontology.
+        _LEGACY_RENDERER_TYPE_SCREEN_ELEMENT_FAMILY_MAP: dict[
+            str, tuple[str, ...]
+        ] = {
             "table": ("table",),
             "tabular": ("table",),
             "calendar": ("calendar_view",),
             "calendar_view": ("calendar_view",),
+            "chart": ("chart_view",),
+            "chart_view": ("chart_view",),
             "citation": ("document_view",),
             "document": ("document_view",),
             "document_view": ("document_view",),
@@ -19208,6 +19653,21 @@ class InternalMCPChatOrchestrator:
             "workflow": ("workflow_view",),
             "workflow_view": ("workflow_view",),
         }
+        _ALLOWED_SCREEN_ELEMENT_FAMILIES: frozenset[str] = frozenset(
+            {
+                "table",
+                "workflow_view",
+                "task_view",
+                "calendar_view",
+                "chart_view",
+                "location_view",
+                "document_view",
+                "kanban_view",
+                "timeline",
+                "hierarchy_view",
+                "relation_graph_view",
+            }
+        )
         _LEGACY_SCREEN_ELEMENT_FAMILIES: frozenset[str] = frozenset(
             {"table", "workflow_view"}
         )
@@ -19223,6 +19683,34 @@ class InternalMCPChatOrchestrator:
                 normalised.append(renderer_type)
             return normalised
 
+        def _normalise_selected_screen_element_families(raw_values: Any) -> list[str]:
+            if isinstance(raw_values, str):
+                values: Sequence[Any] = [raw_values]
+            elif isinstance(raw_values, Sequence) and not isinstance(
+                raw_values, (str, bytes, bytearray)
+            ):
+                values = raw_values
+            else:
+                return []
+
+            normalised: list[str] = []
+            for raw_value in values:
+                if not isinstance(raw_value, str):
+                    continue
+                family = raw_value.strip().lower()
+                if not family:
+                    continue
+                mapped = _LEGACY_RENDERER_TYPE_SCREEN_ELEMENT_FAMILY_MAP.get(
+                    family, (family,)
+                )
+                for candidate in mapped:
+                    if candidate not in _ALLOWED_SCREEN_ELEMENT_FAMILIES:
+                        continue
+                    if candidate in normalised:
+                        continue
+                    normalised.append(candidate)
+            return normalised
+
         def _apply_screen_element_mapping(
             decision: dict[str, Any],
             *,
@@ -19230,6 +19718,7 @@ class InternalMCPChatOrchestrator:
             resolver_attempted: bool,
             resolver_success: bool,
             selected_renderer_types: Sequence[str],
+            selected_renderer_entries: Sequence[Mapping[str, Any]] = (),
         ) -> None:
             renderer_types = _normalise_selected_renderer_types(selected_renderer_types)
             selected_families: set[str] = set()
@@ -19254,15 +19743,50 @@ class InternalMCPChatOrchestrator:
                 )
             else:
                 mapping_mode = "selected_renderer_types"
-                reason_codes.append("renderer_screen_elements:selected_renderer_types")
-                for renderer_type in renderer_types:
-                    mapped_families = _RENDERER_SCREEN_ELEMENT_FAMILY_MAP.get(
+                profile_mapping_used = False
+                legacy_type_mapping_used = False
+
+                entry_rows = (
+                    selected_renderer_entries
+                    if selected_renderer_entries
+                    else tuple({"renderer_type": item} for item in renderer_types)
+                )
+
+                for entry in entry_rows:
+                    if not isinstance(entry, Mapping):
+                        continue
+                    renderer_type_raw = entry.get("renderer_type")
+                    renderer_type = (
+                        str(renderer_type_raw).strip().lower()
+                        if isinstance(renderer_type_raw, str)
+                        else ""
+                    )
+                    profile_families = _normalise_selected_screen_element_families(
+                        entry.get("screen_element_families")
+                    )
+                    if profile_families:
+                        profile_mapping_used = True
+                        selected_families.update(profile_families)
+                        continue
+                    if not renderer_type:
+                        continue
+                    mapped_families = _LEGACY_RENDERER_TYPE_SCREEN_ELEMENT_FAMILY_MAP.get(
                         renderer_type
                     )
-                    if not mapped_families:
+                    if mapped_families:
+                        legacy_type_mapping_used = True
+                        selected_families.update(mapped_families)
+                    elif renderer_type not in unsupported_renderer_types:
                         unsupported_renderer_types.append(renderer_type)
-                        continue
-                    selected_families.update(mapped_families)
+
+                if profile_mapping_used:
+                    reason_codes.append(
+                        "renderer_screen_elements:selected_renderer_profiles"
+                    )
+                if legacy_type_mapping_used:
+                    reason_codes.append(
+                        "renderer_screen_elements:selected_renderer_types"
+                    )
                 if unsupported_renderer_types:
                     reason_codes.append(
                         "renderer_screen_elements:unsupported_renderer_types"
@@ -19276,6 +19800,7 @@ class InternalMCPChatOrchestrator:
             include_workflow_elements = "workflow_view" in selected_families
             include_task_view_elements = "task_view" in selected_families
             include_calendar_elements = "calendar_view" in selected_families
+            include_chart_elements = "chart_view" in selected_families
             include_location_elements = "location_view" in selected_families
             include_document_elements = "document_view" in selected_families
             include_kanban_elements = "kanban_view" in selected_families
@@ -19290,6 +19815,7 @@ class InternalMCPChatOrchestrator:
                 "workflow_view": include_workflow_elements,
                 "task_view": include_task_view_elements,
                 "calendar_view": include_calendar_elements,
+                "chart_view": include_chart_elements,
                 "location_view": include_location_elements,
                 "document_view": include_document_elements,
                 "kanban_view": include_kanban_elements,
@@ -19342,6 +19868,16 @@ class InternalMCPChatOrchestrator:
                     decision["screen_calendar_elements"] = screen_calendar_elements
                     decision["screen_calendar_element_count"] = len(
                         screen_calendar_elements
+                    )
+
+            if include_chart_elements:
+                screen_chart_elements = _extract_renderer_screen_chart_elements(
+                    tool_messages=tool_messages
+                )
+                if screen_chart_elements:
+                    decision["screen_chart_elements"] = screen_chart_elements
+                    decision["screen_chart_element_count"] = len(
+                        screen_chart_elements
                     )
 
             if include_location_elements:
@@ -19573,6 +20109,8 @@ class InternalMCPChatOrchestrator:
             selected_renderer_ids: list[str] = []
             selected_renderer_types: list[str] = []
             selected_modalities: list[str] = []
+            selected_renderer_screen_families: list[str] = []
+            selected_renderer_entries_for_mapping: list[dict[str, Any]] = []
             narration_selected = False
             for item in selected_renderers:
                 if not isinstance(item, Mapping):
@@ -19587,6 +20125,15 @@ class InternalMCPChatOrchestrator:
                     selected_renderer_types.append(renderer_type)
                 if renderer_type == "narration":
                     narration_selected = True
+
+                profile_screen_families = (
+                    _normalise_selected_screen_element_families(
+                        item.get("screen_element_families")
+                    )
+                )
+                for family in profile_screen_families:
+                    if family not in selected_renderer_screen_families:
+                        selected_renderer_screen_families.append(family)
 
                 modalities_raw = item.get("modalities")
                 modalities_iter: list[str] = []
@@ -19606,6 +20153,14 @@ class InternalMCPChatOrchestrator:
                     if normalised not in selected_modalities:
                         selected_modalities.append(normalised)
 
+                selected_renderer_entries_for_mapping.append(
+                    {
+                        "renderer_id": renderer_id,
+                        "renderer_type": renderer_type,
+                        "screen_element_families": list(profile_screen_families),
+                    }
+                )
+
             diagnostics_obj = result_payload.get("diagnostics")
             if isinstance(diagnostics_obj, Mapping):
                 selection_rationale = diagnostics_obj.get("selection_rationale")
@@ -19623,12 +20178,16 @@ class InternalMCPChatOrchestrator:
             decision["selected_renderer_ids"] = selected_renderer_ids
             decision["selected_renderer_types"] = selected_renderer_types
             decision["selected_modalities"] = selected_modalities
+            decision["selected_renderer_screen_element_families"] = (
+                selected_renderer_screen_families
+            )
             _apply_screen_element_mapping(
                 decision,
                 tool_messages=tool_messages,
                 resolver_attempted=True,
                 resolver_success=True,
                 selected_renderer_types=selected_renderer_types,
+                selected_renderer_entries=selected_renderer_entries_for_mapping,
             )
             aux_llm_calls.append(dict(decision))
             return dict(decision)

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -2876,6 +2876,39 @@ def _extract_screen_calendar_elements_from_render_plan(
     return calendar_elements
 
 
+def _extract_screen_chart_elements_from_render_plan(
+    render_plan: dict[str, Any] | None,
+    *,
+    screen_element_targets: dict[str, bool] | None = None,
+) -> list[dict[str, Any]]:
+    """Extract display-contract chart_view specs from renderer plan diagnostics."""
+    if not isinstance(render_plan, dict):
+        return []
+    if isinstance(screen_element_targets, dict) and not bool(
+        screen_element_targets.get("chart_view", True)
+    ):
+        return []
+
+    chart_elements: list[dict[str, Any]] = []
+
+    def _append_chart_specs(raw_value: Any) -> None:
+        if isinstance(raw_value, list):
+            for item in raw_value:
+                if isinstance(item, dict):
+                    chart_elements.append(dict(item))
+        elif isinstance(raw_value, dict):
+            chart_elements.append(dict(raw_value))
+
+    _append_chart_specs(render_plan.get("screen_chart_elements"))
+    _append_chart_specs(render_plan.get("screen_chart_payloads"))
+
+    single_chart = render_plan.get("screen_chart_element")
+    if isinstance(single_chart, dict):
+        chart_elements.append(dict(single_chart))
+
+    return chart_elements
+
+
 def _extract_screen_document_elements_from_render_plan(
     render_plan: dict[str, Any] | None,
     *,
@@ -3120,6 +3153,7 @@ def _extract_screen_element_targets_from_render_plan(
         "workflow_view": True,
         "task_view": True,
         "calendar_view": True,
+        "chart_view": True,
         "location_view": True,
         "document_view": True,
         "kanban_view": True,
@@ -3140,6 +3174,7 @@ def _extract_screen_element_targets_from_render_plan(
         "workflow_view": bool(raw_targets.get("workflow_view", True)),
         "task_view": bool(raw_targets.get("task_view", True)),
         "calendar_view": bool(raw_targets.get("calendar_view", True)),
+        "chart_view": bool(raw_targets.get("chart_view", True)),
         "location_view": bool(raw_targets.get("location_view", True)),
         "document_view": bool(raw_targets.get("document_view", True)),
         "kanban_view": bool(raw_targets.get("kanban_view", True)),
@@ -6984,6 +7019,10 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             render_plan_for_display,
             screen_element_targets=screen_element_targets,
         )
+        screen_chart_elements = _extract_screen_chart_elements_from_render_plan(
+            render_plan_for_display,
+            screen_element_targets=screen_element_targets,
+        )
         screen_location_elements = _extract_screen_location_elements_from_render_plan(
             render_plan_for_display,
             screen_element_targets=screen_element_targets,
@@ -7025,6 +7064,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             screen_workflow_elements=screen_workflow_elements,
             screen_task_view_elements=screen_task_view_elements,
             screen_calendar_elements=screen_calendar_elements,
+            screen_chart_elements=screen_chart_elements,
             screen_location_elements=screen_location_elements,
             screen_document_elements=screen_document_elements,
             screen_kanban_elements=screen_kanban_elements,

--- a/src/backend/services/display_elements_service.py
+++ b/src/backend/services/display_elements_service.py
@@ -17,6 +17,7 @@ DISPLAY_ELEMENT_SCHEMA_VERSION = "turn_display_elements_v1"
 ALLOWED_DISPLAY_ELEMENT_TYPES = frozenset(
     {
         "calendar_view",
+        "chart_view",
         "document_view",
         "hierarchy_view",
         "location_view",
@@ -34,6 +35,7 @@ ALLOWED_DISPLAY_ELEMENT_TYPES = frozenset(
 OPTIONAL_PAYLOAD_TITLE_ELEMENT_TYPES = frozenset(
     {
         "calendar_view",
+        "chart_view",
         "document_view",
         "hierarchy_view",
         "location_view",
@@ -58,6 +60,10 @@ HIERARCHY_EDGE_BRANCH_KINDS = frozenset(
 )
 HIERARCHY_MAX_DEPTH = 12
 CALENDAR_ALLOWED_GRANULARITIES = frozenset({"month", "week", "day"})
+CHART_ALLOWED_TYPES = frozenset({"line", "bar", "area", "scatter"})
+CHART_MAX_SERIES = 20
+CHART_MAX_POINTS_PER_SERIES = 240
+CHART_MAX_TOTAL_POINTS = 1200
 LOCATION_MAX_POINTS = 240
 LOCATION_LATITUDE_MIN = -90.0
 LOCATION_LATITUDE_MAX = 90.0
@@ -1255,6 +1261,132 @@ def validate_turn_display_elements(
                             errors.append(
                                 f"{label}.payload.expansion.max_depth must be an integer between 1 and {HIERARCHY_MAX_DEPTH} when provided"
                             )
+        elif element_type == "chart_view":
+            chart_type_raw = payload.get("chart_type")
+            if not isinstance(chart_type_raw, str) or not chart_type_raw.strip():
+                errors.append(
+                    f"{label}.payload.chart_type must be one of {sorted(CHART_ALLOWED_TYPES)}"
+                )
+            else:
+                chart_type = chart_type_raw.strip().lower()
+                if chart_type not in CHART_ALLOWED_TYPES:
+                    errors.append(
+                        f"{label}.payload.chart_type must be one of {sorted(CHART_ALLOWED_TYPES)}"
+                    )
+
+            series = payload.get("series")
+            if not isinstance(series, list) or not series:
+                errors.append(f"{label}.payload.series must be a non-empty list")
+                series = []
+            if isinstance(series, list) and len(series) > CHART_MAX_SERIES:
+                errors.append(
+                    f"{label}.payload.series exceeds max size {CHART_MAX_SERIES}"
+                )
+
+            seen_series_ids: set[str] = set()
+            total_points = 0
+            for series_index, series_entry in enumerate(series):
+                series_label = f"{label}.payload.series[{series_index}]"
+                if not isinstance(series_entry, Mapping):
+                    errors.append(f"{series_label} must be a mapping")
+                    continue
+
+                series_id = series_entry.get("series_id")
+                if not isinstance(series_id, str) or not series_id.strip():
+                    errors.append(
+                        f"{series_label}.series_id must be a non-empty string"
+                    )
+                elif series_id in seen_series_ids:
+                    errors.append(f"{series_label}.series_id must be unique")
+                else:
+                    seen_series_ids.add(series_id)
+
+                series_name = series_entry.get("label")
+                if not isinstance(series_name, str) or not series_name.strip():
+                    errors.append(f"{series_label}.label must be a non-empty string")
+
+                points = series_entry.get("points")
+                if not isinstance(points, list) or not points:
+                    errors.append(f"{series_label}.points must be a non-empty list")
+                    points = []
+                if isinstance(points, list) and len(points) > CHART_MAX_POINTS_PER_SERIES:
+                    errors.append(
+                        f"{series_label}.points exceeds max size {CHART_MAX_POINTS_PER_SERIES}"
+                    )
+
+                total_points += len(points)
+                for point_index, point in enumerate(points):
+                    point_label = f"{series_label}.points[{point_index}]"
+                    if not isinstance(point, Mapping):
+                        errors.append(f"{point_label} must be a mapping")
+                        continue
+
+                    x_value = point.get("x")
+                    x_is_valid = (
+                        isinstance(x_value, str)
+                        and bool(x_value.strip())
+                    ) or (
+                        isinstance(x_value, (int, float))
+                        and not isinstance(x_value, bool)
+                        and not math.isnan(float(x_value))
+                        and not math.isinf(float(x_value))
+                    )
+                    if not x_is_valid:
+                        errors.append(
+                            f"{point_label}.x must be a non-empty string or finite number"
+                        )
+
+                    y_value = _normalise_float(point.get("y"))
+                    if y_value is None:
+                        errors.append(
+                            f"{point_label}.y must be a finite number"
+                        )
+
+                    point_meta = point.get("meta")
+                    if point_meta is not None and not isinstance(point_meta, Mapping):
+                        errors.append(
+                            f"{point_label}.meta must be a mapping when provided"
+                        )
+
+                    _validate_task_links(
+                        links=point.get("task_links"),
+                        label=f"{point_label}.task_links",
+                        errors=errors,
+                    )
+
+                _validate_task_links(
+                    links=series_entry.get("task_links"),
+                    label=f"{series_label}.task_links",
+                    errors=errors,
+                )
+
+            if total_points > CHART_MAX_TOTAL_POINTS:
+                errors.append(
+                    f"{label}.payload.series total points exceeds max size {CHART_MAX_TOTAL_POINTS}"
+                )
+
+            for axis_key in ("x_axis", "y_axis", "units"):
+                axis_value = payload.get(axis_key)
+                if axis_value is not None and (
+                    not isinstance(axis_value, str) or not axis_value.strip()
+                ):
+                    errors.append(
+                        f"{label}.payload.{axis_key} must be a non-empty string when provided"
+                    )
+
+            stacked = payload.get("stacked")
+            if stacked is not None and not isinstance(stacked, bool):
+                errors.append(f"{label}.payload.stacked must be a boolean when provided")
+
+            legend = payload.get("legend")
+            if legend is not None and not isinstance(legend, bool):
+                errors.append(f"{label}.payload.legend must be a boolean when provided")
+
+            _validate_task_links(
+                links=payload.get("task_links"),
+                label=f"{label}.payload.task_links",
+                errors=errors,
+            )
         elif element_type == "location_view":
             points = payload.get("points")
             if not isinstance(points, list) or not points:
@@ -2253,6 +2385,89 @@ def _normalise_supplied_screen_calendar_views(
     return normalised, dropped_count
 
 
+def _normalise_supplied_screen_chart_views(
+    screen_chart_elements: Sequence[Mapping[str, Any]] | None,
+) -> tuple[list[dict[str, Any]], int]:
+    """Normalise externally supplied screen chart-view specs."""
+    if (
+        not isinstance(screen_chart_elements, Sequence)
+        or isinstance(screen_chart_elements, (str, bytes, bytearray))
+    ):
+        return [], 0
+
+    normalised: list[dict[str, Any]] = []
+    dropped_count = 0
+
+    for index, raw_spec in enumerate(screen_chart_elements, start=1):
+        if not isinstance(raw_spec, Mapping):
+            dropped_count += 1
+            continue
+
+        payload: Mapping[str, Any] | None = None
+        metadata = raw_spec
+        wrapped_payload = raw_spec.get("payload")
+        if isinstance(wrapped_payload, Mapping):
+            payload = wrapped_payload
+        elif "chart_type" in raw_spec and "series" in raw_spec:
+            payload = raw_spec
+
+        if not isinstance(payload, Mapping):
+            dropped_count += 1
+            continue
+
+        intent = (
+            _normalise_text(metadata.get("intent"))
+            or "structured_chart_view"
+        )
+        constraints = metadata.get("constraints")
+        if not isinstance(constraints, Mapping):
+            constraints = {
+                "supports_legend_toggle": True,
+                "supports_series_comparison": True,
+            }
+        provenance = metadata.get("provenance")
+        if not isinstance(provenance, Mapping):
+            provenance = {}
+        canonical_payload = _with_optional_payload_title(payload, metadata=metadata)
+
+        is_valid, _errors = validate_turn_display_elements(
+            {
+                "schema_version": DISPLAY_ELEMENT_SCHEMA_VERSION,
+                "elements": [
+                    {
+                        "element_id": f"screen_structured_chart_view_probe_{index}",
+                        "element_type": "chart_view",
+                        "channel": "screen",
+                        "order": 37,
+                        "intent": intent,
+                        "payload": dict(canonical_payload),
+                        "constraints": dict(constraints),
+                        "provenance": dict(provenance),
+                    }
+                ],
+                "reason_codes": [],
+            }
+        )
+        if not is_valid:
+            dropped_count += 1
+            continue
+
+        normalised.append(
+            {
+                "element_id": _normalise_text(metadata.get("element_id")),
+                "order": metadata.get("order")
+                if isinstance(metadata.get("order"), int)
+                else None,
+                "intent": intent,
+                "payload": dict(canonical_payload),
+                "constraints": dict(constraints),
+                "provenance": dict(provenance),
+            }
+        )
+
+    return normalised, dropped_count
+
+
 def _normalise_supplied_screen_location_views(
     screen_location_elements: Sequence[Mapping[str, Any]] | None,
 ) -> tuple[list[dict[str, Any]], int]:
@@ -2970,6 +3185,7 @@ def build_turn_display_elements(
     screen_workflow_elements: Sequence[Mapping[str, Any]] | None = None,
     screen_task_view_elements: Sequence[Mapping[str, Any]] | None = None,
     screen_calendar_elements: Sequence[Mapping[str, Any]] | None = None,
+    screen_chart_elements: Sequence[Mapping[str, Any]] | None = None,
     screen_location_elements: Sequence[Mapping[str, Any]] | None = None,
     screen_document_elements: Sequence[Mapping[str, Any]] | None = None,
     screen_kanban_elements: Sequence[Mapping[str, Any]] | None = None,
@@ -3129,6 +3345,14 @@ def build_turn_display_elements(
         reason_codes.append("screen_structured_calendar_views_supplied")
     if supplied_calendar_views_dropped:
         reason_codes.append("screen_structured_calendar_views_invalid_dropped")
+
+    supplied_screen_chart_views, supplied_chart_views_dropped = (
+        _normalise_supplied_screen_chart_views(screen_chart_elements)
+    )
+    if supplied_screen_chart_views:
+        reason_codes.append("screen_structured_chart_views_supplied")
+    if supplied_chart_views_dropped:
+        reason_codes.append("screen_structured_chart_views_invalid_dropped")
 
     supplied_screen_location_views, supplied_location_views_dropped = (
         _normalise_supplied_screen_location_views(screen_location_elements)
@@ -3297,6 +3521,27 @@ def build_turn_display_elements(
             }
         )
 
+    chart_specs: list[dict[str, Any]] = []
+    for index, spec in enumerate(supplied_screen_chart_views, start=1):
+        provenance = dict(spec.get("provenance") or {})
+        provenance.setdefault("source", "screen_structured_chart_view")
+        provenance.setdefault("chart_view_index", index)
+        chart_specs.append(
+            {
+                "element_id": spec.get("element_id")
+                or f"screen_structured_chart_view_{index}",
+                "order": spec.get("order"),
+                "intent": spec.get("intent") or "structured_chart_view",
+                "payload": spec.get("payload") or {},
+                "constraints": spec.get("constraints")
+                or {
+                    "supports_legend_toggle": True,
+                    "supports_series_comparison": True,
+                },
+                "provenance": provenance,
+            }
+        )
+
     location_specs: list[dict[str, Any]] = []
     for index, spec in enumerate(supplied_screen_location_views, start=1):
         provenance = dict(spec.get("provenance") or {})
@@ -3453,6 +3698,7 @@ def build_turn_display_elements(
             *table_specs,
             *workflow_specs,
             *task_view_specs,
+            *chart_specs,
             *calendar_specs,
             *location_specs,
             *document_specs,
@@ -3503,6 +3749,30 @@ def build_turn_display_elements(
             {
                 "element_id": element_id,
                 "element_type": "timeline",
+                "channel": "screen",
+                "order": int(order),
+                "intent": str(spec["intent"]),
+                "payload": dict(spec["payload"]),
+                "constraints": dict(spec["constraints"]),
+                "provenance": dict(spec["provenance"]),
+            }
+        )
+
+    next_chart_order = 37
+    for spec in chart_specs:
+        order = spec.get("order") if isinstance(spec.get("order"), int) else None
+        if order is None:
+            while next_chart_order in used_orders:
+                next_chart_order += 1
+            order = next_chart_order
+            used_orders.add(order)
+            next_chart_order += 1
+
+        element_id = _next_unique_element_id(str(spec["element_id"]), used_ids)
+        elements.append(
+            {
+                "element_id": element_id,
+                "element_type": "chart_view",
                 "channel": "screen",
                 "order": int(order),
                 "intent": str(spec["intent"]),

--- a/src/backend/services/renderer_applicability_service.py
+++ b/src/backend/services/renderer_applicability_service.py
@@ -25,6 +25,50 @@ _DEFAULT_OBJECT_KINDS = (
     OBJECT_KIND_TRANSIENT_MICROTHEORY,
 )
 
+_SCREEN_ELEMENT_FAMILY_ALIASES: dict[str, str] = {
+    "table": "table",
+    "tabular": "table",
+    "workflow": "workflow_view",
+    "workflow_view": "workflow_view",
+    "task": "task_view",
+    "task_view": "task_view",
+    "calendar": "calendar_view",
+    "calendar_view": "calendar_view",
+    "chart": "chart_view",
+    "chart_view": "chart_view",
+    "location": "location_view",
+    "location_view": "location_view",
+    "geo": "location_view",
+    "map": "location_view",
+    "document": "document_view",
+    "document_view": "document_view",
+    "citation": "document_view",
+    "kanban": "kanban_view",
+    "kanban_view": "kanban_view",
+    "timeline": "timeline",
+    "hierarchy": "hierarchy_view",
+    "hierarchy_view": "hierarchy_view",
+    "tree": "hierarchy_view",
+    "relation_graph": "relation_graph_view",
+    "relation_graph_view": "relation_graph_view",
+    "graph": "relation_graph_view",
+}
+_ALLOWED_SCREEN_ELEMENT_FAMILIES: frozenset[str] = frozenset(
+    {
+        "table",
+        "workflow_view",
+        "task_view",
+        "calendar_view",
+        "chart_view",
+        "location_view",
+        "document_view",
+        "kanban_view",
+        "timeline",
+        "hierarchy_view",
+        "relation_graph_view",
+    }
+)
+
 
 def _normalise_strings(values: Sequence[Any] | None) -> tuple[str, ...]:
     if not values:
@@ -65,6 +109,27 @@ def _coerce_float(value: Any) -> float | None:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def _normalise_screen_element_families(values: Any) -> tuple[str, ...]:
+    raw_values = _coerce_sequence_values(values)
+    if not raw_values:
+        return ()
+
+    normalised: list[str] = []
+    seen: set[str] = set()
+    for raw_value in raw_values:
+        text = str(raw_value or "").strip().lower()
+        if not text:
+            continue
+        mapped = _SCREEN_ELEMENT_FAMILY_ALIASES.get(text, text)
+        if mapped not in _ALLOWED_SCREEN_ELEMENT_FAMILIES:
+            continue
+        if mapped in seen:
+            continue
+        seen.add(mapped)
+        normalised.append(mapped)
+    return tuple(normalised)
 
 
 @dataclass(frozen=True)
@@ -138,6 +203,7 @@ class RendererProfile:
     minimum_confidence: float | None
     priority: int
     fallback_renderer_ids: tuple[str, ...]
+    screen_element_families: tuple[str, ...]
 
     @classmethod
     def from_mapping(cls, raw: Mapping[str, Any]) -> RendererProfile:
@@ -186,6 +252,9 @@ class RendererProfile:
             priority=priority,
             fallback_renderer_ids=_normalise_strings(
                 _coerce_sequence_values(raw.get("fallback_renderer_ids"))
+            ),
+            screen_element_families=_normalise_screen_element_families(
+                raw.get("screen_element_families")
             ),
         )
 
@@ -258,6 +327,7 @@ class RendererSelection:
     modalities: tuple[str, ...]
     selection_reason: str
     fallback_renderer_ids: tuple[str, ...]
+    screen_element_families: tuple[str, ...]
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -266,6 +336,7 @@ class RendererSelection:
             "modalities": list(self.modalities),
             "selection_reason": self.selection_reason,
             "fallback_renderer_ids": list(self.fallback_renderer_ids),
+            "screen_element_families": list(self.screen_element_families),
         }
 
 
@@ -367,6 +438,7 @@ def _select_renderers(
                         modalities=profile.modalities,
                         selection_reason=f"highest_priority_for_modality:{modality}",
                         fallback_renderer_ids=(),
+                        screen_element_families=profile.screen_element_families,
                     )
                 )
                 selected_ids.add(profile.renderer_id)
@@ -381,6 +453,7 @@ def _select_renderers(
                 modalities=primary.modalities,
                 selection_reason="highest_priority_applicable_renderer",
                 fallback_renderer_ids=(),
+                screen_element_families=primary.screen_element_families,
             )
         )
         selected_ids.add(primary.renderer_id)
@@ -409,6 +482,7 @@ def _select_renderers(
                 modalities=item.modalities,
                 selection_reason=item.selection_reason,
                 fallback_renderer_ids=tuple(fallback_ids),
+                screen_element_families=profile.screen_element_families,
             )
         )
     return tuple(enriched)

--- a/src/backend/services/renderer_applicability_vontology_service.py
+++ b/src/backend/services/renderer_applicability_vontology_service.py
@@ -37,6 +37,7 @@ _CANONICAL_RENDERER_PROFILE_BLUEPRINTS: tuple[dict[str, Any], ...] = (
         "required_context_tags": ["workflow:tool_calling"],
         "priority": 90,
         "fallback_renderer_ids": ["#V#table_renderer"],
+        "screen_element_families": ["timeline"],
     },
     {
         "renderer_id": "#V#workflow_renderer",
@@ -46,6 +47,7 @@ _CANONICAL_RENDERER_PROFILE_BLUEPRINTS: tuple[dict[str, Any], ...] = (
         "required_context_tags": ["workflow:tool_calling"],
         "priority": 80,
         "fallback_renderer_ids": ["#V#table_renderer"],
+        "screen_element_families": ["workflow_view"],
     },
     {
         "renderer_id": "#V#table_renderer",
@@ -53,6 +55,7 @@ _CANONICAL_RENDERER_PROFILE_BLUEPRINTS: tuple[dict[str, Any], ...] = (
         "modalities": ["visual"],
         "applies_to_object_kinds": ["concept", "transient_microtheory"],
         "priority": 60,
+        "screen_element_families": ["table"],
     },
     {
         "renderer_id": "#V#narration_renderer",
@@ -61,6 +64,7 @@ _CANONICAL_RENDERER_PROFILE_BLUEPRINTS: tuple[dict[str, Any], ...] = (
         "applies_to_object_kinds": ["concept", "transient_microtheory"],
         "required_context_tags": ["presenter_mode"],
         "priority": 95,
+        "screen_element_families": [],
     },
 )
 _CANONICAL_RENDERER_PROFILE_BY_ID: dict[str, dict[str, Any]] = {
@@ -202,6 +206,7 @@ def _serialise_renderer_profile(profile: RendererProfile) -> dict[str, Any]:
         "minimum_confidence": profile.minimum_confidence,
         "priority": profile.priority,
         "fallback_renderer_ids": list(profile.fallback_renderer_ids),
+        "screen_element_families": list(profile.screen_element_families),
     }
 
 

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -22,6 +22,7 @@ import {
     copyTextWithClipboardFallback,
     resetCopyJsonButtonPreCopyState
 } from './utils/copyJsonButtonState.js';
+import { saveJsonTextViaDialog } from './utils/fileSave.js';
 import {
     CHAT_HISTORY_RECENT_LIMIT_STORAGE_KEY,
     CHAT_HISTORY_RECENT_WINDOW_DAYS_STORAGE_KEY,
@@ -2203,6 +2204,10 @@ const KANBAN_MAX_COLUMNS = 30;
 const KANBAN_MAX_CARDS = 200;
 const TIMELINE_MAX_ITEMS = 200;
 const CALENDAR_MAX_ITEMS = 240;
+const CHART_ALLOWED_TYPES = new Set(['line', 'bar', 'area', 'scatter']);
+const CHART_MAX_SERIES = 20;
+const CHART_MAX_POINTS_PER_SERIES = 240;
+const CHART_MAX_TOTAL_POINTS = 1200;
 const LOCATION_MAX_POINTS = 200;
 const LOCATION_LATITUDE_MIN = -90;
 const LOCATION_LATITUDE_MAX = 90;
@@ -3324,6 +3329,179 @@ function resolveCalendarDisplayElements(debugData) {
         calendarViews.push(calendarElement);
     }
     return calendarViews;
+}
+
+function normaliseChartType(value) {
+    if (typeof value !== 'string') {
+        return null;
+    }
+    const token = value.trim().toLowerCase();
+    if (!token || !CHART_ALLOWED_TYPES.has(token)) {
+        return null;
+    }
+    return token;
+}
+
+function normaliseChartAxisLabel(value) {
+    if (typeof value !== 'string') {
+        return '';
+    }
+    return value.trim();
+}
+
+function normaliseChartXValue(value) {
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) {
+            return null;
+        }
+        return value;
+    }
+    if (typeof value === 'string') {
+        const cleaned = value.trim();
+        if (!cleaned) {
+            return null;
+        }
+        const numeric = Number(cleaned);
+        if (Number.isFinite(numeric) && /^-?\d+(\.\d+)?$/.test(cleaned)) {
+            return numeric;
+        }
+        return cleaned;
+    }
+    return null;
+}
+
+function normaliseChartDisplayElement(element) {
+    if (!element || typeof element !== 'object') {
+        return null;
+    }
+    if (String(element.element_type || '').trim() !== 'chart_view') {
+        return null;
+    }
+
+    const payload = element.payload;
+    if (!payload || typeof payload !== 'object') {
+        return null;
+    }
+
+    const chartType = normaliseChartType(payload.chart_type);
+    if (!chartType) {
+        return null;
+    }
+
+    const rawSeries = Array.isArray(payload.series) ? payload.series : [];
+    const series = [];
+    let totalPoints = 0;
+    const seenSeriesIds = new Set();
+    for (let seriesIndex = 0; seriesIndex < rawSeries.length; seriesIndex += 1) {
+        if (series.length >= CHART_MAX_SERIES || totalPoints >= CHART_MAX_TOTAL_POINTS) {
+            break;
+        }
+
+        const rawSeriesEntry = rawSeries[seriesIndex];
+        if (!rawSeriesEntry || typeof rawSeriesEntry !== 'object') {
+            continue;
+        }
+        const seriesId = typeof rawSeriesEntry.series_id === 'string' && rawSeriesEntry.series_id.trim()
+            ? rawSeriesEntry.series_id.trim()
+            : `series_${seriesIndex + 1}`;
+        if (seenSeriesIds.has(seriesId)) {
+            continue;
+        }
+
+        const label = typeof rawSeriesEntry.label === 'string' && rawSeriesEntry.label.trim()
+            ? rawSeriesEntry.label.trim()
+            : seriesId;
+        const rawPoints = Array.isArray(rawSeriesEntry.points) ? rawSeriesEntry.points : [];
+        const points = [];
+        for (let pointIndex = 0; pointIndex < rawPoints.length; pointIndex += 1) {
+            if (points.length >= CHART_MAX_POINTS_PER_SERIES || totalPoints >= CHART_MAX_TOTAL_POINTS) {
+                break;
+            }
+            const rawPoint = rawPoints[pointIndex];
+            if (!rawPoint || typeof rawPoint !== 'object') {
+                continue;
+            }
+            const xValue = normaliseChartXValue(rawPoint.x);
+            const yValue = Number(rawPoint.y);
+            if (xValue === null || !Number.isFinite(yValue)) {
+                continue;
+            }
+            const point = {
+                x: xValue,
+                y: yValue
+            };
+            if (rawPoint.meta && typeof rawPoint.meta === 'object') {
+                point.meta = rawPoint.meta;
+            }
+            const rawTaskLinks = Array.isArray(rawPoint.task_links) ? rawPoint.task_links : [];
+            const taskLinks = rawTaskLinks
+                .map((link) => normaliseWorkflowTaskLink(link))
+                .filter(Boolean);
+            if (taskLinks.length) {
+                point.task_links = taskLinks;
+            }
+            points.push(point);
+            totalPoints += 1;
+        }
+        if (!points.length) {
+            continue;
+        }
+
+        const rawTaskLinks = Array.isArray(rawSeriesEntry.task_links) ? rawSeriesEntry.task_links : [];
+        const taskLinks = rawTaskLinks
+            .map((link) => normaliseWorkflowTaskLink(link))
+            .filter(Boolean);
+
+        series.push({
+            series_id: seriesId,
+            label,
+            points,
+            task_links: taskLinks
+        });
+        seenSeriesIds.add(seriesId);
+    }
+
+    if (!series.length) {
+        return null;
+    }
+
+    const rawTaskLinks = Array.isArray(payload.task_links) ? payload.task_links : [];
+    const taskLinks = rawTaskLinks
+        .map((link) => normaliseWorkflowTaskLink(link))
+        .filter(Boolean);
+
+    const stacked = typeof payload.stacked === 'boolean' ? payload.stacked : false;
+    const legend = typeof payload.legend === 'boolean' ? payload.legend : (series.length > 1);
+
+    return {
+        element_id: typeof element.element_id === 'string' ? element.element_id.trim() : null,
+        title: normaliseOptionalDisplayElementTitle(payload.title),
+        chart_type: chartType,
+        x_axis: normaliseChartAxisLabel(payload.x_axis),
+        y_axis: normaliseChartAxisLabel(payload.y_axis),
+        units: normaliseChartAxisLabel(payload.units),
+        stacked,
+        legend,
+        series,
+        task_links: taskLinks
+    };
+}
+
+function resolveChartDisplayElements(debugData) {
+    const contract = normaliseDisplayElementsContract(debugData?.display_elements);
+    if (!contract) {
+        return [];
+    }
+
+    const chartViews = [];
+    for (const element of contract.elements) {
+        const chartElement = normaliseChartDisplayElement(element);
+        if (!chartElement) {
+            continue;
+        }
+        chartViews.push(chartElement);
+    }
+    return chartViews;
 }
 
 function normaliseLocationCoordinate(value, minValue, maxValue) {
@@ -5035,6 +5213,478 @@ function buildHierarchyScene(hierarchyElement) {
     return section;
 }
 
+const CHART_SERIES_COLOURS = [
+    '#1f4f7a',
+    '#0f766e',
+    '#7c3aed',
+    '#b45309',
+    '#be123c',
+    '#047857',
+    '#4c1d95',
+    '#0f766e'
+];
+
+function formatChartTickValue(value) {
+    if (!Number.isFinite(value)) {
+        return '';
+    }
+    const absoluteValue = Math.abs(value);
+    if (absoluteValue >= 1000) {
+        return `${(value / 1000).toFixed(1)}k`;
+    }
+    if (absoluteValue >= 100) {
+        return value.toFixed(0);
+    }
+    if (absoluteValue >= 10) {
+        return value.toFixed(1);
+    }
+    return value.toFixed(2).replace(/\.?0+$/, '');
+}
+
+function toChartPointKey(xValue) {
+    if (typeof xValue === 'number' && Number.isFinite(xValue)) {
+        return `n:${xValue}`;
+    }
+    return `s:${String(xValue)}`;
+}
+
+function createChartSectionElement(chartElement, chartIndex, chartTotal) {
+    if (!chartElement || typeof chartElement !== 'object') {
+        return null;
+    }
+
+    const section = document.createElement('section');
+    section.className = 'chat-display-elements-chart-section';
+
+    const title = document.createElement('div');
+    title.className = 'chat-display-elements-chart-title';
+    title.textContent = resolveDisplayElementSectionTitle(
+        chartElement.title,
+        'Chart view',
+        chartIndex,
+        chartTotal
+    );
+    title.style.cssText = 'font-weight: 600; font-size: 0.85em; color: #2f4f6f; margin-bottom: 6px;';
+    section.appendChild(title);
+
+    const summary = document.createElement('div');
+    summary.className = 'chat-display-elements-chart-summary';
+    const pointCount = chartElement.series.reduce((total, seriesEntry) => (
+        total + (Array.isArray(seriesEntry.points) ? seriesEntry.points.length : 0)
+    ), 0);
+    summary.textContent = `${chartElement.chart_type} chart · ${chartElement.series.length} series · ${pointCount} points`;
+    summary.style.cssText = 'font-size: 0.78em; color: #5a6b7b; margin-bottom: 6px;';
+    section.appendChild(summary);
+
+    const plotWrap = document.createElement('div');
+    plotWrap.className = 'chat-display-elements-chart-plot-wrap';
+    plotWrap.style.cssText = 'border: 1px solid #dce3ea; border-radius: 6px; background: #fff; padding: 8px;';
+    section.appendChild(plotWrap);
+
+    const width = 680;
+    const height = 260;
+    const margin = {
+        top: 12,
+        right: 16,
+        bottom: 42,
+        left: 54
+    };
+    const innerWidth = width - margin.left - margin.right;
+    const innerHeight = height - margin.top - margin.bottom;
+
+    const allPoints = [];
+    for (const seriesEntry of chartElement.series) {
+        for (const point of seriesEntry.points) {
+            allPoints.push(point);
+        }
+    }
+    if (allPoints.length === 0) {
+        return section;
+    }
+
+    const allNumericX = allPoints.every((point) => (
+        typeof point.x === 'number' && Number.isFinite(point.x)
+    ));
+    const categoryKeys = [];
+    const categoryLabelByKey = new Map();
+    const categoryIndexByKey = new Map();
+    const registerCategory = (xValue) => {
+        const key = toChartPointKey(xValue);
+        if (categoryIndexByKey.has(key)) {
+            return key;
+        }
+        categoryIndexByKey.set(key, categoryKeys.length);
+        categoryKeys.push(key);
+        categoryLabelByKey.set(key, String(xValue));
+        return key;
+    };
+
+    if (!allNumericX || chartElement.chart_type === 'bar') {
+        for (const point of allPoints) {
+            registerCategory(point.x);
+        }
+    }
+
+    let xMin = 0;
+    let xMax = 1;
+    if (allNumericX) {
+        xMin = Math.min(...allPoints.map((point) => Number(point.x)));
+        xMax = Math.max(...allPoints.map((point) => Number(point.x)));
+        if (xMin === xMax) {
+            xMin -= 0.5;
+            xMax += 0.5;
+        }
+    }
+
+    const resolveX = (xValue) => {
+        if (allNumericX && chartElement.chart_type !== 'bar') {
+            const numeric = Number(xValue);
+            if (!Number.isFinite(numeric)) {
+                return margin.left;
+            }
+            return margin.left + ((numeric - xMin) / (xMax - xMin)) * innerWidth;
+        }
+        const key = registerCategory(xValue);
+        const index = categoryIndexByKey.get(key) || 0;
+        const step = innerWidth / Math.max(categoryKeys.length, 1);
+        return margin.left + ((index + 0.5) * step);
+    };
+
+    const resolveXFromCategoryKey = (categoryKey) => {
+        const key = typeof categoryKey === 'string' ? categoryKey : toChartPointKey(categoryKey);
+        const index = categoryIndexByKey.get(key) || 0;
+        const step = innerWidth / Math.max(categoryKeys.length, 1);
+        return margin.left + ((index + 0.5) * step);
+    };
+
+    const yValues = [];
+    if (chartElement.chart_type === 'bar' && chartElement.stacked) {
+        const categoryTotals = new Map();
+        for (const seriesEntry of chartElement.series) {
+            for (const point of seriesEntry.points) {
+                const key = registerCategory(point.x);
+                const current = categoryTotals.get(key) || 0;
+                categoryTotals.set(key, current + Number(point.y));
+            }
+        }
+        for (const total of categoryTotals.values()) {
+            yValues.push(Number(total));
+        }
+    } else {
+        for (const point of allPoints) {
+            yValues.push(Number(point.y));
+        }
+    }
+    let yMin = Math.min(...yValues);
+    let yMax = Math.max(...yValues);
+    if (chartElement.chart_type === 'bar' || chartElement.chart_type === 'area') {
+        yMin = Math.min(0, yMin);
+        yMax = Math.max(0, yMax);
+    }
+    if (!Number.isFinite(yMin) || !Number.isFinite(yMax)) {
+        yMin = 0;
+        yMax = 1;
+    }
+    if (yMin === yMax) {
+        yMin -= 0.5;
+        yMax += 0.5;
+    }
+    const resolveY = (value) => (
+        margin.top + ((yMax - Number(value)) / (yMax - yMin)) * innerHeight
+    );
+
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('class', 'chat-display-elements-chart-svg');
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    svg.setAttribute('width', '100%');
+    svg.setAttribute('height', String(height));
+    svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+    svg.style.display = 'block';
+    plotWrap.appendChild(svg);
+
+    const axisColour = '#9aa8b6';
+    const axisGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    svg.appendChild(axisGroup);
+
+    const xAxis = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    xAxis.setAttribute('x1', String(margin.left));
+    xAxis.setAttribute('y1', String(margin.top + innerHeight));
+    xAxis.setAttribute('x2', String(margin.left + innerWidth));
+    xAxis.setAttribute('y2', String(margin.top + innerHeight));
+    xAxis.setAttribute('stroke', axisColour);
+    axisGroup.appendChild(xAxis);
+
+    const yAxis = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    yAxis.setAttribute('x1', String(margin.left));
+    yAxis.setAttribute('y1', String(margin.top));
+    yAxis.setAttribute('x2', String(margin.left));
+    yAxis.setAttribute('y2', String(margin.top + innerHeight));
+    yAxis.setAttribute('stroke', axisColour);
+    axisGroup.appendChild(yAxis);
+
+    const gridTickCount = 4;
+    for (let tickIndex = 0; tickIndex <= gridTickCount; tickIndex += 1) {
+        const ratio = tickIndex / gridTickCount;
+        const yValue = yMin + ((yMax - yMin) * (1 - ratio));
+        const y = margin.top + (ratio * innerHeight);
+
+        const grid = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        grid.setAttribute('x1', String(margin.left));
+        grid.setAttribute('y1', String(y));
+        grid.setAttribute('x2', String(margin.left + innerWidth));
+        grid.setAttribute('y2', String(y));
+        grid.setAttribute('stroke', '#edf2f7');
+        svg.appendChild(grid);
+
+        const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        label.setAttribute('x', String(margin.left - 8));
+        label.setAttribute('y', String(y + 3));
+        label.setAttribute('text-anchor', 'end');
+        label.setAttribute('font-size', '10');
+        label.setAttribute('fill', '#5a6b7b');
+        label.textContent = formatChartTickValue(yValue);
+        svg.appendChild(label);
+    }
+
+    if (!allNumericX || chartElement.chart_type === 'bar') {
+        const maxXTicks = 12;
+        const step = Math.max(1, Math.ceil(categoryKeys.length / maxXTicks));
+        for (let index = 0; index < categoryKeys.length; index += step) {
+            const key = categoryKeys[index];
+            const labelText = categoryLabelByKey.get(key) || key;
+            const x = resolveXFromCategoryKey(key);
+            const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+            label.setAttribute('x', String(x));
+            label.setAttribute('y', String(margin.top + innerHeight + 15));
+            label.setAttribute('text-anchor', 'middle');
+            label.setAttribute('font-size', '10');
+            label.setAttribute('fill', '#5a6b7b');
+            label.textContent = labelText;
+            svg.appendChild(label);
+        }
+    } else {
+        const minLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        minLabel.setAttribute('x', String(margin.left));
+        minLabel.setAttribute('y', String(margin.top + innerHeight + 15));
+        minLabel.setAttribute('text-anchor', 'start');
+        minLabel.setAttribute('font-size', '10');
+        minLabel.setAttribute('fill', '#5a6b7b');
+        minLabel.textContent = formatChartTickValue(xMin);
+        svg.appendChild(minLabel);
+
+        const maxLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        maxLabel.setAttribute('x', String(margin.left + innerWidth));
+        maxLabel.setAttribute('y', String(margin.top + innerHeight + 15));
+        maxLabel.setAttribute('text-anchor', 'end');
+        maxLabel.setAttribute('font-size', '10');
+        maxLabel.setAttribute('fill', '#5a6b7b');
+        maxLabel.textContent = formatChartTickValue(xMax);
+        svg.appendChild(maxLabel);
+    }
+
+    const seriesPointLookup = chartElement.series.map((seriesEntry) => {
+        const map = new Map();
+        for (const point of seriesEntry.points) {
+            map.set(toChartPointKey(point.x), point);
+        }
+        return map;
+    });
+
+    const baselineY = resolveY(Math.max(0, yMin));
+    if (chartElement.chart_type === 'bar') {
+        const categoryStep = innerWidth / Math.max(categoryKeys.length, 1);
+        if (chartElement.stacked) {
+            const runningByCategory = new Map();
+            for (let seriesIndex = 0; seriesIndex < chartElement.series.length; seriesIndex += 1) {
+                const seriesEntry = chartElement.series[seriesIndex];
+                const colour = CHART_SERIES_COLOURS[seriesIndex % CHART_SERIES_COLOURS.length];
+                const pointLookup = seriesPointLookup[seriesIndex];
+                for (const key of categoryKeys) {
+                    const point = pointLookup.get(key);
+                    if (!point) {
+                        continue;
+                    }
+                    const previous = runningByCategory.get(key) || 0;
+                    const next = previous + Number(point.y);
+                    const yTop = resolveY(Math.max(previous, next));
+                    const yBottom = resolveY(Math.min(previous, next));
+                    const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+                    const xCentre = resolveXFromCategoryKey(key);
+                    rect.setAttribute('x', String(xCentre - (categoryStep * 0.31)));
+                    rect.setAttribute('y', String(yTop));
+                    rect.setAttribute('width', String(categoryStep * 0.62));
+                    rect.setAttribute('height', String(Math.max(1, yBottom - yTop)));
+                    rect.setAttribute('fill', colour);
+                    rect.setAttribute('opacity', '0.86');
+                    svg.appendChild(rect);
+                    runningByCategory.set(key, next);
+                }
+            }
+        } else {
+            const groupWidth = categoryStep * 0.72;
+            const barWidth = groupWidth / Math.max(chartElement.series.length, 1);
+            for (let seriesIndex = 0; seriesIndex < chartElement.series.length; seriesIndex += 1) {
+                const seriesEntry = chartElement.series[seriesIndex];
+                const colour = CHART_SERIES_COLOURS[seriesIndex % CHART_SERIES_COLOURS.length];
+                const pointLookup = seriesPointLookup[seriesIndex];
+                for (const key of categoryKeys) {
+                    const point = pointLookup.get(key);
+                    if (!point) {
+                        continue;
+                    }
+                    const xCentre = resolveXFromCategoryKey(key);
+                    const x = (xCentre - (groupWidth / 2)) + (seriesIndex * barWidth);
+                    const y = resolveY(Number(point.y));
+                    const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+                    rect.setAttribute('x', String(x));
+                    rect.setAttribute('y', String(Math.min(y, baselineY)));
+                    rect.setAttribute('width', String(Math.max(1, barWidth - 1)));
+                    rect.setAttribute('height', String(Math.max(1, Math.abs(baselineY - y))));
+                    rect.setAttribute('fill', colour);
+                    rect.setAttribute('opacity', '0.86');
+                    svg.appendChild(rect);
+                }
+            }
+        }
+    } else {
+        for (let seriesIndex = 0; seriesIndex < chartElement.series.length; seriesIndex += 1) {
+            const seriesEntry = chartElement.series[seriesIndex];
+            const colour = CHART_SERIES_COLOURS[seriesIndex % CHART_SERIES_COLOURS.length];
+            const coords = seriesEntry.points
+                .map((point) => ({
+                    point,
+                    x: resolveX(point.x),
+                    y: resolveY(Number(point.y))
+                }))
+                .sort((left, right) => left.x - right.x);
+
+            if (coords.length >= 2 && (chartElement.chart_type === 'line' || chartElement.chart_type === 'area')) {
+                const linePath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+                const pathText = coords.map((coord, index) => (
+                    `${index === 0 ? 'M' : 'L'} ${coord.x.toFixed(3)} ${coord.y.toFixed(3)}`
+                )).join(' ');
+                linePath.setAttribute('d', pathText);
+                linePath.setAttribute('fill', 'none');
+                linePath.setAttribute('stroke', colour);
+                linePath.setAttribute('stroke-width', '2');
+                svg.appendChild(linePath);
+
+                if (chartElement.chart_type === 'area') {
+                    const areaPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+                    const first = coords[0];
+                    const last = coords[coords.length - 1];
+                    const areaSegments = [
+                        `M ${first.x.toFixed(3)} ${baselineY.toFixed(3)}`,
+                        ...coords.map((coord) => `L ${coord.x.toFixed(3)} ${coord.y.toFixed(3)}`),
+                        `L ${last.x.toFixed(3)} ${baselineY.toFixed(3)}`,
+                        'Z'
+                    ];
+                    areaPath.setAttribute('d', areaSegments.join(' '));
+                    areaPath.setAttribute('fill', colour);
+                    areaPath.setAttribute('opacity', '0.18');
+                    svg.appendChild(areaPath);
+                }
+            }
+
+            for (const coord of coords) {
+                const dot = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+                dot.setAttribute('cx', String(coord.x));
+                dot.setAttribute('cy', String(coord.y));
+                dot.setAttribute('r', chartElement.chart_type === 'scatter' ? '3.4' : '2.6');
+                dot.setAttribute('fill', colour);
+                svg.appendChild(dot);
+            }
+        }
+    }
+
+    const axisMeta = [];
+    if (chartElement.x_axis) {
+        axisMeta.push(`X: ${chartElement.x_axis}`);
+    }
+    if (chartElement.y_axis) {
+        axisMeta.push(`Y: ${chartElement.y_axis}`);
+    }
+    if (chartElement.units) {
+        axisMeta.push(`Units: ${chartElement.units}`);
+    }
+    if (axisMeta.length > 0) {
+        const axisLabel = document.createElement('div');
+        axisLabel.className = 'chat-display-elements-chart-axis-meta';
+        axisLabel.textContent = axisMeta.join(' · ');
+        axisLabel.style.cssText = 'margin-top: 6px; font-size: 0.76em; color: #4b5563;';
+        plotWrap.appendChild(axisLabel);
+    }
+
+    if (chartElement.legend) {
+        const legend = document.createElement('div');
+        legend.className = 'chat-display-elements-chart-legend';
+        legend.style.cssText = 'display: flex; flex-wrap: wrap; gap: 8px 12px; margin-top: 7px;';
+        chartElement.series.forEach((seriesEntry, seriesIndex) => {
+            const item = document.createElement('div');
+            item.className = 'chat-display-elements-chart-legend-item';
+            item.style.cssText = 'display: inline-flex; align-items: center; gap: 6px; font-size: 0.76em; color: #334155;';
+
+            const swatch = document.createElement('span');
+            swatch.style.cssText = `display: inline-block; width: 10px; height: 10px; border-radius: 2px; background: ${CHART_SERIES_COLOURS[seriesIndex % CHART_SERIES_COLOURS.length]};`;
+            item.appendChild(swatch);
+
+            const text = document.createElement('span');
+            text.textContent = seriesEntry.label;
+            item.appendChild(text);
+            legend.appendChild(item);
+        });
+        plotWrap.appendChild(legend);
+    }
+
+    const fallback = document.createElement('ul');
+    fallback.className = 'chat-display-elements-chart-fallback-list';
+    fallback.style.cssText = 'margin: 8px 0 0; padding-left: 18px; font-size: 0.77em; color: #334155;';
+    chartElement.series.forEach((seriesEntry) => {
+        const li = document.createElement('li');
+        const preview = seriesEntry.points
+            .slice(0, 4)
+            .map((point) => `${point.x}:${formatChartTickValue(Number(point.y))}`)
+            .join(', ');
+        li.textContent = `${seriesEntry.label}: ${preview}${seriesEntry.points.length > 4 ? ', ...' : ''}`;
+        fallback.appendChild(li);
+    });
+    section.appendChild(fallback);
+
+    const collectedTaskLinks = [];
+    const seenTaskLinkKeys = new Set();
+    const collectTaskLinks = (links) => {
+        if (!Array.isArray(links)) {
+            return;
+        }
+        for (const link of links) {
+            const normalised = normaliseWorkflowTaskLink(link);
+            if (!normalised) {
+                continue;
+            }
+            const key = `${normalised.target_id}|${normalised.href || ''}|${normalised.label || ''}`;
+            if (seenTaskLinkKeys.has(key)) {
+                continue;
+            }
+            seenTaskLinkKeys.add(key);
+            collectedTaskLinks.push(normalised);
+        }
+    };
+    collectTaskLinks(chartElement.task_links);
+    chartElement.series.forEach((seriesEntry) => {
+        collectTaskLinks(seriesEntry.task_links);
+        seriesEntry.points.forEach((point) => {
+            collectTaskLinks(point.task_links);
+        });
+    });
+    appendTaskLinksToCard(
+        section,
+        collectedTaskLinks,
+        'chat-display-elements-chart-links'
+    );
+
+    return section;
+}
+
 function renderTableDisplayElementsIntoContainer(container, debugData) {
     if (!container || typeof container.querySelectorAll !== 'function') {
         return;
@@ -5059,6 +5709,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
     const kanbanElements = resolveKanbanDisplayElements(debugData);
     const timelineElements = resolveTimelineDisplayElements(debugData);
     const calendarElements = resolveCalendarDisplayElements(debugData);
+    const chartElements = resolveChartDisplayElements(debugData);
     const locationElements = resolveLocationDisplayElements(debugData);
     const documentElements = resolveDocumentDisplayElements(debugData);
     const hierarchyElements = resolveHierarchyDisplayElements(debugData);
@@ -5090,6 +5741,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
         && !kanbanElements.length
         && !timelineElements.length
         && !calendarElements.length
+        && !chartElements.length
         && !locationElements.length
         && !documentElements.length
         && !hierarchyElements.length
@@ -5842,6 +6494,27 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
         root.appendChild(section);
     });
 
+    chartElements.forEach((chartElement, chartIndex) => {
+        const section = createChartSectionElement(
+            chartElement,
+            chartIndex,
+            chartElements.length
+        );
+        if (!section) {
+            return;
+        }
+        section.style.cssText = (
+            tableElements.length > 0
+            || workflowElements.length > 0
+            || taskViewElements.length > 0
+            || kanbanElements.length > 0
+            || timelineElements.length > 0
+            || calendarElements.length > 0
+            || chartIndex > 0
+        ) ? 'margin-top: 10px;' : '';
+        root.appendChild(section);
+    });
+
     locationElements.forEach((locationElement, locationIndex) => {
         const section = document.createElement('section');
         section.className = 'chat-display-elements-location-section';
@@ -5852,6 +6525,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
             || kanbanElements.length > 0
             || timelineElements.length > 0
             || calendarElements.length > 0
+            || chartElements.length > 0
             || locationIndex > 0
         ) ? 'margin-top: 10px;' : '';
 
@@ -5987,6 +6661,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
             || kanbanElements.length > 0
             || timelineElements.length > 0
             || calendarElements.length > 0
+            || chartElements.length > 0
             || locationElements.length > 0
             || documentIndex > 0
         ) ? 'margin-top: 10px;' : '';
@@ -6138,6 +6813,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
             || kanbanElements.length > 0
             || timelineElements.length > 0
             || calendarElements.length > 0
+            || chartElements.length > 0
             || locationElements.length > 0
             || documentElements.length > 0
             || hierarchyIndex > 0
@@ -6177,6 +6853,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
             || kanbanElements.length > 0
             || timelineElements.length > 0
             || calendarElements.length > 0
+            || chartElements.length > 0
             || locationElements.length > 0
             || documentElements.length > 0
             || hierarchyElements.length > 0
@@ -6219,6 +6896,7 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
             || hierarchyElements.length > 0
             || relationGraphElements.length > 0
             || calendarElements.length > 0
+            || chartElements.length > 0
             || locationElements.length > 0
             || documentElements.length > 0
             || relationIndex > 0
@@ -6466,6 +7144,7 @@ function extractRenderPlanSourceSummary(
     screenKanbanElements,
     screenTimelineElements,
     screenCalendarElements,
+    screenChartElements,
     screenLocationElements,
     screenDocumentElements,
     screenHierarchyElements,
@@ -6548,6 +7227,12 @@ function extractRenderPlanSourceSummary(
         }
         addProvenance(calendarElement.provenance);
     }
+    for (const chartElement of screenChartElements) {
+        if (!chartElement || typeof chartElement !== 'object') {
+            continue;
+        }
+        addProvenance(chartElement.provenance);
+    }
     for (const locationElement of screenLocationElements) {
         if (!locationElement || typeof locationElement !== 'object') {
             continue;
@@ -6616,6 +7301,9 @@ function buildRenderPlanMetadataSummary(renderPlan) {
     const screenCalendarElements = Array.isArray(renderPlan.screen_calendar_elements)
         ? renderPlan.screen_calendar_elements.filter(item => item && typeof item === 'object')
         : [];
+    const screenChartElements = Array.isArray(renderPlan.screen_chart_elements)
+        ? renderPlan.screen_chart_elements.filter(item => item && typeof item === 'object')
+        : [];
     const screenLocationElements = Array.isArray(renderPlan.screen_location_elements)
         ? renderPlan.screen_location_elements.filter(item => item && typeof item === 'object')
         : [];
@@ -6636,6 +7324,7 @@ function buildRenderPlanMetadataSummary(renderPlan) {
         screenKanbanElements,
         screenTimelineElements,
         screenCalendarElements,
+        screenChartElements,
         screenLocationElements,
         screenDocumentElements,
         screenHierarchyElements,
@@ -6670,6 +7359,7 @@ function buildRenderPlanMetadataSummary(renderPlan) {
         screen_kanban_element_count: screenKanbanElements.length,
         screen_timeline_element_count: screenTimelineElements.length,
         screen_calendar_element_count: screenCalendarElements.length,
+        screen_chart_element_count: screenChartElements.length,
         screen_location_element_count: screenLocationElements.length,
         screen_document_element_count: screenDocumentElements.length,
         screen_hierarchy_element_count: screenHierarchyElements.length,
@@ -6739,6 +7429,7 @@ function buildRenderPlanSummaryHtml(renderPlanSummary) {
     addScalar('Screen kanban elements', renderPlanSummary.screen_kanban_element_count);
     addScalar('Screen timeline elements', renderPlanSummary.screen_timeline_element_count);
     addScalar('Screen calendar elements', renderPlanSummary.screen_calendar_element_count);
+    addScalar('Screen chart elements', renderPlanSummary.screen_chart_element_count);
     addScalar('Screen location elements', renderPlanSummary.screen_location_element_count);
     addScalar('Screen document elements', renderPlanSummary.screen_document_element_count);
     addScalar('Screen hierarchy elements', renderPlanSummary.screen_hierarchy_element_count);
@@ -18089,7 +18780,12 @@ async function showLlmDebugPopup(turnId, options = {}) {
 }
 
 // Handle export full conversation JSON
-function handleExportConversationJson() {
+function buildConversationTelemetryExportFilename() {
+    const timestamp = new Date().toISOString().replace(/:/g, '-').replace(/\.\d{3}Z$/, 'Z');
+    return `von_conversation_telemetry_${timestamp}.json`;
+}
+
+async function handleExportConversationJson() {
     const button = document.getElementById('exportConversationJsonBtn');
     if (!button) return;
     const originalContent = button.innerHTML;
@@ -18141,33 +18837,30 @@ function handleExportConversationJson() {
     // Convert to JSON string
     const jsonString = JSON.stringify(conversationData, null, 2);
 
-    const markSuccess = (message) => {
-        console.log(message, conversationData.turns.length, 'turns');
-        indicateClipboardResult(button, originalContent, true);
-    };
+    try {
+        const result = await saveJsonTextViaDialog(jsonString, {
+            suggestedName: buildConversationTelemetryExportFilename()
+        });
 
-    const markFailure = (message, err) => {
-        console.error(message, err);
-        indicateClipboardResult(button, originalContent, false);
-    };
-
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(jsonString)
-            .then(() => {
-                markSuccess('[chatTab] Exported conversation JSON to clipboard:');
-            })
-            .catch((err) => {
-                console.error('[chatTab] Failed to copy conversation JSON via clipboard API:', err);
-                if (copyTextFallback(jsonString)) {
-                    markSuccess('[chatTab] Exported conversation JSON (fallback):');
-                } else {
-                    markFailure('[chatTab] Failed to copy conversation JSON (fallback):', err);
-                }
+        if (result?.saved) {
+            console.log('[chatTab] Saved conversation telemetry JSON:', {
+                turns: conversationData.turns.length,
+                method: result.method,
+                filename: result.filename
             });
-    } else if (copyTextFallback(jsonString)) {
-        markSuccess('[chatTab] Exported conversation JSON (fallback):');
-    } else {
-        markFailure('[chatTab] Clipboard export unavailable and fallback failed:', new Error('Clipboard unsupported'));
+            indicateClipboardResult(button, originalContent, true);
+            return;
+        }
+
+        if (result?.cancelled) {
+            return;
+        }
+
+        console.error('[chatTab] Failed to save conversation telemetry JSON:', result?.error);
+        indicateClipboardResult(button, originalContent, false);
+    } catch (error) {
+        console.error('[chatTab] Unexpected error while saving conversation telemetry JSON:', error);
+        indicateClipboardResult(button, originalContent, false);
     }
 }
 

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -1366,6 +1366,70 @@ describe('calendar display elements', () => {
     });
 });
 
+describe('chart display elements', () => {
+    test('renders structured chart view with svg and readable legend', () => {
+        const container = document.createElement('div');
+        const debugData = {
+            display_elements: {
+                schema_version: 'turn_display_elements_v1',
+                elements: [
+                    {
+                        element_id: 'screen_chart_view',
+                        element_type: 'chart_view',
+                        channel: 'screen',
+                        order: 37,
+                        intent: 'structured_chart_view',
+                        payload: {
+                            title: 'Task trend',
+                            chart_type: 'line',
+                            x_axis: 'Week',
+                            y_axis: 'Count',
+                            legend: true,
+                            series: [
+                                {
+                                    series_id: 'open_tasks',
+                                    label: 'Open tasks',
+                                    points: [
+                                        { x: '2026-02-17', y: 8 },
+                                        { x: '2026-02-24', y: 6 }
+                                    ]
+                                },
+                                {
+                                    series_id: 'closed_tasks',
+                                    label: 'Closed tasks',
+                                    points: [
+                                        { x: '2026-02-17', y: 2 },
+                                        { x: '2026-02-24', y: 4 }
+                                    ]
+                                }
+                            ]
+                        },
+                        provenance: { source: 'test' }
+                    }
+                ]
+            }
+        };
+
+        __testOnly_renderDisplayElementsIntoContainer(container, debugData);
+
+        const section = container.querySelector('.chat-display-elements-chart-section');
+        expect(section).not.toBeNull();
+        expect(section.textContent).toContain('Task trend');
+        expect(section.textContent).toContain('Open tasks');
+        expect(section.textContent).toContain('Closed tasks');
+
+        const svg = section.querySelector('.chat-display-elements-chart-svg');
+        expect(svg).not.toBeNull();
+        expect(svg.getAttribute('viewBox')).toContain('0 0');
+
+        const legendItems = section.querySelectorAll('.chat-display-elements-chart-legend-item');
+        expect(legendItems.length).toBe(2);
+
+        const fallbackRows = section.querySelectorAll('.chat-display-elements-chart-fallback-list li');
+        expect(fallbackRows.length).toBe(2);
+    });
+});
+
 describe('location display elements', () => {
     test('renders location map markers with address fallback and task links', () => {
         const container = document.createElement('div');
@@ -2227,6 +2291,39 @@ describe('LLM debug popup metadata (internal MCP caps + usage)', () => {
             screen_location_element_count: 1,
             source_tools: ['task_list'],
             record_families: ['location_points']
+        });
+    });
+
+    test('includes chart render plan provenance counts when present', () => {
+        const metadata = __testOnly_buildLlmDebugMetadata({
+            model: 'gpt-test',
+            messages: [],
+            render_plan: {
+                enabled: true,
+                attempted: true,
+                success: true,
+                reason: 'resolved',
+                selected_renderer_ids: ['#V#renderer_chart'],
+                selected_renderer_types: ['chart'],
+                screen_element_families: ['chart_view'],
+                screen_chart_elements: [
+                    {
+                        element_id: 'screen_chart_view',
+                        provenance: {
+                            source_tools: ['task_list'],
+                            record_family: 'chart_series'
+                        }
+                    }
+                ]
+            }
+        });
+
+        expect(metadata.render_plan).toMatchObject({
+            selected_renderer_types: ['chart'],
+            screen_element_families: ['chart_view'],
+            screen_chart_element_count: 1,
+            source_tools: ['task_list'],
+            record_families: ['chart_series']
         });
     });
 

--- a/tests/backend/test_display_elements_service.py
+++ b/tests/backend/test_display_elements_service.py
@@ -670,6 +670,86 @@ def test_build_turn_display_elements_drops_invalid_supplied_calendar_views() -> 
     assert contract["validation"]["valid"] is True
 
 
+def test_build_turn_display_elements_includes_supplied_chart_views() -> None:
+    contract = build_turn_display_elements(
+        response_text="Chart response",
+        presenter_channels={
+            "format": "tagged_blocks_v1",
+            "screen": "Chart response",
+            "spoken": None,
+        },
+        screen_chart_elements=[
+            {
+                "element_id": "screen_chart_view",
+                "intent": "structured_chart_view",
+                "payload": {
+                    "title": "Task trend",
+                    "chart_type": "line",
+                    "x_axis": "Week",
+                    "y_axis": "Count",
+                    "series": [
+                        {
+                            "series_id": "open_tasks",
+                            "label": "Open tasks",
+                            "points": [
+                                {"x": "2026-02-17", "y": 8},
+                                {"x": "2026-02-24", "y": 6},
+                            ],
+                        }
+                    ],
+                },
+            }
+        ],
+    )
+
+    chart_elements = [
+        element
+        for element in contract["elements"]
+        if element["element_type"] == "chart_view"
+    ]
+    assert len(chart_elements) == 1
+    chart_element = chart_elements[0]
+    assert chart_element["element_id"] == "screen_chart_view"
+    assert chart_element["payload"]["chart_type"] == "line"
+    assert chart_element["payload"]["series"][0]["points"][1]["y"] == 6
+    assert "screen_structured_chart_views_supplied" in contract["reason_codes"]
+    assert contract["validation"]["valid"] is True
+
+
+def test_build_turn_display_elements_drops_invalid_supplied_chart_views() -> None:
+    contract = build_turn_display_elements(
+        response_text="Chart response",
+        presenter_channels={
+            "format": "tagged_blocks_v1",
+            "screen": "Chart response",
+            "spoken": None,
+        },
+        screen_chart_elements=[
+            {
+                "payload": {
+                    "chart_type": "line",
+                    "series": [
+                        {
+                            "series_id": "broken_series",
+                            "label": "Broken",
+                            "points": [{"x": "2026-02-17"}],
+                        }
+                    ],
+                }
+            }
+        ],
+    )
+
+    chart_elements = [
+        element
+        for element in contract["elements"]
+        if element["element_type"] == "chart_view"
+    ]
+    assert chart_elements == []
+    assert "screen_structured_chart_views_invalid_dropped" in contract["reason_codes"]
+    assert contract["validation"]["valid"] is True
+
+
 def test_build_turn_display_elements_includes_supplied_location_views() -> None:
     contract = build_turn_display_elements(
         response_text="Location response",
@@ -1349,6 +1429,41 @@ def test_validate_turn_display_elements_rejects_calendar_item_without_title() ->
     assert any("default_granularity must be one of" in message for message in errors)
 
 
+def test_validate_turn_display_elements_rejects_invalid_chart_view_shape() -> None:
+    valid, errors = validate_turn_display_elements(
+        {
+            "schema_version": "turn_display_elements_v1",
+            "elements": [
+                {
+                    "element_id": "screen_chart_view",
+                    "element_type": "chart_view",
+                    "channel": "screen",
+                    "order": 37,
+                    "intent": "structured_chart_view",
+                    "payload": {
+                        "chart_type": "pie",
+                        "series": [
+                            {
+                                "series_id": "alpha",
+                                "label": "Alpha",
+                                "points": [{"x": "2026-02-17"}],
+                            }
+                        ],
+                        "stacked": "yes",
+                    },
+                    "provenance": {"source": "test"},
+                }
+            ],
+            "reason_codes": [],
+        }
+    )
+
+    assert valid is False
+    assert any(".payload.chart_type must be one of" in message for message in errors)
+    assert any(".points[0].y must be a finite number" in message for message in errors)
+    assert any(".payload.stacked must be a boolean" in message for message in errors)
+
+
 def test_validate_turn_display_elements_rejects_invalid_location_view_shape() -> None:
     valid, errors = validate_turn_display_elements(
         {
@@ -1978,6 +2093,24 @@ def test_build_turn_display_elements_preserves_optional_payload_titles() -> None
                 }
             }
         ],
+        screen_chart_elements=[
+            {
+                "payload": {
+                    "title": "Task trend",
+                    "chart_type": "line",
+                    "series": [
+                        {
+                            "series_id": "open_tasks",
+                            "label": "Open tasks",
+                            "points": [
+                                {"x": "2026-02-17", "y": 8},
+                                {"x": "2026-02-24", "y": 6},
+                            ],
+                        }
+                    ],
+                }
+            }
+        ],
         screen_location_elements=[
             {
                 "payload": {
@@ -2080,6 +2213,7 @@ def test_build_turn_display_elements_preserves_optional_payload_titles() -> None
             "kanban_view",
             "timeline",
             "calendar_view",
+            "chart_view",
             "location_view",
             "document_view",
             "hierarchy_view",
@@ -2093,6 +2227,7 @@ def test_build_turn_display_elements_preserves_optional_payload_titles() -> None
     assert payload_title_by_type["kanban_view"] == "Kanban backlog"
     assert payload_title_by_type["timeline"] == "Timeline of changes"
     assert payload_title_by_type["calendar_view"] == "Calendar schedule"
+    assert payload_title_by_type["chart_view"] == "Task trend"
     assert payload_title_by_type["location_view"] == "Location markers"
     assert payload_title_by_type["document_view"] == "Document excerpts"
     assert payload_title_by_type["hierarchy_view"] == "Meeting hierarchy"

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -948,6 +948,7 @@ def test_renderer_selection_gates_screen_element_families(monkeypatch):
         "workflow_view": True,
         "task_view": False,
         "calendar_view": False,
+        "chart_view": False,
         "location_view": False,
         "document_view": False,
         "kanban_view": False,
@@ -961,6 +962,102 @@ def test_renderer_selection_gates_screen_element_families(monkeypatch):
         "renderer_screen_elements:selected_renderer_types"
         in result.render_plan.get("screen_element_reason_codes", [])
     )
+
+
+def test_renderer_selection_uses_profile_screen_families_for_custom_renderer_type(
+    monkeypatch,
+):
+    """Profile-declared screen families should work even for unknown renderer types."""
+    orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
+    monkeypatch.setenv("VON_RENDERER_APPLICABILITY_ROUTING_ENABLE", "1")
+    monkeypatch.setenv(
+        "VON_RENDERER_APPLICABILITY_DEFINITION_IDS",
+        "#V#custom_metric_renderer",
+    )
+
+    def _invoke(tool_name: str, _payload: Mapping[str, Any]):
+        if tool_name != "renderer_resolve_applicability":
+            raise AssertionError(f"Unexpected tool invocation: {tool_name}")
+        return _InvokeResult(
+            {
+                "success": True,
+                "selected_renderers": [
+                    {
+                        "renderer_id": "#V#custom_metric_renderer",
+                        "renderer_type": "custom_metric_renderer",
+                        "modalities": ["visual"],
+                        "screen_element_families": ["chart_view"],
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr(orchestrator._gateway, "invoke", _invoke)
+
+    class _WorkflowResult:
+        def __init__(self):
+            self.data = {
+                "final_response": "Chart summary.",
+                "tool_messages": [
+                    {
+                        "role": "tool",
+                        "content": json.dumps(
+                            {
+                                "tool": "task_list",
+                                "status": "ok",
+                                "duration_ms": 2.0,
+                                "payload": {
+                                    "tasks": [
+                                        {"task_concept_id": "#V#task_alpha", "status": "todo"},
+                                        {"task_concept_id": "#V#task_beta", "status": "done"},
+                                    ]
+                                },
+                            }
+                        ),
+                    }
+                ],
+                "invocations": [],
+                "iteration_count": 1,
+            }
+            self.final_state = "completed"
+            self.completed = True
+
+    def _execute_workflow(workflow_id: str, **_kwargs: Any):
+        if workflow_id != TOOL_CALLING_WORKFLOW_ID:
+            raise AssertionError(f"Unexpected workflow execution: {workflow_id}")
+        return _WorkflowResult()
+
+    monkeypatch.setattr(orchestrator, "execute_workflow", _execute_workflow)
+
+    llm = _CapturingLLM(["tool_seeking"])
+    result = orchestrator.run(
+        prompt="Show metrics chart",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+    )
+
+    assert isinstance(result.render_plan, dict)
+    assert result.render_plan.get("screen_element_targets") == {
+        "table": False,
+        "workflow_view": False,
+        "task_view": False,
+        "calendar_view": False,
+        "chart_view": True,
+        "location_view": False,
+        "document_view": False,
+        "kanban_view": False,
+        "timeline": False,
+        "hierarchy_view": False,
+        "relation_graph_view": False,
+    }
+    assert result.render_plan.get("screen_chart_element_count") == 1
+    assert (
+        "renderer_screen_elements:selected_renderer_profiles"
+        in result.render_plan.get("screen_element_reason_codes", [])
+    )
+    assert "unsupported_selected_renderer_types" not in result.render_plan
 
 
 def test_renderer_selection_emits_timeline_elements_for_timeline_renderer(monkeypatch):
@@ -1049,6 +1146,7 @@ def test_renderer_selection_emits_timeline_elements_for_timeline_renderer(monkey
         "workflow_view": False,
         "task_view": False,
         "calendar_view": False,
+        "chart_view": False,
         "location_view": False,
         "document_view": False,
         "kanban_view": False,
@@ -1152,6 +1250,7 @@ def test_renderer_selection_emits_calendar_elements_for_calendar_renderer(monkey
         "workflow_view": False,
         "task_view": False,
         "calendar_view": True,
+        "chart_view": False,
         "location_view": False,
         "document_view": False,
         "kanban_view": False,
@@ -1175,6 +1274,131 @@ def test_renderer_selection_emits_calendar_elements_for_calendar_renderer(monkey
     assert items[0]["title"] == "Alpha task"
     assert items[0]["all_day"] is True
     assert items[0]["task_links"][0]["target_id"] == "#V#task_alpha"
+
+
+def test_renderer_selection_emits_chart_elements_for_chart_renderer(monkeypatch):
+    """Chart renderer selection should emit chart display elements only."""
+    orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
+    monkeypatch.setenv("VON_RENDERER_APPLICABILITY_ROUTING_ENABLE", "1")
+    monkeypatch.setenv(
+        "VON_RENDERER_APPLICABILITY_DEFINITION_IDS",
+        "#V#chart_renderer,#V#workflow_renderer,#V#table_renderer",
+    )
+
+    def _invoke(tool_name: str, _payload: Mapping[str, Any]):
+        if tool_name != "renderer_resolve_applicability":
+            raise AssertionError(f"Unexpected tool invocation: {tool_name}")
+        return _InvokeResult(
+            {
+                "success": True,
+                "selected_renderers": [
+                    {
+                        "renderer_id": "#V#chart_renderer",
+                        "renderer_type": "chart",
+                        "modalities": ["visual"],
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr(orchestrator._gateway, "invoke", _invoke)
+
+    class _WorkflowResult:
+        def __init__(self):
+            self.data = {
+                "final_response": "Chart summary.",
+                "tool_messages": [
+                    {
+                        "role": "tool",
+                        "content": json.dumps(
+                            {
+                                "tool": "task_list",
+                                "status": "ok",
+                                "duration_ms": 2.4,
+                                "payload": {
+                                    "tasks": [
+                                        {
+                                            "task_concept_id": "#V#task_alpha",
+                                            "title": "Alpha task",
+                                            "status": "pending",
+                                        },
+                                        {
+                                            "task_concept_id": "#V#task_beta",
+                                            "title": "Beta task",
+                                            "status": "done",
+                                        },
+                                        {
+                                            "task_concept_id": "#V#task_gamma",
+                                            "title": "Gamma task",
+                                            "status": "pending",
+                                        },
+                                    ]
+                                },
+                            }
+                        ),
+                    }
+                ],
+                "invocations": [],
+                "iteration_count": 1,
+            }
+            self.final_state = "completed"
+            self.completed = True
+
+    def _execute_workflow(workflow_id: str, **_kwargs: Any):
+        if workflow_id != TOOL_CALLING_WORKFLOW_ID:
+            raise AssertionError(f"Unexpected workflow execution: {workflow_id}")
+        return _WorkflowResult()
+
+    monkeypatch.setattr(orchestrator, "execute_workflow", _execute_workflow)
+
+    llm = _CapturingLLM(["tool_seeking"])
+    result = orchestrator.run(
+        prompt="Show chart",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+    )
+
+    assert isinstance(result.render_plan, dict)
+    assert result.render_plan.get("screen_element_mapping_mode") == "selected_renderer_types"
+    assert result.render_plan.get("screen_element_targets") == {
+        "table": False,
+        "workflow_view": False,
+        "task_view": False,
+        "calendar_view": False,
+        "chart_view": True,
+        "location_view": False,
+        "document_view": False,
+        "kanban_view": False,
+        "timeline": False,
+        "hierarchy_view": False,
+        "relation_graph_view": False,
+    }
+    assert "screen_table_record_sets" not in result.render_plan
+    assert "screen_workflow_elements" not in result.render_plan
+    assert "screen_task_view_elements" not in result.render_plan
+    assert "screen_timeline_elements" not in result.render_plan
+    assert result.render_plan.get("screen_chart_element_count") == 1
+
+    chart_elements = result.render_plan.get("screen_chart_elements")
+    assert isinstance(chart_elements, list)
+    assert len(chart_elements) == 1
+    payload = chart_elements[0].get("payload", {})
+    assert payload.get("chart_type") == "bar"
+    assert payload.get("x_axis") == "Task status"
+    series = payload.get("series")
+    assert isinstance(series, list)
+    assert series[0]["series_id"] == "task_status_counts"
+    points = series[0].get("points")
+    assert isinstance(points, list)
+    point_by_status = {
+        str(point.get("x")): point.get("y")
+        for point in points
+        if isinstance(point, Mapping)
+    }
+    assert point_by_status["pending"] == 2
+    assert point_by_status["done"] == 1
 
 
 def test_renderer_selection_emits_location_elements_for_location_renderer(monkeypatch):
@@ -1268,6 +1492,7 @@ def test_renderer_selection_emits_location_elements_for_location_renderer(monkey
         "workflow_view": False,
         "task_view": False,
         "calendar_view": False,
+        "chart_view": False,
         "location_view": True,
         "document_view": False,
         "kanban_view": False,
@@ -1379,6 +1604,7 @@ def test_renderer_selection_emits_document_elements_for_document_renderer(monkey
         "workflow_view": False,
         "task_view": False,
         "calendar_view": False,
+        "chart_view": False,
         "location_view": False,
         "document_view": True,
         "kanban_view": False,
@@ -1486,6 +1712,7 @@ def test_renderer_selection_emits_task_view_elements_for_task_renderer(monkeypat
         "workflow_view": False,
         "task_view": True,
         "calendar_view": False,
+        "chart_view": False,
         "location_view": False,
         "document_view": False,
         "kanban_view": False,
@@ -1601,6 +1828,7 @@ def test_renderer_selection_emits_kanban_elements_for_kanban_renderer(monkeypatc
         "workflow_view": False,
         "task_view": False,
         "calendar_view": False,
+        "chart_view": False,
         "location_view": False,
         "document_view": False,
         "kanban_view": True,
@@ -1716,6 +1944,7 @@ def test_renderer_selection_emits_relation_graph_elements_for_graph_renderer(mon
         "workflow_view": False,
         "task_view": False,
         "calendar_view": False,
+        "chart_view": False,
         "location_view": False,
         "document_view": False,
         "kanban_view": False,
@@ -1821,6 +2050,7 @@ def test_renderer_selection_fallback_when_no_types_selected(monkeypatch):
         "workflow_view": True,
         "task_view": False,
         "calendar_view": False,
+        "chart_view": False,
         "location_view": False,
         "document_view": False,
         "kanban_view": False,
@@ -2747,4 +2977,6 @@ def test_no_routing_info_when_selector_disabled(monkeypatch):
     )
 
     assert result.workflow_routing is None
+
+
 

--- a/tests/backend/test_renderer_applicability_service.py
+++ b/tests/backend/test_renderer_applicability_service.py
@@ -18,6 +18,7 @@ def test_resolver_selects_highest_priority_concept_renderer() -> None:
                 "applies_to_concept_type_ids": ["#V#task"],
                 "required_predicates": ["#V#has_start_time"],
                 "priority": 90,
+                "screen_element_families": ["timeline"],
             }
         ),
         RendererProfile.from_mapping(
@@ -29,6 +30,7 @@ def test_resolver_selects_highest_priority_concept_renderer() -> None:
                 "applies_to_concept_type_ids": ["#V#task"],
                 "required_predicates": ["#V#has_due_time"],
                 "priority": 60,
+                "screen_element_families": ["table"],
             }
         ),
     )
@@ -50,6 +52,7 @@ def test_resolver_selects_highest_priority_concept_renderer() -> None:
     assert not result.interpreted_as_transient_microtheory
     assert len(result.selected_renderers) == 1
     assert result.selected_renderers[0].renderer_id == "#V#timeline_renderer"
+    assert result.selected_renderers[0].screen_element_families == ("timeline",)
     assert all(item.applicable for item in result.candidate_evaluations)
 
 
@@ -96,6 +99,7 @@ def test_resolver_supports_multimodal_selection_with_fallbacks() -> None:
                 "applies_to_object_kinds": ["concept"],
                 "priority": 100,
                 "fallback_renderer_ids": ["#V#chart_visual_renderer"],
+                "screen_element_families": ["table"],
             }
         ),
         RendererProfile.from_mapping(
@@ -106,6 +110,7 @@ def test_resolver_supports_multimodal_selection_with_fallbacks() -> None:
                 "applies_to_object_kinds": ["concept"],
                 "priority": 90,
                 "fallback_renderer_ids": ["#V#text_summary_renderer"],
+                "screen_element_families": [],
             }
         ),
         RendererProfile.from_mapping(
@@ -115,6 +120,7 @@ def test_resolver_supports_multimodal_selection_with_fallbacks() -> None:
                 "modalities": ["textual"],
                 "applies_to_object_kinds": ["concept"],
                 "priority": 50,
+                "screen_element_families": [],
             }
         ),
         RendererProfile.from_mapping(
@@ -124,6 +130,7 @@ def test_resolver_supports_multimodal_selection_with_fallbacks() -> None:
                 "modalities": ["visual"],
                 "applies_to_object_kinds": ["concept"],
                 "priority": 40,
+                "screen_element_families": ["chart_view"],
             }
         ),
     )
@@ -144,6 +151,20 @@ def test_resolver_supports_multimodal_selection_with_fallbacks() -> None:
     assert selected_ids == ["#V#table_visual_renderer", "#V#narration_renderer"]
     assert result.selected_renderers[0].fallback_renderer_ids == ("#V#chart_visual_renderer",)
     assert result.selected_renderers[1].fallback_renderer_ids == ("#V#text_summary_renderer",)
+    assert result.selected_renderers[0].screen_element_families == ("table",)
+
+
+def test_renderer_profile_normalises_screen_element_family_aliases() -> None:
+    profile = RendererProfile.from_mapping(
+        {
+            "renderer_id": "#V#chart_visual_renderer",
+            "renderer_type": "custom_chart_renderer",
+            "modalities": ["visual"],
+            "applies_to_object_kinds": ["concept"],
+            "screen_element_families": ["chart", "chart_view", "unknown"],
+        }
+    )
+    assert profile.screen_element_families == ("chart_view",)
 
 
 def test_resolver_exposes_rejection_reasons_when_no_renderer_applies() -> None:

--- a/tests/backend/test_renderer_applicability_vontology_service.py
+++ b/tests/backend/test_renderer_applicability_vontology_service.py
@@ -25,7 +25,7 @@ def test_load_renderer_definitions_from_concept_ids_parses_profile_json(
         lambda concept_id, predicate=None, limit=50: [
             {
                 "predicate": predicate,
-                "text": '{"renderer_type":"timeline","modalities":["visual"],"priority":80}',
+                "text": '{"renderer_type":"timeline","modalities":["visual"],"priority":80,"screen_element_families":["timeline"]}',
             }
         ]
         if predicate == "#V#has_renderer_profile_json"
@@ -39,6 +39,7 @@ def test_load_renderer_definitions_from_concept_ids_parses_profile_json(
     assert len(definitions) == 1
     assert definitions[0]["renderer_id"] == "#V#timeline_renderer"
     assert definitions[0]["renderer_type"] == "timeline"
+    assert definitions[0]["screen_element_families"] == ["timeline"]
     assert diagnostics["loaded_concept_ids"] == ["#V#timeline_renderer"]
     assert diagnostics["loaded_definition_count"] == 1
 
@@ -147,12 +148,14 @@ def test_upsert_renderer_profile_validates_and_persists_singleton_text(
             "modalities": ["visual"],
             "applies_to_object_kinds": ["concept"],
             "priority": 90,
+            "screen_element_families": ["timeline"],
         },
     )
 
     assert result["success"] is True
     assert result["renderer_concept_id"] == "#V#timeline_renderer"
     assert result["renderer_profile"]["renderer_id"] == "#V#timeline_renderer"
+    assert result["renderer_profile"]["screen_element_families"] == ["timeline"]
     assert result["text_relation"]["kept_relation_id"] == "rel_1"
 
 

--- a/tests/backend/test_von_generate_render_plan_debug.py
+++ b/tests/backend/test_von_generate_render_plan_debug.py
@@ -623,6 +623,72 @@ def test_generate_builds_location_view_from_render_plan_elements(monkeypatch):
     assert points[1]["address"] == "Wellington, New Zealand"
 
 
+def test_generate_builds_chart_view_from_render_plan_elements(monkeypatch):
+    from src.backend.integrations.internal_mcp.orchestrator import OrchestratorResult
+
+    render_plan = {
+        "enabled": True,
+        "reason": "resolved",
+        "render_mode": "screen_only",
+        "should_narrate": False,
+        "screen_chart_elements": [
+            {
+                "element_id": "screen_chart_view",
+                "intent": "structured_chart_view",
+                "payload": {
+                    "chart_type": "line",
+                    "x_axis": "Week",
+                    "y_axis": "Count",
+                    "series": [
+                        {
+                            "series_id": "open_tasks",
+                            "label": "Open tasks",
+                            "points": [
+                                {"x": "2026-02-17", "y": 8},
+                                {"x": "2026-02-24", "y": 6},
+                            ],
+                        }
+                    ],
+                },
+                "provenance": {"source": "test_render_plan"},
+            }
+        ],
+    }
+    orchestrator_result = OrchestratorResult(
+        response_text="Chart summary",
+        extra_messages=(),
+        tool_invocations=(),
+        aux_llm_calls=(),
+        render_plan=render_plan,
+    )
+    app = _make_app(monkeypatch, _StubOrchestrator(orchestrator_result))
+
+    client = app.test_client()
+    response = client.post("/von/generate", json={"prompt": "Show chart"})
+    assert response.status_code == 200
+    body = response.get_json()
+    assert isinstance(body, dict)
+    display_elements = body.get("display_elements")
+    assert isinstance(display_elements, dict)
+    assert display_elements.get("validation", {}).get("valid") is True
+    assert "screen_structured_chart_views_supplied" in display_elements.get(
+        "reason_codes", []
+    )
+
+    chart_elements = [
+        element
+        for element in display_elements.get("elements", [])
+        if isinstance(element, dict) and element.get("element_type") == "chart_view"
+    ]
+    assert len(chart_elements) == 1
+    chart_payload = chart_elements[0].get("payload", {})
+    assert chart_payload.get("chart_type") == "line"
+    series = chart_payload.get("series")
+    assert isinstance(series, list)
+    assert series[0]["series_id"] == "open_tasks"
+    assert series[0]["points"][1]["y"] == 6
+
+
 def test_generate_builds_document_view_from_render_plan_elements(monkeypatch):
     from src.backend.integrations.internal_mcp.orchestrator import OrchestratorResult
 
@@ -996,6 +1062,7 @@ def test_generate_respects_renderer_screen_element_targets(monkeypatch):
             "workflow_view": True,
             "task_view": False,
             "calendar_view": False,
+            "chart_view": False,
             "location_view": False,
             "document_view": False,
             "kanban_view": False,


### PR DESCRIPTION
## Summary
- add end-to-end chart_view display element extraction, validation, routing, and frontend rendering
- extend renderer applicability profiles with screen_element_families and include them in selected renderer payloads
- generalise orchestrator screen-element gating to use profile-declared families first with legacy renderer-type fallback
- persist updated renderer profile JSON in Vontology for existing and newly created renderer concepts

## Tests
- pdm run pytest tests/backend/test_renderer_applicability_service.py tests/backend/test_renderer_applicability_vontology_service.py tests/backend/test_internal_mcp_renderer_applicability_tool.py tests/backend/test_orchestrator_workflow_selector_routing.py tests/backend/test_von_generate_render_plan_debug.py tests/backend/test_display_elements_service.py
- npm test -- src/frontend/web/von_interface/static/js/test/chatTab.test.js
- npx pyright src/backend/integrations/internal_mcp/orchestrator.py src/backend/server/routes/von_routes.py src/backend/services/display_elements_service.py src/backend/services/renderer_applicability_service.py src/backend/services/renderer_applicability_vontology_service.py tests/backend/test_display_elements_service.py tests/backend/test_orchestrator_workflow_selector_routing.py tests/backend/test_renderer_applicability_service.py tests/backend/test_renderer_applicability_vontology_service.py tests/backend/test_von_generate_render_plan_debug.py