### PR TITLE
JVNAUTOSCI-1393 Add expandable progress-card diagnostics

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -533,6 +533,7 @@ def _normalise_workflow_discovery_progress_payload(
     workflow_discovery: Mapping[str, Any] | None,
     *,
     query: str | None = None,
+    namespace: str | None = None,
     error: str | None = None,
 ) -> dict[str, Any]:
     """Return a stable workflow-discovery payload for live progress rendering.
@@ -577,6 +578,10 @@ def _normalise_workflow_discovery_progress_payload(
 
     if isinstance(query, str) and query.strip():
         payload.setdefault("query", query.strip())
+        payload.setdefault("requested_query", query.strip())
+
+    if isinstance(namespace, str) and namespace.strip():
+        payload["namespace"] = namespace.strip()
 
     errors: list[str] = []
     existing_errors = payload.get("errors")
@@ -968,6 +973,99 @@ def _build_timing_breakdown(
     }
 
 
+def _canonicalise_turn_execution_stage_id(stage: Any) -> str | None:
+    clean_stage = _progress_str(stage)
+    if not clean_stage:
+        return None
+    if clean_stage == "workflow_discovery_complete":
+        return "workflow_discovery"
+    if clean_stage in {"orchestrator_start", "orchestrator_end"}:
+        return "workflow_dispatch"
+    return clean_stage
+
+
+def _build_turn_execution_stage_diagnostics(
+    *,
+    diagnostic_events: list[dict[str, Any]],
+    workflow_stage_path: Mapping[str, Any] | None,
+    tool_history: list[dict[str, Any]],
+    workflow_discovery: Mapping[str, Any] | None,
+    latest_progress: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    path_entries_raw = (
+        workflow_stage_path.get("path")
+        if isinstance(workflow_stage_path, Mapping)
+        else None
+    )
+    path_entries = (
+        [entry for entry in path_entries_raw if isinstance(entry, Mapping)]
+        if isinstance(path_entries_raw, list)
+        else []
+    )
+    if not path_entries:
+        return []
+
+    latest_progress_payload = (
+        latest_progress if isinstance(latest_progress, Mapping) else {}
+    )
+    stage_diagnostics: list[dict[str, Any]] = []
+
+    for stage_entry in path_entries:
+        stage_id = _progress_str(stage_entry.get("stage_id")) or _progress_str(
+            stage_entry.get("runtime_stage_normalised")
+        )
+        if not stage_id:
+            continue
+
+        stage_events = [
+            entry
+            for entry in diagnostic_events
+            if _canonicalise_turn_execution_stage_id(
+                entry.get("phase") or entry.get("stage")
+            )
+            == stage_id
+        ]
+        latest_stage_event = stage_events[-1] if stage_events else None
+        stage_payload: dict[str, Any] = {
+            "stage_id": stage_id,
+            "stage_label": _progress_str(stage_entry.get("stage_label"))
+            or stage_id.replace("_", " ").strip().title(),
+            "event_count": len(stage_events),
+            "latest_status": (
+                _progress_str(latest_stage_event.get("status"))
+                if isinstance(latest_stage_event, Mapping)
+                else None
+            ),
+            "latest_at_utc": (
+                _progress_str(latest_stage_event.get("at_utc"))
+                if isinstance(latest_stage_event, Mapping)
+                else None
+            ),
+        }
+
+        if stage_id == "workflow_discovery" and isinstance(workflow_discovery, Mapping):
+            stage_payload["workflow_discovery"] = dict(workflow_discovery)
+        if stage_id == "tool_execute" and tool_history:
+            stage_payload["tool_history"] = [dict(entry) for entry in tool_history]
+        if stage_id in {"workflow_dispatch", "plain_response"}:
+            stage_payload["selected_workflow_id"] = _progress_str(
+                latest_progress_payload.get("selected_workflow_id")
+            )
+            stage_payload["selected_workflow_name"] = _progress_str(
+                latest_progress_payload.get("selected_workflow_name")
+            )
+            stage_payload["workflow_selector_verdict"] = _progress_str(
+                latest_progress_payload.get("workflow_selector_verdict")
+            )
+            stage_payload["workflow_selector_source"] = _progress_str(
+                latest_progress_payload.get("workflow_selector_source")
+            )
+
+        stage_diagnostics.append(stage_payload)
+
+    return stage_diagnostics
+
+
 def _build_turn_execution_diagnostics(
     *,
     request_id: str | None,
@@ -1027,11 +1125,19 @@ def _build_turn_execution_diagnostics(
         for entry in (llm_calls or [])
         if isinstance(entry, dict)
     ]
+    tool_history = _derive_tool_history_from_diagnostic_events(diagnostic_events)
     timing_breakdown = _build_timing_breakdown(
         diagnostic_events=diagnostic_events,
         phase_history=phase_history,
         llm_calls=llm_call_entries,
         elapsed_ms_value=elapsed_ms_value,
+    )
+    stage_diagnostics = _build_turn_execution_stage_diagnostics(
+        diagnostic_events=diagnostic_events,
+        workflow_stage_path=workflow_stage_path,
+        tool_history=tool_history,
+        workflow_discovery=workflow_payload,
+        latest_progress=latest_progress,
     )
 
     return {
@@ -1044,10 +1150,11 @@ def _build_turn_execution_diagnostics(
             diagnostic_events
         ),
         "phase_history": phase_history,
-        "tool_history": _derive_tool_history_from_diagnostic_events(diagnostic_events),
+        "tool_history": tool_history,
         "workflow_discovery": workflow_payload,
         "workflow_stage_model": build_conversation_turn_stage_model_snapshot(),
         "workflow_stage_path": workflow_stage_path,
+        "stage_diagnostics": stage_diagnostics,
         "timing_breakdown": timing_breakdown,
     }
 
@@ -5787,6 +5894,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                 workflow_discovery_progress = _normalise_workflow_discovery_progress_payload(
                     workflow_discovery_result,
                     query=workflow_discovery_query,
+                    namespace=user_namespace,
                 )
                 if workflow_discovery_result:
                     current_app.logger.info(
@@ -5837,6 +5945,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                             "workflow_discovery": _normalise_workflow_discovery_progress_payload(
                                 None,
                                 query=workflow_discovery_query,
+                                namespace=user_namespace,
                                 error=str(e),
                             ),
                             "workflow_match_count": 0,

--- a/src/backend/services/workflow_discovery_service.py
+++ b/src/backend/services/workflow_discovery_service.py
@@ -198,8 +198,12 @@ class WorkflowDiscoveryResult:
     routing_matches: Optional[List[WorkflowMatch]] = None
     search_time_ms: float = 0.0
     query: str = ""
+    requested_query: str = ""
     threshold: float = DEFAULT_RELEVANCE_THRESHOLD
     errors: List[str] = field(default_factory=list)
+    search_sources: List[str] = field(default_factory=list)
+    keyword_fallback_queries: List[str] = field(default_factory=list)
+    allow_non_executable: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for JSON serialisation."""
@@ -219,9 +223,13 @@ class WorkflowDiscoveryResult:
             "routing_matches": routing_payload,
             "search_time_ms": round(self.search_time_ms, 2),
             "query": self.query,
+            "requested_query": self.requested_query or self.query,
             "threshold": self.threshold,
             "match_count": len(routing_payload),
             "candidate_count": len(candidate_payload),
+            "search_sources": list(self.search_sources),
+            "keyword_fallback_queries": list(self.keyword_fallback_queries),
+            "allow_non_executable": self.allow_non_executable,
             "errors": self.errors if self.errors else None,
         }
 
@@ -855,6 +863,7 @@ def discover_workflows(
     start_time = time.perf_counter()
     all_matches: List[WorkflowMatch] = _seed_workflow_creation_candidate(query)
     errors: List[str] = []
+    search_sources: List[str] = []
     file_copy_contexts, context_errors = _resolve_query_file_copy_contexts(query)
     errors.extend(context_errors)
     search_query = _augment_query_with_file_copy_context(query, file_copy_contexts)
@@ -862,6 +871,7 @@ def discover_workflows(
 
     # Search both sources
     try:
+        search_sources.append("semantic")
         semantic_matches = _search_workflows_semantic(
             search_query, limit=max_results * 2
         )
@@ -874,6 +884,7 @@ def discover_workflows(
     elapsed = time.perf_counter() - start_time
     if elapsed < timeout_seconds:
         try:
+            search_sources.append("vontology")
             vontology_matches = _search_workflows_vontology(
                 search_query, limit=max_results * 2
             )
@@ -884,6 +895,7 @@ def discover_workflows(
 
     if elapsed < timeout_seconds and keyword_fallback_queries:
         try:
+            search_sources.append("name_fallback")
             fallback_matches = _search_workflows_name_fallback(
                 keyword_fallback_queries,
                 limit=max_results * 2,
@@ -939,8 +951,12 @@ def discover_workflows(
         routing_matches=routing_matches,
         search_time_ms=elapsed_ms,
         query=search_query,
+        requested_query=query,
         threshold=relevance_threshold,
         errors=errors if errors else [],
+        search_sources=search_sources,
+        keyword_fallback_queries=keyword_fallback_queries,
+        allow_non_executable=allow_non_executable,
     )
 
 

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -616,6 +616,7 @@ const THINKING_STATUS_TERMINATED = 'terminated';
 const THINKING_CARD_TOGGLE_ARIA_LABEL_EXPANDED = 'Collapse thinking details';
 const THINKING_CARD_TOGGLE_ARIA_LABEL_COLLAPSED = 'Expand thinking details';
 const THINKING_ACTIVITY_LOW_LEVEL_EVENT_KINDS = new Set(['llm_call_chunk', 'heartbeat']);
+const THINKING_DIAGNOSTIC_DETAILS_SELECTOR = 'details[data-thinking-diagnostic-key]';
 const THINKING_TERMINAL_PROGRESS_STATUSES = new Set([
     'completed',
     'complete',
@@ -701,12 +702,15 @@ function setLoadingIndicatorDetailHtml(html) {
     if (!detailEl) {
         return;
     }
+    const request = getThinkingCardDisplayRequest();
+    snapshotThinkingDiagnosticExpansionState(detailEl, request);
     const value = String(html ?? '').trim();
     detailEl.innerHTML = value;
     bindConceptSelectionClicks(detailEl, {
         selector: '.thinking-card-concept-link',
         datasetKey: 'conceptLinkBound'
     });
+    bindThinkingDiagnosticToggles(detailEl, request);
 
     // Update wrapper to show/hide tool list
     const wrapper = document.getElementById('thinkingCardWrapper');
@@ -978,6 +982,18 @@ function createThinkingCardHistorySnapshot(request) {
             ...request.workflowDiscovery,
             matches: Array.isArray(request.workflowDiscovery.matches)
                 ? request.workflowDiscovery.matches.map((match) => ({ ...match }))
+                : [],
+            candidates: Array.isArray(request.workflowDiscovery.candidates)
+                ? request.workflowDiscovery.candidates.map((match) => ({ ...match }))
+                : [],
+            routing_matches: Array.isArray(request.workflowDiscovery.routing_matches)
+                ? request.workflowDiscovery.routing_matches.map((match) => ({ ...match }))
+                : [],
+            search_sources: Array.isArray(request.workflowDiscovery.search_sources)
+                ? request.workflowDiscovery.search_sources.slice()
+                : [],
+            keyword_fallback_queries: Array.isArray(request.workflowDiscovery.keyword_fallback_queries)
+                ? request.workflowDiscovery.keyword_fallback_queries.slice()
                 : []
         }
         : null;
@@ -1002,6 +1018,11 @@ function createThinkingCardHistorySnapshot(request) {
         workflowDiscovery,
         workflowStagePath,
         latestProgress,
+        expandedThinkingDiagnosticKeys: request.expandedThinkingDiagnosticKeys instanceof Set
+            ? Array.from(request.expandedThinkingDiagnosticKeys)
+            : (Array.isArray(request.expandedThinkingDiagnosticKeys)
+                ? request.expandedThinkingDiagnosticKeys.slice()
+                : []),
         thinkingStartedAtMs: Number.isFinite(request.thinkingStartedAtMs) ? Number(request.thinkingStartedAtMs) : null,
         thinkingFinishedAtMs: Date.now(),
         thinkingCardDisplayState: completedDisplayState
@@ -1891,26 +1912,17 @@ function renderThinkingActivityHistoryHTML(request) {
             continue;
         }
 
-        const statusClass = (entry.state === 'success' || entry.state === 'failure') ? entry.state : 'pending';
-        const statusIcon = statusClass === 'success' ? '✓' : (statusClass === 'failure' ? '✗' : '');
-        const detailHtmlParts = [];
-        if (Number.isFinite(entry.groupCount) && Number(entry.groupCount) > 1) {
-            detailHtmlParts.push(escapeHtml(`${Number(entry.groupCount)} updates`));
-        }
-        if (normaliseThinkingActivityString(entry.detailHtml)) {
-            detailHtmlParts.push(entry.detailHtml);
-        } else if (normaliseThinkingActivityString(entry.detail)) {
-            detailHtmlParts.push(escapeHtml(normaliseThinkingActivityString(entry.detail)));
-        }
-        const detailLabel = detailHtmlParts.length > 0
-            ? `<span class="thinking-card-tool-result">${detailHtmlParts.join(' · ')}</span>`
-            : '';
-
         const rowClass = entry.isLowLevel ? 'thinking-card-tool thinking-card-activity is-low-level' : 'thinking-card-tool thinking-card-activity';
-        items.push(`<div class="${rowClass}">
-            <span class="thinking-card-tool-status ${statusClass}">${statusIcon}</span>
-            <span class="thinking-card-tool-name">${escapeHtml(label)}</span>${detailLabel}
-        </div>`);
+        items.push(renderThinkingDiagnosticRowHTML({
+            ...entry,
+            diagnosticKey: buildThinkingDiagnosticKey(
+                'activity',
+                entry.sequenceNo || '',
+                entry.status || label,
+                entry.stage || entry.subtask || ''
+            ),
+            diagnosticHtml: buildThinkingActivityDiagnosticsHTML(entry)
+        }, rowClass));
     }
 
     return items.join('');
@@ -1955,27 +1967,24 @@ function renderToolHistoryHTML(request) {
         const success = entry.success;
 
         // Status icon and class
-        let statusIcon = '';
         let statusClass = 'pending';
         if (success === true) {
-            statusIcon = '✓';
             statusClass = 'success';
         } else if (success === false) {
-            statusIcon = '✗';
             statusClass = 'failure';
         }
 
         const toolLabel = tool
             ? `Tool call: ${tool}`
             : (workflowTask ? `Workflow task: ${workflowTask}` : '');
-        const toolName = escapeHtml(toolLabel);
-        const batchLabel = batchSize !== null ? `<span class="thinking-card-tool-batch">(batch ${batchSize})</span>` : '';
-        const resultLabel = resultSummary ? `<span class="thinking-card-tool-result">${escapeHtml(resultSummary)}</span>` : '';
-
-        items.push(`<div class="thinking-card-tool">
-            <span class="thinking-card-tool-status ${statusClass}">${statusIcon}</span>
-            <span class="thinking-card-tool-name">${toolName}</span>${batchLabel}${resultLabel}
-        </div>`);
+        items.push(renderThinkingDiagnosticRowHTML({
+            label: toolLabel,
+            detail: resultSummary,
+            detailHtml: '',
+            state: statusClass,
+            diagnosticKey: buildThinkingDiagnosticKey('tool', tool || workflowTask, batchSize || ''),
+            diagnosticHtml: buildToolHistoryDiagnosticsHTML(entry)
+        }, 'thinking-card-tool'));
     }
 
     return items.join('');
@@ -2063,6 +2072,551 @@ function renderWorkflowDisplayHtml(workflowId, workflowName, workflowDiscovery =
 
 function formatWorkflowDisplayText(workflowId, workflowName, workflowDiscovery = null) {
     return resolveWorkflowDisplayDescriptor(workflowId, workflowName, workflowDiscovery).label;
+}
+
+function buildThinkingDiagnosticKey(...parts) {
+    return parts
+        .map((value) => {
+            if (Number.isFinite(value)) {
+                return String(value);
+            }
+            if (typeof value === 'boolean') {
+                return value ? 'true' : 'false';
+            }
+            return normaliseThinkingActivityString(value);
+        })
+        .map((value) => value.toLowerCase())
+        .map((value) => value.replace(/[^a-z0-9#:_-]+/g, '-').replace(/^-+|-+$/g, ''))
+        .filter(Boolean)
+        .join('::');
+}
+
+function ensureThinkingDiagnosticExpansionState(request) {
+    if (!request || typeof request !== 'object') {
+        return new Set();
+    }
+
+    if (request.expandedThinkingDiagnosticKeys instanceof Set) {
+        return request.expandedThinkingDiagnosticKeys;
+    }
+
+    const next = new Set(
+        Array.isArray(request.expandedThinkingDiagnosticKeys)
+            ? request.expandedThinkingDiagnosticKeys
+                .map((value) => normaliseThinkingActivityString(value))
+                .filter(Boolean)
+            : []
+    );
+    request.expandedThinkingDiagnosticKeys = next;
+    return next;
+}
+
+function snapshotThinkingDiagnosticExpansionState(container, request = getThinkingCardDisplayRequest()) {
+    if (!(container instanceof HTMLElement) || !request || typeof request !== 'object') {
+        return;
+    }
+
+    const expandedKeys = new Set();
+    const openRows = container.querySelectorAll(`${THINKING_DIAGNOSTIC_DETAILS_SELECTOR}[open]`);
+    openRows.forEach((detailsEl) => {
+        const key = normaliseThinkingActivityString(detailsEl.dataset.thinkingDiagnosticKey);
+        if (key) {
+            expandedKeys.add(key);
+        }
+    });
+    request.expandedThinkingDiagnosticKeys = expandedKeys;
+}
+
+function bindThinkingDiagnosticToggles(container, request = getThinkingCardDisplayRequest()) {
+    if (!(container instanceof HTMLElement)) {
+        return;
+    }
+
+    const expandedKeys = ensureThinkingDiagnosticExpansionState(request);
+    const rows = container.querySelectorAll(THINKING_DIAGNOSTIC_DETAILS_SELECTOR);
+    rows.forEach((detailsEl) => {
+        const key = normaliseThinkingActivityString(detailsEl.dataset.thinkingDiagnosticKey);
+        if (!key) {
+            return;
+        }
+
+        detailsEl.open = expandedKeys.has(key);
+        if (detailsEl.dataset.thinkingDiagnosticToggleBound === 'true') {
+            return;
+        }
+
+        detailsEl.addEventListener('toggle', () => {
+            const currentRequest = getThinkingCardDisplayRequest() || request;
+            const currentExpandedKeys = ensureThinkingDiagnosticExpansionState(currentRequest);
+            if (detailsEl.open) {
+                currentExpandedKeys.add(key);
+            } else {
+                currentExpandedKeys.delete(key);
+            }
+        });
+        detailsEl.dataset.thinkingDiagnosticToggleBound = 'true';
+    });
+}
+
+function formatThinkingDiagnosticFactValue(value) {
+    if (typeof value === 'boolean') {
+        return value ? 'Yes' : 'No';
+    }
+    if (Number.isFinite(value)) {
+        return String(value);
+    }
+    if (Array.isArray(value)) {
+        return value
+            .map((entry) => formatThinkingDiagnosticFactValue(entry))
+            .filter(Boolean)
+            .join(', ');
+    }
+    return normaliseThinkingActivityString(value);
+}
+
+function buildThinkingDiagnosticFactsHTML(facts) {
+    if (!Array.isArray(facts) || facts.length === 0) {
+        return '';
+    }
+
+    const items = facts
+        .map((fact) => {
+            if (!fact || typeof fact !== 'object') {
+                return '';
+            }
+            const label = normaliseThinkingActivityString(fact.label);
+            const htmlValue = normaliseThinkingActivityString(fact.html);
+            const textValue = formatThinkingDiagnosticFactValue(fact.value);
+            if (!label || (!htmlValue && !textValue)) {
+                return '';
+            }
+            return `<div class="thinking-card-diagnostic-fact">
+                <dt>${escapeHtml(label)}</dt>
+                <dd>${htmlValue || escapeHtml(textValue)}</dd>
+            </div>`;
+        })
+        .filter(Boolean);
+
+    if (items.length === 0) {
+        return '';
+    }
+
+    return `<dl class="thinking-card-diagnostic-facts">${items.join('')}</dl>`;
+}
+
+function buildThinkingDiagnosticListHTML(title, values, options = {}) {
+    const items = Array.isArray(values)
+        ? values
+            .map((value) => normaliseThinkingActivityString(value))
+            .filter(Boolean)
+        : [];
+    if (items.length === 0) {
+        return '';
+    }
+
+    const cleanTitle = normaliseThinkingActivityString(title) || 'Details';
+    const codeValues = options.code === true;
+    const renderedItems = items.map((value) => {
+        const content = codeValues
+            ? `<code class="thinking-card-diagnostic-inline-code">${escapeHtml(value)}</code>`
+            : escapeHtml(value);
+        return `<li>${content}</li>`;
+    });
+    return `<div class="thinking-card-diagnostic-section">
+        <div class="thinking-card-diagnostic-section-title">${escapeHtml(cleanTitle)}</div>
+        <ul class="thinking-card-diagnostic-list">${renderedItems.join('')}</ul>
+    </div>`;
+}
+
+function renderThinkingDiagnosticWorkflowCandidatesHTML(candidates, workflowDiscovery = null) {
+    const candidateList = Array.isArray(candidates)
+        ? candidates.filter((candidate) => candidate && typeof candidate === 'object')
+        : [];
+    if (candidateList.length === 0) {
+        return '';
+    }
+
+    const items = candidateList.map((candidate) => {
+        const nameHtml = renderWorkflowDisplayHtml(
+            candidate.concept_id,
+            candidate.name,
+            workflowDiscovery,
+            { classNames: ['thinking-card-diagnostic-workflow-link'] }
+        ) || escapeHtml(formatWorkflowDisplayText(candidate.concept_id, candidate.name, workflowDiscovery) || candidate.concept_id || 'Workflow candidate');
+        const summaryBits = [];
+
+        const matchSource = normaliseThinkingActivityString(candidate.match_source);
+        if (matchSource) {
+            summaryBits.push(`Source: ${formatThinkingActivityFallbackLabel(matchSource)}`);
+        }
+        if (Number.isFinite(candidate.relevance_score)) {
+            summaryBits.push(`Relevance ${Math.round(Number(candidate.relevance_score) * 100)}%`);
+        }
+        if (Number.isFinite(candidate.confidence_score) && Number(candidate.confidence_score) > 0) {
+            summaryBits.push(`Confidence ${Math.round(Number(candidate.confidence_score) * 100)}%`);
+        }
+        if (candidate.routing_eligible === true) {
+            summaryBits.push('Routing eligible');
+        } else if (candidate.routing_eligible === false) {
+            const reason = formatThinkingActivityFallbackLabel(candidate.routing_exclusion_reason);
+            summaryBits.push(reason ? `Routing excluded: ${reason}` : 'Routing excluded');
+        }
+        if (candidate.is_executable === true) {
+            summaryBits.push('Executable');
+        } else if (candidate.is_executable === false) {
+            const reason = formatThinkingActivityFallbackLabel(candidate.executability_reason);
+            summaryBits.push(reason ? `Non-executable: ${reason}` : 'Non-executable');
+        }
+        if (candidate.is_policy_safe === false) {
+            summaryBits.push('Policy blocked');
+        }
+
+        const description = normaliseThinkingActivityString(candidate.description);
+        const executabilityDetail = normaliseThinkingActivityString(candidate.executability_detail);
+        return `<li class="thinking-card-diagnostic-candidate">
+            <div class="thinking-card-diagnostic-candidate-name">${nameHtml}</div>
+            ${summaryBits.length > 0 ? `<div class="thinking-card-diagnostic-candidate-meta">${escapeHtml(summaryBits.join(' · '))}</div>` : ''}
+            ${description ? `<div class="thinking-card-diagnostic-candidate-text">${escapeHtml(description)}</div>` : ''}
+            ${executabilityDetail ? `<div class="thinking-card-diagnostic-candidate-text">${escapeHtml(executabilityDetail)}</div>` : ''}
+        </li>`;
+    });
+
+    return `<div class="thinking-card-diagnostic-section">
+        <div class="thinking-card-diagnostic-section-title">Workflow candidates</div>
+        <ul class="thinking-card-diagnostic-candidates">${items.join('')}</ul>
+    </div>`;
+}
+
+function renderThinkingDiagnosticPanelHTML({ facts = [], sections = [] } = {}) {
+    const factsHtml = buildThinkingDiagnosticFactsHTML(facts);
+    const extraSections = Array.isArray(sections)
+        ? sections.filter((section) => normaliseThinkingActivityString(section))
+        : [];
+    if (!factsHtml && extraSections.length === 0) {
+        return '';
+    }
+
+    return `<div class="thinking-card-diagnostic-panel">${factsHtml}${extraSections.join('')}</div>`;
+}
+
+function renderThinkingDiagnosticRowHTML(entry, rowClass = 'thinking-card-tool') {
+    if (!entry || typeof entry !== 'object') {
+        return '';
+    }
+
+    const label = normaliseThinkingActivityString(entry.label);
+    if (!label) {
+        return '';
+    }
+
+    const statusClass = (entry.state === 'success' || entry.state === 'failure') ? entry.state : 'pending';
+    const statusIcon = statusClass === 'success' ? '✓' : (statusClass === 'failure' ? '✗' : '');
+    const detailHtmlParts = [];
+    if (Number.isFinite(entry.groupCount) && Number(entry.groupCount) > 1) {
+        detailHtmlParts.push(escapeHtml(`${Number(entry.groupCount)} updates`));
+    }
+    if (normaliseThinkingActivityString(entry.detailHtml)) {
+        detailHtmlParts.push(entry.detailHtml);
+    } else if (normaliseThinkingActivityString(entry.detail)) {
+        detailHtmlParts.push(escapeHtml(normaliseThinkingActivityString(entry.detail)));
+    }
+    const detailLabel = detailHtmlParts.length > 0
+        ? `<span class="thinking-card-tool-result">${detailHtmlParts.join(' · ')}</span>`
+        : '';
+
+    const summaryHtml = `<span class="thinking-card-tool-status ${statusClass}">${statusIcon}</span>
+        <span class="thinking-card-tool-name">${escapeHtml(label)}</span>${detailLabel}`;
+    const diagnosticHtml = normaliseThinkingActivityString(entry.diagnosticHtml);
+    if (!diagnosticHtml) {
+        return `<div class="${rowClass}">${summaryHtml}</div>`;
+    }
+
+    const diagnosticKey = normaliseThinkingActivityString(entry.diagnosticKey)
+        || buildThinkingDiagnosticKey(label, entry.detail, statusClass);
+    return `<details class="thinking-card-diagnostic-row${entry.isLowLevel ? ' is-low-level' : ''}" data-thinking-diagnostic-key="${escapeHtml(diagnosticKey)}">
+        <summary class="${rowClass}">${summaryHtml}<span class="thinking-card-diagnostic-toggle-indicator" aria-hidden="true">▸</span></summary>
+        ${diagnosticHtml}
+    </details>`;
+}
+
+function canonicaliseThinkingDiagnosticStageId(stageId) {
+    const cleanStageId = normaliseThinkingActivityString(stageId);
+    if (cleanStageId === 'workflow_discovery_complete') {
+        return 'workflow_discovery';
+    }
+    return cleanStageId;
+}
+
+function getThinkingDiagnosticEvents(request) {
+    const diagnosticEvents = request?.latestProgress?.diagnostic_events;
+    return Array.isArray(diagnosticEvents)
+        ? diagnosticEvents.filter((entry) => entry && typeof entry === 'object')
+        : [];
+}
+
+function getThinkingDiagnosticEventsForStage(request, stageId) {
+    const cleanStageId = canonicaliseThinkingDiagnosticStageId(stageId);
+    if (!cleanStageId) {
+        return [];
+    }
+
+    return getThinkingDiagnosticEvents(request).filter((entry) => (
+        canonicaliseThinkingDiagnosticStageId(entry.phase || entry.stage) === cleanStageId
+    ));
+}
+
+function buildThinkingWorkflowStageDiagnosticData(stageId, stageLabel, request) {
+    const cleanStageId = canonicaliseThinkingDiagnosticStageId(stageId);
+    if (!cleanStageId) {
+        return null;
+    }
+
+    const stageEvents = getThinkingDiagnosticEventsForStage(request, cleanStageId);
+    const latestStageEvent = stageEvents.length > 0 ? stageEvents[stageEvents.length - 1] : null;
+    const workflowDiscovery = (request?.workflowDiscovery && typeof request.workflowDiscovery === 'object')
+        ? request.workflowDiscovery
+        : null;
+    const latestProgress = (request?.latestProgress && typeof request.latestProgress === 'object')
+        ? request.latestProgress
+        : null;
+    const toolHistory = Array.isArray(request?.toolUseProgressHistory)
+        ? request.toolUseProgressHistory
+            .filter((entry) => entry && typeof entry === 'object')
+            .map((entry) => ({ ...entry }))
+        : [];
+
+    const data = {
+        stage_id: cleanStageId,
+        stage_label: normaliseThinkingActivityString(stageLabel) || formatThinkingActivityFallbackLabel(cleanStageId) || 'Workflow step',
+        stage_event_count: stageEvents.length,
+        latest_status: normaliseThinkingActivityString(latestStageEvent?.status) || null,
+        latest_at_utc: normaliseThinkingActivityString(latestStageEvent?.at_utc) || null,
+        latest_result_summary: normaliseThinkingActivityString(latestStageEvent?.result_summary) || null,
+        latest_error: normaliseThinkingActivityString(latestStageEvent?.error) || null
+    };
+
+    if (cleanStageId === 'workflow_discovery' && workflowDiscovery) {
+        data.requested_query = normaliseThinkingActivityString(workflowDiscovery.requested_query) || null;
+        data.query = normaliseThinkingActivityString(workflowDiscovery.query) || null;
+        data.search_sources = Array.isArray(workflowDiscovery.search_sources)
+            ? workflowDiscovery.search_sources
+                .map((value) => normaliseThinkingActivityString(value))
+                .filter(Boolean)
+            : [];
+        data.keyword_fallback_queries = Array.isArray(workflowDiscovery.keyword_fallback_queries)
+            ? workflowDiscovery.keyword_fallback_queries
+                .map((value) => normaliseThinkingActivityString(value))
+                .filter(Boolean)
+            : [];
+        data.threshold = Number.isFinite(workflowDiscovery.threshold) ? Number(workflowDiscovery.threshold) : null;
+        data.search_time_ms = Number.isFinite(workflowDiscovery.search_time_ms) ? Math.round(Number(workflowDiscovery.search_time_ms)) : null;
+        data.namespace = normaliseThinkingActivityString(workflowDiscovery.namespace) || null;
+        data.allow_non_executable = workflowDiscovery.allow_non_executable === true;
+        data.match_count = getWorkflowDiscoveryMatchCount(workflowDiscovery);
+        data.candidate_count = getWorkflowDiscoveryCandidateCount(workflowDiscovery);
+        data.errors = Array.isArray(workflowDiscovery.errors)
+            ? workflowDiscovery.errors
+                .map((value) => normaliseThinkingActivityString(value))
+                .filter(Boolean)
+            : [];
+        data.candidates = normaliseWorkflowDiscoveryCandidates(workflowDiscovery).map((candidate) => ({ ...candidate }));
+    }
+
+    if (cleanStageId === 'workflow_dispatch' || cleanStageId === 'plain_response') {
+        data.selected_workflow_id = normaliseThinkingActivityString(latestProgress?.selected_workflow_id) || null;
+        data.selected_workflow_name = normaliseThinkingActivityString(latestProgress?.selected_workflow_name) || null;
+        data.workflow_selector_verdict = normaliseThinkingActivityString(latestProgress?.workflow_selector_verdict) || null;
+        data.workflow_selector_source = normaliseThinkingActivityString(latestProgress?.workflow_selector_source) || null;
+        data.workflow_match_count = Number.isFinite(latestProgress?.workflow_match_count)
+            ? Number(latestProgress.workflow_match_count)
+            : getWorkflowDiscoveryMatchCount(workflowDiscovery);
+        data.workflow_candidate_count = Number.isFinite(latestProgress?.workflow_candidate_count)
+            ? Number(latestProgress.workflow_candidate_count)
+            : getWorkflowDiscoveryCandidateCount(workflowDiscovery);
+    }
+
+    if (cleanStageId === 'tool_execute') {
+        const successCount = toolHistory.filter((entry) => entry.success === true).length;
+        const failureCount = toolHistory.filter((entry) => entry.success === false).length;
+        data.tool_history = toolHistory;
+        data.tool_call_count = toolHistory.length;
+        data.tool_success_count = successCount;
+        data.tool_failure_count = failureCount;
+        data.tool_pending_count = Math.max(0, toolHistory.length - successCount - failureCount);
+    }
+
+    return data;
+}
+
+function renderThinkingWorkflowStageDiagnosticDataHTML(data, workflowDiscovery = null) {
+    if (!data || typeof data !== 'object') {
+        return '';
+    }
+
+    const facts = [
+        { label: 'Stage id', value: data.stage_id },
+        { label: 'Observed updates', value: data.stage_event_count },
+        { label: 'Latest status', value: data.latest_status ? formatThinkingActivityFallbackLabel(data.latest_status) : '' },
+        { label: 'Latest update', value: data.latest_at_utc },
+        { label: 'Latest result', value: data.latest_result_summary }
+    ];
+    const sections = [];
+
+    if (data.stage_id === 'workflow_discovery') {
+        facts.push(
+            {
+                label: 'Requested search',
+                value: data.requested_query,
+                html: data.requested_query
+                    ? `<code class="thinking-card-diagnostic-inline-code">${escapeHtml(data.requested_query)}</code>`
+                    : ''
+            },
+            {
+                label: 'Executed search',
+                value: data.query,
+                html: data.query
+                    ? `<code class="thinking-card-diagnostic-inline-code">${escapeHtml(data.query)}</code>`
+                    : ''
+            },
+            { label: 'Search sources', value: data.search_sources },
+            { label: 'Namespace', value: data.namespace },
+            { label: 'Threshold', value: data.threshold },
+            { label: 'Search time', value: Number.isFinite(data.search_time_ms) ? `${data.search_time_ms} ms` : '' },
+            { label: 'Routing matches', value: data.match_count },
+            { label: 'Candidates considered', value: data.candidate_count },
+            { label: 'Allow non-executable', value: data.allow_non_executable }
+        );
+        sections.push(buildThinkingDiagnosticListHTML('Fallback queries', data.keyword_fallback_queries, { code: true }));
+        sections.push(buildThinkingDiagnosticListHTML('Errors', data.errors));
+        sections.push(renderThinkingDiagnosticWorkflowCandidatesHTML(data.candidates, workflowDiscovery));
+    } else if (data.stage_id === 'workflow_dispatch' || data.stage_id === 'plain_response') {
+        const selectedWorkflowHtml = renderWorkflowDisplayHtml(
+            data.selected_workflow_id,
+            data.selected_workflow_name,
+            workflowDiscovery
+        );
+        facts.push(
+            {
+                label: 'Selected workflow',
+                value: formatWorkflowDisplayText(
+                    data.selected_workflow_id,
+                    data.selected_workflow_name,
+                    workflowDiscovery
+                ),
+                html: selectedWorkflowHtml
+            },
+            {
+                label: 'Selector verdict',
+                value: data.workflow_selector_verdict
+                    ? formatThinkingActivityFallbackLabel(data.workflow_selector_verdict)
+                    : ''
+            },
+            {
+                label: 'Selector source',
+                value: data.workflow_selector_source
+                    ? formatThinkingActivityFallbackLabel(data.workflow_selector_source)
+                    : ''
+            },
+            { label: 'Routing matches', value: data.workflow_match_count },
+            { label: 'Candidates considered', value: data.workflow_candidate_count }
+        );
+    } else if (data.stage_id === 'tool_execute') {
+        facts.push(
+            { label: 'Tool calls observed', value: data.tool_call_count },
+            { label: 'Successful', value: data.tool_success_count },
+            { label: 'Failed', value: data.tool_failure_count },
+            { label: 'Pending', value: data.tool_pending_count }
+        );
+        const toolLines = Array.isArray(data.tool_history)
+            ? data.tool_history.map((entry) => {
+                const target = normaliseThinkingActivityString(entry.tool || entry.workflowTask);
+                if (!target) {
+                    return '';
+                }
+                const bits = [target];
+                if (Number.isFinite(entry.batchSize)) {
+                    bits.push(`batch ${Number(entry.batchSize)}`);
+                }
+                if (typeof entry.success === 'boolean') {
+                    bits.push(entry.success ? 'success' : 'failed');
+                }
+                const resultSummary = normaliseThinkingActivityString(entry.resultSummary);
+                if (resultSummary) {
+                    bits.push(resultSummary);
+                }
+                return bits.join(' · ');
+            }).filter(Boolean)
+            : [];
+        sections.push(buildThinkingDiagnosticListHTML('Observed tool calls', toolLines));
+    }
+
+    if (data.latest_error) {
+        sections.push(buildThinkingDiagnosticListHTML('Latest error', [data.latest_error]));
+    }
+
+    return renderThinkingDiagnosticPanelHTML({ facts, sections });
+}
+
+function buildThinkingActivityDiagnosticsHTML(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return '';
+    }
+
+    const facts = [
+        { label: 'Sequence', value: entry.sequenceNo },
+        { label: 'Stage', value: entry.stage ? formatThinkingActivityFallbackLabel(entry.stage) : '' },
+        { label: 'Status', value: entry.status ? formatThinkingActivityFallbackLabel(entry.status) : '' },
+        { label: 'Event kind', value: entry.eventKind ? formatThinkingActivityFallbackLabel(entry.eventKind) : '' },
+        { label: 'Merged updates', value: entry.groupCount && Number(entry.groupCount) > 1 ? Number(entry.groupCount) : '' },
+        { label: 'Model', value: entry.model },
+        { label: 'Subtask', value: entry.subtask },
+        { label: 'Timestamp', value: entry.atUtc },
+        {
+            label: 'Detail',
+            value: entry.detail,
+            html: normaliseThinkingActivityString(entry.detailHtml)
+                ? entry.detailHtml
+                : ''
+        }
+    ];
+
+    return renderThinkingDiagnosticPanelHTML({ facts });
+}
+
+function buildToolHistoryDiagnosticsHTML(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return '';
+    }
+
+    const tool = normaliseThinkingActivityString(entry.tool);
+    const workflowTask = normaliseThinkingActivityString(entry.workflowTask);
+    const facts = [
+        { label: 'Tool', value: tool },
+        { label: 'Workflow task', value: workflowTask },
+        { label: 'Phase', value: entry.phase ? formatThinkingActivityFallbackLabel(entry.phase) : '' },
+        { label: 'Batch size', value: entry.batchSize },
+        { label: 'Result', value: entry.resultSummary },
+        {
+            label: 'Outcome',
+            value: typeof entry.success === 'boolean'
+                ? (entry.success ? 'Success' : 'Failed')
+                : 'Pending'
+        }
+    ];
+
+    return renderThinkingDiagnosticPanelHTML({ facts });
+}
+
+function buildThinkingStageDiagnosticsSnapshot(request) {
+    return buildThinkingWorkflowStageRows(request)
+        .map((entry) => ({
+            stage_id: entry.stageId || null,
+            label: entry.label || null,
+            detail: entry.detail || null,
+            state: entry.state || null,
+            diagnostics: entry.diagnosticData || null
+        }))
+        .filter((entry) => entry.stage_id || entry.label);
 }
 
 function buildWorkflowStageDetailPresentation(stageId, request) {
@@ -2237,12 +2791,20 @@ function buildThinkingWorkflowStageRows(request) {
         : null;
     if (path.length === 0) {
         if (workflowDiscovery) {
+            const diagnosticData = buildThinkingWorkflowStageDiagnosticData(
+                'workflow_discovery',
+                'Workflow discovery',
+                request
+            );
             const detailPresentation = buildWorkflowStageDetailPresentation('workflow_discovery', request);
             return [{
+                stageId: 'workflow_discovery',
                 label: 'Workflow discovery',
                 detail: detailPresentation.text,
                 detailHtml: detailPresentation.html,
-                state: getWorkflowDiscoveryMatchCount(workflowDiscovery) > 0 ? 'success' : 'failure'
+                state: getWorkflowDiscoveryMatchCount(workflowDiscovery) > 0 ? 'success' : 'failure',
+                diagnosticKey: buildThinkingDiagnosticKey('stage', 'workflow_discovery'),
+                diagnosticData
             }];
         }
         return [];
@@ -2264,6 +2826,7 @@ function buildThinkingWorkflowStageRows(request) {
         const stageLabel = normaliseThinkingActivityString(entry.stage_label)
             || formatThinkingActivityFallbackLabel(stageId)
             || 'Workflow step';
+        const diagnosticData = buildThinkingWorkflowStageDiagnosticData(stageId, stageLabel, request);
         const detailPresentation = buildWorkflowStageDetailPresentation(stageId, request);
         const detail = detailPresentation.text;
         let state = 'success';
@@ -2286,10 +2849,13 @@ function buildThinkingWorkflowStageRows(request) {
         }
 
         return {
+            stageId,
             label: stageLabel,
             detail,
             detailHtml: detailPresentation.html,
-            state
+            state,
+            diagnosticKey: buildThinkingDiagnosticKey('stage', stageId),
+            diagnosticData
         };
     });
 }
@@ -2300,17 +2866,13 @@ function renderThinkingWorkflowStageHistoryHTML(request) {
         return '';
     }
 
-    return rows.map((entry) => {
-        const statusClass = (entry.state === 'success' || entry.state === 'failure') ? entry.state : 'pending';
-        const statusIcon = statusClass === 'success' ? '✓' : (statusClass === 'failure' ? '✗' : '');
-        const detailLabel = normaliseThinkingActivityString(entry.detailHtml || entry.detail)
-            ? `<span class="thinking-card-tool-result">${entry.detailHtml || escapeHtml(entry.detail)}</span>`
-            : '';
-        return `<div class="thinking-card-tool thinking-card-activity">
-            <span class="thinking-card-tool-status ${statusClass}">${statusIcon}</span>
-            <span class="thinking-card-tool-name">${escapeHtml(entry.label)}</span>${detailLabel}
-        </div>`;
-    }).join('');
+    return rows.map((entry) => renderThinkingDiagnosticRowHTML({
+        ...entry,
+        diagnosticHtml: renderThinkingWorkflowStageDiagnosticDataHTML(
+            entry.diagnosticData,
+            request?.workflowDiscovery || null
+        )
+    }, 'thinking-card-tool thinking-card-activity')).join('');
 }
 
 /**
@@ -17788,7 +18350,8 @@ function buildThinkingDiagnosticsPayload(request) {
         phase_history: Array.isArray(request.phaseHistory) ? request.phaseHistory.slice(-40) : [],
         tool_history: Array.isArray(request.toolUseProgressHistory) ? request.toolUseProgressHistory.slice(-40) : [],
         workflow_discovery: request.workflowDiscovery || null,
-        workflow_stage_path: request.workflowStagePath || null
+        workflow_stage_path: request.workflowStagePath || null,
+        stage_diagnostics: buildThinkingStageDiagnosticsSnapshot(request)
     };
 }
 

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -1213,6 +1213,7 @@ describe('thinking activity history normalisation', () => {
         expect(html).toContain('Workflow discovery');
         expect(html).toContain('No direct workflow match found');
         expect(html).toContain('thinking-card-tool-status failure');
+        expect(html).toContain('data-thinking-diagnostic-key="stage::workflow_discovery"');
     });
 
     test('renders workflow candidates as a successful discovery row when routing is excluded', () => {
@@ -1240,6 +1241,73 @@ describe('thinking activity history normalisation', () => {
         expect(html).toContain('Found candidate <button');
         expect(html).toContain('Scholarly paper representation workflow (#V#scholarly_paper_representation_workflow)');
         expect(html).toContain('thinking-card-tool-status success');
+    });
+
+    test('renders workflow discovery search trace and rejection reasons in expandable diagnostics', () => {
+        const html = __testOnly_renderThinkingCardBodyHTML({
+            workflowStagePath: {
+                path: [
+                    { stage_id: 'workflow_discovery', stage_label: 'Workflow discovery' }
+                ]
+            },
+            workflowDiscovery: {
+                requested_query: 'Represent this uploaded paper',
+                query: 'Represent this uploaded paper\nArtefact typing context: route_hint=scholarly',
+                search_sources: ['semantic', 'vontology', 'name_fallback'],
+                keyword_fallback_queries: ['scholarly workflow', 'paper representation workflow'],
+                threshold: 0.7,
+                search_time_ms: 44,
+                match_count: 0,
+                candidate_count: 1,
+                candidates: [
+                    {
+                        concept_id: '#V#scholarly_paper_representation_workflow',
+                        name: 'Scholarly paper representation workflow',
+                        match_source: 'semantic',
+                        relevance_score: 0.91,
+                        routing_eligible: false,
+                        routing_exclusion_reason: 'graph_incomplete',
+                        is_executable: false,
+                        executability_reason: 'graph_incomplete',
+                        executability_detail: 'Missing terminal node.'
+                    }
+                ]
+            },
+            latestProgress: {
+                phase: 'workflow_discovery_complete'
+            }
+        });
+
+        expect(html).toContain('Requested search');
+        expect(html).toContain('Executed search');
+        expect(html).toContain('Represent this uploaded paper');
+        expect(html).toContain('route_hint=scholarly');
+        expect(html).toContain('semantic, vontology, name_fallback');
+        expect(html).toContain('Fallback queries');
+        expect(html).toContain('Workflow candidates');
+        expect(html).toContain('Routing excluded: Graph incomplete');
+        expect(html).toContain('Missing terminal node.');
+    });
+
+    test('renders fallback activity rows as expandable diagnostics entries', () => {
+        const html = __testOnly_renderThinkingCardBodyHTML({
+            activityHistory: [{
+                sequenceNo: 7,
+                label: 'Tool call failed: fetch_concept',
+                detail: 'Timeout while fetching',
+                state: 'failure',
+                status: 'tool_failed',
+                stage: 'tool_execute',
+                eventKind: 'tool_failed',
+                groupCount: 1,
+                model: 'gpt-test'
+            }]
+        });
+
+        expect(html).toContain('Tool call failed: fetch_concept');
+        expect(html).toContain('data-thinking-diagnostic-key="activity::7::tool_failed::tool_execute"');
+        expect(html).toContain('Sequence');
+        expect(html).toContain('Timeout while fetching');
     });
 });
 

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -6728,7 +6728,7 @@ footer {
 }
 
 .thinking-card-wrapper.has-tools.is-expanded .thinking-card-body {
-    max-height: 180px;
+    max-height: 360px;
     opacity: 1;
     padding: 10px 14px;
     overflow-y: auto;
@@ -6751,6 +6751,27 @@ footer {
 
 .thinking-card-tool:not(:last-child) {
     border-bottom: 1px solid #f1f5f9;
+}
+
+.thinking-card-diagnostic-row {
+    border-bottom: 1px solid #f1f5f9;
+}
+
+.thinking-card-diagnostic-row:last-child {
+    border-bottom: none;
+}
+
+.thinking-card-diagnostic-row>summary {
+    list-style: none;
+    cursor: pointer;
+}
+
+.thinking-card-diagnostic-row>summary.thinking-card-tool:not(:last-child) {
+    border-bottom: none;
+}
+
+.thinking-card-diagnostic-row>summary::-webkit-details-marker {
+    display: none;
 }
 
 .thinking-card-tool-status {
@@ -6791,6 +6812,95 @@ footer {
 .thinking-card-tool-result::before {
     content: '→ ';
     opacity: 0.5;
+}
+
+.thinking-card-diagnostic-toggle-indicator {
+    margin-left: auto;
+    color: #94a3b8;
+    transition: transform 0.16s ease, color 0.16s ease;
+}
+
+.thinking-card-diagnostic-row[open] .thinking-card-diagnostic-toggle-indicator {
+    transform: rotate(90deg);
+    color: #64748b;
+}
+
+.thinking-card-diagnostic-panel {
+    margin: 0 0 8px 20px;
+    padding: 10px 12px;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    background: #f8fafc;
+}
+
+.thinking-card-diagnostic-facts {
+    display: grid;
+    grid-template-columns: minmax(0, 140px) minmax(0, 1fr);
+    gap: 6px 10px;
+    margin: 0;
+}
+
+.thinking-card-diagnostic-fact {
+    display: contents;
+}
+
+.thinking-card-diagnostic-fact dt {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #475569;
+}
+
+.thinking-card-diagnostic-fact dd {
+    margin: 0;
+    color: #1f2937;
+    word-break: break-word;
+}
+
+.thinking-card-diagnostic-inline-code {
+    font-family: Consolas, "Courier New", monospace;
+    font-size: 0.72rem;
+    white-space: pre-wrap;
+    background: #eff6ff;
+    border: 1px solid #bfdbfe;
+    border-radius: 6px;
+    padding: 1px 6px;
+}
+
+.thinking-card-diagnostic-section {
+    margin-top: 10px;
+}
+
+.thinking-card-diagnostic-section-title {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #64748b;
+    margin-bottom: 6px;
+}
+
+.thinking-card-diagnostic-list,
+.thinking-card-diagnostic-candidates {
+    margin: 0;
+    padding-left: 18px;
+    display: grid;
+    gap: 6px;
+}
+
+.thinking-card-diagnostic-candidate {
+    padding: 2px 0;
+}
+
+.thinking-card-diagnostic-candidate-name {
+    font-weight: 600;
+    color: #1e40af;
+}
+
+.thinking-card-diagnostic-candidate-meta,
+.thinking-card-diagnostic-candidate-text {
+    font-size: 0.72rem;
+    color: #64748b;
+    margin-top: 2px;
 }
 
 .thinking-card-activity.is-low-level .thinking-card-tool-name {
@@ -6860,6 +6970,14 @@ footer {
 
     .thinking-card-meta {
         margin-left: 0;
+    }
+
+    .thinking-card-diagnostic-panel {
+        margin-left: 0;
+    }
+
+    .thinking-card-diagnostic-facts {
+        grid-template-columns: 1fr;
     }
 }
 

--- a/tests/backend/test_tool_progress_liveness.py
+++ b/tests/backend/test_tool_progress_liveness.py
@@ -253,9 +253,12 @@ def test_workflow_discovery_progress_payload_preserves_explicit_no_match_state()
     payload = von_routes._normalise_workflow_discovery_progress_payload(
         None,
         query="find a workflow for this task",
+        namespace="#V#test_user",
     )
 
     assert payload["query"] == "find a workflow for this task"
+    assert payload["requested_query"] == "find a workflow for this task"
+    assert payload["namespace"] == "#V#test_user"
     assert payload["matches"] == []
     assert payload["routing_matches"] == []
     assert payload["candidates"] == []
@@ -453,6 +456,16 @@ def test_turn_execution_diagnostics_rebuilds_phase_and_tool_history(monkeypatch)
     ]
     assert workflow_stage_path.get("has_unmapped_runtime_stages") is False
 
+    stage_diagnostics = diagnostics.get("stage_diagnostics")
+    assert isinstance(stage_diagnostics, list)
+    assert [entry.get("stage_id") for entry in stage_diagnostics] == [
+        "workflow_discovery",
+        "tool_execute",
+    ]
+    tool_stage_diagnostics = stage_diagnostics[-1]
+    assert tool_stage_diagnostics.get("tool_history")
+    assert tool_stage_diagnostics.get("event_count") == 3
+
     timing = diagnostics.get("timing_breakdown")
     assert isinstance(timing, dict)
     assert timing.get("schema_version") == "conversation_turn_timing_breakdown.v1"
@@ -513,6 +526,9 @@ def test_turn_execution_diagnostics_stage_path_fallback_for_unknown_phase(
     assert len(path) == 1
     assert path[0].get("mapping_status") == "fallback_unmapped_runtime_stage"
     assert path[0].get("runtime_stage_normalised") == "new_stage_not_in_catalogue"
+    stage_diagnostics = diagnostics.get("stage_diagnostics")
+    assert isinstance(stage_diagnostics, list)
+    assert stage_diagnostics[0].get("stage_id") == "new_stage_not_in_catalogue"
 
 
 def test_latest_turn_completion_gate_uses_latest_entry() -> None:

--- a/tests/backend/test_workflow_discovery_service.py
+++ b/tests/backend/test_workflow_discovery_service.py
@@ -112,17 +112,25 @@ class TestWorkflowDiscoveryResult:
             matches=matches,
             search_time_ms=123.456,
             query="test query",
+            requested_query="requested test query",
             threshold=0.7,
             errors=["minor warning"],
+            search_sources=["semantic", "vontology"],
+            keyword_fallback_queries=["workflow fallback"],
+            allow_non_executable=True,
         )
         output = result.to_dict()
 
         assert len(output["matches"]) == 2
         assert output["search_time_ms"] == 123.46  # Rounded to 2 decimal places
         assert output["query"] == "test query"
+        assert output["requested_query"] == "requested test query"
         assert output["threshold"] == 0.7
         assert output["match_count"] == 2
         assert output["candidate_count"] == 2
+        assert output["search_sources"] == ["semantic", "vontology"]
+        assert output["keyword_fallback_queries"] == ["workflow fallback"]
+        assert output["allow_non_executable"] is True
         assert output["errors"] == ["minor warning"]
 
     def test_to_dict_errors_none_when_empty(self) -> None:
@@ -485,6 +493,7 @@ class TestDiscoverWorkflowsForTurn:
         assert result is not None
         assert result["match_count"] == 1
         assert len(result["matches"]) == 1
+        assert result["requested_query"] == "test query input"
 
     @patch("src.backend.services.workflow_discovery_service._enrich_workflow_matches")
     @patch("src.backend.services.workflow_discovery_service._search_workflows_name_fallback")

--- a/tests/frontend/chatTabLlmDebugWorkflowExecution.test.js
+++ b/tests/frontend/chatTabLlmDebugWorkflowExecution.test.js
@@ -91,7 +91,13 @@ describe('LLM debug popup workflow execution hook', () => {
                 latest_progress: { status: 'completed' },
                 progress_events: [],
                 phase_history: [],
-                tool_history: []
+                tool_history: [],
+                stage_diagnostics: [
+                    {
+                        stage_id: 'workflow_discovery',
+                        event_count: 1
+                    }
+                ]
             }
         });
 
@@ -104,6 +110,12 @@ describe('LLM debug popup workflow execution hook', () => {
         expect(payload.request_id).toBe('req-456');
         expect(payload.prompt_preview).toBe('hello');
         expect(payload.workflow_discovery).toEqual({ matches: [{ concept_id: '#V#demo' }] });
+        expect(payload.stage_diagnostics).toEqual([
+            expect.objectContaining({
+                stage_id: 'workflow_discovery',
+                event_count: 1
+            })
+        ]);
         expect(payload.model).toBeUndefined();
         expect(payload.messages).toBeUndefined();
     });


### PR DESCRIPTION
## Summary
- make progress-card stage, activity, and tool rows expandable with preserved open state during live polling
- expose workflow-discovery search trace metadata so no-match rows show the exact search query, sources, fallback queries, and candidate rejection reasons
- include stage diagnostics in exported turn diagnostics and add regression coverage for the new diagnostics surfaces

## Verification
- npm test -- --runInBand src/frontend/web/von_interface/static/js/test/chatTab.test.js tests/frontend/chatTabLlmDebugWorkflowExecution.test.js tests/frontend/chatTabDiagnosticExportShortcut.test.js
- pdm run pytest tests/backend/test_tool_progress_liveness.py tests/backend/test_workflow_discovery_service.py
- npx pyright src/backend/server/routes/von_routes.py src/backend/services/workflow_discovery_service.py