### PR TITLE
JVNAUTOSCI-1365 Fix timeout-path list-index regression and progress success mismatch

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -1613,6 +1613,16 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
             tools_completed = max(tools_completed, int(explicit_done))
 
         merged = {**existing, **safe_update}
+        if "success" in safe_update:
+            success_value = safe_update.get("success")
+            if isinstance(success_value, bool):
+                merged["success"] = success_value
+            else:
+                merged.pop("success", None)
+        else:
+            # Terminal error/cancel events must not inherit an earlier success=True.
+            if status.lower() in {"error", "cancelled"}:
+                merged.pop("success", None)
         if "error" in safe_update:
             error_text = _progress_str(safe_update.get("error"))
             if error_text:

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -2160,6 +2160,66 @@ def test_renderer_selection_emits_hierarchy_from_taxonomy_screen_text(monkeypatc
     assert "#V#automated_meeting_transcript" in node_ids
 
 
+def test_renderer_selection_hierarchy_parser_tolerates_indented_root_rows(monkeypatch):
+    """Regression for JVNAUTOSCI-1365: avoid index errors on indented first rows."""
+    orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
+    monkeypatch.setenv("VON_RENDERER_APPLICABILITY_ROUTING_ENABLE", "1")
+    monkeypatch.setenv(
+        "VON_RENDERER_APPLICABILITY_DEFINITION_IDS",
+        "#V#workflow_renderer,#V#table_renderer",
+    )
+
+    def _invoke(tool_name: str, _payload: Mapping[str, Any]):
+        if tool_name != "renderer_resolve_applicability":
+            raise AssertionError(f"Unexpected tool invocation: {tool_name}")
+        return _InvokeResult({"success": True, "selected_renderers": []})
+
+    monkeypatch.setattr(orchestrator._gateway, "invoke", _invoke)
+
+    class _WorkflowResult:
+        def __init__(self):
+            self.data = {
+                "final_response": (
+                    "```text\n"
+                    "    #V#document\n"
+                    "    #V#meeting_document\n"
+                    "        #V#meeting_notes\n"
+                    "```"
+                ),
+                "tool_messages": [],
+                "invocations": [],
+                "iteration_count": 1,
+            }
+            self.final_state = "completed"
+            self.completed = True
+
+    def _execute_workflow(workflow_id: str, **_kwargs: Any):
+        if workflow_id != TOOL_CALLING_WORKFLOW_ID:
+            raise AssertionError(f"Unexpected workflow execution: {workflow_id}")
+        return _WorkflowResult()
+
+    monkeypatch.setattr(orchestrator, "execute_workflow", _execute_workflow)
+
+    llm = _CapturingLLM(["tool_seeking"])
+    result = orchestrator.run(
+        prompt="Show a taxonomy hierarchy",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+    )
+
+    assert isinstance(result.render_plan, dict)
+    assert result.render_plan.get("screen_element_targets", {}).get("hierarchy_view") is True
+    hierarchy_elements = result.render_plan.get("screen_hierarchy_elements")
+    assert isinstance(hierarchy_elements, list)
+    assert len(hierarchy_elements) == 1
+    payload = hierarchy_elements[0].get("payload", {})
+    edges = payload.get("edges")
+    assert isinstance(edges, list)
+    assert len(edges) == 2
+
+
 def test_renderer_render_plan_skips_malformed_tool_messages_for_table_record_sets(
     monkeypatch,
 ):

--- a/tests/backend/test_tool_progress_liveness.py
+++ b/tests/backend/test_tool_progress_liveness.py
@@ -206,6 +206,43 @@ def test_progress_clears_stale_error_on_subsequent_success(monkeypatch) -> None:
     assert "error" not in events[-1]
 
 
+def test_progress_clears_stale_success_on_error(monkeypatch) -> None:
+    clock = _set_clock(monkeypatch, start=4700.0)
+
+    von_routes._set_tool_progress(
+        "scope-stale-success",
+        "req-stale-success",
+        {
+            "status": "llm_call_end",
+            "stage": "tool_plan",
+            "request_id": "req-stale-success",
+            "success": True,
+        },
+    )
+    clock["now"] += 0.1
+    von_routes._set_tool_progress(
+        "scope-stale-success",
+        "req-stale-success",
+        {
+            "status": "error",
+            "stage": "tool_call",
+            "request_id": "req-stale-success",
+            "error": "list assignment index out of range",
+        },
+    )
+
+    state = von_routes._get_tool_progress("scope-stale-success", "req-stale-success")
+    assert state is not None
+    assert state["status"] == "error"
+    assert state.get("success") is not True
+    assert state.get("error") == "list assignment index out of range"
+
+    events = state.get("diagnostic_events")
+    assert isinstance(events, list)
+    assert events[-1].get("status") == "error"
+    assert events[-1].get("success") is None
+
+
 def test_turn_execution_diagnostics_rebuilds_phase_and_tool_history(monkeypatch) -> None:
     clock = _set_clock(monkeypatch, start=5000.0)
 


### PR DESCRIPTION
## Summary
- prevent stale success=true from leaking into terminal status=error/cancelled progress records in _set_tool_progress
- add regression coverage for stale-success-on-error tool progress behaviour
- add end-to-end orchestrator regression coverage for hierarchy parsing with indented root rows (the path associated with list assignment index out of range)

## Validation
- pytest tests/backend/test_tool_progress_liveness.py tests/backend/test_orchestrator_workflow_selector_routing.py
- pyright src/backend/server/routes/von_routes.py tests/backend/test_orchestrator_workflow_selector_routing.py tests/backend/test_tool_progress_liveness.py

## Jira
- JVNAUTOSCI-1365