### PR TITLE
JVNAUTOSCI-1377 Externalise representation contract profiles to Vontology

### DIFF
--- a/scripts/bootstrap_representation_contract_profiles.py
+++ b/scripts/bootstrap_representation_contract_profiles.py
@@ -1,0 +1,175 @@
+"""Bootstrap canonical representation contract profiles in Vontology.
+
+This script ensures profile concepts exist, then persists canonical JSON
+profiles using singleton text relations so turn-execution contract logic can
+load semantics from Vontology at runtime.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def _bootstrap_sys_path() -> None:
+    repo_root = Path(__file__).parent.parent
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    src_root = repo_root / "src"
+    if str(src_root) not in sys.path:
+        sys.path.insert(0, str(src_root))
+
+
+_bootstrap_sys_path()
+
+from src.backend.services import concept_service  # noqa: E402
+from src.backend.services.representation_contract_vontology_service import (  # noqa: E402
+    bootstrap_canonical_representation_contract_profiles,
+    canonical_representation_profile_concept_ids,
+)
+
+PROFILE_TYPE_CONCEPT_ID = "#V#representation_contract_profile"
+PROFILE_TYPE_NAME = "Representation Contract Profile"
+
+PROFILE_DEFINITIONS: tuple[tuple[str, str, str], ...] = (
+    (
+        "#V#representation_contract_profile_paper",
+        "Paper Representation Contract Profile",
+        "Profile semantics for scholarly paper representation intents.",
+    ),
+    (
+        "#V#representation_contract_profile_person",
+        "Person Representation Contract Profile",
+        "Profile semantics for person representation intents from CVs or business cards.",
+    ),
+    (
+        "#V#representation_contract_profile_company",
+        "Company Representation Contract Profile",
+        "Profile semantics for company representation intents from web pages or documents.",
+    ),
+    (
+        "#V#representation_contract_profile_meeting",
+        "Meeting Representation Contract Profile",
+        "Profile semantics for meeting representation intents from transcripts or calendar artefacts.",
+    ),
+)
+
+PROFILE_TEXT_PREDICATE_CONCEPT_ID = "#V#has_representation_contract_profile_json"
+PROFILE_TEXT_PREDICATE_NAME = "has_representation_contract_profile_json"
+
+
+def _get_concept(concept_id: str):
+    try:
+        return concept_service.get_concept_by_concept_id(concept_id)
+    except Exception:
+        return None
+
+
+def _ensure_type_concept(concept_id: str, name: str, description: str) -> None:
+    if _get_concept(concept_id):
+        print(f"[bootstrap] exists: {concept_id}")
+        return
+    print(f"[bootstrap] creating type concept: {concept_id}")
+    concept_service.create_concept(
+        concept_id=concept_id,
+        name=name,
+        description=description,
+        instance_of_type="#V#type",
+    )
+
+
+def _ensure_profile_concept(
+    concept_id: str,
+    name: str,
+    description: str,
+) -> None:
+    if _get_concept(concept_id):
+        print(f"[bootstrap] exists: {concept_id}")
+        return
+    print(f"[bootstrap] creating profile concept: {concept_id}")
+    concept_service.create_concept(
+        concept_id=concept_id,
+        name=name,
+        description=description,
+        instance_of_type=PROFILE_TYPE_CONCEPT_ID,
+    )
+
+
+def _ensure_profile_text_predicate_concept() -> None:
+    if _get_concept(PROFILE_TEXT_PREDICATE_CONCEPT_ID):
+        print(f"[bootstrap] exists: {PROFILE_TEXT_PREDICATE_CONCEPT_ID}")
+        return
+    print(
+        "[bootstrap] creating predicate concept: "
+        f"{PROFILE_TEXT_PREDICATE_CONCEPT_ID}"
+    )
+    try:
+        concept_service.create_concept(
+            concept_id=PROFILE_TEXT_PREDICATE_CONCEPT_ID,
+            name=PROFILE_TEXT_PREDICATE_NAME,
+            description=(
+                "Singleton JSON payload that stores representation contract "
+                "profile semantics for turn-execution required-effects contracts."
+            ),
+            instance_of_type="#V#predicate",
+        )
+    except Exception as exc:
+        print(
+            "[bootstrap] warning: could not create predicate concept as "
+            f"#V#predicate instance ({exc}); creating as generic type instead."
+        )
+        concept_service.create_concept(
+            concept_id=PROFILE_TEXT_PREDICATE_CONCEPT_ID,
+            name=PROFILE_TEXT_PREDICATE_NAME,
+            description=(
+                "Singleton JSON payload that stores representation contract "
+                "profile semantics for turn-execution required-effects contracts."
+            ),
+            instance_of_type="#V#type",
+        )
+
+
+def main() -> int:
+    try:
+        print("[bootstrap] ensuring representation profile ontology concepts...")
+        _ensure_type_concept(
+            PROFILE_TYPE_CONCEPT_ID,
+            PROFILE_TYPE_NAME,
+            "Type for representation contract profile concepts.",
+        )
+        _ensure_profile_text_predicate_concept()
+        for concept_id, name, description in PROFILE_DEFINITIONS:
+            _ensure_profile_concept(concept_id, name, description)
+
+        print("[bootstrap] writing canonical profile JSON text relations...")
+        report = bootstrap_canonical_representation_contract_profiles(
+            concept_ids=canonical_representation_profile_concept_ids(),
+            predicate=PROFILE_TEXT_PREDICATE_CONCEPT_ID,
+            language="en-NZ",
+            policy="replace_others",
+            provenance={
+                "source": "scripts/bootstrap_representation_contract_profiles.py",
+                "owner": "JVNAUTOSCI-1377",
+            },
+            context={
+                "purpose": "representation_required_effects_contract_profiles",
+                "task": "JVNAUTOSCI-1377",
+            },
+            garbage_collect=True,
+        )
+        print("[bootstrap] report:")
+        print(report)
+        return 0 if bool(report.get("success")) else 1
+    except Exception as exc:
+        print(f"[bootstrap] failed: {exc}")
+        print(
+            "[bootstrap] hint: ensure Vontology Mongo connectivity is available "
+            "(for Atlas, verify IP allow-list and credentials)."
+        )
+        return 2
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("PYTHONUTF8", "1")
+    raise SystemExit(main())

--- a/src/backend/services/representation_contract_vontology_service.py
+++ b/src/backend/services/representation_contract_vontology_service.py
@@ -1,0 +1,662 @@
+"""Vontology-backed helpers for representation required-effects contracts.
+
+This module keeps ontology profile fetch/normalisation separate from the
+deterministic turn-execution contract builder.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any, Mapping, Sequence
+
+from .concept_service import get_concept_by_concept_id
+from .text_value_service import get_texts_for_concept
+from .text_value_service import upsert_singleton_text_relation
+
+DEFAULT_REPRESENTATION_PROFILE_PREDICATE = "#V#has_representation_contract_profile_json"
+
+_DEFAULT_PROFILE_TEXT_PREDICATES: tuple[str, ...] = (
+    "#V#has_representation_contract_profile_json",
+    "has_representation_contract_profile_json",
+    "hasRepresentationContractProfileJson",
+    "hasContent",
+)
+
+_DEFAULT_DECISION_POLICY: dict[str, bool] = {
+    "completion_block_on_unresolved_effects": True,
+    "fail_closed_on_missing_requirements": True,
+    "auto_apply_low_risk_defaults": True,
+    "requires_explicit_user_decision_for_high_risk": True,
+}
+
+# JVNAUTOSCI-1377: canonical starter profiles are kept here only for bootstrap.
+# Runtime behaviour should read profile semantics from Vontology text relations.
+_CANONICAL_REPRESENTATION_PROFILE_BLUEPRINTS: tuple[dict[str, Any], ...] = (
+    {
+        "profile_concept_id": "#V#representation_contract_profile_paper",
+        "profile_id": "paper",
+        "target_entity_class": "scholarly_paper",
+        "effect_type": "scholarly_representation",
+        "description": (
+            "Ensure the corresponding scholarly-paper concept is materialised from "
+            "the supplied artefact context before final response completion."
+        ),
+        "intent_patterns": [
+            r"\b("
+            r"paper\s+representation"
+            r"|represent(?:ation|ing)?\s+(?:the\s+)?(?:corresponding\s+)?paper"
+            r"|fully\s+represent\s+(?:the\s+)?(?:corresponding\s+)?paper"
+            r"|scholarly\s+paper\s+representation"
+            r")\b"
+        ],
+        "domain_terms": [
+            "paper",
+            "scientific paper",
+            "arxiv",
+            "preprint",
+            "doi",
+            "manuscript",
+            "metadata",
+            "abstract",
+        ],
+        "required_tools_by_source": {
+            "file_copy": ["interpret_file_copy"],
+            "url": ["extract_url", "get_paper_metadata"],
+            "mixed": ["interpret_file_copy", "extract_url"],
+            "unknown": ["interpret_file_copy"],
+        },
+        "required_predicates": [
+            "#V#computer_file_for_propositional_information_thing",
+            "#V#propositional_information_thing_has_computer_file",
+        ],
+        "default_decision_policy": dict(_DEFAULT_DECISION_POLICY),
+    },
+    {
+        "profile_concept_id": "#V#representation_contract_profile_person",
+        "profile_id": "person",
+        "target_entity_class": "person",
+        "effect_type": "representation_person",
+        "description": (
+            "Ensure a person representation is materialised from the supplied "
+            "artefact context before final response completion."
+        ),
+        "intent_patterns": [
+            r"\b("
+            r"(?:business\s+card|cv|curriculum\s+vitae|resume)\b.*\b(?:person|profile|contact)"
+            r"|(?:person|profile|contact)\b.*\b(?:business\s+card|cv|curriculum\s+vitae|resume)"
+            r")\b"
+        ],
+        "domain_terms": [
+            "person",
+            "business card",
+            "cv",
+            "curriculum vitae",
+            "resume",
+            "contact",
+            "profile",
+            "researcher",
+        ],
+        "required_tools_by_source": {
+            "file_copy": ["interpret_file_copy"],
+            "url": ["extract_url"],
+            "mixed": ["interpret_file_copy", "extract_url"],
+            "unknown": ["interpret_file_copy"],
+        },
+        "required_predicates": ["#V#person"],
+        "default_decision_policy": dict(_DEFAULT_DECISION_POLICY),
+    },
+    {
+        "profile_concept_id": "#V#representation_contract_profile_company",
+        "profile_id": "company",
+        "target_entity_class": "company",
+        "effect_type": "representation_company",
+        "description": (
+            "Ensure a company representation is materialised from the supplied "
+            "artefact context before final response completion."
+        ),
+        "intent_patterns": [
+            r"\b("
+            r"(?:company|organisation|organization|business|startup)\b.*\b(?:web\s?page|website|url)"
+            r"|(?:web\s?page|website|url)\b.*\b(?:company|organisation|organization|business|startup)"
+            r")\b"
+        ],
+        "domain_terms": [
+            "company",
+            "organisation",
+            "organization",
+            "business",
+            "startup",
+            "firm",
+            "web page",
+            "website",
+            "url",
+        ],
+        "required_tools_by_source": {
+            "file_copy": ["interpret_file_copy"],
+            "url": ["extract_url"],
+            "mixed": ["interpret_file_copy", "extract_url"],
+            "unknown": ["extract_url"],
+        },
+        "required_predicates": ["#V#organisation"],
+        "default_decision_policy": dict(_DEFAULT_DECISION_POLICY),
+    },
+    {
+        "profile_concept_id": "#V#representation_contract_profile_meeting",
+        "profile_id": "meeting",
+        "target_entity_class": "meeting",
+        "effect_type": "representation_meeting",
+        "description": (
+            "Ensure a meeting representation is materialised from the supplied "
+            "artefact context before final response completion."
+        ),
+        "intent_patterns": [
+            r"\b("
+            r"(?:meeting|calendar\s+event)\b.*\b(?:transcript|calendar|minutes|agenda)"
+            r"|(?:transcript|calendar|minutes|agenda)\b.*\b(?:meeting|calendar\s+event)"
+            r")\b"
+        ],
+        "domain_terms": [
+            "meeting",
+            "calendar event",
+            "transcript",
+            "calendar",
+            "minutes",
+            "agenda",
+            "attendees",
+        ],
+        "required_tools_by_source": {
+            "file_copy": ["interpret_file_copy"],
+            "url": ["extract_url"],
+            "mixed": ["interpret_file_copy", "extract_url"],
+            "unknown": ["interpret_file_copy"],
+        },
+        "required_predicates": ["#V#meeting"],
+        "default_decision_policy": dict(_DEFAULT_DECISION_POLICY),
+    },
+)
+
+_CANONICAL_PROFILE_BY_CONCEPT_ID: dict[str, dict[str, Any]] = {
+    str(item["profile_concept_id"]): dict(item)
+    for item in _CANONICAL_REPRESENTATION_PROFILE_BLUEPRINTS
+}
+
+
+def canonical_representation_profile_concept_ids() -> tuple[str, ...]:
+    """Return canonical representation profile concept IDs in deterministic order."""
+    return tuple(
+        str(item["profile_concept_id"])
+        for item in _CANONICAL_REPRESENTATION_PROFILE_BLUEPRINTS
+    )
+
+
+def canonical_representation_profile_blueprints() -> tuple[dict[str, Any], ...]:
+    """Return copy-on-read canonical representation starter profiles."""
+    return tuple(dict(item) for item in _CANONICAL_REPRESENTATION_PROFILE_BLUEPRINTS)
+
+
+def _safe_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _normalise_strings(values: Any) -> tuple[str, ...]:
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+        return ()
+    seen: set[str] = set()
+    normalised: list[str] = []
+    for value in values:
+        text = _safe_str(value)
+        if not text:
+            continue
+        lowered = text.lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        normalised.append(text)
+    return tuple(normalised)
+
+
+def _normalise_required_tools_by_source(raw: Any) -> dict[str, list[str]]:
+    if not isinstance(raw, Mapping):
+        return {}
+    by_source: dict[str, list[str]] = {}
+    for key, value in raw.items():
+        source = (_safe_str(key) or "").lower()
+        if not source:
+            continue
+        tools = list(_normalise_strings(value))
+        if not tools:
+            continue
+        by_source[source] = tools
+    return by_source
+
+
+def _normalise_decision_policy(raw: Any) -> dict[str, bool]:
+    policy = dict(_DEFAULT_DECISION_POLICY)
+    if not isinstance(raw, Mapping):
+        return policy
+    for key in _DEFAULT_DECISION_POLICY:
+        if key in raw:
+            policy[key] = bool(raw.get(key))
+    return policy
+
+
+def _text_preview(value: Any, *, limit: int = 200) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}..."
+
+
+def _format_parse_error(exc: Exception) -> str:
+    message = str(exc).strip() or exc.__class__.__name__
+    if len(message) > 160:
+        message = f"{message[:157]}..."
+    return f"{exc.__class__.__name__}: {message}"
+
+
+def _parse_profile_json_with_diagnostics(
+    raw_text: Any,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Parse JSON representation profile payloads and return parse diagnostics."""
+    if not isinstance(raw_text, str):
+        return [], ["profile_text_not_string"]
+    text = raw_text.strip()
+    if not text:
+        return [], ["profile_text_empty"]
+
+    def _coerce_parsed(parsed: Any) -> list[dict[str, Any]]:
+        if isinstance(parsed, Mapping):
+            return [dict(parsed)]
+        if isinstance(parsed, list):
+            return [dict(item) for item in parsed if isinstance(item, Mapping)]
+        return []
+
+    parse_errors: list[str] = []
+    try:
+        parsed = json.loads(text)
+        coerced = _coerce_parsed(parsed)
+        if coerced:
+            return coerced, []
+        parse_errors.append("json_payload_not_mapping_or_list")
+    except Exception as exc:
+        parse_errors.append(f"json_decode_failed:{_format_parse_error(exc)}")
+
+    fenced_block_seen = False
+    for match in re.finditer(r"```(?:json)?\s*([\s\S]*?)```", text, flags=re.IGNORECASE):
+        fenced_block_seen = True
+        block = match.group(1).strip()
+        if not block:
+            continue
+        try:
+            parsed = json.loads(block)
+        except Exception as exc:
+            parse_errors.append(f"fenced_json_decode_failed:{_format_parse_error(exc)}")
+            continue
+        coerced = _coerce_parsed(parsed)
+        if coerced:
+            return coerced, []
+        parse_errors.append("fenced_json_payload_not_mapping_or_list")
+    if fenced_block_seen and not parse_errors:
+        parse_errors.append("fenced_json_block_empty")
+    return [], parse_errors
+
+
+def _derive_profile_id(profile_concept_id: str | None) -> str | None:
+    concept_id = _safe_str(profile_concept_id)
+    if not concept_id:
+        return None
+    if concept_id.startswith("#V#"):
+        concept_id = concept_id[3:]
+    concept_id = concept_id.strip().lower()
+    if concept_id.startswith("representation_contract_profile_"):
+        concept_id = concept_id[len("representation_contract_profile_") :]
+    return concept_id or None
+
+
+def _serialise_representation_profile(
+    profile: Mapping[str, Any],
+    *,
+    profile_concept_id: str | None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    if not isinstance(profile, Mapping):
+        return None, ["profile_not_mapping"]
+
+    errors: list[str] = []
+    resolved_profile_concept_id = _safe_str(profile.get("profile_concept_id")) or _safe_str(
+        profile_concept_id
+    )
+    resolved_profile_id = _safe_str(profile.get("profile_id")) or _derive_profile_id(
+        resolved_profile_concept_id
+    )
+    target_entity_class = _safe_str(profile.get("target_entity_class"))
+    effect_type = _safe_str(profile.get("effect_type"))
+    description = _safe_str(profile.get("description")) or (
+        "Ensure the requested representation is materialised from the artefact context."
+    )
+
+    intent_patterns = list(_normalise_strings(profile.get("intent_patterns")))
+    for pattern in intent_patterns:
+        try:
+            re.compile(pattern, flags=re.IGNORECASE)
+        except Exception as exc:
+            errors.append(f"invalid_intent_pattern:{pattern}:{_format_parse_error(exc)}")
+
+    domain_terms = list(_normalise_strings(profile.get("domain_terms")))
+    if not intent_patterns and not domain_terms:
+        errors.append("missing_intent_patterns_and_domain_terms")
+
+    required_tools_by_source = _normalise_required_tools_by_source(
+        profile.get("required_tools_by_source")
+    )
+    required_predicates = list(_normalise_strings(profile.get("required_predicates")))
+    default_decision_policy = _normalise_decision_policy(
+        profile.get("default_decision_policy")
+    )
+
+    if not resolved_profile_id:
+        errors.append("missing_profile_id")
+    if not target_entity_class:
+        errors.append("missing_target_entity_class")
+    if not effect_type:
+        errors.append("missing_effect_type")
+
+    if errors:
+        return None, errors
+
+    serialised: dict[str, Any] = {
+        "profile_id": resolved_profile_id,
+        "target_entity_class": target_entity_class,
+        "effect_type": effect_type,
+        "description": description,
+        "intent_patterns": intent_patterns,
+        "domain_terms": domain_terms,
+        "required_tools_by_source": required_tools_by_source,
+        "required_predicates": required_predicates,
+        "default_decision_policy": default_decision_policy,
+    }
+    if resolved_profile_concept_id:
+        serialised["profile_concept_id"] = resolved_profile_concept_id
+    return serialised, []
+
+
+def _hash_profile_catalogue(profiles: Sequence[Mapping[str, Any]]) -> str | None:
+    if not profiles:
+        return None
+    try:
+        payload = json.dumps(list(profiles), sort_keys=True, separators=(",", ":"))
+    except Exception:
+        return None
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def load_representation_contract_profiles_from_concept_ids(
+    concept_ids: Sequence[str],
+    *,
+    profile_text_predicates: Sequence[str] | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Load representation contract profiles from Vontology concept text relations."""
+    predicates = (
+        _normalise_strings(profile_text_predicates) or _DEFAULT_PROFILE_TEXT_PREDICATES
+    )
+    ordered_concept_ids = _normalise_strings(concept_ids)
+
+    loaded_profiles: list[dict[str, Any]] = []
+    loaded_concept_ids: list[str] = []
+    unresolved_concept_ids: list[str] = []
+    missing_profile_concept_ids: list[str] = []
+    malformed_profile_concept_ids: list[str] = []
+    malformed_profile_entries: list[dict[str, Any]] = []
+
+    for concept_id in ordered_concept_ids:
+        try:
+            concept = get_concept_by_concept_id(concept_id)
+        except Exception:
+            concept = None
+
+        if not isinstance(concept, Mapping):
+            unresolved_concept_ids.append(concept_id)
+            continue
+
+        concept_profiles: list[dict[str, Any]] = []
+        concept_malformed_entries: list[dict[str, Any]] = []
+        profile_rows_found = False
+
+        for predicate in predicates:
+            try:
+                text_rows = get_texts_for_concept(concept_id, predicate=predicate, limit=20)
+            except Exception:
+                text_rows = []
+            if not text_rows:
+                continue
+            profile_rows_found = True
+
+            for row in text_rows:
+                parsed_profiles, parse_errors = _parse_profile_json_with_diagnostics(
+                    row.get("text")
+                )
+                if parse_errors:
+                    concept_malformed_entries.append(
+                        {
+                            "concept_id": concept_id,
+                            "predicate": predicate,
+                            "error": "; ".join(parse_errors),
+                            "text_preview": _text_preview(row.get("text")),
+                        }
+                    )
+                    continue
+
+                for raw_profile in parsed_profiles:
+                    serialised, validation_errors = _serialise_representation_profile(
+                        raw_profile,
+                        profile_concept_id=concept_id,
+                    )
+                    if validation_errors or not isinstance(serialised, Mapping):
+                        concept_malformed_entries.append(
+                            {
+                                "concept_id": concept_id,
+                                "predicate": predicate,
+                                "error": "; ".join(validation_errors or ["invalid_profile"]),
+                                "profile_preview": {
+                                    key: raw_profile.get(key)
+                                    for key in sorted(
+                                        set(raw_profile.keys())
+                                        & {
+                                            "profile_id",
+                                            "target_entity_class",
+                                            "effect_type",
+                                            "required_predicates",
+                                            "required_tools_by_source",
+                                        }
+                                    )
+                                },
+                            }
+                        )
+                        continue
+                    normalised = dict(serialised)
+                    normalised["_source_concept_id"] = concept_id
+                    normalised["_source_predicate"] = predicate
+                    concept_profiles.append(normalised)
+            if concept_profiles:
+                break
+
+        if concept_profiles:
+            loaded_profiles.extend(concept_profiles)
+            loaded_concept_ids.append(concept_id)
+        elif concept_malformed_entries:
+            malformed_profile_concept_ids.append(concept_id)
+            malformed_profile_entries.extend(concept_malformed_entries)
+        elif profile_rows_found:
+            malformed_profile_concept_ids.append(concept_id)
+        else:
+            missing_profile_concept_ids.append(concept_id)
+
+    deduped_profiles: list[dict[str, Any]] = []
+    seen_profile_ids: set[str] = set()
+    duplicate_profile_ids: list[str] = []
+    for profile in loaded_profiles:
+        profile_id = (_safe_str(profile.get("profile_id")) or "").lower()
+        if not profile_id:
+            continue
+        if profile_id in seen_profile_ids:
+            duplicate_profile_ids.append(profile_id)
+            continue
+        seen_profile_ids.add(profile_id)
+        deduped_profiles.append(profile)
+
+    profile_version_hash = _hash_profile_catalogue(deduped_profiles)
+    diagnostics = {
+        "representation_profile_source": "vontology_concept_text_relations",
+        "requested_concept_ids": list(ordered_concept_ids),
+        "profile_text_predicates_checked": list(predicates),
+        "loaded_concept_ids": loaded_concept_ids,
+        "unresolved_concept_ids": unresolved_concept_ids,
+        "missing_profile_concept_ids": missing_profile_concept_ids,
+        "malformed_profile_concept_ids": malformed_profile_concept_ids,
+        "malformed_profile_count": len(malformed_profile_entries),
+        "malformed_profile_entries": malformed_profile_entries[:25],
+        "loaded_profile_count": len(deduped_profiles),
+        "duplicate_profile_ids": sorted(set(duplicate_profile_ids)),
+        "profile_version_hash": profile_version_hash,
+    }
+    return deduped_profiles, diagnostics
+
+
+def upsert_representation_contract_profile(
+    *,
+    profile_concept_id: str,
+    representation_profile: Mapping[str, Any],
+    predicate: str = DEFAULT_REPRESENTATION_PROFILE_PREDICATE,
+    language: str = "en-NZ",
+    policy: str = "replace_others",
+    provenance: Mapping[str, Any] | None = None,
+    context: Mapping[str, Any] | None = None,
+    garbage_collect: bool = True,
+) -> dict[str, Any]:
+    """Validate and persist one representation profile as a singleton text relation."""
+    concept_id = _safe_str(profile_concept_id)
+    if not concept_id:
+        raise ValueError("profile_concept_id is required")
+
+    concept = get_concept_by_concept_id(concept_id)
+    if not isinstance(concept, Mapping):
+        raise ValueError(f"Profile concept not found: {concept_id}")
+
+    if not isinstance(representation_profile, Mapping):
+        raise ValueError("representation_profile must be a mapping")
+
+    serialised_profile, validation_errors = _serialise_representation_profile(
+        dict(representation_profile),
+        profile_concept_id=concept_id,
+    )
+    if validation_errors or not isinstance(serialised_profile, Mapping):
+        raise ValueError(
+            "representation_profile validation failed: "
+            + "; ".join(validation_errors or ["invalid_profile"])
+        )
+
+    json_text = json.dumps(serialised_profile, ensure_ascii=True, sort_keys=True)
+    write_result = upsert_singleton_text_relation(
+        subject_concept_id=concept_id,
+        predicate=str(predicate or DEFAULT_REPRESENTATION_PROFILE_PREDICATE),
+        text=json_text,
+        lang=str(language or "en-NZ"),
+        policy=str(policy or "replace_others"),
+        provenance=dict(provenance or {}),
+        context=dict(context or {}),
+        garbage_collect=bool(garbage_collect),
+    )
+
+    return {
+        "success": bool(write_result.get("success")),
+        "profile_concept_id": concept_id,
+        "predicate": write_result.get("predicate"),
+        "language": write_result.get("language"),
+        "representation_profile": dict(serialised_profile),
+        "text_relation": write_result,
+    }
+
+
+def bootstrap_canonical_representation_contract_profiles(
+    *,
+    concept_ids: Sequence[str] | None = None,
+    predicate: str = DEFAULT_REPRESENTATION_PROFILE_PREDICATE,
+    language: str = "en-NZ",
+    policy: str = "replace_others",
+    provenance: Mapping[str, Any] | None = None,
+    context: Mapping[str, Any] | None = None,
+    garbage_collect: bool = True,
+) -> dict[str, Any]:
+    """Persist canonical representation profiles onto existing profile concepts."""
+    requested_concept_ids = _normalise_strings(concept_ids) or canonical_representation_profile_concept_ids()
+
+    persisted_profile_concept_ids: list[str] = []
+    unknown_canonical_profile_concept_ids: list[str] = []
+    missing_concept_ids: list[str] = []
+    errors_by_concept_id: dict[str, str] = {}
+
+    for concept_id in requested_concept_ids:
+        seed_profile = _CANONICAL_PROFILE_BY_CONCEPT_ID.get(concept_id)
+        if not isinstance(seed_profile, Mapping):
+            unknown_canonical_profile_concept_ids.append(concept_id)
+            continue
+        try:
+            concept = get_concept_by_concept_id(concept_id)
+        except Exception as exc:
+            errors_by_concept_id[concept_id] = f"concept_lookup_failed:{exc}"
+            continue
+
+        if not isinstance(concept, Mapping):
+            missing_concept_ids.append(concept_id)
+            continue
+
+        try:
+            result = upsert_representation_contract_profile(
+                profile_concept_id=concept_id,
+                representation_profile=dict(seed_profile),
+                predicate=predicate,
+                language=language,
+                policy=policy,
+                provenance=provenance,
+                context=context,
+                garbage_collect=garbage_collect,
+            )
+        except Exception as exc:
+            errors_by_concept_id[concept_id] = f"profile_upsert_failed:{exc}"
+            continue
+
+        if bool(result.get("success")):
+            persisted_profile_concept_ids.append(concept_id)
+        else:
+            errors_by_concept_id[concept_id] = "profile_upsert_unsuccessful"
+
+    return {
+        "success": not (
+            unknown_canonical_profile_concept_ids
+            or missing_concept_ids
+            or errors_by_concept_id
+        ),
+        "requested_profile_concept_ids": list(requested_concept_ids),
+        "canonical_profile_concept_ids": list(canonical_representation_profile_concept_ids()),
+        "persisted_profile_concept_ids": persisted_profile_concept_ids,
+        "unknown_canonical_profile_concept_ids": unknown_canonical_profile_concept_ids,
+        "missing_concept_ids": missing_concept_ids,
+        "errors_by_concept_id": errors_by_concept_id,
+        "counts": {
+            "requested": len(requested_concept_ids),
+            "persisted": len(persisted_profile_concept_ids),
+            "missing_concepts": len(missing_concept_ids),
+            "unknown_canonical_ids": len(unknown_canonical_profile_concept_ids),
+            "errors": len(errors_by_concept_id),
+        },
+    }

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -19,6 +19,10 @@ from pymongo import ASCENDING, DESCENDING
 from pymongo.errors import OperationFailure, PyMongoError
 
 from ..db.mongo_client import get_db
+from .representation_contract_vontology_service import (
+    canonical_representation_profile_concept_ids,
+    load_representation_contract_profiles_from_concept_ids,
+)
 from ..workflows.conversation_turn_stage_model import (
     build_conversation_turn_stage_model_snapshot,
     build_conversation_turn_stage_path,
@@ -246,9 +250,33 @@ _REPRESENTATION_ACTION_PATTERN = re.compile(
     r")\b",
     flags=re.IGNORECASE,
 )
+_REPRESENTATION_CREATE_ONLY_PATTERN = re.compile(
+    r"\b(?:create|build|make)\b",
+    flags=re.IGNORECASE,
+)
 _STATUS_CHECK_PROMPT_PATTERN = re.compile(
     r"^\s*(?:did|do|does|have|has|is|are|was|were)\s+you\b",
     flags=re.IGNORECASE,
+)
+_REPRESENTATION_CREATE_OBJECT_CUES = (
+    "representation",
+    "profile",
+    "metadata",
+    "paper",
+    "person",
+    "company",
+    "organisation",
+    "organization",
+    "meeting",
+    "business card",
+    "cv",
+    "curriculum vitae",
+    "resume",
+    "transcript",
+    "calendar",
+    "web page",
+    "website",
+    "url",
 )
 
 _AUX_REQUIRED_FILE_COPY_ID_FIELDS = (
@@ -257,154 +285,25 @@ _AUX_REQUIRED_FILE_COPY_ID_FIELDS = (
     "required_read_file_copy_ids",
 )
 
-_REPRESENTATION_DEFAULT_DECISION_POLICY = {
+_REPRESENTATION_DEFAULT_DECISION_POLICY_FALLBACK = {
     "completion_block_on_unresolved_effects": True,
     "fail_closed_on_missing_requirements": True,
     "auto_apply_low_risk_defaults": True,
     "requires_explicit_user_decision_for_high_risk": True,
 }
 
-# REFERENCE CONFIG: extend representation coverage by adding a profile here
-# instead of introducing prompt-specific branches in execution code.
-_REPRESENTATION_DOMAIN_PROFILES: tuple[dict[str, Any], ...] = (
-    {
-        "profile_id": "paper",
-        "target_entity_class": "scholarly_paper",
-        "effect_type": "scholarly_representation",
-        "intent_pattern": re.compile(
-            r"\b("
-            r"paper\s+representation"
-            r"|represent(?:ation|ing)?\s+(?:the\s+)?(?:corresponding\s+)?paper"
-            r"|fully\s+represent\s+(?:the\s+)?(?:corresponding\s+)?paper"
-            r"|scholarly\s+paper\s+representation"
-            r")\b",
-            flags=re.IGNORECASE,
-        ),
-        "domain_terms": (
-            "paper",
-            "scientific paper",
-            "arxiv",
-            "preprint",
-            "doi",
-            "manuscript",
-            "metadata",
-            "abstract",
-        ),
-        "required_tools_by_source": {
-            "file_copy": ["interpret_file_copy"],
-            "url": ["extract_url", "get_paper_metadata"],
-            "mixed": ["interpret_file_copy", "extract_url"],
-            "unknown": ["interpret_file_copy"],
-        },
-        "required_predicates": [
-            "#V#computer_file_for_propositional_information_thing",
-            "#V#propositional_information_thing_has_computer_file",
-        ],
-        "description": (
-            "Ensure the corresponding scholarly-paper concept is materialised from "
-            "the supplied artefact context before final response completion."
-        ),
-    },
-    {
-        "profile_id": "person",
-        "target_entity_class": "person",
-        "effect_type": "representation_person",
-        "intent_pattern": re.compile(
-            r"\b("
-            r"(?:business\s+card|cv|curriculum\s+vitae|resume)\b.*\b(?:person|profile|contact)"
-            r"|(?:person|profile|contact)\b.*\b(?:business\s+card|cv|curriculum\s+vitae|resume)"
-            r")\b",
-            flags=re.IGNORECASE,
-        ),
-        "domain_terms": (
-            "person",
-            "business card",
-            "cv",
-            "curriculum vitae",
-            "resume",
-            "contact",
-            "profile",
-            "researcher",
-        ),
-        "required_tools_by_source": {
-            "file_copy": ["interpret_file_copy"],
-            "url": ["extract_url"],
-            "mixed": ["interpret_file_copy", "extract_url"],
-            "unknown": ["interpret_file_copy"],
-        },
-        "required_predicates": ["#V#person"],
-        "description": (
-            "Ensure a person representation is materialised from the supplied "
-            "artefact context before final response completion."
-        ),
-    },
-    {
-        "profile_id": "company",
-        "target_entity_class": "company",
-        "effect_type": "representation_company",
-        "intent_pattern": re.compile(
-            r"\b("
-            r"(?:company|organisation|organization|business|startup)\b.*\b(?:web\s?page|website|url)"
-            r"|(?:web\s?page|website|url)\b.*\b(?:company|organisation|organization|business|startup)"
-            r")\b",
-            flags=re.IGNORECASE,
-        ),
-        "domain_terms": (
-            "company",
-            "organisation",
-            "organization",
-            "business",
-            "startup",
-            "firm",
-            "web page",
-            "website",
-            "url",
-        ),
-        "required_tools_by_source": {
-            "file_copy": ["interpret_file_copy"],
-            "url": ["extract_url"],
-            "mixed": ["interpret_file_copy", "extract_url"],
-            "unknown": ["extract_url"],
-        },
-        "required_predicates": ["#V#organisation"],
-        "description": (
-            "Ensure a company representation is materialised from the supplied "
-            "artefact context before final response completion."
-        ),
-    },
-    {
-        "profile_id": "meeting",
-        "target_entity_class": "meeting",
-        "effect_type": "representation_meeting",
-        "intent_pattern": re.compile(
-            r"\b("
-            r"(?:meeting|calendar\s+event)\b.*\b(?:transcript|calendar|minutes|agenda)"
-            r"|(?:transcript|calendar|minutes|agenda)\b.*\b(?:meeting|calendar\s+event)"
-            r")\b",
-            flags=re.IGNORECASE,
-        ),
-        "domain_terms": (
-            "meeting",
-            "calendar event",
-            "transcript",
-            "calendar",
-            "minutes",
-            "agenda",
-            "attendees",
-        ),
-        "required_tools_by_source": {
-            "file_copy": ["interpret_file_copy"],
-            "url": ["extract_url"],
-            "mixed": ["interpret_file_copy", "extract_url"],
-            "unknown": ["interpret_file_copy"],
-        },
-        "required_predicates": ["#V#meeting"],
-        "description": (
-            "Ensure a meeting representation is materialised from the supplied "
-            "artefact context before final response completion."
-        ),
-    },
+_REPRESENTATION_CONFIG_UNAVAILABLE_FAILURE_CODE = (
+    "representation_profile_catalogue_unavailable"
 )
+_REPRESENTATION_PROFILE_UNMATCHED_FAILURE_CODE = "representation_profile_unmatched"
+_REPRESENTATION_FAILURE_REASON_MAP = {
+    _REPRESENTATION_CONFIG_UNAVAILABLE_FAILURE_CODE: (
+        "Required representation profile catalogue is unavailable."
+    ),
+    _REPRESENTATION_PROFILE_UNMATCHED_FAILURE_CODE: (
+        "No representation profile matched the requested intent."
+    ),
+}
 
 
 def _has_affirmative_mutation_term(prompt_text: str) -> bool:
@@ -1085,6 +984,85 @@ def _extract_representation_source_hints(prompt_text: str) -> list[str]:
     return _dedupe_string_sequence(hints)
 
 
+def _normalise_representation_decision_policy(raw: Any) -> dict[str, bool]:
+    policy = dict(_REPRESENTATION_DEFAULT_DECISION_POLICY_FALLBACK)
+    if not isinstance(raw, Mapping):
+        return policy
+    for key in _REPRESENTATION_DEFAULT_DECISION_POLICY_FALLBACK:
+        if key in raw:
+            policy[key] = bool(raw.get(key))
+    return policy
+
+
+def _load_representation_domain_profiles_from_vontology() -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    requested_profile_concept_ids = list(canonical_representation_profile_concept_ids())
+    loaded_profiles, diagnostics = load_representation_contract_profiles_from_concept_ids(
+        requested_profile_concept_ids
+    )
+
+    normalised_profiles: list[dict[str, Any]] = []
+    for profile in loaded_profiles:
+        if not isinstance(profile, Mapping):
+            continue
+        profile_payload = dict(profile)
+        profile_payload["profile_id"] = _safe_str(profile_payload.get("profile_id")) or ""
+        profile_payload["profile_concept_id"] = _safe_str(
+            profile_payload.get("profile_concept_id")
+        ) or _safe_str(profile_payload.get("_source_concept_id"))
+        profile_payload["target_entity_class"] = (
+            _safe_str(profile_payload.get("target_entity_class")) or "thing"
+        )
+        profile_payload["effect_type"] = (
+            _safe_str(profile_payload.get("effect_type"))
+            or "representation_profile_guard"
+        )
+        profile_payload["description"] = (
+            _safe_str(profile_payload.get("description"))
+            or "Ensure the requested representation is materialised from the artefact context."
+        )
+        profile_payload["intent_patterns"] = _dedupe_string_sequence(
+            profile_payload.get("intent_patterns") or []
+        )
+        profile_payload["domain_terms"] = _dedupe_string_sequence(
+            profile_payload.get("domain_terms") or []
+        )
+        profile_payload["required_predicates"] = _dedupe_string_sequence(
+            profile_payload.get("required_predicates") or []
+        )
+
+        normalised_tools_by_source: dict[str, list[str]] = {}
+        raw_tools_by_source = profile_payload.get("required_tools_by_source")
+        if isinstance(raw_tools_by_source, Mapping):
+            for source, raw_tools in raw_tools_by_source.items():
+                source_key = (_safe_str(source) or "").lower()
+                if not source_key:
+                    continue
+                if isinstance(raw_tools, Sequence) and not isinstance(raw_tools, (str, bytes)):
+                    normalised_tools_by_source[source_key] = _dedupe_string_sequence(raw_tools)
+        profile_payload["required_tools_by_source"] = normalised_tools_by_source
+        profile_payload["default_decision_policy"] = _normalise_representation_decision_policy(
+            profile_payload.get("default_decision_policy")
+        )
+
+        if not profile_payload["profile_id"]:
+            continue
+        normalised_profiles.append(profile_payload)
+
+    diagnostics_payload = dict(diagnostics) if isinstance(diagnostics, Mapping) else {}
+    diagnostics_payload.setdefault(
+        "representation_profile_source",
+        "vontology_concept_text_relations",
+    )
+    diagnostics_payload.setdefault(
+        "requested_concept_ids",
+        list(requested_profile_concept_ids),
+    )
+    diagnostics_payload["loaded_profile_count"] = len(normalised_profiles)
+    if not _safe_str(diagnostics_payload.get("profile_version_hash")):
+        diagnostics_payload["profile_version_hash"] = _hash_payload(normalised_profiles)
+    return normalised_profiles, diagnostics_payload
+
+
 def _infer_representation_artefact_source(
     *,
     file_copy_ids: Sequence[str],
@@ -1114,28 +1092,63 @@ def _prompt_requests_representation_action(prompt_text: str) -> bool:
         if not re.search(r"\b(?:can|could|would)\s+you\b|\bplease\b", lowered):
             return False
     if _REPRESENTATION_ACTION_PATTERN.search(lowered):
+        if _REPRESENTATION_CREATE_ONLY_PATTERN.search(lowered) and not _contains_any_phrase(
+            lowered,
+            _REPRESENTATION_CREATE_OBJECT_CUES,
+        ):
+            return False
         return True
-    return _contains_any_phrase(lowered, ("representation", "materialisation", "model"))
+    return _contains_any_phrase(
+        lowered,
+        ("representation", "materialisation", "model", "profile", "metadata"),
+    )
 
 
-def _select_representation_domain_profile(prompt_text: str) -> dict[str, Any] | None:
+def _compile_representation_intent_patterns(patterns: Any) -> list[re.Pattern[str]]:
+    if not isinstance(patterns, Sequence) or isinstance(patterns, (str, bytes)):
+        return []
+    compiled_patterns: list[re.Pattern[str]] = []
+    for raw_pattern in patterns:
+        pattern_text = _safe_str(raw_pattern)
+        if not pattern_text:
+            continue
+        try:
+            compiled_patterns.append(re.compile(pattern_text, flags=re.IGNORECASE))
+        except Exception:
+            continue
+    return compiled_patterns
+
+
+def _select_representation_domain_profile(
+    prompt_text: str,
+    *,
+    profiles: Sequence[Mapping[str, Any]],
+) -> dict[str, Any] | None:
     lowered = prompt_text.lower()
     best_profile: dict[str, Any] | None = None
     best_score = 0
 
-    for profile in _REPRESENTATION_DOMAIN_PROFILES:
+    for profile in profiles:
+        if not isinstance(profile, Mapping):
+            continue
         score = 0
-        intent_pattern = profile.get("intent_pattern")
-        if isinstance(intent_pattern, re.Pattern) and intent_pattern.search(prompt_text):
-            score += 4
+        intent_patterns = _compile_representation_intent_patterns(
+            profile.get("intent_patterns")
+        )
+        for intent_pattern in intent_patterns:
+            if intent_pattern.search(prompt_text):
+                score += 4
+
         domain_terms = profile.get("domain_terms")
-        if isinstance(domain_terms, Sequence):
+        if isinstance(domain_terms, Sequence) and not isinstance(
+            domain_terms, (str, bytes)
+        ):
             for term in domain_terms:
                 if isinstance(term, str) and term and term in lowered:
                     score += 1
         if score > best_score:
             best_score = score
-            best_profile = profile
+            best_profile = dict(profile)
 
     if best_profile is None or best_score <= 0:
         return None
@@ -1165,10 +1178,8 @@ def _build_representation_required_effect_template(
     targets: Sequence[str],
 ) -> dict[str, Any]:
     profile_id = _safe_str(profile.get("profile_id")) or "representation"
-    effect_type = (
-        _safe_str(profile.get("effect_type"))
-        or f"representation_{profile_id}"
-    )
+    profile_concept_id = _safe_str(profile.get("profile_concept_id"))
+    effect_type = _safe_str(profile.get("effect_type")) or f"representation_{profile_id}"
     description = (
         _safe_str(profile.get("description"))
         or "Ensure the requested representation is materialised from the artefact context."
@@ -1184,12 +1195,37 @@ def _build_representation_required_effect_template(
         "intent_origin": "workflow_contract",
         "effect_type": effect_type,
         "representation_domain_id": profile_id,
+        "representation_profile_concept_id": profile_concept_id,
         "description": description,
         "required_tools": _dedupe_string_sequence(required_tools),
         "targets": _dedupe_string_sequence(targets),
         "required_predicates": _dedupe_string_sequence(required_predicates),
         "postcondition_required": True,
         "postcondition_strategy": "execution_observed",
+    }
+
+
+def _build_fail_closed_representation_effect(
+    *,
+    failure_code: str,
+    status_reason: str,
+    targets: Sequence[str],
+) -> dict[str, Any]:
+    return {
+        "effect_id": "effect_representation_contract_guard_1",
+        "intent_origin": "workflow_contract",
+        "effect_type": "representation_contract_guard",
+        "representation_domain_id": "representation",
+        "description": "Required representation contract profile resolution failed.",
+        "required_tools": [],
+        "targets": _dedupe_string_sequence(targets),
+        "required_predicates": [],
+        "postcondition_required": True,
+        "postcondition_strategy": "execution_observed",
+        "status": "not_executed",
+        "status_reason": status_reason,
+        "failure_code": failure_code,
+        "failure_codes": [failure_code],
     }
 
 
@@ -1204,10 +1240,6 @@ def _build_representation_required_effects_contract(
     if not _prompt_requests_representation_action(prompt_clean):
         return None
 
-    profile = _select_representation_domain_profile(prompt_clean)
-    if profile is None:
-        return None
-
     file_copy_ids = _extract_required_file_copy_ids_from_aux(aux_llm_calls)
     if not file_copy_ids:
         file_copy_ids = _extract_file_copy_concept_ids_from_text(prompt_clean)
@@ -1218,24 +1250,130 @@ def _build_representation_required_effects_contract(
         urls=urls,
         source_hints=source_hints,
     )
+    targets = list(file_copy_ids) if file_copy_ids else list(urls)
 
-    required_tools = _resolve_representation_required_tools(
-        profile=profile,
-        artefact_source=artefact_source,
+    profiles, profile_loading = _load_representation_domain_profiles_from_vontology()
+    selected_profile = _select_representation_domain_profile(
+        prompt_clean,
+        profiles=profiles,
     )
 
-    targets = list(file_copy_ids) if file_copy_ids else list(urls)
+    profile_source = (
+        _safe_str(profile_loading.get("representation_profile_source"))
+        or "vontology_concept_text_relations"
+    )
+    profile_version_hash = _safe_str(profile_loading.get("profile_version_hash"))
+    requested_profile_concept_ids = _dedupe_string_sequence(
+        profile_loading.get("requested_concept_ids") or []
+    )
+    loaded_profile_concept_ids = _dedupe_string_sequence(
+        profile_loading.get("loaded_concept_ids") or []
+    )
+    selected_profile_concept_id = (
+        _safe_str(selected_profile.get("profile_concept_id"))
+        if isinstance(selected_profile, Mapping)
+        else None
+    )
+    profile_resolution: dict[str, Any] = {
+        "source": profile_source,
+        "requested_profile_concept_ids": requested_profile_concept_ids,
+        "loaded_profile_concept_ids": loaded_profile_concept_ids,
+        "loaded_profile_count": len(profiles),
+        "profile_version_hash": profile_version_hash,
+        "selected_profile_concept_id": selected_profile_concept_id,
+        "fail_closed": False,
+        "fail_closed_reason": None,
+    }
+
+    if not profiles:
+        fail_closed_reason = "profile_catalogue_unavailable"
+        profile_resolution["fail_closed"] = True
+        profile_resolution["fail_closed_reason"] = fail_closed_reason
+        effect_template = _build_fail_closed_representation_effect(
+            failure_code=_REPRESENTATION_CONFIG_UNAVAILABLE_FAILURE_CODE,
+            status_reason=(
+                "Representation intent was recognised, but the Vontology "
+                "representation profile catalogue could not be resolved."
+            ),
+            targets=targets,
+        )
+        contract_payload: dict[str, Any] = {
+            "schema_version": _REPRESENTATION_CONTRACT_SCHEMA_VERSION,
+            "intent_class": "representation",
+            "domain_profile_id": "representation",
+            "target_entity_class": "thing",
+            "artefact_source": artefact_source,
+            "artefact_context": {
+                "file_copy_ids": list(file_copy_ids),
+                "urls": list(urls),
+                "source_hints": list(source_hints),
+            },
+            "required_effects": [effect_template],
+            "default_decision_policy": dict(
+                _REPRESENTATION_DEFAULT_DECISION_POLICY_FALLBACK
+            ),
+            "profile_source": profile_source,
+            "profile_version_hash": profile_version_hash,
+            "profile_resolution": profile_resolution,
+        }
+        contract_fingerprint = _hash_payload(contract_payload) or ""
+        contract_payload["contract_id"] = f"required_effects_{contract_fingerprint[:16]}"
+        return contract_payload
+
+    if not isinstance(selected_profile, Mapping):
+        fail_closed_reason = "profile_unmatched_for_intent"
+        profile_resolution["fail_closed"] = True
+        profile_resolution["fail_closed_reason"] = fail_closed_reason
+        effect_template = _build_fail_closed_representation_effect(
+            failure_code=_REPRESENTATION_PROFILE_UNMATCHED_FAILURE_CODE,
+            status_reason=(
+                "Representation intent was recognised, but no Vontology "
+                "representation profile matched this prompt."
+            ),
+            targets=targets,
+        )
+        contract_payload = {
+            "schema_version": _REPRESENTATION_CONTRACT_SCHEMA_VERSION,
+            "intent_class": "representation",
+            "domain_profile_id": "representation",
+            "target_entity_class": "thing",
+            "artefact_source": artefact_source,
+            "artefact_context": {
+                "file_copy_ids": list(file_copy_ids),
+                "urls": list(urls),
+                "source_hints": list(source_hints),
+            },
+            "required_effects": [effect_template],
+            "default_decision_policy": dict(
+                _REPRESENTATION_DEFAULT_DECISION_POLICY_FALLBACK
+            ),
+            "profile_source": profile_source,
+            "profile_version_hash": profile_version_hash,
+            "profile_resolution": profile_resolution,
+        }
+        contract_fingerprint = _hash_payload(contract_payload) or ""
+        contract_payload["contract_id"] = f"required_effects_{contract_fingerprint[:16]}"
+        return contract_payload
+
+    required_tools = _resolve_representation_required_tools(
+        profile=selected_profile,
+        artefact_source=artefact_source,
+    )
     effect_template = _build_representation_required_effect_template(
-        profile=profile,
+        profile=selected_profile,
         required_tools=required_tools,
         targets=targets,
+    )
+    default_decision_policy = _normalise_representation_decision_policy(
+        selected_profile.get("default_decision_policy")
     )
 
     contract_payload: dict[str, Any] = {
         "schema_version": _REPRESENTATION_CONTRACT_SCHEMA_VERSION,
         "intent_class": "representation",
-        "domain_profile_id": _safe_str(profile.get("profile_id")) or "representation",
-        "target_entity_class": _safe_str(profile.get("target_entity_class")) or "thing",
+        "domain_profile_id": _safe_str(selected_profile.get("profile_id")) or "representation",
+        "domain_profile_concept_id": _safe_str(selected_profile.get("profile_concept_id")),
+        "target_entity_class": _safe_str(selected_profile.get("target_entity_class")) or "thing",
         "artefact_source": artefact_source,
         "artefact_context": {
             "file_copy_ids": list(file_copy_ids),
@@ -1243,7 +1381,10 @@ def _build_representation_required_effects_contract(
             "source_hints": list(source_hints),
         },
         "required_effects": [effect_template],
-        "default_decision_policy": dict(_REPRESENTATION_DEFAULT_DECISION_POLICY),
+        "default_decision_policy": default_decision_policy,
+        "profile_source": profile_source,
+        "profile_version_hash": profile_version_hash,
+        "profile_resolution": profile_resolution,
     }
     contract_fingerprint = _hash_payload(contract_payload) or ""
     contract_payload["contract_id"] = f"required_effects_{contract_fingerprint[:16]}"
@@ -1282,9 +1423,19 @@ def _materialise_required_effects_from_contract(
         effect = dict(template)
         required_tools = _dedupe_string_sequence(effect.get("required_tools") or [])
 
-        effect_status = "not_executed"
-        status_reason = "No required representation tool execution was observed."
-        failure_code = f"{domain_id}_representation_not_executed"
+        existing_status = (_safe_str(effect.get("status")) or "").lower()
+        effect_status = (
+            existing_status
+            if existing_status in {"satisfied", "not_satisfied", "not_executed"}
+            else "not_executed"
+        )
+        status_reason = _safe_str(effect.get("status_reason")) or (
+            "No required representation tool execution was observed."
+        )
+        failure_codes = _normalise_failure_codes(effect.get("failure_codes"))
+        explicit_failure_code = _safe_str(effect.get("failure_code"))
+        if explicit_failure_code and explicit_failure_code not in failure_codes:
+            failure_codes.append(explicit_failure_code)
 
         first_success_tool = next(
             (tool for tool in required_tools if tool.lower() in successful_lookup),
@@ -1296,7 +1447,7 @@ def _materialise_required_effects_from_contract(
                 "Observed required representation tool invocation: "
                 f"{first_success_tool}."
             )
-            failure_code = ""
+            failure_codes = []
         else:
             first_failed_tool = next(
                 (
@@ -1312,14 +1463,19 @@ def _materialise_required_effects_from_contract(
                     "Required representation tool failed or was blocked: "
                     f"{first_failed_tool}."
                 )
-                failure_code = f"{domain_id}_representation_tool_failed"
+                failure_codes = [f"{domain_id}_representation_tool_failed"]
+            elif not required_tools and not failure_codes:
+                failure_codes = [f"{domain_id}_representation_not_executed"]
+            elif required_tools:
+                failure_codes = [f"{domain_id}_representation_not_executed"]
 
         effect["status"] = effect_status
         effect["status_reason"] = status_reason
-        if failure_code:
-            effect["failure_code"] = failure_code
-            effect["failure_codes"] = [failure_code]
+        if failure_codes:
+            effect["failure_code"] = failure_codes[0]
+            effect["failure_codes"] = failure_codes
         else:
+            effect.pop("failure_code", None)
             effect["failure_codes"] = []
 
         required_effects.append(effect)
@@ -1615,9 +1771,20 @@ def _derive_completion_gate(
             decision_reason = "Mutation attempt failed or was blocked."
         else:
             decision = "escalation_required"
+            representation_failure_reason = next(
+                (
+                    _REPRESENTATION_FAILURE_REASON_MAP.get(code)
+                    for code in blocking_failure_codes
+                    if isinstance(code, str) and code in _REPRESENTATION_FAILURE_REASON_MAP
+                ),
+                None,
+            )
             if unresolved_effect_types == {"tool_execution"}:
                 decision_reason = "Required tool execution was not observed."
-            elif unresolved_effect_types == {"scholarly_representation"}:
+            elif (
+                unresolved_effect_types == {"scholarly_representation"}
+                and not representation_failure_reason
+            ):
                 decision_reason = (
                     "Required scholarly paper representation was not executed."
                 )
@@ -1625,7 +1792,10 @@ def _derive_completion_gate(
                 _is_representation_effect_type(effect_type)
                 for effect_type in unresolved_effect_types
             ):
-                decision_reason = "Required representation was not executed."
+                decision_reason = (
+                    representation_failure_reason
+                    or "Required representation was not executed."
+                )
             else:
                 decision_reason = "Required mutation was not executed."
     elif unresolved_check_ids:
@@ -1832,12 +2002,38 @@ def build_turn_execution_record(
         execution_summary_with_contract["required_effects_contract_domain"] = _safe_str(
             representation_effects_contract.get("domain_profile_id")
         )
+        execution_summary_with_contract["required_effects_contract_domain_concept_id"] = _safe_str(
+            representation_effects_contract.get("domain_profile_concept_id")
+        )
         execution_summary_with_contract["required_effects_contract_intent"] = _safe_str(
             representation_effects_contract.get("intent_class")
+        )
+        execution_summary_with_contract["required_effects_contract_profile_source"] = _safe_str(
+            representation_effects_contract.get("profile_source")
+        )
+        execution_summary_with_contract["required_effects_contract_profile_version_hash"] = _safe_str(
+            representation_effects_contract.get("profile_version_hash")
         )
         execution_summary_with_contract["required_effects_declared_count"] = len(
             representation_effects_contract.get("required_effects") or []
         )
+        profile_resolution = representation_effects_contract.get("profile_resolution")
+        if isinstance(profile_resolution, Mapping):
+            execution_summary_with_contract["required_effects_contract_profile_requested_ids"] = _dedupe_string_sequence(
+                profile_resolution.get("requested_profile_concept_ids") or []
+            )
+            execution_summary_with_contract["required_effects_contract_profile_loaded_ids"] = _dedupe_string_sequence(
+                profile_resolution.get("loaded_profile_concept_ids") or []
+            )
+            execution_summary_with_contract["required_effects_contract_profile_selected_id"] = _safe_str(
+                profile_resolution.get("selected_profile_concept_id")
+            )
+            execution_summary_with_contract["required_effects_contract_fail_closed"] = bool(
+                profile_resolution.get("fail_closed")
+            )
+            execution_summary_with_contract["required_effects_contract_fail_closed_reason"] = _safe_str(
+                profile_resolution.get("fail_closed_reason")
+            )
 
     return {
         "schema_version": TURN_EXECUTION_RECORD_SCHEMA_VERSION,

--- a/tests/backend/test_orchestrator_turn_execution_gate.py
+++ b/tests/backend/test_orchestrator_turn_execution_gate.py
@@ -69,6 +69,51 @@ def _build_request(
     )
 
 
+def _patch_representation_profile_loader(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "src.backend.services.turn_execution_record_service._load_representation_domain_profiles_from_vontology",
+        lambda: (
+            [
+                {
+                    "profile_id": "paper",
+                    "profile_concept_id": "#V#representation_contract_profile_paper",
+                    "target_entity_class": "scholarly_paper",
+                    "effect_type": "scholarly_representation",
+                    "description": "Represent paper metadata.",
+                    "intent_patterns": [
+                        r"\bpaper\s+representation\b",
+                        r"\bcorresponding\s+paper\b",
+                    ],
+                    "domain_terms": ["paper", "arxiv", "metadata", "abstract"],
+                    "required_tools_by_source": {
+                        "file_copy": ["interpret_file_copy"],
+                        "url": ["extract_url", "get_paper_metadata"],
+                        "mixed": ["interpret_file_copy", "extract_url"],
+                        "unknown": ["interpret_file_copy"],
+                    },
+                    "required_predicates": [
+                        "#V#computer_file_for_propositional_information_thing",
+                        "#V#propositional_information_thing_has_computer_file",
+                    ],
+                    "default_decision_policy": {
+                        "completion_block_on_unresolved_effects": True,
+                        "fail_closed_on_missing_requirements": True,
+                        "auto_apply_low_risk_defaults": True,
+                        "requires_explicit_user_decision_for_high_risk": True,
+                    },
+                }
+            ],
+            {
+                "representation_profile_source": "vontology_concept_text_relations",
+                "requested_concept_ids": ["#V#representation_contract_profile_paper"],
+                "loaded_concept_ids": ["#V#representation_contract_profile_paper"],
+                "loaded_profile_count": 1,
+                "profile_version_hash": "hash-paper-profile",
+            },
+        ),
+    )
+
+
 def test_turn_execution_critic_detects_unresolved_kb_mutation() -> None:
     orchestrator = _build_orchestrator()
     aux_llm_calls: list[dict[str, Any]] = []
@@ -393,7 +438,8 @@ def test_turn_execution_critic_flags_worker_unavailable_zero_execution() -> None
     assert completion_gate.get("safe_to_claim_completion") is False
 
 
-def test_turn_execution_critic_flags_missing_scholarly_representation() -> None:
+def test_turn_execution_critic_flags_missing_scholarly_representation(monkeypatch) -> None:
+    _patch_representation_profile_loader(monkeypatch)
     orchestrator = _build_orchestrator()
     request = _build_request(
         action_id="turn_execution.critic",
@@ -445,7 +491,8 @@ def test_turn_execution_critic_flags_missing_scholarly_representation() -> None:
     assert completion_gate.get("safe_to_claim_completion") is False
 
 
-def test_turn_execution_critic_marks_scholarly_representation_satisfied() -> None:
+def test_turn_execution_critic_marks_scholarly_representation_satisfied(monkeypatch) -> None:
+    _patch_representation_profile_loader(monkeypatch)
     orchestrator = _build_orchestrator()
     request = _build_request(
         action_id="turn_execution.critic",

--- a/tests/backend/test_representation_contract_vontology_service.py
+++ b/tests/backend/test_representation_contract_vontology_service.py
@@ -1,0 +1,187 @@
+from src.backend.services import representation_contract_vontology_service as service
+
+
+def test_canonical_representation_profile_concept_ids_are_deterministic() -> None:
+    concept_ids = service.canonical_representation_profile_concept_ids()
+    assert concept_ids == (
+        "#V#representation_contract_profile_paper",
+        "#V#representation_contract_profile_person",
+        "#V#representation_contract_profile_company",
+        "#V#representation_contract_profile_meeting",
+    )
+
+
+def test_load_representation_profiles_from_concept_ids_parses_profile_json(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        service,
+        "get_concept_by_concept_id",
+        lambda concept_id: {"concept_id": concept_id, "relationships": {}},
+    )
+    monkeypatch.setattr(
+        service,
+        "get_texts_for_concept",
+        lambda concept_id, predicate=None, limit=20: [
+            {
+                "predicate": predicate,
+                "text": (
+                    "{"
+                    '"profile_id":"paper",'
+                    '"target_entity_class":"scholarly_paper",'
+                    '"effect_type":"scholarly_representation",'
+                    '"description":"Represent paper metadata.",'
+                    '"intent_patterns":["\\\\bpaper\\\\s+representation\\\\b"],'
+                    '"domain_terms":["paper","arxiv"],'
+                    '"required_tools_by_source":{"file_copy":["interpret_file_copy"]},'
+                    '"required_predicates":["#V#paper"],'
+                    '"default_decision_policy":{"completion_block_on_unresolved_effects":true}'
+                    "}"
+                ),
+            }
+        ]
+        if predicate == "#V#has_representation_contract_profile_json"
+        else [],
+    )
+
+    profiles, diagnostics = service.load_representation_contract_profiles_from_concept_ids(
+        ["#V#representation_contract_profile_paper"]
+    )
+
+    assert len(profiles) == 1
+    assert profiles[0]["profile_id"] == "paper"
+    assert profiles[0]["target_entity_class"] == "scholarly_paper"
+    assert profiles[0]["required_tools_by_source"]["file_copy"] == [
+        "interpret_file_copy"
+    ]
+    assert diagnostics["loaded_concept_ids"] == [
+        "#V#representation_contract_profile_paper"
+    ]
+    assert diagnostics["loaded_profile_count"] == 1
+    assert isinstance(diagnostics.get("profile_version_hash"), str)
+
+
+def test_load_representation_profiles_reports_malformed_profile_json(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        service,
+        "get_concept_by_concept_id",
+        lambda concept_id: {"concept_id": concept_id, "relationships": {}},
+    )
+    monkeypatch.setattr(
+        service,
+        "get_texts_for_concept",
+        lambda concept_id, predicate=None, limit=20: [
+            {
+                "predicate": predicate,
+                "text": "{not valid json}",
+            }
+        ]
+        if predicate == "#V#has_representation_contract_profile_json"
+        else [],
+    )
+
+    profiles, diagnostics = service.load_representation_contract_profiles_from_concept_ids(
+        ["#V#representation_contract_profile_paper"]
+    )
+
+    assert profiles == []
+    assert diagnostics["loaded_profile_count"] == 0
+    assert diagnostics["missing_profile_concept_ids"] == []
+    assert diagnostics["malformed_profile_concept_ids"] == [
+        "#V#representation_contract_profile_paper"
+    ]
+    malformed = diagnostics["malformed_profile_entries"]
+    assert isinstance(malformed, list) and malformed
+    assert malformed[0]["concept_id"] == "#V#representation_contract_profile_paper"
+    assert "json_decode_failed" in malformed[0]["error"]
+
+
+def test_upsert_representation_profile_validates_and_persists_singleton_text(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        service,
+        "get_concept_by_concept_id",
+        lambda concept_id: {"concept_id": concept_id, "relationships": {}},
+    )
+    monkeypatch.setattr(
+        service,
+        "upsert_singleton_text_relation",
+        lambda **kwargs: {
+            "success": True,
+            "concept_id": kwargs["subject_concept_id"],
+            "predicate": kwargs["predicate"],
+            "language": kwargs["lang"],
+            "kept_relation_id": "rel_1",
+            "replaced_relation_ids": [],
+            "replaced_count": 0,
+            "relation_created": True,
+            "text_value_id": "tv_1",
+        },
+    )
+
+    result = service.upsert_representation_contract_profile(
+        profile_concept_id="#V#representation_contract_profile_paper",
+        representation_profile={
+            "profile_id": "paper",
+            "target_entity_class": "scholarly_paper",
+            "effect_type": "scholarly_representation",
+            "intent_patterns": [r"\bpaper\s+representation\b"],
+            "domain_terms": ["paper", "arxiv"],
+            "required_tools_by_source": {"file_copy": ["interpret_file_copy"]},
+            "required_predicates": ["#V#paper"],
+        },
+    )
+
+    assert result["success"] is True
+    assert (
+        result["profile_concept_id"] == "#V#representation_contract_profile_paper"
+    )
+    assert result["representation_profile"]["profile_id"] == "paper"
+    assert result["text_relation"]["kept_relation_id"] == "rel_1"
+
+
+def test_bootstrap_canonical_representation_profiles_persists_existing_only(
+    monkeypatch,
+) -> None:
+    existing_concepts = {
+        "#V#representation_contract_profile_paper",
+        "#V#representation_contract_profile_person",
+    }
+    monkeypatch.setattr(
+        service,
+        "get_concept_by_concept_id",
+        lambda concept_id: {"concept_id": concept_id, "relationships": {}}
+        if concept_id in existing_concepts
+        else None,
+    )
+    persisted: list[str] = []
+    monkeypatch.setattr(
+        service,
+        "upsert_representation_contract_profile",
+        lambda **kwargs: (
+            persisted.append(kwargs["profile_concept_id"]),
+            {"success": True},
+        )[1],
+    )
+
+    report = service.bootstrap_canonical_representation_contract_profiles(
+        concept_ids=[
+            "#V#representation_contract_profile_paper",
+            "#V#representation_contract_profile_person",
+            "#V#representation_contract_profile_company",
+        ]
+    )
+
+    assert report["success"] is False
+    assert set(report["persisted_profile_concept_ids"]) == {
+        "#V#representation_contract_profile_paper",
+        "#V#representation_contract_profile_person",
+    }
+    assert report["missing_concept_ids"] == ["#V#representation_contract_profile_company"]
+    assert set(persisted) == {
+        "#V#representation_contract_profile_paper",
+        "#V#representation_contract_profile_person",
+    }

--- a/tests/backend/test_turn_execution_required_effects_contract.py
+++ b/tests/backend/test_turn_execution_required_effects_contract.py
@@ -3,6 +3,118 @@ from __future__ import annotations
 from src.backend.services.turn_execution_record_service import build_turn_execution_record
 
 
+def _representation_profiles() -> list[dict]:
+    default_policy = {
+        "completion_block_on_unresolved_effects": True,
+        "fail_closed_on_missing_requirements": True,
+        "auto_apply_low_risk_defaults": True,
+        "requires_explicit_user_decision_for_high_risk": True,
+    }
+    return [
+        {
+            "profile_id": "paper",
+            "profile_concept_id": "#V#representation_contract_profile_paper",
+            "target_entity_class": "scholarly_paper",
+            "effect_type": "scholarly_representation",
+            "description": "Represent scholarly paper metadata.",
+            "intent_patterns": [r"\bpaper\s+representation\b", r"\bcorresponding\s+paper\b"],
+            "domain_terms": ["paper", "arxiv", "abstract", "metadata"],
+            "required_tools_by_source": {
+                "file_copy": ["interpret_file_copy"],
+                "url": ["extract_url", "get_paper_metadata"],
+                "mixed": ["interpret_file_copy", "extract_url"],
+                "unknown": ["interpret_file_copy"],
+            },
+            "required_predicates": [
+                "#V#computer_file_for_propositional_information_thing",
+                "#V#propositional_information_thing_has_computer_file",
+            ],
+            "default_decision_policy": default_policy,
+        },
+        {
+            "profile_id": "person",
+            "profile_concept_id": "#V#representation_contract_profile_person",
+            "target_entity_class": "person",
+            "effect_type": "representation_person",
+            "description": "Represent person information from artefacts.",
+            "intent_patterns": [
+                r"\b(?:business\s+card|cv|curriculum\s+vitae|resume)\b.*\b(?:person|profile|contact)"
+            ],
+            "domain_terms": ["person", "business card", "cv", "resume", "contact"],
+            "required_tools_by_source": {
+                "file_copy": ["interpret_file_copy"],
+                "url": ["extract_url"],
+                "mixed": ["interpret_file_copy", "extract_url"],
+                "unknown": ["interpret_file_copy"],
+            },
+            "required_predicates": ["#V#person"],
+            "default_decision_policy": default_policy,
+        },
+        {
+            "profile_id": "company",
+            "profile_concept_id": "#V#representation_contract_profile_company",
+            "target_entity_class": "company",
+            "effect_type": "representation_company",
+            "description": "Represent company information from artefacts.",
+            "intent_patterns": [
+                r"\b(?:company|organisation|organization|business|startup)\b.*\b(?:web\s?page|website|url)"
+            ],
+            "domain_terms": ["company", "organisation", "business", "website", "url"],
+            "required_tools_by_source": {
+                "file_copy": ["interpret_file_copy"],
+                "url": ["extract_url"],
+                "mixed": ["interpret_file_copy", "extract_url"],
+                "unknown": ["extract_url"],
+            },
+            "required_predicates": ["#V#organisation"],
+            "default_decision_policy": default_policy,
+        },
+        {
+            "profile_id": "meeting",
+            "profile_concept_id": "#V#representation_contract_profile_meeting",
+            "target_entity_class": "meeting",
+            "effect_type": "representation_meeting",
+            "description": "Represent meeting information from artefacts.",
+            "intent_patterns": [
+                r"\b(?:meeting|calendar\s+event)\b.*\b(?:transcript|calendar|minutes|agenda)"
+            ],
+            "domain_terms": ["meeting", "transcript", "calendar", "minutes", "agenda"],
+            "required_tools_by_source": {
+                "file_copy": ["interpret_file_copy"],
+                "url": ["extract_url"],
+                "mixed": ["interpret_file_copy", "extract_url"],
+                "unknown": ["interpret_file_copy"],
+            },
+            "required_predicates": ["#V#meeting"],
+            "default_decision_policy": default_policy,
+        },
+    ]
+
+
+def _patch_representation_profile_loader(monkeypatch, *, profiles: list[dict]) -> None:
+    monkeypatch.setattr(
+        "src.backend.services.turn_execution_record_service._load_representation_domain_profiles_from_vontology",
+        lambda: (
+            profiles,
+            {
+                "representation_profile_source": "vontology_concept_text_relations",
+                "requested_concept_ids": [
+                    profile.get("profile_concept_id")
+                    for profile in profiles
+                    if isinstance(profile, dict)
+                ],
+                "loaded_concept_ids": [
+                    profile.get("profile_concept_id")
+                    for profile in profiles
+                    if isinstance(profile, dict)
+                ],
+                "loaded_profile_count": len(profiles),
+                "profile_version_hash": "hash-test-profiles",
+            },
+        ),
+    )
+
+
 def _build_record(**overrides):
     payload = {
         "request_id": "req-contract-1",
@@ -28,7 +140,10 @@ def _build_record(**overrides):
     return build_turn_execution_record(**payload)
 
 
-def test_paper_representation_contract_emitted_with_required_effects() -> None:
+def test_paper_representation_contract_emitted_with_required_effects(monkeypatch) -> None:
+    _patch_representation_profile_loader(
+        monkeypatch, profiles=_representation_profiles()
+    )
     record = _build_record(
         aux_llm_calls=[
             {
@@ -60,7 +175,10 @@ def test_paper_representation_contract_emitted_with_required_effects() -> None:
     assert effect.get("targets") == ["#V#uploaded_file_copy_abc123"]
 
 
-def test_person_company_meeting_profiles_generate_non_empty_effects() -> None:
+def test_person_company_meeting_profiles_generate_non_empty_effects(monkeypatch) -> None:
+    _patch_representation_profile_loader(
+        monkeypatch, profiles=_representation_profiles()
+    )
     person_record = _build_record(
         prompt_text="Create a person profile from this CV file #V#uploaded_file_copy_person_1."
     )
@@ -103,7 +221,10 @@ def test_person_company_meeting_profiles_generate_non_empty_effects() -> None:
     assert meeting_effects[0].get("effect_type") == "representation_meeting"
 
 
-def test_representation_contract_is_idempotent_for_same_prompt_and_context() -> None:
+def test_representation_contract_is_idempotent_for_same_prompt_and_context(monkeypatch) -> None:
+    _patch_representation_profile_loader(
+        monkeypatch, profiles=_representation_profiles()
+    )
     common_payload = {
         "request_id": "req-contract-idempotent",
         "session_id": "session-contract-idempotent",
@@ -122,7 +243,10 @@ def test_representation_contract_is_idempotent_for_same_prompt_and_context() -> 
     assert contract_a == contract_b
 
 
-def test_status_question_does_not_emit_representation_contract() -> None:
+def test_status_question_does_not_emit_representation_contract(monkeypatch) -> None:
+    _patch_representation_profile_loader(
+        monkeypatch, profiles=_representation_profiles()
+    )
     record = _build_record(
         prompt_text=(
             "Did you make a scientific paper concept for "
@@ -138,3 +262,46 @@ def test_status_question_does_not_emit_representation_contract() -> None:
     execution = record.get("execution")
     assert isinstance(execution, dict)
     assert execution.get("required_effects_contract") is None
+
+
+def test_representation_contract_fails_closed_when_profile_catalogue_unavailable(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "src.backend.services.turn_execution_record_service._load_representation_domain_profiles_from_vontology",
+        lambda: (
+            [],
+            {
+                "representation_profile_source": "vontology_concept_text_relations",
+                "requested_concept_ids": [
+                    "#V#representation_contract_profile_paper",
+                    "#V#representation_contract_profile_person",
+                ],
+                "loaded_concept_ids": [],
+                "loaded_profile_count": 0,
+                "profile_version_hash": None,
+            },
+        ),
+    )
+
+    record = _build_record(
+        prompt_text=(
+            "Fully represent the corresponding paper from "
+            "#V#uploaded_file_copy_abc123."
+        )
+    )
+
+    execution = record.get("execution") or {}
+    contract = execution.get("required_effects_contract") or {}
+    assert contract.get("domain_profile_id") == "representation"
+    assert contract.get("profile_source") == "vontology_concept_text_relations"
+    profile_resolution = contract.get("profile_resolution") or {}
+    assert profile_resolution.get("fail_closed") is True
+    assert profile_resolution.get("fail_closed_reason") == "profile_catalogue_unavailable"
+
+    required_effects = record.get("required_effects") or []
+    assert required_effects
+    effect = required_effects[0]
+    assert effect.get("effect_type") == "representation_contract_guard"
+    assert effect.get("status") == "not_executed"
+    assert effect.get("failure_code") == "representation_profile_catalogue_unavailable"


### PR DESCRIPTION
## Summary
- add epresentation_contract_vontology_service to load, validate, bootstrap, and upsert representation contract profiles from Vontology text relations
- refactor 	urn_execution_record_service to consume Vontology-loaded profiles for representation required-effects contracts (paper/person/company/meeting)
- enforce fail-closed behaviour when profile catalogue is unavailable or no profile matches a recognised representation intent, with explicit failure codes and completion-gate reasons
- add contract telemetry for profile source, version hash, requested/loaded/selected profile IDs, and fail-closed reason
- add bootstrap script scripts/bootstrap_representation_contract_profiles.py to materialise profile concepts + singleton profile JSON in Vontology
- add/adjust targeted tests for loader behaviour, fail-closed contract generation, and orchestrator gate coverage

## Validation
- pdm run pyright src/backend/services/turn_execution_record_service.py src/backend/services/representation_contract_vontology_service.py tests/backend/test_orchestrator_turn_execution_gate.py tests/backend/test_turn_execution_required_effects_contract.py tests/backend/test_representation_contract_vontology_service.py scripts/bootstrap_representation_contract_profiles.py
- VON_DB_NAME=test_von_db pdm run pytest tests/backend/test_representation_contract_vontology_service.py tests/backend/test_turn_execution_required_effects_contract.py tests/backend/test_orchestrator_turn_execution_gate.py

## Notes
- attempted to run pdm run python scripts/bootstrap_representation_contract_profiles.py in this environment, but Vontology Mongo connectivity was unavailable (Database collection 'concepts' not available / Atlas TLS handshake failure). The script and fail-closed runtime behaviour are in place for immediate execution once connectivity is restored.