### PR TITLE
JVNAUTOSCI-1323: Enrich uploaded file-copy workflow with subtype assertions

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -3178,11 +3178,13 @@ def _interpret_file_copy(**kwargs):
     from ...services.file_copy_interpretation_service import (
         build_document_interpretation,
         build_image_interpretation,
+        infer_uploaded_file_subtype,
         is_image_file,
     )
     from ...services.rag_text_relation_change_hook_service import (
         maybe_sync_concept_text_relations_to_rag,
     )
+    from ...services.relationship_write_service import add_relationship
     from ...services.text_value_service import upsert_singleton_text_relation
 
     concept_id = kwargs.get("concept_id") or kwargs.get("file_copy_concept_id")
@@ -3312,6 +3314,17 @@ def _interpret_file_copy(**kwargs):
         )
         else "document"
     )
+    subtype_detection = infer_uploaded_file_subtype(
+        content_type=content_type if isinstance(content_type, str) else None,
+        original_filename=(
+            original_filename if isinstance(original_filename, str) else None
+        ),
+    )
+    subtype_type_concept_id = (
+        subtype_detection.get("type_concept_id")
+        if isinstance(subtype_detection, dict)
+        else None
+    )
 
     interpretation: dict[str, Any]
     image_fetch_error: str | None = None
@@ -3382,8 +3395,51 @@ def _interpret_file_copy(**kwargs):
         content_for_persist = None
 
     persisted_relations: list[dict[str, Any]] = []
+    persisted_structural_relations: list[dict[str, Any]] = []
     persist_errors: list[dict[str, Any]] = []
+    subtype_assertion: dict[str, Any] | None = None
+    subtype_assertion_outcome = "not_attempted"
     if persist:
+        if isinstance(subtype_type_concept_id, str) and subtype_type_concept_id.strip():
+            with _with_namespace_actor_override(effective_namespace):
+                subtype_assertion = add_relationship(
+                    source_id=concept_id,
+                    predicate="is_an_instance_of",
+                    target=subtype_type_concept_id.strip(),
+                )
+            if not isinstance(subtype_assertion, dict):
+                subtype_assertion = {
+                    "success": False,
+                    "error": "unexpected_subtype_assertion_response_shape",
+                    "response_type": type(subtype_assertion).__name__,
+                }
+            if subtype_assertion.get("success") is True:
+                subtype_assertion_outcome = (
+                    "subtype_added"
+                    if bool(subtype_assertion.get("forward_modified"))
+                    else "subtype_already_present"
+                )
+                persisted_structural_relations.append(
+                    {
+                        "predicate": "is_an_instance_of",
+                        "target_id": subtype_type_concept_id.strip(),
+                        "modified": bool(subtype_assertion.get("forward_modified")),
+                    }
+                )
+            else:
+                subtype_assertion_outcome = "subtype_assertion_failed"
+                persist_errors.append(
+                    {
+                        "predicate": "is_an_instance_of",
+                        "target_id": subtype_type_concept_id.strip(),
+                        "error": subtype_assertion.get("error")
+                        or "subtype_assertion_failed",
+                        "details": subtype_assertion,
+                    }
+                )
+        else:
+            subtype_assertion_outcome = "subtype_not_determinable"
+
         writes: list[tuple[str, str | None]] = []
         if persist_description and isinstance(description, str) and description.strip():
             writes.append(("hasDescription", description.strip()))
@@ -3441,6 +3497,8 @@ def _interpret_file_copy(**kwargs):
                             "error": str(exc),
                         }
                     )
+    else:
+        subtype_assertion_outcome = "persist_disabled"
 
     content_text = extracted_text if isinstance(extracted_text, str) else None
     text_preview = None
@@ -3455,6 +3513,11 @@ def _interpret_file_copy(**kwargs):
         "success": len(persist_errors) == 0,
         "concept_id": concept_id,
         "file_kind": file_kind,
+        "subtype_type_concept_id": (
+            subtype_type_concept_id
+            if isinstance(subtype_type_concept_id, str) and subtype_type_concept_id.strip()
+            else None
+        ),
         "description": description,
         "content_type": content_type,
         "original_filename": original_filename,
@@ -3465,7 +3528,13 @@ def _interpret_file_copy(**kwargs):
         "interpretation": interpretation,
         "persisted": persist and len(persist_errors) == 0,
         "persisted_relations": persisted_relations,
+        "persisted_structural_relations": persisted_structural_relations,
         "persist_errors": persist_errors,
+        "diagnostics": {
+            "subtype_detection": subtype_detection,
+            "subtype_assertion_outcome": subtype_assertion_outcome,
+            "subtype_assertion": subtype_assertion,
+        },
         "namespace": effective_namespace,
         **ns_report,
         "read_result": {
@@ -6049,6 +6118,7 @@ def _interpret_file_copy_output_schema() -> Schema:
             "message": (str, type(None)),
             "concept_id": (str, type(None)),
             "file_kind": (str, type(None)),
+            "subtype_type_concept_id": (str, type(None)),
             "description": (str, type(None)),
             "content_type": (str, type(None)),
             "original_filename": (str, type(None)),
@@ -6059,7 +6129,9 @@ def _interpret_file_copy_output_schema() -> Schema:
             "interpretation": (dict, type(None)),
             "persisted": (bool, type(None)),
             "persisted_relations": (list, type(None)),
+            "persisted_structural_relations": (list, type(None)),
             "persist_errors": (list, type(None)),
+            "diagnostics": (dict, type(None)),
             "namespace": (str, type(None)),
             "read_result": (dict, type(None)),
             "image_fetch_error": (str, type(None)),

--- a/src/backend/services/file_copy_interpretation_service.py
+++ b/src/backend/services/file_copy_interpretation_service.py
@@ -17,6 +17,22 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+_DOCX_MIME_TYPES: frozenset[str] = frozenset(
+    {
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/msword",
+    }
+)
+
+_FILE_SUBTYPE_RULES: tuple[dict[str, Any], ...] = (
+    {
+        "rule_id": "docx_mime_or_extension",
+        "type_concept_id": "#V#msword_docx_computer_file_copy",
+        "mime_types": _DOCX_MIME_TYPES,
+        "extensions": (".docx",),
+    },
+)
+
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -27,6 +43,74 @@ def _normalise_optional_text(value: Any) -> str | None:
         return None
     cleaned = value.strip()
     return cleaned or None
+
+
+def _normalise_content_type_token(value: Any) -> str | None:
+    content_type = _normalise_optional_text(value)
+    if not content_type:
+        return None
+    # MIME parameters are optional for detection; keep only the media type token.
+    token = content_type.split(";", 1)[0].strip().lower()
+    return token or None
+
+
+def _normalise_filename_extension(value: Any) -> str | None:
+    filename = _normalise_optional_text(value)
+    if not filename:
+        return None
+    _base, extension = os.path.splitext(filename.lower())
+    return extension or None
+
+
+def infer_uploaded_file_subtype(
+    *,
+    content_type: str | None,
+    original_filename: str | None,
+) -> dict[str, Any]:
+    """Infer a specific uploaded file-copy subtype when evidence is sufficient."""
+
+    content_type_token = _normalise_content_type_token(content_type)
+    extension = _normalise_filename_extension(original_filename)
+
+    for rule in _FILE_SUBTYPE_RULES:
+        mime_types = {
+            item.strip().lower()
+            for item in (rule.get("mime_types") or ())
+            if isinstance(item, str) and item.strip()
+        }
+        extensions = {
+            item.strip().lower()
+            for item in (rule.get("extensions") or ())
+            if isinstance(item, str) and item.strip()
+        }
+        mime_match = (
+            isinstance(content_type_token, str) and content_type_token in mime_types
+        )
+        extension_match = isinstance(extension, str) and extension in extensions
+        if not (mime_match or extension_match):
+            continue
+        matched_signals: list[str] = []
+        if mime_match:
+            matched_signals.append("mime_type")
+        if extension_match:
+            matched_signals.append("filename_extension")
+        return {
+            "determinable": True,
+            "type_concept_id": rule.get("type_concept_id"),
+            "rule_id": rule.get("rule_id"),
+            "matched_signals": matched_signals,
+            "content_type_token": content_type_token,
+            "filename_extension": extension,
+        }
+
+    return {
+        "determinable": False,
+        "type_concept_id": None,
+        "rule_id": None,
+        "matched_signals": [],
+        "content_type_token": content_type_token,
+        "filename_extension": extension,
+    }
 
 
 def is_image_file(*, content_type: str | None, filename: str | None) -> bool:

--- a/src/backend/workflows/durable/file_copy_interpretation_workflow.py
+++ b/src/backend/workflows/durable/file_copy_interpretation_workflow.py
@@ -16,6 +16,16 @@ from ..engine import (
 from ..workflow_registry import WorkflowRegistration
 
 FILE_COPY_INTERPRETATION_WORKFLOW_ID = "#V#file_copy_interpretation_workflow"
+_FILE_COPY_CONTEXT_INPUTS = {
+    "concept_id": {
+        "$context_key": "concept_id",
+        "$mapping_concept_id": "#V#workflow_mapping_concept_id_to_concept_id_parameter",
+    },
+    "file_copy_concept_id": {
+        "$context_key": "file_copy_concept_id",
+        "$mapping_concept_id": "#V#workflow_mapping_file_copy_concept_id_to_file_copy_concept_id_parameter",
+    },
+}
 
 
 def build_file_copy_interpretation_workflow() -> WorkflowDefinition:
@@ -24,6 +34,7 @@ def build_file_copy_interpretation_workflow() -> WorkflowDefinition:
         actions=(
             WorkflowActionInvocation(
                 action_id="interpret_file_copy",
+                inputs=dict(_FILE_COPY_CONTEXT_INPUTS),
                 description=(
                     "Extract structured interpretation from a blob-backed "
                     "#V#computer_file_copy and persist canonical text relations."
@@ -49,6 +60,7 @@ def build_file_copy_interpretation_workflow() -> WorkflowDefinition:
         actions=(
             WorkflowActionInvocation(
                 action_id="index_file_copy",
+                inputs=dict(_FILE_COPY_CONTEXT_INPUTS),
                 description="Index extracted file-copy text into RAG for the namespace.",
             ),
         ),

--- a/src/backend/workflows/workflow_concept_authority_service.py
+++ b/src/backend/workflows/workflow_concept_authority_service.py
@@ -126,6 +126,9 @@ _STEP_RELATIONSHIP_ALIAS_KEYS: tuple[str, ...] = tuple(
         (
             *WORKFLOW_GRAPH_PREDICATE_ALIASES["invokesAction"],
             *WORKFLOW_GRAPH_PREDICATE_ALIASES["workflowStepInvokesTool"],
+            *WORKFLOW_GRAPH_PREDICATE_ALIASES[
+                "workflowStepMapsContextKeyToToolParam"
+            ],
             *WORKFLOW_GRAPH_PREDICATE_ALIASES["nextStep"],
             *WORKFLOW_GRAPH_PREDICATE_ALIASES["onTrueNextStep"],
             *WORKFLOW_GRAPH_PREDICATE_ALIASES["onFalseNextStep"],
@@ -144,6 +147,7 @@ class _CanonicalStepPublicationSpec:
     state_id: str
     concept_id: str | None = None
     action_id: str | None = None
+    context_input_mappings: tuple[str, ...] = ()
     next_state: str | None = None
     on_true_state: str | None = None
     on_false_state: str | None = None
@@ -156,6 +160,12 @@ class _CanonicalStepPublicationSpec:
 class _CanonicalWorkflowPublicationSpec:
     initial_state: str
     steps: tuple[_CanonicalStepPublicationSpec, ...]
+
+
+_FILE_COPY_WORKFLOW_CONTEXT_INPUT_MAPPINGS: tuple[str, ...] = (
+    "#V#workflow_mapping_concept_id_to_concept_id_parameter",
+    "#V#workflow_mapping_file_copy_concept_id_to_file_copy_concept_id_parameter",
+)
 
 
 # Keep this mapping deterministic so publication is stable across runs.
@@ -327,12 +337,14 @@ _CANONICAL_WORKFLOW_PUBLICATION_SPECS: Dict[str, _CanonicalWorkflowPublicationSp
             _CanonicalStepPublicationSpec(
                 state_id="interpret",
                 action_id="interpret_file_copy",
+                context_input_mappings=_FILE_COPY_WORKFLOW_CONTEXT_INPUT_MAPPINGS,
                 on_true_state="index",
                 on_false_state="complete",
             ),
             _CanonicalStepPublicationSpec(
                 state_id="index",
                 action_id="index_file_copy",
+                context_input_mappings=_FILE_COPY_WORKFLOW_CONTEXT_INPUT_MAPPINGS,
                 next_state="complete",
             ),
             _CanonicalStepPublicationSpec(state_id="complete"),
@@ -642,6 +654,18 @@ def publish_canonical_chat_workflow_graphs(
                 step_relationships[_CANONICAL_GRAPH_PREDICATES["invokesAction"]] = [
                     step.action_id.strip()
                 ]
+            if step.context_input_mappings:
+                mapping_ids = [
+                    item.strip()
+                    for item in step.context_input_mappings
+                    if isinstance(item, str) and item.strip()
+                ]
+                if mapping_ids:
+                    step_relationships[
+                        _CANONICAL_GRAPH_PREDICATES[
+                            "workflowStepMapsContextKeyToToolParam"
+                        ]
+                    ] = mapping_ids
 
             if isinstance(step.next_state, str) and step.next_state.strip():
                 step_relationships[_CANONICAL_GRAPH_PREDICATES["nextStep"]] = [

--- a/tests/backend/test_file_copy_ingestion_mcp_tools.py
+++ b/tests/backend/test_file_copy_ingestion_mcp_tools.py
@@ -147,6 +147,137 @@ def test_interpret_file_copy_persists_image_interpretation(monkeypatch):
     assert "#V#has_file_copy_interpretation_json" in written_predicates
 
 
+def test_interpret_file_copy_asserts_docx_subtype_when_determinable(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue._read_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "text": "DOCX body text",
+            "content_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "original_filename": "Reading Group(3).docx",
+            "size_bytes": 2048,
+            "byte_length": 2048,
+            "blob": {"backend": "local", "key": "uploads/user/hash/reading-group.docx"},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.file_copy_interpretation_service.build_document_interpretation",
+        lambda **_kwargs: {
+            "kind": "document",
+            "description": "Document text extracted: DOCX body text",
+            "subject_tags": ["document"],
+            "content_text": "DOCX body text",
+            "content_length": 14,
+        },
+    )
+
+    relation_calls: list[dict[str, object]] = []
+    text_writes: list[dict[str, object]] = []
+
+    def _fake_add_relationship(**kwargs):
+        relation_calls.append(dict(kwargs))
+        return {"success": True, "forward_modified": True}
+
+    def _fake_upsert_singleton_text_relation(**kwargs):
+        text_writes.append(dict(kwargs))
+        return {"relation_id": f"rel-{len(text_writes)}"}
+
+    monkeypatch.setattr(
+        "src.backend.services.relationship_write_service.add_relationship",
+        _fake_add_relationship,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.upsert_singleton_text_relation",
+        _fake_upsert_singleton_text_relation,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_text_relation_change_hook_service.maybe_sync_concept_text_relations_to_rag",
+        lambda **_kwargs: None,
+    )
+
+    result = cat._interpret_file_copy(
+        concept_id="#V#file_copy_docx_test",
+        namespace="#V#user@org",
+    )
+
+    assert result["success"] is True
+    assert result["file_kind"] == "document"
+    assert result["subtype_type_concept_id"] == "#V#msword_docx_computer_file_copy"
+    assert result["diagnostics"]["subtype_assertion_outcome"] == "subtype_added"
+    assert result["persisted_structural_relations"] == [
+        {
+            "predicate": "is_an_instance_of",
+            "target_id": "#V#msword_docx_computer_file_copy",
+            "modified": True,
+        }
+    ]
+    assert relation_calls == [
+        {
+            "source_id": "#V#file_copy_docx_test",
+            "predicate": "is_an_instance_of",
+            "target": "#V#msword_docx_computer_file_copy",
+        }
+    ]
+    assert "hasDescription" in [row["predicate"] for row in text_writes]
+
+
+def test_interpret_file_copy_reports_subtype_assertion_failure(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue._read_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "text": "DOCX body text",
+            "content_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "original_filename": "Reading Group(3).docx",
+            "size_bytes": 2048,
+            "byte_length": 2048,
+            "blob": {"backend": "local", "key": "uploads/user/hash/reading-group.docx"},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.file_copy_interpretation_service.build_document_interpretation",
+        lambda **_kwargs: {
+            "kind": "document",
+            "description": "Document text extracted: DOCX body text",
+            "subject_tags": ["document"],
+            "content_text": "DOCX body text",
+            "content_length": 14,
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.relationship_write_service.add_relationship",
+        lambda **_kwargs: {
+            "success": False,
+            "error": "target_not_found",
+            "target_id": "#V#msword_docx_computer_file_copy",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.upsert_singleton_text_relation",
+        lambda **_kwargs: {"relation_id": "rel-test"},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_text_relation_change_hook_service.maybe_sync_concept_text_relations_to_rag",
+        lambda **_kwargs: None,
+    )
+
+    result = cat._interpret_file_copy(
+        concept_id="#V#file_copy_docx_test",
+        namespace="#V#user@org",
+    )
+
+    assert result["success"] is False
+    assert result["subtype_type_concept_id"] == "#V#msword_docx_computer_file_copy"
+    assert result["diagnostics"]["subtype_assertion_outcome"] == "subtype_assertion_failed"
+    assert result["persist_errors"]
+    assert result["persist_errors"][0]["predicate"] == "is_an_instance_of"
+    assert result["persist_errors"][0]["error"] == "target_not_found"
+
+
 def test_interpret_file_copy_supports_non_persist_mode(monkeypatch):
     from src.backend.integrations.internal_mcp import catalogue as cat
 

--- a/tests/backend/test_file_copy_interpretation_workflow.py
+++ b/tests/backend/test_file_copy_interpretation_workflow.py
@@ -19,8 +19,24 @@ def test_build_file_copy_interpretation_workflow_definition_shape() -> None:
 
     interpret_actions = [action.action_id for action in workflow.states["interpret"].actions]
     assert interpret_actions == ["interpret_file_copy"]
+    interpret_inputs = dict(workflow.states["interpret"].actions[0].inputs)
+    assert interpret_inputs["concept_id"]["$context_key"] == "concept_id"
+    assert (
+        interpret_inputs["concept_id"]["$mapping_concept_id"]
+        == "#V#workflow_mapping_concept_id_to_concept_id_parameter"
+    )
+    assert (
+        interpret_inputs["file_copy_concept_id"]["$context_key"]
+        == "file_copy_concept_id"
+    )
     index_actions = [action.action_id for action in workflow.states["index"].actions]
     assert index_actions == ["index_file_copy"]
+    index_inputs = dict(workflow.states["index"].actions[0].inputs)
+    assert index_inputs["concept_id"]["$context_key"] == "concept_id"
+    assert (
+        index_inputs["file_copy_concept_id"]["$mapping_concept_id"]
+        == "#V#workflow_mapping_file_copy_concept_id_to_file_copy_concept_id_parameter"
+    )
 
 
 def test_get_file_copy_interpretation_workflow_registration() -> None:

--- a/tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py
+++ b/tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py
@@ -101,3 +101,65 @@ def test_file_copy_ingestion_tools_gateway_invoke(monkeypatch):
     ).payload
     assert interpreted.get("success") is True
     assert interpreted.get("file_kind") == "document"
+
+
+def test_interpret_file_copy_gateway_asserts_docx_subtype(monkeypatch):
+    gateway = _build_gateway()
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue._read_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "text": "Gateway DOCX text",
+            "content_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "original_filename": "Gateway.docx",
+            "size_bytes": 64,
+            "byte_length": 64,
+            "blob": {"backend": "local", "key": "imports/user/hash/gateway.docx"},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.file_copy_interpretation_service.build_document_interpretation",
+        lambda **_kwargs: {
+            "kind": "document",
+            "description": "Document text extracted: Gateway DOCX text",
+            "subject_tags": ["document"],
+            "content_text": "Gateway DOCX text",
+            "content_length": 17,
+        },
+    )
+
+    relation_calls: list[dict[str, object]] = []
+
+    def _fake_add_relationship(**kwargs):
+        relation_calls.append(dict(kwargs))
+        return {"success": True, "forward_modified": True}
+
+    monkeypatch.setattr(
+        "src.backend.services.relationship_write_service.add_relationship",
+        _fake_add_relationship,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.upsert_singleton_text_relation",
+        lambda **_kwargs: {"relation_id": "rel-gateway"},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_text_relation_change_hook_service.maybe_sync_concept_text_relations_to_rag",
+        lambda **_kwargs: None,
+    )
+
+    interpreted = gateway.invoke(
+        "interpret_file_copy",
+        {"concept_id": "#V#imported_file_gateway", "namespace": "#V#user@org"},
+    ).payload
+
+    assert interpreted.get("success") is True
+    assert interpreted.get("subtype_type_concept_id") == "#V#msword_docx_computer_file_copy"
+    assert interpreted.get("diagnostics", {}).get("subtype_assertion_outcome") == "subtype_added"
+    assert relation_calls == [
+        {
+            "source_id": "#V#imported_file_gateway",
+            "predicate": "is_an_instance_of",
+            "target": "#V#msword_docx_computer_file_copy",
+        }
+    ]

--- a/tests/backend/test_workflow_concept_authority_service.py
+++ b/tests/backend/test_workflow_concept_authority_service.py
@@ -243,6 +243,9 @@ def test_bootstrap_publishes_canonical_chat_graphs_with_loader_runtime_parity(
             assert tuple(action.action_id for action in loaded_state.actions) == tuple(
                 action.action_id for action in built_state.actions
             )
+            assert [dict(action.inputs) for action in loaded_state.actions] == [
+                dict(action.inputs) for action in built_state.actions
+            ]
             assert {transition.to_state for transition in loaded_state.transitions} == {
                 authority_service._step_concept_id(
                     workflow_id=workflow_id,


### PR DESCRIPTION
## Summary
- add deterministic uploaded-file subtype inference helper (DOCX via MIME/extension)
- extend interpret_file_copy to assert subtype is_an_instance_of relationships when determinable and report diagnostics
- add durable workflow action input mappings for concept_id/file_copy_concept_id to prevent missing-input failures
- publish canonical workflow-step context mappings through workflow concept authority bootstrap
- add gateway/service/workflow parity tests for subtype assertion and mapped workflow inputs

## Validation
- pytest tests/backend/test_file_copy_interpretation_workflow.py tests/backend/test_file_copy_ingestion_mcp_tools.py tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py tests/backend/test_workflow_concept_authority_service.py::test_bootstrap_publishes_canonical_chat_graphs_with_loader_runtime_parity -q
- pyright src/backend/integrations/internal_mcp/catalogue.py src/backend/services/file_copy_interpretation_service.py src/backend/workflows/durable/file_copy_interpretation_workflow.py src/backend/workflows/workflow_concept_authority_service.py tests/backend/test_file_copy_ingestion_mcp_tools.py tests/backend/test_file_copy_interpretation_workflow.py tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py tests/backend/test_workflow_concept_authority_service.py

## Notes
- Unrelated local AGENTS.md edits were intentionally left out of this PR.