### PR TITLE
JVNAUTOSCI-1359 implement VWL long-horizon plan state

### DIFF
--- a/docs/engineering/jira_github_autofix_loop_workflow.md
+++ b/docs/engineering/jira_github_autofix_loop_workflow.md
@@ -262,18 +262,15 @@ Executable today with existing surfaces:
 - declarative per-step approval gating,
 - declarative retry/backoff policy execution,
 - declarative per-step idempotency reuse,
+- declarative per-step checkpoint policies,
+- workflow-level plan-state tracking with resumable cursor and summary snapshots,
+- completion gates that fail closed before terminal success when declared deliverables are unmet,
 - prompt and tool metadata resolution from workflow-authored prompt concepts,
 - durable workflow instance management,
 - high-level run summary persistence.
 
-Not cleanly expressible yet without follow-on VWL work:
-
-- long-horizon resumable per-issue checkpoints,
-- completion gates that prove all declared deliverables were met.
-
 ## Follow-on Mapping
 
-- `JVNAUTOSCI-1359`: plan-state, resumable checkpoints, and completion gates for long-running runs.
 - `JVNAUTOSCI-1360`: optional future import or execution of external SKILL artefacts against the stabilised VWL surface.
 
 ## Conformance Note

--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -292,6 +292,7 @@ Per-state metadata keys currently used:
 - `retry_policy`
 - `approval_gate`
 - `idempotency_policy`
+- `checkpoint_policy`
 - `loop_scope_id`
 - `fork_id`
 - `join_fork_id`
@@ -303,19 +304,31 @@ Canonical workflow-step runtime policy payloads are stored as singleton text rel
 - `#V#hasWorkflowStepRetryPolicyJson`
 - `#V#hasWorkflowStepApprovalGateJson`
 - `#V#hasWorkflowStepIdempotencyPolicyJson`
+- `#V#hasWorkflowStepCheckpointPolicyJson`
+
+Workflow-level long-horizon policy payloads are stored as singleton text relations on the workflow concept:
+
+- `#V#hasWorkflowPlanStatePolicyJson`
+- `#V#hasWorkflowCompletionGateJson`
 
 Current schema versions:
 
 - `workflow_step_retry_policy.v1`
 - `workflow_step_approval_gate.v1`
 - `workflow_step_idempotency_policy.v1`
+- `workflow_step_checkpoint_policy.v1`
+- `workflow_plan_state_policy.v1`
+- `workflow_completion_gate.v1`
 
 Normative semantics:
 
 - invalid policy payloads MUST fail workflow loading with deterministic error codes;
 - retry and idempotency policies currently apply only to single-action states;
 - approval gates MUST fail closed when the required approval context key is absent or falsey;
-- approval-gated mutative states SHOULD provide an explicit `on_approval_required` route to a blocked terminal or escalation state.
+- approval-gated mutative states SHOULD provide an explicit `on_approval_required` route to a blocked terminal or escalation state;
+- checkpoint policies update the shared runtime plan-state artefact rather than introducing workflow-specific Python persistence logic;
+- plan-state items support `pending|in_progress|blocked|done` statuses, bounded checkpoint history, periodic summary snapshots, resumable cursor snapshots, and resume telemetry;
+- completion gates MUST fail closed before terminal success when required plan items or required context keys are not satisfied.
 
 Validation phases:
 
@@ -777,9 +790,15 @@ Unless explicitly implemented in runtime code, items below are normative plannin
 
 ### 16.3 Long-Horizon Workflow State
 
-- VWL SHOULD support durable plan-state artefacts for multi-hour workflows.
-- Recommended plan state includes step status (`pending|in_progress|blocked|done`), checkpoint timestamps, and resumable cursors.
-- Long-running workflows SHOULD expose periodic summary hooks and completion gates that verify declared deliverables before terminal success.
+VWL now supports KB-authored long-horizon execution state through workflow-level plan-state and completion-gate policies plus per-step checkpoint policies.
+
+Implemented semantics:
+
+- plan-state items are declared in `workflow_plan_state_policy.v1` and recorded in the shared `workflow_plan_state` runtime artefact;
+- item status is limited to `pending|in_progress|blocked|done`;
+- step checkpoints can update named plan items, emit progress messages, capture summary snapshots, and persist resumable cursor snapshots from declared context paths;
+- resumptions increment runtime resume telemetry and preserve bounded checkpoint history;
+- terminal success is blocked by `workflow_completion_gate.v1` unless all required plan items and required context keys are satisfied.
 
 ### 16.4 Gate and Policy Semantics
 

--- a/src/backend/vontology/code_concepts_registry.py
+++ b/src/backend/vontology/code_concepts_registry.py
@@ -99,6 +99,12 @@ _WORKFLOW_PREDICATE_IDS = [
     "#V#has_workflow_step_approval_gate_json",
     "#V#hasWorkflowStepIdempotencyPolicyJson",
     "#V#has_workflow_step_idempotency_policy_json",
+    "#V#hasWorkflowStepCheckpointPolicyJson",
+    "#V#has_workflow_step_checkpoint_policy_json",
+    "#V#hasWorkflowPlanStatePolicyJson",
+    "#V#has_workflow_plan_state_policy_json",
+    "#V#hasWorkflowCompletionGateJson",
+    "#V#has_workflow_completion_gate_json",
 ]
 
 _WORKFLOW_PROMPT_PREDICATE_IDS = [

--- a/src/backend/workflows/durable/durable_executor.py
+++ b/src/backend/workflows/durable/durable_executor.py
@@ -54,6 +54,13 @@ from ..execution_contracts import (
     get_last_control_signal_scope,
     set_workflow_result_envelope,
 )
+from ..plan_state_runtime import (
+    apply_workflow_step_checkpoint,
+    compute_plan_state_progress,
+    evaluate_workflow_completion_gate,
+    mark_workflow_plan_state_entry,
+    mark_workflow_plan_state_resume,
+)
 from .instance_manager import WorkflowInstanceManager
 from .models import WorkflowInstance, WorkflowInstanceStatus
 
@@ -148,6 +155,13 @@ class DurableWorkflowExecutor:
             context = dict(instance.workflow_data)
             current_state = instance.current_state or definition.initial_state
             step_index = instance.step_index
+            mark_workflow_plan_state_resume(
+                context=context,
+                workflow_id=definition.workflow_id,
+                definition_metadata=definition.metadata,
+                current_state=current_state,
+                retry_count=int(instance.retry_count),
+            )
         else:
             context = dict(instance.inputs)
             current_state = definition.initial_state
@@ -209,6 +223,14 @@ class DurableWorkflowExecutor:
             )
             set_workflow_result_envelope(context=context, envelope=result_envelope)
             if checkpoint:
+                progress_current_value, progress_total_value, progress_message_value = (
+                    compute_plan_state_progress(
+                        context=context,
+                        fallback_current=step_index,
+                        fallback_total=total_steps,
+                        fallback_message=final_state,
+                    )
+                )
                 self._instance_manager.checkpoint(
                     instance_id,
                     current_state=final_state,
@@ -216,9 +238,9 @@ class DurableWorkflowExecutor:
                     step_index=step_index,
                     error=error,
                     error_step=error_step,
-                    progress_current=step_index,
-                    progress_total=total_steps,
-                    progress_message=final_state,
+                    progress_current=progress_current_value,
+                    progress_total=progress_total_value,
+                    progress_message=progress_message_value,
                 )
             return DurableWorkflowResult(
                 instance_id=instance_id,
@@ -228,6 +250,38 @@ class DurableWorkflowExecutor:
                 error=error,
                 step_count=step_index,
                 result_envelope=result_envelope,
+            )
+
+        def _complete_with_gate(final_state: str) -> DurableWorkflowResult:
+            gate_ok, gate_result = evaluate_workflow_completion_gate(
+                context=context,
+                workflow_id=definition.workflow_id,
+                definition_metadata=definition.metadata,
+                final_state=final_state,
+            )
+            if not gate_ok:
+                blocking_reasons = []
+                if isinstance(gate_result, Mapping):
+                    blocking_reasons = [
+                        str(item).strip()
+                        for item in gate_result.get("blocking_reason_codes") or []
+                        if str(item).strip()
+                    ]
+                error = "workflow_completion_gate_unmet"
+                if blocking_reasons:
+                    error = f"{error}:{'|'.join(blocking_reasons)}"
+                trace.finish_failed(error)
+                return _build_result(
+                    completed=False,
+                    final_state=final_state,
+                    error=error,
+                    checkpoint=True,
+                )
+            trace.finish_completed()
+            return _build_result(
+                completed=True,
+                final_state=final_state,
+                checkpoint=True,
             )
 
         while transitions < self._max_transitions:
@@ -257,6 +311,14 @@ class DurableWorkflowExecutor:
                     error=error,
                     checkpoint=True,
                 )
+
+            mark_workflow_plan_state_entry(
+                context=context,
+                workflow_id=definition.workflow_id,
+                state_id=current_state,
+                definition_metadata=definition.metadata,
+                state_metadata=state_spec.metadata,
+            )
 
             # Record state entry in trace
             trace.record_state_transition(
@@ -507,22 +569,22 @@ class DurableWorkflowExecutor:
                     checkpoint=True,
                 )
 
+            apply_workflow_step_checkpoint(
+                context=context,
+                workflow_id=definition.workflow_id,
+                state_id=current_state,
+                step_index=step_index,
+                definition_metadata=definition.metadata,
+                state_metadata=state_spec.metadata,
+                blocked=False,
+            )
+
             if control_signal == WORKFLOW_CONTROL_SIGNAL_RETURN:
-                trace.finish_completed()
-                return _build_result(
-                    completed=True,
-                    final_state=current_state,
-                    checkpoint=True,
-                )
+                return _complete_with_gate(current_state)
 
             # Check for terminal state
             if current_state in termination_states:
-                trace.finish_completed()
-                return _build_result(
-                    completed=True,
-                    final_state=current_state,
-                    checkpoint=True,
-                )
+                return _complete_with_gate(current_state)
 
             # Evaluate transitions
             next_state = None
@@ -561,14 +623,22 @@ class DurableWorkflowExecutor:
                 )
 
             # CHECKPOINT after successful step (before transitioning)
+            progress_current_value, progress_total_value, progress_message_value = (
+                compute_plan_state_progress(
+                    context=context,
+                    fallback_current=step_index,
+                    fallback_total=total_steps,
+                    fallback_message=next_state,
+                )
+            )
             self._instance_manager.checkpoint(
                 instance_id,
                 current_state=next_state,
                 workflow_data=context,
                 step_index=step_index,
-                progress_current=step_index,
-                progress_total=total_steps,
-                progress_message=next_state,
+                progress_current=progress_current_value,
+                progress_total=progress_total_value,
+                progress_message=progress_message_value,
             )
 
             trace.record_state_transition(

--- a/src/backend/workflows/engine.py
+++ b/src/backend/workflows/engine.py
@@ -43,6 +43,11 @@ from .execution_contracts import (
     set_workflow_result_envelope,
     stamp_control_signal_context,
 )
+from .plan_state_runtime import (
+    apply_workflow_step_checkpoint,
+    evaluate_workflow_completion_gate,
+    mark_workflow_plan_state_entry,
+)
 from .trace_model import WorkflowExecutionTrace
 
 _CONTEXT_BINDING_KEYS: tuple[str, ...] = (
@@ -1143,6 +1148,38 @@ class WorkflowExecutor:
                 result_envelope=result_envelope,
             )
 
+        def _complete_with_gate(final_state: str) -> WorkflowResult:
+            gate_ok, gate_result = evaluate_workflow_completion_gate(
+                context=context,
+                workflow_id=definition.workflow_id,
+                definition_metadata=definition.metadata,
+                final_state=final_state,
+            )
+            if not gate_ok:
+                blocking_reasons = []
+                if isinstance(gate_result, Mapping):
+                    blocking_reasons = [
+                        str(item).strip()
+                        for item in gate_result.get("blocking_reason_codes") or []
+                        if str(item).strip()
+                    ]
+                error = "workflow_completion_gate_unmet"
+                if blocking_reasons:
+                    error = f"{error}:{'|'.join(blocking_reasons)}"
+                if trace is not None:
+                    trace.finish_failed(error)
+                return _build_result(
+                    completed=False,
+                    final_state=final_state,
+                    error=error,
+                )
+            if trace is not None:
+                trace.finish_completed()
+            return _build_result(
+                completed=True,
+                final_state=final_state,
+            )
+
         while transitions < self._max_transitions:
             transitions += 1
             state_spec = definition.states.get(current_state)
@@ -1153,6 +1190,14 @@ class WorkflowExecutor:
                     final_state=current_state,
                     error=error,
                 )
+
+            mark_workflow_plan_state_entry(
+                context=context,
+                workflow_id=definition.workflow_id,
+                state_id=current_state,
+                definition_metadata=definition.metadata,
+                state_metadata=state_spec.metadata,
+            )
 
             if trace is not None:
                 trace.record_state_transition(
@@ -1688,21 +1733,21 @@ class WorkflowExecutor:
                     error=error,
                 )
 
+            apply_workflow_step_checkpoint(
+                context=context,
+                workflow_id=definition.workflow_id,
+                state_id=current_state,
+                step_index=transitions,
+                definition_metadata=definition.metadata,
+                state_metadata=state_spec.metadata,
+                blocked=approval_blocked,
+            )
+
             if control_signal == WORKFLOW_CONTROL_SIGNAL_RETURN:
-                if trace is not None:
-                    trace.finish_completed()
-                return _build_result(
-                    completed=True,
-                    final_state=current_state,
-                )
+                return _complete_with_gate(current_state)
 
             if current_state in termination_states:
-                if trace is not None:
-                    trace.finish_completed()
-                return _build_result(
-                    completed=True,
-                    final_state=current_state,
-                )
+                return _complete_with_gate(current_state)
 
             next_state = None
             transition_reason = None

--- a/src/backend/workflows/plan_state_runtime.py
+++ b/src/backend/workflows/plan_state_runtime.py
@@ -1,0 +1,1052 @@
+"""Shared long-horizon workflow plan-state contracts and runtime helpers."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any, Mapping, MutableMapping, Sequence
+
+from .context_paths import resolve_context_path
+from .execution_contracts import append_runtime_event
+
+WORKFLOW_PLAN_STATE_POLICY_SCHEMA_VERSION = "workflow_plan_state_policy.v1"
+WORKFLOW_STEP_CHECKPOINT_POLICY_SCHEMA_VERSION = (
+    "workflow_step_checkpoint_policy.v1"
+)
+WORKFLOW_COMPLETION_GATE_SCHEMA_VERSION = "workflow_completion_gate.v1"
+WORKFLOW_PLAN_STATE_RUNTIME_SCHEMA_VERSION = "workflow_plan_state_runtime.v1"
+
+WORKFLOW_PLAN_STATE_ALLOWED_STATUSES: tuple[str, ...] = (
+    "pending",
+    "in_progress",
+    "blocked",
+    "done",
+)
+
+WORKFLOW_PLAN_STATE_KEY = "workflow_plan_state"
+WORKFLOW_PLAN_STATE_EVENTS_KEY = "workflow_plan_state_events"
+LAST_WORKFLOW_PLAN_STATE_EVENT_KEY = "last_workflow_plan_state_event"
+WORKFLOW_COMPLETION_GATE_KEY = "workflow_completion_gate"
+LAST_WORKFLOW_COMPLETION_GATE_KEY = "last_workflow_completion_gate"
+
+
+def _utc_iso(now_utc: datetime | None = None) -> str:
+    value = now_utc if isinstance(now_utc, datetime) else datetime.now(timezone.utc)
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.isoformat()
+
+
+def _append_context_event(
+    *,
+    context: MutableMapping[str, Any],
+    key: str,
+    last_key: str,
+    event: Mapping[str, Any],
+    max_entries: int | None = None,
+) -> None:
+    existing = context.get(key)
+    if not isinstance(existing, list):
+        existing = []
+        context[key] = existing
+    payload = dict(event)
+    existing.append(payload)
+    if isinstance(max_entries, int) and max_entries > 0 and len(existing) > max_entries:
+        del existing[:-max_entries]
+    context[last_key] = payload
+
+
+def _normalise_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalise_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        token = value.strip().lower()
+        if token in {"1", "true", "yes", "on"}:
+            return True
+        if token in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _normalise_positive_int(
+    value: Any,
+    *,
+    field_name: str,
+    default: int,
+    minimum: int = 1,
+) -> int:
+    if value is None or value == "":
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name}_not_int") from exc
+    if parsed < minimum:
+        raise ValueError(f"{field_name}_below_minimum")
+    return parsed
+
+
+def _normalise_non_negative_int(
+    value: Any,
+    *,
+    field_name: str,
+    default: int,
+) -> int:
+    if value is None or value == "":
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name}_not_int") from exc
+    if parsed < 0:
+        raise ValueError(f"{field_name}_below_minimum")
+    return parsed
+
+
+def _normalise_string_list(value: Any) -> list[str]:
+    raw_items: list[str] = []
+    if isinstance(value, str):
+        raw_items = [value]
+    elif isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        raw_items = [item for item in value if isinstance(item, str)]
+    result: list[str] = []
+    seen: set[str] = set()
+    for raw_item in raw_items:
+        item = _normalise_text(raw_item)
+        if not item or item in seen:
+            continue
+        seen.add(item)
+        result.append(item)
+    return result
+
+
+def _normalise_plan_item_status(value: Any, *, field_name: str) -> str:
+    status = _normalise_text(value).lower()
+    if not status:
+        raise ValueError(f"{field_name}_missing")
+    if status not in set(WORKFLOW_PLAN_STATE_ALLOWED_STATUSES):
+        raise ValueError(f"{field_name}_invalid")
+    return status
+
+
+def _normalise_plan_items(
+    value: Any,
+    *,
+    default_status: str,
+) -> list[dict[str, str]]:
+    if value is None:
+        return []
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise ValueError("plan_items_not_list")
+
+    normalised: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for index, raw_item in enumerate(value):
+        item_id = ""
+        label = ""
+        description = ""
+        item_status = default_status
+        if isinstance(raw_item, str):
+            item_id = _normalise_text(raw_item)
+            label = item_id
+        elif isinstance(raw_item, Mapping):
+            item_id = _normalise_text(
+                raw_item.get("item_id") or raw_item.get("id") or raw_item.get("name")
+            )
+            label = _normalise_text(raw_item.get("label") or item_id)
+            description = _normalise_text(raw_item.get("description"))
+            if raw_item.get("default_status") is not None:
+                item_status = _normalise_plan_item_status(
+                    raw_item.get("default_status"),
+                    field_name=f"plan_item_default_status_{index}",
+                )
+            elif raw_item.get("status") is not None:
+                item_status = _normalise_plan_item_status(
+                    raw_item.get("status"),
+                    field_name=f"plan_item_status_{index}",
+                )
+        else:
+            raise ValueError("plan_item_invalid")
+
+        if not item_id:
+            raise ValueError("plan_item_id_missing")
+        if item_id in seen:
+            raise ValueError("plan_item_id_duplicate")
+        seen.add(item_id)
+        normalised.append(
+            {
+                "item_id": item_id,
+                "label": label or item_id,
+                "description": description,
+                "default_status": item_status,
+            }
+        )
+    return normalised
+
+
+def _normalise_plan_item_updates(value: Any) -> list[dict[str, str]]:
+    if value is None:
+        return []
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise ValueError("plan_item_updates_not_list")
+
+    updates: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for index, raw_item in enumerate(value):
+        item_id = ""
+        status = "done"
+        label = ""
+        if isinstance(raw_item, str):
+            item_id = _normalise_text(raw_item)
+        elif isinstance(raw_item, Mapping):
+            item_id = _normalise_text(
+                raw_item.get("item_id") or raw_item.get("id") or raw_item.get("name")
+            )
+            label = _normalise_text(raw_item.get("label"))
+            status = _normalise_plan_item_status(
+                raw_item.get("status") or "done",
+                field_name=f"plan_item_update_status_{index}",
+            )
+        else:
+            raise ValueError("plan_item_update_invalid")
+        if not item_id:
+            raise ValueError("plan_item_update_id_missing")
+        if item_id in seen:
+            raise ValueError("plan_item_update_duplicate")
+        seen.add(item_id)
+        payload = {"item_id": item_id, "status": status}
+        if label:
+            payload["label"] = label
+        updates.append(payload)
+    return updates
+
+
+def _normalise_required_plan_item_statuses(value: Any) -> dict[str, str]:
+    if value is None:
+        return {}
+    if isinstance(value, Mapping):
+        result: dict[str, str] = {}
+        for raw_key, raw_value in value.items():
+            item_id = _normalise_text(raw_key)
+            if not item_id:
+                raise ValueError("required_plan_item_id_missing")
+            if item_id in result:
+                raise ValueError("required_plan_item_id_duplicate")
+            result[item_id] = _normalise_plan_item_status(
+                raw_value,
+                field_name=f"required_plan_item_status_{item_id}",
+            )
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        result = {}
+        for raw_item in value:
+            item_id = _normalise_text(raw_item)
+            if not item_id:
+                raise ValueError("required_plan_item_id_missing")
+            if item_id in result:
+                raise ValueError("required_plan_item_id_duplicate")
+            result[item_id] = "done"
+        return result
+    raise ValueError("required_plan_item_statuses_invalid")
+
+
+def normalise_workflow_plan_state_policy_spec(
+    value: Any,
+) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ValueError("workflow_plan_state_policy_not_object")
+
+    default_status = (
+        _normalise_plan_item_status(
+            value.get("default_item_status") or "pending",
+            field_name="default_item_status",
+        )
+        if value.get("default_item_status") is not None
+        else "pending"
+    )
+    return {
+        "schema_version": WORKFLOW_PLAN_STATE_POLICY_SCHEMA_VERSION,
+        "plan_items": _normalise_plan_items(
+            value.get("plan_items") or value.get("items"),
+            default_status=default_status,
+        ),
+        "default_item_status": default_status,
+        "summary_context_keys": _normalise_string_list(
+            value.get("summary_context_keys") or value.get("summary_keys")
+        ),
+        "cursor_context_keys": _normalise_string_list(
+            value.get("cursor_context_keys")
+            or value.get("cursor_keys")
+            or value.get("resumable_cursor_context_keys")
+        ),
+        "summary_interval_steps": _normalise_non_negative_int(
+            value.get("summary_interval_steps")
+            or value.get("periodic_summary_interval_steps"),
+            field_name="summary_interval_steps",
+            default=0,
+        ),
+        "max_checkpoint_history": _normalise_positive_int(
+            value.get("max_checkpoint_history") or value.get("max_checkpoints"),
+            field_name="max_checkpoint_history",
+            default=20,
+        ),
+    }
+
+
+def normalise_workflow_step_checkpoint_policy_spec(
+    value: Any,
+) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ValueError("workflow_step_checkpoint_policy_not_object")
+
+    plan_item_updates = _normalise_plan_item_updates(
+        value.get("plan_item_updates") or value.get("plan_items")
+    )
+    return {
+        "schema_version": WORKFLOW_STEP_CHECKPOINT_POLICY_SCHEMA_VERSION,
+        "plan_item_updates": plan_item_updates,
+        "checkpoint_label": _normalise_text(
+            value.get("checkpoint_label") or value.get("label")
+        ),
+        "summary_context_keys": _normalise_string_list(
+            value.get("summary_context_keys") or value.get("summary_keys")
+        ),
+        "cursor_context_keys": _normalise_string_list(
+            value.get("cursor_context_keys")
+            or value.get("cursor_keys")
+            or value.get("resumable_cursor_context_keys")
+        ),
+        "progress_message": _normalise_text(
+            value.get("progress_message") or value.get("message")
+        ),
+        "force_summary": _normalise_bool(value.get("force_summary"), default=False),
+    }
+
+
+def normalise_workflow_completion_gate_spec(
+    value: Any,
+) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ValueError("workflow_completion_gate_not_object")
+
+    required_plan_item_statuses = _normalise_required_plan_item_statuses(
+        value.get("required_plan_item_statuses")
+        if "required_plan_item_statuses" in value
+        else value.get("required_done_plan_items")
+    )
+    blocked_statuses = _normalise_string_list(value.get("blocked_statuses"))
+    if blocked_statuses:
+        blocked_statuses = [
+            _normalise_plan_item_status(item, field_name="blocked_status")
+            for item in blocked_statuses
+        ]
+    else:
+        blocked_statuses = ["blocked"]
+
+    return {
+        "schema_version": WORKFLOW_COMPLETION_GATE_SCHEMA_VERSION,
+        "required_plan_item_statuses": required_plan_item_statuses,
+        "required_context_keys": _normalise_string_list(
+            value.get("required_context_keys") or value.get("required_outputs")
+        ),
+        "blocked_statuses": blocked_statuses,
+        "require_declared_plan_items_done": _normalise_bool(
+            value.get("require_declared_plan_items_done"),
+            default=True,
+        ),
+        "allow_missing_plan_state": _normalise_bool(
+            value.get("allow_missing_plan_state"),
+            default=False,
+        ),
+    }
+
+
+def _declared_item_map(
+    plan_state_policy: Mapping[str, Any] | None,
+) -> dict[str, dict[str, str]]:
+    policy = plan_state_policy if isinstance(plan_state_policy, Mapping) else {}
+    result: dict[str, dict[str, str]] = {}
+    for raw_item in policy.get("plan_items") or []:
+        if not isinstance(raw_item, Mapping):
+            continue
+        item_id = _normalise_text(raw_item.get("item_id"))
+        if not item_id:
+            continue
+        result[item_id] = {
+            "label": _normalise_text(raw_item.get("label") or item_id),
+            "description": _normalise_text(raw_item.get("description")),
+            "default_status": _normalise_text(raw_item.get("default_status") or "pending")
+            or "pending",
+        }
+    return result
+
+
+def _coerce_plan_state_policy(
+    value: Any,
+) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    try:
+        return normalise_workflow_plan_state_policy_spec(value)
+    except ValueError:
+        return value if isinstance(value, dict) else dict(value)
+
+
+def _coerce_step_checkpoint_policy(
+    value: Any,
+) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    try:
+        return normalise_workflow_step_checkpoint_policy_spec(value)
+    except ValueError:
+        return value if isinstance(value, dict) else dict(value)
+
+
+def _coerce_completion_gate(
+    value: Any,
+) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    try:
+        return normalise_workflow_completion_gate_spec(value)
+    except ValueError:
+        return value if isinstance(value, dict) else dict(value)
+
+
+def _ensure_plan_item(
+    *,
+    plan_state: MutableMapping[str, Any],
+    item_id: str,
+    declared_items: Mapping[str, Mapping[str, Any]],
+    default_status: str,
+    now_iso: str,
+    label: str | None = None,
+) -> MutableMapping[str, Any]:
+    items_raw = plan_state.get("items")
+    if not isinstance(items_raw, MutableMapping):
+        items_raw = {}
+        plan_state["items"] = items_raw
+
+    item = items_raw.get(item_id)
+    if not isinstance(item, MutableMapping):
+        declared = (
+            declared_items.get(item_id) if isinstance(declared_items, Mapping) else None
+        )
+        item = {
+            "item_id": item_id,
+            "label": label
+            or _normalise_text((declared or {}).get("label") or item_id)
+            or item_id,
+            "description": _normalise_text((declared or {}).get("description")),
+            "status": _normalise_text(
+                (declared or {}).get("default_status") or default_status
+            )
+            or default_status,
+            "updated_at_utc": now_iso,
+            "last_state_id": None,
+            "checkpoint_count": 0,
+        }
+        items_raw[item_id] = item
+
+    order_raw = plan_state.get("item_order")
+    if not isinstance(order_raw, list):
+        order_raw = []
+        plan_state["item_order"] = order_raw
+    if item_id not in order_raw:
+        order_raw.append(item_id)
+    if label:
+        item["label"] = label
+    return item
+
+
+def _capture_context_snapshot(
+    *,
+    context: Mapping[str, Any],
+    keys: Sequence[str],
+) -> dict[str, Any]:
+    snapshot: dict[str, Any] = {}
+    for raw_key in keys:
+        key = _normalise_text(raw_key)
+        if not key:
+            continue
+        found, value = resolve_context_path(context=context, path=key)
+        if not found:
+            continue
+        snapshot[key] = deepcopy(value)
+    return snapshot
+
+
+def ensure_workflow_plan_state(
+    *,
+    context: MutableMapping[str, Any],
+    workflow_id: str,
+    definition_metadata: Mapping[str, Any] | None,
+    now_utc: datetime | None = None,
+) -> MutableMapping[str, Any] | None:
+    raw_policy = (
+        definition_metadata.get("plan_state_policy")
+        if isinstance(definition_metadata, Mapping)
+        else None
+    )
+    plan_state_policy = _coerce_plan_state_policy(raw_policy)
+
+    existing = context.get(WORKFLOW_PLAN_STATE_KEY)
+    if isinstance(existing, MutableMapping):
+        if not existing.get("workflow_id"):
+            existing["workflow_id"] = workflow_id
+        if not existing.get("schema_version"):
+            existing["schema_version"] = WORKFLOW_PLAN_STATE_RUNTIME_SCHEMA_VERSION
+        declared_items = _declared_item_map(plan_state_policy)
+        now_iso = _utc_iso(now_utc)
+        default_status = "pending"
+        if isinstance(plan_state_policy, Mapping):
+            default_status = _normalise_text(
+                plan_state_policy.get("default_item_status") or "pending"
+            )
+        for item_id, item_details in declared_items.items():
+            _ensure_plan_item(
+                plan_state=existing,
+                item_id=item_id,
+                declared_items=declared_items,
+                default_status=default_status or "pending",
+                now_iso=now_iso,
+                label=_normalise_text(item_details.get("label")),
+            )
+        return existing
+
+    if plan_state_policy is None:
+        return None
+
+    now_iso = _utc_iso(now_utc)
+    default_status = _normalise_text(
+        plan_state_policy.get("default_item_status") or "pending"
+    )
+    plan_state: MutableMapping[str, Any] = {
+        "schema_version": WORKFLOW_PLAN_STATE_RUNTIME_SCHEMA_VERSION,
+        "workflow_id": workflow_id,
+        "started_at_utc": now_iso,
+        "updated_at_utc": now_iso,
+        "current_state": "",
+        "checkpoint_count": 0,
+        "summary_count": 0,
+        "resume_count": 0,
+        "item_order": [],
+        "items": {},
+        "checkpoints": [],
+        "last_checkpoint": None,
+        "last_summary": None,
+        "declared_item_ids": [
+            _normalise_text(item.get("item_id"))
+            for item in plan_state_policy.get("plan_items") or []
+            if isinstance(item, Mapping) and _normalise_text(item.get("item_id"))
+        ],
+    }
+    declared_items = _declared_item_map(plan_state_policy)
+    for item_id, item_details in declared_items.items():
+        _ensure_plan_item(
+            plan_state=plan_state,
+            item_id=item_id,
+            declared_items=declared_items,
+            default_status=default_status or "pending",
+            now_iso=now_iso,
+            label=_normalise_text(item_details.get("label")),
+        )
+
+    context[WORKFLOW_PLAN_STATE_KEY] = plan_state
+    return plan_state
+
+
+def mark_workflow_plan_state_resume(
+    *,
+    context: MutableMapping[str, Any],
+    workflow_id: str,
+    definition_metadata: Mapping[str, Any] | None,
+    current_state: str,
+    retry_count: int = 0,
+    now_utc: datetime | None = None,
+) -> MutableMapping[str, Any] | None:
+    plan_state = ensure_workflow_plan_state(
+        context=context,
+        workflow_id=workflow_id,
+        definition_metadata=definition_metadata,
+        now_utc=now_utc,
+    )
+    if not isinstance(plan_state, MutableMapping):
+        return None
+
+    now_iso = _utc_iso(now_utc)
+    plan_state["resume_count"] = int(plan_state.get("resume_count") or 0) + 1
+    plan_state["updated_at_utc"] = now_iso
+    plan_state["current_state"] = _normalise_text(current_state)
+
+    max_entries = int(
+        (
+            _coerce_plan_state_policy(
+                definition_metadata.get("plan_state_policy", {})
+                if isinstance(definition_metadata, Mapping)
+                else {}
+            )
+            or {}
+        ).get("max_checkpoint_history")
+        or 20
+    )
+    event = {
+        "status": "workflow_plan_state_resumed",
+        "workflow_id": workflow_id,
+        "state_id": _normalise_text(current_state) or None,
+        "retry_count": int(retry_count),
+        "resume_count": int(plan_state.get("resume_count") or 0),
+        "occurred_at_utc": now_iso,
+    }
+    _append_context_event(
+        context=context,
+        key=WORKFLOW_PLAN_STATE_EVENTS_KEY,
+        last_key=LAST_WORKFLOW_PLAN_STATE_EVENT_KEY,
+        event=event,
+        max_entries=max_entries,
+    )
+    append_runtime_event(context=context, event=event)
+    return plan_state
+
+
+def mark_workflow_plan_state_entry(
+    *,
+    context: MutableMapping[str, Any],
+    workflow_id: str,
+    state_id: str,
+    definition_metadata: Mapping[str, Any] | None,
+    state_metadata: Mapping[str, Any] | None,
+    now_utc: datetime | None = None,
+) -> MutableMapping[str, Any] | None:
+    plan_state = ensure_workflow_plan_state(
+        context=context,
+        workflow_id=workflow_id,
+        definition_metadata=definition_metadata,
+        now_utc=now_utc,
+    )
+    if not isinstance(plan_state, MutableMapping):
+        return None
+
+    now_iso = _utc_iso(now_utc)
+    raw_plan_policy = (
+        definition_metadata.get("plan_state_policy")
+        if isinstance(definition_metadata, Mapping)
+        else None
+    )
+    plan_state_policy = _coerce_plan_state_policy(raw_plan_policy) or {}
+    declared_items = _declared_item_map(plan_state_policy)
+    default_status = _normalise_text(
+        plan_state_policy.get("default_item_status") or "pending"
+    )
+    state_id_text = _normalise_text(state_id)
+    items_raw = plan_state.get("items")
+    item_exists = isinstance(items_raw, Mapping) and state_id_text in items_raw
+    if declared_items and state_id_text not in declared_items and not item_exists:
+        plan_state["current_state"] = state_id_text
+        plan_state["updated_at_utc"] = now_iso
+        return plan_state
+    state_item = _ensure_plan_item(
+        plan_state=plan_state,
+        item_id=state_id_text,
+        declared_items=declared_items,
+        default_status=default_status or "pending",
+        now_iso=now_iso,
+    )
+    if _normalise_text(state_item.get("status")) != "done":
+        state_item["status"] = "in_progress"
+        state_item["updated_at_utc"] = now_iso
+        state_item["last_state_id"] = state_id_text
+
+    plan_state["current_state"] = state_id_text
+    plan_state["updated_at_utc"] = now_iso
+    return plan_state
+
+
+def apply_workflow_step_checkpoint(
+    *,
+    context: MutableMapping[str, Any],
+    workflow_id: str,
+    state_id: str,
+    step_index: int,
+    definition_metadata: Mapping[str, Any] | None,
+    state_metadata: Mapping[str, Any] | None,
+    blocked: bool = False,
+    now_utc: datetime | None = None,
+) -> MutableMapping[str, Any] | None:
+    plan_state = ensure_workflow_plan_state(
+        context=context,
+        workflow_id=workflow_id,
+        definition_metadata=definition_metadata,
+        now_utc=now_utc,
+    )
+    if not isinstance(plan_state, MutableMapping):
+        return None
+
+    raw_plan_policy = (
+        definition_metadata.get("plan_state_policy")
+        if isinstance(definition_metadata, Mapping)
+        else None
+    )
+    plan_state_policy = _coerce_plan_state_policy(raw_plan_policy) or {}
+    raw_checkpoint_policy = (
+        state_metadata.get("checkpoint_policy")
+        if isinstance(state_metadata, Mapping)
+        else None
+    )
+    checkpoint_policy = _coerce_step_checkpoint_policy(raw_checkpoint_policy) or {}
+
+    now_iso = _utc_iso(now_utc)
+    declared_items = _declared_item_map(plan_state_policy)
+    default_status = _normalise_text(
+        plan_state_policy.get("default_item_status") or "pending"
+    )
+    state_id_text = _normalise_text(state_id)
+    plan_state["current_state"] = state_id_text
+    plan_state["updated_at_utc"] = now_iso
+    plan_state["checkpoint_count"] = int(plan_state.get("checkpoint_count") or 0) + 1
+    checkpoint_count = int(plan_state.get("checkpoint_count") or 0)
+
+    updates = checkpoint_policy.get("plan_item_updates")
+    if not isinstance(updates, list):
+        updates = []
+    normalised_updates = [
+        dict(item)
+        for item in updates
+        if isinstance(item, Mapping) and _normalise_text(item.get("item_id"))
+    ]
+    items_raw = plan_state.get("items")
+    state_item_exists = isinstance(items_raw, Mapping) and state_id_text in items_raw
+    if not normalised_updates and (
+        not declared_items or state_id_text in declared_items or state_item_exists
+    ):
+        normalised_updates = [
+            {
+                "item_id": state_id_text,
+                "status": "blocked" if blocked else "done",
+            }
+        ]
+
+    cursor_keys = checkpoint_policy.get("cursor_context_keys")
+    if not isinstance(cursor_keys, list) or not cursor_keys:
+        cursor_keys = plan_state_policy.get("cursor_context_keys") or []
+    summary_keys = checkpoint_policy.get("summary_context_keys")
+    if not isinstance(summary_keys, list) or not summary_keys:
+        summary_keys = plan_state_policy.get("summary_context_keys") or []
+
+    cursor_snapshot = _capture_context_snapshot(context=context, keys=cursor_keys)
+    summary_snapshot = _capture_context_snapshot(context=context, keys=summary_keys)
+
+    summary_interval = int(plan_state_policy.get("summary_interval_steps") or 0)
+    force_summary = bool(checkpoint_policy.get("force_summary"))
+    should_emit_summary = force_summary or (
+        summary_interval > 0
+        and checkpoint_count % summary_interval == 0
+        and bool(summary_snapshot)
+    )
+    last_summary_raw = plan_state.get("last_summary")
+    last_summary: dict[str, Any] | None = None
+    if isinstance(last_summary_raw, Mapping):
+        last_summary = {
+            str(key): value for key, value in last_summary_raw.items() if isinstance(key, str)
+        }
+    if should_emit_summary:
+        summary_event: dict[str, Any] = {
+            "status": "workflow_plan_state_summary",
+            "workflow_id": workflow_id,
+            "state_id": state_id_text,
+            "step_index": int(step_index),
+            "summary_snapshot": summary_snapshot,
+            "occurred_at_utc": now_iso,
+        }
+        plan_state["summary_count"] = int(plan_state.get("summary_count") or 0) + 1
+        plan_state["last_summary"] = summary_event
+        last_summary = summary_event
+
+    applied_updates: list[dict[str, Any]] = []
+    for update in normalised_updates:
+        item_id = _normalise_text(update.get("item_id"))
+        if not item_id:
+            continue
+        item = _ensure_plan_item(
+            plan_state=plan_state,
+            item_id=item_id,
+            declared_items=declared_items,
+            default_status=default_status or "pending",
+            now_iso=now_iso,
+            label=_normalise_text(update.get("label")),
+        )
+        status = _normalise_text(
+            update.get("status") or ("blocked" if blocked else "done")
+        )
+        item["status"] = status
+        item["updated_at_utc"] = now_iso
+        item["last_state_id"] = state_id_text
+        item["checkpoint_count"] = int(item.get("checkpoint_count") or 0) + 1
+        if cursor_snapshot:
+            item["cursor_snapshot"] = deepcopy(cursor_snapshot)
+        if summary_snapshot:
+            item["summary_snapshot"] = deepcopy(summary_snapshot)
+        applied_updates.append({"item_id": item_id, "status": status})
+
+    checkpoint_event: dict[str, Any] = {
+        "status": "workflow_plan_state_checkpoint",
+        "workflow_id": workflow_id,
+        "state_id": state_id_text,
+        "step_index": int(step_index),
+        "checkpoint_index": checkpoint_count,
+        "checkpoint_label": _normalise_text(
+            checkpoint_policy.get("checkpoint_label") or state_id
+        )
+        or state_id_text,
+        "progress_message": _normalise_text(
+            checkpoint_policy.get("progress_message")
+            or checkpoint_policy.get("checkpoint_label")
+            or state_id
+        )
+        or state_id_text,
+        "plan_item_updates": applied_updates,
+        "cursor_snapshot": cursor_snapshot,
+        "summary_snapshot": summary_snapshot if should_emit_summary else {},
+        "blocked": bool(blocked),
+        "occurred_at_utc": now_iso,
+    }
+    if last_summary is not None:
+        checkpoint_event["last_summary"] = deepcopy(last_summary)
+
+    checkpoints_raw = plan_state.get("checkpoints")
+    if not isinstance(checkpoints_raw, list):
+        checkpoints_raw = []
+        plan_state["checkpoints"] = checkpoints_raw
+    checkpoints_raw.append(checkpoint_event)
+    max_entries = int(plan_state_policy.get("max_checkpoint_history") or 20)
+    if max_entries > 0 and len(checkpoints_raw) > max_entries:
+        del checkpoints_raw[:-max_entries]
+    plan_state["last_checkpoint"] = checkpoint_event
+
+    _append_context_event(
+        context=context,
+        key=WORKFLOW_PLAN_STATE_EVENTS_KEY,
+        last_key=LAST_WORKFLOW_PLAN_STATE_EVENT_KEY,
+        event=checkpoint_event,
+        max_entries=max_entries,
+    )
+    append_runtime_event(context=context, event=checkpoint_event)
+    if last_summary is not None:
+        _append_context_event(
+            context=context,
+            key=WORKFLOW_PLAN_STATE_EVENTS_KEY,
+            last_key=LAST_WORKFLOW_PLAN_STATE_EVENT_KEY,
+            event=last_summary,
+            max_entries=max_entries,
+        )
+        append_runtime_event(context=context, event=last_summary)
+    return plan_state
+
+
+def compute_plan_state_progress(
+    *,
+    context: Mapping[str, Any],
+    fallback_current: int,
+    fallback_total: int,
+    fallback_message: str | None,
+) -> tuple[int, int, str | None]:
+    plan_state = context.get(WORKFLOW_PLAN_STATE_KEY)
+    if not isinstance(plan_state, Mapping):
+        return int(fallback_current), int(fallback_total), fallback_message
+
+    item_order = [
+        _normalise_text(item_id)
+        for item_id in plan_state.get("item_order") or []
+        if _normalise_text(item_id)
+    ]
+    items = plan_state.get("items")
+    if not item_order or not isinstance(items, Mapping):
+        return int(fallback_current), int(fallback_total), fallback_message
+
+    done_count = 0
+    for item_id in item_order:
+        raw_item = items.get(item_id)
+        if not isinstance(raw_item, Mapping):
+            continue
+        if _normalise_text(raw_item.get("status")) == "done":
+            done_count += 1
+
+    message = fallback_message
+    last_checkpoint = plan_state.get("last_checkpoint")
+    if isinstance(last_checkpoint, Mapping):
+        checkpoint_message = _normalise_text(last_checkpoint.get("progress_message"))
+        if checkpoint_message:
+            message = checkpoint_message
+
+    return done_count, len(item_order), message
+
+
+def evaluate_workflow_completion_gate(
+    *,
+    context: MutableMapping[str, Any],
+    workflow_id: str,
+    definition_metadata: Mapping[str, Any] | None,
+    final_state: str,
+    now_utc: datetime | None = None,
+) -> tuple[bool, dict[str, Any] | None]:
+    raw_gate = (
+        definition_metadata.get("completion_gate")
+        if isinstance(definition_metadata, Mapping)
+        else None
+    )
+    completion_gate = _coerce_completion_gate(raw_gate)
+    if completion_gate is None:
+        return True, None
+
+    raw_plan_policy = (
+        definition_metadata.get("plan_state_policy")
+        if isinstance(definition_metadata, Mapping)
+        else None
+    )
+    plan_state_policy = _coerce_plan_state_policy(raw_plan_policy) or {}
+    plan_state = context.get(WORKFLOW_PLAN_STATE_KEY)
+    plan_items = (
+        plan_state.get("items")
+        if isinstance(plan_state, Mapping) and isinstance(plan_state.get("items"), Mapping)
+        else {}
+    )
+
+    blocking_reason_codes: list[str] = []
+    missing_context_keys: list[str] = []
+    unmet_plan_items: list[dict[str, str]] = []
+    blocked_plan_items: list[dict[str, str]] = []
+
+    required_context_keys = completion_gate.get("required_context_keys") or []
+    for raw_key in required_context_keys:
+        key = _normalise_text(raw_key)
+        if not key:
+            continue
+        found, value = resolve_context_path(context=context, path=key)
+        if not found or value in (None, False, "", [], {}, ()):
+            missing_context_keys.append(key)
+
+    declared_plan_items = [
+        _normalise_text(raw_item.get("item_id"))
+        for raw_item in plan_state_policy.get("plan_items") or []
+        if isinstance(raw_item, Mapping) and _normalise_text(raw_item.get("item_id"))
+    ]
+
+    if not isinstance(plan_state, Mapping):
+        if (
+            completion_gate.get("required_plan_item_statuses")
+            or (
+                completion_gate.get("require_declared_plan_items_done")
+                and bool(declared_plan_items)
+            )
+        ) and not bool(completion_gate.get("allow_missing_plan_state")):
+            blocking_reason_codes.append("plan_state_missing")
+    else:
+        required_statuses = dict(completion_gate.get("required_plan_item_statuses") or {})
+        if bool(completion_gate.get("require_declared_plan_items_done")):
+            for item_id in declared_plan_items:
+                if item_id and item_id not in required_statuses:
+                    required_statuses[item_id] = "done"
+
+        for item_id, required_status in required_statuses.items():
+            raw_item = plan_items.get(item_id) if isinstance(plan_items, Mapping) else None
+            actual_status = (
+                _normalise_text(raw_item.get("status"))
+                if isinstance(raw_item, Mapping)
+                else ""
+            )
+            if actual_status != _normalise_text(required_status):
+                unmet_plan_items.append(
+                    {
+                        "item_id": item_id,
+                        "required_status": _normalise_text(required_status),
+                        "actual_status": actual_status or "missing",
+                    }
+                )
+
+        blocked_statuses = {
+            _normalise_text(item)
+            for item in completion_gate.get("blocked_statuses") or []
+            if _normalise_text(item)
+        }
+        if isinstance(plan_items, Mapping):
+            for item_id, raw_item in plan_items.items():
+                if not isinstance(raw_item, Mapping):
+                    continue
+                actual_status = _normalise_text(raw_item.get("status"))
+                if actual_status in blocked_statuses:
+                    blocked_plan_items.append(
+                        {
+                            "item_id": _normalise_text(item_id),
+                            "status": actual_status,
+                        }
+                    )
+
+    if missing_context_keys:
+        blocking_reason_codes.append("missing_required_context_keys")
+    if unmet_plan_items:
+        blocking_reason_codes.append("required_plan_items_unmet")
+    if blocked_plan_items:
+        blocking_reason_codes.append("blocked_plan_items_present")
+
+    decision = {
+        "schema_version": WORKFLOW_COMPLETION_GATE_SCHEMA_VERSION,
+        "workflow_id": workflow_id,
+        "final_state": _normalise_text(final_state),
+        "safe_to_claim_completion": len(blocking_reason_codes) == 0,
+        "blocking_reason_codes": blocking_reason_codes,
+        "missing_context_keys": missing_context_keys,
+        "unmet_plan_items": unmet_plan_items,
+        "blocked_plan_items": blocked_plan_items,
+        "checked_at_utc": _utc_iso(now_utc),
+    }
+    context[WORKFLOW_COMPLETION_GATE_KEY] = decision
+    context[LAST_WORKFLOW_COMPLETION_GATE_KEY] = decision
+    append_runtime_event(
+        context=context,
+        event={
+            "status": "workflow_completion_gate",
+            "workflow_id": workflow_id,
+            "final_state": _normalise_text(final_state),
+            "safe_to_claim_completion": decision["safe_to_claim_completion"],
+            "blocking_reason_codes": list(blocking_reason_codes),
+        },
+    )
+    return bool(decision["safe_to_claim_completion"]), decision
+
+
+__all__ = [
+    "LAST_WORKFLOW_COMPLETION_GATE_KEY",
+    "LAST_WORKFLOW_PLAN_STATE_EVENT_KEY",
+    "WORKFLOW_COMPLETION_GATE_KEY",
+    "WORKFLOW_COMPLETION_GATE_SCHEMA_VERSION",
+    "WORKFLOW_PLAN_STATE_ALLOWED_STATUSES",
+    "WORKFLOW_PLAN_STATE_EVENTS_KEY",
+    "WORKFLOW_PLAN_STATE_KEY",
+    "WORKFLOW_PLAN_STATE_POLICY_SCHEMA_VERSION",
+    "WORKFLOW_PLAN_STATE_RUNTIME_SCHEMA_VERSION",
+    "WORKFLOW_STEP_CHECKPOINT_POLICY_SCHEMA_VERSION",
+    "apply_workflow_step_checkpoint",
+    "compute_plan_state_progress",
+    "ensure_workflow_plan_state",
+    "evaluate_workflow_completion_gate",
+    "mark_workflow_plan_state_entry",
+    "mark_workflow_plan_state_resume",
+    "normalise_workflow_completion_gate_spec",
+    "normalise_workflow_plan_state_policy_spec",
+    "normalise_workflow_step_checkpoint_policy_spec",
+]

--- a/src/backend/workflows/vontology_loader.py
+++ b/src/backend/workflows/vontology_loader.py
@@ -17,6 +17,11 @@ from .prompt_metadata_resolution import (
     normalise_prompt_validation_policy,
     resolve_workflow_prompt_metadata,
 )
+from .plan_state_runtime import (
+    normalise_workflow_completion_gate_spec,
+    normalise_workflow_plan_state_policy_spec,
+    normalise_workflow_step_checkpoint_policy_spec,
+)
 from .subworkflow_contracts import (
     WORKFLOW_SUBWORKFLOW_ACTION_ID,
     build_subworkflow_contract,
@@ -205,6 +210,16 @@ WORKFLOW_STEP_IDEMPOTENCY_POLICY_TEXT_PREDICATE_PRECEDENCE: Tuple[
         "has_workflow_step_idempotency_policy_json",
     ),
 )
+WORKFLOW_STEP_CHECKPOINT_POLICY_TEXT_PREDICATE_PRECEDENCE: Tuple[
+    Tuple[str, ...], ...
+] = (
+    (
+        "#V#hasWorkflowStepCheckpointPolicyJson",
+        "hasWorkflowStepCheckpointPolicyJson",
+        "#V#has_workflow_step_checkpoint_policy_json",
+        "has_workflow_step_checkpoint_policy_json",
+    ),
+)
 WORKFLOW_BACKGROUND_LAUNCH_POLICY_TEXT_PREDICATE_PRECEDENCE: Tuple[
     Tuple[str, ...], ...
 ] = (
@@ -225,6 +240,24 @@ WORKFLOW_BACKGROUND_LAUNCH_POLICY_TEXT_PREDICATE_PRECEDENCE: Tuple[
         "hasBackgroundRunPolicyJson",
         "#V#has_background_run_policy_json",
         "has_background_run_policy_json",
+    ),
+)
+WORKFLOW_PLAN_STATE_POLICY_TEXT_PREDICATE_PRECEDENCE: Tuple[Tuple[str, ...], ...] = (
+    (
+        "#V#hasWorkflowPlanStatePolicyJson",
+        "hasWorkflowPlanStatePolicyJson",
+        "#V#has_workflow_plan_state_policy_json",
+        "has_workflow_plan_state_policy_json",
+    ),
+)
+WORKFLOW_COMPLETION_GATE_TEXT_PREDICATE_PRECEDENCE: Tuple[
+    Tuple[str, ...], ...
+] = (
+    (
+        "#V#hasWorkflowCompletionGateJson",
+        "hasWorkflowCompletionGateJson",
+        "#V#has_workflow_completion_gate_json",
+        "has_workflow_completion_gate_json",
     ),
 )
 WORKFLOW_BACKGROUND_LAUNCH_INTERVAL_SECONDS_TEXT_PREDICATE_PRECEDENCE: Tuple[
@@ -1221,14 +1254,14 @@ def _parse_json_object_text_value(text_value: Any) -> dict[str, Any] | None:
     return None
 
 
-def _resolve_step_policy_from_text_relations(
+def _resolve_policy_from_text_relations(
     *,
-    step_id: str,
+    concept_id: str,
     predicate_precedence: Tuple[Tuple[str, ...], ...],
     normaliser: Callable[[Any], dict[str, Any] | None],
 ) -> tuple[dict[str, Any] | None, str | None]:
     try:
-        raw_texts = get_texts_for_concept(step_id)
+        raw_texts = get_texts_for_concept(concept_id)
     except Exception:
         raw_texts = []
     texts = [item for item in raw_texts if isinstance(item, Mapping)]
@@ -1264,8 +1297,8 @@ def resolve_workflow_step_runtime_policies(
     if not isinstance(step_id, str) or not step_id.strip():
         return policies, warnings
 
-    retry_policy, retry_source = _resolve_step_policy_from_text_relations(
-        step_id=step_id,
+    retry_policy, retry_source = _resolve_policy_from_text_relations(
+        concept_id=step_id,
         predicate_precedence=WORKFLOW_STEP_RETRY_POLICY_TEXT_PREDICATE_PRECEDENCE,
         normaliser=_normalise_retry_policy_spec,
     )
@@ -1274,8 +1307,8 @@ def resolve_workflow_step_runtime_policies(
     elif isinstance(retry_source, str) and retry_source:
         warnings.append(f"workflow_step_retry_policy_invalid:{step_id}:{retry_source}")
 
-    approval_gate, approval_source = _resolve_step_policy_from_text_relations(
-        step_id=step_id,
+    approval_gate, approval_source = _resolve_policy_from_text_relations(
+        concept_id=step_id,
         predicate_precedence=WORKFLOW_STEP_APPROVAL_GATE_TEXT_PREDICATE_PRECEDENCE,
         normaliser=_normalise_approval_gate_spec,
     )
@@ -1286,8 +1319,8 @@ def resolve_workflow_step_runtime_policies(
             f"workflow_step_approval_gate_invalid:{step_id}:{approval_source}"
         )
 
-    idempotency_policy, idempotency_source = _resolve_step_policy_from_text_relations(
-        step_id=step_id,
+    idempotency_policy, idempotency_source = _resolve_policy_from_text_relations(
+        concept_id=step_id,
         predicate_precedence=WORKFLOW_STEP_IDEMPOTENCY_POLICY_TEXT_PREDICATE_PRECEDENCE,
         normaliser=_normalise_idempotency_policy_spec,
     )
@@ -1297,6 +1330,55 @@ def resolve_workflow_step_runtime_policies(
         warnings.append(
             "workflow_step_idempotency_policy_invalid:"
             f"{step_id}:{idempotency_source}"
+        )
+
+    checkpoint_policy, checkpoint_source = _resolve_policy_from_text_relations(
+        concept_id=step_id,
+        predicate_precedence=WORKFLOW_STEP_CHECKPOINT_POLICY_TEXT_PREDICATE_PRECEDENCE,
+        normaliser=normalise_workflow_step_checkpoint_policy_spec,
+    )
+    if checkpoint_policy is not None:
+        policies["checkpoint_policy"] = checkpoint_policy
+    elif isinstance(checkpoint_source, str) and checkpoint_source:
+        warnings.append(
+            "workflow_step_checkpoint_policy_invalid:"
+            f"{step_id}:{checkpoint_source}"
+        )
+
+    return policies, warnings
+
+
+def resolve_workflow_long_horizon_policies(
+    workflow_id: str,
+) -> tuple[dict[str, Any], list[str]]:
+    policies: dict[str, Any] = {}
+    warnings: list[str] = []
+    if not isinstance(workflow_id, str) or not workflow_id.strip():
+        return policies, warnings
+
+    plan_state_policy, plan_state_source = _resolve_policy_from_text_relations(
+        concept_id=workflow_id,
+        predicate_precedence=WORKFLOW_PLAN_STATE_POLICY_TEXT_PREDICATE_PRECEDENCE,
+        normaliser=normalise_workflow_plan_state_policy_spec,
+    )
+    if plan_state_policy is not None:
+        policies["plan_state_policy"] = plan_state_policy
+    elif isinstance(plan_state_source, str) and plan_state_source:
+        warnings.append(
+            f"workflow_plan_state_policy_invalid:{workflow_id}:{plan_state_source}"
+        )
+
+    completion_gate, completion_gate_source = _resolve_policy_from_text_relations(
+        concept_id=workflow_id,
+        predicate_precedence=WORKFLOW_COMPLETION_GATE_TEXT_PREDICATE_PRECEDENCE,
+        normaliser=normalise_workflow_completion_gate_spec,
+    )
+    if completion_gate is not None:
+        policies["completion_gate"] = completion_gate
+    elif isinstance(completion_gate_source, str) and completion_gate_source:
+        warnings.append(
+            "workflow_completion_gate_invalid:"
+            f"{workflow_id}:{completion_gate_source}"
         )
 
     return policies, warnings
@@ -1398,6 +1480,11 @@ def build_workflow_process_graph(
     relationships = workflow_doc.get("relationships") or {}
     if not isinstance(relationships, dict):
         relationships = {}
+
+    workflow_runtime_policies, workflow_policy_warnings = (
+        resolve_workflow_long_horizon_policies(workflow_id)
+    )
+    warnings.extend(workflow_policy_warnings)
 
     legacy_aliases: set[str] = set()
 
@@ -1761,6 +1848,7 @@ def build_workflow_process_graph(
         "representation": "vontology_process_graph_v1",
         "workflow_id": workflow_id,
         "initial_step": initial_step,
+        "workflow_metadata": workflow_runtime_policies,
         "steps": step_items,
         "edges": edges,
         "warnings": warnings,
@@ -1807,6 +1895,9 @@ def load_workflow_definition_from_vontology(
         "workflow_step_retry_policy_invalid:",
         "workflow_step_approval_gate_invalid:",
         "workflow_step_idempotency_policy_invalid:",
+        "workflow_step_checkpoint_policy_invalid:",
+        "workflow_plan_state_policy_invalid:",
+        "workflow_completion_gate_invalid:",
     )
     for warning in warnings:
         if isinstance(warning, str) and warning.startswith(fatal_warning_prefixes):
@@ -2166,6 +2257,7 @@ def load_workflow_definition_from_vontology(
         retry_policy = step.get("retry_policy")
         approval_gate = step.get("approval_gate")
         idempotency_policy = step.get("idempotency_policy")
+        checkpoint_policy = step.get("checkpoint_policy")
         prompt_contract = step.get("prompt_contract")
         if preconditions:
             step_metadata["preconditions"] = preconditions
@@ -2185,6 +2277,8 @@ def load_workflow_definition_from_vontology(
             step_metadata["approval_gate"] = approval_gate
         if idempotency_policy:
             step_metadata["idempotency_policy"] = idempotency_policy
+        if checkpoint_policy:
+            step_metadata["checkpoint_policy"] = checkpoint_policy
         if prompt_contract:
             step_metadata["prompt_contract"] = prompt_contract
         if is_subworkflow_action:
@@ -2238,6 +2332,9 @@ def load_workflow_definition_from_vontology(
         resolve_workflow_background_launch_policy(workflow_id)
     )
     workflow_metadata: Dict[str, Any] = {}
+    graph_workflow_metadata = graph.get("workflow_metadata")
+    if isinstance(graph_workflow_metadata, Mapping):
+        workflow_metadata.update(dict(graph_workflow_metadata))
     if background_launch_policy is not None:
         workflow_metadata["background_launch_policy"] = background_launch_policy
     if (

--- a/src/backend/workflows/workflow_definition_identity_service.py
+++ b/src/backend/workflows/workflow_definition_identity_service.py
@@ -16,6 +16,11 @@ from .subworkflow_contracts import (
     WORKFLOW_SUBWORKFLOW_ACTION_ID,
     normalise_subworkflow_contract,
 )
+from .plan_state_runtime import (
+    normalise_workflow_completion_gate_spec,
+    normalise_workflow_plan_state_policy_spec,
+    normalise_workflow_step_checkpoint_policy_spec,
+)
 from .execution_contracts import (
     WORKFLOW_CONTROL_BREAK_ACTION_IDS,
     WORKFLOW_CONTROL_CONTINUE_ACTION_IDS,
@@ -46,6 +51,7 @@ _STATE_METADATA_CONTRACT_KEYS: tuple[str, ...] = (
     "retry_policy",
     "approval_gate",
     "idempotency_policy",
+    "checkpoint_policy",
     "prompt_contract",
 )
 
@@ -406,12 +412,21 @@ def _normalise_workflow_contract_shape_from_graph(
             }
         )
 
+    graph_metadata_raw = graph.get("workflow_metadata")
+    if not isinstance(graph_metadata_raw, Mapping):
+        graph_metadata_raw = graph.get("metadata")
+    graph_metadata = (
+        _normalise_json_like(dict(graph_metadata_raw))
+        if isinstance(graph_metadata_raw, Mapping)
+        else {}
+    )
+
     return {
         "schema_version": WORKFLOW_CONTRACT_SHAPE_SCHEMA_VERSION,
         "workflow_id": workflow_id,
         "initial_state": str(graph.get("initial_step") or "").strip(),
         "termination_states": sorted(set(termination_states)),
-        "metadata": {},
+        "metadata": graph_metadata,
         "states": step_entries,
     }
 
@@ -606,6 +621,8 @@ def validate_workflow_definition_contract(
             "subworkflow_contract_issues": [],
             "control_signal_issues": [],
             "fork_join_issues": [],
+            "plan_state_issues": [],
+            "completion_gate_issues": [],
             "prompt_contract_issues": [],
         }
 
@@ -634,6 +651,8 @@ def validate_workflow_definition_contract(
     iterator_issues: list[dict[str, Any]] = []
     approval_gate_issues: list[dict[str, Any]] = []
     runtime_policy_issues: list[dict[str, Any]] = []
+    plan_state_issues: list[dict[str, Any]] = []
+    completion_gate_issues: list[dict[str, Any]] = []
     prompt_contract_issues: list[dict[str, Any]] = []
     declared_fork_ids: set[str] = set()
 
@@ -651,6 +670,37 @@ def validate_workflow_definition_contract(
             for workflow_id in known_workflow_ids
             if isinstance(workflow_id, str) and str(workflow_id).strip()
         }
+
+    definition_metadata_raw = getattr(definition, "metadata", {})
+    definition_metadata = (
+        dict(definition_metadata_raw)
+        if isinstance(definition_metadata_raw, Mapping)
+        else {}
+    )
+    try:
+        plan_state_policy = normalise_workflow_plan_state_policy_spec(
+            definition_metadata.get("plan_state_policy")
+        )
+    except ValueError as exc:
+        plan_state_policy = None
+        plan_state_issues.append(
+            {
+                "scope": "workflow",
+                "reason_code": str(exc),
+            }
+        )
+    try:
+        completion_gate = normalise_workflow_completion_gate_spec(
+            definition_metadata.get("completion_gate")
+        )
+    except ValueError as exc:
+        completion_gate = None
+        completion_gate_issues.append(
+            {
+                "scope": "workflow",
+                "reason_code": str(exc),
+            }
+        )
 
     for scan_state_id in sorted(str(item) for item in states.keys()):
         scan_state_spec = states[scan_state_id]
@@ -751,6 +801,18 @@ def validate_workflow_definition_contract(
                 {
                     "state_id": state_id,
                     "reason_code": "idempotency_policy_multi_action_state_unsupported",
+                }
+            )
+        try:
+            normalise_workflow_step_checkpoint_policy_spec(
+                metadata.get("checkpoint_policy")
+            )
+        except ValueError as exc:
+            plan_state_issues.append(
+                {
+                    "scope": "state",
+                    "state_id": state_id,
+                    "reason_code": str(exc),
                 }
             )
         requested_prompt_concept_ids = _normalise_symbol_list(
@@ -1097,9 +1159,9 @@ def validate_workflow_definition_contract(
                                     "state_id": state_id,
                                     "workflow_id": child_workflow_id,
                                     "reason_code": "subworkflow_output_contract_mismatch",
-                                    "unknown_outputs": unknown_output_fields,
-                                }
-                            )
+                                "unknown_outputs": unknown_output_fields,
+                            }
+                        )
 
         if enforce_supported_actions:
             for action_id in actions:
@@ -1178,6 +1240,22 @@ def validate_workflow_definition_contract(
             str(item.get("reason_code") or ""),
         ),
     )
+    plan_state_issues = sorted(
+        plan_state_issues,
+        key=lambda item: (
+            str(item.get("scope") or ""),
+            str(item.get("state_id") or ""),
+            str(item.get("reason_code") or ""),
+        ),
+    )
+    completion_gate_issues = sorted(
+        completion_gate_issues,
+        key=lambda item: (
+            str(item.get("scope") or ""),
+            str(item.get("state_id") or ""),
+            str(item.get("reason_code") or ""),
+        ),
+    )
     prompt_contract_issues = sorted(
         prompt_contract_issues,
         key=lambda item: (
@@ -1213,6 +1291,10 @@ def validate_workflow_definition_contract(
         errors.append("workflow_approval_gate_invalid")
     if runtime_policy_issues:
         errors.append("workflow_runtime_policy_invalid")
+    if plan_state_issues:
+        errors.append("workflow_plan_state_policy_invalid")
+    if completion_gate_issues:
+        errors.append("workflow_completion_gate_invalid")
     if any(
         str(item.get("severity") or "").strip().lower() == "error"
         for item in prompt_contract_issues
@@ -1261,6 +1343,8 @@ def validate_workflow_definition_contract(
         "iterator_issues": iterator_issues,
         "approval_gate_issues": approval_gate_issues,
         "runtime_policy_issues": runtime_policy_issues,
+        "plan_state_issues": plan_state_issues,
+        "completion_gate_issues": completion_gate_issues,
         "prompt_contract_issues": prompt_contract_issues,
     }
 

--- a/tests/backend/test_code_concepts_registry.py
+++ b/tests/backend/test_code_concepts_registry.py
@@ -42,6 +42,12 @@ def test_workflow_runtime_policy_predicates_are_registered():
     assert "#V#has_workflow_step_approval_gate_json" in ids
     assert "#V#hasWorkflowStepIdempotencyPolicyJson" in ids
     assert "#V#has_workflow_step_idempotency_policy_json" in ids
+    assert "#V#hasWorkflowStepCheckpointPolicyJson" in ids
+    assert "#V#has_workflow_step_checkpoint_policy_json" in ids
+    assert "#V#hasWorkflowPlanStatePolicyJson" in ids
+    assert "#V#has_workflow_plan_state_policy_json" in ids
+    assert "#V#hasWorkflowCompletionGateJson" in ids
+    assert "#V#has_workflow_completion_gate_json" in ids
 
 
 def test_workflow_prompt_contract_predicates_are_registered():

--- a/tests/backend/test_durable_workflow_executor_safety.py
+++ b/tests/backend/test_durable_workflow_executor_safety.py
@@ -623,3 +623,163 @@ def test_durable_executor_populates_result_envelope_for_return_signal() -> None:
     assert result.result_envelope.get("control_signal") == "return"
     assert result.result_envelope.get("declared_output_payload") == {"answer": "done"}
 
+
+def test_durable_executor_records_plan_state_checkpoint_progress() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="#V#durable_plan_state_progress",
+        initial_state="dispatch",
+        states={
+            "dispatch": WorkflowStateSpec(
+                state_id="dispatch",
+                actions=(WorkflowActionInvocation(action_id="dispatch.action"),),
+                terminal=True,
+                metadata={
+                    "checkpoint_policy": {
+                        "schema_version": "workflow_step_checkpoint_policy.v1",
+                        "plan_item_updates": [
+                            {"item_id": "dispatch", "status": "done"}
+                        ],
+                        "summary_context_keys": ["dispatch.completed"],
+                        "cursor_context_keys": ["page_cursor"],
+                        "progress_message": "Dispatching",
+                        "force_summary": True,
+                    }
+                },
+            ),
+        },
+        termination_states=("dispatch",),
+        metadata={
+            "plan_state_policy": {
+                "schema_version": "workflow_plan_state_policy.v1",
+                "plan_items": ["dispatch"],
+                "summary_interval_steps": 1,
+            },
+            "completion_gate": {
+                "schema_version": "workflow_completion_gate.v1",
+                "required_done_plan_items": ["dispatch"],
+                "required_context_keys": ["dispatch.completed"],
+            },
+        },
+    )
+
+    registry = ActionRegistry()
+    registry.register(
+        ActionSpec(
+            action_id="dispatch.action",
+            handler=lambda _request: WorkflowActionResult(
+                outputs={
+                    "dispatch": {"completed": True},
+                    "page_cursor": "cursor-2",
+                }
+            ),
+        )
+    )
+
+    instance = _build_instance(definition.workflow_id)
+    instance.inputs = {"page_cursor": "cursor-1"}
+
+    manager = MagicMock()
+    manager.get_instance.return_value = instance
+    manager.is_cancelled.return_value = False
+    manager.extend_lock.return_value = True
+    manager.checkpoint.return_value = True
+
+    executor = DurableWorkflowExecutor(registry=registry, instance_manager=manager)
+    with (
+        patch(
+            "src.backend.languagemodels.llm_interface.get_llm_client",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "src.backend.languagemodels.llm_interface.get_active_model_name",
+            return_value="test-model",
+        ),
+    ):
+        result = executor.run_durable(
+            "instance-1",
+            definition,
+            resume_from_checkpoint=False,
+        )
+
+    assert result.completed is True
+    plan_state = result.data.get("workflow_plan_state")
+    assert isinstance(plan_state, dict)
+    assert plan_state["items"]["dispatch"]["status"] == "done"
+    gate = result.data.get("workflow_completion_gate")
+    assert isinstance(gate, dict)
+    assert gate["safe_to_claim_completion"] is True
+    assert manager.checkpoint.call_args_list
+    assert any(
+        call.kwargs.get("progress_current") == 1
+        and call.kwargs.get("progress_total") == 1
+        and call.kwargs.get("progress_message") == "Dispatching"
+        for call in manager.checkpoint.call_args_list
+        if isinstance(call.kwargs, dict)
+    )
+
+
+def test_durable_executor_blocks_false_terminal_success_when_completion_gate_unmet() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="#V#durable_completion_gate_unmet",
+        initial_state="dispatch",
+        states={
+            "dispatch": WorkflowStateSpec(
+                state_id="dispatch",
+                actions=(WorkflowActionInvocation(action_id="dispatch.action"),),
+                terminal=True,
+            ),
+        },
+        termination_states=("dispatch",),
+        metadata={
+            "plan_state_policy": {
+                "schema_version": "workflow_plan_state_policy.v1",
+                "plan_items": ["dispatch", "finalise"],
+            },
+            "completion_gate": {
+                "schema_version": "workflow_completion_gate.v1",
+                "required_done_plan_items": ["dispatch", "finalise"],
+                "required_context_keys": ["dispatch.completed"],
+            },
+        },
+    )
+
+    registry = ActionRegistry()
+    registry.register(
+        ActionSpec(
+            action_id="dispatch.action",
+            handler=lambda _request: WorkflowActionResult(outputs={}),
+        )
+    )
+
+    manager = MagicMock()
+    manager.get_instance.return_value = _build_instance(definition.workflow_id)
+    manager.is_cancelled.return_value = False
+    manager.extend_lock.return_value = True
+    manager.checkpoint.return_value = True
+
+    executor = DurableWorkflowExecutor(registry=registry, instance_manager=manager)
+    with (
+        patch(
+            "src.backend.languagemodels.llm_interface.get_llm_client",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "src.backend.languagemodels.llm_interface.get_active_model_name",
+            return_value="test-model",
+        ),
+    ):
+        result = executor.run_durable(
+            "instance-1",
+            definition,
+            resume_from_checkpoint=False,
+        )
+
+    assert result.completed is False
+    assert result.error is not None
+    assert result.error.startswith("workflow_completion_gate_unmet")
+    gate = result.data.get("workflow_completion_gate")
+    assert isinstance(gate, dict)
+    assert gate["safe_to_claim_completion"] is False
+    assert "required_plan_items_unmet" in gate["blocking_reason_codes"]
+    assert "missing_required_context_keys" in gate["blocking_reason_codes"]
+

--- a/tests/backend/test_vontology_loader.py
+++ b/tests/backend/test_vontology_loader.py
@@ -38,6 +38,7 @@ from src.backend.workflows.vontology_loader import (
     _all_relationship_targets,
     resolve_workflow_background_launch_policy,
     resolve_workflow_description,
+    resolve_workflow_long_horizon_policies,
     resolve_workflow_narrative_text,
     resolve_workflow_step_runtime_policies,
 )
@@ -58,12 +59,14 @@ def _make_graph(
     initial_step: str = "#V#step_a",
     steps: List[Dict[str, Any]] | None = None,
     edges: List[Dict[str, Any]] | None = None,
+    workflow_metadata: Dict[str, Any] | None = None,
 ) -> Dict[str, Any]:
     """Build a raw process graph dict matching build_workflow_process_graph output."""
     return {
         "representation": "vontology_process_graph_v1",
         "workflow_id": workflow_id,
         "initial_step": initial_step,
+        "workflow_metadata": workflow_metadata or {},
         "steps": steps or [],
         "edges": edges or [],
         "warnings": [],
@@ -93,6 +96,7 @@ def _make_step(
     retry_policy: Dict[str, Any] | None = None,
     approval_gate: Dict[str, Any] | None = None,
     idempotency_policy: Dict[str, Any] | None = None,
+    checkpoint_policy: Dict[str, Any] | None = None,
 ) -> Dict[str, Any]:
     return {
         "step_id": step_id,
@@ -109,6 +113,7 @@ def _make_step(
         "retry_policy": retry_policy,
         "approval_gate": approval_gate,
         "idempotency_policy": idempotency_policy,
+        "checkpoint_policy": checkpoint_policy,
         "control_flow": {
             "next": next_step,
             "on_true": on_true,
@@ -307,6 +312,14 @@ class TestWorkflowStepRuntimePolicyResolution:
                         '"key_paths":["request_id"]}'
                     ),
                 },
+                {
+                    "predicate": "#V#hasWorkflowStepCheckpointPolicyJson",
+                    "text": (
+                        '{"schema_version":"workflow_step_checkpoint_policy.v1",'
+                        '"plan_item_updates":[{"item_id":"dispatch","status":"done"}],'
+                        '"summary_context_keys":["dispatch.summary"]}'
+                    ),
+                },
             ],
         ):
             policies, warnings = resolve_workflow_step_runtime_policies("#V#step")
@@ -315,6 +328,61 @@ class TestWorkflowStepRuntimePolicyResolution:
         assert policies["retry_policy"]["max_attempts"] == 3
         assert policies["approval_gate"]["approval_context_key"] == "write_approved"
         assert policies["idempotency_policy"]["key_paths"] == ["request_id"]
+        assert policies["checkpoint_policy"]["plan_item_updates"] == [
+            {"item_id": "dispatch", "status": "done"}
+        ]
+        assert policies["checkpoint_policy"]["summary_context_keys"] == [
+            "dispatch.summary"
+        ]
+
+
+class TestWorkflowLongHorizonPolicyResolution:
+    def test_resolve_workflow_long_horizon_policies_reads_text_relations(self):
+        with patch(
+            "src.backend.workflows.vontology_loader.get_texts_for_concept",
+            return_value=[
+                {
+                    "predicate": "#V#hasWorkflowPlanStatePolicyJson",
+                    "text": (
+                        '{"schema_version":"workflow_plan_state_policy.v1",'
+                        '"plan_items":["discover","dispatch"],'
+                        '"summary_interval_steps":2,'
+                        '"cursor_context_keys":["page_cursor"]}'
+                    ),
+                },
+                {
+                    "predicate": "#V#hasWorkflowCompletionGateJson",
+                    "text": (
+                        '{"schema_version":"workflow_completion_gate.v1",'
+                        '"required_done_plan_items":["discover","dispatch"],'
+                        '"required_context_keys":["dispatch.completed"]}'
+                    ),
+                },
+            ],
+        ):
+            policies, warnings = resolve_workflow_long_horizon_policies(
+                "#V#long_horizon_workflow"
+            )
+
+        assert warnings == []
+        assert policies["plan_state_policy"]["plan_items"] == [
+            {
+                "item_id": "discover",
+                "label": "discover",
+                "description": "",
+                "default_status": "pending",
+            },
+            {
+                "item_id": "dispatch",
+                "label": "dispatch",
+                "description": "",
+                "default_status": "pending",
+            },
+        ]
+        assert policies["completion_gate"]["required_plan_item_statuses"] == {
+            "discover": "done",
+            "dispatch": "done",
+        }
 
 
 class TestWorkflowPromptContracts:
@@ -890,6 +958,74 @@ class TestInitialStepKey:
             metadata["background_launch_policy_source"]
             == "text_relation:#V#hasBackgroundLaunchPolicyJson"
         )
+
+    def test_load_definition_carries_long_horizon_metadata(self):
+        graph = _make_graph(
+            initial_step="#V#start",
+            workflow_metadata={
+                "plan_state_policy": {
+                    "schema_version": "workflow_plan_state_policy.v1",
+                    "plan_items": [
+                        {
+                            "item_id": "discover",
+                            "label": "Discover",
+                            "description": "",
+                            "default_status": "pending",
+                        }
+                    ],
+                    "summary_interval_steps": 2,
+                    "max_checkpoint_history": 10,
+                    "summary_context_keys": ["discover.summary"],
+                    "cursor_context_keys": ["discover.cursor"],
+                    "default_item_status": "pending",
+                },
+                "completion_gate": {
+                    "schema_version": "workflow_completion_gate.v1",
+                    "required_plan_item_statuses": {"discover": "done"},
+                    "required_context_keys": ["discover.completed"],
+                    "blocked_statuses": ["blocked"],
+                    "require_declared_plan_items_done": True,
+                    "allow_missing_plan_state": False,
+                },
+            },
+            steps=[
+                _make_step(
+                    "#V#start",
+                    invokes_action="test.action",
+                    checkpoint_policy={
+                        "schema_version": "workflow_step_checkpoint_policy.v1",
+                        "plan_item_updates": [
+                            {"item_id": "discover", "status": "done"}
+                        ],
+                        "checkpoint_label": "discover_step",
+                        "summary_context_keys": ["discover.summary"],
+                        "cursor_context_keys": ["discover.cursor"],
+                        "progress_message": "Discovering",
+                        "force_summary": True,
+                    },
+                )
+            ],
+        )
+
+        with _stub_fetch_concepts(), _stub_narrative():
+            with patch(
+                "src.backend.workflows.vontology_loader.build_workflow_process_graph",
+                return_value=(graph, []),
+            ):
+                with patch(
+                    "src.backend.workflows.vontology_loader.resolve_workflow_background_launch_policy",
+                    return_value=(None, "none"),
+                ):
+                    defn = load_workflow_definition_from_vontology("#V#test_workflow")
+
+        assert defn is not None
+        assert defn.metadata["plan_state_policy"]["summary_interval_steps"] == 2
+        assert defn.metadata["completion_gate"]["required_context_keys"] == [
+            "discover.completed"
+        ]
+        assert defn.states["#V#start"].metadata["checkpoint_policy"]["plan_item_updates"] == [
+            {"item_id": "discover", "status": "done"}
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/test_workflow_definition_identity_service.py
+++ b/tests/backend/test_workflow_definition_identity_service.py
@@ -444,6 +444,66 @@ def test_validate_contract_keeps_prompt_contract_warnings_non_blocking() -> None
     )
 
 
+def test_validate_contract_reports_invalid_checkpoint_policy() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="#V#checkpoint_policy_invalid_workflow",
+        initial_state="dispatch",
+        states={
+            "dispatch": WorkflowStateSpec(
+                state_id="dispatch",
+                actions=(WorkflowActionInvocation(action_id="dispatch.action"),),
+                terminal=True,
+                metadata={
+                    "checkpoint_policy": {
+                        "schema_version": "workflow_step_checkpoint_policy.v1",
+                        "plan_item_updates": [
+                            {"item_id": "dispatch", "status": "invalid_status"}
+                        ],
+                    }
+                },
+            ),
+        },
+        termination_states=("dispatch",),
+    )
+
+    validation = validate_workflow_definition_contract(definition=definition)
+
+    assert validation["valid"] is False
+    assert "workflow_plan_state_policy_invalid" in (validation.get("errors") or [])
+    assert any(
+        issue.get("state_id") == "dispatch"
+        and issue.get("reason_code") == "plan_item_update_status_0_invalid"
+        for issue in validation.get("plan_state_issues", [])
+    )
+
+
+def test_validate_contract_accepts_context_only_completion_gate() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="#V#completion_gate_context_only_workflow",
+        initial_state="done",
+        states={
+            "done": WorkflowStateSpec(
+                state_id="done",
+                actions=(WorkflowActionInvocation(action_id="mark.done"),),
+                terminal=True,
+            ),
+        },
+        termination_states=("done",),
+        metadata={
+            "completion_gate": {
+                "schema_version": "workflow_completion_gate.v1",
+                "required_context_keys": ["deliverable_ready"],
+                "require_declared_plan_items_done": False,
+            }
+        },
+    )
+
+    validation = validate_workflow_definition_contract(definition=definition)
+
+    assert validation["valid"] is True
+    assert validation.get("completion_gate_issues") == []
+
+
 def test_validate_contract_accepts_join_with_declared_fork() -> None:
     definition = WorkflowDefinition(
         workflow_id="#V#join_valid_workflow",

--- a/tests/backend/test_workflow_runtime_policies.py
+++ b/tests/backend/test_workflow_runtime_policies.py
@@ -207,3 +207,65 @@ def test_idempotency_policy_reuses_prior_success_outputs() -> None:
     idempotency_events = second_result.data.get("workflow_idempotency_events")
     assert isinstance(idempotency_events, list)
     assert any(event.get("status") == "idempotent_reuse" for event in idempotency_events)
+
+
+def test_completion_gate_blocks_false_terminal_success_and_records_plan_state() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="#V#completion_gate_workflow",
+        initial_state="dispatch",
+        states={
+            "dispatch": WorkflowStateSpec(
+                state_id="dispatch",
+                actions=(WorkflowActionInvocation(action_id="dispatch.action"),),
+                terminal=True,
+                metadata={
+                    "checkpoint_policy": {
+                        "schema_version": "workflow_step_checkpoint_policy.v1",
+                        "plan_item_updates": [
+                            {"item_id": "dispatch", "status": "done"}
+                        ],
+                        "progress_message": "Dispatching",
+                    }
+                },
+            ),
+        },
+        termination_states=("dispatch",),
+        metadata={
+            "plan_state_policy": {
+                "schema_version": "workflow_plan_state_policy.v1",
+                "plan_items": ["dispatch", "finalise"],
+            },
+            "completion_gate": {
+                "schema_version": "workflow_completion_gate.v1",
+                "required_done_plan_items": ["dispatch", "finalise"],
+                "required_context_keys": ["dispatch.completed"],
+            },
+        },
+    )
+
+    registry = ActionRegistry()
+    registry.register(
+        ActionSpec(
+            action_id="dispatch.action",
+            handler=lambda _request: WorkflowActionResult(outputs={}),
+        )
+    )
+
+    result = WorkflowExecutor(registry=registry, max_transitions=5).run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={},
+    )
+
+    assert result.completed is False
+    assert result.error is not None
+    assert result.error.startswith("workflow_completion_gate_unmet")
+    plan_state = result.data.get("workflow_plan_state")
+    assert isinstance(plan_state, dict)
+    assert plan_state["items"]["dispatch"]["status"] == "done"
+    assert plan_state["items"]["finalise"]["status"] == "pending"
+    gate = result.data.get("workflow_completion_gate")
+    assert isinstance(gate, dict)
+    assert gate["safe_to_claim_completion"] is False
+    assert "required_plan_items_unmet" in gate["blocking_reason_codes"]
+    assert "missing_required_context_keys" in gate["blocking_reason_codes"]


### PR DESCRIPTION
## Summary
- add shared VWL plan-state runtime support for checkpoints, resumable summaries, and completion gates
- load and validate workflow-level long-horizon policy payloads plus step checkpoint policies from Vontology
- document the new KB-first long-horizon semantics and register the new workflow policy predicates

## Verification
- pdm run pytest tests/backend/test_vontology_loader.py tests/backend/test_workflow_definition_identity_service.py tests/backend/test_workflow_runtime_policies.py tests/backend/test_durable_workflow_executor_safety.py tests/backend/test_code_concepts_registry.py
- pdm run pyright src/backend/vontology/code_concepts_registry.py src/backend/workflows/plan_state_runtime.py src/backend/workflows/vontology_loader.py src/backend/workflows/workflow_definition_identity_service.py src/backend/workflows/engine.py src/backend/workflows/durable/durable_executor.py tests/backend/test_code_concepts_registry.py tests/backend/test_durable_workflow_executor_safety.py tests/backend/test_vontology_loader.py tests/backend/test_workflow_definition_identity_service.py tests/backend/test_workflow_runtime_policies.py