### PR TITLE
JVNAUTOSCI-1371: enforce completion-gate failure-code blocking

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -5215,6 +5215,25 @@ class InternalMCPChatOrchestrator:
                 for code in _normalise_string_list(unresolved.get("failure_codes")):
                     if code not in blocking_failure_codes:
                         blocking_failure_codes.append(code)
+        if not blocking_failure_codes and unresolved_preconditions:
+            unresolved_statuses = {
+                str(unresolved.get("status") or "").strip()
+                for unresolved in unresolved_preconditions
+                if isinstance(unresolved, Mapping)
+            }
+            blocking_failure_codes.append("required_effects_unresolved")
+            if "not_satisfied" in unresolved_statuses:
+                blocking_failure_codes.append("required_effect_not_satisfied")
+            if "not_executed" in unresolved_statuses:
+                blocking_failure_codes.append("required_effect_not_executed")
+        if not blocking_failure_codes:
+            if decision == "failed":
+                blocking_failure_codes.append("required_effect_not_satisfied")
+            elif decision == "escalation_required":
+                blocking_failure_codes.append("required_effect_not_executed")
+            elif decision == "partial":
+                blocking_failure_codes.append("postcondition_inconclusive")
+        blocking_failure_codes = sorted(set(blocking_failure_codes))
 
         safe_to_claim_completion = bool(
             completion_gate_payload.get("safe_to_claim_completion", True)

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -1519,6 +1519,7 @@ def _infer_mutation_required_effect(
 
     effect_status = "pending"
     status_reason: str | None = None
+    failure_codes: list[str] = []
     if successful_write_tools:
         effect_status = "satisfied"
         status_reason = (
@@ -1533,12 +1534,14 @@ def _infer_mutation_required_effect(
             if names
             else "Write attempt failed or was blocked."
         )
+        failure_codes = ["kb_mutation_write_failed_or_blocked"]
     else:
         effect_status = "not_executed"
         status_reason = "No write-capable tool invocation was observed."
+        failure_codes = ["kb_mutation_not_executed"]
 
     required_tools = list(successful_write_tools[:3]) or ["add_relationship"]
-    return {
+    mutation_effect = {
         "effect_id": "effect_1",
         "intent_origin": "implicit" if mutation_intent else "explicit",
         "effect_type": "kb_mutation",
@@ -1551,6 +1554,12 @@ def _infer_mutation_required_effect(
         "status": effect_status,
         "status_reason": status_reason,
     }
+    if failure_codes:
+        mutation_effect["failure_code"] = failure_codes[0]
+        mutation_effect["failure_codes"] = list(failure_codes)
+    else:
+        mutation_effect["failure_codes"] = []
+    return mutation_effect
 
 
 def _build_postcondition_checks(
@@ -1763,6 +1772,18 @@ def _derive_completion_gate(
                     if isinstance(code, str) and code.strip()
                 }
             )
+        else:
+            unresolved_statuses = {
+                _safe_str(entry.get("status")) or ""
+                for entry in unresolved_preconditions
+                if isinstance(entry, Mapping)
+            }
+            fallback_codes: list[str] = ["required_effects_unresolved"]
+            if "not_satisfied" in unresolved_statuses:
+                fallback_codes.append("required_effect_not_satisfied")
+            if "not_executed" in unresolved_statuses:
+                fallback_codes.append("required_effect_not_executed")
+            blocking_failure_codes = sorted(set(fallback_codes))
         if any(
             (_safe_str(effect.get("status")) or "") == "not_satisfied"
             for effect in required_effects
@@ -1802,12 +1823,16 @@ def _derive_completion_gate(
         blocking_effect_ids = sorted(set(unresolved_check_ids))
         decision = "partial"
         decision_reason = "Mutation execution observed but postcondition verification is inconclusive."
+        if not blocking_failure_codes:
+            blocking_failure_codes = ["postcondition_inconclusive"]
 
     if decision == "completed" and not completion_claim_validated:
         decision = "partial"
         decision_reason = (
             "Completion claim was detected but could not be fully validated."
         )
+        if not blocking_failure_codes:
+            blocking_failure_codes = ["completion_claim_unvalidated"]
 
     safe_to_claim = decision == "completed"
     evidence_payload = {

--- a/tests/backend/test_orchestrator_turn_execution_gate.py
+++ b/tests/backend/test_orchestrator_turn_execution_gate.py
@@ -146,11 +146,16 @@ def test_turn_execution_critic_detects_unresolved_kb_mutation() -> None:
     assert isinstance(required_effects, list)
     assert len(required_effects) == 1
     assert required_effects[0]["status"] == "not_executed"
+    assert required_effects[0]["failure_code"] == "kb_mutation_not_executed"
+    assert required_effects[0]["failure_codes"] == ["kb_mutation_not_executed"]
 
     completion_gate = record.get("completion_gate")
     assert isinstance(completion_gate, dict)
     assert completion_gate.get("decision") == "escalation_required"
     assert completion_gate.get("safe_to_claim_completion") is False
+    assert completion_gate.get("blocking_failure_codes") == [
+        "kb_mutation_not_executed"
+    ]
     evidence_payload = completion_gate.get("evidence_payload")
     assert isinstance(evidence_payload, dict)
     assert evidence_payload.get("completion_outcome") == "failure"
@@ -304,6 +309,43 @@ def test_turn_completion_gate_appends_execution_status_for_unresolved_effect() -
     )
 
 
+def test_turn_completion_gate_backfills_failure_codes_for_unresolved_preconditions() -> None:
+    orchestrator = _build_orchestrator()
+    request = _build_request(
+        action_id="turn_execution.completion_gate",
+        data={
+            "final_response": "I have completed the update.",
+            "turn_execution_record": {
+                "completion_gate": {
+                    "decision": "escalation_required",
+                    "decision_reason": "Required mutation was not executed.",
+                    "safe_to_claim_completion": False,
+                    "requires_follow_up": True,
+                    "blocking_effect_ids": ["effect_1"],
+                    "evidence_payload": {
+                        "unresolved_preconditions": [
+                            {
+                                "effect_id": "effect_1",
+                                "effect_type": "kb_mutation",
+                                "status": "not_executed",
+                                "status_reason": "No write-capable tool invocation was observed.",
+                            }
+                        ]
+                    },
+                }
+            },
+        },
+    )
+
+    result = orchestrator._action_turn_execution_completion_gate(request)
+
+    assert result.ok
+    assert result.outputs.get("completion_gate_blocking_failure_codes") == [
+        "required_effect_not_executed",
+        "required_effects_unresolved",
+    ]
+
+
 def test_turn_execution_critic_flags_missing_non_kb_mutation_execution() -> None:
     orchestrator = _build_orchestrator()
     request = _build_request(
@@ -333,11 +375,16 @@ def test_turn_execution_critic_flags_missing_non_kb_mutation_execution() -> None
     assert isinstance(required_effects, list)
     assert len(required_effects) == 1
     assert required_effects[0]["status"] == "not_executed"
+    assert required_effects[0]["failure_code"] == "kb_mutation_not_executed"
+    assert required_effects[0]["failure_codes"] == ["kb_mutation_not_executed"]
 
     completion_gate = record.get("completion_gate")
     assert isinstance(completion_gate, dict)
     assert completion_gate.get("decision") == "escalation_required"
     assert completion_gate.get("safe_to_claim_completion") is False
+    assert completion_gate.get("blocking_failure_codes") == [
+        "kb_mutation_not_executed"
+    ]
 
 
 def test_turn_execution_critic_treats_diagnostic_prompt_as_non_mutating() -> None:


### PR DESCRIPTION
## Summary
- emit canonical failure codes for unresolved KB mutation required-effects (kb_mutation_not_executed, kb_mutation_write_failed_or_blocked)
- backfill deterministic completion-gate blocking codes when legacy payloads have unresolved preconditions without explicit codes
- add fallback completion-gate codes for postcondition-inconclusive and unvalidated completion-claim partial outcomes
- extend turn-execution gate tests to assert failure-code propagation and backfill behaviour

## Verification
- pytest tests/backend/test_orchestrator_turn_execution_gate.py tests/backend/test_turn_execution_required_effects_contract.py -q
- pytest tests/backend/test_rag_turn_execution_records_mcp_read_tools.py -q
- pyright src/backend/integrations/internal_mcp/orchestrator.py src/backend/services/turn_execution_record_service.py tests/backend/test_orchestrator_turn_execution_gate.py

## Notes
- 	ests/backend/test_orchestrator_durable_instance_telemetry.py could be collected, but execution exceeded the local tool timeout in this environment.