### PR TITLE
JVNAUTOSCI-1316: make terminal thinking status authoritative over liveness

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -200,6 +200,16 @@ Control-signal keys:
 - `last_control_signal_scope`
 - boolean convenience flags (`last_control_signal_break`, `last_control_signal_continue`, `last_control_signal_return`, `last_control_signal_error`)
 
+### 7.1 Thinking-Card Progress Terminal Precedence (JVNAUTOSCI-1316)
+
+For chat progress payloads consumed by the thinking card:
+
+- Terminal status MUST be authoritative over liveness when rendering run-state badges.
+- Terminal detection MUST check both `status` and `orchestrator_status` (and treat values such as `completed|done`, `failed|error`, `cancelled|aborted|canceled`, `terminated` as terminal).
+- If any terminal status is present, the badge MUST render terminal state immediately (never remain `Active`/`Waiting`/`Stalled` because of `liveness_state`).
+- `liveness_state` remains informational for metadata (for example "Last activity"), not authoritative for terminality.
+- Progress polling SHOULD stop once terminality is detected (except explicit user-triggered refresh flows).
+
 ## 8. Metadata Contract Semantics
 
 Per-state metadata keys currently used:

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -603,17 +603,32 @@ const TOOL_USE_SETTING_REFRESH_COOLDOWN_MS = 30_000;
 const THINKING_STATUS_ACTIVE = 'active';
 const THINKING_STATUS_WAITING = 'waiting';
 const THINKING_STATUS_STALLED = 'stalled';
+const THINKING_STATUS_COMPLETED = 'completed';
+const THINKING_STATUS_FAILED = 'failed';
+const THINKING_STATUS_CANCELLED = 'cancelled';
+const THINKING_STATUS_TERMINATED = 'terminated';
 const THINKING_CARD_TOGGLE_ARIA_LABEL_EXPANDED = 'Collapse thinking details';
 const THINKING_CARD_TOGGLE_ARIA_LABEL_COLLAPSED = 'Expand thinking details';
 const THINKING_ACTIVITY_LOW_LEVEL_EVENT_KINDS = new Set(['llm_call_chunk', 'heartbeat']);
 const THINKING_TERMINAL_PROGRESS_STATUSES = new Set([
     'completed',
+    'complete',
     'done',
     'error',
     'cancelled',
     'canceled',
     'aborted',
-    'failed'
+    'failed',
+    'terminated'
+]);
+const THINKING_STATUS_CLASS_NAMES = new Set([
+    THINKING_STATUS_ACTIVE,
+    THINKING_STATUS_WAITING,
+    THINKING_STATUS_STALLED,
+    THINKING_STATUS_COMPLETED,
+    THINKING_STATUS_FAILED,
+    THINKING_STATUS_CANCELLED,
+    THINKING_STATUS_TERMINATED
 ]);
 const DIAGNOSTICS_EXPORT_ENDPOINT = '/von/diagnostics/export';
 const DIAGNOSTICS_EXPORT_SHORTCUT_HINT = 'Ctrl+Shift+D';
@@ -738,19 +753,51 @@ function normaliseThinkingCardDisplayState(state) {
     };
 }
 
-function normaliseThinkingProgressStatus(progress) {
-    const status = (progress && typeof progress.status === 'string')
-        ? progress.status.trim().toLowerCase()
-        : '';
-    return status;
+function normaliseThinkingProgressStatusValue(value) {
+    return (typeof value === 'string') ? value.trim().toLowerCase() : '';
+}
+
+function canonicalThinkingTerminalStatus(value) {
+    const status = normaliseThinkingProgressStatusValue(value);
+    if (!THINKING_TERMINAL_PROGRESS_STATUSES.has(status)) {
+        return null;
+    }
+    if (status === 'completed' || status === 'complete' || status === 'done') {
+        return THINKING_STATUS_COMPLETED;
+    }
+    if (status === 'error' || status === 'failed') {
+        return THINKING_STATUS_FAILED;
+    }
+    if (status === 'cancelled' || status === 'canceled' || status === 'aborted') {
+        return THINKING_STATUS_CANCELLED;
+    }
+    if (status === 'terminated') {
+        return THINKING_STATUS_TERMINATED;
+    }
+    return null;
+}
+
+function resolveThinkingTerminalStatus(progress) {
+    if (!progress || typeof progress !== 'object') {
+        return null;
+    }
+    const candidates = [
+        progress.status,
+        progress.orchestrator_status,
+        progress.terminal_status,
+        progress.final_status
+    ];
+    for (const value of candidates) {
+        const canonical = canonicalThinkingTerminalStatus(value);
+        if (canonical) {
+            return canonical;
+        }
+    }
+    return null;
 }
 
 function isTerminalThinkingProgress(progress) {
-    const status = normaliseThinkingProgressStatus(progress);
-    if (!status) {
-        return false;
-    }
-    return THINKING_TERMINAL_PROGRESS_STATUSES.has(status);
+    return resolveThinkingTerminalStatus(progress) !== null;
 }
 
 function reduceThinkingCardDisplayState(state, event = {}) {
@@ -1086,6 +1133,14 @@ function thinkingLivenessLabel(state) {
     return 'Active';
 }
 
+function thinkingTerminalLabel(status) {
+    if (status === THINKING_STATUS_COMPLETED) return 'Complete';
+    if (status === THINKING_STATUS_FAILED) return 'Failed';
+    if (status === THINKING_STATUS_CANCELLED) return 'Cancelled';
+    if (status === THINKING_STATUS_TERMINATED) return 'Terminated';
+    return 'Complete';
+}
+
 function formatAbsoluteTimestamp(value) {
     if (!value) {
         return '';
@@ -1190,8 +1245,11 @@ function formatThinkingEtaText(progress) {
 }
 
 function buildThinkingProgressPresentation(progress, request = null) {
-    const livenessState = normaliseThinkingLivenessState(progress);
-    const livenessLabel = thinkingLivenessLabel(livenessState);
+    const terminalStatus = resolveThinkingTerminalStatus(progress);
+    const livenessState = terminalStatus || normaliseThinkingLivenessState(progress);
+    const livenessLabel = terminalStatus
+        ? thinkingTerminalLabel(terminalStatus)
+        : thinkingLivenessLabel(livenessState);
 
     if (!progress || typeof progress !== 'object') {
         return {
@@ -1222,7 +1280,9 @@ function buildThinkingProgressPresentation(progress, request = null) {
         stageText = `${stageText}: ${detail}`;
     }
 
-    if (livenessState === THINKING_STATUS_STALLED) {
+    if (terminalStatus) {
+        stageText = livenessLabel;
+    } else if (livenessState === THINKING_STATUS_STALLED) {
         stageText = stageText ? `Stalled: ${stageText}` : 'Stalled';
     } else if (livenessState === THINKING_STATUS_WAITING) {
         stageText = stageText ? `Waiting: ${stageText}` : 'Waiting';
@@ -1271,7 +1331,7 @@ function updateThinkingCardStatusBadge(progress) {
 
     const presentation = buildThinkingProgressPresentation(progress);
     badgeEl.textContent = presentation.livenessLabel;
-    badgeEl.classList.remove(THINKING_STATUS_ACTIVE, THINKING_STATUS_WAITING, THINKING_STATUS_STALLED);
+    THINKING_STATUS_CLASS_NAMES.forEach((stateClass) => badgeEl.classList.remove(stateClass));
     badgeEl.classList.add(presentation.livenessState);
     badgeEl.setAttribute('aria-hidden', 'false');
 }
@@ -1991,14 +2051,14 @@ function startToolUseProgressPolling(request) {
             setLoadingIndicatorDetailHtml(renderThinkingCardBodyHTML(request));
 
             const status = typeof progress?.status === 'string' ? progress.status : null;
-            if (status === 'disabled') {
-                poll.nextDelayMs = 10_000;
-                scheduleNextPoll(poll.nextDelayMs);
+            if (isTerminalThinkingProgress(progress)) {
+                stopToolUseProgressPolling(request);
                 return;
             }
 
-            if (status === 'completed' || status === 'error') {
-                stopToolUseProgressPolling(request);
+            if (normaliseThinkingProgressStatusValue(status) === 'disabled') {
+                poll.nextDelayMs = 10_000;
+                scheduleNextPoll(poll.nextDelayMs);
                 return;
             }
 
@@ -16967,7 +17027,7 @@ function setThinkingState(isThinking, request = activeChatRequest, options = {})
     if (statusBadge) {
         if (isThinking) {
             statusBadge.textContent = 'Active';
-            statusBadge.classList.remove(THINKING_STATUS_WAITING, THINKING_STATUS_STALLED);
+            THINKING_STATUS_CLASS_NAMES.forEach((stateClass) => statusBadge.classList.remove(stateClass));
             statusBadge.classList.add(THINKING_STATUS_ACTIVE);
             statusBadge.setAttribute('aria-hidden', 'false');
         } else {

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -687,6 +687,21 @@ describe('thinking liveness presentation', () => {
         expect(__testOnly_formatThinkingEtaText({ eta_ms: 250 })).toBe('ETA <1s');
         expect(__testOnly_formatThinkingEtaText({})).toBeNull();
     });
+
+    test('treats terminal status as authoritative over active liveness', () => {
+        const presentation = __testOnly_buildThinkingProgressPresentation({
+            status: 'pending',
+            orchestrator_status: 'completed',
+            liveness_state: 'active',
+            stage: 'response_finalising',
+            idle_ms: 1800
+        });
+
+        expect(presentation.livenessState).toBe('completed');
+        expect(presentation.livenessLabel).toBe('Complete');
+        expect(presentation.stageText).toBe('Complete');
+        expect(presentation.lastActivityText).toContain('Last activity');
+    });
 });
 
 describe('thinking card display state reducer', () => {
@@ -738,6 +753,21 @@ describe('thinking card display state reducer', () => {
             progress: { status: 'completed' }
         });
         expect(state.expanded).toBe(true);
+        expect(state.autoFurlApplied).toBe(true);
+    });
+
+    test('treats orchestrator terminal status as terminal progress update', () => {
+        let state = __testOnly_reduceThinkingCardDisplayState(null, { type: 'reset_for_active' });
+        state = __testOnly_reduceThinkingCardDisplayState(state, {
+            type: 'progress_update',
+            progress: {
+                status: 'pending',
+                orchestrator_status: 'completed',
+                liveness_state: 'active'
+            }
+        });
+
+        expect(state.expanded).toBe(false);
         expect(state.autoFurlApplied).toBe(true);
     });
 });
@@ -1005,7 +1035,9 @@ describe('thinking card toggle accessibility', () => {
                 return Promise.resolve({
                     ok: true,
                     json: async () => ({
-                        status: 'completed',
+                        status: 'pending',
+                        orchestrator_status: 'completed',
+                        liveness_state: 'active',
                         phase: 'response_finalising',
                         phase_label: 'Finalising response',
                         tool: 'response_finalising',
@@ -1052,6 +1084,8 @@ describe('thinking card toggle accessibility', () => {
         expect(toggleButton.getAttribute('aria-expanded')).toBe('false');
         expect(wrapper.classList.contains('is-collapsed')).toBe(true);
         expect(detail.getAttribute('aria-hidden')).toBe('true');
+        expect(document.getElementById('thinkingCardStatusBadge').textContent).toBe('Complete');
+        expect(document.getElementById('thinkingCardStatusBadge').classList.contains('completed')).toBe(true);
 
         toggleButton.click();
 

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -6566,6 +6566,26 @@ footer {
     color: #b91c1c;
 }
 
+.thinking-card-status.completed {
+    background: #dcfce7;
+    color: #166534;
+}
+
+.thinking-card-status.failed {
+    background: #fee2e2;
+    color: #b91c1c;
+}
+
+.thinking-card-status.cancelled {
+    background: #e2e8f0;
+    color: #334155;
+}
+
+.thinking-card-status.terminated {
+    background: #ffedd5;
+    color: #9a3412;
+}
+
 .thinking-card-action {
     display: none;
     align-items: center;


### PR DESCRIPTION
## Summary
- make terminal status authoritative over liveness-state when rendering thinking-card badges
- treat terminality as present when any of status, orchestrator_status, terminal_status, or final_status is terminal
- stop thinking-progress polling as soon as terminality is detected
- add terminal badge classes (completed, failed, cancelled, terminated) and clear/apply status classes centrally
- extend tests to cover terminal-over-liveness precedence and orchestrator-status terminal handling
- update workflow manual with explicit terminal precedence semantics for thinking-card progress

## Validation
- pdm run pyright
- npm test -- src/frontend/web/von_interface/static/js/test/chatTab.test.js --runInBand