### PR TITLE
JVNAUTOSCI-1333: add stalled-loop latency guardrails and escalation signals

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -752,6 +752,13 @@ class InternalMCPChatOrchestrator:
             min_value=0,
             max_value=10,
         )
+        self._completion_gate_loop_stall_max_elapsed_ms = self._coerce_int(
+            None,
+            env_var="VON_COMPLETION_GATE_LOOP_STALL_MAX_ELAPSED_MS",
+            default=10_000,
+            min_value=500,
+            max_value=600_000,
+        )
         self._default_gmail_profile = default_gmail_profile
 
         # Optional progress callback for UI telemetry (JVNAUTOSCI-942).
@@ -4958,14 +4965,40 @@ class InternalMCPChatOrchestrator:
             if isinstance(loop_last_blocking_signature_raw, str)
             else ""
         )
+        current_monotonic = time.monotonic()
         loop_started_monotonic_raw = data.get("completion_gate_loop_started_monotonic")
         if isinstance(loop_started_monotonic_raw, (int, float)):
             loop_started_monotonic = float(loop_started_monotonic_raw)
         else:
-            loop_started_monotonic = time.monotonic()
+            loop_started_monotonic = current_monotonic
         loop_elapsed_ms = max(
             0,
-            int((time.monotonic() - loop_started_monotonic) * 1000),
+            int((current_monotonic - loop_started_monotonic) * 1000),
+        )
+        loop_stall_started_monotonic_raw = data.get(
+            "completion_gate_loop_stall_started_monotonic"
+        )
+        loop_stall_started_monotonic = (
+            float(loop_stall_started_monotonic_raw)
+            if isinstance(loop_stall_started_monotonic_raw, (int, float))
+            else None
+        )
+        loop_stall_events = self._coerce_non_negative_int(
+            data.get("completion_gate_loop_stall_events"),
+            default=0,
+            max_value=100,
+        )
+        loop_stall_max_elapsed_ms = self._coerce_non_negative_int(
+            data.get("completion_gate_loop_stall_max_elapsed_ms"),
+            default=int(
+                getattr(self, "_completion_gate_loop_stall_max_elapsed_ms", 10_000)
+            ),
+            max_value=600_000,
+        )
+        loop_stall_elapsed_ms = self._coerce_non_negative_int(
+            data.get("completion_gate_loop_stall_elapsed_ms"),
+            default=0,
+            max_value=600_000,
         )
 
         final_response = data.get("final_response")
@@ -5028,10 +5061,22 @@ class InternalMCPChatOrchestrator:
             bool(loop_last_blocking_signature)
             and loop_last_blocking_signature == blocking_signature
         )
-        if requires_follow_up and (not progress_observed) and same_blocking_signature:
+        stalled_checkpoint = (
+            requires_follow_up and (not progress_observed) and same_blocking_signature
+        )
+        if stalled_checkpoint:
             loop_no_progress_streak += 1
+            if loop_stall_started_monotonic is None:
+                loop_stall_started_monotonic = current_monotonic
+            loop_stall_events += 1
+            loop_stall_elapsed_ms = max(
+                0,
+                int((current_monotonic - loop_stall_started_monotonic) * 1000),
+            )
         else:
             loop_no_progress_streak = 0
+            loop_stall_started_monotonic = None
+            loop_stall_elapsed_ms = 0
 
         repeat_iteration = False
         repeat_stop_reason: str | None = None
@@ -5042,6 +5087,11 @@ class InternalMCPChatOrchestrator:
                 repeat_stop_reason = "attempt_budget_exhausted"
             elif loop_elapsed_ms >= loop_max_elapsed_ms:
                 repeat_stop_reason = "elapsed_budget_exhausted"
+            elif (
+                loop_stall_max_elapsed_ms > 0
+                and loop_stall_elapsed_ms >= loop_stall_max_elapsed_ms
+            ):
+                repeat_stop_reason = "stall_latency_budget_exhausted"
             elif (
                 loop_no_progress_limit > 0
                 and loop_attempts > 0
@@ -5075,6 +5125,20 @@ class InternalMCPChatOrchestrator:
             terminal_outcome = repeat_stop_reason
         elif requires_follow_up:
             terminal_outcome = "follow_up_required"
+        escalation_signal = bool(requires_follow_up and not repeat_iteration and repeat_stop_reason)
+        escalation_reason = repeat_stop_reason if escalation_signal else None
+        if escalation_signal:
+            escalation_line = (
+                f"Escalation trigger: {repeat_stop_reason}. "
+                f"Loop attempts {loop_attempts}/{loop_max_attempts}; "
+                f"loop elapsed {loop_elapsed_ms}ms/{loop_max_elapsed_ms}ms; "
+                f"stall elapsed {loop_stall_elapsed_ms}ms/{loop_stall_max_elapsed_ms}ms."
+            )
+            if isinstance(final_response, str) and final_response.strip():
+                if "Escalation trigger:" not in final_response:
+                    final_response = f"{final_response.rstrip()}\n\n{escalation_line}"
+            else:
+                final_response = escalation_line
 
         completion_gate_evidence_payload: dict[str, Any] = dict(record_evidence_payload)
         completion_gate_evidence_payload.update(
@@ -5095,6 +5159,11 @@ class InternalMCPChatOrchestrator:
                 "repeat_iteration": repeat_iteration,
                 "repeat_stop_reason": repeat_stop_reason,
                 "loop_retry_reason": loop_retry_reason,
+                "loop_stall_events": loop_stall_events,
+                "loop_stall_elapsed_ms": loop_stall_elapsed_ms,
+                "loop_stall_max_elapsed_ms": loop_stall_max_elapsed_ms,
+                "escalation_signal": escalation_signal,
+                "escalation_reason": escalation_reason,
             }
         )
 
@@ -5230,6 +5299,11 @@ class InternalMCPChatOrchestrator:
                         "loop_max_elapsed_ms": loop_max_elapsed_ms,
                         "loop_no_progress_streak": loop_no_progress_streak,
                         "loop_no_progress_limit": loop_no_progress_limit,
+                        "loop_stall_events": loop_stall_events,
+                        "loop_stall_elapsed_ms": loop_stall_elapsed_ms,
+                        "loop_stall_max_elapsed_ms": loop_stall_max_elapsed_ms,
+                        "escalation_signal": escalation_signal,
+                        "escalation_reason": escalation_reason,
                         "loop_retry_reason": loop_retry_reason,
                         "workflow_introspection_autotrigger": introspection_autotrigger,
                     }
@@ -5259,8 +5333,14 @@ class InternalMCPChatOrchestrator:
                 "completion_gate_loop_started_monotonic": loop_started_monotonic,
                 "completion_gate_loop_no_progress_streak": loop_no_progress_streak,
                 "completion_gate_loop_no_progress_limit": loop_no_progress_limit,
+                "completion_gate_loop_stall_events": loop_stall_events,
+                "completion_gate_loop_stall_elapsed_ms": loop_stall_elapsed_ms,
+                "completion_gate_loop_stall_max_elapsed_ms": loop_stall_max_elapsed_ms,
+                "completion_gate_loop_stall_started_monotonic": loop_stall_started_monotonic,
                 "completion_gate_loop_last_invocation_count": invocation_count,
                 "completion_gate_loop_last_blocking_signature": blocking_signature,
+                "completion_gate_escalation_signal": escalation_signal,
+                "completion_gate_escalation_reason": escalation_reason,
                 "workflow_introspection_autotrigger": introspection_autotrigger,
                 "result": requires_follow_up,
             }
@@ -15722,6 +15802,22 @@ class InternalMCPChatOrchestrator:
                     "loop_no_progress_limit": int(
                         workflow_data.get("completion_gate_loop_no_progress_limit") or 0
                     ),
+                    "loop_stall_events": int(
+                        workflow_data.get("completion_gate_loop_stall_events") or 0
+                    ),
+                    "loop_stall_elapsed_ms": int(
+                        workflow_data.get("completion_gate_loop_stall_elapsed_ms") or 0
+                    ),
+                    "loop_stall_max_elapsed_ms": int(
+                        workflow_data.get("completion_gate_loop_stall_max_elapsed_ms")
+                        or 0
+                    ),
+                    "escalation_signal": bool(
+                        workflow_data.get("completion_gate_escalation_signal", False)
+                    ),
+                    "escalation_reason": _safe_scalar_text(
+                        workflow_data.get("completion_gate_escalation_reason")
+                    ),
                 },
                 "terminal": {
                     "completed": bool(completed),
@@ -15872,6 +15968,12 @@ class InternalMCPChatOrchestrator:
                 "completion_gate_loop_max_elapsed_ms",
                 "completion_gate_loop_no_progress_streak",
                 "completion_gate_loop_no_progress_limit",
+                "completion_gate_loop_stall_events",
+                "completion_gate_loop_stall_elapsed_ms",
+                "completion_gate_loop_stall_max_elapsed_ms",
+                "completion_gate_loop_stall_started_monotonic",
+                "completion_gate_escalation_signal",
+                "completion_gate_escalation_reason",
                 "completion_gate_unresolved_preconditions",
                 "completion_gate_evidence_payload",
             ):
@@ -21514,8 +21616,16 @@ class InternalMCPChatOrchestrator:
             "completion_gate_loop_no_progress_limit": int(
                 self._completion_gate_loop_no_progress_limit
             ),
+            "completion_gate_loop_stall_events": 0,
+            "completion_gate_loop_stall_elapsed_ms": 0,
+            "completion_gate_loop_stall_max_elapsed_ms": int(
+                self._completion_gate_loop_stall_max_elapsed_ms
+            ),
+            "completion_gate_loop_stall_started_monotonic": None,
             "completion_gate_loop_last_invocation_count": 0,
             "completion_gate_loop_last_blocking_signature": "",
+            "completion_gate_escalation_signal": False,
+            "completion_gate_escalation_reason": None,
         }
 
         tc_result = self.execute_workflow(

--- a/tests/backend/test_orchestrator_durable_instance_telemetry.py
+++ b/tests/backend/test_orchestrator_durable_instance_telemetry.py
@@ -99,7 +99,15 @@ def test_execute_workflow_persists_completed_durable_instance_with_turn_summary(
             "completion_gate_decision_reason": "Required mutation was not executed.",
             "completion_gate_requires_follow_up": True,
             "completion_gate_safe_to_claim_completion": False,
+            "completion_gate_escalation_signal": True,
+            "completion_gate_escalation_reason": "no_progress_guard_triggered",
             "critic_summary": {"not_verified_count": 1},
+            "completion_gate_loop_stall_events": 3,
+            "completion_gate_loop_stall_elapsed_ms": 1_250,
+            "completion_gate_loop_stall_max_elapsed_ms": 1_000,
+            "completion_gate_loop_no_progress_streak": 2,
+            "completion_gate_loop_no_progress_limit": 2,
+            "completion_gate_loop_stop_reason": "no_progress_guard_triggered",
             "workflow_routing": {
                 "workflow_id": "#V#tool_calling_workflow",
                 "verdict": "tool_seeking",
@@ -185,6 +193,11 @@ def test_execute_workflow_persists_completed_durable_instance_with_turn_summary(
     assert isinstance(outputs, dict)
     assert outputs.get("completed") is True
     assert outputs.get("completion_gate_decision") == "escalation_required"
+    assert outputs.get("completion_gate_escalation_signal") is True
+    assert outputs.get("completion_gate_escalation_reason") == "no_progress_guard_triggered"
+    assert outputs.get("completion_gate_loop_stall_events") == 3
+    assert outputs.get("completion_gate_loop_stall_elapsed_ms") == 1_250
+    assert outputs.get("completion_gate_loop_stall_max_elapsed_ms") == 1_000
     turn_execution = outputs.get("turn_execution")
     assert isinstance(turn_execution, dict)
     assert turn_execution.get("request_id") == "req-123"
@@ -209,6 +222,11 @@ def test_execute_workflow_persists_completed_durable_instance_with_turn_summary(
     assert isinstance(completion_state, dict)
     assert completion_state.get("decision") == "escalation_required"
     assert completion_state.get("requires_follow_up") is True
+    assert completion_state.get("escalation_signal") is True
+    assert completion_state.get("escalation_reason") == "no_progress_guard_triggered"
+    assert completion_state.get("loop_stall_events") == 3
+    assert completion_state.get("loop_stall_elapsed_ms") == 1_250
+    assert completion_state.get("loop_stall_max_elapsed_ms") == 1_000
 
 
 def test_execute_workflow_marks_durable_instance_failed_on_exception(

--- a/tests/backend/test_orchestrator_turn_execution_gate.py
+++ b/tests/backend/test_orchestrator_turn_execution_gate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from typing import Any, cast
 
 from src.backend.integrations.internal_mcp.orchestrator import (
@@ -509,6 +510,69 @@ def test_turn_completion_gate_stops_repeat_when_no_progress_guard_triggers() -> 
         result.outputs.get("completion_gate_terminal_outcome")
         == "no_progress_guard_triggered"
     )
+    assert result.outputs.get("completion_gate_escalation_signal") is True
+    assert (
+        result.outputs.get("completion_gate_escalation_reason")
+        == "no_progress_guard_triggered"
+    )
+
+
+def test_turn_completion_gate_stops_repeat_when_stall_latency_budget_exhausted() -> None:
+    orchestrator = _build_orchestrator()
+    request = _build_request(
+        action_id="turn_execution.completion_gate",
+        data={
+            "final_response": "I have completed the update.",
+            "invocations": [],
+            "turn_execution_record": {
+                "completion_gate": {
+                    "decision": "escalation_required",
+                    "decision_reason": "Required mutation was not executed.",
+                    "safe_to_claim_completion": False,
+                    "requires_follow_up": True,
+                    "blocking_effect_ids": ["effect_1"],
+                }
+            },
+            "completion_gate_loop_attempts": 1,
+            "completion_gate_loop_max_attempts": 5,
+            "completion_gate_loop_max_elapsed_ms": 60_000,
+            "completion_gate_loop_no_progress_streak": 0,
+            "completion_gate_loop_no_progress_limit": 5,
+            "completion_gate_loop_last_invocation_count": 0,
+            "completion_gate_loop_last_blocking_signature": "escalation_required:effect_1",
+            "completion_gate_loop_stall_started_monotonic": time.monotonic() - 2.0,
+            "completion_gate_loop_stall_elapsed_ms": 0,
+            "completion_gate_loop_stall_max_elapsed_ms": 500,
+            "completion_gate_loop_stall_events": 0,
+        },
+    )
+
+    result = orchestrator._action_turn_execution_completion_gate(request)
+    assert result.ok
+    assert result.outputs.get("completion_gate_repeat_iteration") is False
+    assert (
+        result.outputs.get("completion_gate_loop_stop_reason")
+        == "stall_latency_budget_exhausted"
+    )
+    assert (
+        result.outputs.get("completion_gate_terminal_outcome")
+        == "stall_latency_budget_exhausted"
+    )
+    assert result.outputs.get("completion_gate_escalation_signal") is True
+    assert (
+        result.outputs.get("completion_gate_escalation_reason")
+        == "stall_latency_budget_exhausted"
+    )
+    assert int(result.outputs.get("completion_gate_loop_stall_events") or 0) >= 1
+    assert int(result.outputs.get("completion_gate_loop_stall_elapsed_ms") or 0) >= 500
+    final_response = result.outputs.get("final_response")
+    assert isinstance(final_response, str)
+    assert "Escalation trigger: stall_latency_budget_exhausted." in final_response
+    evidence_payload = result.outputs.get("completion_gate_evidence_payload")
+    assert isinstance(evidence_payload, dict)
+    assert evidence_payload.get("terminal_outcome") == "stall_latency_budget_exhausted"
+    assert evidence_payload.get("escalation_signal") is True
+    assert evidence_payload.get("escalation_reason") == "stall_latency_budget_exhausted"
 
 
 def test_turn_completion_gate_autotriggers_workflow_introspection(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add completion-gate stall-latency guardrails with bounded thresholds
- emit explicit escalation signal/reason telemetry when loop guardrails stop retries
- project new stall/escalation fields into durable runtime/outcome snapshots
- add regression tests for stall-latency stop reason and telemetry propagation

## Validation
- pdm run pyright src/backend/integrations/internal_mcp/orchestrator.py tests/backend/test_orchestrator_turn_execution_gate.py tests/backend/test_orchestrator_durable_instance_telemetry.py
- targeted direct test invocation for updated completion-gate + durable telemetry tests (pytest command hangs in this host session)