### PR TITLE
JVNAUTOSCI-1341: Handle workflow-definition refresh contention without hard failure UI

### DIFF
--- a/src/backend/server/routes/workflows_routes.py
+++ b/src/backend/server/routes/workflows_routes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
 import threading
 import time
@@ -55,6 +56,7 @@ _WORKFLOW_DEFINITIONS_REFRESH_LOCKS: Dict[
 ] = {}
 _WORKFLOW_DEFINITIONS_CACHE_MAX_ENTRIES = 32
 _WORKFLOW_DEFINITIONS_CACHE_TTL_SECONDS_DEFAULT = 8.0
+_WORKFLOW_DEFINITIONS_REFRESH_RETRY_AFTER_SECONDS_DEFAULT = 1.0
 
 
 def _read_workflow_definitions_cache_ttl_seconds() -> float:
@@ -67,6 +69,18 @@ def _read_workflow_definitions_cache_ttl_seconds() -> float:
     except (TypeError, ValueError):
         return _WORKFLOW_DEFINITIONS_CACHE_TTL_SECONDS_DEFAULT
     return max(0.0, ttl)
+
+
+def _read_workflow_definitions_refresh_retry_after_seconds() -> float:
+    raw = os.getenv(
+        "VON_WORKFLOW_DEFINITIONS_REFRESH_RETRY_AFTER_SECONDS",
+        str(_WORKFLOW_DEFINITIONS_REFRESH_RETRY_AFTER_SECONDS_DEFAULT),
+    )
+    try:
+        delay_seconds = float(raw)
+    except (TypeError, ValueError):
+        return _WORKFLOW_DEFINITIONS_REFRESH_RETRY_AFTER_SECONDS_DEFAULT
+    return max(0.1, delay_seconds)
 
 
 def _read_cached_workflow_definitions_entry(
@@ -237,15 +251,21 @@ def api_list_workflow_definitions():
                         cache_key,
                     )
                     return jsonify(cached_payload)
-                return (
-                    jsonify(
-                        {
-                            "error": "workflow_definitions_refresh_in_progress",
-                            "detail": "Workflow definitions refresh is already running; retry shortly.",
-                        }
-                    ),
-                    503,
+                retry_after_seconds = (
+                    _read_workflow_definitions_refresh_retry_after_seconds()
                 )
+                payload = {
+                    "error": "workflow_definitions_refresh_in_progress",
+                    "detail": "Workflow definitions refresh is already running; retry shortly.",
+                    "retryable": True,
+                    "retry_after_seconds": retry_after_seconds,
+                }
+                response = jsonify(payload)
+                response.status_code = 503
+                response.headers["Retry-After"] = str(
+                    max(1, int(math.ceil(retry_after_seconds)))
+                )
+                return response
 
         from ...workflows.durable.registry_factory import (
             build_durable_workflow_registry_read_only,

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -152,10 +152,16 @@ const workflowDefinitionsState = {
     lastFetchedAt: 0,
     lastPayload: null,
     lastRequestQuery: '',
-    showDesigns: false
+    showDesigns: false,
+    retryTimeoutId: null,
+    retryAttempt: 0
 };
 const WORKFLOW_DEFINITIONS_SILENT_REFRESH_COOLDOWN_MS = 15_000;
 const WORKFLOW_DEFINITIONS_FETCH_TIMEOUT_MS = 20_000;
+const WORKFLOW_DEFINITIONS_CONTENTION_RETRY_BASE_MS = 750;
+const WORKFLOW_DEFINITIONS_CONTENTION_RETRY_MAX_MS = 5000;
+const WORKFLOW_DEFINITIONS_CONTENTION_RETRY_MAX_ATTEMPTS = 3;
+const WORKFLOW_DEFINITIONS_CONTENTION_RETRY_DEFAULT_SECONDS = 1;
 let workflowStatusPanelInitialised = false;
 let chatTabInitialised = false;
 const REALTIME_CONNECTION_TELEMETRY_SCHEMA_VERSION = 1;
@@ -15926,10 +15932,55 @@ async function refreshWorkflowStatusSnapshot({ silent = false } = {}) {
     }
 }
 
+function parseRetryAfterHeaderSeconds(headerValue) {
+    if (typeof headerValue !== 'string') return null;
+    const raw = headerValue.trim();
+    if (!raw) return null;
+    const asNumber = Number(raw);
+    if (Number.isFinite(asNumber) && asNumber > 0) {
+        return asNumber;
+    }
+    const asDateMs = Date.parse(raw);
+    if (!Number.isFinite(asDateMs)) return null;
+    const seconds = (asDateMs - Date.now()) / 1000;
+    if (!Number.isFinite(seconds) || seconds <= 0) return null;
+    return seconds;
+}
+
+function parseWorkflowDefinitionsRetryAfterSeconds(payload, response) {
+    const payloadValue = Number(payload?.retry_after_seconds);
+    if (Number.isFinite(payloadValue) && payloadValue > 0) {
+        return payloadValue;
+    }
+    const headerValue = response?.headers?.get?.('Retry-After');
+    const headerSeconds = parseRetryAfterHeaderSeconds(headerValue);
+    if (Number.isFinite(headerSeconds) && headerSeconds > 0) {
+        return headerSeconds;
+    }
+    return WORKFLOW_DEFINITIONS_CONTENTION_RETRY_DEFAULT_SECONDS;
+}
+
+function clearWorkflowDefinitionsRetryTimer() {
+    if (workflowDefinitionsState.retryTimeoutId) {
+        clearTimeout(workflowDefinitionsState.retryTimeoutId);
+        workflowDefinitionsState.retryTimeoutId = null;
+    }
+}
+
+function scheduleWorkflowDefinitionsRetry({ delayMs, silent = true } = {}) {
+    clearWorkflowDefinitionsRetryTimer();
+    const boundedDelay = Math.max(50, Math.round(Number(delayMs) || 0));
+    workflowDefinitionsState.retryTimeoutId = setTimeout(() => {
+        workflowDefinitionsState.retryTimeoutId = null;
+        void refreshAvailableWorkflowDefinitions({ silent: Boolean(silent) });
+    }, boundedDelay);
+}
+
 async function refreshAvailableWorkflowDefinitions({ silent = false } = {}) {
     const { panel } = getWorkflowStatusElements();
     if (!panel) return;
     if (workflowDefinitionsState.loading) return;
+    clearWorkflowDefinitionsRetryTimer();
 
     const now = Date.now();
     if (
@@ -15961,22 +16012,91 @@ async function refreshAvailableWorkflowDefinitions({ silent = false } = {}) {
         );
         clearTimeout(timeoutId);
         timeoutId = null;
+        const responsePayload = await resp.json().catch(() => null);
         if (!resp.ok) {
-            throw new Error(`HTTP ${resp.status}`);
+            const responseError = typeof responsePayload?.error === 'string'
+                ? responsePayload.error.trim()
+                : '';
+            if (responseError === 'workflow_definitions_refresh_in_progress') {
+                const retryAfterSeconds = parseWorkflowDefinitionsRetryAfterSeconds(responsePayload, resp);
+                const nextRetryAttempt = workflowDefinitionsState.retryAttempt + 1;
+                workflowDefinitionsState.retryAttempt = nextRetryAttempt;
+                const exponentialDelayMs = Math.min(
+                    WORKFLOW_DEFINITIONS_CONTENTION_RETRY_BASE_MS * (2 ** (nextRetryAttempt - 1)),
+                    WORKFLOW_DEFINITIONS_CONTENTION_RETRY_MAX_MS
+                );
+                const retryAfterMs = Math.round(retryAfterSeconds * 1000);
+                const retryDelayMs = Math.max(exponentialDelayMs, retryAfterMs);
+                const shouldRetry = nextRetryAttempt <= WORKFLOW_DEFINITIONS_CONTENTION_RETRY_MAX_ATTEMPTS;
+                const retryDelaySecondsRounded = Math.max(
+                    0.1,
+                    Math.round((retryDelayMs / 1000) * 10) / 10
+                );
+                workflowDefinitionsState.error = shouldRetry
+                    ? `Workflow definitions are refreshing, retrying in ${retryDelaySecondsRounded}s...`
+                    : 'Workflow definitions are still refreshing. Press Refresh to try again.';
+                workflowDefinitionsState.lastPayload = {
+                    error: 'workflow_definitions_refresh_in_progress',
+                    detail: (typeof responsePayload?.detail === 'string' && responsePayload.detail.trim())
+                        ? responsePayload.detail.trim()
+                        : 'Workflow definitions refresh is already running; retry shortly.',
+                    retryable: shouldRetry,
+                    retry_after_seconds: retryAfterSeconds,
+                    retry_attempt: nextRetryAttempt,
+                    retry_scheduled_in_ms: shouldRetry ? retryDelayMs : null,
+                    status: resp.status,
+                    request_query: workflowDefinitionsState.lastRequestQuery || null
+                };
+                if (shouldRetry) {
+                    scheduleWorkflowDefinitionsRetry({ delayMs: retryDelayMs, silent: true });
+                }
+                if (!silent) {
+                    console.info('[workflowStatus] Workflow definitions refresh contention', workflowDefinitionsState.lastPayload);
+                }
+                return;
+            }
+            const detail = (typeof responsePayload?.detail === 'string' && responsePayload.detail.trim())
+                ? responsePayload.detail.trim()
+                : '';
+            const err = new Error(detail ? `HTTP ${resp.status}: ${detail}` : `HTTP ${resp.status}`);
+            err.name = 'WorkflowDefinitionsHttpError';
+            err.status = resp.status;
+            err.responsePayload = responsePayload;
+            throw err;
         }
-        const data = await resp.json();
+        const data = (responsePayload && typeof responsePayload === 'object') ? responsePayload : {};
         workflowDefinitionsState.lastPayload = (data && typeof data === 'object') ? data : null;
         workflowDefinitionsState.items = Array.isArray(data?.items) ? data.items : [];
         workflowDefinitionsState.lastFetchedAt = Date.now();
         workflowDefinitionsState.error = '';
+        workflowDefinitionsState.retryAttempt = 0;
+        clearWorkflowDefinitionsRetryTimer();
     } catch (err) {
         const isAbortError = err && typeof err === 'object' && err.name === 'AbortError';
-        workflowDefinitionsState.error = 'Could not load available workflows';
+        const status = Number.isFinite(Number(err?.status)) ? Number(err.status) : null;
+        const responsePayload = (err?.responsePayload && typeof err.responsePayload === 'object')
+            ? err.responsePayload
+            : null;
+        const responseDetail = (typeof responsePayload?.detail === 'string' && responsePayload.detail.trim())
+            ? responsePayload.detail.trim()
+            : '';
+        workflowDefinitionsState.error = isAbortError
+            ? 'Workflow definitions request timed out. Please retry.'
+            : (responseDetail
+                ? `Could not load available workflows: ${responseDetail}`
+                : 'Could not load available workflows');
+        workflowDefinitionsState.retryAttempt = 0;
+        clearWorkflowDefinitionsRetryTimer();
         workflowDefinitionsState.lastPayload = {
-            error: 'workflow_definitions_fetch_failed',
+            error: (typeof responsePayload?.error === 'string' && responsePayload.error.trim())
+                ? responsePayload.error.trim()
+                : 'workflow_definitions_fetch_failed',
             detail: isAbortError
                 ? `Request timed out after ${Math.round(WORKFLOW_DEFINITIONS_FETCH_TIMEOUT_MS / 1000)}s`
-                : (err instanceof Error ? err.message : String(err || 'unknown_error')),
+                : (responseDetail || (err instanceof Error ? err.message : String(err || 'unknown_error'))),
+            status,
+            retryable: false,
+            response_payload: responsePayload,
             request_query: workflowDefinitionsState.lastRequestQuery || null
         };
         if (!silent) {
@@ -16133,6 +16253,7 @@ function initializeWorkflowStatusPanel() {
             if (workflowDefinitionsState.visible) {
                 void refreshAvailableWorkflowDefinitions({ silent: true });
             } else {
+                clearWorkflowDefinitionsRetryTimer();
                 renderWorkflowStatusBody();
             }
         });
@@ -19005,6 +19126,21 @@ export function __testOnly_renderWorkflowDefinitionsBody(items = []) {
 }
 export function __testOnly_setWorkflowShowDesigns(enabled) {
     workflowDefinitionsState.showDesigns = Boolean(enabled);
+}
+export async function __testOnly_refreshAvailableWorkflowDefinitions(options = {}) {
+    return refreshAvailableWorkflowDefinitions(options);
+}
+export function __testOnly_resetWorkflowDefinitionsState() {
+    clearWorkflowDefinitionsRetryTimer();
+    workflowDefinitionsState.visible = false;
+    workflowDefinitionsState.loading = false;
+    workflowDefinitionsState.error = '';
+    workflowDefinitionsState.items = [];
+    workflowDefinitionsState.lastFetchedAt = 0;
+    workflowDefinitionsState.lastPayload = null;
+    workflowDefinitionsState.lastRequestQuery = '';
+    workflowDefinitionsState.showDesigns = false;
+    workflowDefinitionsState.retryAttempt = 0;
 }
 export function __testOnly_buildWorkflowMonitorExportPayload() {
     return buildWorkflowMonitorExportPayload();

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -1,6 +1,8 @@
 import {
     __testOnly_buildThinkingProgressPresentation,
     __testOnly_buildWorkflowMonitorExportPayload,
+    __testOnly_refreshAvailableWorkflowDefinitions,
+    __testOnly_resetWorkflowDefinitionsState,
     __testOnly_formatAbsoluteTimestamp,
     __testOnly_formatThinkingEtaText,
     __testOnly_renderWorkflowDefinitionsBody,
@@ -533,6 +535,117 @@ describe('workflow monitor concept links', () => {
         ]);
 
         expect(document.body.textContent).toContain('Episodes: 8 scoped (12 total)');
+    });
+});
+
+describe('workflow monitor definitions refresh contention handling', () => {
+    async function flushMicrotasks() {
+        await Promise.resolve();
+        await Promise.resolve();
+    }
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        document.body.innerHTML = `
+            <div id="workflowStatusPanel"></div>
+            <div id="workflowStatusBody"></div>
+            <button id="workflowStatusRefresh"></button>
+            <button id="workflowStatusToggleAvailable"></button>
+            <input id="workflowStatusShowDesigns" type="checkbox" />
+        `;
+        __testOnly_resetWorkflowDefinitionsState();
+        __testOnly_renderWorkflowDefinitionsBody([]);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        delete global.fetch;
+        __testOnly_resetWorkflowDefinitionsState();
+    });
+
+    test('treats refresh-in-progress response as transient and auto-retries with bounded delay', async () => {
+        let fetchCount = 0;
+        global.fetch = jest.fn(() => {
+            fetchCount += 1;
+            if (fetchCount === 1) {
+                return Promise.resolve({
+                    ok: false,
+                    status: 503,
+                    headers: {
+                        get: (name) => (String(name).toLowerCase() === 'retry-after' ? '1' : null)
+                    },
+                    json: async () => ({
+                        error: 'workflow_definitions_refresh_in_progress',
+                        detail: 'Workflow definitions refresh is already running; retry shortly.',
+                        retry_after_seconds: 1
+                    })
+                });
+            }
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                headers: { get: () => null },
+                json: async () => ({
+                    items: [
+                        {
+                            workflow_id: '#V#demo_retry_workflow',
+                            description: 'Retry test workflow.',
+                            initial_state: 'pending',
+                            source: 'built_in'
+                        }
+                    ]
+                })
+            });
+        });
+
+        await __testOnly_refreshAvailableWorkflowDefinitions();
+
+        expect(fetchCount).toBe(1);
+        expect(document.getElementById('workflowStatusBody').textContent).toContain(
+            'Workflow definitions are refreshing, retrying'
+        );
+        const contentionExport = __testOnly_buildWorkflowMonitorExportPayload();
+        expect(contentionExport.definitions_snapshot.payload.error).toBe(
+            'workflow_definitions_refresh_in_progress'
+        );
+        expect(contentionExport.definitions_snapshot.payload.retry_after_seconds).toBe(1);
+        expect(contentionExport.definitions_snapshot.payload.retry_attempt).toBe(1);
+
+        jest.advanceTimersByTime(1100);
+        await flushMicrotasks();
+
+        expect(fetchCount).toBe(2);
+        expect(document.getElementById('workflowStatusBody').textContent).toContain(
+            'demo retry workflow'
+        );
+        const successExport = __testOnly_buildWorkflowMonitorExportPayload();
+        expect(successExport.monitor_state.available_error).toBeNull();
+    });
+
+    test('keeps hard error state for non-contention 5xx responses', async () => {
+        global.fetch = jest.fn(() => Promise.resolve({
+            ok: false,
+            status: 500,
+            headers: { get: () => null },
+            json: async () => ({
+                error: 'workflow_definitions_fetch_failed',
+                detail: 'Workflow registry unavailable'
+            })
+        }));
+
+        await __testOnly_refreshAvailableWorkflowDefinitions();
+        jest.advanceTimersByTime(3000);
+        await flushMicrotasks();
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(document.getElementById('workflowStatusBody').textContent).toContain(
+            'Could not load available workflows: Workflow registry unavailable'
+        );
+        const exportPayload = __testOnly_buildWorkflowMonitorExportPayload();
+        expect(exportPayload.definitions_snapshot.payload.error).toBe(
+            'workflow_definitions_fetch_failed'
+        );
+        expect(exportPayload.definitions_snapshot.payload.status).toBe(500);
     });
 });
 

--- a/tests/backend/test_workflows_routes.py
+++ b/tests/backend/test_workflows_routes.py
@@ -915,3 +915,6 @@ def test_workflow_definitions_list_refresh_in_progress_without_stale_returns_503
     assert resp.status_code == 503
     payload = resp.get_json()
     assert payload["error"] == "workflow_definitions_refresh_in_progress"
+    assert payload["retryable"] is True
+    assert float(payload["retry_after_seconds"]) > 0.0
+    assert resp.headers.get("Retry-After") == "1"


### PR DESCRIPTION
## Summary
- frontend: parse non-2xx workflow-definition responses as JSON when available
- frontend: special-case workflow_definitions_refresh_in_progress as transient contention with bounded retry/backoff, retry-aware monitor messaging, and structured diagnostics payload details
- frontend: preserve hard-error behaviour for non-contention failures with clearer actionable message/detail
- backend: include machine-readable retry guidance (retryable, retry_after_seconds) plus Retry-After header on contention 503 responses
- tests: add workflow monitor contention retry path and hard-failure regression coverage in chatTab tests; extend workflows routes test assertions for retry hints

## Validation
- pytest tests/backend/test_workflows_routes.py -k "workflow_definitions_list_refresh_in_progress_without_stale_returns_503 or workflow_definitions_list_serves_stale_when_refresh_in_progress" -q
- npx jest src/frontend/web/von_interface/static/js/test/chatTab.test.js --runInBand
- pyright src/backend/server/routes/workflows_routes.py tests/backend/test_workflows_routes.py

## Notes
- Unrelated local AGENTS.md edits were intentionally left out of this PR.