### PR TITLE
JVNAUTOSCI-1309: workflow-first file upload handler with classification routing

### DIFF
--- a/src/backend/services/workflow_event_integration_service.py
+++ b/src/backend/services/workflow_event_integration_service.py
@@ -39,6 +39,7 @@ EVENT_TYPE_TEXT_RELATION_UPDATED = "text_relation.updated"
 EVENT_TYPE_TEXT_RELATION_DELETED = "text_relation.deleted"
 EVENT_TYPE_VONTOLOGY_MUTATED = "vontology.mutated"
 EVENT_TYPE_FILE_COPY_UPLOADED = "file_copy.uploaded"
+DEFAULT_FILE_COPY_UPLOADED_WORKFLOW_ID = "#V#file_copy_upload_handler_workflow"
 
 # Backward-compatible environment wiring (legacy/system bootstrap).
 EVENT_WORKFLOW_ID_ENV_MAP: dict[str, str] = {
@@ -59,7 +60,7 @@ _DEFAULT_EVENT_BINDINGS: tuple[dict[str, Any], ...] = (
     },
     {
         "event_type": EVENT_TYPE_FILE_COPY_UPLOADED,
-        "workflow_id": "#V#file_copy_interpretation_workflow",
+        "workflow_id": DEFAULT_FILE_COPY_UPLOADED_WORKFLOW_ID,
         "input_mapping": {
             "concept_id": "event.file_copy_concept_id",
             "file_copy_concept_id": "event.file_copy_concept_id",
@@ -1366,7 +1367,11 @@ def maybe_launch_file_copy_uploaded_workflow(
     uploaded_at_iso: str | None = None,
     index_in_rag: bool = True,
 ) -> dict[str, Any]:
-    """Launch interpretation workflow(s) for a newly uploaded file copy."""
+    """Launch upload-handler workflow for a newly uploaded file copy.
+
+    File uploads are routed through a single selected workflow ID to avoid
+    duplicate uncontrolled launches when multiple bindings may exist.
+    """
 
     concept_id = str(file_copy_concept_id or "").strip()
     if not concept_id:
@@ -1380,12 +1385,17 @@ def maybe_launch_file_copy_uploaded_workflow(
         }
 
     ensure_report = ensure_default_event_bindings()
+    selected_workflow_id = (
+        _workflow_id_for_event(EVENT_TYPE_FILE_COPY_UPLOADED)
+        or DEFAULT_FILE_COPY_UPLOADED_WORKFLOW_ID
+    )
     launch_result = launch_event_workflow(
         event_type=EVENT_TYPE_FILE_COPY_UPLOADED,
         event_id=concept_id,
         user_id=uploaded_by_concept_id,
         org_id=organisation_concept_id,
         namespace=namespace,
+        workflow_id=selected_workflow_id,
         event_payload={
             "concept_id": concept_id,
             "file_copy_concept_id": concept_id,
@@ -1411,4 +1421,6 @@ def maybe_launch_file_copy_uploaded_workflow(
     )
     if isinstance(launch_result, dict):
         launch_result["default_binding_bootstrap"] = ensure_report
+        launch_result["selected_workflow_id"] = selected_workflow_id
+        launch_result["launch_strategy"] = "single_selected_binding"
     return launch_result

--- a/src/backend/workflows/durable/file_copy_upload_classification_workflow.py
+++ b/src/backend/workflows/durable/file_copy_upload_classification_workflow.py
@@ -1,0 +1,600 @@
+"""Durable file-copy upload classification subworkflow (JVNAUTOSCI-1309).
+
+This workflow classifies newly uploaded file copies into a routing mode:
+- specialised subworkflow route (when available and high confidence),
+- baseline interpretation route,
+- explicit fail-closed route for low-confidence mutation paths, or
+- no-op route when interpretation fallback is disabled.
+
+The classification decision is persisted as a singleton text relation so route
+selection remains inspectable after execution.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from functools import lru_cache
+import json
+import os
+import re
+from typing import Any, Mapping
+
+from ...services.text_value_service import upsert_singleton_text_relation
+from ..action_registry import (
+    ActionRegistry,
+    ActionSpec,
+    WorkflowActionRequest,
+    WorkflowActionResult,
+)
+from ..engine import (
+    WorkflowActionInvocation,
+    WorkflowDefinition,
+    WorkflowStateSpec,
+    WorkflowTransitionSpec,
+)
+from ..workflow_registry import WorkflowRegistration
+
+FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID = (
+    "#V#file_copy_upload_classification_workflow"
+)
+
+FILE_COPY_UPLOAD_ROUTE_DECISION_PREDICATE = (
+    "#V#has_file_copy_upload_route_decision_json"
+)
+FILE_COPY_UPLOAD_CLASSIFICATION_VERSION = "file_copy_upload_classification.v1"
+
+DEFAULT_SCHOLARLY_WORKFLOW_ID = "#V#integration_scholarly_paper_representation_workflow"
+DEFAULT_CV_WORKFLOW_ID = "#V#file_copy_cv_representation_workflow"
+DEFAULT_BUSINESS_CARD_WORKFLOW_ID = "#V#file_copy_business_card_representation_workflow"
+
+ROUTE_KEY_SCHOLARLY = "scholarly"
+ROUTE_KEY_CV = "cv"
+ROUTE_KEY_BUSINESS_CARD = "business_card"
+ROUTE_KEY_INTERPRET = "interpret"
+ROUTE_KEY_NOOP = "noop"
+
+ROUTE_MODE_SPECIALISED = "specialised"
+ROUTE_MODE_INTERPRET = "interpret"
+ROUTE_MODE_FAIL_CLOSED = "fail_closed"
+ROUTE_MODE_NOOP = "noop"
+
+_ARXIV_FILENAME_RE = re.compile(r"(?<!\d)\d{4}\.\d{4,5}(?:v\d+)?", re.IGNORECASE)
+_SCHOLARLY_TOKEN_RE = re.compile(
+    r"\b(arxiv|paper|preprint|manuscript|journal|conference|doi)\b",
+    re.IGNORECASE,
+)
+_CV_TOKEN_RE = re.compile(
+    r"\b(cv|resume|résumé|curriculum[\s\-_]*vitae)\b",
+    re.IGNORECASE,
+)
+_BUSINESS_CARD_TOKEN_RE = re.compile(
+    r"\b(business[\s\-_]*card|biz[\s\-_]*card|contact[\s\-_]*card)\b",
+    re.IGNORECASE,
+)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _clean_text(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
+
+def _normalise_filename(value: Any) -> str:
+    return _clean_text(value).lower()
+
+
+def _normalise_content_type(value: Any) -> str:
+    raw = _clean_text(value).lower()
+    if not raw:
+        return ""
+    token = raw.split(";", 1)[0].strip()
+    return token
+
+
+def _coerce_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _coerce_float(
+    value: Any,
+    *,
+    default: float,
+    minimum: float,
+    maximum: float,
+) -> float:
+    try:
+        parsed = float(value)
+    except Exception:
+        parsed = default
+    return max(minimum, min(maximum, parsed))
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except Exception:
+        return None
+    return parsed
+
+
+def _extract_route_from_force_override(value: Any) -> str | None:
+    token = _clean_text(value).lower()
+    if token in {
+        ROUTE_KEY_SCHOLARLY,
+        ROUTE_KEY_CV,
+        ROUTE_KEY_BUSINESS_CARD,
+        ROUTE_KEY_INTERPRET,
+        ROUTE_KEY_NOOP,
+    }:
+        return token
+    return None
+
+
+def _candidate_list_from_any(value: Any) -> list[str]:
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        token = item.strip()
+        if not token or token in seen:
+            continue
+        seen.add(token)
+        out.append(token)
+    return out
+
+
+@lru_cache(maxsize=1)
+def _discover_known_workflow_ids() -> tuple[str, ...]:
+    """Resolve currently registered workflow IDs for availability checks."""
+
+    try:
+        from .registry_factory import build_workflow_registry_read_only
+
+        registry = build_workflow_registry_read_only()
+        ids = sorted(
+            {
+                str(workflow_id).strip()
+                for workflow_id in registry.all_workflow_ids()
+                if isinstance(workflow_id, str) and str(workflow_id).strip()
+            }
+        )
+        return tuple(ids)
+    except Exception:
+        return ()
+
+
+def _resolve_available_workflow_ids(payload: Mapping[str, Any]) -> tuple[str, ...]:
+    explicit = _candidate_list_from_any(payload.get("available_workflow_ids"))
+    if explicit:
+        return tuple(explicit)
+    return _discover_known_workflow_ids()
+
+
+def _resolve_specialised_candidates(
+    *,
+    route_key: str,
+    payload: Mapping[str, Any],
+) -> list[str]:
+    nested = payload.get("specialised_workflow_ids")
+    nested_map = nested if isinstance(nested, Mapping) else {}
+    candidates: list[str] = []
+
+    if route_key == ROUTE_KEY_SCHOLARLY:
+        candidates.extend(
+            _candidate_list_from_any(payload.get("scholarly_workflow_id"))
+        )
+        candidates.extend(
+            _candidate_list_from_any(nested_map.get("scholarly"))
+        )
+        env_value = _clean_text(os.getenv("VON_FILE_COPY_SCHOLARLY_WORKFLOW_ID"))
+        if env_value:
+            candidates.append(env_value)
+        candidates.append(DEFAULT_SCHOLARLY_WORKFLOW_ID)
+    elif route_key == ROUTE_KEY_CV:
+        candidates.extend(_candidate_list_from_any(payload.get("cv_workflow_id")))
+        candidates.extend(_candidate_list_from_any(nested_map.get("cv")))
+        env_value = _clean_text(os.getenv("VON_FILE_COPY_CV_WORKFLOW_ID"))
+        if env_value:
+            candidates.append(env_value)
+        candidates.append(DEFAULT_CV_WORKFLOW_ID)
+    elif route_key == ROUTE_KEY_BUSINESS_CARD:
+        candidates.extend(
+            _candidate_list_from_any(payload.get("business_card_workflow_id"))
+        )
+        candidates.extend(
+            _candidate_list_from_any(nested_map.get("business_card"))
+        )
+        env_value = _clean_text(os.getenv("VON_FILE_COPY_BUSINESS_CARD_WORKFLOW_ID"))
+        if env_value:
+            candidates.append(env_value)
+        candidates.append(DEFAULT_BUSINESS_CARD_WORKFLOW_ID)
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for item in candidates:
+        token = _clean_text(item)
+        if not token or token in seen:
+            continue
+        seen.add(token)
+        deduped.append(token)
+    return deduped
+
+
+def _resolve_score_candidates(
+    *,
+    filename: str,
+    content_type: str,
+    size_bytes: int | None,
+) -> dict[str, float]:
+    is_pdf = content_type == "application/pdf" or filename.endswith(".pdf")
+    is_image = content_type.startswith("image/") or filename.endswith(
+        (
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".webp",
+            ".gif",
+            ".bmp",
+            ".tif",
+            ".tiff",
+            ".heic",
+            ".heif",
+        )
+    )
+
+    scholarly_score = 0.0
+    if is_pdf:
+        scholarly_score += 0.2
+    if _ARXIV_FILENAME_RE.search(filename):
+        scholarly_score += 0.65
+    if _SCHOLARLY_TOKEN_RE.search(filename):
+        scholarly_score += 0.2
+    scholarly_score = min(0.99, scholarly_score)
+
+    cv_score = 0.0
+    if _CV_TOKEN_RE.search(filename):
+        cv_score += 0.72
+    if is_pdf:
+        cv_score += 0.2
+    if content_type in {
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/msword",
+    }:
+        cv_score += 0.15
+    cv_score = min(0.99, cv_score)
+
+    business_card_score = 0.0
+    if _BUSINESS_CARD_TOKEN_RE.search(filename):
+        business_card_score += 0.78
+    if is_image:
+        business_card_score += 0.16
+    if isinstance(size_bytes, int) and size_bytes > 0 and size_bytes < 3_000_000:
+        business_card_score += 0.05
+    business_card_score = min(0.99, business_card_score)
+
+    return {
+        ROUTE_KEY_SCHOLARLY: round(scholarly_score, 4),
+        ROUTE_KEY_CV: round(cv_score, 4),
+        ROUTE_KEY_BUSINESS_CARD: round(business_card_score, 4),
+    }
+
+
+def _select_primary_route(
+    scored: Mapping[str, float],
+    *,
+    minimum_score: float,
+) -> tuple[str, float]:
+    winner = ROUTE_KEY_INTERPRET
+    winner_score = 0.0
+    for key, value in scored.items():
+        if value > winner_score:
+            winner = key
+            winner_score = float(value)
+    if winner_score < minimum_score:
+        return ROUTE_KEY_INTERPRET, round(max(0.4, winner_score), 4)
+    return winner, round(winner_score, 4)
+
+
+def _build_classification_payload(raw: Mapping[str, Any]) -> dict[str, Any]:
+    filename = _normalise_filename(raw.get("original_filename"))
+    content_type = _normalise_content_type(raw.get("content_type"))
+    size_bytes = _coerce_int(raw.get("size_bytes"))
+    allow_interpret_fallback = _coerce_bool(
+        raw.get("allow_interpret_fallback"),
+        default=True,
+    )
+    min_route_score = _coerce_float(
+        raw.get("minimum_route_score"),
+        default=0.58,
+        minimum=0.2,
+        maximum=0.95,
+    )
+    min_mutation_confidence = _coerce_float(
+        raw.get("minimum_mutation_confidence"),
+        default=0.84,
+        minimum=0.5,
+        maximum=0.99,
+    )
+
+    forced_route = _extract_route_from_force_override(raw.get("force_route_key"))
+    scored = _resolve_score_candidates(
+        filename=filename,
+        content_type=content_type,
+        size_bytes=size_bytes,
+    )
+    route_key: str
+    route_confidence: float
+    reasons: list[str] = []
+    if forced_route is not None:
+        route_key = forced_route
+        route_confidence = 1.0
+        reasons.append("forced_route_override")
+    else:
+        route_key, route_confidence = _select_primary_route(
+            scored,
+            minimum_score=min_route_score,
+        )
+        reasons.append("heuristic_classifier")
+
+    available_workflow_ids = set(_resolve_available_workflow_ids(raw))
+    target_workflow_id: str | None = None
+    target_workflow_available = False
+    mutation_route = route_key in {
+        ROUTE_KEY_SCHOLARLY,
+        ROUTE_KEY_CV,
+        ROUTE_KEY_BUSINESS_CARD,
+    }
+
+    route_mode = ROUTE_MODE_INTERPRET
+    fail_closed = False
+    if route_key == ROUTE_KEY_NOOP:
+        route_mode = ROUTE_MODE_NOOP
+        reasons.append("noop_route_selected")
+    elif mutation_route:
+        candidates = _resolve_specialised_candidates(route_key=route_key, payload=raw)
+        for candidate in candidates:
+            if candidate in available_workflow_ids:
+                target_workflow_id = candidate
+                target_workflow_available = True
+                break
+
+        if not target_workflow_available:
+            reasons.append("specialised_workflow_unavailable")
+            mutation_route = False
+            route_mode = (
+                ROUTE_MODE_INTERPRET if allow_interpret_fallback else ROUTE_MODE_NOOP
+            )
+        else:
+            route_mode = ROUTE_MODE_SPECIALISED
+            if route_confidence < min_mutation_confidence:
+                fail_closed = True
+                route_mode = ROUTE_MODE_FAIL_CLOSED
+                reasons.append("mutation_route_confidence_below_threshold")
+    else:
+        route_mode = (
+            ROUTE_MODE_INTERPRET if allow_interpret_fallback else ROUTE_MODE_NOOP
+        )
+        if route_mode == ROUTE_MODE_NOOP:
+            reasons.append("interpret_fallback_disabled")
+
+    concept_id = _clean_text(raw.get("file_copy_concept_id")) or _clean_text(
+        raw.get("concept_id")
+    )
+    return {
+        "classification_version": FILE_COPY_UPLOAD_CLASSIFICATION_VERSION,
+        "classified_at": _utc_now_iso(),
+        "concept_id": concept_id or None,
+        "file_copy_concept_id": concept_id or None,
+        "route_key": route_key,
+        "route_mode": route_mode,
+        "route_confidence": route_confidence,
+        "minimum_route_score": min_route_score,
+        "minimum_mutation_confidence": min_mutation_confidence,
+        "mutation_route": bool(mutation_route),
+        "fail_closed": bool(fail_closed),
+        "target_workflow_id": target_workflow_id,
+        "target_workflow_available": bool(target_workflow_available),
+        "allow_interpret_fallback": bool(allow_interpret_fallback),
+        "route_reasons": list(reasons),
+        "scored_candidates": dict(scored),
+        "filename": filename or None,
+        "content_type": content_type or None,
+        "size_bytes": size_bytes,
+    }
+
+
+def _handle_classify_upload(request: WorkflowActionRequest) -> WorkflowActionResult:
+    combined: dict[str, Any] = dict(request.data or {})
+    combined.update(dict(request.inputs or {}))
+    decision = _build_classification_payload(combined)
+    return WorkflowActionResult(status="success", outputs=decision)
+
+
+def _handle_persist_route_decision(request: WorkflowActionRequest) -> WorkflowActionResult:
+    concept_id = _clean_text(request.data.get("file_copy_concept_id")) or _clean_text(
+        request.data.get("concept_id")
+    )
+    if not concept_id:
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "route_decision_persisted": False,
+                "route_decision_persist_error": "missing_file_copy_concept_id",
+            },
+        )
+
+    payload = {
+        "classification_version": str(
+            request.data.get("classification_version")
+            or FILE_COPY_UPLOAD_CLASSIFICATION_VERSION
+        ),
+        "classified_at": request.data.get("classified_at"),
+        "route_key": request.data.get("route_key"),
+        "route_mode": request.data.get("route_mode"),
+        "route_confidence": request.data.get("route_confidence"),
+        "minimum_route_score": request.data.get("minimum_route_score"),
+        "minimum_mutation_confidence": request.data.get("minimum_mutation_confidence"),
+        "mutation_route": bool(request.data.get("mutation_route")),
+        "fail_closed": bool(request.data.get("fail_closed")),
+        "target_workflow_id": request.data.get("target_workflow_id"),
+        "target_workflow_available": bool(request.data.get("target_workflow_available")),
+        "allow_interpret_fallback": bool(request.data.get("allow_interpret_fallback", True)),
+        "route_reasons": list(request.data.get("route_reasons") or []),
+        "scored_candidates": dict(request.data.get("scored_candidates") or {}),
+        "filename": request.data.get("filename"),
+        "content_type": request.data.get("content_type"),
+    }
+
+    try:
+        upsert = upsert_singleton_text_relation(
+            subject_concept_id=concept_id,
+            predicate=FILE_COPY_UPLOAD_ROUTE_DECISION_PREDICATE,
+            text=json.dumps(payload, ensure_ascii=False, sort_keys=True),
+            lang="en-NZ",
+            garbage_collect=True,
+            context={
+                "source": FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID,
+                "classification_version": FILE_COPY_UPLOAD_CLASSIFICATION_VERSION,
+            },
+        )
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "route_decision_persisted": True,
+                "route_decision_predicate": FILE_COPY_UPLOAD_ROUTE_DECISION_PREDICATE,
+                "route_decision_relation_id": (
+                    upsert.get("kept_relation_id") if isinstance(upsert, Mapping) else None
+                ),
+                "route_decision_replaced_count": (
+                    int(upsert.get("replaced_count") or 0)
+                    if isinstance(upsert, Mapping)
+                    else 0
+                ),
+            },
+        )
+    except Exception as exc:
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "route_decision_persisted": False,
+                "route_decision_persist_error": str(exc),
+                "route_decision_predicate": FILE_COPY_UPLOAD_ROUTE_DECISION_PREDICATE,
+            },
+        )
+
+
+def build_file_copy_upload_classification_workflow() -> WorkflowDefinition:
+    classify = WorkflowStateSpec(
+        state_id="classify",
+        actions=(
+            WorkflowActionInvocation(
+                action_id="file_copy_upload.classify",
+                description=(
+                    "Classify uploaded file-copy routing mode and confidence for "
+                    "workflow-first upload handling."
+                ),
+            ),
+        ),
+        transitions=(
+            WorkflowTransitionSpec(
+                to_state="persist_decision",
+                condition=lambda _ctx: True,
+                reason="classification_completed",
+            ),
+        ),
+    )
+
+    persist_decision = WorkflowStateSpec(
+        state_id="persist_decision",
+        actions=(
+            WorkflowActionInvocation(
+                action_id="file_copy_upload.persist_decision",
+                description=(
+                    "Persist upload route decision so branch-selection behaviour "
+                    "remains inspectable."
+                ),
+            ),
+        ),
+        transitions=(
+            WorkflowTransitionSpec(
+                to_state="complete",
+                condition=lambda _ctx: True,
+                reason="decision_persisted",
+            ),
+        ),
+    )
+
+    return WorkflowDefinition(
+        workflow_id=FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID,
+        initial_state="classify",
+        states={
+            "classify": classify,
+            "persist_decision": persist_decision,
+            "complete": WorkflowStateSpec(state_id="complete", terminal=True),
+            "failed": WorkflowStateSpec(state_id="failed", terminal=True),
+        },
+        termination_states=("complete", "failed"),
+        purpose=(
+            "Classify uploaded file copies for workflow routing with explicit "
+            "confidence guardrails and inspectable decision persistence."
+        ),
+    )
+
+
+def get_file_copy_upload_classification_workflow_registration() -> WorkflowRegistration:
+    return WorkflowRegistration(
+        workflow_id=FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID,
+        definition=build_file_copy_upload_classification_workflow(),
+        purpose=(
+            "Classify uploaded file copies and persist route decisions before "
+            "dispatching into specialised or baseline workflows."
+        ),
+        source="built_in",
+    )
+
+
+def register_file_copy_upload_classification_actions(registry: ActionRegistry) -> None:
+    registry.register_if_absent(
+        ActionSpec(
+            action_id="file_copy_upload.classify",
+            handler=_handle_classify_upload,
+            description="Classify uploaded file-copy routing mode and confidence.",
+        )
+    )
+    registry.register_if_absent(
+        ActionSpec(
+            action_id="file_copy_upload.persist_decision",
+            handler=_handle_persist_route_decision,
+            description=(
+                "Persist file-copy upload route decision as singleton text relation."
+            ),
+        )
+    )
+
+
+__all__ = [
+    "FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID",
+    "FILE_COPY_UPLOAD_ROUTE_DECISION_PREDICATE",
+    "FILE_COPY_UPLOAD_CLASSIFICATION_VERSION",
+    "build_file_copy_upload_classification_workflow",
+    "get_file_copy_upload_classification_workflow_registration",
+    "register_file_copy_upload_classification_actions",
+]

--- a/src/backend/workflows/durable/file_copy_upload_handler_workflow.py
+++ b/src/backend/workflows/durable/file_copy_upload_handler_workflow.py
@@ -1,0 +1,610 @@
+"""Durable workflow-first upload handler for file-copy uploads (JVNAUTOSCI-1309).
+
+The handler composes:
+1. a dedicated classification subworkflow,
+2. conditional routing to specialised workflows where available,
+3. fail-closed handling for low-confidence mutation routes, and
+4. persisted route outcomes for post-run inspection.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from typing import Any, Mapping
+
+from ...services.text_value_service import upsert_singleton_text_relation
+from ..action_registry import (
+    ActionRegistry,
+    ActionSpec,
+    WorkflowActionRequest,
+    WorkflowActionResult,
+)
+from ..engine import (
+    WorkflowActionInvocation,
+    WorkflowDefinition,
+    WorkflowStateSpec,
+    WorkflowTransitionSpec,
+)
+from ..subworkflow_contracts import (
+    WORKFLOW_SUBWORKFLOW_ACTION_ID,
+    WORKFLOW_SUBWORKFLOW_FAILURE_MODE_CAPTURE,
+)
+from ..workflow_registry import WorkflowRegistration
+from .file_copy_interpretation_workflow import FILE_COPY_INTERPRETATION_WORKFLOW_ID
+from .file_copy_upload_classification_workflow import (
+    FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID,
+    FILE_COPY_UPLOAD_CLASSIFICATION_VERSION,
+)
+
+FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID = "#V#file_copy_upload_handler_workflow"
+FILE_COPY_UPLOAD_ROUTE_OUTCOME_PREDICATE = "#V#has_file_copy_upload_route_outcome_json"
+FILE_COPY_UPLOAD_HANDLER_VERSION = "file_copy_upload_handler.v1"
+
+_FILE_COPY_CONTEXT_INPUTS = {
+    "concept_id": {
+        "$context_key": "concept_id",
+        "$mapping_concept_id": "#V#workflow_mapping_concept_id_to_concept_id_parameter",
+    },
+    "file_copy_concept_id": {
+        "$context_key": "file_copy_concept_id",
+        "$mapping_concept_id": "#V#workflow_mapping_file_copy_concept_id_to_file_copy_concept_id_parameter",
+    },
+    "content_type": {"$context_key": "content_type"},
+    "original_filename": {"$context_key": "original_filename"},
+    "size_bytes": {"$context_key": "size_bytes"},
+    "sha256": {"$context_key": "sha256"},
+    "blob_uri": {"$context_key": "blob_uri"},
+    "uploaded_at": {"$context_key": "uploaded_at"},
+    "index_in_rag": {"$context_key": "index_in_rag"},
+}
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _clean_text(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
+
+def _as_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _map_from_subworkflow_result(
+    *,
+    outputs: dict[str, Any],
+    prefix: str,
+) -> dict[str, Any]:
+    payload = dict(outputs)
+    mapped: dict[str, Any] = {}
+    for key, value in payload.items():
+        mapped[f"{prefix}{key}"] = value
+    return mapped
+
+
+def _handle_mark_noop(_request: WorkflowActionRequest) -> WorkflowActionResult:
+    return WorkflowActionResult(
+        status="success",
+        outputs={
+            "upload_effective_route_mode": "noop",
+            "upload_route_success": True,
+            "upload_route_terminal_reason": "noop_route_selected",
+        },
+    )
+
+
+def _handle_mark_fail_closed(request: WorkflowActionRequest) -> WorkflowActionResult:
+    reason = _clean_text(request.data.get("upload_route_reasons"))
+    if not reason:
+        reason = "low_confidence_mutation_route"
+    return WorkflowActionResult(
+        status="success",
+        outputs={
+            "upload_effective_route_mode": "fail_closed",
+            "upload_route_success": False,
+            "upload_fail_closed_applied": True,
+            "upload_route_terminal_reason": reason,
+        },
+    )
+
+
+def _handle_mark_specialised_failure(
+    request: WorkflowActionRequest,
+) -> WorkflowActionResult:
+    error = _clean_text(request.data.get("upload_specialised_error")) or "specialised_failed"
+    return WorkflowActionResult(
+        status="success",
+        outputs={
+            "upload_specialised_fallback_triggered": True,
+            "upload_route_success": False,
+            "upload_route_terminal_reason": error,
+        },
+    )
+
+
+def _resolve_effective_mode(data: Mapping[str, Any]) -> str:
+    explicit = _clean_text(data.get("upload_effective_route_mode"))
+    if explicit:
+        return explicit
+
+    selected_mode = _clean_text(data.get("upload_route_mode"))
+    fallback_triggered = bool(data.get("upload_specialised_fallback_triggered"))
+    interpret_attempted = bool(_clean_text(data.get("upload_interpret_workflow_id")))
+    if fallback_triggered and interpret_attempted:
+        return "interpret_after_specialised_failure"
+    if fallback_triggered:
+        return "specialised_failed"
+    if selected_mode:
+        return selected_mode
+    return "interpret"
+
+
+def _resolve_route_success(data: Mapping[str, Any], effective_mode: str) -> bool:
+    explicit_success = data.get("upload_route_success")
+    if isinstance(explicit_success, bool):
+        return explicit_success
+
+    if effective_mode in {"fail_closed", "specialised_failed"}:
+        return False
+    if effective_mode == "noop":
+        return True
+    if effective_mode in {"interpret", "interpret_after_specialised_failure"}:
+        return not bool(data.get("upload_interpret_child_failed"))
+    if effective_mode == "specialised":
+        return not bool(data.get("upload_specialised_child_failed"))
+    return not bool(data.get("last_action_failed"))
+
+
+def _resolve_final_workflow_id(data: Mapping[str, Any]) -> str | None:
+    for key in (
+        "upload_interpret_workflow_id",
+        "upload_specialised_workflow_id",
+        "upload_target_workflow_id",
+    ):
+        token = _clean_text(data.get(key))
+        if token:
+            return token
+    return None
+
+
+def _handle_persist_route_outcome(request: WorkflowActionRequest) -> WorkflowActionResult:
+    concept_id = _clean_text(request.data.get("file_copy_concept_id")) or _clean_text(
+        request.data.get("concept_id")
+    )
+    if not concept_id:
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "upload_route_outcome_persisted": False,
+                "upload_route_outcome_persist_error": "missing_file_copy_concept_id",
+            },
+        )
+
+    effective_mode = _resolve_effective_mode(request.data)
+    route_success = _resolve_route_success(request.data, effective_mode)
+    final_workflow_id = _resolve_final_workflow_id(request.data)
+    route_reasons_raw = request.data.get("upload_route_reasons")
+    route_reasons: list[str] = []
+    if isinstance(route_reasons_raw, list):
+        route_reasons = [
+            str(item).strip()
+            for item in route_reasons_raw
+            if isinstance(item, str) and str(item).strip()
+        ]
+
+    payload = {
+        "handler_version": FILE_COPY_UPLOAD_HANDLER_VERSION,
+        "classification_version": str(
+            request.data.get("classification_version")
+            or FILE_COPY_UPLOAD_CLASSIFICATION_VERSION
+        ),
+        "recorded_at": _utc_now_iso(),
+        "route_key": request.data.get("upload_route_key"),
+        "selected_route_mode": request.data.get("upload_route_mode"),
+        "effective_route_mode": effective_mode,
+        "route_confidence": request.data.get("upload_route_confidence"),
+        "minimum_mutation_confidence": request.data.get(
+            "upload_minimum_mutation_confidence"
+        ),
+        "mutation_route": bool(request.data.get("upload_mutation_route")),
+        "fail_closed": bool(request.data.get("upload_fail_closed")),
+        "route_success": bool(route_success),
+        "route_reasons": route_reasons,
+        "decision_persisted": bool(request.data.get("upload_route_decision_persisted")),
+        "target_workflow_id": request.data.get("upload_target_workflow_id"),
+        "target_workflow_available": bool(
+            request.data.get("upload_target_workflow_available")
+        ),
+        "final_executed_workflow_id": final_workflow_id,
+        "specialised_child_failed": bool(request.data.get("upload_specialised_child_failed")),
+        "specialised_error": request.data.get("upload_specialised_error"),
+        "specialised_final_state": request.data.get("upload_specialised_final_state"),
+        "interpret_child_failed": bool(request.data.get("upload_interpret_child_failed")),
+        "interpret_error": request.data.get("upload_interpret_error"),
+        "interpret_final_state": request.data.get("upload_interpret_final_state"),
+        "specialised_fallback_triggered": bool(
+            request.data.get("upload_specialised_fallback_triggered")
+        ),
+    }
+
+    try:
+        upsert = upsert_singleton_text_relation(
+            subject_concept_id=concept_id,
+            predicate=FILE_COPY_UPLOAD_ROUTE_OUTCOME_PREDICATE,
+            text=json.dumps(payload, ensure_ascii=False, sort_keys=True),
+            lang="en-NZ",
+            garbage_collect=True,
+            context={
+                "source": FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
+                "handler_version": FILE_COPY_UPLOAD_HANDLER_VERSION,
+            },
+        )
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "upload_route_outcome_persisted": True,
+                "upload_route_outcome_predicate": FILE_COPY_UPLOAD_ROUTE_OUTCOME_PREDICATE,
+                "upload_route_outcome_relation_id": (
+                    upsert.get("kept_relation_id") if isinstance(upsert, Mapping) else None
+                ),
+                "upload_route_outcome_replaced_count": (
+                    int(upsert.get("replaced_count") or 0)
+                    if isinstance(upsert, Mapping)
+                    else 0
+                ),
+                "upload_effective_route_mode": effective_mode,
+                "upload_route_success": route_success,
+                "upload_final_executed_workflow_id": final_workflow_id,
+            },
+        )
+    except Exception as exc:
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "upload_route_outcome_persisted": False,
+                "upload_route_outcome_predicate": FILE_COPY_UPLOAD_ROUTE_OUTCOME_PREDICATE,
+                "upload_route_outcome_persist_error": str(exc),
+                "upload_effective_route_mode": effective_mode,
+                "upload_route_success": route_success,
+                "upload_final_executed_workflow_id": final_workflow_id,
+            },
+        )
+
+
+def build_file_copy_upload_handler_workflow() -> WorkflowDefinition:
+    classify = WorkflowStateSpec(
+        state_id="classify",
+        actions=(
+            WorkflowActionInvocation(
+                action_id=WORKFLOW_SUBWORKFLOW_ACTION_ID,
+                inputs={
+                    **dict(_FILE_COPY_CONTEXT_INPUTS),
+                    "workflow_id": FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID,
+                    "failure_mode": WORKFLOW_SUBWORKFLOW_FAILURE_MODE_CAPTURE,
+                    "minimum_route_score": {"$context_key": "minimum_route_score"},
+                    "minimum_mutation_confidence": {
+                        "$context_key": "minimum_mutation_confidence"
+                    },
+                    "force_route_key": {"$context_key": "force_route_key"},
+                    "allow_interpret_fallback": {
+                        "$context_key": "allow_interpret_fallback"
+                    },
+                    "scholarly_workflow_id": {
+                        "$context_key": "scholarly_workflow_id"
+                    },
+                    "cv_workflow_id": {"$context_key": "cv_workflow_id"},
+                    "business_card_workflow_id": {
+                        "$context_key": "business_card_workflow_id"
+                    },
+                },
+                description=(
+                    "Invoke file-copy upload classification subworkflow to "
+                    "determine route mode and confidence."
+                ),
+            ),
+        ),
+        metadata={
+            "tool_output_context_mappings": [
+                {"tool_output_field": "result.classification_version", "context_key": "classification_version"},
+                {"tool_output_field": "result.route_key", "context_key": "upload_route_key"},
+                {"tool_output_field": "result.route_mode", "context_key": "upload_route_mode"},
+                {"tool_output_field": "result.route_confidence", "context_key": "upload_route_confidence"},
+                {"tool_output_field": "result.minimum_mutation_confidence", "context_key": "upload_minimum_mutation_confidence"},
+                {"tool_output_field": "result.minimum_route_score", "context_key": "upload_minimum_route_score"},
+                {"tool_output_field": "result.route_reasons", "context_key": "upload_route_reasons"},
+                {"tool_output_field": "result.mutation_route", "context_key": "upload_mutation_route"},
+                {"tool_output_field": "result.fail_closed", "context_key": "upload_fail_closed"},
+                {"tool_output_field": "result.target_workflow_id", "context_key": "upload_target_workflow_id"},
+                {"tool_output_field": "result.target_workflow_available", "context_key": "upload_target_workflow_available"},
+                {"tool_output_field": "result.allow_interpret_fallback", "context_key": "upload_allow_interpret_fallback"},
+                {"tool_output_field": "result.route_decision_persisted", "context_key": "upload_route_decision_persisted"},
+                {"tool_output_field": "child_workflow_failed", "context_key": "upload_classifier_child_failed"},
+                {"tool_output_field": "subworkflow_error", "context_key": "upload_classifier_error"},
+            ]
+        },
+        transitions=(
+            WorkflowTransitionSpec(
+                to_state="fail_closed",
+                condition=lambda ctx: bool(ctx.get("upload_fail_closed")),
+                reason="fail_closed_selected",
+            ),
+            WorkflowTransitionSpec(
+                to_state="specialised",
+                condition=lambda ctx: (
+                    str(ctx.get("upload_route_mode") or "").strip().lower()
+                    == "specialised"
+                    and bool(str(ctx.get("upload_target_workflow_id") or "").strip())
+                ),
+                reason="specialised_route_selected",
+            ),
+            WorkflowTransitionSpec(
+                to_state="interpret",
+                condition=lambda ctx: (
+                    str(ctx.get("upload_route_mode") or "").strip().lower() == "interpret"
+                ),
+                reason="interpret_route_selected",
+            ),
+            WorkflowTransitionSpec(
+                to_state="noop",
+                condition=lambda ctx: (
+                    str(ctx.get("upload_route_mode") or "").strip().lower() == "noop"
+                ),
+                reason="noop_route_selected",
+            ),
+            WorkflowTransitionSpec(
+                to_state="interpret",
+                condition=lambda ctx: _as_bool(
+                    ctx.get("upload_allow_interpret_fallback"),
+                    default=True,
+                ),
+                reason="fallback_interpret_default",
+            ),
+            WorkflowTransitionSpec(
+                to_state="noop",
+                condition=lambda _ctx: True,
+                reason="fallback_noop_default",
+            ),
+        ),
+    )
+
+    specialised = WorkflowStateSpec(
+        state_id="specialised",
+        actions=(
+            WorkflowActionInvocation(
+                action_id=WORKFLOW_SUBWORKFLOW_ACTION_ID,
+                inputs={
+                    **dict(_FILE_COPY_CONTEXT_INPUTS),
+                    "workflow_id": {"$context_key": "upload_target_workflow_id"},
+                    "failure_mode": WORKFLOW_SUBWORKFLOW_FAILURE_MODE_CAPTURE,
+                },
+                description=(
+                    "Invoke specialised workflow selected by upload "
+                    "classification route."
+                ),
+            ),
+        ),
+        metadata={
+            "tool_output_context_mappings": [
+                {"tool_output_field": "child_workflow_failed", "context_key": "upload_specialised_child_failed"},
+                {"tool_output_field": "subworkflow_error", "context_key": "upload_specialised_error"},
+                {"tool_output_field": "subworkflow_invocation.child_workflow_id", "context_key": "upload_specialised_workflow_id"},
+                {"tool_output_field": "subworkflow_invocation.child_final_state", "context_key": "upload_specialised_final_state"},
+            ]
+        },
+        transitions=(
+            WorkflowTransitionSpec(
+                to_state="specialised_failed",
+                condition=lambda ctx: bool(ctx.get("upload_specialised_child_failed")),
+                reason="specialised_child_failed",
+            ),
+            WorkflowTransitionSpec(
+                to_state="record_outcome",
+                condition=lambda _ctx: True,
+                reason="specialised_completed",
+            ),
+        ),
+    )
+
+    specialised_failed = WorkflowStateSpec(
+        state_id="specialised_failed",
+        actions=(
+            WorkflowActionInvocation(
+                action_id="file_copy_upload.mark_specialised_failure",
+                description=(
+                    "Record specialised-route failure and optionally fall back "
+                    "to baseline interpretation."
+                ),
+            ),
+        ),
+        transitions=(
+            WorkflowTransitionSpec(
+                to_state="interpret",
+                condition=lambda ctx: _as_bool(
+                    ctx.get("upload_allow_interpret_fallback"),
+                    default=True,
+                ),
+                reason="fallback_to_interpret",
+            ),
+            WorkflowTransitionSpec(
+                to_state="record_outcome",
+                condition=lambda _ctx: True,
+                reason="no_fallback_after_specialised_failure",
+            ),
+        ),
+    )
+
+    interpret = WorkflowStateSpec(
+        state_id="interpret",
+        actions=(
+            WorkflowActionInvocation(
+                action_id=WORKFLOW_SUBWORKFLOW_ACTION_ID,
+                inputs={
+                    **dict(_FILE_COPY_CONTEXT_INPUTS),
+                    "workflow_id": FILE_COPY_INTERPRETATION_WORKFLOW_ID,
+                    "failure_mode": WORKFLOW_SUBWORKFLOW_FAILURE_MODE_CAPTURE,
+                },
+                description=(
+                    "Invoke baseline file-copy interpretation workflow for "
+                    "safe non-specialised handling."
+                ),
+            ),
+        ),
+        metadata={
+            "tool_output_context_mappings": [
+                {"tool_output_field": "child_workflow_failed", "context_key": "upload_interpret_child_failed"},
+                {"tool_output_field": "subworkflow_error", "context_key": "upload_interpret_error"},
+                {"tool_output_field": "subworkflow_invocation.child_workflow_id", "context_key": "upload_interpret_workflow_id"},
+                {"tool_output_field": "subworkflow_invocation.child_final_state", "context_key": "upload_interpret_final_state"},
+            ]
+        },
+        transitions=(
+            WorkflowTransitionSpec(
+                to_state="record_outcome",
+                condition=lambda _ctx: True,
+                reason="interpret_completed",
+            ),
+        ),
+    )
+
+    noop = WorkflowStateSpec(
+        state_id="noop",
+        actions=(
+            WorkflowActionInvocation(
+                action_id="file_copy_upload.mark_noop",
+                description="Record explicit no-op route for unsupported uploads.",
+            ),
+        ),
+        transitions=(
+            WorkflowTransitionSpec(
+                to_state="record_outcome",
+                condition=lambda _ctx: True,
+                reason="noop_recorded",
+            ),
+        ),
+    )
+
+    fail_closed = WorkflowStateSpec(
+        state_id="fail_closed",
+        actions=(
+            WorkflowActionInvocation(
+                action_id="file_copy_upload.mark_fail_closed",
+                description=(
+                    "Fail closed for low-confidence mutation routes instead of "
+                    "executing specialised mutations."
+                ),
+            ),
+        ),
+        transitions=(
+            WorkflowTransitionSpec(
+                to_state="record_outcome",
+                condition=lambda _ctx: True,
+                reason="fail_closed_recorded",
+            ),
+        ),
+    )
+
+    record_outcome = WorkflowStateSpec(
+        state_id="record_outcome",
+        actions=(
+            WorkflowActionInvocation(
+                action_id="file_copy_upload.persist_route_outcome",
+                description=(
+                    "Persist final upload route outcome for inspectability and "
+                    "post-run diagnostics."
+                ),
+            ),
+        ),
+        transitions=(
+            WorkflowTransitionSpec(
+                to_state="complete",
+                condition=lambda _ctx: True,
+                reason="outcome_persisted",
+            ),
+        ),
+    )
+
+    return WorkflowDefinition(
+        workflow_id=FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
+        initial_state="classify",
+        states={
+            "classify": classify,
+            "specialised": specialised,
+            "specialised_failed": specialised_failed,
+            "interpret": interpret,
+            "noop": noop,
+            "fail_closed": fail_closed,
+            "record_outcome": record_outcome,
+            "complete": WorkflowStateSpec(state_id="complete", terminal=True),
+            "failed": WorkflowStateSpec(state_id="failed", terminal=True),
+        },
+        termination_states=("complete", "failed"),
+        purpose=(
+            "Workflow-first file upload handler with classification subworkflow, "
+            "specialised routing, fail-closed guardrails, and inspectable outcomes."
+        ),
+    )
+
+
+def get_file_copy_upload_handler_workflow_registration() -> WorkflowRegistration:
+    return WorkflowRegistration(
+        workflow_id=FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
+        definition=build_file_copy_upload_handler_workflow(),
+        purpose=(
+            "General workflow-first upload handler that routes file copies into "
+            "specialised or baseline interpretation workflows."
+        ),
+        source="built_in",
+    )
+
+
+def register_file_copy_upload_handler_actions(registry: ActionRegistry) -> None:
+    registry.register_if_absent(
+        ActionSpec(
+            action_id="file_copy_upload.mark_noop",
+            handler=_handle_mark_noop,
+            description="Record explicit no-op route outcome.",
+        )
+    )
+    registry.register_if_absent(
+        ActionSpec(
+            action_id="file_copy_upload.mark_fail_closed",
+            handler=_handle_mark_fail_closed,
+            description="Record fail-closed route outcome.",
+        )
+    )
+    registry.register_if_absent(
+        ActionSpec(
+            action_id="file_copy_upload.mark_specialised_failure",
+            handler=_handle_mark_specialised_failure,
+            description="Record specialised route failure before fallback.",
+        )
+    )
+    registry.register_if_absent(
+        ActionSpec(
+            action_id="file_copy_upload.persist_route_outcome",
+            handler=_handle_persist_route_outcome,
+            description="Persist final upload route outcome as singleton text relation.",
+        )
+    )
+
+
+__all__ = [
+    "FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID",
+    "FILE_COPY_UPLOAD_ROUTE_OUTCOME_PREDICATE",
+    "FILE_COPY_UPLOAD_HANDLER_VERSION",
+    "build_file_copy_upload_handler_workflow",
+    "get_file_copy_upload_handler_workflow_registration",
+    "register_file_copy_upload_handler_actions",
+]

--- a/src/backend/workflows/durable/registry_factory.py
+++ b/src/backend/workflows/durable/registry_factory.py
@@ -11,6 +11,7 @@ See JVNAUTOSCI-922 Phase 1 for the motivation and design.
 from __future__ import annotations
 
 import copy
+from functools import lru_cache
 import logging
 import os
 from datetime import datetime, timezone
@@ -42,6 +43,14 @@ from .workflow_introspection_maintenance_workflow import (
 from .file_copy_interpretation_workflow import (
     get_file_copy_interpretation_workflow_registration,
     register_file_copy_interpretation_actions,
+)
+from .file_copy_upload_classification_workflow import (
+    get_file_copy_upload_classification_workflow_registration,
+    register_file_copy_upload_classification_actions,
+)
+from .file_copy_upload_handler_workflow import (
+    get_file_copy_upload_handler_workflow_registration,
+    register_file_copy_upload_handler_actions,
 )
 from .entity_identity_resolution_workflow import (
     get_entity_identity_resolution_workflow_registration,
@@ -412,6 +421,8 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
     registry.register(get_rumination_workflow_registration())
     registry.register(get_planning_workflow_registration())
     registry.register(get_workflow_introspection_maintenance_registration())
+    registry.register(get_file_copy_upload_classification_workflow_registration())
+    registry.register(get_file_copy_upload_handler_workflow_registration())
     registry.register(get_file_copy_interpretation_workflow_registration())
     registry.register(get_entity_identity_resolution_workflow_registration())
 
@@ -546,11 +557,35 @@ def build_durable_action_registry() -> ActionRegistry:
     register_rumination_actions(registry)
     register_planning_actions(registry)
     register_workflow_introspection_maintenance_actions(registry)
+    register_file_copy_upload_classification_actions(registry)
+    register_file_copy_upload_handler_actions(registry)
     register_file_copy_interpretation_actions(registry)
     register_entity_identity_resolution_actions(registry)
-    register_subworkflow_actions(registry)
+    register_subworkflow_actions(registry, definition_loader=_resolve_subworkflow_definition)
     register_workflow_creation_actions(registry)
     # Keep durable action routing aligned with orchestrator routing: if an
     # action ID is not explicitly registered, treat it as an MCP tool name.
     registry.set_fallback_handler(_durable_mcp_fallback_action)
     return registry
+
+
+@lru_cache(maxsize=128)
+def _resolve_subworkflow_definition(workflow_id: str):
+    """Resolve subworkflow definitions from registry first, then Vontology loader.
+
+    This keeps built-in durable subworkflow composition runnable even when
+    Vontology publication is unavailable or intentionally read-only in tests.
+    """
+    workflow_id_clean = str(workflow_id or "").strip()
+    if not workflow_id_clean:
+        return None
+
+    try:
+        registry = build_workflow_registry_read_only()
+        definition = registry.get(workflow_id_clean)
+        if definition is not None:
+            return definition
+    except Exception:
+        definition = None
+
+    return load_workflow_definition_from_vontology(workflow_id_clean)

--- a/src/backend/workflows/workflow_concept_authority_service.py
+++ b/src/backend/workflows/workflow_concept_authority_service.py
@@ -43,6 +43,10 @@ logger = logging.getLogger(__name__)
 # ``workflows.durable`` during authority bootstrap (that path imports registry
 # factory and can create circular imports).
 FILE_COPY_INTERPRETATION_WORKFLOW_ID = "#V#file_copy_interpretation_workflow"
+FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID = (
+    "#V#file_copy_upload_classification_workflow"
+)
+FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID = "#V#file_copy_upload_handler_workflow"
 WORKFLOW_CREATION_WORKFLOW_ID = "#V#von_workflow_creation_workflow"
 
 WORKFLOW_CREATION_STEP_IDENTIFY_NEED = "#V#workflow_creation_step_identify_need"
@@ -329,6 +333,68 @@ _CANONICAL_WORKFLOW_PUBLICATION_SPECS: Dict[str, _CanonicalWorkflowPublicationSp
                 next_state="completed",
             ),
             _CanonicalStepPublicationSpec(state_id="completed"),
+        ),
+    ),
+    FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID: _CanonicalWorkflowPublicationSpec(
+        initial_state="classify",
+        steps=(
+            _CanonicalStepPublicationSpec(
+                state_id="classify",
+                action_id="file_copy_upload.classify",
+                next_state="persist_decision",
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="persist_decision",
+                action_id="file_copy_upload.persist_decision",
+                next_state="complete",
+            ),
+            _CanonicalStepPublicationSpec(state_id="complete"),
+            _CanonicalStepPublicationSpec(state_id="failed"),
+        ),
+    ),
+    FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID: _CanonicalWorkflowPublicationSpec(
+        initial_state="classify",
+        steps=(
+            _CanonicalStepPublicationSpec(
+                state_id="classify",
+                action_id="workflow_invoke_subworkflow",
+                on_true_state="specialised",
+                on_false_state="interpret",
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="specialised",
+                action_id="workflow_invoke_subworkflow",
+                on_true_state="record_outcome",
+                on_false_state="specialised_failed",
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="specialised_failed",
+                action_id="file_copy_upload.mark_specialised_failure",
+                on_true_state="interpret",
+                on_false_state="record_outcome",
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="interpret",
+                action_id="workflow_invoke_subworkflow",
+                next_state="record_outcome",
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="noop",
+                action_id="file_copy_upload.mark_noop",
+                next_state="record_outcome",
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="fail_closed",
+                action_id="file_copy_upload.mark_fail_closed",
+                next_state="record_outcome",
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="record_outcome",
+                action_id="file_copy_upload.persist_route_outcome",
+                next_state="complete",
+            ),
+            _CanonicalStepPublicationSpec(state_id="complete"),
+            _CanonicalStepPublicationSpec(state_id="failed"),
         ),
     ),
     FILE_COPY_INTERPRETATION_WORKFLOW_ID: _CanonicalWorkflowPublicationSpec(

--- a/tests/backend/test_file_copy_upload_classification_workflow.py
+++ b/tests/backend/test_file_copy_upload_classification_workflow.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+
+from src.backend.workflows.action_registry import ActionRegistry, WorkflowEnvironment
+from src.backend.workflows.durable.file_copy_upload_classification_workflow import (
+    DEFAULT_SCHOLARLY_WORKFLOW_ID,
+    FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID,
+    FILE_COPY_UPLOAD_ROUTE_DECISION_PREDICATE,
+    build_file_copy_upload_classification_workflow,
+    register_file_copy_upload_classification_actions,
+)
+
+
+def test_build_file_copy_upload_classification_workflow_definition_shape() -> None:
+    workflow = build_file_copy_upload_classification_workflow()
+
+    assert workflow.workflow_id == FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID
+    assert workflow.initial_state == "classify"
+    assert set(workflow.states.keys()) == {
+        "classify",
+        "persist_decision",
+        "complete",
+        "failed",
+    }
+    assert workflow.termination_states == ("complete", "failed")
+    assert [a.action_id for a in workflow.states["classify"].actions] == [
+        "file_copy_upload.classify"
+    ]
+    assert [a.action_id for a in workflow.states["persist_decision"].actions] == [
+        "file_copy_upload.persist_decision"
+    ]
+
+
+def test_classification_selects_specialised_route_when_confident(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.file_copy_upload_classification_workflow._resolve_available_workflow_ids",
+        lambda _payload: (DEFAULT_SCHOLARLY_WORKFLOW_ID,),
+    )
+    registry = ActionRegistry()
+    register_file_copy_upload_classification_actions(registry)
+
+    context: dict[str, object] = {
+        "file_copy_concept_id": "#V#file_copy_1",
+        "original_filename": "2502.14996.pdf",
+        "content_type": "application/pdf",
+        "minimum_mutation_confidence": 0.8,
+    }
+    result = registry.execute(
+        "file_copy_upload.classify",
+        inputs={},
+        context=context,
+        env=WorkflowEnvironment(llm_client=None),
+    )
+
+    assert result.status == "success"
+    assert result.outputs["route_key"] == "scholarly"
+    assert result.outputs["route_mode"] == "specialised"
+    assert result.outputs["mutation_route"] is True
+    assert result.outputs["target_workflow_available"] is True
+    assert result.outputs["target_workflow_id"] == DEFAULT_SCHOLARLY_WORKFLOW_ID
+
+
+def test_classification_fail_closes_low_confidence_mutation_route(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.file_copy_upload_classification_workflow._resolve_available_workflow_ids",
+        lambda _payload: (DEFAULT_SCHOLARLY_WORKFLOW_ID,),
+    )
+    registry = ActionRegistry()
+    register_file_copy_upload_classification_actions(registry)
+
+    context: dict[str, object] = {
+        "file_copy_concept_id": "#V#file_copy_2",
+        "original_filename": "2502.14996.pdf",
+        "content_type": "application/pdf",
+        "minimum_mutation_confidence": 0.95,
+    }
+    result = registry.execute(
+        "file_copy_upload.classify",
+        inputs={},
+        context=context,
+        env=WorkflowEnvironment(llm_client=None),
+    )
+
+    assert result.status == "success"
+    assert result.outputs["route_key"] == "scholarly"
+    assert result.outputs["route_mode"] == "fail_closed"
+    assert result.outputs["fail_closed"] is True
+    assert "mutation_route_confidence_below_threshold" in result.outputs["route_reasons"]
+
+
+def test_persist_route_decision_writes_singleton_text_relation(monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def _fake_upsert_singleton_text_relation(**kwargs):
+        calls.append(dict(kwargs))
+        return {"kept_relation_id": "rel-1", "replaced_count": 0}
+
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.file_copy_upload_classification_workflow.upsert_singleton_text_relation",
+        _fake_upsert_singleton_text_relation,
+    )
+    registry = ActionRegistry()
+    register_file_copy_upload_classification_actions(registry)
+
+    context: dict[str, object] = {
+        "file_copy_concept_id": "#V#file_copy_3",
+        "classification_version": "file_copy_upload_classification.v1",
+        "route_key": "cv",
+        "route_mode": "specialised",
+        "route_confidence": 0.9,
+        "target_workflow_id": "#V#file_copy_cv_representation_workflow",
+        "target_workflow_available": True,
+        "route_reasons": ["heuristic_classifier"],
+        "scored_candidates": {"cv": 0.9},
+    }
+    result = registry.execute(
+        "file_copy_upload.persist_decision",
+        inputs={},
+        context=context,
+        env=WorkflowEnvironment(llm_client=None),
+    )
+
+    assert result.status == "success"
+    assert result.outputs["route_decision_persisted"] is True
+    assert result.outputs["route_decision_predicate"] == FILE_COPY_UPLOAD_ROUTE_DECISION_PREDICATE
+    assert len(calls) == 1
+    assert calls[0]["subject_concept_id"] == "#V#file_copy_3"
+    assert calls[0]["predicate"] == FILE_COPY_UPLOAD_ROUTE_DECISION_PREDICATE
+    persisted = json.loads(str(calls[0]["text"]))
+    assert persisted["route_key"] == "cv"
+    assert persisted["route_mode"] == "specialised"

--- a/tests/backend/test_file_copy_upload_handler_workflow.py
+++ b/tests/backend/test_file_copy_upload_handler_workflow.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+
+from src.backend.workflows.action_registry import ActionRegistry, WorkflowEnvironment
+from src.backend.workflows.durable.file_copy_upload_handler_workflow import (
+    FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
+    FILE_COPY_UPLOAD_ROUTE_OUTCOME_PREDICATE,
+    build_file_copy_upload_handler_workflow,
+    register_file_copy_upload_handler_actions,
+)
+
+
+def test_build_file_copy_upload_handler_workflow_definition_shape() -> None:
+    workflow = build_file_copy_upload_handler_workflow()
+
+    assert workflow.workflow_id == FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID
+    assert workflow.initial_state == "classify"
+    assert set(workflow.states.keys()) == {
+        "classify",
+        "specialised",
+        "specialised_failed",
+        "interpret",
+        "noop",
+        "fail_closed",
+        "record_outcome",
+        "complete",
+        "failed",
+    }
+    assert workflow.termination_states == ("complete", "failed")
+    assert [a.action_id for a in workflow.states["fail_closed"].actions] == [
+        "file_copy_upload.mark_fail_closed"
+    ]
+    assert [a.action_id for a in workflow.states["record_outcome"].actions] == [
+        "file_copy_upload.persist_route_outcome"
+    ]
+
+
+def test_register_file_copy_upload_handler_actions_registers_expected_ids() -> None:
+    registry = ActionRegistry()
+    register_file_copy_upload_handler_actions(registry)
+    assert set(registry.all_action_ids()) == {
+        "file_copy_upload.mark_noop",
+        "file_copy_upload.mark_fail_closed",
+        "file_copy_upload.mark_specialised_failure",
+        "file_copy_upload.persist_route_outcome",
+    }
+
+
+def test_mark_fail_closed_action_sets_fail_closed_outputs() -> None:
+    registry = ActionRegistry()
+    register_file_copy_upload_handler_actions(registry)
+    context: dict[str, object] = {"upload_route_reasons": ["confidence_below_threshold"]}
+    result = registry.execute(
+        "file_copy_upload.mark_fail_closed",
+        inputs={},
+        context=context,
+        env=WorkflowEnvironment(llm_client=None),
+    )
+
+    assert result.status == "success"
+    assert result.outputs["upload_effective_route_mode"] == "fail_closed"
+    assert result.outputs["upload_fail_closed_applied"] is True
+    assert result.outputs["upload_route_success"] is False
+
+
+def test_persist_route_outcome_writes_singleton_text_relation(monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def _fake_upsert_singleton_text_relation(**kwargs):
+        calls.append(dict(kwargs))
+        return {"kept_relation_id": "rel-2", "replaced_count": 1}
+
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.file_copy_upload_handler_workflow.upsert_singleton_text_relation",
+        _fake_upsert_singleton_text_relation,
+    )
+
+    registry = ActionRegistry()
+    register_file_copy_upload_handler_actions(registry)
+    context: dict[str, object] = {
+        "file_copy_concept_id": "#V#file_copy_77",
+        "classification_version": "file_copy_upload_classification.v1",
+        "upload_route_key": "scholarly",
+        "upload_route_mode": "specialised",
+        "upload_route_confidence": 0.83,
+        "upload_minimum_mutation_confidence": 0.9,
+        "upload_mutation_route": True,
+        "upload_fail_closed": True,
+        "upload_route_reasons": ["mutation_route_confidence_below_threshold"],
+        "upload_route_decision_persisted": True,
+        "upload_target_workflow_id": "#V#integration_scholarly_paper_representation_workflow",
+        "upload_target_workflow_available": True,
+        "upload_effective_route_mode": "fail_closed",
+    }
+    result = registry.execute(
+        "file_copy_upload.persist_route_outcome",
+        inputs={},
+        context=context,
+        env=WorkflowEnvironment(llm_client=None),
+    )
+
+    assert result.status == "success"
+    assert result.outputs["upload_route_outcome_persisted"] is True
+    assert result.outputs["upload_effective_route_mode"] == "fail_closed"
+    assert result.outputs["upload_route_success"] is False
+    assert len(calls) == 1
+    assert calls[0]["subject_concept_id"] == "#V#file_copy_77"
+    assert calls[0]["predicate"] == FILE_COPY_UPLOAD_ROUTE_OUTCOME_PREDICATE
+    payload = json.loads(str(calls[0]["text"]))
+    assert payload["effective_route_mode"] == "fail_closed"
+    assert payload["route_success"] is False

--- a/tests/backend/test_internal_mcp_workflow_tools.py
+++ b/tests/backend/test_internal_mcp_workflow_tools.py
@@ -477,6 +477,8 @@ def test_workflow_list_definitions_exists_and_returns_data():
     assert "#V#rag_text_relation_sync_workflow" in def_ids
     assert "#V#enrichment_workflow" in def_ids
     assert "#V#planning_workflow" in def_ids
+    assert "#V#file_copy_upload_classification_workflow" in def_ids
+    assert "#V#file_copy_upload_handler_workflow" in def_ids
     assert "#V#file_copy_interpretation_workflow" in def_ids
     assert any("description_source" in d for d in result["definitions"])
     assert any("definition_identity" in d for d in result["definitions"])

--- a/tests/backend/test_von_file_upload_endpoint.py
+++ b/tests/backend/test_von_file_upload_endpoint.py
@@ -204,7 +204,7 @@ def app(monkeypatch):
             "success": True,
             "triggered": True,
             "event_type": "file_copy.uploaded",
-            "workflow_id": "#V#file_copy_interpretation_workflow",
+            "workflow_id": "#V#file_copy_upload_handler_workflow",
             "reason": "created_new_instance",
             "instance_id": "test-instance-1",
         }

--- a/tests/backend/test_von_file_upload_scholarly_integration.py
+++ b/tests/backend/test_von_file_upload_scholarly_integration.py
@@ -12,9 +12,8 @@ from src.backend.services.kb_clone_benchmark_service import (
     ONTOLOGY_SLICE_COLLECTIONS,
     clone_database_ontology_slice,
 )
-from src.backend.workflows.durable.file_copy_interpretation_workflow import (
-    FILE_COPY_INTERPRETATION_WORKFLOW_ID,
-    build_file_copy_interpretation_workflow,
+from src.backend.workflows.durable.file_copy_upload_handler_workflow import (
+    FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
 )
 from src.backend.workflows.durable.models import WorkflowInstanceStatus
 from src.backend.workflows.durable.registry_factory import (
@@ -182,18 +181,22 @@ def _mock_paper_metadata(**kwargs):
 
 def _run_pending_file_copy_instance(instance_id: str):
     manager = get_instance_manager()
+    instance = manager.get_instance(instance_id)
+    assert instance is not None
+    workflow_id = str(instance.workflow_id or "").strip()
+    assert workflow_id
+
     claimed = manager.find_and_claim_instance(
         _TEST_WORKER_ID,
-        workflow_ids=[FILE_COPY_INTERPRETATION_WORKFLOW_ID],
+        workflow_ids=[workflow_id],
     )
     assert claimed is not None
     assert claimed.instance_id == instance_id
     assert claimed.status == WorkflowInstanceStatus.RUNNING
 
     registry = build_workflow_registry_read_only()
-    definition = registry.get(FILE_COPY_INTERPRETATION_WORKFLOW_ID)
-    if definition is None:
-        definition = build_file_copy_interpretation_workflow()
+    definition = registry.get(workflow_id)
+    assert definition is not None
 
     executor = create_durable_executor(
         build_durable_action_registry(),
@@ -317,7 +320,7 @@ def test_upload_event_workflow_materialises_scholarly_representation_in_ontology
     launch_payload = first_body.get("workflow_event_launch") or {}
     assert launch_payload.get("success") is True
     assert launch_payload.get("triggered") is True
-    assert launch_payload.get("workflow_id") == FILE_COPY_INTERPRETATION_WORKFLOW_ID
+    assert launch_payload.get("workflow_id") == FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID
 
     first_instance_id = str(launch_payload.get("instance_id") or "").strip()
     assert first_instance_id

--- a/tests/backend/test_workflow_event_integration_service.py
+++ b/tests/backend/test_workflow_event_integration_service.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 from src.backend.workflows.durable.models import EventWorkflowBinding
 from src.backend.services.workflow_event_integration_service import (
+    DEFAULT_FILE_COPY_UPLOADED_WORKFLOW_ID,
     EVENT_TYPE_CONCEPT_UPDATED,
     EVENT_TYPE_EFFORT_UNIT_COMPLETED,
     EVENT_TYPE_FILE_COPY_UPLOADED,
@@ -517,12 +518,15 @@ def test_maybe_launch_file_copy_uploaded_workflow_emits_upload_event(
     assert result["success"] is True
     assert result["triggered"] is True
     assert result["default_binding_bootstrap"]["ensured"] is True
+    assert result["launch_strategy"] == "single_selected_binding"
+    assert result["selected_workflow_id"] == DEFAULT_FILE_COPY_UPLOADED_WORKFLOW_ID
     mock_ensure_default_event_bindings.assert_called_once()
 
     called_args = mock_launch_event_workflow.call_args
     assert called_args is not None
     assert called_args.kwargs["event_type"] == EVENT_TYPE_FILE_COPY_UPLOADED
     assert called_args.kwargs["event_id"] == "#V#uploaded_file_copy_123"
+    assert called_args.kwargs["workflow_id"] == DEFAULT_FILE_COPY_UPLOADED_WORKFLOW_ID
     assert called_args.kwargs["inputs"]["file_copy_concept_id"] == "#V#uploaded_file_copy_123"
     assert called_args.kwargs["inputs"]["index_in_rag"] is True
 


### PR DESCRIPTION
## Summary
- add durable `#V#file_copy_upload_classification_workflow` for routing classification
- add durable `#V#file_copy_upload_handler_workflow` for workflow-first upload orchestration
- enforce low-confidence fail-closed behaviour for mutation routes and persist inspectable decisions/outcomes
- switch `file_copy.uploaded` default binding to handler workflow and single selected binding launch strategy
- register new workflows/actions in durable registry and add reliable subworkflow definition resolution fallback
- update and add backend tests for routing, fail-closed behaviour, inspectability, and upload integration paths

## Validation
- `pdm run pytest tests/backend/test_file_copy_upload_classification_workflow.py tests/backend/test_file_copy_upload_handler_workflow.py tests/backend/test_workflow_event_integration_service.py tests/backend/test_von_file_upload_endpoint.py tests/backend/test_von_file_upload_scholarly_integration.py tests/backend/test_internal_mcp_workflow_tools.py -q`
- `pdm run pytest tests/backend/test_subworkflow_actions.py tests/backend/test_workflow_registry_factory_parity.py tests/backend/test_workflow_concept_authority_service.py tests/backend/test_file_copy_interpretation_workflow.py -q`
- `pdm run pyright src/backend/services/workflow_event_integration_service.py src/backend/workflows/durable/registry_factory.py src/backend/workflows/workflow_concept_authority_service.py src/backend/workflows/durable/file_copy_upload_classification_workflow.py src/backend/workflows/durable/file_copy_upload_handler_workflow.py tests/backend/test_internal_mcp_workflow_tools.py tests/backend/test_von_file_upload_endpoint.py tests/backend/test_von_file_upload_scholarly_integration.py tests/backend/test_workflow_event_integration_service.py tests/backend/test_file_copy_upload_classification_workflow.py tests/backend/test_file_copy_upload_handler_workflow.py`