### PR TITLE
JVNAUTOSCI-1324: add file-copy download action and guarded delete

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -1407,6 +1407,55 @@ def _record_file_upload_in_chat_history(
         return False
 
 
+_FILE_DELETE_CONFIRM_PHRASE = "DELETE FILE"
+
+
+def _get_effective_user_concept_id_for_file_routes() -> str | None:
+    try:
+        from ...security.access_control import get_effective_user_concept_id
+
+        user_concept_id = get_effective_user_concept_id()
+    except Exception:
+        user_concept_id = session.get("user_concept_id")
+
+    if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+        return None
+    return user_concept_id.strip()
+
+
+def _load_authorised_file_copy_concept_doc(
+    *,
+    concept_id: str,
+    user_concept_id: str,
+    log_prefix: str,
+) -> dict[str, Any] | None:
+    try:
+        from ...db.repositories.concepts_repository import ConceptsRepository
+
+        concept_doc = ConceptsRepository.find_one({"concept_id": concept_id})
+    except Exception as exc:
+        current_app.logger.warning("[%s] Concept lookup failed: %s", log_prefix, exc)
+        concept_doc = None
+
+    if not isinstance(concept_doc, dict):
+        return None
+
+    relationships = concept_doc.get("relationships")
+    from ...security.access_control import _get_specific_to_user_values
+
+    specific = (
+        _get_specific_to_user_values(relationships)
+        if isinstance(relationships, dict)
+        else []
+    )
+    if specific and user_concept_id not in {
+        str(x).strip() for x in specific if x is not None
+    }:
+        return None
+
+    return concept_doc
+
+
 @von_bp.route("/api/files/<path:file_copy_concept_id>/download", methods=["GET"])
 def download_file_copy(file_copy_concept_id: str):
     """Download an uploaded file-copy by its Vontology concept id.
@@ -1420,14 +1469,8 @@ def download_file_copy(file_copy_concept_id: str):
       - concept_id: optional override (for callers that prefer query param)
     """
 
-    try:
-        from ...security.access_control import get_effective_user_concept_id
-
-        user_concept_id = get_effective_user_concept_id()
-    except Exception:
-        user_concept_id = session.get("user_concept_id")
-
-    if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+    user_concept_id = _get_effective_user_concept_id_for_file_routes()
+    if user_concept_id is None:
         return (
             jsonify(
                 {
@@ -1445,32 +1488,12 @@ def download_file_copy(file_copy_concept_id: str):
     if not concept_id:
         return jsonify({"success": False, "error": "missing_concept_id"}), 400
 
-    try:
-        from ...db.repositories.concepts_repository import ConceptsRepository
-
-        concept_doc = ConceptsRepository.find_one({"concept_id": concept_id})
-    except Exception as exc:
-        current_app.logger.warning("[files/download] Concept lookup failed: %s", exc)
-        concept_doc = None
-
-    if not isinstance(concept_doc, dict):
-        # Avoid leaking which concept IDs exist.
-        return jsonify({"success": False, "error": "not_found"}), 404
-
-    relationships = (
-        concept_doc.get("relationships") if isinstance(concept_doc, dict) else None
+    concept_doc = _load_authorised_file_copy_concept_doc(
+        concept_id=concept_id,
+        user_concept_id=user_concept_id,
+        log_prefix="files/download",
     )
-    # Check both legacy and predicate-style specific_to_user fields
-    from ...security.access_control import _get_specific_to_user_values
-
-    specific = (
-        _get_specific_to_user_values(relationships)
-        if isinstance(relationships, dict)
-        else []
-    )
-    if specific and user_concept_id.strip() not in {
-        str(x).strip() for x in specific if x is not None
-    }:
+    if concept_doc is None:
         # Avoid leaking which concept IDs exist.
         return jsonify({"success": False, "error": "not_found"}), 404
 
@@ -1519,6 +1542,90 @@ def download_file_copy(file_copy_concept_id: str):
     resp.headers["Cache-Control"] = "no-store"
     resp.headers["Pragma"] = "no-cache"
     return resp
+
+
+@von_bp.route("/api/files/<path:file_copy_concept_id>", methods=["DELETE"])
+def delete_file_copy(file_copy_concept_id: str):
+    """Delete a file-copy concept and its backing blob bytes.
+
+    This route is intentionally stricter than normal concept deletion:
+    callers must supply a typed confirmation phrase to reduce accidental
+    destructive operations.
+    """
+
+    user_concept_id = _get_effective_user_concept_id_for_file_routes()
+    if user_concept_id is None:
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "missing_user_context",
+                    "message": "Missing user context: establish an authenticated session first.",
+                }
+            ),
+            401,
+        )
+
+    concept_id = request.args.get("concept_id") or file_copy_concept_id
+    concept_id = str(concept_id or "").strip()
+    if not concept_id:
+        return jsonify({"success": False, "error": "missing_concept_id"}), 400
+
+    payload = request.get_json(silent=True) or {}
+    confirm_phrase = str(payload.get("confirm_phrase") or "").strip()
+    if confirm_phrase != _FILE_DELETE_CONFIRM_PHRASE:
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "confirmation_required",
+                    "message": (
+                        "Strong confirmation required. "
+                        f"Set confirm_phrase to '{_FILE_DELETE_CONFIRM_PHRASE}'."
+                    ),
+                    "expected_confirm_phrase": _FILE_DELETE_CONFIRM_PHRASE,
+                }
+            ),
+            400,
+        )
+
+    concept_doc = _load_authorised_file_copy_concept_doc(
+        concept_id=concept_id,
+        user_concept_id=user_concept_id,
+        log_prefix="files/delete",
+    )
+    if concept_doc is None:
+        return jsonify({"success": False, "error": "not_found"}), 404
+
+    from ...services.computer_file_copy_service import delete_file_copy_blob_and_concept
+
+    result = delete_file_copy_blob_and_concept(
+        file_copy_concept_id=concept_id,
+        logger=current_app.logger,
+    )
+    if not isinstance(result, dict):
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "delete_failed",
+                    "message": "Unexpected delete result.",
+                }
+            ),
+            500,
+        )
+
+    if result.get("success") is True:
+        return jsonify(result), 200
+
+    error = str(result.get("error") or "delete_failed").strip().lower()
+    if error == "not_found":
+        return jsonify(result), 404
+    if error == "blob_delete_failed":
+        return jsonify(result), 502
+    if error == "concept_delete_failed":
+        return jsonify(result), 500
+    return jsonify(result), 500
 
 
 def _prune_tool_progress() -> None:

--- a/src/backend/services/computer_file_copy_service.py
+++ b/src/backend/services/computer_file_copy_service.py
@@ -440,6 +440,104 @@ def fetch_file_copy_bytes(
     }
 
 
+def delete_file_copy_blob_and_concept(
+    *,
+    file_copy_concept_id: str,
+    logger: Any | None = None,
+) -> dict[str, Any]:
+    """Delete a blob-backed file-copy concept and its backing bytes.
+
+    This helper intentionally reports partial outcomes explicitly. If blob
+    deletion succeeds but concept deletion fails, callers receive
+    ``partial=true`` and can surface a clear, non-ambiguous failure message.
+    """
+
+    info = resolve_file_copy_blob_info(file_copy_concept_id=file_copy_concept_id)
+    if info is None:
+        return {
+            "success": False,
+            "error": "not_found",
+            "message": "File-copy concept not found or missing blob metadata.",
+            "concept_deleted": False,
+            "blob_deleted": False,
+            "partial": False,
+        }
+
+    from .blob_store import get_blob_store_from_env
+
+    try:
+        store = get_blob_store_from_env()
+        store.delete(info.blob_key)
+    except Exception as exc:
+        if logger is not None:
+            logger.warning("[file_copy] Blob delete failed for %s: %s", info.concept_id, exc)
+        return {
+            "success": False,
+            "error": "blob_delete_failed",
+            "message": f"Failed to delete backing file bytes: {exc}",
+            "concept_id": info.concept_id,
+            "blob_key": info.blob_key,
+            "blob_uri": info.blob_uri,
+            "concept_deleted": False,
+            "blob_deleted": False,
+            "partial": False,
+        }
+
+    try:
+        from . import concept_service
+
+        concept_deleted = bool(concept_service.delete_concept(info.concept_id))
+    except Exception as exc:
+        if logger is not None:
+            logger.error(
+                "[file_copy] Concept delete failed after blob delete for %s: %s",
+                info.concept_id,
+                exc,
+            )
+        return {
+            "success": False,
+            "error": "concept_delete_failed",
+            "message": (
+                "Backing file bytes were deleted, but concept deletion failed. "
+                "The operation is partial and needs follow-up cleanup."
+            ),
+            "detail": str(exc),
+            "concept_id": info.concept_id,
+            "blob_key": info.blob_key,
+            "blob_uri": info.blob_uri,
+            "concept_deleted": False,
+            "blob_deleted": True,
+            "partial": True,
+        }
+
+    if not concept_deleted:
+        return {
+            "success": False,
+            "error": "concept_delete_failed",
+            "message": (
+                "Backing file bytes were deleted, but concept deletion did not complete. "
+                "The operation is partial and needs follow-up cleanup."
+            ),
+            "concept_id": info.concept_id,
+            "blob_key": info.blob_key,
+            "blob_uri": info.blob_uri,
+            "concept_deleted": False,
+            "blob_deleted": True,
+            "partial": True,
+        }
+
+    return {
+        "success": True,
+        "message": "File copy and backing file bytes deleted successfully.",
+        "concept_id": info.concept_id,
+        "blob_key": info.blob_key,
+        "blob_uri": info.blob_uri,
+        "concept_deleted": True,
+        "blob_deleted": True,
+        "partial": False,
+    }
+
+
 def _normalise_optional_text(value: Any) -> str | None:
     if not isinstance(value, str):
         return None

--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -1340,7 +1340,7 @@ export async function loadDynamicConceptTabContent(tabId, conceptId) {
                 attachConceptIdCopyChip(headerDiv, conceptId, kind);
                 attachRawDataButton(headerDiv, conceptId, kind, tabInfo.content);
                 attachKeyConceptStarButton(headerDiv, conceptId);
-                attachAnalysisButtons(headerDiv, conceptId, kind);
+                attachAnalysisButtons(headerDiv, conceptId, kind, nodeJson);
             }
         } catch (e) {
             console.warn('[dynamicTabs] Could not attach kind badge:', e);
@@ -6395,7 +6395,63 @@ async function renderRelationships(conceptId, suffix, kind) {
     }
 }
 // Helper: Add analysis and relationship buttons next to JSON button
-function attachAnalysisButtons(headerDiv, conceptId, kind) {
+const FILE_DELETE_CONFIRM_PHRASE = 'DELETE FILE';
+
+function toConceptIdArray(value) {
+    if (Array.isArray(value)) {
+        return value.map((item) => String(item || '').trim()).filter(Boolean);
+    }
+    if (typeof value === 'string' && value.trim()) {
+        return [value.trim()];
+    }
+    return [];
+}
+
+export function deriveFileCopyActionState(nodePayload = null) {
+    const rawDoc = (nodePayload && typeof nodePayload.raw_doc === 'object' && nodePayload.raw_doc)
+        ? nodePayload.raw_doc
+        : (nodePayload && typeof nodePayload === 'object' ? nodePayload : {});
+
+    const attributes = (rawDoc && typeof rawDoc.attributes === 'object' && rawDoc.attributes)
+        ? rawDoc.attributes
+        : {};
+    const relationships = (rawDoc && typeof rawDoc.relationships === 'object' && rawDoc.relationships)
+        ? rawDoc.relationships
+        : {};
+
+    const blobKey = String(
+        attributes.blob_key ||
+        attributes.has_blob_key ||
+        rawDoc.blob_key ||
+        ''
+    ).trim();
+    const blobUri = String(
+        attributes.blob_uri ||
+        attributes.has_blob_uri ||
+        rawDoc.blob_uri ||
+        ''
+    ).trim();
+    const hasResolvableBlobRef = !!(blobKey || blobUri);
+
+    const instanceTypeIds = toConceptIdArray(relationships.is_an_instance_of).map((id) => id.toLowerCase());
+    const typeHints = [
+        ...instanceTypeIds,
+        String(rawDoc.concept_id || '').toLowerCase(),
+    ];
+    const looksLikeFileCopyType = typeHints.some((value) =>
+        value.includes('file_copy') ||
+        value.includes('arxiv_pdf_file') ||
+        value.includes('arxiv_markdown_file')
+    );
+
+    return {
+        isFileCopyConcept: looksLikeFileCopyType || hasResolvableBlobRef,
+        hasResolvableBlobRef,
+        showFileActions: hasResolvableBlobRef && (looksLikeFileCopyType || hasResolvableBlobRef),
+    };
+}
+
+function attachAnalysisButtons(headerDiv, conceptId, kind, nodePayload = null) {
     try {
         if (!headerDiv || !conceptId) return;
 
@@ -6468,7 +6524,8 @@ function attachAnalysisButtons(headerDiv, conceptId, kind) {
         headerDiv.appendChild(buttonGroup);
 
         // After analysis buttons, attach delete concept button (unified endpoint)
-        attachDeleteConceptButton(headerDiv, conceptId, kind);
+        const fileCopyActionState = deriveFileCopyActionState(nodePayload);
+        attachDeleteConceptButton(headerDiv, conceptId, kind, fileCopyActionState);
 
     } catch (e) {
         console.warn('[dynamicTabs] attachAnalysisButtons failed', e);
@@ -6476,14 +6533,50 @@ function attachAnalysisButtons(headerDiv, conceptId, kind) {
 }
 
 // Helper: attach delete concept button to header
-function attachDeleteConceptButton(headerDiv, conceptId, kind) {
+function attachDeleteConceptButton(headerDiv, conceptId, kind, fileCopyActionState = null) {
     try {
         if (!headerDiv || !conceptId) return;
         if (headerDiv.querySelector('.delete-concept-button')) return; // already added
+        const fileActionsEnabled = !!(fileCopyActionState && fileCopyActionState.showFileActions);
+
+        if (fileActionsEnabled && !headerDiv.querySelector('.download-file-copy-button')) {
+            const downloadBtn = document.createElement('button');
+            downloadBtn.className = 'download-file-copy-button';
+            downloadBtn.title = 'Download backing file';
+            downloadBtn.setAttribute('aria-label', 'Download backing file');
+            downloadBtn.setAttribute('data-keep-title', 'true');
+            downloadBtn.textContent = '⬇️';
+            downloadBtn.style.padding = '2px 6px';
+            downloadBtn.style.border = '1px solid #d1d5db';
+            downloadBtn.style.borderRadius = '4px';
+            downloadBtn.style.background = '#eff6ff';
+            downloadBtn.style.color = '#1d4ed8';
+            downloadBtn.style.cursor = 'pointer';
+            downloadBtn.style.fontSize = '0.9rem';
+            downloadBtn.style.marginLeft = '4px';
+            downloadBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const downloadUrl = `/von/api/files/${encodeURIComponent(conceptId)}/download`;
+                try {
+                    window.open(downloadUrl, '_blank', 'noopener,noreferrer');
+                } catch (_) {
+                    window.location.href = downloadUrl;
+                }
+            });
+            headerDiv.appendChild(downloadBtn);
+        }
+
         const btn = document.createElement('button');
         btn.className = 'delete-concept-button';
-        btn.title = 'Delete this concept';
-        btn.setAttribute('aria-label', 'Delete this concept');
+        btn.title = fileActionsEnabled
+            ? 'Delete concept and backing file'
+            : 'Delete this concept';
+        btn.setAttribute(
+            'aria-label',
+            fileActionsEnabled
+                ? 'Delete concept and backing file'
+                : 'Delete this concept'
+        );
         btn.setAttribute('data-keep-title', 'true');
         btn.textContent = '🗑️';
         btn.style.padding = '2px 6px';
@@ -6496,12 +6589,36 @@ function attachDeleteConceptButton(headerDiv, conceptId, kind) {
         btn.style.marginLeft = '4px';
         btn.addEventListener('click', async (e) => {
             e.stopPropagation();
-            if (!confirm('Permanently delete this concept? This cannot be undone.')) return;
+            if (!fileActionsEnabled) {
+                if (!confirm('Permanently delete this concept? This cannot be undone.')) return;
+            } else {
+                const warningAccepted = confirm(
+                    'This will permanently delete both the concept and its backing file bytes. This cannot be undone. Continue?'
+                );
+                if (!warningAccepted) return;
+                const typed = window.prompt(
+                    `Type "${FILE_DELETE_CONFIRM_PHRASE}" to confirm permanent file deletion.`
+                );
+                if (typed === null) return;
+                if (String(typed || '').trim() !== FILE_DELETE_CONFIRM_PHRASE) {
+                    showToast('Delete cancelled: confirmation phrase did not match.', 'error');
+                    return;
+                }
+            }
             const originalText = btn.textContent;
             btn.disabled = true; btn.textContent = '…';
             try {
-                const url = `/vontology/api/vontology/node?concept_id=${encodeURIComponent(conceptId)}&simulate=0`;
-                const resp = await fetch(url, { method: 'DELETE' });
+                const url = fileActionsEnabled
+                    ? `/von/api/files/${encodeURIComponent(conceptId)}`
+                    : `/vontology/api/vontology/node?concept_id=${encodeURIComponent(conceptId)}&simulate=0`;
+                const fetchOptions = fileActionsEnabled
+                    ? {
+                        method: 'DELETE',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ confirm_phrase: FILE_DELETE_CONFIRM_PHRASE })
+                    }
+                    : { method: 'DELETE' };
+                const resp = await fetch(url, fetchOptions);
                 const data = await resp.json().catch(() => ({}));
                 if (!resp.ok || !data.success) throw new Error(data.error || data.message || `HTTP ${resp.status}`);
                 // Dispatch global event so other modules (tree, tabs) react
@@ -6512,10 +6629,14 @@ function attachDeleteConceptButton(headerDiv, conceptId, kind) {
                         document.dispatchEvent(evt);
                     } catch (_) { /* no-op */ }
                 });
-                alert(`Deleted concept ${conceptId}`);
+                showToast(
+                    fileActionsEnabled
+                        ? `Deleted file copy ${conceptId}`
+                        : `Deleted concept ${conceptId}`
+                );
             } catch (err) {
                 console.warn('[dynamicTabs] delete concept failed', err);
-                alert(`Delete failed: ${err.message}`);
+                showToast(`Delete failed: ${err.message}`, 'error');
             } finally {
                 btn.disabled = false; btn.textContent = originalText;
             }

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -8475,6 +8475,7 @@ button.prompt-vontology-cartouche {
 .concept-header {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 8px;
     /* use gap instead of relying on ad-hoc margins */
 }

--- a/tests/backend/test_von_file_upload_endpoint.py
+++ b/tests/backend/test_von_file_upload_endpoint.py
@@ -12,6 +12,7 @@ class _FakeStore:
         self._blob_ref_cls = blob_ref_cls
         self.last_put = None
         self._bytes_by_key = {}
+        self.deleted_keys: list[str] = []
 
     def put_bytes(self, key, data, content_type=None, metadata=None):
         self.last_put = {
@@ -34,6 +35,10 @@ class _FakeStore:
         if key not in self._bytes_by_key:
             raise FileNotFoundError(key)
         return self._bytes_by_key[key]
+
+    def delete(self, key):
+        self.deleted_keys.append(key)
+        self._bytes_by_key.pop(key, None)
 
 
 @pytest.fixture()
@@ -121,6 +126,14 @@ def app(monkeypatch):
     monkeypatch.setattr(
         "src.backend.services.concept_service.create_concept",
         fake_create_concept,
+    )
+
+    def fake_delete_concept(concept_id):
+        return concept_docs.pop(str(concept_id), None) is not None
+
+    monkeypatch.setattr(
+        "src.backend.services.concept_service.delete_concept",
+        fake_delete_concept,
     )
 
     upserts = []
@@ -354,3 +367,110 @@ def test_upload_returns_error_when_blob_store_fails(app, monkeypatch):
     assert created == []
     workflow_calls = app.config["TEST_WORKFLOW_LAUNCH_CALLS"]
     assert workflow_calls == []
+
+
+def test_file_copy_delete_removes_blob_and_concept(app):
+    client = app.test_client()
+
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#user"
+        sess["session_id"] = "test-session"
+
+    payload = b"delete me"
+    upload_resp = client.post(
+        "/von/api/files/upload",
+        data={"file": (io.BytesIO(payload), "delete.txt")},
+        content_type="multipart/form-data",
+    )
+    assert upload_resp.status_code == 200
+    uploaded = upload_resp.get_json()["uploaded"]
+    concept_id = uploaded["concept_id"]
+
+    encoded = urllib.parse.quote(concept_id, safe="")
+    delete_resp = client.delete(
+        f"/von/api/files/{encoded}",
+        json={"confirm_phrase": "DELETE FILE"},
+    )
+    assert delete_resp.status_code == 200
+    body = delete_resp.get_json()
+    assert body["success"] is True
+    assert body["blob_deleted"] is True
+    assert body["concept_deleted"] is True
+
+    fake_store = app.config["TEST_FAKE_STORE"]
+    assert fake_store.deleted_keys
+    assert fake_store.deleted_keys[-1].endswith("delete.txt")
+
+    concept_docs = app.config["TEST_CONCEPT_DOCS"]
+    assert concept_id not in concept_docs
+
+
+def test_file_copy_delete_requires_confirmation_phrase(app):
+    client = app.test_client()
+
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#user"
+        sess["session_id"] = "test-session"
+
+    payload = b"confirm me"
+    upload_resp = client.post(
+        "/von/api/files/upload",
+        data={"file": (io.BytesIO(payload), "confirm.txt")},
+        content_type="multipart/form-data",
+    )
+    assert upload_resp.status_code == 200
+    concept_id = upload_resp.get_json()["uploaded"]["concept_id"]
+
+    encoded = urllib.parse.quote(concept_id, safe="")
+    delete_resp = client.delete(
+        f"/von/api/files/{encoded}",
+        json={"confirm_phrase": "WRONG"},
+    )
+    assert delete_resp.status_code == 400
+    body = delete_resp.get_json()
+    assert body["error"] == "confirmation_required"
+    assert body["expected_confirm_phrase"] == "DELETE FILE"
+
+    concept_docs = app.config["TEST_CONCEPT_DOCS"]
+    assert concept_id in concept_docs
+
+
+def test_file_copy_delete_reports_blob_failure_without_deleting_concept(
+    app, monkeypatch
+):
+    client = app.test_client()
+
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#user"
+        sess["session_id"] = "test-session"
+
+    payload = b"blob failure"
+    upload_resp = client.post(
+        "/von/api/files/upload",
+        data={"file": (io.BytesIO(payload), "blobfail.txt")},
+        content_type="multipart/form-data",
+    )
+    assert upload_resp.status_code == 200
+    concept_id = upload_resp.get_json()["uploaded"]["concept_id"]
+
+    fake_store = app.config["TEST_FAKE_STORE"]
+
+    def boom(_key):
+        raise RuntimeError("swift unavailable")
+
+    monkeypatch.setattr(fake_store, "delete", boom)
+
+    encoded = urllib.parse.quote(concept_id, safe="")
+    delete_resp = client.delete(
+        f"/von/api/files/{encoded}",
+        json={"confirm_phrase": "DELETE FILE"},
+    )
+    assert delete_resp.status_code == 502
+    body = delete_resp.get_json()
+    assert body["success"] is False
+    assert body["error"] == "blob_delete_failed"
+    assert body["concept_deleted"] is False
+    assert body["blob_deleted"] is False
+
+    concept_docs = app.config["TEST_CONCEPT_DOCS"]
+    assert concept_id in concept_docs

--- a/tests/frontend/dynamicTabsFileCopyActions.test.js
+++ b/tests/frontend/dynamicTabsFileCopyActions.test.js
@@ -1,0 +1,93 @@
+/** @jest-environment jsdom */
+
+const dynamicTabsModulePath = '../../src/frontend/web/von_interface/static/js/dynamicTabs.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/annotationTab.js', () => ({
+    initializeAnnotationTab: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/conceptTab.js', () => ({
+    fetchConceptListWithSuffix: jest.fn(),
+    fetchSubtypesWithSuffix: jest.fn(),
+    initializeNamesForm: jest.fn(),
+    loadConceptAttributes: jest.fn(),
+    loadConceptNames: jest.fn(),
+    selectConceptWithSuffix: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
+    getCurrentUserConceptId: jest.fn(() => '#V#user')
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/languageConfig.js', () => ({
+    DEFAULT_LANGUAGE: 'en-NZ'
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/markdownUtils.js', () => ({
+    detectMarkdown: jest.fn(() => false),
+    renderSmartTextAsync: jest.fn(async (text) => String(text ?? ''))
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/predicateView.js', () => ({
+    destroyPredicateView: jest.fn(),
+    initializePredicateView: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/state.js', () => ({
+    getConceptTypeDisplayNames: jest.fn(() => ({ singular: 'Concept', plural: 'Concepts' })),
+    setCurrentConceptType: jest.fn(),
+    setCurrentlySelectedConceptId: jest.fn(),
+    setSelectedConceptOriginalName: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/tabNavigation.js', () => ({
+    activateTab: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/vontology.js', () => ({
+    getKeyConceptIds: jest.fn(() => new Set()),
+    updateTabHeaderStarButtons: jest.fn(),
+    updateTreeKeyConceptBadge: jest.fn()
+}));
+
+describe('deriveFileCopyActionState', () => {
+    afterEach(() => {
+        jest.resetModules();
+    });
+
+    test('enables file actions for blob-backed file-copy concepts', () => {
+        const { deriveFileCopyActionState } = require(dynamicTabsModulePath);
+        const state = deriveFileCopyActionState({
+            raw_doc: {
+                concept_id: '#V#uploaded_file_copy_abc',
+                attributes: {
+                    blob_key: 'uploads/user/abc/file.txt',
+                },
+                relationships: {
+                    is_an_instance_of: ['#V#computer_file_copy'],
+                },
+            },
+        });
+
+        expect(state.showFileActions).toBe(true);
+        expect(state.isFileCopyConcept).toBe(true);
+        expect(state.hasResolvableBlobRef).toBe(true);
+    });
+
+    test('disables file actions when no durable blob reference exists', () => {
+        const { deriveFileCopyActionState } = require(dynamicTabsModulePath);
+        const state = deriveFileCopyActionState({
+            raw_doc: {
+                concept_id: '#V#person_abc',
+                attributes: {},
+                relationships: {
+                    is_an_instance_of: ['#V#person'],
+                },
+            },
+        });
+
+        expect(state.showFileActions).toBe(false);
+        expect(state.hasResolvableBlobRef).toBe(false);
+    });
+});
+


### PR DESCRIPTION
## Summary
- add a dedicated file-copy delete service path that deletes both blob bytes and concept, with explicit partial-outcome reporting
- add DELETE /von/api/files/<concept_id> requiring typed confirmation phrase (DELETE FILE) and shared file-route authorisation checks
- keep non-file concept delete behaviour unchanged, while adding file-copy-only download + guarded delete actions in dynamic concept headers
- allow concept header action clusters to wrap on narrow widths for responsive usability

## Tests
- pdm run pytest tests/backend/test_von_file_upload_endpoint.py
- npx jest tests/frontend/dynamicTabsFileCopyActions.test.js --runInBand
- npx jest tests/frontend/dynamicTabsIdCollision.test.js --runInBand
- npx pyright src/backend/services/computer_file_copy_service.py src/backend/server/routes/von_routes.py tests/backend/test_von_file_upload_endpoint.py