### PR TITLE
JVNAUTOSCI-1379 prevent workflow monitor definition timeouts

### DIFF
--- a/src/backend/server/routes/workflows_routes.py
+++ b/src/backend/server/routes/workflows_routes.py
@@ -87,29 +87,34 @@ def _read_cached_workflow_definitions_entry(
     *,
     cache_key: Tuple[int, Optional[str], Optional[str], Optional[str]],
     bypass_cache: bool,
-) -> Tuple[Optional[Dict[str, Any]], bool]:
+) -> Tuple[Optional[Dict[str, Any]], bool, Optional[float]]:
     if bypass_cache:
-        return None, False
+        return None, False, None
 
     ttl_seconds = _read_workflow_definitions_cache_ttl_seconds()
     if ttl_seconds <= 0.0:
-        return None, False
+        return None, False, None
 
     now_monotonic = time.monotonic()
     with _WORKFLOW_DEFINITIONS_CACHE_LOCK:
         entry = _WORKFLOW_DEFINITIONS_CACHE.get(cache_key)
         if not isinstance(entry, dict):
-            return None, False
+            return None, False, None
         expires_at = entry.get("expires_at_monotonic")
+        stored_at = entry.get("stored_at_monotonic")
         payload = entry.get("payload")
         if not isinstance(payload, dict):
             _WORKFLOW_DEFINITIONS_CACHE.pop(cache_key, None)
-            return None, False
+            return None, False, None
         if not isinstance(expires_at, (int, float)):
             _WORKFLOW_DEFINITIONS_CACHE.pop(cache_key, None)
-            return None, False
+            return None, False, None
+        if not isinstance(stored_at, (int, float)):
+            _WORKFLOW_DEFINITIONS_CACHE.pop(cache_key, None)
+            return None, False, None
         is_fresh = now_monotonic < float(expires_at)
-        return payload, is_fresh
+        age_seconds = max(0.0, now_monotonic - float(stored_at))
+        return payload, is_fresh, age_seconds
 
 
 def _read_cached_workflow_definitions(
@@ -117,13 +122,53 @@ def _read_cached_workflow_definitions(
     cache_key: Tuple[int, Optional[str], Optional[str], Optional[str]],
     bypass_cache: bool,
 ) -> Optional[Dict[str, Any]]:
-    payload, is_fresh = _read_cached_workflow_definitions_entry(
+    payload, is_fresh, _age_seconds = _read_cached_workflow_definitions_entry(
         cache_key=cache_key,
         bypass_cache=bypass_cache,
     )
     if is_fresh and isinstance(payload, dict):
         return payload
     return None
+
+
+def _build_workflow_definitions_cache_metadata(
+    *,
+    state: str,
+    age_seconds: float | None,
+    refresh_in_progress: bool,
+    retry_after_seconds: float | None = None,
+) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {
+        "state": state,
+        "refresh_in_progress": bool(refresh_in_progress),
+        "age_seconds": (
+            round(float(age_seconds), 3)
+            if isinstance(age_seconds, (int, float))
+            else None
+        ),
+        "ttl_seconds": round(_read_workflow_definitions_cache_ttl_seconds(), 3),
+    }
+    if isinstance(retry_after_seconds, (int, float)) and retry_after_seconds > 0:
+        metadata["retry_after_seconds"] = round(float(retry_after_seconds), 3)
+    return metadata
+
+
+def _attach_workflow_definitions_cache_metadata(
+    payload: Dict[str, Any],
+    *,
+    state: str,
+    age_seconds: float | None,
+    refresh_in_progress: bool,
+    retry_after_seconds: float | None = None,
+) -> Dict[str, Any]:
+    response_payload = dict(payload)
+    response_payload["cache"] = _build_workflow_definitions_cache_metadata(
+        state=state,
+        age_seconds=age_seconds,
+        refresh_in_progress=refresh_in_progress,
+        retry_after_seconds=retry_after_seconds,
+    )
+    return response_payload
 
 
 def _get_workflow_definitions_refresh_lock(
@@ -165,6 +210,196 @@ def _write_cached_workflow_definitions(
                 oldest_stamp = float(stored_at)
         if oldest_key is not None:
             _WORKFLOW_DEFINITIONS_CACHE.pop(oldest_key, None)
+
+
+def _build_workflow_definitions_payload(
+    *,
+    limit: int,
+    namespace: str | None,
+    session_id: str | None,
+    turn_id: str | None,
+) -> Dict[str, Any]:
+    from ...workflows.durable.registry_factory import (
+        build_durable_workflow_registry_read_only,
+        get_workflow_registry_inventory_snapshot,
+    )
+    from ...services.workflow_discovery_service import (
+        classify_workflow_concept_executability,
+    )
+
+    # Read-only build avoids concept bootstrap writes on list/introspection paths.
+    registry = build_durable_workflow_registry_read_only()
+    inventory_snapshot = get_workflow_registry_inventory_snapshot()
+    if not isinstance(inventory_snapshot, dict):
+        inventory_snapshot = {}
+    workflow_ids = sorted(list(registry.all_workflow_ids()))
+    selected_ids = workflow_ids[:limit]
+    usage_aggregate_map = get_workflow_usage_aggregates_for_workflows(selected_ids)
+    episode_count_map = get_workflow_episode_counts_for_workflows(
+        selected_ids,
+        namespace=namespace or None,
+        session_id=session_id or None,
+        turn_id=turn_id or None,
+    )
+
+    items: List[Dict[str, Any]] = []
+    for workflow_id in selected_ids:
+        registration = registry.get_registration(workflow_id)
+        definition = (
+            registration.definition if registration is not None else registry.get(workflow_id)
+        )
+
+        registration_purpose = registration.purpose if registration is not None else None
+        definition_purpose = (
+            getattr(definition, "purpose", "") if definition is not None else None
+        )
+        description, description_source = resolve_workflow_description(
+            workflow_id,
+            workflow_source=(registration.source if registration is not None else None),
+            registration_purpose=registration_purpose,
+            definition_purpose=definition_purpose,
+        )
+        source = "unknown"
+        if registration is not None:
+            if isinstance(registration.source, str) and registration.source.strip():
+                source = registration.source.strip()
+        definition_identity = build_workflow_definition_identity(
+            workflow_id=workflow_id,
+            source=source,
+            definition=definition,
+            authoritative_definition=(
+                definition if source.lower() == "vontology" and definition is not None else None
+            ),
+        )
+
+        initial_state = ""
+        if definition is not None:
+            state_value = getattr(definition, "initial_state", "")
+            if isinstance(state_value, str):
+                initial_state = state_value
+
+        usage = (
+            usage_aggregate_map.get(workflow_id, {})
+            if isinstance(usage_aggregate_map, dict)
+            else {}
+        )
+        attempts = usage.get("attempts")
+        completions = usage.get("completions")
+        completion_rate = usage.get("completion_rate")
+
+        try:
+            is_executable, executability_reason, executability_detail = (
+                classify_workflow_concept_executability(workflow_id)
+            )
+        except Exception as exc:
+            logger.warning(
+                "Workflow executability classification failed for %s: %s",
+                workflow_id,
+                exc,
+            )
+            is_executable = False
+            executability_reason = "classification_error"
+            executability_detail = f"classification_error:{type(exc).__name__}"
+
+        items.append(
+            {
+                "workflow_id": workflow_id,
+                "description": description,
+                "description_source": description_source,
+                "initial_state": initial_state,
+                "source": source,
+                "definition_identity": definition_identity,
+                "attempts": int(attempts) if isinstance(attempts, (int, float)) else 0,
+                "completions": (
+                    int(completions) if isinstance(completions, (int, float)) else 0
+                ),
+                "completion_rate": (
+                    float(completion_rate)
+                    if isinstance(completion_rate, (int, float))
+                    else None
+                ),
+                "last_episode_at": (
+                    str(usage.get("last_episode_at"))
+                    if usage.get("last_episode_at") is not None
+                    else None
+                ),
+                "episodes_count": int(episode_count_map.get(workflow_id, 0)),
+                "is_executable": bool(is_executable),
+                "executability_reason": executability_reason,
+                "executability_detail": executability_detail,
+            }
+        )
+
+    return {
+        "items": items,
+        "count": len(items),
+        "total": len(workflow_ids),
+        "episodes_scope": {
+            "namespace": namespace or None,
+            "session_id": session_id or None,
+            "turn_id": turn_id or None,
+        },
+        "parity_inventory": inventory_snapshot,
+    }
+
+
+def _refresh_workflow_definitions_cache_entry(
+    *,
+    cache_key: Tuple[int, Optional[str], Optional[str], Optional[str]],
+    limit: int,
+    namespace: str | None,
+    session_id: str | None,
+    turn_id: str | None,
+    refresh_lock: threading.Lock,
+) -> None:
+    try:
+        payload = _build_workflow_definitions_payload(
+            limit=limit,
+            namespace=namespace,
+            session_id=session_id,
+            turn_id=turn_id,
+        )
+        _write_cached_workflow_definitions(cache_key=cache_key, payload=payload)
+    except Exception:
+        logger.exception(
+            "Background workflow definitions refresh failed for key=%s",
+            cache_key,
+        )
+    finally:
+        refresh_lock.release()
+
+
+def _start_workflow_definitions_background_refresh(
+    *,
+    cache_key: Tuple[int, Optional[str], Optional[str], Optional[str]],
+    limit: int,
+    namespace: str | None,
+    session_id: str | None,
+    turn_id: str | None,
+    refresh_lock: threading.Lock,
+) -> bool:
+    try:
+        thread = threading.Thread(
+            target=_refresh_workflow_definitions_cache_entry,
+            kwargs={
+                "cache_key": cache_key,
+                "limit": limit,
+                "namespace": namespace,
+                "session_id": session_id,
+                "turn_id": turn_id,
+                "refresh_lock": refresh_lock,
+            },
+            name="workflow-definitions-refresh",
+            daemon=True,
+        )
+        thread.start()
+        return True
+    except Exception:
+        logger.exception(
+            "Could not start background workflow definitions refresh for key=%s",
+            cache_key,
+        )
+        return False
 
 
 @workflows_bp.get("/api/workflows/definitions/<path:workflow_id>")
@@ -234,26 +469,73 @@ def api_list_workflow_definitions():
     refresh_lock: threading.Lock | None = None
     refresh_lock_acquired = False
     try:
-        cached_payload, cached_is_fresh = _read_cached_workflow_definitions_entry(
-            cache_key=cache_key,
-            bypass_cache=bypass_cache,
+        cached_payload, cached_is_fresh, cached_age_seconds = (
+            _read_cached_workflow_definitions_entry(
+                cache_key=cache_key,
+                bypass_cache=bypass_cache,
+            )
         )
         if cached_is_fresh and isinstance(cached_payload, dict):
-            return jsonify(cached_payload)
+            return jsonify(
+                _attach_workflow_definitions_cache_metadata(
+                    cached_payload,
+                    state="fresh",
+                    age_seconds=cached_age_seconds,
+                    refresh_in_progress=False,
+                )
+            )
 
-        if not bypass_cache:
+        retry_after_seconds = _read_workflow_definitions_refresh_retry_after_seconds()
+
+        # Serve expired payloads immediately and refresh in the background so the
+        # monitor stays responsive even when registry rebuilds take longer than
+        # the UI timeout budget. The cache metadata keeps stale responses explicit.
+        if isinstance(cached_payload, dict) and not bypass_cache:
+            refresh_lock = _get_workflow_definitions_refresh_lock(cache_key)
+            refresh_lock_acquired = refresh_lock.acquire(blocking=False)
+            if refresh_lock_acquired:
+                refresh_started = _start_workflow_definitions_background_refresh(
+                    cache_key=cache_key,
+                    limit=limit,
+                    namespace=namespace or None,
+                    session_id=session_id or None,
+                    turn_id=turn_id or None,
+                    refresh_lock=refresh_lock,
+                )
+                if refresh_started:
+                    refresh_lock_acquired = False
+                    logger.info(
+                        "[workflow_definitions] Serving stale cache and refreshing in background for key=%s",
+                        cache_key,
+                    )
+                    return jsonify(
+                        _attach_workflow_definitions_cache_metadata(
+                            cached_payload,
+                            state="stale",
+                            age_seconds=cached_age_seconds,
+                            refresh_in_progress=True,
+                            retry_after_seconds=retry_after_seconds,
+                        )
+                    )
+            else:
+                logger.info(
+                    "[workflow_definitions] Serving stale cache while refresh in progress for key=%s",
+                    cache_key,
+                )
+                return jsonify(
+                    _attach_workflow_definitions_cache_metadata(
+                        cached_payload,
+                        state="stale",
+                        age_seconds=cached_age_seconds,
+                        refresh_in_progress=True,
+                        retry_after_seconds=retry_after_seconds,
+                    )
+                )
+
+        if not bypass_cache and not refresh_lock_acquired:
             refresh_lock = _get_workflow_definitions_refresh_lock(cache_key)
             refresh_lock_acquired = refresh_lock.acquire(blocking=False)
             if not refresh_lock_acquired:
-                if isinstance(cached_payload, dict):
-                    logger.info(
-                        "[workflow_definitions] Serving stale cache while refresh in progress for key=%s",
-                        cache_key,
-                    )
-                    return jsonify(cached_payload)
-                retry_after_seconds = (
-                    _read_workflow_definitions_refresh_retry_after_seconds()
-                )
                 payload = {
                     "error": "workflow_definitions_refresh_in_progress",
                     "detail": "Workflow definitions refresh is already running; retry shortly.",
@@ -267,140 +549,21 @@ def api_list_workflow_definitions():
                 )
                 return response
 
-        from ...workflows.durable.registry_factory import (
-            build_durable_workflow_registry_read_only,
-            get_workflow_registry_inventory_snapshot,
-        )
-        from ...services.workflow_discovery_service import (
-            classify_workflow_concept_executability,
-        )
-
-        # Read-only build avoids concept bootstrap writes on list/introspection paths.
-        registry = build_durable_workflow_registry_read_only()
-        inventory_snapshot = get_workflow_registry_inventory_snapshot()
-        if not isinstance(inventory_snapshot, dict):
-            inventory_snapshot = {}
-        workflow_ids = sorted(list(registry.all_workflow_ids()))
-        selected_ids = workflow_ids[:limit]
-        usage_aggregate_map = get_workflow_usage_aggregates_for_workflows(selected_ids)
-        episode_count_map = get_workflow_episode_counts_for_workflows(
-            selected_ids,
+        payload = _build_workflow_definitions_payload(
+            limit=limit,
             namespace=namespace or None,
             session_id=session_id or None,
             turn_id=turn_id or None,
         )
-
-        items: List[Dict[str, Any]] = []
-        for workflow_id in selected_ids:
-            registration = registry.get_registration(workflow_id)
-            definition = (
-                registration.definition
-                if registration is not None
-                else registry.get(workflow_id)
-            )
-
-            registration_purpose = (
-                registration.purpose if registration is not None else None
-            )
-            definition_purpose = (
-                getattr(definition, "purpose", "") if definition is not None else None
-            )
-            description, description_source = resolve_workflow_description(
-                workflow_id,
-                workflow_source=(registration.source if registration is not None else None),
-                registration_purpose=registration_purpose,
-                definition_purpose=definition_purpose,
-            )
-            source = "unknown"
-            if registration is not None:
-                if isinstance(registration.source, str) and registration.source.strip():
-                    source = registration.source.strip()
-            definition_identity = build_workflow_definition_identity(
-                workflow_id=workflow_id,
-                source=source,
-                definition=definition,
-                authoritative_definition=(
-                    definition
-                    if source.lower() == "vontology" and definition is not None
-                    else None
-                ),
-            )
-
-            initial_state = ""
-            if definition is not None:
-                state_value = getattr(definition, "initial_state", "")
-                if isinstance(state_value, str):
-                    initial_state = state_value
-
-            usage = (
-                usage_aggregate_map.get(workflow_id, {})
-                if isinstance(usage_aggregate_map, dict)
-                else {}
-            )
-            attempts = usage.get("attempts")
-            completions = usage.get("completions")
-            completion_rate = usage.get("completion_rate")
-
-            try:
-                is_executable, executability_reason, executability_detail = (
-                    classify_workflow_concept_executability(workflow_id)
-                )
-            except Exception as exc:
-                logger.warning(
-                    "Workflow executability classification failed for %s: %s",
-                    workflow_id,
-                    exc,
-                )
-                is_executable = False
-                executability_reason = "classification_error"
-                executability_detail = f"classification_error:{type(exc).__name__}"
-
-            items.append(
-                {
-                    "workflow_id": workflow_id,
-                    "description": description,
-                    "description_source": description_source,
-                    "initial_state": initial_state,
-                    "source": source,
-                    "definition_identity": definition_identity,
-                    "attempts": (
-                        int(attempts) if isinstance(attempts, (int, float)) else 0
-                    ),
-                    "completions": (
-                        int(completions)
-                        if isinstance(completions, (int, float))
-                        else 0
-                    ),
-                    "completion_rate": (
-                        float(completion_rate)
-                        if isinstance(completion_rate, (int, float))
-                        else None
-                    ),
-                    "last_episode_at": (
-                        str(usage.get("last_episode_at"))
-                        if usage.get("last_episode_at") is not None
-                        else None
-                    ),
-                    "episodes_count": int(episode_count_map.get(workflow_id, 0)),
-                    "is_executable": bool(is_executable),
-                    "executability_reason": executability_reason,
-                    "executability_detail": executability_detail,
-                }
-            )
-
-        payload = {
-            "items": items,
-            "count": len(items),
-            "total": len(workflow_ids),
-            "episodes_scope": {
-                "namespace": namespace or None,
-                "session_id": session_id or None,
-                "turn_id": turn_id or None,
-            },
-            "parity_inventory": inventory_snapshot,
-        }
         _write_cached_workflow_definitions(cache_key=cache_key, payload=payload)
-        return jsonify(payload)
+        return jsonify(
+            _attach_workflow_definitions_cache_metadata(
+                payload,
+                state="fresh",
+                age_seconds=0.0,
+                refresh_in_progress=False,
+            )
+        )
     except Exception as exc:
         logger.exception("Failed to list workflow definitions via API")
         return jsonify({"error": "workflow_definitions_list_failed", "detail": str(exc)}), 500

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -153,7 +153,9 @@ const workflowDefinitionsState = {
     visible: false,
     loading: false,
     error: '',
+    notice: '',
     items: [],
+    cacheState: 'none',
     lastFetchedAt: 0,
     lastPayload: null,
     lastRequestQuery: '',
@@ -167,6 +169,9 @@ const WORKFLOW_DEFINITIONS_CONTENTION_RETRY_BASE_MS = 750;
 const WORKFLOW_DEFINITIONS_CONTENTION_RETRY_MAX_MS = 5000;
 const WORKFLOW_DEFINITIONS_CONTENTION_RETRY_MAX_ATTEMPTS = 3;
 const WORKFLOW_DEFINITIONS_CONTENTION_RETRY_DEFAULT_SECONDS = 1;
+const WORKFLOW_DEFINITIONS_TIMEOUT_RETRY_BASE_MS = 1200;
+const WORKFLOW_DEFINITIONS_TIMEOUT_RETRY_MAX_MS = 6000;
+const WORKFLOW_DEFINITIONS_TIMEOUT_RETRY_MAX_ATTEMPTS = 2;
 let workflowStatusPanelInitialised = false;
 let chatTabInitialised = false;
 const REALTIME_CONNECTION_TELEMETRY_SCHEMA_VERSION = 1;
@@ -15965,6 +15970,7 @@ function buildWorkflowMonitorExportPayload() {
             show_designs: Boolean(workflowDefinitionsState.showDesigns),
             loading_available: Boolean(workflowDefinitionsState.loading),
             available_error: workflowDefinitionsState.error || null,
+            available_notice: workflowDefinitionsState.notice || null,
             available_last_fetched_at: workflowDefinitionsState.lastFetchedAt
                 ? new Date(workflowDefinitionsState.lastFetchedAt).toISOString()
                 : null
@@ -16102,24 +16108,30 @@ function renderWorkflowDefinitionsList(items) {
     const { body } = getWorkflowStatusElements();
     if (!body) return;
 
-    if (workflowDefinitionsState.loading) {
+    if (workflowDefinitionsState.loading && !items.length) {
         body.innerHTML = '<div class="workflow-status-empty">Loading available workflows…</div>';
         return;
     }
 
-    if (workflowDefinitionsState.error && !items.length) {
-        body.innerHTML = `<div class="workflow-status-empty workflow-status-error">${escapeHtml(workflowDefinitionsState.error)}</div>`;
-        return;
+    const bannerParts = [];
+    if (workflowDefinitionsState.loading && items.length) {
+        bannerParts.push('<div class="workflow-status-empty">Refreshing available workflows…</div>');
     }
+    if (workflowDefinitionsState.error) {
+        bannerParts.push(`<div class="workflow-status-empty workflow-status-error">${escapeHtml(workflowDefinitionsState.error)}</div>`);
+    } else if (workflowDefinitionsState.notice) {
+        bannerParts.push(`<div class="workflow-status-empty workflow-status-info">${escapeHtml(workflowDefinitionsState.notice)}</div>`);
+    }
+    const bannerHtml = bannerParts.join('');
 
     if (!items.length) {
-        body.innerHTML = '<div class="workflow-status-empty">No available workflows</div>';
+        body.innerHTML = bannerHtml || '<div class="workflow-status-empty">No available workflows</div>';
         return;
     }
 
     const filteredItems = filterWorkflowDefinitionsForDisplay(items);
     if (!filteredItems.length) {
-        body.innerHTML = '<div class="workflow-status-empty">No available workflows (design artefacts hidden)</div>';
+        body.innerHTML = bannerHtml || '<div class="workflow-status-empty">No available workflows (design artefacts hidden)</div>';
         return;
     }
 
@@ -16187,7 +16199,7 @@ function renderWorkflowDefinitionsList(items) {
         `;
     }).join('');
 
-    body.innerHTML = html;
+    body.innerHTML = `${bannerHtml}${html}`;
 }
 
 function bindWorkflowStatusConceptLinks() {
@@ -16321,6 +16333,18 @@ function parseWorkflowDefinitionsRetryAfterSeconds(payload, response) {
     return WORKFLOW_DEFINITIONS_CONTENTION_RETRY_DEFAULT_SECONDS;
 }
 
+function parseWorkflowDefinitionsCacheRetryAfterSeconds(payload) {
+    const cacheValue = Number(payload?.cache?.retry_after_seconds);
+    if (Number.isFinite(cacheValue) && cacheValue > 0) {
+        return cacheValue;
+    }
+    return WORKFLOW_DEFINITIONS_CONTENTION_RETRY_DEFAULT_SECONDS;
+}
+
+function formatWorkflowDefinitionsRetryDelaySeconds(delayMs) {
+    return Math.max(0.1, Math.round((delayMs / 1000) * 10) / 10);
+}
+
 function clearWorkflowDefinitionsRetryTimer() {
     if (workflowDefinitionsState.retryTimeoutId) {
         clearTimeout(workflowDefinitionsState.retryTimeoutId);
@@ -16337,6 +16361,55 @@ function scheduleWorkflowDefinitionsRetry({ delayMs, silent = true } = {}) {
     }, boundedDelay);
 }
 
+function applyWorkflowDefinitionsRetryableState({
+    nextRetryAttempt,
+    retryAfterSeconds = 0,
+    maxAttempts,
+    baseDelayMs,
+    maxDelayMs,
+    pendingMessage,
+    exhaustedMessage,
+    exhaustedKind = 'notice',
+    payload
+} = {}) {
+    const attempt = Math.max(1, Math.round(Number(nextRetryAttempt) || 1));
+    const boundedBaseDelayMs = Math.max(50, Math.round(Number(baseDelayMs) || 0));
+    const boundedMaxDelayMs = Math.max(
+        boundedBaseDelayMs,
+        Math.round(Number(maxDelayMs) || boundedBaseDelayMs)
+    );
+    const retryAfterMs = Math.max(0, Math.round(Number(retryAfterSeconds) * 1000) || 0);
+    const exponentialDelayMs = Math.min(
+        boundedBaseDelayMs * (2 ** (attempt - 1)),
+        boundedMaxDelayMs
+    );
+    const retryDelayMs = Math.max(exponentialDelayMs, retryAfterMs);
+    const shouldRetry = attempt <= Math.max(1, Math.round(Number(maxAttempts) || 1));
+    const retryDelaySecondsRounded = formatWorkflowDefinitionsRetryDelaySeconds(retryDelayMs);
+
+    workflowDefinitionsState.retryAttempt = attempt;
+    workflowDefinitionsState.error = '';
+    workflowDefinitionsState.notice = '';
+    if (shouldRetry) {
+        workflowDefinitionsState.notice = pendingMessage(retryDelaySecondsRounded);
+        scheduleWorkflowDefinitionsRetry({ delayMs: retryDelayMs, silent: true });
+    } else {
+        clearWorkflowDefinitionsRetryTimer();
+        if (exhaustedKind === 'error') {
+            workflowDefinitionsState.error = exhaustedMessage;
+        } else {
+            workflowDefinitionsState.notice = exhaustedMessage;
+        }
+    }
+
+    workflowDefinitionsState.lastPayload = {
+        ...(payload && typeof payload === 'object' ? payload : {}),
+        retryable: shouldRetry,
+        retry_attempt: attempt,
+        retry_scheduled_in_ms: shouldRetry ? retryDelayMs : null
+    };
+}
+
 async function refreshAvailableWorkflowDefinitions({ silent = false } = {}) {
     const { panel } = getWorkflowStatusElements();
     if (!panel) return;
@@ -16348,6 +16421,7 @@ async function refreshAvailableWorkflowDefinitions({ silent = false } = {}) {
         silent
         && Number.isFinite(workflowDefinitionsState.lastFetchedAt)
         && workflowDefinitionsState.lastFetchedAt > 0
+        && workflowDefinitionsState.cacheState !== 'stale'
         && (now - workflowDefinitionsState.lastFetchedAt) < WORKFLOW_DEFINITIONS_SILENT_REFRESH_COOLDOWN_MS
     ) {
         return;
@@ -16355,6 +16429,7 @@ async function refreshAvailableWorkflowDefinitions({ silent = false } = {}) {
 
     workflowDefinitionsState.loading = true;
     workflowDefinitionsState.error = '';
+    workflowDefinitionsState.notice = '';
     if (workflowDefinitionsState.visible) {
         renderWorkflowStatusBody();
     }
@@ -16380,37 +16455,25 @@ async function refreshAvailableWorkflowDefinitions({ silent = false } = {}) {
                 : '';
             if (responseError === 'workflow_definitions_refresh_in_progress') {
                 const retryAfterSeconds = parseWorkflowDefinitionsRetryAfterSeconds(responsePayload, resp);
-                const nextRetryAttempt = workflowDefinitionsState.retryAttempt + 1;
-                workflowDefinitionsState.retryAttempt = nextRetryAttempt;
-                const exponentialDelayMs = Math.min(
-                    WORKFLOW_DEFINITIONS_CONTENTION_RETRY_BASE_MS * (2 ** (nextRetryAttempt - 1)),
-                    WORKFLOW_DEFINITIONS_CONTENTION_RETRY_MAX_MS
-                );
-                const retryAfterMs = Math.round(retryAfterSeconds * 1000);
-                const retryDelayMs = Math.max(exponentialDelayMs, retryAfterMs);
-                const shouldRetry = nextRetryAttempt <= WORKFLOW_DEFINITIONS_CONTENTION_RETRY_MAX_ATTEMPTS;
-                const retryDelaySecondsRounded = Math.max(
-                    0.1,
-                    Math.round((retryDelayMs / 1000) * 10) / 10
-                );
-                workflowDefinitionsState.error = shouldRetry
-                    ? `Workflow definitions are refreshing, retrying in ${retryDelaySecondsRounded}s...`
-                    : 'Workflow definitions are still refreshing. Press Refresh to try again.';
-                workflowDefinitionsState.lastPayload = {
-                    error: 'workflow_definitions_refresh_in_progress',
-                    detail: (typeof responsePayload?.detail === 'string' && responsePayload.detail.trim())
-                        ? responsePayload.detail.trim()
-                        : 'Workflow definitions refresh is already running; retry shortly.',
-                    retryable: shouldRetry,
-                    retry_after_seconds: retryAfterSeconds,
-                    retry_attempt: nextRetryAttempt,
-                    retry_scheduled_in_ms: shouldRetry ? retryDelayMs : null,
-                    status: resp.status,
-                    request_query: workflowDefinitionsState.lastRequestQuery || null
-                };
-                if (shouldRetry) {
-                    scheduleWorkflowDefinitionsRetry({ delayMs: retryDelayMs, silent: true });
-                }
+                applyWorkflowDefinitionsRetryableState({
+                    nextRetryAttempt: workflowDefinitionsState.retryAttempt + 1,
+                    retryAfterSeconds,
+                    maxAttempts: WORKFLOW_DEFINITIONS_CONTENTION_RETRY_MAX_ATTEMPTS,
+                    baseDelayMs: WORKFLOW_DEFINITIONS_CONTENTION_RETRY_BASE_MS,
+                    maxDelayMs: WORKFLOW_DEFINITIONS_CONTENTION_RETRY_MAX_MS,
+                    pendingMessage: (delaySeconds) => `Workflow definitions are refreshing, retrying in ${delaySeconds}s...`,
+                    exhaustedMessage: 'Workflow definitions are still refreshing. Press Refresh to try again.',
+                    exhaustedKind: 'notice',
+                    payload: {
+                        error: 'workflow_definitions_refresh_in_progress',
+                        detail: (typeof responsePayload?.detail === 'string' && responsePayload.detail.trim())
+                            ? responsePayload.detail.trim()
+                            : 'Workflow definitions refresh is already running; retry shortly.',
+                        retry_after_seconds: retryAfterSeconds,
+                        status: resp.status,
+                        request_query: workflowDefinitionsState.lastRequestQuery || null
+                    }
+                });
                 if (!silent) {
                     console.info('[workflowStatus] Workflow definitions refresh contention', workflowDefinitionsState.lastPayload);
                 }
@@ -16430,6 +16493,30 @@ async function refreshAvailableWorkflowDefinitions({ silent = false } = {}) {
         workflowDefinitionsState.items = Array.isArray(data?.items) ? data.items : [];
         workflowDefinitionsState.lastFetchedAt = Date.now();
         workflowDefinitionsState.error = '';
+        workflowDefinitionsState.notice = '';
+        workflowDefinitionsState.cacheState = (
+            typeof data?.cache?.state === 'string' && data.cache.state.trim() === 'stale'
+        ) ? 'stale' : 'fresh';
+        if (workflowDefinitionsState.cacheState === 'stale' && data?.cache?.refresh_in_progress) {
+            applyWorkflowDefinitionsRetryableState({
+                nextRetryAttempt: workflowDefinitionsState.retryAttempt + 1,
+                retryAfterSeconds: parseWorkflowDefinitionsCacheRetryAfterSeconds(data),
+                maxAttempts: WORKFLOW_DEFINITIONS_CONTENTION_RETRY_MAX_ATTEMPTS,
+                baseDelayMs: WORKFLOW_DEFINITIONS_CONTENTION_RETRY_BASE_MS,
+                maxDelayMs: WORKFLOW_DEFINITIONS_CONTENTION_RETRY_MAX_MS,
+                pendingMessage: (delaySeconds) => (
+                    `Showing cached workflow definitions while the monitor refreshes in the background. Retrying in ${delaySeconds}s...`
+                ),
+                exhaustedMessage: 'Showing cached workflow definitions. Press Refresh to check again.',
+                exhaustedKind: 'notice',
+                payload: {
+                    ...data,
+                    detail: 'Showing cached workflow definitions while a background refresh completes.',
+                    request_query: workflowDefinitionsState.lastRequestQuery || null
+                }
+            });
+            return;
+        }
         workflowDefinitionsState.retryAttempt = 0;
         clearWorkflowDefinitionsRetryTimer();
     } catch (err) {
@@ -16441,25 +16528,52 @@ async function refreshAvailableWorkflowDefinitions({ silent = false } = {}) {
         const responseDetail = (typeof responsePayload?.detail === 'string' && responsePayload.detail.trim())
             ? responsePayload.detail.trim()
             : '';
-        workflowDefinitionsState.error = isAbortError
-            ? 'Workflow definitions request timed out. Please retry.'
-            : (responseDetail
+        if (isAbortError) {
+            const hasItems = Array.isArray(workflowDefinitionsState.items) && workflowDefinitionsState.items.length > 0;
+            applyWorkflowDefinitionsRetryableState({
+                nextRetryAttempt: workflowDefinitionsState.retryAttempt + 1,
+                retryAfterSeconds: 0,
+                maxAttempts: WORKFLOW_DEFINITIONS_TIMEOUT_RETRY_MAX_ATTEMPTS,
+                baseDelayMs: WORKFLOW_DEFINITIONS_TIMEOUT_RETRY_BASE_MS,
+                maxDelayMs: WORKFLOW_DEFINITIONS_TIMEOUT_RETRY_MAX_MS,
+                pendingMessage: (delaySeconds) => (
+                    hasItems
+                        ? `Showing last loaded workflow definitions while the request catches up. Retrying in ${delaySeconds}s...`
+                        : `Workflow definitions are taking longer than expected. Retrying in ${delaySeconds}s...`
+                ),
+                exhaustedMessage: hasItems
+                    ? 'Showing last loaded workflow definitions. Press Refresh to try again.'
+                    : 'Workflow definitions request timed out. Please retry.',
+                exhaustedKind: hasItems ? 'notice' : 'error',
+                payload: {
+                    error: 'workflow_definitions_request_timed_out',
+                    detail: `Request timed out after ${Math.round(WORKFLOW_DEFINITIONS_FETCH_TIMEOUT_MS / 1000)}s`,
+                    status,
+                    response_payload: responsePayload,
+                    request_query: workflowDefinitionsState.lastRequestQuery || null
+                }
+            });
+        } else {
+            workflowDefinitionsState.error = responseDetail
                 ? `Could not load available workflows: ${responseDetail}`
-                : 'Could not load available workflows');
-        workflowDefinitionsState.retryAttempt = 0;
-        clearWorkflowDefinitionsRetryTimer();
-        workflowDefinitionsState.lastPayload = {
-            error: (typeof responsePayload?.error === 'string' && responsePayload.error.trim())
-                ? responsePayload.error.trim()
-                : 'workflow_definitions_fetch_failed',
-            detail: isAbortError
-                ? `Request timed out after ${Math.round(WORKFLOW_DEFINITIONS_FETCH_TIMEOUT_MS / 1000)}s`
-                : (responseDetail || (err instanceof Error ? err.message : String(err || 'unknown_error'))),
-            status,
-            retryable: false,
-            response_payload: responsePayload,
-            request_query: workflowDefinitionsState.lastRequestQuery || null
-        };
+                : 'Could not load available workflows';
+            workflowDefinitionsState.notice = '';
+            workflowDefinitionsState.retryAttempt = 0;
+            workflowDefinitionsState.cacheState = workflowDefinitionsState.items.length
+                ? workflowDefinitionsState.cacheState
+                : 'none';
+            clearWorkflowDefinitionsRetryTimer();
+            workflowDefinitionsState.lastPayload = {
+                error: (typeof responsePayload?.error === 'string' && responsePayload.error.trim())
+                    ? responsePayload.error.trim()
+                    : 'workflow_definitions_fetch_failed',
+                detail: responseDetail || (err instanceof Error ? err.message : String(err || 'unknown_error')),
+                status,
+                retryable: false,
+                response_payload: responsePayload,
+                request_query: workflowDefinitionsState.lastRequestQuery || null
+            };
+        }
         if (!silent) {
             console.warn('[workflowStatus] Available workflow fetch failed', err);
         }
@@ -19645,7 +19759,9 @@ export function __testOnly_renderWorkflowDefinitionsBody(items = []) {
     workflowDefinitionsState.visible = true;
     workflowDefinitionsState.loading = false;
     workflowDefinitionsState.error = '';
+    workflowDefinitionsState.notice = '';
     workflowDefinitionsState.items = Array.isArray(items) ? items : [];
+    workflowDefinitionsState.cacheState = workflowDefinitionsState.items.length ? 'fresh' : 'none';
     renderWorkflowStatusBody();
 }
 export function __testOnly_setWorkflowShowDesigns(enabled) {
@@ -19659,7 +19775,9 @@ export function __testOnly_resetWorkflowDefinitionsState() {
     workflowDefinitionsState.visible = false;
     workflowDefinitionsState.loading = false;
     workflowDefinitionsState.error = '';
+    workflowDefinitionsState.notice = '';
     workflowDefinitionsState.items = [];
+    workflowDefinitionsState.cacheState = 'none';
     workflowDefinitionsState.lastFetchedAt = 0;
     workflowDefinitionsState.lastPayload = null;
     workflowDefinitionsState.lastRequestQuery = '';

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -622,6 +622,131 @@ describe('workflow monitor definitions refresh contention handling', () => {
         expect(successExport.monitor_state.available_error).toBeNull();
     });
 
+    test('shows cached workflows while a stale background refresh completes', async () => {
+        let fetchCount = 0;
+        global.fetch = jest.fn(() => {
+            fetchCount += 1;
+            if (fetchCount === 1) {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    headers: { get: () => null },
+                    json: async () => ({
+                        items: [
+                            {
+                                workflow_id: '#V#cached_workflow',
+                                description: 'Cached workflow.',
+                                initial_state: 'start',
+                                source: 'built_in'
+                            }
+                        ],
+                        cache: {
+                            state: 'stale',
+                            refresh_in_progress: true,
+                            retry_after_seconds: 1
+                        }
+                    })
+                });
+            }
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                headers: { get: () => null },
+                json: async () => ({
+                    items: [
+                        {
+                            workflow_id: '#V#fresh_workflow',
+                            description: 'Fresh workflow.',
+                            initial_state: 'ready',
+                            source: 'built_in'
+                        }
+                    ],
+                    cache: {
+                        state: 'fresh',
+                        refresh_in_progress: false
+                    }
+                })
+            });
+        });
+
+        await __testOnly_refreshAvailableWorkflowDefinitions();
+
+        expect(fetchCount).toBe(1);
+        expect(document.getElementById('workflowStatusBody').textContent).toContain(
+            'Showing cached workflow definitions while the monitor refreshes in the background'
+        );
+        expect(document.getElementById('workflowStatusBody').textContent).toContain(
+            'cached workflow'
+        );
+        const staleExport = __testOnly_buildWorkflowMonitorExportPayload();
+        expect(staleExport.monitor_state.available_notice).toContain('Showing cached workflow definitions');
+        expect(staleExport.definitions_snapshot.payload.cache.state).toBe('stale');
+
+        jest.advanceTimersByTime(1100);
+        await flushMicrotasks();
+
+        expect(fetchCount).toBe(2);
+        expect(document.getElementById('workflowStatusBody').textContent).toContain(
+            'fresh workflow'
+        );
+        const successExport = __testOnly_buildWorkflowMonitorExportPayload();
+        expect(successExport.monitor_state.available_notice).toBeNull();
+    });
+
+    test('treats timeout as transient and retries before surfacing a hard timeout', async () => {
+        let fetchCount = 0;
+        global.fetch = jest.fn(() => {
+            fetchCount += 1;
+            if (fetchCount === 1) {
+                const err = new Error('timeout');
+                err.name = 'AbortError';
+                return Promise.reject(err);
+            }
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                headers: { get: () => null },
+                json: async () => ({
+                    items: [
+                        {
+                            workflow_id: '#V#timeout_recovery_workflow',
+                            description: 'Recovered after timeout.',
+                            initial_state: 'ready',
+                            source: 'built_in'
+                        }
+                    ],
+                    cache: {
+                        state: 'fresh',
+                        refresh_in_progress: false
+                    }
+                })
+            });
+        });
+
+        await __testOnly_refreshAvailableWorkflowDefinitions();
+
+        expect(fetchCount).toBe(1);
+        expect(document.getElementById('workflowStatusBody').textContent).toContain(
+            'Workflow definitions are taking longer than expected. Retrying in'
+        );
+        const timeoutExport = __testOnly_buildWorkflowMonitorExportPayload();
+        expect(timeoutExport.monitor_state.available_notice).toContain('Retrying');
+        expect(timeoutExport.definitions_snapshot.payload.error).toBe(
+            'workflow_definitions_request_timed_out'
+        );
+
+        jest.advanceTimersByTime(1300);
+        await flushMicrotasks();
+
+        expect(fetchCount).toBe(2);
+        expect(document.getElementById('workflowStatusBody').textContent).toContain(
+            'timeout recovery workflow'
+        );
+        const successExport = __testOnly_buildWorkflowMonitorExportPayload();
+        expect(successExport.monitor_state.available_error).toBeNull();
+        expect(successExport.monitor_state.available_notice).toBeNull();
+    });
+
     test('keeps hard error state for non-contention 5xx responses', async () => {
         global.fetch = jest.fn(() => Promise.resolve({
             ok: false,

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -6091,6 +6091,11 @@ footer {
     color: #991b1b;
 }
 
+.workflow-status-empty.workflow-status-info {
+    background: rgba(239, 246, 255, 0.92);
+    color: #1d4ed8;
+}
+
 .workflow-episodes-popup {
     max-width: 720px;
 }

--- a/tests/backend/test_workflows_routes.py
+++ b/tests/backend/test_workflows_routes.py
@@ -893,6 +893,84 @@ def test_workflow_definitions_list_serves_stale_when_refresh_in_progress(
     payload = resp.get_json()
     assert payload["count"] == 1
     assert payload["items"][0]["workflow_id"] == "#V#stale_workflow"
+    assert payload["cache"]["state"] == "stale"
+    assert payload["cache"]["refresh_in_progress"] is True
+    assert float(payload["cache"]["retry_after_seconds"]) > 0.0
+
+
+def test_workflow_definitions_list_serves_expired_cache_and_starts_background_refresh(
+    monkeypatch, app_client
+):
+    import src.backend.server.routes.workflows_routes as workflows_routes
+    import src.backend.workflows.durable.registry_factory as registry_factory
+
+    cache_key = (10, None, None, None)
+    stale_payload = {
+        "items": [
+            {
+                "workflow_id": "#V#stale_workflow",
+                "description": "stale",
+                "description_source": "cache",
+                "initial_state": "start",
+                "source": "built_in",
+                "definition_identity": None,
+                "attempts": 0,
+                "completions": 0,
+                "completion_rate": None,
+                "last_episode_at": None,
+                "episodes_count": 0,
+                "is_executable": True,
+                "executability_reason": "executable_now",
+                "executability_detail": None,
+            }
+        ],
+        "count": 1,
+        "total": 1,
+        "episodes_scope": {"namespace": None, "session_id": None, "turn_id": None},
+        "parity_inventory": {},
+    }
+
+    refresh_calls: list[dict[str, object]] = []
+
+    monkeypatch.setenv("VON_WORKFLOW_DEFINITIONS_CACHE_TTL_SECONDS", "60")
+    monkeypatch.setattr(
+        registry_factory,
+        "build_durable_workflow_registry_read_only",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("Should not rebuild registry in foreground")
+        ),
+    )
+    def _fake_start_background_refresh(**kwargs):
+        refresh_calls.append(kwargs)
+        refresh_lock = kwargs.get("refresh_lock")
+        if refresh_lock is not None:
+            refresh_lock.release()
+        return True
+
+    monkeypatch.setattr(
+        workflows_routes,
+        "_start_workflow_definitions_background_refresh",
+        _fake_start_background_refresh,
+    )
+
+    with workflows_routes._WORKFLOW_DEFINITIONS_CACHE_LOCK:
+        workflows_routes._WORKFLOW_DEFINITIONS_CACHE.clear()
+        workflows_routes._WORKFLOW_DEFINITIONS_CACHE[cache_key] = {
+            "expires_at_monotonic": time.monotonic() - 1.0,
+            "stored_at_monotonic": time.monotonic() - 5.0,
+            "payload": stale_payload,
+        }
+
+    resp = app_client.get("/api/workflows/definitions?limit=10")
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["items"][0]["workflow_id"] == "#V#stale_workflow"
+    assert payload["cache"]["state"] == "stale"
+    assert payload["cache"]["refresh_in_progress"] is True
+    assert float(payload["cache"]["retry_after_seconds"]) > 0.0
+    assert refresh_calls
+    assert refresh_calls[0]["cache_key"] == cache_key
 
 
 def test_workflow_definitions_list_refresh_in_progress_without_stale_returns_503(


### PR DESCRIPTION
## Summary
- serve stale workflow definitions immediately with explicit cache metadata while a single background refresh repopulates the shared cache
- treat workflow monitor definition timeouts and refresh contention as bounded retry states in the client instead of dropping straight to a hard banner
- add backend and frontend regression coverage for stale-while-refresh and timeout recovery paths

## Testing
- `pdm run pytest tests/backend/test_workflows_routes.py -k "workflow_definitions_list"`
- `npx jest src/frontend/web/von_interface/static/js/test/chatTab.test.js --runInBand`
- `npx pyright src/backend/server/routes/workflows_routes.py tests/backend/test_workflows_routes.py`
