### PR TITLE
JVNAUTOSCI-1372 Fix and verify paper representation workflow (arXiv URL and uploaded PDF)

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -1,7 +1,7 @@
 # Von Workflow Language (VWL) Manual
 
 Status: Draft (current implementation-aligned)
-Last updated: 2026-03-03 (Pacific/Auckland)
+Last updated: 2026-03-05 (Pacific/Auckland)
 Audience: Human engineers and AI agents
 
 ## 1. Purpose and Scope
@@ -368,6 +368,30 @@ When `#V#file_copy_interpretation_workflow` runs `interpret_file_copy` for PDF d
 - Every extracted diagram candidate MUST carry provenance metadata (source, page/figure scope, extraction method, timestamp/evidence).
 - Output MUST include explicit `requires_human_confirmation=true` semantics for diagram-derived candidates.
 - If diagram OCR dependencies are unavailable, interpretation MUST fail soft (diagnostic payload preserved) rather than silently asserting diagram-derived facts.
+
+### 10.6 Scholarly Paper Representation Contract (JVNAUTOSCI-1369 / JVNAUTOSCI-1372)
+
+For paper-representation intents, VWL required-effects semantics MUST ensure execution paths include mutation-capable tooling, not read-only enrichment alone.
+
+Canonical paper profile source expectations:
+
+- `file_copy` source: required tool set MUST include `interpret_file_copy`.
+- `url` source (including arXiv URLs/IDs): required tool set MUST include `download_paper`.
+- `mixed` source: required tool set SHOULD include both `download_paper` and `interpret_file_copy`.
+
+Important runtime contract note:
+
+- Current `required_effects_contract.v1` evaluates `required_tools` as an any-of set (one observed required tool can satisfy the effect), so source-specific tool lists MUST be authored to preserve mutation guarantees.
+- Read-only tools such as `extract_url` or `get_paper_metadata` MAY be used for enrichment, but MUST NOT be the sole required-effect satisfaction path for paper representation.
+
+Operational expectations for arXiv tool handlers:
+
+- `download_paper` and `finalise_cached_paper` SHOULD attempt scholarly representation materialisation for authenticated file-copy registrations.
+- Tool responses SHOULD expose `scholarly_representation` diagnostics (`attempted`, `verified`, `paper_concept_id`, `metadata_source`, `metadata_available`, and explicit error/fallback fields when not verified).
+
+Turn-execution gate expectation:
+
+- Tool invocations whose payload explicitly reports `success=false` MUST be treated as failed execution for required-effect evaluation and completion gating.
 
 ## 11. Durable Runtime Semantics
 

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -272,6 +272,127 @@ def _get_paper_metadata(**kwargs):
     return _run_async_compat(_async_metadata)
 
 
+def _coerce_arxiv_metadata_record(metadata_payload: Any) -> tuple[dict[str, Any] | None, str | None]:
+    """Normalise arXiv metadata payloads to a single mapping shape."""
+
+    if not isinstance(metadata_payload, Mapping):
+        return None, f"unexpected_metadata_response:{type(metadata_payload).__name__}"
+
+    if metadata_payload.get("success") is False:
+        return None, str(
+            metadata_payload.get("error")
+            or metadata_payload.get("message")
+            or "metadata_fetch_failed"
+        )
+
+    paper_payload = metadata_payload.get("paper")
+    if isinstance(paper_payload, Mapping):
+        return dict(paper_payload), None
+
+    result_payload = metadata_payload.get("result")
+    if isinstance(result_payload, Mapping):
+        return dict(result_payload), None
+
+    if any(
+        key in metadata_payload
+        for key in ("title", "summary", "abstract", "authors", "categories", "id")
+    ):
+        return dict(metadata_payload), None
+
+    return None, "metadata_payload_unusable"
+
+
+def _materialise_arxiv_file_copy_representation(
+    *,
+    user_concept_id: str,
+    arxiv_id: str,
+    file_copy_concept_id: str,
+    fallback_title: str | None = None,
+    namespace: str | None = None,
+) -> dict[str, Any]:
+    """Attempt deterministic scholarly representation materialisation for an arXiv file copy."""
+
+    try:
+        from ...services.arxiv_paper_link_service import (
+            materialise_scholarly_representation_for_arxiv_file_copy,
+            materialise_scholarly_representation_for_file_copy,
+        )
+
+        metadata_payload = _get_paper_metadata(arxiv_id=arxiv_id)
+        metadata_record, metadata_error = _coerce_arxiv_metadata_record(metadata_payload)
+
+        if isinstance(metadata_record, Mapping):
+            with _with_namespace_actor_override(namespace):
+                arxiv_report = materialise_scholarly_representation_for_arxiv_file_copy(
+                    user_concept_id=user_concept_id,
+                    arxiv_id=arxiv_id,
+                    file_copy_concept_id=file_copy_concept_id,
+                    metadata=dict(metadata_record),
+                    logger=logger,
+                )
+            if isinstance(arxiv_report, Mapping):
+                materialised = dict(arxiv_report)
+            else:
+                materialised = {
+                    "success": False,
+                    "verified": False,
+                    "reason": "unexpected_arxiv_materialisation_response",
+                    "response_type": type(arxiv_report).__name__,
+                }
+            materialised["attempted"] = True
+            materialised["metadata_source"] = "get_paper_metadata"
+            materialised["metadata_available"] = True
+            if metadata_error:
+                materialised["metadata_error"] = metadata_error
+            if bool(materialised.get("verified")):
+                return materialised
+
+        generic_metadata: dict[str, Any] = {}
+        if isinstance(metadata_record, Mapping):
+            generic_metadata.update(dict(metadata_record))
+        if (
+            isinstance(fallback_title, str)
+            and fallback_title.strip()
+            and "title" not in generic_metadata
+        ):
+            generic_metadata["title"] = fallback_title.strip()
+
+        with _with_namespace_actor_override(namespace):
+            fallback_report = materialise_scholarly_representation_for_file_copy(
+                user_concept_id=user_concept_id,
+                file_copy_concept_id=file_copy_concept_id,
+                metadata=generic_metadata or None,
+                logger=logger,
+            )
+        if isinstance(fallback_report, Mapping):
+            materialised = dict(fallback_report)
+        else:
+            materialised = {
+                "success": False,
+                "verified": False,
+                "reason": "unexpected_generic_materialisation_response",
+                "response_type": type(fallback_report).__name__,
+            }
+
+        materialised["attempted"] = True
+        materialised["arxiv_id"] = arxiv_id
+        materialised["fallback_mode"] = "from_arxiv_path"
+        materialised["metadata_source"] = "get_paper_metadata"
+        materialised["metadata_available"] = bool(metadata_record)
+        if metadata_error:
+            materialised["metadata_error"] = metadata_error
+        return materialised
+    except Exception as exc:
+        return {
+            "attempted": True,
+            "success": False,
+            "verified": False,
+            "arxiv_id": arxiv_id,
+            "reason": "scholarly_representation_materialisation_exception",
+            "error": str(exc),
+        }
+
+
 _CREATE_CONCEPTS_SCOPE_DEFAULT = "user_org_default"
 _CREATE_CONCEPTS_SCOPE_ORGANISATION_GENERAL = "organisation_general"
 _CREATE_CONCEPTS_SCOPE_GLOBAL_GENERAL = "global_general"
@@ -1706,6 +1827,8 @@ def _download_paper(**kwargs):
             ],
         )
 
+    namespace_override = _normalise_namespace_override(kwargs.get("namespace"))
+
     # If the PDF is already present in the local arXiv cache, prefer finalise_cached_paper so
     # we can upload to durable storage and register the Computer File Copy without calling
     # the upstream MCP server again.
@@ -1808,6 +1931,33 @@ def _download_paper(**kwargs):
                                 "paper_concept_id"
                             ):
                                 stored["paper_concept_id"] = link_result.get(
+                                    "paper_concept_id"
+                                )
+                        except Exception:
+                            pass
+
+                        try:
+                            filename_override = kwargs.get("filename")
+                            fallback_title = (
+                                filename_override.strip()
+                                if isinstance(filename_override, str)
+                                and filename_override.strip()
+                                else None
+                            )
+                            representation = _materialise_arxiv_file_copy_representation(
+                                user_concept_id=str(user_concept_id),
+                                arxiv_id=str(stored.get("arxiv_id") or arxiv_id),
+                                file_copy_concept_id=str(record.concept_id),
+                                fallback_title=fallback_title,
+                                namespace=namespace_override,
+                            )
+                            stored["scholarly_representation"] = representation
+                            if (
+                                not stored.get("paper_concept_id")
+                                and isinstance(representation, Mapping)
+                                and representation.get("paper_concept_id")
+                            ):
+                                stored["paper_concept_id"] = representation.get(
                                     "paper_concept_id"
                                 )
                         except Exception:
@@ -1937,6 +2087,7 @@ def _finalise_cached_paper(**kwargs):
         sha256 = hashlib.sha256(data).hexdigest()
         storage_key = _arxiv_pdf_blob_key(str(arxiv_id))
         stable_id = _normalise_arxiv_id(str(arxiv_id))
+        namespace_override = _normalise_namespace_override(kwargs.get("namespace"))
 
         stored = put_bytes_durable(
             key=storage_key,
@@ -1985,6 +2136,27 @@ def _finalise_cached_paper(**kwargs):
                 paper_concept_id = link_result.get("paper_concept_id")
         except Exception:
             paper_concept_id = None
+
+        name_override = kwargs.get("name")
+        fallback_title = (
+            name_override.strip()
+            if isinstance(name_override, str) and name_override.strip()
+            else str(cached.stem)
+        )
+
+        scholarly_representation = _materialise_arxiv_file_copy_representation(
+            user_concept_id=str(user_concept_id),
+            arxiv_id=stable_id,
+            file_copy_concept_id=str(record.concept_id),
+            fallback_title=fallback_title,
+            namespace=namespace_override,
+        )
+        if (
+            paper_concept_id is None
+            and isinstance(scholarly_representation, Mapping)
+            and scholarly_representation.get("paper_concept_id")
+        ):
+            paper_concept_id = scholarly_representation.get("paper_concept_id")
 
         include_markdown = kwargs.get("include_markdown")
         if include_markdown is None:
@@ -2130,6 +2302,7 @@ def _finalise_cached_paper(**kwargs):
             "uploaded_at": record.uploaded_at,
             "local_cache_deleted": local_deleted,
             "local_cache_delete_error": local_error,
+            "scholarly_representation": scholarly_representation,
             "markdown": markdown_payload,
         }
     except BlobUploadError as exc:

--- a/src/backend/services/representation_contract_vontology_service.py
+++ b/src/backend/services/representation_contract_vontology_service.py
@@ -63,8 +63,8 @@ _CANONICAL_REPRESENTATION_PROFILE_BLUEPRINTS: tuple[dict[str, Any], ...] = (
         ],
         "required_tools_by_source": {
             "file_copy": ["interpret_file_copy"],
-            "url": ["extract_url", "get_paper_metadata"],
-            "mixed": ["interpret_file_copy", "extract_url"],
+            "url": ["download_paper"],
+            "mixed": ["download_paper", "interpret_file_copy"],
             "unknown": ["interpret_file_copy"],
         },
         "required_predicates": [

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -642,15 +642,23 @@ def _summarise_tool_invocations(
         error_value = _safe_str(invocation.get("error"))
         blocked = bool(invocation.get("blocked"))
         payload_status = ""
+        payload_success: bool | None = None
         if isinstance(payload_value, Mapping):
             payload_status = (
                 _safe_str(payload_value.get("status")) or ""
             ).lower()
+            raw_success = payload_value.get("success")
+            if isinstance(raw_success, bool):
+                payload_success = raw_success
 
         status = "ok"
         if blocked:
             status = "blocked"
-        elif error_value or payload_status in {"error", "failed", "failure"}:
+        elif (
+            error_value
+            or payload_status in {"error", "failed", "failure"}
+            or payload_success is False
+        ):
             status = "error"
 
         result_summary = _safe_str(invocation.get("result_summary"))

--- a/tests/backend/test_catalogue_download_paper_prefers_finalise.py
+++ b/tests/backend/test_catalogue_download_paper_prefers_finalise.py
@@ -183,3 +183,104 @@ def test_download_paper_registers_file_copy_when_authenticated(monkeypatch, tmp_
     # And local cache is deleted by default when authenticated.
     assert result.get("local_cache_deleted") is True
     assert pdf_path.exists() is False
+
+
+def test_download_paper_materialises_scholarly_representation_when_metadata_available(
+    monkeypatch, tmp_path
+):
+    cache_dir = tmp_path / "arxiv_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("ARXIV_CACHE_PATH", str(cache_dir))
+
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#user_test",
+    )
+
+    from src.backend.integrations.internal_mcp import catalogue
+
+    pdf_path = cache_dir / "2502.14996.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n%fake\n")
+
+    class _Proxy:
+        async def download_paper(self, *, arxiv_id: str, filename=None):
+            return {
+                "success": True,
+                "arxiv_id": arxiv_id,
+                "file_path": str(pdf_path),
+                "size_bytes": pdf_path.stat().st_size,
+                "sha256": "deadbeef",
+                "storage": {
+                    "backend": "local",
+                    "key": f"arxiv/papers/{arxiv_id}.pdf",
+                    "uri": f"local://arxiv/papers/{arxiv_id}.pdf",
+                },
+            }
+
+    async def _fake_get_proxy():
+        return _Proxy()
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.arxiv_proxy_mcp.get_arxiv_proxy",
+        _fake_get_proxy,
+    )
+
+    class _FakeRecord:
+        concept_id = "#V#computer_file_copy_test"
+        uploaded_at = "2026-01-01T00:00:00+00:00"
+
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.create_computer_file_copy_instance",
+        lambda **_kwargs: _FakeRecord(),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.arxiv_paper_link_service.link_file_copy_to_arxiv_paper",
+        lambda **_kwargs: {"paper_concept_id": "#V#paper_on_arxiv_2502_14996_deadbeef"},
+    )
+    monkeypatch.setattr(
+        catalogue,
+        "_get_paper_metadata",
+        lambda **_kwargs: {
+            "success": True,
+            "paper": {
+                "id": "2502.14996",
+                "title": "Paper Title",
+                "summary": "Paper summary",
+                "authors": ["A. Author"],
+                "categories": ["cs.AI"],
+            },
+        },
+    )
+
+    materialise_calls: list[dict] = []
+
+    def _fake_materialise_arxiv_file_copy(**kwargs):
+        materialise_calls.append(dict(kwargs))
+        return {
+            "success": True,
+            "verified": True,
+            "paper_concept_id": "#V#paper_on_arxiv_2502_14996_deadbeef",
+            "file_copy_concept_id": kwargs.get("file_copy_concept_id"),
+        }
+
+    monkeypatch.setattr(
+        "src.backend.services.arxiv_paper_link_service.materialise_scholarly_representation_for_arxiv_file_copy",
+        _fake_materialise_arxiv_file_copy,
+    )
+
+    result = catalogue._download_paper(arxiv_id="2502.14996")
+
+    assert result["success"] is True
+    scholarly = result.get("scholarly_representation") or {}
+    assert scholarly.get("verified") is True
+    assert scholarly.get("metadata_source") == "get_paper_metadata"
+    assert scholarly.get("metadata_available") is True
+    assert result.get("paper_concept_id") == "#V#paper_on_arxiv_2502_14996_deadbeef"
+
+    assert len(materialise_calls) == 1
+    assert materialise_calls[0]["user_concept_id"] == "#V#user_test"
+    assert materialise_calls[0]["arxiv_id"] == "2502.14996"
+    assert (
+        materialise_calls[0]["file_copy_concept_id"]
+        == "#V#computer_file_copy_test"
+    )

--- a/tests/backend/test_finalise_cached_paper_tool.py
+++ b/tests/backend/test_finalise_cached_paper_tool.py
@@ -124,3 +124,84 @@ def test_finalise_cached_paper_errors_when_cache_missing(monkeypatch, tmp_path):
 
     assert result["success"] is False
     assert result["error"] == "cached_pdf_not_found"
+
+
+def test_finalise_cached_paper_materialises_scholarly_representation(
+    monkeypatch, tmp_path
+):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    cache_dir = tmp_path / "arxiv_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    pdf_path = cache_dir / "2502.14996.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n%fake\n")
+
+    monkeypatch.setenv("ARXIV_CACHE_PATH", str(cache_dir))
+    monkeypatch.setenv("VON_BLOB_STORE_BACKEND", "local")
+    monkeypatch.setenv("VON_BLOB_STORE_LOCAL_ROOT", str(tmp_path / "blob_store"))
+
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#user_test",
+    )
+
+    class _FakeRecord:
+        concept_id = "#V#computer_file_copy_test"
+        uploaded_at = "2026-01-01T00:00:00+00:00"
+
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.create_computer_file_copy_instance",
+        lambda **_kwargs: _FakeRecord(),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.arxiv_paper_link_service.link_file_copy_to_arxiv_paper",
+        lambda **_kwargs: {"paper_concept_id": "#V#paper_on_arxiv_2502_14996_deadbeef"},
+    )
+    monkeypatch.setattr(
+        catalogue,
+        "_get_paper_metadata",
+        lambda **_kwargs: {
+            "success": True,
+            "paper": {
+                "id": "2502.14996",
+                "title": "Paper Title",
+                "summary": "Paper summary",
+                "authors": ["A. Author"],
+                "categories": ["cs.AI"],
+            },
+        },
+    )
+
+    materialise_calls: list[dict] = []
+
+    def _fake_materialise_arxiv_file_copy(**kwargs):
+        materialise_calls.append(dict(kwargs))
+        return {
+            "success": True,
+            "verified": True,
+            "paper_concept_id": "#V#paper_on_arxiv_2502_14996_deadbeef",
+        }
+
+    monkeypatch.setattr(
+        "src.backend.services.arxiv_paper_link_service.materialise_scholarly_representation_for_arxiv_file_copy",
+        _fake_materialise_arxiv_file_copy,
+    )
+
+    result = catalogue._finalise_cached_paper(
+        arxiv_id="2502.14996",
+        include_markdown=False,
+    )
+
+    assert result["success"] is True
+    scholarly = result.get("scholarly_representation") or {}
+    assert scholarly.get("verified") is True
+    assert scholarly.get("metadata_source") == "get_paper_metadata"
+    assert scholarly.get("metadata_available") is True
+    assert result.get("paper_concept_id") == "#V#paper_on_arxiv_2502_14996_deadbeef"
+    assert len(materialise_calls) == 1
+    assert materialise_calls[0]["user_concept_id"] == "#V#user_test"
+    assert materialise_calls[0]["arxiv_id"] == "2502.14996"
+    assert (
+        materialise_calls[0]["file_copy_concept_id"]
+        == "#V#computer_file_copy_test"
+    )

--- a/tests/backend/test_orchestrator_turn_execution_gate.py
+++ b/tests/backend/test_orchestrator_turn_execution_gate.py
@@ -87,8 +87,8 @@ def _patch_representation_profile_loader(monkeypatch) -> None:
                     "domain_terms": ["paper", "arxiv", "metadata", "abstract"],
                     "required_tools_by_source": {
                         "file_copy": ["interpret_file_copy"],
-                        "url": ["extract_url", "get_paper_metadata"],
-                        "mixed": ["interpret_file_copy", "extract_url"],
+                        "url": ["download_paper"],
+                        "mixed": ["download_paper", "interpret_file_copy"],
                         "unknown": ["interpret_file_copy"],
                     },
                     "required_predicates": [

--- a/tests/backend/test_turn_execution_required_effects_contract.py
+++ b/tests/backend/test_turn_execution_required_effects_contract.py
@@ -21,8 +21,8 @@ def _representation_profiles() -> list[dict]:
             "domain_terms": ["paper", "arxiv", "abstract", "metadata"],
             "required_tools_by_source": {
                 "file_copy": ["interpret_file_copy"],
-                "url": ["extract_url", "get_paper_metadata"],
-                "mixed": ["interpret_file_copy", "extract_url"],
+                "url": ["download_paper"],
+                "mixed": ["download_paper", "interpret_file_copy"],
                 "unknown": ["interpret_file_copy"],
             },
             "required_predicates": [
@@ -173,6 +173,81 @@ def test_paper_representation_contract_emitted_with_required_effects(monkeypatch
     assert effect.get("effect_type") == "scholarly_representation"
     assert effect.get("required_tools") == ["interpret_file_copy"]
     assert effect.get("targets") == ["#V#uploaded_file_copy_abc123"]
+
+
+def test_paper_url_representation_contract_requires_download_paper(monkeypatch) -> None:
+    _patch_representation_profile_loader(
+        monkeypatch, profiles=_representation_profiles()
+    )
+    record = _build_record(
+        prompt_text=(
+            "Download and represent metadata on this scientific paper "
+            "https://arxiv.org/abs/2502.14996"
+        ),
+        response_text="Observed required tool execution.",
+        tool_invocations=[
+            {
+                "tool": "download_paper",
+                "payload": {
+                    "success": True,
+                    "arxiv_id": "2502.14996",
+                    "computer_file_copy_concept_id": "#V#uploaded_file_copy_2502_14996",
+                },
+            },
+            {
+                "tool": "fetch_concept",
+                "payload": {"success": True, "concept_id": "#V#paper_on_arxiv_2502_14996"},
+            },
+        ],
+    )
+
+    execution = record.get("execution")
+    assert isinstance(execution, dict)
+    contract = execution.get("required_effects_contract") or {}
+    assert contract.get("artefact_source") == "url"
+
+    required_effects = record.get("required_effects")
+    assert isinstance(required_effects, list)
+    assert required_effects
+    effect = required_effects[0]
+    assert effect.get("required_tools") == ["download_paper"]
+    assert effect.get("status") == "satisfied"
+
+    completion_gate = record.get("completion_gate") or {}
+    assert completion_gate.get("decision") == "completed"
+    assert completion_gate.get("safe_to_claim_completion") is True
+
+
+def test_representation_tool_success_false_marks_effect_unresolved(monkeypatch) -> None:
+    _patch_representation_profile_loader(
+        monkeypatch, profiles=_representation_profiles()
+    )
+    record = _build_record(
+        prompt_text=(
+            "Download and represent metadata on this scientific paper "
+            "https://arxiv.org/abs/2502.14996"
+        ),
+        tool_invocations=[
+            {
+                "tool": "download_paper",
+                "payload": {
+                    "success": False,
+                    "error": "arxiv_proxy_timeout",
+                },
+            }
+        ],
+    )
+
+    required_effects = record.get("required_effects")
+    assert isinstance(required_effects, list)
+    assert required_effects
+    effect = required_effects[0]
+    assert effect.get("status") == "not_satisfied"
+    assert effect.get("failure_code") == "paper_representation_tool_failed"
+
+    completion_gate = record.get("completion_gate") or {}
+    assert completion_gate.get("decision") == "failed"
+    assert completion_gate.get("safe_to_claim_completion") is False
 
 
 def test_person_company_meeting_profiles_generate_non_empty_effects(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Add deterministic scholarly-representation materialisation for authenticated arXiv file-copy registration flows in download_paper and inalise_cached_paper.
- Treat tool payloads with success=false as failed invocations in turn-execution required-effect gating.
- Update paper representation contract defaults so URL-source paper intents require mutation-capable execution (download_paper).
- Extend workflow manual and regression tests for arXiv URL + uploaded PDF representation paths.

## Testing
- pytest tests/backend/test_catalogue_download_paper_prefers_finalise.py tests/backend/test_finalise_cached_paper_tool.py tests/backend/test_turn_execution_required_effects_contract.py tests/backend/test_orchestrator_turn_execution_gate.py -q
- pyright src/backend/integrations/internal_mcp/catalogue.py src/backend/services/representation_contract_vontology_service.py src/backend/services/turn_execution_record_service.py tests/backend/test_catalogue_download_paper_prefers_finalise.py tests/backend/test_finalise_cached_paper_tool.py tests/backend/test_orchestrator_turn_execution_gate.py tests/backend/test_turn_execution_required_effects_contract.py