### PR TITLE
JVNAUTOSCI-1401 Reset minimal-imposition mutation policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,10 @@ All AI agents must read this file and `docs/engineering/security_considerations.
 29. **Definition of fully complete Jira task**: implementation committed and pushed, PR created, PR merged to `main`, Jira transitioned/commented accordingly, and any required Vontology workflow/state changes actually materialised.
 30. **Fail closed when Vontology is unavailable for Vontology-governed behaviour**: do not silently fall back to in-code prompts, stale context reuse, or heuristic hacks. If required Vontology prompts/workflow data cannot be resolved, no-op that transformation and emit a clear user-visible and telemetry-visible reason.
 31. **Minimal-imposition principle**: exhaust existing context/data/search first; ask humans only when necessary, and then only for concise, low-effort, high-value inputs they are likely to know without extra work.
+31A. **Minimal-imposition mutation policy**: low-risk additive Vontology writes should default-allow when evidence-backed inputs make the intended additive action clear and the user has not explicitly denied it.
+31B. **Canonical identifiers/URLs can be permission**: pasted canonical sources such as arXiv abstract URLs/IDs can constitute sufficient permission for low-risk additive representation work; do not require redundant verbs like `download`, `store`, or `represent`.
+31C. **Destructive actions require workflow confirmation**: deletes, removals, and other destructive mutations should branch to explicit workflow confirmation/escalation rather than being executed immediately.
+31D. **Human in the loop is not the default doctrine**: outside genuinely safety-critical cases, do not interrupt users or route to human approval without evidence that it is necessary.
 32. When the user asks whether something is "finished" or "complete", do not treat Jira status alone as the answer. Verify effective implementation state in both code and Vontology, then report whether it is unimplemented, partly implemented, or fully implemented (with concise evidence).
 
 ## Core AI-Focused Documents
@@ -57,6 +61,7 @@ All AI agents must read this file and `docs/engineering/security_considerations.
 - **Telemetry correctness is mandatory**: diagnostic payloads, stage paths, counters, and progress summaries are operational interfaces, not optional polish. If they are internally inconsistent with the underlying event stream, treat that as a bug and fix it with the same urgency as a behavioural regression.
 - When fixing reliability issues, prefer **systemic, general fixes** over point fixes: update shared pipelines, validators, and policies so that behaviour remains stable across model changes and configuration drift.
 - For question-generation or elicitation flows, apply the minimal-imposition principle explicitly in prompts/fallbacks: avoid broad requests, and prefer one focused ask only when machine-side retrieval cannot close the gap.
+- For write-policy work, treat minimal imposition as a risk-class decision rule: additive low-risk Vontology mutations should usually proceed, while destructive mutations should route to explicit confirmation workflows.
 - **DRY refactoring discipline** (CRITICAL — WET code is unacceptable):
 	1. **Search first, always**: Before writing ANY function that might exist elsewhere, run `grep_search` or `semantic_search`. This is not optional.
 	2. **3-strike rule**: If you're about to write similar code for the 3rd time, STOP. Do not proceed. Create a central helper first.

--- a/docs/engineering/jvnautosci_1399_bare_arxiv_url_integration_test_design.md
+++ b/docs/engineering/jvnautosci_1399_bare_arxiv_url_integration_test_design.md
@@ -21,7 +21,7 @@ and the targeted-testing constraint tracked in `JVNAUTOSCI-1400`.
 
 Two cases must be separated.
 
-### 1. Bare URL only
+### 1. Bare canonical arXiv URL
 
 Prompt shape:
 
@@ -31,41 +31,49 @@ https://arxiv.org/abs/2510.06248
 
 Authoritative behaviour:
 
-- This is **not** enough to authorise `download_paper`.
-- The turn must remain read-only unless the user also expresses explicit
-  download/store/representation intent.
-- The route may choose plain response, clarification, or read-only URL
-  extraction, but it must not silently persist artefacts or mutate the
-  ontology.
-
-Why:
-
-- `download_paper` is a write-category tool and existing write-guard coverage
-  blocks it when the user does not explicitly ask for storage/download.
-- Auto-persisting from a pasted URL would currently conflict with the
-  minimal-imposition and fail-closed policies.
-
-### 2. URL plus explicit representation intent
-
-Prompt shape:
-
-```text
-https://arxiv.org/abs/2510.06248 represent that paper
-```
-
-Authoritative behaviour:
-
-- This is the positive mutation path that `JVNAUTOSCI-1394` must fix.
-- The turn must enter the workflow/tool pipeline rather than falling through to
-  plain response.
+- This **is** sufficient permission for `download_paper` and additive scholarly
+  representation.
+- The turn must enter the workflow/tool pipeline rather than collapsing into a
+  read-only or plain-response path.
 - The turn must carry a paper representation contract with
   `artefact_source="url"` and must require `download_paper`.
 - Successful completion requires real tool execution plus verified scholarly
   representation postconditions.
 
-This explicit-intent case is the canonical integration regression for
-`JVNAUTOSCI-1394`, because it exercises the failure boundary without violating
-the current write guard.
+Why:
+
+- A canonical arXiv abstract URL is evidence-backed, low-risk input for
+  additive representation work.
+- Minimal imposition means not making the user add extra phrasing such as
+  "download", "store", or "represent" when the intended low-risk additive
+  action is already clear from the supplied canonical source.
+- This is the primary positive mutation path that `JVNAUTOSCI-1394` must fix.
+
+Equivalent positive prompts MAY also include explicit phrasing such as:
+
+```text
+https://arxiv.org/abs/2510.06248 represent that paper
+```
+
+but that wording is no longer the sole authorising form.
+
+### 2. URL plus explicit denial
+
+Prompt shape:
+
+```text
+Do not download or store this: https://arxiv.org/abs/2510.06248
+```
+
+Authoritative behaviour:
+
+- Explicit user denial must block mutation.
+- The route may still answer read-only, but it must not invoke
+  `download_paper`, persist artefacts, or claim successful representation.
+
+This explicit-denial case is the canonical negative regression for
+`JVNAUTOSCI-1394`, because it preserves fail-closed behaviour where the user
+has provided direct contrary instruction.
 
 ## Runtime Boundary To Test
 
@@ -175,7 +183,7 @@ Assert:
 - `body["llm_debug"]["workflow_routing"]["verdict"]`
 - `body["llm_debug"]["workflow_routing"]["source"]`
 
-For the explicit-intent positive case, the expected selected workflow ID is:
+For the bare-URL positive case, the expected selected workflow ID is:
 
 - `#V#tool_calling_workflow`
 
@@ -227,7 +235,7 @@ The authoritative postconditions should match the deterministic arXiv
 materialisation helper in
 `src/backend/services/arxiv_paper_link_service.py`.
 
-For the positive explicit-intent case, assert:
+For the positive bare-URL case, assert:
 
 - a stable paper concept exists
 - the paper concept is an instance of `#V#scholarly_article`
@@ -349,32 +357,14 @@ authoritative cleanup mechanism should remain clone-DB deletion.
 
 ## Proposed Targeted Test Matrix
 
-### A. Negative safety case
+### A. Positive regression case
 
-`test_von_generate_bare_arxiv_url_only_remains_non_mutating`
+`test_von_generate_bare_arxiv_url_auto_represents_paper`
 
 Prompt:
 
 ```text
 https://arxiv.org/abs/2510.06248
-```
-
-Assert:
-
-- no `download_paper` invocation
-- no created paper/file-copy concepts for the fixture
-- no completion claim that implies successful representation
-
-This protects the write-guard and minimal-imposition boundary.
-
-### B. Positive regression case
-
-`test_von_generate_arxiv_url_with_explicit_representation_intent_executes_download_and_materialises_representation`
-
-Prompt:
-
-```text
-https://arxiv.org/abs/2510.06248 represent that paper
 ```
 
 Assert:
@@ -387,8 +377,26 @@ Assert:
 - completion gate is `completed` and `safe_to_claim_completion=True`
 - scholarly ontology postconditions exist
 
-This is the regression that should fail on the current `JVNAUTOSCI-1394`
+This is the regression that should fail on the broken `JVNAUTOSCI-1394`
 behaviour.
+
+### B. Negative safety case
+
+`test_von_generate_bare_arxiv_url_with_explicit_denial_stays_non_mutating`
+
+Prompt:
+
+```text
+Do not download or store this: https://arxiv.org/abs/2510.06248
+```
+
+Assert:
+
+- no `download_paper` invocation
+- no completion claim that implies successful representation
+- the turn remains non-mutating despite the canonical URL being present
+
+This protects the explicit-denial boundary.
 
 ## Validation Scope
 
@@ -403,8 +411,8 @@ Do not make the fix depend on a monolithic full-suite pytest run.
 
 ## Implementation Sequence For JVNAUTOSCI-1394
 
-1. Add the negative bare-URL safety test.
-2. Add the positive explicit-intent route-level integration test.
+1. Add the positive bare-URL route-level integration test.
+2. Add the explicit-denial negative regression.
 3. Fix the URL-first routing/tool-requirement gap until the positive test passes.
 4. Only then tighten any telemetry assertions that depend on
    `JVNAUTOSCI-1397`.

--- a/docs/engineering/llm_workflows_design.md
+++ b/docs/engineering/llm_workflows_design.md
@@ -202,6 +202,26 @@ Across all subsystems, the following **workflow primitives** emerge:
 - **Real-Time Workflow Modification**: Runtime changes require explicit API (future feature)
 - **Cross-System Orchestration**: External system integrations (beyond MCP) not covered
 
+### 3.3 Minimal-Imposition Mutation Policy
+
+Workflow policy should minimise unnecessary interruption, not default to
+hesitation.
+
+Normative implications:
+
+- low-risk additive Vontology writes should default-allow when the workflow has
+  evidence-backed inputs and no explicit user denial;
+- canonical identifiers or URLs may themselves constitute sufficient permission
+  for low-risk additive representation or artefact-ingestion work;
+- write-policy decisions should be based on risk class, not primarily on
+  whether the prompt happened to include verbs such as `download`, `store`, or
+  `create`;
+- destructive or otherwise high-risk mutations should route to explicit
+  approval/confirmation workflow states;
+- human interruption is an exception path for destructive, ambiguous, or
+  genuinely safety-critical cases, not the default doctrine for ordinary Von
+  operation.
+
 ---
 
 ## 4. Conceptual Model

--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -1,7 +1,7 @@
 # Von Workflow Language (VWL) Manual
 
 Status: Draft (current implementation-aligned)
-Last updated: 2026-03-07 (Pacific/Auckland)
+Last updated: 2026-03-08 (Pacific/Auckland)
 Audience: Human engineers and AI agents
 
 ## 1. Purpose and Scope
@@ -325,7 +325,7 @@ Normative semantics:
 - invalid policy payloads MUST fail workflow loading with deterministic error codes;
 - retry and idempotency policies currently apply only to single-action states;
 - approval gates MUST fail closed when the required approval context key is absent or falsey;
-- approval-gated mutative states SHOULD provide an explicit `on_approval_required` route to a blocked terminal or escalation state;
+- destructive or otherwise high-risk approval-gated states SHOULD provide an explicit `on_approval_required` route to a blocked terminal or escalation state;
 - checkpoint policies update the shared runtime plan-state artefact rather than introducing workflow-specific Python persistence logic;
 - plan-state items support `pending|in_progress|blocked|done` statuses, bounded checkpoint history, periodic summary snapshots, resumable cursor snapshots, and resume telemetry;
 - completion gates MUST fail closed before terminal success when required plan items or required context keys are not satisfied.
@@ -512,9 +512,16 @@ Canonical paper profile source expectations:
 
 Intent boundary for URL inputs:
 
-- A bare arXiv URL on its own does **not** authorise artefact download or ontology mutation.
-- URL-driven scholarly materialisation requires explicit download/store/representation intent in the user turn.
+- A canonical arXiv abstract URL or ID on its own **does** authorise low-risk additive `download_paper` execution and scholarly representation, unless the user explicitly denies mutation.
+- Explicit phrasing such as "represent that paper" remains an equivalent positive signal, but it is not required.
+- Explicit denial (for example "do not download/store this") MUST block mutation even when a canonical arXiv source is present.
 - Deterministic route-level coverage for this boundary is tracked by `JVNAUTOSCI-1399`; the current URL-first regression to fix is `JVNAUTOSCI-1394`.
+
+Minimal-imposition rationale:
+
+- a pasted canonical source URL is sufficient evidence for this low-risk additive representation path;
+- workflow policy SHOULD prefer acting on that evidence over asking the user for redundant permission language;
+- the fail-closed boundary for this path is explicit denial, not absence of verbs such as `download` or `store`.
 
 Important runtime contract note:
 
@@ -631,6 +638,14 @@ Normative policy semantics:
 - high-risk or ambiguous changes MUST require explicit user confirmation;
 - relation-completion runs SHOULD ask at most one focused clarification question per run when machine-side evidence is insufficient;
 - if the linked acquisition profile cannot be resolved, the workflow MUST fail closed with explicit `knowledge_acquisition_profile_unavailable` diagnostics rather than falling back to ad hoc prompting.
+
+Minimal-imposition mutation semantics:
+
+- human interruption is an exception path, not the default operational posture for ordinary Von workflows;
+- low-risk additive Vontology writes SHOULD default-allow when the workflow has evidence-backed inputs and there is no explicit user denial;
+- non-delete mutations of existing state MAY proceed when the user has clearly requested them;
+- destructive mutations MUST branch through explicit `on_approval_required` confirmation/escalation states rather than relying on blanket pre-emptive hesitation;
+- approval gates are targeted risk controls for destructive/high-risk actions, not a default doctrine for all mutations.
 
 Persistence semantics:
 
@@ -984,7 +999,7 @@ Minimal per-item dispatch shape:
 
 Blocked-state routing:
 
-- mutative child-dispatch steps SHOULD declare `on_approval_required` to an explicit blocked or escalation state;
+- destructive or otherwise approval-gated child-dispatch steps SHOULD declare `on_approval_required` to an explicit blocked or escalation state;
 - blocked runs MUST preserve `approval_required`, `approval_state`, and approval-gate event diagnostics rather than silently continuing.
 
 ---

--- a/orchestrator_test_harness.py
+++ b/orchestrator_test_harness.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from src.backend.integrations.internal_mcp.orchestrator import (
+    InternalMCPChatOrchestrator,
+    _WorkflowModelPolicyState,
+)
+
+
+def _stub_stage_model_snapshot() -> dict[str, Any]:
+    stages = [
+        ("workflow_discovery", "Workflow discovery", None, None),
+        ("workflow_dispatch", "Workflow dispatch", None, None),
+        ("tool_plan", "Plan tool calls", "#V#tool_calling_workflow", "plan"),
+        ("tool_execute", "Execute tool calls", "#V#tool_calling_workflow", "execute"),
+        ("screen_backfill", "Summarise/backfill response", "#V#tool_calling_workflow", "backfill"),
+        ("response_finalising", "Finalising response", None, None),
+        ("completed", "Completed", None, None),
+    ]
+    return {
+        "schema_version": "conversation_turn_stage_model.v1",
+        "workflow_representation_id": "#V#conversation_turn_execution_workflow",
+        "stages": [
+            {
+                "stage_id": stage_id,
+                "stage_label": stage_label,
+                "runtime_aliases": [stage_id],
+                "workflow_id": workflow_id,
+                "workflow_state_id": workflow_state_id,
+            }
+            for stage_id, stage_label, workflow_id, workflow_state_id in stages
+        ],
+    }
+
+
+def _stub_stage_path(*, runtime_stages: Any, **_kwargs) -> dict[str, Any]:
+    snapshot = _stub_stage_model_snapshot()
+    stage_lookup = {
+        str(entry.get("stage_id")): dict(entry)
+        for entry in snapshot["stages"]
+        if isinstance(entry, dict) and isinstance(entry.get("stage_id"), str)
+    }
+    ordered_runtime_stages: list[str] = []
+    for item in runtime_stages or []:
+        if not isinstance(item, str):
+            continue
+        cleaned = item.strip()
+        if not cleaned or cleaned in ordered_runtime_stages:
+            continue
+        if cleaned == "workflow_discovery_complete":
+            cleaned = "workflow_discovery"
+        elif cleaned in {"orchestrator_start", "orchestrator_end"}:
+            cleaned = "workflow_dispatch"
+        ordered_runtime_stages.append(cleaned)
+
+    path = []
+    for sequence_no, stage_id in enumerate(ordered_runtime_stages):
+        entry: dict[str, Any] = dict(
+            stage_lookup.get(stage_id) or {"stage_id": stage_id}
+        )
+        entry.setdefault("stage_label", stage_id.replace("_", " ").title())
+        entry["sequence_no"] = sequence_no
+        entry["runtime_stage"] = stage_id
+        entry["runtime_stage_normalised"] = stage_id
+        entry["mapping_status"] = "mapped"
+        path.append(entry)
+
+    return {
+        "schema_version": "conversation_turn_stage_path.v1",
+        "stage_model_schema_version": snapshot["schema_version"],
+        "workflow_representation_id": snapshot["workflow_representation_id"],
+        "workflow_id": None,
+        "has_unmapped_runtime_stages": False,
+        "unmapped_runtime_stages": [],
+        "path": path,
+    }
+
+
+def build_db_independent_orchestrator(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    gateway: Any,
+    selector_enabled: bool = False,
+    max_tool_invocations: int = 1,
+    tool_batch_cap: int = 3,
+) -> InternalMCPChatOrchestrator:
+    """Build an orchestrator without DB/model-registry dependencies.
+
+    These tests target routing and write-policy behaviour, not Mongo-backed
+    workflow discovery or model registry resolution. Keep the harness minimal
+    so orchestration-path regressions fail fast instead of hanging on startup.
+    """
+
+    env_val = "1" if selector_enabled else "0"
+    monkeypatch.setenv("VON_CHAT_WORKFLOW_SELECTOR_ENABLED", env_val)
+
+    from src.backend.workflows import WorkflowRegistry, register_default_workflows
+    from src.backend.workflows.action_registry import ActionRegistry
+
+    def _build_test_registry() -> WorkflowRegistry:
+        registry = WorkflowRegistry()
+        register_default_workflows(registry)
+        return registry
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.orchestrator.build_workflow_registry",
+        _build_test_registry,
+    )
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.orchestrator.build_durable_action_registry",
+        lambda: ActionRegistry(),
+    )
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.orchestrator.get_tool_metadata",
+        lambda *_a, **_kw: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.orchestrator.get_tool_salience",
+        lambda *_a, **_kw: "medium",
+    )
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.orchestrator.is_tool_visible",
+        lambda *_a, **_kw: True,
+    )
+
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=cast(Any, gateway),
+        max_tool_invocations=max_tool_invocations,
+        tool_batch_cap=tool_batch_cap,
+    )
+
+    monkeypatch.setattr(
+        orchestrator,
+        "_load_workflow_model_policy",
+        lambda *_a, **_kw: (
+            _WorkflowModelPolicyState(
+                enabled=False,
+                policy=None,
+                policy_id=None,
+                predicate_id=None,
+                errors=[],
+            ),
+            None,
+        ),
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "_build_ontology_preflight",
+        lambda *_a, **_kw: type(
+            "_Preflight", (), {"telemetry": None, "message": None}
+        )(),
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "_resolve_concept_id_by_name",
+        lambda *_a, **_kw: None,
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "_load_base_system_prompt_from_vontology",
+        lambda *_a, **_kw: (None, None),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.model_registry_service.get_model_registry_snapshot",
+        lambda *_a, **_kw: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.orchestrator.build_conversation_turn_stage_model_snapshot",
+        _stub_stage_model_snapshot,
+    )
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.orchestrator.build_conversation_turn_stage_path",
+        _stub_stage_path,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.turn_execution_record_service.build_conversation_turn_stage_model_snapshot",
+        _stub_stage_model_snapshot,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.turn_execution_record_service.build_conversation_turn_stage_path",
+        _stub_stage_path,
+    )
+
+    return orchestrator

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -70,10 +70,14 @@ from ...workflows.workflow_gap_workflow_contracts import (
 )
 
 from src.backend.workflows.write_tool_policy import (
+    classify_write_tool_risk,
     compute_allowed_write_tools,
-    is_high_impact_vontology_write_tool,
+    prompt_has_low_risk_additive_write_evidence,
     prompt_grants_high_impact_kb_write_approval,
     prompt_explicitly_denies_write,
+    REASON_DEFAULT_ALLOW_ADDITIVE_LOW_RISK,
+    tool_requires_confirmation,
+    write_policy_reason_is_session_memory_eligible,
 )
 from ...services.turn_execution_record_service import build_turn_execution_record
 from src.backend.services.buttonify_service import (
@@ -233,6 +237,18 @@ class _StructuredToolCandidateResolution:
     truncation_applied: bool
     write_policy_reason: str
     warnings: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _ResolvedWritePolicyDecision:
+    allowed_tools: frozenset[str]
+    reason: str
+    decision_basis: str
+    user_denial_detected: bool
+    risk_classes: Mapping[str, str]
+    blocked_reasons: Mapping[str, str]
+    confirmation_required_tools: frozenset[str]
+    confirmation_prompts: Mapping[str, str]
 
 
 class ProgressTracker:
@@ -764,8 +780,6 @@ class InternalMCPChatOrchestrator:
         "source_concept_not_found": ("source_id",),
         "predicate_concept_not_found": ("predicate",),
     }
-    _HIGH_IMPACT_REVIEW_REASON = "high_impact_kb_write_requires_human_review"
-    _HIGH_IMPACT_NAMESPACE_REASON = "high_impact_kb_write_requires_namespace"
     _WRITE_INTENT_SESSION_MEMORY_TTL_SECONDS = 900
     _WRITE_INTENT_SESSION_MEMORY_MAX_SESSIONS = 256
     _WRITE_INTENT_SESSION_MEMORY_FOLLOW_UP_TURNS = 2
@@ -1666,6 +1680,10 @@ class InternalMCPChatOrchestrator:
             if get_disable_write_tool_conservatism():
                 if not prompt_explicitly_denies_write(prompt):
                     allowed = sorted({str(tool) for tool in requested_tools if tool})
+                    risk_classes = {
+                        tool_name: classify_write_tool_risk(tool_name)
+                        for tool_name in allowed
+                    }
                     try:
                         from ...workflows.workflow_baseline_telemetry import (
                             record_write_policy_decision,
@@ -1681,6 +1699,12 @@ class InternalMCPChatOrchestrator:
                         outputs={
                             "allowed_write_tools": allowed,
                             "write_policy_reason": "write_conservatism_disabled_by_admin_setting",
+                            "write_policy_decision_basis": "write_conservatism_disabled_by_admin_setting",
+                            "write_policy_user_denial_detected": False,
+                            "write_policy_risk_classes": risk_classes,
+                            "write_policy_blocked_reasons": {},
+                            "write_policy_requires_confirmation": [],
+                            "approval_required": False,
                         }
                     )
         except Exception:
@@ -1710,6 +1734,25 @@ class InternalMCPChatOrchestrator:
             outputs={
                 "allowed_write_tools": sorted(decision.allowed_tools),
                 "write_policy_reason": decision.reason,
+                "write_policy_decision_basis": decision.decision_basis,
+                "write_policy_user_denial_detected": decision.user_denial_detected,
+                "write_policy_risk_classes": {
+                    item.tool_name: item.risk_class for item in decision.tool_decisions
+                },
+                "write_policy_blocked_reasons": {
+                    item.tool_name: item.blocked_reason
+                    for item in decision.tool_decisions
+                    if isinstance(item.blocked_reason, str) and item.blocked_reason
+                },
+                "write_policy_requires_confirmation": [
+                    item.tool_name
+                    for item in decision.tool_decisions
+                    if item.requires_confirmation
+                ],
+                "approval_required": any(
+                    item.requires_confirmation and not item.allowed
+                    for item in decision.tool_decisions
+                ),
             }
         )
 
@@ -3965,19 +4008,25 @@ class InternalMCPChatOrchestrator:
         gmail_profile = data.get("gmail_profile") or env.default_gmail_profile
         conversation_session_id = data.get("conversation_session_id")
 
-        # Build method catalogue on first validation pass.
-        if "method_catalogue" not in data:
+        # Build method catalogue on first validation pass. Keep tool category
+        # derivation independent so earlier prompt-requirement seeding of
+        # method_catalogue cannot silently skip write-gate enforcement.
+        method_catalogue = data.get("method_catalogue")
+        if not isinstance(method_catalogue, Mapping):
             method_catalogue = self._gateway.describe_methods()
-            tool_categories: dict[str, str] = {}
+            data["method_catalogue"] = method_catalogue
+
+        tool_categories = data.get("tool_categories")
+        if not isinstance(tool_categories, Mapping):
+            resolved_categories: dict[str, str] = {}
             for name, meta in method_catalogue.items():
                 if not isinstance(meta, Mapping):
                     continue
                 category = meta.get("category")
                 if isinstance(category, str):
-                    tool_categories[name] = category
-            data["method_catalogue"] = method_catalogue
-            data["tool_categories"] = tool_categories
-        method_catalogue = data["method_catalogue"]
+                    resolved_categories[name] = category
+            tool_categories = resolved_categories
+            data["tool_categories"] = resolved_categories
 
         preflight = self._preflight_tool_calls(
             cast(list, tool_calls),
@@ -4189,6 +4238,27 @@ class InternalMCPChatOrchestrator:
                 )
 
         write_policy_reason = data.get("write_policy_reason", "")
+        write_policy_decision_basis = data.get(
+            "write_policy_decision_basis", write_policy_reason
+        )
+        write_policy_user_denial_detected = bool(
+            data.get("write_policy_user_denial_detected")
+        )
+        write_policy_risk_classes = (
+            dict(data.get("write_policy_risk_classes"))
+            if isinstance(data.get("write_policy_risk_classes"), Mapping)
+            else {}
+        )
+        write_policy_blocked_reasons = (
+            dict(data.get("write_policy_blocked_reasons"))
+            if isinstance(data.get("write_policy_blocked_reasons"), Mapping)
+            else {}
+        )
+        write_policy_requires_confirmation = {
+            str(item)
+            for item in (data.get("write_policy_requires_confirmation") or [])
+            if isinstance(item, str) and str(item).strip()
+        }
         turn_id = data.get("turn_id")
 
         for tool_request in tool_calls:
@@ -4232,35 +4302,52 @@ class InternalMCPChatOrchestrator:
                     turn_id=turn_id if isinstance(turn_id, str) else None,
                 )
             if tool_category == "write" and tool_name not in allowed_write_tools:
-                allowed_write_tools, write_policy_reason = (
-                    self._resolve_allowed_write_tools(
-                        prompt=prompt,
-                        requested_write_tools=[tool_name],
-                        recent_user_prompts=recent_user_prompts,
-                        llm_client=llm_client,
-                        model=env.model,
-                        user_namespace=env.user_namespace,
-                        auxiliary_system_prompt=env.auxiliary_system_prompt,
-                        trace=request.trace,
-                        conversation_session_id=conversation_session_id,
-                        turn_id=data.get("turn_id"),
-                        aux_llm_calls=data.get("aux_llm_calls"),
-                    )
+                resolved_write_policy = self._resolve_allowed_write_tools(
+                    prompt=prompt,
+                    requested_write_tools=[tool_name],
+                    recent_user_prompts=recent_user_prompts,
+                    llm_client=llm_client,
+                    model=env.model,
+                    user_namespace=env.user_namespace,
+                    auxiliary_system_prompt=env.auxiliary_system_prompt,
+                    trace=request.trace,
+                    conversation_session_id=conversation_session_id,
+                    turn_id=data.get("turn_id"),
+                    aux_llm_calls=data.get("aux_llm_calls"),
                 )
+                allowed_write_tools = set(resolved_write_policy.allowed_tools)
+                write_policy_reason = resolved_write_policy.reason
+                write_policy_decision_basis = resolved_write_policy.decision_basis
+                write_policy_user_denial_detected = (
+                    resolved_write_policy.user_denial_detected
+                )
+                write_policy_risk_classes = dict(resolved_write_policy.risk_classes)
+                write_policy_blocked_reasons = dict(
+                    resolved_write_policy.blocked_reasons
+                )
+                write_policy_requires_confirmation = set(
+                    resolved_write_policy.confirmation_required_tools
+                )
+
+            tool_write_risk_class = str(
+                write_policy_risk_classes.get(tool_name)
+                or classify_write_tool_risk(tool_name)
+            )
+            tool_blocked_reason = str(
+                write_policy_blocked_reasons.get(tool_name) or write_policy_reason or ""
+            ).strip()
+            tool_requires_confirmation = tool_name in write_policy_requires_confirmation
 
             if tool_category == "write" and tool_name not in allowed_write_tools:
                 _record_write_gate_decision(
                     tool_name=tool_name,
                     allowed=False,
-                    reason=(
-                        write_policy_reason
-                        if isinstance(write_policy_reason, str)
-                        else None
-                    ),
+                    reason=tool_blocked_reason or None,
                 )
                 message = self._build_blocked_write_message(
                     tool_name=tool_name,
-                    reason=write_policy_reason if isinstance(write_policy_reason, str) else None,
+                    reason=tool_blocked_reason or None,
+                    payload=payload,
                 )
                 tool_payload = self._format_tool_result(
                     tool_name, None, None, "error", message
@@ -4270,9 +4357,21 @@ class InternalMCPChatOrchestrator:
                     "payload": dict(payload),
                     "error": message,
                     "blocked": True,
+                    "write_policy_risk_class": tool_write_risk_class,
+                    "write_policy_decision_basis": write_policy_decision_basis,
+                    "write_policy_requires_confirmation": tool_requires_confirmation,
+                    "write_policy_blocked_reason": tool_blocked_reason or None,
+                    "write_policy_user_denial_detected": write_policy_user_denial_detected,
                 }
                 if write_policy_reason:
                     blocked_record["write_policy_reason"] = write_policy_reason
+                if tool_requires_confirmation:
+                    blocked_record["confirmation_prompt"] = (
+                        self._build_destructive_confirmation_prompt(
+                            tool_name=tool_name,
+                            payload=payload,
+                        )
+                    )
                 if write_interaction_metadata:
                     blocked_record["knowledge_interaction"] = write_interaction_metadata
                 if call_id:
@@ -4291,62 +4390,8 @@ class InternalMCPChatOrchestrator:
                             ),
                             "call_id": call_id,
                             "error": message,
-                        }
-                    )
-                augmented_context.append({"role": "tool", "content": tool_payload})
-                tool_messages.append({"role": "tool", "content": tool_payload})
-                continue
-
-            high_impact_guard_reason: str | None = None
-            if tool_category == "write":
-                high_impact_guard_reason = self._evaluate_high_impact_write_guard(
-                    tool_name=tool_name,
-                    prompt=prompt if isinstance(prompt, str) else "",
-                    recent_user_prompts=list(recent_user_prompts or []),
-                    user_namespace=env.user_namespace,
-                )
-
-            if tool_category == "write" and high_impact_guard_reason:
-                _record_write_gate_decision(
-                    tool_name=tool_name,
-                    allowed=False,
-                    reason=high_impact_guard_reason,
-                )
-                message = self._build_blocked_write_message(
-                    tool_name=tool_name,
-                    reason=high_impact_guard_reason,
-                )
-                tool_payload = self._format_tool_result(
-                    tool_name, None, None, "error", message
-                )
-                blocked_record = {
-                    "tool": tool_name,
-                    "payload": dict(payload),
-                    "error": message,
-                    "blocked": True,
-                    "write_policy_reason": high_impact_guard_reason,
-                }
-                if write_interaction_metadata:
-                    blocked_record["knowledge_interaction"] = {
-                        **write_interaction_metadata,
-                        "guard_reason": high_impact_guard_reason,
-                    }
-                if call_id:
-                    blocked_record["call_id"] = call_id
-                invocations.append(blocked_record)
-                if callable(emit_progress):
-                    emit_progress(
-                        {
-                            "status": "tool_blocked",
-                            "tool": tool_name,
-                            "batch_size": current_batch_size,
-                            "tool_calls_done": iteration_count,
-                            "tool_calls_cap": int(max_tool_invocations),
-                            "tool_calls_remaining": max(
-                                0, max_tool_invocations - iteration_count
-                            ),
-                            "call_id": call_id,
-                            "error": message,
+                            "blocked_reason": tool_blocked_reason or None,
+                            "requires_confirmation": tool_requires_confirmation,
                         }
                     )
                 augmented_context.append({"role": "tool", "content": tool_payload})
@@ -4358,11 +4403,7 @@ class InternalMCPChatOrchestrator:
                     _record_write_gate_decision(
                         tool_name=tool_name,
                         allowed=True,
-                        reason=(
-                            write_policy_reason
-                            if isinstance(write_policy_reason, str)
-                            else "allowed"
-                        ),
+                        reason=tool_blocked_reason or write_policy_reason or "allowed",
                     )
                 payload_before_invoke = dict(payload)
                 schema = self._tool_schema_for_name(tool_name, method_catalogue)
@@ -4431,6 +4472,11 @@ class InternalMCPChatOrchestrator:
                     invocation_record["auto_retry"] = auto_retry_details
                 if write_interaction_metadata:
                     invocation_record["knowledge_interaction"] = write_interaction_metadata
+                if tool_category == "write":
+                    invocation_record["write_policy_risk_class"] = tool_write_risk_class
+                    invocation_record["write_policy_decision_basis"] = (
+                        write_policy_decision_basis
+                    )
                 if call_id:
                     invocation_record["call_id"] = call_id
                 invocations.append(invocation_record)
@@ -5987,6 +6033,11 @@ class InternalMCPChatOrchestrator:
             for tool_name in write_policy_decision.allowed_tools
             if isinstance(tool_name, str) and str(tool_name).strip()
         }
+        confirmation_required_write_tools = {
+            item.tool_name.strip().lower()
+            for item in write_policy_decision.tool_decisions
+            if item.requires_confirmation and item.tool_name.strip()
+        }
         write_explicitly_denied = prompt_explicitly_denies_write(prompt)
         if write_explicitly_denied:
             allowed_write_tools = set()
@@ -6019,7 +6070,10 @@ class InternalMCPChatOrchestrator:
                 if write_explicitly_denied:
                     _mark_excluded(tool_name, "write_tool_explicitly_denied")
                     return
-                if key not in allowed_write_tools:
+                if (
+                    key not in allowed_write_tools
+                    and key not in confirmation_required_write_tools
+                ):
                     _mark_excluded(tool_name, "write_tool_not_allowed_for_prompt")
                     return
             included_lookup.add(key)
@@ -7345,6 +7399,11 @@ class InternalMCPChatOrchestrator:
         )
         if not _tool_available("create_concepts"):
             required_create_type_name = None
+        prompt_text = user_prompt if isinstance(user_prompt, str) else ""
+        prompt_arxiv_id = cls._extract_arxiv_id_from_text(prompt_text)
+        allow_default_arxiv_download = bool(prompt_arxiv_id) and not (
+            prompt_explicitly_denies_write(prompt_text)
+        )
         has_prompt_url = (
             isinstance(user_prompt, str)
             and bool(re.search(r"https?://\S+", user_prompt, re.IGNORECASE))
@@ -7355,7 +7414,11 @@ class InternalMCPChatOrchestrator:
             for tool_name in required_tools
             if isinstance(tool_name, str) and tool_name.strip()
         }
-        if has_prompt_url:
+        if allow_default_arxiv_download and _tool_available("download_paper"):
+            if "download_paper" not in seen_required:
+                required_tools.append("download_paper")
+                seen_required.add("download_paper")
+        elif has_prompt_url:
             url_tool_name: str | None = None
             if _tool_available("resilient_extract_url"):
                 url_tool_name = "resilient_extract_url"
@@ -10914,59 +10977,87 @@ class InternalMCPChatOrchestrator:
         user_part = cleaned.split("@", 1)[0].strip()
         return user_part or None
 
-    @staticmethod
-    def _is_high_impact_review_mode_enabled() -> bool:
-        try:
-            from src.backend.services.settings_service import (
-                get_require_human_review_for_high_impact_kb_writes,
-            )
+    def _summarise_write_target_for_confirmation(
+        self,
+        *,
+        payload: Mapping[str, Any] | None,
+    ) -> str | None:
+        if not isinstance(payload, Mapping):
+            return None
 
-            return bool(get_require_human_review_for_high_impact_kb_writes())
-        except Exception:
-            return False
+        ordered_keys = (
+            "concept_id",
+            "source_id",
+            "target_id",
+            "relation_id",
+            "task_concept_id",
+            "issue_key",
+            "schedule_id",
+            "binding_id",
+            "instance_id",
+            "arxiv_id",
+        )
+        parts: list[str] = []
+        for key in ordered_keys:
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                parts.append(f"{key}={value.strip()}")
+        predicate = payload.get("predicate")
+        target = payload.get("target")
+        if isinstance(predicate, str) and predicate.strip():
+            parts.append(f"predicate={predicate.strip()}")
+        if isinstance(target, str) and target.strip():
+            parts.append(f"target={target.strip()}")
+        if not parts:
+            return None
+        return ", ".join(parts[:4])
 
-    def _evaluate_high_impact_write_guard(
+    def _build_destructive_confirmation_prompt(
         self,
         *,
         tool_name: str,
-        prompt: str,
-        recent_user_prompts: list[str],
-        user_namespace: str | None,
-    ) -> str | None:
-        if not self._is_high_impact_review_mode_enabled():
-            return None
-        if not is_high_impact_vontology_write_tool(tool_name):
-            return None
-        if not (isinstance(user_namespace, str) and user_namespace.strip()):
-            return self._HIGH_IMPACT_NAMESPACE_REASON
-        approved = prompt_grants_high_impact_kb_write_approval(
-            prompt=prompt,
-            recent_user_prompts=recent_user_prompts,
+        payload: Mapping[str, Any] | None,
+    ) -> str:
+        target_summary = self._summarise_write_target_for_confirmation(payload=payload)
+        if target_summary:
+            return (
+                f"Confirmation required before running {tool_name!r} "
+                f"({target_summary}). Reply with a clear confirmation such as "
+                f"'Confirm {tool_name} {target_summary}'."
+            )
+        return (
+            f"Confirmation required before running {tool_name!r}. "
+            f"Reply with a clear confirmation such as 'Confirm {tool_name}'."
         )
-        if not approved:
-            return self._HIGH_IMPACT_REVIEW_REASON
-        return None
 
     def _build_blocked_write_message(
         self,
         *,
         tool_name: str,
         reason: str | None,
+        payload: Mapping[str, Any] | None = None,
     ) -> str:
-        if reason == self._HIGH_IMPACT_NAMESPACE_REASON:
+        if reason == "explicit_write_denial_detected":
             return (
-                f"Blocked high-impact Vontology write tool {tool_name!r}: "
-                "an authenticated namespace is required to preserve namespace isolation."
+                f"Blocked write tool {tool_name!r}: the user explicitly denied write "
+                "side-effects for this turn."
             )
-        if reason == self._HIGH_IMPACT_REVIEW_REASON:
+        if reason == "destructive_confirmation_required":
+            return self._build_destructive_confirmation_prompt(
+                tool_name=tool_name,
+                payload=payload,
+            )
+        if reason in {
+            "mutative_non_destructive_request_required",
+            "external_write_requires_explicit_request",
+        }:
             return (
-                f"Blocked high-impact Vontology write tool {tool_name!r}: "
-                "human review approval is required. Include explicit approval wording "
-                "for the Vontology mutation and retry."
+                f"Blocked write tool {tool_name!r}: restate the requested write "
+                "explicitly if you want this non-default mutation to proceed."
             )
         return (
-            f"Blocked write tool {tool_name!r}: the user request appears read-only. "
-            "If you intended to perform a write, restate the request explicitly."
+            f"Blocked write tool {tool_name!r}: the write policy did not allow this "
+            "tool for the current turn."
         )
 
     @staticmethod
@@ -10980,14 +11071,12 @@ class InternalMCPChatOrchestrator:
 
         lowered_reason = str(reason or "").strip().lower()
         if lowered_reason in {
-            "no_explicit_write_intent_detected",
-            "recent_vontology_mutation_request_without_confirmation",
+            "default_allow_additive_low_risk",
+            "mutative_non_destructive_request_required",
+            "external_write_requires_explicit_request",
+            "destructive_confirmation_required",
             "workflow_unavailable",
             "no_write_tools_available",
-        }:
-            return "pending"
-        if lowered_reason in {
-            "high_impact_kb_write_requires_human_review",
         }:
             return "pending"
         return "denied"
@@ -12614,15 +12703,15 @@ class InternalMCPChatOrchestrator:
                 additions.append(candidate)
                 seen_recent.add(candidate.lower())
 
-        high_impact_approval_from_continuation = False
-        if bool(memory_entry.get("has_high_impact_tools")):
+        confirmation_from_continuation = False
+        if bool(memory_entry.get("has_confirmation_required_tools")):
             synthetic_approval_prompt = (
-                "Approved Vontology mutation continuation for the current context."
+                "Confirmed destructive Vontology mutation continuation for the current context."
             )
             if synthetic_approval_prompt.lower() not in seen_recent:
                 additions.append(synthetic_approval_prompt)
                 seen_recent.add(synthetic_approval_prompt.lower())
-            high_impact_approval_from_continuation = True
+            confirmation_from_continuation = True
 
         cleaned_recent.extend(additions)
         remaining_after = max(0, remaining_before - 1)
@@ -12640,7 +12729,7 @@ class InternalMCPChatOrchestrator:
             "added_prompts": len(additions),
             "remaining_before": remaining_before,
             "remaining_after": remaining_after,
-            "high_impact_approval_from_continuation": high_impact_approval_from_continuation,
+            "confirmation_from_continuation": confirmation_from_continuation,
         }
 
     def _persist_write_intent_session_memory(
@@ -12667,13 +12756,7 @@ class InternalMCPChatOrchestrator:
         )
 
         policy_reason = str(write_policy_reason or "").strip()
-        explicit_or_recent_reason = policy_reason in {
-            "explicit_vontology_mutation_request",
-            "recent_vontology_mutation_request",
-            "explicit_artefact_download_request",
-            "recent_artefact_download_request",
-        }
-        if not explicit_or_recent_reason:
+        if not write_policy_reason_is_session_memory_eligible(policy_reason):
             return {
                 "type": "write_intent_session_memory",
                 "stage": "persist",
@@ -12718,10 +12801,10 @@ class InternalMCPChatOrchestrator:
                 anchor_prompt = cleaned
                 break
 
-        has_high_impact_tools = any(
-            is_high_impact_vontology_write_tool(tool_name) for tool_name in tools_to_store
+        has_confirmation_required_tools = any(
+            tool_requires_confirmation(tool_name) for tool_name in tools_to_store
         )
-        approval_detected = prompt_grants_high_impact_kb_write_approval(
+        confirmation_granted = prompt_grants_high_impact_kb_write_approval(
             prompt=prompt,
             recent_user_prompts=[
                 str(item).strip()
@@ -12729,15 +12812,15 @@ class InternalMCPChatOrchestrator:
                 if isinstance(item, str) and str(item).strip()
             ],
         )
-        # A bounded continuation prompt ("yes", "do it") should carry approval
-        # only when a compatible high-impact write intent was already established.
-        if continuation_prompt and has_high_impact_tools and policy_reason.startswith(
-            "recent_"
+        if (
+            continuation_prompt
+            and has_confirmation_required_tools
+            and policy_reason.startswith("recent_")
         ):
-            approval_detected = True
-        high_impact_approved = bool(existing_mapping.get("high_impact_approved")) or bool(
-            approval_detected
-        )
+            confirmation_granted = True
+        confirmation_granted = bool(
+            existing_mapping.get("confirmation_granted")
+        ) or bool(confirmation_granted)
 
         self._write_intent_session_memory[session_key] = {
             "timestamp": now,
@@ -12747,8 +12830,8 @@ class InternalMCPChatOrchestrator:
             ),
             "intent_anchor_prompt": anchor_prompt,
             "write_tools": tools_to_store,
-            "has_high_impact_tools": has_high_impact_tools,
-            "high_impact_approved": high_impact_approved,
+            "has_confirmation_required_tools": has_confirmation_required_tools,
+            "confirmation_granted": confirmation_granted,
             "write_policy_reason": policy_reason,
         }
 
@@ -12758,8 +12841,8 @@ class InternalMCPChatOrchestrator:
             "updated": True,
             "write_policy_reason": policy_reason,
             "write_tool_count": len(tools_to_store),
-            "has_high_impact_tools": has_high_impact_tools,
-            "high_impact_approved": high_impact_approved,
+            "has_confirmation_required_tools": has_confirmation_required_tools,
+            "confirmation_granted": confirmation_granted,
         }
 
     def _get_topic_vocabulary_cache_key(self, keywords: list[str]) -> str:
@@ -15993,8 +16076,9 @@ class InternalMCPChatOrchestrator:
         return (
             "Your previous message described an action that requires MCP tools, but you did not emit a tool call. "
             "NOW respond with ONLY a tool-call JSON object or a JSON array of tool-call objects. "
-            "Choose a tool that matches the user's request; do NOT call write tools unless the user explicitly asked for the write-side effect (e.g., Vontology changes or downloading/storing an artefact). "
-            "If the user provided an arXiv ID/URL and asked to download/store/upload/finalise an artefact, call download_paper or finalise_cached_paper with the arxiv_id (do NOT call list_papers). "
+            "Choose a tool that matches the user's request. Low-risk additive Vontology writes may proceed by default unless the user explicitly denied them. "
+            "If the user provided a canonical arXiv ID/URL, treat that as sufficient permission for additive scholarly-paper materialisation and call download_paper with the arxiv_id (do NOT call list_papers). "
+            "Destructive writes still require explicit confirmation. "
             "No prose. No Markdown. Do NOT wrap the JSON in ``` fences (including ```json). "
             "The first character MUST be an opening curly brace or an opening square bracket, and the response must contain only valid JSON."
         )
@@ -16249,6 +16333,19 @@ class InternalMCPChatOrchestrator:
                     )
                 continue
 
+            if name in {"download_paper", "finalise_cached_paper"}:
+                arxiv_id = self._extract_arxiv_id_from_text(user_text)
+                if not arxiv_id:
+                    continue
+                forced_calls.append(
+                    {
+                        "action": "call_tool",
+                        "tool": name,
+                        "payload": {"arxiv_id": arxiv_id},
+                    }
+                )
+                continue
+
             if name == "interpret_file_copy":
                 scholarly_file_copy_ids = list(
                     missing_required_scholarly_representation_file_copy_ids
@@ -16285,8 +16382,9 @@ class InternalMCPChatOrchestrator:
     ) -> list[_ToolCallRequest] | None:
         """Best-effort deterministic recovery for common missing-tool-call cases.
 
-        This is intentionally narrow: we only force a write tool when the user
-        explicitly requests the write-side effect.
+        This is intentionally narrow: we force write tools only when the prompt
+        itself establishes a deterministic required-effect path, such as
+        additive arXiv materialisation from a canonical source.
         """
 
         last_user_text: str | None = None
@@ -16406,7 +16504,7 @@ class InternalMCPChatOrchestrator:
         conversation_session_id: str | None = None,
         turn_id: str | None = None,
         aux_llm_calls: list[Mapping[str, Any]] | None = None,
-    ) -> tuple[set[str], str]:
+    ) -> _ResolvedWritePolicyDecision:
         workflow_result = self.execute_workflow(
             WRITE_TOOL_POLICY_WORKFLOW_ID,
             data={
@@ -16429,15 +16527,75 @@ class InternalMCPChatOrchestrator:
             episode_source="chat_turn_workflow",
         )
         if workflow_result is None:
-            return set(), "workflow_unavailable"
+            blocked_reasons = {
+                str(tool_name): "workflow_unavailable"
+                for tool_name in requested_write_tools
+                if isinstance(tool_name, str) and str(tool_name).strip()
+            }
+            return _ResolvedWritePolicyDecision(
+                allowed_tools=frozenset(),
+                reason="workflow_unavailable",
+                decision_basis="workflow_unavailable",
+                user_denial_detected=False,
+                risk_classes={
+                    str(tool_name): classify_write_tool_risk(str(tool_name))
+                    for tool_name in requested_write_tools
+                    if isinstance(tool_name, str) and str(tool_name).strip()
+                },
+                blocked_reasons=blocked_reasons,
+                confirmation_required_tools=frozenset(),
+                confirmation_prompts={},
+            )
         allowed = workflow_result.data.get("allowed_write_tools")
         reason = workflow_result.data.get("write_policy_reason")
+        decision_basis = workflow_result.data.get("write_policy_decision_basis")
+        user_denial_detected = workflow_result.data.get(
+            "write_policy_user_denial_detected"
+        )
+        risk_classes = workflow_result.data.get("write_policy_risk_classes")
+        blocked_reasons = workflow_result.data.get("write_policy_blocked_reasons")
+        confirmation_required = workflow_result.data.get(
+            "write_policy_requires_confirmation"
+        )
         allowed_set: set[str] = set()
         if isinstance(allowed, list):
             allowed_set = {
                 str(item) for item in allowed if isinstance(item, str) and item
             }
-        return allowed_set, str(reason or "")
+        confirmation_required_tools = frozenset(
+            str(item)
+            for item in (confirmation_required or [])
+            if isinstance(item, str) and str(item).strip()
+        )
+        confirmation_prompts = {
+            tool_name: self._build_destructive_confirmation_prompt(
+                tool_name=tool_name,
+                payload=None,
+            )
+            for tool_name in confirmation_required_tools
+        }
+        return _ResolvedWritePolicyDecision(
+            allowed_tools=frozenset(allowed_set),
+            reason=str(reason or ""),
+            decision_basis=str(decision_basis or reason or ""),
+            user_denial_detected=bool(user_denial_detected),
+            risk_classes=(
+                dict(risk_classes)
+                if isinstance(risk_classes, Mapping)
+                else {
+                    str(tool_name): classify_write_tool_risk(str(tool_name))
+                    for tool_name in requested_write_tools
+                    if isinstance(tool_name, str) and str(tool_name).strip()
+                }
+            ),
+            blocked_reasons=(
+                dict(blocked_reasons)
+                if isinstance(blocked_reasons, Mapping)
+                else {}
+            ),
+            confirmation_required_tools=confirmation_required_tools,
+            confirmation_prompts=confirmation_prompts,
+        )
 
     def execute_workflow(
         self,
@@ -18981,14 +19139,41 @@ class InternalMCPChatOrchestrator:
             write_routing_policy_reason = str(
                 write_routing_policy_decision.reason or ""
             ).strip()
-            mutative_intent_requires_tool_routing = bool(
-                write_routing_policy_decision.allowed_tools
-            ) and not prompt_explicitly_denies_write(prompt)
+            low_risk_additive_routing_evidence = (
+                prompt_has_low_risk_additive_write_evidence(prompt)
+                or bool(
+                    isinstance(write_intent_rehydrate_telemetry, Mapping)
+                    and write_intent_rehydrate_telemetry.get("reused")
+                )
+            )
+            routing_gate_allowed = any(
+                item.allowed
+                and (
+                    item.decision_basis != REASON_DEFAULT_ALLOW_ADDITIVE_LOW_RISK
+                    or low_risk_additive_routing_evidence
+                )
+                for item in write_routing_policy_decision.tool_decisions
+            ) or any(
+                item.requires_confirmation
+                for item in write_routing_policy_decision.tool_decisions
+            )
+            mutative_intent_requires_tool_routing = routing_gate_allowed
+            if prompt_explicitly_denies_write(prompt):
+                mutative_intent_requires_tool_routing = False
             write_gate_state = self._classify_write_gate_state(
-                allowed=bool(write_routing_policy_decision.allowed_tools),
+                allowed=routing_gate_allowed,
                 reason=write_routing_policy_reason,
             )
             if isinstance(aux_llm_calls, list):
+                routing_risk_classes = {
+                    item.tool_name: item.risk_class
+                    for item in write_routing_policy_decision.tool_decisions
+                }
+                confirmation_required_tools = [
+                    item.tool_name
+                    for item in write_routing_policy_decision.tool_decisions
+                    if item.requires_confirmation
+                ]
                 try:
                     aux_llm_calls.append(
                         {
@@ -18996,6 +19181,17 @@ class InternalMCPChatOrchestrator:
                             "stage": "routing",
                             "gate_state": write_gate_state,
                             "reason": write_routing_policy_reason,
+                            "decision_basis": write_routing_policy_decision.decision_basis,
+                            "risk_classes": routing_risk_classes,
+                            "requires_confirmation": bool(
+                                confirmation_required_tools
+                            ),
+                            "confirmation_required_tools": confirmation_required_tools,
+                            "blocked_reason": write_routing_policy_reason
+                            if not write_routing_policy_decision.allowed_tools
+                            else None,
+                            "user_denial_detected": write_routing_policy_decision.user_denial_detected,
+                            "low_risk_additive_routing_evidence": low_risk_additive_routing_evidence,
                             "requested_write_tools_count": len(
                                 write_tool_candidates_for_routing
                             ),

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -26,6 +26,7 @@ from .representation_contract_vontology_service import (
     ensure_canonical_representation_contract_profiles,
     load_representation_contract_profiles_from_concept_ids,
 )
+from ..workflows.write_tool_policy import prompt_explicitly_denies_write
 from ..workflows.conversation_turn_stage_model import (
     build_conversation_turn_stage_model_snapshot,
     build_conversation_turn_stage_path,
@@ -618,6 +619,12 @@ def _extract_tool_invocation_payload(
     payload_value = invocation.get("payload")
     if isinstance(payload_value, Mapping):
         return payload_value
+    payload_value = invocation.get("effective_arguments")
+    if isinstance(payload_value, Mapping):
+        return payload_value
+    payload_value = invocation.get("arguments")
+    if isinstance(payload_value, Mapping):
+        return payload_value
     return None
 
 
@@ -1169,6 +1176,46 @@ def _prompt_requests_representation_action(prompt_text: str) -> bool:
     )
 
 
+def _prompt_implies_low_risk_arxiv_representation(
+    prompt_text: str,
+    *,
+    aux_llm_calls: Sequence[Mapping[str, Any]] | None = None,
+) -> bool:
+    if not prompt_text:
+        return False
+    lowered = prompt_text.lower()
+    if _looks_like_diagnostic_only_prompt(lowered):
+        return False
+    if prompt_explicitly_denies_write(prompt_text):
+        return False
+
+    arxiv_ids = extract_arxiv_id_candidates(prompt_text)
+    if not arxiv_ids:
+        return False
+
+    urls = _extract_urls_from_text(prompt_text)
+    if any("arxiv.org/" in url.lower() for url in urls):
+        return True
+
+    if "arxiv" in lowered:
+        return True
+
+    for entry in aux_llm_calls or ():
+        if not isinstance(entry, Mapping):
+            continue
+        if _safe_str(entry.get("type")) != "write_policy_gate":
+            continue
+        if _safe_str(entry.get("reason")) != "default_allow_additive_low_risk":
+            continue
+        risk_classes = entry.get("risk_classes")
+        if not isinstance(risk_classes, Mapping):
+            continue
+        if _safe_str(risk_classes.get("download_paper")) == "additive_low_risk":
+            return True
+
+    return False
+
+
 def _compile_representation_intent_patterns(patterns: Any) -> list[re.Pattern[str]]:
     if not isinstance(patterns, Sequence) or isinstance(patterns, (str, bytes)):
         return []
@@ -1341,7 +1388,12 @@ def _build_representation_required_effects_contract(
     continuation_contract = _representation_contract_from_continuation_context(
         continuation_context
     )
-    if not _prompt_requests_representation_action(prompt_clean):
+    if not _prompt_requests_representation_action(
+        prompt_clean
+    ) and not _prompt_implies_low_risk_arxiv_representation(
+        prompt_clean,
+        aux_llm_calls=aux_llm_calls,
+    ):
         return continuation_contract
 
     file_copy_ids = _extract_required_file_copy_ids_from_aux(aux_llm_calls)
@@ -1512,16 +1564,30 @@ _REPRESENTATION_EFFECT_PAYLOAD_KEYS: dict[str, str] = {
 }
 
 
-def _extract_tool_invocation_target_ids(payload: Mapping[str, Any] | None) -> list[str]:
-    if not isinstance(payload, Mapping):
-        return []
+def _extract_tool_invocation_target_ids(invocation: Mapping[str, Any]) -> list[str]:
+    payload = _extract_tool_invocation_payload(invocation)
+    arguments = invocation.get("effective_arguments")
+    if not isinstance(arguments, Mapping):
+        raw_arguments = invocation.get("arguments")
+        arguments = raw_arguments if isinstance(raw_arguments, Mapping) else None
+
     return _normalise_representation_target_tokens(
-        payload.get("concept_id"),
-        payload.get("file_copy_concept_id"),
-        payload.get("computer_file_copy_concept_id"),
-        payload.get("url"),
-        payload.get("source_url"),
-        payload.get("arxiv_id"),
+        payload.get("concept_id") if isinstance(payload, Mapping) else None,
+        payload.get("file_copy_concept_id") if isinstance(payload, Mapping) else None,
+        payload.get("computer_file_copy_concept_id")
+        if isinstance(payload, Mapping)
+        else None,
+        payload.get("url") if isinstance(payload, Mapping) else None,
+        payload.get("source_url") if isinstance(payload, Mapping) else None,
+        payload.get("arxiv_id") if isinstance(payload, Mapping) else None,
+        arguments.get("concept_id") if isinstance(arguments, Mapping) else None,
+        arguments.get("file_copy_concept_id") if isinstance(arguments, Mapping) else None,
+        arguments.get("computer_file_copy_concept_id")
+        if isinstance(arguments, Mapping)
+        else None,
+        arguments.get("url") if isinstance(arguments, Mapping) else None,
+        arguments.get("source_url") if isinstance(arguments, Mapping) else None,
+        arguments.get("arxiv_id") if isinstance(arguments, Mapping) else None,
     )
 
 
@@ -1564,7 +1630,7 @@ def _collect_successful_tool_payloads(
             continue
         payload_target_ids = {
             item.lower()
-            for item in _extract_tool_invocation_target_ids(payload)
+            for item in _extract_tool_invocation_target_ids(invocation)
             if isinstance(item, str) and item.strip()
         }
         if payload_target_ids and payload_target_ids.intersection(target_lookup):
@@ -2210,12 +2276,14 @@ def build_turn_execution_record(
     required_effects: list[dict[str, Any]] = []
     required_effects.extend(representation_effects)
 
-    mutation_effect = _infer_mutation_required_effect(
-        prompt_text=prompt_text,
-        successful_write_tools=successful_write_tools,
-        failed_tools=failed_tools,
-        blocked_tools=blocked_tools,
-    )
+    mutation_effect = None
+    if not representation_effects:
+        mutation_effect = _infer_mutation_required_effect(
+            prompt_text=prompt_text,
+            successful_write_tools=successful_write_tools,
+            failed_tools=failed_tools,
+            blocked_tools=blocked_tools,
+        )
     if mutation_effect is not None:
         required_effects.append(mutation_effect)
     elif not successful_write_tools and not representation_effects:

--- a/src/backend/workflows/definitions.py
+++ b/src/backend/workflows/definitions.py
@@ -338,6 +338,11 @@ def build_write_tool_policy_workflow() -> WorkflowDefinition:
             ),
         ),
         transitions=(
+            _transition_if_flag_set(
+                "approval_required",
+                to_state="approval_required",
+                reason="on_approval_required",
+            ),
             WorkflowTransitionSpec(
                 to_state="completed",
                 condition=lambda ctx: True,
@@ -346,6 +351,7 @@ def build_write_tool_policy_workflow() -> WorkflowDefinition:
         ),
     )
 
+    approval_required = WorkflowStateSpec(state_id="approval_required", terminal=True)
     completed = WorkflowStateSpec(state_id="completed", terminal=True)
 
     return WorkflowDefinition(
@@ -353,9 +359,10 @@ def build_write_tool_policy_workflow() -> WorkflowDefinition:
         initial_state="decide",
         states={
             "decide": decide,
+            "approval_required": approval_required,
             "completed": completed,
         },
-        termination_states=("completed",),
+        termination_states=("approval_required", "completed"),
         purpose="Determine which write tools are allowed for a chat prompt.",
     )
 

--- a/src/backend/workflows/write_tool_policy.py
+++ b/src/backend/workflows/write_tool_policy.py
@@ -1,38 +1,246 @@
 """Write-tool policy helpers.
 
-This module centralises the policy for when a user prompt should allow invoking
-write-category tools.
+This module centralises write-policy classification so routing, execution, and
+telemetry all reason about the same mutation semantics.
 
-The policy is intentionally conservative and aims to prevent accidental writes
-caused by the model emitting an unrelated tool call.
+Minimal imposition here means:
+- low-risk additive Vontology writes default-allow unless explicitly denied;
+- non-destructive edits to existing state require a clear request;
+- destructive writes require explicit confirmation or a preserved continuation;
+- external-system writes remain stricter than Vontology-governed writes.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 import re
+from typing import Sequence
+
+WRITE_RISK_ADDITIVE_LOW_RISK = "additive_low_risk"
+WRITE_RISK_MUTATIVE_NON_DESTRUCTIVE = "mutative_non_destructive"
+WRITE_RISK_DESTRUCTIVE = "destructive"
+WRITE_RISK_EXTERNAL_NON_VONTOLOGY = "external_non_vontology"
+
+REASON_DEFAULT_ALLOW_ADDITIVE_LOW_RISK = "default_allow_additive_low_risk"
+REASON_EXPLICIT_NON_DESTRUCTIVE_MUTATION_REQUEST = (
+    "explicit_non_destructive_mutation_request"
+)
+REASON_RECENT_NON_DESTRUCTIVE_MUTATION_REQUEST = (
+    "recent_non_destructive_mutation_request"
+)
+REASON_MUTATIVE_NON_DESTRUCTIVE_REQUEST_REQUIRED = (
+    "mutative_non_destructive_request_required"
+)
+REASON_EXPLICIT_DESTRUCTIVE_CONFIRMATION = "explicit_destructive_confirmation"
+REASON_RECENT_DESTRUCTIVE_CONFIRMATION = "recent_destructive_confirmation"
+REASON_DESTRUCTIVE_CONFIRMATION_REQUIRED = "destructive_confirmation_required"
+REASON_EXPLICIT_EXTERNAL_WRITE_REQUEST = "explicit_external_write_request"
+REASON_RECENT_EXTERNAL_WRITE_REQUEST = "recent_external_write_request"
+REASON_EXTERNAL_WRITE_REQUIRES_EXPLICIT_REQUEST = (
+    "external_write_requires_explicit_request"
+)
+REASON_EXPLICIT_WRITE_DENIAL_DETECTED = "explicit_write_denial_detected"
+
+_EXTERNAL_WRITE_PREFIXES: tuple[str, ...] = (
+    "jira_",
+    "github_",
+    "gmail_",
+)
+
+_ADDITIVE_LOW_RISK_WRITE_TOOLS: frozenset[str] = frozenset(
+    {
+        "create_concepts",
+        "add_relationship",
+        "add_names",
+        "upsert_text_relation",
+        "upsert_singleton_text_relation",
+        "download_paper",
+        "finalise_cached_paper",
+        "create_task",
+        "assign_task",
+        "workflow_create_instance",
+        "workflow_bind_event",
+        "workflow_create_schedule",
+        "workflow_trigger_schedule",
+    }
+)
+
+_MUTATIVE_NON_DESTRUCTIVE_WRITE_TOOLS: frozenset[str] = frozenset(
+    {
+        "update_concept",
+        "update_text_relation",
+        "update_task_status",
+        "undo_relationship_removal",
+        "workflow_retry_instance",
+        "workflow_set_event_binding_enabled",
+        "workflow_set_schedule_enabled",
+    }
+)
+
+_DESTRUCTIVE_WRITE_TOOLS: frozenset[str] = frozenset(
+    {
+        "delete_concept",
+        "delete_text_relation",
+        "remove_relationship",
+        "remove_relationships_bulk",
+        "merge_concepts",
+        "workflow_cancel_instance",
+        "workflow_delete_event_binding",
+        "workflow_delete_schedule",
+    }
+)
+
+_CONFIRMATION_PATTERN = re.compile(
+    r"\b("
+    r"confirm(?:ed|ation)?|approved?|i approve|go ahead|do it|yes\b|proceed|"
+    r"permission granted|you may proceed|continue with|carry on"
+    r")\b",
+    flags=re.IGNORECASE,
+)
+
+_NON_DESTRUCTIVE_MUTATION_PATTERN = re.compile(
+    r"\b("
+    r"update|edit|change|rename|set|adjust|revise|modify|"
+    r"assign|mark|move|reword|rewrite|replace"
+    r")\b",
+    flags=re.IGNORECASE,
+)
+
+_DESTRUCTIVE_MUTATION_PATTERN = re.compile(
+    r"\b("
+    r"delete|remove|unlink|detach|drop|purge|erase|destroy|merge"
+    r")\b",
+    flags=re.IGNORECASE,
+)
+
+_EXTERNAL_WRITE_PATTERN = re.compile(
+    r"\b("
+    r"create|update|edit|change|delete|remove|comment|attach|transition|"
+    r"open|file|submit|merge|label|assign"
+    r")\b",
+    flags=re.IGNORECASE,
+)
+
+_NON_DESTRUCTIVE_CONTEXT_TERMS: tuple[str, ...] = (
+    "#v#",
+    "vontology",
+    "ontology",
+    "concept",
+    "relationship",
+    "predicate",
+    "text relation",
+    "note",
+    "description",
+    "metadata",
+    "task",
+    "workflow",
+    "schedule",
+    "binding",
+)
+
+_EXTERNAL_CONTEXT_TERMS_BY_PREFIX: dict[str, tuple[str, ...]] = {
+    "jira_": ("jira", "issue", "ticket", "atlassian"),
+    "github_": ("github", "pull request", "pr", "issue", "review", "repository"),
+    "gmail_": ("gmail", "email", "mail", "label", "message"),
+}
+
+_ADDITIVE_MUTATION_PATTERN = re.compile(
+    r"\b("
+    r"create|add|insert|upsert|link|attach|store|save|download|finalise|"
+    r"finalize|represent|materialise|materialize|capture|record"
+    r")\b",
+    flags=re.IGNORECASE,
+)
+
+_ARXIV_ID_OR_URL_PATTERN = re.compile(
+    r"(?:arxiv\.org/(?:abs|pdf)/(?:(?:[a-z\-]+/\d{7})|(?:\d{4}\.\d{4,5}))(?:v\d+)?)"
+    r"|(?:\barxiv:\s*(?:(?:[a-z\-]+/\d{7})|(?:\d{4}\.\d{4,5}))(?:v\d+)?\b)"
+    r"|(?:\b\d{4}\.\d{4,5}(?:v\d+)?\b)",
+    flags=re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class WriteToolDecision:
+    tool_name: str
+    risk_class: str
+    allowed: bool
+    decision_basis: str
+    requires_confirmation: bool = False
+    blocked_reason: str | None = None
 
 
 @dataclass(frozen=True)
 class WriteToolPolicyDecision:
     allowed_tools: frozenset[str]
     reason: str
+    decision_basis: str
+    user_denial_detected: bool
+    tool_decisions: tuple[WriteToolDecision, ...]
+
+    def decision_for_tool(self, tool_name: str) -> WriteToolDecision | None:
+        if not isinstance(tool_name, str):
+            return None
+        lowered = tool_name.strip().lower()
+        for decision in self.tool_decisions:
+            if decision.tool_name.lower() == lowered:
+                return decision
+        return None
 
 
-# High-impact KB writes mutate ontology structure and should be review-gated when
-# the admin toggle is enabled (JVNAUTOSCI-925).
-HIGH_IMPACT_VONTOLOGY_WRITE_TOOLS: frozenset[str] = frozenset(
-    {
-        "create_concepts",
-        "add_relationship",
-        "remove_relationship",
-        "remove_relationships_bulk",
-        "undo_relationship_removal",
-        "merge_concepts",
-        "delete_concept",
-        "update_concept",
+def classify_write_tool_risk(tool_name: str) -> str:
+    """Return the central write-risk class for a tool name."""
+
+    if not isinstance(tool_name, str):
+        return WRITE_RISK_EXTERNAL_NON_VONTOLOGY
+
+    lowered = tool_name.strip().lower()
+    if not lowered:
+        return WRITE_RISK_EXTERNAL_NON_VONTOLOGY
+
+    if any(lowered.startswith(prefix) for prefix in _EXTERNAL_WRITE_PREFIXES):
+        return WRITE_RISK_EXTERNAL_NON_VONTOLOGY
+    if lowered in _DESTRUCTIVE_WRITE_TOOLS:
+        return WRITE_RISK_DESTRUCTIVE
+    if lowered in _MUTATIVE_NON_DESTRUCTIVE_WRITE_TOOLS:
+        return WRITE_RISK_MUTATIVE_NON_DESTRUCTIVE
+    if lowered in _ADDITIVE_LOW_RISK_WRITE_TOOLS:
+        return WRITE_RISK_ADDITIVE_LOW_RISK
+
+    if lowered.startswith(("delete_", "remove_", "merge_")):
+        return WRITE_RISK_DESTRUCTIVE
+    if lowered.startswith(("update_", "rename_", "assign_", "set_")):
+        return WRITE_RISK_MUTATIVE_NON_DESTRUCTIVE
+    if lowered.startswith(
+        ("create_", "add_", "upsert_", "download_", "finalise_", "finalize_")
+    ):
+        return WRITE_RISK_ADDITIVE_LOW_RISK
+
+    return WRITE_RISK_EXTERNAL_NON_VONTOLOGY
+
+
+def tool_requires_confirmation(tool_name: str) -> bool:
+    return classify_write_tool_risk(tool_name) == WRITE_RISK_DESTRUCTIVE
+
+
+def tool_requires_explicit_request(tool_name: str) -> bool:
+    return classify_write_tool_risk(tool_name) in {
+        WRITE_RISK_MUTATIVE_NON_DESTRUCTIVE,
+        WRITE_RISK_EXTERNAL_NON_VONTOLOGY,
     }
-)
+
+
+def is_high_impact_vontology_write_tool(tool_name: str) -> bool:
+    """Compatibility shim for legacy "high-impact" routing code.
+
+    "High-impact" now means mutating existing state or removing it. Additive
+    writes no longer count as high-impact by default.
+    """
+
+    return classify_write_tool_risk(tool_name) in {
+        WRITE_RISK_MUTATIVE_NON_DESTRUCTIVE,
+        WRITE_RISK_DESTRUCTIVE,
+    }
 
 
 def compute_allowed_write_tools(
@@ -41,68 +249,123 @@ def compute_allowed_write_tools(
     requested_tools: list[str],
     recent_user_prompts: list[str] | None = None,
 ) -> WriteToolPolicyDecision:
-    """Compute which write tools are allowed for this user prompt.
+    """Compute which write tools are allowed for this user prompt."""
 
-    Currently heuristic-based and workflow-friendly (deterministic), with
-    conservative defaults.
-    """
-
-    allowed: set[str] = set()
-    requested = [tool for tool in requested_tools if isinstance(tool, str) and tool]
-    recent_prompts = [
-        str(item).strip()
-        for item in (recent_user_prompts or [])
-        if isinstance(item, str) and str(item).strip()
-    ]
-
-    explicit_vontology_intent = _prompt_allows_vontology_mutation(prompt)
-    explicit_artefact_intent = _prompt_allows_artefact_download(prompt)
-    recent_vontology_intent = any(
-        _prompt_allows_vontology_mutation(item) for item in recent_prompts
-    )
-    recent_artefact_intent = any(
-        _prompt_allows_artefact_download(item) for item in recent_prompts
-    )
-
-    if explicit_vontology_intent or recent_vontology_intent:
-        allowed.update(requested)
+    requested = _normalise_tool_names(requested_tools)
+    recent_prompts = _clean_prompt_list(recent_user_prompts)
+    if not requested:
         return WriteToolPolicyDecision(
-            allowed_tools=frozenset(allowed),
-            reason=(
-                "explicit_vontology_mutation_request"
-                if explicit_vontology_intent
-                else "recent_vontology_mutation_request"
-            ),
+            allowed_tools=frozenset(),
+            reason="no_requested_write_tools",
+            decision_basis="no_requested_write_tools",
+            user_denial_detected=False,
+            tool_decisions=(),
         )
 
-    # Side-effect writes (artefact storage) are allowed when explicitly requested.
-    artefact_tools = {"download_paper", "finalise_cached_paper"}
-    requested_artefact_tools = artefact_tools.intersection(set(requested))
-    if requested_artefact_tools and (
-        explicit_artefact_intent or recent_artefact_intent
-    ):
-        allowed.update(requested_artefact_tools)
-        return WriteToolPolicyDecision(
-            allowed_tools=frozenset(allowed),
-            reason=(
-                "explicit_artefact_download_request"
-                if explicit_artefact_intent
-                else "recent_artefact_download_request"
-            ),
+    if prompt_explicitly_denies_write(prompt):
+        tool_decisions = tuple(
+            WriteToolDecision(
+                tool_name=tool_name,
+                risk_class=classify_write_tool_risk(tool_name),
+                allowed=False,
+                decision_basis=REASON_EXPLICIT_WRITE_DENIAL_DETECTED,
+                requires_confirmation=False,
+                blocked_reason=REASON_EXPLICIT_WRITE_DENIAL_DETECTED,
+            )
+            for tool_name in requested
         )
+        return WriteToolPolicyDecision(
+            allowed_tools=frozenset(),
+            reason=REASON_EXPLICIT_WRITE_DENIAL_DETECTED,
+            decision_basis=REASON_EXPLICIT_WRITE_DENIAL_DETECTED,
+            user_denial_detected=True,
+            tool_decisions=tool_decisions,
+        )
+
+    decisions: list[WriteToolDecision] = []
+    allowed_tools: set[str] = set()
+    overall_reason = ""
+
+    for tool_name in requested:
+        decision = _decide_single_tool(
+            tool_name=tool_name,
+            prompt=prompt,
+            recent_user_prompts=recent_prompts,
+        )
+        decisions.append(decision)
+        if decision.allowed:
+            allowed_tools.add(tool_name)
+        if not overall_reason or not decision.allowed:
+            overall_reason = decision.blocked_reason or decision.decision_basis
+
+    if not overall_reason and decisions:
+        overall_reason = decisions[0].decision_basis
 
     return WriteToolPolicyDecision(
-        allowed_tools=frozenset(),
-        reason="no_explicit_write_intent_detected",
+        allowed_tools=frozenset(allowed_tools),
+        reason=overall_reason or "write_policy_evaluated",
+        decision_basis=overall_reason or "write_policy_evaluated",
+        user_denial_detected=False,
+        tool_decisions=tuple(decisions),
     )
 
 
-def is_high_impact_vontology_write_tool(tool_name: str) -> bool:
-    """Return whether a tool is considered high-impact for ontology writes."""
+def write_policy_reason_is_session_memory_eligible(reason: str | None) -> bool:
+    """Return whether a policy result should be persisted for continuation."""
 
-    if not isinstance(tool_name, str):
+    return str(reason or "").strip() in {
+        REASON_DEFAULT_ALLOW_ADDITIVE_LOW_RISK,
+        REASON_EXPLICIT_NON_DESTRUCTIVE_MUTATION_REQUEST,
+        REASON_RECENT_NON_DESTRUCTIVE_MUTATION_REQUEST,
+        REASON_DESTRUCTIVE_CONFIRMATION_REQUIRED,
+        REASON_EXPLICIT_DESTRUCTIVE_CONFIRMATION,
+        REASON_RECENT_DESTRUCTIVE_CONFIRMATION,
+        REASON_EXPLICIT_EXTERNAL_WRITE_REQUEST,
+        REASON_RECENT_EXTERNAL_WRITE_REQUEST,
+    }
+
+
+def prompt_has_low_risk_additive_write_evidence(prompt: str) -> bool:
+    """Return whether the prompt gives affirmative evidence for additive writes.
+
+    This routing helper is intentionally narrower than the allow-policy itself:
+    additive tools may be allowed if requested, but we should only force the
+    tool route when the prompt itself supplies concrete evidence of an additive
+    mutation task.
+    """
+
+    if not isinstance(prompt, str):
         return False
-    return tool_name.strip().lower() in HIGH_IMPACT_VONTOLOGY_WRITE_TOOLS
+    text = prompt.strip()
+    if not text or prompt_explicitly_denies_write(text):
+        return False
+
+    lowered = text.lower()
+    if _ARXIV_ID_OR_URL_PATTERN.search(text):
+        return True
+
+    additive_context_terms = (
+        "#v#",
+        "vontology",
+        "ontology",
+        "concept",
+        "relationship",
+        "predicate",
+        "text relation",
+        "note",
+        "description",
+        "metadata",
+        "task",
+        "workflow",
+        "schedule",
+        "binding",
+    )
+    if any(token in lowered for token in additive_context_terms) and _ADDITIVE_MUTATION_PATTERN.search(
+        text
+    ):
+        return True
+
+    return False
 
 
 def prompt_grants_high_impact_kb_write_approval(
@@ -110,40 +373,39 @@ def prompt_grants_high_impact_kb_write_approval(
     prompt: str,
     recent_user_prompts: list[str] | None = None,
 ) -> bool:
-    """Detect explicit human approval phrasing for high-impact KB writes.
+    """Compatibility shim for historic review-gate code paths.
 
-    This is intentionally strict: simple write intent ("add", "create") is not
-    treated as review approval. We require explicit approval language.
+    High-impact approval now maps to explicit confirmation of a destructive
+    mutation in the current or immediately preceding preserved context.
     """
 
-    candidates: list[str] = []
-    if isinstance(prompt, str) and prompt.strip():
-        candidates.append(prompt.strip())
-    for item in recent_user_prompts or []:
-        if isinstance(item, str) and item.strip():
-            candidates.append(item.strip())
+    return prompt_grants_destructive_write_confirmation(
+        prompt=prompt,
+        recent_user_prompts=recent_user_prompts,
+    )
 
-    if not candidates:
+
+def prompt_grants_destructive_write_confirmation(
+    *,
+    prompt: str,
+    recent_user_prompts: list[str] | None = None,
+) -> bool:
+    """Return True when the user explicitly confirms a destructive mutation."""
+
+    prompt_text = prompt.strip() if isinstance(prompt, str) else ""
+    recent_prompts = _clean_prompt_list(recent_user_prompts)
+
+    prompt_confirms = bool(prompt_text and _CONFIRMATION_PATTERN.search(prompt_text))
+    prompt_is_destructive = bool(
+        prompt_text and _DESTRUCTIVE_MUTATION_PATTERN.search(prompt_text)
+    )
+    if prompt_confirms and prompt_is_destructive:
+        return True
+
+    if not prompt_confirms:
         return False
 
-    approval_pattern = re.compile(
-        r"\b("
-        r"approved|approve this|i approve|explicitly approved|"
-        r"go ahead|proceed now|proceed with write|authori[sz]e(?:d)?|"
-        r"you may write|human review complete|reviewed and approved|"
-        r"confirmed(?: for write)?|permission granted"
-        r")\b",
-        flags=re.IGNORECASE,
-    )
-    kb_context_pattern = re.compile(
-        r"\b(vontology|ontology|knowledge base|kb|concept|relationship|predicate)\b",
-        flags=re.IGNORECASE,
-    )
-
-    for text in candidates:
-        if approval_pattern.search(text) and kb_context_pattern.search(text):
-            return True
-    return False
+    return any(_DESTRUCTIVE_MUTATION_PATTERN.search(text) for text in recent_prompts)
 
 
 def prompt_explicitly_denies_write(prompt: str) -> bool:
@@ -153,7 +415,6 @@ def prompt_explicitly_denies_write(prompt: str) -> bool:
         return False
 
     lowered = prompt.lower()
-
     verbs = (
         "create",
         "add",
@@ -179,6 +440,11 @@ def prompt_explicitly_denies_write(prompt: str) -> bool:
         "upload",
         "finalise",
         "finalize",
+        "comment",
+        "attach",
+        "transition",
+        "label",
+        "assign",
     )
 
     return any(
@@ -190,120 +456,164 @@ def prompt_explicitly_denies_write(prompt: str) -> bool:
     )
 
 
-def _prompt_allows_vontology_mutation(prompt: str) -> bool:
-    """Return True when the user explicitly requests a Vontology mutation."""
+def _decide_single_tool(
+    *,
+    tool_name: str,
+    prompt: str,
+    recent_user_prompts: Sequence[str],
+) -> WriteToolDecision:
+    risk_class = classify_write_tool_risk(tool_name)
 
+    if risk_class == WRITE_RISK_ADDITIVE_LOW_RISK:
+        return WriteToolDecision(
+            tool_name=tool_name,
+            risk_class=risk_class,
+            allowed=True,
+            decision_basis=REASON_DEFAULT_ALLOW_ADDITIVE_LOW_RISK,
+        )
+
+    if risk_class == WRITE_RISK_MUTATIVE_NON_DESTRUCTIVE:
+        explicit = _prompt_requests_non_destructive_mutation(prompt)
+        recent = any(
+            _prompt_requests_non_destructive_mutation(text)
+            for text in recent_user_prompts
+        )
+        if explicit or recent:
+            reason = (
+                REASON_EXPLICIT_NON_DESTRUCTIVE_MUTATION_REQUEST
+                if explicit
+                else REASON_RECENT_NON_DESTRUCTIVE_MUTATION_REQUEST
+            )
+            return WriteToolDecision(
+                tool_name=tool_name,
+                risk_class=risk_class,
+                allowed=True,
+                decision_basis=reason,
+            )
+        return WriteToolDecision(
+            tool_name=tool_name,
+            risk_class=risk_class,
+            allowed=False,
+            decision_basis=REASON_MUTATIVE_NON_DESTRUCTIVE_REQUEST_REQUIRED,
+            blocked_reason=REASON_MUTATIVE_NON_DESTRUCTIVE_REQUEST_REQUIRED,
+        )
+
+    if risk_class == WRITE_RISK_DESTRUCTIVE:
+        explicit_confirmation = prompt_grants_destructive_write_confirmation(
+            prompt=prompt,
+            recent_user_prompts=[],
+        )
+        recent_confirmation = (
+            not explicit_confirmation
+            and prompt_grants_destructive_write_confirmation(
+                prompt=prompt,
+                recent_user_prompts=list(recent_user_prompts),
+            )
+        )
+        if explicit_confirmation or recent_confirmation:
+            reason = (
+                REASON_EXPLICIT_DESTRUCTIVE_CONFIRMATION
+                if explicit_confirmation
+                else REASON_RECENT_DESTRUCTIVE_CONFIRMATION
+            )
+            return WriteToolDecision(
+                tool_name=tool_name,
+                risk_class=risk_class,
+                allowed=True,
+                decision_basis=reason,
+                requires_confirmation=True,
+            )
+        return WriteToolDecision(
+            tool_name=tool_name,
+            risk_class=risk_class,
+            allowed=False,
+            decision_basis=REASON_DESTRUCTIVE_CONFIRMATION_REQUIRED,
+            requires_confirmation=True,
+            blocked_reason=REASON_DESTRUCTIVE_CONFIRMATION_REQUIRED,
+        )
+
+    explicit_external = _prompt_requests_external_write(
+        prompt=prompt,
+        tool_name=tool_name,
+    )
+    recent_external = any(
+        _prompt_requests_external_write(prompt=text, tool_name=tool_name)
+        for text in recent_user_prompts
+    )
+    if explicit_external or recent_external:
+        reason = (
+            REASON_EXPLICIT_EXTERNAL_WRITE_REQUEST
+            if explicit_external
+            else REASON_RECENT_EXTERNAL_WRITE_REQUEST
+        )
+        return WriteToolDecision(
+            tool_name=tool_name,
+            risk_class=risk_class,
+            allowed=True,
+            decision_basis=reason,
+        )
+
+    return WriteToolDecision(
+        tool_name=tool_name,
+        risk_class=risk_class,
+        allowed=False,
+        decision_basis=REASON_EXTERNAL_WRITE_REQUIRES_EXPLICIT_REQUEST,
+        blocked_reason=REASON_EXTERNAL_WRITE_REQUIRES_EXPLICIT_REQUEST,
+    )
+
+
+def _prompt_requests_non_destructive_mutation(prompt: str) -> bool:
     if not isinstance(prompt, str):
         return False
-
-    lowered = prompt.lower()
-
-    mentions_vontology = any(
-        token in lowered
-        for token in (
-            "#v#",
-            "vontology",
-            "ontology",
-            "concept",
-            "relationship",
-            "predicate",
-            "text relation",
-            "note",
-            "notes",
-            "description",
-            "summary",
-            "annotation",
-            "metadata",
-        )
-    )
-    if not mentions_vontology:
+    text = prompt.strip()
+    if not text:
         return False
-
-    verbs = (
-        "create",
-        "add",
-        "insert",
-        "upsert",
-        "update",
-        "edit",
-        "change",
-        "delete",
-        "remove",
-        "rename",
-        "merge",
-        "link",
-        "unlink",
-        "set",
-    )
-
-    negated = {
-        match.group(1)
-        for match in re.finditer(
-            r"\b(?:do not|don't|dont|never)\s+(create|add|insert|upsert|update|edit|change|delete|remove|rename|merge|link|unlink|set)\b",
-            lowered,
-        )
-    }
-
-    for verb in verbs:
-        if re.search(rf"\b{re.escape(verb)}\b", lowered) and verb not in negated:
-            return True
-
-    return False
+    lowered = text.lower()
+    if not any(token in lowered for token in _NON_DESTRUCTIVE_CONTEXT_TERMS):
+        return False
+    return bool(_NON_DESTRUCTIVE_MUTATION_PATTERN.search(text))
 
 
-def _prompt_allows_artefact_download(prompt: str) -> bool:
-    """Detect explicit requests to download/store an artefact (e.g., arXiv PDF)."""
-
+def _prompt_requests_external_write(*, prompt: str, tool_name: str) -> bool:
     if not isinstance(prompt, str):
         return False
-
-    lowered = prompt.lower()
-
-    action_verbs = (
-        "get",
-        "download",
-        "fetch",
-        "retrieve",
-        "save",
-        "store",
-        "cache",
-        "archive",
-        "persist",
-        "upload",
-        "finalise",
-        "finalize",
-    )
-    artefact_terms = (
-        "arxiv",
-        "paper",
-        "pdf",
-        "artefact",
-        "artifact",
-        "blob",
-        "blob store",
-        "artefact store",
-        "artifact store",
-        "swift",
-        "object store",
-        "storage",
-        "container",
-    )
-
-    mentions_artefact = any(token in lowered for token in artefact_terms)
-    mentions_arxiv_id = bool(re.search(r"\b\d{4}\.\d{4,5}\b", lowered))
-    if not (mentions_artefact or mentions_arxiv_id):
+    text = prompt.strip()
+    if not text:
         return False
 
-    negated = {
-        match.group(1)
-        for match in re.finditer(
-            r"\b(?:do not|don't|dont|never)\s+(download|fetch|save|store|cache|archive|persist|upload|finalise|finalize)\b",
-            lowered,
-        )
-    }
+    lowered_tool = str(tool_name or "").strip().lower()
+    context_terms: Sequence[str] = ()
+    for prefix, terms in _EXTERNAL_CONTEXT_TERMS_BY_PREFIX.items():
+        if lowered_tool.startswith(prefix):
+            context_terms = terms
+            break
+    if not context_terms:
+        return False
 
-    for verb in action_verbs:
-        if re.search(rf"\b{re.escape(verb)}\b", lowered) and verb not in negated:
-            return True
+    lowered = text.lower()
+    if not any(token in lowered for token in context_terms):
+        return False
+    return bool(_EXTERNAL_WRITE_PATTERN.search(text))
 
-    return False
+
+def _clean_prompt_list(values: Sequence[str] | None) -> list[str]:
+    return [
+        str(item).strip()
+        for item in (values or [])
+        if isinstance(item, str) and str(item).strip()
+    ]
+
+
+def _normalise_tool_names(values: Sequence[str] | None) -> list[str]:
+    tools: list[str] = []
+    seen: set[str] = set()
+    for raw in values or []:
+        if not isinstance(raw, str):
+            continue
+        tool_name = raw.strip()
+        lowered = tool_name.lower()
+        if not tool_name or lowered in seen:
+            continue
+        seen.add(lowered)
+        tools.append(tool_name)
+    return tools

--- a/tests/backend/test_orchestrator_high_impact_review_guard.py
+++ b/tests/backend/test_orchestrator_high_impact_review_guard.py
@@ -1,13 +1,11 @@
-"""High-impact Vontology write guard tests (JVNAUTOSCI-925)."""
+"""Destructive-write confirmation guard tests."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional, Sequence, cast
 
-from src.backend.integrations.internal_mcp.orchestrator import (
-    InternalMCPChatOrchestrator,
-)
+from orchestrator_test_harness import build_db_independent_orchestrator
 from src.backend.services import settings_service
 
 
@@ -17,7 +15,7 @@ class _TransportResult:
     duration_ms: float
 
 
-class _CreateConceptsGateway:
+class _DeleteConceptGateway:
     enabled = True
 
     def __init__(self) -> None:
@@ -25,9 +23,9 @@ class _CreateConceptsGateway:
 
     def describe_methods(self) -> dict[str, Any]:
         return {
-            "create_concepts": {
+            "delete_concept": {
                 "category": "write",
-                "description": "Create one or more Vontology concepts.",
+                "description": "Delete a Vontology concept.",
             }
         }
 
@@ -57,129 +55,81 @@ class _CapturingLLM:
 
 def _tool_call() -> str:
     return (
-        '{"action":"call_tool","tool":"create_concepts","payload":'
-        '{"parent_id":"#V#thing","concepts":[{"name":"guarded concept"}]}}'
+        '{"action":"call_tool","tool":"delete_concept","payload":'
+        '{"concept_id":"#V#guarded_concept"}}'
     )
 
 
-def test_high_impact_guard_blocks_without_explicit_review_approval(monkeypatch):
+def test_destructive_write_blocks_pending_confirmation(monkeypatch):
     monkeypatch.setattr(
-        settings_service, "get_disable_write_tool_conservatism", lambda: True
-    )
-    monkeypatch.setattr(
-        settings_service,
-        "get_require_human_review_for_high_impact_kb_writes",
-        lambda: True,
+        settings_service, "get_disable_write_tool_conservatism", lambda: False
     )
 
-    gateway = _CreateConceptsGateway()
-    orchestrator = InternalMCPChatOrchestrator(
+    gateway = _DeleteConceptGateway()
+    orchestrator = build_db_independent_orchestrator(
+        monkeypatch,
         gateway=cast(Any, gateway),
         max_tool_invocations=1,
     )
     llm = _CapturingLLM([_tool_call(), "Done."])
 
     result = orchestrator.run(
-        prompt="Create a concept in the Vontology for guarded extension.",
+        prompt="Delete concept #V#guarded_concept.",
         context=[],
         llm_client=llm,
         model=None,
         user_namespace="#V#michael_witbrock@nao",
     )
 
-    create_invocations = [
-        call for call in gateway.invocations if call.get("tool") == "create_concepts"
-    ]
-    assert create_invocations == []
+    assert not any(
+        call.get("tool") == "delete_concept" for call in gateway.invocations
+    )
     blocked = [
         record
         for record in result.tool_invocations
-        if record.get("tool") == "create_concepts"
+        if record.get("tool") == "delete_concept"
     ]
     assert blocked
     assert blocked[0].get("blocked") is True
-    assert (
-        blocked[0].get("write_policy_reason")
-        == "high_impact_kb_write_requires_human_review"
+    assert blocked[0].get("write_policy_blocked_reason") == (
+        "destructive_confirmation_required"
     )
+    assert blocked[0].get("write_policy_requires_confirmation") is True
+    assert "Confirm delete_concept" in str(blocked[0].get("confirmation_prompt"))
 
 
-def test_high_impact_guard_blocks_when_namespace_missing(monkeypatch):
+def test_destructive_write_allows_recent_confirmation(monkeypatch):
     monkeypatch.setattr(
-        settings_service, "get_disable_write_tool_conservatism", lambda: True
-    )
-    monkeypatch.setattr(
-        settings_service,
-        "get_require_human_review_for_high_impact_kb_writes",
-        lambda: True,
+        settings_service, "get_disable_write_tool_conservatism", lambda: False
     )
 
-    gateway = _CreateConceptsGateway()
-    orchestrator = InternalMCPChatOrchestrator(
+    gateway = _DeleteConceptGateway()
+    orchestrator = build_db_independent_orchestrator(
+        monkeypatch,
         gateway=cast(Any, gateway),
         max_tool_invocations=1,
     )
     llm = _CapturingLLM([_tool_call(), "Done."])
 
     result = orchestrator.run(
-        prompt="Approved: proceed with the Vontology write.",
-        context=[],
-        llm_client=llm,
-        model=None,
-        user_namespace=None,
-    )
-
-    create_invocations = [
-        call for call in gateway.invocations if call.get("tool") == "create_concepts"
-    ]
-    assert create_invocations == []
-    blocked = [
-        record
-        for record in result.tool_invocations
-        if record.get("tool") == "create_concepts"
-    ]
-    assert blocked
-    assert blocked[0].get("blocked") is True
-    assert (
-        blocked[0].get("write_policy_reason")
-        == "high_impact_kb_write_requires_namespace"
-    )
-
-
-def test_high_impact_guard_allows_namespaced_approved_write(monkeypatch):
-    monkeypatch.setattr(
-        settings_service, "get_disable_write_tool_conservatism", lambda: True
-    )
-    monkeypatch.setattr(
-        settings_service,
-        "get_require_human_review_for_high_impact_kb_writes",
-        lambda: True,
-    )
-
-    gateway = _CreateConceptsGateway()
-    orchestrator = InternalMCPChatOrchestrator(
-        gateway=cast(Any, gateway),
-        max_tool_invocations=1,
-    )
-    llm = _CapturingLLM([_tool_call(), "Done."])
-
-    result = orchestrator.run(
-        prompt="Approved. Go ahead with the Vontology concept write now.",
-        context=[],
+        prompt="Yes, do it.",
+        context=[{"role": "user", "content": "Delete concept #V#guarded_concept."}],
         llm_client=llm,
         model=None,
         user_namespace="#V#michael_witbrock@nao",
     )
 
     create_invocations = [
-        call for call in gateway.invocations if call.get("tool") == "create_concepts"
+        call for call in gateway.invocations if call.get("tool") == "delete_concept"
     ]
     assert len(create_invocations) == 1
-    invoked = create_invocations[0]
     records = [
         record
         for record in result.tool_invocations
-        if record.get("tool") == "create_concepts"
+        if record.get("tool") == "delete_concept"
     ]
     assert records
     assert all(not record.get("blocked") for record in records)
+    assert all(
+        record.get("write_policy_risk_class") == "destructive" for record in records
+    )

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -43,6 +43,7 @@ from src.backend.workflows.workflow_gap_workflow_contracts import (
     WORKFLOW_DISCOVERY_GAP_RECOVERY_WORKFLOW_ID,
 )
 from src.backend.workflows.workflow_selector import WorkflowSelection, WorkflowSelector
+from orchestrator_test_harness import build_db_independent_orchestrator
 
 
 # ---------------------------------------------------------------------------
@@ -92,77 +93,12 @@ def _build_orchestrator(
     *,
     selector_enabled: bool = False,
 ) -> InternalMCPChatOrchestrator:
-    """Build an orchestrator with DB-dependent methods stubbed out.
-
-    This avoids hanging on MongoDB connections during unit tests.
-    """
-    env_val = "1" if selector_enabled else "0"
-    monkeypatch.setenv("VON_CHAT_WORKFLOW_SELECTOR_ENABLED", env_val)
-
-    # Keep this unit-test harness DB-independent even if the production
-    # registry factory discovers workflows from Vontology.
-    from src.backend.workflows import WorkflowRegistry, register_default_workflows
-
-    def _build_test_registry() -> WorkflowRegistry:
-        registry = WorkflowRegistry()
-        register_default_workflows(registry)
-        return registry
-
-    monkeypatch.setattr(
-        "src.backend.integrations.internal_mcp.orchestrator.build_workflow_registry",
-        _build_test_registry,
-    )
-
-    gateway = cast(Any, _StubGateway())
-    orchestrator = InternalMCPChatOrchestrator(
-        gateway=gateway,
+    return build_db_independent_orchestrator(
+        monkeypatch,
+        gateway=cast(Any, _StubGateway()),
+        selector_enabled=selector_enabled,
         max_tool_invocations=1,
     )
-
-    # Stub DB-dependent methods to avoid blocking on MongoDB.
-    from src.backend.integrations.internal_mcp.orchestrator import (
-        _WorkflowModelPolicyState,
-    )
-
-    monkeypatch.setattr(
-        orchestrator,
-        "_load_workflow_model_policy",
-        lambda *_a, **_kw: (
-            _WorkflowModelPolicyState(
-                enabled=False,
-                policy=None,
-                policy_id=None,
-                predicate_id=None,
-                errors=[],
-            ),
-            None,
-        ),
-    )
-    monkeypatch.setattr(
-        orchestrator,
-        "_build_ontology_preflight",
-        lambda *_a, **_kw: type(
-            "_Preflight", (), {"telemetry": None, "message": None}
-        )(),
-    )
-    monkeypatch.setattr(
-        orchestrator,
-        "_resolve_concept_id_by_name",
-        lambda *_a, **_kw: None,
-    )
-    monkeypatch.setattr(
-        orchestrator,
-        "_load_base_system_prompt_from_vontology",
-        lambda *_a, **_kw: (None, None),
-    )
-
-    # Prevent get_model_registry_snapshot from reaching MongoDB.
-    monkeypatch.setattr(
-        "src.backend.services.model_registry_service.get_model_registry_snapshot",
-        lambda *_a, **_kw: None,
-    )
-
-    return orchestrator
 
 
 # ---------------------------------------------------------------------------
@@ -3483,7 +3419,8 @@ def test_write_intent_memory_rejects_cross_session_continuation(monkeypatch):
     )
     assert gate_entry is not None
     assert gate_entry.get("gate_state") == "pending"
-    assert gate_entry.get("reason") == "no_explicit_write_intent_detected"
+    assert gate_entry.get("reason") == "default_allow_additive_low_risk"
+    assert gate_entry.get("low_risk_additive_routing_evidence") is False
     assert gate_entry.get("continuation_context_reused") is False
 
 

--- a/tests/backend/test_orchestrator_write_guardrail.py
+++ b/tests/backend/test_orchestrator_write_guardrail.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional, Sequence, cast
 
-from src.backend.integrations.internal_mcp.orchestrator import (
-    InternalMCPChatOrchestrator,
-)
+from orchestrator_test_harness import build_db_independent_orchestrator
 from src.backend.services import settings_service
 
 
@@ -35,8 +33,14 @@ class _WriteToolGateway:
         self.invocations.append({"tool": tool_name, "payload": dict(payload)})
         return _TransportResult(
             payload={
-                "file_path": "data/arxiv_cache/2506.16596.pdf",
-                "uri": "swift://von-artifacts/arxiv/2506.16596.pdf",
+                "file_path": "data/arxiv_cache/2510.06248.pdf",
+                "uri": "swift://von-artifacts/arxiv/2510.06248.pdf",
+                "computer_file_copy_concept_id": "#V#computer_file_copy_2510_06248",
+                "scholarly_representation": {
+                    "attempted": True,
+                    "verified": True,
+                    "paper_concept_id": "#V#paper_on_arxiv_2510_06248",
+                },
             },
             duration_ms=1.23,
         )
@@ -61,24 +65,23 @@ class _CapturingLLM:
         return self._responses.pop(0)
 
 
-def test_write_guard_allows_download_paper_when_user_requests_artefact_download():
-    """download_paper should not be blocked when the user explicitly asks for it."""
-
+def test_write_guard_allows_download_paper_for_bare_arxiv_url(monkeypatch):
     gateway = _WriteToolGateway()
-    orchestrator = InternalMCPChatOrchestrator(
+    orchestrator = build_db_independent_orchestrator(
+        monkeypatch,
         gateway=cast(Any, gateway),
         max_tool_invocations=1,
     )
 
     llm = _CapturingLLM(
         [
-            '{"action":"call_tool","tool":"download_paper","payload":{"arxiv_id":"2506.16596"}}',
+            '{"action":"call_tool","tool":"download_paper","payload":{"arxiv_id":"2510.06248"}}',
             "Done.",
         ]
     )
 
     result = orchestrator.run(
-        prompt="Download arXiv:2506.16596 and save it as an artefact.",
+        prompt="https://arxiv.org/abs/2510.06248",
         context=[],
         llm_client=llm,
         model=None,
@@ -86,42 +89,49 @@ def test_write_guard_allows_download_paper_when_user_requests_artefact_download(
     )
 
     assert any(call["tool"] == "download_paper" for call in gateway.invocations)
-    assert all(
-        not record.get("blocked")
+    records = [
+        record
         for record in result.tool_invocations
         if record.get("tool") == "download_paper"
+    ]
+    assert records
+    assert all(not record.get("blocked") for record in records)
+    assert all(
+        record.get("write_policy_risk_class") == "additive_low_risk"
+        for record in records
     )
 
 
-def test_write_guard_blocks_download_paper_without_explicit_request(monkeypatch):
-    """download_paper should be blocked when the user does not ask for storage."""
-
+def test_write_guard_blocks_download_paper_when_user_explicitly_denies_write(monkeypatch):
     monkeypatch.setattr(
         settings_service, "get_disable_write_tool_conservatism", lambda: False
     )
 
     gateway = _WriteToolGateway()
-    orchestrator = InternalMCPChatOrchestrator(
+    orchestrator = build_db_independent_orchestrator(
+        monkeypatch,
         gateway=cast(Any, gateway),
         max_tool_invocations=1,
     )
 
     llm = _CapturingLLM(
         [
-            '{"action":"call_tool","tool":"download_paper","payload":{"arxiv_id":"2506.16596"}}',
+            '{"action":"call_tool","tool":"download_paper","payload":{"arxiv_id":"2510.06248"}}',
             "Done.",
         ]
     )
 
     result = orchestrator.run(
-        prompt="Summarise arXiv:2506.16596.",
+        prompt="Do not download or store this: https://arxiv.org/abs/2510.06248",
         context=[],
         llm_client=llm,
         model=None,
         user_namespace="#V#user",
     )
 
-    assert gateway.invocations == []
+    assert not any(
+        call.get("tool") == "download_paper" for call in gateway.invocations
+    )
     blocked = [
         record
         for record in result.tool_invocations
@@ -129,4 +139,7 @@ def test_write_guard_blocks_download_paper_without_explicit_request(monkeypatch)
     ]
     assert blocked, "Expected blocked download_paper invocation"
     assert all(record.get("blocked") for record in blocked)
-    assert all("read-only" in record.get("error", "") for record in blocked)
+    assert all(
+        record.get("write_policy_blocked_reason") == "explicit_write_denial_detected"
+        for record in blocked
+    )

--- a/tests/backend/test_von_generate_bare_arxiv_url_integration.py
+++ b/tests/backend/test_von_generate_bare_arxiv_url_integration.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from flask import Flask
+
+from representation_intent_regression_helpers import (
+    patch_representation_profile_loader,
+)
+from src.backend.integrations.internal_mcp.catalogue import (
+    _download_paper,
+    _download_paper_input_schema,
+    _download_paper_output_schema,
+)
+from src.backend.integrations.internal_mcp.gateway import (
+    InternalMCPGateway,
+    MethodCatalogue,
+    MethodDefinition,
+)
+from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+from orchestrator_test_harness import (
+    _stub_stage_model_snapshot,
+    _stub_stage_path,
+    build_db_independent_orchestrator,
+)
+
+
+class _LLMSequence:
+    def __init__(self, responses: list[str]):
+        self._responses = list(responses)
+        self.calls: list[dict] = []
+
+    def generate(self, prompt, context, model):
+        self.calls.append({"prompt": prompt, "context": list(context), "model": model})
+        if not self._responses:
+            raise AssertionError("No stubbed LLM responses remaining")
+        return self._responses.pop(0)
+
+
+class _ArxivProxyStub:
+    async def download_paper(self, *, arxiv_id: str, filename=None):
+        return {
+            "success": True,
+            "file_path": f"data/arxiv_cache/{arxiv_id}.pdf",
+            "arxiv_id": arxiv_id,
+            "version": 1,
+            "size_bytes": 12345,
+            "sha256": "abc123",
+            "storage": {
+                "backend": "swift",
+                "key": f"arxiv/{arxiv_id}.pdf",
+                "uri": f"swift://von-artifacts/arxiv/{arxiv_id}.pdf",
+            },
+        }
+
+
+@dataclass(frozen=True)
+class _FileCopyRecord:
+    concept_id: str
+    uploaded_at: str
+
+
+def _build_gateway(monkeypatch) -> InternalMCPGateway:
+    async def _get_proxy():
+        return _ArxivProxyStub()
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.arxiv_proxy_mcp._find_cached_pdf_for_arxiv_id",
+        lambda *_a, **_kw: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.arxiv_proxy_mcp.get_arxiv_proxy",
+        _get_proxy,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.create_computer_file_copy_instance",
+        lambda **_kwargs: _FileCopyRecord(
+            concept_id="#V#uploaded_file_copy_2510_06248",
+            uploaded_at="2026-03-08T02:00:00Z",
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.arxiv_paper_link_service.link_file_copy_to_arxiv_paper",
+        lambda **_kwargs: {"paper_concept_id": "#V#paper_on_arxiv_2510_06248"},
+    )
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue._materialise_arxiv_file_copy_representation",
+        lambda **_kwargs: {
+            "attempted": True,
+            "verified": True,
+            "paper_concept_id": "#V#paper_on_arxiv_2510_06248",
+            "author_concept_ids": [
+                "#V#person_author_alpha",
+                "#V#person_author_beta",
+            ],
+        },
+    )
+
+    catalogue = MethodCatalogue()
+    catalogue.register(
+        MethodDefinition(
+            name="download_paper",
+            handler=_download_paper,
+            input_schema=_download_paper_input_schema(),
+            output_schema=_download_paper_output_schema(),
+            category="write",
+            description="Download and persist an arXiv paper.",
+        )
+    )
+    gateway = InternalMCPGateway(
+        catalogue=catalogue,
+        transport=InternalMCPTransport(read_timeout_sec=2.0, write_timeout_sec=2.0),
+        enabled=True,
+    )
+    return gateway
+
+
+def _make_app(monkeypatch, *, llm: _LLMSequence) -> Flask:
+    from src.backend.server.routes.von_routes import von_bp
+
+    monkeypatch.setenv("VON_WORKFLOW_DISCOVERY_ENABLE", "0")
+    monkeypatch.setenv("VON_DB_NAME", "test_von_db")
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.build_conversation_turn_stage_model_snapshot",
+        _stub_stage_model_snapshot,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.build_conversation_turn_stage_path",
+        _stub_stage_path,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_llm_client",
+        lambda **_kwargs: llm,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_active_model_name",
+        lambda: "test-model",
+    )
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#test_user",
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.chat_history_service.add_message_to_history",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.chat_history_service.get_chat_history",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
+        lambda _user_id, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "src.backend.services.workflow_discovery_service.discover_workflows_for_turn",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.workflow_continuation_service.get_session_workflow_continuation_context",
+        lambda **_kwargs: None,
+    )
+    patch_representation_profile_loader(monkeypatch)
+
+    gateway = _build_gateway(monkeypatch)
+    orchestrator = build_db_independent_orchestrator(
+        monkeypatch,
+        gateway=gateway,
+        selector_enabled=True,
+        max_tool_invocations=1,
+    )
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.register_blueprint(von_bp, url_prefix="/von")
+    app.config["CONTEXT"] = []
+    app.config["INTERNAL_MCP_ORCHESTRATOR"] = orchestrator
+    app.config["INTERNAL_MCP_GATEWAY"] = gateway
+    app.config["_test_llm"] = llm
+    return app
+
+
+def test_generate_bare_arxiv_url_auto_represents_paper(monkeypatch):
+    llm = _LLMSequence(
+        [
+            "plain_response",
+            '{"action":"call_tool","tool":"download_paper","payload":{"arxiv_id":"2510.06248"}}',
+            "Downloaded and represented the paper.",
+        ]
+    )
+    app = _make_app(monkeypatch, llm=llm)
+
+    client = app.test_client()
+    response = client.post("/von/generate", json={"prompt": "https://arxiv.org/abs/2510.06248"})
+    assert response.status_code == 200
+
+    body = response.get_json()
+    assert isinstance(body, dict)
+    llm_debug = body.get("llm_debug") or {}
+
+    workflow_routing = llm_debug.get("workflow_routing") or {}
+    assert workflow_routing.get("workflow_id") == "#V#tool_calling_workflow"
+    assert workflow_routing.get("verdict") == "tool_seeking"
+
+    tool_invocations = llm_debug.get("tool_invocations") or []
+    download_records = [
+        record
+        for record in tool_invocations
+        if isinstance(record, dict)
+        and (record.get("tool") or record.get("method")) == "download_paper"
+    ]
+    assert download_records
+    assert all(not record.get("blocked") for record in download_records)
+
+    diagnostics = llm_debug.get("turn_execution_diagnostics") or {}
+    tool_history = diagnostics.get("tool_history") or []
+    assert any(
+        isinstance(entry, dict)
+        and entry.get("tool") == "download_paper"
+        and entry.get("success") is True
+        for entry in tool_history
+    )
+
+    turn_record = llm_debug.get("turn_execution_record") or {}
+    execution = turn_record.get("execution") or {}
+    contract = execution.get("required_effects_contract") or {}
+    assert contract.get("domain_profile_id") == "paper"
+    assert contract.get("artefact_source") == "url"
+
+    required_effects = turn_record.get("required_effects") or []
+    assert required_effects
+    effect = required_effects[0]
+    assert effect.get("required_tools") == ["download_paper"]
+    assert effect.get("status") == "satisfied"
+
+    completion_gate = turn_record.get("completion_gate") or {}
+    assert completion_gate.get("decision") == "completed"
+    assert completion_gate.get("safe_to_claim_completion") is True
+
+
+def test_generate_bare_arxiv_url_with_explicit_denial_stays_non_mutating(monkeypatch):
+    llm = _LLMSequence(
+        [
+            "plain_response",
+            "Read-only response.",
+        ]
+    )
+    app = _make_app(monkeypatch, llm=llm)
+
+    client = app.test_client()
+    response = client.post(
+        "/von/generate",
+        json={"prompt": "Do not download or store this: https://arxiv.org/abs/2510.06248"},
+    )
+    assert response.status_code == 200
+
+    body = response.get_json()
+    assert isinstance(body, dict)
+    llm_debug = body.get("llm_debug") or {}
+
+    tool_invocations = llm_debug.get("tool_invocations") or []
+    assert not any(
+        isinstance(record, dict)
+        and (record.get("tool") or record.get("method")) == "download_paper"
+        for record in tool_invocations
+    )
+
+    turn_record = llm_debug.get("turn_execution_record") or {}
+    required_effects = turn_record.get("required_effects") or []
+    assert not required_effects

--- a/tests/backend/test_write_tool_policy.py
+++ b/tests/backend/test_write_tool_policy.py
@@ -3,138 +3,156 @@
 from __future__ import annotations
 
 
-def test_recent_prompt_allows_vontology_write():
-    from src.backend.workflows.write_tool_policy import compute_allowed_write_tools
-
-    decision = compute_allowed_write_tools(
-        prompt="These predicates are just instances of #V#nearly_functional_binary_predicate.",
-        requested_tools=["create_concepts"],
-        recent_user_prompts=[
-            "Please create the predicate has_blob_key in the ontology.",
-        ],
+def test_classify_write_tool_risk_covers_policy_classes():
+    from src.backend.workflows.write_tool_policy import (
+        WRITE_RISK_ADDITIVE_LOW_RISK,
+        WRITE_RISK_DESTRUCTIVE,
+        WRITE_RISK_EXTERNAL_NON_VONTOLOGY,
+        WRITE_RISK_MUTATIVE_NON_DESTRUCTIVE,
+        classify_write_tool_risk,
     )
 
-    assert "create_concepts" in decision.allowed_tools
-    assert decision.reason == "recent_vontology_mutation_request"
-
-
-def test_recent_prompt_allows_artefact_download():
-    from src.backend.workflows.write_tool_policy import compute_allowed_write_tools
-
-    decision = compute_allowed_write_tools(
-        prompt="What is arxiv 1234.5678 about?",
-        requested_tools=["download_paper"],
-        recent_user_prompts=["Download and store the arxiv 1234.5678 PDF."],
+    assert classify_write_tool_risk("add_relationship") == WRITE_RISK_ADDITIVE_LOW_RISK
+    assert (
+        classify_write_tool_risk("update_concept")
+        == WRITE_RISK_MUTATIVE_NON_DESTRUCTIVE
+    )
+    assert classify_write_tool_risk("delete_concept") == WRITE_RISK_DESTRUCTIVE
+    assert (
+        classify_write_tool_risk("jira_create_issue")
+        == WRITE_RISK_EXTERNAL_NON_VONTOLOGY
     )
 
-    assert "download_paper" in decision.allowed_tools
-    assert decision.reason == "recent_artefact_download_request"
 
-
-def test_recent_prompt_allows_cached_paper_finalise():
-    from src.backend.workflows.write_tool_policy import compute_allowed_write_tools
-
-    decision = compute_allowed_write_tools(
-        prompt="What is arxiv 1234.5678 about?",
-        requested_tools=["finalise_cached_paper"],
-        recent_user_prompts=["Finalise and store the cached arxiv 1234.5678 PDF."],
+def test_bare_arxiv_url_allows_additive_download_by_default():
+    from src.backend.workflows.write_tool_policy import (
+        REASON_DEFAULT_ALLOW_ADDITIVE_LOW_RISK,
+        compute_allowed_write_tools,
     )
 
-    assert "finalise_cached_paper" in decision.allowed_tools
-    assert decision.reason == "recent_artefact_download_request"
-
-
-def test_explicit_get_arxiv_paper_allows_download():
-    from src.backend.workflows.write_tool_policy import compute_allowed_write_tools
-
     decision = compute_allowed_write_tools(
-        prompt="2512.23959 get that arxiv paper",
+        prompt="https://arxiv.org/abs/2510.06248",
         requested_tools=["download_paper"],
         recent_user_prompts=[],
     )
 
     assert "download_paper" in decision.allowed_tools
-    assert decision.reason == "explicit_artefact_download_request"
+    assert decision.reason == REASON_DEFAULT_ALLOW_ADDITIVE_LOW_RISK
+    tool_decision = decision.decision_for_tool("download_paper")
+    assert tool_decision is not None
+    assert tool_decision.allowed is True
+    assert tool_decision.requires_confirmation is False
 
 
-def test_explicit_finalise_cached_arxiv_paper_allows_write():
-    from src.backend.workflows.write_tool_policy import compute_allowed_write_tools
-
-    decision = compute_allowed_write_tools(
-        prompt="Finalise cached arXiv:2512.23959 and store it.",
-        requested_tools=["finalise_cached_paper"],
-        recent_user_prompts=[],
-    )
-
-    assert "finalise_cached_paper" in decision.allowed_tools
-    assert decision.reason == "explicit_artefact_download_request"
-
-
-def test_minimal_finalise_arxiv_id_allows_write():
-    from src.backend.workflows.write_tool_policy import compute_allowed_write_tools
-
-    decision = compute_allowed_write_tools(
-        prompt="finalise 2505.12477",
-        requested_tools=["finalise_cached_paper"],
-        recent_user_prompts=[],
-    )
-
-    assert "finalise_cached_paper" in decision.allowed_tools
-    assert decision.reason == "explicit_artefact_download_request"
-
-
-def test_no_recent_write_intent_blocks():
-    from src.backend.workflows.write_tool_policy import compute_allowed_write_tools
-
-    decision = compute_allowed_write_tools(
-        prompt="These predicates are just instances of #V#nearly_functional_binary_predicate.",
-        requested_tools=["create_concepts"],
-        recent_user_prompts=["Explain how predicates relate to instances."],
-    )
-
-    assert "create_concepts" not in decision.allowed_tools
-    assert decision.reason == "no_explicit_write_intent_detected"
-
-
-def test_explicit_note_request_allows_text_relation_write():
-    from src.backend.workflows.write_tool_policy import compute_allowed_write_tools
-
-    decision = compute_allowed_write_tools(
-        prompt="Add the note now.",
-        requested_tools=["upsert_text_relation"],
-        recent_user_prompts=[],
-    )
-
-    assert "upsert_text_relation" in decision.allowed_tools
-    assert decision.reason == "explicit_vontology_mutation_request"
-
-
-def test_high_impact_tool_detection():
+def test_explicit_denial_blocks_additive_write():
     from src.backend.workflows.write_tool_policy import (
-        is_high_impact_vontology_write_tool,
+        REASON_EXPLICIT_WRITE_DENIAL_DETECTED,
+        compute_allowed_write_tools,
     )
 
-    assert is_high_impact_vontology_write_tool("create_concepts") is True
-    assert is_high_impact_vontology_write_tool("add_relationship") is True
-    assert is_high_impact_vontology_write_tool("upsert_text_relation") is False
+    decision = compute_allowed_write_tools(
+        prompt="Do not download or store this arXiv paper: https://arxiv.org/abs/2510.06248",
+        requested_tools=["download_paper"],
+        recent_user_prompts=[],
+    )
+
+    assert "download_paper" not in decision.allowed_tools
+    assert decision.reason == REASON_EXPLICIT_WRITE_DENIAL_DETECTED
+    assert decision.user_denial_detected is True
 
 
-def test_prompt_grants_high_impact_kb_write_approval():
+def test_mutative_non_destructive_write_requires_explicit_request():
     from src.backend.workflows.write_tool_policy import (
-        prompt_grants_high_impact_kb_write_approval,
+        REASON_MUTATIVE_NON_DESTRUCTIVE_REQUEST_REQUIRED,
+        compute_allowed_write_tools,
+    )
+
+    decision = compute_allowed_write_tools(
+        prompt="Tell me about this concept.",
+        requested_tools=["update_concept"],
+        recent_user_prompts=[],
+    )
+
+    assert "update_concept" not in decision.allowed_tools
+    assert decision.reason == REASON_MUTATIVE_NON_DESTRUCTIVE_REQUEST_REQUIRED
+
+
+def test_recent_prompt_allows_mutative_non_destructive_write():
+    from src.backend.workflows.write_tool_policy import (
+        REASON_RECENT_NON_DESTRUCTIVE_MUTATION_REQUEST,
+        compute_allowed_write_tools,
+    )
+
+    decision = compute_allowed_write_tools(
+        prompt="Yes, do it.",
+        requested_tools=["update_concept"],
+        recent_user_prompts=["Update the Vontology concept description now."],
+    )
+
+    assert "update_concept" in decision.allowed_tools
+    assert decision.reason == REASON_RECENT_NON_DESTRUCTIVE_MUTATION_REQUEST
+
+
+def test_destructive_write_requires_confirmation():
+    from src.backend.workflows.write_tool_policy import (
+        REASON_DESTRUCTIVE_CONFIRMATION_REQUIRED,
+        compute_allowed_write_tools,
+    )
+
+    decision = compute_allowed_write_tools(
+        prompt="Delete concept #V#paper_on_arxiv_2510_06248.",
+        requested_tools=["delete_concept"],
+        recent_user_prompts=[],
+    )
+
+    assert "delete_concept" not in decision.allowed_tools
+    assert decision.reason == REASON_DESTRUCTIVE_CONFIRMATION_REQUIRED
+    tool_decision = decision.decision_for_tool("delete_concept")
+    assert tool_decision is not None
+    assert tool_decision.requires_confirmation is True
+
+
+def test_recent_confirmation_allows_destructive_write():
+    from src.backend.workflows.write_tool_policy import (
+        REASON_RECENT_DESTRUCTIVE_CONFIRMATION,
+        compute_allowed_write_tools,
+    )
+
+    decision = compute_allowed_write_tools(
+        prompt="Yes, do it.",
+        requested_tools=["delete_concept"],
+        recent_user_prompts=["Delete concept #V#paper_on_arxiv_2510_06248."],
+    )
+
+    assert "delete_concept" in decision.allowed_tools
+    assert decision.reason == REASON_RECENT_DESTRUCTIVE_CONFIRMATION
+
+
+def test_external_write_requires_explicit_request():
+    from src.backend.workflows.write_tool_policy import (
+        REASON_EXTERNAL_WRITE_REQUIRES_EXPLICIT_REQUEST,
+        compute_allowed_write_tools,
+    )
+
+    decision = compute_allowed_write_tools(
+        prompt="Summarise the Jira issue state.",
+        requested_tools=["jira_update_issue"],
+        recent_user_prompts=[],
+    )
+
+    assert "jira_update_issue" not in decision.allowed_tools
+    assert decision.reason == REASON_EXTERNAL_WRITE_REQUIRES_EXPLICIT_REQUEST
+
+
+def test_prompt_has_low_risk_additive_write_evidence_for_arxiv_url():
+    from src.backend.workflows.write_tool_policy import (
+        prompt_has_low_risk_additive_write_evidence,
     )
 
     assert (
-        prompt_grants_high_impact_kb_write_approval(
-            prompt="Approved. Proceed with the Vontology concept write.",
-            recent_user_prompts=[],
+        prompt_has_low_risk_additive_write_evidence(
+            "https://arxiv.org/abs/2510.06248"
         )
         is True
     )
-    assert (
-        prompt_grants_high_impact_kb_write_approval(
-            prompt="Please create a concept in the ontology.",
-            recent_user_prompts=[],
-        )
-        is False
-    )
+    assert prompt_has_low_risk_additive_write_evidence("Yes, do it.") is False


### PR DESCRIPTION
## Summary
- replace prompt-verb write gating with central risk-classed minimal-imposition policy
- default-allow low-risk additive Vontology/arXiv representation writes while routing destructive mutations to approval-required workflow states
- add route-level /von/generate regression coverage for bare arXiv URL auto-representation plus explicit-denial blocking, and update docs/AGENTS to match the new doctrine

## Testing
- pytest tests/backend/test_write_tool_policy.py -q
- pytest tests/backend/test_orchestrator_write_guardrail.py -q
- pytest tests/backend/test_orchestrator_high_impact_review_guard.py -q
- pytest tests/backend/test_orchestrator_workflow_selector_routing.py -k "write_intent_memory" -q
- pytest tests/backend/test_von_generate_bare_arxiv_url_integration.py -q
- pyright src/backend/integrations/internal_mcp/orchestrator.py src/backend/workflows/definitions.py src/backend/workflows/write_tool_policy.py src/backend/services/turn_execution_record_service.py tests/backend/test_write_tool_policy.py tests/backend/test_orchestrator_write_guardrail.py tests/backend/test_orchestrator_high_impact_review_guard.py tests/backend/test_orchestrator_workflow_selector_routing.py tests/backend/test_von_generate_bare_arxiv_url_integration.py orchestrator_test_harness.py
