### PR TITLE
JVNAUTOSCI-1392 unify execution cap handling

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -1004,6 +1004,22 @@ class InternalMCPChatOrchestrator:
             ),
         }
 
+    def _resolve_environment_max_tool_invocations(self, env: Any) -> int:
+        """Resolve the per-turn tool cap without reviving retired fallback values.
+
+        A configured ``0`` must remain ``0`` so callers can intentionally disable
+        tool execution. Falling back with ``or 8`` reintroduced the legacy cap and
+        made the runtime disagree with Settings/JVNAUTOSCI-1392 diagnostics.
+        """
+
+        raw_value = getattr(env, "max_tool_invocations", None)
+        if raw_value is None:
+            return int(self._max_tool_invocations)
+        try:
+            return max(0, min(50, int(raw_value)))
+        except Exception:
+            return int(self._max_tool_invocations)
+
     def set_progress_callback(
         self, callback: Callable[[Mapping[str, Any]], None] | None
     ) -> None:
@@ -4085,7 +4101,7 @@ class InternalMCPChatOrchestrator:
         conversation_session_id = data.get("conversation_session_id")
         emit_progress = data.get("emit_progress")
         check_cancellation = data.get("check_cancellation")
-        max_tool_invocations = env.max_tool_invocations or 8
+        max_tool_invocations = self._resolve_environment_max_tool_invocations(env)
         batch_cap = max(1, int(getattr(self, "_tool_batch_cap", 4)))
         aux_llm_calls = data.get("aux_llm_calls")
         continuation_context_reused = bool(data.get("write_intent_context_reused", False))
@@ -4520,7 +4536,7 @@ class InternalMCPChatOrchestrator:
         aux_llm_calls = data["aux_llm_calls"]
         llm_calls = data["llm_calls"]
         iteration_count = data.get("iteration_count", 0)
-        max_tool_invocations = env.max_tool_invocations or 8
+        max_tool_invocations = self._resolve_environment_max_tool_invocations(env)
         missing_tool_call_retry_attempts = self._coerce_non_negative_int(
             data.get("missing_tool_call_retry_attempts"),
             default=0,
@@ -5456,20 +5472,10 @@ class InternalMCPChatOrchestrator:
             terminal_outcome = repeat_stop_reason
         elif requires_follow_up:
             terminal_outcome = "follow_up_required"
-        escalation_signal = bool(requires_follow_up and not repeat_iteration and repeat_stop_reason)
+        escalation_signal = bool(
+            requires_follow_up and not repeat_iteration and repeat_stop_reason
+        )
         escalation_reason = repeat_stop_reason if escalation_signal else None
-        if escalation_signal:
-            escalation_line = (
-                f"Escalation trigger: {repeat_stop_reason}. "
-                f"Loop attempts {loop_attempts}/{loop_max_attempts}; "
-                f"loop elapsed {loop_elapsed_ms}ms/{loop_max_elapsed_ms}ms; "
-                f"stall elapsed {loop_stall_elapsed_ms}ms/{loop_stall_max_elapsed_ms}ms."
-            )
-            if isinstance(final_response, str) and final_response.strip():
-                if "Escalation trigger:" not in final_response:
-                    final_response = f"{final_response.rstrip()}\n\n{escalation_line}"
-            else:
-                final_response = escalation_line
 
         completion_gate_evidence_payload: dict[str, Any] = dict(record_evidence_payload)
         completion_gate_evidence_payload.update(
@@ -6441,7 +6447,6 @@ class InternalMCPChatOrchestrator:
                 "- DO NOT output JSON as an example or description - only output JSON when you want to invoke a tool NOW\n"
                 "- DO NOT say 'I will call' or 'Let me call' - just call it\n"
                 "- You MAY batch multiple tool calls in ONE message as a JSON array (keep it to <= {batch_cap} calls)\n"
-                "- Server limits: max tool invocations per turn = {max_tool_invocations}; tool calls per batch = {batch_cap}\n"
                 "- After you receive the tool result (role 'tool'), respond naturally to the user\n\n"
                 "VONTOLOGY KINDS & PREDICATES (MUST FOLLOW):\n"
                 "- Predicates are a distinct logical kind. A usable predicate MUST satisfy: is_an_instance_of #V#predicate (or a predicate subtype).\n"
@@ -6480,6 +6485,14 @@ class InternalMCPChatOrchestrator:
         base_message = self._inject_prompt_variable(
             base_message, key="listing", value=listing
         )
+        if "INTERNAL EXECUTION GUARDRAILS:" not in base_message:
+            base_message = (
+                f"{base_message.rstrip()}\n\n"
+                "INTERNAL EXECUTION GUARDRAILS:\n"
+                "- Treat tool-invocation and batch caps as internal loop-safety guardrails, not as a user-facing reason to stop.\n"
+                "- Do NOT mention budgets, caps, or internal limits unless the user explicitly asks for diagnostics.\n"
+                "- If work remains unresolved, explain the concrete blocker or next best action instead of citing internal caps.\n"
+            )
 
         self._last_base_system_prompt_telemetry = {
             "type": "base_system_prompt",

--- a/src/backend/integrations/internal_mcp/tool_contract_registry.py
+++ b/src/backend/integrations/internal_mcp/tool_contract_registry.py
@@ -479,7 +479,7 @@ def _supplemental_surface_only_contracts() -> dict[str, CanonicalMCPToolContract
                     },
                     "max_tool_invocations": {
                         "type": "integer",
-                        "default": 8,
+                        "default": 30,
                         "description": "Maximum number of tool calls in one run",
                     },
                     "dry_run": {

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -98,6 +98,10 @@ from src.backend.services.settings_service import (
     resolve_llm_setting,
     get_preferred_language,
     get_setting,
+    INTERNAL_MCP_MAX_TOOL_INVOCATIONS_DEFAULT,
+    INTERNAL_MCP_MAX_TOOL_INVOCATIONS_MAX,
+    INTERNAL_MCP_MAX_TOOL_INVOCATIONS_MIN,
+    INTERNAL_MCP_TOOL_BATCH_CAP_DEFAULT,
 )
 from src.backend.integrations.internal_mcp.catalogue import _add_relationship
 from src.backend.integrations.internal_mcp.catalogue import _jira_add_comment
@@ -730,10 +734,17 @@ async def _handle_von_chat_run(arguments: dict[str, Any]) -> list[TextContent]:
     )
 
     try:
-        max_tool_invocations = int(arguments.get("max_tool_invocations", 8))
+        max_tool_invocations = int(
+            arguments.get(
+                "max_tool_invocations", INTERNAL_MCP_MAX_TOOL_INVOCATIONS_DEFAULT
+            )
+        )
     except Exception:
-        max_tool_invocations = 8
-    max_tool_invocations = max(0, min(16, max_tool_invocations))
+        max_tool_invocations = INTERNAL_MCP_MAX_TOOL_INVOCATIONS_DEFAULT
+    max_tool_invocations = max(
+        INTERNAL_MCP_MAX_TOOL_INVOCATIONS_MIN,
+        min(INTERNAL_MCP_MAX_TOOL_INVOCATIONS_MAX, max_tool_invocations),
+    )
 
     dry_run = bool(arguments.get("dry_run", True))
     allow_writes = bool(arguments.get("allow_writes", False))
@@ -796,6 +807,7 @@ async def _handle_von_chat_run(arguments: dict[str, Any]) -> list[TextContent]:
         gateway=gateway,  # type: ignore[arg-type]
         logger=_LOG.getChild("von_chat_run"),
         max_tool_invocations=max_tool_invocations,
+        tool_batch_cap=INTERNAL_MCP_TOOL_BATCH_CAP_DEFAULT,
         default_gmail_profile=None,
         max_context_chars=max_context_chars,
         max_tool_result_chars=max_tool_result_chars,

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -2477,7 +2477,7 @@
                     },
                     "max_tool_invocations": {
                         "type": "integer",
-                        "default": 8,
+                        "default": 30,
                         "description": "Maximum number of tool calls in one run"
                     },
                     "dry_run": {

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -2077,8 +2077,25 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
             else:
                 merged.pop("error", None)
         else:
-            # Avoid stale-provider error leakage into later unrelated progress events.
+            # Avoid stale failure metadata leaking into later unrelated progress
+            # events after a subsequent success or neutral heartbeat.
             merged.pop("error", None)
+        if "error_class" in safe_update:
+            error_class = _progress_str(safe_update.get("error_class"))
+            if error_class:
+                merged["error_class"] = error_class
+            else:
+                merged.pop("error_class", None)
+        else:
+            merged.pop("error_class", None)
+        if "failure_kind" in safe_update:
+            failure_kind = _progress_str(safe_update.get("failure_kind"))
+            if failure_kind:
+                merged["failure_kind"] = failure_kind
+            else:
+                merged.pop("failure_kind", None)
+        else:
+            merged.pop("failure_kind", None)
         merged["request_id"] = request_id
         merged["status"] = status
         merged["stage"] = stage
@@ -2705,7 +2722,7 @@ def _derive_llm_debug_warnings(debug_info: dict) -> list[str]:
         )
         if looks_like_tool_call:
             warnings.append(
-                f"Reached max tool invocation limit ({max_invocations}); additional tool calls were not executed."
+                f"Configured tool-invocation cap ({max_invocations}) was reached; later tool-shaped output was not executed."
             )
 
     # Check presenter channel health (screen/spoken routes)

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -72,6 +72,10 @@ from ..services.mongo_startup_config import (
     run_mongo_startup_probe,
     validate_mongo_startup_or_raise,
 )
+from ..services.settings_service import (
+    get_internal_mcp_max_tool_invocations,
+    get_internal_mcp_tool_batch_cap,
+)
 
 # Define a version string
 APP_VERSION = "v20250421_1015_backend"  # Updated version
@@ -679,10 +683,21 @@ def create_flask_app(
                 "started_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
             }
             try:
+                try:
+                    bootstrap_max_tool_invocations = (
+                        get_internal_mcp_max_tool_invocations()
+                    )
+                except Exception:
+                    bootstrap_max_tool_invocations = 30
+                try:
+                    bootstrap_tool_batch_cap = get_internal_mcp_tool_batch_cap()
+                except Exception:
+                    bootstrap_tool_batch_cap = 10
                 orchestrator_instance = InternalMCPChatOrchestrator(
                     gateway=gateway_instance,
                     logger=orchestrator_logger,
-                    max_tool_invocations=8,  # JVNAUTOSCI-699: Allow complex chained workflows
+                    max_tool_invocations=bootstrap_max_tool_invocations,
+                    tool_batch_cap=bootstrap_tool_batch_cap,
                     default_gmail_profile=os.getenv("VON_GMAIL_DEFAULT_PROFILE") or None,
                 )
                 duration_ms = int((time.perf_counter() - start_perf) * 1000)

--- a/src/backend/services/settings_service.py
+++ b/src/backend/services/settings_service.py
@@ -42,6 +42,14 @@ AUTO_PROCEED_MINIMAL_IMPOSITION_ENABLED_SETTING_NAME = (
 # Internal MCP orchestrator caps (Settings → Agent Configuration)
 INTERNAL_MCP_MAX_TOOL_INVOCATIONS_SETTING_NAME = "internal_mcp_max_tool_invocations"
 INTERNAL_MCP_TOOL_BATCH_CAP_SETTING_NAME = "internal_mcp_tool_batch_cap"
+# Canonical cap defaults/clamps must stay aligned across getters, settings batch,
+# runtime bootstrap, and MCP surfaces so users do not see contradictory budgets.
+INTERNAL_MCP_MAX_TOOL_INVOCATIONS_DEFAULT = 30
+INTERNAL_MCP_MAX_TOOL_INVOCATIONS_MIN = 0
+INTERNAL_MCP_MAX_TOOL_INVOCATIONS_MAX = 50
+INTERNAL_MCP_TOOL_BATCH_CAP_DEFAULT = 10
+INTERNAL_MCP_TOOL_BATCH_CAP_MIN = 1
+INTERNAL_MCP_TOOL_BATCH_CAP_MAX = 50
 
 # Chat UI: show tool use during the “Thinking…” indicator (JVNAUTOSCI-942)
 SHOW_TOOL_USE_DURING_THINKING_SETTING_NAME = "show_tool_use_during_thinking"
@@ -209,10 +217,12 @@ def get_all_settings_batch() -> Dict[str, Any]:
             default=True,
         ),
         "internal_mcp_max_tool_invocations": _coerce_int(
-            raw.get(INTERNAL_MCP_MAX_TOOL_INVOCATIONS_SETTING_NAME), default=8
+            raw.get(INTERNAL_MCP_MAX_TOOL_INVOCATIONS_SETTING_NAME),
+            default=INTERNAL_MCP_MAX_TOOL_INVOCATIONS_DEFAULT,
         ),
         "internal_mcp_tool_batch_cap": _coerce_int(
-            raw.get(INTERNAL_MCP_TOOL_BATCH_CAP_SETTING_NAME), default=3
+            raw.get(INTERNAL_MCP_TOOL_BATCH_CAP_SETTING_NAME),
+            default=INTERNAL_MCP_TOOL_BATCH_CAP_DEFAULT,
         ),
         "disable_write_tool_conservatism": _coerce_bool(
             raw.get(DISABLE_WRITE_TOOL_CONSERVATISM_SETTING_NAME), default=False
@@ -1030,13 +1040,23 @@ def get_internal_mcp_max_tool_invocations() -> int:
     """
 
     val = get_setting(INTERNAL_MCP_MAX_TOOL_INVOCATIONS_SETTING_NAME)
-    return _coerce_int_setting(val, default=30, min_value=0, max_value=50)
+    return _coerce_int_setting(
+        val,
+        default=INTERNAL_MCP_MAX_TOOL_INVOCATIONS_DEFAULT,
+        min_value=INTERNAL_MCP_MAX_TOOL_INVOCATIONS_MIN,
+        max_value=INTERNAL_MCP_MAX_TOOL_INVOCATIONS_MAX,
+    )
 
 
 def set_internal_mcp_max_tool_invocations(value: Any) -> bool:
     """Persist the max internal MCP tool invocations (canonical int, clamped)."""
 
-    coerced = _coerce_int_setting(value, default=30, min_value=0, max_value=50)
+    coerced = _coerce_int_setting(
+        value,
+        default=INTERNAL_MCP_MAX_TOOL_INVOCATIONS_DEFAULT,
+        min_value=INTERNAL_MCP_MAX_TOOL_INVOCATIONS_MIN,
+        max_value=INTERNAL_MCP_MAX_TOOL_INVOCATIONS_MAX,
+    )
     return update_setting(INTERNAL_MCP_MAX_TOOL_INVOCATIONS_SETTING_NAME, coerced)
 
 
@@ -1048,13 +1068,23 @@ def get_internal_mcp_tool_batch_cap() -> int:
     """
 
     val = get_setting(INTERNAL_MCP_TOOL_BATCH_CAP_SETTING_NAME)
-    return _coerce_int_setting(val, default=10, min_value=1, max_value=50)
+    return _coerce_int_setting(
+        val,
+        default=INTERNAL_MCP_TOOL_BATCH_CAP_DEFAULT,
+        min_value=INTERNAL_MCP_TOOL_BATCH_CAP_MIN,
+        max_value=INTERNAL_MCP_TOOL_BATCH_CAP_MAX,
+    )
 
 
 def set_internal_mcp_tool_batch_cap(value: Any) -> bool:
     """Persist the tool-call batch cap (canonical int, clamped)."""
 
-    coerced = _coerce_int_setting(value, default=10, min_value=1, max_value=50)
+    coerced = _coerce_int_setting(
+        value,
+        default=INTERNAL_MCP_TOOL_BATCH_CAP_DEFAULT,
+        min_value=INTERNAL_MCP_TOOL_BATCH_CAP_MIN,
+        max_value=INTERNAL_MCP_TOOL_BATCH_CAP_MAX,
+    )
     return update_setting(INTERNAL_MCP_TOOL_BATCH_CAP_SETTING_NAME, coerced)
 
 

--- a/src/backend/workflows/durable/workflow_gap_recovery_workflow.py
+++ b/src/backend/workflows/durable/workflow_gap_recovery_workflow.py
@@ -19,6 +19,9 @@ from ...services.concept_service import (
     get_concept_by_concept_id,
 )
 from ...services.prompt_template_service import PromptTemplateService
+from ...services.settings_service import (
+    INTERNAL_MCP_MAX_TOOL_INVOCATIONS_DEFAULT,
+)
 from ...services.text_value_service import upsert_singleton_text_relation
 from ...services.workflow_gap_vontology_service import (
     render_workflow_gap_analysis_prompt,
@@ -902,9 +905,18 @@ def _handle_execute_candidate(request: WorkflowActionRequest) -> WorkflowActionR
     from ...integrations.internal_mcp.orchestrator import InternalMCPChatOrchestrator
 
     dry_run = _coerce_bool(inputs.get("workflow_gap_dry_run"))
-    max_tool_invocations = (
-        0 if dry_run else int(request.environment.max_tool_invocations or 8)
-    )
+    if dry_run:
+        max_tool_invocations = 0
+    else:
+        raw_max_tool_invocations = request.environment.max_tool_invocations
+        try:
+            max_tool_invocations = (
+                INTERNAL_MCP_MAX_TOOL_INVOCATIONS_DEFAULT
+                if raw_max_tool_invocations is None
+                else int(raw_max_tool_invocations)
+            )
+        except Exception:
+            max_tool_invocations = INTERNAL_MCP_MAX_TOOL_INVOCATIONS_DEFAULT
     orchestrator = InternalMCPChatOrchestrator(
         gateway=gateway,
         max_tool_invocations=max_tool_invocations,

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -10978,7 +10978,7 @@ function deriveLlmDebugWarnings(debugData) {
             && trimmed.includes('"tool"');
         if (looksLikeToolCall) {
             warnings.push(
-                `Reached max tool invocation limit (${maxToolInvocations}); additional tool calls were not executed.`
+                `Configured tool-invocation cap (${maxToolInvocations}) was reached; later tool-shaped output was not executed.`
             );
         }
     }

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -2775,7 +2775,7 @@ describe('LLM debug warnings (presenter channel health)', () => {
         });
 
         expect(warnings).toContain(
-            'Reached max tool invocation limit (2); additional tool calls were not executed.'
+            'Configured tool-invocation cap (2) was reached; later tool-shaped output was not executed.'
         );
     });
 });

--- a/src/frontend/web/von_interface/templates/settings_tab.html
+++ b/src/frontend/web/von_interface/templates/settings_tab.html
@@ -445,7 +445,7 @@
                     tool use during thinking</label>
             </div>
             <small id="showToolUseDuringThinkingHelp" class="settings-note">Default: enabled. Shows last tool name,
-                batch size, and remaining tool-call budget.</small>
+                batch size, and current tool-call progress.</small>
 
             <div class="inline-form inline-form-tight mt-2">
                 <input type="checkbox" id="buttonifyModelEnabledToggle" aria-describedby="buttonifyModelEnabledHelp" />

--- a/tests/backend/test_internal_mcp_cap_settings.py
+++ b/tests/backend/test_internal_mcp_cap_settings.py
@@ -60,6 +60,21 @@ def test_get_internal_mcp_tool_batch_cap_clamps(raw: Any, expected: int, monkeyp
     assert settings_service.get_internal_mcp_tool_batch_cap() == expected
 
 
+def test_get_all_settings_batch_uses_canonical_internal_mcp_defaults(monkeypatch):
+    monkeypatch.setattr(settings_service, "get_settings_batch", lambda _names: {})
+
+    result = settings_service.get_all_settings_batch()
+
+    assert (
+        result["internal_mcp_max_tool_invocations"]
+        == settings_service.INTERNAL_MCP_MAX_TOOL_INVOCATIONS_DEFAULT
+    )
+    assert (
+        result["internal_mcp_tool_batch_cap"]
+        == settings_service.INTERNAL_MCP_TOOL_BATCH_CAP_DEFAULT
+    )
+
+
 def test_set_internal_mcp_max_tool_invocations_persists_clamped_value(monkeypatch):
     captured = {}
 

--- a/tests/backend/test_internal_mcp_orchestrator_preflight.py
+++ b/tests/backend/test_internal_mcp_orchestrator_preflight.py
@@ -37,6 +37,28 @@ class _CapturingLLM:
         return "ok"
 
 
+def test_instruction_message_uses_internal_guardrail_wording_without_budget_leak(
+    monkeypatch,
+):
+    orchestrator = object.__new__(InternalMCPChatOrchestrator)
+    orchestrator._gateway = cast(Any, _CapturingGateway())
+    orchestrator._max_tool_invocations = 30
+    orchestrator._tool_batch_cap = 10
+    orchestrator._last_base_system_prompt_telemetry = None
+
+    monkeypatch.setattr(
+        orchestrator,
+        "_load_base_system_prompt_from_vontology",
+        lambda preferred_language=None: (None, None),
+    )
+
+    instruction = orchestrator._instruction_message(preferred_language="en")
+
+    assert "Server limits:" not in instruction
+    assert "INTERNAL EXECUTION GUARDRAILS:" in instruction
+    assert "Do NOT mention budgets, caps, or internal limits" in instruction
+
+
 def test_orchestrator_injects_deterministic_preflight_context(monkeypatch):
     def _fake_search_concepts(
         *, query="", instance_of=None, filter_kind=None, **_kwargs

--- a/tests/backend/test_orchestrator_turn_execution_gate.py
+++ b/tests/backend/test_orchestrator_turn_execution_gate.py
@@ -764,7 +764,9 @@ def test_turn_completion_gate_stops_repeat_when_stall_latency_budget_exhausted()
     assert int(result.outputs.get("completion_gate_loop_stall_elapsed_ms") or 0) >= 500
     final_response = result.outputs.get("final_response")
     assert isinstance(final_response, str)
-    assert "Escalation trigger: stall_latency_budget_exhausted." in final_response
+    assert "Execution status:" in final_response
+    assert "Escalation trigger:" not in final_response
+    assert "stall_latency_budget_exhausted" not in final_response
     evidence_payload = result.outputs.get("completion_gate_evidence_payload")
     assert isinstance(evidence_payload, dict)
     assert evidence_payload.get("terminal_outcome") == "stall_latency_budget_exhausted"

--- a/tests/backend/test_tool_progress_liveness.py
+++ b/tests/backend/test_tool_progress_liveness.py
@@ -292,6 +292,7 @@ def test_progress_clears_stale_error_on_subsequent_success(monkeypatch) -> None:
             "success": False,
             "error": "Ollama unexpected error: failed to connect",
             "error_class": "RuntimeError",
+            "failure_kind": "provider_unreachable",
         },
     )
     clock["now"] += 0.2
@@ -310,11 +311,17 @@ def test_progress_clears_stale_error_on_subsequent_success(monkeypatch) -> None:
     state = von_routes._get_tool_progress("scope-stale", "req-stale")
     assert state is not None
     assert "error" not in state
+    assert "error_class" not in state
+    assert "failure_kind" not in state
 
     events = state.get("diagnostic_events")
     assert isinstance(events, list)
     assert events[0].get("error") == "Ollama unexpected error: failed to connect"
+    assert events[0].get("error_class") == "RuntimeError"
+    assert events[0].get("failure_kind") == "provider_unreachable"
     assert "error" not in events[-1]
+    assert "error_class" not in events[-1]
+    assert "failure_kind" not in events[-1]
 
 
 def test_progress_clears_stale_success_on_error(monkeypatch) -> None:

--- a/tests/backend/test_workflow_gap_recovery_workflow.py
+++ b/tests/backend/test_workflow_gap_recovery_workflow.py
@@ -166,9 +166,73 @@ def test_execute_candidate_disables_recursive_gap_recovery(monkeypatch) -> None:
     assert result.status == "success"
     assert result.outputs["response_text"] == "Retried response."
     assert captured["max_tool_invocations"] == 0
-    run_kwargs = captured["run_kwargs"]
+    run_kwargs = cast(dict[str, Any], captured["run_kwargs"])
     assert run_kwargs["workflow_gap_recovery_enabled"] is False
     assert run_kwargs["prompt"] == "Please recover this workflow gap."
+
+
+def test_execute_candidate_uses_canonical_cap_default_when_env_cap_missing(
+    monkeypatch,
+) -> None:
+    import src.backend.workflows.durable.workflow_gap_recovery_workflow as mod
+
+    captured: dict[str, object] = {}
+
+    class _FakePromptService:
+        def __init__(self, *, default_max_chars: int = 0) -> None:
+            self.default_max_chars = default_max_chars
+
+        def render_prompt(self, *_args, **_kwargs):
+            return SimpleNamespace(text="Candidate prompt")
+
+    class _FakeOrchestrator:
+        def __init__(
+            self,
+            *,
+            gateway,
+            max_tool_invocations,
+            default_gmail_profile=None,
+        ) -> None:
+            captured["max_tool_invocations"] = max_tool_invocations
+
+        def run(self, **kwargs):
+            return OrchestratorResult(
+                response_text="Retried response.",
+                extra_messages=(),
+                tool_invocations=(),
+                aux_llm_calls=(),
+                llm_calls=(),
+            )
+
+    monkeypatch.setattr(mod, "PromptTemplateService", _FakePromptService)
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.orchestrator.InternalMCPChatOrchestrator",
+        _FakeOrchestrator,
+    )
+
+    registry = ActionRegistry()
+    register_workflow_gap_recovery_actions(registry)
+    result = registry.execute(
+        WORKFLOW_GAP_EXECUTE_CANDIDATE_ACTION_ID,
+        inputs={
+            "prompt_concept_id": "#V#candidate_gap_prompt",
+            "workflow_gap_dry_run": False,
+            "prompt": "Please recover this workflow gap.",
+        },
+        context={},
+        env=WorkflowEnvironment(
+            llm_client=object(),
+            gateway=SimpleNamespace(enabled=True),
+            model="gpt-5.2-chat-latest",
+            max_tool_invocations=None,
+        ),
+    )
+
+    assert result.status == "success"
+    assert (
+        captured["max_tool_invocations"]
+        == mod.INTERNAL_MCP_MAX_TOOL_INVOCATIONS_DEFAULT
+    )
 
 
 def test_workflow_gap_recovery_workflows_publish_authoritatively(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- make internal MCP execution cap defaults authoritative across settings, bootstrap, MCP surfaces, and workflow-gap recovery
- stop leaking raw budget exhaustion reasons into user-facing responses while keeping structured telemetry intact
- clear stale progress failure metadata and reword debug/UI cap messaging so caps stay diagnostic rather than explanatory

## Verification
- `python -m pytest tests/backend/test_internal_mcp_cap_settings.py::test_get_all_settings_batch_uses_canonical_internal_mcp_defaults tests/backend/test_internal_mcp_orchestrator_preflight.py::test_instruction_message_uses_internal_guardrail_wording_without_budget_leak tests/backend/test_orchestrator_turn_execution_gate.py::test_turn_completion_gate_stops_repeat_when_stall_latency_budget_exhausted tests/backend/test_tool_progress_liveness.py::test_progress_clears_stale_error_on_subsequent_success tests/backend/test_workflow_gap_recovery_workflow.py::test_execute_candidate_uses_canonical_cap_default_when_env_cap_missing -q -s`
- `npx jest src/frontend/web/von_interface/static/js/test/chatTab.test.js -t "flags when max tool invocation cap is hit but response still looks tool-shaped" --runInBand`
- `npx pyright <all changed Python files>`