### PR TITLE
JVNAUTOSCI-1358: implement VWL prompt metadata contracts

### DIFF
--- a/docs/engineering/jira_github_autofix_loop_workflow.md
+++ b/docs/engineering/jira_github_autofix_loop_workflow.md
@@ -262,18 +262,17 @@ Executable today with existing surfaces:
 - declarative per-step approval gating,
 - declarative retry/backoff policy execution,
 - declarative per-step idempotency reuse,
+- prompt and tool metadata resolution from workflow-authored prompt concepts,
 - durable workflow instance management,
 - high-level run summary persistence.
 
 Not cleanly expressible yet without follow-on VWL work:
 
 - long-horizon resumable per-issue checkpoints,
-- prompt/tool metadata resolution from workflow-authored prompt metadata,
 - completion gates that prove all declared deliverables were met.
 
 ## Follow-on Mapping
 
-- `JVNAUTOSCI-1358`: prompt and tool metadata resolution for deterministic workflow authoring.
 - `JVNAUTOSCI-1359`: plan-state, resumable checkpoints, and completion gates for long-running runs.
 - `JVNAUTOSCI-1360`: optional future import or execution of external SKILL artefacts against the stabilised VWL surface.
 

--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -90,6 +90,7 @@ Canonical graph families include:
 - `hasInitialStep`, `hasStep`
 - `invokesAction`, `invokesWorkflow`
 - `workflowStepInvokesTool`
+- `workflowStepUsesLlmPrompt`
 - `nextStep`
 - `onTrueNextStep`, `onFalseNextStep`, `onFailureNextStep`, `onUnknownNextStep`
 - `onApprovalRequiredNextStep`
@@ -111,6 +112,8 @@ A VWL program is a workflow concept graph:
 - Per-step invocation target:
   - tool/action (`invokesAction` or `workflow_step_invokes_tool`), or
   - subworkflow (`invokesWorkflow`).
+- Optional per-step prompt contract link:
+  - `workflow_step_uses_llm_prompt` (legacy aliases accepted for compatibility).
 - Per-step control flow links:
   - `next`
   - `on_true`, `on_false`
@@ -786,9 +789,16 @@ Unless explicitly implemented in runtime code, items below are normative plannin
 
 ### 16.5 Prompt Metadata Contract Extensions
 
-For prompt-bearing workflow or prompt concepts, VWL planning SHOULD support metadata fields equivalent to modern prompt-file ecosystems.
+Prompt-bearing workflow steps now support a first-class KB-authored prompt contract. The canonical step-level prompt link is:
 
-Candidate predicate set (planning):
+- `#V#workflow_step_uses_llm_prompt`
+
+Accepted legacy aliases remain:
+
+- `#V#uses_prompt`
+- `#V#hasPromptTemplate`
+
+Prompt or prompt-related concepts MAY declare the following metadata predicates:
 
 - `#V#hasPromptName`
 - `#V#hasPromptDescription`
@@ -801,7 +811,30 @@ Candidate predicate set (planning):
 - `#V#hasPromptSource`
 - `#V#hasToolResolutionPriority`
 
-Conflict handling for prompt metadata SHOULD be deterministic, with documented precedence (for example prompt-level over agent defaults).
+Step-local defaults MAY be supplied through reserved `hasInputMap` entries:
+
+- `__prompt_defaults=<json object>` (or `prompt_defaults=<json object>`)
+- `__prompt_validation_policy=warn|fail` (or `prompt_validation_policy=warn|fail`)
+
+Deterministic merge precedence is:
+
+1. prompt concept metadata,
+2. metadata on the first resolved `#V#usesAgentProfile`,
+3. step-local defaults from `hasInputMap`.
+
+Conflict handling is field-wise rather than union-based. In particular:
+
+- scalar fields use first-non-empty precedence,
+- list-valued fields (`allowed_tools`, `prompt_variables`, `tool_resolution_priority`, `agent_profile_ids`) use the first populated source wholesale,
+- `hasToolResolutionPriority` reorders the selected `allowed_tools` subset without expanding it.
+
+Validation and fail-closed behaviour:
+
+- missing prompt text for a declared prompt is always an error,
+- unavailable tools or agent profiles follow the declared validation policy (`warn` or `fail`),
+- stable merged prompt state is carried in workflow-state metadata as `prompt_contract`,
+- runtime diagnostics are attached to action inputs as `__prompt_resolution_diagnostics`,
+- fail-policy violations reject workflow loading with deterministic `workflow_prompt_contract_invalid` errors.
 
 ### 16.6 External SKILL Interoperability
 

--- a/src/backend/services/prompt_template_service.py
+++ b/src/backend/services/prompt_template_service.py
@@ -14,10 +14,10 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 from src.backend.services.text_value_service import get_texts_for_concept
 
 
-_PREFERRED_PREDICATES: Tuple[str, ...] = (
-    "hasContent",
-    "hasDefinition",
-    "hasDescription",
+_PREFERRED_PREDICATE_ALIASES: Tuple[Tuple[str, ...], ...] = (
+    ("hasContent", "#V#hasContent"),
+    ("hasDefinition", "#V#hasDefinition"),
+    ("hasDescription", "#V#hasDescription"),
 )
 
 
@@ -62,11 +62,11 @@ def _best_effort_text_for_concept(concept_id: str) -> Optional[str]:
     if not isinstance(texts, list):
         return None
 
-    for predicate in _PREFERRED_PREDICATES:
+    for predicate_aliases in _PREFERRED_PREDICATE_ALIASES:
         for item in texts:
             if not isinstance(item, dict):
                 continue
-            if item.get("predicate") != predicate:
+            if item.get("predicate") not in predicate_aliases:
                 continue
             text_value = item.get("text")
             if isinstance(text_value, str) and text_value.strip():

--- a/src/backend/vontology/code_concepts_registry.py
+++ b/src/backend/vontology/code_concepts_registry.py
@@ -101,6 +101,30 @@ _WORKFLOW_PREDICATE_IDS = [
     "#V#has_workflow_step_idempotency_policy_json",
 ]
 
+_WORKFLOW_PROMPT_PREDICATE_IDS = [
+    "#V#workflow_step_uses_llm_prompt",
+    "#V#hasPromptName",
+    "#V#has_prompt_name",
+    "#V#hasPromptDescription",
+    "#V#has_prompt_description",
+    "#V#hasArgumentHint",
+    "#V#has_argument_hint",
+    "#V#usesAgentProfile",
+    "#V#uses_agent_profile",
+    "#V#usesModelPreference",
+    "#V#uses_model_preference",
+    "#V#allowsTool",
+    "#V#allows_tool",
+    "#V#hasPromptScope",
+    "#V#has_prompt_scope",
+    "#V#hasPromptVariables",
+    "#V#has_prompt_variables",
+    "#V#hasPromptSource",
+    "#V#has_prompt_source",
+    "#V#hasToolResolutionPriority",
+    "#V#has_tool_resolution_priority",
+]
+
 _WORKFLOW_BACKGROUND_POLICY_PREDICATE_IDS = [
     "#V#hasBackgroundLaunchPolicyJson",
     "#V#has_background_launch_policy_json",
@@ -184,6 +208,7 @@ _CODE_PREDICATE_IDS = _unique_ids(
         *_TEXT_PREDICATE_IDS,
         *_FILE_METADATA_PREDICATE_IDS,
         *_WORKFLOW_PREDICATE_IDS,
+        *_WORKFLOW_PROMPT_PREDICATE_IDS,
         *_WORKFLOW_BACKGROUND_POLICY_PREDICATE_IDS,
         *_RELATION_META_PREDICATE_IDS,
         *_STRUCTURAL_PREDICATE_IDS,

--- a/src/backend/workflows/prompt_metadata_resolution.py
+++ b/src/backend/workflows/prompt_metadata_resolution.py
@@ -1,0 +1,682 @@
+"""Resolve workflow-authored prompt metadata from Vontology concepts.
+
+The workflow runtime needs a deterministic, auditable way to attach prompt
+configuration to prompt-bearing workflow steps without drifting into bespoke
+Python orchestration. This module resolves:
+
+- which prompt concept is authoritative for a step,
+- prompt metadata declared directly on that prompt concept,
+- agent-profile defaults linked from the prompt,
+- caller-supplied defaults,
+- and warn/fail diagnostics for unavailable tools or agent profiles.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Any, Dict, Iterable, Mapping, Sequence
+
+from ..db.repositories.concepts_repository import ConceptsRepository
+from ..services.prompt_template_service import PromptTemplateService
+from ..services.text_value_service import get_texts_for_concept
+from ..vontology.code_concepts_registry import is_code_concept_id
+
+logger = logging.getLogger(__name__)
+
+PROMPT_VALIDATION_POLICY_WARN = "warn"
+PROMPT_VALIDATION_POLICY_FAIL = "fail"
+PROMPT_VALIDATION_POLICIES: tuple[str, ...] = (
+    PROMPT_VALIDATION_POLICY_WARN,
+    PROMPT_VALIDATION_POLICY_FAIL,
+)
+
+WORKFLOW_STEP_PROMPT_LINK_PREDICATE_ALIASES: tuple[str, ...] = (
+    "#V#workflow_step_uses_llm_prompt",
+    "workflow_step_uses_llm_prompt",
+    "#V#workflowStepUsesLlmPrompt",
+    "workflowStepUsesLlmPrompt",
+    "#V#uses_prompt",
+    "uses_prompt",
+    "#V#hasPromptTemplate",
+    "hasPromptTemplate",
+    "#V#has_prompt_template",
+    "has_prompt_template",
+)
+
+_PROMPT_NAME_PREDICATES: tuple[str, ...] = (
+    "#V#hasPromptName",
+    "hasPromptName",
+    "#V#has_prompt_name",
+    "has_prompt_name",
+    "#V#hasName",
+    "hasName",
+    "has_name",
+)
+_PROMPT_DESCRIPTION_PREDICATES: tuple[str, ...] = (
+    "#V#hasPromptDescription",
+    "hasPromptDescription",
+    "#V#has_prompt_description",
+    "has_prompt_description",
+    "#V#hasDescription",
+    "hasDescription",
+    "has_description",
+)
+_ARGUMENT_HINT_PREDICATES: tuple[str, ...] = (
+    "#V#hasArgumentHint",
+    "hasArgumentHint",
+    "#V#has_argument_hint",
+    "has_argument_hint",
+)
+_AGENT_PROFILE_PREDICATES: tuple[str, ...] = (
+    "#V#usesAgentProfile",
+    "usesAgentProfile",
+    "#V#uses_agent_profile",
+    "uses_agent_profile",
+)
+_MODEL_PREFERENCE_PREDICATES: tuple[str, ...] = (
+    "#V#usesModelPreference",
+    "usesModelPreference",
+    "#V#uses_model_preference",
+    "uses_model_preference",
+    "#V#uses_llm_model",
+    "uses_llm_model",
+)
+_ALLOWED_TOOL_PREDICATES: tuple[str, ...] = (
+    "#V#allowsTool",
+    "allowsTool",
+    "#V#allows_tool",
+    "allows_tool",
+)
+_PROMPT_SCOPE_PREDICATES: tuple[str, ...] = (
+    "#V#hasPromptScope",
+    "hasPromptScope",
+    "#V#has_prompt_scope",
+    "has_prompt_scope",
+)
+_PROMPT_VARIABLES_PREDICATES: tuple[str, ...] = (
+    "#V#hasPromptVariables",
+    "hasPromptVariables",
+    "#V#has_prompt_variables",
+    "has_prompt_variables",
+)
+_PROMPT_SOURCE_PREDICATES: tuple[str, ...] = (
+    "#V#hasPromptSource",
+    "hasPromptSource",
+    "#V#has_prompt_source",
+    "has_prompt_source",
+)
+_TOOL_PRIORITY_PREDICATES: tuple[str, ...] = (
+    "#V#hasToolResolutionPriority",
+    "hasToolResolutionPriority",
+    "#V#has_tool_resolution_priority",
+    "has_tool_resolution_priority",
+)
+
+_PROMPT_METADATA_ALIAS_GROUPS: dict[str, tuple[str, ...]] = {
+    "prompt_name": _PROMPT_NAME_PREDICATES,
+    "prompt_description": _PROMPT_DESCRIPTION_PREDICATES,
+    "argument_hint": _ARGUMENT_HINT_PREDICATES,
+    "agent_profile_ids": _AGENT_PROFILE_PREDICATES,
+    "model_preference": _MODEL_PREFERENCE_PREDICATES,
+    "allowed_tools": _ALLOWED_TOOL_PREDICATES,
+    "prompt_scope": _PROMPT_SCOPE_PREDICATES,
+    "prompt_variables": _PROMPT_VARIABLES_PREDICATES,
+    "prompt_source": _PROMPT_SOURCE_PREDICATES,
+    "tool_resolution_priority": _TOOL_PRIORITY_PREDICATES,
+}
+
+_LIST_METADATA_FIELDS: tuple[str, ...] = (
+    "agent_profile_ids",
+    "allowed_tools",
+    "prompt_variables",
+    "tool_resolution_priority",
+)
+_SCALAR_METADATA_FIELDS: tuple[str, ...] = (
+    "prompt_name",
+    "prompt_description",
+    "argument_hint",
+    "model_preference",
+    "prompt_scope",
+    "prompt_source",
+)
+_PROMPT_VARIABLE_RE = re.compile(r"{([A-Za-z0-9_]+)}")
+
+
+@dataclass(frozen=True)
+class WorkflowPromptResolution:
+    requested_prompt_concept_ids: tuple[str, ...] = ()
+    resolved_prompt_concept_id: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    diagnostics: Mapping[str, Any] = field(default_factory=dict)
+
+
+def _safe_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalise_predicate_key(value: Any) -> str:
+    text = _safe_text(value)
+    if text.lower().startswith("#v#"):
+        text = text[3:]
+    text = re.sub(r"[-\s]+", "_", text)
+    return text.lower()
+
+
+def _ordered_unique_strings(values: Iterable[Any] | Any) -> list[str]:
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, Iterable):
+        return []
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = _safe_text(value)
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        ordered.append(text)
+    return ordered
+
+
+def _is_nonempty_value(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return len(value) > 0
+    return value is not None
+
+
+def _coerce_multi_value_text(value: Any) -> list[str]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return _ordered_unique_strings(value)
+    text = _safe_text(value)
+    if not text:
+        return []
+    try:
+        parsed = json.loads(text)
+    except Exception:
+        parsed = None
+    if isinstance(parsed, list):
+        return _ordered_unique_strings(parsed)
+    if isinstance(parsed, str):
+        return _ordered_unique_strings([parsed])
+    if "\n" in text:
+        line_values = []
+        for line in text.splitlines():
+            cleaned = line.strip().lstrip("-").strip()
+            if cleaned:
+                line_values.append(cleaned)
+        if line_values:
+            return _ordered_unique_strings(line_values)
+    if "," in text:
+        return _ordered_unique_strings(part.strip() for part in text.split(","))
+    return [text]
+
+
+def _detect_template_variables(prompt_text: str | None) -> list[str]:
+    if not isinstance(prompt_text, str):
+        return []
+    return _ordered_unique_strings(match.group(1) for match in _PROMPT_VARIABLE_RE.finditer(prompt_text))
+
+
+def _normalise_validation_policy(value: Any) -> str:
+    policy = _safe_text(value).lower()
+    if policy in PROMPT_VALIDATION_POLICIES:
+        return policy
+    return PROMPT_VALIDATION_POLICY_FAIL
+
+
+def normalise_prompt_validation_policy(value: Any) -> str:
+    return _normalise_validation_policy(value)
+
+
+def _build_alias_key_set(aliases: Sequence[str]) -> set[str]:
+    return {_normalise_predicate_key(alias) for alias in aliases if _safe_text(alias)}
+
+
+def _load_text_rows(concept_id: str) -> list[Mapping[str, Any]]:
+    try:
+        rows = get_texts_for_concept(concept_id)
+    except Exception:
+        return []
+    if not isinstance(rows, list):
+        return []
+    return [row for row in rows if isinstance(row, Mapping)]
+
+
+def _load_relationship_index(concept_id: str) -> dict[str, list[str]]:
+    doc = ConceptsRepository.find_one({"concept_id": concept_id}) or {}
+    relationships = doc.get("relationships") if isinstance(doc, Mapping) else {}
+    if not isinstance(relationships, Mapping):
+        return {}
+    index: dict[str, list[str]] = {}
+    for predicate, raw_values in relationships.items():
+        predicate_key = _normalise_predicate_key(predicate)
+        values = _ordered_unique_strings(raw_values)
+        if not values:
+            continue
+        index[predicate_key] = values
+    return index
+
+
+def _select_text_value(
+    rows: Sequence[Mapping[str, Any]],
+    aliases: Sequence[str],
+) -> tuple[str | None, str | None]:
+    alias_keys = _build_alias_key_set(aliases)
+    for row in rows:
+        predicate_key = _normalise_predicate_key(row.get("predicate"))
+        if predicate_key not in alias_keys:
+            continue
+        text = _safe_text(row.get("text"))
+        if text:
+            return text, _safe_text(row.get("predicate")) or predicate_key
+    return None, None
+
+
+def _select_text_values(
+    rows: Sequence[Mapping[str, Any]],
+    aliases: Sequence[str],
+) -> tuple[list[str], list[str]]:
+    alias_keys = _build_alias_key_set(aliases)
+    values: list[str] = []
+    predicates: list[str] = []
+    for row in rows:
+        predicate_key = _normalise_predicate_key(row.get("predicate"))
+        if predicate_key not in alias_keys:
+            continue
+        raw_values = _coerce_multi_value_text(row.get("text"))
+        if raw_values:
+            values.extend(raw_values)
+            predicate = _safe_text(row.get("predicate")) or predicate_key
+            if predicate:
+                predicates.append(predicate)
+    return _ordered_unique_strings(values), _ordered_unique_strings(predicates)
+
+
+def _select_relationship_values(
+    relationship_index: Mapping[str, Sequence[str]],
+    aliases: Sequence[str],
+) -> tuple[list[str], list[str]]:
+    alias_keys = _build_alias_key_set(aliases)
+    values: list[str] = []
+    predicates: list[str] = []
+    for predicate_key, targets in relationship_index.items():
+        if predicate_key not in alias_keys:
+            continue
+        values.extend(_ordered_unique_strings(targets))
+        predicates.append(predicate_key)
+    return _ordered_unique_strings(values), _ordered_unique_strings(predicates)
+
+
+def _load_concept_metadata(concept_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    rows = _load_text_rows(concept_id)
+    relationship_index = _load_relationship_index(concept_id)
+    prompt_service = PromptTemplateService(default_max_chars=24000)
+    resolved_prompt_id, prompt_text = prompt_service.resolve_prompt_text(
+        [concept_id],
+        fallback=None,
+        max_chars=24000,
+    )
+
+    metadata: dict[str, Any] = {}
+    sources: dict[str, dict[str, Any]] = {}
+
+    for field_name in _SCALAR_METADATA_FIELDS:
+        value, predicate = _select_text_value(
+            rows,
+            _PROMPT_METADATA_ALIAS_GROUPS[field_name],
+        )
+        if value:
+            metadata[field_name] = value
+            sources[field_name] = {
+                "source": "text_relation",
+                "predicate": predicate,
+            }
+
+    for field_name in _LIST_METADATA_FIELDS:
+        text_values, text_predicates = _select_text_values(
+            rows,
+            _PROMPT_METADATA_ALIAS_GROUPS[field_name],
+        )
+        relationship_values, relationship_predicates = _select_relationship_values(
+            relationship_index,
+            _PROMPT_METADATA_ALIAS_GROUPS[field_name],
+        )
+        values = _ordered_unique_strings([*text_values, *relationship_values])
+        if values:
+            metadata[field_name] = values
+            predicate_sources = [*text_predicates, *relationship_predicates]
+            sources[field_name] = {
+                "source": "mixed"
+                if text_predicates and relationship_predicates
+                else ("text_relation" if text_predicates else "relationship"),
+                "predicates": _ordered_unique_strings(predicate_sources),
+            }
+
+    if metadata.get("agent_profile_ids"):
+        metadata["agent_profile_id"] = metadata["agent_profile_ids"][0]
+    if metadata.get("tool_resolution_priority"):
+        metadata["tool_resolution_priority"] = _ordered_unique_strings(
+            metadata["tool_resolution_priority"]
+        )
+
+    diagnostics = {
+        "concept_id": concept_id,
+        "prompt_text_available": bool(prompt_text),
+        "resolved_prompt_concept_id": resolved_prompt_id,
+        "detected_template_variables": _detect_template_variables(prompt_text),
+        "metadata_sources": sources,
+    }
+    return metadata, diagnostics
+
+
+def normalise_prompt_metadata_defaults(
+    raw_defaults: Mapping[str, Any] | str | None,
+) -> dict[str, Any]:
+    defaults_map: dict[str, Any] = {}
+    if isinstance(raw_defaults, Mapping):
+        defaults_map = dict(raw_defaults)
+    elif isinstance(raw_defaults, str):
+        try:
+            parsed = json.loads(raw_defaults)
+        except Exception:
+            parsed = None
+        if isinstance(parsed, Mapping):
+            defaults_map = dict(parsed)
+
+    if not defaults_map:
+        return {}
+
+    normalised: dict[str, Any] = {}
+    for field_name in _SCALAR_METADATA_FIELDS:
+        value = defaults_map.get(field_name)
+        if isinstance(value, Mapping):
+            continue
+        if _is_nonempty_value(value):
+            normalised[field_name] = value
+
+    for field_name in _LIST_METADATA_FIELDS:
+        value = defaults_map.get(field_name)
+        if isinstance(value, Mapping):
+            continue
+        values = _coerce_multi_value_text(value)
+        if values:
+            normalised[field_name] = values
+
+    agent_profile_ids = _ordered_unique_strings(
+        normalised.get("agent_profile_ids")
+        or defaults_map.get("agent_profile_ids")
+        or defaults_map.get("agent_profile_id")
+        or []
+    )
+    if agent_profile_ids:
+        normalised["agent_profile_ids"] = agent_profile_ids
+        normalised["agent_profile_id"] = agent_profile_ids[0]
+    return normalised
+
+
+def _merge_prompt_metadata(
+    *,
+    prompt_metadata: Mapping[str, Any],
+    agent_metadata: Mapping[str, Any],
+    defaults: Mapping[str, Any],
+    detected_template_variables: Sequence[str],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    merged: dict[str, Any] = {}
+    overrides: list[dict[str, Any]] = []
+
+    for field_name in _SCALAR_METADATA_FIELDS:
+        candidates = [
+            ("prompt", prompt_metadata.get(field_name)),
+            ("agent_profile", agent_metadata.get(field_name)),
+            ("defaults", defaults.get(field_name)),
+        ]
+        winner_source = None
+        winner_value = None
+        populated_sources: list[str] = []
+        for source_name, value in candidates:
+            if not _is_nonempty_value(value):
+                continue
+            populated_sources.append(source_name)
+            if winner_source is None:
+                winner_source = source_name
+                winner_value = value
+        if winner_source is not None and winner_value is not None:
+            merged[field_name] = winner_value
+            if len(populated_sources) > 1:
+                overrides.append(
+                    {
+                        "field": field_name,
+                        "winner_source": winner_source,
+                        "overridden_sources": populated_sources[1:],
+                    }
+                )
+
+    for field_name in _LIST_METADATA_FIELDS:
+        candidates = [
+            ("prompt", _ordered_unique_strings(prompt_metadata.get(field_name, []))),
+            ("agent_profile", _ordered_unique_strings(agent_metadata.get(field_name, []))),
+            ("defaults", _ordered_unique_strings(defaults.get(field_name, []))),
+        ]
+        winner_source = None
+        winner_values: list[str] = []
+        populated_sources: list[str] = []
+        for source_name, values in candidates:
+            if not values:
+                continue
+            populated_sources.append(source_name)
+            if winner_source is None:
+                winner_source = source_name
+                winner_values = values
+        if winner_source is not None and winner_values:
+            merged[field_name] = winner_values
+            if len(populated_sources) > 1:
+                overrides.append(
+                    {
+                        "field": field_name,
+                        "winner_source": winner_source,
+                        "overridden_sources": populated_sources[1:],
+                    }
+                )
+
+    if not merged.get("prompt_variables"):
+        detected = _ordered_unique_strings(detected_template_variables)
+        if detected:
+            merged["prompt_variables"] = detected
+    if merged.get("agent_profile_ids"):
+        merged["agent_profile_id"] = merged["agent_profile_ids"][0]
+    return merged, overrides
+
+
+def _apply_tool_priority(
+    *,
+    allowed_tools: Sequence[str],
+    priority: Sequence[str],
+) -> tuple[list[str], list[str]]:
+    allowed = _ordered_unique_strings(allowed_tools)
+    ordered_priority = _ordered_unique_strings(priority)
+    if not allowed or not ordered_priority:
+        return allowed, []
+    prioritised = [tool for tool in ordered_priority if tool in allowed]
+    remainder = [tool for tool in allowed if tool not in prioritised]
+    unknown_priority_tools = [tool for tool in ordered_priority if tool not in allowed]
+    return [*prioritised, *remainder], unknown_priority_tools
+
+
+def _concept_exists(concept_id: str) -> bool:
+    if not concept_id:
+        return False
+    if is_code_concept_id(concept_id):
+        return True
+    return ConceptsRepository.find_one({"concept_id": concept_id}, {"_id": 1}) is not None
+
+
+@lru_cache(maxsize=1)
+def _default_available_tool_names() -> frozenset[str]:
+    try:
+        from ..integrations.internal_mcp.catalogue import build_default_catalogue
+
+        return frozenset(build_default_catalogue().list_methods())
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Unable to build default internal MCP catalogue: %s", exc)
+        return frozenset()
+
+
+def resolve_workflow_prompt_metadata(
+    *,
+    prompt_concept_ids: Sequence[str],
+    defaults: Mapping[str, Any] | None = None,
+    validation_policy: str = PROMPT_VALIDATION_POLICY_FAIL,
+    available_tools: Iterable[str] | None = None,
+) -> WorkflowPromptResolution:
+    requested_prompt_ids = tuple(_ordered_unique_strings(prompt_concept_ids))
+    defaults_map = dict(defaults) if isinstance(defaults, Mapping) else {}
+    policy = _normalise_validation_policy(validation_policy)
+
+    prompt_service = PromptTemplateService(default_max_chars=24000)
+    resolved_prompt_id, prompt_text = prompt_service.resolve_prompt_text(
+        requested_prompt_ids,
+        fallback=None,
+        max_chars=24000,
+    )
+    selected_prompt_id = resolved_prompt_id or (
+        requested_prompt_ids[0] if requested_prompt_ids else None
+    )
+
+    prompt_metadata: dict[str, Any] = {}
+    prompt_diagnostics: dict[str, Any] = {}
+    if selected_prompt_id:
+        prompt_metadata, prompt_diagnostics = _load_concept_metadata(selected_prompt_id)
+
+    default_agent_profiles = _ordered_unique_strings(
+        defaults_map.get("agent_profile_ids")
+        or defaults_map.get("agent_profile_id")
+        or []
+    )
+    prompt_agent_profiles = _ordered_unique_strings(
+        prompt_metadata.get("agent_profile_ids")
+        or prompt_metadata.get("agent_profile_id")
+        or []
+    )
+    agent_profile_ids = prompt_agent_profiles or default_agent_profiles
+
+    agent_metadata: dict[str, Any] = {}
+    agent_diagnostics: dict[str, Any] = {}
+    if agent_profile_ids:
+        primary_agent_id = agent_profile_ids[0]
+        if _concept_exists(primary_agent_id):
+            agent_metadata, agent_diagnostics = _load_concept_metadata(primary_agent_id)
+        else:
+            agent_diagnostics = {
+                "concept_id": primary_agent_id,
+                "error": "agent_profile_unavailable",
+            }
+
+    merged_metadata, overrides = _merge_prompt_metadata(
+        prompt_metadata=prompt_metadata,
+        agent_metadata=agent_metadata,
+        defaults=normalise_prompt_metadata_defaults(defaults_map),
+        detected_template_variables=_detect_template_variables(prompt_text),
+    )
+
+    resolved_allowed_tools, unknown_priority_tools = _apply_tool_priority(
+        allowed_tools=merged_metadata.get("allowed_tools", []),
+        priority=merged_metadata.get("tool_resolution_priority", []),
+    )
+    if resolved_allowed_tools:
+        merged_metadata["allowed_tools"] = resolved_allowed_tools
+
+    available_tool_set = frozenset(
+        _ordered_unique_strings(available_tools) if available_tools is not None else _default_available_tool_names()
+    )
+    unavailable_tools = [
+        tool
+        for tool in resolved_allowed_tools
+        if available_tool_set and tool not in available_tool_set
+    ]
+    unavailable_agents = [
+        agent_id
+        for agent_id in agent_profile_ids
+        if agent_id and not _concept_exists(agent_id)
+    ]
+
+    warnings: list[str] = []
+    errors: list[str] = []
+    if requested_prompt_ids and not prompt_text:
+        errors.append("prompt_text_missing_or_empty")
+    if unavailable_agents:
+        message = "agent_profile_unavailable:" + ",".join(unavailable_agents)
+        if policy == PROMPT_VALIDATION_POLICY_FAIL:
+            errors.append(message)
+        else:
+            warnings.append(message)
+    if unavailable_tools:
+        message = "prompt_allowed_tools_unavailable:" + ",".join(unavailable_tools)
+        if policy == PROMPT_VALIDATION_POLICY_FAIL:
+            errors.append(message)
+        else:
+            warnings.append(message)
+    if unknown_priority_tools:
+        warnings.append(
+            "prompt_tool_priority_unknown:" + ",".join(unknown_priority_tools)
+        )
+
+    diagnostics: dict[str, Any] = {
+        "requested_prompt_concept_ids": list(requested_prompt_ids),
+        "resolved_prompt_concept_id": selected_prompt_id,
+        "prompt_text_available": bool(prompt_text),
+        "validation_policy": policy,
+        "status": "error" if errors else ("warning" if warnings else "ok"),
+        "warnings": warnings,
+        "errors": errors,
+        "overrides": overrides,
+        "unavailable_tools": unavailable_tools,
+        "unavailable_agent_profiles": unavailable_agents,
+        "unknown_tool_priority_entries": unknown_priority_tools,
+        "prompt_diagnostics": prompt_diagnostics,
+        "agent_profile_diagnostics": agent_diagnostics,
+    }
+
+    return WorkflowPromptResolution(
+        requested_prompt_concept_ids=requested_prompt_ids,
+        resolved_prompt_concept_id=selected_prompt_id,
+        metadata=merged_metadata,
+        diagnostics=diagnostics,
+    )
+
+
+def build_workflow_prompt_contract(
+    *,
+    resolution: WorkflowPromptResolution,
+    validation_policy: str,
+) -> dict[str, Any]:
+    contract: dict[str, Any] = {
+        "validation_policy": _normalise_validation_policy(validation_policy)
+    }
+    if resolution.requested_prompt_concept_ids:
+        contract["requested_prompt_concept_ids"] = list(
+            resolution.requested_prompt_concept_ids
+        )
+    if resolution.resolved_prompt_concept_id:
+        contract["resolved_prompt_concept_id"] = resolution.resolved_prompt_concept_id
+    if resolution.metadata:
+        contract["metadata"] = dict(resolution.metadata)
+    return contract
+
+
+__all__ = [
+    "PROMPT_VALIDATION_POLICIES",
+    "PROMPT_VALIDATION_POLICY_FAIL",
+    "PROMPT_VALIDATION_POLICY_WARN",
+    "WORKFLOW_STEP_PROMPT_LINK_PREDICATE_ALIASES",
+    "WorkflowPromptResolution",
+    "build_workflow_prompt_contract",
+    "normalise_prompt_metadata_defaults",
+    "normalise_prompt_validation_policy",
+    "resolve_workflow_prompt_metadata",
+]

--- a/src/backend/workflows/vontology_loader.py
+++ b/src/backend/workflows/vontology_loader.py
@@ -10,6 +10,13 @@ from ..services.text_value_service import (
     get_preferred_text_for_concept,
     get_texts_for_concept,
 )
+from .prompt_metadata_resolution import (
+    WORKFLOW_STEP_PROMPT_LINK_PREDICATE_ALIASES,
+    build_workflow_prompt_contract,
+    normalise_prompt_metadata_defaults,
+    normalise_prompt_validation_policy,
+    resolve_workflow_prompt_metadata,
+)
 from .subworkflow_contracts import (
     WORKFLOW_SUBWORKFLOW_ACTION_ID,
     build_subworkflow_contract,
@@ -59,6 +66,7 @@ WORKFLOW_GRAPH_PREDICATE_ALIASES: Dict[str, Tuple[str, ...]] = {
         "#V#workflowStepInvokesTool",
         "workflowStepInvokesTool",
     ),
+    "workflowStepUsesLlmPrompt": WORKFLOW_STEP_PROMPT_LINK_PREDICATE_ALIASES,
     "nextStep": ("#V#nextStep", "nextStep", "#V#next_step", "next_step"),
     "onTrueNextStep": (
         "#V#onTrueNextStep",
@@ -259,6 +267,16 @@ _WORKFLOW_MAPPING_ID_RE = re.compile(
 _WORKFLOW_MAPPING_DESCRIPTION_RE = re.compile(
     r"context key\s+['\"]([^'\"]+)['\"].*?['\"]([^'\"]+)['\"]\s+parameter",
     re.IGNORECASE,
+)
+_WORKFLOW_PROMPT_DEFAULTS_INPUT_KEYS: tuple[str, ...] = (
+    "__prompt_defaults",
+    "prompt_defaults",
+    "__prompt_defaults_json",
+    "prompt_defaults_json",
+)
+_WORKFLOW_PROMPT_VALIDATION_POLICY_INPUT_KEYS: tuple[str, ...] = (
+    "__prompt_validation_policy",
+    "prompt_validation_policy",
 )
 _WORKFLOW_OUTPUT_MAPPING_ID_RE = re.compile(
     r"^#V#workflow_mapping_tool_field_([a-z0-9_]+)_to_([a-z0-9_]+)$",
@@ -755,6 +773,52 @@ def _mapping_description_text(
                 return raw_value.strip()
 
     return ""
+
+
+def _parse_step_input_map(step_relationships: Mapping[str, Any]) -> Dict[str, Any]:
+    input_map: Dict[str, Any] = {}
+    if not isinstance(step_relationships, Mapping):
+        return input_map
+
+    raw_inputs = _all_relationship_targets(
+        dict(step_relationships),
+        WORKFLOW_GRAPH_PREDICATE_ALIASES["hasInputMap"],
+    )
+    for entry in raw_inputs:
+        if "=" in entry:
+            key, _, value = entry.partition("=")
+        elif ":" in entry:
+            key, _, value = entry.partition(":")
+        else:
+            continue
+        key = key.strip()
+        value = value.strip()
+        if key:
+            input_map[key] = value
+    return input_map
+
+
+def _extract_step_prompt_resolution_config(
+    input_map: Dict[str, Any],
+) -> tuple[dict[str, Any], str]:
+    defaults_raw: Any = None
+    for key in _WORKFLOW_PROMPT_DEFAULTS_INPUT_KEYS:
+        if key not in input_map:
+            continue
+        defaults_raw = input_map.pop(key)
+        break
+
+    policy_raw: Any = None
+    for key in _WORKFLOW_PROMPT_VALIDATION_POLICY_INPUT_KEYS:
+        if key not in input_map:
+            continue
+        policy_raw = input_map.pop(key)
+        break
+
+    return (
+        normalise_prompt_metadata_defaults(defaults_raw),
+        normalise_prompt_validation_policy(policy_raw),
+    )
 
 
 def _extract_tool_output_mapping(
@@ -1386,6 +1450,7 @@ def build_workflow_process_graph(
         step_rels = doc.get("relationships") or {}
         if not isinstance(step_rels, dict):
             step_rels = {}
+        step_input_map = _parse_step_input_map(step_rels)
 
         invokes_action_candidates = (
             *WORKFLOW_GRAPH_PREDICATE_ALIASES["invokesAction"],
@@ -1401,6 +1466,43 @@ def build_workflow_process_graph(
             canonical_predicate=WORKFLOW_GRAPH_PREDICATE_ALIASES["invokesAction"][0],
             matched_predicates=(invokes_action_predicate,),
         )
+
+        prompt_candidates = WORKFLOW_GRAPH_PREDICATE_ALIASES["workflowStepUsesLlmPrompt"]
+        prompt_concept_ids, prompt_predicates = _all_relationship_targets_with_predicates(
+            step_rels,
+            prompt_candidates,
+        )
+        _record_legacy_alias_use(
+            legacy_aliases=legacy_aliases,
+            canonical_predicate=prompt_candidates[0],
+            matched_predicates=prompt_predicates,
+        )
+        prompt_defaults, prompt_validation_policy = (
+            _extract_step_prompt_resolution_config(dict(step_input_map))
+        )
+        prompt_contract: dict[str, Any] | None = None
+        prompt_resolution_diagnostics: dict[str, Any] | None = None
+        if prompt_concept_ids:
+            prompt_resolution = resolve_workflow_prompt_metadata(
+                prompt_concept_ids=prompt_concept_ids,
+                defaults=prompt_defaults,
+                validation_policy=prompt_validation_policy,
+            )
+            prompt_contract = build_workflow_prompt_contract(
+                resolution=prompt_resolution,
+                validation_policy=prompt_validation_policy,
+            )
+            prompt_resolution_diagnostics = dict(prompt_resolution.diagnostics)
+            prompt_errors = prompt_resolution.diagnostics.get("errors") or []
+            if prompt_errors:
+                raise ValueError(
+                    "workflow_prompt_contract_invalid:"
+                    f"{workflow_id}:{step_id}:{'|'.join(str(item) for item in prompt_errors)}"
+                )
+            for warning in prompt_resolution.diagnostics.get("warnings") or []:
+                warnings.append(
+                    f"workflow_prompt_contract_warning:{workflow_id}:{step_id}:{warning}"
+                )
 
         invokes_workflow_candidates = WORKFLOW_GRAPH_PREDICATE_ALIASES[
             "invokesWorkflow"
@@ -1625,6 +1727,8 @@ def build_workflow_process_graph(
                 "context_input_mappings": context_input_mappings,
                 "tool_output_context_mappings": tool_output_context_mappings,
                 "writes_context_keys": writes_context_keys,
+                "prompt_contract": prompt_contract,
+                "prompt_resolution_diagnostics": prompt_resolution_diagnostics,
                 **runtime_policies,
                 "control_flow": {
                     "next": next_step,
@@ -1768,25 +1872,22 @@ def load_workflow_definition_from_vontology(
         subworkflow_failure_mode = ""
         if invocation_action_id:
             # Read input mapping from Vontology (hasInputMap relationships).
-            input_map: Dict[str, Any] = {}
             doc = step_docs.get(step_id, {})
             step_rels = doc.get("relationships") or {}
-            if isinstance(step_rels, dict):
-                raw_inputs = _all_relationship_targets(
-                    step_rels,
-                    WORKFLOW_GRAPH_PREDICATE_ALIASES["hasInputMap"],
-                )
-                # Input maps are stored as "key=value" or "key:value" strings.
-                for entry in raw_inputs:
-                    if "=" in entry:
-                        k, _, v = entry.partition("=")
-                    elif ":" in entry:
-                        k, _, v = entry.partition(":")
-                    else:
-                        continue
-                    k, v = k.strip(), v.strip()
-                    if k:
-                        input_map[k] = v
+            if not isinstance(step_rels, dict):
+                step_rels = {}
+            input_map = _parse_step_input_map(step_rels)
+            _extract_step_prompt_resolution_config(input_map)
+            prompt_contract = (
+                dict(step.get("prompt_contract"))
+                if isinstance(step.get("prompt_contract"), Mapping)
+                else None
+            )
+            prompt_resolution_diagnostics = (
+                dict(step.get("prompt_resolution_diagnostics"))
+                if isinstance(step.get("prompt_resolution_diagnostics"), Mapping)
+                else None
+            )
 
             # Read semantic context mappings from dedicated mapping concepts.
             semantic_mapping_ids = step.get("context_input_mappings") or []
@@ -1832,6 +1933,12 @@ def load_workflow_definition_from_vontology(
                 input_map["workflow_id"] = str(invokes_workflow).strip()
                 input_map["__parent_workflow_id"] = str(workflow_id or "").strip()
                 input_map["__parent_state_id"] = str(step_id or "").strip()
+            if prompt_contract:
+                input_map["__prompt_contract"] = prompt_contract
+            if prompt_resolution_diagnostics:
+                input_map["__prompt_resolution_diagnostics"] = (
+                    prompt_resolution_diagnostics
+                )
 
             actions.append(
                 WorkflowActionInvocation(
@@ -2059,6 +2166,7 @@ def load_workflow_definition_from_vontology(
         retry_policy = step.get("retry_policy")
         approval_gate = step.get("approval_gate")
         idempotency_policy = step.get("idempotency_policy")
+        prompt_contract = step.get("prompt_contract")
         if preconditions:
             step_metadata["preconditions"] = preconditions
         if effects:
@@ -2077,6 +2185,8 @@ def load_workflow_definition_from_vontology(
             step_metadata["approval_gate"] = approval_gate
         if idempotency_policy:
             step_metadata["idempotency_policy"] = idempotency_policy
+        if prompt_contract:
+            step_metadata["prompt_contract"] = prompt_contract
         if is_subworkflow_action:
             workflow_target = str(invokes_workflow or "").strip()
             workflow_id_context_key = ""

--- a/src/backend/workflows/workflow_definition_identity_service.py
+++ b/src/backend/workflows/workflow_definition_identity_service.py
@@ -46,6 +46,7 @@ _STATE_METADATA_CONTRACT_KEYS: tuple[str, ...] = (
     "retry_policy",
     "approval_gate",
     "idempotency_policy",
+    "prompt_contract",
 )
 
 
@@ -605,6 +606,7 @@ def validate_workflow_definition_contract(
             "subworkflow_contract_issues": [],
             "control_signal_issues": [],
             "fork_join_issues": [],
+            "prompt_contract_issues": [],
         }
 
     states_raw = getattr(definition, "states", {})
@@ -632,6 +634,7 @@ def validate_workflow_definition_contract(
     iterator_issues: list[dict[str, Any]] = []
     approval_gate_issues: list[dict[str, Any]] = []
     runtime_policy_issues: list[dict[str, Any]] = []
+    prompt_contract_issues: list[dict[str, Any]] = []
     declared_fork_ids: set[str] = set()
 
     supported_action_set: set[str] = set()
@@ -725,6 +728,10 @@ def validate_workflow_definition_contract(
             for transition in transitions
         )
         loop_scope_id = str(metadata.get("loop_scope_id") or "").strip()
+        raw_prompt_contract = metadata.get("prompt_contract")
+        prompt_contract: Mapping[str, Any] = (
+            raw_prompt_contract if isinstance(raw_prompt_contract, Mapping) else {}
+        )
         if metadata.get("approval_gate") and not has_on_approval_required_transition:
             approval_gate_issues.append(
                 {
@@ -746,7 +753,54 @@ def validate_workflow_definition_contract(
                     "reason_code": "idempotency_policy_multi_action_state_unsupported",
                 }
             )
+        requested_prompt_concept_ids = _normalise_symbol_list(
+            prompt_contract.get("requested_prompt_concept_ids")
+        )
+        resolved_prompt_concept_id = str(
+            prompt_contract.get("resolved_prompt_concept_id") or ""
+        ).strip()
+        if prompt_contract and not actions:
+            prompt_contract_issues.append(
+                {
+                    "state_id": state_id,
+                    "reason_code": "prompt_contract_without_action",
+                    "severity": "error",
+                }
+            )
+        if requested_prompt_concept_ids and not resolved_prompt_concept_id:
+            prompt_contract_issues.append(
+                {
+                    "state_id": state_id,
+                    "reason_code": "prompt_resolution_missing",
+                    "severity": "error",
+                    "requested_prompt_concept_ids": requested_prompt_concept_ids,
+                }
+            )
         for action_id, action_inputs in action_specs:
+            raw_prompt_diagnostics = action_inputs.get("__prompt_resolution_diagnostics")
+            prompt_diagnostics: Mapping[str, Any] = (
+                raw_prompt_diagnostics
+                if isinstance(raw_prompt_diagnostics, Mapping)
+                else {}
+            )
+            for reason_code in _normalise_symbol_list(prompt_diagnostics.get("errors")):
+                prompt_contract_issues.append(
+                    {
+                        "state_id": state_id,
+                        "action_id": action_id,
+                        "reason_code": reason_code,
+                        "severity": "error",
+                    }
+                )
+            for reason_code in _normalise_symbol_list(prompt_diagnostics.get("warnings")):
+                prompt_contract_issues.append(
+                    {
+                        "state_id": state_id,
+                        "action_id": action_id,
+                        "reason_code": reason_code,
+                        "severity": "warning",
+                    }
+                )
             if action_id in WORKFLOW_CONTROL_BREAK_ACTION_IDS:
                 action_scope = str(
                     action_inputs.get("loop_scope_id")
@@ -1124,6 +1178,15 @@ def validate_workflow_definition_contract(
             str(item.get("reason_code") or ""),
         ),
     )
+    prompt_contract_issues = sorted(
+        prompt_contract_issues,
+        key=lambda item: (
+            str(item.get("state_id") or ""),
+            str(item.get("action_id") or ""),
+            str(item.get("severity") or ""),
+            str(item.get("reason_code") or ""),
+        ),
+    )
 
     errors: list[str] = []
     if vacuous_state_ids:
@@ -1150,6 +1213,11 @@ def validate_workflow_definition_contract(
         errors.append("workflow_approval_gate_invalid")
     if runtime_policy_issues:
         errors.append("workflow_runtime_policy_invalid")
+    if any(
+        str(item.get("severity") or "").strip().lower() == "error"
+        for item in prompt_contract_issues
+    ):
+        errors.append("workflow_prompt_contract_invalid")
     if subworkflow_contract_issues:
         unresolved_reason_codes = {
             "subworkflow_workflow_not_found",
@@ -1193,6 +1261,7 @@ def validate_workflow_definition_contract(
         "iterator_issues": iterator_issues,
         "approval_gate_issues": approval_gate_issues,
         "runtime_policy_issues": runtime_policy_issues,
+        "prompt_contract_issues": prompt_contract_issues,
     }
 
 

--- a/tests/backend/test_code_concepts_registry.py
+++ b/tests/backend/test_code_concepts_registry.py
@@ -42,3 +42,18 @@ def test_workflow_runtime_policy_predicates_are_registered():
     assert "#V#has_workflow_step_approval_gate_json" in ids
     assert "#V#hasWorkflowStepIdempotencyPolicyJson" in ids
     assert "#V#has_workflow_step_idempotency_policy_json" in ids
+
+
+def test_workflow_prompt_contract_predicates_are_registered():
+    ids = set(list_code_predicate_ids())
+
+    assert "#V#workflow_step_uses_llm_prompt" in ids
+    assert "#V#hasPromptName" in ids
+    assert "#V#has_prompt_name" in ids
+    assert "#V#usesAgentProfile" in ids
+    assert "#V#usesModelPreference" in ids
+    assert "#V#allowsTool" in ids
+    assert "#V#hasPromptScope" in ids
+    assert "#V#hasPromptVariables" in ids
+    assert "#V#hasPromptSource" in ids
+    assert "#V#hasToolResolutionPriority" in ids

--- a/tests/backend/test_prompt_template_service.py
+++ b/tests/backend/test_prompt_template_service.py
@@ -29,3 +29,19 @@ def test_render_prompt_missing_variable_raises(monkeypatch):
     service = pts.PromptTemplateService()
     with pytest.raises(ValueError):
         service.render_prompt(["#V#demo_prompt"], variables={})
+
+
+def test_resolve_prompt_text_supports_v_prefixed_text_relations(monkeypatch):
+    monkeypatch.setattr(
+        pts,
+        "get_texts_for_concept",
+        lambda concept_id: [
+            {"predicate": "#V#hasContent", "text": "Canonical prompt body"}
+        ],
+    )
+    service = pts.PromptTemplateService()
+
+    prompt_id, prompt_text = service.resolve_prompt_text(["#V#demo_prompt"])
+
+    assert prompt_id == "#V#demo_prompt"
+    assert prompt_text == "Canonical prompt body"

--- a/tests/backend/test_vontology_loader.py
+++ b/tests/backend/test_vontology_loader.py
@@ -317,6 +317,146 @@ class TestWorkflowStepRuntimePolicyResolution:
         assert policies["idempotency_policy"]["key_paths"] == ["request_id"]
 
 
+class TestWorkflowPromptContracts:
+    def test_build_workflow_process_graph_resolves_prompt_contract(self):
+        workflow_doc = {
+            "concept_id": "#V#test_workflow",
+            "relationships": {
+                "#V#hasInitialStep": ["#V#prompt_step"],
+                "#V#hasStep": ["#V#prompt_step"],
+            },
+        }
+        step_docs = {
+            "#V#prompt_step": {
+                "concept_id": "#V#prompt_step",
+                "name": "Prompt step",
+                "relationships": {
+                    "#V#invokesAction": ["llm.action"],
+                    "#V#workflow_step_uses_llm_prompt": ["#V#issue_prompt"],
+                    "#V#hasInputMap": [
+                        '__prompt_defaults={"prompt_source":"workflow_default"}'
+                    ],
+                },
+            }
+        }
+        prompt_texts = {
+            "#V#prompt_step": [],
+            "#V#issue_prompt": [
+                {"predicate": "#V#hasContent", "text": "Fix issue {issue_key}"},
+                {"predicate": "#V#hasPromptName", "text": "Issue fixer"},
+            ],
+            "#V#default_agent_profile": [
+                {"predicate": "#V#hasPromptDescription", "text": "Agent description"}
+            ],
+        }
+
+        def _fake_find_one(query, projection=None):
+            concept_id = query.get("concept_id") if isinstance(query, dict) else None
+            if concept_id == "#V#test_workflow":
+                return workflow_doc
+            if concept_id == "#V#issue_prompt":
+                return {
+                    "concept_id": "#V#issue_prompt",
+                    "relationships": {
+                        "#V#usesAgentProfile": ["#V#default_agent_profile"],
+                    },
+                }
+            if concept_id == "#V#default_agent_profile":
+                return {
+                    "concept_id": "#V#default_agent_profile",
+                    "relationships": {},
+                }
+            return None
+
+        with patch(
+            "src.backend.workflows.vontology_loader.ConceptsRepository.find_one",
+            side_effect=_fake_find_one,
+        ), patch(
+            "src.backend.workflows.vontology_loader._fetch_concepts_by_id",
+            return_value=step_docs,
+        ), patch(
+            "src.backend.workflows.prompt_metadata_resolution.get_texts_for_concept",
+            side_effect=lambda concept_id, *args, **kwargs: prompt_texts.get(
+                concept_id, []
+            ),
+        ), patch(
+            "src.backend.services.prompt_template_service.get_texts_for_concept",
+            side_effect=lambda concept_id, *args, **kwargs: prompt_texts.get(
+                concept_id, []
+            ),
+        ):
+            graph, warnings = build_workflow_process_graph("#V#test_workflow")
+
+        assert warnings == []
+        assert graph is not None
+        step = graph["steps"][0]
+        assert step["prompt_contract"]["resolved_prompt_concept_id"] == "#V#issue_prompt"
+        assert step["prompt_contract"]["metadata"]["prompt_name"] == "Issue fixer"
+        assert (
+            step["prompt_contract"]["metadata"]["prompt_description"]
+            == "Agent description"
+        )
+        assert step["prompt_contract"]["metadata"]["prompt_source"] == "workflow_default"
+        assert step["prompt_contract"]["metadata"]["prompt_variables"] == ["issue_key"]
+        assert step["prompt_resolution_diagnostics"]["status"] == "ok"
+
+    def test_load_workflow_definition_carries_prompt_contract_into_action_inputs(self):
+        steps = [
+            {
+                **_make_step(
+                    "#V#prompt_step",
+                    invokes_action="llm.action",
+                    next_step="#V#done",
+                ),
+                "prompt_contract": {
+                    "validation_policy": "warn",
+                    "requested_prompt_concept_ids": ["#V#issue_prompt"],
+                    "resolved_prompt_concept_id": "#V#issue_prompt",
+                    "metadata": {"prompt_name": "Issue fixer"},
+                },
+                "prompt_resolution_diagnostics": {
+                    "status": "warning",
+                    "errors": [],
+                    "warnings": [
+                        "prompt_allowed_tools_unavailable:missing.tool",
+                    ],
+                },
+            },
+            _make_step("#V#done"),
+        ]
+        graph = _make_graph(initial_step="#V#prompt_step", steps=steps)
+        step_docs = {
+            "#V#prompt_step": {
+                "relationships": {
+                    "#V#hasInputMap": [
+                        "ticket_id=JVNAUTOSCI-1358",
+                        '__prompt_defaults={"prompt_source":"workflow_default"}',
+                    ]
+                }
+            }
+        }
+
+        with _stub_fetch_concepts(step_docs), _stub_narrative():
+            with patch(
+                "src.backend.workflows.vontology_loader.build_workflow_process_graph",
+                return_value=(graph, []),
+            ):
+                definition = load_workflow_definition_from_vontology("#V#test_workflow")
+
+        assert definition is not None
+        prompt_state = definition.states["#V#prompt_step"]
+        assert prompt_state.metadata["prompt_contract"]["resolved_prompt_concept_id"] == (
+            "#V#issue_prompt"
+        )
+        action_inputs = prompt_state.actions[0].inputs
+        assert action_inputs["ticket_id"] == "JVNAUTOSCI-1358"
+        assert "__prompt_defaults" not in action_inputs
+        assert action_inputs["__prompt_contract"]["metadata"]["prompt_name"] == (
+            "Issue fixer"
+        )
+        assert action_inputs["__prompt_resolution_diagnostics"]["status"] == "warning"
+
+
 class TestWorkflowBackgroundLaunchPolicyResolution:
     def test_prefers_canonical_json_policy_relation(self):
         with patch(

--- a/tests/backend/test_workflow_definition_identity_service.py
+++ b/tests/backend/test_workflow_definition_identity_service.py
@@ -358,6 +358,92 @@ def test_validate_contract_rejects_join_without_matching_fork() -> None:
     )
 
 
+def test_validate_contract_reports_prompt_contract_errors() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="#V#prompt_contract_invalid_workflow",
+        initial_state="prompted",
+        states={
+            "prompted": WorkflowStateSpec(
+                state_id="prompted",
+                actions=(
+                    WorkflowActionInvocation(
+                        action_id="llm.action",
+                        inputs={
+                            "__prompt_resolution_diagnostics": {
+                                "errors": ["prompt_text_missing_or_empty"],
+                                "warnings": [],
+                            }
+                        },
+                    ),
+                ),
+                terminal=True,
+                metadata={
+                    "prompt_contract": {
+                        "validation_policy": "fail",
+                        "requested_prompt_concept_ids": ["#V#missing_prompt"],
+                        "resolved_prompt_concept_id": "#V#missing_prompt",
+                    }
+                },
+            ),
+        },
+        termination_states=("prompted",),
+    )
+
+    validation = validate_workflow_definition_contract(definition=definition)
+
+    assert validation["valid"] is False
+    assert "workflow_prompt_contract_invalid" in (validation.get("errors") or [])
+    assert any(
+        issue.get("reason_code") == "prompt_text_missing_or_empty"
+        and issue.get("severity") == "error"
+        for issue in validation.get("prompt_contract_issues", [])
+    )
+
+
+def test_validate_contract_keeps_prompt_contract_warnings_non_blocking() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="#V#prompt_contract_warning_workflow",
+        initial_state="prompted",
+        states={
+            "prompted": WorkflowStateSpec(
+                state_id="prompted",
+                actions=(
+                    WorkflowActionInvocation(
+                        action_id="llm.action",
+                        inputs={
+                            "__prompt_resolution_diagnostics": {
+                                "errors": [],
+                                "warnings": [
+                                    "prompt_allowed_tools_unavailable:missing.tool"
+                                ],
+                            }
+                        },
+                    ),
+                ),
+                terminal=True,
+                metadata={
+                    "prompt_contract": {
+                        "validation_policy": "warn",
+                        "requested_prompt_concept_ids": ["#V#prompt"],
+                        "resolved_prompt_concept_id": "#V#prompt",
+                    }
+                },
+            ),
+        },
+        termination_states=("prompted",),
+    )
+
+    validation = validate_workflow_definition_contract(definition=definition)
+
+    assert validation["valid"] is True
+    assert "workflow_prompt_contract_invalid" not in (validation.get("errors") or [])
+    assert any(
+        issue.get("reason_code") == "prompt_allowed_tools_unavailable:missing.tool"
+        and issue.get("severity") == "warning"
+        for issue in validation.get("prompt_contract_issues", [])
+    )
+
+
 def test_validate_contract_accepts_join_with_declared_fork() -> None:
     definition = WorkflowDefinition(
         workflow_id="#V#join_valid_workflow",

--- a/tests/backend/test_workflow_prompt_metadata_resolution.py
+++ b/tests/backend/test_workflow_prompt_metadata_resolution.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from src.backend.services import prompt_template_service as pts
+from src.backend.workflows import prompt_metadata_resolution as pmr
+
+
+def _install_prompt_resolution_fixtures(*, texts: dict, docs: dict):
+    def _fake_find_one(query, projection=None):
+        concept_id = query.get("concept_id") if isinstance(query, dict) else None
+        if not isinstance(concept_id, str):
+            return None
+        if concept_id not in docs:
+            return None
+        if projection == {"_id": 1}:
+            return {"_id": concept_id}
+        return docs[concept_id]
+
+    return (
+        patch.object(
+            pmr.ConceptsRepository,
+            "find_one",
+            side_effect=_fake_find_one,
+        ),
+        patch.object(
+            pmr,
+            "get_texts_for_concept",
+            side_effect=lambda concept_id, *args, **kwargs: texts.get(concept_id, []),
+        ),
+        patch.object(
+            pts,
+            "get_texts_for_concept",
+            side_effect=lambda concept_id, *args, **kwargs: texts.get(concept_id, []),
+        ),
+    )
+
+
+def test_resolve_workflow_prompt_metadata_merges_prompt_agent_and_defaults():
+    texts = {
+        "#V#issue_prompt": [
+            {"predicate": "#V#hasContent", "text": "Fix issue {issue_key}"},
+            {"predicate": "#V#hasPromptName", "text": "Issue fixer"},
+            {"predicate": "#V#usesModelPreference", "text": "gpt-5"},
+            {
+                "predicate": "#V#hasToolResolutionPriority",
+                "text": "github_create_pull_request_with_copilot,jira_add_comment",
+            },
+        ],
+        "#V#default_agent_profile": [
+            {"predicate": "#V#hasPromptDescription", "text": "Agent-supplied description"},
+            {"predicate": "#V#hasPromptScope", "text": "organisation"},
+        ],
+    }
+    docs = {
+        "#V#issue_prompt": {
+            "concept_id": "#V#issue_prompt",
+            "relationships": {
+                "#V#usesAgentProfile": ["#V#default_agent_profile"],
+                "#V#allowsTool": [
+                    "jira_add_comment",
+                    "github_create_pull_request_with_copilot",
+                ],
+            },
+        },
+        "#V#default_agent_profile": {
+            "concept_id": "#V#default_agent_profile",
+            "relationships": {
+                "#V#allowsTool": ["jira_add_comment"],
+                "#V#usesModelPreference": ["gpt-4.1"],
+            },
+        },
+    }
+
+    patches = _install_prompt_resolution_fixtures(texts=texts, docs=docs)
+    with patches[0], patches[1], patches[2]:
+        resolution = pmr.resolve_workflow_prompt_metadata(
+            prompt_concept_ids=["#V#issue_prompt"],
+            defaults={
+                "allowed_tools": ["fallback_tool"],
+                "prompt_source": "workflow_default",
+            },
+            available_tools=[
+                "jira_add_comment",
+                "github_create_pull_request_with_copilot",
+            ],
+        )
+        contract = pmr.build_workflow_prompt_contract(
+            resolution=resolution,
+            validation_policy=pmr.PROMPT_VALIDATION_POLICY_FAIL,
+        )
+
+    assert resolution.resolved_prompt_concept_id == "#V#issue_prompt"
+    assert resolution.metadata["prompt_name"] == "Issue fixer"
+    assert resolution.metadata["prompt_description"] == "Agent-supplied description"
+    assert resolution.metadata["model_preference"] == "gpt-5"
+    assert resolution.metadata["prompt_scope"] == "organisation"
+    assert resolution.metadata["prompt_source"] == "workflow_default"
+    assert resolution.metadata["prompt_variables"] == ["issue_key"]
+    assert resolution.metadata["allowed_tools"] == [
+        "github_create_pull_request_with_copilot",
+        "jira_add_comment",
+    ]
+    assert resolution.diagnostics["status"] == "ok"
+    assert resolution.diagnostics["errors"] == []
+    assert contract["validation_policy"] == "fail"
+    assert contract["requested_prompt_concept_ids"] == ["#V#issue_prompt"]
+    assert contract["resolved_prompt_concept_id"] == "#V#issue_prompt"
+
+
+def test_resolve_workflow_prompt_metadata_warns_for_unavailable_tools():
+    texts = {
+        "#V#limited_prompt": [
+            {"predicate": "#V#hasContent", "text": "Summarise {issue_key}"}
+        ]
+    }
+    docs = {
+        "#V#limited_prompt": {
+            "concept_id": "#V#limited_prompt",
+            "relationships": {
+                "#V#allowsTool": ["missing.tool"],
+            },
+        }
+    }
+
+    patches = _install_prompt_resolution_fixtures(texts=texts, docs=docs)
+    with patches[0], patches[1], patches[2]:
+        resolution = pmr.resolve_workflow_prompt_metadata(
+            prompt_concept_ids=["#V#limited_prompt"],
+            validation_policy=pmr.PROMPT_VALIDATION_POLICY_WARN,
+            available_tools=["jira_search"],
+        )
+
+    assert resolution.diagnostics["status"] == "warning"
+    assert resolution.diagnostics["errors"] == []
+    assert resolution.diagnostics["warnings"] == [
+        "prompt_allowed_tools_unavailable:missing.tool"
+    ]


### PR DESCRIPTION
## Summary
- add a reusable VWL prompt metadata resolver with deterministic prompt > agent-profile > step-default precedence and warn/fail diagnostics
- wire prompt contracts into the Vontology workflow loader and workflow contract validation surfaces without introducing bespoke Python orchestration
- register the prompt-contract predicate vocabulary, add regression tests, and update the VWL manual plus the canonical Jira-GitHub autofix workflow artefact

## Verification
- `pdm run pytest tests/backend/test_prompt_template_service.py tests/backend/test_workflow_prompt_metadata_resolution.py tests/backend/test_vontology_loader.py tests/backend/test_workflow_definition_identity_service.py tests/backend/test_code_concepts_registry.py`
- `pdm run pyright src/backend/services/prompt_template_service.py src/backend/workflows/prompt_metadata_resolution.py src/backend/workflows/vontology_loader.py src/backend/workflows/workflow_definition_identity_service.py src/backend/vontology/code_concepts_registry.py tests/backend/test_prompt_template_service.py tests/backend/test_workflow_prompt_metadata_resolution.py tests/backend/test_vontology_loader.py tests/backend/test_workflow_definition_identity_service.py tests/backend/test_code_concepts_registry.py`