### PR TITLE
JVNAUTOSCI-1363: fail-fast fallback telemetry and stale error cleanup

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import time
+import requests
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from typing import (
@@ -2696,6 +2697,12 @@ class InternalMCPChatOrchestrator:
             user_concept_id = request.data.get("user_concept_id")
             org_concept_id = request.data.get("org_concept_id")
             llm_calls_log = request.data.get("llm_calls_log")
+            emit_progress_raw = request.data.get("emit_progress")
+            emit_progress_cb: Callable[[Mapping[str, Any]], None] | None = (
+                cast(Callable[[Mapping[str, Any]], None], emit_progress_raw)
+                if callable(emit_progress_raw)
+                else None
+            )
 
             if (
                 isinstance(policy_state, _WorkflowModelPolicyState)
@@ -2726,6 +2733,7 @@ class InternalMCPChatOrchestrator:
                             llm_calls_log=llm_calls_log,
                             aux_log=aux_llm_calls,
                             record_llm_call=cast(Callable[..., Any], record_llm_call),
+                            emit_progress=emit_progress_cb,
                         )
                     )
                 except Exception as exc:
@@ -2735,21 +2743,63 @@ class InternalMCPChatOrchestrator:
             if buttonify_response is None:
                 llm_start = time.perf_counter()
                 try:
+                    if callable(emit_progress_cb):
+                        emit_progress_cb(
+                            {
+                                "status": "llm_call_start",
+                                "stage": "buttonify",
+                                "model": buttonify_model_used,
+                            }
+                        )
                     buttonify_response = request.environment.llm_client.generate(
                         prompt=buttonify_prompt_text,
                         context=[],
                         model=buttonify_model_used,
                     )
+                    llm_duration_ms = (time.perf_counter() - llm_start) * 1000.0
+                    if callable(emit_progress_cb):
+                        emit_progress_cb(
+                            {
+                                "status": "llm_call_chunk",
+                                "stage": "buttonify",
+                                "model": buttonify_model_used,
+                                "chunks": 1,
+                                "duration_ms": int(llm_duration_ms),
+                            }
+                        )
+                        emit_progress_cb(
+                            {
+                                "status": "llm_call_end",
+                                "stage": "buttonify",
+                                "model": buttonify_model_used,
+                                "duration_ms": int(llm_duration_ms),
+                                "success": True,
+                                "error": None,
+                            }
+                        )
                     if callable(record_llm_call):
                         cast(Callable[..., Any], record_llm_call)(
                             call_type="llm.generate",
                             model_name=buttonify_model_used,
-                            duration_ms=(time.perf_counter() - llm_start) * 1000.0,
+                            duration_ms=llm_duration_ms,
                             usage=None,
                             note="Buttonify quick-reply extraction (workflow fallback).",
                             stage="buttonify",
                         )
                 except Exception as exc:
+                    llm_duration_ms = (time.perf_counter() - llm_start) * 1000.0
+                    if callable(emit_progress_cb):
+                        emit_progress_cb(
+                            {
+                                "status": "llm_call_end",
+                                "stage": "buttonify",
+                                "model": buttonify_model_used,
+                                "duration_ms": int(llm_duration_ms),
+                                "success": False,
+                                "error": str(exc),
+                                "error_class": type(exc).__name__,
+                            }
+                        )
                     buttonify_error_class = type(exc).__name__
                     buttonify_response = None
 
@@ -8247,6 +8297,79 @@ class InternalMCPChatOrchestrator:
             telemetry["error"] = str(exc)
             return default_client, default_model, telemetry
 
+    @staticmethod
+    def _normalise_ollama_probe_host(raw_host: Any) -> str:
+        host = str(raw_host).strip() if isinstance(raw_host, str) else ""
+        if not host:
+            host = str(os.environ.get("OLLAMA_HOST") or "").strip()
+        if not host:
+            return "http://localhost:11434"
+        if host.startswith(("http://", "https://")):
+            return host.rstrip("/")
+        if ":" in host:
+            return f"http://{host}".rstrip("/")
+        return f"http://{host}:11434"
+
+    def _probe_model_candidate_reachability(
+        self,
+        *,
+        telemetry: Mapping[str, Any],
+    ) -> Mapping[str, Any] | None:
+        """Fast-fail provider candidates that are immediately unreachable.
+
+        This currently probes Ollama connectivity because local-runtime outages
+        are common and can otherwise add avoidable fallback latency.
+        """
+
+        provider = str(telemetry.get("provider") or "").strip().lower()
+        if provider != "ollama":
+            return None
+        if os.environ.get("VON_INTERNAL_MCP_OLLAMA_PROBE_ENABLED", "1").lower() not in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }:
+            return None
+
+        timeout_ms = self._coerce_int(
+            None,
+            env_var="VON_INTERNAL_MCP_OLLAMA_PROBE_TIMEOUT_MS",
+            default=1200,
+            min_value=100,
+            max_value=10000,
+        )
+        host = self._normalise_ollama_probe_host(telemetry.get("host"))
+        probe_url = f"{host}/api/tags"
+
+        probe_start = time.perf_counter()
+        try:
+            response = requests.get(
+                probe_url,
+                headers={"Accept": "application/json"},
+                timeout=max(0.1, float(timeout_ms) / 1000.0),
+            )
+            response.raise_for_status()
+            return {
+                "provider": provider,
+                "host": host,
+                "probe_url": probe_url,
+                "probe_timeout_ms": int(timeout_ms),
+                "duration_ms": int((time.perf_counter() - probe_start) * 1000.0),
+                "reachable": True,
+            }
+        except Exception as exc:
+            return {
+                "provider": provider,
+                "host": host,
+                "probe_url": probe_url,
+                "probe_timeout_ms": int(timeout_ms),
+                "duration_ms": int((time.perf_counter() - probe_start) * 1000.0),
+                "reachable": False,
+                "error": str(exc),
+                "error_class": type(exc).__name__,
+            }
+
     def _run_llm_with_fallbacks(
         self,
         *,
@@ -8272,9 +8395,11 @@ class InternalMCPChatOrchestrator:
         )
 
         errors: list[Mapping[str, Any]] = []
+        fallback_attempts: list[Mapping[str, Any]] = []
         last_exception: Exception | None = None
+        total_candidates = len(candidates)
 
-        for candidate in candidates:
+        for attempt_no, candidate in enumerate(candidates, start=1):
             client, model_name, telemetry = self._create_client_for_candidate(
                 candidate,
                 default_client=default_client,
@@ -8282,6 +8407,18 @@ class InternalMCPChatOrchestrator:
                 user_concept_id=user_concept_id,
                 org_concept_id=org_concept_id,
             )
+            provider = (
+                str(telemetry.get("provider")).strip()
+                if isinstance(telemetry, Mapping) and telemetry.get("provider")
+                else None
+            )
+
+            attempt_meta: dict[str, Any] = {
+                "fallback_attempt_no": attempt_no,
+                "fallback_candidate_count": total_candidates,
+            }
+            if provider:
+                attempt_meta["provider"] = provider
 
             if callable(emit_progress):
                 emit_progress(
@@ -8292,8 +8429,76 @@ class InternalMCPChatOrchestrator:
                         "candidate": (
                             dict(telemetry) if isinstance(telemetry, Mapping) else None
                         ),
+                        **attempt_meta,
                     }
                 )
+
+            reachability = self._probe_model_candidate_reachability(
+                telemetry=telemetry,
+            )
+            if isinstance(reachability, Mapping) and (
+                reachability.get("reachable") is False
+            ):
+                duration_ms = int(
+                    max(0.0, float(reachability.get("duration_ms") or 0.0))
+                )
+                probe_error = str(
+                    reachability.get("error")
+                    or "Provider preflight probe failed."
+                )
+                probe_error_class = str(
+                    reachability.get("error_class") or "ProviderProbeError"
+                )
+                if callable(emit_progress):
+                    emit_progress(
+                        {
+                            "status": "llm_call_end",
+                            "stage": stage,
+                            "model": model_name,
+                            "duration_ms": duration_ms,
+                            "success": False,
+                            "error": probe_error,
+                            "error_class": probe_error_class,
+                            "failure_kind": "provider_unreachable",
+                            **attempt_meta,
+                        }
+                    )
+                record_llm_call(
+                    call_type="llm.generate",
+                    model_name=model_name,
+                    duration_ms=duration_ms,
+                    usage=None,
+                    note="candidate reachability probe failed; trying fallback",
+                    stage=stage,
+                    provider=provider,
+                    candidate=telemetry,
+                )
+                error_entry = {
+                    "candidate": telemetry,
+                    "model_resolved": model_name,
+                    "error": probe_error,
+                    "error_class": probe_error_class,
+                    "failure_kind": "provider_unreachable",
+                }
+                errors.append(error_entry)
+                fallback_attempts.append(
+                    {
+                        "attempt_no": attempt_no,
+                        "provider": provider,
+                        "model": model_name,
+                        "status": "failed",
+                        "error": probe_error,
+                        "error_class": probe_error_class,
+                        "failure_kind": "provider_unreachable",
+                        "duration_ms": duration_ms,
+                        "candidate": dict(telemetry)
+                        if isinstance(telemetry, Mapping)
+                        else None,
+                        "probe": dict(reachability),
+                    }
+                )
+                continue
+
             llm_start = time.perf_counter()
             try:
                 response = client.generate(
@@ -8310,6 +8515,7 @@ class InternalMCPChatOrchestrator:
                             "model": model_name,
                             "chunks": 1,
                             "duration_ms": int(duration_ms),
+                            **attempt_meta,
                         }
                     )
                     emit_progress(
@@ -8319,6 +8525,9 @@ class InternalMCPChatOrchestrator:
                             "model": model_name,
                             "duration_ms": int(duration_ms),
                             "success": True,
+                            "error": None,
+                            "fallback_used": bool(errors),
+                            **attempt_meta,
                         }
                     )
                 record_llm_call(
@@ -8335,6 +8544,18 @@ class InternalMCPChatOrchestrator:
                     ),
                     candidate=telemetry,
                 )
+                fallback_attempts.append(
+                    {
+                        "attempt_no": attempt_no,
+                        "provider": provider,
+                        "model": model_name,
+                        "status": "succeeded",
+                        "duration_ms": int(duration_ms),
+                        "candidate": dict(telemetry)
+                        if isinstance(telemetry, Mapping)
+                        else None,
+                    }
+                )
                 aux_log.append(
                     {
                         "type": "workflow_model_policy_stage",
@@ -8344,6 +8565,9 @@ class InternalMCPChatOrchestrator:
                             "model_resolved": model_name,
                         },
                         "fallback_used": bool(errors),
+                        "fallback_attempt_count": len(fallback_attempts),
+                        "fallback_attempts": list(fallback_attempts),
+                        "failure_count": len(errors),
                         "errors": list(errors),
                     }
                 )
@@ -8359,6 +8583,9 @@ class InternalMCPChatOrchestrator:
                             "duration_ms": int(duration_ms),
                             "success": False,
                             "error": str(exc),
+                            "error_class": type(exc).__name__,
+                            "failure_kind": "candidate_error",
+                            **attempt_meta,
                         }
                     )
                 record_llm_call(
@@ -8379,8 +8606,25 @@ class InternalMCPChatOrchestrator:
                     "candidate": telemetry,
                     "model_resolved": model_name,
                     "error": str(exc),
+                    "error_class": type(exc).__name__,
+                    "failure_kind": "candidate_error",
                 }
                 errors.append(error_entry)
+                fallback_attempts.append(
+                    {
+                        "attempt_no": attempt_no,
+                        "provider": provider,
+                        "model": model_name,
+                        "status": "failed",
+                        "error": str(exc),
+                        "error_class": type(exc).__name__,
+                        "failure_kind": "candidate_error",
+                        "duration_ms": int(duration_ms),
+                        "candidate": dict(telemetry)
+                        if isinstance(telemetry, Mapping)
+                        else None,
+                    }
+                )
                 last_exception = exc
                 continue
 
@@ -8391,6 +8635,9 @@ class InternalMCPChatOrchestrator:
                     "stage": stage,
                     "selected": None,
                     "fallback_used": True,
+                    "fallback_attempt_count": len(fallback_attempts),
+                    "fallback_attempts": list(fallback_attempts),
+                    "failure_count": len(errors),
                     "errors": list(errors),
                 }
             )
@@ -8428,9 +8675,11 @@ class InternalMCPChatOrchestrator:
         )
 
         errors: list[Mapping[str, Any]] = []
+        fallback_attempts: list[Mapping[str, Any]] = []
         last_exception: Exception | None = None
+        total_candidates = len(candidates)
 
-        for candidate in candidates:
+        for attempt_no, candidate in enumerate(candidates, start=1):
             client, model_name, telemetry = self._create_client_for_candidate(
                 candidate,
                 default_client=default_client,
@@ -8438,6 +8687,17 @@ class InternalMCPChatOrchestrator:
                 user_concept_id=user_concept_id,
                 org_concept_id=org_concept_id,
             )
+            provider = (
+                str(telemetry.get("provider")).strip()
+                if isinstance(telemetry, Mapping) and telemetry.get("provider")
+                else None
+            )
+            attempt_meta: dict[str, Any] = {
+                "fallback_attempt_no": attempt_no,
+                "fallback_candidate_count": total_candidates,
+            }
+            if provider:
+                attempt_meta["provider"] = provider
 
             supports_structured = (
                 hasattr(client, "generate_with_tools")
@@ -8445,11 +8705,27 @@ class InternalMCPChatOrchestrator:
                 and client._should_use_structured_calling()
             )
             if not supports_structured:
-                errors.append(
+                error_entry = {
+                    "candidate": telemetry,
+                    "model_resolved": model_name,
+                    "error": "structured_tool_calling_disabled",
+                    "error_class": "StructuredToolCallingDisabled",
+                    "failure_kind": "candidate_capability",
+                }
+                errors.append(error_entry)
+                fallback_attempts.append(
                     {
-                        "candidate": telemetry,
-                        "model_resolved": model_name,
+                        "attempt_no": attempt_no,
+                        "provider": provider,
+                        "model": model_name,
+                        "status": "failed",
                         "error": "structured_tool_calling_disabled",
+                        "error_class": "StructuredToolCallingDisabled",
+                        "failure_kind": "candidate_capability",
+                        "duration_ms": 0,
+                        "candidate": dict(telemetry)
+                        if isinstance(telemetry, Mapping)
+                        else None,
                     }
                 )
                 continue
@@ -8527,6 +8803,84 @@ class InternalMCPChatOrchestrator:
                     else "none",
                 )
 
+            reachability = self._probe_model_candidate_reachability(
+                telemetry=telemetry,
+            )
+            if isinstance(reachability, Mapping) and (
+                reachability.get("reachable") is False
+            ):
+                duration_ms = int(
+                    max(0.0, float(reachability.get("duration_ms") or 0.0))
+                )
+                probe_error = str(
+                    reachability.get("error")
+                    or "Provider preflight probe failed."
+                )
+                probe_error_class = str(
+                    reachability.get("error_class") or "ProviderProbeError"
+                )
+                if callable(emit_progress):
+                    emit_progress(
+                        {
+                            "status": "llm_call_start",
+                            "stage": stage,
+                            "model": model_name,
+                            "candidate": (
+                                dict(telemetry) if isinstance(telemetry, Mapping) else None
+                            ),
+                            **attempt_meta,
+                        }
+                    )
+                    emit_progress(
+                        {
+                            "status": "llm_call_end",
+                            "stage": stage,
+                            "model": model_name,
+                            "duration_ms": duration_ms,
+                            "success": False,
+                            "error": probe_error,
+                            "error_class": probe_error_class,
+                            "failure_kind": "provider_unreachable",
+                            **attempt_meta,
+                        }
+                    )
+                record_llm_call(
+                    call_type="llm.generate_with_tools",
+                    model_name=model_name,
+                    duration_ms=duration_ms,
+                    usage=None,
+                    note="candidate reachability probe failed; trying fallback",
+                    stage=stage,
+                    provider=provider,
+                    candidate=telemetry,
+                )
+                errors.append(
+                    {
+                        "candidate": telemetry,
+                        "model_resolved": model_name,
+                        "error": probe_error,
+                        "error_class": probe_error_class,
+                        "failure_kind": "provider_unreachable",
+                    }
+                )
+                fallback_attempts.append(
+                    {
+                        "attempt_no": attempt_no,
+                        "provider": provider,
+                        "model": model_name,
+                        "status": "failed",
+                        "error": probe_error,
+                        "error_class": probe_error_class,
+                        "failure_kind": "provider_unreachable",
+                        "duration_ms": duration_ms,
+                        "candidate": dict(telemetry)
+                        if isinstance(telemetry, Mapping)
+                        else None,
+                        "probe": dict(reachability),
+                    }
+                )
+                continue
+
             if callable(emit_progress):
                 emit_progress(
                     {
@@ -8536,6 +8890,7 @@ class InternalMCPChatOrchestrator:
                         "candidate": (
                             dict(telemetry) if isinstance(telemetry, Mapping) else None
                         ),
+                        **attempt_meta,
                     }
                 )
             llm_start = time.perf_counter()
@@ -8564,6 +8919,7 @@ class InternalMCPChatOrchestrator:
                             "chunks": 1,
                             "tokens_streamed": completion_tokens,
                             "duration_ms": int(duration_ms),
+                            **attempt_meta,
                         }
                     )
                     emit_progress(
@@ -8573,6 +8929,9 @@ class InternalMCPChatOrchestrator:
                             "model": model_name,
                             "duration_ms": int(duration_ms),
                             "success": True,
+                            "error": None,
+                            "fallback_used": bool(errors),
+                            **attempt_meta,
                         }
                     )
                 record_llm_call(
@@ -8596,6 +8955,18 @@ class InternalMCPChatOrchestrator:
                     ),
                     candidate=telemetry,
                 )
+                fallback_attempts.append(
+                    {
+                        "attempt_no": attempt_no,
+                        "provider": provider,
+                        "model": model_name,
+                        "status": "succeeded",
+                        "duration_ms": int(duration_ms),
+                        "candidate": dict(telemetry)
+                        if isinstance(telemetry, Mapping)
+                        else None,
+                    }
+                )
                 aux_log.append(
                     {
                         "type": "workflow_model_policy_stage",
@@ -8605,6 +8976,9 @@ class InternalMCPChatOrchestrator:
                             "model_resolved": model_name,
                         },
                         "fallback_used": bool(errors),
+                        "fallback_attempt_count": len(fallback_attempts),
+                        "fallback_attempts": list(fallback_attempts),
+                        "failure_count": len(errors),
                         "errors": list(errors),
                     }
                 )
@@ -8620,6 +8994,9 @@ class InternalMCPChatOrchestrator:
                             "duration_ms": int(duration_ms),
                             "success": False,
                             "error": str(exc),
+                            "error_class": type(exc).__name__,
+                            "failure_kind": "candidate_error",
+                            **attempt_meta,
                         }
                     )
                 record_llm_call(
@@ -8641,6 +9018,23 @@ class InternalMCPChatOrchestrator:
                         "candidate": telemetry,
                         "model_resolved": model_name,
                         "error": str(exc),
+                        "error_class": type(exc).__name__,
+                        "failure_kind": "candidate_error",
+                    }
+                )
+                fallback_attempts.append(
+                    {
+                        "attempt_no": attempt_no,
+                        "provider": provider,
+                        "model": model_name,
+                        "status": "failed",
+                        "error": str(exc),
+                        "error_class": type(exc).__name__,
+                        "failure_kind": "candidate_error",
+                        "duration_ms": int(duration_ms),
+                        "candidate": dict(telemetry)
+                        if isinstance(telemetry, Mapping)
+                        else None,
                     }
                 )
                 last_exception = exc
@@ -8653,6 +9047,9 @@ class InternalMCPChatOrchestrator:
                     "stage": stage,
                     "selected": None,
                     "fallback_used": True,
+                    "fallback_attempt_count": len(fallback_attempts),
+                    "fallback_attempts": list(fallback_attempts),
+                    "failure_count": len(errors),
                     "errors": list(errors),
                 }
             )

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -1613,6 +1613,15 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
             tools_completed = max(tools_completed, int(explicit_done))
 
         merged = {**existing, **safe_update}
+        if "error" in safe_update:
+            error_text = _progress_str(safe_update.get("error"))
+            if error_text:
+                merged["error"] = error_text
+            else:
+                merged.pop("error", None)
+        else:
+            # Avoid stale-provider error leakage into later unrelated progress events.
+            merged.pop("error", None)
         merged["request_id"] = request_id
         merged["status"] = status
         merged["stage"] = stage
@@ -1682,6 +1691,25 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
             event_entry["success"] = success_flag
         if _progress_str(merged.get("error")):
             event_entry["error"] = str(merged.get("error"))
+        error_class = _progress_str(merged.get("error_class"))
+        if error_class:
+            event_entry["error_class"] = error_class
+        candidate = merged.get("candidate")
+        if isinstance(candidate, Mapping):
+            event_entry["candidate"] = dict(candidate)
+        fallback_attempt_no = _progress_number(merged.get("fallback_attempt_no"))
+        if fallback_attempt_no is not None:
+            event_entry["fallback_attempt_no"] = int(max(0.0, fallback_attempt_no))
+        fallback_candidate_count = _progress_number(
+            merged.get("fallback_candidate_count")
+        )
+        if fallback_candidate_count is not None:
+            event_entry["fallback_candidate_count"] = int(
+                max(0.0, fallback_candidate_count)
+            )
+        failure_kind = _progress_str(merged.get("failure_kind"))
+        if failure_kind:
+            event_entry["failure_kind"] = failure_kind
         trimmed_events = [
             *existing_events[-(_TOOL_PROGRESS_DIAGNOSTIC_EVENT_LIMIT - 1) :],
             event_entry,
@@ -5859,6 +5887,13 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                 payload["candidate"] = dict(candidate)
             llm_interaction["calls"].append(payload)
 
+        def _emit_stage_progress(info: Mapping[str, Any] | None) -> None:
+            if not show_tool_use_progress:
+                return
+            payload = dict(info) if isinstance(info, Mapping) else {"status": "unknown"}
+            payload.setdefault("request_id", request_id)
+            _set_tool_progress(progress_scope_key, request_id, payload)
+
         if orchestrator is None:
             llm_start_perf = time.perf_counter()
             response_text = llm_client.generate(
@@ -6434,7 +6469,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                             orchestrator, "_run_llm_with_fallbacks"
                         ):
                             try:
-                                policy_state, _ = (
+                                policy_state, registry_snapshot = (
                                     orchestrator._load_workflow_model_policy(
                                         request_language
                                     )
@@ -6453,11 +6488,17 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                                         default_client=llm_client,
                                         default_model=model_name,
                                         policy_state=policy_state,
+                                        registry_snapshot=(
+                                            registry_snapshot
+                                            if isinstance(registry_snapshot, Mapping)
+                                            else None
+                                        ),
                                         user_concept_id=user_concept_id,
                                         org_concept_id=org_concept_id,
                                         llm_calls_log=llm_interaction["calls"],
                                         aux_log=auxiliary_llm_calls,
                                         record_llm_call=_record_stage_llm_call,
+                                        emit_progress=_emit_stage_progress,
                                     )
                                 )
                                 screen_backfill_model_id = screen_model_used
@@ -6467,6 +6508,13 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                             llm_start = time.perf_counter()
                             screen_model_used = model_name
                             screen_backfill_model_id = screen_model_used
+                            _emit_stage_progress(
+                                {
+                                    "status": "llm_call_start",
+                                    "stage": "screen_backfill",
+                                    "model": screen_model_used,
+                                }
+                            )
                             synthesis_response = llm_client.generate(
                                 prompt="Generate <screen> display content",
                                 context=[
@@ -6475,10 +6523,32 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                                 ],
                                 model=screen_model_used,
                             )
+                            screen_duration_ms = (
+                                time.perf_counter() - llm_start
+                            ) * 1000.0
+                            _emit_stage_progress(
+                                {
+                                    "status": "llm_call_chunk",
+                                    "stage": "screen_backfill",
+                                    "model": screen_model_used,
+                                    "chunks": 1,
+                                    "duration_ms": int(screen_duration_ms),
+                                }
+                            )
+                            _emit_stage_progress(
+                                {
+                                    "status": "llm_call_end",
+                                    "stage": "screen_backfill",
+                                    "model": screen_model_used,
+                                    "duration_ms": int(screen_duration_ms),
+                                    "success": True,
+                                    "error": None,
+                                }
+                            )
                             _record_stage_llm_call(
                                 call_type="llm.generate",
                                 model_name=screen_model_used,
-                                duration_ms=(time.perf_counter() - llm_start) * 1000.0,
+                                duration_ms=screen_duration_ms,
                                 usage=None,
                                 note="Screen backfill synthesis (legacy).",
                                 stage="screen_backfill",
@@ -7210,12 +7280,14 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                 buttonify_workflow_used = True
                 buttonify_workflow_result = None
                 policy_state = None
+                registry_snapshot = None
                 try:
-                    policy_state, _ = orchestrator._load_workflow_model_policy(
+                    policy_state, registry_snapshot = orchestrator._load_workflow_model_policy(
                         request_language
                     )
                 except Exception:
                     policy_state = None
+                    registry_snapshot = None
 
                 try:
                     buttonify_workflow_result = orchestrator.execute_workflow(
@@ -7229,7 +7301,9 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                             "buttonify_prompt_ids": list(BUTTONIFY_PROMPT_IDS),
                             "default_model": model_name,
                             "policy_state": policy_state,
+                            "registry_snapshot": registry_snapshot,
                             "record_llm_call": _record_stage_llm_call,
+                            "emit_progress": _emit_stage_progress,
                             "llm_calls_log": llm_interaction["calls"],
                             "aux_llm_calls": auxiliary_llm_calls,
                             "user_concept_id": user_concept_id,

--- a/tests/backend/test_orchestrator_model_fallback_execution.py
+++ b/tests/backend/test_orchestrator_model_fallback_execution.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, cast
+
+from src.backend.integrations.internal_mcp.orchestrator import (
+    InternalMCPChatOrchestrator,
+    _ModelCandidate,
+    _WorkflowModelPolicyState,
+)
+
+
+class _StubGateway:
+    enabled = True
+
+    def describe_methods(self) -> dict[str, Any]:
+        return {}
+
+    def invoke(self, _tool_name: str, _payload: Mapping[str, Any]):  # pragma: no cover
+        raise AssertionError("Gateway should not be invoked in this test")
+
+
+class _FailingClient:
+    def generate(self, *_args: Any, **_kwargs: Any) -> str:
+        raise RuntimeError("primary model unavailable")
+
+
+class _SuccessfulClient:
+    def generate(self, *_args: Any, **_kwargs: Any) -> str:
+        return '["Proceed", "Hold"]'
+
+
+def _policy_state() -> _WorkflowModelPolicyState:
+    return _WorkflowModelPolicyState(
+        enabled=True,
+        policy={"stages": {"buttonify": {"primary": "ollama:granite3.3:2b"}}},
+        policy_id="#V#default_workflow_model_policy",
+        predicate_id="#V#has_model_policy_json",
+        errors=(),
+    )
+
+
+def test_run_llm_with_fallbacks_records_attempt_chain_and_fallback_metadata(
+    monkeypatch,
+) -> None:
+    orchestrator = InternalMCPChatOrchestrator(gateway=cast(Any, _StubGateway()))
+    ollama_candidate = _ModelCandidate(
+        provider="ollama",
+        model="granite3.3:2b",
+        raw="ollama:granite3.3:2b",
+        source="policy",
+        host="http://localhost:11434",
+    )
+    openai_candidate = _ModelCandidate(
+        provider="openai",
+        model="gpt-5.2-chat-latest",
+        raw="openai:gpt-5.2-chat-latest",
+        source="policy",
+    )
+
+    monkeypatch.setattr(
+        orchestrator,
+        "_stage_model_candidates",
+        lambda **_kwargs: [ollama_candidate, openai_candidate],
+    )
+
+    def _create_client_for_candidate(
+        candidate: _ModelCandidate,
+        **_kwargs: Any,
+    ) -> tuple[Any, str, Mapping[str, Any]]:
+        if candidate.provider == "ollama":
+            return (
+                _FailingClient(),
+                "granite3.3:2b",
+                {
+                    "provider": "ollama",
+                    "model": "granite3.3:2b",
+                    "raw": candidate.raw,
+                    "source": candidate.source,
+                    "host": "http://localhost:11434",
+                },
+            )
+        return (
+            _SuccessfulClient(),
+            "gpt-5.2-chat-latest",
+            {
+                "provider": "openai",
+                "model": "gpt-5.2-chat-latest",
+                "raw": candidate.raw,
+                "source": candidate.source,
+                "host": None,
+            },
+        )
+
+    monkeypatch.setattr(
+        orchestrator,
+        "_create_client_for_candidate",
+        _create_client_for_candidate,
+    )
+
+    def _probe_model_candidate_reachability(
+        *,
+        telemetry: Mapping[str, Any],
+    ) -> Mapping[str, Any] | None:
+        if telemetry.get("provider") != "ollama":
+            return None
+        return {
+            "provider": "ollama",
+            "host": "http://localhost:11434",
+            "probe_url": "http://localhost:11434/api/tags",
+            "probe_timeout_ms": 1200,
+            "duration_ms": 7,
+            "reachable": False,
+            "error": "connection refused",
+            "error_class": "ConnectionError",
+        }
+
+    monkeypatch.setattr(
+        orchestrator,
+        "_probe_model_candidate_reachability",
+        _probe_model_candidate_reachability,
+    )
+
+    progress_events: list[dict[str, Any]] = []
+    llm_calls_log: list[dict[str, Any]] = []
+    aux_log: list[Mapping[str, Any]] = []
+    recorded_calls: list[dict[str, Any]] = []
+
+    def _record_llm_call(**payload: Any) -> None:
+        recorded_calls.append(dict(payload))
+
+    response, model_name, telemetry = orchestrator._run_llm_with_fallbacks(
+        stage="buttonify",
+        prompt="Return quick-reply options",
+        context=[],
+        default_client=object(),
+        default_model="gpt-5.2-chat-latest",
+        policy_state=_policy_state(),
+        registry_snapshot=None,
+        user_concept_id=None,
+        org_concept_id=None,
+        llm_calls_log=llm_calls_log,
+        aux_log=aux_log,
+        record_llm_call=_record_llm_call,
+        emit_progress=lambda payload: progress_events.append(dict(payload)),
+    )
+
+    assert response == '["Proceed", "Hold"]'
+    assert model_name == "gpt-5.2-chat-latest"
+    assert telemetry.get("provider") == "openai"
+
+    first_end = next(
+        event
+        for event in progress_events
+        if event.get("status") == "llm_call_end"
+        and event.get("fallback_attempt_no") == 1
+    )
+    assert first_end["success"] is False
+    assert first_end["failure_kind"] == "provider_unreachable"
+    assert first_end["error_class"] == "ConnectionError"
+
+    second_end = next(
+        event
+        for event in progress_events
+        if event.get("status") == "llm_call_end"
+        and event.get("fallback_attempt_no") == 2
+    )
+    assert second_end["success"] is True
+    assert second_end["fallback_used"] is True
+
+    stage_summary = next(
+        entry
+        for entry in aux_log
+        if entry.get("type") == "workflow_model_policy_stage"
+    )
+    assert stage_summary["fallback_attempt_count"] == 2
+    assert stage_summary["failure_count"] == 1
+    assert stage_summary["selected"]["provider"] == "openai"
+
+    attempts = stage_summary["fallback_attempts"]
+    assert isinstance(attempts, list)
+    assert attempts[0]["failure_kind"] == "provider_unreachable"
+    assert attempts[0]["error_class"] == "ConnectionError"
+    assert attempts[1]["status"] == "succeeded"
+
+    assert recorded_calls[0]["note"] == "candidate reachability probe failed; trying fallback"

--- a/tests/backend/test_tool_progress_liveness.py
+++ b/tests/backend/test_tool_progress_liveness.py
@@ -167,6 +167,45 @@ def test_progress_event_contains_required_telemetry_fields(monkeypatch) -> None:
     assert isinstance(serialised["activity_idle_ms"], int)
 
 
+def test_progress_clears_stale_error_on_subsequent_success(monkeypatch) -> None:
+    clock = _set_clock(monkeypatch, start=4500.0)
+
+    von_routes._set_tool_progress(
+        "scope-stale",
+        "req-stale",
+        {
+            "status": "llm_call_end",
+            "stage": "buttonify",
+            "request_id": "req-stale",
+            "model": "granite3.3:2b",
+            "success": False,
+            "error": "Ollama unexpected error: failed to connect",
+            "error_class": "RuntimeError",
+        },
+    )
+    clock["now"] += 0.2
+    von_routes._set_tool_progress(
+        "scope-stale",
+        "req-stale",
+        {
+            "status": "llm_call_end",
+            "stage": "buttonify",
+            "request_id": "req-stale",
+            "model": "gpt-5.2-chat-latest",
+            "success": True,
+        },
+    )
+
+    state = von_routes._get_tool_progress("scope-stale", "req-stale")
+    assert state is not None
+    assert "error" not in state
+
+    events = state.get("diagnostic_events")
+    assert isinstance(events, list)
+    assert events[0].get("error") == "Ollama unexpected error: failed to connect"
+    assert "error" not in events[-1]
+
+
 def test_turn_execution_diagnostics_rebuilds_phase_and_tool_history(monkeypatch) -> None:
     clock = _set_clock(monkeypatch, start=5000.0)
 


### PR DESCRIPTION
## Summary
- add fast Ollama reachability precheck in shared model fallback execution to fail quickly when provider is unavailable
- add explicit fallback-chain telemetry fields in fallback execution (allback_attempt_no, candidate count, failure kind/class, attempt list, selected candidate)
- wire progress emission into route-level screen_backfill and workflow buttonify execution so fallback chains are visible in diagnostics
- stop stale rror propagation in tool-progress state by clearing error unless explicitly present in the current update

## Tests
- pytest tests/backend/test_orchestrator_model_fallback_execution.py tests/backend/test_tool_progress_liveness.py tests/backend/test_von_generate_presenter_protocol.py -q
- pyright src/backend/integrations/internal_mcp/orchestrator.py src/backend/server/routes/von_routes.py tests/backend/test_orchestrator_model_fallback_execution.py tests/backend/test_tool_progress_liveness.py

## Jira
- JVNAUTOSCI-1363