### PR TITLE
JVNAUTOSCI-1309: complete workflow-first upload routing semantics

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -322,6 +322,32 @@ Nested propagation:
 - child workflow envelopes are surfaced through `subworkflow_result_envelope`,
 - non-`none` child control signals propagate to parent action outputs.
 
+### 10.4 File-Copy Upload Routing Workflows (JVNAUTOSCI-1309)
+
+Built-in workflow IDs:
+
+- `#V#file_copy_upload_classification_workflow`
+- `#V#file_copy_upload_handler_workflow`
+- `#V#file_copy_interpretation_workflow` (baseline safe path)
+
+Classification outputs (persisted and propagated to the handler) include:
+
+- `route_key` (`scholarly|cv|business_card|interpret|noop`)
+- `route_mode` (`specialised|interpret|fail_closed|noop`)
+- `route_confidence`, `route_reasons`, `target_workflow_id`, `target_workflow_available`
+- `unsupported_specialised_route` and `unsupported_route_reason` when a mutation-class route was selected but no specialised workflow is available.
+
+Safety semantics:
+
+- Low-confidence mutation routes MUST fail closed (`route_mode=fail_closed`) rather than invoking mutation workflows.
+- When specialised CV/business-card workflows are not available, classification MUST emit explicit unsupported-route diagnostics (`unsupported_specialised_route=true`) and route to non-mutation handling (`interpret` or `noop` per fallback policy).
+- Handler outcome persistence (`#V#has_file_copy_upload_route_outcome_json`) records selected/effective route mode, success, reasons, and unsupported-route diagnostics for post-run inspection.
+
+Event-launch semantics:
+
+- `file_copy.uploaded` launches use a single selected workflow strategy (`#V#file_copy_upload_handler_workflow` by default) to avoid duplicate uncontrolled launches.
+- Default event bindings are bootstrapped idempotently; conflicting bindings are not overwritten.
+
 ## 11. Durable Runtime Semantics
 
 ### 11.1 Instance Model

--- a/src/backend/workflows/durable/file_copy_upload_classification_workflow.py
+++ b/src/backend/workflows/durable/file_copy_upload_classification_workflow.py
@@ -357,6 +357,8 @@ def _build_classification_payload(raw: Mapping[str, Any]) -> dict[str, Any]:
     available_workflow_ids = set(_resolve_available_workflow_ids(raw))
     target_workflow_id: str | None = None
     target_workflow_available = False
+    unsupported_specialised_route = False
+    unsupported_route_reason: str | None = None
     mutation_route = route_key in {
         ROUTE_KEY_SCHOLARLY,
         ROUTE_KEY_CV,
@@ -377,7 +379,9 @@ def _build_classification_payload(raw: Mapping[str, Any]) -> dict[str, Any]:
                 break
 
         if not target_workflow_available:
-            reasons.append("specialised_workflow_unavailable")
+            unsupported_specialised_route = True
+            unsupported_route_reason = "specialised_workflow_unavailable"
+            reasons.append(unsupported_route_reason)
             mutation_route = False
             route_mode = (
                 ROUTE_MODE_INTERPRET if allow_interpret_fallback else ROUTE_MODE_NOOP
@@ -412,6 +416,8 @@ def _build_classification_payload(raw: Mapping[str, Any]) -> dict[str, Any]:
         "fail_closed": bool(fail_closed),
         "target_workflow_id": target_workflow_id,
         "target_workflow_available": bool(target_workflow_available),
+        "unsupported_specialised_route": bool(unsupported_specialised_route),
+        "unsupported_route_reason": unsupported_route_reason,
         "allow_interpret_fallback": bool(allow_interpret_fallback),
         "route_reasons": list(reasons),
         "scored_candidates": dict(scored),
@@ -456,6 +462,10 @@ def _handle_persist_route_decision(request: WorkflowActionRequest) -> WorkflowAc
         "fail_closed": bool(request.data.get("fail_closed")),
         "target_workflow_id": request.data.get("target_workflow_id"),
         "target_workflow_available": bool(request.data.get("target_workflow_available")),
+        "unsupported_specialised_route": bool(
+            request.data.get("unsupported_specialised_route")
+        ),
+        "unsupported_route_reason": request.data.get("unsupported_route_reason"),
         "allow_interpret_fallback": bool(request.data.get("allow_interpret_fallback", True)),
         "route_reasons": list(request.data.get("route_reasons") or []),
         "scored_candidates": dict(request.data.get("scored_candidates") or {}),

--- a/src/backend/workflows/durable/file_copy_upload_handler_workflow.py
+++ b/src/backend/workflows/durable/file_copy_upload_handler_workflow.py
@@ -82,16 +82,31 @@ def _as_bool(value: Any, *, default: bool) -> bool:
     return default
 
 
-def _map_from_subworkflow_result(
+def _normalise_reason_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        token = value.strip()
+        return [token] if token else []
+    if not isinstance(value, list):
+        return []
+    return [
+        str(item).strip()
+        for item in value
+        if isinstance(item, str) and str(item).strip()
+    ]
+
+
+def _resolve_route_terminal_reason(
+    data: Mapping[str, Any],
     *,
-    outputs: dict[str, Any],
-    prefix: str,
-) -> dict[str, Any]:
-    payload = dict(outputs)
-    mapped: dict[str, Any] = {}
-    for key, value in payload.items():
-        mapped[f"{prefix}{key}"] = value
-    return mapped
+    fallback: str,
+) -> str:
+    explicit = _clean_text(data.get("upload_route_terminal_reason"))
+    if explicit:
+        return explicit
+    reasons = _normalise_reason_list(data.get("upload_route_reasons"))
+    if reasons:
+        return reasons[0]
+    return fallback
 
 
 def _handle_mark_noop(_request: WorkflowActionRequest) -> WorkflowActionResult:
@@ -106,9 +121,10 @@ def _handle_mark_noop(_request: WorkflowActionRequest) -> WorkflowActionResult:
 
 
 def _handle_mark_fail_closed(request: WorkflowActionRequest) -> WorkflowActionResult:
-    reason = _clean_text(request.data.get("upload_route_reasons"))
-    if not reason:
-        reason = "low_confidence_mutation_route"
+    reason = _resolve_route_terminal_reason(
+        request.data,
+        fallback="low_confidence_mutation_route",
+    )
     return WorkflowActionResult(
         status="success",
         outputs={
@@ -123,12 +139,14 @@ def _handle_mark_fail_closed(request: WorkflowActionRequest) -> WorkflowActionRe
 def _handle_mark_specialised_failure(
     request: WorkflowActionRequest,
 ) -> WorkflowActionResult:
-    error = _clean_text(request.data.get("upload_specialised_error")) or "specialised_failed"
+    error = (
+        _clean_text(request.data.get("upload_specialised_error"))
+        or "specialised_failed"
+    )
     return WorkflowActionResult(
         status="success",
         outputs={
             "upload_specialised_fallback_triggered": True,
-            "upload_route_success": False,
             "upload_route_terminal_reason": error,
         },
     )
@@ -195,14 +213,11 @@ def _handle_persist_route_outcome(request: WorkflowActionRequest) -> WorkflowAct
     effective_mode = _resolve_effective_mode(request.data)
     route_success = _resolve_route_success(request.data, effective_mode)
     final_workflow_id = _resolve_final_workflow_id(request.data)
-    route_reasons_raw = request.data.get("upload_route_reasons")
-    route_reasons: list[str] = []
-    if isinstance(route_reasons_raw, list):
-        route_reasons = [
-            str(item).strip()
-            for item in route_reasons_raw
-            if isinstance(item, str) and str(item).strip()
-        ]
+    route_reasons = _normalise_reason_list(request.data.get("upload_route_reasons"))
+    route_terminal_reason = _resolve_route_terminal_reason(
+        request.data,
+        fallback="route_completed",
+    )
 
     payload = {
         "handler_version": FILE_COPY_UPLOAD_HANDLER_VERSION,
@@ -221,7 +236,12 @@ def _handle_persist_route_outcome(request: WorkflowActionRequest) -> WorkflowAct
         "mutation_route": bool(request.data.get("upload_mutation_route")),
         "fail_closed": bool(request.data.get("upload_fail_closed")),
         "route_success": bool(route_success),
+        "route_terminal_reason": route_terminal_reason,
         "route_reasons": route_reasons,
+        "unsupported_specialised_route": bool(
+            request.data.get("upload_unsupported_specialised_route")
+        ),
+        "unsupported_route_reason": request.data.get("upload_unsupported_route_reason"),
         "decision_persisted": bool(request.data.get("upload_route_decision_persisted")),
         "target_workflow_id": request.data.get("upload_target_workflow_id"),
         "target_workflow_available": bool(
@@ -328,6 +348,14 @@ def build_file_copy_upload_handler_workflow() -> WorkflowDefinition:
                 {"tool_output_field": "result.fail_closed", "context_key": "upload_fail_closed"},
                 {"tool_output_field": "result.target_workflow_id", "context_key": "upload_target_workflow_id"},
                 {"tool_output_field": "result.target_workflow_available", "context_key": "upload_target_workflow_available"},
+                {
+                    "tool_output_field": "result.unsupported_specialised_route",
+                    "context_key": "upload_unsupported_specialised_route",
+                },
+                {
+                    "tool_output_field": "result.unsupported_route_reason",
+                    "context_key": "upload_unsupported_route_reason",
+                },
                 {"tool_output_field": "result.allow_interpret_fallback", "context_key": "upload_allow_interpret_fallback"},
                 {"tool_output_field": "result.route_decision_persisted", "context_key": "upload_route_decision_persisted"},
                 {"tool_output_field": "child_workflow_failed", "context_key": "upload_classifier_child_failed"},

--- a/tests/backend/test_file_copy_upload_classification_workflow.py
+++ b/tests/backend/test_file_copy_upload_classification_workflow.py
@@ -89,6 +89,37 @@ def test_classification_fail_closes_low_confidence_mutation_route(monkeypatch) -
     assert "mutation_route_confidence_below_threshold" in result.outputs["route_reasons"]
 
 
+def test_classification_marks_unsupported_specialised_route_when_unavailable(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.file_copy_upload_classification_workflow._resolve_available_workflow_ids",
+        lambda _payload: ("#V#integration_scholarly_paper_representation_workflow",),
+    )
+    registry = ActionRegistry()
+    register_file_copy_upload_classification_actions(registry)
+
+    context: dict[str, object] = {
+        "file_copy_concept_id": "#V#file_copy_unsupported_cv",
+        "original_filename": "candidate-resume.pdf",
+        "content_type": "application/pdf",
+    }
+    result = registry.execute(
+        "file_copy_upload.classify",
+        inputs={},
+        context=context,
+        env=WorkflowEnvironment(llm_client=None),
+    )
+
+    assert result.status == "success"
+    assert result.outputs["route_key"] == "cv"
+    assert result.outputs["route_mode"] == "interpret"
+    assert result.outputs["target_workflow_available"] is False
+    assert result.outputs["unsupported_specialised_route"] is True
+    assert result.outputs["unsupported_route_reason"] == "specialised_workflow_unavailable"
+    assert "specialised_workflow_unavailable" in result.outputs["route_reasons"]
+
+
 def test_persist_route_decision_writes_singleton_text_relation(monkeypatch) -> None:
     calls: list[dict[str, object]] = []
 

--- a/tests/backend/test_file_copy_upload_handler_workflow.py
+++ b/tests/backend/test_file_copy_upload_handler_workflow.py
@@ -62,6 +62,24 @@ def test_mark_fail_closed_action_sets_fail_closed_outputs() -> None:
     assert result.outputs["upload_effective_route_mode"] == "fail_closed"
     assert result.outputs["upload_fail_closed_applied"] is True
     assert result.outputs["upload_route_success"] is False
+    assert result.outputs["upload_route_terminal_reason"] == "confidence_below_threshold"
+
+
+def test_mark_specialised_failure_does_not_force_route_success_false() -> None:
+    registry = ActionRegistry()
+    register_file_copy_upload_handler_actions(registry)
+    context: dict[str, object] = {"upload_specialised_error": "child_failed"}
+    result = registry.execute(
+        "file_copy_upload.mark_specialised_failure",
+        inputs={},
+        context=context,
+        env=WorkflowEnvironment(llm_client=None),
+    )
+
+    assert result.status == "success"
+    assert result.outputs["upload_specialised_fallback_triggered"] is True
+    assert result.outputs["upload_route_terminal_reason"] == "child_failed"
+    assert "upload_route_success" not in result.outputs
 
 
 def test_persist_route_outcome_writes_singleton_text_relation(monkeypatch) -> None:
@@ -110,3 +128,51 @@ def test_persist_route_outcome_writes_singleton_text_relation(monkeypatch) -> No
     payload = json.loads(str(calls[0]["text"]))
     assert payload["effective_route_mode"] == "fail_closed"
     assert payload["route_success"] is False
+    assert payload["route_terminal_reason"] == "mutation_route_confidence_below_threshold"
+
+
+def test_persist_route_outcome_marks_interpret_fallback_success(monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def _fake_upsert_singleton_text_relation(**kwargs):
+        calls.append(dict(kwargs))
+        return {"kept_relation_id": "rel-3", "replaced_count": 0}
+
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.file_copy_upload_handler_workflow.upsert_singleton_text_relation",
+        _fake_upsert_singleton_text_relation,
+    )
+
+    registry = ActionRegistry()
+    register_file_copy_upload_handler_actions(registry)
+    context: dict[str, object] = {
+        "file_copy_concept_id": "#V#file_copy_78",
+        "classification_version": "file_copy_upload_classification.v1",
+        "upload_route_key": "cv",
+        "upload_route_mode": "specialised",
+        "upload_route_confidence": 0.88,
+        "upload_mutation_route": True,
+        "upload_route_reasons": ["specialised_workflow_unavailable"],
+        "upload_specialised_fallback_triggered": True,
+        "upload_interpret_workflow_id": "#V#file_copy_interpretation_workflow",
+        "upload_interpret_child_failed": False,
+        "upload_unsupported_specialised_route": True,
+        "upload_unsupported_route_reason": "specialised_workflow_unavailable",
+    }
+    result = registry.execute(
+        "file_copy_upload.persist_route_outcome",
+        inputs={},
+        context=context,
+        env=WorkflowEnvironment(llm_client=None),
+    )
+
+    assert result.status == "success"
+    assert result.outputs["upload_route_outcome_persisted"] is True
+    assert result.outputs["upload_effective_route_mode"] == "interpret_after_specialised_failure"
+    assert result.outputs["upload_route_success"] is True
+    assert len(calls) == 1
+    payload = json.loads(str(calls[0]["text"]))
+    assert payload["route_success"] is True
+    assert payload["effective_route_mode"] == "interpret_after_specialised_failure"
+    assert payload["unsupported_specialised_route"] is True
+    assert payload["unsupported_route_reason"] == "specialised_workflow_unavailable"


### PR DESCRIPTION
## Summary\n- add explicit unsupported-route diagnostics for mutation-class uploads when specialised workflows are unavailable\n- fix upload handler outcome semantics so specialised->interpret fallback can resolve as successful final handling\n- fix fail-closed terminal reason extraction from list-based route reasons\n- persist unsupported-route and terminal-reason diagnostics in upload route outcome payloads\n- document file-copy upload routing workflow semantics in the VWL manual\n\n## Tests\n- pdm run pytest tests/backend/test_file_copy_upload_classification_workflow.py tests/backend/test_file_copy_upload_handler_workflow.py\n- pdm run pytest tests/backend/test_von_file_upload_endpoint.py tests/backend/test_workflow_event_integration_service.py tests/backend/test_von_file_upload_scholarly_integration.py\n- pdm run pyright src/backend/workflows/durable/file_copy_upload_classification_workflow.py src/backend/workflows/durable/file_copy_upload_handler_workflow.py tests/backend/test_file_copy_upload_classification_workflow.py tests/backend/test_file_copy_upload_handler_workflow.py