### PR TITLE
JVNAUTOSCI-1374: fail-close company representation from web page artefacts

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -413,6 +413,26 @@ Completion-gate expectation:
 
 - Person-representation turns MUST remain non-complete when `interpret_file_copy` reports unresolved core identity effects (for example `reason=person_identity_unresolved`).
 
+### 10.8 Company Representation Contract (JVNAUTOSCI-1369 / JVNAUTOSCI-1374)
+
+For company-representation intents driven by web-page artefacts, required-effects semantics MUST enforce company identity + URL identity materialisation and source linkage before completion can be claimed.
+
+Canonical company profile source expectations:
+
+- `file_copy` source (uploaded web-page artefacts): required tool set MUST include `interpret_file_copy`.
+- `url` source MAY use `extract_url` for enrichment, but file-copy company materialisation is the canonical mutation path for uploaded web-page artefacts.
+
+Operational expectations for `interpret_file_copy` on company artefacts:
+
+- The handler SHOULD attempt deterministic company materialisation when web-page/company cues are detected.
+- Materialisation SHOULD persist core identity effects (company concept + `hasName`), URL identity (`#V#has_url`), and source linkage (`#V#documentary_evidence_for` from file-copy concept to company concept).
+- Descriptor extraction MAY use conservative defaults (`#V#hasNote`) without additional user questioning.
+- If core company identity, URL identity, or source linkage cannot be resolved, the tool MUST fail closed (`success=false`) and return explicit `company_representation` diagnostics (`attempted`, `verified`, `reason`, IDs, URLs, and error details).
+
+Completion-gate expectation:
+
+- Company-representation turns MUST remain non-complete when `interpret_file_copy` reports unresolved core company effects (for example `reason=company_identity_unresolved` or `reason=company_url_unresolved`).
+
 ## 11. Durable Runtime Semantics
 
 ### 11.1 Instance Model

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -3368,6 +3368,9 @@ def _interpret_file_copy(**kwargs):
     from ...services.person_file_representation_service import (
         materialise_person_representation_for_file_copy,
     )
+    from ...services.company_file_representation_service import (
+        materialise_company_representation_for_file_copy,
+    )
     from ...services.text_value_service import upsert_singleton_text_relation
 
     concept_id = kwargs.get("concept_id") or kwargs.get("file_copy_concept_id")
@@ -3713,6 +3716,11 @@ def _interpret_file_copy(**kwargs):
         "verified": False,
         "reason": "not_applicable",
     }
+    company_representation: dict[str, Any] = {
+        "attempted": False,
+        "verified": False,
+        "reason": "not_applicable",
+    }
     subtype_assertion: dict[str, Any] | None = None
     subtype_assertion_outcome = "not_attempted"
     if persist:
@@ -3967,6 +3975,33 @@ def _interpret_file_copy(**kwargs):
                     "details": dict(person_representation),
                 }
             )
+
+        company_representation = materialise_company_representation_for_file_copy(
+            user_concept_id=(
+                user_concept_id.strip()
+                if isinstance(user_concept_id, str) and user_concept_id.strip()
+                else None
+            ),
+            file_copy_concept_id=concept_id,
+            extracted_text=extracted_text,
+            original_filename=(
+                original_filename if isinstance(original_filename, str) else None
+            ),
+            interpretation=interpretation,
+            logger=logger,
+        )
+        if (
+            isinstance(company_representation, Mapping)
+            and bool(company_representation.get("attempted"))
+            and not bool(company_representation.get("verified"))
+        ):
+            persist_errors.append(
+                {
+                    "predicate": "#V#company_representation_verification",
+                    "error": "company_representation_not_verified",
+                    "details": dict(company_representation),
+                }
+            )
     else:
         subtype_assertion_outcome = "persist_disabled"
         scholarly_representation = {
@@ -3975,6 +4010,11 @@ def _interpret_file_copy(**kwargs):
             "reason": "persist_disabled",
         }
         person_representation = {
+            "attempted": False,
+            "verified": False,
+            "reason": "persist_disabled",
+        }
+        company_representation = {
             "attempted": False,
             "verified": False,
             "reason": "persist_disabled",
@@ -4044,6 +4084,7 @@ def _interpret_file_copy(**kwargs):
         },
         "scholarly_representation": scholarly_representation,
         "person_representation": person_representation,
+        "company_representation": company_representation,
         "namespace": effective_namespace,
         **ns_report,
         "read_result": {
@@ -6647,6 +6688,9 @@ def _interpret_file_copy_output_schema() -> Schema:
             "persisted_structural_relations": (list, type(None)),
             "persist_errors": (list, type(None)),
             "diagnostics": (dict, type(None)),
+            "scholarly_representation": (dict, type(None)),
+            "person_representation": (dict, type(None)),
+            "company_representation": (dict, type(None)),
             "namespace": (str, type(None)),
             "read_result": (dict, type(None)),
             "image_fetch_error": (str, type(None)),

--- a/src/backend/services/company_file_representation_service.py
+++ b/src/backend/services/company_file_representation_service.py
@@ -1,0 +1,512 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Mapping
+from urllib.parse import urlparse
+
+from . import concept_search_service
+from .relationship_write_service import add_relationship
+from .text_value_service import upsert_text_for_concept
+
+_URL_PATTERN = re.compile(r"\bhttps?://[^\s<>()\"']+", re.IGNORECASE)
+_COMPANY_LABEL_PATTERN = re.compile(
+    r"(?:^|\n)\s*(?:company|organisation|organization|business|startup|firm|name)\s*[:\-]\s*([^\n]{2,200})",
+    re.IGNORECASE,
+)
+_ABOUT_NAME_PATTERN = re.compile(
+    r"\babout\s+([A-Z][A-Za-z0-9&'`.,\- ]{2,100})",
+    re.IGNORECASE,
+)
+_WEB_FILENAME_HINT_PATTERN = re.compile(
+    r"\b(web[\s\-_]*page|website|about[\s\-_]*us|company[\s\-_]*profile|home[\s\-_]*page)\b",
+    re.IGNORECASE,
+)
+_COMPANY_TEXT_HINT_PATTERN = re.compile(
+    r"\b(company|organisation|organization|business|startup|our\s+mission|about\s+us|services)\b",
+    re.IGNORECASE,
+)
+_COMPANY_SUFFIX_HINT_PATTERN = re.compile(
+    r"\b(inc|inc\.|ltd|limited|llc|plc|corp|corp\.|corporation|company|co\.|group|labs?|systems?|technologies?)\b",
+    re.IGNORECASE,
+)
+_GENERIC_HEADER_PATTERN = re.compile(
+    r"^(about\s+us|home|contact|privacy\s+policy|terms|blog|careers|news)$",
+    re.IGNORECASE,
+)
+_NON_NAME_HINT_PATTERN = re.compile(
+    r"\b(email|phone|mobile|address|website|www\.|http|privacy|terms)\b",
+    re.IGNORECASE,
+)
+_WHITESPACE_SEPARATOR_PATTERN = re.compile(r"[\s._\-]+")
+
+
+def _safe_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _dedupe_casefold(values: list[str]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        cleaned = value.strip()
+        if not cleaned:
+            continue
+        key = cleaned.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(cleaned)
+    return deduped
+
+
+def _normalise_line(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip(" \t\r\n;|")
+
+
+def _extract_lines(text: str) -> list[str]:
+    lines: list[str] = []
+    for raw_line in text.splitlines():
+        normalised = _normalise_line(raw_line)
+        if not normalised:
+            continue
+        lines.append(normalised)
+    return lines
+
+
+def _extract_urls(text: str) -> list[str]:
+    urls: list[str] = []
+    for match in _URL_PATTERN.finditer(text):
+        value = _normalise_line(match.group(0))
+        if value:
+            urls.append(value)
+    return _dedupe_casefold(urls)
+
+
+def _host_to_company_candidate(host: str) -> str | None:
+    cleaned_host = host.strip().lower().rstrip(".")
+    if not cleaned_host:
+        return None
+    if cleaned_host.startswith("www."):
+        cleaned_host = cleaned_host[4:]
+    parts = [part for part in cleaned_host.split(".") if part]
+    if not parts:
+        return None
+
+    if len(parts) >= 3 and parts[-2] in {"co", "com", "org", "net", "gov", "ac"}:
+        label = parts[-3]
+    elif len(parts) >= 2:
+        label = parts[-2]
+    else:
+        label = parts[0]
+
+    tokens = [token for token in _WHITESPACE_SEPARATOR_PATTERN.split(label) if token]
+    if not tokens:
+        return None
+    candidate = " ".join(token.capitalize() for token in tokens)
+    return candidate.strip() or None
+
+
+def _looks_like_company_name(candidate: str) -> bool:
+    text = _normalise_line(candidate)
+    if not text:
+        return False
+    if len(text) < 2 or len(text) > 140:
+        return False
+    if _GENERIC_HEADER_PATTERN.fullmatch(text):
+        return False
+    if _NON_NAME_HINT_PATTERN.search(text):
+        return False
+    if text.count("http://") or text.count("https://"):
+        return False
+    if sum(char.isalpha() for char in text) < 2:
+        return False
+
+    tokens = [token for token in _WHITESPACE_SEPARATOR_PATTERN.split(text) if token]
+    if len(tokens) < 1 or len(tokens) > 8:
+        return False
+    if not _COMPANY_SUFFIX_HINT_PATTERN.search(text) and len(tokens) == 1 and len(tokens[0]) < 4:
+        return False
+    return True
+
+
+def _extract_candidate_company_names(
+    *,
+    text: str,
+    lines: list[str],
+    urls: list[str],
+) -> list[str]:
+    candidates: list[str] = []
+
+    for match in _COMPANY_LABEL_PATTERN.finditer(text):
+        candidate = _normalise_line(match.group(1))
+        if _looks_like_company_name(candidate):
+            candidates.append(candidate)
+
+    for match in _ABOUT_NAME_PATTERN.finditer(text):
+        candidate = _normalise_line(match.group(1))
+        if _looks_like_company_name(candidate):
+            candidates.append(candidate)
+
+    for line in lines[:12]:
+        if _looks_like_company_name(line) and (
+            _COMPANY_SUFFIX_HINT_PATTERN.search(line) or line[0].isupper()
+        ):
+            candidates.append(line)
+
+    for url in urls:
+        parsed = urlparse(url)
+        host = _safe_str(parsed.netloc)
+        if not host:
+            continue
+        fallback = _host_to_company_candidate(host)
+        if fallback and _looks_like_company_name(fallback):
+            candidates.append(fallback)
+
+    return _dedupe_casefold(candidates)
+
+
+def _extract_descriptor_lines(lines: list[str]) -> list[str]:
+    descriptors: list[str] = []
+    descriptor_hint_pattern = re.compile(
+        r"\b(mission|vision|services|products|founded|headquarters|industry|platform|solutions)\b",
+        re.IGNORECASE,
+    )
+    for line in lines:
+        if _URL_PATTERN.search(line):
+            continue
+        if descriptor_hint_pattern.search(line):
+            descriptors.append(line)
+    return _dedupe_casefold(descriptors)[:4]
+
+
+def _infer_representation_mode(
+    *,
+    original_filename: str | None,
+    text: str,
+    urls: list[str],
+) -> str | None:
+    filename = (original_filename or "").strip().lower()
+    if filename and _WEB_FILENAME_HINT_PATTERN.search(filename):
+        return "web_page"
+    if urls and _COMPANY_TEXT_HINT_PATTERN.search(text):
+        return "web_page"
+    return None
+
+
+def _stable_named_instance_concept_id(name: str, *, prefix: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", str(name or "").strip().lower()).strip("_")
+    if not slug:
+        slug = "unnamed"
+    digest = hashlib.sha256(str(name or "").strip().casefold().encode("utf-8")).hexdigest()[
+        :8
+    ]
+    return f"#V#{prefix}_{slug}_{digest}"
+
+
+def _resolve_or_create_company_concept_id(
+    *,
+    user_concept_id: str,
+    company_name: str,
+    logger: Any | None = None,
+) -> tuple[str, bool]:
+    from . import concept_service
+
+    for instance_type in ("#V#company", "#V#organization"):
+        search_result = concept_search_service.search_concepts(
+            query=company_name,
+            instance_of=instance_type,
+            match_type="exact",
+            limit=10,
+        )
+        for item in search_result.get("results") or []:
+            if not isinstance(item, Mapping):
+                continue
+            candidate_id = _safe_str(item.get("concept_id"))
+            candidate_name = _safe_str(item.get("name"))
+            if not candidate_id:
+                continue
+            if candidate_name and candidate_name.casefold() == company_name.casefold():
+                return candidate_id, False
+
+    concept_id = _stable_named_instance_concept_id(company_name, prefix="company")
+    try:
+        concept_service.create_concept(
+            name=company_name,
+            concept_id=concept_id,
+            parent_concept_ids=["#V#company"],
+            create_as_instance=True,
+            system_tags=["company", "representation", "file_copy"],
+        )
+        concept_service.update_concept(
+            concept_id,
+            {"relationships.specific_to_user": [user_concept_id.strip()]},
+        )
+    except Exception as exc:
+        if logger is not None:
+            logger.warning(
+                "[company_file_representation] Company concept create failed for %s: %s",
+                company_name,
+                exc,
+            )
+    return concept_id, True
+
+
+def _write_text_relation(
+    *,
+    subject_concept_id: str,
+    predicate: str,
+    text: str,
+    context: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        relation = upsert_text_for_concept(
+            subject_concept_id=subject_concept_id,
+            predicate=predicate,
+            text=text,
+            lang="en-NZ",
+            context=dict(context or {}),
+        )
+        return dict(relation) if isinstance(relation, Mapping) else None, None
+    except Exception as exc:
+        return None, str(exc)
+
+
+def materialise_company_representation_for_file_copy(
+    *,
+    user_concept_id: str | None,
+    file_copy_concept_id: str,
+    extracted_text: str | None,
+    original_filename: str | None = None,
+    interpretation: Mapping[str, Any] | None = None,
+    logger: Any | None = None,
+) -> dict[str, Any]:
+    """Deterministically materialise a company representation from webpage artefacts."""
+
+    report: dict[str, Any] = {
+        "success": False,
+        "attempted": False,
+        "verified": False,
+        "reason": "not_company_artefact",
+        "representation_mode": None,
+        "file_copy_concept_id": file_copy_concept_id,
+        "company_concept_id": None,
+        "company_name": None,
+        "aliases": [],
+        "urls": [],
+        "descriptors": [],
+        "created_company_concept": False,
+        "persisted_text_relations": [],
+        "persisted_structural_relations": [],
+        "errors": [],
+    }
+
+    text = _safe_str(extracted_text)
+    if not text:
+        report["reason"] = "no_extracted_text"
+        return report
+
+    lines = _extract_lines(text)
+    urls = _extract_urls(text)
+    if isinstance(interpretation, Mapping):
+        for key in ("source_url", "url", "canonical_url"):
+            value = _safe_str(interpretation.get(key))
+            if value:
+                urls.append(value)
+    urls = _dedupe_casefold(urls)[:4]
+    report["urls"] = list(urls)
+
+    representation_mode = _infer_representation_mode(
+        original_filename=original_filename,
+        text=text,
+        urls=urls,
+    )
+    if representation_mode is None:
+        return report
+
+    report["attempted"] = True
+    report["representation_mode"] = representation_mode
+
+    actor_id = _safe_str(user_concept_id)
+    if not actor_id:
+        report["reason"] = "missing_user_context_for_company_representation"
+        return report
+
+    company_names = _extract_candidate_company_names(text=text, lines=lines, urls=urls)
+    company_name = company_names[0] if company_names else None
+    aliases = company_names[1:4]
+    descriptors = _extract_descriptor_lines(lines)
+
+    report["company_name"] = company_name
+    report["aliases"] = list(aliases)
+    report["descriptors"] = list(descriptors)
+
+    if not company_name:
+        report["reason"] = "company_identity_unresolved"
+        return report
+    if not urls:
+        report["reason"] = "company_url_unresolved"
+        return report
+
+    company_concept_id, created_company = _resolve_or_create_company_concept_id(
+        user_concept_id=actor_id,
+        company_name=company_name,
+        logger=logger,
+    )
+    report["company_concept_id"] = company_concept_id
+    report["created_company_concept"] = created_company
+
+    relation_specs: list[tuple[str, str, Mapping[str, Any]]] = [
+        (
+            "hasName",
+            company_name,
+            {
+                "name_type": "NL",
+                "source": "company_file_representation",
+                "source_file_copy_concept_id": file_copy_concept_id,
+            },
+        )
+    ]
+    for alias in aliases:
+        relation_specs.append(
+            (
+                "hasName",
+                alias,
+                {
+                    "name_type": "NL",
+                    "is_alias": True,
+                    "source": "company_file_representation",
+                    "source_file_copy_concept_id": file_copy_concept_id,
+                },
+            )
+        )
+    for url in urls:
+        relation_specs.append(
+            (
+                "#V#has_url",
+                url,
+                {
+                    "source": "company_file_representation",
+                    "source_file_copy_concept_id": file_copy_concept_id,
+                },
+            )
+        )
+    for descriptor in descriptors:
+        relation_specs.append(
+            (
+                "#V#hasNote",
+                f"Descriptor: {descriptor}",
+                {
+                    "note_type": "company_descriptor",
+                    "source": "company_file_representation",
+                    "source_file_copy_concept_id": file_copy_concept_id,
+                },
+            )
+        )
+
+    interpretation_description = (
+        _safe_str(interpretation.get("description"))
+        if isinstance(interpretation, Mapping)
+        else None
+    )
+    if interpretation_description:
+        relation_specs.append(
+            (
+                "#V#hasNote",
+                f"Interpretation summary: {interpretation_description}",
+                {
+                    "note_type": "interpretation_summary",
+                    "source": "company_file_representation",
+                    "source_file_copy_concept_id": file_copy_concept_id,
+                },
+            )
+        )
+
+    relation_specs.append(
+        (
+            "#V#hasNote",
+            f"Source file copy: {file_copy_concept_id}",
+            {
+                "note_type": "source_linkage",
+                "source": "company_file_representation",
+                "source_file_copy_concept_id": file_copy_concept_id,
+            },
+        )
+    )
+
+    name_persisted = False
+    url_persisted = False
+    for predicate, value, context in relation_specs:
+        relation, error = _write_text_relation(
+            subject_concept_id=company_concept_id,
+            predicate=predicate,
+            text=value,
+            context=context,
+        )
+        if error:
+            report["errors"].append(
+                {
+                    "stage": "text_relation_upsert",
+                    "predicate": predicate,
+                    "text": value,
+                    "error": error,
+                }
+            )
+            continue
+        if predicate == "hasName" and value.casefold() == company_name.casefold():
+            name_persisted = True
+        if predicate == "#V#has_url":
+            url_persisted = True
+        report["persisted_text_relations"].append(
+            {
+                "predicate": predicate,
+                "relation_id": relation.get("relation_id") if isinstance(relation, Mapping) else None,
+            }
+        )
+
+    evidence_relation = add_relationship(
+        source_id=file_copy_concept_id,
+        predicate="#V#documentary_evidence_for",
+        target=company_concept_id,
+    )
+    if isinstance(evidence_relation, Mapping) and evidence_relation.get("success") is True:
+        report["persisted_structural_relations"].append(
+            {
+                "predicate": "#V#documentary_evidence_for",
+                "source_id": file_copy_concept_id,
+                "target_id": company_concept_id,
+                "modified": bool(evidence_relation.get("forward_modified")),
+            }
+        )
+        evidence_linked = True
+    else:
+        evidence_linked = False
+        report["errors"].append(
+            {
+                "stage": "source_evidence_link",
+                "predicate": "#V#documentary_evidence_for",
+                "source_id": file_copy_concept_id,
+                "target_id": company_concept_id,
+                "error": (
+                    evidence_relation.get("error")
+                    if isinstance(evidence_relation, Mapping)
+                    else "unexpected_relationship_response"
+                ),
+                "details": evidence_relation,
+            }
+        )
+
+    if name_persisted and url_persisted and evidence_linked:
+        report["verified"] = True
+        report["success"] = True
+        report["reason"] = "company_representation_verified"
+    elif not name_persisted:
+        report["reason"] = "company_name_persist_failed"
+    elif not url_persisted:
+        report["reason"] = "company_url_persist_failed"
+    else:
+        report["reason"] = "source_linkage_failed"
+    return report

--- a/tests/backend/test_company_file_representation_service.py
+++ b/tests/backend/test_company_file_representation_service.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+
+def test_materialise_company_representation_for_webpage_persists_core_effects(monkeypatch):
+    from src.backend.services.company_file_representation_service import (
+        materialise_company_representation_for_file_copy,
+    )
+
+    monkeypatch.setattr(
+        "src.backend.services.concept_search_service.search_concepts",
+        lambda **_kwargs: {"results": []},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_service.create_concept",
+        lambda **_kwargs: {"success": True},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_service.update_concept",
+        lambda *_args, **_kwargs: {"success": True},
+    )
+
+    relation_writes: list[dict[str, object]] = []
+
+    def _fake_upsert_text_for_concept(**kwargs):
+        relation_writes.append(dict(kwargs))
+        return {
+            "relation_id": f"rel-{len(relation_writes)}",
+            "relation_created": True,
+            "predicate": kwargs.get("predicate"),
+        }
+
+    relationship_writes: list[dict[str, object]] = []
+
+    def _fake_add_relationship(**kwargs):
+        relationship_writes.append(dict(kwargs))
+        return {"success": True, "forward_modified": True}
+
+    monkeypatch.setattr(
+        "src.backend.services.company_file_representation_service.upsert_text_for_concept",
+        _fake_upsert_text_for_concept,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.company_file_representation_service.add_relationship",
+        _fake_add_relationship,
+    )
+
+    result = materialise_company_representation_for_file_copy(
+        user_concept_id="#V#user_test",
+        file_copy_concept_id="#V#uploaded_file_copy_company_1",
+        extracted_text=(
+            "Company: Example Labs Ltd\n"
+            "Website: https://examplelabs.ai/about\n"
+            "Our mission is to build safe AI products.\n"
+            "Products: research and tooling.\n"
+        ),
+        original_filename="example-company-webpage.txt",
+        interpretation={"description": "Extracted from the company about page."},
+    )
+
+    assert result["attempted"] is True
+    assert result["verified"] is True
+    assert result["success"] is True
+    assert result["reason"] == "company_representation_verified"
+    assert result["representation_mode"] == "web_page"
+    assert result["company_name"] == "Example Labs Ltd"
+    assert "https://examplelabs.ai/about" in result["urls"]
+    assert result["company_concept_id"].startswith("#V#company_example_labs_ltd_")
+
+    predicates = [row["predicate"] for row in relation_writes]
+    assert "hasName" in predicates
+    assert "#V#has_url" in predicates
+    assert "#V#hasNote" in predicates
+
+    assert relationship_writes == [
+        {
+            "source_id": "#V#uploaded_file_copy_company_1",
+            "predicate": "#V#documentary_evidence_for",
+            "target": result["company_concept_id"],
+        }
+    ]
+
+
+def test_materialise_company_representation_fails_when_url_unresolved():
+    from src.backend.services.company_file_representation_service import (
+        materialise_company_representation_for_file_copy,
+    )
+
+    result = materialise_company_representation_for_file_copy(
+        user_concept_id="#V#user_test",
+        file_copy_concept_id="#V#uploaded_file_copy_company_2",
+        extracted_text=(
+            "Company: Example Labs Ltd\n"
+            "Our mission is to build safe AI products.\n"
+        ),
+        original_filename="company-website-profile.txt",
+    )
+
+    assert result["attempted"] is True
+    assert result["verified"] is False
+    assert result["success"] is False
+    assert result["reason"] == "company_url_unresolved"
+    assert result["company_concept_id"] is None
+
+
+def test_materialise_company_representation_is_not_attempted_for_unrelated_text():
+    from src.backend.services.company_file_representation_service import (
+        materialise_company_representation_for_file_copy,
+    )
+
+    result = materialise_company_representation_for_file_copy(
+        user_concept_id="#V#user_test",
+        file_copy_concept_id="#V#uploaded_file_copy_generic_1",
+        extracted_text="This is an ecosystem planning document about transport policy.",
+        original_filename="planning-notes.txt",
+    )
+
+    assert result["attempted"] is False
+    assert result["verified"] is False
+    assert result["success"] is False
+    assert result["reason"] == "not_company_artefact"

--- a/tests/backend/test_file_copy_ingestion_mcp_tools.py
+++ b/tests/backend/test_file_copy_ingestion_mcp_tools.py
@@ -410,6 +410,78 @@ def test_interpret_file_copy_fails_closed_when_person_representation_unverified(
     )
 
 
+def test_interpret_file_copy_fails_closed_when_company_representation_unverified(
+    monkeypatch,
+):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue._read_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "text": "Company profile content for uploaded web page.",
+            "content_type": "text/plain",
+            "original_filename": "company-webpage.txt",
+            "size_bytes": 256,
+            "byte_length": 256,
+            "blob": {"backend": "local", "key": "uploads/user/hash/company-webpage.txt"},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.file_copy_interpretation_service.build_document_interpretation",
+        lambda **_kwargs: {
+            "kind": "document",
+            "description": "Document text extracted: Company profile content for uploaded web page.",
+            "subject_tags": ["document"],
+            "content_text": "Company profile content for uploaded web page.",
+            "content_length": 47,
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.arxiv_paper_link_service.materialise_scholarly_representation_for_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "verified": True,
+            "paper_concept_id": "#V#paper_from_file_copy",
+            "file_copy_concept_id": "#V#file_copy_company_test",
+            "representation_mode": "generic_file_copy",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.company_file_representation_service.materialise_company_representation_for_file_copy",
+        lambda **_kwargs: {
+            "success": False,
+            "attempted": True,
+            "verified": False,
+            "reason": "company_identity_unresolved",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.upsert_singleton_text_relation",
+        lambda **_kwargs: {"relation_id": "rel-company"},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_text_relation_change_hook_service.maybe_sync_concept_text_relations_to_rag",
+        lambda **_kwargs: None,
+    )
+
+    result = cat._interpret_file_copy(
+        concept_id="#V#file_copy_company_test",
+        namespace="#V#user@org",
+    )
+
+    assert result["success"] is False
+    company_representation = result.get("company_representation") or {}
+    assert company_representation.get("attempted") is True
+    assert company_representation.get("verified") is False
+    persist_errors = result.get("persist_errors") or []
+    assert any(
+        row.get("predicate") == "#V#company_representation_verification"
+        for row in persist_errors
+        if isinstance(row, dict)
+    )
+
+
 def test_interpret_file_copy_includes_pdf_diagram_analysis(monkeypatch):
     from src.backend.integrations.internal_mcp import catalogue as cat
 

--- a/tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py
+++ b/tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py
@@ -257,6 +257,78 @@ def test_interpret_file_copy_gateway_fails_closed_on_unverified_person_represent
     )
 
 
+def test_interpret_file_copy_gateway_fails_closed_on_unverified_company_representation(
+    monkeypatch,
+):
+    gateway = _build_gateway()
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue._read_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "text": "Company profile content for uploaded web page.",
+            "content_type": "text/plain",
+            "original_filename": "company-webpage.txt",
+            "size_bytes": 96,
+            "byte_length": 96,
+            "blob": {"backend": "local", "key": "imports/user/hash/company-webpage.txt"},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.file_copy_interpretation_service.build_document_interpretation",
+        lambda **_kwargs: {
+            "kind": "document",
+            "description": "Document text extracted: Company profile content for uploaded web page.",
+            "subject_tags": ["document"],
+            "content_text": "Company profile content for uploaded web page.",
+            "content_length": 47,
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.arxiv_paper_link_service.materialise_scholarly_representation_for_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "verified": True,
+            "paper_concept_id": "#V#paper_from_file_copy_gateway",
+            "file_copy_concept_id": "#V#imported_file_gateway",
+            "representation_mode": "generic_file_copy",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.company_file_representation_service.materialise_company_representation_for_file_copy",
+        lambda **_kwargs: {
+            "success": False,
+            "attempted": True,
+            "verified": False,
+            "reason": "company_identity_unresolved",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.upsert_singleton_text_relation",
+        lambda **_kwargs: {"relation_id": "rel-gateway-company"},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_text_relation_change_hook_service.maybe_sync_concept_text_relations_to_rag",
+        lambda **_kwargs: None,
+    )
+
+    interpreted = gateway.invoke(
+        "interpret_file_copy",
+        {"concept_id": "#V#imported_file_gateway", "namespace": "#V#user@org"},
+    ).payload
+
+    assert interpreted.get("success") is False
+    company_representation = interpreted.get("company_representation") or {}
+    assert company_representation.get("attempted") is True
+    assert company_representation.get("verified") is False
+    persist_errors = interpreted.get("persist_errors") or []
+    assert any(
+        row.get("predicate") == "#V#company_representation_verification"
+        for row in persist_errors
+        if isinstance(row, dict)
+    )
+
+
 def test_interpret_file_copy_gateway_returns_pdf_diagram_candidates(monkeypatch):
     gateway = _build_gateway()
 

--- a/tests/backend/test_turn_execution_required_effects_contract.py
+++ b/tests/backend/test_turn_execution_required_effects_contract.py
@@ -320,6 +320,78 @@ def test_person_representation_marks_completion_when_verified(monkeypatch) -> No
     assert completion_gate.get("safe_to_claim_completion") is True
 
 
+def test_company_representation_blocks_completion_when_identity_unresolved(
+    monkeypatch,
+) -> None:
+    _patch_representation_profile_loader(
+        monkeypatch, profiles=_representation_profiles()
+    )
+    record = _build_record(
+        prompt_text="Represent this company from this web page file #V#uploaded_file_copy_company_1.",
+        response_text="Progress note.",
+        tool_invocations=[
+            {
+                "tool": "interpret_file_copy",
+                "payload": {
+                    "success": False,
+                    "error": "company_identity_unresolved",
+                    "company_representation": {
+                        "attempted": True,
+                        "verified": False,
+                        "reason": "company_identity_unresolved",
+                    },
+                },
+            }
+        ],
+    )
+
+    required_effects = record.get("required_effects")
+    assert isinstance(required_effects, list)
+    assert required_effects
+    effect = required_effects[0]
+    assert effect.get("effect_type") == "representation_company"
+    assert effect.get("status") == "not_satisfied"
+    assert effect.get("failure_code") == "company_representation_tool_failed"
+
+    completion_gate = record.get("completion_gate") or {}
+    assert completion_gate.get("decision") == "failed"
+    assert completion_gate.get("safe_to_claim_completion") is False
+
+
+def test_company_representation_marks_completion_when_verified(monkeypatch) -> None:
+    _patch_representation_profile_loader(
+        monkeypatch, profiles=_representation_profiles()
+    )
+    record = _build_record(
+        prompt_text="Represent this company from this web page file #V#uploaded_file_copy_company_1.",
+        response_text="Progress note.",
+        tool_invocations=[
+            {
+                "tool": "interpret_file_copy",
+                "payload": {
+                    "success": True,
+                    "company_representation": {
+                        "attempted": True,
+                        "verified": True,
+                        "company_concept_id": "#V#company_example_labs_ltd_1234abcd",
+                    },
+                },
+            }
+        ],
+    )
+
+    required_effects = record.get("required_effects")
+    assert isinstance(required_effects, list)
+    assert required_effects
+    effect = required_effects[0]
+    assert effect.get("effect_type") == "representation_company"
+    assert effect.get("status") == "satisfied"
+
+    completion_gate = record.get("completion_gate") or {}
+    assert completion_gate.get("decision") == "completed"
+    assert completion_gate.get("safe_to_claim_completion") is True
+
+
 def test_person_company_meeting_profiles_generate_non_empty_effects(monkeypatch) -> None:
     _patch_representation_profile_loader(
         monkeypatch, profiles=_representation_profiles()


### PR DESCRIPTION
## Summary
- add deterministic company file-copy materialisation service for web-page artefacts
- integrate company materialisation into interpret_file_copy and fail closed when required company effects are unresolved
- extend gateway/handler/contract tests and update VWL manual company representation semantics

## Validation
- pytest tests/backend/test_company_file_representation_service.py tests/backend/test_file_copy_ingestion_mcp_tools.py tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py tests/backend/test_turn_execution_required_effects_contract.py -q
- pyright 
