### PR TITLE
JVNAUTOSCI-1373: Fix person representation workflow from CV/business card artefacts

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -393,6 +393,26 @@ Turn-execution gate expectation:
 
 - Tool invocations whose payload explicitly reports `success=false` MUST be treated as failed execution for required-effect evaluation and completion gating.
 
+### 10.7 Person Representation Contract (JVNAUTOSCI-1369 / JVNAUTOSCI-1373)
+
+For person-representation intents driven by CV/business-card artefacts, required-effects semantics MUST enforce identity materialisation and source linkage before completion can be claimed.
+
+Canonical person profile source expectations:
+
+- `file_copy` source (CV/business-card uploads): required tool set MUST include `interpret_file_copy`.
+- `url` source MAY use `extract_url` for enrichment, but file-copy person materialisation remains the canonical mutation path for uploaded artefacts.
+
+Operational expectations for `interpret_file_copy` on person artefacts:
+
+- The handler SHOULD attempt deterministic person materialisation when CV/business-card cues are detected.
+- Materialisation SHOULD persist core identity effects (person concept + `hasName`) and source linkage (`#V#documentary_evidence_for` from file-copy concept to person concept).
+- Contact/role/affiliation extraction MAY use conservative defaults (`#V#has_email`, `#V#hasRole`, `#V#hasNote`) without additional user questioning.
+- If core identity cannot be resolved or source linkage fails, the tool MUST fail closed (`success=false`) and return explicit `person_representation` diagnostics (`attempted`, `verified`, `reason`, IDs, and error details).
+
+Completion-gate expectation:
+
+- Person-representation turns MUST remain non-complete when `interpret_file_copy` reports unresolved core identity effects (for example `reason=person_identity_unresolved`).
+
 ## 11. Durable Runtime Semantics
 
 ### 11.1 Instance Model

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -3365,6 +3365,9 @@ def _interpret_file_copy(**kwargs):
         maybe_sync_concept_text_relations_to_rag,
     )
     from ...services.relationship_write_service import add_relationship
+    from ...services.person_file_representation_service import (
+        materialise_person_representation_for_file_copy,
+    )
     from ...services.text_value_service import upsert_singleton_text_relation
 
     concept_id = kwargs.get("concept_id") or kwargs.get("file_copy_concept_id")
@@ -3699,7 +3702,13 @@ def _interpret_file_copy(**kwargs):
     persist_errors: list[dict[str, Any]] = []
     arxiv_id_candidates: list[str] = []
     selected_arxiv_id: str | None = None
+    user_concept_id, _organisation_concept_id = _resolve_rag_actor_scope_ids(ns_report)
     scholarly_representation: dict[str, Any] = {
+        "attempted": False,
+        "verified": False,
+        "reason": "not_applicable",
+    }
+    person_representation: dict[str, Any] = {
         "attempted": False,
         "verified": False,
         "reason": "not_applicable",
@@ -3815,9 +3824,6 @@ def _interpret_file_copy(**kwargs):
                 content_for_persist,
             )
             selected_arxiv_id = arxiv_id_candidates[0] if arxiv_id_candidates else None
-            user_concept_id, _organisation_concept_id = _resolve_rag_actor_scope_ids(
-                ns_report
-            )
             metadata_record: dict[str, Any] | None = None
             metadata_error: str | None = None
 
@@ -3934,9 +3940,41 @@ def _interpret_file_copy(**kwargs):
                             "details": scholarly_representation,
                         }
                     )
+
+        person_representation = materialise_person_representation_for_file_copy(
+            user_concept_id=(
+                user_concept_id.strip()
+                if isinstance(user_concept_id, str) and user_concept_id.strip()
+                else None
+            ),
+            file_copy_concept_id=concept_id,
+            extracted_text=extracted_text,
+            original_filename=(
+                original_filename if isinstance(original_filename, str) else None
+            ),
+            interpretation=interpretation,
+            logger=logger,
+        )
+        if (
+            isinstance(person_representation, Mapping)
+            and bool(person_representation.get("attempted"))
+            and not bool(person_representation.get("verified"))
+        ):
+            persist_errors.append(
+                {
+                    "predicate": "#V#person_representation_verification",
+                    "error": "person_representation_not_verified",
+                    "details": dict(person_representation),
+                }
+            )
     else:
         subtype_assertion_outcome = "persist_disabled"
         scholarly_representation = {
+            "attempted": False,
+            "verified": False,
+            "reason": "persist_disabled",
+        }
+        person_representation = {
             "attempted": False,
             "verified": False,
             "reason": "persist_disabled",
@@ -4005,6 +4043,7 @@ def _interpret_file_copy(**kwargs):
             },
         },
         "scholarly_representation": scholarly_representation,
+        "person_representation": person_representation,
         "namespace": effective_namespace,
         **ns_report,
         "read_result": {

--- a/src/backend/services/person_file_representation_service.py
+++ b/src/backend/services/person_file_representation_service.py
@@ -1,0 +1,529 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Mapping
+
+from . import concept_search_service
+from .relationship_write_service import add_relationship
+from .text_value_service import upsert_text_for_concept
+
+_EMAIL_PATTERN = re.compile(r"\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+_PHONE_PATTERN = re.compile(
+    r"(?:\+?\d[\d()\s\-]{7,}\d)",
+    re.IGNORECASE,
+)
+_CV_HINT_PATTERN = re.compile(
+    r"\b(cv|resume|curriculum[\s\-_]*vitae)\b",
+    re.IGNORECASE,
+)
+_BUSINESS_CARD_HINT_PATTERN = re.compile(
+    r"\b(business[\s\-_]*card|biz[\s\-_]*card|contact[\s\-_]*card)\b",
+    re.IGNORECASE,
+)
+_NAME_LABEL_PATTERN = re.compile(
+    r"(?:^|\n)\s*(?:name|full\s+name|candidate|contact)\s*[:\-]\s*([^\n]{2,120})",
+    re.IGNORECASE,
+)
+_AFFILIATION_LABEL_PATTERN = re.compile(
+    r"(?:^|\n)\s*(?:affiliation|organisation|organization|company|institution)\s*[:\-]\s*([^\n]{2,200})",
+    re.IGNORECASE,
+)
+_ROLE_LABEL_PATTERN = re.compile(
+    r"(?:^|\n)\s*(?:role|title|position)\s*[:\-]\s*([^\n]{2,120})",
+    re.IGNORECASE,
+)
+_AFFILIATION_LINE_HINT_PATTERN = re.compile(
+    r"\b(university|institute|organisation|organization|company|department|school|laboratory|lab|group|inc|ltd|llc)\b",
+    re.IGNORECASE,
+)
+_ROLE_LINE_HINT_PATTERN = re.compile(
+    r"\b(professor|dr\.?|researcher|engineer|scientist|director|manager|student|lecturer|founder|ceo|cto|coo)\b",
+    re.IGNORECASE,
+)
+_NON_NAME_HINT_PATTERN = re.compile(
+    r"\b(email|phone|mobile|address|website|www\.|http|curriculum|resume|business|card)\b",
+    re.IGNORECASE,
+)
+_SEPARATOR_PATTERN = re.compile(r"[\s._\-]+")
+
+
+def _safe_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _dedupe_casefold(values: list[str]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        cleaned = value.strip()
+        if not cleaned:
+            continue
+        key = cleaned.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(cleaned)
+    return deduped
+
+
+def _normalise_line(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip(" \t\r\n;|")
+
+
+def _extract_lines(text: str) -> list[str]:
+    lines: list[str] = []
+    for raw_line in text.splitlines():
+        normalised = _normalise_line(raw_line)
+        if not normalised:
+            continue
+        lines.append(normalised)
+    return lines
+
+
+def _normalise_person_name(value: Any) -> str:
+    text = _safe_str(value)
+    if not text:
+        return ""
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _looks_like_person_name(candidate: str) -> bool:
+    text = _normalise_person_name(candidate)
+    if not text:
+        return False
+    if len(text) < 3 or len(text) > 120:
+        return False
+    if _NON_NAME_HINT_PATTERN.search(text):
+        return False
+    if any(char.isdigit() for char in text):
+        return False
+
+    tokens = [token for token in _SEPARATOR_PATTERN.split(text) if token]
+    if len(tokens) < 2 or len(tokens) > 5:
+        return False
+    for token in tokens:
+        if len(token) < 2:
+            return False
+        if not re.fullmatch(r"[A-Za-z'`]+", token):
+            return False
+    return True
+
+
+def _extract_emails(text: str) -> list[str]:
+    return _dedupe_casefold([match.group(0) for match in _EMAIL_PATTERN.finditer(text)])
+
+
+def _extract_phone_numbers(text: str) -> list[str]:
+    numbers: list[str] = []
+    for match in _PHONE_PATTERN.finditer(text):
+        value = _normalise_line(match.group(0))
+        digit_count = sum(char.isdigit() for char in value)
+        if digit_count < 8:
+            continue
+        numbers.append(value)
+    return _dedupe_casefold(numbers)
+
+
+def _name_from_email(email: str) -> str | None:
+    local = email.split("@", 1)[0].strip()
+    if not local:
+        return None
+    parts = [part for part in _SEPARATOR_PATTERN.split(local) if part]
+    if len(parts) < 2 or len(parts) > 4:
+        return None
+    candidate = " ".join(part.capitalize() for part in parts)
+    return candidate if _looks_like_person_name(candidate) else None
+
+
+def _extract_candidate_names(*, text: str, lines: list[str], emails: list[str]) -> list[str]:
+    candidates: list[str] = []
+
+    for match in _NAME_LABEL_PATTERN.finditer(text):
+        candidate = _normalise_line(match.group(1))
+        if _looks_like_person_name(candidate):
+            candidates.append(candidate)
+
+    for line in lines[:8]:
+        if _looks_like_person_name(line):
+            candidates.append(line)
+
+    for email in emails:
+        fallback = _name_from_email(email)
+        if fallback:
+            candidates.append(fallback)
+
+    return _dedupe_casefold(candidates)
+
+
+def _extract_affiliations(*, text: str, lines: list[str]) -> list[str]:
+    affiliations: list[str] = []
+
+    for match in _AFFILIATION_LABEL_PATTERN.finditer(text):
+        value = _normalise_line(match.group(1))
+        if value:
+            affiliations.append(value)
+
+    for line in lines:
+        if _EMAIL_PATTERN.search(line) or _PHONE_PATTERN.search(line):
+            continue
+        if _AFFILIATION_LINE_HINT_PATTERN.search(line):
+            affiliations.append(line)
+
+    return _dedupe_casefold(affiliations)[:3]
+
+
+def _extract_roles(*, text: str, lines: list[str]) -> list[str]:
+    roles: list[str] = []
+
+    for match in _ROLE_LABEL_PATTERN.finditer(text):
+        value = _normalise_line(match.group(1))
+        if value:
+            roles.append(value)
+
+    for line in lines:
+        if _ROLE_LINE_HINT_PATTERN.search(line):
+            roles.append(line)
+
+    return _dedupe_casefold(roles)[:3]
+
+
+def _infer_representation_mode(
+    *,
+    original_filename: str | None,
+    text: str,
+    lines: list[str],
+    emails: list[str],
+    phone_numbers: list[str],
+) -> str | None:
+    filename = (original_filename or "").strip().lower()
+    if filename and _CV_HINT_PATTERN.search(filename):
+        return "cv"
+    if filename and _BUSINESS_CARD_HINT_PATTERN.search(filename):
+        return "business_card"
+
+    if _CV_HINT_PATTERN.search(text):
+        return "cv"
+    if _BUSINESS_CARD_HINT_PATTERN.search(text):
+        return "business_card"
+
+    # Business cards are often short OCR snippets containing contact fields.
+    if len(lines) <= 24 and emails and phone_numbers:
+        return "business_card"
+    return None
+
+
+def _stable_named_instance_concept_id(name: str, *, prefix: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", str(name or "").strip().lower()).strip("_")
+    if not slug:
+        slug = "unnamed"
+    digest = hashlib.sha256(str(name or "").strip().casefold().encode("utf-8")).hexdigest()[
+        :8
+    ]
+    return f"#V#{prefix}_{slug}_{digest}"
+
+
+def _resolve_or_create_person_concept_id(
+    *,
+    user_concept_id: str,
+    person_name: str,
+    logger: Any | None = None,
+) -> tuple[str, bool]:
+    from . import concept_service
+
+    search_result = concept_search_service.search_concepts(
+        query=person_name,
+        instance_of="#V#person",
+        match_type="exact",
+        limit=10,
+    )
+    for item in search_result.get("results") or []:
+        if not isinstance(item, Mapping):
+            continue
+        candidate_id = _safe_str(item.get("concept_id"))
+        candidate_name = _safe_str(item.get("name"))
+        if not candidate_id:
+            continue
+        if candidate_name and candidate_name.casefold() == person_name.casefold():
+            return candidate_id, False
+
+    concept_id = _stable_named_instance_concept_id(person_name, prefix="person")
+    try:
+        concept_service.create_concept(
+            name=person_name,
+            concept_id=concept_id,
+            parent_concept_ids=["#V#person"],
+            create_as_instance=True,
+            system_tags=["person", "representation", "file_copy"],
+        )
+        concept_service.update_concept(
+            concept_id,
+            {"relationships.specific_to_user": [user_concept_id.strip()]},
+        )
+    except Exception as exc:
+        if logger is not None:
+            logger.warning(
+                "[person_file_representation] Person concept create failed for %s: %s",
+                person_name,
+                exc,
+            )
+    return concept_id, True
+
+
+def _write_text_relation(
+    *,
+    subject_concept_id: str,
+    predicate: str,
+    text: str,
+    context: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        relation = upsert_text_for_concept(
+            subject_concept_id=subject_concept_id,
+            predicate=predicate,
+            text=text,
+            lang="en-NZ",
+            context=dict(context or {}),
+        )
+        return dict(relation) if isinstance(relation, Mapping) else None, None
+    except Exception as exc:
+        return None, str(exc)
+
+
+def materialise_person_representation_for_file_copy(
+    *,
+    user_concept_id: str | None,
+    file_copy_concept_id: str,
+    extracted_text: str | None,
+    original_filename: str | None = None,
+    interpretation: Mapping[str, Any] | None = None,
+    logger: Any | None = None,
+) -> dict[str, Any]:
+    """Deterministically materialise a person representation from CV/card artefacts."""
+
+    report: dict[str, Any] = {
+        "success": False,
+        "attempted": False,
+        "verified": False,
+        "reason": "not_person_artefact",
+        "representation_mode": None,
+        "file_copy_concept_id": file_copy_concept_id,
+        "person_concept_id": None,
+        "person_name": None,
+        "emails": [],
+        "phone_numbers": [],
+        "affiliations": [],
+        "roles": [],
+        "created_person_concept": False,
+        "persisted_text_relations": [],
+        "persisted_structural_relations": [],
+        "errors": [],
+    }
+
+    text = _safe_str(extracted_text)
+    if not text:
+        report["reason"] = "no_extracted_text"
+        return report
+
+    lines = _extract_lines(text)
+    emails = _extract_emails(text)
+    phone_numbers = _extract_phone_numbers(text)
+    representation_mode = _infer_representation_mode(
+        original_filename=original_filename,
+        text=text,
+        lines=lines,
+        emails=emails,
+        phone_numbers=phone_numbers,
+    )
+    if representation_mode is None:
+        return report
+
+    report["attempted"] = True
+    report["representation_mode"] = representation_mode
+    report["emails"] = list(emails)
+    report["phone_numbers"] = list(phone_numbers)
+
+    actor_id = _safe_str(user_concept_id)
+    if not actor_id:
+        report["reason"] = "missing_user_context_for_person_representation"
+        return report
+
+    name_candidates = _extract_candidate_names(text=text, lines=lines, emails=emails)
+    person_name = name_candidates[0] if name_candidates else None
+    if not person_name:
+        report["reason"] = "person_identity_unresolved"
+        return report
+
+    affiliations = _extract_affiliations(text=text, lines=lines)
+    roles = _extract_roles(text=text, lines=lines)
+    report["person_name"] = person_name
+    report["affiliations"] = list(affiliations)
+    report["roles"] = list(roles)
+
+    person_concept_id, created_person = _resolve_or_create_person_concept_id(
+        user_concept_id=actor_id,
+        person_name=person_name,
+        logger=logger,
+    )
+    report["person_concept_id"] = person_concept_id
+    report["created_person_concept"] = created_person
+
+    relation_specs: list[tuple[str, str, Mapping[str, Any]]] = [
+        (
+            "hasName",
+            person_name,
+            {
+                "name_type": "NL",
+                "source": "person_file_representation",
+                "source_file_copy_concept_id": file_copy_concept_id,
+            },
+        )
+    ]
+    for email in emails:
+        relation_specs.append(
+            (
+                "#V#has_email",
+                email,
+                {
+                    "source": "person_file_representation",
+                    "source_file_copy_concept_id": file_copy_concept_id,
+                },
+            )
+        )
+    for role in roles:
+        relation_specs.append(
+            (
+                "#V#hasRole",
+                role,
+                {
+                    "source": "person_file_representation",
+                    "source_file_copy_concept_id": file_copy_concept_id,
+                },
+            )
+        )
+    for affiliation in affiliations:
+        relation_specs.append(
+            (
+                "#V#hasNote",
+                f"Affiliation: {affiliation}",
+                {
+                    "note_type": "affiliation",
+                    "source": "person_file_representation",
+                    "source_file_copy_concept_id": file_copy_concept_id,
+                },
+            )
+        )
+    for phone in phone_numbers:
+        relation_specs.append(
+            (
+                "#V#hasNote",
+                f"Phone: {phone}",
+                {
+                    "note_type": "phone",
+                    "source": "person_file_representation",
+                    "source_file_copy_concept_id": file_copy_concept_id,
+                },
+            )
+        )
+
+    interpretation_description = (
+        _safe_str(interpretation.get("description"))
+        if isinstance(interpretation, Mapping)
+        else None
+    )
+    if interpretation_description:
+        relation_specs.append(
+            (
+                "#V#hasNote",
+                f"Interpretation summary: {interpretation_description}",
+                {
+                    "note_type": "interpretation_summary",
+                    "source": "person_file_representation",
+                    "source_file_copy_concept_id": file_copy_concept_id,
+                },
+            )
+        )
+
+    relation_specs.append(
+        (
+            "#V#hasNote",
+            f"Source file copy: {file_copy_concept_id}",
+            {
+                "note_type": "source_linkage",
+                "source": "person_file_representation",
+                "source_file_copy_concept_id": file_copy_concept_id,
+            },
+        )
+    )
+
+    name_persisted = False
+    for predicate, value, context in relation_specs:
+        relation, error = _write_text_relation(
+            subject_concept_id=person_concept_id,
+            predicate=predicate,
+            text=value,
+            context=context,
+        )
+        if error:
+            report["errors"].append(
+                {
+                    "stage": "text_relation_upsert",
+                    "predicate": predicate,
+                    "text": value,
+                    "error": error,
+                }
+            )
+            continue
+        if predicate == "hasName":
+            name_persisted = True
+        report["persisted_text_relations"].append(
+            {
+                "predicate": predicate,
+                "relation_id": relation.get("relation_id") if isinstance(relation, Mapping) else None,
+            }
+        )
+
+    evidence_relation = add_relationship(
+        source_id=file_copy_concept_id,
+        predicate="#V#documentary_evidence_for",
+        target=person_concept_id,
+    )
+    if isinstance(evidence_relation, Mapping) and evidence_relation.get("success") is True:
+        report["persisted_structural_relations"].append(
+            {
+                "predicate": "#V#documentary_evidence_for",
+                "source_id": file_copy_concept_id,
+                "target_id": person_concept_id,
+                "modified": bool(evidence_relation.get("forward_modified")),
+            }
+        )
+        evidence_linked = True
+    else:
+        evidence_linked = False
+        report["errors"].append(
+            {
+                "stage": "source_evidence_link",
+                "predicate": "#V#documentary_evidence_for",
+                "source_id": file_copy_concept_id,
+                "target_id": person_concept_id,
+                "error": (
+                    evidence_relation.get("error")
+                    if isinstance(evidence_relation, Mapping)
+                    else "unexpected_relationship_response"
+                ),
+                "details": evidence_relation,
+            }
+        )
+
+    if name_persisted and evidence_linked:
+        report["verified"] = True
+        report["success"] = True
+        report["reason"] = "person_representation_verified"
+    elif not name_persisted:
+        report["reason"] = "person_name_persist_failed"
+    else:
+        report["reason"] = "source_linkage_failed"
+    return report

--- a/tests/backend/test_file_copy_ingestion_mcp_tools.py
+++ b/tests/backend/test_file_copy_ingestion_mcp_tools.py
@@ -340,6 +340,76 @@ def test_interpret_file_copy_supports_non_persist_mode(monkeypatch):
     assert result["persisted_relations"] == []
 
 
+def test_interpret_file_copy_fails_closed_when_person_representation_unverified(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue._read_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "text": "Candidate CV details",
+            "content_type": "text/plain",
+            "original_filename": "candidate-cv.txt",
+            "size_bytes": 128,
+            "byte_length": 128,
+            "blob": {"backend": "local", "key": "uploads/user/hash/candidate-cv.txt"},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.file_copy_interpretation_service.build_document_interpretation",
+        lambda **_kwargs: {
+            "kind": "document",
+            "description": "Document text extracted: Candidate CV details",
+            "subject_tags": ["document"],
+            "content_text": "Candidate CV details",
+            "content_length": 20,
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.arxiv_paper_link_service.materialise_scholarly_representation_for_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "verified": True,
+            "paper_concept_id": "#V#paper_from_file_copy",
+            "file_copy_concept_id": "#V#file_copy_cv_test",
+            "representation_mode": "generic_file_copy",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.person_file_representation_service.materialise_person_representation_for_file_copy",
+        lambda **_kwargs: {
+            "success": False,
+            "attempted": True,
+            "verified": False,
+            "reason": "person_identity_unresolved",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.upsert_singleton_text_relation",
+        lambda **_kwargs: {"relation_id": "rel-cv"},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_text_relation_change_hook_service.maybe_sync_concept_text_relations_to_rag",
+        lambda **_kwargs: None,
+    )
+
+    result = cat._interpret_file_copy(
+        concept_id="#V#file_copy_cv_test",
+        namespace="#V#user@org",
+    )
+
+    assert result["success"] is False
+    person_representation = result.get("person_representation") or {}
+    assert person_representation.get("attempted") is True
+    assert person_representation.get("verified") is False
+    persist_errors = result.get("persist_errors") or []
+    assert any(
+        row.get("predicate") == "#V#person_representation_verification"
+        for row in persist_errors
+        if isinstance(row, dict)
+    )
+
+
 def test_interpret_file_copy_includes_pdf_diagram_analysis(monkeypatch):
     from src.backend.integrations.internal_mcp import catalogue as cat
 

--- a/tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py
+++ b/tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py
@@ -185,6 +185,78 @@ def test_interpret_file_copy_gateway_asserts_docx_subtype(monkeypatch):
     ]
 
 
+def test_interpret_file_copy_gateway_fails_closed_on_unverified_person_representation(
+    monkeypatch,
+):
+    gateway = _build_gateway()
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue._read_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "text": "Candidate CV details",
+            "content_type": "text/plain",
+            "original_filename": "candidate-cv.txt",
+            "size_bytes": 64,
+            "byte_length": 64,
+            "blob": {"backend": "local", "key": "imports/user/hash/candidate-cv.txt"},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.file_copy_interpretation_service.build_document_interpretation",
+        lambda **_kwargs: {
+            "kind": "document",
+            "description": "Document text extracted: Candidate CV details",
+            "subject_tags": ["document"],
+            "content_text": "Candidate CV details",
+            "content_length": 20,
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.arxiv_paper_link_service.materialise_scholarly_representation_for_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "verified": True,
+            "paper_concept_id": "#V#paper_from_file_copy_gateway",
+            "file_copy_concept_id": "#V#imported_file_gateway",
+            "representation_mode": "generic_file_copy",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.person_file_representation_service.materialise_person_representation_for_file_copy",
+        lambda **_kwargs: {
+            "success": False,
+            "attempted": True,
+            "verified": False,
+            "reason": "person_identity_unresolved",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.upsert_singleton_text_relation",
+        lambda **_kwargs: {"relation_id": "rel-gateway-cv"},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_text_relation_change_hook_service.maybe_sync_concept_text_relations_to_rag",
+        lambda **_kwargs: None,
+    )
+
+    interpreted = gateway.invoke(
+        "interpret_file_copy",
+        {"concept_id": "#V#imported_file_gateway", "namespace": "#V#user@org"},
+    ).payload
+
+    assert interpreted.get("success") is False
+    person_representation = interpreted.get("person_representation") or {}
+    assert person_representation.get("attempted") is True
+    assert person_representation.get("verified") is False
+    persist_errors = interpreted.get("persist_errors") or []
+    assert any(
+        row.get("predicate") == "#V#person_representation_verification"
+        for row in persist_errors
+        if isinstance(row, dict)
+    )
+
+
 def test_interpret_file_copy_gateway_returns_pdf_diagram_candidates(monkeypatch):
     gateway = _build_gateway()
 

--- a/tests/backend/test_person_file_representation_service.py
+++ b/tests/backend/test_person_file_representation_service.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+
+def test_materialise_person_representation_for_cv_persists_core_effects(monkeypatch):
+    from src.backend.services.person_file_representation_service import (
+        materialise_person_representation_for_file_copy,
+    )
+
+    monkeypatch.setattr(
+        "src.backend.services.concept_search_service.search_concepts",
+        lambda **_kwargs: {"results": []},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_service.create_concept",
+        lambda **_kwargs: {"success": True},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_service.update_concept",
+        lambda *_args, **_kwargs: {"success": True},
+    )
+
+    relation_writes: list[dict[str, object]] = []
+
+    def _fake_upsert_text_for_concept(**kwargs):
+        relation_writes.append(dict(kwargs))
+        return {
+            "relation_id": f"rel-{len(relation_writes)}",
+            "relation_created": True,
+            "predicate": kwargs.get("predicate"),
+        }
+
+    relationship_writes: list[dict[str, object]] = []
+
+    def _fake_add_relationship(**kwargs):
+        relationship_writes.append(dict(kwargs))
+        return {"success": True, "forward_modified": True}
+
+    monkeypatch.setattr(
+        "src.backend.services.person_file_representation_service.upsert_text_for_concept",
+        _fake_upsert_text_for_concept,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.person_file_representation_service.add_relationship",
+        _fake_add_relationship,
+    )
+
+    result = materialise_person_representation_for_file_copy(
+        user_concept_id="#V#user_test",
+        file_copy_concept_id="#V#uploaded_file_copy_person_1",
+        extracted_text=(
+            "Name: Jane Doe\n"
+            "Email: jane.doe@example.org\n"
+            "Role: Senior Researcher\n"
+            "Affiliation: University of Auckland\n"
+            "Phone: +64 21 123 4567\n"
+        ),
+        original_filename="jane-doe-cv.pdf",
+        interpretation={"description": "CV extracted from uploaded document."},
+    )
+
+    assert result["attempted"] is True
+    assert result["verified"] is True
+    assert result["success"] is True
+    assert result["reason"] == "person_representation_verified"
+    assert result["representation_mode"] == "cv"
+    assert result["person_name"] == "Jane Doe"
+    assert result["emails"] == ["jane.doe@example.org"]
+    assert "Senior Researcher" in result["roles"]
+    assert "University of Auckland" in result["affiliations"]
+    assert result["person_concept_id"].startswith("#V#person_jane_doe_")
+
+    predicates = [row["predicate"] for row in relation_writes]
+    assert "hasName" in predicates
+    assert "#V#has_email" in predicates
+    assert "#V#hasRole" in predicates
+    assert "#V#hasNote" in predicates
+
+    assert relationship_writes == [
+        {
+            "source_id": "#V#uploaded_file_copy_person_1",
+            "predicate": "#V#documentary_evidence_for",
+            "target": result["person_concept_id"],
+        }
+    ]
+
+
+def test_materialise_person_representation_fails_when_identity_unresolved():
+    from src.backend.services.person_file_representation_service import (
+        materialise_person_representation_for_file_copy,
+    )
+
+    result = materialise_person_representation_for_file_copy(
+        user_concept_id="#V#user_test",
+        file_copy_concept_id="#V#uploaded_file_copy_person_2",
+        extracted_text=(
+            "Business Card\n"
+            "Email: info@example.org\n"
+            "Phone: +64 21 555 1111\n"
+            "Address: Auckland\n"
+        ),
+        original_filename="contact-card.png",
+    )
+
+    assert result["attempted"] is True
+    assert result["verified"] is False
+    assert result["success"] is False
+    assert result["reason"] == "person_identity_unresolved"
+    assert result["person_concept_id"] is None
+
+
+def test_materialise_person_representation_is_not_attempted_for_unrelated_text():
+    from src.backend.services.person_file_representation_service import (
+        materialise_person_representation_for_file_copy,
+    )
+
+    result = materialise_person_representation_for_file_copy(
+        user_concept_id="#V#user_test",
+        file_copy_concept_id="#V#uploaded_file_copy_generic_1",
+        extracted_text="This is an ecosystem planning document about transport policy.",
+        original_filename="planning-notes.txt",
+    )
+
+    assert result["attempted"] is False
+    assert result["verified"] is False
+    assert result["success"] is False
+    assert result["reason"] == "not_person_artefact"

--- a/tests/backend/test_turn_execution_required_effects_contract.py
+++ b/tests/backend/test_turn_execution_required_effects_contract.py
@@ -250,6 +250,76 @@ def test_representation_tool_success_false_marks_effect_unresolved(monkeypatch) 
     assert completion_gate.get("safe_to_claim_completion") is False
 
 
+def test_person_representation_blocks_completion_when_identity_unresolved(monkeypatch) -> None:
+    _patch_representation_profile_loader(
+        monkeypatch, profiles=_representation_profiles()
+    )
+    record = _build_record(
+        prompt_text="Represent this person profile from this CV file #V#uploaded_file_copy_person_1.",
+        response_text="Progress note.",
+        tool_invocations=[
+            {
+                "tool": "interpret_file_copy",
+                "payload": {
+                    "success": False,
+                    "error": "person_identity_unresolved",
+                    "person_representation": {
+                        "attempted": True,
+                        "verified": False,
+                        "reason": "person_identity_unresolved",
+                    },
+                },
+            }
+        ],
+    )
+
+    required_effects = record.get("required_effects")
+    assert isinstance(required_effects, list)
+    assert required_effects
+    effect = required_effects[0]
+    assert effect.get("effect_type") == "representation_person"
+    assert effect.get("status") == "not_satisfied"
+    assert effect.get("failure_code") == "person_representation_tool_failed"
+
+    completion_gate = record.get("completion_gate") or {}
+    assert completion_gate.get("decision") == "failed"
+    assert completion_gate.get("safe_to_claim_completion") is False
+
+
+def test_person_representation_marks_completion_when_verified(monkeypatch) -> None:
+    _patch_representation_profile_loader(
+        monkeypatch, profiles=_representation_profiles()
+    )
+    record = _build_record(
+        prompt_text="Represent this person profile from this CV file #V#uploaded_file_copy_person_1.",
+        response_text="Progress note.",
+        tool_invocations=[
+            {
+                "tool": "interpret_file_copy",
+                "payload": {
+                    "success": True,
+                    "person_representation": {
+                        "attempted": True,
+                        "verified": True,
+                        "person_concept_id": "#V#person_jane_doe_1234abcd",
+                    },
+                },
+            }
+        ],
+    )
+
+    required_effects = record.get("required_effects")
+    assert isinstance(required_effects, list)
+    assert required_effects
+    effect = required_effects[0]
+    assert effect.get("effect_type") == "representation_person"
+    assert effect.get("status") == "satisfied"
+
+    completion_gate = record.get("completion_gate") or {}
+    assert completion_gate.get("decision") == "completed"
+    assert completion_gate.get("safe_to_claim_completion") is True
+
+
 def test_person_company_meeting_profiles_generate_non_empty_effects(monkeypatch) -> None:
     _patch_representation_profile_loader(
         monkeypatch, profiles=_representation_profiles()


### PR DESCRIPTION
## Summary
- add deterministic person materialisation from CV/business-card file-copy interpretation
- fail closed when core identity or source linkage cannot be verified, surfaced via `person_representation` diagnostics
- extend turn-execution required-effects tests so unresolved person identity blocks completion
- add gateway + handler regression tests and update the workflow language manual

## Validation
- pytest tests/backend/test_person_file_representation_service.py tests/backend/test_file_copy_ingestion_mcp_tools.py tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py tests/backend/test_turn_execution_required_effects_contract.py -q
- pyright src/backend/integrations/internal_mcp/catalogue.py src/backend/services/person_file_representation_service.py tests/backend/test_file_copy_ingestion_mcp_tools.py tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py tests/backend/test_person_file_representation_service.py tests/backend/test_turn_execution_required_effects_contract.py