### PR TITLE
JVNAUTOSCI-1330: Stabilise completion gate evidence and terminal outcomes

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -4668,12 +4668,89 @@ class InternalMCPChatOrchestrator:
             decision_reason = ""
         decision_reason = decision_reason.strip()
 
-        blocking_effect_ids_raw = completion_gate_payload.get("blocking_effect_ids")
-        blocking_effect_ids: list[str] = []
-        if isinstance(blocking_effect_ids_raw, list):
-            for item in blocking_effect_ids_raw:
-                if isinstance(item, str) and item.strip():
-                    blocking_effect_ids.append(item.strip())
+        def _normalise_string_list(raw_values: Any) -> list[str]:
+            normalised: list[str] = []
+            if not isinstance(raw_values, list):
+                return normalised
+            for item in raw_values:
+                if not isinstance(item, str):
+                    continue
+                cleaned = item.strip()
+                if cleaned:
+                    normalised.append(cleaned)
+            return normalised
+
+        blocking_effect_ids = _normalise_string_list(
+            completion_gate_payload.get("blocking_effect_ids")
+        )
+        blocking_failure_codes = _normalise_string_list(
+            completion_gate_payload.get("blocking_failure_codes")
+        )
+
+        record_evidence_payload_raw = completion_gate_payload.get("evidence_payload")
+        record_evidence_payload: dict[str, Any] = (
+            dict(record_evidence_payload_raw)
+            if isinstance(record_evidence_payload_raw, Mapping)
+            else {}
+        )
+
+        unresolved_preconditions: list[dict[str, Any]] = []
+        unresolved_preconditions_raw = record_evidence_payload.get("unresolved_preconditions")
+        if isinstance(unresolved_preconditions_raw, list):
+            for item in unresolved_preconditions_raw:
+                if not isinstance(item, Mapping):
+                    continue
+                unresolved_preconditions.append(
+                    {
+                        "effect_id": str(item.get("effect_id") or "").strip() or None,
+                        "effect_type": str(item.get("effect_type") or "").strip() or None,
+                        "status": str(item.get("status") or "").strip() or None,
+                        "status_reason": str(item.get("status_reason") or "").strip() or None,
+                        "failure_codes": _normalise_string_list(item.get("failure_codes")),
+                    }
+                )
+
+        if not unresolved_preconditions:
+            required_effects_raw = record.get("required_effects")
+            required_effects = (
+                required_effects_raw if isinstance(required_effects_raw, list) else []
+            )
+            for effect in required_effects:
+                if not isinstance(effect, Mapping):
+                    continue
+                effect_status = str(effect.get("status") or "").strip()
+                if effect_status not in {"not_satisfied", "not_executed"}:
+                    continue
+                failure_codes = _normalise_string_list(effect.get("failure_codes"))
+                single_failure_code = str(effect.get("failure_code") or "").strip()
+                if single_failure_code and single_failure_code not in failure_codes:
+                    failure_codes.append(single_failure_code)
+                unresolved_preconditions.append(
+                    {
+                        "effect_id": str(effect.get("effect_id") or "").strip() or None,
+                        "effect_type": str(effect.get("effect_type") or "").strip() or None,
+                        "status": effect_status,
+                        "status_reason": str(effect.get("status_reason") or "").strip()
+                        or None,
+                        "failure_codes": failure_codes,
+                    }
+                )
+
+        postcondition_summary = record_evidence_payload.get("postcondition_summary")
+        if not isinstance(postcondition_summary, Mapping):
+            critic_payload_raw = record.get("critic")
+            critic_payload = (
+                critic_payload_raw if isinstance(critic_payload_raw, Mapping) else {}
+            )
+            summary_raw = critic_payload.get("summary")
+            postcondition_summary = summary_raw if isinstance(summary_raw, Mapping) else {}
+        if not blocking_failure_codes:
+            for unresolved in unresolved_preconditions:
+                if not isinstance(unresolved, Mapping):
+                    continue
+                for code in _normalise_string_list(unresolved.get("failure_codes")):
+                    if code not in blocking_failure_codes:
+                        blocking_failure_codes.append(code)
 
         safe_to_claim_completion = bool(
             completion_gate_payload.get("safe_to_claim_completion", True)
@@ -4752,6 +4829,28 @@ class InternalMCPChatOrchestrator:
                 status_line = (
                     f"{status_line} Blocking effect IDs: {', '.join(blocking_effect_ids)}."
                 )
+            if unresolved_preconditions:
+                unresolved_reasons: list[str] = []
+                unresolved_failure_codes: list[str] = []
+                for unresolved in unresolved_preconditions:
+                    if not isinstance(unresolved, Mapping):
+                        continue
+                    reason = unresolved.get("status_reason")
+                    if isinstance(reason, str) and reason.strip():
+                        unresolved_reasons.append(reason.strip())
+                    for code in _normalise_string_list(unresolved.get("failure_codes")):
+                        if code not in unresolved_failure_codes:
+                            unresolved_failure_codes.append(code)
+                if unresolved_reasons:
+                    status_line = (
+                        f"{status_line} Unresolved preconditions: "
+                        f"{'; '.join(unresolved_reasons[:2])}."
+                    )
+                if unresolved_failure_codes:
+                    status_line = (
+                        f"{status_line} Failure codes: "
+                        f"{', '.join(unresolved_failure_codes[:3])}."
+                    )
 
             if isinstance(final_response, str) and final_response.strip():
                 if "Execution status:" not in final_response:
@@ -4806,6 +4905,36 @@ class InternalMCPChatOrchestrator:
             # bounded retry context, then clear the marker.
             safe_to_claim_completion = False
             requires_follow_up = True
+
+        terminal_outcome = "completed"
+        if repeat_iteration:
+            terminal_outcome = "retrying"
+        elif requires_follow_up and repeat_stop_reason:
+            terminal_outcome = repeat_stop_reason
+        elif requires_follow_up:
+            terminal_outcome = "follow_up_required"
+
+        completion_gate_evidence_payload: dict[str, Any] = dict(record_evidence_payload)
+        completion_gate_evidence_payload.update(
+            {
+                "decision": decision,
+                "decision_reason": decision_reason,
+                "safe_to_claim_completion": safe_to_claim_completion,
+                "requires_follow_up": requires_follow_up,
+                "blocking_effect_ids": list(blocking_effect_ids),
+                "blocking_failure_codes": list(blocking_failure_codes),
+                "unresolved_preconditions": unresolved_preconditions,
+                "postcondition_summary": (
+                    dict(postcondition_summary)
+                    if isinstance(postcondition_summary, Mapping)
+                    else {}
+                ),
+                "terminal_outcome": terminal_outcome,
+                "repeat_iteration": repeat_iteration,
+                "repeat_stop_reason": repeat_stop_reason,
+                "loop_retry_reason": loop_retry_reason,
+            }
+        )
 
         introspection_autotrigger: dict[str, Any] | None = None
         autotrigger_enabled = os.getenv(
@@ -4927,6 +5056,10 @@ class InternalMCPChatOrchestrator:
                         "safe_to_claim_completion": safe_to_claim_completion,
                         "requires_follow_up": requires_follow_up,
                         "blocking_effect_ids": list(blocking_effect_ids),
+                        "blocking_failure_codes": list(blocking_failure_codes),
+                        "unresolved_preconditions": unresolved_preconditions,
+                        "terminal_outcome": terminal_outcome,
+                        "evidence_payload": completion_gate_evidence_payload,
                         "repeat_iteration": repeat_iteration,
                         "repeat_stop_reason": repeat_stop_reason,
                         "loop_attempts": loop_attempts,
@@ -4948,8 +5081,12 @@ class InternalMCPChatOrchestrator:
                 "completion_gate_decision": decision,
                 "completion_gate_decision_reason": decision_reason,
                 "completion_gate_blocking_effect_ids": list(blocking_effect_ids),
+                "completion_gate_blocking_failure_codes": list(blocking_failure_codes),
                 "completion_gate_safe_to_claim_completion": safe_to_claim_completion,
                 "completion_gate_requires_follow_up": requires_follow_up,
+                "completion_gate_unresolved_preconditions": unresolved_preconditions,
+                "completion_gate_evidence_payload": completion_gate_evidence_payload,
+                "completion_gate_terminal_outcome": terminal_outcome,
                 "completion_gate_repeat_iteration": repeat_iteration,
                 "completion_gate_loop_retry_reason": loop_retry_reason,
                 "completion_gate_loop_stop_reason": repeat_stop_reason,
@@ -15173,6 +15310,71 @@ class InternalMCPChatOrchestrator:
                     if item_text:
                         blocking_effect_ids.append(item_text)
 
+            blocking_failure_codes_raw = workflow_data.get(
+                "completion_gate_blocking_failure_codes"
+            )
+            if not isinstance(blocking_failure_codes_raw, list):
+                blocking_failure_codes_raw = completion_gate.get("blocking_failure_codes")
+            blocking_failure_codes: list[str] = []
+            if isinstance(blocking_failure_codes_raw, list):
+                for item in blocking_failure_codes_raw:
+                    item_text = _safe_scalar_text(item)
+                    if item_text:
+                        blocking_failure_codes.append(item_text)
+
+            completion_gate_evidence_payload_raw = workflow_data.get(
+                "completion_gate_evidence_payload"
+            )
+            if not isinstance(completion_gate_evidence_payload_raw, Mapping):
+                completion_gate_evidence_payload_raw = completion_gate.get("evidence_payload")
+            completion_gate_evidence_payload = (
+                _safe_mapping_snapshot(
+                    completion_gate_evidence_payload_raw, max_depth=3, max_items=40
+                )
+                if isinstance(completion_gate_evidence_payload_raw, Mapping)
+                else None
+            )
+
+            unresolved_preconditions_raw = workflow_data.get(
+                "completion_gate_unresolved_preconditions"
+            )
+            if not isinstance(unresolved_preconditions_raw, list):
+                evidence_payload_raw = completion_gate.get("evidence_payload")
+                if isinstance(evidence_payload_raw, Mapping):
+                    unresolved_preconditions_raw = evidence_payload_raw.get(
+                        "unresolved_preconditions"
+                    )
+            unresolved_preconditions: list[dict[str, Any]] = []
+            if isinstance(unresolved_preconditions_raw, list):
+                for item in unresolved_preconditions_raw:
+                    if not isinstance(item, Mapping):
+                        continue
+                    snapshot = _safe_mapping_snapshot(item, max_depth=2, max_items=20)
+                    if isinstance(snapshot, dict):
+                        unresolved_preconditions.append(snapshot)
+
+            completion_gate_terminal_outcome = _safe_scalar_text(
+                workflow_data.get("completion_gate_terminal_outcome")
+            )
+            if not completion_gate_terminal_outcome and isinstance(
+                completion_gate_evidence_payload_raw, Mapping
+            ):
+                completion_gate_terminal_outcome = _safe_scalar_text(
+                    completion_gate_evidence_payload_raw.get("terminal_outcome")
+                )
+            repeat_iteration = bool(
+                workflow_data.get("completion_gate_repeat_iteration", False)
+            )
+            if not completion_gate_terminal_outcome:
+                if repeat_iteration:
+                    completion_gate_terminal_outcome = "retrying"
+                elif requires_follow_up:
+                    completion_gate_terminal_outcome = _safe_scalar_text(
+                        workflow_data.get("completion_gate_loop_stop_reason")
+                    ) or "follow_up_required"
+                else:
+                    completion_gate_terminal_outcome = "completed"
+
             check_instances: list[dict[str, Any]] = []
             for check in postcondition_checks:
                 observed_payload = check.get("observed")
@@ -15282,9 +15484,11 @@ class InternalMCPChatOrchestrator:
                     "safe_to_claim_completion": safe_to_claim_completion,
                     "requires_follow_up": requires_follow_up,
                     "blocking_effect_ids": blocking_effect_ids,
-                    "repeat_iteration": bool(
-                        workflow_data.get("completion_gate_repeat_iteration", False)
-                    ),
+                    "blocking_failure_codes": blocking_failure_codes,
+                    "unresolved_preconditions": unresolved_preconditions,
+                    "evidence_payload": completion_gate_evidence_payload,
+                    "terminal_outcome": completion_gate_terminal_outcome,
+                    "repeat_iteration": repeat_iteration,
                     "loop_stop_reason": _safe_scalar_text(
                         workflow_data.get("completion_gate_loop_stop_reason")
                     ),
@@ -15443,16 +15647,22 @@ class InternalMCPChatOrchestrator:
             for key in (
                 "completion_gate_decision",
                 "completion_gate_decision_reason",
+                "completion_gate_blocking_effect_ids",
+                "completion_gate_blocking_failure_codes",
                 "completion_gate_requires_follow_up",
                 "completion_gate_safe_to_claim_completion",
+                "completion_gate_terminal_outcome",
                 "completion_gate_repeat_iteration",
                 "completion_gate_loop_stop_reason",
+                "completion_gate_loop_retry_reason",
                 "completion_gate_loop_attempts",
                 "completion_gate_loop_max_attempts",
                 "completion_gate_loop_elapsed_ms",
                 "completion_gate_loop_max_elapsed_ms",
                 "completion_gate_loop_no_progress_streak",
                 "completion_gate_loop_no_progress_limit",
+                "completion_gate_unresolved_preconditions",
+                "completion_gate_evidence_payload",
             ):
                 if key in workflow_data:
                     payload[key] = workflow_data.get(key)

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -91,6 +91,57 @@ _READ_ONLY_JIRA_TOOLS = {
     "jira_search",
 }
 
+_VERIFICATION_READ_TOOL_NAMES = {
+    "count",
+    "fetch_concept",
+    "fetch_concept_content",
+    "find_concepts_by_name",
+    "find_relations_with_argument",
+    "find_subconcepts",
+    "get_context",
+    "get_file_contents",
+    "get_paper_metadata",
+    "get_task",
+    "get_team_members",
+    "get_teams",
+    "get_text_relations",
+    "get_text_relations_summary",
+    "get_tree",
+    "issue_read",
+    "jira_get_issue",
+    "jira_get_myself",
+    "jira_get_transitions",
+    "jira_search",
+    "list_my_tasks",
+    "list_pull_requests",
+    "resolve_concept_by_name",
+    "search_code",
+    "search_concepts",
+    "search_issues",
+    "search_pull_requests",
+    "search_repositories",
+    "search_users",
+    "search_knowledge_base",
+    "vontology_concept_search",
+    "workflow_get_instance",
+    "workflow_get_schedule",
+    "workflow_list_definitions",
+    "workflow_list_event_bindings",
+    "workflow_list_instances",
+    "workflow_list_schedules",
+}
+
+_VERIFICATION_READ_TOOL_PREFIXES = (
+    "count_",
+    "fetch_",
+    "find_",
+    "get_",
+    "list_",
+    "read_",
+    "resolve_",
+    "search_",
+)
+
 _MUTATION_INTENT_TERMS = (
     "add",
     "added",
@@ -350,6 +401,24 @@ def _is_write_tool(tool_name: str | None) -> bool:
     return False
 
 
+def _is_verification_read_tool(tool_name: str | None) -> bool:
+    if not isinstance(tool_name, str):
+        return False
+    cleaned = tool_name.strip()
+    if not cleaned:
+        return False
+    lowered = cleaned.lower()
+    if lowered.startswith("__"):
+        return False
+    if _is_write_tool(cleaned):
+        return False
+    if lowered in _VERIFICATION_READ_TOOL_NAMES:
+        return True
+    return any(
+        lowered.startswith(prefix) for prefix in _VERIFICATION_READ_TOOL_PREFIXES
+    )
+
+
 def _extract_workflow_ids(raw_items: Any) -> list[str]:
     if not isinstance(raw_items, list):
         return []
@@ -463,12 +532,20 @@ def _extract_completion_claim_signals(
 
 def _summarise_tool_invocations(
     tool_invocations: Sequence[Mapping[str, Any]] | None,
-) -> tuple[list[dict[str, Any]], list[str], list[str], list[str], list[str]]:
+) -> tuple[
+    list[dict[str, Any]],
+    list[str],
+    list[str],
+    list[str],
+    list[str],
+    list[str],
+]:
     serialised: list[dict[str, Any]] = []
     successful_tools: list[str] = []
     failed_tools: list[str] = []
     blocked_tools: list[str] = []
     successful_write_tools: list[str] = []
+    successful_verification_tools: list[str] = []
 
     for invocation in tool_invocations or ():
         if not isinstance(invocation, Mapping):
@@ -524,6 +601,10 @@ def _summarise_tool_invocations(
                 name.lower() for name in successful_write_tools
             }:
                 successful_write_tools.append(tool_name)
+            if _is_verification_read_tool(tool_name) and lowered not in {
+                name.lower() for name in successful_verification_tools
+            }:
+                successful_verification_tools.append(tool_name)
         elif status == "blocked":
             if lowered not in {name.lower() for name in blocked_tools}:
                 blocked_tools.append(tool_name)
@@ -537,6 +618,7 @@ def _summarise_tool_invocations(
         failed_tools,
         blocked_tools,
         successful_write_tools,
+        successful_verification_tools,
     )
 
 
@@ -803,6 +885,7 @@ def _build_postcondition_checks(
     *,
     required_effects: Sequence[Mapping[str, Any]],
     successful_write_tools: Sequence[str],
+    successful_verification_tools: Sequence[str],
 ) -> list[dict[str, Any]]:
     checks: list[dict[str, Any]] = []
     for effect in required_effects:
@@ -813,27 +896,42 @@ def _build_postcondition_checks(
             if effect_status == "satisfied":
                 check_status = "verified"
                 evidence = "Required tool execution was observed."
+                verification_mode = "execution_observed"
             elif effect_status in {"not_satisfied", "not_executed"}:
                 check_status = "not_verified"
                 evidence = (
                     _safe_str(effect.get("status_reason"))
                     or "Required tool execution was not observed."
                 )
+                verification_mode = "execution_missing"
             else:
                 check_status = "inconclusive"
                 evidence = "Tool execution verification outcome is inconclusive."
+                verification_mode = "execution_inconclusive"
         else:
             if effect_status == "satisfied" and successful_write_tools:
-                check_status = "inconclusive"
-                evidence = (
-                    "Write tool invocation succeeded but explicit state re-query was not run."
-                )
+                if successful_verification_tools:
+                    check_status = "verified"
+                    evidence = (
+                        "Observed postcondition verification read/check tool(s): "
+                        + ", ".join(successful_verification_tools[:3])
+                    )
+                    verification_mode = "state_requery_observed"
+                else:
+                    check_status = "inconclusive"
+                    evidence = (
+                        "Write tool invocation succeeded but explicit state "
+                        "re-query/check tool invocation was not observed."
+                    )
+                    verification_mode = "state_requery_missing"
             elif effect_status in {"not_satisfied", "not_executed"}:
                 check_status = "not_verified"
                 evidence = "Required mutation effect is unresolved."
+                verification_mode = "state_requery_blocked"
             else:
                 check_status = "inconclusive"
                 evidence = "Mutation verification outcome is inconclusive."
+                verification_mode = "state_requery_inconclusive"
 
         checks.append(
             {
@@ -848,10 +946,14 @@ def _build_postcondition_checks(
                 "check_payload": {},
                 "observed": {
                     "successful_write_tools": list(successful_write_tools),
+                    "successful_verification_tools": list(
+                        successful_verification_tools
+                    ),
                     "effect_status": effect_status,
                     "effect_type": effect_type,
                 },
                 "status": check_status,
+                "verification_mode": verification_mode,
                 "evidence": evidence,
                 "error": None,
             }
@@ -913,10 +1015,45 @@ def _derive_completion_gate(
                 unresolved_failure_codes.append(single_failure_code)
 
     unresolved_check_ids: list[str] = []
+    verified_check_effect_ids: list[str] = []
+    unresolved_postcondition_checks: list[dict[str, Any]] = []
     for check in postcondition_checks:
         check_status = _safe_str(check.get("status")) or ""
+        check_effect_id = _safe_str(check.get("effect_id")) or "effect_1"
+        if check_status == "verified":
+            verified_check_effect_ids.append(check_effect_id)
+            continue
         if check_status in {"not_verified", "inconclusive", "error"}:
-            unresolved_check_ids.append(_safe_str(check.get("effect_id")) or "effect_1")
+            unresolved_check_ids.append(check_effect_id)
+            unresolved_postcondition_checks.append(
+                {
+                    "effect_id": check_effect_id,
+                    "check_id": _safe_str(check.get("check_id")),
+                    "check_type": _safe_str(check.get("check_type")),
+                    "status": check_status,
+                    "verification_mode": _safe_str(check.get("verification_mode")),
+                    "evidence": _safe_str(check.get("evidence")),
+                }
+            )
+
+    unresolved_preconditions: list[dict[str, Any]] = []
+    for effect in required_effects:
+        effect_status = _safe_str(effect.get("status")) or ""
+        if effect_status not in {"not_satisfied", "not_executed"}:
+            continue
+        failure_codes = _normalise_failure_codes(effect.get("failure_codes"))
+        single_failure_code = _safe_str(effect.get("failure_code"))
+        if single_failure_code and single_failure_code not in failure_codes:
+            failure_codes.append(single_failure_code)
+        unresolved_preconditions.append(
+            {
+                "effect_id": _safe_str(effect.get("effect_id")) or "effect_1",
+                "effect_type": _safe_str(effect.get("effect_type")) or "kb_mutation",
+                "status": effect_status,
+                "status_reason": _safe_str(effect.get("status_reason")),
+                "failure_codes": failure_codes,
+            }
+        )
 
     if unresolved_effect_ids:
         blocking_effect_ids = sorted(set(unresolved_effect_ids))
@@ -952,6 +1089,23 @@ def _derive_completion_gate(
         )
 
     safe_to_claim = decision == "completed"
+    evidence_payload = {
+        "evaluation_basis": "required_effects_and_postcondition_checks",
+        "required_effect_count": len(required_effects),
+        "postcondition_check_count": len(postcondition_checks),
+        "postcondition_summary": _summarise_check_counts(postcondition_checks),
+        "verified_effect_ids": sorted(set(verified_check_effect_ids)),
+        "unresolved_effect_ids": sorted(set(unresolved_check_ids)),
+        "unresolved_preconditions": unresolved_preconditions,
+        "unresolved_postcondition_checks": unresolved_postcondition_checks,
+        "completion_outcome": (
+            "success"
+            if decision == "completed"
+            else "inconclusive"
+            if decision == "partial"
+            else "failure"
+        ),
+    }
     return {
         "workflow_id": "#V#turn_completion_gate_workflow",
         "decision": decision,
@@ -960,6 +1114,7 @@ def _derive_completion_gate(
         "blocking_failure_codes": blocking_failure_codes,
         "safe_to_claim_completion": safe_to_claim,
         "requires_follow_up": not safe_to_claim,
+        "evidence_payload": evidence_payload,
     }
 
 
@@ -1002,6 +1157,7 @@ def build_turn_execution_record(
         failed_tools,
         blocked_tools,
         successful_write_tools,
+        successful_verification_tools,
     ) = _summarise_tool_invocations(tool_invocations)
     execution_summary = _summarise_tool_execution_context(
         workflow_routing=workflow_routing,
@@ -1033,6 +1189,7 @@ def build_turn_execution_record(
     postcondition_checks = _build_postcondition_checks(
         required_effects=required_effects,
         successful_write_tools=successful_write_tools,
+        successful_verification_tools=successful_verification_tools,
     )
     critic_summary = _summarise_check_counts(postcondition_checks)
 

--- a/tests/backend/test_orchestrator_turn_execution_gate.py
+++ b/tests/backend/test_orchestrator_turn_execution_gate.py
@@ -105,6 +105,12 @@ def test_turn_execution_critic_detects_unresolved_kb_mutation() -> None:
     assert isinstance(completion_gate, dict)
     assert completion_gate.get("decision") == "escalation_required"
     assert completion_gate.get("safe_to_claim_completion") is False
+    evidence_payload = completion_gate.get("evidence_payload")
+    assert isinstance(evidence_payload, dict)
+    assert evidence_payload.get("completion_outcome") == "failure"
+    unresolved_preconditions = evidence_payload.get("unresolved_preconditions")
+    assert isinstance(unresolved_preconditions, list)
+    assert unresolved_preconditions
 
     assert any(
         entry.get("type") == "turn_execution_critic"
@@ -140,6 +146,51 @@ def test_turn_execution_critic_prefers_explicit_actor_concept_id() -> None:
     assert record.get("actor_concept_id") == "#V#github_copilot_instance"
 
 
+def test_turn_execution_critic_prefers_concrete_verification_reads() -> None:
+    orchestrator = _build_orchestrator()
+    request = _build_request(
+        action_id="turn_execution.critic",
+        data={
+            "prompt": "Please add this relation to the knowledge base.",
+            "final_response": "Response recorded.",
+            "invocations": [
+                {"tool": "add_relationship", "payload": {"status": "ok"}},
+                {"tool": "fetch_concept", "payload": {"status": "ok"}},
+            ],
+            "aux_llm_calls": [],
+            "turn_id": "req-turn-critic-verified",
+            "conversation_session_id": "session-critic-verified",
+            "workflow_discovery_result": None,
+            "workflow_routing": {
+                "workflow_id": "#V#tool_calling_workflow",
+                "verdict": "tool_seeking",
+            },
+        },
+    )
+
+    result = orchestrator._action_turn_execution_critic(request)
+    assert result.ok
+    record = result.outputs.get("turn_execution_record")
+    assert isinstance(record, dict)
+
+    postcondition_checks = record.get("postcondition_checks")
+    assert isinstance(postcondition_checks, list)
+    assert postcondition_checks
+    check = postcondition_checks[0]
+    assert check.get("status") == "verified"
+    assert check.get("verification_mode") == "state_requery_observed"
+    observed = check.get("observed")
+    assert isinstance(observed, dict)
+    assert "fetch_concept" in list(observed.get("successful_verification_tools") or [])
+
+    completion_gate = record.get("completion_gate")
+    assert isinstance(completion_gate, dict)
+    assert completion_gate.get("decision") == "completed"
+    evidence_payload = completion_gate.get("evidence_payload")
+    assert isinstance(evidence_payload, dict)
+    assert evidence_payload.get("completion_outcome") == "success"
+
+
 def test_turn_completion_gate_appends_execution_status_for_unresolved_effect() -> None:
     orchestrator = _build_orchestrator()
     aux_llm_calls: list[dict[str, Any]] = []
@@ -155,6 +206,21 @@ def test_turn_completion_gate_appends_execution_status_for_unresolved_effect() -
                     "safe_to_claim_completion": False,
                     "requires_follow_up": True,
                     "blocking_effect_ids": ["effect_1"],
+                    "blocking_failure_codes": ["worker_unavailable_zero_execution"],
+                    "evidence_payload": {
+                        "unresolved_preconditions": [
+                            {
+                                "effect_id": "effect_1",
+                                "effect_type": "tool_execution",
+                                "status": "not_executed",
+                                "status_reason": (
+                                    "Tool execution was blocked while workers "
+                                    "were unavailable."
+                                ),
+                                "failure_codes": ["worker_unavailable_zero_execution"],
+                            }
+                        ]
+                    },
                 }
             },
         },
@@ -166,11 +232,24 @@ def test_turn_completion_gate_appends_execution_status_for_unresolved_effect() -
     assert result.outputs.get("completion_gate_decision") == "escalation_required"
     assert result.outputs.get("completion_gate_safe_to_claim_completion") is False
     assert result.outputs.get("completion_gate_requires_follow_up") is True
+    assert result.outputs.get("completion_gate_terminal_outcome") == "retrying"
+    assert result.outputs.get("completion_gate_blocking_failure_codes") == [
+        "worker_unavailable_zero_execution"
+    ]
+    unresolved_preconditions = result.outputs.get("completion_gate_unresolved_preconditions")
+    assert isinstance(unresolved_preconditions, list)
+    assert unresolved_preconditions
 
     final_response = result.outputs.get("final_response")
     assert isinstance(final_response, str)
     assert "Execution status:" in final_response
     assert "Blocking effect IDs: effect_1." in final_response
+    assert "Unresolved preconditions:" in final_response
+    assert "Failure codes: worker_unavailable_zero_execution." in final_response
+
+    evidence_payload = result.outputs.get("completion_gate_evidence_payload")
+    assert isinstance(evidence_payload, dict)
+    assert evidence_payload.get("terminal_outcome") == "retrying"
 
     assert any(
         entry.get("type") == "turn_completion_gate"
@@ -345,6 +424,10 @@ def test_turn_completion_gate_requests_repeat_when_budget_available() -> None:
     assert result.outputs.get("completion_gate_loop_attempts") == 1
     assert result.outputs.get("completion_gate_loop_stop_reason") is None
     assert result.outputs.get("completion_gate_requires_follow_up") is True
+    assert result.outputs.get("completion_gate_terminal_outcome") == "retrying"
+    evidence_payload = result.outputs.get("completion_gate_evidence_payload")
+    assert isinstance(evidence_payload, dict)
+    assert evidence_payload.get("terminal_outcome") == "retrying"
 
 
 def test_turn_completion_gate_stops_repeat_when_attempt_budget_exhausted() -> None:
@@ -380,6 +463,13 @@ def test_turn_completion_gate_stops_repeat_when_attempt_budget_exhausted() -> No
         result.outputs.get("completion_gate_loop_stop_reason")
         == "attempt_budget_exhausted"
     )
+    assert (
+        result.outputs.get("completion_gate_terminal_outcome")
+        == "attempt_budget_exhausted"
+    )
+    evidence_payload = result.outputs.get("completion_gate_evidence_payload")
+    assert isinstance(evidence_payload, dict)
+    assert evidence_payload.get("terminal_outcome") == "attempt_budget_exhausted"
 
 
 def test_turn_completion_gate_stops_repeat_when_no_progress_guard_triggers() -> None:
@@ -413,6 +503,10 @@ def test_turn_completion_gate_stops_repeat_when_no_progress_guard_triggers() -> 
     assert result.outputs.get("completion_gate_repeat_iteration") is False
     assert (
         result.outputs.get("completion_gate_loop_stop_reason")
+        == "no_progress_guard_triggered"
+    )
+    assert (
+        result.outputs.get("completion_gate_terminal_outcome")
         == "no_progress_guard_triggered"
     )
 


### PR DESCRIPTION
## Summary
- add deterministic completion-gate evidence payloads to turn-execution records, including unresolved preconditions and postcondition summary data
- prefer concrete verification-read evidence for satisfied mutation effects before classifying postconditions as inconclusive
- emit explicit completion_gate_terminal_outcome values and structured unresolved-precondition metadata from the completion gate action
- propagate new completion-gate telemetry/output fields into durable workflow runtime snapshots
- extend turn-execution gate tests to cover verification-read preference, evidence payloads, unresolved precondition surfacing, and terminal outcomes under bounded retry stops

## Validation
- pytest tests/backend/test_orchestrator_turn_execution_gate.py -q
- pytest tests/backend/test_turn_execution_record_projection.py -q
- pyright src/backend/integrations/internal_mcp/orchestrator.py src/backend/services/turn_execution_record_service.py tests/backend/test_orchestrator_turn_execution_gate.py