### PR TITLE
JVNAUTOSCI-1378 Clarify thinking card workflow progress

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -210,6 +210,16 @@ For chat progress payloads consumed by the thinking card:
 - `liveness_state` remains informational for metadata (for example "Last activity"), not authoritative for terminality.
 - Progress polling SHOULD stop once terminality is detected (except explicit user-triggered refresh flows).
 
+### 7.2 Thinking-Card Workflow Visibility Contract (JVNAUTOSCI-1378)
+
+For live chat progress payloads used by workflow-aware thinking-card rendering:
+
+- the payload SHOULD include `workflow_stage_path` derived from the canonical conversation-turn stage model, not just raw internal event/status labels;
+- workflow discovery SHOULD emit an explicit completion payload even when zero workflows match, so the UI can render a visible "no applicable workflow found" step rather than silently omitting discovery outcome;
+- live workflow-dispatch progress SHOULD expose `selected_workflow_id` and SHOULD expose a human-readable `selected_workflow_name` when available;
+- selector metadata such as `workflow_selector_verdict` and `workflow_selector_source` SHOULD be preserved in the live payload so the UI can explain why a workflow route was chosen;
+- thinking-card step labels SHOULD prefer canonical workflow-stage labels (for example `Workflow discovery`, `Workflow dispatch`, `Plan tool calls`) over transport/internal labels such as `orchestrator_start`.
+
 ## 8. Metadata Contract Semantics
 
 Per-state metadata keys currently used:

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -254,6 +254,8 @@ class ProgressTracker:
     # Phase labels mirrored from orchestrator for convenience.
     _PHASE_LABELS: Mapping[str, str] = {
         "context_build": "Building context",
+        "workflow_dispatch": "Workflow dispatch",
+        "plain_response": "Plain-response routing",
         "tool_plan": "Planning tool calls",
         "tool_execute": "Executing tools",
         "screen_backfill": "Generating response",
@@ -457,6 +459,8 @@ class InternalMCPChatOrchestrator:
     # --- Tool-use progress phases (JVNAUTOSCI-984) ---
     # Used to provide phase-aware status updates during tool execution.
     PHASE_CONTEXT_BUILD = "context_build"
+    PHASE_WORKFLOW_DISPATCH = "workflow_dispatch"
+    PHASE_PLAIN_RESPONSE = "plain_response"
     PHASE_TOOL_PLAN = "tool_plan"
     PHASE_TOOL_EXECUTE = "tool_execute"
     PHASE_SCREEN_BACKFILL = "screen_backfill"
@@ -467,6 +471,8 @@ class InternalMCPChatOrchestrator:
 
     _PHASE_LABELS: Mapping[str, str] = {
         PHASE_CONTEXT_BUILD: "Building context",
+        PHASE_WORKFLOW_DISPATCH: "Workflow dispatch",
+        PHASE_PLAIN_RESPONSE: "Plain-response routing",
         PHASE_TOOL_PLAN: "Planning tool calls",
         PHASE_TOOL_EXECUTE: "Executing tools",
         PHASE_SCREEN_BACKFILL: "Generating response",
@@ -18649,6 +18655,34 @@ class InternalMCPChatOrchestrator:
             if isinstance(selected_workflow_id, str) and selected_workflow_id.strip()
             else None
         )
+
+        def _resolve_selected_workflow_name(workflow_id: str | None) -> str | None:
+            clean_workflow_id = (
+                workflow_id.strip()
+                if isinstance(workflow_id, str) and workflow_id.strip()
+                else None
+            )
+            if not clean_workflow_id:
+                return None
+
+            for match in (*discovered_matches, *excluded_discovered_matches):
+                if not isinstance(match, Mapping):
+                    continue
+                match_id = match.get("concept_id")
+                if (
+                    isinstance(match_id, str)
+                    and match_id.strip() == clean_workflow_id
+                ):
+                    match_name = match.get("name")
+                    if isinstance(match_name, str) and match_name.strip():
+                        return match_name.strip()
+
+            pretty_name = clean_workflow_id
+            if pretty_name.startswith("#V#"):
+                pretty_name = pretty_name[3:]
+            pretty_name = pretty_name.replace("_", " ").strip()
+            return pretty_name[:1].upper() + pretty_name[1:] if pretty_name else clean_workflow_id
+
         selector_verdict = (
             routing_info.verdict.strip().lower()
             if isinstance(routing_info, WorkflowRoutingInfo)
@@ -23081,6 +23115,27 @@ class InternalMCPChatOrchestrator:
                 if trace_enabled and trace is not None:
                     trace.metadata["workflow_selector_override"] = dict(override_payload)
 
+        selected_workflow_name = _resolve_selected_workflow_name(
+            selected_workflow_id_text
+        )
+        workflow_dispatch_progress: dict[str, Any] = {
+            "selected_workflow_id": selected_workflow_id_text,
+            "selected_workflow_name": selected_workflow_name,
+            "workflow_selector_verdict": selector_verdict or None,
+            "workflow_selector_source": (
+                routing_info.source
+                if isinstance(routing_info, WorkflowRoutingInfo)
+                else None
+            ),
+            "workflow_match_count": len(discovered_matches),
+            "workflow_candidate_count": len(discovered_matches)
+            + len(excluded_discovered_matches),
+        }
+        _emit_phase_transition_local(
+            self.PHASE_WORKFLOW_DISPATCH,
+            extra=workflow_dispatch_progress,
+        )
+
         selected_uses_tool_pipeline_contract = _workflow_matches_action_contract(
             selected_workflow_id_text,
             required_action_ids=_TOOL_PIPELINE_ACTION_IDS,
@@ -23092,6 +23147,10 @@ class InternalMCPChatOrchestrator:
         # plan→validate→execute→backfill pipeline.  This saves an LLM
         # round-trip worth of system prompt tokens and reduces latency.
         if selector_verdict == "plain_response":
+            _emit_phase_transition_local(
+                self.PHASE_PLAIN_RESPONSE,
+                extra=workflow_dispatch_progress,
+            )
             planner_model = _model_for_stage("planner")
             if trace_enabled and trace is not None:
                 llm_step = trace.start_step(

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -372,6 +372,13 @@ def _serialise_tool_progress_state(
             events[-_TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT :]
         )
 
+    payload["workflow_stage_path"] = _build_live_workflow_stage_path(payload)
+    workflow_discovery = payload.get("workflow_discovery")
+    if isinstance(workflow_discovery, Mapping):
+        payload["workflow_discovery"] = _normalise_workflow_discovery_progress_payload(
+            workflow_discovery
+        )
+
     return payload
 
 
@@ -423,6 +430,126 @@ def _iso_utc_to_epoch_ms(value: Any) -> int | None:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     return int(parsed.timestamp() * 1000.0)
+
+
+def _normalise_workflow_discovery_progress_payload(
+    workflow_discovery: Mapping[str, Any] | None,
+    *,
+    query: str | None = None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    """Return a stable workflow-discovery payload for live progress rendering.
+
+    The thinking card needs a deterministic shape even when discovery produces
+    zero matches. This keeps "no workflow found" distinct from "no payload was
+    emitted yet", and gives the frontend one canonical contract to render.
+    """
+
+    payload = (
+        {
+            key: value
+            for key, value in workflow_discovery.items()
+            if isinstance(key, str)
+        }
+        if isinstance(workflow_discovery, Mapping)
+        else {}
+    )
+
+    matches_raw = payload.get("matches")
+    matches = [dict(item) for item in matches_raw if isinstance(item, Mapping)] if isinstance(matches_raw, list) else []
+    payload["matches"] = matches
+
+    candidates_raw = payload.get("candidates")
+    if isinstance(candidates_raw, list):
+        payload["candidates"] = [
+            dict(item) for item in candidates_raw if isinstance(item, Mapping)
+        ]
+    else:
+        payload["candidates"] = list(matches)
+
+    routing_matches_raw = payload.get("routing_matches")
+    if isinstance(routing_matches_raw, list):
+        payload["routing_matches"] = [
+            dict(item) for item in routing_matches_raw if isinstance(item, Mapping)
+        ]
+    else:
+        payload["routing_matches"] = list(matches)
+
+    payload["match_count"] = len(payload["matches"])
+    payload["candidate_count"] = len(payload["candidates"])
+
+    if isinstance(query, str) and query.strip():
+        payload.setdefault("query", query.strip())
+
+    errors: list[str] = []
+    existing_errors = payload.get("errors")
+    if isinstance(existing_errors, list):
+        errors.extend(
+            str(item).strip()
+            for item in existing_errors
+            if isinstance(item, str) and item.strip()
+        )
+    elif isinstance(existing_errors, str) and existing_errors.strip():
+        errors.append(existing_errors.strip())
+
+    if isinstance(error, str) and error.strip():
+        errors.append(error.strip())
+
+    payload["errors"] = errors or None
+    return payload
+
+
+def _build_live_workflow_stage_path(
+    state: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if not isinstance(state, Mapping):
+        return build_conversation_turn_stage_path(runtime_stages=(), workflow_id=None)
+
+    def _canonicalise_live_runtime_stage(stage: str | None) -> str | None:
+        if not isinstance(stage, str):
+            return None
+        clean_stage = stage.strip()
+        if not clean_stage:
+            return None
+        if clean_stage == "workflow_discovery_complete":
+            return "workflow_discovery"
+        if clean_stage == "orchestrator_start":
+            return "workflow_dispatch"
+        if clean_stage == "orchestrator_end":
+            return None
+        return clean_stage
+
+    diagnostic_events_raw = state.get("diagnostic_events")
+    diagnostic_events = (
+        [cast(dict[str, Any], entry) for entry in diagnostic_events_raw if isinstance(entry, dict)]
+        if isinstance(diagnostic_events_raw, list)
+        else []
+    )
+    runtime_stages: list[str] = []
+    last_stage_normalised: str | None = None
+    for entry in diagnostic_events:
+        raw_stage = _progress_str(entry.get("phase")) or _progress_str(entry.get("stage"))
+        canonical_stage = _canonicalise_live_runtime_stage(raw_stage)
+        if not canonical_stage:
+            continue
+        canonical_stage_normalised = canonical_stage.strip().lower()
+        if canonical_stage_normalised == last_stage_normalised:
+            continue
+        runtime_stages.append(canonical_stage)
+        last_stage_normalised = canonical_stage_normalised
+
+    current_stage = _canonicalise_live_runtime_stage(
+        _progress_str(state.get("phase")) or _progress_str(state.get("stage"))
+    )
+    if current_stage:
+        current_stage_normalised = current_stage.strip().lower()
+        if current_stage_normalised != last_stage_normalised:
+            runtime_stages.append(current_stage)
+    selected_workflow_id = _progress_str(state.get("selected_workflow_id"))
+    return build_conversation_turn_stage_path(
+        runtime_stages=runtime_stages,
+        workflow_id=selected_workflow_id,
+    )
 
 
 def _normalise_progress_events_from_diagnostic_events(
@@ -788,9 +915,14 @@ def _build_turn_execution_diagnostics(
 
     phase_history = _derive_phase_history_from_diagnostic_events(diagnostic_events)
     runtime_stages = [entry.get("phase") for entry in phase_history]
+    selected_workflow_id = (
+        _progress_str(latest_progress.get("selected_workflow_id"))
+        if isinstance(latest_progress, dict)
+        else None
+    )
     workflow_stage_path = build_conversation_turn_stage_path(
         runtime_stages=runtime_stages,
-        workflow_id=None,
+        workflow_id=selected_workflow_id,
     )
     llm_call_entries = [
         cast(dict[str, Any], entry)
@@ -1830,6 +1962,21 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
         failure_kind = _progress_str(merged.get("failure_kind"))
         if failure_kind:
             event_entry["failure_kind"] = failure_kind
+        selected_workflow_id = _progress_str(merged.get("selected_workflow_id"))
+        if selected_workflow_id:
+            event_entry["selected_workflow_id"] = selected_workflow_id
+        selected_workflow_name = _progress_str(merged.get("selected_workflow_name"))
+        if selected_workflow_name:
+            event_entry["selected_workflow_name"] = selected_workflow_name
+        selector_verdict = _progress_str(merged.get("workflow_selector_verdict"))
+        if selector_verdict:
+            event_entry["workflow_selector_verdict"] = selector_verdict
+        selector_source = _progress_str(merged.get("workflow_selector_source"))
+        if selector_source:
+            event_entry["workflow_selector_source"] = selector_source
+        workflow_match_count = _progress_number(merged.get("workflow_match_count"))
+        if workflow_match_count is not None:
+            event_entry["workflow_match_count"] = int(max(0.0, workflow_match_count))
         trimmed_events = [
             *existing_events[-(_TOOL_PROGRESS_DIAGNOSTIC_EVENT_LIMIT - 1) :],
             event_entry,
@@ -5466,27 +5613,56 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                     prompt_text,
                     namespace=user_namespace,
                 )
+                workflow_discovery_progress = _normalise_workflow_discovery_progress_payload(
+                    workflow_discovery_result,
+                    query=prompt_text,
+                )
                 if workflow_discovery_result:
                     current_app.logger.info(
                         "[WORKFLOW_DISCOVERY] Found %d relevant workflows for prompt",
                         workflow_discovery_result.get("match_count", 0),
                     )
-                    # Emit workflow discovery results in tool progress for frontend
-                    if show_tool_use_progress:
-                        _set_tool_progress(
-                            progress_scope_key,
-                            request_id,
-                            {
-                                "status": "thinking",
-                                "phase": "workflow_discovery_complete",
-                                "phase_label": "Found workflows",
-                                "request_id": request_id,
-                                "workflow_discovery": workflow_discovery_result,
-                            },
-                        )
+                # Emit workflow discovery outcome for frontend even when no
+                # workflow matched, so the thinking card can show an explicit
+                # "no workflow found" step instead of silently skipping it.
+                if show_tool_use_progress:
+                    match_count = int(workflow_discovery_progress.get("match_count", 0))
+                    _set_tool_progress(
+                        progress_scope_key,
+                        request_id,
+                        {
+                            "status": "thinking",
+                            "phase": "workflow_discovery_complete",
+                            "phase_label": (
+                                "Found workflows"
+                                if match_count > 0
+                                else "No workflows found"
+                            ),
+                            "request_id": request_id,
+                            "workflow_discovery": workflow_discovery_progress,
+                            "workflow_match_count": match_count,
+                        },
+                    )
             except Exception as e:
                 current_app.logger.warning("[WORKFLOW_DISCOVERY] Search failed: %s", e)
                 workflow_discovery_result = None
+                if show_tool_use_progress:
+                    _set_tool_progress(
+                        progress_scope_key,
+                        request_id,
+                        {
+                            "status": "thinking",
+                            "phase": "workflow_discovery_complete",
+                            "phase_label": "Workflow discovery failed",
+                            "request_id": request_id,
+                            "workflow_discovery": _normalise_workflow_discovery_progress_payload(
+                                None,
+                                query=prompt_text,
+                                error=str(e),
+                            ),
+                            "workflow_match_count": 0,
+                        },
+                    )
 
         # ---------------------------------------------------------
         # Tool-backed RAG counts (avoid KA vs chat-history confusion)

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -960,6 +960,14 @@ function createThinkingCardHistorySnapshot(request) {
                 : []
         }
         : null;
+    const workflowStagePath = (request.workflowStagePath && typeof request.workflowStagePath === 'object')
+        ? {
+            ...request.workflowStagePath,
+            path: Array.isArray(request.workflowStagePath.path)
+                ? request.workflowStagePath.path.map((entry) => ({ ...entry }))
+                : []
+        }
+        : null;
 
     const effectiveProgressForTerminal = latestProgress || { status: 'completed' };
     const completedDisplayState = reduceThinkingCardDisplayState(
@@ -971,6 +979,7 @@ function createThinkingCardHistorySnapshot(request) {
         activityHistory,
         toolUseProgressHistory: toolHistory,
         workflowDiscovery,
+        workflowStagePath,
         latestProgress,
         thinkingStartedAtMs: Number.isFinite(request.thinkingStartedAtMs) ? Number(request.thinkingStartedAtMs) : null,
         thinkingFinishedAtMs: Date.now(),
@@ -1270,9 +1279,32 @@ function buildThinkingProgressPresentation(progress, request = null) {
         ? progress.stage_label.trim()
         : null;
     const tool = (typeof progress.tool === 'string' && progress.tool.trim()) ? progress.tool.trim() : null;
-    const subtask = (typeof progress.subtask === 'string' && progress.subtask.trim())
+    let subtask = (typeof progress.subtask === 'string' && progress.subtask.trim())
         ? progress.subtask.trim()
         : ((typeof progress.workflow_task === 'string' && progress.workflow_task.trim()) ? progress.workflow_task.trim() : null);
+    const workflowDiscovery = (progress.workflow_discovery && typeof progress.workflow_discovery === 'object')
+        ? progress.workflow_discovery
+        : ((request?.workflowDiscovery && typeof request.workflowDiscovery === 'object') ? request.workflowDiscovery : null);
+
+    if ((stage === 'workflow_dispatch' || stage === 'plain_response') && !subtask) {
+        subtask = formatWorkflowDisplayText(
+            progress.selected_workflow_id,
+            progress.selected_workflow_name,
+            workflowDiscovery
+        ) || subtask;
+    } else if (stage === 'workflow_discovery_complete') {
+        const matchCount = getWorkflowDiscoveryMatchCount(workflowDiscovery);
+        if (matchCount === 0) {
+            subtask = 'No applicable workflow found';
+        } else if (matchCount > 0 && !subtask) {
+            const primaryMatch = normaliseWorkflowDiscoveryMatches(workflowDiscovery)[0] || null;
+            subtask = formatWorkflowDisplayText(
+                primaryMatch?.concept_id,
+                primaryMatch?.name,
+                workflowDiscovery
+            ) || subtask;
+        }
+    }
 
     let stageText = phaseLabel || stageLabel || (stage ? toTitleCaseWords(stage) : DEFAULT_THINKING_TEXT);
     const detail = tool || subtask;
@@ -1519,6 +1551,11 @@ function buildThinkingActivityLabelAndDetail(entry) {
     const provider = normaliseThinkingActivityString(entry.provider);
     const resultSummary = normaliseThinkingActivityString(entry.result_summary);
     const error = normaliseThinkingActivityString(entry.error);
+    const selectedWorkflowId = normaliseThinkingActivityString(entry.selected_workflow_id);
+    const selectedWorkflowName = normaliseThinkingActivityString(entry.selected_workflow_name);
+    const workflowMatchCount = Number.isFinite(entry.workflow_match_count)
+        ? Math.max(0, Number(entry.workflow_match_count))
+        : null;
     const batchSize = Number.isFinite(entry.batch_size) ? Number(entry.batch_size) : null;
 
     const stageText = stageLabel || formatThinkingActivityFallbackLabel(stage);
@@ -1533,11 +1570,28 @@ function buildThinkingActivityLabelAndDetail(entry) {
             detailParts.push(formatThinkingActivityFallbackLabel(stage));
         }
     } else if (status === 'workflow_discovery') {
-        label = 'Searching workflows';
+        label = 'Workflow discovery';
+        detailParts.push('Searching applicable workflows');
     } else if (status === 'workflow_discovery_complete') {
-        label = 'Found workflows';
+        label = 'Workflow discovery';
+        if (workflowMatchCount === 0) {
+            detailParts.push('No applicable workflow found');
+        } else if (workflowMatchCount && workflowMatchCount > 0) {
+            detailParts.push(
+                workflowMatchCount > 1
+                    ? `${workflowMatchCount} workflows found`
+                    : '1 workflow found'
+            );
+        }
     } else if (status === 'orchestrator_start') {
-        label = 'Starting orchestrator';
+        label = 'Workflow dispatch';
+        const workflowLabel = formatWorkflowDisplayText(
+            selectedWorkflowId,
+            selectedWorkflowName
+        );
+        if (workflowLabel) {
+            detailParts.push(`Selected ${workflowLabel}`);
+        }
     } else if (status === 'orchestrator_end') {
         label = 'Finished orchestrator';
     } else if (status === 'llm_call_start') {
@@ -1556,13 +1610,13 @@ function buildThinkingActivityLabelAndDetail(entry) {
             detailParts.push(modelText);
         }
     } else if (status === 'tool_call_start') {
-        label = toolName ? `Starting ${toolName}` : 'Starting tool call';
+        label = toolName ? `Tool call: ${toolName}` : 'Starting tool call';
     } else if (status === 'tool_invoked') {
-        label = toolName ? `${toolName} completed` : 'Tool call completed';
+        label = toolName ? `Tool call completed: ${toolName}` : 'Tool call completed';
     } else if (status === 'tool_failed') {
-        label = toolName ? `${toolName} failed` : 'Tool call failed';
+        label = toolName ? `Tool call failed: ${toolName}` : 'Tool call failed';
     } else if (status === 'tool_blocked') {
-        label = toolName ? `${toolName} blocked` : 'Tool call blocked';
+        label = toolName ? `Tool call blocked: ${toolName}` : 'Tool call blocked';
     } else if (status === 'retry_start') {
         label = 'Retrying step';
         if (subtask) {
@@ -1780,7 +1834,10 @@ function renderToolHistoryHTML(request) {
             statusClass = 'failure';
         }
 
-        const toolName = escapeHtml(tool || workflowTask);
+        const toolLabel = tool
+            ? `Tool call: ${tool}`
+            : (workflowTask ? `Workflow task: ${workflowTask}` : '');
+        const toolName = escapeHtml(toolLabel);
         const batchLabel = batchSize !== null ? `<span class="thinking-card-tool-batch">(batch ${batchSize})</span>` : '';
         const resultLabel = resultSummary ? `<span class="thinking-card-tool-result">${escapeHtml(resultSummary)}</span>` : '';
 
@@ -1791,6 +1848,218 @@ function renderToolHistoryHTML(request) {
     }
 
     return items.join('');
+}
+
+function normaliseWorkflowDiscoveryMatches(workflowDiscovery) {
+    if (!workflowDiscovery || typeof workflowDiscovery !== 'object') {
+        return [];
+    }
+
+    const matches = Array.isArray(workflowDiscovery.matches) ? workflowDiscovery.matches : [];
+    return matches.filter((match) => match && typeof match === 'object');
+}
+
+function getWorkflowDiscoveryMatchCount(workflowDiscovery) {
+    if (!workflowDiscovery || typeof workflowDiscovery !== 'object') {
+        return null;
+    }
+
+    if (Number.isFinite(workflowDiscovery.match_count)) {
+        return Math.max(0, Number(workflowDiscovery.match_count));
+    }
+
+    return normaliseWorkflowDiscoveryMatches(workflowDiscovery).length;
+}
+
+function findWorkflowDiscoveryMatchById(workflowDiscovery, workflowId) {
+    const cleanWorkflowId = normaliseThinkingActivityString(workflowId);
+    if (!cleanWorkflowId) {
+        return null;
+    }
+
+    return normaliseWorkflowDiscoveryMatches(workflowDiscovery).find((match) => (
+        normaliseThinkingActivityString(match.concept_id) === cleanWorkflowId
+    )) || null;
+}
+
+function formatWorkflowDisplayText(workflowId, workflowName, workflowDiscovery = null) {
+    const cleanWorkflowId = normaliseThinkingActivityString(workflowId);
+    let cleanWorkflowName = normaliseThinkingActivityString(workflowName);
+
+    if (!cleanWorkflowName && cleanWorkflowId) {
+        const match = findWorkflowDiscoveryMatchById(workflowDiscovery, cleanWorkflowId);
+        cleanWorkflowName = normaliseThinkingActivityString(match?.name);
+    }
+
+    if (cleanWorkflowName && cleanWorkflowId && cleanWorkflowName !== cleanWorkflowId) {
+        return `${cleanWorkflowName} (${cleanWorkflowId})`;
+    }
+
+    return cleanWorkflowName || cleanWorkflowId || '';
+}
+
+function buildWorkflowStageDetail(stageId, request) {
+    const workflowDiscovery = (request?.workflowDiscovery && typeof request.workflowDiscovery === 'object')
+        ? request.workflowDiscovery
+        : null;
+    const latestProgress = (request?.latestProgress && typeof request.latestProgress === 'object')
+        ? request.latestProgress
+        : null;
+    const cleanStageId = normaliseThinkingActivityString(stageId);
+
+    if (cleanStageId === 'workflow_discovery') {
+        const errors = Array.isArray(workflowDiscovery?.errors)
+            ? workflowDiscovery.errors.filter((item) => typeof item === 'string' && item.trim())
+            : [];
+        if (errors.length > 0) {
+            return errors[0].trim();
+        }
+
+        const matchCount = getWorkflowDiscoveryMatchCount(workflowDiscovery);
+        if (matchCount === null) {
+            return 'Searching applicable workflows';
+        }
+        if (matchCount <= 0) {
+            return 'No applicable workflow found';
+        }
+
+        const primaryMatch = normaliseWorkflowDiscoveryMatches(workflowDiscovery)[0] || null;
+        const primaryLabel = formatWorkflowDisplayText(
+            primaryMatch?.concept_id,
+            primaryMatch?.name,
+            workflowDiscovery
+        );
+        if (primaryLabel) {
+            return matchCount > 1
+                ? `Found ${primaryLabel} · ${matchCount} matches`
+                : `Found ${primaryLabel}`;
+        }
+        return matchCount > 1
+            ? `Found ${matchCount} applicable workflows`
+            : 'Found 1 applicable workflow';
+    }
+
+    if (cleanStageId === 'workflow_dispatch' || cleanStageId === 'plain_response') {
+        const workflowLabel = formatWorkflowDisplayText(
+            latestProgress?.selected_workflow_id,
+            latestProgress?.selected_workflow_name,
+            workflowDiscovery
+        );
+        const verdict = normaliseThinkingActivityString(latestProgress?.workflow_selector_verdict);
+        const detailParts = [];
+        if (workflowLabel) {
+            detailParts.push(`Selected ${workflowLabel}`);
+        }
+        if (verdict) {
+            detailParts.push(formatThinkingActivityFallbackLabel(verdict));
+        }
+        return detailParts.join(' · ');
+    }
+
+    if (cleanStageId === 'tool_execute') {
+        const toolNames = Array.isArray(request?.toolUseProgressHistory)
+            ? request.toolUseProgressHistory
+                .map((entry) => normaliseThinkingActivityString(entry?.tool || entry?.workflowTask))
+                .filter(Boolean)
+            : [];
+        const uniqueToolNames = [...new Set(toolNames)];
+        if (uniqueToolNames.length > 0) {
+            const preview = uniqueToolNames.slice(0, 3).join(', ');
+            return uniqueToolNames.length > 3
+                ? `Tools: ${preview} +${uniqueToolNames.length - 3} more`
+                : `Tools: ${preview}`;
+        }
+    }
+
+    return '';
+}
+
+function buildThinkingWorkflowStageRows(request) {
+    if (!request || typeof request !== 'object') {
+        return [];
+    }
+
+    const workflowStagePath = (request.workflowStagePath && typeof request.workflowStagePath === 'object')
+        ? request.workflowStagePath
+        : null;
+    const path = Array.isArray(workflowStagePath?.path)
+        ? workflowStagePath.path.filter((entry) => entry && typeof entry === 'object')
+        : [];
+
+    const workflowDiscovery = (request.workflowDiscovery && typeof request.workflowDiscovery === 'object')
+        ? request.workflowDiscovery
+        : null;
+    if (path.length === 0) {
+        if (workflowDiscovery) {
+            return [{
+                label: 'Workflow discovery',
+                detail: buildWorkflowStageDetail('workflow_discovery', request),
+                state: getWorkflowDiscoveryMatchCount(workflowDiscovery) > 0 ? 'success' : 'failure'
+            }];
+        }
+        return [];
+    }
+
+    const latestProgress = (request.latestProgress && typeof request.latestProgress === 'object')
+        ? request.latestProgress
+        : null;
+    const latestStageId = (() => {
+        const lastStage = path[path.length - 1];
+        return normaliseThinkingActivityString(lastStage?.stage_id || lastStage?.runtime_stage_normalised);
+    })();
+    const latestStatus = normaliseThinkingActivityString(latestProgress?.status).toLowerCase();
+    const latestIsTerminal = isTerminalThinkingProgress(latestProgress);
+    const latestIsFailure = latestStatus === 'error' || latestStatus === 'failed';
+
+    return path.map((entry, index) => {
+        const stageId = normaliseThinkingActivityString(entry.stage_id || entry.runtime_stage_normalised);
+        const stageLabel = normaliseThinkingActivityString(entry.stage_label)
+            || formatThinkingActivityFallbackLabel(stageId)
+            || 'Workflow step';
+        const detail = buildWorkflowStageDetail(stageId, request);
+        let state = 'success';
+
+        if (stageId === 'workflow_discovery') {
+            const matchCount = getWorkflowDiscoveryMatchCount(workflowDiscovery);
+            const discoveryErrors = Array.isArray(workflowDiscovery?.errors)
+                ? workflowDiscovery.errors.filter((item) => typeof item === 'string' && item.trim())
+                : [];
+            if (discoveryErrors.length > 0 || matchCount === 0) {
+                state = 'failure';
+            } else if (matchCount === null) {
+                state = 'pending';
+            }
+        } else if (index === path.length - 1 && !latestIsTerminal) {
+            state = 'pending';
+        } else if (latestIsFailure && stageId === latestStageId) {
+            state = 'failure';
+        }
+
+        return {
+            label: stageLabel,
+            detail,
+            state
+        };
+    });
+}
+
+function renderThinkingWorkflowStageHistoryHTML(request) {
+    const rows = buildThinkingWorkflowStageRows(request);
+    if (rows.length === 0) {
+        return '';
+    }
+
+    return rows.map((entry) => {
+        const statusClass = (entry.state === 'success' || entry.state === 'failure') ? entry.state : 'pending';
+        const statusIcon = statusClass === 'success' ? '✓' : (statusClass === 'failure' ? '✗' : '');
+        const detailLabel = normaliseThinkingActivityString(entry.detail)
+            ? `<span class="thinking-card-tool-result">${escapeHtml(entry.detail)}</span>`
+            : '';
+        return `<div class="thinking-card-tool thinking-card-activity">
+            <span class="thinking-card-tool-status ${statusClass}">${statusIcon}</span>
+            <span class="thinking-card-tool-name">${escapeHtml(entry.label)}</span>${detailLabel}
+        </div>`;
+    }).join('');
 }
 
 /**
@@ -1823,12 +2092,21 @@ function renderWorkflowDiscoveryHTML(workflows) {
 }
 
 /**
- * Render the complete thinking card body HTML including tool history and workflow discovery.
- * JVNAUTOSCI-1076: Combines tool history with workflow suggestions.
+ * Render the complete thinking card body HTML including canonical workflow
+ * stages and lower-level tool activity.
  */
 function renderThinkingCardBodyHTML(request) {
+    const workflowStageHtml = renderThinkingWorkflowStageHistoryHTML(request);
+    if (workflowStageHtml) {
+        return workflowStageHtml + renderToolHistoryHTML(request);
+    }
+
     const activityHistoryHtml = renderThinkingActivityHistoryHTML(request);
-    const toolHistoryHtml = activityHistoryHtml || renderToolHistoryHTML(request);
+    if (activityHistoryHtml) {
+        return activityHistoryHtml;
+    }
+
+    const toolHistoryHtml = renderToolHistoryHTML(request);
     const workflowHtml = request?.workflowDiscovery?.matches
         ? renderWorkflowDiscoveryHTML(request.workflowDiscovery.matches)
         : '';
@@ -2043,8 +2321,13 @@ function startToolUseProgressPolling(request) {
                 request.activityHistory = request.activityHistory.slice(-80);
             }
 
-            // JVNAUTOSCI-1076: Capture workflow discovery from progress
-            if (progress.workflow_discovery && progress.workflow_discovery.matches) {
+            if (progress.workflow_stage_path && typeof progress.workflow_stage_path === 'object') {
+                request.workflowStagePath = progress.workflow_stage_path;
+            }
+
+            // JVNAUTOSCI-1076: Capture workflow discovery from progress,
+            // including explicit no-match payloads.
+            if (progress.workflow_discovery && typeof progress.workflow_discovery === 'object') {
                 request.workflowDiscovery = progress.workflow_discovery;
             }
 
@@ -17151,7 +17434,8 @@ function buildThinkingDiagnosticsPayload(request) {
         progress_events: Array.isArray(request.progressEvents) ? request.progressEvents.slice(-40) : [],
         phase_history: Array.isArray(request.phaseHistory) ? request.phaseHistory.slice(-40) : [],
         tool_history: Array.isArray(request.toolUseProgressHistory) ? request.toolUseProgressHistory.slice(-40) : [],
-        workflow_discovery: request.workflowDiscovery || null
+        workflow_discovery: request.workflowDiscovery || null,
+        workflow_stage_path: request.workflowStagePath || null
     };
 }
 
@@ -17686,6 +17970,7 @@ async function handleSendPrompt(options = {}) {
         thinkingStartedAtMs: Date.now(),
         activityHistory: [],
         toolUseProgressHistory: [],
+        workflowStagePath: null,
         latestProgress: null,
         progressEvents: [],
         thinkingCardDisplayState: reduceThinkingCardDisplayState(null, { type: 'reset_for_active' })

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -825,15 +825,14 @@ describe('thinking activity history normalisation', () => {
 
         expect(rows.map((row) => row.label)).toEqual(expect.arrayContaining([
             'Building context',
-            'Searching workflows',
-            'Found workflows',
-            'Starting orchestrator',
+            'Workflow discovery',
+            'Workflow dispatch',
             'Starting LLM call',
-            'Starting fetch_concept',
-            'fetch_concept failed',
+            'Tool call: fetch_concept',
+            'Tool call failed: fetch_concept',
             'Turn completed'
         ]));
-        const failureRow = rows.find((row) => row.label === 'fetch_concept failed');
+        const failureRow = rows.find((row) => row.label === 'Tool call failed: fetch_concept');
         expect(failureRow?.state).toBe('failure');
     });
 
@@ -894,6 +893,60 @@ describe('thinking activity history normalisation', () => {
         });
         expect(fallbackHtml).toContain('fetch_concept');
         expect(fallbackHtml).toContain('Fetched');
+    });
+
+    test('renders canonical workflow stages with selected workflow details', () => {
+        const html = __testOnly_renderThinkingCardBodyHTML({
+            workflowStagePath: {
+                path: [
+                    { stage_id: 'workflow_discovery', stage_label: 'Workflow discovery' },
+                    { stage_id: 'workflow_dispatch', stage_label: 'Workflow dispatch' },
+                    { stage_id: 'tool_plan', stage_label: 'Plan tool calls' }
+                ]
+            },
+            workflowDiscovery: {
+                match_count: 1,
+                matches: [
+                    {
+                        concept_id: '#V#tool_calling_workflow',
+                        name: 'Tool calling workflow'
+                    }
+                ]
+            },
+            latestProgress: {
+                phase: 'workflow_dispatch',
+                selected_workflow_id: '#V#tool_calling_workflow',
+                selected_workflow_name: 'Tool calling workflow',
+                workflow_selector_verdict: 'tool_seeking'
+            }
+        });
+
+        expect(html).toContain('Workflow discovery');
+        expect(html).toContain('Found Tool calling workflow (#V#tool_calling_workflow)');
+        expect(html).toContain('Workflow dispatch');
+        expect(html).toContain('Selected Tool calling workflow (#V#tool_calling_workflow)');
+        expect(html).toContain('Plan tool calls');
+    });
+
+    test('renders explicit no-workflow-found state as a failure row', () => {
+        const html = __testOnly_renderThinkingCardBodyHTML({
+            workflowStagePath: {
+                path: [
+                    { stage_id: 'workflow_discovery', stage_label: 'Workflow discovery' }
+                ]
+            },
+            workflowDiscovery: {
+                match_count: 0,
+                matches: []
+            },
+            latestProgress: {
+                phase: 'workflow_discovery_complete'
+            }
+        });
+
+        expect(html).toContain('Workflow discovery');
+        expect(html).toContain('No applicable workflow found');
+        expect(html).toContain('thinking-card-tool-status failure');
     });
 });
 

--- a/tests/backend/test_tool_progress_liveness.py
+++ b/tests/backend/test_tool_progress_liveness.py
@@ -167,6 +167,65 @@ def test_progress_event_contains_required_telemetry_fields(monkeypatch) -> None:
     assert isinstance(serialised["activity_idle_ms"], int)
 
 
+def test_live_progress_serialisation_includes_workflow_stage_path(monkeypatch) -> None:
+    clock = _set_clock(monkeypatch, start=4200.0)
+
+    von_routes._set_tool_progress(
+        "scope-workflow",
+        "req-workflow",
+        {
+            "status": "thinking",
+            "phase": "workflow_discovery",
+            "request_id": "req-workflow",
+        },
+    )
+    clock["now"] += 0.1
+    von_routes._set_tool_progress(
+        "scope-workflow",
+        "req-workflow",
+        {
+            "status": "phase_transition",
+            "phase": "workflow_dispatch",
+            "request_id": "req-workflow",
+            "selected_workflow_id": "#V#tool_calling_workflow",
+            "selected_workflow_name": "Tool calling workflow",
+        },
+    )
+
+    state = von_routes._get_tool_progress("scope-workflow", "req-workflow")
+    assert state is not None
+
+    serialised = von_routes._serialise_tool_progress_state(
+        state,
+        now_epoch=clock["now"],
+    )
+
+    workflow_stage_path = serialised.get("workflow_stage_path")
+    assert isinstance(workflow_stage_path, dict)
+    assert workflow_stage_path.get("workflow_id") == "#V#tool_calling_workflow"
+    path = workflow_stage_path.get("path")
+    assert isinstance(path, list)
+    assert [entry.get("stage_id") for entry in path] == [
+        "workflow_discovery",
+        "workflow_dispatch",
+    ]
+
+
+def test_workflow_discovery_progress_payload_preserves_explicit_no_match_state() -> None:
+    payload = von_routes._normalise_workflow_discovery_progress_payload(
+        None,
+        query="find a workflow for this task",
+    )
+
+    assert payload["query"] == "find a workflow for this task"
+    assert payload["matches"] == []
+    assert payload["routing_matches"] == []
+    assert payload["candidates"] == []
+    assert payload["match_count"] == 0
+    assert payload["candidate_count"] == 0
+    assert payload["errors"] is None
+
+
 def test_orchestrator_start_uses_startup_wait_liveness_reason() -> None:
     assert (
         von_routes._classify_progress_cause("orchestrator_start", "heartbeat")


### PR DESCRIPTION
## Summary
- expose a canonical live workflow_stage_path and explicit workflow-discovery outcome in /von/progress
- emit workflow-dispatch selection details from the orchestrator so the Thinking card can show which workflow was chosen
- render canonical workflow stages and explicit no-match states in the Thinking card, with targeted tests and a manual update

## Validation
- pdm run pytest tests/backend/test_tool_progress_liveness.py -q
- npx jest src/frontend/web/von_interface/static/js/test/chatTab.test.js --runInBand --silent
- npx pyright src/backend/server/routes/von_routes.py src/backend/integrations/internal_mcp/orchestrator.py tests/backend/test_tool_progress_liveness.py