### PR TITLE
Complete remaining JVNAUTOSCI-833 reliability and GitHub workflow tasks

### DIFF
--- a/docs/engineering/github_internal_mcp_runbook.md
+++ b/docs/engineering/github_internal_mcp_runbook.md
@@ -1,0 +1,60 @@
+# GitHub Internal MCP Runbook
+
+This runbook documents the GitHub MCP proxy used by Von internal MCP tools.
+
+## Purpose
+- Provide a bounded GitHub tool surface for workflows and orchestrator actions.
+- Keep writes fail-closed by default.
+- Preserve deterministic diagnostics for operator troubleshooting.
+
+## Environment setup
+- `GITHUB_PERSONAL_ACCESS_TOKEN` or `GITHUB_TOKEN` or `GH_TOKEN`: GitHub token (required).
+- `VON_GITHUB_MCP_COMMAND`: command for GitHub MCP server process (default `npx`).
+- `VON_GITHUB_MCP_ARGS`: args for GitHub MCP server process (default `-y @modelcontextprotocol/server-github`).
+- `VON_GITHUB_REPO_ALLOW_LIST`: comma-separated owner/repo allow-list (default `Strong-AI-Lab/Von`).
+- `VON_INTERNAL_MCP_GITHUB_EXECUTE_MODE`: set `1`/`true` to allow execute-mode writes when `execute=true`.
+
+## Guardrail model
+- Write tools default to `dry_run=true`.
+- Non-dry-run writes require one of:
+  - `approved=true`, or
+  - `execute=true` and `VON_INTERNAL_MCP_GITHUB_EXECUTE_MODE=1`.
+- Owner/repo must be in `VON_GITHUB_REPO_ALLOW_LIST`.
+- Idempotency cache is applied for non-dry-run calls when `request_id` is supplied.
+
+## Internal tool matrix
+Read:
+- `github_get_auth_config`
+- `github_list_tools`
+- `github_get_me`
+- `github_get_file_contents`
+- `github_list_commits`
+- `github_search_code`
+- `github_list_pull_requests`
+- `github_pull_request_read`
+- `github_issue_read`
+- `github_list_releases`
+- `github_get_latest_release`
+- `github_list_tags`
+- `github_list_branches`
+
+Write (guarded):
+- `github_create_branch`
+- `github_create_or_update_file`
+- `github_create_pull_request`
+- `github_update_pull_request`
+- `github_create_pull_request_with_copilot`
+
+## Operational checks
+1. Run `github_get_auth_config` and confirm:
+   - `token_present=true`
+   - expected allow-list
+   - expected command/args
+   - `proxy_tools_available=true`
+2. Run `github_list_tools` to verify external GitHub MCP server surface.
+3. Run a dry-run write (`github_create_branch` with `dry_run=true`) before live writes.
+
+## Failure modes
+- `github_proxy_error`: subprocess/auth/server issue.
+- `repository_not_allowlisted`: owner/repo not in allow-list.
+- `approval_required`: non-dry-run write without explicit approval.

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -10033,6 +10033,374 @@ def _upsert_renderer_profile_output_schema() -> Schema:
     )
 
 
+# GitHub schema helpers
+def _github_get_auth_config_input_schema() -> Schema:
+    return Schema(
+        required={},
+        optional={},
+        allow_unknown=True,
+        description="github_get_auth_config input: no arguments",
+    )
+
+
+def _github_list_tools_input_schema() -> Schema:
+    return Schema(
+        required={},
+        optional={},
+        allow_unknown=True,
+        description="github_list_tools input: no arguments",
+    )
+
+
+def _github_get_me_input_schema() -> Schema:
+    return Schema(
+        required={},
+        optional={},
+        allow_unknown=True,
+        description="github_get_me input: no arguments",
+    )
+
+
+def _github_get_file_contents_input_schema() -> Schema:
+    return Schema(
+        required={"owner": str, "repo": str},
+        optional={
+            "path": (str, type(None)),
+            "ref": (str, type(None)),
+            "sha": (str, type(None)),
+            "namespace": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "github_get_file_contents input: owner/repo required; optional path/ref/sha."
+        ),
+    )
+
+
+def _github_list_commits_input_schema() -> Schema:
+    return Schema(
+        required={"owner": str, "repo": str},
+        optional={
+            "sha": (str, type(None)),
+            "author": (str, type(None)),
+            "page": (int, type(None)),
+            "perPage": (int, type(None)),
+            "namespace": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "github_list_commits input: owner/repo required; optional sha/author/page/perPage."
+        ),
+    )
+
+
+def _github_search_code_input_schema() -> Schema:
+    return Schema(
+        required={"query": str},
+        optional={
+            "page": (int, type(None)),
+            "perPage": (int, type(None)),
+            "sort": (str, type(None)),
+            "order": (str, type(None)),
+            "namespace": (str, type(None)),
+        },
+        allow_unknown=True,
+        description="github_search_code input: query required, paging/sort optional.",
+    )
+
+
+def _github_list_pull_requests_input_schema() -> Schema:
+    return Schema(
+        required={"owner": str, "repo": str},
+        optional={
+            "state": (str, type(None)),
+            "base": (str, type(None)),
+            "head": (str, type(None)),
+            "sort": (str, type(None)),
+            "direction": (str, type(None)),
+            "page": (int, type(None)),
+            "perPage": (int, type(None)),
+            "namespace": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "github_list_pull_requests input: owner/repo required; filtering/sort/paging optional."
+        ),
+    )
+
+
+def _github_pull_request_read_input_schema() -> Schema:
+    return Schema(
+        required={
+            "owner": str,
+            "repo": str,
+            "pullNumber": int,
+            "method": str,
+        },
+        optional={
+            "page": (int, type(None)),
+            "perPage": (int, type(None)),
+            "namespace": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "github_pull_request_read input: owner/repo/pullNumber/method required."
+        ),
+    )
+
+
+def _github_issue_read_input_schema() -> Schema:
+    return Schema(
+        required={
+            "owner": str,
+            "repo": str,
+            "issue_number": int,
+            "method": str,
+        },
+        optional={
+            "page": (int, type(None)),
+            "perPage": (int, type(None)),
+            "namespace": (str, type(None)),
+        },
+        allow_unknown=True,
+        description="github_issue_read input: owner/repo/issue_number/method required.",
+    )
+
+
+def _github_list_releases_input_schema() -> Schema:
+    return Schema(
+        required={"owner": str, "repo": str},
+        optional={
+            "page": (int, type(None)),
+            "perPage": (int, type(None)),
+            "namespace": (str, type(None)),
+        },
+        allow_unknown=True,
+        description="github_list_releases input: owner/repo required.",
+    )
+
+
+def _github_get_latest_release_input_schema() -> Schema:
+    return Schema(
+        required={"owner": str, "repo": str},
+        optional={"namespace": (str, type(None))},
+        allow_unknown=True,
+        description="github_get_latest_release input: owner/repo required.",
+    )
+
+
+def _github_list_tags_input_schema() -> Schema:
+    return Schema(
+        required={"owner": str, "repo": str},
+        optional={
+            "page": (int, type(None)),
+            "perPage": (int, type(None)),
+            "namespace": (str, type(None)),
+        },
+        allow_unknown=True,
+        description="github_list_tags input: owner/repo required.",
+    )
+
+
+def _github_list_branches_input_schema() -> Schema:
+    return Schema(
+        required={"owner": str, "repo": str},
+        optional={
+            "page": (int, type(None)),
+            "perPage": (int, type(None)),
+            "namespace": (str, type(None)),
+        },
+        allow_unknown=True,
+        description="github_list_branches input: owner/repo required.",
+    )
+
+
+def _github_create_branch_input_schema() -> Schema:
+    return Schema(
+        required={"owner": str, "repo": str, "branch": str},
+        optional={
+            "from_branch": (str, type(None)),
+            "dry_run": (bool,),
+            "approved": (bool,),
+            "execute": (bool,),
+            "request_id": (str, type(None)),
+            "namespace": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "github_create_branch input: owner/repo/branch required with write guardrails."
+        ),
+    )
+
+
+def _github_create_or_update_file_input_schema() -> Schema:
+    return Schema(
+        required={
+            "owner": str,
+            "repo": str,
+            "branch": str,
+            "path": str,
+            "content": str,
+            "message": str,
+        },
+        optional={
+            "sha": (str, type(None)),
+            "dry_run": (bool,),
+            "approved": (bool,),
+            "execute": (bool,),
+            "request_id": (str, type(None)),
+            "namespace": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "github_create_or_update_file input: owner/repo/branch/path/content/message required with write guardrails."
+        ),
+    )
+
+
+def _github_create_pull_request_input_schema() -> Schema:
+    return Schema(
+        required={
+            "owner": str,
+            "repo": str,
+            "title": str,
+            "head": str,
+            "base": str,
+        },
+        optional={
+            "body": (str, type(None)),
+            "draft": (bool, type(None)),
+            "maintainer_can_modify": (bool, type(None)),
+            "dry_run": (bool,),
+            "approved": (bool,),
+            "execute": (bool,),
+            "request_id": (str, type(None)),
+            "namespace": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "github_create_pull_request input: owner/repo/title/head/base required with write guardrails."
+        ),
+    )
+
+
+def _github_update_pull_request_input_schema() -> Schema:
+    return Schema(
+        required={"owner": str, "repo": str, "pullNumber": int},
+        optional={
+            "title": (str, type(None)),
+            "body": (str, type(None)),
+            "base": (str, type(None)),
+            "state": (str, type(None)),
+            "draft": (bool, type(None)),
+            "maintainer_can_modify": (bool, type(None)),
+            "reviewers": (list, type(None)),
+            "dry_run": (bool,),
+            "approved": (bool,),
+            "execute": (bool,),
+            "request_id": (str, type(None)),
+            "namespace": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "github_update_pull_request input: owner/repo/pullNumber required with write guardrails."
+        ),
+    )
+
+
+def _github_create_pull_request_with_copilot_input_schema() -> Schema:
+    return Schema(
+        required={
+            "owner": str,
+            "repo": str,
+            "title": str,
+            "problem_statement": str,
+        },
+        optional={
+            "base_ref": (str, type(None)),
+            "dry_run": (bool,),
+            "approved": (bool,),
+            "execute": (bool,),
+            "request_id": (str, type(None)),
+            "namespace": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "github_create_pull_request_with_copilot input: owner/repo/title/problem_statement required with write guardrails."
+        ),
+    )
+
+
+def _github_get_auth_config_output_schema() -> Schema:
+    return Schema(
+        required={
+            "success": bool,
+            "token_present": bool,
+            "token_length": int,
+            "env_keys_used": dict,
+            "allow_repositories": list,
+            "execute_mode_enabled": bool,
+        },
+        optional={
+            "command": (str, type(None)),
+            "args": (list, type(None)),
+            "proxy_tool_count": (int, type(None)),
+            "proxy_tools_available": (bool, type(None)),
+            "proxy_error": (str, type(None)),
+            "error": (str, type(None)),
+            "error_code": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "github_get_auth_config output: token presence and non-secret GitHub MCP diagnostics."
+        ),
+    )
+
+
+def _github_list_tools_output_schema() -> Schema:
+    return Schema(
+        required={"success": bool},
+        optional={
+            "tools": (list, type(None)),
+            "count": (int, type(None)),
+            "proxy_stats": (dict, type(None)),
+            "error": (str, type(None)),
+            "error_code": (str, type(None)),
+            "suggestions": (list, type(None)),
+        },
+        allow_unknown=True,
+        description="github_list_tools output: available external GitHub MCP tools and proxy stats.",
+    )
+
+
+def _github_generic_output_schema(action: str) -> Schema:
+    return Schema(
+        required={"success": bool},
+        optional={
+            "error": (str, type(None)),
+            "error_code": (str, type(None)),
+            "action": (str, type(None)),
+            "tool": (str, type(None)),
+            "executed": (bool, type(None)),
+            "dry_run": (bool, type(None)),
+            "reused": (bool, type(None)),
+            "owner": (str, type(None)),
+            "repo": (str, type(None)),
+            "repository": (str, type(None)),
+            "proxy_stats": (dict, type(None)),
+            "result": (dict, list, str, int, float, bool, type(None)),
+            "items": (list, type(None)),
+            "count": (int, type(None)),
+            "proposed_payload": (dict, type(None)),
+            "suggestions": (list, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            f"github_{action} output: normalised GitHub proxy payload with guardrail metadata."
+        ),
+    )
+
+
 # Jira schema helpers
 def _jira_search_input_schema() -> Schema:
     return Schema(
@@ -12436,6 +12804,396 @@ _JIRA_ATTACHMENT_ALLOWED_MIME_TYPES_DEFAULT = frozenset(
         "application/json",
     }
 )
+_GITHUB_WRITE_CACHE: dict[str, dict[str, Any]] = {}
+_GITHUB_WRITE_CACHE_TTL_SEC = 3600.0
+_GITHUB_WRITE_CACHE_MAX = 200
+
+
+def _github_repo_allow_list() -> list[str]:
+    import os
+
+    raw = os.getenv("VON_GITHUB_REPO_ALLOW_LIST") or "Strong-AI-Lab/Von"
+    repos: list[str] = []
+    for part in raw.split(","):
+        candidate = str(part or "").strip().strip("/")
+        if not candidate or "/" not in candidate:
+            continue
+        owner, repo = candidate.split("/", 1)
+        normalised = f"{owner.strip().lower()}/{repo.strip().lower()}"
+        if not normalised or normalised not in repos:
+            repos.append(normalised)
+    return repos
+
+
+def _github_repo_key(owner: Any, repo: Any) -> str | None:
+    owner_text = str(owner).strip().lower() if isinstance(owner, str) else ""
+    repo_text = str(repo).strip().lower() if isinstance(repo, str) else ""
+    if not owner_text or not repo_text:
+        return None
+    return f"{owner_text}/{repo_text}"
+
+
+def _github_execute_mode_enabled() -> bool:
+    import os
+
+    return os.getenv("VON_INTERNAL_MCP_GITHUB_EXECUTE_MODE", "0").lower() in {
+        "1",
+        "true",
+    }
+
+
+def _github_write_guardrails(
+    *,
+    action: str,
+    repositories: Sequence[str],
+    dry_run: bool,
+    approved: bool,
+    execute: bool,
+) -> dict[str, Any] | None:
+    allowed = _github_repo_allow_list()
+    if not allowed:
+        return {
+            "success": False,
+            "error": "GitHub writes are blocked: repository allow-list is empty",
+            "error_code": "allowlist_missing",
+            "action": action,
+        }
+
+    for repository in repositories:
+        candidate = str(repository or "").strip().lower()
+        if not candidate:
+            return {
+                "success": False,
+                "error": "GitHub writes require owner/repo for allow-list checks",
+                "error_code": "repository_required",
+                "action": action,
+            }
+        if candidate not in allowed:
+            return {
+                "success": False,
+                "error": (
+                    f"GitHub writes are blocked for repository '{candidate}'. "
+                    f"Allowed: {', '.join(allowed)}"
+                ),
+                "error_code": "repository_not_allowlisted",
+                "repository": candidate,
+                "allowed_repositories": allowed,
+                "action": action,
+            }
+
+    if dry_run:
+        return None
+    if execute and _github_execute_mode_enabled():
+        return None
+    if approved:
+        return None
+    return {
+        "success": False,
+        "error": (
+            "Approval required for GitHub write. Set approved=true to confirm this write, "
+            "or run in execute mode (set VON_INTERNAL_MCP_GITHUB_EXECUTE_MODE=1 and pass execute=true)."
+        ),
+        "error_code": "approval_required",
+        "action": action,
+        "allowed_repositories": allowed,
+    }
+
+
+def _github_cache_get(tool: str, request_id: str) -> dict[str, Any] | None:
+    import time
+
+    key = f"{tool}:{request_id}"
+    record = _GITHUB_WRITE_CACHE.get(key)
+    if not isinstance(record, dict):
+        return None
+    ts = record.get("timestamp")
+    if not isinstance(ts, (int, float)):
+        return None
+    if (time.time() - float(ts)) > _GITHUB_WRITE_CACHE_TTL_SEC:
+        _GITHUB_WRITE_CACHE.pop(key, None)
+        return None
+    payload = record.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    return dict(payload)
+
+
+def _github_cache_set(tool: str, request_id: str, payload: dict[str, Any]) -> None:
+    import time
+
+    if len(_GITHUB_WRITE_CACHE) >= _GITHUB_WRITE_CACHE_MAX:
+        oldest_key = None
+        oldest_ts = None
+        for key, record in _GITHUB_WRITE_CACHE.items():
+            ts = record.get("timestamp") if isinstance(record, dict) else None
+            if not isinstance(ts, (int, float)):
+                continue
+            if oldest_ts is None or float(ts) < oldest_ts:
+                oldest_ts = float(ts)
+                oldest_key = key
+        if oldest_key:
+            _GITHUB_WRITE_CACHE.pop(oldest_key, None)
+
+    _GITHUB_WRITE_CACHE[f"{tool}:{request_id}"] = {
+        "timestamp": time.time(),
+        "payload": dict(payload),
+    }
+
+
+def _github_clean_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _github_normalise_response(
+    *,
+    tool_name: str,
+    raw_result: Any,
+    proxy_stats: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    payload: dict[str, Any]
+    if isinstance(raw_result, dict):
+        payload = dict(raw_result)
+        payload.setdefault("success", True)
+    elif isinstance(raw_result, list):
+        payload = {"success": True, "items": list(raw_result), "count": len(raw_result)}
+    else:
+        payload = {"success": True, "result": raw_result}
+
+    payload.setdefault("tool", tool_name)
+    if isinstance(proxy_stats, Mapping):
+        payload.setdefault("proxy_stats", dict(proxy_stats))
+    return payload
+
+
+def _github_invoke_proxy_tool(tool_name: str, arguments: Mapping[str, Any]) -> dict[str, Any]:
+    from .github_proxy_mcp import GitHubProxyError, get_github_proxy
+
+    async def _async_call():
+        proxy = await get_github_proxy()
+        result = await proxy.call_tool(tool_name, dict(arguments))
+        return result, proxy.get_stats()
+
+    try:
+        raw_result, proxy_stats = _run_async_compat(_async_call)
+    except GitHubProxyError as exc:
+        return make_error_response(
+            "github_proxy_error",
+            str(exc),
+            details={"exception_type": "GitHubProxyError", "tool": tool_name},
+            suggestions=["Check GitHub MCP connectivity, command args, and token configuration"],
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        return make_error_response(
+            "github_proxy_error",
+            f"GitHub proxy invocation failed: {exc}",
+            details={"exception_type": type(exc).__name__, "tool": tool_name},
+            suggestions=["Check GitHub MCP server availability"],
+        )
+
+    return _github_normalise_response(
+        tool_name=tool_name,
+        raw_result=raw_result,
+        proxy_stats=proxy_stats if isinstance(proxy_stats, Mapping) else None,
+    )
+
+
+def _github_extract_owner_repo(kwargs: Mapping[str, Any]) -> tuple[str | None, str | None]:
+    owner = _github_clean_text(kwargs.get("owner"))
+    repo = _github_clean_text(kwargs.get("repo"))
+    return owner, repo
+
+
+def _github_require_owner_repo(kwargs: Mapping[str, Any]) -> tuple[str, str] | dict[str, Any]:
+    owner, repo = _github_extract_owner_repo(kwargs)
+    if not owner or not repo:
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameters: owner and repo",
+            details={"missing": ["owner", "repo"]},
+            suggestions=["Provide GitHub repository owner and repo names"],
+        )
+    return owner, repo
+
+
+def _github_execute_write_tool(
+    *,
+    action: str,
+    proxy_tool_name: str,
+    owner: str,
+    repo: str,
+    dry_run: bool,
+    approved: bool,
+    execute: bool,
+    request_id: str | None,
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    repository = _github_repo_key(owner, repo)
+    if not repository:
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameters: owner and repo",
+            details={"missing": ["owner", "repo"]},
+        )
+
+    guardrail_error = _github_write_guardrails(
+        action=action,
+        repositories=[repository],
+        dry_run=dry_run,
+        approved=approved,
+        execute=execute,
+    )
+    if guardrail_error is not None:
+        return guardrail_error
+
+    if isinstance(request_id, str) and request_id.strip() and not dry_run:
+        cached = _github_cache_get(proxy_tool_name, request_id.strip())
+        if cached is not None:
+            cached["reused"] = True
+            return cached
+
+    proposed_payload = dict(payload)
+    if dry_run:
+        return {
+            "success": True,
+            "dry_run": True,
+            "executed": False,
+            "action": action,
+            "owner": owner,
+            "repo": repo,
+            "repository": repository,
+            "proposed_payload": proposed_payload,
+        }
+
+    result = _github_invoke_proxy_tool(proxy_tool_name, proposed_payload)
+    if not isinstance(result, dict):
+        result = {"success": False, "error": "Unexpected GitHub proxy response shape"}
+
+    if result.get("success") is False:
+        result.setdefault("action", action)
+        result.setdefault("dry_run", False)
+        result.setdefault("executed", True)
+        result.setdefault("owner", owner)
+        result.setdefault("repo", repo)
+        result.setdefault("repository", repository)
+        return result
+
+    result = dict(result)
+    result.setdefault("success", True)
+    result["action"] = action
+    result["dry_run"] = False
+    result["executed"] = True
+    result["owner"] = owner
+    result["repo"] = repo
+    result["repository"] = repository
+    if isinstance(request_id, str) and request_id.strip():
+        _github_cache_set(proxy_tool_name, request_id.strip(), result)
+    return result
+
+
+def _github_get_auth_config(**kwargs):
+    import os
+    import shlex
+    from .github_proxy_mcp import GitHubProxyError, get_github_proxy
+
+    env = os.environ.copy()
+
+    def _clean(value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if len(cleaned) >= 2 and cleaned[0] == cleaned[-1] and cleaned[0] in ('"', "'"):
+            cleaned = cleaned[1:-1].strip()
+        return cleaned or None
+
+    token_key = None
+    token: str | None = None
+    for candidate_key in ("GITHUB_PERSONAL_ACCESS_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"):
+        candidate_value = _clean(env.get(candidate_key))
+        if candidate_value:
+            token_key = candidate_key
+            token = candidate_value
+            break
+
+    command = str(os.getenv("VON_GITHUB_MCP_COMMAND") or "npx").strip() or "npx"
+    raw_args = os.getenv("VON_GITHUB_MCP_ARGS")
+    if isinstance(raw_args, str) and raw_args.strip():
+        args = shlex.split(raw_args.strip())
+    else:
+        args = ["-y", "@modelcontextprotocol/server-github"]
+
+    payload: dict[str, Any] = {
+        "success": True,
+        "token_present": bool(token),
+        "token_length": len(token) if token else 0,
+        "env_keys_used": {
+            "token": token_key,
+            "command": "VON_GITHUB_MCP_COMMAND" if os.getenv("VON_GITHUB_MCP_COMMAND") else None,
+            "args": "VON_GITHUB_MCP_ARGS" if os.getenv("VON_GITHUB_MCP_ARGS") else None,
+            "allow_list": "VON_GITHUB_REPO_ALLOW_LIST",
+            "execute_mode": "VON_INTERNAL_MCP_GITHUB_EXECUTE_MODE",
+        },
+        "allow_repositories": _github_repo_allow_list(),
+        "execute_mode_enabled": _github_execute_mode_enabled(),
+        "command": command,
+        "args": args,
+    }
+
+    async def _async_probe():
+        proxy = await get_github_proxy()
+        tools = await proxy.list_tools()
+        return tools, proxy.get_stats()
+
+    try:
+        tools, stats = _run_async_compat(_async_probe)
+        payload["proxy_tools_available"] = True
+        payload["proxy_tool_count"] = len(tools) if isinstance(tools, list) else 0
+        if isinstance(stats, Mapping):
+            payload["proxy_stats"] = dict(stats)
+    except GitHubProxyError as exc:
+        payload["proxy_tools_available"] = False
+        payload["proxy_error"] = str(exc)
+        payload["error"] = str(exc)
+        payload["error_code"] = "github_proxy_error"
+    except Exception as exc:  # pragma: no cover - defensive
+        payload["proxy_tools_available"] = False
+        payload["proxy_error"] = str(exc)
+        payload["error"] = str(exc)
+        payload["error_code"] = "github_proxy_error"
+    return payload
+
+
+def _github_list_tools(**kwargs):
+    from .github_proxy_mcp import GitHubProxyError, get_github_proxy
+
+    async def _async_list():
+        proxy = await get_github_proxy()
+        tools = await proxy.list_tools()
+        return tools, proxy.get_stats()
+
+    try:
+        tools, stats = _run_async_compat(_async_list)
+        return {
+            "success": True,
+            "tools": tools if isinstance(tools, list) else [],
+            "count": len(tools) if isinstance(tools, list) else 0,
+            "proxy_stats": dict(stats) if isinstance(stats, Mapping) else {},
+        }
+    except GitHubProxyError as exc:
+        return make_error_response(
+            "github_proxy_error",
+            str(exc),
+            details={"exception_type": "GitHubProxyError"},
+            suggestions=["Check GitHub MCP connectivity and authentication"],
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        return make_error_response(
+            "github_proxy_error",
+            f"GitHub tool listing failed: {exc}",
+            details={"exception_type": type(exc).__name__},
+        )
 
 
 def _jira_project_allow_list() -> list[str]:
@@ -12651,6 +13409,394 @@ def _jira_decode_attachment_bytes(content_base64: Any) -> bytes | None:
             return base64.urlsafe_b64decode(compact + padding)
         except (binascii.Error, ValueError):
             return None
+
+
+def _github_get_me(**kwargs):
+    return _github_invoke_proxy_tool("github_get_me", {})
+
+
+def _github_get_file_contents(**kwargs):
+    owner_repo = _github_require_owner_repo(kwargs)
+    if isinstance(owner_repo, dict):
+        return owner_repo
+    owner, repo = owner_repo
+    payload: dict[str, Any] = {"owner": owner, "repo": repo}
+    path = _github_clean_text(kwargs.get("path"))
+    if path is not None:
+        payload["path"] = path
+    ref = _github_clean_text(kwargs.get("ref"))
+    if ref is not None:
+        payload["ref"] = ref
+    sha = _github_clean_text(kwargs.get("sha"))
+    if sha is not None:
+        payload["sha"] = sha
+    return _github_invoke_proxy_tool("github_get_file_contents", payload)
+
+
+def _github_list_commits(**kwargs):
+    owner_repo = _github_require_owner_repo(kwargs)
+    if isinstance(owner_repo, dict):
+        return owner_repo
+    owner, repo = owner_repo
+    payload: dict[str, Any] = {"owner": owner, "repo": repo}
+    for field in ("sha", "author"):
+        value = _github_clean_text(kwargs.get(field))
+        if value is not None:
+            payload[field] = value
+    for field in ("page", "perPage"):
+        value = kwargs.get(field)
+        if isinstance(value, int):
+            payload[field] = value
+    return _github_invoke_proxy_tool("github_list_commits", payload)
+
+
+def _github_search_code(**kwargs):
+    query = _github_clean_text(kwargs.get("query"))
+    if not query:
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameter: query",
+            details={"missing": ["query"]},
+            suggestions=["Provide a GitHub code-search query string"],
+        )
+    payload: dict[str, Any] = {"query": query}
+    for field in ("sort", "order"):
+        value = _github_clean_text(kwargs.get(field))
+        if value is not None:
+            payload[field] = value
+    for field in ("page", "perPage"):
+        value = kwargs.get(field)
+        if isinstance(value, int):
+            payload[field] = value
+    return _github_invoke_proxy_tool("github_search_code", payload)
+
+
+def _github_list_pull_requests(**kwargs):
+    owner_repo = _github_require_owner_repo(kwargs)
+    if isinstance(owner_repo, dict):
+        return owner_repo
+    owner, repo = owner_repo
+    payload: dict[str, Any] = {"owner": owner, "repo": repo}
+    for field in ("state", "base", "head", "sort", "direction"):
+        value = _github_clean_text(kwargs.get(field))
+        if value is not None:
+            payload[field] = value
+    for field in ("page", "perPage"):
+        value = kwargs.get(field)
+        if isinstance(value, int):
+            payload[field] = value
+    return _github_invoke_proxy_tool("github_list_pull_requests", payload)
+
+
+def _github_pull_request_read(**kwargs):
+    owner_repo = _github_require_owner_repo(kwargs)
+    if isinstance(owner_repo, dict):
+        return owner_repo
+    owner, repo = owner_repo
+
+    pull_number = kwargs.get("pullNumber")
+    method = _github_clean_text(kwargs.get("method"))
+    if not isinstance(pull_number, int) or pull_number <= 0 or not method:
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameters: pullNumber (positive int) and method",
+            details={"missing": ["pullNumber", "method"]},
+            suggestions=[
+                "Provide pullNumber and method (e.g. get, get_files, get_status, get_diff)",
+            ],
+        )
+
+    payload: dict[str, Any] = {
+        "owner": owner,
+        "repo": repo,
+        "pullNumber": pull_number,
+        "method": method,
+    }
+    for field in ("page", "perPage"):
+        value = kwargs.get(field)
+        if isinstance(value, int):
+            payload[field] = value
+    return _github_invoke_proxy_tool("github_pull_request_read", payload)
+
+
+def _github_issue_read(**kwargs):
+    owner_repo = _github_require_owner_repo(kwargs)
+    if isinstance(owner_repo, dict):
+        return owner_repo
+    owner, repo = owner_repo
+
+    issue_number = kwargs.get("issue_number")
+    method = _github_clean_text(kwargs.get("method"))
+    if not isinstance(issue_number, int) or issue_number <= 0 or not method:
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameters: issue_number (positive int) and method",
+            details={"missing": ["issue_number", "method"]},
+            suggestions=["Provide method (e.g. get, get_comments, get_labels)"],
+        )
+
+    payload: dict[str, Any] = {
+        "owner": owner,
+        "repo": repo,
+        "issue_number": issue_number,
+        "method": method,
+    }
+    for field in ("page", "perPage"):
+        value = kwargs.get(field)
+        if isinstance(value, int):
+            payload[field] = value
+    return _github_invoke_proxy_tool("github_issue_read", payload)
+
+
+def _github_list_releases(**kwargs):
+    owner_repo = _github_require_owner_repo(kwargs)
+    if isinstance(owner_repo, dict):
+        return owner_repo
+    owner, repo = owner_repo
+    payload: dict[str, Any] = {"owner": owner, "repo": repo}
+    for field in ("page", "perPage"):
+        value = kwargs.get(field)
+        if isinstance(value, int):
+            payload[field] = value
+    return _github_invoke_proxy_tool("github_list_releases", payload)
+
+
+def _github_get_latest_release(**kwargs):
+    owner_repo = _github_require_owner_repo(kwargs)
+    if isinstance(owner_repo, dict):
+        return owner_repo
+    owner, repo = owner_repo
+    return _github_invoke_proxy_tool(
+        "github_get_latest_release",
+        {"owner": owner, "repo": repo},
+    )
+
+
+def _github_list_tags(**kwargs):
+    owner_repo = _github_require_owner_repo(kwargs)
+    if isinstance(owner_repo, dict):
+        return owner_repo
+    owner, repo = owner_repo
+    payload: dict[str, Any] = {"owner": owner, "repo": repo}
+    for field in ("page", "perPage"):
+        value = kwargs.get(field)
+        if isinstance(value, int):
+            payload[field] = value
+    return _github_invoke_proxy_tool("github_list_tags", payload)
+
+
+def _github_list_branches(**kwargs):
+    owner_repo = _github_require_owner_repo(kwargs)
+    if isinstance(owner_repo, dict):
+        return owner_repo
+    owner, repo = owner_repo
+    payload: dict[str, Any] = {"owner": owner, "repo": repo}
+    for field in ("page", "perPage"):
+        value = kwargs.get(field)
+        if isinstance(value, int):
+            payload[field] = value
+    return _github_invoke_proxy_tool("github_list_branches", payload)
+
+
+def _github_create_branch(**kwargs):
+    owner_repo = _github_require_owner_repo(kwargs)
+    if isinstance(owner_repo, dict):
+        return owner_repo
+    owner, repo = owner_repo
+    branch = _github_clean_text(kwargs.get("branch"))
+    if not branch:
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameter: branch",
+            details={"missing": ["branch"]},
+        )
+
+    payload: dict[str, Any] = {"owner": owner, "repo": repo, "branch": branch}
+    from_branch = _github_clean_text(kwargs.get("from_branch"))
+    if from_branch is not None:
+        payload["from_branch"] = from_branch
+
+    return _github_execute_write_tool(
+        action="create_branch",
+        proxy_tool_name="github_create_branch",
+        owner=owner,
+        repo=repo,
+        dry_run=bool(kwargs.get("dry_run", True)),
+        approved=bool(kwargs.get("approved", False)),
+        execute=bool(kwargs.get("execute", False)),
+        request_id=_github_clean_text(kwargs.get("request_id")),
+        payload=payload,
+    )
+
+
+def _github_create_or_update_file(**kwargs):
+    owner_repo = _github_require_owner_repo(kwargs)
+    if isinstance(owner_repo, dict):
+        return owner_repo
+    owner, repo = owner_repo
+
+    branch = _github_clean_text(kwargs.get("branch"))
+    path = _github_clean_text(kwargs.get("path"))
+    message = _github_clean_text(kwargs.get("message"))
+    content = kwargs.get("content")
+    if (
+        not branch
+        or not path
+        or not message
+        or not isinstance(content, str)
+        or content == ""
+    ):
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameters: branch, path, message, content",
+            details={"missing": ["branch", "path", "message", "content"]},
+        )
+
+    payload: dict[str, Any] = {
+        "owner": owner,
+        "repo": repo,
+        "branch": branch,
+        "path": path,
+        "message": message,
+        "content": content,
+    }
+    sha = _github_clean_text(kwargs.get("sha"))
+    if sha is not None:
+        payload["sha"] = sha
+
+    return _github_execute_write_tool(
+        action="create_or_update_file",
+        proxy_tool_name="github_create_or_update_file",
+        owner=owner,
+        repo=repo,
+        dry_run=bool(kwargs.get("dry_run", True)),
+        approved=bool(kwargs.get("approved", False)),
+        execute=bool(kwargs.get("execute", False)),
+        request_id=_github_clean_text(kwargs.get("request_id")),
+        payload=payload,
+    )
+
+
+def _github_create_pull_request(**kwargs):
+    owner_repo = _github_require_owner_repo(kwargs)
+    if isinstance(owner_repo, dict):
+        return owner_repo
+    owner, repo = owner_repo
+
+    title = _github_clean_text(kwargs.get("title"))
+    head = _github_clean_text(kwargs.get("head"))
+    base = _github_clean_text(kwargs.get("base"))
+    if not title or not head or not base:
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameters: title, head, base",
+            details={"missing": ["title", "head", "base"]},
+        )
+
+    payload: dict[str, Any] = {
+        "owner": owner,
+        "repo": repo,
+        "title": title,
+        "head": head,
+        "base": base,
+    }
+    body = kwargs.get("body")
+    if isinstance(body, str):
+        payload["body"] = body
+    for field in ("draft", "maintainer_can_modify"):
+        value = kwargs.get(field)
+        if isinstance(value, bool):
+            payload[field] = value
+
+    return _github_execute_write_tool(
+        action="create_pull_request",
+        proxy_tool_name="github_create_pull_request",
+        owner=owner,
+        repo=repo,
+        dry_run=bool(kwargs.get("dry_run", True)),
+        approved=bool(kwargs.get("approved", False)),
+        execute=bool(kwargs.get("execute", False)),
+        request_id=_github_clean_text(kwargs.get("request_id")),
+        payload=payload,
+    )
+
+
+def _github_update_pull_request(**kwargs):
+    owner_repo = _github_require_owner_repo(kwargs)
+    if isinstance(owner_repo, dict):
+        return owner_repo
+    owner, repo = owner_repo
+
+    pull_number = kwargs.get("pullNumber")
+    if not isinstance(pull_number, int) or pull_number <= 0:
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameter: pullNumber (positive int)",
+            details={"missing": ["pullNumber"]},
+        )
+
+    payload: dict[str, Any] = {"owner": owner, "repo": repo, "pullNumber": pull_number}
+    for field in ("title", "body", "base", "state"):
+        value = _github_clean_text(kwargs.get(field))
+        if value is not None:
+            payload[field] = value
+    for field in ("draft", "maintainer_can_modify"):
+        value = kwargs.get(field)
+        if isinstance(value, bool):
+            payload[field] = value
+    reviewers = kwargs.get("reviewers")
+    if isinstance(reviewers, list):
+        payload["reviewers"] = [str(item) for item in reviewers if str(item).strip()]
+
+    return _github_execute_write_tool(
+        action="update_pull_request",
+        proxy_tool_name="github_update_pull_request",
+        owner=owner,
+        repo=repo,
+        dry_run=bool(kwargs.get("dry_run", True)),
+        approved=bool(kwargs.get("approved", False)),
+        execute=bool(kwargs.get("execute", False)),
+        request_id=_github_clean_text(kwargs.get("request_id")),
+        payload=payload,
+    )
+
+
+def _github_create_pull_request_with_copilot(**kwargs):
+    owner_repo = _github_require_owner_repo(kwargs)
+    if isinstance(owner_repo, dict):
+        return owner_repo
+    owner, repo = owner_repo
+
+    title = _github_clean_text(kwargs.get("title"))
+    problem_statement = _github_clean_text(kwargs.get("problem_statement"))
+    if not title or not problem_statement:
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameters: title and problem_statement",
+            details={"missing": ["title", "problem_statement"]},
+        )
+
+    payload: dict[str, Any] = {
+        "owner": owner,
+        "repo": repo,
+        "title": title,
+        "problem_statement": problem_statement,
+    }
+    base_ref = _github_clean_text(kwargs.get("base_ref"))
+    if base_ref is not None:
+        payload["base_ref"] = base_ref
+
+    return _github_execute_write_tool(
+        action="create_pull_request_with_copilot",
+        proxy_tool_name="github_create_pull_request_with_copilot",
+        owner=owner,
+        repo=repo,
+        dry_run=bool(kwargs.get("dry_run", True)),
+        approved=bool(kwargs.get("approved", False)),
+        execute=bool(kwargs.get("execute", False)),
+        request_id=_github_clean_text(kwargs.get("request_id")),
+        payload=payload,
+    )
 
 
 def _jira_search(**kwargs):
@@ -16556,6 +17702,40 @@ def build_default_catalogue() -> MethodCatalogue:
     jira_hygiene_emit_audit_output_schema = _jira_generic_output_schema(
         "hygiene_emit_audit"
     )
+    github_get_auth_config_output_schema = _github_get_auth_config_output_schema()
+    github_list_tools_output_schema = _github_list_tools_output_schema()
+    github_get_me_output_schema = _github_generic_output_schema("get_me")
+    github_get_file_contents_output_schema = _github_generic_output_schema(
+        "get_file_contents"
+    )
+    github_list_commits_output_schema = _github_generic_output_schema("list_commits")
+    github_search_code_output_schema = _github_generic_output_schema("search_code")
+    github_list_pull_requests_output_schema = _github_generic_output_schema(
+        "list_pull_requests"
+    )
+    github_pull_request_read_output_schema = _github_generic_output_schema(
+        "pull_request_read"
+    )
+    github_issue_read_output_schema = _github_generic_output_schema("issue_read")
+    github_list_releases_output_schema = _github_generic_output_schema("list_releases")
+    github_get_latest_release_output_schema = _github_generic_output_schema(
+        "get_latest_release"
+    )
+    github_list_tags_output_schema = _github_generic_output_schema("list_tags")
+    github_list_branches_output_schema = _github_generic_output_schema("list_branches")
+    github_create_branch_output_schema = _github_generic_output_schema("create_branch")
+    github_create_or_update_file_output_schema = _github_generic_output_schema(
+        "create_or_update_file"
+    )
+    github_create_pull_request_output_schema = _github_generic_output_schema(
+        "create_pull_request"
+    )
+    github_update_pull_request_output_schema = _github_generic_output_schema(
+        "update_pull_request"
+    )
+    github_create_pull_request_with_copilot_output_schema = _github_generic_output_schema(
+        "create_pull_request_with_copilot"
+    )
     task_create_output_schema = _task_generic_output_schema("create")
     task_get_output_schema = _task_generic_output_schema("get")
     task_list_output_schema = _task_generic_output_schema("list")
@@ -17470,6 +18650,185 @@ def build_default_catalogue() -> MethodCatalogue:
             description=(
                 "Force reindex a specific concept's text relations into RAG for the current namespace. "
                 "Useful after bulk edits or when RAG appears stale."
+            ),
+        ),
+        # GitHub MCP tools
+        MethodDefinition(
+            name="github_get_auth_config",
+            handler=_github_get_auth_config,
+            input_schema=_github_get_auth_config_input_schema(),
+            output_schema=github_get_auth_config_output_schema,
+            category="read",
+            timeout_sec=12.0,
+            description=(
+                "Inspect GitHub MCP auth/config state (token presence, allow-list, execute mode, command args) "
+                "without exposing secrets. Also probes tool availability."
+            ),
+        ),
+        MethodDefinition(
+            name="github_list_tools",
+            handler=_github_list_tools,
+            input_schema=_github_list_tools_input_schema(),
+            output_schema=github_list_tools_output_schema,
+            category="read",
+            timeout_sec=20.0,
+            description="List tools exposed by the configured external GitHub MCP server.",
+        ),
+        MethodDefinition(
+            name="github_get_me",
+            handler=_github_get_me,
+            input_schema=_github_get_me_input_schema(),
+            output_schema=github_get_me_output_schema,
+            category="read",
+            timeout_sec=20.0,
+            description="Get details of the authenticated GitHub user.",
+        ),
+        MethodDefinition(
+            name="github_get_file_contents",
+            handler=_github_get_file_contents,
+            input_schema=_github_get_file_contents_input_schema(),
+            output_schema=github_get_file_contents_output_schema,
+            category="read",
+            timeout_sec=30.0,
+            description="Get the contents of a file or directory from a GitHub repository.",
+        ),
+        MethodDefinition(
+            name="github_list_commits",
+            handler=_github_list_commits,
+            input_schema=_github_list_commits_input_schema(),
+            output_schema=github_list_commits_output_schema,
+            category="read",
+            timeout_sec=30.0,
+            description="List commits for a branch, tag, or repository default branch.",
+        ),
+        MethodDefinition(
+            name="github_search_code",
+            handler=_github_search_code,
+            input_schema=_github_search_code_input_schema(),
+            output_schema=github_search_code_output_schema,
+            category="read",
+            timeout_sec=30.0,
+            description="Search code across GitHub repositories using GitHub search syntax.",
+        ),
+        MethodDefinition(
+            name="github_list_pull_requests",
+            handler=_github_list_pull_requests,
+            input_schema=_github_list_pull_requests_input_schema(),
+            output_schema=github_list_pull_requests_output_schema,
+            category="read",
+            timeout_sec=30.0,
+            description="List pull requests for a GitHub repository.",
+        ),
+        MethodDefinition(
+            name="github_pull_request_read",
+            handler=_github_pull_request_read,
+            input_schema=_github_pull_request_read_input_schema(),
+            output_schema=github_pull_request_read_output_schema,
+            category="read",
+            timeout_sec=30.0,
+            description="Read pull request details/files/reviews/status for a repository pull request.",
+        ),
+        MethodDefinition(
+            name="github_issue_read",
+            handler=_github_issue_read,
+            input_schema=_github_issue_read_input_schema(),
+            output_schema=github_issue_read_output_schema,
+            category="read",
+            timeout_sec=30.0,
+            description="Read issue details/comments/labels for a repository issue.",
+        ),
+        MethodDefinition(
+            name="github_list_releases",
+            handler=_github_list_releases,
+            input_schema=_github_list_releases_input_schema(),
+            output_schema=github_list_releases_output_schema,
+            category="read",
+            timeout_sec=20.0,
+            description="List releases in a GitHub repository.",
+        ),
+        MethodDefinition(
+            name="github_get_latest_release",
+            handler=_github_get_latest_release,
+            input_schema=_github_get_latest_release_input_schema(),
+            output_schema=github_get_latest_release_output_schema,
+            category="read",
+            timeout_sec=20.0,
+            description="Get the latest release in a GitHub repository.",
+        ),
+        MethodDefinition(
+            name="github_list_tags",
+            handler=_github_list_tags,
+            input_schema=_github_list_tags_input_schema(),
+            output_schema=github_list_tags_output_schema,
+            category="read",
+            timeout_sec=20.0,
+            description="List tags in a GitHub repository.",
+        ),
+        MethodDefinition(
+            name="github_list_branches",
+            handler=_github_list_branches,
+            input_schema=_github_list_branches_input_schema(),
+            output_schema=github_list_branches_output_schema,
+            category="read",
+            timeout_sec=20.0,
+            description="List branches in a GitHub repository.",
+        ),
+        MethodDefinition(
+            name="github_create_branch",
+            handler=_github_create_branch,
+            input_schema=_github_create_branch_input_schema(),
+            output_schema=github_create_branch_output_schema,
+            category="write",
+            timeout_sec=30.0,
+            description=(
+                "Create a branch in a GitHub repository with write guardrails "
+                "(dry-run by default, repository allow-list, explicit approval/execute mode)."
+            ),
+        ),
+        MethodDefinition(
+            name="github_create_or_update_file",
+            handler=_github_create_or_update_file,
+            input_schema=_github_create_or_update_file_input_schema(),
+            output_schema=github_create_or_update_file_output_schema,
+            category="write",
+            timeout_sec=35.0,
+            description=(
+                "Create or update a file in a GitHub repository with write guardrails "
+                "(dry-run by default, repository allow-list, explicit approval/execute mode)."
+            ),
+        ),
+        MethodDefinition(
+            name="github_create_pull_request",
+            handler=_github_create_pull_request,
+            input_schema=_github_create_pull_request_input_schema(),
+            output_schema=github_create_pull_request_output_schema,
+            category="write",
+            timeout_sec=35.0,
+            description=(
+                "Create a pull request with write guardrails (dry-run default plus explicit approval controls)."
+            ),
+        ),
+        MethodDefinition(
+            name="github_update_pull_request",
+            handler=_github_update_pull_request,
+            input_schema=_github_update_pull_request_input_schema(),
+            output_schema=github_update_pull_request_output_schema,
+            category="write",
+            timeout_sec=35.0,
+            description=(
+                "Update pull request metadata with write guardrails (dry-run default plus explicit approval controls)."
+            ),
+        ),
+        MethodDefinition(
+            name="github_create_pull_request_with_copilot",
+            handler=_github_create_pull_request_with_copilot,
+            input_schema=_github_create_pull_request_with_copilot_input_schema(),
+            output_schema=github_create_pull_request_with_copilot_output_schema,
+            category="write",
+            timeout_sec=35.0,
+            description=(
+                "Delegate implementation to GitHub Copilot coding agent with write guardrails "
+                "(dry-run by default plus approval/execute controls)."
             ),
         ),
         # Jira MCP tools

--- a/src/backend/integrations/internal_mcp/github_proxy_mcp.py
+++ b/src/backend/integrations/internal_mcp/github_proxy_mcp.py
@@ -1,0 +1,131 @@
+"""GitHub MCP proxy using the shared stdio client helper.
+
+This bridges an external GitHub MCP server so Von's internal MCP gateway can
+invoke GitHub tools through a single managed stdio client.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shlex
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from .mcp_proxy_base import MCPServerConfig, MCPStdIOClient, MCPToolClientError
+
+logger = logging.getLogger(__name__)
+_LOG_TAG = "[github_proxy]"
+
+
+class GitHubProxyError(Exception):
+    """Raised when GitHub proxy operations fail."""
+
+
+@dataclass
+class GitHubProxyConfig:
+    """Configuration for GitHub MCP subprocess."""
+
+    command: str
+    args: list[str]
+    env: Dict[str, str]
+    timeout_sec: float = 30.0
+
+
+class GitHubMCPProxy:
+    """Manages external GitHub MCP server subprocess using MCP SDK client."""
+
+    def __init__(self, config: GitHubProxyConfig):
+        client_config = MCPServerConfig(
+            command=config.command,
+            args=config.args,
+            env=config.env,
+            timeout_sec=config.timeout_sec,
+            log_tag=_LOG_TAG,
+        )
+        self._client = MCPStdIOClient(client_config)
+
+    async def call_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Any:
+        try:
+            return await self._client.call_tool(tool_name, arguments)
+        except MCPToolClientError as exc:
+            raise GitHubProxyError(str(exc)) from exc
+
+    async def list_tools(self) -> list[Dict[str, Any]]:
+        try:
+            return await self._client.list_tools()
+        except MCPToolClientError as exc:
+            raise GitHubProxyError(str(exc)) from exc
+
+    def get_stats(self) -> Dict[str, int]:
+        return {
+            "call_count": self._client.call_count,
+            "error_count": self._client.error_count,
+        }
+
+
+def _build_github_env() -> Dict[str, str]:
+    env = os.environ.copy()
+
+    def _clean(value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if len(cleaned) >= 2 and cleaned[0] == cleaned[-1] and cleaned[0] in ('"', "'"):
+            cleaned = cleaned[1:-1].strip()
+        return cleaned or None
+
+    token = _clean(
+        env.get("GITHUB_PERSONAL_ACCESS_TOKEN")
+        or env.get("GITHUB_TOKEN")
+        or env.get("GH_TOKEN")
+    )
+    if not token:
+        raise GitHubProxyError(
+            "Missing GitHub token. Set one of: GITHUB_PERSONAL_ACCESS_TOKEN, "
+            "GITHUB_TOKEN, or GH_TOKEN."
+        )
+
+    # Populate common token keys used by GitHub MCP server variants.
+    env["GITHUB_PERSONAL_ACCESS_TOKEN"] = token
+    env["GITHUB_TOKEN"] = token
+    env["GH_TOKEN"] = token
+    return env
+
+
+def _build_github_config() -> GitHubProxyConfig:
+    command = str(os.getenv("VON_GITHUB_MCP_COMMAND") or "npx").strip() or "npx"
+    raw_args = os.getenv("VON_GITHUB_MCP_ARGS")
+    if isinstance(raw_args, str) and raw_args.strip():
+        args = shlex.split(raw_args.strip())
+    else:
+        args = ["-y", "@modelcontextprotocol/server-github"]
+    if not args:
+        raise GitHubProxyError("GitHub MCP args cannot be empty")
+    return GitHubProxyConfig(
+        command=command,
+        args=args,
+        env=_build_github_env(),
+    )
+
+
+_proxy_instance: Optional[GitHubMCPProxy] = None
+_proxy_lock = asyncio.Lock()
+
+
+async def get_github_proxy() -> GitHubMCPProxy:
+    """Get or create the global GitHub MCP proxy instance."""
+    global _proxy_instance
+
+    async with _proxy_lock:
+        if _proxy_instance is None:
+            config = _build_github_config()
+            _proxy_instance = GitHubMCPProxy(config)
+            logger.info(
+                "%s Initialised GitHub MCP proxy via command=%s args=%s",
+                _LOG_TAG,
+                config.command,
+                config.args,
+            )
+        return _proxy_instance

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -551,6 +551,20 @@ class InternalMCPChatOrchestrator:
         r"\bcall\s+`?([a-z_][a-z0-9_]*)`?\b",
         flags=re.IGNORECASE,
     )
+    _PROMPT_CONCEPT_VERIFICATION_HINT_PATTERN = re.compile(
+        r"\b("
+        r"verify|verification|check|confirm|validate|"
+        r"exist(?:s|ence)?|real|valid|"
+        r"do(?:es)?\s+.+?\s+exist|"
+        r"is\s+.+?\s+(?:real|valid)"
+        r")\b",
+        flags=re.IGNORECASE,
+    )
+    _PROMPT_FILE_COPY_REFERENCE_PATTERN = re.compile(
+        r"(#V#[A-Za-z0-9][A-Za-z0-9._-]*file_copy[A-Za-z0-9._-]*"
+        r"|\b(?:computer_)?file_copy_[A-Za-z0-9][A-Za-z0-9._-]*\b)",
+        flags=re.IGNORECASE,
+    )
     _WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID = (
         "#V#workflow_introspection_maintenance_workflow"
     )
@@ -806,6 +820,22 @@ class InternalMCPChatOrchestrator:
 
         # Deterministic ontology preflight cache (per language).
         self._preflight_cache: dict[str, dict[str, Any]] = {}
+        # Provider reachability probe cache used to throttle repeated failing probes.
+        self._provider_probe_cache: dict[str, dict[str, Any]] = {}
+        self._provider_probe_cache_max_entries = self._coerce_int(
+            None,
+            env_var="VON_INTERNAL_MCP_PROVIDER_PROBE_CACHE_MAX_ENTRIES",
+            default=64,
+            min_value=8,
+            max_value=512,
+        )
+        self._provider_probe_cooldown_seconds = self._coerce_int(
+            None,
+            env_var="VON_INTERNAL_MCP_PROVIDER_PROBE_COOLDOWN_SEC",
+            default=20,
+            min_value=0,
+            max_value=600,
+        )
 
         # Topic vocabulary cache for context-based discovery (JVNAUTOSCI-1052).
         # Key: hash of extracted topic keywords; Value: {timestamp, types, predicates}.
@@ -1832,6 +1862,14 @@ class InternalMCPChatOrchestrator:
             for item in missing_required_fetch_concept_ids
             if isinstance(item, str) and item.strip()
         ]
+        missing_required_read_file_copy_ids = data.get("missing_prompt_read_file_copy_ids")
+        if not isinstance(missing_required_read_file_copy_ids, list):
+            missing_required_read_file_copy_ids = []
+        missing_required_read_file_copy_ids = [
+            str(item).strip()
+            for item in missing_required_read_file_copy_ids
+            if isinstance(item, str) and item.strip()
+        ]
         required_create_type_name_raw = data.get("required_prompt_create_type_name")
         required_create_type_name = (
             str(required_create_type_name_raw).strip()
@@ -1949,6 +1987,7 @@ class InternalMCPChatOrchestrator:
             user_prompt=data.get("user_prompt"),
             missing_required_tools=missing_required_tools,
             missing_required_fetch_concept_ids=missing_required_fetch_concept_ids,
+            missing_required_read_file_copy_ids=missing_required_read_file_copy_ids,
             required_create_type_name=required_create_type_name,
         )
         if forced:
@@ -2284,12 +2323,18 @@ class InternalMCPChatOrchestrator:
             "required_prompt_fetch_concept_ids": data.get(
                 "required_prompt_fetch_concept_ids"
             ),
+            "required_prompt_read_file_copy_ids": data.get(
+                "required_prompt_read_file_copy_ids"
+            ),
             "required_prompt_create_type_name": data.get(
                 "required_prompt_create_type_name"
             ),
             "missing_prompt_tools": data.get("missing_prompt_tools"),
             "missing_prompt_fetch_concept_ids": data.get(
                 "missing_prompt_fetch_concept_ids"
+            ),
+            "missing_prompt_read_file_copy_ids": data.get(
+                "missing_prompt_read_file_copy_ids"
             ),
             "missing_tool_call_retry_reason_override": data.get(
                 "missing_tool_call_retry_reason_override"
@@ -3486,6 +3531,12 @@ class InternalMCPChatOrchestrator:
                 prompt_requirement_state.get("required_fetch_concept_ids") or [],
             )
         )
+        required_prompt_read_file_copy_ids = list(
+            cast(
+                list[str],
+                prompt_requirement_state.get("required_read_file_copy_ids") or [],
+            )
+        )
         required_prompt_create_type_name_raw = prompt_requirement_state.get(
             "required_create_type_name"
         )
@@ -3497,6 +3548,9 @@ class InternalMCPChatOrchestrator:
         data["required_prompt_tools"] = list(required_prompt_tools)
         data["required_prompt_fetch_concept_ids"] = list(
             required_prompt_fetch_concept_ids
+        )
+        data["required_prompt_read_file_copy_ids"] = list(
+            required_prompt_read_file_copy_ids
         )
         data["required_prompt_create_type_name"] = required_prompt_create_type_name
 
@@ -3608,19 +3662,28 @@ class InternalMCPChatOrchestrator:
 
         # Missing-tool-call recovery.
         if not has_valid_tool_call:
-            missing_prompt_tools, missing_prompt_fetch_concept_ids = (
+            (
+                missing_prompt_tools,
+                missing_prompt_fetch_concept_ids,
+                missing_prompt_read_file_copy_ids,
+            ) = (
                 self._derive_missing_prompt_requirements(
                     required_tools=required_prompt_tools,
                     required_fetch_concept_ids=required_prompt_fetch_concept_ids,
+                    required_read_file_copy_ids=required_prompt_read_file_copy_ids,
                     tool_invocations=(),
                 )
             )
             data["missing_prompt_fetch_concept_ids"] = list(
                 missing_prompt_fetch_concept_ids
             )
+            data["missing_prompt_read_file_copy_ids"] = list(
+                missing_prompt_read_file_copy_ids
+            )
             missing_retry_reason = self._build_missing_prompt_retry_reason(
                 missing_tools=missing_prompt_tools,
                 missing_fetch_concept_ids=missing_prompt_fetch_concept_ids,
+                missing_read_file_copy_ids=missing_prompt_read_file_copy_ids,
             )
             data["missing_prompt_tools"] = list(missing_prompt_tools)
             if missing_retry_reason:
@@ -4482,6 +4545,12 @@ class InternalMCPChatOrchestrator:
                     prompt_requirement_state.get("required_fetch_concept_ids") or [],
                 )
             )
+            required_prompt_read_file_copy_ids = list(
+                cast(
+                    list[str],
+                    prompt_requirement_state.get("required_read_file_copy_ids") or [],
+                )
+            )
             required_prompt_create_type_name_raw = prompt_requirement_state.get(
                 "required_create_type_name"
             )
@@ -4494,15 +4563,23 @@ class InternalMCPChatOrchestrator:
             data["required_prompt_fetch_concept_ids"] = list(
                 required_prompt_fetch_concept_ids
             )
+            data["required_prompt_read_file_copy_ids"] = list(
+                required_prompt_read_file_copy_ids
+            )
             data["required_prompt_create_type_name"] = required_prompt_create_type_name
 
             invocations_for_requirements = cast(
                 Sequence[Mapping[str, Any]], data.get("invocations") or []
             )
-            missing_prompt_tools, missing_prompt_fetch_concept_ids = (
+            (
+                missing_prompt_tools,
+                missing_prompt_fetch_concept_ids,
+                missing_prompt_read_file_copy_ids,
+            ) = (
                 self._derive_missing_prompt_requirements(
                     required_tools=required_prompt_tools,
                     required_fetch_concept_ids=required_prompt_fetch_concept_ids,
+                    required_read_file_copy_ids=required_prompt_read_file_copy_ids,
                     tool_invocations=invocations_for_requirements,
                 )
             )
@@ -4510,9 +4587,13 @@ class InternalMCPChatOrchestrator:
             data["missing_prompt_fetch_concept_ids"] = list(
                 missing_prompt_fetch_concept_ids
             )
+            data["missing_prompt_read_file_copy_ids"] = list(
+                missing_prompt_read_file_copy_ids
+            )
             missing_retry_reason = self._build_missing_prompt_retry_reason(
                 missing_tools=missing_prompt_tools,
                 missing_fetch_concept_ids=missing_prompt_fetch_concept_ids,
+                missing_read_file_copy_ids=missing_prompt_read_file_copy_ids,
             )
             if missing_retry_reason:
                 data["missing_tool_call_retry_reason_override"] = missing_retry_reason
@@ -4531,6 +4612,12 @@ class InternalMCPChatOrchestrator:
                             ),
                             "missing_fetch_concept_ids": list(
                                 missing_prompt_fetch_concept_ids
+                            ),
+                            "required_read_file_copy_ids": list(
+                                required_prompt_read_file_copy_ids
+                            ),
+                            "missing_read_file_copy_ids": list(
+                                missing_prompt_read_file_copy_ids
                             ),
                             "required_create_type_name": (
                                 required_prompt_create_type_name
@@ -6698,6 +6785,11 @@ class InternalMCPChatOrchestrator:
         if not isinstance(user_prompt, str) or not user_prompt.strip():
             return []
 
+        explicit_concept_ids = cls._extract_explicit_concept_ids_from_prompt(user_prompt)
+        has_verification_intent = bool(
+            cls._PROMPT_CONCEPT_VERIFICATION_HINT_PATTERN.search(user_prompt)
+        )
+
         # Require multiple suffix segments so field names like
         # "workflow_mapping_spec" are not treated as concept IDs.
         matches = re.findall(
@@ -6708,6 +6800,13 @@ class InternalMCPChatOrchestrator:
         )
         concept_ids: list[str] = []
         seen: set[str] = set()
+        if has_verification_intent:
+            for concept_id in explicit_concept_ids:
+                key = concept_id.lower()
+                if key in seen:
+                    continue
+                seen.add(key)
+                concept_ids.append(concept_id)
         for match in matches:
             concept_id = cls._normalise_concept_id_candidate(match)
             if not concept_id:
@@ -6716,6 +6815,53 @@ class InternalMCPChatOrchestrator:
             if key in seen:
                 continue
             seen.add(key)
+            concept_ids.append(concept_id)
+        return concept_ids
+
+    @classmethod
+    def _extract_explicit_concept_ids_from_prompt(
+        cls,
+        user_prompt: Any,
+    ) -> list[str]:
+        if not isinstance(user_prompt, str) or not user_prompt.strip():
+            return []
+        raw_matches = re.findall(
+            r"#V#[A-Za-z0-9][A-Za-z0-9._-]*",
+            user_prompt,
+            flags=re.IGNORECASE,
+        )
+        concept_ids: list[str] = []
+        seen: set[str] = set()
+        for raw_match in raw_matches:
+            concept_id = cls._normalise_concept_id_candidate(raw_match)
+            if not concept_id:
+                continue
+            lowered = concept_id.lower()
+            if lowered in seen:
+                continue
+            seen.add(lowered)
+            concept_ids.append(concept_id)
+        return concept_ids
+
+    @classmethod
+    def _extract_required_read_file_copy_ids_from_prompt(
+        cls,
+        user_prompt: Any,
+    ) -> list[str]:
+        if not isinstance(user_prompt, str) or not user_prompt.strip():
+            return []
+
+        references = cls._PROMPT_FILE_COPY_REFERENCE_PATTERN.findall(user_prompt)
+        concept_ids: list[str] = []
+        seen: set[str] = set()
+        for reference in references:
+            concept_id = cls._normalise_concept_id_candidate(reference)
+            if not concept_id:
+                continue
+            lowered = concept_id.lower()
+            if lowered in seen:
+                continue
+            seen.add(lowered)
             concept_ids.append(concept_id)
         return concept_ids
 
@@ -6844,6 +6990,40 @@ class InternalMCPChatOrchestrator:
         return concept_ids
 
     @classmethod
+    def _extract_read_file_copy_ids_from_invocations(
+        cls,
+        tool_invocations: Sequence[Mapping[str, Any]],
+    ) -> list[str]:
+        """Collect file-copy concept IDs already read via read_file_copy calls."""
+
+        concept_ids: list[str] = []
+        seen: set[str] = set()
+
+        for invocation in tool_invocations:
+            if not isinstance(invocation, Mapping):
+                continue
+            raw_tool = invocation.get("tool")
+            if not isinstance(raw_tool, str) or raw_tool.strip().lower() != "read_file_copy":
+                continue
+
+            payload = invocation.get("effective_payload")
+            if not isinstance(payload, Mapping):
+                payload = invocation.get("payload")
+            if not isinstance(payload, Mapping):
+                continue
+
+            concept_id = cls._normalise_concept_id_candidate(payload.get("concept_id"))
+            if not concept_id:
+                continue
+            key = concept_id.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            concept_ids.append(concept_id)
+
+        return concept_ids
+
+    @classmethod
     def _derive_prompt_tool_requirements(
         cls,
         user_prompt: Any,
@@ -6871,8 +7051,9 @@ class InternalMCPChatOrchestrator:
         required_fetch_concept_ids = cls._extract_required_fetch_concept_ids_from_prompt(
             user_prompt
         )
-        if not _tool_available("fetch_concept"):
-            required_fetch_concept_ids = []
+        required_read_file_copy_ids = cls._extract_required_read_file_copy_ids_from_prompt(
+            user_prompt
+        )
 
         required_create_type_name = cls._extract_required_create_type_name_from_prompt(
             user_prompt
@@ -6903,11 +7084,26 @@ class InternalMCPChatOrchestrator:
             seen_required.add("create_concepts")
         if required_fetch_concept_ids and "fetch_concept" not in seen_required:
             required_tools.append("fetch_concept")
+            seen_required.add("fetch_concept")
+        if required_read_file_copy_ids and "read_file_copy" not in seen_required:
+            required_tools.append("read_file_copy")
+            seen_required.add("read_file_copy")
+
+        unavailable_required_tools: list[str] = []
+        if available_tools:
+            for tool_name in required_tools:
+                lowered = str(tool_name or "").strip().lower()
+                if not lowered:
+                    continue
+                if lowered not in available_tools and lowered not in unavailable_required_tools:
+                    unavailable_required_tools.append(lowered)
 
         return {
             "required_tools": required_tools,
             "required_fetch_concept_ids": required_fetch_concept_ids,
+            "required_read_file_copy_ids": required_read_file_copy_ids,
             "required_create_type_name": required_create_type_name,
+            "unavailable_required_tools": unavailable_required_tools,
         }
 
     @classmethod
@@ -6916,8 +7112,9 @@ class InternalMCPChatOrchestrator:
         *,
         required_tools: Sequence[str],
         required_fetch_concept_ids: Sequence[str],
+        required_read_file_copy_ids: Sequence[str] = (),
         tool_invocations: Sequence[Mapping[str, Any]],
-    ) -> tuple[list[str], list[str]]:
+    ) -> tuple[list[str], list[str], list[str]]:
         """Determine missing prompt requirements from invocation history."""
 
         missing_tools = cls._missing_prompt_tool_requirements(
@@ -6948,13 +7145,37 @@ class InternalMCPChatOrchestrator:
             if "fetch_concept" not in missing_lookup:
                 missing_tools.append("fetch_concept")
 
-        return missing_tools, missing_fetch_concept_ids
+        missing_read_file_copy_ids: list[str] = []
+        if required_read_file_copy_ids:
+            read_file_copy_ids = cls._extract_read_file_copy_ids_from_invocations(
+                tool_invocations
+            )
+            read_lookup = {concept_id.lower() for concept_id in read_file_copy_ids}
+            for concept_id in required_read_file_copy_ids:
+                if (
+                    isinstance(concept_id, str)
+                    and concept_id.strip()
+                    and concept_id.lower() not in read_lookup
+                ):
+                    missing_read_file_copy_ids.append(concept_id)
+
+        if missing_read_file_copy_ids:
+            missing_lookup = {
+                tool_name.lower()
+                for tool_name in missing_tools
+                if isinstance(tool_name, str) and tool_name.strip()
+            }
+            if "read_file_copy" not in missing_lookup:
+                missing_tools.append("read_file_copy")
+
+        return missing_tools, missing_fetch_concept_ids, missing_read_file_copy_ids
 
     @staticmethod
     def _build_missing_prompt_retry_reason(
         *,
         missing_tools: Sequence[str],
         missing_fetch_concept_ids: Sequence[str],
+        missing_read_file_copy_ids: Sequence[str] = (),
     ) -> str | None:
         """Build a stable retry reason for unmet prompt requirements."""
 
@@ -6963,7 +7184,11 @@ class InternalMCPChatOrchestrator:
             for tool_name in missing_tools
             if isinstance(tool_name, str) and tool_name.strip()
         ]
-        if not missing_names and not missing_fetch_concept_ids:
+        if (
+            not missing_names
+            and not missing_fetch_concept_ids
+            and not missing_read_file_copy_ids
+        ):
             return None
 
         details: list[str] = list(missing_names)
@@ -6973,6 +7198,15 @@ class InternalMCPChatOrchestrator:
                 + ", ".join(
                     str(concept_id).strip()
                     for concept_id in missing_fetch_concept_ids
+                    if isinstance(concept_id, str) and concept_id.strip()
+                )
+            )
+        if missing_read_file_copy_ids:
+            details.append(
+                "read_file_copy targets: "
+                + ", ".join(
+                    str(concept_id).strip()
+                    for concept_id in missing_read_file_copy_ids
                     if isinstance(concept_id, str) and concept_id.strip()
                 )
             )
@@ -8311,6 +8545,63 @@ class InternalMCPChatOrchestrator:
             return f"http://{host}".rstrip("/")
         return f"http://{host}:11434"
 
+    @staticmethod
+    def _provider_probe_cache_key(*, provider: str, host: str | None = None) -> str:
+        provider_key = str(provider or "").strip().lower()
+        host_key = str(host or "").strip().lower()
+        return f"{provider_key}:{host_key}"
+
+    def _provider_probe_cache_get(
+        self,
+        *,
+        provider: str,
+        host: str | None = None,
+    ) -> Mapping[str, Any] | None:
+        key = self._provider_probe_cache_key(provider=provider, host=host)
+        cached = self._provider_probe_cache.get(key)
+        if not isinstance(cached, Mapping):
+            return None
+        return dict(cached)
+
+    def _provider_probe_cache_set(
+        self,
+        *,
+        provider: str,
+        host: str | None = None,
+        result: Mapping[str, Any],
+    ) -> None:
+        key = self._provider_probe_cache_key(provider=provider, host=host)
+        now_epoch = float(time.time())
+        entry = {
+            "provider": str(provider).strip().lower(),
+            "host": str(host).strip().lower() if isinstance(host, str) else "",
+            "recorded_at_epoch": now_epoch,
+            "reachable": bool(result.get("reachable")),
+            "result": dict(result),
+        }
+        self._provider_probe_cache[key] = entry
+        max_entries = max(1, int(self._provider_probe_cache_max_entries))
+        if len(self._provider_probe_cache) <= max_entries:
+            return
+        oldest_key = None
+        oldest_ts = None
+        for cache_key, cache_entry in self._provider_probe_cache.items():
+            if not isinstance(cache_entry, Mapping):
+                continue
+            raw_ts = cache_entry.get("recorded_at_epoch")
+            if isinstance(raw_ts, (int, float, str)):
+                try:
+                    ts = float(raw_ts)
+                except Exception:
+                    ts = now_epoch
+            else:
+                ts = now_epoch
+            if oldest_ts is None or ts < oldest_ts:
+                oldest_ts = ts
+                oldest_key = cache_key
+        if oldest_key:
+            self._provider_probe_cache.pop(oldest_key, None)
+
     def _probe_model_candidate_reachability(
         self,
         *,
@@ -8342,16 +8633,47 @@ class InternalMCPChatOrchestrator:
         )
         host = self._normalise_ollama_probe_host(telemetry.get("host"))
         probe_url = f"{host}/api/tags"
+        cooldown_seconds = max(0, int(self._provider_probe_cooldown_seconds))
+        if cooldown_seconds > 0:
+            cached = self._provider_probe_cache_get(provider=provider, host=host)
+            if isinstance(cached, Mapping):
+                cached_reachable = bool(cached.get("reachable"))
+                recorded_at_raw = cached.get("recorded_at_epoch")
+                if isinstance(recorded_at_raw, (int, float, str)):
+                    try:
+                        recorded_at = float(recorded_at_raw)
+                    except Exception:
+                        recorded_at = 0.0
+                else:
+                    recorded_at = 0.0
+                age_seconds = max(0.0, time.time() - recorded_at)
+                if (not cached_reachable) and age_seconds < float(cooldown_seconds):
+                    cached_result = cached.get("result")
+                    if isinstance(cached_result, Mapping):
+                        cached_payload: dict[str, Any] = dict(cached_result)
+                    else:
+                        cached_payload = {}
+                    cached_payload.setdefault("provider", provider)
+                    cached_payload.setdefault("host", host)
+                    cached_payload.setdefault("probe_url", probe_url)
+                    cached_payload["cached"] = True
+                    cached_payload["cooldown_hit"] = True
+                    cached_payload["cooldown_seconds"] = cooldown_seconds
+                    cached_payload["cooldown_remaining_ms"] = int(
+                        max(0.0, (float(cooldown_seconds) - age_seconds) * 1000.0)
+                    )
+                    cached_payload["cache_age_ms"] = int(age_seconds * 1000.0)
+                    return cached_payload
 
         probe_start = time.perf_counter()
         try:
-            response = requests.get(
+            http_response = requests.get(
                 probe_url,
                 headers={"Accept": "application/json"},
                 timeout=max(0.1, float(timeout_ms) / 1000.0),
             )
-            response.raise_for_status()
-            return {
+            http_response.raise_for_status()
+            result = {
                 "provider": provider,
                 "host": host,
                 "probe_url": probe_url,
@@ -8359,8 +8681,10 @@ class InternalMCPChatOrchestrator:
                 "duration_ms": int((time.perf_counter() - probe_start) * 1000.0),
                 "reachable": True,
             }
+            self._provider_probe_cache_set(provider=provider, host=host, result=result)
+            return result
         except Exception as exc:
-            return {
+            result = {
                 "provider": provider,
                 "host": host,
                 "probe_url": probe_url,
@@ -8370,6 +8694,8 @@ class InternalMCPChatOrchestrator:
                 "error": str(exc),
                 "error_class": type(exc).__name__,
             }
+            self._provider_probe_cache_set(provider=provider, host=host, result=result)
+            return result
 
     def _invoke_with_llm_heartbeat(
         self,
@@ -15457,6 +15783,7 @@ class InternalMCPChatOrchestrator:
         user_text: str,
         missing_required_tools: Sequence[str],
         missing_required_fetch_concept_ids: Sequence[str] | None = None,
+        missing_required_read_file_copy_ids: Sequence[str] | None = None,
         required_create_type_name: str | None = None,
     ) -> list[_ToolCallRequest] | None:
         """Build deterministic tool calls for still-missing explicit requirements."""
@@ -15467,6 +15794,11 @@ class InternalMCPChatOrchestrator:
         missing_required_fetch_concept_ids = [
             str(item).strip()
             for item in (missing_required_fetch_concept_ids or [])
+            if isinstance(item, str) and str(item).strip()
+        ]
+        missing_required_read_file_copy_ids = [
+            str(item).strip()
+            for item in (missing_required_read_file_copy_ids or [])
             if isinstance(item, str) and str(item).strip()
         ]
 
@@ -15553,6 +15885,22 @@ class InternalMCPChatOrchestrator:
                     )
                 continue
 
+            if name == "read_file_copy":
+                read_file_copy_ids = list(missing_required_read_file_copy_ids)
+                if not read_file_copy_ids:
+                    read_file_copy_ids = self._extract_required_read_file_copy_ids_from_prompt(
+                        user_text
+                    )
+                for concept_id in read_file_copy_ids:
+                    forced_calls.append(
+                        {
+                            "action": "call_tool",
+                            "tool": name,
+                            "payload": {"concept_id": concept_id},
+                        }
+                    )
+                continue
+
         return forced_calls or None
 
     def _infer_missing_tool_call_retry_tool_calls(
@@ -15561,6 +15909,7 @@ class InternalMCPChatOrchestrator:
         user_prompt: Any | None = None,
         missing_required_tools: Sequence[str] | None = None,
         missing_required_fetch_concept_ids: Sequence[str] | None = None,
+        missing_required_read_file_copy_ids: Sequence[str] | None = None,
         required_create_type_name: str | None = None,
     ) -> list[_ToolCallRequest] | None:
         """Best-effort deterministic recovery for common missing-tool-call cases.
@@ -15598,6 +15947,11 @@ class InternalMCPChatOrchestrator:
             missing_required_fetch_concept_ids=(
                 list(missing_required_fetch_concept_ids)
                 if missing_required_fetch_concept_ids
+                else []
+            ),
+            missing_required_read_file_copy_ids=(
+                list(missing_required_read_file_copy_ids)
+                if missing_required_read_file_copy_ids
                 else []
             ),
             required_create_type_name=(
@@ -22097,6 +22451,9 @@ class InternalMCPChatOrchestrator:
                 loading_diag = diagnostics_obj.get("renderer_definition_loading")
                 if isinstance(loading_diag, Mapping):
                     decision["renderer_definition_loading"] = dict(loading_diag)
+                filtering_boundary = diagnostics_obj.get("filtering_boundary")
+                if isinstance(filtering_boundary, Mapping):
+                    decision["renderer_filtering_boundary"] = dict(filtering_boundary)
 
             decision["reason"] = "resolved"
             decision["should_narrate"] = narration_selected
@@ -22266,6 +22623,100 @@ class InternalMCPChatOrchestrator:
             aux_llm_calls.append(override_payload)
             if trace_enabled and trace is not None:
                 trace.metadata["workflow_selector_override"] = dict(override_payload)
+
+        if selector_verdict == "plain_response":
+            plain_requirement_state = self._derive_prompt_tool_requirements(
+                prompt,
+                method_catalogue=method_catalogue_for_routing,
+            )
+            required_prompt_tools = list(
+                cast(list[str], plain_requirement_state.get("required_tools") or [])
+            )
+            required_prompt_fetch_concept_ids = list(
+                cast(
+                    list[str],
+                    plain_requirement_state.get("required_fetch_concept_ids") or [],
+                )
+            )
+            required_prompt_read_file_copy_ids = list(
+                cast(
+                    list[str],
+                    plain_requirement_state.get("required_read_file_copy_ids") or [],
+                )
+            )
+            unavailable_required_tools = list(
+                cast(
+                    list[str],
+                    plain_requirement_state.get("unavailable_required_tools") or [],
+                )
+            )
+            (
+                missing_prompt_tools,
+                missing_prompt_fetch_concept_ids,
+                missing_prompt_read_file_copy_ids,
+            ) = self._derive_missing_prompt_requirements(
+                required_tools=required_prompt_tools,
+                required_fetch_concept_ids=required_prompt_fetch_concept_ids,
+                required_read_file_copy_ids=required_prompt_read_file_copy_ids,
+                tool_invocations=(),
+            )
+            missing_retry_reason = self._build_missing_prompt_retry_reason(
+                missing_tools=missing_prompt_tools,
+                missing_fetch_concept_ids=missing_prompt_fetch_concept_ids,
+                missing_read_file_copy_ids=missing_prompt_read_file_copy_ids,
+            )
+
+            if (
+                missing_prompt_tools
+                or missing_prompt_fetch_concept_ids
+                or missing_prompt_read_file_copy_ids
+            ):
+                excluded_workflow_ids = sorted(
+                    {
+                        CHAT_ASSISTANT_WORKFLOW_ID,
+                        selected_workflow_id_text or CHAT_ASSISTANT_WORKFLOW_ID,
+                    }
+                )
+                selected_workflow_id = TOOL_CALLING_WORKFLOW_ID
+                selected_workflow_id_text = TOOL_CALLING_WORKFLOW_ID
+                selector_verdict = "tool_seeking"
+                selector_requests_narration = False
+                selector_requests_custom_workflow = False
+                if isinstance(routing_info, WorkflowRoutingInfo):
+                    routing_info = WorkflowRoutingInfo(
+                        workflow_id=TOOL_CALLING_WORKFLOW_ID,
+                        verdict="tool_seeking",
+                        prompt_id=routing_info.prompt_id,
+                        discovered_workflow_ids=routing_info.discovered_workflow_ids,
+                        routing_duration_ms=routing_info.routing_duration_ms,
+                        source="selector_override",
+                    )
+                override_payload = {
+                    "type": "workflow_selector_override",
+                    "reason": "required_prompt_tools_missing",
+                    "selected_workflow_id": TOOL_CALLING_WORKFLOW_ID,
+                    "excluded_workflow_ids": excluded_workflow_ids,
+                    "excluded_selector_verdicts": ["plain_response"],
+                    "required_prompt_tools": list(required_prompt_tools),
+                    "missing_prompt_tools": list(missing_prompt_tools),
+                    "required_prompt_fetch_concept_ids": list(
+                        required_prompt_fetch_concept_ids
+                    ),
+                    "missing_prompt_fetch_concept_ids": list(
+                        missing_prompt_fetch_concept_ids
+                    ),
+                    "required_prompt_read_file_copy_ids": list(
+                        required_prompt_read_file_copy_ids
+                    ),
+                    "missing_prompt_read_file_copy_ids": list(
+                        missing_prompt_read_file_copy_ids
+                    ),
+                    "unavailable_required_tools": list(unavailable_required_tools),
+                    "retry_reason": missing_retry_reason,
+                }
+                aux_llm_calls.append(override_payload)
+                if trace_enabled and trace is not None:
+                    trace.metadata["workflow_selector_override"] = dict(override_payload)
 
         selected_uses_tool_pipeline_contract = _workflow_matches_action_contract(
             selected_workflow_id_text,

--- a/src/backend/integrations/internal_mcp/tool_contract_registry.py
+++ b/src/backend/integrations/internal_mcp/tool_contract_registry.py
@@ -262,6 +262,8 @@ def schema_to_json_schema(schema: Schema) -> dict[str, Any]:
 def _infer_tool_family(tool_name: str) -> str:
     if tool_name.startswith("jira_"):
         return "jira"
+    if tool_name.startswith("github_"):
+        return "github"
     if tool_name.startswith("workflow_"):
         return "workflow"
     if tool_name.startswith("gmail_"):

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -48,8 +48,8 @@ from ...services.chat_concept_reference_service import (
 from ...services.buttonify_service import (
     BUTTONIFY_PROMPT_IDS,
     enforce_buttonify_prompt_contract,
-    parse_buttonify_options_json,
-    sanitise_buttonify_options,
+    parse_buttonify_options_json_with_telemetry,
+    sanitise_buttonify_options_with_telemetry,
 )
 from ...services.prompt_template_service import PromptTemplateService
 from ...services.display_elements_service import (
@@ -7371,6 +7371,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
         buttonify_model_attempted = False
         buttonify_workflow_used = False
         buttonify_preflight_rejection_reason = None
+        buttonify_filtering_boundary: dict[str, Any] | None = None
 
         if not buttonify_enabled:
             buttonify_suppression_reason = "buttonify_disabled"
@@ -7448,7 +7449,10 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
 
                 raw_options = workflow_payload.get("buttonify_options")
                 if isinstance(raw_options, list):
-                    buttonify_options = sanitise_buttonify_options(raw_options)
+                    (
+                        buttonify_options,
+                        buttonify_filtering_boundary,
+                    ) = sanitise_buttonify_options_with_telemetry(raw_options)
 
                 if isinstance(workflow_payload.get("buttonify_source"), str):
                     buttonify_source = workflow_payload.get("buttonify_source", "none")
@@ -7540,7 +7544,10 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                         buttonify_error_class = type(exc).__name__
                         buttonify_response = None
 
-                    buttonify_options = parse_buttonify_options_json(buttonify_response)
+                    (
+                        buttonify_options,
+                        buttonify_filtering_boundary,
+                    ) = parse_buttonify_options_json_with_telemetry(buttonify_response)
                     buttonify_source = "llm" if buttonify_options else "none"
 
             if buttonify_source == "llm":
@@ -7570,6 +7577,8 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                 "workflow_available": buttonify_workflow_available,
                 "preflight_rejection_reason": buttonify_preflight_rejection_reason,
             }
+            if isinstance(buttonify_filtering_boundary, Mapping):
+                buttonify_meta["filtering_boundary"] = dict(buttonify_filtering_boundary)
             if buttonify_workflow_contract is not None:
                 buttonify_meta["workflow_contract"] = buttonify_workflow_contract
 
@@ -7595,6 +7604,11 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                     "prompt_truncated": buttonify_prompt_truncated,
                     "prompt_available": buttonify_prompt_available,
                     "prompt_error": buttonify_prompt_error,
+                    "filtering_boundary": (
+                        dict(buttonify_filtering_boundary)
+                        if isinstance(buttonify_filtering_boundary, Mapping)
+                        else None
+                    ),
                 },
                 options_emitted_count=len(buttonify_options),
                 source_path=buttonify_source,

--- a/src/backend/services/buttonify_service.py
+++ b/src/backend/services/buttonify_service.py
@@ -17,23 +17,30 @@ _BUTTONIFY_PROMPT_CONTRACT_SUFFIX = (
     "- Do NOT output noun/topic fragments.\n"
     '- If uncertain, output [].'
 )
+_BUTTONIFY_FILTERING_BOUNDARY_SCHEMA_VERSION = "buttonify_filtering_boundary_v1"
+_BUTTONIFY_FILTERING_PREVIEW_LIMIT = 8
 
 
-def normalise_buttonify_option(value: str | None) -> str | None:
+def _normalise_buttonify_option_with_reason(value: str | None) -> tuple[str | None, str | None]:
     if not isinstance(value, str):
-        return None
+        return None, "non_string"
     cleaned = re.sub(r"\s+", " ", value).strip()
     if not cleaned:
-        return None
+        return None, "empty"
     cleaned = cleaned.strip("-–—•*\t ")
     cleaned = re.sub(r"^[\"'“‘]+|[\"'”’]+$", "", cleaned).strip()
     cleaned = cleaned.rstrip(".,;:")
     if not cleaned:
-        return None
+        return None, "empty"
     if len(cleaned) > 60:
-        return None
+        return None, "too_long_chars"
     if len(cleaned.split()) > 4:
-        return None
+        return None, "too_many_words"
+    return cleaned, None
+
+
+def normalise_buttonify_option(value: str | None) -> str | None:
+    cleaned, _ = _normalise_buttonify_option_with_reason(value)
     return cleaned
 
 
@@ -147,16 +154,60 @@ def parse_buttonify_options_json(
     *,
     max_options: int = 4,
 ) -> list[str]:
+    options, _telemetry = parse_buttonify_options_json_with_telemetry(
+        raw_response,
+        max_options=max_options,
+    )
+    return options
+
+
+def _option_preview(value: Any, *, max_chars: int = 80) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_chars:
+        return text
+    return f"{text[: max_chars - 3]}..."
+
+
+def parse_buttonify_options_json_with_telemetry(
+    raw_response: Any,
+    *,
+    max_options: int = 4,
+) -> tuple[list[str], dict[str, Any]]:
+    telemetry: dict[str, Any] = {
+        "schema_version": _BUTTONIFY_FILTERING_BOUNDARY_SCHEMA_VERSION,
+        "source": "json",
+        "parse_success": False,
+        "parse_reason": None,
+        "raw_response_kind": type(raw_response).__name__,
+        "raw_response_preview": _option_preview(raw_response),
+        "input_candidate_count": 0,
+        "accepted_candidate_count": 0,
+        "rejected_candidate_count": 0,
+        "rejection_reason_counts": {},
+        "accepted_preview": [],
+        "rejected_preview": [],
+    }
     try:
         parsed = json.loads(str(raw_response))
-    except Exception:
-        return []
+    except Exception as exc:
+        telemetry["parse_reason"] = f"json_decode_failed:{type(exc).__name__}"
+        return [], telemetry
     if not isinstance(parsed, list):
-        return []
-    return sanitise_buttonify_options(
+        telemetry["parse_reason"] = "json_payload_not_list"
+        return [], telemetry
+
+    telemetry["parse_success"] = True
+    telemetry["parse_reason"] = "ok"
+    telemetry["input_candidate_count"] = len(parsed)
+    options, filtering_boundary = sanitise_buttonify_options_with_telemetry(
         (item for item in parsed if isinstance(item, str)),
         max_options=max_options,
     )
+    telemetry.update(dict(filtering_boundary))
+    telemetry["source"] = "json"
+    telemetry["parse_success"] = True
+    telemetry["parse_reason"] = "ok"
+    return options, telemetry
 
 
 _BUTTONIFY_CONCEPT_ID_PATTERN = re.compile(
@@ -188,12 +239,75 @@ def sanitise_buttonify_options(
     max_options: int = 4,
 ) -> list[str]:
     """Remove code-like options so quick replies stay user-facing."""
-    candidates = dedupe_buttonify_options(values, max_options=max_options * 3)
-    return [
-        option
-        for option in candidates
-        if not _looks_like_code_or_identifier(option)
-    ][:max_options]
+    options, _telemetry = sanitise_buttonify_options_with_telemetry(
+        values,
+        max_options=max_options,
+    )
+    return options
+
+
+def sanitise_buttonify_options_with_telemetry(
+    values: Iterable[str | None],
+    *,
+    max_options: int = 4,
+) -> tuple[list[str], dict[str, Any]]:
+    """Return cleaned options plus deterministic filtering-boundary telemetry."""
+
+    raw_values = list(values)
+    accepted_candidates: list[str] = []
+    accepted_seen: set[str] = set()
+    rejection_reason_counts: dict[str, int] = {}
+    rejected_preview: list[dict[str, Any]] = []
+
+    def _reject(reason: str, value: Any) -> None:
+        rejection_reason_counts[reason] = rejection_reason_counts.get(reason, 0) + 1
+        if len(rejected_preview) >= _BUTTONIFY_FILTERING_PREVIEW_LIMIT:
+            return
+        rejected_preview.append(
+            {
+                "reason": reason,
+                "value_preview": _option_preview(value),
+            }
+        )
+
+    for raw_value in raw_values:
+        cleaned, normalise_reason = _normalise_buttonify_option_with_reason(raw_value)
+        if normalise_reason:
+            _reject(normalise_reason, raw_value)
+            continue
+        if cleaned is None:
+            _reject("empty", raw_value)
+            continue
+        cleaned_key = cleaned.lower()
+        if cleaned_key in accepted_seen:
+            _reject("duplicate", raw_value)
+            continue
+        if _looks_like_code_or_identifier(cleaned):
+            _reject("code_or_identifier", raw_value)
+            continue
+        accepted_seen.add(cleaned_key)
+        accepted_candidates.append(cleaned)
+
+    overflow_count = max(0, len(accepted_candidates) - max_options)
+    if overflow_count > 0:
+        rejection_reason_counts["max_options_cap"] = (
+            rejection_reason_counts.get("max_options_cap", 0) + overflow_count
+        )
+
+    accepted = accepted_candidates[:max_options]
+    telemetry = {
+        "schema_version": _BUTTONIFY_FILTERING_BOUNDARY_SCHEMA_VERSION,
+        "source": "candidate_filter",
+        "input_candidate_count": len(raw_values),
+        "accepted_candidate_count": len(accepted),
+        "rejected_candidate_count": int(sum(rejection_reason_counts.values())),
+        "rejection_reason_counts": dict(
+            sorted(rejection_reason_counts.items(), key=lambda item: item[0])
+        ),
+        "accepted_preview": list(accepted[:_BUTTONIFY_FILTERING_PREVIEW_LIMIT]),
+        "rejected_preview": list(rejected_preview),
+    }
+    return accepted, telemetry
 
 
 def sanitise_buttonify_heuristic_options(

--- a/src/backend/services/renderer_applicability_service.py
+++ b/src/backend/services/renderer_applicability_service.py
@@ -68,6 +68,8 @@ _ALLOWED_SCREEN_ELEMENT_FAMILIES: frozenset[str] = frozenset(
         "relation_graph_view",
     }
 )
+_RENDERER_FILTERING_BOUNDARY_SCHEMA_VERSION = "renderer_filtering_boundary_v1"
+_RENDERER_FILTERING_PREVIEW_LIMIT = 12
 
 
 def _normalise_strings(values: Sequence[Any] | None) -> tuple[str, ...]:
@@ -488,6 +490,71 @@ def _select_renderers(
     return tuple(enriched)
 
 
+def _build_renderer_filtering_boundary(
+    *,
+    evaluations: Sequence[RendererCandidateEvaluation],
+    selections: Sequence[RendererSelection],
+) -> dict[str, Any]:
+    rejection_reason_counts: dict[str, int] = {}
+    rejected_preview: list[dict[str, Any]] = []
+    applicable_preview: list[dict[str, Any]] = []
+
+    for evaluation in evaluations:
+        row = evaluation.to_dict()
+        if evaluation.applicable:
+            if len(applicable_preview) < _RENDERER_FILTERING_PREVIEW_LIMIT:
+                applicable_preview.append(
+                    {
+                        "renderer_id": row.get("renderer_id"),
+                        "priority": row.get("priority"),
+                        "modalities": row.get("modalities", []),
+                    }
+                )
+            continue
+
+        reasons = [
+            str(reason).strip()
+            for reason in row.get("rejection_reasons", [])
+            if isinstance(reason, str) and str(reason).strip()
+        ]
+        for reason in reasons:
+            rejection_reason_counts[reason] = rejection_reason_counts.get(reason, 0) + 1
+        if len(rejected_preview) < _RENDERER_FILTERING_PREVIEW_LIMIT:
+            rejected_preview.append(
+                {
+                    "renderer_id": row.get("renderer_id"),
+                    "rejection_reasons": reasons,
+                    "priority": row.get("priority"),
+                }
+            )
+
+    selected_preview = [
+        {
+            "renderer_id": item.renderer_id,
+            "renderer_type": item.renderer_type,
+            "selection_reason": item.selection_reason,
+            "modalities": list(item.modalities),
+        }
+        for item in list(selections)[:_RENDERER_FILTERING_PREVIEW_LIMIT]
+    ]
+
+    applicable_count = sum(1 for evaluation in evaluations if evaluation.applicable)
+    rejected_count = max(0, len(evaluations) - applicable_count)
+    return {
+        "schema_version": _RENDERER_FILTERING_BOUNDARY_SCHEMA_VERSION,
+        "candidate_count": len(evaluations),
+        "applicable_count": applicable_count,
+        "rejected_count": rejected_count,
+        "selected_count": len(selections),
+        "rejection_reason_counts": dict(
+            sorted(rejection_reason_counts.items(), key=lambda item: item[0])
+        ),
+        "applicable_preview": applicable_preview,
+        "rejected_preview": rejected_preview,
+        "selected_preview": selected_preview,
+    }
+
+
 def resolve_renderer_applicability(
     *,
     renderer_profiles: Sequence[RendererProfile],
@@ -545,6 +612,10 @@ def resolve_renderer_applicability(
             "provenance": dict(transient.provenance) if transient else dict(request.provenance),
         },
     }
+    diagnostics["filtering_boundary"] = _build_renderer_filtering_boundary(
+        evaluations=evaluations,
+        selections=selections,
+    )
 
     return RendererResolutionResult(
         interpreted_object_kind=object_kind,

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -733,7 +733,11 @@ def _summarise_tool_execution_context(
     observed_executed_count = max(progress_tools_completed, invocation_count)
 
     failure_codes: list[str] = []
-    if observed_executed_count <= 0 and worker_unavailable_event_count > 0:
+    if (
+        tool_route_selected
+        and observed_executed_count <= 0
+        and worker_unavailable_event_count > 0
+    ):
         failure_codes.append("worker_unavailable_zero_execution")
     if missing_tool_parse_error_count > 0 or parse_error_invocation_count > 0:
         failure_codes.append("missing_tool_call_parse_error")

--- a/src/backend/workflows/conversation_turn_stage_model.py
+++ b/src/backend/workflows/conversation_turn_stage_model.py
@@ -108,6 +108,15 @@ _NON_FORMAL_STAGE_SPECS: tuple[_StageSpec, ...] = (
         runtime_aliases=("buttonify",),
     ),
     _StageSpec(
+        stage_id="response_finalising",
+        stage_label="Finalising response",
+        order=128,
+        stage_kind="non_formal",
+        boundary_type="postprocess",
+        stage_concept_id="#V#conversation_turn_stage_response_finalising",
+        runtime_aliases=("response_finalising",),
+    ),
+    _StageSpec(
         stage_id="plain_response",
         stage_label="Plain-response routing",
         order=130,

--- a/src/backend/workflows/durable/workflow_introspection_maintenance_workflow.py
+++ b/src/backend/workflows/durable/workflow_introspection_maintenance_workflow.py
@@ -16,6 +16,7 @@ access so maintenance remains aligned with Vontology-first operations.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import hashlib
 import logging
 import re
 from threading import Lock
@@ -45,6 +46,20 @@ _GUARDRAIL_MARKER = "WORKFLOW MAINTENANCE GUARDRAIL"
 _DEFAULT_LANGUAGE = "en-NZ"
 _DEFAULT_MAX_PROMPT_CHARS = 16_000
 _DEFAULT_OPERATION_CAP = 8
+_DEFAULT_GITHUB_REPOSITORY = "Strong-AI-Lab/Von"
+_DEFAULT_JIRA_PROJECT_KEY = "JVNAUTOSCI"
+_DEFAULT_JIRA_ISSUE_TYPE = "Task"
+_MAX_GITHUB_EVIDENCE_PATHS = 3
+_MAX_GITHUB_EVIDENCE_PREVIEW_CHARS = 1200
+_SELF_DIAGNOSIS_LABELS: tuple[str, ...] = (
+    "workflow-self-diagnosis",
+    "github-readonly",
+    "workflow-introspection",
+)
+_SELF_DIAGNOSIS_TOOL_NAME = "__jira_self_diagnosis_upsert__"
+_SOURCE_PATH_PATTERN = re.compile(
+    r"((?:src|tests|docs)/[A-Za-z0-9_.\-/]+\.(?:py|md|json|yml|yaml|ts|js|tsx|jsx))"
+)
 
 _ABSOLUTE_TERMS: tuple[str, ...] = (
     "always",
@@ -183,6 +198,412 @@ def _normalise_prompt_lookup_candidates(namespace: str | None) -> list[str]:
         seen.add(item)
         deduped.append(item)
     return deduped
+
+
+def _normalise_repository_from_text(value: Any) -> tuple[str | None, str | None, str | None]:
+    text = _normalise_text(value)
+    if not text:
+        return None, None, None
+    cleaned = text.strip().strip("/")
+    if "/" not in cleaned:
+        return None, None, None
+    owner, repo = cleaned.split("/", 1)
+    owner_clean = _normalise_text(owner)
+    repo_clean = _normalise_text(repo)
+    if not owner_clean or not repo_clean:
+        return None, None, None
+    return owner_clean, repo_clean, f"{owner_clean}/{repo_clean}"
+
+
+def _resolve_github_repository(
+    maintenance_context: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+) -> tuple[str | None, str | None, str | None]:
+    for owner_key, repo_key in (
+        ("github_owner", "github_repo"),
+        ("owner", "repo"),
+    ):
+        owner = _normalise_text(maintenance_context.get(owner_key))
+        repo = _normalise_text(maintenance_context.get(repo_key))
+        if owner and repo:
+            return owner, repo, f"{owner}/{repo}"
+
+    for key in ("github_repository", "repository"):
+        owner, repo, repository = _normalise_repository_from_text(maintenance_context.get(key))
+        if repository:
+            return owner, repo, repository
+
+    incident_text = _incident_text_from_evidence(evidence)
+    if incident_text:
+        repo_match = re.search(r"\b([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)\b", incident_text)
+        if repo_match:
+            owner, repo, repository = _normalise_repository_from_text(repo_match.group(1))
+            if repository:
+                return owner, repo, repository
+
+    try:
+        import os
+
+        raw_allow_list = os.getenv("VON_GITHUB_REPO_ALLOW_LIST") or _DEFAULT_GITHUB_REPOSITORY
+        first_repo = _normalise_text(raw_allow_list.split(",")[0] if raw_allow_list else None)
+        owner, repo, repository = _normalise_repository_from_text(first_repo)
+        if repository:
+            return owner, repo, repository
+    except Exception:
+        pass
+
+    owner, repo, repository = _normalise_repository_from_text(_DEFAULT_GITHUB_REPOSITORY)
+    return owner, repo, repository
+
+
+def _extract_candidate_source_paths(*texts: str) -> list[str]:
+    paths: list[str] = []
+    seen: set[str] = set()
+    for text in texts:
+        for match in _SOURCE_PATH_PATTERN.finditer(str(text or "")):
+            candidate = _normalise_text(match.group(1))
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            paths.append(candidate)
+            if len(paths) >= _MAX_GITHUB_EVIDENCE_PATHS:
+                return paths
+    return paths
+
+
+def _summarise_github_file_content(payload: Mapping[str, Any]) -> dict[str, Any]:
+    text_preview: str | None = None
+    if isinstance(payload.get("content"), str):
+        text_preview = payload.get("content")
+    elif isinstance(payload.get("text"), str):
+        text_preview = payload.get("text")
+    elif isinstance(payload.get("result"), Mapping):
+        result = payload.get("result")
+        if isinstance(result, Mapping) and isinstance(result.get("content"), str):
+            text_preview = result.get("content")
+
+    preview = ""
+    if isinstance(text_preview, str):
+        preview = text_preview[:_MAX_GITHUB_EVIDENCE_PREVIEW_CHARS]
+
+    return {
+        "path": payload.get("path"),
+        "sha": payload.get("sha"),
+        "size": payload.get("size"),
+        "preview": preview,
+    }
+
+
+def _collect_github_evidence(
+    maintenance_context: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+) -> dict[str, Any]:
+    owner, repo, repository = _resolve_github_repository(maintenance_context, evidence)
+    payload: dict[str, Any] = {
+        "repository": repository,
+        "owner": owner,
+        "repo": repo,
+        "auth": _invoke_mcp_tool("github_get_auth_config", {}),
+        "latest_commits": {},
+        "open_pull_requests": {},
+        "file_evidence": [],
+        "errors": [],
+    }
+
+    if not owner or not repo:
+        payload["errors"].append("repository_resolution_failed")
+        payload["success"] = False
+        return payload
+
+    commits = _invoke_mcp_tool(
+        "github_list_commits",
+        {"owner": owner, "repo": repo, "perPage": 5},
+    )
+    payload["latest_commits"] = commits
+    if not bool(commits.get("success")):
+        payload["errors"].append("github_list_commits_failed")
+
+    pull_requests = _invoke_mcp_tool(
+        "github_list_pull_requests",
+        {
+            "owner": owner,
+            "repo": repo,
+            "state": "open",
+            "sort": "updated",
+            "direction": "desc",
+            "perPage": 5,
+        },
+    )
+    payload["open_pull_requests"] = pull_requests
+    if not bool(pull_requests.get("success")):
+        payload["errors"].append("github_list_pull_requests_failed")
+
+    incident_text = _incident_text_from_evidence(evidence)
+    prompt_preview = _normalise_text(
+        _coerce_mapping(evidence.get("turn_execution")).get("prompt_preview")
+    ) or ""
+    paths = _extract_candidate_source_paths(incident_text, prompt_preview)
+    for source_path in paths:
+        file_result = _invoke_mcp_tool(
+            "github_get_file_contents",
+            {"owner": owner, "repo": repo, "path": source_path},
+        )
+        summary = {"path": source_path, "success": bool(file_result.get("success"))}
+        if bool(file_result.get("success")):
+            summary.update(_summarise_github_file_content(file_result))
+        else:
+            summary["error"] = file_result.get("error")
+            summary["error_code"] = file_result.get("error_code")
+            payload["errors"].append(f"github_get_file_contents_failed:{source_path}")
+        payload["file_evidence"].append(summary)
+
+    auth_payload = _coerce_mapping(payload.get("auth"))
+    auth_success = bool(auth_payload.get("success"))
+    tools_available = bool(auth_payload.get("proxy_tools_available", False))
+    payload["success"] = auth_success and tools_available and not payload["errors"]
+    if not auth_success:
+        payload["errors"].append("github_auth_probe_failed")
+    elif not tools_available:
+        payload["errors"].append("github_tools_unavailable")
+    return payload
+
+
+def _diagnosis_cause_ids(diagnosis: Mapping[str, Any]) -> list[str]:
+    cause_ids: list[str] = []
+    for row in _coerce_mapping_list(diagnosis.get("root_causes"), max_items=50):
+        cause_id = _normalise_text(row.get("cause_id"))
+        if cause_id and cause_id not in cause_ids:
+            cause_ids.append(cause_id)
+    return cause_ids
+
+
+def _build_self_diagnosis_fingerprint(
+    *,
+    maintenance_context: Mapping[str, Any],
+    diagnosis: Mapping[str, Any],
+    github_evidence: Mapping[str, Any],
+) -> str:
+    fingerprint_parts = [
+        _normalise_text(maintenance_context.get("selected_workflow_id")) or "",
+        _normalise_text(maintenance_context.get("request_id")) or "",
+        _normalise_text(github_evidence.get("repository")) or "",
+        ",".join(sorted(_diagnosis_cause_ids(diagnosis))),
+    ]
+    canonical = "|".join(fingerprint_parts).lower()
+    return hashlib.sha1(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+def _extract_jira_issue_key(payload: Mapping[str, Any]) -> str | None:
+    for key in ("issue_key", "key"):
+        value = _normalise_text(payload.get(key))
+        if value:
+            return value
+    result = payload.get("result")
+    if isinstance(result, Mapping):
+        for key in ("issue_key", "key"):
+            value = _normalise_text(result.get(key))
+            if value:
+                return value
+    return None
+
+
+def _extract_jira_search_issue_keys(payload: Mapping[str, Any]) -> list[str]:
+    issues = payload.get("issues")
+    if not isinstance(issues, list):
+        result = payload.get("result")
+        if isinstance(result, Mapping) and isinstance(result.get("issues"), list):
+            issues = result.get("issues")
+    if not isinstance(issues, list):
+        return []
+    keys: list[str] = []
+    for issue in issues:
+        if not isinstance(issue, Mapping):
+            continue
+        key = _normalise_text(issue.get("key"))
+        if key and key not in keys:
+            keys.append(key)
+    return keys
+
+
+def _extract_jira_account_id(payload: Mapping[str, Any]) -> str | None:
+    account_id = _normalise_text(payload.get("accountId"))
+    if account_id:
+        return account_id
+    user = payload.get("user")
+    if isinstance(user, Mapping):
+        return _normalise_text(user.get("accountId"))
+    result = payload.get("result")
+    if isinstance(result, Mapping):
+        account_id = _normalise_text(result.get("accountId"))
+        if account_id:
+            return account_id
+        user = result.get("user")
+        if isinstance(user, Mapping):
+            return _normalise_text(user.get("accountId"))
+    return None
+
+
+def _build_jira_remediation_summary(
+    diagnosis: Mapping[str, Any],
+    maintenance_context: Mapping[str, Any],
+) -> str:
+    cause_ids = _diagnosis_cause_ids(diagnosis)
+    cause_fragment = ", ".join(cause_ids[:2]) if cause_ids else "unknown root cause"
+    workflow_id = _normalise_text(maintenance_context.get("selected_workflow_id")) or "workflow"
+    return f"Workflow self-diagnosis remediation: {cause_fragment} ({workflow_id})"
+
+
+def _build_jira_remediation_description(
+    *,
+    maintenance_context: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+    diagnosis: Mapping[str, Any],
+    github_evidence: Mapping[str, Any],
+    fingerprint: str,
+) -> str:
+    incident_text = _incident_text_from_evidence(evidence) or "No incident text provided."
+    cause_ids = _diagnosis_cause_ids(diagnosis)
+    github_errors: list[str] = []
+    errors = github_evidence.get("errors")
+    if isinstance(errors, list):
+        github_errors = [str(item) for item in errors if isinstance(item, str)]
+    lines = [
+        "Generated by Codex on behalf of Michael Witbrock.",
+        "",
+        f"Self-diagnosis fingerprint: {fingerprint}",
+        f"Request ID: {_normalise_text(maintenance_context.get('request_id')) or 'unknown'}",
+        f"Selected workflow: {_normalise_text(maintenance_context.get('selected_workflow_id')) or 'unknown'}",
+        f"Repository (read-only evidence): {_normalise_text(github_evidence.get('repository')) or 'unknown'}",
+        "",
+        "Incident summary:",
+        incident_text[:1200],
+        "",
+        "Root-cause IDs:",
+        ", ".join(cause_ids) if cause_ids else "none",
+        "",
+        "GitHub evidence status:",
+        f"success={bool(github_evidence.get('success'))}; errors={', '.join(github_errors) if github_errors else 'none'}",
+        "",
+        "Acceptance checks:",
+        "1. Reproduce and verify the diagnosis signal.",
+        "2. Implement a bounded fix through workflow/tool pathways.",
+        "3. Add or update regression tests for the observed failure mode.",
+    ]
+    return "\n".join(lines)
+
+
+def _execute_jira_self_diagnosis_upsert(payload: Mapping[str, Any]) -> dict[str, Any]:
+    project_key = _normalise_text(payload.get("project_key")) or _DEFAULT_JIRA_PROJECT_KEY
+    issue_type = _normalise_text(payload.get("issue_type")) or _DEFAULT_JIRA_ISSUE_TYPE
+    summary = _normalise_text(payload.get("summary"))
+    description = _normalise_text(payload.get("description"))
+    fingerprint = _normalise_text(payload.get("fingerprint"))
+    request_id = _normalise_text(payload.get("request_id"))
+
+    if not summary or not description or not fingerprint:
+        return {
+            "success": False,
+            "error": "jira_remediation_payload_invalid",
+            "error_code": "jira_remediation_payload_invalid",
+        }
+
+    search_jql = (
+        f'project = "{project_key}" '
+        f'AND labels = "{_SELF_DIAGNOSIS_LABELS[0]}" '
+        f'AND text ~ "\\"{fingerprint}\\"" '
+        "ORDER BY updated DESC"
+    )
+    search_result = _invoke_mcp_tool(
+        "jira_search",
+        {
+            "jql": search_jql,
+            "max_results": 5,
+            "fields": ["summary", "status", "assignee", "labels"],
+        },
+    )
+    if not bool(search_result.get("success")):
+        return {
+            "success": False,
+            "error": search_result.get("error") or "jira_search_failed",
+            "error_code": search_result.get("error_code") or "jira_search_failed",
+            "search_jql": search_jql,
+        }
+
+    existing_keys = _extract_jira_search_issue_keys(search_result)
+    if existing_keys:
+        issue_key = existing_keys[0]
+        comment = (
+            "Generated by Codex on behalf of Michael Witbrock.\n\n"
+            "Self-diagnosis rerun found matching fingerprint "
+            f"`{fingerprint}`.\n\n"
+            f"Latest incident summary:\n{description[:1200]}"
+        )
+        comment_result = _invoke_mcp_tool(
+            "jira_add_comment",
+            {"issue_key": issue_key, "comment": comment},
+        )
+        if not bool(comment_result.get("success")):
+            return {
+                "success": False,
+                "error": comment_result.get("error") or "jira_add_comment_failed",
+                "error_code": comment_result.get("error_code") or "jira_add_comment_failed",
+                "issue_key": issue_key,
+            }
+        return {
+            "success": True,
+            "mode": "updated_existing",
+            "issue_key": issue_key,
+            "fingerprint": fingerprint,
+            "search_jql": search_jql,
+        }
+
+    myself = _invoke_mcp_tool("jira_get_myself", {})
+    assignee_account_id = _extract_jira_account_id(myself)
+    if not assignee_account_id:
+        return {
+            "success": False,
+            "error": "jira_assignee_resolution_failed",
+            "error_code": "jira_assignee_resolution_failed",
+        }
+
+    labels = payload.get("labels")
+    final_labels = (
+        [str(item) for item in labels if isinstance(item, str) and item.strip()]
+        if isinstance(labels, list)
+        else list(_SELF_DIAGNOSIS_LABELS)
+    )
+    if fingerprint not in final_labels:
+        final_labels.append(f"diag-{fingerprint}")
+
+    create_result = _invoke_mcp_tool(
+        "jira_create_issue",
+        {
+            "project_key": project_key,
+            "issue_type": issue_type,
+            "summary": summary,
+            "description": description,
+            "labels": final_labels,
+            "assignee_account_id": assignee_account_id,
+            "dry_run": False,
+            "approved": True,
+            "request_id": request_id or f"diag-{fingerprint}",
+        },
+    )
+    if not bool(create_result.get("success")):
+        return {
+            "success": False,
+            "error": create_result.get("error") or "jira_create_issue_failed",
+            "error_code": create_result.get("error_code") or "jira_create_issue_failed",
+        }
+
+    issue_key = _extract_jira_issue_key(_coerce_mapping(create_result))
+    return {
+        "success": True,
+        "mode": "created_new",
+        "issue_key": issue_key,
+        "fingerprint": fingerprint,
+        "project_key": project_key,
+    }
 
 
 def _get_gateway():
@@ -506,21 +927,6 @@ def _handle_assess_context(request: WorkflowActionRequest) -> WorkflowActionResu
             },
         )
 
-    known_tools = _available_tool_names()
-    trace = _append_trace_event(
-        context,
-        stage="assess",
-        event="evidence_collected",
-        details={
-            "namespace": namespace,
-            "request_id": request_id,
-            "prompt_lookup_namespace": prompt_lookup_namespace,
-            "selected_workflow_id": selected_workflow_id,
-            "known_tool_count": len(known_tools),
-            "workflow_definition_count": int(workflow_definitions.get("count") or 0),
-        },
-    )
-
     maintenance_context = {
         "namespace": namespace,
         "request_id": request_id,
@@ -534,7 +940,45 @@ def _handle_assess_context(request: WorkflowActionRequest) -> WorkflowActionResu
             minimum=1,
             maximum=50,
         ),
+        "emit_jira_remediation": _coerce_bool(
+            context.get("emit_jira_remediation"),
+            default=True,
+        ),
+        "jira_project_key": _normalise_text(context.get("jira_project_key"))
+        or _DEFAULT_JIRA_PROJECT_KEY,
+        "jira_issue_type": _normalise_text(context.get("jira_issue_type"))
+        or _DEFAULT_JIRA_ISSUE_TYPE,
+        "github_owner": _normalise_text(context.get("github_owner")),
+        "github_repo": _normalise_text(context.get("github_repo")),
+        "github_repository": _normalise_text(context.get("github_repository"))
+        or _normalise_text(context.get("repository")),
     }
+    known_tools = _available_tool_names()
+    github_evidence = _collect_github_evidence(
+        maintenance_context,
+        {
+            "incident_text": _normalise_text(context.get("incident_text")),
+            "turn_execution": turn_execution,
+        },
+    )
+    trace = _append_trace_event(
+        context,
+        stage="assess",
+        event="evidence_collected",
+        details={
+            "namespace": namespace,
+            "request_id": request_id,
+            "prompt_lookup_namespace": prompt_lookup_namespace,
+            "selected_workflow_id": selected_workflow_id,
+            "known_tool_count": len(known_tools),
+            "workflow_definition_count": int(workflow_definitions.get("count") or 0),
+            "github_repository": github_evidence.get("repository"),
+            "github_evidence_success": bool(github_evidence.get("success")),
+            "github_error_count": len(github_evidence.get("errors", []))
+            if isinstance(github_evidence.get("errors"), list)
+            else 0,
+        },
+    )
     maintenance_evidence = {
         "incident_text": _normalise_text(context.get("incident_text")),
         "workflow_definitions": workflow_definitions,
@@ -542,6 +986,7 @@ def _handle_assess_context(request: WorkflowActionRequest) -> WorkflowActionResu
         "turn_execution": turn_execution,
         "workflow_concept": workflow_concept,
         "known_tool_names": known_tools,
+        "github_evidence": github_evidence,
     }
 
     return WorkflowActionResult(
@@ -692,6 +1137,24 @@ def _handle_diagnose_conflation(request: WorkflowActionRequest) -> WorkflowActio
             ],
         )
 
+    github_evidence = _coerce_mapping(evidence.get("github_evidence"))
+    if github_evidence:
+        github_success = bool(github_evidence.get("success"))
+        if not github_success:
+            github_errors = github_evidence.get("errors")
+            error_summary = (
+                ", ".join([str(item) for item in github_errors if isinstance(item, str)])
+                if isinstance(github_errors, list)
+                else "unknown"
+            )
+            _append_cause(
+                "github_read_evidence_unavailable",
+                summary="Read-only GitHub evidence collection is unavailable; fail closed for repository-grounded diagnosis.",
+                scope="github",
+                evidence_items=[error_summary],
+                severity="high",
+            )
+
     conflation_detected = len(root_causes) > 0
     confidence = "low"
     if len(root_causes) >= 3:
@@ -714,6 +1177,8 @@ def _handle_diagnose_conflation(request: WorkflowActionRequest) -> WorkflowActio
         "directive_findings": directives,
         "implicated_prompt_concept_ids": implicated_prompt_ids,
         "selected_workflow_id": maintenance_context.get("selected_workflow_id"),
+        "github_repository": github_evidence.get("repository"),
+        "github_evidence_success": bool(github_evidence.get("success")),
     }
 
     trace = _append_trace_event(
@@ -740,6 +1205,7 @@ def _handle_plan_repairs(request: WorkflowActionRequest) -> WorkflowActionResult
     maintenance_context = _coerce_mapping(context.get("maintenance_context"))
     evidence = _coerce_mapping(context.get("maintenance_evidence"))
     diagnosis = _coerce_mapping(context.get("maintenance_diagnosis"))
+    github_evidence = _coerce_mapping(evidence.get("github_evidence"))
     prompt_context = _coerce_mapping(evidence.get("prompt_context"))
     prompt_concepts = _coerce_mapping_list(prompt_context.get("behaviour_prompt_concepts"))
     directive_findings = _coerce_mapping_list(diagnosis.get("directive_findings"))
@@ -822,6 +1288,54 @@ def _handle_plan_repairs(request: WorkflowActionRequest) -> WorkflowActionResult
             }
         )
 
+    jira_remediation_skipped_reason: str | None = None
+    if _coerce_bool(maintenance_context.get("emit_jira_remediation"), default=True) and bool(
+        diagnosis.get("conflation_detected")
+    ):
+        if not bool(github_evidence.get("success")):
+            jira_remediation_skipped_reason = "github_evidence_unavailable"
+        else:
+            fingerprint = _build_self_diagnosis_fingerprint(
+                maintenance_context=maintenance_context,
+                diagnosis=diagnosis,
+                github_evidence=github_evidence,
+            )
+            summary = _build_jira_remediation_summary(diagnosis, maintenance_context)
+            description = _build_jira_remediation_description(
+                maintenance_context=maintenance_context,
+                evidence=evidence,
+                diagnosis=diagnosis,
+                github_evidence=github_evidence,
+                fingerprint=fingerprint,
+            )
+            operations.append(
+                {
+                    "operation_id": (
+                        f"jira_remediation:{maintenance_context.get('request_id') or fingerprint}"
+                    ),
+                    "risk": "medium",
+                    "tool_name": _SELF_DIAGNOSIS_TOOL_NAME,
+                    "reason": (
+                        "Create or update a deduplicated Jira remediation issue from workflow self-diagnosis evidence."
+                    ),
+                    "payload": {
+                        "project_key": _normalise_text(
+                            maintenance_context.get("jira_project_key")
+                        )
+                        or _DEFAULT_JIRA_PROJECT_KEY,
+                        "issue_type": _normalise_text(
+                            maintenance_context.get("jira_issue_type")
+                        )
+                        or _DEFAULT_JIRA_ISSUE_TYPE,
+                        "summary": summary,
+                        "description": description,
+                        "fingerprint": fingerprint,
+                        "labels": list(_SELF_DIAGNOSIS_LABELS),
+                        "request_id": maintenance_context.get("request_id"),
+                    },
+                }
+            )
+
     apply_requested = bool(maintenance_context.get("apply_repairs", True))
     max_operations = _coerce_int(
         maintenance_context.get("max_operations"),
@@ -837,6 +1351,7 @@ def _handle_plan_repairs(request: WorkflowActionRequest) -> WorkflowActionResult
         "dry_run": bool(maintenance_context.get("dry_run", False)),
         "operation_count": len(operations),
         "operations": operations,
+        "jira_remediation_skipped_reason": jira_remediation_skipped_reason,
     }
 
     trace = _append_trace_event(
@@ -901,7 +1416,10 @@ def _handle_apply_repairs(request: WorkflowActionRequest) -> WorkflowActionResul
                 }
             )
             continue
-        result = _invoke_mcp_tool(tool_name, payload)
+        if tool_name == _SELF_DIAGNOSIS_TOOL_NAME:
+            result = _execute_jira_self_diagnosis_upsert(payload)
+        else:
+            result = _invoke_mcp_tool(tool_name, payload)
         ok = bool(result.get("success", False))
         if ok:
             success_count += 1
@@ -912,6 +1430,9 @@ def _handle_apply_repairs(request: WorkflowActionRequest) -> WorkflowActionResul
                 "status": "success" if ok else "failed",
                 "error": result.get("error"),
                 "error_code": result.get("error_code"),
+                "mode": result.get("mode"),
+                "issue_key": result.get("issue_key"),
+                "fingerprint": result.get("fingerprint"),
             }
         )
 
@@ -937,6 +1458,8 @@ def _handle_verify_repairs(request: WorkflowActionRequest) -> WorkflowActionResu
     verification: dict[str, Any] = {
         "expected_prompt_updates": expected_prompt_ids,
         "verified_prompt_updates": [],
+        "expected_remediation_issue_keys": [],
+        "verified_remediation_issue_keys": [],
         "verification_errors": [],
         "verified": True,
     }
@@ -965,12 +1488,44 @@ def _handle_verify_repairs(request: WorkflowActionRequest) -> WorkflowActionResu
             if concept_id in expected_prompt_ids and _GUARDRAIL_MARKER in content:
                 verification["verified_prompt_updates"].append(concept_id)
 
+    remediation_issue_keys: list[str] = []
+    for row in _coerce_mapping_list(apply_report.get("results"), max_items=100):
+        if _normalise_text(row.get("tool_name")) != _SELF_DIAGNOSIS_TOOL_NAME:
+            continue
+        if _normalise_text(row.get("status")) != "success":
+            continue
+        issue_key = _normalise_text(row.get("issue_key"))
+        if issue_key and issue_key not in remediation_issue_keys:
+            remediation_issue_keys.append(issue_key)
+    verification["expected_remediation_issue_keys"] = remediation_issue_keys
+
+    for issue_key in remediation_issue_keys:
+        issue_result = _invoke_mcp_tool(
+            "jira_get_issue",
+            {"issue_key": issue_key, "fields": ["summary", "status", "labels"]},
+        )
+        if bool(issue_result.get("success")):
+            verification["verified_remediation_issue_keys"].append(issue_key)
+        else:
+            verification["verification_errors"].append(
+                f"jira_issue_not_observable:{issue_key}"
+            )
+
     missing = sorted(set(expected_prompt_ids) - set(verification["verified_prompt_updates"]))
     if missing:
         verification["verified"] = False
         verification["verification_errors"].append(
             f"guardrail_marker_missing_for_prompts:{','.join(missing)}"
         )
+    missing_remediation_keys = sorted(
+        set(remediation_issue_keys) - set(verification["verified_remediation_issue_keys"])
+    )
+    if missing_remediation_keys:
+        verification["verified"] = False
+        verification["verification_errors"].append(
+            f"remediation_issue_not_verified:{','.join(missing_remediation_keys)}"
+        )
+    if verification["verification_errors"]:
         return WorkflowActionResult(
             status="failed",
             error="repair_verification_failed",

--- a/tests/backend/test_conversation_turn_stage_model.py
+++ b/tests/backend/test_conversation_turn_stage_model.py
@@ -69,3 +69,16 @@ def test_stage_path_maps_buttonify_runtime_stage() -> None:
     assert len(path) == 1
     assert path[0]["stage_id"] == "buttonify"
     assert path[0]["workflow_id"] == CHAT_BUTTONIFY_WORKFLOW_ID
+
+
+def test_stage_path_maps_response_finalising_runtime_stage() -> None:
+    result = build_conversation_turn_stage_path(
+        runtime_stages=["response_finalising"],
+        workflow_id=TOOL_CALLING_WORKFLOW_ID,
+    )
+
+    assert result["has_unmapped_runtime_stages"] is False
+    path = result["path"]
+    assert len(path) == 1
+    assert path[0]["stage_id"] == "response_finalising"
+    assert path[0]["runtime_stage_normalised"] == "response_finalising"

--- a/tests/backend/test_internal_mcp_github_tools.py
+++ b/tests/backend/test_internal_mcp_github_tools.py
@@ -1,0 +1,201 @@
+"""Smoke tests for GitHub MCP integration in the internal MCP catalogue."""
+
+from __future__ import annotations
+
+from src.backend.integrations.internal_mcp.catalogue import (
+    _github_create_branch,
+    _github_create_pull_request,
+    _github_get_file_contents,
+    _github_search_code,
+    build_default_catalogue,
+)
+
+
+def test_github_methods_registered_in_catalogue() -> None:
+    catalogue = build_default_catalogue()
+    names = set(catalogue.list_methods())
+    assert "github_get_auth_config" in names
+    assert "github_list_tools" in names
+    assert "github_get_me" in names
+    assert "github_get_file_contents" in names
+    assert "github_list_commits" in names
+    assert "github_search_code" in names
+    assert "github_list_pull_requests" in names
+    assert "github_pull_request_read" in names
+    assert "github_issue_read" in names
+    assert "github_list_releases" in names
+    assert "github_get_latest_release" in names
+    assert "github_list_tags" in names
+    assert "github_list_branches" in names
+    assert "github_create_branch" in names
+    assert "github_create_or_update_file" in names
+    assert "github_create_pull_request" in names
+    assert "github_update_pull_request" in names
+    assert "github_create_pull_request_with_copilot" in names
+
+
+def test_github_handlers_require_minimum_fields() -> None:
+    err_file = _github_get_file_contents(owner=None, repo=None)
+    assert err_file.get("success") is False
+    assert "owner" in str(err_file.get("error", "")).lower()
+
+    err_search = _github_search_code(query=None)
+    assert err_search.get("success") is False
+    assert "query" in str(err_search.get("error", "")).lower()
+
+
+def test_github_write_tools_allowlist_and_dry_run_defaults() -> None:
+    ok_branch = _github_create_branch(
+        owner="Strong-AI-Lab",
+        repo="Von",
+        branch="feature/test",
+    )
+    assert ok_branch.get("success") is True
+    assert ok_branch.get("dry_run") is True
+    assert ok_branch.get("executed") is False
+
+    bad_branch = _github_create_branch(
+        owner="OtherOrg",
+        repo="OtherRepo",
+        branch="feature/test",
+    )
+    assert bad_branch.get("success") is False
+    assert bad_branch.get("error_code") == "repository_not_allowlisted"
+
+
+def test_github_write_tools_require_approval_when_not_dry_run() -> None:
+    err = _github_create_branch(
+        owner="Strong-AI-Lab",
+        repo="Von",
+        branch="feature/live",
+        dry_run=False,
+    )
+    assert err.get("success") is False
+    assert err.get("error_code") == "approval_required"
+
+
+def test_github_get_file_contents_success_through_gateway_invoke(monkeypatch) -> None:
+    from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
+    from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+
+    class _FakeProxy:
+        async def call_tool(self, tool_name: str, arguments: dict):
+            assert tool_name == "github_get_file_contents"
+            assert arguments["owner"] == "Strong-AI-Lab"
+            assert arguments["repo"] == "Von"
+            return {
+                "path": arguments.get("path"),
+                "content": "example",
+            }
+
+        async def list_tools(self):
+            return [{"name": "github_get_file_contents"}]
+
+        def get_stats(self):
+            return {"call_count": 1, "error_count": 0}
+
+    async def _fake_get_github_proxy():
+        return _FakeProxy()
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.github_proxy_mcp.get_github_proxy",
+        _fake_get_github_proxy,
+    )
+
+    gateway = InternalMCPGateway(
+        catalogue=build_default_catalogue(),
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+    result = gateway.invoke(
+        "github_get_file_contents",
+        {"owner": "Strong-AI-Lab", "repo": "Von", "path": "README.md"},
+    )
+    payload = result.payload
+    assert payload.get("success") is True
+    assert payload.get("path") == "README.md"
+
+
+def test_github_proxy_error_through_gateway_invoke(monkeypatch) -> None:
+    from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
+    from src.backend.integrations.internal_mcp.github_proxy_mcp import GitHubProxyError
+    from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+
+    class _FailingProxy:
+        async def call_tool(self, tool_name: str, arguments: dict):  # noqa: ARG002
+            raise GitHubProxyError("proxy unavailable")
+
+        async def list_tools(self):
+            return []
+
+        def get_stats(self):
+            return {"call_count": 0, "error_count": 1}
+
+    async def _fake_get_github_proxy():
+        return _FailingProxy()
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.github_proxy_mcp.get_github_proxy",
+        _fake_get_github_proxy,
+    )
+
+    gateway = InternalMCPGateway(
+        catalogue=build_default_catalogue(),
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+    result = gateway.invoke(
+        "github_get_file_contents",
+        {"owner": "Strong-AI-Lab", "repo": "Von", "path": "README.md"},
+    )
+    payload = result.payload
+    assert payload.get("success") is False
+    assert payload.get("error_code") == "github_proxy_error"
+
+
+def test_github_create_pull_request_success_through_gateway_invoke(monkeypatch) -> None:
+    from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
+    from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+
+    class _FakeProxy:
+        async def call_tool(self, tool_name: str, arguments: dict):
+            assert tool_name == "github_create_pull_request"
+            assert arguments["owner"] == "Strong-AI-Lab"
+            assert arguments["repo"] == "Von"
+            return {"number": 42, "html_url": "https://example.test/pr/42"}
+
+        async def list_tools(self):
+            return [{"name": "github_create_pull_request"}]
+
+        def get_stats(self):
+            return {"call_count": 1, "error_count": 0}
+
+    async def _fake_get_github_proxy():
+        return _FakeProxy()
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.github_proxy_mcp.get_github_proxy",
+        _fake_get_github_proxy,
+    )
+
+    gateway = InternalMCPGateway(
+        catalogue=build_default_catalogue(),
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+    result = gateway.invoke(
+        "github_create_pull_request",
+        {
+            "owner": "Strong-AI-Lab",
+            "repo": "Von",
+            "title": "Test PR",
+            "head": "feature/test",
+            "base": "main",
+            "dry_run": False,
+            "approved": True,
+        },
+    )
+    payload = result.payload
+    assert payload.get("success") is True
+    assert payload.get("executed") is True
+    assert payload.get("action") == "create_pull_request"

--- a/tests/backend/test_orchestrator_extraction.py
+++ b/tests/backend/test_orchestrator_extraction.py
@@ -59,6 +59,14 @@ class _ChecklistPromptToolGateway(_DummyGateway):
         }
 
 
+class _FileCopyPromptToolGateway(_DummyGateway):
+    def describe_methods(self):
+        return {
+            "read_file_copy": {"description": "read a file copy concept"},
+            "fetch_concept": {"description": "fetch concept"},
+        }
+
+
 class _RelationshipGateway(_DummyGateway):
     def describe_methods(self):
         return {"add_relationship": {"description": "relationship write"}}
@@ -1121,7 +1129,11 @@ def test_derive_missing_prompt_requirements_tracks_missing_fetch_targets():
         "#V#workflow_mapping_tool_field_concept_id_to_validated_type_id",
     ]
 
-    missing_tools, missing_fetch_ids = orchestrator._derive_missing_prompt_requirements(
+    (
+        missing_tools,
+        missing_fetch_ids,
+        missing_read_file_copy_ids,
+    ) = orchestrator._derive_missing_prompt_requirements(
         required_tools=["fetch_concept"],
         required_fetch_concept_ids=required_fetch_ids,
         tool_invocations=[
@@ -1138,6 +1150,7 @@ def test_derive_missing_prompt_requirements_tracks_missing_fetch_targets():
     assert missing_fetch_ids == [
         "#V#workflow_mapping_tool_field_concept_id_to_validated_type_id"
     ]
+    assert missing_read_file_copy_ids == []
     reason = orchestrator._build_missing_prompt_retry_reason(
         missing_tools=missing_tools,
         missing_fetch_concept_ids=missing_fetch_ids,
@@ -1147,6 +1160,52 @@ def test_derive_missing_prompt_requirements_tracks_missing_fetch_targets():
         "fetch_concept; "
         "fetch_concept targets: #V#workflow_mapping_tool_field_concept_id_to_validated_type_id"
     )
+
+
+def test_derive_prompt_tool_requirements_detects_concept_verification_intent():
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=_ChecklistPromptToolGateway()  # type: ignore[arg-type]
+    )
+
+    requirements = orchestrator._derive_prompt_tool_requirements(
+        "Can you verify whether #V#workflow_mapping_target_type_id_to_concept_id_param exists?",
+        method_catalogue=orchestrator._gateway.describe_methods(),
+    )
+
+    assert "fetch_concept" in (requirements.get("required_tools") or [])
+    assert requirements.get("required_fetch_concept_ids") == [
+        "#V#workflow_mapping_target_type_id_to_concept_id_param"
+    ]
+
+
+def test_run_forces_read_file_copy_when_prompt_references_file_copy_concept():
+    gateway = _FileCopyPromptToolGateway()
+    llm = _RecorderLLM(
+        [
+            "I should inspect the uploaded file first.",
+            "File copy inspected.",
+        ]
+    )
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=gateway,  # type: ignore[arg-type]
+        max_tool_invocations=2,
+    )
+
+    result = orchestrator.run(
+        prompt=(
+            "Please review uploaded file #V#computer_file_copy_case_1 and summarise key points."
+        ),
+        context=None,
+        llm_client=llm,
+        model="primary-model",
+        user_namespace="#V#user",
+    )
+
+    called_tools = [tool for tool, _ in gateway.calls]
+    assert called_tools.count("read_file_copy") == 1
+    read_payload = next(payload for tool, payload in gateway.calls if tool == "read_file_copy")
+    assert read_payload.get("concept_id") == "#V#computer_file_copy_case_1"
+    assert result.response_text == "File copy inspected."
 
 
 def test_run_forces_checklist_tools_when_retry_response_has_no_tool_json():

--- a/tests/backend/test_orchestrator_model_fallback_execution.py
+++ b/tests/backend/test_orchestrator_model_fallback_execution.py
@@ -183,3 +183,43 @@ def test_run_llm_with_fallbacks_records_attempt_chain_and_fallback_metadata(
     assert attempts[1]["status"] == "succeeded"
 
     assert recorded_calls[0]["note"] == "candidate reachability probe failed; trying fallback"
+
+
+def test_probe_model_candidate_reachability_uses_failure_cooldown_cache(
+    monkeypatch,
+) -> None:
+    orchestrator = InternalMCPChatOrchestrator(gateway=cast(Any, _StubGateway()))
+    orchestrator._provider_probe_cooldown_seconds = 120
+
+    request_calls = {"count": 0}
+
+    class _FailingResponse:
+        def raise_for_status(self) -> None:
+            raise RuntimeError("connection refused")
+
+    def _fake_get(*_args: Any, **_kwargs: Any) -> _FailingResponse:
+        request_calls["count"] += 1
+        return _FailingResponse()
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.orchestrator.requests.get",
+        _fake_get,
+    )
+
+    telemetry = {
+        "provider": "ollama",
+        "host": "http://localhost:11434",
+        "model": "granite3.3:2b",
+    }
+    first = orchestrator._probe_model_candidate_reachability(telemetry=telemetry)
+    second = orchestrator._probe_model_candidate_reachability(telemetry=telemetry)
+
+    assert isinstance(first, Mapping)
+    assert first.get("reachable") is False
+    assert first.get("cooldown_hit") is not True
+
+    assert isinstance(second, Mapping)
+    assert second.get("reachable") is False
+    assert second.get("cooldown_hit") is True
+    assert second.get("cached") is True
+    assert request_calls["count"] == 1

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -286,6 +286,23 @@ def test_renderer_applicability_can_enable_narration_when_flag_enabled(monkeypat
                         "modalities": ["narrated_audio"],
                     }
                 ],
+                "diagnostics": {
+                    "filtering_boundary": {
+                        "schema_version": "renderer_filtering_boundary_v1",
+                        "candidate_count": 1,
+                        "applicable_count": 1,
+                        "rejected_count": 0,
+                        "selected_count": 1,
+                        "rejection_reason_counts": {},
+                        "applicable_preview": [
+                            {"renderer_id": "#V#narration_renderer"}
+                        ],
+                        "rejected_preview": [],
+                        "selected_preview": [
+                            {"renderer_id": "#V#narration_renderer"}
+                        ],
+                    }
+                },
             }
         )
 
@@ -336,6 +353,11 @@ def test_renderer_applicability_can_enable_narration_when_flag_enabled(monkeypat
     assert renderer_entry.get("should_narrate") is True
     assert renderer_entry.get("render_mode") == "spoken+screen"
     assert "#V#narration_renderer" in renderer_entry.get("selected_renderer_ids", [])
+    assert isinstance(renderer_entry.get("renderer_filtering_boundary"), dict)
+    assert (
+        renderer_entry.get("renderer_filtering_boundary", {}).get("schema_version")
+        == "renderer_filtering_boundary_v1"
+    )
 
 
 def test_renderer_applicability_error_preserves_selector_narration(monkeypatch):
@@ -3051,6 +3073,52 @@ def test_plain_response_overridden_to_tool_pipeline_for_mutative_intent(monkeypa
         entry.get("type") for entry in result.aux_llm_calls if isinstance(entry, dict)
     ]
     assert "workflow_selector_override" in aux_types
+
+
+def test_plain_response_overridden_when_prompt_requires_tool_verification(monkeypatch):
+    """Prompt-required tool checks must not be bypassed by plain-response routing."""
+    orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
+
+    monkeypatch.setattr(
+        orchestrator._gateway,
+        "describe_methods",
+        lambda: {"workflow_list_definitions": {"category": "read"}},
+    )
+
+    llm = _CapturingLLM(
+        [
+            "plain_response",
+            "I inspected workflow definitions.",
+        ]
+    )
+
+    result = orchestrator.run(
+        prompt="Call workflow_list_definitions and confirm what exists.",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+    )
+
+    assert result.workflow_routing is not None
+    assert result.workflow_routing.verdict == "tool_seeking"
+    assert result.workflow_routing.workflow_id == TOOL_CALLING_WORKFLOW_ID
+    assert result.workflow_routing.source == "selector_override"
+
+    override_entry = next(
+        (
+            entry
+            for entry in result.aux_llm_calls
+            if isinstance(entry, dict)
+            and entry.get("type") == "workflow_selector_override"
+            and entry.get("reason") == "required_prompt_tools_missing"
+        ),
+        None,
+    )
+    assert override_entry is not None
+    assert "workflow_list_definitions" in (
+        override_entry.get("required_prompt_tools") or []
+    )
 
 
 def test_write_intent_memory_rehydrates_for_same_session_continuation(monkeypatch):

--- a/tests/backend/test_turn_execution_record_service_execution_summary.py
+++ b/tests/backend/test_turn_execution_record_service_execution_summary.py
@@ -1,0 +1,32 @@
+from src.backend.services.turn_execution_record_service import (
+    _summarise_tool_execution_context,
+)
+
+
+def test_worker_unavailable_failure_code_only_applies_to_tool_routes() -> None:
+    summary = _summarise_tool_execution_context(
+        workflow_routing={
+            "workflow_id": "#V#chat_assistant_workflow",
+            "verdict": "plain_response",
+        },
+        turn_execution_diagnostics={
+            "latest_progress": {
+                "counters": {"tools_started": 0, "tools_completed": 0},
+                "diagnostic_events": [
+                    {
+                        "liveness_reason": "worker_unavailable",
+                        "event_kind": "heartbeat",
+                        "stage": "orchestrator_start",
+                        "phase": "orchestrator_start",
+                    }
+                ],
+            }
+        },
+        aux_llm_calls=[],
+        serialised_invocations=[],
+    )
+
+    assert summary["tool_route_selected"] is False
+    assert "worker_unavailable_zero_execution" not in list(
+        summary.get("failure_codes") or []
+    )

--- a/tests/backend/test_von_generate_presenter_protocol.py
+++ b/tests/backend/test_von_generate_presenter_protocol.py
@@ -243,10 +243,15 @@ def test_generate_buttonify_uses_llm_extraction(monkeypatch):
     assert isinstance(buttonify, dict)
     assert buttonify.get("source") == "llm"
     assert buttonify.get("options") == ["Proceed", "Hold"]
+    filtering_boundary = buttonify.get("filtering_boundary")
+    assert isinstance(filtering_boundary, dict)
+    assert filtering_boundary.get("schema_version") == "buttonify_filtering_boundary_v1"
+    assert filtering_boundary.get("accepted_candidate_count") == 2
     buttonify_event = _find_transformation_event(llm_debug, "buttonify")
     assert buttonify_event["status"] == "success"
     assert buttonify_event["source_path"] == "llm"
     assert buttonify_event["options_emitted_count"] == 2
+    assert isinstance(buttonify_event["output_summary"].get("filtering_boundary"), dict)
     assert "timestamp_utc" in buttonify_event
 
     # First call is assistant response, second call is buttonify extraction.
@@ -309,6 +314,9 @@ def test_generate_buttonify_non_json_llm_output_noops(monkeypatch):
     assert buttonify.get("source") == "none"
     assert buttonify.get("options") == []
     assert buttonify.get("suppression_reason") == "no_candidates"
+    filtering_boundary = buttonify.get("filtering_boundary")
+    assert isinstance(filtering_boundary, dict)
+    assert filtering_boundary.get("schema_version") == "buttonify_filtering_boundary_v1"
 
     buttonify_event = _find_transformation_event(llm_debug, "buttonify")
     assert buttonify_event["status"] == "no_op"

--- a/tests/backend/test_workflow_introspection_maintenance_workflow.py
+++ b/tests/backend/test_workflow_introspection_maintenance_workflow.py
@@ -70,13 +70,56 @@ def test_assess_prefers_user_namespace_for_prompt_lookup(monkeypatch):
     result = mod._handle_assess_context(
         _request(
             action_id="workflow_introspection.assess_context",
-            data={"request_id": "req-1"},
+            data={"request_id": "req-1", "github_owner": "Strong-AI-Lab", "github_repo": "Von"},
             namespace="#V#user@org",
         )
     )
     assert result.ok
     assert result.outputs["maintenance_context"]["prompt_lookup_namespace"] == "#V#user"
     assert lookup_calls[0] == "#V#user"
+
+
+def test_assess_collects_github_evidence(monkeypatch):
+    from src.backend.workflows.durable import workflow_introspection_maintenance_workflow as mod
+
+    def _fake_invoke(tool_name: str, payload: dict):
+        if tool_name == "workflow_list_definitions":
+            return {"success": True, "count": 1, "definitions": []}
+        if tool_name == "chat_get_prompt_context":
+            return {"success": True, "behaviour_prompt_concepts": []}
+        if tool_name == "turn_execution_get":
+            return {"success": True, "selected_workflow_id": "#V#tool_calling_workflow"}
+        if tool_name == "fetch_concept":
+            return {"success": True, "concept_id": "#V#tool_calling_workflow"}
+        if tool_name == "github_get_auth_config":
+            return {"success": True, "proxy_tools_available": True}
+        if tool_name == "github_list_commits":
+            return {"success": True, "items": []}
+        if tool_name == "github_list_pull_requests":
+            return {"success": True, "items": []}
+        if tool_name == "github_get_file_contents":
+            return {"success": True, "content": "x", "path": payload.get("path")}
+        return {"success": True}
+
+    monkeypatch.setattr(mod, "_invoke_mcp_tool", _fake_invoke)
+    monkeypatch.setattr(mod, "_available_tool_names", lambda: ["task_create"])
+
+    result = mod._handle_assess_context(
+        _request(
+            action_id="workflow_introspection.assess_context",
+            data={
+                "request_id": "req-gh-1",
+                "github_owner": "Strong-AI-Lab",
+                "github_repo": "Von",
+                "incident_text": "Please inspect src/backend/workflows/durable/workflow_introspection_maintenance_workflow.py",
+            },
+            namespace="#V#user@org",
+        )
+    )
+    assert result.ok
+    github_evidence = result.outputs["maintenance_evidence"]["github_evidence"]
+    assert github_evidence["success"] is True
+    assert github_evidence["repository"] == "Strong-AI-Lab/Von"
 
 
 def test_diagnose_detects_alias_scope_and_cross_domain_signals():
@@ -166,6 +209,46 @@ def test_plan_repairs_builds_prompt_patch_and_workflow_note():
     assert "upsert_text_relation" in tools
 
 
+def test_plan_repairs_adds_jira_remediation_operation_when_evidence_available():
+    from src.backend.workflows.durable import workflow_introspection_maintenance_workflow as mod
+
+    data = {
+        "maintenance_context": {
+            "namespace": "#V#user@org",
+            "request_id": "req-1361",
+            "selected_workflow_id": "#V#tool_calling_workflow",
+            "apply_repairs": True,
+            "dry_run": False,
+            "max_operations": 10,
+            "emit_jira_remediation": True,
+            "jira_project_key": "JVNAUTOSCI",
+            "jira_issue_type": "Task",
+        },
+        "maintenance_evidence": {
+            "incident_text": "Investigate workflow failure in src/backend/workflows/durable/workflow_introspection_maintenance_workflow.py",
+            "prompt_context": {"behaviour_prompt_concepts": []},
+            "github_evidence": {
+                "success": True,
+                "repository": "Strong-AI-Lab/Von",
+                "errors": [],
+            },
+        },
+        "maintenance_diagnosis": {
+            "conflation_detected": True,
+            "root_causes": [{"cause_id": "prompt_scope_overreach"}],
+            "directive_findings": [],
+            "implicated_prompt_concept_ids": [],
+        },
+    }
+    result = mod._handle_plan_repairs(
+        _request(action_id="workflow_introspection.plan_repairs", data=data)
+    )
+    assert result.ok
+    repair_plan = result.outputs["maintenance_repair_plan"]
+    tools = {item["tool_name"] for item in repair_plan["operations"]}
+    assert "__jira_self_diagnosis_upsert__" in tools
+
+
 def test_apply_repairs_executes_operations(monkeypatch):
     from src.backend.workflows.durable import workflow_introspection_maintenance_workflow as mod
 
@@ -199,6 +282,51 @@ def test_apply_repairs_executes_operations(monkeypatch):
     report = result.outputs["maintenance_apply_report"]
     assert report["successful_operations"] == 1
     assert calls[0][0] == "upsert_singleton_text_relation"
+
+
+def test_apply_repairs_executes_jira_self_diagnosis_upsert(monkeypatch):
+    from src.backend.workflows.durable import workflow_introspection_maintenance_workflow as mod
+
+    def _fake_invoke(tool_name: str, payload: dict):
+        if tool_name == "jira_search":
+            return {"success": True, "issues": [{"key": "JVNAUTOSCI-1600"}]}
+        if tool_name == "jira_add_comment":
+            assert payload["issue_key"] == "JVNAUTOSCI-1600"
+            return {"success": True}
+        return {"success": True}
+
+    monkeypatch.setattr(mod, "_invoke_mcp_tool", _fake_invoke)
+
+    result = mod._handle_apply_repairs(
+        _request(
+            action_id="workflow_introspection.apply_repairs",
+            data={
+                "maintenance_repair_plan": {
+                    "apply_requested": True,
+                    "dry_run": False,
+                    "operations": [
+                        {
+                            "operation_id": "jira-remediation",
+                            "tool_name": "__jira_self_diagnosis_upsert__",
+                            "payload": {
+                                "project_key": "JVNAUTOSCI",
+                                "issue_type": "Task",
+                                "summary": "Remediation summary",
+                                "description": "Generated by Codex",
+                                "fingerprint": "abc12345",
+                                "request_id": "req-1361",
+                            },
+                        }
+                    ],
+                }
+            },
+        )
+    )
+    assert result.ok
+    report = result.outputs["maintenance_apply_report"]
+    assert report["successful_operations"] == 1
+    assert report["results"][0]["tool_name"] == "__jira_self_diagnosis_upsert__"
+    assert report["results"][0]["issue_key"] == "JVNAUTOSCI-1600"
 
 
 def test_verify_repairs_fails_when_guardrail_not_observable(monkeypatch):


### PR DESCRIPTION
## Summary
- complete the remaining reliability fixes for JVNAUTOSCI-1256, JVNAUTOSCI-1318, and JVNAUTOSCI-1367
- add GitHub proxy integration and guarded GitHub internal MCP tools for JVNAUTOSCI-1340
- extend workflow introspection maintenance workflow with read-only GitHub evidence and Jira remediation upsert flow for JVNAUTOSCI-1361
- add targeted gateway/workflow tests and a GitHub MCP runbook

## Verification
- pytest -q tests/backend/test_internal_mcp_github_tools.py tests/backend/test_workflow_introspection_maintenance_workflow.py tests/backend/test_internal_mcp_catalogue_builds.py tests/backend/test_mcp_tool_contract_registry.py
- pytest -q tests/backend/test_orchestrator_model_fallback_execution.py::test_probe_model_candidate_reachability_uses_failure_cooldown_cache tests/backend/test_internal_mcp_github_tools.py tests/backend/test_workflow_introspection_maintenance_workflow.py
- pytest -q tests/backend/test_orchestrator_extraction.py::test_derive_prompt_tool_requirements_detects_concept_verification_intent tests/backend/test_orchestrator_extraction.py::test_run_forces_read_file_copy_when_prompt_references_file_copy_concept tests/backend/test_orchestrator_extraction.py::test_derive_missing_prompt_requirements_tracks_missing_fetch_targets tests/backend/test_orchestrator_workflow_selector_routing.py::test_plain_response_overridden_when_prompt_requires_tool_verification tests/backend/test_orchestrator_workflow_selector_routing.py::test_renderer_applicability_can_enable_narration_when_flag_enabled
- pytest -q tests/backend/test_orchestrator_model_fallback_execution.py tests/backend/test_conversation_turn_stage_model.py tests/backend/test_turn_execution_record_service_execution_summary.py tests/backend/test_von_generate_presenter_protocol.py
- pyright <all changed python files from git diff --name-only>