### PR TITLE
JVNAUTOSCI-1380 Make workflows authoritative for continuation, repair, and low-imposition execution

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -1,7 +1,7 @@
 # Von Workflow Language (VWL) Manual
 
 Status: Draft (current implementation-aligned)
-Last updated: 2026-03-05 (Pacific/Auckland)
+Last updated: 2026-03-06 (Pacific/Auckland)
 Audience: Human engineers and AI agents
 
 ## 1. Purpose and Scope
@@ -59,6 +59,10 @@ Canonical concepts (confirmed via Vontology MCP):
 - `#V#workflow_context_key`: type for deterministic context key symbols.
 - `#V#workflow_stage`: type for model-policy stage scoping.
 - `#V#workflow_model_policy`: type for stage-aware model selection policy.
+
+Typing rule:
+
+- A workflow concept typed as a subtype of `#V#ai_workflow` (for example `#V#durable_workflow`) MUST satisfy workflow-authority checks that require `#V#ai_workflow`.
 
 ### 3.2 Core Predicate Concepts
 
@@ -219,6 +223,34 @@ For live chat progress payloads used by workflow-aware thinking-card rendering:
 - live workflow-dispatch progress SHOULD expose `selected_workflow_id` and SHOULD expose a human-readable `selected_workflow_name` when available;
 - selector metadata such as `workflow_selector_verdict` and `workflow_selector_source` SHOULD be preserved in the live payload so the UI can explain why a workflow route was chosen;
 - thinking-card step labels SHOULD prefer canonical workflow-stage labels (for example `Workflow discovery`, `Workflow dispatch`, `Plan tool calls`) over transport/internal labels such as `orchestrator_start`.
+
+### 7.3 Completion-Gate Terminal Semantics (JVNAUTOSCI-1380)
+
+For workflow-governed conversation turns:
+
+- completion safety MUST be determined by completion-gate outputs, not by whether a response text was produced;
+- if `completion_gate_safe_to_claim_completion=false`, the orchestrator MUST NOT surface the turn as `completed`;
+- unresolved required effects or inconclusive mutation/representation verification MUST produce `follow_up_required` or `failed`, with explicit blocking effect IDs and failure codes preserved in diagnostics;
+- UI/progress surfaces MUST derive terminal state from authoritative completion status (`completed`, `follow_up_required`, `failed`, `cancelled`) rather than from liveness/heartbeat signals.
+
+### 7.4 Workflow Episode Continuation and Repair Semantics (JVNAUTOSCI-1380)
+
+Workflow routing for multi-turn agentive work MUST be stateful.
+
+Authoritative routing context SHOULD include:
+
+- active workflow/episode identity,
+- active workflow source (`conversation_turn`, `durable_instance`, or equivalent),
+- unresolved required effects,
+- prior completion-gate verdict,
+- and any workflow contract/profile identifiers already resolved for the episode.
+
+Continuation/repair rules:
+
+- terse continuation turns such as `please proceed`, `continue`, or `go ahead` SHOULD prefer continuing the active workflow episode over rediscovering a new workflow from the raw prompt;
+- terse repair turns such as `you did not create it`, `that relation was not added`, or `this is still missing` SHOULD route into verification/repair on the active workflow episode rather than generic search fallback;
+- previously resolved representation contract profiles MAY be reused for follow-up and repair turns when the active episode and artefact context remain compatible;
+- if the active workflow episode cannot be resumed safely, the system MUST fail closed with explicit diagnostics rather than silently claiming the work was completed.
 
 ## 8. Metadata Contract Semantics
 
@@ -482,6 +514,47 @@ Extension rule:
 
 - Any new representation domain profile added to VWL MUST add a corresponding scenario to this suite before merge.
 
+### 10.11 Workflow-Governed Low-Imposition Knowledge Acquisition (JVNAUTOSCI-1380)
+
+Low-imposition knowledge acquisition is a workflow policy, not just a prompt style.
+
+Canonical Vontology surface:
+
+- profile type: `#V#knowledge_acquisition_profile`
+- profile payload predicate: `#V#has_knowledge_acquisition_profile_json`
+- workflow-to-profile link predicate: `#V#has_knowledge_acquisition_profile`
+- current canonical profile: `#V#knowledge_acquisition_profile_low_imposition_relation_completion`
+
+Current runtime anchor:
+
+- `#V#rumination_workflow` relation-completion dispatch reads its knowledge-acquisition policy from the linked profile concept.
+
+Normative policy semantics:
+
+- workflows MUST retrieve existing context/evidence first before asking the user for new input;
+- low-risk defaults MAY be auto-applied only when the linked profile policy allows it and confidence/evidence thresholds are met;
+- high-risk or ambiguous changes MUST require explicit user confirmation;
+- relation-completion runs SHOULD ask at most one focused clarification question per run when machine-side evidence is insufficient;
+- if the linked acquisition profile cannot be resolved, the workflow MUST fail closed with explicit `knowledge_acquisition_profile_unavailable` diagnostics rather than falling back to ad hoc prompting.
+
+Persistence semantics:
+
+- uncertain or provisional relation proposals SHOULD be stored through the canonical uncertain-assertion pathway, not legacy side channels;
+- acquisition workflows SHOULD preserve provenance (`source`, interaction identifier, evidence count, confidence score) for later promotion/audit.
+
+### 10.12 Representation and Acquisition Profiles as Workflow Contracts (JVNAUTOSCI-1380)
+
+Representation profiles and knowledge-acquisition profiles are workflow contracts.
+
+Therefore:
+
+- workflow-governed runtime code SHOULD resolve contract/profile semantics from Vontology profile concepts, not from hard-coded prompt wording;
+- canonical profile concepts SHOULD exist before runtime use and SHOULD be bootstrapped through shared service pathways;
+- missing canonical profile concepts are configuration/runtime dependency failures and MUST remain visible in diagnostics;
+- adding a new agentive workflow domain SHOULD normally include both:
+  - a workflow/process graph, and
+  - a Vontology-backed contract/profile concept that defines completion or acquisition policy for that domain.
+
 ## 11. Durable Runtime Semantics
 
 ### 11.1 Instance Model
@@ -603,6 +676,7 @@ A VWL workflow is conformant when:
 - metadata contracts are syntactically valid,
 - required mappings are parseable,
 - discovered actions are runnable in current registry,
+- workflow typing satisfies canonical workflow authority rules, including subtype satisfaction for required workflow types,
 - submission verification passes preflight and postflight.
 
 ## 16. Analysis-Driven Refinements (March 2026 Planning Baseline)

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -3586,8 +3586,12 @@ class InternalMCPChatOrchestrator:
         if isinstance(method_catalogue_for_requirements, Mapping):
             data["method_catalogue"] = method_catalogue_for_requirements
 
+        prompt_for_requirements = data.get("prompt_for_requirements")
+        if not isinstance(prompt_for_requirements, str) or not prompt_for_requirements.strip():
+            prompt_for_requirements = prompt
+
         prompt_requirement_state = self._derive_prompt_tool_requirements(
-            prompt,
+            prompt_for_requirements,
             method_catalogue=(
                 method_catalogue_for_requirements
                 if isinstance(method_catalogue_for_requirements, Mapping)
@@ -4619,8 +4623,12 @@ class InternalMCPChatOrchestrator:
                 except Exception:
                     method_catalogue_for_requirements = None
 
+            prompt_for_requirements = data.get("prompt_for_requirements")
+            if not isinstance(prompt_for_requirements, str) or not prompt_for_requirements.strip():
+                prompt_for_requirements = data.get("prompt")
+
             prompt_requirement_state = self._derive_prompt_tool_requirements(
-                data.get("prompt"),
+                prompt_for_requirements,
                 method_catalogue=(
                     method_catalogue_for_requirements
                     if isinstance(method_catalogue_for_requirements, Mapping)
@@ -17967,6 +17975,7 @@ class InternalMCPChatOrchestrator:
         conversation_session_id: Optional[str] = None,
         turn_id: Optional[str] = None,
         workflow_discovery_result: Mapping[str, Any] | None = None,
+        workflow_continuation_context: Mapping[str, Any] | None = None,
     ) -> OrchestratorResult:
         aux_llm_calls: List[Mapping[str, Any]] = []
         llm_calls: list[dict[str, Any]] = []
@@ -18518,6 +18527,92 @@ class InternalMCPChatOrchestrator:
             preferred_language=preferred_language,
         )
 
+        effective_prompt_for_routing = prompt
+        workflow_continuation_payload = (
+            dict(workflow_continuation_context)
+            if isinstance(workflow_continuation_context, Mapping)
+            else None
+        )
+        try:
+            from ...services.workflow_continuation_service import (
+                assess_prompt_for_workflow_continuation,
+                build_workflow_continuation_routing_prompt,
+                build_workflow_continuation_system_message,
+                get_session_workflow_continuation_context,
+            )
+
+            if workflow_continuation_payload is None and conversation_session_id:
+                workflow_continuation_payload = get_session_workflow_continuation_context(
+                    session_id=conversation_session_id,
+                    namespace=user_namespace,
+                    user_id=None,
+                )
+
+            if isinstance(workflow_continuation_payload, Mapping):
+                apply_decision = assess_prompt_for_workflow_continuation(
+                    prompt=prompt,
+                    continuation_context=workflow_continuation_payload,
+                )
+                workflow_continuation_payload = dict(workflow_continuation_payload)
+                workflow_continuation_payload["applied"] = bool(
+                    apply_decision.get("applies", False)
+                )
+                workflow_continuation_payload["apply_reason"] = str(
+                    apply_decision.get("reason") or ""
+                ).strip() or None
+                if bool(workflow_continuation_payload.get("applied")):
+                    system_message = build_workflow_continuation_system_message(
+                        workflow_continuation_payload
+                    )
+                    if isinstance(system_message, str) and system_message.strip():
+                        insert_at = (
+                            1
+                            if augmented_context
+                            and isinstance(augmented_context[0], Mapping)
+                            and augmented_context[0].get("role") == "system"
+                            else 0
+                        )
+                        augmented_context.insert(
+                            insert_at,
+                            {
+                                "role": "system",
+                                "content": system_message.strip(),
+                            },
+                        )
+                    effective_prompt_for_routing = (
+                        build_workflow_continuation_routing_prompt(
+                            prompt=prompt,
+                            continuation_context=workflow_continuation_payload,
+                        )
+                        or prompt
+                    )
+                aux_llm_calls.append(
+                    {
+                        "type": "workflow_continuation_context",
+                        "applied": bool(workflow_continuation_payload.get("applied", False)),
+                        "reason": workflow_continuation_payload.get("apply_reason"),
+                        "context": dict(workflow_continuation_payload),
+                    }
+                )
+                if trace_enabled and trace is not None:
+                    trace.metadata["workflow_continuation_context"] = {
+                        "applied": bool(workflow_continuation_payload.get("applied", False)),
+                        "reason": workflow_continuation_payload.get("apply_reason"),
+                        "selected_workflow_id": workflow_continuation_payload.get(
+                            "selected_workflow_id"
+                        ),
+                        "requires_follow_up": bool(
+                            workflow_continuation_payload.get("requires_follow_up", False)
+                        ),
+                        "has_unresolved_required_effects": bool(
+                            workflow_continuation_payload.get(
+                                "has_unresolved_required_effects", False
+                            )
+                        ),
+                    }
+        except Exception:
+            workflow_continuation_payload = None
+
         base_prompt_telemetry = self._consume_base_system_prompt_telemetry()
         if base_prompt_telemetry:
             aux_llm_calls.append(base_prompt_telemetry)
@@ -18574,7 +18669,7 @@ class InternalMCPChatOrchestrator:
                 selector_selection = self._workflow_selector.select_workflow(
                     llm_client=llm_client,
                     model=classifier_model,
-                    turn_text=prompt,
+                    turn_text=effective_prompt_for_routing,
                     discovered_workflows=discovered_matches or None,
                 )
                 routing_duration_ms = (time.perf_counter() - selector_start) * 1000.0
@@ -23003,7 +23098,7 @@ class InternalMCPChatOrchestrator:
 
         if selector_verdict == "plain_response":
             plain_requirement_state = self._derive_prompt_tool_requirements(
-                prompt,
+                effective_prompt_for_routing,
                 method_catalogue=method_catalogue_for_routing,
                 context_messages=augmented_context,
             )
@@ -23348,6 +23443,7 @@ class InternalMCPChatOrchestrator:
         tc_data: dict[str, Any] = {
             # Inputs.
             "prompt": prompt,
+            "prompt_for_requirements": effective_prompt_for_routing,
             "augmented_context": augmented_context,
             "policy_state": policy_state,
             "registry_snapshot": registry_snapshot,

--- a/src/backend/server/routes/elicitation_routes.py
+++ b/src/backend/server/routes/elicitation_routes.py
@@ -53,7 +53,6 @@ def ask_question():
             f"[elicitation/ask] user={user_ctx.get('user_id')} org={user_ctx.get('org_id')} lang={user_ctx.get('language')}"
         )
 
-        # This part of the service needs to be refactored to not be interactive
         question = service.generate_question_for_elicit(instance_id, predicate)
         if question:
             return jsonify({"question": question}), 200
@@ -88,7 +87,6 @@ def submit_response():
             f"[elicitation/submit] user={user_ctx.get('user_id')} org={user_ctx.get('org_id')} instance={instance_id} predicate={predicate}"
         )
 
-        # This part of the service needs to be refactored
         hypothesis = service.process_and_store_hypothesis(
             instance_id, predicate, answer
         )

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -91,8 +91,15 @@ von_bp = Blueprint("von", __name__, template_folder=_TEMPLATE_DIR)
 _TOOL_PROGRESS_TTL_SEC = 10 * 60
 _TOOL_PROGRESS_LOCK = threading.Lock()
 _TOOL_PROGRESS: dict[tuple[str, str], dict[str, Any]] = {}
-_TOOL_PROGRESS_TERMINAL_STATUSES = {"completed", "error", "cancelled"}
-_TOOL_PROGRESS_TERMINAL_PHASES = {"completed", "failed", "error", "cancelled", "terminated"}
+_TOOL_PROGRESS_TERMINAL_STATUSES = {"completed", "follow_up_required", "error", "cancelled"}
+_TOOL_PROGRESS_TERMINAL_PHASES = {
+    "completed",
+    "follow_up_required",
+    "failed",
+    "error",
+    "cancelled",
+    "terminated",
+}
 _TOOL_PROGRESS_DIAGNOSTIC_EVENT_LIMIT = 80
 
 _ONBOARDING_WORKFLOW_IDS_ENV = "VON_NEW_MEMBER_ONBOARDING_WORKFLOW_IDS"
@@ -214,6 +221,7 @@ def _default_stage_label(stage: str) -> str:
         "orchestrator_start": "Starting orchestrator",
         "orchestrator_end": "Finishing orchestrator",
         "completed": "Complete",
+        "follow_up_required": "Follow-up required",
         "error": "Error",
     }
     if stage in mapping:
@@ -244,6 +252,7 @@ def _derive_progress_stage(update: dict[str, Any], existing: dict[str, Any]) -> 
         "retry_start": "tool_recovery",
         "retry_end": "tool_recovery",
         "completed": "completed",
+        "follow_up_required": "follow_up_required",
         "error": "error",
     }
     derived = status_stage_map.get(status)
@@ -282,6 +291,7 @@ def _derive_progress_event_kind(update: dict[str, Any]) -> str:
         "retry_start": "retry_start",
         "retry_end": "retry_end",
         "completed": "completed",
+        "follow_up_required": "completed",
         "error": "error",
     }
     return status_kind_map.get(status, status or "status_update")
@@ -2642,18 +2652,18 @@ def _build_terminal_tool_progress_payload(
         else True
     )
     progress_success = bool(safe_to_claim_completion and not requires_follow_up)
+    terminal_status = "completed" if progress_success else "follow_up_required"
+    terminal_label = "Complete" if progress_success else "Follow-up required"
 
     payload: dict[str, Any] = {
-        "status": "completed",
-        "stage": "completed",
-        "phase_label": "Complete",
+        "status": terminal_status,
+        "stage": terminal_status,
+        "phase_label": terminal_label,
         "request_id": request_id,
         "success": progress_success,
         "completion_gate_requires_follow_up": requires_follow_up,
         "completion_gate_safe_to_claim_completion": safe_to_claim_completion,
-        "orchestrator_status": (
-            "completed" if progress_success else "follow_up_required"
-        ),
+        "orchestrator_status": terminal_status,
     }
     if isinstance(completion_gate, dict):
         payload["completion_gate_decision"] = completion_gate.get("decision")
@@ -5581,6 +5591,44 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             "tools_invoked": [],
             "tool_results_included_in_prompt": False,
         }
+        workflow_continuation_context: dict[str, Any] | None = None
+        workflow_discovery_query = prompt_text
+        try:
+            from ...services.workflow_continuation_service import (
+                assess_prompt_for_workflow_continuation,
+                build_workflow_continuation_routing_prompt,
+                get_session_workflow_continuation_context,
+            )
+
+            workflow_continuation_context = get_session_workflow_continuation_context(
+                session_id=session_id,
+                namespace=user_namespace,
+                user_id=history_user_id,
+            )
+            if isinstance(workflow_continuation_context, Mapping):
+                apply_decision = assess_prompt_for_workflow_continuation(
+                    prompt=prompt_text,
+                    continuation_context=workflow_continuation_context,
+                )
+                workflow_continuation_context = dict(workflow_continuation_context)
+                workflow_continuation_context["applied"] = bool(
+                    apply_decision.get("applies", False)
+                )
+                workflow_continuation_context["apply_reason"] = str(
+                    apply_decision.get("reason") or ""
+                ).strip() or None
+                if bool(workflow_continuation_context.get("applied")):
+                    workflow_discovery_query = build_workflow_continuation_routing_prompt(
+                        prompt=prompt_text,
+                        continuation_context=workflow_continuation_context,
+                    )
+        except Exception as exc:
+            current_app.logger.debug(
+                "[WORKFLOW_CONTINUATION] Context lookup skipped: %s",
+                exc,
+            )
+            workflow_continuation_context = None
+            workflow_discovery_query = prompt_text
 
         # ---------------------------------------------------------
         # JVNAUTOSCI-1076: Workflow discovery during conversation turn
@@ -5610,12 +5658,12 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                 )
 
                 workflow_discovery_result = discover_workflows_for_turn(
-                    prompt_text,
+                    workflow_discovery_query,
                     namespace=user_namespace,
                 )
                 workflow_discovery_progress = _normalise_workflow_discovery_progress_payload(
                     workflow_discovery_result,
-                    query=prompt_text,
+                    query=workflow_discovery_query,
                 )
                 if workflow_discovery_result:
                     current_app.logger.info(
@@ -5657,7 +5705,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                             "request_id": request_id,
                             "workflow_discovery": _normalise_workflow_discovery_progress_payload(
                                 None,
-                                query=prompt_text,
+                                query=workflow_discovery_query,
                                 error=str(e),
                             ),
                             "workflow_match_count": 0,
@@ -6429,6 +6477,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                                 conversation_session_id=bg_session_id,
                                 turn_id=request_id,
                                 workflow_discovery_result=workflow_discovery_result,
+                                workflow_continuation_context=workflow_continuation_context,
                             )
 
                             # Phase 4: Persist to chat history
@@ -6535,6 +6584,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                     conversation_session_id=session_id,
                     turn_id=request_id,
                     workflow_discovery_result=workflow_discovery_result,
+                    workflow_continuation_context=workflow_continuation_context,
                 )
                 llm_interaction["duration_ms"] = (
                     time.perf_counter() - orchestrator_start_perf

--- a/src/backend/services/__init__.py
+++ b/src/backend/services/__init__.py
@@ -7,20 +7,24 @@ from . import (
     annotation_extraction_service,
     concept_normalization,
     concept_service,
+    knowledge_acquisition_profile_vontology_service,
     meta_relations_service,
     relation_elicitation_service,
     settings_service,
     text_value_service,
     vontology_service,
+    workflow_continuation_service,
 )
 
 __all__ = [
     "annotation_extraction_service",
     "concept_normalization",
     "concept_service",
+    "knowledge_acquisition_profile_vontology_service",
     "meta_relations_service",
     "relation_elicitation_service",
     "settings_service",
     "text_value_service",
     "vontology_service",
+    "workflow_continuation_service",
 ]

--- a/src/backend/services/knowledge_acquisition_profile_vontology_service.py
+++ b/src/backend/services/knowledge_acquisition_profile_vontology_service.py
@@ -1,0 +1,418 @@
+"""Vontology-backed policy profiles for low-imposition knowledge acquisition.
+
+This module gives workflow-governed acquisition behaviours the same kind of
+authoritative Vontology profile surface that representation intents now use.
+The initial canonical profile targets relation-completion inside
+``#V#rumination_workflow``, but the loader/ensure helpers are intentionally
+generic so other acquisition workflows can adopt the same pattern.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Sequence
+
+from . import concept_service
+from .concept_service import ConceptNotFoundError, get_concept_by_concept_id
+from .text_value_service import get_texts_for_concept, upsert_singleton_text_relation
+
+DEFAULT_KNOWLEDGE_ACQUISITION_PROFILE_PREDICATE = (
+    "#V#has_knowledge_acquisition_profile_json"
+)
+DEFAULT_KNOWLEDGE_ACQUISITION_PROFILE_CONCEPT_ID = (
+    "#V#knowledge_acquisition_profile_low_imposition_relation_completion"
+)
+KNOWLEDGE_ACQUISITION_PROFILE_TYPE_ID = "#V#knowledge_acquisition_profile"
+KNOWLEDGE_ACQUISITION_PROFILE_LINK_PREDICATE = "#V#has_knowledge_acquisition_profile"
+DEFAULT_PROFILE_WORKFLOW_IDS: tuple[str, ...] = ("#V#rumination_workflow",)
+
+_PROFILE_TEXT_PREDICATES: tuple[str, ...] = (
+    "#V#has_knowledge_acquisition_profile_json",
+    "has_knowledge_acquisition_profile_json",
+    "hasKnowledgeAcquisitionProfileJson",
+    "hasContent",
+)
+_WORKFLOW_LINK_TEXT_PREDICATES: tuple[str, ...] = (
+    "#V#has_knowledge_acquisition_profile",
+    "has_knowledge_acquisition_profile",
+    "hasKnowledgeAcquisitionProfile",
+)
+
+_DEFAULT_DECISION_POLICY: dict[str, bool] = {
+    "retrieve_existing_context_first": True,
+    "auto_apply_low_risk_defaults": True,
+    "requires_explicit_user_decision_for_high_risk": True,
+    "ask_at_most_one_question_per_run": True,
+    "fail_closed_on_missing_profile": True,
+}
+
+_CANONICAL_KNOWLEDGE_ACQUISITION_PROFILE_BLUEPRINTS: tuple[dict[str, Any], ...] = (
+    {
+        "profile_concept_id": DEFAULT_KNOWLEDGE_ACQUISITION_PROFILE_CONCEPT_ID,
+        "profile_id": "low_imposition_relation_completion",
+        "dispatch_mode": "relation_completion",
+        "description": (
+            "Low-imposition knowledge-acquisition profile for workflow-governed "
+            "relation completion. Retrieve existing context first, auto-apply "
+            "only high-confidence low-risk defaults, and ask at most one narrow "
+            "question per run when machine-side evidence is insufficient."
+        ),
+        "decision_policy": dict(_DEFAULT_DECISION_POLICY),
+        "question_limit": 1,
+        "detail_limit": 80,
+        "relation_auto_apply_policy": {
+            "policy_version": "knowledge_acquisition_profile.v1",
+            "default_threshold": 0.95,
+            "class_thresholds": {
+                "ownership": 0.98,
+                "affiliation": 0.96,
+                "project": 0.96,
+                "deadline": 0.97,
+                "paper_link": 0.95,
+                "supervision": 0.97,
+                "dependency": 0.98,
+                "membership": 0.96,
+                "generic": 0.95,
+            },
+            "source_adjustments": {
+                "human_validated": 0.08,
+                "user_confirmed": 0.06,
+                "explicit_user_input": 0.05,
+                "llm_extraction": 0.0,
+                "heuristic_inference": -0.05,
+                "unknown": 0.0,
+            },
+            "min_evidence_count": 1,
+            "min_evidence_by_predicate": {},
+        },
+    },
+)
+_CANONICAL_PROFILE_BY_CONCEPT_ID: dict[str, dict[str, Any]] = {
+    str(item["profile_concept_id"]): dict(item)
+    for item in _CANONICAL_KNOWLEDGE_ACQUISITION_PROFILE_BLUEPRINTS
+}
+
+
+def _safe_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _normalise_strings(values: Any) -> tuple[str, ...]:
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+        return ()
+    seen: set[str] = set()
+    output: list[str] = []
+    for value in values:
+        text = _safe_str(value)
+        if not text:
+            continue
+        lowered = text.lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        output.append(text)
+    return tuple(output)
+
+
+def _safe_get_concept(concept_id: str) -> Mapping[str, Any] | None:
+    """Return ``None`` for absent concepts so bootstrap can create them cleanly."""
+
+    try:
+        concept = get_concept_by_concept_id(concept_id)
+    except ConceptNotFoundError:
+        return None
+    return concept if isinstance(concept, Mapping) else None
+
+
+def _profile_display_name(profile: Mapping[str, Any]) -> str:
+    profile_id = _safe_str(profile.get("profile_id")) or "knowledge acquisition"
+    pretty = profile_id.replace("_", " ").strip()
+    return f"{pretty[:1].upper() + pretty[1:] if pretty else 'Knowledge acquisition'} profile"
+
+
+def canonical_knowledge_acquisition_profile_concept_ids() -> tuple[str, ...]:
+    """Return canonical knowledge-acquisition profile IDs in deterministic order."""
+
+    return tuple(
+        str(item["profile_concept_id"])
+        for item in _CANONICAL_KNOWLEDGE_ACQUISITION_PROFILE_BLUEPRINTS
+    )
+
+
+def canonical_knowledge_acquisition_profile_blueprints() -> tuple[dict[str, Any], ...]:
+    """Return copy-on-read canonical profile blueprints."""
+
+    return tuple(
+        dict(item) for item in _CANONICAL_KNOWLEDGE_ACQUISITION_PROFILE_BLUEPRINTS
+    )
+
+
+def _normalise_profile(
+    raw_profile: Mapping[str, Any],
+    *,
+    profile_concept_id: str,
+) -> dict[str, Any]:
+    decision_policy = raw_profile.get("decision_policy")
+    decision_policy = dict(decision_policy) if isinstance(decision_policy, Mapping) else {}
+
+    relation_policy = raw_profile.get("relation_auto_apply_policy")
+    relation_policy = dict(relation_policy) if isinstance(relation_policy, Mapping) else {}
+
+    return {
+        "profile_concept_id": profile_concept_id,
+        "profile_id": _safe_str(raw_profile.get("profile_id")) or profile_concept_id,
+        "dispatch_mode": _safe_str(raw_profile.get("dispatch_mode")) or "relation_completion",
+        "description": _safe_str(raw_profile.get("description")),
+        "decision_policy": {
+            **dict(_DEFAULT_DECISION_POLICY),
+            **decision_policy,
+        },
+        "question_limit": max(
+            1,
+            int(raw_profile.get("question_limit", 1) or 1),
+        ),
+        "detail_limit": max(
+            1,
+            int(raw_profile.get("detail_limit", 80) or 80),
+        ),
+        "relation_auto_apply_policy": relation_policy,
+    }
+
+
+def resolve_knowledge_acquisition_profile_concept_id(
+    *,
+    workflow_id: str | None = None,
+    profile_concept_id: str | None = None,
+) -> str | None:
+    """Resolve a profile concept ID from explicit input, workflow link, or default."""
+
+    explicit_id = _safe_str(profile_concept_id)
+    if explicit_id:
+        return explicit_id
+
+    workflow_concept_id = _safe_str(workflow_id)
+    if workflow_concept_id:
+        for predicate in _WORKFLOW_LINK_TEXT_PREDICATES:
+            texts = get_texts_for_concept(
+                workflow_concept_id,
+                predicate=predicate,
+                limit=1,
+            )
+            if not texts:
+                continue
+            text = _safe_str((texts[0] or {}).get("text"))
+            if text and text.startswith("#V#"):
+                return text
+
+    return DEFAULT_KNOWLEDGE_ACQUISITION_PROFILE_CONCEPT_ID
+
+
+def load_knowledge_acquisition_profile(
+    *,
+    workflow_id: str | None = None,
+    profile_concept_id: str | None = None,
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    """Load a knowledge-acquisition policy profile from Vontology."""
+
+    resolved_profile_id = resolve_knowledge_acquisition_profile_concept_id(
+        workflow_id=workflow_id,
+        profile_concept_id=profile_concept_id,
+    )
+    diagnostics: dict[str, Any] = {
+        "requested_workflow_id": _safe_str(workflow_id),
+        "requested_profile_concept_id": _safe_str(profile_concept_id),
+        "resolved_profile_concept_id": resolved_profile_id,
+        "loaded_profile_concept_id": None,
+        "source_predicate": None,
+        "missing_profile_concept_ids": [],
+        "malformed_profile_concept_ids": [],
+    }
+    if not resolved_profile_id:
+        diagnostics["missing_profile_concept_ids"] = [None]
+        return None, diagnostics
+
+    concept_doc = _safe_get_concept(resolved_profile_id)
+    if not isinstance(concept_doc, Mapping):
+        diagnostics["missing_profile_concept_ids"] = [resolved_profile_id]
+        return None, diagnostics
+
+    for predicate in _PROFILE_TEXT_PREDICATES:
+        texts = get_texts_for_concept(
+            resolved_profile_id,
+            predicate=predicate,
+            limit=10,
+        )
+        for row in texts:
+            text = _safe_str((row or {}).get("text"))
+            if not text:
+                continue
+            try:
+                raw_profile = json.loads(text)
+            except json.JSONDecodeError:
+                diagnostics["malformed_profile_concept_ids"].append(resolved_profile_id)
+                continue
+            if isinstance(raw_profile, Mapping):
+                diagnostics["loaded_profile_concept_id"] = resolved_profile_id
+                diagnostics["source_predicate"] = predicate
+                return (
+                    _normalise_profile(
+                        raw_profile,
+                        profile_concept_id=resolved_profile_id,
+                    ),
+                    diagnostics,
+                )
+
+    diagnostics["missing_profile_concept_ids"] = [resolved_profile_id]
+    return None, diagnostics
+
+
+def ensure_canonical_knowledge_acquisition_profiles(
+    *,
+    concept_ids: Sequence[str] | None = None,
+    profile_predicate: str = DEFAULT_KNOWLEDGE_ACQUISITION_PROFILE_PREDICATE,
+    workflow_link_predicate: str = KNOWLEDGE_ACQUISITION_PROFILE_LINK_PREDICATE,
+    language: str = "en-NZ",
+    policy: str = "replace_others",
+    provenance: Mapping[str, Any] | None = None,
+    context: Mapping[str, Any] | None = None,
+    garbage_collect: bool = True,
+    create_missing_concepts: bool = True,
+    link_workflow_ids: Sequence[str] | None = DEFAULT_PROFILE_WORKFLOW_IDS,
+) -> dict[str, Any]:
+    """Ensure canonical knowledge-acquisition profiles exist and are linked."""
+
+    requested_concept_ids = (
+        _normalise_strings(concept_ids) or canonical_knowledge_acquisition_profile_concept_ids()
+    )
+    workflow_ids = _normalise_strings(link_workflow_ids)
+    type_created = False
+    created_profile_concept_ids: list[str] = []
+    persisted_profile_concept_ids: list[str] = []
+    linked_workflow_ids: list[str] = []
+    unknown_canonical_profile_concept_ids: list[str] = []
+    missing_concept_ids: list[str] = []
+    errors_by_concept_id: dict[str, str] = {}
+
+    profile_type = _safe_get_concept(KNOWLEDGE_ACQUISITION_PROFILE_TYPE_ID)
+    if not isinstance(profile_type, Mapping) and create_missing_concepts:
+        try:
+            concept_service.create_concept(
+                name="Knowledge acquisition profile",
+                concept_id=KNOWLEDGE_ACQUISITION_PROFILE_TYPE_ID,
+                description=(
+                    "Type for workflow-governed knowledge-acquisition policy profiles."
+                ),
+                parent_concept_ids=["#V#thing"],
+                create_as_instance=False,
+            )
+            type_created = True
+        except Exception as exc:
+            errors_by_concept_id[KNOWLEDGE_ACQUISITION_PROFILE_TYPE_ID] = (
+                f"type_create_failed:{exc}"
+            )
+
+    for concept_id in requested_concept_ids:
+        seed_profile = _CANONICAL_PROFILE_BY_CONCEPT_ID.get(concept_id)
+        if not isinstance(seed_profile, Mapping):
+            unknown_canonical_profile_concept_ids.append(concept_id)
+            continue
+
+        concept_doc = _safe_get_concept(concept_id)
+        if not isinstance(concept_doc, Mapping):
+            if not create_missing_concepts:
+                missing_concept_ids.append(concept_id)
+                continue
+            try:
+                concept_service.create_concept(
+                    name=_profile_display_name(seed_profile),
+                    concept_id=concept_id,
+                    description=_safe_str(seed_profile.get("description")),
+                    parent_concept_ids=[KNOWLEDGE_ACQUISITION_PROFILE_TYPE_ID],
+                    create_as_instance=True,
+                )
+                created_profile_concept_ids.append(concept_id)
+                concept_doc = _safe_get_concept(concept_id)
+            except Exception as exc:
+                errors_by_concept_id[concept_id] = f"create_failed:{exc}"
+                continue
+
+        if not isinstance(concept_doc, Mapping):
+            missing_concept_ids.append(concept_id)
+            continue
+
+        profile_json = json.dumps(
+            dict(seed_profile),
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        try:
+            upsert_singleton_text_relation(
+                subject_concept_id=concept_id,
+                predicate=profile_predicate,
+                lang=language,
+                text=profile_json,
+                policy=policy,
+                provenance=provenance,
+                context=context,
+                garbage_collect=garbage_collect,
+            )
+            persisted_profile_concept_ids.append(concept_id)
+        except Exception as exc:
+            errors_by_concept_id[concept_id] = f"profile_upsert_failed:{exc}"
+
+    link_target_id = (
+        persisted_profile_concept_ids[0]
+        if persisted_profile_concept_ids
+        else _safe_str(DEFAULT_KNOWLEDGE_ACQUISITION_PROFILE_CONCEPT_ID)
+    )
+    if link_target_id:
+        for workflow_id in workflow_ids:
+            try:
+                upsert_singleton_text_relation(
+                    subject_concept_id=workflow_id,
+                    predicate=workflow_link_predicate,
+                    lang=language,
+                    text=link_target_id,
+                    policy=policy,
+                    provenance=provenance,
+                    context=context,
+                    garbage_collect=garbage_collect,
+                )
+                linked_workflow_ids.append(workflow_id)
+            except Exception as exc:
+                errors_by_concept_id[workflow_id] = f"workflow_link_failed:{exc}"
+
+    return {
+        "success": not (
+            unknown_canonical_profile_concept_ids
+            or missing_concept_ids
+            or errors_by_concept_id
+        ),
+        "requested_profile_concept_ids": list(requested_concept_ids),
+        "canonical_profile_concept_ids": list(
+            canonical_knowledge_acquisition_profile_concept_ids()
+        ),
+        "profile_type_id": KNOWLEDGE_ACQUISITION_PROFILE_TYPE_ID,
+        "profile_type_created": type_created,
+        "created_profile_concept_ids": created_profile_concept_ids,
+        "persisted_profile_concept_ids": persisted_profile_concept_ids,
+        "linked_workflow_ids": linked_workflow_ids,
+        "unknown_canonical_profile_concept_ids": unknown_canonical_profile_concept_ids,
+        "missing_concept_ids": missing_concept_ids,
+        "errors_by_concept_id": errors_by_concept_id,
+        "counts": {
+            "requested": len(requested_concept_ids),
+            "created_concepts": len(created_profile_concept_ids),
+            "persisted_profiles": len(persisted_profile_concept_ids),
+            "linked_workflows": len(linked_workflow_ids),
+            "missing_concepts": len(missing_concept_ids),
+            "unknown_canonical_ids": len(unknown_canonical_profile_concept_ids),
+            "errors": len(errors_by_concept_id),
+        },
+    }

--- a/src/backend/services/relation_elicitation_service.py
+++ b/src/backend/services/relation_elicitation_service.py
@@ -160,7 +160,13 @@ class RelationElicitationService:
     def process_and_store_hypothesis(
         self, instance_id: str, predicate: str, answer: str
     ) -> Optional[Dict[str, Any]]:
-        """Process user answer and store as hypothesized relation."""
+        """Process user answer and store a canonical uncertain assertion.
+
+        Legacy ``hypothesized_relations`` writes are intentionally avoided here.
+        Workflow-governed acquisition should persist through the canonical
+        ``uncertain_relationship_assertions`` pathway so promotion, auditing,
+        and low-imposition policy all operate on the same source of truth.
+        """
         understanding_prompt_concept = concept_service.get_concept_by_concept_id(
             "understand_user_response_for_relation"
         )
@@ -187,7 +193,7 @@ class RelationElicitationService:
             "source": "llm_extraction",
             "evidence_count": 1,
         }
-        upsert_uncertain_relationship_assertion(
+        upsert_result = upsert_uncertain_relationship_assertion(
             source_id=instance_id,
             predicate=predicate,
             target=hypothesis["value"],
@@ -199,11 +205,21 @@ class RelationElicitationService:
             },
             evidence_count=int(hypothesis.get("evidence_count", 1)),
         )
-        ConceptsRepository.update_one(
-            {"concept_id": instance_id},
-            {"$push": {f"hypothesized_relations.{predicate}": hypothesis}},
-        )
-        return hypothesis
+        if not bool(upsert_result.get("success")):
+            return None
+
+        assertion = upsert_result.get("assertion")
+        assertion = dict(assertion) if isinstance(assertion, dict) else {}
+        return {
+            "assertion_id": assertion.get("assertion_id"),
+            "value": hypothesis["value"],
+            "confidence_score": float(hypothesis["confidence_score"]),
+            "source_interaction_id": hypothesis["source_interaction_id"],
+            "source": hypothesis["source"],
+            "evidence_count": int(hypothesis.get("evidence_count", 1)),
+            "status": assertion.get("status", "proposed"),
+            "stored_in": "uncertain_relationship_assertions",
+        }
 
     def elicit_relation(
         self, instance_id: str, predicate: str

--- a/src/backend/services/representation_contract_vontology_service.py
+++ b/src/backend/services/representation_contract_vontology_service.py
@@ -11,11 +11,13 @@ import json
 import re
 from typing import Any, Mapping, Sequence
 
-from .concept_service import get_concept_by_concept_id
+from . import concept_service
+from .concept_service import ConceptNotFoundError, get_concept_by_concept_id
 from .text_value_service import get_texts_for_concept
 from .text_value_service import upsert_singleton_text_relation
 
 DEFAULT_REPRESENTATION_PROFILE_PREDICATE = "#V#has_representation_contract_profile_json"
+REPRESENTATION_CONTRACT_PROFILE_TYPE_ID = "#V#representation_contract_profile"
 
 _DEFAULT_PROFILE_TEXT_PREDICATES: tuple[str, ...] = (
     "#V#has_representation_contract_profile_json",
@@ -183,6 +185,12 @@ _CANONICAL_PROFILE_BY_CONCEPT_ID: dict[str, dict[str, Any]] = {
 }
 
 
+def _profile_display_name(profile: Mapping[str, Any]) -> str:
+    profile_id = _safe_str(profile.get("profile_id")) or "representation"
+    pretty = profile_id.replace("_", " ").strip()
+    return f"{pretty[:1].upper() + pretty[1:] if pretty else 'Representation'} representation contract profile"
+
+
 def canonical_representation_profile_concept_ids() -> tuple[str, ...]:
     """Return canonical representation profile concept IDs in deterministic order."""
     return tuple(
@@ -194,6 +202,123 @@ def canonical_representation_profile_concept_ids() -> tuple[str, ...]:
 def canonical_representation_profile_blueprints() -> tuple[dict[str, Any], ...]:
     """Return copy-on-read canonical representation starter profiles."""
     return tuple(dict(item) for item in _CANONICAL_REPRESENTATION_PROFILE_BLUEPRINTS)
+
+
+def ensure_canonical_representation_contract_profiles(
+    *,
+    concept_ids: Sequence[str] | None = None,
+    predicate: str = DEFAULT_REPRESENTATION_PROFILE_PREDICATE,
+    language: str = "en-NZ",
+    policy: str = "replace_others",
+    provenance: Mapping[str, Any] | None = None,
+    context: Mapping[str, Any] | None = None,
+    garbage_collect: bool = True,
+    create_missing_concepts: bool = True,
+) -> dict[str, Any]:
+    """Ensure canonical representation-profile concepts exist and carry profile JSON."""
+
+    requested_concept_ids = (
+        _normalise_strings(concept_ids) or canonical_representation_profile_concept_ids()
+    )
+    type_created = False
+    created_profile_concept_ids: list[str] = []
+    persisted_profile_concept_ids: list[str] = []
+    unknown_canonical_profile_concept_ids: list[str] = []
+    missing_concept_ids: list[str] = []
+    errors_by_concept_id: dict[str, str] = {}
+
+    profile_type = _safe_get_concept(REPRESENTATION_CONTRACT_PROFILE_TYPE_ID)
+    if not isinstance(profile_type, Mapping) and create_missing_concepts:
+        try:
+            concept_service.create_concept(
+                name="Representation contract profile",
+                concept_id=REPRESENTATION_CONTRACT_PROFILE_TYPE_ID,
+                description=(
+                    "Type for canonical workflow contract profiles that declare "
+                    "required-effects semantics for representation intents."
+                ),
+                parent_concept_ids=["#V#thing"],
+                create_as_instance=False,
+            )
+            type_created = True
+        except Exception as exc:
+            errors_by_concept_id[REPRESENTATION_CONTRACT_PROFILE_TYPE_ID] = (
+                f"type_create_failed:{exc}"
+            )
+
+    for concept_id in requested_concept_ids:
+        seed_profile = _CANONICAL_PROFILE_BY_CONCEPT_ID.get(concept_id)
+        if not isinstance(seed_profile, Mapping):
+            unknown_canonical_profile_concept_ids.append(concept_id)
+            continue
+
+        concept = _safe_get_concept(concept_id)
+        if not isinstance(concept, Mapping):
+            if not create_missing_concepts:
+                missing_concept_ids.append(concept_id)
+                continue
+            try:
+                concept_service.create_concept(
+                    name=_profile_display_name(seed_profile),
+                    concept_id=concept_id,
+                    description=_safe_str(seed_profile.get("description")),
+                    parent_concept_ids=[REPRESENTATION_CONTRACT_PROFILE_TYPE_ID],
+                    create_as_instance=True,
+                )
+                created_profile_concept_ids.append(concept_id)
+                concept = _safe_get_concept(concept_id)
+            except Exception as exc:
+                errors_by_concept_id[concept_id] = f"create_failed:{exc}"
+                continue
+
+        if not isinstance(concept, Mapping):
+            missing_concept_ids.append(concept_id)
+            continue
+
+        try:
+            result = upsert_representation_contract_profile(
+                profile_concept_id=concept_id,
+                representation_profile=dict(seed_profile),
+                predicate=predicate,
+                language=language,
+                policy=policy,
+                provenance=provenance,
+                context=context,
+                garbage_collect=garbage_collect,
+            )
+        except Exception as exc:
+            errors_by_concept_id[concept_id] = f"profile_upsert_failed:{exc}"
+            continue
+
+        if bool(result.get("success")):
+            persisted_profile_concept_ids.append(concept_id)
+        else:
+            errors_by_concept_id[concept_id] = "profile_upsert_unsuccessful"
+
+    return {
+        "success": not (
+            unknown_canonical_profile_concept_ids
+            or missing_concept_ids
+            or errors_by_concept_id
+        ),
+        "requested_profile_concept_ids": list(requested_concept_ids),
+        "canonical_profile_concept_ids": list(canonical_representation_profile_concept_ids()),
+        "profile_type_id": REPRESENTATION_CONTRACT_PROFILE_TYPE_ID,
+        "profile_type_created": type_created,
+        "created_profile_concept_ids": created_profile_concept_ids,
+        "persisted_profile_concept_ids": persisted_profile_concept_ids,
+        "unknown_canonical_profile_concept_ids": unknown_canonical_profile_concept_ids,
+        "missing_concept_ids": missing_concept_ids,
+        "errors_by_concept_id": errors_by_concept_id,
+        "counts": {
+            "requested": len(requested_concept_ids),
+            "created_concepts": len(created_profile_concept_ids),
+            "persisted_profiles": len(persisted_profile_concept_ids),
+            "missing_concepts": len(missing_concept_ids),
+            "unknown_canonical_ids": len(unknown_canonical_profile_concept_ids),
+            "errors": len(errors_by_concept_id),
+        },
+    }
 
 
 def _safe_str(value: Any) -> str | None:
@@ -263,6 +388,16 @@ def _format_parse_error(exc: Exception) -> str:
     if len(message) > 160:
         message = f"{message[:157]}..."
     return f"{exc.__class__.__name__}: {message}"
+
+
+def _safe_get_concept(concept_id: str) -> Mapping[str, Any] | None:
+    """Return ``None`` for absent concepts so bootstrap can create them cleanly."""
+
+    try:
+        concept = get_concept_by_concept_id(concept_id)
+    except ConceptNotFoundError:
+        return None
+    return concept if isinstance(concept, Mapping) else None
 
 
 def _parse_profile_json_with_diagnostics(
@@ -420,7 +555,7 @@ def load_representation_contract_profiles_from_concept_ids(
 
     for concept_id in ordered_concept_ids:
         try:
-            concept = get_concept_by_concept_id(concept_id)
+            concept = _safe_get_concept(concept_id)
         except Exception:
             concept = None
 
@@ -548,7 +683,7 @@ def upsert_representation_contract_profile(
     if not concept_id:
         raise ValueError("profile_concept_id is required")
 
-    concept = get_concept_by_concept_id(concept_id)
+    concept = _safe_get_concept(concept_id)
     if not isinstance(concept, Mapping):
         raise ValueError(f"Profile concept not found: {concept_id}")
 
@@ -611,7 +746,7 @@ def bootstrap_canonical_representation_contract_profiles(
             unknown_canonical_profile_concept_ids.append(concept_id)
             continue
         try:
-            concept = get_concept_by_concept_id(concept_id)
+            concept = _safe_get_concept(concept_id)
         except Exception as exc:
             errors_by_concept_id[concept_id] = f"concept_lookup_failed:{exc}"
             continue

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -21,6 +21,7 @@ from pymongo.errors import OperationFailure, PyMongoError
 from ..db.mongo_client import get_db
 from .representation_contract_vontology_service import (
     canonical_representation_profile_concept_ids,
+    ensure_canonical_representation_contract_profiles,
     load_representation_contract_profiles_from_concept_ids,
 )
 from ..workflows.conversation_turn_stage_model import (
@@ -1007,6 +1008,43 @@ def _load_representation_domain_profiles_from_vontology() -> tuple[list[dict[str
     loaded_profiles, diagnostics = load_representation_contract_profiles_from_concept_ids(
         requested_profile_concept_ids
     )
+    bootstrap_report: dict[str, Any] | None = None
+    diagnostics_mapping = diagnostics if isinstance(diagnostics, Mapping) else {}
+    missing_profile_concept_ids = _dedupe_string_sequence(
+        diagnostics_mapping.get("missing_profile_concept_ids") or []
+    )
+    malformed_profile_concept_ids = _dedupe_string_sequence(
+        diagnostics_mapping.get("malformed_profile_concept_ids") or []
+    )
+    if (
+        not loaded_profiles
+        or missing_profile_concept_ids
+        or malformed_profile_concept_ids
+    ):
+        try:
+            bootstrap_targets = (
+                missing_profile_concept_ids
+                or malformed_profile_concept_ids
+                or requested_profile_concept_ids
+            )
+            bootstrap_report = ensure_canonical_representation_contract_profiles(
+                concept_ids=bootstrap_targets,
+                provenance={
+                    "source": "turn_execution_record_service",
+                    "reason": "representation_profile_catalogue_drift_repair",
+                },
+                context={"path": "_load_representation_domain_profiles_from_vontology"},
+            )
+        except Exception as exc:
+            bootstrap_report = {
+                "success": False,
+                "reason": "bootstrap_exception",
+                "error": str(exc),
+            }
+
+        loaded_profiles, diagnostics = load_representation_contract_profiles_from_concept_ids(
+            requested_profile_concept_ids
+        )
 
     normalised_profiles: list[dict[str, Any]] = []
     for profile in loaded_profiles:
@@ -1068,6 +1106,8 @@ def _load_representation_domain_profiles_from_vontology() -> tuple[list[dict[str
     diagnostics_payload["loaded_profile_count"] = len(normalised_profiles)
     if not _safe_str(diagnostics_payload.get("profile_version_hash")):
         diagnostics_payload["profile_version_hash"] = _hash_payload(normalised_profiles)
+    if isinstance(bootstrap_report, Mapping):
+        diagnostics_payload["bootstrap"] = dict(bootstrap_report)
     return normalised_profiles, diagnostics_payload
 
 
@@ -1237,6 +1277,41 @@ def _build_fail_closed_representation_effect(
     }
 
 
+def _extract_applied_workflow_continuation_context(
+    aux_llm_calls: Sequence[Mapping[str, Any]] | None,
+) -> dict[str, Any] | None:
+    if not isinstance(aux_llm_calls, Sequence) or isinstance(aux_llm_calls, (str, bytes)):
+        return None
+    for entry in reversed(aux_llm_calls):
+        if not isinstance(entry, Mapping):
+            continue
+        if _safe_str(entry.get("type")) != "workflow_continuation_context":
+            continue
+        if not bool(entry.get("applied", False)):
+            continue
+        context = entry.get("context")
+        if isinstance(context, Mapping):
+            return dict(context)
+    return None
+
+
+def _representation_contract_from_continuation_context(
+    continuation_context: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not isinstance(continuation_context, Mapping):
+        return None
+    contract = continuation_context.get("required_effects_contract")
+    if not isinstance(contract, Mapping):
+        return None
+    intent_class = _safe_str(contract.get("intent_class"))
+    schema_version = _safe_str(contract.get("schema_version"))
+    if intent_class != "representation":
+        return None
+    if schema_version and schema_version != _REPRESENTATION_CONTRACT_SCHEMA_VERSION:
+        return None
+    return dict(contract)
+
+
 def _build_representation_required_effects_contract(
     *,
     prompt_text: Any,
@@ -1245,8 +1320,12 @@ def _build_representation_required_effects_contract(
     # Contract generation is intentionally deterministic and prompt/aux-driven
     # so repeated runs over the same context produce the same contract_id.
     prompt_clean = _safe_str(prompt_text) or ""
+    continuation_context = _extract_applied_workflow_continuation_context(aux_llm_calls)
+    continuation_contract = _representation_contract_from_continuation_context(
+        continuation_context
+    )
     if not _prompt_requests_representation_action(prompt_clean):
-        return None
+        return continuation_contract
 
     file_copy_ids = _extract_required_file_copy_ids_from_aux(aux_llm_calls)
     if not file_copy_ids:
@@ -1265,6 +1344,8 @@ def _build_representation_required_effects_contract(
         prompt_clean,
         profiles=profiles,
     )
+    if selected_profile is None and isinstance(continuation_contract, Mapping):
+        return continuation_contract
 
     profile_source = (
         _safe_str(profile_loading.get("representation_profile_source"))
@@ -2137,6 +2218,11 @@ def _ensure_turn_execution_indexes(collection) -> None:
                     [("namespace", ASCENDING), ("created_at_utc", DESCENDING)],
                     name="namespace_created_desc",
                 )
+            if "session_created_desc" not in existing_indexes:
+                collection.create_index(
+                    [("session_id", ASCENDING), ("created_at_utc", DESCENDING)],
+                    name="session_created_desc",
+                )
             if "decision_created_desc" not in existing_indexes:
                 collection.create_index(
                     [
@@ -2243,6 +2329,53 @@ def upsert_turn_execution_record_projection(
             "reason": "mongo_error",
             "request_id": request_id,
         }
+
+
+def get_latest_turn_execution_record_projection(
+    *,
+    session_id: str | None,
+    namespace: str | None = None,
+    user_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Return the latest projected turn-execution record for a chat session."""
+
+    clean_session_id = _safe_str(session_id)
+    if not clean_session_id:
+        return None
+
+    coll = get_turn_execution_records_collection()
+    if coll is None:
+        return None
+
+    query: dict[str, Any] = {"session_id": clean_session_id}
+    clean_namespace = _safe_str(namespace)
+    if clean_namespace:
+        query["namespace"] = clean_namespace
+    clean_user_id = _safe_str(user_id)
+    if clean_user_id:
+        query["user_id"] = clean_user_id
+
+    projection = {"_id": 0}
+    doc = coll.find_one(
+        query,
+        projection=projection,
+        sort=[("created_at_utc", DESCENDING), ("updated_at_utc", DESCENDING)],
+    )
+    if isinstance(doc, Mapping):
+        return dict(doc)
+
+    # Older projections may be missing namespace/user_id even when session_id is
+    # stable, so fall back to session-scoped lookup before giving up.
+    if clean_namespace or clean_user_id:
+        doc = coll.find_one(
+            {"session_id": clean_session_id},
+            projection=projection,
+            sort=[("created_at_utc", DESCENDING), ("updated_at_utc", DESCENDING)],
+        )
+        if isinstance(doc, Mapping):
+            return dict(doc)
+
+    return None
 
 
 def _normalise_positive_int(

--- a/src/backend/services/workflow_continuation_service.py
+++ b/src/backend/services/workflow_continuation_service.py
@@ -1,0 +1,370 @@
+"""Authoritative session-scoped workflow continuation context helpers.
+
+This module turns prior turn-execution state into deterministic continuation
+context for follow-up / repair turns. The goal is to route off persisted
+workflow evidence rather than loose prompt-shape guessing.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+from .turn_execution_record_service import get_latest_turn_execution_record_projection
+from .workflow_episode_service import get_latest_workflow_use_episode
+
+_FILE_COPY_CONCEPT_ID_PATTERN = re.compile(
+    r"#V#[A-Za-z0-9][A-Za-z0-9._-]*file_copy[A-Za-z0-9._-]*",
+    flags=re.IGNORECASE,
+)
+_CONCEPT_ID_PATTERN = re.compile(
+    r"#V#[A-Za-z0-9][A-Za-z0-9._-]*",
+    flags=re.IGNORECASE,
+)
+_SHORT_CONTINUATION_PROMPT_PATTERN = re.compile(
+    r"^\s*(?:yes|yep|yeah|ok|okay|sure|do it|go ahead|proceed|continue|"
+    r"please do|sounds good|looks good|that works|finish|retry|repair|fix|"
+    r"verify|check|status|again)\b",
+    flags=re.IGNORECASE,
+)
+_FOLLOW_UP_REPAIR_PROMPT_PATTERN = re.compile(
+    r"\b(?:continue|proceed|finish|complete|retry|repair|fix|verify|check|"
+    r"still missing|not created|not added|didn't|did not|wasn't|was not|"
+    r"weren't|were not|why didn't|why did not|why wasn't|why was not|yet)\b",
+    flags=re.IGNORECASE,
+)
+_REPRESENTATION_TERM_PATTERN = re.compile(
+    r"\b(?:represent|representation|materialis(?:e|ation)|model|profile)\b",
+    flags=re.IGNORECASE,
+)
+
+
+def _safe_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _dedupe_strings(values: Any) -> list[str]:
+    if not isinstance(values, (list, tuple)):
+        return []
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        text = _safe_str(value)
+        if not text:
+            continue
+        lowered = text.lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        deduped.append(text)
+    return deduped
+
+
+def _normalise_required_effect(effect: Mapping[str, Any]) -> dict[str, Any] | None:
+    effect_id = _safe_str(effect.get("effect_id"))
+    effect_type = _safe_str(effect.get("effect_type"))
+    status = _safe_str(effect.get("status"))
+    if not effect_type or status not in {"not_executed", "not_satisfied"}:
+        return None
+
+    return {
+        "effect_id": effect_id,
+        "effect_type": effect_type,
+        "status": status,
+        "description": _safe_str(effect.get("description")),
+        "required_tools": _dedupe_strings(effect.get("required_tools")),
+        "targets": _dedupe_strings(effect.get("targets")),
+        "representation_domain_id": _safe_str(effect.get("representation_domain_id")),
+        "representation_profile_concept_id": _safe_str(
+            effect.get("representation_profile_concept_id")
+        ),
+        "failure_code": _safe_str(effect.get("failure_code")),
+        "status_reason": _safe_str(effect.get("status_reason")),
+    }
+
+
+def get_session_workflow_continuation_context(
+    *,
+    session_id: str | None,
+    namespace: str | None = None,
+    user_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Return the latest authoritative follow-up context for a chat session."""
+
+    clean_session_id = _safe_str(session_id)
+    if not clean_session_id:
+        return None
+
+    latest_record = get_latest_turn_execution_record_projection(
+        session_id=clean_session_id,
+        namespace=namespace,
+        user_id=user_id,
+    )
+    latest_episode = get_latest_workflow_use_episode(
+        namespace=namespace,
+        session_id=clean_session_id,
+    )
+
+    if not isinstance(latest_record, Mapping) and not isinstance(latest_episode, Mapping):
+        return None
+
+    workflow_selection = (
+        latest_record.get("workflow_selection")
+        if isinstance(latest_record, Mapping)
+        else None
+    )
+    workflow_selection = workflow_selection if isinstance(workflow_selection, Mapping) else {}
+    completion_gate = (
+        latest_record.get("completion_gate") if isinstance(latest_record, Mapping) else None
+    )
+    completion_gate = completion_gate if isinstance(completion_gate, Mapping) else {}
+    execution = latest_record.get("execution") if isinstance(latest_record, Mapping) else None
+    execution = execution if isinstance(execution, Mapping) else {}
+    raw_required_effects = (
+        latest_record.get("required_effects") if isinstance(latest_record, Mapping) else None
+    )
+    unresolved_required_effects = [
+        item
+        for item in (
+            _normalise_required_effect(effect)
+            for effect in (raw_required_effects if isinstance(raw_required_effects, list) else [])
+            if isinstance(effect, Mapping)
+        )
+        if isinstance(item, dict)
+    ]
+
+    requires_follow_up = bool(completion_gate.get("requires_follow_up", False))
+    safe_to_claim_completion = bool(
+        completion_gate.get("safe_to_claim_completion", not requires_follow_up)
+    )
+    selected_workflow_id = _safe_str(workflow_selection.get("selected_workflow_id"))
+    if selected_workflow_id is None and isinstance(latest_episode, Mapping):
+        selected_workflow_id = _safe_str(latest_episode.get("workflow_id"))
+
+    if (
+        not unresolved_required_effects
+        and not requires_follow_up
+        and not isinstance(latest_episode, Mapping)
+    ):
+        return None
+
+    required_effects_contract = execution.get("required_effects_contract")
+    required_effects_contract = (
+        dict(required_effects_contract)
+        if isinstance(required_effects_contract, Mapping)
+        else None
+    )
+
+    return {
+        "session_id": clean_session_id,
+        "source_request_id": (
+            _safe_str(latest_record.get("request_id"))
+            if isinstance(latest_record, Mapping)
+            else None
+        ),
+        "selected_workflow_id": selected_workflow_id,
+        "selector_verdict": _safe_str(workflow_selection.get("selector_verdict")),
+        "selector_source": _safe_str(workflow_selection.get("selector_source")) or "default",
+        "completion_gate_decision": _safe_str(completion_gate.get("decision")),
+        "completion_gate_decision_reason": _safe_str(
+            completion_gate.get("decision_reason")
+        ),
+        "requires_follow_up": requires_follow_up,
+        "safe_to_claim_completion": safe_to_claim_completion,
+        "has_unresolved_required_effects": bool(unresolved_required_effects),
+        "unresolved_required_effects": unresolved_required_effects,
+        "required_effects_contract": required_effects_contract,
+        "latest_workflow_episode": (
+            dict(latest_episode) if isinstance(latest_episode, Mapping) else None
+        ),
+    }
+
+
+def assess_prompt_for_workflow_continuation(
+    *,
+    prompt: str | None,
+    continuation_context: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Classify whether the current prompt should continue prior workflow state."""
+
+    prompt_text = _safe_str(prompt) or ""
+    if not prompt_text:
+        return {"applies": False, "reason": "empty_prompt"}
+    if not isinstance(continuation_context, Mapping):
+        return {"applies": False, "reason": "no_continuation_context"}
+
+    has_open_work = bool(
+        continuation_context.get("requires_follow_up")
+        or continuation_context.get("has_unresolved_required_effects")
+    )
+    if not has_open_work:
+        return {"applies": False, "reason": "no_open_work"}
+
+    if len(prompt_text) <= 24 and _SHORT_CONTINUATION_PROMPT_PATTERN.search(prompt_text):
+        return {"applies": True, "reason": "short_follow_up_prompt"}
+
+    if _FOLLOW_UP_REPAIR_PROMPT_PATTERN.search(prompt_text):
+        return {"applies": True, "reason": "explicit_follow_up_or_repair_prompt"}
+
+    unresolved_effects = continuation_context.get("unresolved_required_effects")
+    if isinstance(unresolved_effects, list):
+        for effect in unresolved_effects:
+            if not isinstance(effect, Mapping):
+                continue
+            effect_type = _safe_str(effect.get("effect_type")) or ""
+            if "representation" in effect_type.lower() and _REPRESENTATION_TERM_PATTERN.search(
+                prompt_text
+            ):
+                return {
+                    "applies": True,
+                    "reason": "representation_follow_up_prompt",
+                }
+
+    return {"applies": False, "reason": "prompt_not_continuation"}
+
+
+def build_workflow_continuation_routing_prompt(
+    *,
+    prompt: str,
+    continuation_context: Mapping[str, Any],
+) -> str:
+    """Return routing/planning text enriched with authoritative continuation facts."""
+
+    prompt_text = _safe_str(prompt) or ""
+    if not prompt_text or not isinstance(continuation_context, Mapping):
+        return prompt_text
+
+    summary_lines = [
+        "ACTIVE WORKFLOW CONTINUATION CONTEXT",
+        f"Session: {_safe_str(continuation_context.get('session_id')) or 'unknown'}",
+        (
+            "Selected workflow: "
+            f"{_safe_str(continuation_context.get('selected_workflow_id')) or 'unknown'}"
+        ),
+        (
+            "Completion gate: "
+            f"{_safe_str(continuation_context.get('completion_gate_decision')) or 'unknown'}"
+        ),
+    ]
+
+    unresolved_effects = continuation_context.get("unresolved_required_effects")
+    if isinstance(unresolved_effects, list) and unresolved_effects:
+        summary_lines.append("Unresolved required effects:")
+        for effect in unresolved_effects[:6]:
+            if not isinstance(effect, Mapping):
+                continue
+            effect_type = _safe_str(effect.get("effect_type")) or "unknown"
+            targets = ", ".join(_dedupe_strings(effect.get("targets")))
+            required_tools = ", ".join(_dedupe_strings(effect.get("required_tools")))
+            description = _safe_str(effect.get("description")) or ""
+            line = f"- {effect_type}"
+            if targets:
+                line += f" | targets: {targets}"
+            if required_tools:
+                line += f" | required_tools: {required_tools}"
+            if description:
+                line += f" | description: {description}"
+            summary_lines.append(line)
+
+    required_effects_contract = continuation_context.get("required_effects_contract")
+    if isinstance(required_effects_contract, Mapping):
+        artefact_context = required_effects_contract.get("artefact_context")
+        if isinstance(artefact_context, Mapping):
+            file_copy_ids = ", ".join(
+                _dedupe_strings(artefact_context.get("file_copy_ids"))
+            )
+            urls = ", ".join(_dedupe_strings(artefact_context.get("urls")))
+            if file_copy_ids:
+                summary_lines.append(f"Artefact file_copy_ids: {file_copy_ids}")
+            if urls:
+                summary_lines.append(f"Artefact urls: {urls}")
+
+    summary_lines.append("Current user turn:")
+    summary_lines.append(prompt_text)
+    return "\n".join(summary_lines)
+
+
+def build_workflow_continuation_system_message(
+    continuation_context: Mapping[str, Any] | None,
+) -> str | None:
+    """Return a system message for planner/tool-routing context, if available."""
+
+    if not isinstance(continuation_context, Mapping):
+        return None
+    summary = build_workflow_continuation_routing_prompt(
+        prompt="Use this authoritative session state when deciding continuation, repair, or verification work.",
+        continuation_context=continuation_context,
+    )
+    if not summary:
+        return None
+    return summary
+
+
+def extract_file_copy_targets_from_continuation_context(
+    continuation_context: Mapping[str, Any] | None,
+) -> list[str]:
+    """Return file-copy concept targets referenced by unresolved continuation state."""
+
+    if not isinstance(continuation_context, Mapping):
+        return []
+    found: list[str] = []
+    seen: set[str] = set()
+
+    def _add(candidate: str | None) -> None:
+        text = _safe_str(candidate)
+        if not text or not _FILE_COPY_CONCEPT_ID_PATTERN.fullmatch(text):
+            return
+        lowered = text.lower()
+        if lowered in seen:
+            return
+        seen.add(lowered)
+        found.append(text)
+
+    unresolved_effects = continuation_context.get("unresolved_required_effects")
+    if isinstance(unresolved_effects, list):
+        for effect in unresolved_effects:
+            if not isinstance(effect, Mapping):
+                continue
+            for target in _dedupe_strings(effect.get("targets")):
+                _add(target)
+
+    required_effects_contract = continuation_context.get("required_effects_contract")
+    if isinstance(required_effects_contract, Mapping):
+        artefact_context = required_effects_contract.get("artefact_context")
+        if isinstance(artefact_context, Mapping):
+            for target in _dedupe_strings(artefact_context.get("file_copy_ids")):
+                _add(target)
+
+    return found
+
+
+def extract_concept_targets_from_continuation_context(
+    continuation_context: Mapping[str, Any] | None,
+) -> list[str]:
+    """Return concept-id targets referenced by unresolved continuation state."""
+
+    if not isinstance(continuation_context, Mapping):
+        return []
+    found: list[str] = []
+    seen: set[str] = set()
+
+    unresolved_effects = continuation_context.get("unresolved_required_effects")
+    if not isinstance(unresolved_effects, list):
+        return found
+
+    for effect in unresolved_effects:
+        if not isinstance(effect, Mapping):
+            continue
+        for target in _dedupe_strings(effect.get("targets")):
+            if not _CONCEPT_ID_PATTERN.fullmatch(target):
+                continue
+            lowered = target.lower()
+            if lowered in seen:
+                continue
+            seen.add(lowered)
+            found.append(target)
+
+    return found

--- a/src/backend/services/workflow_episode_service.py
+++ b/src/backend/services/workflow_episode_service.py
@@ -229,6 +229,11 @@ def _ensure_indexes() -> None:
                 [("turn_id", ASCENDING), ("attempt_started_at", DESCENDING)],
                 name="turn_attempted_at",
             )
+        if "session_attempted_at" not in existing:
+            coll.create_index(
+                [("session_id", ASCENDING), ("attempt_started_at", DESCENDING)],
+                name="session_attempted_at",
+            )
     except OperationFailure as exc:
         logger.warning("[workflow_episode] Index creation partially failed: %s", exc)
     except Exception as exc:  # pragma: no cover - defensive
@@ -556,6 +561,31 @@ def list_workflow_use_episodes(
 
     cursor = coll.find(query).sort("attempt_started_at", DESCENDING).limit(safe_limit)
     return [_serialise_episode(doc) for doc in cursor]
+
+
+def get_latest_workflow_use_episode(
+    *,
+    workflow_id: str | None = None,
+    namespace: str | None = None,
+    session_id: str | None = None,
+    turn_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Return the newest workflow-use episode matching the supplied filters."""
+
+    coll = _get_collection()
+    if coll is None:
+        return None
+
+    query = _build_episode_query(
+        workflow_id=workflow_id,
+        namespace=namespace,
+        session_id=session_id,
+        turn_id=turn_id,
+    )
+    doc = coll.find_one(query, sort=[("attempt_started_at", DESCENDING)])
+    if not isinstance(doc, Mapping):
+        return None
+    return _serialise_episode(doc)
 
 
 def count_workflow_use_episodes(

--- a/src/backend/workflows/durable/rumination_workflow.py
+++ b/src/backend/workflows/durable/rumination_workflow.py
@@ -57,7 +57,7 @@ DEFAULT_RELATION_SCAN_LIMIT = 120
 DEFAULT_RELATION_MAX_PREDICATES_PER_CONCEPT = 4
 DEFAULT_RELATION_AUTO_APPLY_CONFIDENCE_THRESHOLD = 0.95
 DEFAULT_RELATION_DETAIL_LIMIT = 80
-DEFAULT_RELATION_QUESTION_LIMIT = 50
+DEFAULT_RELATION_QUESTION_LIMIT = 1
 RELATION_AUTO_APPLY_POLICY_VERSION = "relation_auto_apply_policy.v1"
 RELATION_PRIORITY_KEYWORDS: tuple[str, ...] = (
     "owner",
@@ -116,6 +116,102 @@ DEFAULT_GAP_DIMENSIONS: List[Dict[str, Any]] = [
         "prompt_concept_id": None,  # Uses default enrichment prompt
     },
 ]
+
+
+def _resolve_relation_policy_input(
+    *,
+    task: dict[str, Any],
+    ctx: dict[str, Any],
+) -> dict[str, Any]:
+    """Resolve low-imposition acquisition policy from Vontology profiles.
+
+    The profile surface is Vontology-backed so workflow-governed acquisition can
+    evolve without hard-coding fresh heuristics for every new workflow.
+    """
+
+    from ...services.knowledge_acquisition_profile_vontology_service import (
+        ensure_canonical_knowledge_acquisition_profiles,
+        load_knowledge_acquisition_profile,
+    )
+
+    requested_profile_concept_id = (
+        task.get("knowledge_acquisition_profile_concept_id")
+        or ctx.get("knowledge_acquisition_profile_concept_id")
+    )
+    workflow_id = str(
+        task.get("workflow_id")
+        or ctx.get("workflow_id")
+        or RUMINATION_WORKFLOW_ID
+    ).strip() or RUMINATION_WORKFLOW_ID
+
+    profile, diagnostics = load_knowledge_acquisition_profile(
+        workflow_id=workflow_id,
+        profile_concept_id=(
+            str(requested_profile_concept_id).strip()
+            if isinstance(requested_profile_concept_id, str)
+            and str(requested_profile_concept_id).strip()
+            else None
+        ),
+    )
+    bootstrap_report: dict[str, Any] | None = None
+    if profile is None:
+        bootstrap_report = ensure_canonical_knowledge_acquisition_profiles(
+            concept_ids=[requested_profile_concept_id]
+            if isinstance(requested_profile_concept_id, str)
+            and str(requested_profile_concept_id).strip()
+            else None,
+            link_workflow_ids=[workflow_id],
+            provenance={
+                "source": "rumination_workflow",
+                "reason": "knowledge_acquisition_profile_bootstrap",
+            },
+            context={"workflow_id": workflow_id},
+        )
+        profile, diagnostics = load_knowledge_acquisition_profile(
+            workflow_id=workflow_id,
+            profile_concept_id=(
+                str(requested_profile_concept_id).strip()
+                if isinstance(requested_profile_concept_id, str)
+                and str(requested_profile_concept_id).strip()
+                else None
+            ),
+        )
+
+    relation_auto_apply_policy = {}
+    decision_policy = {}
+    question_limit = DEFAULT_RELATION_QUESTION_LIMIT
+    detail_limit = DEFAULT_RELATION_DETAIL_LIMIT
+    profile_concept_id = None
+    policy_error = None
+    if isinstance(profile, dict):
+        relation_auto_apply_policy = dict(
+            profile.get("relation_auto_apply_policy") or {}
+        )
+        decision_policy = dict(profile.get("decision_policy") or {})
+        question_limit = int(profile.get("question_limit") or question_limit)
+        detail_limit = int(profile.get("detail_limit") or detail_limit)
+        profile_concept_id = str(profile.get("profile_concept_id") or "").strip() or None
+        if "policy_version" not in relation_auto_apply_policy:
+            relation_auto_apply_policy["policy_version"] = str(
+                relation_auto_apply_policy.get("policy_version")
+                or profile.get("profile_id")
+                or RELATION_AUTO_APPLY_POLICY_VERSION
+            ).strip() or RELATION_AUTO_APPLY_POLICY_VERSION
+    else:
+        policy_error = "knowledge_acquisition_profile_unavailable"
+
+    return {
+        "workflow_id": workflow_id,
+        "requested_profile_concept_id": requested_profile_concept_id,
+        "profile_concept_id": profile_concept_id,
+        "relation_auto_apply_policy": relation_auto_apply_policy,
+        "decision_policy": decision_policy,
+        "question_limit": max(1, question_limit),
+        "detail_limit": max(1, detail_limit),
+        "diagnostics": diagnostics,
+        "bootstrap_report": bootstrap_report,
+        "error": policy_error,
+    }
 
 
 def build_rumination_workflow() -> WorkflowDefinition:
@@ -427,8 +523,7 @@ def _resolve_relation_auto_apply_candidate(
     instance_doc: dict[str, Any],
     predicate: str,
     confidence_threshold: float,
-    task: dict[str, Any],
-    ctx: dict[str, Any],
+    policy_input: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Resolve an auto-apply candidate and return eligibility diagnostics."""
     if not isinstance(predicate, str) or not predicate.startswith("#V#"):
@@ -476,8 +571,7 @@ def _resolve_relation_auto_apply_candidate(
     policy = _resolve_relation_auto_apply_policy(
         predicate=predicate,
         confidence_threshold=confidence_threshold,
-        task=task,
-        ctx=ctx,
+        policy_input=policy_input,
     )
     effective_threshold = float(policy["effective_threshold"])
     min_evidence_count = int(policy["min_evidence_count"])
@@ -632,22 +726,10 @@ def _resolve_relation_auto_apply_policy(
     *,
     predicate: str,
     confidence_threshold: float,
-    task: dict[str, Any],
-    ctx: dict[str, Any],
+    policy_input: dict[str, Any] | None,
 ) -> dict[str, Any]:
     """Resolve auto-apply policy from defaults plus optional context overrides."""
-    policy_input_raw = ctx.get("relation_auto_apply_policy")
-    policy_input: dict[str, Any]
-    if isinstance(policy_input_raw, dict):
-        policy_input = dict(policy_input_raw)
-    else:
-        policy_input = {}
-
-    task_policy = task.get("auto_apply_policy")
-    if isinstance(task_policy, dict):
-        merged_policy = dict(policy_input)
-        merged_policy.update(task_policy)
-        policy_input = merged_policy
+    policy_input = dict(policy_input or {})
 
     predicate_class = _classify_relation_predicate(predicate)
     class_thresholds = dict(DEFAULT_RELATION_CLASS_THRESHOLDS)
@@ -693,7 +775,6 @@ def _resolve_relation_auto_apply_policy(
 
     policy_version = str(
         policy_input.get("policy_version")
-        or ctx.get("relation_auto_apply_policy_version")
         or RELATION_AUTO_APPLY_POLICY_VERSION
     ).strip() or RELATION_AUTO_APPLY_POLICY_VERSION
 
@@ -796,11 +877,23 @@ def _dispatch_relation_completion_task(
         ),
         default=DEFAULT_RELATION_AUTO_APPLY_CONFIDENCE_THRESHOLD,
     )
+    relation_policy_context = _resolve_relation_policy_input(task=task, ctx=ctx)
     detail_limit = int(
-        ctx.get("relation_detail_limit", DEFAULT_RELATION_DETAIL_LIMIT)
+        ctx.get(
+            "relation_detail_limit",
+            relation_policy_context.get("detail_limit", DEFAULT_RELATION_DETAIL_LIMIT),
+        )
     )
     question_limit = int(
-        ctx.get("relation_question_limit", DEFAULT_RELATION_QUESTION_LIMIT)
+        ctx.get(
+            "relation_question_limit",
+            relation_policy_context.get(
+                "question_limit", DEFAULT_RELATION_QUESTION_LIMIT
+            ),
+        )
+    )
+    relation_auto_apply_policy = dict(
+        relation_policy_context.get("relation_auto_apply_policy") or {}
     )
 
     candidates = list(ctx.get("relation_gap_candidates") or [])
@@ -816,6 +909,32 @@ def _dispatch_relation_completion_task(
     deferral_reason_counts: dict[str, int] = {}
     proposal_details: list[dict[str, Any]] = []
     deferred_questions: list[dict[str, Any]] = []
+
+    if relation_policy_context.get("error"):
+        return {
+            "gap_name": task.get("gap_name"),
+            "predicate": task.get("predicate"),
+            "dispatch_mode": "relation_completion",
+            "allocation": allocation,
+            "dry_run": dry_run,
+            "metrics": {
+                "concepts_considered": 0,
+                "proposed_relations": 0,
+                "auto_applied_relations": 0,
+                "would_apply_relations": 0,
+                "deferred_relations": 0,
+                "confirmed_relations": 0,
+                "failed_relations": 1,
+                "deferral_reason_counts": {},
+            },
+            "proposal_details": [],
+            "deferred_questions": [],
+            "policy_profile_concept_id": relation_policy_context.get(
+                "profile_concept_id"
+            ),
+            "policy_resolution": relation_policy_context,
+            "policy_error": relation_policy_context.get("error"),
+        }
 
     for candidate in selected_candidates:
         concept_id = candidate.get("concept_id")
@@ -852,8 +971,7 @@ def _dispatch_relation_completion_task(
                 instance_doc=instance_doc,
                 predicate=predicate,
                 confidence_threshold=confidence_threshold,
-                task=task,
-                ctx=ctx,
+                policy_input=relation_auto_apply_policy,
             )
             if auto_candidate.get("status") == "eligible":
                 detail["target_id"] = auto_candidate["target_id"]
@@ -969,6 +1087,8 @@ def _dispatch_relation_completion_task(
         "metrics": relation_metrics,
         "proposal_details": proposal_details,
         "deferred_questions": deferred_questions,
+        "policy_profile_concept_id": relation_policy_context.get("profile_concept_id"),
+        "policy_resolution": relation_policy_context,
     }
     return task_result
 

--- a/src/backend/workflows/workflow_concept_authority_service.py
+++ b/src/backend/workflows/workflow_concept_authority_service.py
@@ -47,6 +47,7 @@ FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID = (
     "#V#file_copy_upload_classification_workflow"
 )
 FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID = "#V#file_copy_upload_handler_workflow"
+RUMINATION_WORKFLOW_ID = "#V#rumination_workflow"
 WORKFLOW_CREATION_WORKFLOW_ID = "#V#von_workflow_creation_workflow"
 
 WORKFLOW_CREATION_STEP_IDENTIFY_NEED = "#V#workflow_creation_step_identify_need"
@@ -106,6 +107,7 @@ CANONICAL_CHAT_WORKFLOW_IDS: tuple[str, ...] = (
 # Additional built-in workflows that should be published when registered.
 CANONICAL_DURABLE_WORKFLOW_IDS: tuple[str, ...] = (
     FILE_COPY_INTERPRETATION_WORKFLOW_ID,
+    RUMINATION_WORKFLOW_ID,
 )
 
 # Additional Vontology-authored governance workflows that should be repaired to
@@ -414,6 +416,34 @@ _CANONICAL_WORKFLOW_PUBLICATION_SPECS: Dict[str, _CanonicalWorkflowPublicationSp
                 next_state="complete",
             ),
             _CanonicalStepPublicationSpec(state_id="complete"),
+            _CanonicalStepPublicationSpec(state_id="failed"),
+        ),
+    ),
+    RUMINATION_WORKFLOW_ID: _CanonicalWorkflowPublicationSpec(
+        initial_state="assess",
+        steps=(
+            _CanonicalStepPublicationSpec(
+                state_id="assess",
+                action_id="rumination.assess_gaps",
+                on_true_state="plan",
+                on_false_state="complete",
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="plan",
+                action_id="rumination.plan_enrichment",
+                on_true_state="dispatch",
+                on_false_state="complete",
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="dispatch",
+                action_id="rumination.dispatch_enrichment",
+                on_true_state="dispatch",
+                on_false_state="complete",
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="complete",
+                action_id="rumination.finalise",
+            ),
             _CanonicalStepPublicationSpec(state_id="failed"),
         ),
     ),
@@ -891,6 +921,18 @@ def _extract_instance_of(concept_doc: Dict[str, Any]) -> List[str]:
     return []
 
 
+def _extract_type_parents(concept_doc: Dict[str, Any]) -> List[str]:
+    relationships = concept_doc.get("relationships") or {}
+    if not isinstance(relationships, dict):
+        return []
+    raw_values = relationships.get("is_a_type_of", [])
+    if isinstance(raw_values, str):
+        return [raw_values] if raw_values else []
+    if isinstance(raw_values, list):
+        return [item for item in raw_values if isinstance(item, str) and item]
+    return []
+
+
 def _load_concept(concept_id: str) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
     try:
         return concept_service.get_concept_by_concept_id(concept_id), None
@@ -898,6 +940,54 @@ def _load_concept(concept_id: str) -> Tuple[Optional[Dict[str, Any]], Optional[s
         return None, None
     except Exception as exc:  # pragma: no cover - defensive
         return None, str(exc)
+
+
+def _instance_of_satisfies_required_types(
+    instance_of: List[str],
+    *,
+    required_type_ids: List[str],
+) -> bool:
+    """Return whether direct or inherited workflow typing satisfies policy.
+
+    Some workflow concepts are intentionally typed as ``#V#durable_workflow``,
+    which is itself a subtype of ``#V#ai_workflow``. Authority checks must
+    treat that as valid instead of forcing redundant direct typing writes.
+    """
+
+    if not required_type_ids:
+        return True
+
+    required = {
+        item.strip().lower()
+        for item in required_type_ids
+        if isinstance(item, str) and item.strip()
+    }
+    if not required:
+        return True
+
+    queue = [
+        item.strip()
+        for item in instance_of
+        if isinstance(item, str) and item.strip()
+    ]
+    seen: set[str] = set()
+    while queue:
+        candidate = queue.pop(0)
+        lowered = candidate.lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        if lowered in required:
+            return True
+
+        concept_doc, load_error = _load_concept(candidate)
+        if load_error or not isinstance(concept_doc, dict):
+            continue
+        for parent_id in _extract_type_parents(concept_doc):
+            parent_lowered = parent_id.lower()
+            if parent_lowered not in seen:
+                queue.append(parent_id)
+    return False
 
 
 @lru_cache(maxsize=1)
@@ -1013,7 +1103,10 @@ def bootstrap_workflow_concepts(
             continue
 
         current_instance_of = _extract_instance_of(concept_doc)
-        if any(type_id in current_instance_of for type_id in required_type_ids):
+        if _instance_of_satisfies_required_types(
+            current_instance_of,
+            required_type_ids=required_type_ids,
+        ):
             unchanged.append(workflow_id)
             continue
 
@@ -1102,8 +1195,9 @@ def build_workflow_concept_authority_report(
             continue
 
         instance_of = _extract_instance_of(concept_doc)
-        if required_type_ids and not any(
-            type_id in instance_of for type_id in required_type_ids
+        if required_type_ids and not _instance_of_satisfies_required_types(
+            instance_of,
+            required_type_ids=required_type_ids,
         ):
             missing_required_type[workflow_id] = instance_of
             continue

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -609,6 +609,7 @@ const THINKING_STATUS_ACTIVE = 'active';
 const THINKING_STATUS_WAITING = 'waiting';
 const THINKING_STATUS_STALLED = 'stalled';
 const THINKING_STATUS_COMPLETED = 'completed';
+const THINKING_STATUS_FOLLOW_UP_REQUIRED = 'follow_up_required';
 const THINKING_STATUS_FAILED = 'failed';
 const THINKING_STATUS_CANCELLED = 'cancelled';
 const THINKING_STATUS_TERMINATED = 'terminated';
@@ -619,6 +620,9 @@ const THINKING_TERMINAL_PROGRESS_STATUSES = new Set([
     'completed',
     'complete',
     'done',
+    'follow_up_required',
+    'follow-up-required',
+    'follow up required',
     'error',
     'cancelled',
     'canceled',
@@ -631,6 +635,7 @@ const THINKING_STATUS_CLASS_NAMES = new Set([
     THINKING_STATUS_WAITING,
     THINKING_STATUS_STALLED,
     THINKING_STATUS_COMPLETED,
+    THINKING_STATUS_FOLLOW_UP_REQUIRED,
     THINKING_STATUS_FAILED,
     THINKING_STATUS_CANCELLED,
     THINKING_STATUS_TERMINATED
@@ -769,6 +774,13 @@ function canonicalThinkingTerminalStatus(value) {
     }
     if (status === 'completed' || status === 'complete' || status === 'done') {
         return THINKING_STATUS_COMPLETED;
+    }
+    if (
+        status === 'follow_up_required'
+        || status === 'follow-up-required'
+        || status === 'follow up required'
+    ) {
+        return THINKING_STATUS_FOLLOW_UP_REQUIRED;
     }
     if (status === 'error' || status === 'failed') {
         return THINKING_STATUS_FAILED;
@@ -1149,6 +1161,7 @@ function thinkingLivenessLabel(state) {
 
 function thinkingTerminalLabel(status) {
     if (status === THINKING_STATUS_COMPLETED) return 'Complete';
+    if (status === THINKING_STATUS_FOLLOW_UP_REQUIRED) return 'Follow-up required';
     if (status === THINKING_STATUS_FAILED) return 'Failed';
     if (status === THINKING_STATUS_CANCELLED) return 'Cancelled';
     if (status === THINKING_STATUS_TERMINATED) return 'Terminated';

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -827,6 +827,21 @@ describe('thinking liveness presentation', () => {
         expect(presentation.stageText).toBe('Complete');
         expect(presentation.lastActivityText).toContain('Last activity');
     });
+
+    test('renders follow-up-required as a distinct terminal state', () => {
+        const presentation = __testOnly_buildThinkingProgressPresentation({
+            status: 'pending',
+            orchestrator_status: 'follow_up_required',
+            liveness_state: 'active',
+            stage: 'response_finalising',
+            idle_ms: 900
+        });
+
+        expect(presentation.livenessState).toBe('follow_up_required');
+        expect(presentation.livenessLabel).toBe('Follow-up required');
+        expect(presentation.stageText).toBe('Follow-up required');
+        expect(presentation.lastActivityText).toContain('Last activity');
+    });
 });
 
 describe('thinking card display state reducer', () => {
@@ -888,6 +903,20 @@ describe('thinking card display state reducer', () => {
             progress: {
                 status: 'pending',
                 orchestrator_status: 'completed',
+                liveness_state: 'active'
+            }
+        });
+
+        expect(state.expanded).toBe(false);
+        expect(state.autoFurlApplied).toBe(true);
+    });
+
+    test('treats follow-up-required as a terminal progress update', () => {
+        let state = __testOnly_reduceThinkingCardDisplayState(null, { type: 'reset_for_active' });
+        state = __testOnly_reduceThinkingCardDisplayState(state, {
+            type: 'progress_update',
+            progress: {
+                status: 'follow_up_required',
                 liveness_state: 'active'
             }
         });

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -6576,6 +6576,11 @@ footer {
     color: #166534;
 }
 
+.thinking-card-status.follow_up_required {
+    background: #fef3c7;
+    color: #92400e;
+}
+
 .thinking-card-status.failed {
     background: #fee2e2;
     color: #b91c1c;

--- a/tests/backend/test_knowledge_acquisition_profile_vontology_service.py
+++ b/tests/backend/test_knowledge_acquisition_profile_vontology_service.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+
+from src.backend.services import knowledge_acquisition_profile_vontology_service as service
+
+
+def test_canonical_knowledge_acquisition_profile_concept_ids_are_deterministic() -> None:
+    concept_ids = service.canonical_knowledge_acquisition_profile_concept_ids()
+    assert concept_ids == (
+        "#V#knowledge_acquisition_profile_low_imposition_relation_completion",
+    )
+
+
+def test_ensure_canonical_knowledge_acquisition_profiles_creates_and_links(monkeypatch) -> None:
+    concept_docs: dict[str, dict] = {}
+    upserts: list[dict[str, str]] = []
+
+    def _mock_get_concept_by_concept_id(concept_id: str):
+        return concept_docs.get(concept_id)
+
+    def _mock_create_concept(**kwargs):
+        concept_docs[kwargs["concept_id"]] = {
+            "concept_id": kwargs["concept_id"],
+            "relationships": {},
+        }
+        return {"concept_id": kwargs["concept_id"]}
+
+    def _mock_upsert_singleton_text_relation(**kwargs):
+        upserts.append(
+            {
+                "concept_id": kwargs["subject_concept_id"],
+                "predicate": kwargs["predicate"],
+                "text": kwargs["text"],
+            }
+        )
+        return {"success": True}
+
+    monkeypatch.setattr(
+        service,
+        "get_concept_by_concept_id",
+        _mock_get_concept_by_concept_id,
+    )
+    monkeypatch.setattr(
+        service.concept_service,
+        "create_concept",
+        _mock_create_concept,
+    )
+    monkeypatch.setattr(
+        service,
+        "upsert_singleton_text_relation",
+        _mock_upsert_singleton_text_relation,
+    )
+
+    report = service.ensure_canonical_knowledge_acquisition_profiles()
+
+    assert report["success"] is True
+    assert report["profile_type_created"] is True
+    assert report["created_profile_concept_ids"] == [
+        "#V#knowledge_acquisition_profile_low_imposition_relation_completion"
+    ]
+    assert report["linked_workflow_ids"] == ["#V#rumination_workflow"]
+    texts_by_concept = {
+        (item["concept_id"], item["predicate"]): item["text"] for item in upserts
+    }
+    assert (
+        "#V#knowledge_acquisition_profile_low_imposition_relation_completion",
+        "#V#has_knowledge_acquisition_profile_json",
+    ) in texts_by_concept
+    assert (
+        "#V#rumination_workflow",
+        "#V#has_knowledge_acquisition_profile",
+    ) in texts_by_concept
+
+
+def test_load_knowledge_acquisition_profile_uses_workflow_link(monkeypatch) -> None:
+    payload = {
+        "profile_id": "low_imposition_relation_completion",
+        "dispatch_mode": "relation_completion",
+        "question_limit": 1,
+        "detail_limit": 12,
+        "decision_policy": {"ask_at_most_one_question_per_run": True},
+        "relation_auto_apply_policy": {"policy_version": "knowledge_acquisition_profile.v1"},
+    }
+
+    monkeypatch.setattr(
+        service,
+        "get_concept_by_concept_id",
+        lambda concept_id: {"concept_id": concept_id, "relationships": {}}
+        if concept_id
+        == "#V#knowledge_acquisition_profile_low_imposition_relation_completion"
+        else {"concept_id": concept_id, "relationships": {}}
+        if concept_id == "#V#rumination_workflow"
+        else None,
+    )
+
+    def _mock_get_texts_for_concept(concept_id: str, predicate: str, limit: int = 1):
+        if (
+            concept_id == "#V#rumination_workflow"
+            and predicate == "#V#has_knowledge_acquisition_profile"
+        ):
+            return [
+                {
+                    "text": "#V#knowledge_acquisition_profile_low_imposition_relation_completion"
+                }
+            ]
+        if (
+            concept_id == "#V#knowledge_acquisition_profile_low_imposition_relation_completion"
+            and predicate == "#V#has_knowledge_acquisition_profile_json"
+        ):
+            return [{"text": json.dumps(payload)}]
+        return []
+
+    monkeypatch.setattr(
+        service,
+        "get_texts_for_concept",
+        _mock_get_texts_for_concept,
+    )
+
+    profile, diagnostics = service.load_knowledge_acquisition_profile(
+        workflow_id="#V#rumination_workflow"
+    )
+
+    assert profile is not None
+    assert profile["profile_concept_id"] == (
+        "#V#knowledge_acquisition_profile_low_imposition_relation_completion"
+    )
+    assert profile["question_limit"] == 1
+    assert profile["detail_limit"] == 12
+    assert (
+        diagnostics["loaded_profile_concept_id"]
+        == "#V#knowledge_acquisition_profile_low_imposition_relation_completion"
+    )

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -3327,6 +3327,86 @@ def test_write_intent_memory_rehydrates_for_low_risk_confirm_structure_prompt(
     assert gate_entry.get("continuation_context_reused") is True
 
 
+def test_selector_receives_authoritative_workflow_continuation_context(monkeypatch):
+    orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
+
+    monkeypatch.setattr(
+        "src.backend.services.workflow_continuation_service.get_session_workflow_continuation_context",
+        lambda **_kwargs: {
+            "session_id": "session-1380",
+            "selected_workflow_id": "#V#scholarly_paper_representation_workflow",
+            "completion_gate_decision": "escalation_required",
+            "requires_follow_up": True,
+            "safe_to_claim_completion": False,
+            "has_unresolved_required_effects": True,
+            "unresolved_required_effects": [
+                {
+                    "effect_id": "effect_paper_representation_1",
+                    "effect_type": "scholarly_representation",
+                    "description": "Represent the corresponding scholarly paper.",
+                    "required_tools": ["interpret_file_copy"],
+                    "targets": ["#V#uploaded_file_copy_abc123"],
+                }
+            ],
+            "required_effects_contract": {
+                "schema_version": "required_effects_contract.v1",
+                "intent_class": "representation",
+                "domain_profile_id": "paper",
+                "artefact_context": {
+                    "file_copy_ids": ["#V#uploaded_file_copy_abc123"],
+                    "urls": [],
+                },
+            },
+        },
+    )
+
+    llm = _CapturingLLM(
+        [
+            "tool_seeking",
+            "I'll continue the representation work.",
+        ]
+    )
+
+    result = orchestrator.run(
+        prompt="Please proceed.",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+        conversation_session_id="session-1380",
+    )
+
+    assert result.workflow_routing is not None
+    assert result.workflow_routing.verdict == "tool_seeking"
+
+    selector_context = llm.calls[0]["context"] or []
+    selector_prompt = "\n".join(
+        str(message.get("content") or "")
+        for message in selector_context
+        if isinstance(message, dict)
+    )
+    assert "ACTIVE WORKFLOW CONTINUATION CONTEXT" in selector_prompt
+    assert "#V#scholarly_paper_representation_workflow" in selector_prompt
+    assert "#V#uploaded_file_copy_abc123" in selector_prompt
+    assert "Please proceed." in selector_prompt
+
+    continuation_entry = next(
+        (
+            entry
+            for entry in result.aux_llm_calls
+            if isinstance(entry, dict)
+            and entry.get("type") == "workflow_continuation_context"
+        ),
+        None,
+    )
+    assert continuation_entry is not None
+    assert continuation_entry.get("applied") is True
+    assert continuation_entry.get("reason") in {
+        "short_follow_up_prompt",
+        "explicit_follow_up_or_repair_prompt",
+    }
+
+
 # ---------------------------------------------------------------------------
 # JVNAUTOSCI-825: Routing info on tool-calling path.
 # ---------------------------------------------------------------------------

--- a/tests/backend/test_relation_elicitation_service.py
+++ b/tests/backend/test_relation_elicitation_service.py
@@ -79,6 +79,44 @@ class TestRelationElicitationService(unittest.TestCase):
 
         self.assertEqual(opportunities, ["hypothesized_relation", "new_opportunity"])
 
+    @patch(
+        "src.backend.services.relation_elicitation_service.upsert_uncertain_relationship_assertion"
+    )
+    @patch("src.backend.services.concept_service.get_concept_by_concept_id")
+    def test_process_and_store_hypothesis_uses_canonical_uncertain_assertions(
+        self,
+        mock_get_by_concept_id,
+        mock_upsert_uncertain,
+    ):
+        mock_get_by_concept_id.return_value = {
+            "concept_id": "understand_user_response_for_relation",
+            "attributes": {
+                "prompt_template": "Extract [Relation Name] from: [User Response]"
+            },
+        }
+        mock_upsert_uncertain.return_value = {
+            "success": True,
+            "assertion": {"assertion_id": "ura_123", "status": "proposed"},
+        }
+
+        llm_client = MagicMock()
+        llm_client.generate.return_value = "#V#strong_ai_lab"
+        service = RelationElicitationService(llm_client=llm_client)
+
+        result = service.process_and_store_hypothesis(
+            "#V#alice",
+            "#V#has_affiliation",
+            "Alice is affiliated with Strong AI Lab.",
+        )
+        assert result is not None
+
+        self.assertEqual(result["assertion_id"], "ura_123")
+        self.assertEqual(result["value"], "#V#strong_ai_lab")
+        self.assertEqual(result["confidence_score"], 0.85)
+        self.assertEqual(result["status"], "proposed")
+        self.assertEqual(result["stored_in"], "uncertain_relationship_assertions")
+        mock_upsert_uncertain.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/backend/test_representation_contract_vontology_service.py
+++ b/tests/backend/test_representation_contract_vontology_service.py
@@ -185,3 +185,67 @@ def test_bootstrap_canonical_representation_profiles_persists_existing_only(
         "#V#representation_contract_profile_paper",
         "#V#representation_contract_profile_person",
     }
+
+
+def test_ensure_canonical_representation_profiles_creates_missing_type_and_profiles(
+    monkeypatch,
+) -> None:
+    existing_concepts: set[str] = set()
+    created_concepts: list[dict[str, object]] = []
+    persisted_profiles: list[str] = []
+
+    def _fake_get_concept(concept_id):
+        if concept_id in existing_concepts:
+            return {"concept_id": concept_id, "relationships": {}}
+        return None
+
+    def _fake_create_concept(**kwargs):
+        concept_id = kwargs["concept_id"]
+        existing_concepts.add(concept_id)
+        created_concepts.append(dict(kwargs))
+        return {"concept_id": concept_id}
+
+    def _fake_upsert_profile(**kwargs):
+        persisted_profiles.append(kwargs["profile_concept_id"])
+        return {"success": True, "profile_concept_id": kwargs["profile_concept_id"]}
+
+    monkeypatch.setattr(service, "get_concept_by_concept_id", _fake_get_concept)
+    monkeypatch.setattr(service.concept_service, "create_concept", _fake_create_concept)
+    monkeypatch.setattr(
+        service,
+        "upsert_representation_contract_profile",
+        _fake_upsert_profile,
+    )
+
+    report = service.ensure_canonical_representation_contract_profiles(
+        concept_ids=[
+            "#V#representation_contract_profile_paper",
+            "#V#representation_contract_profile_person",
+        ]
+    )
+
+    assert report["success"] is True
+    assert report["profile_type_created"] is True
+    assert report["profile_type_id"] == "#V#representation_contract_profile"
+    assert set(report["created_profile_concept_ids"]) == {
+        "#V#representation_contract_profile_paper",
+        "#V#representation_contract_profile_person",
+    }
+    assert set(report["persisted_profile_concept_ids"]) == {
+        "#V#representation_contract_profile_paper",
+        "#V#representation_contract_profile_person",
+    }
+    assert report["missing_concept_ids"] == []
+    assert report["unknown_canonical_profile_concept_ids"] == []
+    assert report["errors_by_concept_id"] == {}
+
+    created_ids = [entry["concept_id"] for entry in created_concepts]
+    assert created_ids[0] == "#V#representation_contract_profile"
+    assert set(created_ids[1:]) == {
+        "#V#representation_contract_profile_paper",
+        "#V#representation_contract_profile_person",
+    }
+    assert set(persisted_profiles) == {
+        "#V#representation_contract_profile_paper",
+        "#V#representation_contract_profile_person",
+    }

--- a/tests/backend/test_rumination_workflow.py
+++ b/tests/backend/test_rumination_workflow.py
@@ -586,6 +586,101 @@ class TestRuminationFinalise:
 
 
 class TestRuminationRelationCompletionHelpers:
+    def test_dispatch_relation_completion_limits_questions_via_profile(self) -> None:
+        from src.backend.workflows.durable.rumination_workflow import (
+            _dispatch_relation_completion_task,
+        )
+
+        instance_doc = {
+            "concept_id": "#V#alice",
+            "relationships": {},
+            "hypothesized_relations": {},
+            "name": "Alice",
+        }
+
+        with (
+            patch(
+                "src.backend.workflows.durable.rumination_workflow."
+                "_resolve_relation_policy_input",
+                return_value={
+                    "profile_concept_id": "#V#knowledge_acquisition_profile_low_imposition_relation_completion",
+                    "relation_auto_apply_policy": {
+                        "policy_version": "knowledge_acquisition_profile.v1"
+                    },
+                    "question_limit": 1,
+                    "detail_limit": 10,
+                },
+            ),
+            patch(
+                "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+                return_value=instance_doc,
+            ),
+            patch(
+                "src.backend.services.relation_elicitation_service."
+                "RelationElicitationService.generate_question_for_elicit",
+                side_effect=[
+                    "What is Alice's affiliation?",
+                    "What project is Alice working on?",
+                ],
+            ),
+        ):
+            result = _dispatch_relation_completion_task(
+                task={
+                    "gap_name": "missing_relations",
+                    "predicate": "__relation_completion__",
+                    "allocation": 1,
+                },
+                ctx={
+                    "dry_run": True,
+                    "relation_gap_candidates": [
+                        {
+                            "concept_id": "#V#alice",
+                            "missing_predicates": [
+                                "#V#has_affiliation",
+                                "#V#works_on_project",
+                            ],
+                        }
+                    ],
+                },
+            )
+
+        assert result["metrics"]["deferred_relations"] == 2
+        assert len(result["deferred_questions"]) == 1
+        assert result["policy_profile_concept_id"] == (
+            "#V#knowledge_acquisition_profile_low_imposition_relation_completion"
+        )
+
+    def test_dispatch_relation_completion_reports_profile_resolution_failure(self) -> None:
+        from src.backend.workflows.durable.rumination_workflow import (
+            _dispatch_relation_completion_task,
+        )
+
+        with patch(
+            "src.backend.workflows.durable.rumination_workflow."
+            "_resolve_relation_policy_input",
+            return_value={
+                "profile_concept_id": None,
+                "relation_auto_apply_policy": {},
+                "question_limit": 1,
+                "detail_limit": 10,
+                "error": "knowledge_acquisition_profile_unavailable",
+            },
+        ):
+            result = _dispatch_relation_completion_task(
+                task={
+                    "gap_name": "missing_relations",
+                    "predicate": "__relation_completion__",
+                    "allocation": 1,
+                },
+                ctx={
+                    "dry_run": True,
+                    "relation_gap_candidates": [],
+                },
+            )
+
+        assert result["policy_error"] == "knowledge_acquisition_profile_unavailable"
+        assert result["metrics"]["failed_relations"] == 1
+
     def test_dispatch_relation_completion_auto_apply_dry_run(self) -> None:
         from src.backend.workflows.durable.rumination_workflow import (
             _dispatch_relation_completion_task,
@@ -611,6 +706,18 @@ class TestRuminationRelationCompletionHelpers:
             return None
 
         with (
+            patch(
+                "src.backend.workflows.durable.rumination_workflow."
+                "_resolve_relation_policy_input",
+                return_value={
+                    "profile_concept_id": "#V#knowledge_acquisition_profile_low_imposition_relation_completion",
+                    "relation_auto_apply_policy": {
+                        "policy_version": "knowledge_acquisition_profile.v1"
+                    },
+                    "question_limit": 1,
+                    "detail_limit": 80,
+                },
+            ),
             patch(
                 "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
                 side_effect=_fake_find_one,
@@ -681,9 +788,23 @@ class TestRuminationRelationCompletionHelpers:
                 return {"concept_id": "#V#strong_ai_lab"}
             return None
 
-        with patch(
-            "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
-            side_effect=_fake_find_one,
+        with (
+            patch(
+                "src.backend.workflows.durable.rumination_workflow."
+                "_resolve_relation_policy_input",
+                return_value={
+                    "profile_concept_id": "#V#knowledge_acquisition_profile_low_imposition_relation_completion",
+                    "relation_auto_apply_policy": {
+                        "policy_version": "knowledge_acquisition_profile.v1"
+                    },
+                    "question_limit": 1,
+                    "detail_limit": 80,
+                },
+            ),
+            patch(
+                "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+                side_effect=_fake_find_one,
+            ),
         ):
             result = _dispatch_relation_completion_task(
                 task={
@@ -743,6 +864,18 @@ class TestRuminationRelationCompletionHelpers:
             return None
 
         with (
+            patch(
+                "src.backend.workflows.durable.rumination_workflow."
+                "_resolve_relation_policy_input",
+                return_value={
+                    "profile_concept_id": "#V#knowledge_acquisition_profile_low_imposition_relation_completion",
+                    "relation_auto_apply_policy": {
+                        "policy_version": "knowledge_acquisition_profile.v1"
+                    },
+                    "question_limit": 1,
+                    "detail_limit": 80,
+                },
+            ),
             patch(
                 "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
                 side_effect=_fake_find_one,
@@ -819,23 +952,35 @@ class TestRuminationRelationCompletionHelpers:
             }
         )
 
-        result = _dispatch_relation_completion_task(
-            task={
-                "gap_name": "missing_relations",
-                "predicate": "__relation_completion__",
-                "allocation": 1,
-                "auto_apply_confidence_threshold": 0.95,
+        with patch(
+            "src.backend.workflows.durable.rumination_workflow."
+            "_resolve_relation_policy_input",
+            return_value={
+                "profile_concept_id": "#V#knowledge_acquisition_profile_low_imposition_relation_completion",
+                "relation_auto_apply_policy": {
+                    "policy_version": "knowledge_acquisition_profile.v1"
+                },
+                "question_limit": 1,
+                "detail_limit": 80,
             },
-            ctx={
-                "dry_run": False,
-                "relation_gap_candidates": [
-                    {
-                        "concept_id": "#V#alice",
-                        "missing_predicates": ["#V#related_to"],
-                    }
-                ],
-            },
-        )
+        ):
+            result = _dispatch_relation_completion_task(
+                task={
+                    "gap_name": "missing_relations",
+                    "predicate": "__relation_completion__",
+                    "allocation": 1,
+                    "auto_apply_confidence_threshold": 0.95,
+                },
+                ctx={
+                    "dry_run": False,
+                    "relation_gap_candidates": [
+                        {
+                            "concept_id": "#V#alice",
+                            "missing_predicates": ["#V#related_to"],
+                        }
+                    ],
+                },
+            )
 
         metrics = result["metrics"]
         assert metrics["auto_applied_relations"] == 1
@@ -848,7 +993,7 @@ class TestRuminationRelationCompletionHelpers:
         audit_log = (source_doc or {}).get("relationship_auto_apply_audit") or []
         assert isinstance(audit_log, list) and len(audit_log) > 0
         assert audit_log[-1]["hypothesis_id"] == "hyp-real-1"
-        assert audit_log[-1]["policy_version"] == "relation_auto_apply_policy.v1"
+        assert audit_log[-1]["policy_version"] == "knowledge_acquisition_profile.v1"
 
 
 class TestRuminationRegistration:

--- a/tests/backend/test_tool_progress_liveness.py
+++ b/tests/backend/test_tool_progress_liveness.py
@@ -519,7 +519,9 @@ def test_terminal_progress_payload_reflects_completion_gate_follow_up() -> None:
         ],
     )
     assert payload["request_id"] == "req-f"
-    assert payload["status"] == "completed"
+    assert payload["status"] == "follow_up_required"
+    assert payload["stage"] == "follow_up_required"
+    assert payload["phase_label"] == "Follow-up required"
     assert payload["success"] is False
     assert payload["completion_gate_decision"] == "escalation_required"
     assert payload["completion_gate_requires_follow_up"] is True

--- a/tests/backend/test_turn_execution_required_effects_contract.py
+++ b/tests/backend/test_turn_execution_required_effects_contract.py
@@ -9,6 +9,7 @@ from representation_intent_regression_helpers import (
 from representation_intent_regression_helpers import (
     representation_profiles as _representation_profiles,
 )
+from src.backend.services import turn_execution_record_service
 
 
 def test_paper_representation_contract_emitted_with_required_effects(monkeypatch) -> None:
@@ -465,3 +466,80 @@ def test_representation_contract_fails_closed_when_profile_catalogue_unavailable
     assert effect.get("effect_type") == "representation_contract_guard"
     assert effect.get("status") == "not_executed"
     assert effect.get("failure_code") == "representation_profile_catalogue_unavailable"
+
+
+def test_terse_follow_up_reuses_representation_contract_from_continuation_context(
+    monkeypatch,
+) -> None:
+    _patch_representation_profile_loader(
+        monkeypatch, profiles=_representation_profiles()
+    )
+    initial = _build_record(
+        aux_llm_calls=[
+            {
+                "type": "prompt_tool_requirements",
+                "required_scholarly_representation_for_file_copy_ids": [
+                    "#V#uploaded_file_copy_abc123"
+                ],
+            }
+        ]
+    )
+
+    execution = initial.get("execution")
+    assert isinstance(execution, dict)
+    prior_contract = execution.get("required_effects_contract")
+    assert isinstance(prior_contract, dict)
+
+    monkeypatch.setattr(
+        turn_execution_record_service,
+        "_load_representation_domain_profiles_from_vontology",
+        lambda: (
+            [],
+            {
+                "representation_profile_source": "vontology_concept_text_relations",
+                "requested_concept_ids": [],
+                "loaded_concept_ids": [],
+                "loaded_profile_count": 0,
+                "profile_version_hash": None,
+            },
+        ),
+    )
+
+    follow_up = _build_record(
+        prompt_text="Please proceed.",
+        response_text="Still working on it.",
+        aux_llm_calls=[
+            {
+                "type": "workflow_continuation_context",
+                "applied": True,
+                "context": {
+                    "selected_workflow_id": "#V#scholarly_paper_representation_workflow",
+                    "requires_follow_up": True,
+                    "has_unresolved_required_effects": True,
+                    "required_effects_contract": prior_contract,
+                },
+            }
+        ],
+    )
+
+    follow_up_execution = follow_up.get("execution")
+    assert isinstance(follow_up_execution, dict)
+    contract = follow_up_execution.get("required_effects_contract")
+    assert isinstance(contract, dict)
+    assert contract.get("intent_class") == "representation"
+    assert contract.get("domain_profile_id") == "paper"
+    assert contract.get("artefact_context", {}).get("file_copy_ids") == [
+        "#V#uploaded_file_copy_abc123"
+    ]
+
+    required_effects = follow_up.get("required_effects")
+    assert isinstance(required_effects, list)
+    assert required_effects
+    effect = required_effects[0]
+    assert effect.get("effect_type") == "scholarly_representation"
+    assert effect.get("status") == "not_executed"
+    assert effect.get("targets") == ["#V#uploaded_file_copy_abc123"]
+
+    completion_gate = follow_up.get("completion_gate") or {}
+    assert completion_gate.get("requires_follow_up") is True
+    assert completion_gate.get("safe_to_claim_completion") is False

--- a/tests/backend/test_workflow_concept_authority_service.py
+++ b/tests/backend/test_workflow_concept_authority_service.py
@@ -68,6 +68,39 @@ def test_workflow_authority_report_classifies_missing_and_untyped(monkeypatch):
     assert "#V#wf_untyped" in report["missing_required_type_by_workflow_id"]
 
 
+def test_workflow_authority_report_accepts_required_type_via_subtype(monkeypatch):
+    registry = _DummyRegistry(workflow_ids=["#V#wf_durable"])
+
+    monkeypatch.setattr(
+        authority_service,
+        "resolve_available_workflow_type_ids",
+        lambda: ("#V#ai_workflow",),
+    )
+
+    def _mock_load_concept(concept_id: str):
+        if concept_id == "#V#wf_durable":
+            return {
+                "concept_id": concept_id,
+                "relationships": {"is_an_instance_of": ["#V#durable_workflow"]},
+            }, None
+        if concept_id == "#V#durable_workflow":
+            return {
+                "concept_id": concept_id,
+                "relationships": {"is_a_type_of": ["#V#ai_workflow"]},
+            }, None
+        return None, None
+
+    monkeypatch.setattr(authority_service, "_load_concept", _mock_load_concept)
+
+    report = authority_service.build_workflow_concept_authority_report(
+        registry=cast(Any, registry)
+    )
+
+    assert report["drift_detected"] is False
+    assert report["counts"]["missing_required_type"] == 0
+    assert report["valid_workflow_ids"] == ["#V#wf_durable"]
+
+
 def test_bootstrap_workflow_concepts_creates_missing(monkeypatch):
     registry = _DummyRegistry(workflow_ids=["#V#wf_create"])
 
@@ -148,6 +181,44 @@ def test_bootstrap_workflow_concepts_enforces_required_type(monkeypatch):
     assert "#V#ai_workflow" in payload["relationships"]["is_an_instance_of"]
 
 
+def test_bootstrap_workflow_concepts_preserves_valid_subtype_typing(monkeypatch):
+    registry = _DummyRegistry(workflow_ids=["#V#wf_durable"])
+
+    monkeypatch.setattr(
+        authority_service,
+        "resolve_available_workflow_type_ids",
+        lambda: ("#V#ai_workflow",),
+    )
+
+    def _mock_load_concept(concept_id: str):
+        if concept_id == "#V#wf_durable":
+            return {
+                "concept_id": concept_id,
+                "relationships": {"is_an_instance_of": ["#V#durable_workflow"]},
+            }, None
+        if concept_id == "#V#durable_workflow":
+            return {
+                "concept_id": concept_id,
+                "relationships": {"is_a_type_of": ["#V#ai_workflow"]},
+            }, None
+        return None, None
+
+    monkeypatch.setattr(authority_service, "_load_concept", _mock_load_concept)
+
+    monkeypatch.setattr(
+        authority_service.concept_service,
+        "update_concept",
+        lambda *args, **kwargs: pytest.fail("update_concept should not be called"),
+    )
+
+    report = authority_service.bootstrap_workflow_concepts(
+        registry=cast(Any, registry)
+    )
+
+    assert report["counts"]["updated"] == 0
+    assert report["unchanged_workflow_ids"] == ["#V#wf_durable"]
+
+
 @pytest.fixture
 def _reset_mock_workflow_graph_db(monkeypatch):
     monkeypatch.setenv("VON_USE_MOCK_DB", "1")
@@ -179,27 +250,33 @@ def test_bootstrap_publishes_canonical_chat_graphs_with_loader_runtime_parity(
         classify_workflow_concept_executability,
         invalidate_workflow_discovery_executability_caches,
     )
-    from src.backend.workflows.definitions import register_default_workflows
+    from src.backend.workflows.durable.registry_factory import (
+        build_workflow_registry_read_only,
+    )
     from src.backend.workflows.vontology_loader import (
         build_workflow_process_graph,
         load_workflow_definition_from_vontology,
     )
-    from src.backend.workflows.workflow_registry import WorkflowRegistry
 
-    registry = WorkflowRegistry()
-    register_default_workflows(registry)
+    registry = build_workflow_registry_read_only()
+    expected_published_ids = {
+        workflow_id
+        for workflow_id in (
+            *authority_service.CANONICAL_CHAT_WORKFLOW_IDS,
+            *authority_service.CANONICAL_DURABLE_WORKFLOW_IDS,
+        )
+        if registry.get_registration(workflow_id) is not None
+    }
 
     report = authority_service.bootstrap_workflow_concepts(registry=cast(Any, registry))
     graph_publication = report.get("graph_publication") or {}
     counts = graph_publication.get("counts") or {}
-    assert counts.get("workflows_published") == len(
-        authority_service.CANONICAL_CHAT_WORKFLOW_IDS
-    )
+    assert counts.get("workflows_published") == len(expected_published_ids)
     assert counts.get("errors") == 0
 
     invalidate_workflow_discovery_executability_caches()
 
-    for workflow_id in authority_service.CANONICAL_CHAT_WORKFLOW_IDS:
+    for workflow_id in sorted(expected_published_ids):
         graph, warnings = build_workflow_process_graph(workflow_id)
         assert isinstance(graph, dict), f"{workflow_id}: graph_missing {warnings}"
         assert warnings == []

--- a/tests/backend/test_workflow_continuation_service.py
+++ b/tests/backend/test_workflow_continuation_service.py
@@ -1,0 +1,120 @@
+from src.backend.services import workflow_continuation_service as service
+
+
+def test_get_session_workflow_continuation_context_uses_latest_record_and_episode(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        service,
+        "get_latest_turn_execution_record_projection",
+        lambda **_kwargs: {
+            "request_id": "req-1380",
+            "workflow_selection": {
+                "selected_workflow_id": None,
+                "selector_verdict": "fallback",
+                "selector_source": "default",
+            },
+            "completion_gate": {
+                "decision": "escalation_required",
+                "decision_reason": "Representation was not executed.",
+                "requires_follow_up": True,
+                "safe_to_claim_completion": False,
+            },
+            "execution": {
+                "required_effects_contract": {
+                    "schema_version": "required_effects_contract.v1",
+                    "intent_class": "representation",
+                    "domain_profile_id": "paper",
+                    "artefact_context": {
+                        "file_copy_ids": ["#V#uploaded_file_copy_abc123"],
+                        "urls": [],
+                    },
+                }
+            },
+            "required_effects": [
+                {
+                    "effect_id": "effect_paper_representation_1",
+                    "effect_type": "scholarly_representation",
+                    "status": "not_executed",
+                    "description": "Represent the corresponding scholarly paper.",
+                    "required_tools": ["interpret_file_copy"],
+                    "targets": ["#V#uploaded_file_copy_abc123"],
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        service,
+        "get_latest_workflow_use_episode",
+        lambda **_kwargs: {
+            "workflow_id": "#V#scholarly_paper_representation_workflow",
+            "session_id": "session-1380",
+        },
+    )
+
+    context = service.get_session_workflow_continuation_context(
+        session_id="session-1380",
+        namespace="#V#user@test_org",
+        user_id="#V#user",
+    )
+
+    assert context is not None
+    assert context["source_request_id"] == "req-1380"
+    assert context["selected_workflow_id"] == "#V#scholarly_paper_representation_workflow"
+    assert context["requires_follow_up"] is True
+    assert context["safe_to_claim_completion"] is False
+    assert context["has_unresolved_required_effects"] is True
+    assert context["unresolved_required_effects"][0]["required_tools"] == [
+        "interpret_file_copy"
+    ]
+    assert context["required_effects_contract"]["domain_profile_id"] == "paper"
+
+
+def test_assess_prompt_for_workflow_continuation_detects_repair_turn() -> None:
+    decision = service.assess_prompt_for_workflow_continuation(
+        prompt="You did not create this concept at all.",
+        continuation_context={
+            "requires_follow_up": True,
+            "has_unresolved_required_effects": True,
+            "unresolved_required_effects": [
+                {"effect_type": "scholarly_representation"}
+            ],
+        },
+    )
+
+    assert decision == {
+        "applies": True,
+        "reason": "explicit_follow_up_or_repair_prompt",
+    }
+
+
+def test_build_workflow_continuation_routing_prompt_summarises_targets_and_tools() -> None:
+    prompt = service.build_workflow_continuation_routing_prompt(
+        prompt="Please proceed.",
+        continuation_context={
+            "session_id": "session-1380",
+            "selected_workflow_id": "#V#scholarly_paper_representation_workflow",
+            "completion_gate_decision": "escalation_required",
+            "unresolved_required_effects": [
+                {
+                    "effect_type": "scholarly_representation",
+                    "targets": ["#V#uploaded_file_copy_abc123"],
+                    "required_tools": ["interpret_file_copy"],
+                    "description": "Represent the corresponding scholarly paper.",
+                }
+            ],
+            "required_effects_contract": {
+                "artefact_context": {
+                    "file_copy_ids": ["#V#uploaded_file_copy_abc123"],
+                    "urls": ["https://arxiv.org/abs/2502.14996"],
+                }
+            },
+        },
+    )
+
+    assert "ACTIVE WORKFLOW CONTINUATION CONTEXT" in prompt
+    assert "Selected workflow: #V#scholarly_paper_representation_workflow" in prompt
+    assert "required_tools: interpret_file_copy" in prompt
+    assert "Artefact file_copy_ids: #V#uploaded_file_copy_abc123" in prompt
+    assert "Artefact urls: https://arxiv.org/abs/2502.14996" in prompt
+    assert prompt.rstrip().endswith("Please proceed.")

--- a/tests/backend/test_workflow_episode_service.py
+++ b/tests/backend/test_workflow_episode_service.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import importlib
+from datetime import datetime, timezone
 
 import pytest
 
+from src.backend.db.mongo_client import get_db
 from src.backend.db.repositories.concepts_repository import ConceptsRepository
 from src.backend.services import concept_service
 from src.backend.services.workflow_episode_service import (
     build_workflow_episode_stable_key,
     finalise_workflow_use_episode,
+    get_latest_workflow_use_episode,
     get_workflow_episode_counts_for_workflows,
     get_workflow_usage_aggregates_for_workflows,
     list_workflow_use_episodes,
@@ -259,3 +262,69 @@ def test_namespace_equivalence_includes_user_only_and_default_legacy_forms():
         namespace="#V#michael_witbrock@university_of_auckland_strong_ai_lab",
     )
     assert counts[workflow_id] == 2
+
+
+def test_get_latest_workflow_use_episode_returns_newest_session_episode():
+    workflow_id = "#V#workflow_episode_latest_lookup"
+    namespace = "#V#michael_witbrock/#V#university_of_auckland_strong_ai_lab"
+
+    first = start_workflow_use_episode(
+        workflow_id=workflow_id,
+        source="chat_turn_workflow",
+        stable_key=build_workflow_episode_stable_key(
+            workflow_id=workflow_id,
+            source="chat_turn_workflow",
+            turn_id="turn-old",
+            session_id="session-latest",
+            stage="tool_calling",
+        ),
+        namespace=namespace,
+        turn_id="turn-old",
+        session_id="session-latest",
+    )
+    second = start_workflow_use_episode(
+        workflow_id=workflow_id,
+        source="chat_turn_workflow",
+        stable_key=build_workflow_episode_stable_key(
+            workflow_id=workflow_id,
+            source="chat_turn_workflow",
+            turn_id="turn-new",
+            session_id="session-latest",
+            stage="tool_calling",
+        ),
+        namespace=namespace,
+        turn_id="turn-new",
+        session_id="session-latest",
+    )
+
+    assert first is not None
+    assert second is not None
+
+    db = get_db()
+    assert db is not None
+    coll = db["workflow_use_episodes"]
+    coll.update_one(
+        {"episode_id": first["episode_id"]},
+        {
+            "$set": {
+                "attempt_started_at": datetime(2026, 3, 5, 12, 0, tzinfo=timezone.utc)
+            }
+        },
+    )
+    coll.update_one(
+        {"episode_id": second["episode_id"]},
+        {
+            "$set": {
+                "attempt_started_at": datetime(2026, 3, 5, 12, 5, tzinfo=timezone.utc)
+            }
+        },
+    )
+
+    latest = get_latest_workflow_use_episode(
+        namespace="#V#michael_witbrock@university_of_auckland_strong_ai_lab",
+        session_id="session-latest",
+    )
+    assert latest is not None
+    assert latest["episode_id"] == second["episode_id"]
+    assert latest["turn_id"] == "turn-new"
+    assert latest["workflow_id"] == workflow_id


### PR DESCRIPTION
## Summary
- make workflow continuation and repair state authoritative across turns
- add Vontology-backed knowledge acquisition profiles and bind rumination relation completion to them
- align workflow authority checks, completion/follow-up UI semantics, and VWL documentation

## Verification
- `npx pyright <changed python files>`
- `pdm run pytest tests/backend/test_representation_contract_vontology_service.py tests/backend/test_knowledge_acquisition_profile_vontology_service.py tests/backend/test_workflow_concept_authority_service.py::test_bootstrap_publishes_canonical_chat_graphs_with_loader_runtime_parity tests/backend/test_workflow_concept_authority_service.py::test_canonical_workflow_runtime_identity_matches_authoritative_loader tests/backend/test_workflow_concept_authority_service.py::test_publish_canonical_graphs_reports_validation_failures`
- `pdm run pytest tests/backend/test_relation_elicitation_service.py tests/backend/test_knowledge_acquisition_profile_vontology_service.py tests/backend/test_rumination_workflow.py`
- `pdm run pytest tests/backend/test_workflow_continuation_service.py tests/backend/test_workflow_episode_service.py`
- `pdm run pytest tests/backend/test_tool_progress_liveness.py`
- `pdm run pytest tests/backend/test_turn_execution_required_effects_contract.py`
- `pdm run pytest tests/backend/test_orchestrator_workflow_selector_routing.py`
- `npx jest src/frontend/web/von_interface/static/js/test/chatTab.test.js --runInBand`

## Live Vontology verification
- canonical representation-contract profile concepts exist and carry singleton profile JSON text
- canonical knowledge-acquisition profile concept exists and is linked from `#V#rumination_workflow`
- fresh Python-side workflow authority report now returns `missing_concepts=0` and `missing_required_type=0`

## Notes
- The currently running long-lived MCP/catalogue process may still show a stale parity snapshot until it reloads; fresh code paths and live ontology state are aligned.