### PR TITLE
JVNAUTOSCI-1332: Fix terminal-effect metadata validation for workflow episodes

### DIFF
--- a/src/backend/workflows/engine.py
+++ b/src/backend/workflows/engine.py
@@ -43,6 +43,8 @@ _NESTED_CONTEXT_KEYS: tuple[str, ...] = (
 )
 WORKFLOW_TOOL_OUTPUT_MAPPING_EVENTS_KEY = "workflow_tool_output_mapping_events"
 LAST_WORKFLOW_TOOL_OUTPUT_MAPPING_EVENT_KEY = "last_workflow_tool_output_mapping_event"
+WORKFLOW_TERMINAL_EFFECT_EVENTS_KEY = "workflow_terminal_effect_events"
+LAST_WORKFLOW_TERMINAL_EFFECT_EVENT_KEY = "last_workflow_terminal_effect_event"
 
 
 def _extract_context_binding_symbol(value: Any) -> str | None:
@@ -253,6 +255,87 @@ def apply_tool_output_context_mappings(
             context[WORKFLOW_TOOL_OUTPUT_MAPPING_EVENTS_KEY] = existing
         existing.extend(events)
         context[LAST_WORKFLOW_TOOL_OUTPUT_MAPPING_EVENT_KEY] = events[-1]
+
+    return events
+
+
+def _normalise_metadata_symbols(value: Any) -> List[str]:
+    if isinstance(value, str):
+        candidate = value.strip()
+        return [candidate] if candidate else []
+    if not isinstance(value, list):
+        return []
+    symbols: List[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        candidate = item.strip()
+        if candidate:
+            symbols.append(candidate)
+    return symbols
+
+
+def _looks_like_terminal_effect_symbol(symbol: str) -> bool:
+    token = str(symbol or "").strip().lower()
+    if token.startswith("#v#"):
+        token = token[3:]
+    return token.endswith("_terminal") or token.endswith(":terminal")
+
+
+def materialise_terminal_effect_context(
+    *,
+    context: Dict[str, Any],
+    state_spec: WorkflowStateSpec,
+    state_id: str,
+) -> List[Dict[str, Any]]:
+    """Materialise terminal-effect evidence into context before validation.
+
+    Vontology-authored workflows can declare synthetic terminal effects
+    (e.g., ``#V#workflow_effect_<workflow>_<state>_terminal``) on terminal
+    states. These effects are execution-boundary evidence rather than outputs
+    from a concrete action, so the engine materialises them deterministically
+    before post-action metadata validation.
+    """
+
+    metadata = state_spec.metadata if isinstance(state_spec.metadata, Mapping) else {}
+    effect_symbols = [
+        symbol
+        for symbol in _normalise_metadata_symbols(metadata.get("effects"))
+        if _looks_like_terminal_effect_symbol(symbol)
+    ]
+    if not effect_symbols:
+        return []
+
+    context["workflow_terminal"] = True
+    context["workflow_terminal_state"] = state_id
+
+    events: List[Dict[str, Any]] = []
+    for symbol in effect_symbols:
+        was_present = bool(context.get(symbol))
+        context[symbol] = True
+        alias = symbol[3:] if symbol.startswith("#V#") else symbol
+        alias_was_present = bool(context.get(alias)) if alias else False
+        if alias:
+            context[alias] = True
+
+        events.append(
+            {
+                "status": "terminal_effect_materialised",
+                "state_id": state_id,
+                "symbol": symbol,
+                "alias": alias if alias else None,
+                "already_present": was_present,
+                "alias_already_present": alias_was_present,
+                "applied": (not was_present) or (bool(alias) and not alias_was_present),
+            }
+        )
+
+    existing_events = context.get(WORKFLOW_TERMINAL_EFFECT_EVENTS_KEY)
+    if not isinstance(existing_events, list):
+        existing_events = []
+        context[WORKFLOW_TERMINAL_EFFECT_EVENTS_KEY] = existing_events
+    existing_events.extend(events)
+    context[LAST_WORKFLOW_TERMINAL_EFFECT_EVENT_KEY] = events[-1]
 
     return events
 
@@ -677,6 +760,13 @@ class WorkflowExecutor:
                         final_state=current_state,
                         error=unknown_error,
                     )
+
+            if current_state in termination_states:
+                materialise_terminal_effect_context(
+                    context=context,
+                    state_spec=state_spec,
+                    state_id=current_state,
+                )
 
             if state_has_unknown_route and bool(context.get("last_action_unknown")):
                 post_validation = skipped_metadata_validation(

--- a/tests/backend/test_orchestrator_durable_instance_telemetry.py
+++ b/tests/backend/test_orchestrator_durable_instance_telemetry.py
@@ -8,6 +8,11 @@ import pytest
 from src.backend.integrations.internal_mcp.orchestrator import (
     InternalMCPChatOrchestrator,
 )
+from src.backend.workflows import (
+    WorkflowDefinition,
+    WorkflowStateSpec,
+)
+from src.backend.workflows.workflow_registry import WorkflowRegistration
 
 
 class _DummyGateway:
@@ -264,3 +269,66 @@ def test_execute_workflow_marks_durable_instance_failed_on_exception(
     assert failed_call["instance_id"] == "wf-inst-1"
     assert failed_call.get("error_step") == "workflow_exception"
     assert "exception:boom" in str(failed_call.get("error"))
+
+
+def test_execute_workflow_materialises_terminal_effect_evidence_on_gateway_path(
+    monkeypatch,
+) -> None:
+    orchestrator = _build_orchestrator()
+    fake_manager = _FakeWorkflowInstanceManager()
+
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.WorkflowInstanceManager",
+        lambda: fake_manager,
+    )
+
+    workflow_id = "#V#terminal_effect_gateway_workflow"
+    terminal_effect_id = (
+        "#V#workflow_effect_terminal_effect_gateway_workflow_done_terminal"
+    )
+    definition = WorkflowDefinition(
+        workflow_id=workflow_id,
+        initial_state="done",
+        states={
+            "done": WorkflowStateSpec(
+                state_id="done",
+                terminal=True,
+                metadata={"effects": [terminal_effect_id]},
+            )
+        },
+    )
+    orchestrator._workflow_registry.register_or_replace(
+        WorkflowRegistration(
+            workflow_id=workflow_id,
+            definition=definition,
+            source="test",
+        )
+    )
+
+    result = orchestrator.execute_workflow(
+        workflow_id,
+        data={
+            "prompt": "Run terminal metadata workflow.",
+            "user_concept_id": "#V#user",
+            "org_concept_id": "#V#org",
+            "conversation_session_id": "chat-terminal",
+            "turn_id": "turn-terminal",
+            "workflow_episode_source": "chat_turn_workflow",
+            "workflow_episode_stage": "tool_calling",
+        },
+        llm_client=object(),
+        model="test-model",
+        user_namespace="#V#user@org",
+        conversation_session_id="chat-terminal",
+        turn_id="turn-terminal",
+        episode_source="chat_turn_workflow",
+    )
+
+    assert result is not None
+    assert result.completed is True
+    assert result.error is None
+    assert result.data.get(terminal_effect_id) is True
+    assert fake_manager.mark_completed_calls
+    outputs = fake_manager.mark_completed_calls[0].get("outputs")
+    assert isinstance(outputs, dict)
+    assert outputs.get("completed") is True

--- a/tests/backend/test_workflow_metadata_validation.py
+++ b/tests/backend/test_workflow_metadata_validation.py
@@ -155,6 +155,67 @@ def test_metadata_validation_blocks_missing_write_variable() -> None:
     )
 
 
+def test_metadata_validation_materialises_terminal_effect_evidence() -> None:
+    workflow_id = "#V#terminal_effect_validation"
+    terminal_effect_id = "#V#workflow_effect_terminal_effect_validation_done_terminal"
+    definition = WorkflowDefinition(
+        workflow_id=workflow_id,
+        initial_state="done",
+        states={
+            "done": WorkflowStateSpec(
+                state_id="done",
+                terminal=True,
+                metadata={"effects": [terminal_effect_id]},
+            )
+        },
+    )
+    executor = WorkflowExecutor(registry=ActionRegistry(), max_transitions=5)
+
+    result = executor.run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={},
+    )
+
+    assert result.completed is True
+    assert result.error is None
+    assert result.data.get(terminal_effect_id) is True
+    assert result.data.get("workflow_effect_terminal_effect_validation_done_terminal") is True
+
+    events = result.data.get("workflow_terminal_effect_events")
+    assert isinstance(events, list)
+    assert events
+    assert events[-1].get("status") == "terminal_effect_materialised"
+    assert events[-1].get("symbol") == terminal_effect_id
+
+
+def test_metadata_validation_terminal_effect_materialisation_is_not_over_broad() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="#V#terminal_effect_validation_non_terminal_symbol",
+        initial_state="done",
+        states={
+            "done": WorkflowStateSpec(
+                state_id="done",
+                terminal=True,
+                metadata={"effects": ["#V#workflow_effect_missing_terminal_suffix"]},
+            )
+        },
+    )
+    executor = WorkflowExecutor(registry=ActionRegistry(), max_transitions=5)
+
+    result = executor.run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={},
+    )
+
+    assert result.completed is False
+    assert result.error is not None
+    assert result.error.startswith(
+        "metadata_validation_failed:metadata_effect_unsatisfied:done:"
+    )
+
+
 def test_metadata_validation_warn_mode_records_failure_without_blocking(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary\n- materialise terminal-effect evidence into workflow context before post-action metadata validation on terminal states\n- add terminal-effect diagnostics in context (workflow_terminal_effect_events) for traceability\n- keep synthesis narrowly scoped to terminal-effect symbols (suffix _terminal) to avoid masking malformed metadata\n- add workflow metadata validation tests for valid terminal-effect materialisation and malformed non-terminal effect symbols\n- add orchestrator execute_workflow regression test (gateway path) for terminal-effect materialisation\n\n## Validation\n- pdm run pyright src/backend/workflows/engine.py tests/backend/test_workflow_metadata_validation.py tests/backend/test_orchestrator_durable_instance_telemetry.py\n- manual invocation of new targeted tests via Python (pytest runner hangs in this host session)\n