### PR TITLE
JVNAUTOSCI-1311: Add workflow control-flow primitives and return envelopes

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -1,7 +1,7 @@
 # Von Workflow Language (VWL) Manual
 
 Status: Draft (current implementation-aligned)
-Last updated: 2026-03-01 (Pacific/Auckland)
+Last updated: 2026-03-03 (Pacific/Auckland)
 Audience: Human engineers and AI agents
 
 ## 1. Purpose and Scope
@@ -35,10 +35,12 @@ Primary implementation anchors:
 
 - `src/backend/workflows/vontology_loader.py`
 - `src/backend/workflows/engine.py`
+- `src/backend/workflows/execution_contracts.py`
 - `src/backend/workflows/metadata_validation.py`
 - `src/backend/workflows/subworkflow_contracts.py`
 - `src/backend/workflows/workflow_definition_identity_service.py`
 - `src/backend/workflows/durable/models.py`
+- `src/backend/workflows/durable/control_flow_actions.py`
 - `src/backend/workflows/durable/worker.py`
 - `src/backend/workflows/durable/scheduler.py`
 - `src/backend/workflows/durable/workflow_instance_submission_service.py`
@@ -78,6 +80,7 @@ Canonical graph families include:
 - `workflowStepInvokesTool`
 - `nextStep`
 - `onTrueNextStep`, `onFalseNextStep`, `onFailureNextStep`, `onUnknownNextStep`
+- `onBreakNextStep`, `onContinueNextStep`
 - `hasPrecondition`, `hasEffect`
 - `readsVariable`, `writesVariable`
 - `hasInputMap`
@@ -99,6 +102,7 @@ A VWL program is a workflow concept graph:
   - `next`
   - `on_true`, `on_false`
   - `on_failure`, `on_unknown`.
+  - `on_break`, `on_continue`.
 - Optional metadata and mapping contracts.
 
 ## 5. Condition Language (Transition Expressions)
@@ -111,6 +115,7 @@ Supported kinds:
 - `context_flag`
 - `context_value_equals`
 - `transition_result_truth`
+- `control_signal`
 - `all`
 - `any`
 - `not`
@@ -122,6 +127,8 @@ Canonical forms:
 {"kind":"context_flag","key":"last_action_failed","expected":true}
 {"kind":"context_value_equals","key":"mode","value":"strict"}
 {"kind":"transition_result_truth","expected":false}
+{"kind":"control_signal","signal":"break"}
+{"kind":"control_signal","signal":"continue","scope":"main_loop"}
 {"kind":"all","conditions":[{"kind":"context_flag","key":"a"},{"kind":"context_flag","key":"b"}]}
 {"kind":"any","conditions":[...]}
 {"kind":"not","condition":{"kind":"context_flag","key":"disabled"}}
@@ -150,10 +157,13 @@ Important deterministic ordering:
 - Generated branch precedence for implicit branch links is:
   - `on_failure`
   - `on_unknown`
+  - `on_break`
+  - `on_continue`
   - `on_true`/`on_false`
   - `next_step`
 
 `on_failure` and `on_unknown` compile to context-flag conditions (`last_action_failed`, `last_action_unknown`).
+`on_break`/`on_continue` compile to control-signal conditions (`last_control_signal == break|continue`).
 
 ## 7. Execution Semantics
 
@@ -164,9 +174,11 @@ Runtime execution model (`WorkflowExecutor`):
 3. Execute actions in state order.
 4. Merge action outputs into context for non-failure outcomes.
 5. Apply tool-output-to-context mappings.
-6. Evaluate transitions in stored order and take first satisfied transition.
-7. If no valid transition and state terminal, complete.
-8. Abort on max transition count or unrecoverable errors.
+6. Emit canonical step-result envelope for each executed action.
+7. Evaluate transitions in stored order and take first satisfied transition.
+8. If no valid transition and state terminal, complete.
+9. Emit canonical workflow-result envelope at completion/failure.
+10. Abort on max transition count or unrecoverable errors.
 
 Action outcomes are normalised to:
 
@@ -175,6 +187,18 @@ Action outcomes are normalised to:
 - unknown.
 
 `last_action_failed` and `last_action_unknown` flags drive explicit failure/unknown routes.
+
+Canonical envelope keys:
+
+- step envelope list: `workflow_step_result_envelopes`
+- latest step envelope: `last_workflow_step_result_envelope`
+- workflow envelope: `workflow_result_envelope`
+
+Control-signal keys:
+
+- `last_control_signal` (`none|break|continue|return|error`)
+- `last_control_signal_scope`
+- boolean convenience flags (`last_control_signal_break`, `last_control_signal_continue`, `last_control_signal_return`, `last_control_signal_error`)
 
 ## 8. Metadata Contract Semantics
 
@@ -190,6 +214,9 @@ Per-state metadata keys currently used:
 - `tool_output_context_mappings`
 - `subworkflow_contract`
 - `invokes_workflow`
+- `loop_scope_id`
+- `fork_id`
+- `join_fork_id`
 
 Validation phases:
 
@@ -231,7 +258,37 @@ Semantic mappings bind:
 
 Runtime writes mapping events into context diagnostics for traceability.
 
-## 10. Subworkflow Semantics
+## 10. Control-Flow and Subworkflow Semantics
+
+Control-flow action IDs:
+
+- `workflow_control.break`
+- `workflow_control.continue`
+- `workflow_control.fork`
+- `workflow_control.join`
+
+### 10.1 Break/Continue
+
+- `workflow_control.break` MUST be routed by an explicit `on_break` transition.
+- `workflow_control.continue` MUST be routed by an explicit `on_continue` transition.
+- Validation rejects break/continue usage without loop-scope declaration (`loop_scope_id` metadata or explicit action input).
+
+### 10.2 Fork/Join
+
+Fork defaults:
+
+- failure policy default: `fail_fast`
+- supported failure policies: `fail_fast`, `collect_errors`, `allow_partial_success`
+- merge policy default: `deterministic_last_writer_wins`
+
+Runtime semantics:
+
+- Fork executes branch workflows in isolated branch contexts.
+- Join requires a matching prior fork ID.
+- Join merges successful branch declared outputs in deterministic branch-ID order.
+- Validation rejects join usage without a matching fork declaration.
+
+### 10.3 Subworkflow
 
 Subworkflow action ID:
 
@@ -253,6 +310,17 @@ Subworkflow contracts carry:
 - output mappings,
 - required/provided input-output lists,
 - failure mode.
+
+Recursion guards:
+
+- cycle guard via invocation chain check,
+- depth limit (env: `VON_WORKFLOW_SUBWORKFLOW_MAX_DEPTH`),
+- invocation budget limit (env: `VON_WORKFLOW_SUBWORKFLOW_MAX_INVOCATIONS`).
+
+Nested propagation:
+
+- child workflow envelopes are surfaced through `subworkflow_result_envelope`,
+- non-`none` child control signals propagate to parent action outputs.
 
 ## 11. Durable Runtime Semantics
 
@@ -371,6 +439,7 @@ A VWL workflow is conformant when:
 - step graph is loadable and initial step is determinable,
 - step invocation targets are unambiguous,
 - transition conditions are valid,
+- break/continue and fork/join control contracts are valid,
 - metadata contracts are syntactically valid,
 - required mappings are parseable,
 - discovered actions are runnable in current registry,

--- a/src/backend/workflows/action_registry.py
+++ b/src/backend/workflows/action_registry.py
@@ -15,6 +15,12 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Mapping, Optional
 
+from .execution_contracts import (
+    WORKFLOW_CONTROL_SIGNAL_ERROR,
+    resolve_control_signal_from_outputs,
+    stamp_control_signal_context,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -112,6 +118,20 @@ def _apply_action_outcome_context(
     context["last_action_error"] = result.error
     context["last_action_call_id"] = result.call_id
     context["last_action_duration_ms"] = result.duration_ms
+
+    control_signal, control_scope, return_payload = resolve_control_signal_from_outputs(
+        action_outcome=outcome,
+        outputs=result.outputs,
+    )
+    stamp_control_signal_context(
+        context=context,
+        signal=control_signal,
+        scope=control_scope,
+        return_payload=return_payload,
+    )
+    if control_signal == WORKFLOW_CONTROL_SIGNAL_ERROR:
+        context["last_action_failed"] = True
+        context["last_step_ok"] = False
 
 
 class ActionRegistry:

--- a/src/backend/workflows/durable/control_flow_actions.py
+++ b/src/backend/workflows/durable/control_flow_actions.py
@@ -1,0 +1,463 @@
+"""Action handlers for first-class workflow control-flow primitives.
+
+JVNAUTOSCI-1311:
+- explicit break/continue step semantics for loop contexts,
+- first-class fork/join semantics with deterministic merge and failure policy,
+- shared runtime metrics/events for observability.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Callable, Dict, Mapping, Sequence
+
+from ..action_registry import (
+    ActionRegistry,
+    ActionSpec,
+    WorkflowActionRequest,
+    WorkflowActionResult,
+)
+from ..engine import WorkflowDefinition, WorkflowExecutor
+from ..execution_contracts import (
+    LAST_WORKFLOW_STEP_RESULT_ENVELOPE_KEY,
+    WORKFLOW_CONTROL_ACTION_BREAK_ID,
+    WORKFLOW_CONTROL_ACTION_CONTINUE_ID,
+    WORKFLOW_CONTROL_ACTION_FORK_ID,
+    WORKFLOW_CONTROL_ACTION_JOIN_ID,
+    WORKFLOW_CONTROL_SIGNAL_BREAK,
+    WORKFLOW_CONTROL_SIGNAL_CONTINUE,
+    WORKFLOW_FORK_ALLOWED_FAILURE_POLICIES,
+    WORKFLOW_FORK_ALLOWED_MERGE_POLICIES,
+    WORKFLOW_FORK_CONTEXTS_KEY,
+    WORKFLOW_FORK_FAILURE_POLICY_COLLECT_ERRORS,
+    WORKFLOW_FORK_FAILURE_POLICY_FAIL_FAST,
+    WORKFLOW_FORK_MERGE_POLICY_LAST_WRITER_WINS,
+    append_runtime_event,
+    increment_runtime_metric,
+)
+from ..trace_model import WorkflowExecutionTrace
+from ..vontology_loader import load_workflow_definition_from_vontology
+
+
+_DEFAULT_FORK_BRANCH_LIMIT = 8
+_MAX_FORK_BRANCH_LIMIT = 32
+_DEFAULT_BRANCH_MAX_TRANSITIONS = 40
+_MAX_BRANCH_MAX_TRANSITIONS = 200
+_FORK_BRANCH_LIMIT_ENV = "VON_WORKFLOW_FORK_MAX_BRANCHES"
+_FORK_BRANCH_TRANSITIONS_ENV = "VON_WORKFLOW_FORK_BRANCH_MAX_TRANSITIONS"
+
+
+def _normalise_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _coerce_int(value: Any, *, default: int, min_value: int, max_value: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = int(default)
+    return max(min_value, min(max_value, parsed))
+
+
+def _coerce_branch_limit() -> int:
+    return _coerce_int(
+        os.getenv(_FORK_BRANCH_LIMIT_ENV),
+        default=_DEFAULT_FORK_BRANCH_LIMIT,
+        min_value=1,
+        max_value=_MAX_FORK_BRANCH_LIMIT,
+    )
+
+
+def _coerce_branch_max_transitions(value: Any) -> int:
+    default_value = _coerce_int(
+        os.getenv(_FORK_BRANCH_TRANSITIONS_ENV),
+        default=_DEFAULT_BRANCH_MAX_TRANSITIONS,
+        min_value=5,
+        max_value=_MAX_BRANCH_MAX_TRANSITIONS,
+    )
+    return _coerce_int(
+        value,
+        default=default_value,
+        min_value=5,
+        max_value=_MAX_BRANCH_MAX_TRANSITIONS,
+    )
+
+
+def _normalise_failure_policy(value: Any) -> str:
+    text = _normalise_text(value).lower()
+    if text in WORKFLOW_FORK_ALLOWED_FAILURE_POLICIES:
+        return text
+    return WORKFLOW_FORK_FAILURE_POLICY_FAIL_FAST
+
+
+def _normalise_merge_policy(value: Any) -> str:
+    text = _normalise_text(value).lower()
+    if text in WORKFLOW_FORK_ALLOWED_MERGE_POLICIES:
+        return text
+    return WORKFLOW_FORK_MERGE_POLICY_LAST_WRITER_WINS
+
+
+def _normalise_branch_specs(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    specs: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        workflow_id = _normalise_text(item.get("workflow_id") or item.get("workflow"))
+        branch_id = _normalise_text(item.get("branch_id") or workflow_id)
+        if not workflow_id or not branch_id:
+            continue
+        inputs = item.get("inputs")
+        branch_inputs = dict(inputs) if isinstance(inputs, Mapping) else {}
+        specs.append(
+            {
+                "branch_id": branch_id,
+                "workflow_id": workflow_id,
+                "inputs": branch_inputs,
+                "max_transitions": _coerce_branch_max_transitions(
+                    item.get("max_transitions")
+                ),
+            }
+        )
+    return sorted(specs, key=lambda spec: spec["branch_id"])
+
+
+def _emit_signal_result(
+    *,
+    signal: str,
+    scope: str | None,
+) -> WorkflowActionResult:
+    outputs: Dict[str, Any] = {
+        "control_signal": signal,
+        "workflow_control": {"signal": signal},
+    }
+    if scope:
+        outputs["control_scope"] = scope
+        outputs["workflow_control"]["scope"] = scope
+    return WorkflowActionResult(status="success", outputs=outputs)
+
+
+def _build_break_handler() -> Callable[[WorkflowActionRequest], WorkflowActionResult]:
+    def _handle(request: WorkflowActionRequest) -> WorkflowActionResult:
+        loop_scope = _normalise_text(
+            request.inputs.get("loop_scope_id") or request.inputs.get("scope")
+        )
+        return _emit_signal_result(
+            signal=WORKFLOW_CONTROL_SIGNAL_BREAK,
+            scope=loop_scope or None,
+        )
+
+    return _handle
+
+
+def _extract_declared_output_payload(result: Any) -> dict[str, Any]:
+    result_envelope = getattr(result, "result_envelope", None)
+    if isinstance(result_envelope, Mapping):
+        declared_payload = result_envelope.get("declared_output_payload")
+        if isinstance(declared_payload, Mapping):
+            return dict(declared_payload)
+
+    data = getattr(result, "data", None)
+    if isinstance(data, Mapping):
+        last_step = data.get(LAST_WORKFLOW_STEP_RESULT_ENVELOPE_KEY)
+        if isinstance(last_step, Mapping):
+            output_payload = last_step.get("output_payload")
+            if isinstance(output_payload, Mapping):
+                return dict(output_payload)
+    return {}
+
+
+def _build_continue_handler() -> Callable[[WorkflowActionRequest], WorkflowActionResult]:
+    def _handle(request: WorkflowActionRequest) -> WorkflowActionResult:
+        loop_scope = _normalise_text(
+            request.inputs.get("loop_scope_id") or request.inputs.get("scope")
+        )
+        return _emit_signal_result(
+            signal=WORKFLOW_CONTROL_SIGNAL_CONTINUE,
+            scope=loop_scope or None,
+        )
+
+    return _handle
+
+
+def _build_fork_handler(
+    *,
+    registry: ActionRegistry,
+    definition_loader: Callable[[str], WorkflowDefinition | None],
+) -> Callable[[WorkflowActionRequest], WorkflowActionResult]:
+    def _handle(request: WorkflowActionRequest) -> WorkflowActionResult:
+        fork_id = _normalise_text(request.inputs.get("fork_id")) or "default"
+        failure_policy = _normalise_failure_policy(request.inputs.get("failure_policy"))
+        merge_policy = _normalise_merge_policy(request.inputs.get("merge_policy"))
+        branch_specs = _normalise_branch_specs(request.inputs.get("branches"))
+        max_branches = _coerce_branch_limit()
+
+        if not branch_specs:
+            return WorkflowActionResult(status="failed", error="fork_branches_missing")
+        if len(branch_specs) > max_branches:
+            return WorkflowActionResult(
+                status="failed",
+                error=f"fork_branch_limit_exceeded:max={max_branches}",
+            )
+
+        branch_results: list[dict[str, Any]] = []
+        failed_branch: dict[str, Any] | None = None
+
+        for branch in branch_specs:
+            child_workflow_id = branch["workflow_id"]
+            child_definition = definition_loader(child_workflow_id)
+            if child_definition is None:
+                branch_result = {
+                    "branch_id": branch["branch_id"],
+                    "workflow_id": child_workflow_id,
+                    "completed": False,
+                    "final_state": "",
+                    "error": f"fork_child_definition_not_found:{child_workflow_id}",
+                    "result": {},
+                    "result_envelope": None,
+                }
+                branch_results.append(branch_result)
+                failed_branch = branch_result
+                if failure_policy == WORKFLOW_FORK_FAILURE_POLICY_FAIL_FAST:
+                    break
+                continue
+
+            child_context = dict(request.data)
+            child_context.update(branch["inputs"])
+            child_context["__workflow_fork_id"] = fork_id
+            child_context["__workflow_fork_branch_id"] = branch["branch_id"]
+
+            child_trace = WorkflowExecutionTrace(
+                workflow_id=child_workflow_id,
+                user_namespace=request.environment.user_namespace,
+                metadata={
+                    "fork_id": fork_id,
+                    "fork_branch_id": branch["branch_id"],
+                    "failure_policy": failure_policy,
+                    "merge_policy": merge_policy,
+                },
+            )
+            child_result = WorkflowExecutor(
+                registry=registry,
+                max_transitions=branch["max_transitions"],
+            ).run(
+                child_definition,
+                environment=request.environment,
+                data=child_context,
+                trace=child_trace,
+            )
+
+            branch_result = {
+                "branch_id": branch["branch_id"],
+                "workflow_id": child_workflow_id,
+                "completed": bool(child_result.completed),
+                "final_state": _normalise_text(child_result.final_state),
+                "error": _normalise_text(child_result.error) or None,
+                "result": _extract_declared_output_payload(child_result),
+                "result_envelope": (
+                    dict(child_result.result_envelope)
+                    if isinstance(child_result.result_envelope, Mapping)
+                    else None
+                ),
+            }
+            branch_results.append(branch_result)
+            if not child_result.completed:
+                failed_branch = branch_result
+                if failure_policy == WORKFLOW_FORK_FAILURE_POLICY_FAIL_FAST:
+                    break
+
+        success_count = len([item for item in branch_results if item.get("completed")])
+        error_count = len(branch_results) - success_count
+        fork_snapshot = {
+            "fork_id": fork_id,
+            "failure_policy": failure_policy,
+            "merge_policy": merge_policy,
+            "branch_results": branch_results,
+            "success_count": success_count,
+            "error_count": error_count,
+            "joined": False,
+        }
+        fork_contexts = request.data.get(WORKFLOW_FORK_CONTEXTS_KEY)
+        if not isinstance(fork_contexts, dict):
+            fork_contexts = {}
+            request.data[WORKFLOW_FORK_CONTEXTS_KEY] = fork_contexts
+        fork_contexts[fork_id] = fork_snapshot
+
+        increment_runtime_metric(context=request.data, key="fork_invocations")
+        append_runtime_event(
+            context=request.data,
+            event={
+                "status": "fork_executed",
+                "fork_id": fork_id,
+                "failure_policy": failure_policy,
+                "merge_policy": merge_policy,
+                "success_count": success_count,
+                "error_count": error_count,
+            },
+        )
+
+        outputs: Dict[str, Any] = {
+            "fork_id": fork_id,
+            "fork_failure_policy": failure_policy,
+            "fork_merge_policy": merge_policy,
+            "fork_branch_results": branch_results,
+            "fork_success_count": success_count,
+            "fork_error_count": error_count,
+            "fork_partial_success": error_count > 0 and success_count > 0,
+        }
+
+        if (
+            failure_policy == WORKFLOW_FORK_FAILURE_POLICY_FAIL_FAST
+            and failed_branch is not None
+        ):
+            return WorkflowActionResult(
+                status="failed",
+                error=(
+                    "fork_branch_failed:"
+                    f"{failed_branch.get('branch_id')}:{failed_branch.get('error')}"
+                ),
+                outputs=outputs,
+            )
+
+        return WorkflowActionResult(status="success", outputs=outputs)
+
+    return _handle
+
+
+def _build_join_handler() -> Callable[[WorkflowActionRequest], WorkflowActionResult]:
+    def _handle(request: WorkflowActionRequest) -> WorkflowActionResult:
+        fork_id = _normalise_text(request.inputs.get("fork_id"))
+        if not fork_id:
+            return WorkflowActionResult(status="failed", error="join_fork_id_missing")
+
+        fork_contexts = request.data.get(WORKFLOW_FORK_CONTEXTS_KEY)
+        if not isinstance(fork_contexts, Mapping):
+            return WorkflowActionResult(
+                status="failed",
+                error=f"join_without_matching_fork:{fork_id}",
+            )
+        fork_snapshot_raw = fork_contexts.get(fork_id)
+        fork_snapshot = (
+            dict(fork_snapshot_raw)
+            if isinstance(fork_snapshot_raw, Mapping)
+            else None
+        )
+        if fork_snapshot is None:
+            return WorkflowActionResult(
+                status="failed",
+                error=f"join_without_matching_fork:{fork_id}",
+            )
+
+        branch_results_raw = fork_snapshot.get("branch_results")
+        branch_results = (
+            list(branch_results_raw)
+            if isinstance(branch_results_raw, Sequence)
+            and not isinstance(branch_results_raw, (str, bytes, bytearray))
+            else []
+        )
+        ordered_successes = sorted(
+            [
+                item
+                for item in branch_results
+                if isinstance(item, Mapping) and bool(item.get("completed"))
+            ],
+            key=lambda item: _normalise_text(item.get("branch_id")),
+        )
+        errors = [
+            item
+            for item in branch_results
+            if isinstance(item, Mapping) and not bool(item.get("completed"))
+        ]
+
+        merged: Dict[str, Any] = {}
+        for entry in ordered_successes:
+            payload = entry.get("result")
+            if isinstance(payload, Mapping):
+                merged.update(payload)
+
+        failure_policy = _normalise_failure_policy(fork_snapshot.get("failure_policy"))
+        fork_snapshot["joined"] = True
+        fork_snapshot["joined_result"] = dict(merged)
+        if isinstance(fork_contexts, dict):
+            fork_contexts[fork_id] = fork_snapshot
+
+        increment_runtime_metric(context=request.data, key="join_invocations")
+        append_runtime_event(
+            context=request.data,
+            event={
+                "status": "join_executed",
+                "fork_id": fork_id,
+                "success_count": len(ordered_successes),
+                "error_count": len(errors),
+                "failure_policy": failure_policy,
+            },
+        )
+
+        outputs: Dict[str, Any] = {
+            "fork_id": fork_id,
+            "result": merged,
+            "fork_joined": True,
+            "fork_error_count": len(errors),
+            "fork_success_count": len(ordered_successes),
+            "fork_branch_results": branch_results,
+        }
+        if errors and failure_policy in {
+            WORKFLOW_FORK_FAILURE_POLICY_FAIL_FAST,
+            WORKFLOW_FORK_FAILURE_POLICY_COLLECT_ERRORS,
+        }:
+            return WorkflowActionResult(
+                status="failed",
+                error=f"join_branch_errors:{fork_id}",
+                outputs=outputs,
+            )
+
+        return WorkflowActionResult(status="success", outputs=outputs)
+
+    return _handle
+
+
+def register_control_flow_actions(
+    registry: ActionRegistry,
+    *,
+    definition_loader: Callable[[str], WorkflowDefinition | None] | None = None,
+) -> None:
+    """Register break/continue/fork/join primitives in the action registry."""
+
+    loader = definition_loader or load_workflow_definition_from_vontology
+    registry.register_if_absent(
+        ActionSpec(
+            action_id=WORKFLOW_CONTROL_ACTION_BREAK_ID,
+            handler=_build_break_handler(),
+            description="Emit loop break control signal for explicit on_break routing.",
+        )
+    )
+    registry.register_if_absent(
+        ActionSpec(
+            action_id=WORKFLOW_CONTROL_ACTION_CONTINUE_ID,
+            handler=_build_continue_handler(),
+            description=(
+                "Emit loop continue control signal for explicit on_continue routing."
+            ),
+        )
+    )
+    registry.register_if_absent(
+        ActionSpec(
+            action_id=WORKFLOW_CONTROL_ACTION_FORK_ID,
+            handler=_build_fork_handler(registry=registry, definition_loader=loader),
+            description=(
+                "Execute independent child workflow branches with deterministic "
+                "failure and merge policy semantics."
+            ),
+        )
+    )
+    registry.register_if_absent(
+        ActionSpec(
+            action_id=WORKFLOW_CONTROL_ACTION_JOIN_ID,
+            handler=_build_join_handler(),
+            description="Join and merge results for a previously executed fork.",
+        )
+    )
+
+
+__all__ = ["register_control_flow_actions"]

--- a/src/backend/workflows/durable/durable_executor.py
+++ b/src/backend/workflows/durable/durable_executor.py
@@ -14,7 +14,10 @@ from typing import Any, Mapping
 from ..engine import (
     WorkflowDefinition,
     apply_tool_output_context_mappings,
+    evaluate_transition_condition_spec,
     resolve_action_inputs_from_context,
+    state_has_on_break_transition,
+    state_has_on_continue_transition,
     state_has_on_failure_transition,
     state_has_on_unknown_transition,
 )
@@ -37,6 +40,20 @@ from ..action_registry import (
     normalise_action_outcome,
 )
 from ..trace_model import WorkflowExecutionTrace
+from ..execution_contracts import (
+    WORKFLOW_CONTROL_SIGNAL_BREAK,
+    WORKFLOW_CONTROL_SIGNAL_CONTINUE,
+    WORKFLOW_CONTROL_SIGNAL_RETURN,
+    WORKFLOW_RETURN_PAYLOAD_KEY,
+    append_runtime_event,
+    append_step_result_envelope,
+    build_step_result_envelope,
+    build_workflow_result_envelope,
+    clear_control_signal_context,
+    get_last_control_signal,
+    get_last_control_signal_scope,
+    set_workflow_result_envelope,
+)
 from .instance_manager import WorkflowInstanceManager
 from .models import WorkflowInstance, WorkflowInstanceStatus
 
@@ -53,6 +70,7 @@ class DurableWorkflowResult:
     final_state: str
     error: str | None = None
     step_count: int = 0
+    result_envelope: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to JSON-serialisable dict."""
@@ -63,6 +81,7 @@ class DurableWorkflowResult:
             "final_state": self.final_state,
             "error": self.error,
             "step_count": self.step_count,
+            "result_envelope": self.result_envelope,
         }
 
 
@@ -133,6 +152,7 @@ class DurableWorkflowExecutor:
             context = dict(instance.inputs)
             current_state = definition.initial_state
             step_index = 0
+        clear_control_signal_context(context)
 
         # Create execution environment
         from ...languagemodels.llm_interface import (
@@ -168,19 +188,59 @@ class DurableWorkflowExecutor:
         )
 
         transitions = 0
+
+        def _build_result(
+            *,
+            completed: bool,
+            final_state: str,
+            error: str | None = None,
+            checkpoint: bool = False,
+            error_step: str | None = None,
+        ) -> DurableWorkflowResult:
+            result_envelope = build_workflow_result_envelope(
+                workflow_id=definition.workflow_id,
+                completed=completed,
+                final_state=final_state,
+                error=error,
+                control_signal=get_last_control_signal(context),
+                return_payload=context.get(WORKFLOW_RETURN_PAYLOAD_KEY),
+                context=context,
+                transition_count=transitions,
+            )
+            set_workflow_result_envelope(context=context, envelope=result_envelope)
+            if checkpoint:
+                self._instance_manager.checkpoint(
+                    instance_id,
+                    current_state=final_state,
+                    workflow_data=context,
+                    step_index=step_index,
+                    error=error,
+                    error_step=error_step,
+                    progress_current=step_index,
+                    progress_total=total_steps,
+                    progress_message=final_state,
+                )
+            return DurableWorkflowResult(
+                instance_id=instance_id,
+                data=context,
+                completed=completed,
+                final_state=final_state,
+                error=error,
+                step_count=step_index,
+                result_envelope=result_envelope,
+            )
+
         while transitions < self._max_transitions:
             transitions += 1
             step_index += 1
 
             # Check for cancellation
             if self._instance_manager.is_cancelled(instance_id):
-                return DurableWorkflowResult(
-                    instance_id=instance_id,
-                    data=context,
+                return _build_result(
                     completed=False,
                     final_state=current_state,
                     error="cancelled",
-                    step_count=step_index,
+                    checkpoint=True,
                 )
 
             # Extend lock if worker_id provided
@@ -191,23 +251,11 @@ class DurableWorkflowExecutor:
             state_spec = definition.states.get(current_state)
             if state_spec is None:
                 error = f"unknown_state:{current_state}"
-                self._instance_manager.checkpoint(
-                    instance_id,
-                    current_state=current_state,
-                    workflow_data=context,
-                    step_index=step_index,
-                    error=error,
-                    progress_current=step_index,
-                    progress_total=total_steps,
-                    progress_message=current_state,
-                )
-                return DurableWorkflowResult(
-                    instance_id=instance_id,
-                    data=context,
+                return _build_result(
                     completed=False,
                     final_state=current_state,
                     error=error,
-                    step_count=step_index,
+                    checkpoint=True,
                 )
 
             # Record state entry in trace
@@ -253,31 +301,22 @@ class DurableWorkflowExecutor:
                 )
             if not pre_validation.ok and enforce_metadata_failures:
                 error = format_metadata_validation_error(pre_validation)
-                self._instance_manager.checkpoint(
-                    instance_id,
-                    current_state=current_state,
-                    workflow_data=context,
-                    step_index=step_index,
-                    error=error,
-                    progress_current=step_index,
-                    progress_total=total_steps,
-                    progress_message=current_state,
-                )
                 trace.finish_failed(error)
-                return DurableWorkflowResult(
-                    instance_id=instance_id,
-                    data=context,
+                return _build_result(
                     completed=False,
                     final_state=current_state,
                     error=error,
-                    step_count=step_index,
+                    checkpoint=True,
                 )
 
             # Execute actions
             state_has_failure_route = state_has_on_failure_transition(state_spec)
             state_has_unknown_route = state_has_on_unknown_transition(state_spec)
+            state_has_break_route = state_has_on_break_transition(state_spec)
+            state_has_continue_route = state_has_on_continue_transition(state_spec)
             context_before_actions = dict(context)
             for action in state_spec.actions:
+                context_before_action = dict(context)
                 resolved_inputs = resolve_action_inputs_from_context(
                     action_inputs=action.inputs,
                     context=context,
@@ -314,6 +353,39 @@ class DurableWorkflowExecutor:
                         action_id=action.action_id,
                     )
 
+                step_envelope = build_step_result_envelope(
+                    workflow_id=definition.workflow_id,
+                    state_id=current_state,
+                    action_id=action.action_id,
+                    action_status=result.status,
+                    action_outcome=action_outcome,
+                    action_error=result.error,
+                    action_outputs=result.outputs if isinstance(result.outputs, Mapping) else {},
+                    control_signal=get_last_control_signal(context),
+                    control_signal_scope=get_last_control_signal_scope(context),
+                    duration_ms=result.duration_ms,
+                    context_before=context_before_action,
+                    context_after=context,
+                )
+                append_step_result_envelope(context=context, envelope=step_envelope)
+                if step_envelope["control_signal"] != "none":
+                    event = {
+                        "status": "control_signal",
+                        "workflow_id": definition.workflow_id,
+                        "state_id": current_state,
+                        "action_id": action.action_id,
+                        "control_signal": step_envelope["control_signal"],
+                        "control_signal_scope": step_envelope.get(
+                            "control_signal_scope"
+                        ),
+                    }
+                    append_runtime_event(context=context, event=event)
+                    trace.record_state_transition(
+                        current_state,
+                        current_state,
+                        verdict=event,
+                    )
+
                 if action_outcome == WORKFLOW_ACTION_OUTCOME_FAILURE:
                     if state_has_failure_route:
                         # Safety envelope (JVNAUTOSCI-1087): if the state defines
@@ -322,25 +394,13 @@ class DurableWorkflowExecutor:
                         break
                     error = result.error or "action_failed"
                     # Checkpoint the failure state
-                    self._instance_manager.checkpoint(
-                        instance_id,
-                        current_state=current_state,
-                        workflow_data=context,
-                        step_index=step_index,
-                        error=error,
-                        error_step=action.action_id,
-                        progress_current=step_index,
-                        progress_total=total_steps,
-                        progress_message=current_state,
-                    )
                     trace.finish_failed(error)
-                    return DurableWorkflowResult(
-                        instance_id=instance_id,
-                        data=context,
+                    return _build_result(
                         completed=False,
                         final_state=current_state,
                         error=error,
-                        step_count=step_index,
+                        checkpoint=True,
+                        error_step=action.action_id,
                     )
                 if action_outcome == WORKFLOW_ACTION_OUTCOME_UNKNOWN:
                     if state_has_unknown_route:
@@ -348,26 +408,43 @@ class DurableWorkflowExecutor:
                         # silently continue via default transitions.
                         break
                     error = result.error or "action_unknown"
-                    self._instance_manager.checkpoint(
-                        instance_id,
-                        current_state=current_state,
-                        workflow_data=context,
-                        step_index=step_index,
-                        error=error,
-                        error_step=action.action_id,
-                        progress_current=step_index,
-                        progress_total=total_steps,
-                        progress_message=current_state,
-                    )
                     trace.finish_failed(error)
-                    return DurableWorkflowResult(
-                        instance_id=instance_id,
-                        data=context,
+                    return _build_result(
                         completed=False,
                         final_state=current_state,
                         error=error,
-                        step_count=step_index,
+                        checkpoint=True,
+                        error_step=action.action_id,
                     )
+
+                control_signal = get_last_control_signal(context)
+                if control_signal in {
+                    WORKFLOW_CONTROL_SIGNAL_BREAK,
+                    WORKFLOW_CONTROL_SIGNAL_CONTINUE,
+                    WORKFLOW_CONTROL_SIGNAL_RETURN,
+                }:
+                    break
+
+            control_signal = get_last_control_signal(context)
+            if control_signal == WORKFLOW_CONTROL_SIGNAL_BREAK and not state_has_break_route:
+                trace.finish_failed("workflow_break_outside_loop_scope")
+                return _build_result(
+                    completed=False,
+                    final_state=current_state,
+                    error="workflow_break_outside_loop_scope",
+                    checkpoint=True,
+                )
+            if (
+                control_signal == WORKFLOW_CONTROL_SIGNAL_CONTINUE
+                and not state_has_continue_route
+            ):
+                trace.finish_failed("workflow_continue_outside_loop_scope")
+                return _build_result(
+                    completed=False,
+                    final_state=current_state,
+                    error="workflow_continue_outside_loop_scope",
+                    checkpoint=True,
+                )
 
             if state_has_unknown_route and bool(context.get("last_action_unknown")):
                 post_validation = skipped_metadata_validation(
@@ -422,45 +499,29 @@ class DurableWorkflowExecutor:
                 )
             if not post_validation.ok and enforce_metadata_failures:
                 error = format_metadata_validation_error(post_validation)
-                self._instance_manager.checkpoint(
-                    instance_id,
-                    current_state=current_state,
-                    workflow_data=context,
-                    step_index=step_index,
-                    error=error,
-                    progress_current=step_index,
-                    progress_total=total_steps,
-                    progress_message=current_state,
-                )
                 trace.finish_failed(error)
-                return DurableWorkflowResult(
-                    instance_id=instance_id,
-                    data=context,
+                return _build_result(
                     completed=False,
                     final_state=current_state,
                     error=error,
-                    step_count=step_index,
+                    checkpoint=True,
+                )
+
+            if control_signal == WORKFLOW_CONTROL_SIGNAL_RETURN:
+                trace.finish_completed()
+                return _build_result(
+                    completed=True,
+                    final_state=current_state,
+                    checkpoint=True,
                 )
 
             # Check for terminal state
             if current_state in termination_states:
-                # Final checkpoint
-                self._instance_manager.checkpoint(
-                    instance_id,
-                    current_state=current_state,
-                    workflow_data=context,
-                    step_index=step_index,
-                    progress_current=step_index,
-                    progress_total=total_steps,
-                    progress_message=current_state,
-                )
                 trace.finish_completed()
-                return DurableWorkflowResult(
-                    instance_id=instance_id,
-                    data=context,
+                return _build_result(
                     completed=True,
                     final_state=current_state,
-                    step_count=step_index,
+                    checkpoint=True,
                 )
 
             # Evaluate transitions
@@ -468,7 +529,16 @@ class DurableWorkflowExecutor:
             transition_reason = None
             for transition in state_spec.transitions:
                 try:
-                    if transition.condition(context):
+                    condition_result = bool(transition.condition(context))
+                    if (
+                        not condition_result
+                        and isinstance(transition.condition_spec, Mapping)
+                    ):
+                        condition_result = evaluate_transition_condition_spec(
+                            context=context,
+                            condition_spec=transition.condition_spec,
+                        )
+                    if condition_result:
                         next_state = transition.to_state
                         transition_reason = transition.reason
                         break
@@ -482,24 +552,12 @@ class DurableWorkflowExecutor:
 
             if next_state is None:
                 error = "no_transition"
-                self._instance_manager.checkpoint(
-                    instance_id,
-                    current_state=current_state,
-                    workflow_data=context,
-                    step_index=step_index,
-                    error=error,
-                    progress_current=step_index,
-                    progress_total=total_steps,
-                    progress_message=current_state,
-                )
                 trace.finish_failed(error)
-                return DurableWorkflowResult(
-                    instance_id=instance_id,
-                    data=context,
+                return _build_result(
                     completed=False,
                     final_state=current_state,
                     error=error,
-                    step_count=step_index,
+                    checkpoint=True,
                 )
 
             # CHECKPOINT after successful step (before transitioning)
@@ -519,27 +577,16 @@ class DurableWorkflowExecutor:
                 reason=transition_reason,
             )
             current_state = next_state
+            clear_control_signal_context(context)
 
         # Transition limit exceeded
         error = "transition_limit"
-        self._instance_manager.checkpoint(
-            instance_id,
-            current_state=current_state,
-            workflow_data=context,
-            step_index=step_index,
-            error=error,
-            progress_current=step_index,
-            progress_total=total_steps,
-            progress_message=current_state,
-        )
         trace.finish_failed(error)
-        return DurableWorkflowResult(
-            instance_id=instance_id,
-            data=context,
+        return _build_result(
             completed=False,
             final_state=current_state,
             error=error,
-            step_count=step_index,
+            checkpoint=True,
         )
 
     def run_new_instance(

--- a/src/backend/workflows/durable/registry_factory.py
+++ b/src/backend/workflows/durable/registry_factory.py
@@ -57,6 +57,7 @@ from .entity_identity_resolution_workflow import (
     register_entity_identity_resolution_actions,
 )
 from .subworkflow_actions import register_subworkflow_actions
+from .control_flow_actions import register_control_flow_actions
 from .workflow_creation_workflow import register_workflow_creation_actions
 from ..vontology_loader import (
     build_workflow_process_graph,
@@ -561,6 +562,7 @@ def build_durable_action_registry() -> ActionRegistry:
     register_file_copy_upload_handler_actions(registry)
     register_file_copy_interpretation_actions(registry)
     register_entity_identity_resolution_actions(registry)
+    register_control_flow_actions(registry, definition_loader=_resolve_subworkflow_definition)
     register_subworkflow_actions(registry, definition_loader=_resolve_subworkflow_definition)
     register_workflow_creation_actions(registry)
     # Keep durable action routing aligned with orchestrator routing: if an

--- a/src/backend/workflows/durable/subworkflow_actions.py
+++ b/src/backend/workflows/durable/subworkflow_actions.py
@@ -23,6 +23,12 @@ from ..subworkflow_contracts import (
     WORKFLOW_SUBWORKFLOW_FAILURE_MODE_CAPTURE,
     WORKFLOW_SUBWORKFLOW_FAILURE_MODE_PROPAGATE,
 )
+from ..execution_contracts import (
+    WORKFLOW_CONTROL_SIGNAL_NONE,
+    append_runtime_event,
+    increment_runtime_metric,
+    normalise_control_signal,
+)
 from ..trace_model import WorkflowExecutionTrace
 from ..vontology_loader import load_workflow_definition_from_vontology
 
@@ -39,6 +45,8 @@ _RESERVED_SUBWORKFLOW_INPUT_KEYS: set[str] = {
 _INVOCATION_CHAIN_KEY = "__workflow_invocation_chain"
 _MAX_SUBWORKFLOW_DEPTH_ENV = "VON_WORKFLOW_SUBWORKFLOW_MAX_DEPTH"
 _DEFAULT_SUBWORKFLOW_DEPTH_LIMIT = 8
+_MAX_SUBWORKFLOW_INVOCATIONS_ENV = "VON_WORKFLOW_SUBWORKFLOW_MAX_INVOCATIONS"
+_DEFAULT_SUBWORKFLOW_INVOCATION_LIMIT = 64
 _DEFAULT_MAX_TRANSITIONS = 40
 _MAX_TRANSITIONS_LIMIT = 300
 
@@ -70,6 +78,17 @@ def _coerce_max_depth() -> int:
     except (TypeError, ValueError):
         return _DEFAULT_SUBWORKFLOW_DEPTH_LIMIT
     return max(1, min(32, parsed))
+
+
+def _coerce_invocation_limit() -> int:
+    raw = os.getenv(_MAX_SUBWORKFLOW_INVOCATIONS_ENV)
+    if raw is None:
+        return _DEFAULT_SUBWORKFLOW_INVOCATION_LIMIT
+    try:
+        parsed = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return _DEFAULT_SUBWORKFLOW_INVOCATION_LIMIT
+    return max(1, min(512, parsed))
 
 
 def _coerce_max_transitions(value: Any) -> int:
@@ -168,6 +187,20 @@ def _build_subworkflow_handler(
                 ),
             )
 
+        invocation_limit = _coerce_invocation_limit()
+        try:
+            invocation_count = int(request.data.get("__workflow_subworkflow_invocation_count", 0))
+        except (TypeError, ValueError):
+            invocation_count = 0
+        if invocation_count >= invocation_limit:
+            return WorkflowActionResult(
+                status="failed",
+                error=(
+                    "subworkflow_invocation_budget_exceeded:"
+                    f"max_invocations={invocation_limit}"
+                ),
+            )
+
         definition = definition_loader(child_workflow_id)
         if definition is None:
             return WorkflowActionResult(
@@ -182,6 +215,8 @@ def _build_subworkflow_handler(
             parent_workflow_id=parent_workflow_id,
             parent_state_id=parent_state_id,
         )
+        child_inputs["__workflow_subworkflow_invocation_count"] = invocation_count + 1
+        request.data["__workflow_subworkflow_invocation_count"] = invocation_count + 1
         child_trace = WorkflowExecutionTrace(
             workflow_id=child_workflow_id,
             user_namespace=request.environment.user_namespace,
@@ -190,6 +225,8 @@ def _build_subworkflow_handler(
                 "parent_state_id": parent_state_id or None,
                 "failure_mode": failure_mode,
                 "invocation_chain": list(child_chain),
+                "invocation_count": invocation_count + 1,
+                "invocation_limit": invocation_limit,
             },
         )
         executor = WorkflowExecutor(
@@ -209,6 +246,8 @@ def _build_subworkflow_handler(
             "child_workflow_id": child_workflow_id,
             "failure_mode": failure_mode,
             "invocation_chain": list(child_chain),
+            "invocation_count": invocation_count + 1,
+            "invocation_limit": invocation_limit,
             "child_completed": bool(child_result.completed),
             "child_final_state": _normalise_text(child_result.final_state),
             "child_error": _normalise_text(child_result.error) or None,
@@ -217,11 +256,46 @@ def _build_subworkflow_handler(
             request_trace=request.trace,
             invocation_event=invocation_event,
         )
+        increment_runtime_metric(context=request.data, key="subworkflow_invocations")
+        append_runtime_event(
+            context=request.data,
+            event={
+                "status": "subworkflow_invoked",
+                "child_workflow_id": child_workflow_id,
+                "child_completed": bool(child_result.completed),
+                "child_final_state": _normalise_text(child_result.final_state),
+                "invocation_count": invocation_count + 1,
+                "invocation_limit": invocation_limit,
+            },
+        )
 
         outputs: Dict[str, Any] = {
             "result": dict(child_result.data),
             "subworkflow_invocation": invocation_event,
+            "subworkflow_result_envelope": (
+                dict(child_result.result_envelope)
+                if isinstance(child_result.result_envelope, Mapping)
+                else None
+            ),
         }
+        child_control_signal = normalise_control_signal(
+            (
+                child_result.result_envelope or {}
+            ).get("control_signal")
+            if isinstance(child_result.result_envelope, Mapping)
+            else None
+        )
+        if child_control_signal != WORKFLOW_CONTROL_SIGNAL_NONE:
+            outputs["control_signal"] = child_control_signal
+            outputs["workflow_control"] = {"signal": child_control_signal}
+            child_scope = (
+                (child_result.result_envelope or {}).get("control_signal_scope")
+                if isinstance(child_result.result_envelope, Mapping)
+                else None
+            )
+            if isinstance(child_scope, str) and child_scope.strip():
+                outputs["control_scope"] = child_scope.strip()
+                outputs["workflow_control"]["scope"] = child_scope.strip()
         if child_result.completed:
             return WorkflowActionResult(status="success", outputs=outputs)
 

--- a/src/backend/workflows/engine.py
+++ b/src/backend/workflows/engine.py
@@ -24,6 +24,20 @@ from .metadata_validation import (
     validate_state_metadata_post_action,
     validate_state_metadata_pre_action,
 )
+from .execution_contracts import (
+    WORKFLOW_CONTROL_SIGNAL_BREAK,
+    WORKFLOW_CONTROL_SIGNAL_CONTINUE,
+    WORKFLOW_CONTROL_SIGNAL_RETURN,
+    WORKFLOW_RETURN_PAYLOAD_KEY,
+    append_runtime_event,
+    append_step_result_envelope,
+    build_step_result_envelope,
+    build_workflow_result_envelope,
+    clear_control_signal_context,
+    get_last_control_signal,
+    get_last_control_signal_scope,
+    set_workflow_result_envelope,
+)
 from .trace_model import WorkflowExecutionTrace
 
 _CONTEXT_BINDING_KEYS: tuple[str, ...] = (
@@ -404,6 +418,16 @@ def _normalise_transition_condition_spec(
             "expected": expected,
         }
 
+    if kind == "control_signal":
+        signal = str(condition_spec.get("signal") or "").strip().lower()
+        if signal not in {"break", "continue", "return", "error"}:
+            raise ValueError("workflow_condition_invalid:control_signal_invalid")
+        scope = str(condition_spec.get("scope") or "").strip()
+        payload: Dict[str, Any] = {"kind": "control_signal", "signal": signal}
+        if scope:
+            payload["scope"] = scope
+        return payload
+
     if kind == "all":
         children = condition_spec.get("conditions")
         if not isinstance(children, list) or not children:
@@ -478,6 +502,16 @@ def evaluate_transition_condition_spec(
     if kind == "transition_result_truth":
         expected = bool(condition_spec.get("expected", True))
         return _evaluate_transition_result_truth(context) is expected
+    if kind == "control_signal":
+        expected_signal = str(condition_spec.get("signal") or "").strip().lower()
+        observed_signal = get_last_control_signal(context)
+        if observed_signal != expected_signal:
+            return False
+        expected_scope = str(condition_spec.get("scope") or "").strip()
+        if not expected_scope:
+            return True
+        observed_scope = get_last_control_signal_scope(context)
+        return bool(observed_scope) and observed_scope == expected_scope
     if kind == "all":
         children = condition_spec.get("conditions") or []
         if not isinstance(children, list):
@@ -580,6 +614,7 @@ class WorkflowResult:
     completed: bool
     final_state: str
     error: str | None = None
+    result_envelope: Dict[str, Any] | None = None
 
 
 def state_has_on_failure_transition(state_spec: WorkflowStateSpec) -> bool:
@@ -590,6 +625,16 @@ def state_has_on_failure_transition(state_spec: WorkflowStateSpec) -> bool:
 def state_has_on_unknown_transition(state_spec: WorkflowStateSpec) -> bool:
     """Return True when a state declares an explicit `on_unknown` route."""
     return state_has_transition_reason(state_spec, "on_unknown")
+
+
+def state_has_on_break_transition(state_spec: WorkflowStateSpec) -> bool:
+    """Return True when a state declares an explicit `on_break` route."""
+    return state_has_transition_reason(state_spec, "on_break")
+
+
+def state_has_on_continue_transition(state_spec: WorkflowStateSpec) -> bool:
+    """Return True when a state declares an explicit `on_continue` route."""
+    return state_has_transition_reason(state_spec, "on_continue")
 
 
 def state_has_transition_reason(state_spec: WorkflowStateSpec, reason: str) -> bool:
@@ -621,6 +666,7 @@ class WorkflowExecutor:
         trace: WorkflowExecutionTrace | None = None,
     ) -> WorkflowResult:
         context: Dict[str, Any] = data or {}
+        clear_control_signal_context(context)
         current_state = definition.initial_state
         transitions = 0
         termination_states = set(definition.termination_states) | {
@@ -631,13 +677,37 @@ class WorkflowExecutor:
             validation_mode
         )
 
+        def _build_result(
+            *,
+            completed: bool,
+            final_state: str,
+            error: str | None = None,
+        ) -> WorkflowResult:
+            result_envelope = build_workflow_result_envelope(
+                workflow_id=definition.workflow_id,
+                completed=completed,
+                final_state=final_state,
+                error=error,
+                control_signal=get_last_control_signal(context),
+                return_payload=context.get(WORKFLOW_RETURN_PAYLOAD_KEY),
+                context=context,
+                transition_count=transitions,
+            )
+            set_workflow_result_envelope(context=context, envelope=result_envelope)
+            return WorkflowResult(
+                data=context,
+                completed=completed,
+                final_state=final_state,
+                error=error,
+                result_envelope=result_envelope,
+            )
+
         while transitions < self._max_transitions:
             transitions += 1
             state_spec = definition.states.get(current_state)
             if state_spec is None:
                 error = f"unknown_state:{current_state}"
-                return WorkflowResult(
-                    data=context,
+                return _build_result(
                     completed=False,
                     final_state=current_state,
                     error=error,
@@ -688,8 +758,7 @@ class WorkflowExecutor:
                 error = format_metadata_validation_error(pre_validation)
                 if trace is not None:
                     trace.finish_failed(error)
-                return WorkflowResult(
-                    data=context,
+                return _build_result(
                     completed=False,
                     final_state=current_state,
                     error=error,
@@ -697,8 +766,11 @@ class WorkflowExecutor:
 
             state_has_failure_route = state_has_on_failure_transition(state_spec)
             state_has_unknown_route = state_has_on_unknown_transition(state_spec)
+            state_has_break_route = state_has_on_break_transition(state_spec)
+            state_has_continue_route = state_has_on_continue_transition(state_spec)
             context_before_actions = dict(context)
             for action in state_spec.actions:
+                context_before_action = dict(context)
                 resolved_inputs = resolve_action_inputs_from_context(
                     action_inputs=action.inputs,
                     context=context,
@@ -733,6 +805,38 @@ class WorkflowExecutor:
                         state_id=current_state,
                         action_id=action.action_id,
                     )
+                step_envelope = build_step_result_envelope(
+                    workflow_id=definition.workflow_id,
+                    state_id=current_state,
+                    action_id=action.action_id,
+                    action_status=result.status,
+                    action_outcome=action_outcome,
+                    action_error=result.error,
+                    action_outputs=result.outputs if isinstance(result.outputs, Mapping) else {},
+                    control_signal=get_last_control_signal(context),
+                    control_signal_scope=get_last_control_signal_scope(context),
+                    duration_ms=result.duration_ms,
+                    context_before=context_before_action,
+                    context_after=context,
+                )
+                append_step_result_envelope(context=context, envelope=step_envelope)
+                if trace is not None and step_envelope["control_signal"] != "none":
+                    event = {
+                        "status": "control_signal",
+                        "workflow_id": definition.workflow_id,
+                        "state_id": current_state,
+                        "action_id": action.action_id,
+                        "control_signal": step_envelope["control_signal"],
+                        "control_signal_scope": step_envelope.get(
+                            "control_signal_scope"
+                        ),
+                    }
+                    append_runtime_event(context=context, event=event)
+                    trace.record_state_transition(
+                        current_state,
+                        current_state,
+                        verdict=event,
+                    )
                 if action_outcome == WORKFLOW_ACTION_OUTCOME_FAILURE:
                     if state_has_failure_route:
                         # Safety envelope (JVNAUTOSCI-1087): preserve the failure
@@ -740,8 +844,7 @@ class WorkflowExecutor:
                         break
                     if trace is not None:
                         trace.finish_failed(result.error or "action_failed")
-                    return WorkflowResult(
-                        data=context,
+                    return _build_result(
                         completed=False,
                         final_state=current_state,
                         error=result.error or "action_failed",
@@ -754,18 +857,46 @@ class WorkflowExecutor:
                     unknown_error = result.error or "action_unknown"
                     if trace is not None:
                         trace.finish_failed(unknown_error)
-                    return WorkflowResult(
-                        data=context,
+                    return _build_result(
                         completed=False,
                         final_state=current_state,
                         error=unknown_error,
                     )
+
+                control_signal = get_last_control_signal(context)
+                if control_signal in {
+                    WORKFLOW_CONTROL_SIGNAL_BREAK,
+                    WORKFLOW_CONTROL_SIGNAL_CONTINUE,
+                    WORKFLOW_CONTROL_SIGNAL_RETURN,
+                }:
+                    break
 
             if current_state in termination_states:
                 materialise_terminal_effect_context(
                     context=context,
                     state_spec=state_spec,
                     state_id=current_state,
+                )
+
+            control_signal = get_last_control_signal(context)
+            if control_signal == WORKFLOW_CONTROL_SIGNAL_BREAK and not state_has_break_route:
+                if trace is not None:
+                    trace.finish_failed("workflow_break_outside_loop_scope")
+                return _build_result(
+                    completed=False,
+                    final_state=current_state,
+                    error="workflow_break_outside_loop_scope",
+                )
+            if (
+                control_signal == WORKFLOW_CONTROL_SIGNAL_CONTINUE
+                and not state_has_continue_route
+            ):
+                if trace is not None:
+                    trace.finish_failed("workflow_continue_outside_loop_scope")
+                return _build_result(
+                    completed=False,
+                    final_state=current_state,
+                    error="workflow_continue_outside_loop_scope",
                 )
 
             if state_has_unknown_route and bool(context.get("last_action_unknown")):
@@ -823,16 +954,26 @@ class WorkflowExecutor:
                 error = format_metadata_validation_error(post_validation)
                 if trace is not None:
                     trace.finish_failed(error)
-                return WorkflowResult(
-                    data=context,
+                return _build_result(
                     completed=False,
                     final_state=current_state,
                     error=error,
                 )
 
+            if control_signal == WORKFLOW_CONTROL_SIGNAL_RETURN:
+                if trace is not None:
+                    trace.finish_completed()
+                return _build_result(
+                    completed=True,
+                    final_state=current_state,
+                )
+
             if current_state in termination_states:
-                return WorkflowResult(
-                    data=context, completed=True, final_state=current_state
+                if trace is not None:
+                    trace.finish_completed()
+                return _build_result(
+                    completed=True,
+                    final_state=current_state,
                 )
 
             next_state = None
@@ -856,8 +997,9 @@ class WorkflowExecutor:
                     continue
 
             if next_state is None:
-                return WorkflowResult(
-                    data=context,
+                if trace is not None:
+                    trace.finish_failed("no_transition")
+                return _build_result(
                     completed=False,
                     final_state=current_state,
                     error="no_transition",
@@ -870,9 +1012,11 @@ class WorkflowExecutor:
                     reason=transition_reason,
                 )
             current_state = next_state
+            clear_control_signal_context(context)
 
-        return WorkflowResult(
-            data=context,
+        if trace is not None:
+            trace.finish_failed("transition_limit")
+        return _build_result(
             completed=False,
             final_state=current_state,
             error="transition_limit",

--- a/src/backend/workflows/execution_contracts.py
+++ b/src/backend/workflows/execution_contracts.py
@@ -1,0 +1,326 @@
+"""Shared workflow execution contracts for control signals and result envelopes.
+
+JVNAUTOSCI-1311 introduced first-class control-flow primitives and canonical
+step/workflow return envelopes. Keep these helpers central so conversation-turn
+and durable executors remain behaviourally aligned.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, MutableMapping
+
+
+WORKFLOW_CONTROL_SIGNAL_NONE = "none"
+WORKFLOW_CONTROL_SIGNAL_BREAK = "break"
+WORKFLOW_CONTROL_SIGNAL_CONTINUE = "continue"
+WORKFLOW_CONTROL_SIGNAL_RETURN = "return"
+WORKFLOW_CONTROL_SIGNAL_ERROR = "error"
+
+WORKFLOW_CONTROL_SIGNAL_ALLOWED: tuple[str, ...] = (
+    WORKFLOW_CONTROL_SIGNAL_NONE,
+    WORKFLOW_CONTROL_SIGNAL_BREAK,
+    WORKFLOW_CONTROL_SIGNAL_CONTINUE,
+    WORKFLOW_CONTROL_SIGNAL_RETURN,
+    WORKFLOW_CONTROL_SIGNAL_ERROR,
+)
+
+WORKFLOW_CONTROL_ACTION_BREAK_ID = "workflow_control.break"
+WORKFLOW_CONTROL_ACTION_CONTINUE_ID = "workflow_control.continue"
+WORKFLOW_CONTROL_ACTION_FORK_ID = "workflow_control.fork"
+WORKFLOW_CONTROL_ACTION_JOIN_ID = "workflow_control.join"
+
+WORKFLOW_CONTROL_BREAK_ACTION_IDS: tuple[str, ...] = (
+    WORKFLOW_CONTROL_ACTION_BREAK_ID,
+)
+WORKFLOW_CONTROL_CONTINUE_ACTION_IDS: tuple[str, ...] = (
+    WORKFLOW_CONTROL_ACTION_CONTINUE_ID,
+)
+WORKFLOW_CONTROL_FORK_ACTION_IDS: tuple[str, ...] = (
+    WORKFLOW_CONTROL_ACTION_FORK_ID,
+)
+WORKFLOW_CONTROL_JOIN_ACTION_IDS: tuple[str, ...] = (
+    WORKFLOW_CONTROL_ACTION_JOIN_ID,
+)
+
+WORKFLOW_FORK_FAILURE_POLICY_FAIL_FAST = "fail_fast"
+WORKFLOW_FORK_FAILURE_POLICY_COLLECT_ERRORS = "collect_errors"
+WORKFLOW_FORK_FAILURE_POLICY_ALLOW_PARTIAL_SUCCESS = "allow_partial_success"
+WORKFLOW_FORK_ALLOWED_FAILURE_POLICIES: tuple[str, ...] = (
+    WORKFLOW_FORK_FAILURE_POLICY_FAIL_FAST,
+    WORKFLOW_FORK_FAILURE_POLICY_COLLECT_ERRORS,
+    WORKFLOW_FORK_FAILURE_POLICY_ALLOW_PARTIAL_SUCCESS,
+)
+
+WORKFLOW_FORK_MERGE_POLICY_LAST_WRITER_WINS = "deterministic_last_writer_wins"
+WORKFLOW_FORK_ALLOWED_MERGE_POLICIES: tuple[str, ...] = (
+    WORKFLOW_FORK_MERGE_POLICY_LAST_WRITER_WINS,
+)
+
+WORKFLOW_STEP_RESULT_ENVELOPE_SCHEMA_VERSION = "workflow_step_result_envelope.v1"
+WORKFLOW_RESULT_ENVELOPE_SCHEMA_VERSION = "workflow_result_envelope.v1"
+
+WORKFLOW_STEP_RESULT_ENVELOPES_KEY = "workflow_step_result_envelopes"
+LAST_WORKFLOW_STEP_RESULT_ENVELOPE_KEY = "last_workflow_step_result_envelope"
+WORKFLOW_RESULT_ENVELOPE_KEY = "workflow_result_envelope"
+
+WORKFLOW_RUNTIME_METRICS_KEY = "workflow_runtime_metrics"
+WORKFLOW_RUNTIME_EVENTS_KEY = "workflow_control_flow_events"
+WORKFLOW_FORK_CONTEXTS_KEY = "__workflow_fork_contexts"
+
+LAST_CONTROL_SIGNAL_KEY = "last_control_signal"
+LAST_CONTROL_SIGNAL_SCOPE_KEY = "last_control_signal_scope"
+LAST_CONTROL_SIGNAL_BREAK_KEY = "last_control_signal_break"
+LAST_CONTROL_SIGNAL_CONTINUE_KEY = "last_control_signal_continue"
+LAST_CONTROL_SIGNAL_RETURN_KEY = "last_control_signal_return"
+LAST_CONTROL_SIGNAL_ERROR_KEY = "last_control_signal_error"
+WORKFLOW_RETURN_PAYLOAD_KEY = "workflow_return_payload"
+
+
+def _normalise_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def normalise_control_signal(
+    value: Any,
+    *,
+    default: str = WORKFLOW_CONTROL_SIGNAL_NONE,
+) -> str:
+    raw = _normalise_text(value).lower()
+    if raw in WORKFLOW_CONTROL_SIGNAL_ALLOWED:
+        return raw
+    return default
+
+
+def normalise_signal_scope(value: Any) -> str | None:
+    text = _normalise_text(value)
+    return text or None
+
+
+def resolve_control_signal_from_outputs(
+    *,
+    action_outcome: str,
+    outputs: Mapping[str, Any] | None,
+) -> tuple[str, str | None, Any | None]:
+    payload = outputs if isinstance(outputs, Mapping) else {}
+    nested_control = payload.get("workflow_control")
+    nested_control_map = nested_control if isinstance(nested_control, Mapping) else {}
+
+    signal = normalise_control_signal(
+        payload.get("control_signal")
+        or payload.get("workflow_control_signal")
+        or nested_control_map.get("signal")
+    )
+    scope = normalise_signal_scope(
+        payload.get("control_scope")
+        or payload.get("control_signal_scope")
+        or nested_control_map.get("scope")
+    )
+    return_payload = payload.get("return_payload")
+    if return_payload is None and signal == WORKFLOW_CONTROL_SIGNAL_RETURN:
+        return_payload = payload.get("result")
+
+    if signal == WORKFLOW_CONTROL_SIGNAL_NONE and action_outcome == "failure":
+        signal = WORKFLOW_CONTROL_SIGNAL_ERROR
+
+    return signal, scope, return_payload
+
+
+def clear_control_signal_context(context: MutableMapping[str, Any]) -> None:
+    context[LAST_CONTROL_SIGNAL_KEY] = WORKFLOW_CONTROL_SIGNAL_NONE
+    context[LAST_CONTROL_SIGNAL_SCOPE_KEY] = None
+    context[LAST_CONTROL_SIGNAL_BREAK_KEY] = False
+    context[LAST_CONTROL_SIGNAL_CONTINUE_KEY] = False
+    context[LAST_CONTROL_SIGNAL_RETURN_KEY] = False
+    context[LAST_CONTROL_SIGNAL_ERROR_KEY] = False
+
+
+def stamp_control_signal_context(
+    *,
+    context: MutableMapping[str, Any],
+    signal: str,
+    scope: str | None = None,
+    return_payload: Any | None = None,
+) -> None:
+    normalised_signal = normalise_control_signal(signal)
+    clear_control_signal_context(context)
+    context[LAST_CONTROL_SIGNAL_KEY] = normalised_signal
+    context[LAST_CONTROL_SIGNAL_SCOPE_KEY] = normalise_signal_scope(scope)
+    context[LAST_CONTROL_SIGNAL_BREAK_KEY] = (
+        normalised_signal == WORKFLOW_CONTROL_SIGNAL_BREAK
+    )
+    context[LAST_CONTROL_SIGNAL_CONTINUE_KEY] = (
+        normalised_signal == WORKFLOW_CONTROL_SIGNAL_CONTINUE
+    )
+    context[LAST_CONTROL_SIGNAL_RETURN_KEY] = (
+        normalised_signal == WORKFLOW_CONTROL_SIGNAL_RETURN
+    )
+    context[LAST_CONTROL_SIGNAL_ERROR_KEY] = (
+        normalised_signal == WORKFLOW_CONTROL_SIGNAL_ERROR
+    )
+
+    if normalised_signal == WORKFLOW_CONTROL_SIGNAL_RETURN:
+        context[WORKFLOW_RETURN_PAYLOAD_KEY] = return_payload
+    elif WORKFLOW_RETURN_PAYLOAD_KEY in context:
+        context[WORKFLOW_RETURN_PAYLOAD_KEY] = None
+
+
+def get_last_control_signal(context: Mapping[str, Any]) -> str:
+    return normalise_control_signal(context.get(LAST_CONTROL_SIGNAL_KEY))
+
+
+def get_last_control_signal_scope(context: Mapping[str, Any]) -> str | None:
+    return normalise_signal_scope(context.get(LAST_CONTROL_SIGNAL_SCOPE_KEY))
+
+
+def append_runtime_event(
+    *,
+    context: MutableMapping[str, Any],
+    event: Mapping[str, Any],
+) -> None:
+    existing = context.get(WORKFLOW_RUNTIME_EVENTS_KEY)
+    if not isinstance(existing, list):
+        existing = []
+        context[WORKFLOW_RUNTIME_EVENTS_KEY] = existing
+    existing.append(dict(event))
+
+
+def increment_runtime_metric(
+    *,
+    context: MutableMapping[str, Any],
+    key: str,
+    amount: int = 1,
+) -> None:
+    metrics = context.get(WORKFLOW_RUNTIME_METRICS_KEY)
+    if not isinstance(metrics, dict):
+        metrics = {}
+        context[WORKFLOW_RUNTIME_METRICS_KEY] = metrics
+    metrics[key] = int(metrics.get(key, 0)) + int(amount)
+
+
+def _build_mutation_summary(
+    *,
+    context_before: Mapping[str, Any],
+    context_after: Mapping[str, Any],
+    declared_output_payload: Mapping[str, Any] | None = None,
+) -> Dict[str, Any]:
+    before_keys = set(context_before.keys())
+    after_keys = set(context_after.keys())
+    added_keys = sorted(after_keys - before_keys)
+    removed_keys = sorted(before_keys - after_keys)
+
+    changed_keys = sorted(
+        key
+        for key in before_keys.intersection(after_keys)
+        if context_before.get(key) != context_after.get(key)
+    )
+    declared_output_keys = sorted(
+        key
+        for key in (declared_output_payload or {}).keys()
+        if isinstance(key, str) and key
+    )
+    return {
+        "declared_output_keys": declared_output_keys,
+        "added_keys": added_keys,
+        "changed_keys": changed_keys,
+        "removed_keys": removed_keys,
+        "changed_key_count": len(added_keys) + len(changed_keys) + len(removed_keys),
+    }
+
+
+def build_step_result_envelope(
+    *,
+    workflow_id: str,
+    state_id: str,
+    action_id: str,
+    action_status: str,
+    action_outcome: str,
+    action_error: str | None,
+    action_outputs: Mapping[str, Any] | None,
+    control_signal: str,
+    control_signal_scope: str | None,
+    duration_ms: float | None,
+    context_before: Mapping[str, Any],
+    context_after: Mapping[str, Any],
+) -> Dict[str, Any]:
+    output_payload = (
+        dict(action_outputs)
+        if isinstance(action_outputs, Mapping)
+        else {}
+    )
+    return {
+        "schema_version": WORKFLOW_STEP_RESULT_ENVELOPE_SCHEMA_VERSION,
+        "workflow_id": str(workflow_id or "").strip(),
+        "state_id": str(state_id or "").strip(),
+        "action_id": str(action_id or "").strip(),
+        "action_status": str(action_status or "").strip(),
+        "action_outcome": str(action_outcome or "").strip(),
+        "control_signal": normalise_control_signal(control_signal),
+        "control_signal_scope": normalise_signal_scope(control_signal_scope),
+        "output_payload": output_payload,
+        "mutation_summary": _build_mutation_summary(
+            context_before=context_before,
+            context_after=context_after,
+            declared_output_payload=output_payload,
+        ),
+        "diagnostics": {
+            "error": str(action_error) if action_error else None,
+            "duration_ms": duration_ms,
+        },
+    }
+
+
+def append_step_result_envelope(
+    *,
+    context: MutableMapping[str, Any],
+    envelope: Mapping[str, Any],
+) -> None:
+    existing = context.get(WORKFLOW_STEP_RESULT_ENVELOPES_KEY)
+    if not isinstance(existing, list):
+        existing = []
+        context[WORKFLOW_STEP_RESULT_ENVELOPES_KEY] = existing
+    payload = dict(envelope)
+    existing.append(payload)
+    context[LAST_WORKFLOW_STEP_RESULT_ENVELOPE_KEY] = payload
+
+
+def build_workflow_result_envelope(
+    *,
+    workflow_id: str,
+    completed: bool,
+    final_state: str,
+    error: str | None,
+    control_signal: str,
+    return_payload: Any,
+    context: Mapping[str, Any],
+    transition_count: int,
+) -> Dict[str, Any]:
+    step_envelopes = context.get(WORKFLOW_STEP_RESULT_ENVELOPES_KEY)
+    step_count = len(step_envelopes) if isinstance(step_envelopes, list) else 0
+    runtime_metrics = context.get(WORKFLOW_RUNTIME_METRICS_KEY)
+    metrics_payload = dict(runtime_metrics) if isinstance(runtime_metrics, Mapping) else {}
+    return {
+        "schema_version": WORKFLOW_RESULT_ENVELOPE_SCHEMA_VERSION,
+        "workflow_id": str(workflow_id or "").strip(),
+        "completed": bool(completed),
+        "final_state": str(final_state or "").strip(),
+        "control_signal": normalise_control_signal(control_signal),
+        "declared_output_payload": return_payload,
+        "mutation_summary": {
+            "step_count": step_count,
+            "context_key_count": len(context),
+        },
+        "diagnostics": {
+            "error": str(error) if error else None,
+            "transition_count": int(transition_count),
+            "metrics": metrics_payload,
+        },
+    }
+
+
+def set_workflow_result_envelope(
+    *,
+    context: MutableMapping[str, Any],
+    envelope: Mapping[str, Any],
+) -> None:
+    context[WORKFLOW_RESULT_ENVELOPE_KEY] = dict(envelope)
+

--- a/src/backend/workflows/vontology_loader.py
+++ b/src/backend/workflows/vontology_loader.py
@@ -81,6 +81,18 @@ WORKFLOW_GRAPH_PREDICATE_ALIASES: Dict[str, Tuple[str, ...]] = {
         "#V#on_unknown_next_step",
         "on_unknown_next_step",
     ),
+    "onBreakNextStep": (
+        "#V#onBreakNextStep",
+        "onBreakNextStep",
+        "#V#on_break_next_step",
+        "on_break_next_step",
+    ),
+    "onContinueNextStep": (
+        "#V#onContinueNextStep",
+        "onContinueNextStep",
+        "#V#on_continue_next_step",
+        "on_continue_next_step",
+    ),
     "hasPrecondition": (
         "#V#hasPrecondition",
         "hasPrecondition",
@@ -1312,6 +1324,28 @@ def build_workflow_process_graph(
             matched_predicates=(on_unknown_predicate,),
         )
 
+        on_break_candidates = WORKFLOW_GRAPH_PREDICATE_ALIASES["onBreakNextStep"]
+        on_break, on_break_predicate = _first_relationship_target_with_predicate(
+            step_rels,
+            on_break_candidates,
+        )
+        _record_legacy_alias_use(
+            legacy_aliases=legacy_aliases,
+            canonical_predicate=on_break_candidates[0],
+            matched_predicates=(on_break_predicate,),
+        )
+
+        on_continue_candidates = WORKFLOW_GRAPH_PREDICATE_ALIASES["onContinueNextStep"]
+        on_continue, on_continue_predicate = _first_relationship_target_with_predicate(
+            step_rels,
+            on_continue_candidates,
+        )
+        _record_legacy_alias_use(
+            legacy_aliases=legacy_aliases,
+            canonical_predicate=on_continue_candidates[0],
+            matched_predicates=(on_continue_predicate,),
+        )
+
         precondition_candidates = WORKFLOW_GRAPH_PREDICATE_ALIASES["hasPrecondition"]
         preconditions, precondition_predicates = _all_relationship_targets_with_predicates(
             step_rels,
@@ -1420,6 +1454,8 @@ def build_workflow_process_graph(
                     "on_false": on_false,
                     "on_failure": on_failure,
                     "on_unknown": on_unknown,
+                    "on_break": on_break,
+                    "on_continue": on_continue,
                 },
             }
         )
@@ -1429,6 +1465,8 @@ def build_workflow_process_graph(
         _edge(step_id, "onFalseNextStep", on_false)
         _edge(step_id, "onFailureNextStep", on_failure)
         _edge(step_id, "onUnknownNextStep", on_unknown)
+        _edge(step_id, "onBreakNextStep", on_break)
+        _edge(step_id, "onContinueNextStep", on_continue)
 
     if legacy_aliases:
         warnings.append(
@@ -1645,6 +1683,8 @@ def load_workflow_definition_from_vontology(
 
         on_failure_target = control_flow.get("on_failure")
         on_unknown_target = control_flow.get("on_unknown")
+        on_break_target = control_flow.get("on_break")
+        on_continue_target = control_flow.get("on_continue")
         on_true_target = control_flow.get("on_true")
         on_false_target = control_flow.get("on_false")
         next_target = control_flow.get("next")
@@ -1721,7 +1761,8 @@ def load_workflow_definition_from_vontology(
                     condition_spec=raw_condition_spec,
                 )
 
-        # Priority: on_failure → on_unknown → on_true/on_false → next.
+        # Priority: on_failure → on_unknown → on_break/on_continue →
+        # on_true/on_false → next.
         # Canonical Vontology workflows rely on this deterministic ordering.
         if on_failure_target:
             _append_transition_from_spec(
@@ -1742,6 +1783,26 @@ def load_workflow_definition_from_vontology(
                     "kind": "context_flag",
                     "key": "last_action_unknown",
                     "expected": True,
+                },
+            )
+
+        if on_break_target:
+            _append_transition_from_spec(
+                to_state=on_break_target,
+                reason="on_break",
+                condition_spec={
+                    "kind": "control_signal",
+                    "signal": "break",
+                },
+            )
+
+        if on_continue_target:
+            _append_transition_from_spec(
+                to_state=on_continue_target,
+                reason="on_continue",
+                condition_spec={
+                    "kind": "control_signal",
+                    "signal": "continue",
                 },
             )
 

--- a/src/backend/workflows/workflow_definition_identity_service.py
+++ b/src/backend/workflows/workflow_definition_identity_service.py
@@ -16,6 +16,12 @@ from .subworkflow_contracts import (
     WORKFLOW_SUBWORKFLOW_ACTION_ID,
     normalise_subworkflow_contract,
 )
+from .execution_contracts import (
+    WORKFLOW_CONTROL_BREAK_ACTION_IDS,
+    WORKFLOW_CONTROL_CONTINUE_ACTION_IDS,
+    WORKFLOW_CONTROL_FORK_ACTION_IDS,
+    WORKFLOW_CONTROL_JOIN_ACTION_IDS,
+)
 
 WORKFLOW_DEFINITION_IDENTITY_SCHEMA_VERSION = "workflow_definition_identity.v1"
 WORKFLOW_DEFINITION_IDENTITY_VERSION = 1
@@ -32,6 +38,9 @@ _STATE_METADATA_CONTRACT_KEYS: tuple[str, ...] = (
     "tool_output_context_mappings",
     "subworkflow_contract",
     "invokes_workflow",
+    "loop_scope_id",
+    "fork_id",
+    "join_fork_id",
 )
 
 
@@ -123,6 +132,79 @@ def _extract_possible_outputs(definition: Any) -> set[str]:
     return outputs
 
 
+def _extract_action_input_text(action: Any, *keys: str) -> str:
+    inputs = getattr(action, "inputs", {})
+    if not isinstance(inputs, Mapping):
+        return ""
+    for key in keys:
+        value = inputs.get(key)
+        text = str(value or "").strip()
+        if text:
+            return text
+    return ""
+
+
+def _collect_subworkflow_children(definition: Any) -> set[str]:
+    children: set[str] = set()
+    states_raw = getattr(definition, "states", {})
+    states = states_raw if isinstance(states_raw, Mapping) else {}
+    for state_spec in states.values():
+        actions_raw = getattr(state_spec, "actions", ())
+        actions = actions_raw if _is_sequence_like(actions_raw) else ()
+        metadata = _state_metadata(state_spec)
+        contract_raw = metadata.get("subworkflow_contract")
+        contract, _ = normalise_subworkflow_contract(contract_raw)
+        if isinstance(contract, Mapping):
+            workflow_id = str(contract.get("workflow_id") or "").strip()
+            if workflow_id:
+                children.add(workflow_id)
+        for action in actions:
+            action_id = str(getattr(action, "action_id", "") or "").strip()
+            if action_id != WORKFLOW_SUBWORKFLOW_ACTION_ID:
+                continue
+            workflow_id = _extract_action_input_text(action, "workflow_id")
+            if workflow_id:
+                children.add(workflow_id)
+    return children
+
+
+def _find_recursive_subworkflow_cycle(
+    *,
+    parent_workflow_id: str,
+    child_workflow_id: str,
+    loader: Callable[[str], Any | None] | None,
+    max_depth: int = 16,
+) -> list[str] | None:
+    if (
+        not parent_workflow_id
+        or not child_workflow_id
+        or not callable(loader)
+        or max_depth < 1
+    ):
+        return None
+
+    stack: list[tuple[str, list[str]]] = [(child_workflow_id, [child_workflow_id])]
+    while stack:
+        workflow_id, path = stack.pop()
+        if len(path) > max_depth:
+            continue
+        if workflow_id == parent_workflow_id and len(path) > 1:
+            return path
+        try:
+            definition = loader(workflow_id)
+        except Exception:
+            continue
+        if definition is None:
+            continue
+        for child_id in sorted(_collect_subworkflow_children(definition)):
+            if child_id == parent_workflow_id:
+                return [*path, child_id]
+            if child_id in path:
+                continue
+            stack.append((child_id, [*path, child_id]))
+    return None
+
+
 def collect_workflow_action_ids(definition: Any) -> tuple[str, ...]:
     """Collect unique action IDs referenced by a workflow definition."""
 
@@ -195,6 +277,32 @@ def _transition_payload_from_graph_step(
                     "kind": "context_flag",
                     "key": "last_action_unknown",
                     "expected": True,
+                },
+            }
+        )
+
+    on_break_target = str(control_flow.get("on_break") or "").strip()
+    if on_break_target:
+        transitions.append(
+            {
+                "to_state": on_break_target,
+                "reason": "on_break",
+                "condition_spec": {
+                    "kind": "control_signal",
+                    "signal": "break",
+                },
+            }
+        )
+
+    on_continue_target = str(control_flow.get("on_continue") or "").strip()
+    if on_continue_target:
+        transitions.append(
+            {
+                "to_state": on_continue_target,
+                "reason": "on_continue",
+                "condition_spec": {
+                    "kind": "control_signal",
+                    "signal": "continue",
                 },
             }
         )
@@ -486,6 +594,8 @@ def validate_workflow_definition_contract(
             "unresolved_output_mapping_states": [],
             "invalid_output_mapping_specs": [],
             "subworkflow_contract_issues": [],
+            "control_signal_issues": [],
+            "fork_join_issues": [],
         }
 
     states_raw = getattr(definition, "states", {})
@@ -508,6 +618,9 @@ def validate_workflow_definition_contract(
     unresolved_output_mapping_states: list[str] = []
     invalid_output_mapping_specs: list[dict[str, Any]] = []
     subworkflow_contract_issues: list[dict[str, Any]] = []
+    control_signal_issues: list[dict[str, Any]] = []
+    fork_join_issues: list[dict[str, Any]] = []
+    declared_fork_ids: set[str] = set()
 
     supported_action_set: set[str] = set()
     if supported_action_ids is not None:
@@ -524,16 +637,36 @@ def validate_workflow_definition_contract(
             if isinstance(workflow_id, str) and str(workflow_id).strip()
         }
 
+    for scan_state_id in sorted(str(item) for item in states.keys()):
+        scan_state_spec = states[scan_state_id]
+        actions_raw = getattr(scan_state_spec, "actions", ())
+        actions = actions_raw if _is_sequence_like(actions_raw) else ()
+        for action in actions:
+            action_id = str(getattr(action, "action_id", "") or "").strip()
+            if action_id not in WORKFLOW_CONTROL_FORK_ACTION_IDS:
+                continue
+            fork_id = _extract_action_input_text(action, "fork_id", "fork_context_id")
+            declared_fork_ids.add(fork_id or scan_state_id)
+
     for state_id in sorted(str(item) for item in states.keys()):
         state_spec = states[state_id]
         metadata_raw = getattr(state_spec, "metadata", {})
         metadata = dict(metadata_raw) if isinstance(metadata_raw, Mapping) else {}
         actions_raw = getattr(state_spec, "actions", ())
-        actions = [
-            str(getattr(action, "action_id", "") or "").strip()
-            for action in (actions_raw if _is_sequence_like(actions_raw) else ())
-        ]
-        actions = [item for item in actions if item]
+        action_objects = actions_raw if _is_sequence_like(actions_raw) else ()
+        action_specs: list[tuple[str, Mapping[str, Any]]] = []
+        for action in action_objects:
+            action_id = str(getattr(action, "action_id", "") or "").strip()
+            if not action_id:
+                continue
+            action_inputs_raw = getattr(action, "inputs", {})
+            action_inputs = (
+                dict(action_inputs_raw)
+                if isinstance(action_inputs_raw, Mapping)
+                else {}
+            )
+            action_specs.append((action_id, action_inputs))
+        actions = [action_id for action_id, _ in action_specs]
         is_terminal_state = bool(getattr(state_spec, "terminal", False)) or (
             state_id in termination_states
         )
@@ -564,6 +697,79 @@ def validate_workflow_definition_contract(
                         ),
                     }
                 )
+
+        has_on_break_transition = any(
+            str(getattr(transition, "reason", "") or "").strip().lower() == "on_break"
+            for transition in transitions
+        )
+        has_on_continue_transition = any(
+            str(getattr(transition, "reason", "") or "").strip().lower()
+            == "on_continue"
+            for transition in transitions
+        )
+        loop_scope_id = str(metadata.get("loop_scope_id") or "").strip()
+        for action_id, action_inputs in action_specs:
+            if action_id in WORKFLOW_CONTROL_BREAK_ACTION_IDS:
+                action_scope = str(
+                    action_inputs.get("loop_scope_id")
+                    or action_inputs.get("scope")
+                    or ""
+                ).strip()
+                if not (action_scope or loop_scope_id):
+                    control_signal_issues.append(
+                        {
+                            "state_id": state_id,
+                            "action_id": action_id,
+                            "reason_code": "break_outside_loop_scope",
+                        }
+                    )
+                if not has_on_break_transition:
+                    control_signal_issues.append(
+                        {
+                            "state_id": state_id,
+                            "action_id": action_id,
+                            "reason_code": "break_transition_missing",
+                        }
+                    )
+            if action_id in WORKFLOW_CONTROL_CONTINUE_ACTION_IDS:
+                action_scope = str(
+                    action_inputs.get("loop_scope_id")
+                    or action_inputs.get("scope")
+                    or ""
+                ).strip()
+                if not (action_scope or loop_scope_id):
+                    control_signal_issues.append(
+                        {
+                            "state_id": state_id,
+                            "action_id": action_id,
+                            "reason_code": "continue_outside_loop_scope",
+                        }
+                    )
+                if not has_on_continue_transition:
+                    control_signal_issues.append(
+                        {
+                            "state_id": state_id,
+                            "action_id": action_id,
+                            "reason_code": "continue_transition_missing",
+                        }
+                    )
+            if action_id in WORKFLOW_CONTROL_JOIN_ACTION_IDS:
+                join_fork_id = str(
+                    action_inputs.get("fork_id")
+                    or action_inputs.get("fork_context_id")
+                    or metadata.get("fork_id")
+                    or metadata.get("join_fork_id")
+                    or state_id
+                ).strip()
+                if join_fork_id not in declared_fork_ids:
+                    fork_join_issues.append(
+                        {
+                            "state_id": state_id,
+                            "action_id": action_id,
+                            "fork_id": join_fork_id,
+                            "reason_code": "join_without_matching_fork",
+                        }
+                    )
 
         if metadata.get("unresolved_input_mappings"):
             unresolved_input_mapping_states.append(state_id)
@@ -635,6 +841,20 @@ def validate_workflow_definition_contract(
                                 "detail": str(exc),
                             }
                         )
+                recursive_cycle_path = _find_recursive_subworkflow_cycle(
+                    parent_workflow_id=parent_workflow_id,
+                    child_workflow_id=child_workflow_id,
+                    loader=workflow_definition_loader,
+                )
+                if recursive_cycle_path:
+                    subworkflow_contract_issues.append(
+                        {
+                            "state_id": state_id,
+                            "workflow_id": child_workflow_id,
+                            "reason_code": "subworkflow_recursive_cycle",
+                            "cycle_path": recursive_cycle_path,
+                        }
+                    )
 
                 child_known = bool(child_definition is not None)
                 if child_workflow_id and not child_known and known_workflow_set:
@@ -748,6 +968,23 @@ def validate_workflow_definition_contract(
             str(item.get("reason_code") or ""),
         ),
     )
+    control_signal_issues = sorted(
+        control_signal_issues,
+        key=lambda item: (
+            str(item.get("state_id") or ""),
+            str(item.get("action_id") or ""),
+            str(item.get("reason_code") or ""),
+        ),
+    )
+    fork_join_issues = sorted(
+        fork_join_issues,
+        key=lambda item: (
+            str(item.get("state_id") or ""),
+            str(item.get("action_id") or ""),
+            str(item.get("fork_id") or ""),
+            str(item.get("reason_code") or ""),
+        ),
+    )
 
     errors: list[str] = []
     if vacuous_state_ids:
@@ -764,6 +1001,10 @@ def validate_workflow_definition_contract(
         errors.append("workflow_output_mapping_unresolved")
     if invalid_output_mapping_specs:
         errors.append("workflow_output_mapping_invalid")
+    if control_signal_issues:
+        errors.append("workflow_control_signal_invalid")
+    if fork_join_issues:
+        errors.append("workflow_fork_join_invalid")
     if subworkflow_contract_issues:
         unresolved_reason_codes = {
             "subworkflow_workflow_not_found",
@@ -802,6 +1043,8 @@ def validate_workflow_definition_contract(
         "unresolved_output_mapping_states": unresolved_output_mapping_states,
         "invalid_output_mapping_specs": invalid_output_mapping_specs,
         "subworkflow_contract_issues": subworkflow_contract_issues,
+        "control_signal_issues": control_signal_issues,
+        "fork_join_issues": fork_join_issues,
     }
 
 

--- a/tests/backend/test_control_flow_actions.py
+++ b/tests/backend/test_control_flow_actions.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from src.backend.workflows.action_registry import (
+    ActionRegistry,
+    ActionSpec,
+    WorkflowActionResult,
+    WorkflowEnvironment,
+)
+from src.backend.workflows.durable.control_flow_actions import register_control_flow_actions
+from src.backend.workflows.execution_contracts import (
+    WORKFLOW_CONTROL_ACTION_BREAK_ID,
+    WORKFLOW_CONTROL_ACTION_FORK_ID,
+    WORKFLOW_CONTROL_ACTION_JOIN_ID,
+)
+from src.backend.workflows.engine import (
+    WorkflowActionInvocation,
+    WorkflowDefinition,
+    WorkflowStateSpec,
+)
+
+
+def _child_definition(workflow_id: str, action_id: str) -> WorkflowDefinition:
+    return WorkflowDefinition(
+        workflow_id=workflow_id,
+        initial_state="start",
+        states={
+            "start": WorkflowStateSpec(
+                state_id="start",
+                actions=(WorkflowActionInvocation(action_id=action_id),),
+                terminal=True,
+            )
+        },
+        termination_states=("start",),
+    )
+
+
+def test_break_action_emits_control_signal() -> None:
+    registry = ActionRegistry()
+    register_control_flow_actions(registry, definition_loader=lambda _workflow_id: None)
+
+    context: dict[str, object] = {}
+    result = registry.execute(
+        WORKFLOW_CONTROL_ACTION_BREAK_ID,
+        inputs={"loop_scope_id": "main"},
+        context=context,
+        env=WorkflowEnvironment(llm_client=None),
+    )
+
+    assert result.status == "success"
+    assert result.outputs.get("control_signal") == "break"
+    assert result.outputs.get("control_scope") == "main"
+
+
+def test_fork_join_actions_execute_and_merge_branch_results() -> None:
+    registry = ActionRegistry()
+    registry.register(
+        ActionSpec(
+            action_id="child.emit_one",
+            handler=lambda _request: WorkflowActionResult(outputs={"value_one": 1}),
+        )
+    )
+    registry.register(
+        ActionSpec(
+            action_id="child.emit_two",
+            handler=lambda _request: WorkflowActionResult(outputs={"value_two": 2}),
+        )
+    )
+    definitions = {
+        "#V#child_one": _child_definition("#V#child_one", "child.emit_one"),
+        "#V#child_two": _child_definition("#V#child_two", "child.emit_two"),
+    }
+    register_control_flow_actions(
+        registry,
+        definition_loader=lambda workflow_id: definitions.get(workflow_id),
+    )
+
+    context: dict[str, object] = {}
+    fork_result = registry.execute(
+        WORKFLOW_CONTROL_ACTION_FORK_ID,
+        inputs={
+            "fork_id": "main_fork",
+            "failure_policy": "collect_errors",
+            "branches": [
+                {"branch_id": "a", "workflow_id": "#V#child_one"},
+                {"branch_id": "b", "workflow_id": "#V#child_two"},
+            ],
+        },
+        context=context,
+        env=WorkflowEnvironment(llm_client=None),
+    )
+
+    assert fork_result.status == "success"
+    assert fork_result.outputs.get("fork_success_count") == 2
+    join_result = registry.execute(
+        WORKFLOW_CONTROL_ACTION_JOIN_ID,
+        inputs={"fork_id": "main_fork"},
+        context=context,
+        env=WorkflowEnvironment(llm_client=None),
+    )
+
+    assert join_result.status == "success"
+    assert join_result.outputs.get("fork_joined") is True
+    merged = join_result.outputs.get("result")
+    assert merged == {"value_one": 1, "value_two": 2}
+
+
+def test_join_action_fails_without_matching_fork() -> None:
+    registry = ActionRegistry()
+    register_control_flow_actions(registry, definition_loader=lambda _workflow_id: None)
+
+    result = registry.execute(
+        WORKFLOW_CONTROL_ACTION_JOIN_ID,
+        inputs={"fork_id": "missing"},
+        context={},
+        env=WorkflowEnvironment(llm_client=None),
+    )
+
+    assert result.status == "failed"
+    assert "join_without_matching_fork" in str(result.error or "")

--- a/tests/backend/test_durable_workflow_executor_safety.py
+++ b/tests/backend/test_durable_workflow_executor_safety.py
@@ -560,3 +560,66 @@ def test_durable_executor_applies_output_mapping_before_metadata_validation() ->
     assert events[0].get("context_key") == "validated_type_id"
     assert events[0].get("value_present") is True
 
+
+def test_durable_executor_populates_result_envelope_for_return_signal() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="#V#durable_return_signal",
+        initial_state="compute",
+        states={
+            "compute": WorkflowStateSpec(
+                state_id="compute",
+                actions=(WorkflowActionInvocation(action_id="emit.return"),),
+                transitions=(
+                    WorkflowTransitionSpec(
+                        to_state="done",
+                        reason="next_step",
+                        condition=lambda _ctx: True,
+                    ),
+                ),
+            ),
+            "done": WorkflowStateSpec(state_id="done", terminal=True),
+        },
+    )
+
+    registry = ActionRegistry()
+    registry.register(
+        ActionSpec(
+            action_id="emit.return",
+            handler=lambda _request: WorkflowActionResult(
+                outputs={
+                    "control_signal": "return",
+                    "return_payload": {"answer": "done"},
+                }
+            ),
+        )
+    )
+
+    manager = MagicMock()
+    manager.get_instance.return_value = _build_instance(definition.workflow_id)
+    manager.is_cancelled.return_value = False
+    manager.extend_lock.return_value = True
+    manager.checkpoint.return_value = True
+
+    executor = DurableWorkflowExecutor(registry=registry, instance_manager=manager)
+    with (
+        patch(
+            "src.backend.languagemodels.llm_interface.get_llm_client",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "src.backend.languagemodels.llm_interface.get_active_model_name",
+            return_value="test-model",
+        ),
+    ):
+        result = executor.run_durable(
+            "instance-1",
+            definition,
+            resume_from_checkpoint=False,
+        )
+
+    assert result.completed is True
+    assert result.final_state == "compute"
+    assert isinstance(result.result_envelope, dict)
+    assert result.result_envelope.get("control_signal") == "return"
+    assert result.result_envelope.get("declared_output_payload") == {"answer": "done"}
+

--- a/tests/backend/test_subworkflow_actions.py
+++ b/tests/backend/test_subworkflow_actions.py
@@ -312,3 +312,82 @@ def test_subworkflow_action_is_idempotent_for_same_inputs() -> None:
     assert first.outputs["result"]["answer"] == "stable"
     assert second.outputs["result"]["answer"] == "stable"
     assert first.outputs["result"]["answer"] == second.outputs["result"]["answer"]
+
+
+def test_subworkflow_action_enforces_invocation_budget(monkeypatch) -> None:
+    registry = ActionRegistry()
+    register_subworkflow_actions(
+        registry,
+        definition_loader=lambda _workflow_id: _child_success_definition(),
+    )
+    monkeypatch.setenv("VON_WORKFLOW_SUBWORKFLOW_MAX_INVOCATIONS", "1")
+
+    context: dict[str, object] = {"__workflow_subworkflow_invocation_count": 1}
+    execution = registry.execute(
+        WORKFLOW_SUBWORKFLOW_ACTION_ID,
+        inputs={
+            "workflow_id": "#V#child_success",
+            "__parent_workflow_id": "#V#parent",
+            "__parent_state_id": "start",
+        },
+        context=context,
+        env=WorkflowEnvironment(llm_client=None),
+        trace=None,
+    )
+
+    assert execution.status == "failed"
+    assert "subworkflow_invocation_budget_exceeded" in str(execution.error or "")
+
+
+def test_subworkflow_action_propagates_child_control_signal() -> None:
+    registry = ActionRegistry()
+
+    child_definition = WorkflowDefinition(
+        workflow_id="#V#child_return",
+        initial_state="start",
+        states={
+            "start": WorkflowStateSpec(
+                state_id="start",
+                actions=(WorkflowActionInvocation(action_id="child.return"),),
+                terminal=True,
+            )
+        },
+        termination_states=("start",),
+    )
+
+    registry.register(
+        ActionSpec(
+            action_id="child.return",
+            handler=lambda _request: WorkflowActionResult(
+                outputs={
+                    "control_signal": "return",
+                    "return_payload": {"value": 7},
+                }
+            ),
+        )
+    )
+    register_subworkflow_actions(
+        registry,
+        definition_loader=lambda workflow_id: (
+            child_definition if workflow_id == "#V#child_return" else None
+        ),
+    )
+
+    context: dict[str, object] = {}
+    execution = registry.execute(
+        WORKFLOW_SUBWORKFLOW_ACTION_ID,
+        inputs={
+            "workflow_id": "#V#child_return",
+            "__parent_workflow_id": "#V#parent",
+            "__parent_state_id": "start",
+        },
+        context=context,
+        env=WorkflowEnvironment(llm_client=None),
+        trace=None,
+    )
+
+    assert execution.status == "success"
+    assert execution.outputs.get("control_signal") == "return"
+    nested = execution.outputs.get("subworkflow_result_envelope")
+    assert isinstance(nested, dict)
+    assert nested.get("control_signal") == "return"

--- a/tests/backend/test_vontology_loader.py
+++ b/tests/backend/test_vontology_loader.py
@@ -76,6 +76,8 @@ def _make_step(
     on_false: str | None = None,
     on_failure: str | None = None,
     on_unknown: str | None = None,
+    on_break: str | None = None,
+    on_continue: str | None = None,
     preconditions: List[str] | None = None,
     effects: List[str] | None = None,
     reads_variables: List[str] | None = None,
@@ -102,6 +104,8 @@ def _make_step(
             "on_false": on_false,
             "on_failure": on_failure,
             "on_unknown": on_unknown,
+            "on_break": on_break,
+            "on_continue": on_continue,
         },
     }
 
@@ -579,6 +583,53 @@ class TestWorkflowGraphPredicateCompatibility:
             for edge in graph["edges"]
         )
 
+    def test_build_graph_reads_on_break_and_on_continue_next_step_predicates(self):
+        workflow_doc = {
+            "concept_id": "#V#workflow_loop_controls",
+            "relationships": {
+                "hasInitialStep": "#V#step_a",
+                "hasStep": ["#V#step_a", "#V#loop_head", "#V#loop_exit"],
+            },
+        }
+        step_docs = {
+            "#V#step_a": {
+                "concept_id": "#V#step_a",
+                "name": "Loop Step",
+                "relationships": {
+                    "invokesAction": "loop_tool",
+                    "onBreakNextStep": "#V#loop_exit",
+                    "onContinueNextStep": "#V#loop_head",
+                },
+            },
+            "#V#loop_head": {
+                "concept_id": "#V#loop_head",
+                "name": "Loop Head",
+                "relationships": {},
+            },
+            "#V#loop_exit": {
+                "concept_id": "#V#loop_exit",
+                "name": "Loop Exit",
+                "relationships": {},
+            },
+        }
+
+        with patch(
+            "src.backend.workflows.vontology_loader.ConceptsRepository.find_one",
+            return_value=workflow_doc,
+        ):
+            with patch(
+                "src.backend.workflows.vontology_loader._fetch_concepts_by_id",
+                return_value=step_docs,
+            ):
+                graph, _warnings = build_workflow_process_graph(
+                    "#V#workflow_loop_controls"
+                )
+
+        assert graph is not None
+        step = graph["steps"][0]
+        assert step["control_flow"]["on_break"] == "#V#loop_exit"
+        assert step["control_flow"]["on_continue"] == "#V#loop_head"
+
 
 # ---------------------------------------------------------------------------
 # Key fix: initial_step key (not initial_state).
@@ -876,6 +927,50 @@ class TestOnUnknownTransitions:
         transitions = defn.states["#V#step"].transitions
         assert transitions[0].reason == "on_unknown"
         assert transitions[1].reason == "next_step"
+
+
+class TestOnBreakContinueTransitions:
+    def test_on_break_and_on_continue_become_control_signal_transitions(self):
+        steps = [
+            _make_step(
+                "#V#loop_step",
+                invokes_action="loop.action",
+                on_break="#V#loop_exit",
+                on_continue="#V#loop_head",
+                next_step="#V#fallback",
+            ),
+            _make_step("#V#loop_head"),
+            _make_step("#V#loop_exit"),
+            _make_step("#V#fallback"),
+        ]
+        graph = _make_graph(initial_step="#V#loop_step", steps=steps)
+
+        with _stub_fetch_concepts(), _stub_narrative():
+            with patch(
+                "src.backend.workflows.vontology_loader.build_workflow_process_graph",
+                return_value=(graph, []),
+            ):
+                defn = load_workflow_definition_from_vontology("#V#test_workflow")
+
+        assert defn is not None
+        loop_step = defn.states["#V#loop_step"]
+        reasons = [transition.reason for transition in loop_step.transitions]
+        assert reasons == ["on_break", "on_continue", "next_step"]
+
+        on_break = loop_step.transitions[0]
+        on_continue = loop_step.transitions[1]
+        assert on_break.condition_spec == {"kind": "control_signal", "signal": "break"}
+        assert on_continue.condition_spec == {
+            "kind": "control_signal",
+            "signal": "continue",
+        }
+        assert (
+            on_break.condition(
+                {"last_control_signal": "break", "last_control_signal_scope": "main"}
+            )
+            is True
+        )
+        assert on_continue.condition({"last_control_signal": "continue"}) is True
 
 
 class TestDeclarativeConditionBranches:

--- a/tests/backend/test_workflow_definition_identity_service.py
+++ b/tests/backend/test_workflow_definition_identity_service.py
@@ -12,6 +12,11 @@ from src.backend.workflows.subworkflow_contracts import (
     WORKFLOW_SUBWORKFLOW_ACTION_ID,
     build_subworkflow_contract,
 )
+from src.backend.workflows.execution_contracts import (
+    WORKFLOW_CONTROL_ACTION_BREAK_ID,
+    WORKFLOW_CONTROL_ACTION_FORK_ID,
+    WORKFLOW_CONTROL_ACTION_JOIN_ID,
+)
 from src.backend.workflows.workflow_definition_identity_service import (
     validate_workflow_definition_contract,
 )
@@ -238,4 +243,138 @@ def test_validate_contract_rejects_recursive_subworkflow_reference() -> None:
     assert any(
         issue.get("reason_code") == "subworkflow_recursive_self_reference"
         for issue in validation["subworkflow_contract_issues"]
+    )
+
+
+def test_validate_contract_rejects_break_without_loop_scope_and_route() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="#V#break_invalid_workflow",
+        initial_state="loop",
+        states={
+            "loop": WorkflowStateSpec(
+                state_id="loop",
+                actions=(
+                    WorkflowActionInvocation(action_id=WORKFLOW_CONTROL_ACTION_BREAK_ID),
+                ),
+                transitions=(
+                    WorkflowTransitionSpec(
+                        to_state="done",
+                        condition=lambda _ctx: True,
+                        reason="next_step",
+                    ),
+                ),
+            ),
+            "done": WorkflowStateSpec(state_id="done", terminal=True),
+        },
+        termination_states=("done",),
+    )
+
+    validation = validate_workflow_definition_contract(definition=definition)
+
+    assert validation["valid"] is False
+    assert "workflow_control_signal_invalid" in (validation.get("errors") or [])
+    assert any(
+        issue.get("reason_code") == "break_outside_loop_scope"
+        for issue in validation.get("control_signal_issues", [])
+    )
+    assert any(
+        issue.get("reason_code") == "break_transition_missing"
+        for issue in validation.get("control_signal_issues", [])
+    )
+
+
+def test_validate_contract_rejects_join_without_matching_fork() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="#V#join_invalid_workflow",
+        initial_state="join_state",
+        states={
+            "join_state": WorkflowStateSpec(
+                state_id="join_state",
+                actions=(
+                    WorkflowActionInvocation(
+                        action_id=WORKFLOW_CONTROL_ACTION_JOIN_ID,
+                        inputs={"fork_id": "missing_fork"},
+                    ),
+                ),
+                terminal=True,
+            )
+        },
+        termination_states=("join_state",),
+    )
+
+    validation = validate_workflow_definition_contract(definition=definition)
+
+    assert validation["valid"] is False
+    assert "workflow_fork_join_invalid" in (validation.get("errors") or [])
+    assert any(
+        issue.get("reason_code") == "join_without_matching_fork"
+        for issue in validation.get("fork_join_issues", [])
+    )
+
+
+def test_validate_contract_accepts_join_with_declared_fork() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="#V#join_valid_workflow",
+        initial_state="fork_state",
+        states={
+            "fork_state": WorkflowStateSpec(
+                state_id="fork_state",
+                actions=(
+                    WorkflowActionInvocation(
+                        action_id=WORKFLOW_CONTROL_ACTION_FORK_ID,
+                        inputs={"fork_id": "main"},
+                    ),
+                ),
+                transitions=(
+                    WorkflowTransitionSpec(
+                        to_state="join_state",
+                        condition=lambda _ctx: True,
+                        reason="next_step",
+                    ),
+                ),
+            ),
+            "join_state": WorkflowStateSpec(
+                state_id="join_state",
+                actions=(
+                    WorkflowActionInvocation(
+                        action_id=WORKFLOW_CONTROL_ACTION_JOIN_ID,
+                        inputs={"fork_id": "main"},
+                    ),
+                ),
+                terminal=True,
+            ),
+        },
+        termination_states=("join_state",),
+    )
+
+    validation = validate_workflow_definition_contract(definition=definition)
+
+    assert validation["valid"] is True
+    assert validation.get("fork_join_issues") == []
+
+
+def test_validate_contract_detects_recursive_subworkflow_cycle() -> None:
+    parent = _parent_with_subworkflow_contract(child_workflow_id="#V#child")
+    child = _parent_with_subworkflow_contract(child_workflow_id="#V#parent_workflow")
+    child = WorkflowDefinition(
+        workflow_id="#V#child",
+        initial_state=child.initial_state,
+        states=child.states,
+        termination_states=child.termination_states,
+        purpose="child",
+    )
+    loader_map = {
+        "#V#child": child,
+        "#V#parent_workflow": parent,
+    }
+
+    validation = validate_workflow_definition_contract(
+        definition=parent,
+        workflow_definition_loader=lambda workflow_id: loader_map.get(workflow_id),
+    )
+
+    assert validation["valid"] is False
+    assert any(
+        issue.get("reason_code") == "subworkflow_recursive_cycle"
+        for issue in validation.get("subworkflow_contract_issues", [])
     )

--- a/tests/backend/test_workflow_execution_contracts.py
+++ b/tests/backend/test_workflow_execution_contracts.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from src.backend.workflows.action_registry import (
+    ActionRegistry,
+    ActionSpec,
+    WorkflowActionRequest,
+    WorkflowActionResult,
+    WorkflowEnvironment,
+)
+from src.backend.workflows.engine import (
+    WorkflowActionInvocation,
+    WorkflowDefinition,
+    WorkflowExecutor,
+    WorkflowStateSpec,
+    WorkflowTransitionSpec,
+)
+
+
+def test_workflow_executor_emits_step_and_workflow_result_envelopes() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="#V#return_signal_workflow",
+        initial_state="compute",
+        states={
+            "compute": WorkflowStateSpec(
+                state_id="compute",
+                actions=(WorkflowActionInvocation(action_id="emit.return"),),
+                transitions=(
+                    WorkflowTransitionSpec(
+                        to_state="next",
+                        reason="next_step",
+                        condition=lambda _ctx: True,
+                    ),
+                ),
+            ),
+            "next": WorkflowStateSpec(state_id="next", terminal=True),
+        },
+    )
+
+    registry = ActionRegistry()
+
+    def _emit_return(_request: WorkflowActionRequest) -> WorkflowActionResult:
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "control_signal": "return",
+                "return_payload": {"answer": 42},
+                "intermediate": "ok",
+            },
+        )
+
+    registry.register(ActionSpec(action_id="emit.return", handler=_emit_return))
+
+    result = WorkflowExecutor(registry=registry, max_transitions=5).run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={},
+    )
+
+    assert result.completed is True
+    assert result.final_state == "compute"
+    assert result.result_envelope is not None
+    assert result.result_envelope.get("control_signal") == "return"
+    assert result.result_envelope.get("declared_output_payload") == {"answer": 42}
+    envelopes = result.data.get("workflow_step_result_envelopes")
+    assert isinstance(envelopes, list)
+    assert len(envelopes) == 1
+    assert envelopes[0].get("control_signal") == "return"
+    assert envelopes[0].get("state_id") == "compute"
+    assert isinstance(envelopes[0].get("mutation_summary"), dict)
+
+
+def test_workflow_executor_fails_break_without_explicit_on_break_route() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="#V#break_without_route",
+        initial_state="loop_step",
+        states={
+            "loop_step": WorkflowStateSpec(
+                state_id="loop_step",
+                actions=(WorkflowActionInvocation(action_id="emit.break"),),
+                transitions=(
+                    WorkflowTransitionSpec(
+                        to_state="fallback",
+                        reason="next_step",
+                        condition=lambda _ctx: True,
+                    ),
+                ),
+            ),
+            "fallback": WorkflowStateSpec(state_id="fallback", terminal=True),
+        },
+    )
+
+    registry = ActionRegistry()
+    registry.register(
+        ActionSpec(
+            action_id="emit.break",
+            handler=lambda _request: WorkflowActionResult(
+                status="success",
+                outputs={"control_signal": "break", "control_scope": "main_loop"},
+            ),
+        )
+    )
+
+    result = WorkflowExecutor(registry=registry, max_transitions=5).run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={},
+    )
+
+    assert result.completed is False
+    assert result.error == "workflow_break_outside_loop_scope"

--- a/tests/backend/test_workflow_transition_conditions.py
+++ b/tests/backend/test_workflow_transition_conditions.py
@@ -155,3 +155,63 @@ def test_executor_evaluates_transition_result_truth_condition_spec(
 
     assert result.completed is True
     assert result.final_state == expected_state
+
+
+def test_executor_routes_on_break_control_signal_condition() -> None:
+    on_break_spec, on_break_fn = build_transition_condition(
+        {"kind": "control_signal", "signal": "break", "scope": "main_loop"}
+    )
+    next_spec, next_fn = build_transition_condition({"kind": "always"})
+
+    definition = WorkflowDefinition(
+        workflow_id="#V#condition_spec_break_workflow",
+        initial_state="loop_step",
+        states={
+            "loop_step": WorkflowStateSpec(
+                state_id="loop_step",
+                actions=(WorkflowActionInvocation(action_id="emit.break"),),
+                transitions=(
+                    WorkflowTransitionSpec(
+                        to_state="loop_exit",
+                        reason="on_break",
+                        condition=on_break_fn,
+                        condition_spec=on_break_spec,
+                    ),
+                    WorkflowTransitionSpec(
+                        to_state="loop_continue",
+                        reason="next_step",
+                        condition=next_fn,
+                        condition_spec=next_spec,
+                    ),
+                ),
+            ),
+            "loop_exit": WorkflowStateSpec(state_id="loop_exit", terminal=True),
+            "loop_continue": WorkflowStateSpec(state_id="loop_continue", terminal=True),
+        },
+    )
+
+    registry = ActionRegistry()
+    registry.register(
+        ActionSpec(
+            action_id="emit.break",
+            handler=lambda _request: WorkflowActionResult(
+                status="success",
+                outputs={"control_signal": "break", "control_scope": "main_loop"},
+            ),
+        )
+    )
+
+    result = WorkflowExecutor(registry=registry, max_transitions=5).run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={},
+    )
+
+    assert result.completed is True
+    assert result.final_state == "loop_exit"
+
+
+def test_build_transition_condition_rejects_invalid_control_signal() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        build_transition_condition({"kind": "control_signal", "signal": "pause"})
+    assert "workflow_condition_invalid:control_signal_invalid" in str(exc_info.value)


### PR DESCRIPTION
Implements JVNAUTOSCI-1311 workflow control-flow primitives, canonical return envelopes, validation gates, and manual updates.\n\nValidation:\n- pdm run pyright (changed workflow files/tests)\n- pdm run pytest tests/backend/test_workflow_transition_conditions.py tests/backend/test_workflow_execution_contracts.py tests/backend/test_control_flow_actions.py tests/backend/test_subworkflow_actions.py tests/backend/test_workflow_definition_identity_service.py tests/backend/test_vontology_loader.py tests/backend/test_durable_workflow_executor_safety.py -q