### PR TITLE
JVNAUTOSCI-1337: Integration test for upload-triggered arXiv scholarly representation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ All AI agents must read this file and `docs/engineering/security_considerations.
 27. **Definition of fully complete Jira task**: implementation committed and pushed, PR created, PR merged to `main`, and Jira transitioned/commented accordingly.
 28. **Fail closed when Vontology is unavailable for Vontology-governed behaviour**: do not silently fall back to in-code prompts, stale context reuse, or heuristic hacks. If required Vontology prompts/workflow data cannot be resolved, no-op that transformation and emit a clear user-visible and telemetry-visible reason.
 29. **Minimal-imposition principle**: exhaust existing context/data/search first; ask humans only when necessary, and then only for concise, low-effort, high-value inputs they are likely to know without extra work.
+30. When the user asks whether something is "finished" or "complete", do not treat Jira status alone as the answer. Verify effective implementation state in both code and Vontology, then report whether it is unimplemented, partly implemented, or fully implemented (with concise evidence).
 
 ## Core AI-Focused Documents
 - `docs/AINotes.md`: short-term memory and tactical log.

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -3174,6 +3174,10 @@ def _read_file_copy(**kwargs):
 def _interpret_file_copy(**kwargs):
     import json
 
+    from ...services.arxiv_paper_link_service import (
+        extract_arxiv_id_candidates,
+        materialise_scholarly_representation_for_arxiv_file_copy,
+    )
     from ...services.computer_file_copy_service import fetch_file_copy_bytes
     from ...services.file_copy_interpretation_service import (
         build_document_interpretation,
@@ -3397,6 +3401,13 @@ def _interpret_file_copy(**kwargs):
     persisted_relations: list[dict[str, Any]] = []
     persisted_structural_relations: list[dict[str, Any]] = []
     persist_errors: list[dict[str, Any]] = []
+    arxiv_id_candidates: list[str] = []
+    selected_arxiv_id: str | None = None
+    scholarly_representation: dict[str, Any] = {
+        "attempted": False,
+        "verified": False,
+        "reason": "not_applicable",
+    }
     subtype_assertion: dict[str, Any] | None = None
     subtype_assertion_outcome = "not_attempted"
     if persist:
@@ -3497,8 +3508,92 @@ def _interpret_file_copy(**kwargs):
                             "error": str(exc),
                         }
                     )
+
+        if file_kind == "document":
+            arxiv_id_candidates = extract_arxiv_id_candidates(
+                kwargs.get("arxiv_id"),
+                kwargs.get("source_identifier"),
+                original_filename,
+                read_payload.get("blob"),
+                extracted_text,
+                content_for_persist,
+            )
+            selected_arxiv_id = arxiv_id_candidates[0] if arxiv_id_candidates else None
+            if isinstance(selected_arxiv_id, str) and selected_arxiv_id.strip():
+                scholarly_representation = {
+                    "attempted": True,
+                    "verified": False,
+                    "arxiv_id": selected_arxiv_id,
+                    "reason": "metadata_resolution_pending",
+                }
+
+                metadata_payload = _get_paper_metadata(arxiv_id=selected_arxiv_id)
+                metadata_error: str | None = None
+                metadata_record: dict[str, Any] | None = None
+                if isinstance(metadata_payload, dict):
+                    if metadata_payload.get("success") is False:
+                        metadata_error = str(
+                            metadata_payload.get("error")
+                            or metadata_payload.get("message")
+                            or "metadata_fetch_failed"
+                        )
+                    elif isinstance(metadata_payload.get("paper"), Mapping):
+                        metadata_record = dict(metadata_payload.get("paper") or {})
+                    elif isinstance(metadata_payload.get("result"), Mapping):
+                        metadata_record = dict(metadata_payload.get("result") or {})
+                    else:
+                        metadata_record = dict(metadata_payload)
+                else:
+                    metadata_error = f"unexpected_metadata_response:{type(metadata_payload).__name__}"
+
+                user_concept_id, _organisation_concept_id = _resolve_rag_actor_scope_ids(
+                    ns_report
+                )
+                if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+                    scholarly_representation = {
+                        "attempted": True,
+                        "verified": False,
+                        "arxiv_id": selected_arxiv_id,
+                        "reason": "missing_user_context_for_arxiv_representation",
+                    }
+                elif metadata_error:
+                    scholarly_representation = {
+                        "attempted": True,
+                        "verified": False,
+                        "arxiv_id": selected_arxiv_id,
+                        "reason": metadata_error,
+                        "metadata_error": metadata_error,
+                    }
+                else:
+                    with _with_namespace_actor_override(effective_namespace):
+                        scholarly_representation = (
+                            materialise_scholarly_representation_for_arxiv_file_copy(
+                                user_concept_id=user_concept_id.strip(),
+                                arxiv_id=selected_arxiv_id,
+                                file_copy_concept_id=concept_id,
+                                metadata=metadata_record,
+                                logger=logger,
+                            )
+                        )
+                    scholarly_representation["attempted"] = True
+                    scholarly_representation["metadata_source"] = "get_paper_metadata"
+                    scholarly_representation["metadata_available"] = bool(metadata_record)
+
+                if not bool(scholarly_representation.get("verified")):
+                    persist_errors.append(
+                        {
+                            "predicate": "#V#scholarly_representation_verification",
+                            "error": "scholarly_representation_not_verified",
+                            "details": scholarly_representation,
+                        }
+                    )
     else:
         subtype_assertion_outcome = "persist_disabled"
+        scholarly_representation = {
+            "attempted": False,
+            "verified": False,
+            "reason": "persist_disabled",
+        }
 
     content_text = extracted_text if isinstance(extracted_text, str) else None
     text_preview = None
@@ -3534,7 +3629,10 @@ def _interpret_file_copy(**kwargs):
             "subtype_detection": subtype_detection,
             "subtype_assertion_outcome": subtype_assertion_outcome,
             "subtype_assertion": subtype_assertion,
+            "arxiv_id_candidates": arxiv_id_candidates,
+            "selected_arxiv_id": selected_arxiv_id,
         },
+        "scholarly_representation": scholarly_representation,
         "namespace": effective_namespace,
         **ns_report,
         "read_result": {

--- a/src/backend/services/arxiv_paper_link_service.py
+++ b/src/backend/services/arxiv_paper_link_service.py
@@ -2,13 +2,29 @@ from __future__ import annotations
 
 import hashlib
 import re
-from typing import Any
+from typing import Any, Iterable, Mapping
+
+from . import concept_search_service
+from .relationship_write_service import add_relationship
+from .text_value_service import get_texts_for_concept, upsert_text_for_concept
+
+_ARXIV_ID_PATTERN = re.compile(
+    r"(?i)\b(?:arxiv:\s*|arxiv\.org/(?:abs|pdf)/)?"
+    r"((?:[a-z\-]+/\d{7})|(?:\d{4}\.\d{4,5})(?:v\d+)?)\b"
+)
+
+_MAX_TOPIC_RELATIONS = 3
+
+
+def _normalise_arxiv_id(arxiv_id: str) -> str:
+    value = str(arxiv_id or "").strip()
+    if value.lower().startswith("arxiv:"):
+        value = value.split(":", 1)[1].strip()
+    return value
 
 
 def _stable_paper_instance_concept_id(arxiv_id: str) -> str:
-    raw = (arxiv_id or "").strip().lower()
-    if raw.startswith("arxiv:"):
-        raw = raw.split(":", 1)[1].strip()
+    raw = _normalise_arxiv_id(arxiv_id).lower()
 
     slug = re.sub(r"[^a-z0-9]+", "_", raw).strip("_")
     digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:8]
@@ -22,6 +38,310 @@ def _stable_paper_instance_concept_id(arxiv_id: str) -> str:
     )
 
 
+def _extract_string_candidates(raw_values: Iterable[Any]) -> list[str]:
+    candidates: list[str] = []
+    for value in raw_values:
+        if isinstance(value, str):
+            cleaned = value.strip()
+            if cleaned:
+                candidates.append(cleaned)
+            continue
+        if isinstance(value, Mapping):
+            nested = value.values()
+            candidates.extend(_extract_string_candidates(nested))
+            continue
+        if isinstance(value, (list, tuple, set)):
+            candidates.extend(_extract_string_candidates(value))
+    return candidates
+
+
+def extract_arxiv_id_candidates(*raw_values: Any) -> list[str]:
+    """Extract unique arXiv IDs from free text values."""
+
+    matches: list[str] = []
+    seen: set[str] = set()
+    for candidate in _extract_string_candidates(raw_values):
+        for match in _ARXIV_ID_PATTERN.finditer(candidate):
+            arxiv_id = _normalise_arxiv_id(match.group(1)).lower()
+            if not arxiv_id or arxiv_id in seen:
+                continue
+            seen.add(arxiv_id)
+            matches.append(arxiv_id)
+    return matches
+
+
+def _concept_exists(concept_id: str) -> bool:
+    from . import concept_service
+
+    try:
+        return concept_service.get_concept_by_concept_id(concept_id) is not None
+    except Exception:
+        return False
+
+
+def _ensure_type_concept(
+    concept_id: str,
+    name: str,
+    *,
+    preferred_parent_id: str,
+    logger: Any | None = None,
+) -> None:
+    from . import concept_service
+    from ..vontology.utils_vontology import THING_PRIMARY_ID
+
+    if _concept_exists(concept_id):
+        return
+
+    parent_id = preferred_parent_id if _concept_exists(preferred_parent_id) else THING_PRIMARY_ID
+    try:
+        concept_service.create_concept(
+            name=name,
+            concept_id=concept_id,
+            parent_concept_ids=[parent_id],
+            create_as_instance=False,
+        )
+    except Exception as exc:
+        if logger is not None:
+            logger.warning("[%s] Type ensure failed (continuing): %s", concept_id, exc)
+
+
+def _ensure_predicate_concept(
+    concept_id: str,
+    name: str,
+    *,
+    logger: Any | None = None,
+) -> None:
+    from . import concept_service
+
+    if _concept_exists(concept_id):
+        return
+
+    try:
+        concept_service.create_concept(
+            name=name,
+            concept_id=concept_id,
+            parent_concept_ids=["#V#predicate"],
+            create_as_instance=True,
+        )
+    except Exception as exc:
+        if logger is not None:
+            logger.warning(
+                "[%s] Predicate ensure failed (continuing): %s",
+                concept_id,
+                exc,
+            )
+
+
+def _normalise_person_name(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    cleaned = re.sub(r"\s+", " ", value).strip()
+    return cleaned
+
+
+def _extract_author_names(metadata: Mapping[str, Any] | None) -> list[str]:
+    if not isinstance(metadata, Mapping):
+        return []
+
+    raw = metadata.get("authors")
+    candidates: list[str] = []
+    if isinstance(raw, str):
+        candidates.extend(re.split(r"[,\n;]+", raw))
+    elif isinstance(raw, list):
+        for item in raw:
+            if isinstance(item, str):
+                candidates.append(item)
+            elif isinstance(item, Mapping):
+                for key in ("name", "full_name", "display_name", "author"):
+                    value = item.get(key)
+                    if isinstance(value, str) and value.strip():
+                        candidates.append(value)
+                        break
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for item in candidates:
+        normalised = _normalise_person_name(item)
+        if not normalised:
+            continue
+        fingerprint = normalised.casefold()
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        deduped.append(normalised)
+    return deduped
+
+
+def _extract_topic_labels(metadata: Mapping[str, Any] | None) -> list[str]:
+    if not isinstance(metadata, Mapping):
+        return []
+
+    labels: list[str] = []
+    for key in ("primary_category", "category", "topic", "field"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            labels.append(value.strip())
+
+    categories = metadata.get("categories")
+    if isinstance(categories, str):
+        labels.extend(part.strip() for part in categories.split() if part.strip())
+    elif isinstance(categories, list):
+        for item in categories:
+            if isinstance(item, str) and item.strip():
+                labels.append(item.strip())
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for label in labels:
+        fingerprint = label.casefold()
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        deduped.append(label)
+    return deduped
+
+
+def _stable_named_instance_concept_id(name: str, *, prefix: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", str(name or "").strip().lower()).strip("_")
+    if not slug:
+        slug = "unnamed"
+    digest = hashlib.sha256(str(name or "").strip().casefold().encode("utf-8")).hexdigest()[
+        :8
+    ]
+    return f"#V#{prefix}_{slug}_{digest}"
+
+
+def _resolve_or_create_person_concept_id(
+    *,
+    user_concept_id: str,
+    person_name: str,
+    logger: Any | None = None,
+) -> str:
+    from . import concept_service
+
+    search_result = concept_search_service.search_concepts(
+        query=person_name,
+        instance_of="#V#person",
+        match_type="exact",
+        limit=10,
+    )
+    for item in search_result.get("results") or []:
+        if not isinstance(item, Mapping):
+            continue
+        candidate_id = item.get("concept_id")
+        candidate_name = item.get("name")
+        if not isinstance(candidate_id, str) or not candidate_id.strip():
+            continue
+        if isinstance(candidate_name, str) and candidate_name.strip():
+            if candidate_name.strip().casefold() == person_name.casefold():
+                return candidate_id.strip()
+
+    concept_id = _stable_named_instance_concept_id(person_name, prefix="person")
+    try:
+        concept_service.create_concept(
+            name=person_name,
+            concept_id=concept_id,
+            parent_concept_ids=["#V#person"],
+            create_as_instance=True,
+            system_tags=["author", "scholarly", "arxiv"],
+        )
+        concept_service.update_concept(
+            concept_id,
+            {"relationships.specific_to_user": [user_concept_id.strip()]},
+        )
+    except Exception as exc:
+        if logger is not None:
+            logger.warning(
+                "[arxiv_paper_representation] Author concept create failed for %s: %s",
+                person_name,
+                exc,
+            )
+    return concept_id
+
+
+def _resolve_or_create_topic_concept_id(
+    *,
+    user_concept_id: str,
+    topic_label: str,
+    logger: Any | None = None,
+) -> str:
+    from . import concept_service
+
+    search_result = concept_search_service.search_concepts(
+        query=topic_label,
+        instance_of="#V#research_topic",
+        match_type="exact",
+        limit=10,
+    )
+    for item in search_result.get("results") or []:
+        if not isinstance(item, Mapping):
+            continue
+        candidate_id = item.get("concept_id")
+        candidate_name = item.get("name")
+        if not isinstance(candidate_id, str) or not candidate_id.strip():
+            continue
+        if isinstance(candidate_name, str) and candidate_name.strip():
+            if candidate_name.strip().casefold() == topic_label.casefold():
+                return candidate_id.strip()
+
+    concept_id = _stable_named_instance_concept_id(topic_label, prefix="research_topic")
+    try:
+        concept_service.create_concept(
+            name=topic_label,
+            concept_id=concept_id,
+            parent_concept_ids=["#V#research_topic"],
+            create_as_instance=True,
+            system_tags=["topic", "scholarly", "arxiv"],
+        )
+        concept_service.update_concept(
+            concept_id,
+            {"relationships.specific_to_user": [user_concept_id.strip()]},
+        )
+    except Exception as exc:
+        if logger is not None:
+            logger.warning(
+                "[arxiv_paper_representation] Topic concept create failed for %s: %s",
+                topic_label,
+                exc,
+            )
+    return concept_id
+
+
+def _extract_metadata_title(metadata: Mapping[str, Any] | None) -> str | None:
+    if not isinstance(metadata, Mapping):
+        return None
+    for key in ("title", "paper_title", "name"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _extract_metadata_summary(metadata: Mapping[str, Any] | None) -> str | None:
+    if not isinstance(metadata, Mapping):
+        return None
+    for key in ("summary", "abstract", "description"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _relation_contains_target(
+    concept_id: str,
+    predicate: str,
+    target_concept_id: str,
+) -> bool:
+    from . import concept_service
+
+    concept_doc = concept_service.get_concept_by_concept_id(concept_id) or {}
+    relationships = concept_doc.get("relationships") or {}
+    raw_targets = relationships.get(predicate) or []
+    if isinstance(raw_targets, str):
+        raw_targets = [raw_targets]
+    return target_concept_id in raw_targets
+
+
 def ensure_paper_on_arxiv_type_exists(*, logger: Any | None = None) -> None:
     """Best-effort ensure the #V#paper_on_arxiv type exists."""
 
@@ -33,12 +353,6 @@ def ensure_paper_on_arxiv_type_exists(*, logger: Any | None = None) -> None:
             THING_PRIMARY_ID,
             ensure_thing_exists_and_link_orphans,
         )
-
-        def _concept_exists(concept_id: str) -> bool:
-            try:
-                return concept_service.get_concept_by_concept_id(concept_id) is not None
-            except Exception:
-                return False
 
         if _concept_exists(type_concept_id):
             return
@@ -76,10 +390,10 @@ def ensure_arxiv_paper_instance(
     ensure_paper_on_arxiv_type_exists(logger=logger)
 
     from . import concept_service
-    from .text_value_service import upsert_text_for_concept
 
     type_concept_id = "#V#paper_on_arxiv"
-    instance_concept_id = _stable_paper_instance_concept_id(arxiv_id)
+    normalised_arxiv_id = _normalise_arxiv_id(arxiv_id)
+    instance_concept_id = _stable_paper_instance_concept_id(normalised_arxiv_id)
 
     existing = None
     try:
@@ -89,14 +403,14 @@ def ensure_arxiv_paper_instance(
 
     if not existing:
         concept_service.create_concept(
-            name=f"arXiv paper {arxiv_id}",
+            name=f"arXiv paper {normalised_arxiv_id}",
             concept_id=instance_concept_id,
             parent_concept_ids=[type_concept_id],
             create_as_instance=True,
             system_tags=["arxiv", "paper"],
             attributes={
                 "source": "arxiv",
-                "arxiv_id": arxiv_id,
+                "arxiv_id": normalised_arxiv_id,
             },
         )
         concept_service.update_concept(
@@ -108,14 +422,14 @@ def ensure_arxiv_paper_instance(
         upsert_text_for_concept(
             subject_concept_id=instance_concept_id,
             predicate="hasName",
-            text=str(arxiv_id).strip(),
+            text=str(normalised_arxiv_id).strip(),
             lang="en-NZ",
             context={"name_type": "CODE"},
         )
         upsert_text_for_concept(
             subject_concept_id=instance_concept_id,
             predicate="hasName",
-            text=f"https://arxiv.org/abs/{str(arxiv_id).strip()}",
+            text=f"https://arxiv.org/abs/{str(normalised_arxiv_id).strip()}",
             lang="en-NZ",
             context={"name_type": "CODE"},
         )
@@ -176,3 +490,248 @@ def link_file_copy_to_arxiv_paper(
         "linked": True,
         "changed": bool(changed),
     }
+
+
+def materialise_scholarly_representation_for_arxiv_file_copy(
+    *,
+    user_concept_id: str,
+    arxiv_id: str,
+    file_copy_concept_id: str,
+    metadata: Mapping[str, Any] | None = None,
+    logger: Any | None = None,
+) -> dict[str, Any]:
+    """Materialise a rich scholarly-paper representation for an uploaded arXiv file.
+
+    This helper is intentionally deterministic and tool-free so workflow-driven
+    upload pipelines can assert strong postconditions without relying on chat
+    heuristics.
+    """
+
+    normalised_arxiv_id = _normalise_arxiv_id(arxiv_id)
+    link_result = link_file_copy_to_arxiv_paper(
+        user_concept_id=user_concept_id,
+        arxiv_id=normalised_arxiv_id,
+        file_copy_concept_id=file_copy_concept_id,
+        logger=logger,
+    )
+    paper_concept_id = str(link_result.get("paper_concept_id") or "").strip()
+    if not paper_concept_id:
+        return {
+            "success": False,
+            "verified": False,
+            "error": "missing_paper_concept_id",
+            "arxiv_id": normalised_arxiv_id,
+            "file_copy_concept_id": file_copy_concept_id,
+        }
+
+    _ensure_type_concept(
+        "#V#scholarly_article",
+        "Scholarly Article",
+        preferred_parent_id="#V#paper_on_arxiv",
+        logger=logger,
+    )
+    _ensure_type_concept(
+        "#V#person",
+        "Person",
+        preferred_parent_id="#V#thing",
+        logger=logger,
+    )
+    _ensure_type_concept(
+        "#V#research_topic",
+        "Research Topic",
+        preferred_parent_id="#V#thing",
+        logger=logger,
+    )
+    _ensure_predicate_concept("#V#authored_by", "Authored By", logger=logger)
+    _ensure_predicate_concept("#V#about", "About", logger=logger)
+
+    type_relation = add_relationship(
+        source_id=paper_concept_id,
+        predicate="is_an_instance_of",
+        target="#V#scholarly_article",
+    )
+
+    title = _extract_metadata_title(metadata)
+    summary = _extract_metadata_summary(metadata)
+    author_names = _extract_author_names(metadata)
+    topic_labels = _extract_topic_labels(metadata)
+
+    title_asserted = False
+    summary_asserted = False
+    if isinstance(title, str) and title.strip():
+        upsert_text_for_concept(
+            subject_concept_id=paper_concept_id,
+            predicate="hasName",
+            text=title.strip(),
+            lang="en-NZ",
+            context={"name_type": "NL", "source": "arxiv_metadata"},
+        )
+        title_asserted = True
+
+    if isinstance(summary, str) and summary.strip():
+        upsert_text_for_concept(
+            subject_concept_id=paper_concept_id,
+            predicate="hasDescription",
+            text=summary.strip(),
+            lang="en-NZ",
+            context={"source": "arxiv_metadata"},
+        )
+        summary_asserted = True
+
+    if topic_labels:
+        upsert_text_for_concept(
+            subject_concept_id=paper_concept_id,
+            predicate="#V#has_topic_labels",
+            text=", ".join(topic_labels),
+            lang="en-NZ",
+            context={"source": "arxiv_metadata"},
+        )
+
+    author_concept_ids: list[str] = []
+    author_links_written = 0
+    for author_name in author_names:
+        author_concept_id = _resolve_or_create_person_concept_id(
+            user_concept_id=user_concept_id,
+            person_name=author_name,
+            logger=logger,
+        )
+        author_concept_ids.append(author_concept_id)
+        add_relationship(
+            source_id=paper_concept_id,
+            predicate="#V#authored_by",
+            target=author_concept_id,
+        )
+        if not _relation_contains_target(
+            paper_concept_id,
+            "#V#authored_by",
+            author_concept_id,
+        ):
+            from ..db.repositories.concepts_repository import ConceptsRepository
+
+            ConceptsRepository.mutate_relationship_edge(
+                paper_concept_id,
+                "#V#authored_by",
+                author_concept_id,
+                action="add",
+                maintain_inverse=False,
+            )
+        if _relation_contains_target(
+            paper_concept_id,
+            "#V#authored_by",
+            author_concept_id,
+        ):
+            author_links_written += 1
+
+    topic_concept_ids: list[str] = []
+    topic_links_written = 0
+    for label in topic_labels[:_MAX_TOPIC_RELATIONS]:
+        topic_concept_id = _resolve_or_create_topic_concept_id(
+            user_concept_id=user_concept_id,
+            topic_label=label,
+            logger=logger,
+        )
+        topic_concept_ids.append(topic_concept_id)
+        add_relationship(
+            source_id=paper_concept_id,
+            predicate="#V#about",
+            target=topic_concept_id,
+        )
+        if not _relation_contains_target(
+            paper_concept_id,
+            "#V#about",
+            topic_concept_id,
+        ):
+            from ..db.repositories.concepts_repository import ConceptsRepository
+
+            ConceptsRepository.mutate_relationship_edge(
+                paper_concept_id,
+                "#V#about",
+                topic_concept_id,
+                action="add",
+                maintain_inverse=False,
+            )
+        if _relation_contains_target(
+            paper_concept_id,
+            "#V#about",
+            topic_concept_id,
+        ):
+            topic_links_written += 1
+
+    has_name_rows = get_texts_for_concept(
+        subject_concept_id=paper_concept_id,
+        predicate="hasName",
+        limit=200,
+    )
+    paper_names = [
+        str(row.get("text")).strip()
+        for row in has_name_rows
+        if isinstance(row, Mapping) and isinstance(row.get("text"), str)
+    ]
+    has_description_rows = get_texts_for_concept(
+        subject_concept_id=paper_concept_id,
+        predicate="hasDescription",
+        limit=50,
+    )
+
+    id_asserted = normalised_arxiv_id.casefold() in {
+        name.casefold() for name in paper_names
+    }
+    file_link_verified = _relation_contains_target(
+        paper_concept_id,
+        "#V#propositional_information_thing_has_computer_file",
+        file_copy_concept_id,
+    )
+    type_asserted = bool(type_relation.get("success")) and _relation_contains_target(
+        paper_concept_id,
+        "is_an_instance_of",
+        "#V#scholarly_article",
+    )
+    author_asserted = bool(author_concept_ids) and author_links_written >= len(
+        author_concept_ids
+    )
+    topic_asserted = bool(topic_labels) and topic_links_written > 0
+    summary_present = bool(has_description_rows) or summary_asserted
+
+    verification_failures: list[str] = []
+    if not id_asserted:
+        verification_failures.append("arxiv_identifier_missing")
+    if not title_asserted:
+        verification_failures.append("title_missing")
+    if not summary_present:
+        verification_failures.append("summary_missing")
+    if not author_asserted:
+        verification_failures.append("authors_missing")
+    if not type_asserted:
+        verification_failures.append("type_missing")
+    if not topic_asserted:
+        verification_failures.append("topic_missing")
+    if not file_link_verified:
+        verification_failures.append("file_link_missing")
+
+    return {
+        "success": len(verification_failures) == 0,
+        "verified": len(verification_failures) == 0,
+        "arxiv_id": normalised_arxiv_id,
+        "paper_concept_id": paper_concept_id,
+        "file_copy_concept_id": file_copy_concept_id,
+        "title": title,
+        "author_names": author_names,
+        "author_concept_ids": author_concept_ids,
+        "author_links_written": author_links_written,
+        "topic_labels": topic_labels,
+        "topic_concept_ids": topic_concept_ids,
+        "topic_links_written": topic_links_written,
+        "summary_present": summary_present,
+        "type_asserted": type_asserted,
+        "file_link_verified": file_link_verified,
+        "verification_failures": verification_failures,
+    }
+
+
+__all__ = [
+    "ensure_arxiv_paper_instance",
+    "ensure_paper_on_arxiv_type_exists",
+    "extract_arxiv_id_candidates",
+    "link_file_copy_to_arxiv_paper",
+    "materialise_scholarly_representation_for_arxiv_file_copy",
+]

--- a/src/backend/services/kb_clone_benchmark_service.py
+++ b/src/backend/services/kb_clone_benchmark_service.py
@@ -81,6 +81,12 @@ _INDEX_OPTION_KEYS = (
     "hidden",
 )
 
+ONTOLOGY_SLICE_COLLECTIONS: tuple[str, ...] = (
+    "concepts",
+    "text_relations",
+    "text_values",
+)
+
 
 class BenchmarkHarnessError(RuntimeError):
     """Raised when benchmark harness preconditions or lifecycle steps fail."""
@@ -299,13 +305,36 @@ def _copy_indexes(source: Collection, target: Collection) -> None:
 def _clone_database(
     client: MongoClient, *, source_db_name: str, clone_db_name: str
 ) -> dict[str, int]:
+    return _clone_database_subset(
+        client,
+        source_db_name=source_db_name,
+        clone_db_name=clone_db_name,
+        include_collections=None,
+    )
+
+
+def _clone_database_subset(
+    client: MongoClient,
+    *,
+    source_db_name: str,
+    clone_db_name: str,
+    include_collections: Sequence[str] | None,
+) -> dict[str, int]:
     source_db = client[source_db_name]
     if clone_db_name in client.list_database_names():
         client.drop_database(clone_db_name)
     clone_db = client[clone_db_name]
 
+    include_set = (
+        {str(name).strip() for name in include_collections if str(name).strip()}
+        if include_collections is not None
+        else None
+    )
+
     collection_counts: dict[str, int] = {}
     for collection_name in sorted(source_db.list_collection_names()):
+        if include_set is not None and collection_name not in include_set:
+            continue
         source_collection = source_db[collection_name]
         clone_collection = clone_db[collection_name]
 
@@ -315,6 +344,19 @@ def _clone_database(
         _copy_indexes(source_collection, clone_collection)
         collection_counts[collection_name] = len(docs)
     return collection_counts
+
+
+def clone_database_ontology_slice(
+    client: MongoClient, *, source_db_name: str, clone_db_name: str
+) -> dict[str, int]:
+    """Clone only ontology graph collections into an isolated benchmark DB."""
+
+    return _clone_database_subset(
+        client,
+        source_db_name=source_db_name,
+        clone_db_name=clone_db_name,
+        include_collections=ONTOLOGY_SLICE_COLLECTIONS,
+    )
 
 
 def _iter_collection_json_lines(collection: Collection) -> tuple[bytes, int]:

--- a/tests/backend/test_arxiv_paper_link_service.py
+++ b/tests/backend/test_arxiv_paper_link_service.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_db_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VON_USE_MOCK_DB", "1")
+
 
 def test_link_file_copy_to_arxiv_paper_creates_stable_paper_instance_and_links(
     monkeypatch,
@@ -63,4 +70,85 @@ def test_link_file_copy_to_arxiv_paper_creates_stable_paper_instance_and_links(
     )
     assert record.concept_id in (paper_doc.get("relationships", {}) or {}).get(
         "#V#propositional_information_thing_has_computer_file", []
+    )
+
+
+def test_materialise_scholarly_representation_adds_metadata_authors_and_topics():
+    from src.backend.services.computer_file_copy_service import (
+        create_computer_file_copy_instance,
+    )
+    from src.backend.services.arxiv_paper_link_service import (
+        materialise_scholarly_representation_for_arxiv_file_copy,
+    )
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.services.text_value_service import get_texts_for_concept
+
+    record = create_computer_file_copy_instance(
+        type_concept_id="#V#arxiv_pdf_file",
+        user_concept_id="#V#user_test",
+        name="2502.14996.pdf",
+        sha256="cafebabe",
+        size_bytes=456,
+        content_type="application/pdf",
+        blob_backend="local",
+        blob_key="uploads/user/2502.14996.pdf",
+        blob_uri="local://uploads/user/2502.14996.pdf",
+        metadata={"source": "upload"},
+    )
+
+    metadata = {
+        "title": "Reasoning with Structured Retrieval for Scientific Documents",
+        "authors": ["Jane Example", "Alan Example"],
+        "summary": "A deterministic pipeline for scholarly paper representation.",
+        "categories": ["cs.AI", "cs.CL"],
+    }
+    report = materialise_scholarly_representation_for_arxiv_file_copy(
+        user_concept_id="#V#user_test",
+        arxiv_id="2502.14996",
+        file_copy_concept_id=record.concept_id,
+        metadata=metadata,
+    )
+
+    assert report["success"] is True
+    assert report["verified"] is True
+    assert report["author_links_written"] >= 2
+    assert report["topic_labels"] == ["cs.AI", "cs.CL"]
+    assert report["type_asserted"] is True
+    assert report["file_link_verified"] is True
+
+    paper_id = report["paper_concept_id"]
+    paper_doc = ConceptsRepository.find_one({"concept_id": paper_id})
+    assert paper_doc is not None
+    rel = paper_doc.get("relationships") or {}
+    assert "#V#scholarly_article" in (rel.get("is_an_instance_of") or [])
+    assert record.concept_id in (
+        rel.get("#V#propositional_information_thing_has_computer_file") or []
+    )
+    assert len(rel.get("#V#authored_by") or []) >= 2
+    assert len(rel.get("#V#about") or []) >= 1
+
+    name_texts = get_texts_for_concept(
+        subject_concept_id=paper_id,
+        predicate="hasName",
+        limit=200,
+    )
+    assert any(
+        isinstance(item, dict)
+        and item.get("text") == metadata["title"]
+        for item in name_texts
+    )
+    assert any(
+        isinstance(item, dict) and item.get("text") == "2502.14996"
+        for item in name_texts
+    )
+
+    summary_texts = get_texts_for_concept(
+        subject_concept_id=paper_id,
+        predicate="hasDescription",
+        limit=50,
+    )
+    assert any(
+        isinstance(item, dict)
+        and item.get("text") == metadata["summary"]
+        for item in summary_texts
     )

--- a/tests/backend/test_kb_clone_benchmark_service.py
+++ b/tests/backend/test_kb_clone_benchmark_service.py
@@ -105,6 +105,48 @@ def _scenario(source_db_name: str) -> dict[str, Any]:
     }
 
 
+def test_clone_database_ontology_slice_excludes_non_ontology_collections() -> None:
+    source_db_name = "test_von_db_slice_source"
+    clone_db_name = "test_von_db_slice_clone"
+    mongo_client = _seed_source_db(source_db_name)
+    source_db = mongo_client[source_db_name]
+
+    source_db["text_values"].insert_one({"text": "seed", "lang": "en-NZ"})
+    source_db["text_relations"].insert_one(
+        {
+            "subject_concept_id": "#V#thing",
+            "predicate": "hasDescription",
+            "text": "seed",
+            "lang": "en-NZ",
+        }
+    )
+    source_db["interaction_sessions"].insert_one(
+        {"session_id": "noise", "history": [{"role": "user", "content": "noise"}]}
+    )
+    source_db["chat_history"].insert_one({"session_id": "noise-chat"})
+
+    counts = benchmark_service.clone_database_ontology_slice(
+        mongo_client,
+        source_db_name=source_db_name,
+        clone_db_name=clone_db_name,
+    )
+
+    assert set(counts.keys()) == {"concepts", "text_relations", "text_values"}
+    clone_db = mongo_client[clone_db_name]
+    clone_collections = set(clone_db.list_collection_names())
+    assert "interaction_sessions" not in clone_collections
+    assert "chat_history" not in clone_collections
+    assert clone_db["concepts"].count_documents({}) == source_db["concepts"].count_documents(
+        {}
+    )
+    assert clone_db["text_relations"].count_documents({}) == source_db[
+        "text_relations"
+    ].count_documents({})
+    assert clone_db["text_values"].count_documents({}) == source_db[
+        "text_values"
+    ].count_documents({})
+
+
 def test_kb_clone_benchmark_runs_end_to_end_and_cleans_up(tmp_path: Path) -> None:
     source_db_name = "test_von_db"
     mongo_client = _seed_source_db(source_db_name)

--- a/tests/backend/test_von_file_upload_scholarly_integration.py
+++ b/tests/backend/test_von_file_upload_scholarly_integration.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+import io
+from typing import Any
+
+import pytest
+from flask import Flask
+
+from src.backend.db import mongo_client as mongo_client_module
+from src.backend.server.routes.von_routes import von_bp
+from src.backend.services.kb_clone_benchmark_service import (
+    ONTOLOGY_SLICE_COLLECTIONS,
+    clone_database_ontology_slice,
+)
+from src.backend.workflows.durable.file_copy_interpretation_workflow import (
+    FILE_COPY_INTERPRETATION_WORKFLOW_ID,
+    build_file_copy_interpretation_workflow,
+)
+from src.backend.workflows.durable.models import WorkflowInstanceStatus
+from src.backend.workflows.durable.registry_factory import (
+    build_durable_action_registry,
+    build_workflow_registry_read_only,
+)
+from src.backend.workflows.durable.startup import (
+    create_durable_executor,
+    get_instance_manager,
+)
+
+_SOURCE_DB_NAME = "test_1337_source_db"
+_CLONE_DB_NAME = "test_1337_clone_db"
+_TEST_WORKER_ID = "worker-1337"
+_TEST_ARXIV_ID = "2502.14996"
+_TEST_ARXIV_TITLE = "Self-Issues in Face Recognition: Why Existing Methods Ignore Them and How to Correct Them?"
+_TEST_ARXIV_AUTHORS = ["Yihan Wang", "Yingjie Xia", "Haoran Wang"]
+_TEST_ARXIV_CATEGORIES = ["cs.CV", "cs.AI"]
+_TEST_ARXIV_SUMMARY = (
+    "A deterministic metadata fixture used to validate upload-triggered "
+    "scholarly representation postconditions for arXiv integration."
+)
+
+
+class _FakeStore:
+    def __init__(self, blob_ref_cls):
+        self._blob_ref_cls = blob_ref_cls
+        self._bytes_by_key: dict[str, bytes] = {}
+
+    def put_bytes(self, key, data, content_type=None, metadata=None):
+        key_str = str(key)
+        payload = bytes(data)
+        self._bytes_by_key[key_str] = payload
+        return self._blob_ref_cls(
+            backend="local",
+            key=key_str,
+            uri=f"local://{key_str}",
+            content_type=content_type,
+            size_bytes=len(payload),
+            metadata=dict(metadata or {}),
+        )
+
+    def get_bytes(self, key):
+        key_str = str(key)
+        if key_str not in self._bytes_by_key:
+            raise FileNotFoundError(key_str)
+        return self._bytes_by_key[key_str]
+
+    def delete(self, key):
+        self._bytes_by_key.pop(str(key), None)
+
+
+@pytest.fixture(autouse=True)
+def _integration_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VON_USE_MOCK_DB", "1")
+    monkeypatch.setenv("VON_DURABLE_WORKFLOWS_ENABLE", "1")
+    monkeypatch.setenv("VON_EVENT_WORKFLOW_INTEGRATION_ENABLE", "1")
+    monkeypatch.setenv("VON_WORKFLOW_PARITY_ENFORCEMENT", "off")
+    monkeypatch.setenv("VON_DB_NAME", _SOURCE_DB_NAME)
+
+    from src.backend.services import workflow_event_integration_service
+    from src.backend.workflows.durable import instance_manager, startup, registry_factory
+
+    mongo_client_module.invalidate_connection()
+    startup._instance_manager = None
+    instance_manager._indexes_ensured = False
+    workflow_event_integration_service._DEFAULT_BINDINGS_ENSURED = False
+    registry_factory._durable_mcp_gateway = None
+    yield
+    mongo_client_module.invalidate_connection()
+
+
+def _seed_source_database() -> Any:
+    db = mongo_client_module.get_db()
+    assert db is not None
+    for collection_name in db.list_collection_names():
+        db.drop_collection(collection_name)
+
+    db["concepts"].insert_many(
+        [
+            {
+                "concept_id": "#V#thing",
+                "relationships": {"is_a_type_of": [], "is_an_instance_of": []},
+            },
+            {
+                "concept_id": "#V#predicate",
+                "relationships": {"is_a_type_of": ["#V#thing"], "is_an_instance_of": []},
+            },
+            {
+                "concept_id": "#V#store_of_information",
+                "relationships": {
+                    "is_a_type_of": ["#V#thing"],
+                    "is_an_instance_of": [],
+                },
+            },
+            {
+                "concept_id": "#V#computer_file_copy",
+                "relationships": {
+                    "is_a_type_of": ["#V#store_of_information"],
+                    "is_an_instance_of": [],
+                },
+            },
+            {
+                "concept_id": "#V#person",
+                "relationships": {"is_a_type_of": ["#V#thing"], "is_an_instance_of": []},
+            },
+            {
+                "concept_id": "#V#organisation",
+                "relationships": {"is_a_type_of": ["#V#thing"], "is_an_instance_of": []},
+            },
+            {
+                "concept_id": "#V#user_test",
+                "relationships": {"is_an_instance_of": ["#V#person"]},
+            },
+            {
+                "concept_id": "#V#org_test",
+                "relationships": {"is_an_instance_of": ["#V#organisation"]},
+            },
+        ]
+    )
+    db["text_values"].insert_one({"text": "seed", "lang": "en-NZ"})
+    db["text_relations"].insert_one(
+        {
+            "subject_concept_id": "#V#thing",
+            "predicate": "hasDescription",
+            "text": "seed description",
+            "lang": "en-NZ",
+        }
+    )
+
+    db["interaction_sessions"].insert_one(
+        {"session_id": "noise-session", "history": [{"role": "user", "content": "noise"}]}
+    )
+    db["chat_history"].insert_one(
+        {"session_id": "noise-chat", "messages": [{"role": "assistant", "content": "noise"}]}
+    )
+    db["workflow_use_episodes"].insert_one({"stable_key": "noise-episode"})
+
+    return db.client
+
+
+def _build_upload_app() -> Flask:
+    app = Flask(__name__)
+    app.testing = True
+    app.secret_key = "test-secret"
+    app.register_blueprint(von_bp, url_prefix="/von")
+    return app
+
+
+def _mock_paper_metadata(**kwargs):
+    arxiv_id = str(kwargs.get("arxiv_id") or "").strip().lower()
+    if arxiv_id != _TEST_ARXIV_ID:
+        return {"success": False, "error": "unexpected_arxiv_id", "arxiv_id": arxiv_id}
+    return {
+        "success": True,
+        "paper": {
+            "id": _TEST_ARXIV_ID,
+            "title": _TEST_ARXIV_TITLE,
+            "authors": list(_TEST_ARXIV_AUTHORS),
+            "summary": _TEST_ARXIV_SUMMARY,
+            "categories": list(_TEST_ARXIV_CATEGORIES),
+        },
+    }
+
+
+def _run_pending_file_copy_instance(instance_id: str):
+    manager = get_instance_manager()
+    claimed = manager.find_and_claim_instance(
+        _TEST_WORKER_ID,
+        workflow_ids=[FILE_COPY_INTERPRETATION_WORKFLOW_ID],
+    )
+    assert claimed is not None
+    assert claimed.instance_id == instance_id
+    assert claimed.status == WorkflowInstanceStatus.RUNNING
+
+    registry = build_workflow_registry_read_only()
+    definition = registry.get(FILE_COPY_INTERPRETATION_WORKFLOW_ID)
+    if definition is None:
+        definition = build_file_copy_interpretation_workflow()
+
+    executor = create_durable_executor(
+        build_durable_action_registry(),
+        instance_manager=manager,
+        max_transitions=40,
+    )
+    result = executor.run_durable(
+        instance_id,
+        definition,
+        worker_id=_TEST_WORKER_ID,
+        resume_from_checkpoint=True,
+    )
+    if result.completed:
+        manager.mark_completed(
+            instance_id,
+            outputs=result.data,
+            final_state=result.final_state,
+        )
+    elif result.error != "cancelled":
+        manager.mark_failed(
+            instance_id,
+            error=result.error or "unknown_error",
+            error_step=result.final_state,
+        )
+    manager.release_lock(instance_id, _TEST_WORKER_ID)
+    final_instance = manager.get_instance(instance_id)
+    assert final_instance is not None
+    return result, final_instance
+
+
+def _get_paper_doc_for_file_copy(file_copy_concept_id: str) -> dict[str, Any]:
+    db = mongo_client_module.get_db()
+    assert db is not None
+    paper_doc = db["concepts"].find_one(
+        {
+            "relationships.#V#propositional_information_thing_has_computer_file": {
+                "$in": [file_copy_concept_id]
+            }
+        }
+    )
+    assert isinstance(paper_doc, dict)
+    return paper_doc
+
+
+def _collect_text_values(concept_id: str, predicate: str) -> list[str]:
+    from src.backend.services.text_value_service import get_texts_for_concept
+
+    rows = get_texts_for_concept(concept_id, predicate=predicate, limit=200)
+    texts: list[str] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        text = row.get("text")
+        if isinstance(text, str) and text.strip():
+            texts.append(text.strip())
+    return texts
+
+
+def test_upload_event_workflow_materialises_scholarly_representation_in_ontology_clone(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    mongo_client = _seed_source_database()
+    source_db = mongo_client[_SOURCE_DB_NAME]
+    source_noise_counts_before = {
+        "interaction_sessions": source_db["interaction_sessions"].count_documents({}),
+        "chat_history": source_db["chat_history"].count_documents({}),
+        "workflow_use_episodes": source_db["workflow_use_episodes"].count_documents({}),
+    }
+
+    clone_counts = clone_database_ontology_slice(
+        mongo_client,
+        source_db_name=_SOURCE_DB_NAME,
+        clone_db_name=_CLONE_DB_NAME,
+    )
+    assert set(clone_counts.keys()) <= set(ONTOLOGY_SLICE_COLLECTIONS)
+    assert "concepts" in clone_counts
+    assert "text_relations" in clone_counts
+    assert "text_values" in clone_counts
+
+    clone_db = mongo_client[_CLONE_DB_NAME]
+    clone_collections = set(clone_db.list_collection_names())
+    assert "interaction_sessions" not in clone_collections
+    assert "chat_history" not in clone_collections
+    assert "workflow_use_episodes" not in clone_collections
+
+    monkeypatch.setenv("VON_DB_NAME", _CLONE_DB_NAME)
+    mongo_client_module.invalidate_connection()
+
+    from src.backend.services.blob_store import BlobRef
+
+    fake_store = _FakeStore(BlobRef)
+    monkeypatch.setattr(
+        "src.backend.services.blob_store.get_blob_store_from_env",
+        lambda: fake_store,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes._record_file_upload_in_chat_history",
+        lambda **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue._get_paper_metadata",
+        _mock_paper_metadata,
+    )
+
+    app = _build_upload_app()
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#user_test"
+        sess["session_id"] = "integration-session-1337"
+
+    upload_payload = b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\n%%EOF\n"
+    first_upload = client.post(
+        "/von/api/files/upload",
+        data={"file": (io.BytesIO(upload_payload), "2502.14996.pdf")},
+        content_type="multipart/form-data",
+    )
+    assert first_upload.status_code == 200
+    first_body = first_upload.get_json()
+    assert isinstance(first_body, dict)
+    assert first_body.get("success") is True
+    launch_payload = first_body.get("workflow_event_launch") or {}
+    assert launch_payload.get("success") is True
+    assert launch_payload.get("triggered") is True
+    assert launch_payload.get("workflow_id") == FILE_COPY_INTERPRETATION_WORKFLOW_ID
+
+    first_instance_id = str(launch_payload.get("instance_id") or "").strip()
+    assert first_instance_id
+    first_result, first_instance = _run_pending_file_copy_instance(first_instance_id)
+    assert first_result.completed is True
+    assert first_result.final_state == "complete"
+    assert first_instance.status == WorkflowInstanceStatus.COMPLETED
+
+    first_file_copy_id = str((first_body.get("uploaded") or {}).get("concept_id") or "")
+    assert first_file_copy_id
+    paper_doc = _get_paper_doc_for_file_copy(first_file_copy_id)
+    paper_id = str(paper_doc.get("concept_id") or "").strip()
+    assert paper_id
+
+    relationships = paper_doc.get("relationships") or {}
+    assert "#V#scholarly_article" in (relationships.get("is_an_instance_of") or [])
+    assert first_file_copy_id in (
+        relationships.get("#V#propositional_information_thing_has_computer_file") or []
+    )
+    assert len(relationships.get("#V#authored_by") or []) >= len(_TEST_ARXIV_AUTHORS)
+    assert len(relationships.get("#V#about") or []) >= 1
+
+    has_name_values = _collect_text_values(paper_id, "hasName")
+    has_description_values = _collect_text_values(paper_id, "hasDescription")
+    topic_label_values = _collect_text_values(paper_id, "#V#has_topic_labels")
+
+    assert _TEST_ARXIV_ID in has_name_values
+    assert _TEST_ARXIV_TITLE in has_name_values
+    assert _TEST_ARXIV_SUMMARY in has_description_values
+    assert topic_label_values
+    assert _TEST_ARXIV_CATEGORIES[0] in topic_label_values[0]
+
+    second_upload = client.post(
+        "/von/api/files/upload",
+        data={"file": (io.BytesIO(upload_payload), "2502.14996.pdf")},
+        content_type="multipart/form-data",
+    )
+    assert second_upload.status_code == 200
+    second_body = second_upload.get_json()
+    assert isinstance(second_body, dict)
+    assert second_body.get("success") is True
+    second_launch = second_body.get("workflow_event_launch") or {}
+    second_instance_id = str(second_launch.get("instance_id") or "").strip()
+    assert second_instance_id
+
+    second_result, second_instance = _run_pending_file_copy_instance(second_instance_id)
+    assert second_result.completed is True
+    assert second_instance.status == WorkflowInstanceStatus.COMPLETED
+
+    second_file_copy_id = str((second_body.get("uploaded") or {}).get("concept_id") or "")
+    assert second_file_copy_id
+    paper_after_repeat = _get_paper_doc_for_file_copy(second_file_copy_id)
+    assert str(paper_after_repeat.get("concept_id")) == paper_id
+    repeat_relationships = paper_after_repeat.get("relationships") or {}
+    linked_files = repeat_relationships.get(
+        "#V#propositional_information_thing_has_computer_file"
+    ) or []
+    assert first_file_copy_id in linked_files
+    assert second_file_copy_id in linked_files
+
+    source_noise_counts_after = {
+        "interaction_sessions": source_db["interaction_sessions"].count_documents({}),
+        "chat_history": source_db["chat_history"].count_documents({}),
+        "workflow_use_episodes": source_db["workflow_use_episodes"].count_documents({}),
+    }
+    assert source_noise_counts_after == source_noise_counts_before


### PR DESCRIPTION
## Summary
- add a deterministic integration test that uploads `2502.14996.pdf` through `/von/api/files/upload` and verifies workflow-driven scholarly representation postconditions
- add ontology-only clone helper and regression test to ensure integration runs isolate ontology collections from non-ontology noise
- harden arXiv scholarly materialisation so author/topic links are deterministically persisted and verified
- include agent guidance update clarifying that "complete" means implemented in code + Vontology, not Jira status alone

## Verification
- `pytest tests/backend/test_file_copy_ingestion_mcp_tools.py tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py tests/backend/test_von_file_upload_endpoint.py tests/backend/test_arxiv_paper_link_service.py tests/backend/test_kb_clone_benchmark_service.py tests/backend/test_von_file_upload_scholarly_integration.py -q`
- `pyright src/backend/integrations/internal_mcp/catalogue.py src/backend/services/arxiv_paper_link_service.py src/backend/services/kb_clone_benchmark_service.py tests/backend/test_arxiv_paper_link_service.py tests/backend/test_kb_clone_benchmark_service.py tests/backend/test_von_file_upload_scholarly_integration.py`

Closes JVNAUTOSCI-1337.