### PR TITLE
JVNAUTOSCI-1375: fail-close meeting representation from transcript/calendar artefacts

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -433,6 +433,26 @@ Completion-gate expectation:
 
 - Company-representation turns MUST remain non-complete when `interpret_file_copy` reports unresolved core company effects (for example `reason=company_identity_unresolved` or `reason=company_url_unresolved`).
 
+### 10.9 Meeting Representation Contract (JVNAUTOSCI-1369 / JVNAUTOSCI-1375)
+
+For meeting-representation intents driven by transcript/calendar artefacts, required-effects semantics MUST enforce meeting identity materialisation and source linkage before completion can be claimed.
+
+Canonical meeting profile source expectations:
+
+- `file_copy` source (transcript/calendar uploads): required tool set MUST include `interpret_file_copy`.
+- `url` source MAY use `extract_url` for enrichment, but file-copy meeting materialisation is the canonical mutation path for uploaded artefacts.
+
+Operational expectations for `interpret_file_copy` on meeting artefacts:
+
+- The handler SHOULD attempt deterministic meeting materialisation when transcript/calendar cues are detected.
+- Materialisation SHOULD persist core identity effects (meeting concept + `hasName`) and source linkage (`#V#documentary_evidence_for` from file-copy concept to meeting concept).
+- Date/time, participant, and outcome extraction MAY use conservative defaults (`#V#hasNote`) with explicit provenance.
+- If core meeting identity cannot be resolved or source linkage fails, the tool MUST fail closed (`success=false`) and return explicit `meeting_representation` diagnostics (`attempted`, `verified`, `reason`, IDs, and error details).
+
+Completion-gate expectation:
+
+- Meeting-representation turns MUST remain non-complete when `interpret_file_copy` reports unresolved core meeting effects (for example `reason=meeting_identity_unresolved`).
+
 ## 11. Durable Runtime Semantics
 
 ### 11.1 Instance Model

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -3368,6 +3368,9 @@ def _interpret_file_copy(**kwargs):
     from ...services.person_file_representation_service import (
         materialise_person_representation_for_file_copy,
     )
+    from ...services.meeting_file_representation_service import (
+        materialise_meeting_representation_for_file_copy,
+    )
     from ...services.company_file_representation_service import (
         materialise_company_representation_for_file_copy,
     )
@@ -3721,6 +3724,11 @@ def _interpret_file_copy(**kwargs):
         "verified": False,
         "reason": "not_applicable",
     }
+    meeting_representation: dict[str, Any] = {
+        "attempted": False,
+        "verified": False,
+        "reason": "not_applicable",
+    }
     subtype_assertion: dict[str, Any] | None = None
     subtype_assertion_outcome = "not_attempted"
     if persist:
@@ -4002,6 +4010,33 @@ def _interpret_file_copy(**kwargs):
                     "details": dict(company_representation),
                 }
             )
+
+        meeting_representation = materialise_meeting_representation_for_file_copy(
+            user_concept_id=(
+                user_concept_id.strip()
+                if isinstance(user_concept_id, str) and user_concept_id.strip()
+                else None
+            ),
+            file_copy_concept_id=concept_id,
+            extracted_text=extracted_text,
+            original_filename=(
+                original_filename if isinstance(original_filename, str) else None
+            ),
+            interpretation=interpretation,
+            logger=logger,
+        )
+        if (
+            isinstance(meeting_representation, Mapping)
+            and bool(meeting_representation.get("attempted"))
+            and not bool(meeting_representation.get("verified"))
+        ):
+            persist_errors.append(
+                {
+                    "predicate": "#V#meeting_representation_verification",
+                    "error": "meeting_representation_not_verified",
+                    "details": dict(meeting_representation),
+                }
+            )
     else:
         subtype_assertion_outcome = "persist_disabled"
         scholarly_representation = {
@@ -4015,6 +4050,11 @@ def _interpret_file_copy(**kwargs):
             "reason": "persist_disabled",
         }
         company_representation = {
+            "attempted": False,
+            "verified": False,
+            "reason": "persist_disabled",
+        }
+        meeting_representation = {
             "attempted": False,
             "verified": False,
             "reason": "persist_disabled",
@@ -4085,6 +4125,7 @@ def _interpret_file_copy(**kwargs):
         "scholarly_representation": scholarly_representation,
         "person_representation": person_representation,
         "company_representation": company_representation,
+        "meeting_representation": meeting_representation,
         "namespace": effective_namespace,
         **ns_report,
         "read_result": {
@@ -6691,6 +6732,7 @@ def _interpret_file_copy_output_schema() -> Schema:
             "scholarly_representation": (dict, type(None)),
             "person_representation": (dict, type(None)),
             "company_representation": (dict, type(None)),
+            "meeting_representation": (dict, type(None)),
             "namespace": (str, type(None)),
             "read_result": (dict, type(None)),
             "image_fetch_error": (str, type(None)),

--- a/src/backend/services/meeting_file_representation_service.py
+++ b/src/backend/services/meeting_file_representation_service.py
@@ -1,0 +1,513 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Mapping
+
+from . import concept_search_service
+from .relationship_write_service import add_relationship
+from .text_value_service import upsert_text_for_concept
+
+_MEETING_FILENAME_HINT_PATTERN = re.compile(
+    r"\b(meeting|transcript|minutes|agenda|calendar|invite|invitation)\b",
+    re.IGNORECASE,
+)
+_MEETING_TEXT_HINT_PATTERN = re.compile(
+    r"\b(meeting|agenda|minutes|attendees|participants|calendar(?:\s+event)?|transcript|zoom|teams)\b",
+    re.IGNORECASE,
+)
+_TRANSCRIPT_HINT_PATTERN = re.compile(r"\b(transcript|speaker|discussion)\b", re.IGNORECASE)
+_CALENDAR_HINT_PATTERN = re.compile(r"\b(calendar|invite|invitation|ics|event)\b", re.IGNORECASE)
+_MEETING_TITLE_LABEL_PATTERN = re.compile(
+    r"(?:^|\n)\s*(?:meeting|title|subject|event)\s*[:\-]\s*([^\n]{3,180})",
+    re.IGNORECASE,
+)
+_ATTENDEES_LABEL_PATTERN = re.compile(
+    r"(?:^|\n)\s*(?:attendees|participants|guests)\s*[:\-]\s*([^\n]{2,400})",
+    re.IGNORECASE,
+)
+_ISO_DATETIME_PATTERN = re.compile(
+    r"\b\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2})?(?:Z|[+\-]\d{2}:\d{2})?)?\b"
+)
+_HUMAN_DATE_PATTERN = re.compile(
+    r"\b(?:"
+    r"(?:\d{1,2}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{4})"
+    r"|(?:"
+    r"(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{1,2},\s+\d{4}"
+    r")"
+    r")"
+    r"(?:\s+\d{1,2}:\d{2}(?:\s?(?:AM|PM))?)?\b",
+    re.IGNORECASE,
+)
+_SPEAKER_LINE_PATTERN = re.compile(
+    r"^(?:[-*]\s*)?([A-Z][A-Za-z'`.\-]+(?:\s+[A-Z][A-Za-z'`.\-]+){0,2})\s*:",
+    re.IGNORECASE,
+)
+_GENERIC_TITLE_PATTERN = re.compile(
+    r"^(meeting|meeting transcript|transcript|agenda|minutes|calendar event)$",
+    re.IGNORECASE,
+)
+_NON_TITLE_HINT_PATTERN = re.compile(
+    r"\b(email|phone|mobile|address|website|www\.|http)\b",
+    re.IGNORECASE,
+)
+_SEPARATOR_PATTERN = re.compile(r"[\s._\-]+")
+
+
+def _safe_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _dedupe_casefold(values: list[str]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        cleaned = value.strip()
+        if not cleaned:
+            continue
+        key = cleaned.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(cleaned)
+    return deduped
+
+
+def _normalise_line(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip(" \t\r\n;|")
+
+
+def _extract_lines(text: str) -> list[str]:
+    lines: list[str] = []
+    for raw_line in text.splitlines():
+        normalised = _normalise_line(raw_line)
+        if not normalised:
+            continue
+        lines.append(normalised)
+    return lines
+
+
+def _looks_like_meeting_title(candidate: str) -> bool:
+    text = _normalise_line(candidate)
+    if not text:
+        return False
+    if len(text) < 3 or len(text) > 180:
+        return False
+    if _GENERIC_TITLE_PATTERN.fullmatch(text):
+        return False
+    if _NON_TITLE_HINT_PATTERN.search(text):
+        return False
+    if _ISO_DATETIME_PATTERN.search(text):
+        return False
+    if sum(char.isalpha() for char in text) < 3:
+        return False
+    return True
+
+
+def _extract_meeting_titles(*, text: str, lines: list[str]) -> list[str]:
+    candidates: list[str] = []
+
+    for match in _MEETING_TITLE_LABEL_PATTERN.finditer(text):
+        candidate = _normalise_line(match.group(1))
+        if _looks_like_meeting_title(candidate):
+            candidates.append(candidate)
+
+    for line in lines[:8]:
+        if _looks_like_meeting_title(line):
+            candidates.append(line)
+
+    return _dedupe_casefold(candidates)
+
+
+def _extract_datetime_candidates(text: str) -> list[str]:
+    candidates: list[str] = []
+    for match in _ISO_DATETIME_PATTERN.finditer(text):
+        candidates.append(_normalise_line(match.group(0)))
+    for match in _HUMAN_DATE_PATTERN.finditer(text):
+        candidates.append(_normalise_line(match.group(0)))
+    return _dedupe_casefold(candidates)[:3]
+
+
+def _looks_like_participant_name(candidate: str) -> bool:
+    text = _normalise_line(candidate)
+    if not text:
+        return False
+    if len(text) < 3 or len(text) > 100:
+        return False
+    if any(char.isdigit() for char in text):
+        return False
+    if _NON_TITLE_HINT_PATTERN.search(text):
+        return False
+    tokens = [token for token in _SEPARATOR_PATTERN.split(text) if token]
+    if len(tokens) < 1 or len(tokens) > 4:
+        return False
+    for token in tokens:
+        if len(token) < 2:
+            return False
+        if not re.fullmatch(r"[A-Za-z'`.\-]+", token):
+            return False
+    return True
+
+
+def _extract_participants(*, text: str, lines: list[str]) -> list[str]:
+    participants: list[str] = []
+
+    for match in _ATTENDEES_LABEL_PATTERN.finditer(text):
+        raw = _normalise_line(match.group(1))
+        for part in re.split(r"[;,]|(?:\band\b)", raw):
+            candidate = _normalise_line(part)
+            if _looks_like_participant_name(candidate):
+                participants.append(candidate)
+
+    for line in lines:
+        speaker_match = _SPEAKER_LINE_PATTERN.match(line)
+        if speaker_match:
+            candidate = _normalise_line(speaker_match.group(1))
+            if _looks_like_participant_name(candidate):
+                participants.append(candidate)
+
+    return _dedupe_casefold(participants)[:10]
+
+
+def _extract_outcome_lines(lines: list[str]) -> list[str]:
+    outcomes: list[str] = []
+    outcome_pattern = re.compile(
+        r"\b(action(?:\s+item)?|decision|outcome|follow[\s\-]?up|next steps?)\b",
+        re.IGNORECASE,
+    )
+    for line in lines:
+        if outcome_pattern.search(line):
+            outcomes.append(line)
+    return _dedupe_casefold(outcomes)[:5]
+
+
+def _infer_representation_mode(
+    *,
+    original_filename: str | None,
+    text: str,
+    lines: list[str],
+) -> str | None:
+    filename = (original_filename or "").strip().lower()
+    if filename and _MEETING_FILENAME_HINT_PATTERN.search(filename):
+        if _TRANSCRIPT_HINT_PATTERN.search(filename) or any(
+            _SPEAKER_LINE_PATTERN.match(line or "") for line in lines[:20]
+        ):
+            return "transcript"
+        if _CALENDAR_HINT_PATTERN.search(filename):
+            return "calendar"
+        return "meeting"
+
+    if _MEETING_TEXT_HINT_PATTERN.search(text):
+        if _TRANSCRIPT_HINT_PATTERN.search(text) or any(
+            _SPEAKER_LINE_PATTERN.match(line or "") for line in lines[:30]
+        ):
+            return "transcript"
+        if _CALENDAR_HINT_PATTERN.search(text):
+            return "calendar"
+        return "meeting"
+    return None
+
+
+def _stable_named_instance_concept_id(name: str, *, prefix: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", str(name or "").strip().lower()).strip("_")
+    if not slug:
+        slug = "unnamed"
+    digest = hashlib.sha256(str(name or "").strip().casefold().encode("utf-8")).hexdigest()[
+        :8
+    ]
+    return f"#V#{prefix}_{slug}_{digest}"
+
+
+def _resolve_or_create_meeting_concept_id(
+    *,
+    user_concept_id: str,
+    meeting_name: str,
+    logger: Any | None = None,
+) -> tuple[str, bool]:
+    from . import concept_service
+
+    search_result = concept_search_service.search_concepts(
+        query=meeting_name,
+        instance_of="#V#meeting",
+        match_type="exact",
+        limit=10,
+    )
+    for item in search_result.get("results") or []:
+        if not isinstance(item, Mapping):
+            continue
+        candidate_id = _safe_str(item.get("concept_id"))
+        candidate_name = _safe_str(item.get("name"))
+        if not candidate_id:
+            continue
+        if candidate_name and candidate_name.casefold() == meeting_name.casefold():
+            return candidate_id, False
+
+    concept_id = _stable_named_instance_concept_id(meeting_name, prefix="meeting")
+    try:
+        concept_service.create_concept(
+            name=meeting_name,
+            concept_id=concept_id,
+            parent_concept_ids=["#V#meeting"],
+            create_as_instance=True,
+            system_tags=["meeting", "representation", "file_copy"],
+        )
+        concept_service.update_concept(
+            concept_id,
+            {"relationships.specific_to_user": [user_concept_id.strip()]},
+        )
+    except Exception as exc:
+        if logger is not None:
+            logger.warning(
+                "[meeting_file_representation] Meeting concept create failed for %s: %s",
+                meeting_name,
+                exc,
+            )
+    return concept_id, True
+
+
+def _write_text_relation(
+    *,
+    subject_concept_id: str,
+    predicate: str,
+    text: str,
+    context: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        relation = upsert_text_for_concept(
+            subject_concept_id=subject_concept_id,
+            predicate=predicate,
+            text=text,
+            lang="en-NZ",
+            context=dict(context or {}),
+        )
+        return dict(relation) if isinstance(relation, Mapping) else None, None
+    except Exception as exc:
+        return None, str(exc)
+
+
+def materialise_meeting_representation_for_file_copy(
+    *,
+    user_concept_id: str | None,
+    file_copy_concept_id: str,
+    extracted_text: str | None,
+    original_filename: str | None = None,
+    interpretation: Mapping[str, Any] | None = None,
+    logger: Any | None = None,
+) -> dict[str, Any]:
+    """Deterministically materialise a meeting representation from transcript/calendar artefacts."""
+
+    report: dict[str, Any] = {
+        "success": False,
+        "attempted": False,
+        "verified": False,
+        "reason": "not_meeting_artefact",
+        "representation_mode": None,
+        "file_copy_concept_id": file_copy_concept_id,
+        "meeting_concept_id": None,
+        "meeting_name": None,
+        "datetime_candidates": [],
+        "participants": [],
+        "outcomes": [],
+        "created_meeting_concept": False,
+        "persisted_text_relations": [],
+        "persisted_structural_relations": [],
+        "errors": [],
+    }
+
+    text = _safe_str(extracted_text)
+    if not text:
+        report["reason"] = "no_extracted_text"
+        return report
+
+    lines = _extract_lines(text)
+    representation_mode = _infer_representation_mode(
+        original_filename=original_filename,
+        text=text,
+        lines=lines,
+    )
+    if representation_mode is None:
+        return report
+
+    report["attempted"] = True
+    report["representation_mode"] = representation_mode
+
+    actor_id = _safe_str(user_concept_id)
+    if not actor_id:
+        report["reason"] = "missing_user_context_for_meeting_representation"
+        return report
+
+    title_candidates = _extract_meeting_titles(text=text, lines=lines)
+    datetime_candidates = _extract_datetime_candidates(text)
+    participants = _extract_participants(text=text, lines=lines)
+    outcomes = _extract_outcome_lines(lines)
+
+    meeting_name = title_candidates[0] if title_candidates else None
+    if not meeting_name and datetime_candidates:
+        meeting_name = f"Meeting on {datetime_candidates[0]}"
+
+    report["meeting_name"] = meeting_name
+    report["datetime_candidates"] = list(datetime_candidates)
+    report["participants"] = list(participants)
+    report["outcomes"] = list(outcomes)
+
+    if not meeting_name:
+        report["reason"] = "meeting_identity_unresolved"
+        return report
+
+    meeting_concept_id, created_meeting = _resolve_or_create_meeting_concept_id(
+        user_concept_id=actor_id,
+        meeting_name=meeting_name,
+        logger=logger,
+    )
+    report["meeting_concept_id"] = meeting_concept_id
+    report["created_meeting_concept"] = created_meeting
+
+    relation_specs: list[tuple[str, str, Mapping[str, Any]]] = [
+        (
+            "hasName",
+            meeting_name,
+            {
+                "name_type": "NL",
+                "source": "meeting_file_representation",
+                "source_file_copy_concept_id": file_copy_concept_id,
+            },
+        )
+    ]
+    for value in datetime_candidates:
+        relation_specs.append(
+            (
+                "#V#hasNote",
+                f"Date/time: {value}",
+                {
+                    "note_type": "meeting_datetime",
+                    "source": "meeting_file_representation",
+                    "source_file_copy_concept_id": file_copy_concept_id,
+                },
+            )
+        )
+    for participant in participants:
+        relation_specs.append(
+            (
+                "#V#hasNote",
+                f"Participant: {participant}",
+                {
+                    "note_type": "meeting_participant",
+                    "source": "meeting_file_representation",
+                    "source_file_copy_concept_id": file_copy_concept_id,
+                },
+            )
+        )
+    for outcome in outcomes:
+        relation_specs.append(
+            (
+                "#V#hasNote",
+                f"Outcome/action: {outcome}",
+                {
+                    "note_type": "meeting_outcome",
+                    "source": "meeting_file_representation",
+                    "source_file_copy_concept_id": file_copy_concept_id,
+                },
+            )
+        )
+
+    interpretation_description = (
+        _safe_str(interpretation.get("description"))
+        if isinstance(interpretation, Mapping)
+        else None
+    )
+    if interpretation_description:
+        relation_specs.append(
+            (
+                "#V#hasNote",
+                f"Interpretation summary: {interpretation_description}",
+                {
+                    "note_type": "interpretation_summary",
+                    "source": "meeting_file_representation",
+                    "source_file_copy_concept_id": file_copy_concept_id,
+                },
+            )
+        )
+
+    relation_specs.append(
+        (
+            "#V#hasNote",
+            f"Source file copy: {file_copy_concept_id}",
+            {
+                "note_type": "source_linkage",
+                "source": "meeting_file_representation",
+                "source_file_copy_concept_id": file_copy_concept_id,
+            },
+        )
+    )
+
+    name_persisted = False
+    for predicate, value, context in relation_specs:
+        relation, error = _write_text_relation(
+            subject_concept_id=meeting_concept_id,
+            predicate=predicate,
+            text=value,
+            context=context,
+        )
+        if error:
+            report["errors"].append(
+                {
+                    "stage": "text_relation_upsert",
+                    "predicate": predicate,
+                    "text": value,
+                    "error": error,
+                }
+            )
+            continue
+        if predicate == "hasName":
+            name_persisted = True
+        report["persisted_text_relations"].append(
+            {
+                "predicate": predicate,
+                "relation_id": relation.get("relation_id") if isinstance(relation, Mapping) else None,
+            }
+        )
+
+    evidence_relation = add_relationship(
+        source_id=file_copy_concept_id,
+        predicate="#V#documentary_evidence_for",
+        target=meeting_concept_id,
+    )
+    if isinstance(evidence_relation, Mapping) and evidence_relation.get("success") is True:
+        report["persisted_structural_relations"].append(
+            {
+                "predicate": "#V#documentary_evidence_for",
+                "source_id": file_copy_concept_id,
+                "target_id": meeting_concept_id,
+                "modified": bool(evidence_relation.get("forward_modified")),
+            }
+        )
+        evidence_linked = True
+    else:
+        evidence_linked = False
+        report["errors"].append(
+            {
+                "stage": "source_evidence_link",
+                "predicate": "#V#documentary_evidence_for",
+                "source_id": file_copy_concept_id,
+                "target_id": meeting_concept_id,
+                "error": (
+                    evidence_relation.get("error")
+                    if isinstance(evidence_relation, Mapping)
+                    else "unexpected_relationship_response"
+                ),
+                "details": evidence_relation,
+            }
+        )
+
+    if name_persisted and evidence_linked:
+        report["verified"] = True
+        report["success"] = True
+        report["reason"] = "meeting_representation_verified"
+    elif not name_persisted:
+        report["reason"] = "meeting_name_persist_failed"
+    else:
+        report["reason"] = "source_linkage_failed"
+    return report

--- a/tests/backend/test_file_copy_ingestion_mcp_tools.py
+++ b/tests/backend/test_file_copy_ingestion_mcp_tools.py
@@ -482,6 +482,78 @@ def test_interpret_file_copy_fails_closed_when_company_representation_unverified
     )
 
 
+def test_interpret_file_copy_fails_closed_when_meeting_representation_unverified(
+    monkeypatch,
+):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue._read_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "text": "Meeting transcript content.",
+            "content_type": "text/plain",
+            "original_filename": "meeting-transcript.txt",
+            "size_bytes": 256,
+            "byte_length": 256,
+            "blob": {"backend": "local", "key": "uploads/user/hash/meeting-transcript.txt"},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.file_copy_interpretation_service.build_document_interpretation",
+        lambda **_kwargs: {
+            "kind": "document",
+            "description": "Document text extracted: Meeting transcript content.",
+            "subject_tags": ["document"],
+            "content_text": "Meeting transcript content.",
+            "content_length": 27,
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.arxiv_paper_link_service.materialise_scholarly_representation_for_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "verified": True,
+            "paper_concept_id": "#V#paper_from_file_copy",
+            "file_copy_concept_id": "#V#file_copy_meeting_test",
+            "representation_mode": "generic_file_copy",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.meeting_file_representation_service.materialise_meeting_representation_for_file_copy",
+        lambda **_kwargs: {
+            "success": False,
+            "attempted": True,
+            "verified": False,
+            "reason": "meeting_identity_unresolved",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.upsert_singleton_text_relation",
+        lambda **_kwargs: {"relation_id": "rel-meeting"},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_text_relation_change_hook_service.maybe_sync_concept_text_relations_to_rag",
+        lambda **_kwargs: None,
+    )
+
+    result = cat._interpret_file_copy(
+        concept_id="#V#file_copy_meeting_test",
+        namespace="#V#user@org",
+    )
+
+    assert result["success"] is False
+    meeting_representation = result.get("meeting_representation") or {}
+    assert meeting_representation.get("attempted") is True
+    assert meeting_representation.get("verified") is False
+    persist_errors = result.get("persist_errors") or []
+    assert any(
+        row.get("predicate") == "#V#meeting_representation_verification"
+        for row in persist_errors
+        if isinstance(row, dict)
+    )
+
+
 def test_interpret_file_copy_includes_pdf_diagram_analysis(monkeypatch):
     from src.backend.integrations.internal_mcp import catalogue as cat
 

--- a/tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py
+++ b/tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py
@@ -329,6 +329,78 @@ def test_interpret_file_copy_gateway_fails_closed_on_unverified_company_represen
     )
 
 
+def test_interpret_file_copy_gateway_fails_closed_on_unverified_meeting_representation(
+    monkeypatch,
+):
+    gateway = _build_gateway()
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue._read_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "text": "Meeting transcript content.",
+            "content_type": "text/plain",
+            "original_filename": "meeting-transcript.txt",
+            "size_bytes": 96,
+            "byte_length": 96,
+            "blob": {"backend": "local", "key": "imports/user/hash/meeting-transcript.txt"},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.file_copy_interpretation_service.build_document_interpretation",
+        lambda **_kwargs: {
+            "kind": "document",
+            "description": "Document text extracted: Meeting transcript content.",
+            "subject_tags": ["document"],
+            "content_text": "Meeting transcript content.",
+            "content_length": 27,
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.arxiv_paper_link_service.materialise_scholarly_representation_for_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "verified": True,
+            "paper_concept_id": "#V#paper_from_file_copy_gateway",
+            "file_copy_concept_id": "#V#imported_file_gateway",
+            "representation_mode": "generic_file_copy",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.meeting_file_representation_service.materialise_meeting_representation_for_file_copy",
+        lambda **_kwargs: {
+            "success": False,
+            "attempted": True,
+            "verified": False,
+            "reason": "meeting_identity_unresolved",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.upsert_singleton_text_relation",
+        lambda **_kwargs: {"relation_id": "rel-gateway-meeting"},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_text_relation_change_hook_service.maybe_sync_concept_text_relations_to_rag",
+        lambda **_kwargs: None,
+    )
+
+    interpreted = gateway.invoke(
+        "interpret_file_copy",
+        {"concept_id": "#V#imported_file_gateway", "namespace": "#V#user@org"},
+    ).payload
+
+    assert interpreted.get("success") is False
+    meeting_representation = interpreted.get("meeting_representation") or {}
+    assert meeting_representation.get("attempted") is True
+    assert meeting_representation.get("verified") is False
+    persist_errors = interpreted.get("persist_errors") or []
+    assert any(
+        row.get("predicate") == "#V#meeting_representation_verification"
+        for row in persist_errors
+        if isinstance(row, dict)
+    )
+
+
 def test_interpret_file_copy_gateway_returns_pdf_diagram_candidates(monkeypatch):
     gateway = _build_gateway()
 

--- a/tests/backend/test_meeting_file_representation_service.py
+++ b/tests/backend/test_meeting_file_representation_service.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+
+def test_materialise_meeting_representation_for_transcript_persists_core_effects(
+    monkeypatch,
+):
+    from src.backend.services.meeting_file_representation_service import (
+        materialise_meeting_representation_for_file_copy,
+    )
+
+    monkeypatch.setattr(
+        "src.backend.services.concept_search_service.search_concepts",
+        lambda **_kwargs: {"results": []},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_service.create_concept",
+        lambda **_kwargs: {"success": True},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_service.update_concept",
+        lambda *_args, **_kwargs: {"success": True},
+    )
+
+    relation_writes: list[dict[str, object]] = []
+
+    def _fake_upsert_text_for_concept(**kwargs):
+        relation_writes.append(dict(kwargs))
+        return {
+            "relation_id": f"rel-{len(relation_writes)}",
+            "relation_created": True,
+            "predicate": kwargs.get("predicate"),
+        }
+
+    relationship_writes: list[dict[str, object]] = []
+
+    def _fake_add_relationship(**kwargs):
+        relationship_writes.append(dict(kwargs))
+        return {"success": True, "forward_modified": True}
+
+    monkeypatch.setattr(
+        "src.backend.services.meeting_file_representation_service.upsert_text_for_concept",
+        _fake_upsert_text_for_concept,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.meeting_file_representation_service.add_relationship",
+        _fake_add_relationship,
+    )
+
+    result = materialise_meeting_representation_for_file_copy(
+        user_concept_id="#V#user_test",
+        file_copy_concept_id="#V#uploaded_file_copy_meeting_1",
+        extracted_text=(
+            "Meeting: Weekly Research Sync\n"
+            "Date: 2026-03-05 10:00\n"
+            "Attendees: Jane Doe, John Smith\n"
+            "Action item: Jane to prepare summary for next week.\n"
+        ),
+        original_filename="weekly-research-transcript.txt",
+        interpretation={"description": "Transcript extracted from uploaded meeting notes."},
+    )
+
+    assert result["attempted"] is True
+    assert result["verified"] is True
+    assert result["success"] is True
+    assert result["reason"] == "meeting_representation_verified"
+    assert result["representation_mode"] == "transcript"
+    assert result["meeting_name"] == "Weekly Research Sync"
+    assert "2026-03-05 10:00" in result["datetime_candidates"]
+    assert "Jane Doe" in result["participants"]
+    assert result["meeting_concept_id"].startswith("#V#meeting_weekly_research_sync_")
+
+    predicates = [row["predicate"] for row in relation_writes]
+    assert "hasName" in predicates
+    assert "#V#hasNote" in predicates
+
+    assert relationship_writes == [
+        {
+            "source_id": "#V#uploaded_file_copy_meeting_1",
+            "predicate": "#V#documentary_evidence_for",
+            "target": result["meeting_concept_id"],
+        }
+    ]
+
+
+def test_materialise_meeting_representation_fails_when_identity_unresolved():
+    from src.backend.services.meeting_file_representation_service import (
+        materialise_meeting_representation_for_file_copy,
+    )
+
+    result = materialise_meeting_representation_for_file_copy(
+        user_concept_id="#V#user_test",
+        file_copy_concept_id="#V#uploaded_file_copy_meeting_2",
+        extracted_text=(
+            "Meeting transcript\n"
+            "Agenda\n"
+            "Minutes\n"
+        ),
+        original_filename="meeting-transcript.txt",
+    )
+
+    assert result["attempted"] is True
+    assert result["verified"] is False
+    assert result["success"] is False
+    assert result["reason"] == "meeting_identity_unresolved"
+    assert result["meeting_concept_id"] is None
+
+
+def test_materialise_meeting_representation_is_not_attempted_for_unrelated_text():
+    from src.backend.services.meeting_file_representation_service import (
+        materialise_meeting_representation_for_file_copy,
+    )
+
+    result = materialise_meeting_representation_for_file_copy(
+        user_concept_id="#V#user_test",
+        file_copy_concept_id="#V#uploaded_file_copy_generic_1",
+        extracted_text="This is a product specification and architecture document.",
+        original_filename="specification.txt",
+    )
+
+    assert result["attempted"] is False
+    assert result["verified"] is False
+    assert result["success"] is False
+    assert result["reason"] == "not_meeting_artefact"

--- a/tests/backend/test_turn_execution_required_effects_contract.py
+++ b/tests/backend/test_turn_execution_required_effects_contract.py
@@ -392,6 +392,78 @@ def test_company_representation_marks_completion_when_verified(monkeypatch) -> N
     assert completion_gate.get("safe_to_claim_completion") is True
 
 
+def test_meeting_representation_blocks_completion_when_identity_unresolved(
+    monkeypatch,
+) -> None:
+    _patch_representation_profile_loader(
+        monkeypatch, profiles=_representation_profiles()
+    )
+    record = _build_record(
+        prompt_text="Represent this meeting from this transcript file #V#uploaded_file_copy_meeting_1.",
+        response_text="Progress note.",
+        tool_invocations=[
+            {
+                "tool": "interpret_file_copy",
+                "payload": {
+                    "success": False,
+                    "error": "meeting_identity_unresolved",
+                    "meeting_representation": {
+                        "attempted": True,
+                        "verified": False,
+                        "reason": "meeting_identity_unresolved",
+                    },
+                },
+            }
+        ],
+    )
+
+    required_effects = record.get("required_effects")
+    assert isinstance(required_effects, list)
+    assert required_effects
+    effect = required_effects[0]
+    assert effect.get("effect_type") == "representation_meeting"
+    assert effect.get("status") == "not_satisfied"
+    assert effect.get("failure_code") == "meeting_representation_tool_failed"
+
+    completion_gate = record.get("completion_gate") or {}
+    assert completion_gate.get("decision") == "failed"
+    assert completion_gate.get("safe_to_claim_completion") is False
+
+
+def test_meeting_representation_marks_completion_when_verified(monkeypatch) -> None:
+    _patch_representation_profile_loader(
+        monkeypatch, profiles=_representation_profiles()
+    )
+    record = _build_record(
+        prompt_text="Represent this meeting from this transcript file #V#uploaded_file_copy_meeting_1.",
+        response_text="Progress note.",
+        tool_invocations=[
+            {
+                "tool": "interpret_file_copy",
+                "payload": {
+                    "success": True,
+                    "meeting_representation": {
+                        "attempted": True,
+                        "verified": True,
+                        "meeting_concept_id": "#V#meeting_weekly_research_sync_1234abcd",
+                    },
+                },
+            }
+        ],
+    )
+
+    required_effects = record.get("required_effects")
+    assert isinstance(required_effects, list)
+    assert required_effects
+    effect = required_effects[0]
+    assert effect.get("effect_type") == "representation_meeting"
+    assert effect.get("status") == "satisfied"
+
+    completion_gate = record.get("completion_gate") or {}
+    assert completion_gate.get("decision") == "completed"
+    assert completion_gate.get("safe_to_claim_completion") is True
+
+
 def test_person_company_meeting_profiles_generate_non_empty_effects(monkeypatch) -> None:
     _patch_representation_profile_loader(
         monkeypatch, profiles=_representation_profiles()


### PR DESCRIPTION
## Summary
- add deterministic meeting file-copy materialisation service for transcript/calendar artefacts
- integrate meeting materialisation into interpret_file_copy and fail closed when required meeting effects are unresolved
- extend handler/gateway/contract tests and update VWL manual meeting representation semantics

## Validation
- pytest tests/backend/test_meeting_file_representation_service.py tests/backend/test_file_copy_ingestion_mcp_tools.py tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py tests/backend/test_turn_execution_required_effects_contract.py -q
- pyright 
