### PR TITLE
JVNAUTOSCI-1397 reconcile turn-execution diagnostics

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -242,9 +242,12 @@ For chat progress payloads consumed by the thinking card:
 For live chat progress payloads used by workflow-aware thinking-card rendering:
 
 - the payload SHOULD include `workflow_stage_path` derived from the canonical conversation-turn stage model, not just raw internal event/status labels;
+- `workflow_stage_path.workflow_id` SHOULD represent the mapped execution-stage consensus when the observed stage path yields one unambiguous workflow, and SHOULD fall back to the selected-route hint only when the stage path itself carries no workflow membership;
+- `workflow_stage_path.observed_workflow_ids` SHOULD expose the workflow IDs actually observed in the mapped stage path so route selection (`selected_workflow_id`) and execution-stage membership can be compared without ambiguity;
 - workflow discovery SHOULD emit an explicit completion payload even when zero workflows match, so the UI can render a visible "no applicable workflow found" step rather than silently omitting discovery outcome;
 - live workflow-dispatch progress SHOULD expose `selected_workflow_id` and SHOULD expose a human-readable `selected_workflow_name` when available;
 - selector metadata such as `workflow_selector_verdict` and `workflow_selector_source` SHOULD be preserved in the live payload so the UI can explain why a workflow route was chosen;
+- tool history and tool success/failure/pending counters SHOULD be derived from concrete tool lifecycle events (`tool_call_start` / terminal tool events) rather than route-selection metadata such as `workflow_task`;
 - thinking-card step labels SHOULD prefer canonical workflow-stage labels (for example `Workflow discovery`, `Workflow dispatch`, `Plan tool calls`) over transport/internal labels such as `orchestrator_start`.
 
 ### 7.3 Completion-Gate Terminal Semantics (JVNAUTOSCI-1380)

--- a/orchestrator_test_harness.py
+++ b/orchestrator_test_harness.py
@@ -36,13 +36,15 @@ def _stub_stage_model_snapshot() -> dict[str, Any]:
     }
 
 
-def _stub_stage_path(*, runtime_stages: Any, **_kwargs) -> dict[str, Any]:
+def _stub_stage_path(*, runtime_stages: Any, **kwargs) -> dict[str, Any]:
     snapshot = _stub_stage_model_snapshot()
     stage_lookup = {
         str(entry.get("stage_id")): dict(entry)
         for entry in snapshot["stages"]
         if isinstance(entry, dict) and isinstance(entry.get("stage_id"), str)
     }
+    workflow_hint = kwargs.get("workflow_id")
+    workflow_hint = workflow_hint.strip() if isinstance(workflow_hint, str) and workflow_hint.strip() else None
     ordered_runtime_stages: list[str] = []
     for item in runtime_stages or []:
         if not isinstance(item, str):
@@ -57,6 +59,8 @@ def _stub_stage_path(*, runtime_stages: Any, **_kwargs) -> dict[str, Any]:
         ordered_runtime_stages.append(cleaned)
 
     path = []
+    observed_workflow_ids: list[str] = []
+    observed_workflow_keys: set[str] = set()
     for sequence_no, stage_id in enumerate(ordered_runtime_stages):
         entry: dict[str, Any] = dict(
             stage_lookup.get(stage_id) or {"stage_id": stage_id}
@@ -67,12 +71,30 @@ def _stub_stage_path(*, runtime_stages: Any, **_kwargs) -> dict[str, Any]:
         entry["runtime_stage_normalised"] = stage_id
         entry["mapping_status"] = "mapped"
         path.append(entry)
+        mapped_workflow_id = entry.get("workflow_id")
+        if isinstance(mapped_workflow_id, str) and mapped_workflow_id.strip():
+            dedupe_key = mapped_workflow_id.strip().lower()
+            if dedupe_key not in observed_workflow_keys:
+                observed_workflow_keys.add(dedupe_key)
+                observed_workflow_ids.append(mapped_workflow_id.strip())
+
+    if len(observed_workflow_ids) == 1:
+        root_workflow_id = observed_workflow_ids[0]
+        workflow_id_source = "mapped_stage_consensus"
+    elif observed_workflow_ids:
+        root_workflow_id = None
+        workflow_id_source = "mixed_stage_membership"
+    else:
+        root_workflow_id = workflow_hint
+        workflow_id_source = "route_hint" if workflow_hint else None
 
     return {
         "schema_version": "conversation_turn_stage_path.v1",
         "stage_model_schema_version": snapshot["schema_version"],
         "workflow_representation_id": snapshot["workflow_representation_id"],
-        "workflow_id": None,
+        "workflow_id": root_workflow_id,
+        "workflow_id_source": workflow_id_source,
+        "observed_workflow_ids": observed_workflow_ids,
         "has_unmapped_runtime_stages": False,
         "unmapped_runtime_stages": [],
         "path": path,

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -62,6 +62,9 @@ from ...services.response_transformation_telemetry import (
     build_response_transformation_telemetry_payload,
     record_response_transformation_event,
 )
+from ...services.turn_execution_diagnostic_event_service import (
+    derive_tool_observations_from_diagnostic_events,
+)
 from ...services.turn_execution_record_service import build_turn_execution_record
 from ...workflows import (
     CHAT_BUTTONIFY_WORKFLOW_ID,
@@ -729,60 +732,16 @@ def _derive_phase_history_from_diagnostic_events(
 def _derive_tool_history_from_diagnostic_events(
     events: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    tool_history: list[dict[str, Any]] = []
-
-    for entry in events:
-        tool = _progress_str(entry.get("tool")) or ""
-        workflow_task = _progress_str(entry.get("workflow_task")) or ""
-        if not tool and not workflow_task:
-            continue
-
-        phase = _progress_str(entry.get("phase")) or _progress_str(entry.get("stage")) or ""
-        result_summary = _progress_str(entry.get("result_summary")) or ""
-        status = (_progress_str(entry.get("status")) or "").lower()
-
-        batch_size_raw = _progress_number(entry.get("batch_size"))
-        batch_size: int | float | None
-        if batch_size_raw is None:
-            batch_size = None
-        elif float(batch_size_raw).is_integer():
-            batch_size = int(batch_size_raw)
-        else:
-            batch_size = float(batch_size_raw)
-
-        last = tool_history[-1] if tool_history else None
-        if (
-            isinstance(last, dict)
-            and last.get("tool") == tool
-            and last.get("workflowTask") == workflow_task
-            and last.get("batchSize") == batch_size
-        ):
-            if result_summary:
-                last["resultSummary"] = result_summary
-            if status == "tool_invoked":
-                last["success"] = True
-            elif status in {"tool_failed", "tool_blocked", "error"}:
-                last["success"] = False
-            continue
-
-        success: bool | None = None
-        if status == "tool_invoked":
-            success = True
-        elif status in {"tool_failed", "tool_blocked", "error"}:
-            success = False
-
-        tool_history.append(
-            {
-                "tool": tool,
-                "workflowTask": workflow_task,
-                "batchSize": batch_size,
-                "phase": phase,
-                "resultSummary": result_summary,
-                "success": success,
-            }
-        )
-
-    return tool_history[-_TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT :]
+    tool_observations = derive_tool_observations_from_diagnostic_events(
+        events,
+        limit=_TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT,
+    )
+    tool_history = tool_observations.get("tool_history")
+    return (
+        [cast(dict[str, Any], entry) for entry in tool_history if isinstance(entry, dict)]
+        if isinstance(tool_history, list)
+        else []
+    )
 
 
 def _latest_event_timestamp_ms(events: list[dict[str, Any]]) -> int | None:
@@ -989,6 +948,7 @@ def _build_turn_execution_stage_diagnostics(
     diagnostic_events: list[dict[str, Any]],
     workflow_stage_path: Mapping[str, Any] | None,
     tool_history: list[dict[str, Any]],
+    tool_observation_summary: Mapping[str, Any] | None,
     workflow_discovery: Mapping[str, Any] | None,
     latest_progress: Mapping[str, Any] | None,
 ) -> list[dict[str, Any]]:
@@ -1045,8 +1005,30 @@ def _build_turn_execution_stage_diagnostics(
 
         if stage_id == "workflow_discovery" and isinstance(workflow_discovery, Mapping):
             stage_payload["workflow_discovery"] = dict(workflow_discovery)
-        if stage_id == "tool_execute" and tool_history:
-            stage_payload["tool_history"] = [dict(entry) for entry in tool_history]
+        if stage_id == "tool_execute":
+            summary_payload = (
+                tool_observation_summary if isinstance(tool_observation_summary, Mapping) else {}
+            )
+            stage_payload["tool_call_count"] = int(
+                _progress_number(summary_payload.get("tool_call_count")) or 0
+            )
+            stage_payload["tool_success_count"] = int(
+                _progress_number(summary_payload.get("tool_success_count")) or 0
+            )
+            stage_payload["tool_failure_count"] = int(
+                _progress_number(summary_payload.get("tool_failure_count")) or 0
+            )
+            stage_payload["tool_pending_count"] = int(
+                _progress_number(summary_payload.get("tool_pending_count")) or 0
+            )
+            stage_payload["tool_call_start_count"] = int(
+                _progress_number(summary_payload.get("tool_call_start_count")) or 0
+            )
+            stage_payload["tool_call_end_count"] = int(
+                _progress_number(summary_payload.get("tool_call_end_count")) or 0
+            )
+            if tool_history:
+                stage_payload["tool_history"] = [dict(entry) for entry in tool_history]
         if stage_id in {"workflow_dispatch", "plain_response"}:
             stage_payload["selected_workflow_id"] = _progress_str(
                 latest_progress_payload.get("selected_workflow_id")
@@ -1125,7 +1107,15 @@ def _build_turn_execution_diagnostics(
         for entry in (llm_calls or [])
         if isinstance(entry, dict)
     ]
-    tool_history = _derive_tool_history_from_diagnostic_events(diagnostic_events)
+    tool_observation_summary = derive_tool_observations_from_diagnostic_events(
+        diagnostic_events,
+        limit=_TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT,
+    )
+    tool_history = [
+        cast(dict[str, Any], entry)
+        for entry in (tool_observation_summary.get("tool_history") or [])
+        if isinstance(entry, dict)
+    ]
     timing_breakdown = _build_timing_breakdown(
         diagnostic_events=diagnostic_events,
         phase_history=phase_history,
@@ -1136,6 +1126,7 @@ def _build_turn_execution_diagnostics(
         diagnostic_events=diagnostic_events,
         workflow_stage_path=workflow_stage_path,
         tool_history=tool_history,
+        tool_observation_summary=tool_observation_summary,
         workflow_discovery=workflow_payload,
         latest_progress=latest_progress,
     )
@@ -1151,6 +1142,16 @@ def _build_turn_execution_diagnostics(
         ),
         "phase_history": phase_history,
         "tool_history": tool_history,
+        "tool_call_count": int(_progress_number(tool_observation_summary.get("tool_call_count")) or 0),
+        "tool_success_count": int(_progress_number(tool_observation_summary.get("tool_success_count")) or 0),
+        "tool_failure_count": int(_progress_number(tool_observation_summary.get("tool_failure_count")) or 0),
+        "tool_pending_count": int(_progress_number(tool_observation_summary.get("tool_pending_count")) or 0),
+        "tool_call_start_count": int(
+            _progress_number(tool_observation_summary.get("tool_call_start_count")) or 0
+        ),
+        "tool_call_end_count": int(
+            _progress_number(tool_observation_summary.get("tool_call_end_count")) or 0
+        ),
         "workflow_discovery": workflow_payload,
         "workflow_stage_model": build_conversation_turn_stage_model_snapshot(),
         "workflow_stage_path": workflow_stage_path,

--- a/src/backend/services/knowledge_acquisition_profile_vontology_service.py
+++ b/src/backend/services/knowledge_acquisition_profile_vontology_service.py
@@ -290,6 +290,8 @@ def ensure_canonical_knowledge_acquisition_profiles(
         _normalise_strings(concept_ids) or canonical_knowledge_acquisition_profile_concept_ids()
     )
     workflow_ids = _normalise_strings(link_workflow_ids)
+    provenance_payload = dict(provenance) if isinstance(provenance, Mapping) else None
+    context_payload = dict(context) if isinstance(context, Mapping) else None
     type_created = False
     created_profile_concept_ids: list[str] = []
     persisted_profile_concept_ids: list[str] = []
@@ -358,8 +360,8 @@ def ensure_canonical_knowledge_acquisition_profiles(
                 lang=language,
                 text=profile_json,
                 policy=policy,
-                provenance=provenance,
-                context=context,
+                provenance=provenance_payload,
+                context=context_payload,
                 garbage_collect=garbage_collect,
             )
             persisted_profile_concept_ids.append(concept_id)
@@ -380,8 +382,8 @@ def ensure_canonical_knowledge_acquisition_profiles(
                     lang=language,
                     text=link_target_id,
                     policy=policy,
-                    provenance=provenance,
-                    context=context,
+                    provenance=provenance_payload,
+                    context=context_payload,
                     garbage_collect=garbage_collect,
                 )
                 linked_workflow_ids.append(workflow_id)

--- a/src/backend/services/turn_execution_diagnostic_event_service.py
+++ b/src/backend/services/turn_execution_diagnostic_event_service.py
@@ -1,0 +1,136 @@
+"""Helpers for deriving consistent turn-execution telemetry from event streams."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+_TOOL_START_STATUSES = frozenset({"tool_call_start"})
+_TOOL_SUCCESS_STATUSES = frozenset({"tool_invoked"})
+_TOOL_FAILURE_STATUSES = frozenset({"tool_failed", "tool_blocked", "error"})
+_TOOL_START_EVENT_KINDS = frozenset({"tool_call_start"})
+_TOOL_END_EVENT_KINDS = frozenset({"tool_call_end"})
+
+
+def _safe_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _safe_number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _normalise_batch_size(value: Any) -> int | float | None:
+    raw_value = _safe_number(value)
+    if raw_value is None:
+        return None
+    if float(raw_value).is_integer():
+        return int(raw_value)
+    return float(raw_value)
+
+
+def derive_tool_observations_from_diagnostic_events(
+    events: Sequence[Mapping[str, Any]] | None,
+    *,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Derive tool history and counts from concrete tool lifecycle events only."""
+
+    tool_history: list[dict[str, Any]] = []
+    history_indexes_by_key: dict[str, list[int]] = {}
+    tool_call_start_count = 0
+    tool_call_end_count = 0
+
+    for raw_entry in events or ():
+        if not isinstance(raw_entry, Mapping):
+            continue
+
+        tool_name = _safe_str(raw_entry.get("tool"))
+        if not tool_name:
+            continue
+
+        status = (_safe_str(raw_entry.get("status")) or "").lower()
+        event_kind = (_safe_str(raw_entry.get("event_kind")) or "").lower()
+        is_tool_start = status in _TOOL_START_STATUSES or event_kind in _TOOL_START_EVENT_KINDS
+        is_tool_terminal = (
+            status in _TOOL_SUCCESS_STATUSES
+            or status in _TOOL_FAILURE_STATUSES
+            or event_kind in _TOOL_END_EVENT_KINDS
+        )
+        if not is_tool_start and not is_tool_terminal:
+            continue
+
+        if is_tool_start:
+            tool_call_start_count += 1
+        if is_tool_terminal:
+            tool_call_end_count += 1
+
+        batch_size = _normalise_batch_size(raw_entry.get("batch_size"))
+        call_id = _safe_str(raw_entry.get("call_id"))
+        phase = _safe_str(raw_entry.get("phase")) or _safe_str(raw_entry.get("stage")) or ""
+        result_summary = _safe_str(raw_entry.get("result_summary")) or ""
+        workflow_task = _safe_str(raw_entry.get("workflow_task")) or ""
+        key = call_id or f"{tool_name.lower()}::{batch_size!r}"
+
+        history_index: int | None = None
+        for candidate_index in reversed(history_indexes_by_key.get(key, [])):
+            candidate_entry = tool_history[candidate_index]
+            if candidate_entry.get("success") is None:
+                history_index = candidate_index
+                break
+
+        if history_index is None:
+            tool_history.append(
+                {
+                    "tool": tool_name,
+                    "workflowTask": workflow_task,
+                    "batchSize": batch_size,
+                    "phase": phase,
+                    "resultSummary": result_summary,
+                    "success": None,
+                    "callId": call_id,
+                }
+            )
+            history_index = len(tool_history) - 1
+            history_indexes_by_key.setdefault(key, []).append(history_index)
+
+        history_entry = tool_history[history_index]
+        if workflow_task and not history_entry.get("workflowTask"):
+            history_entry["workflowTask"] = workflow_task
+        if phase and not history_entry.get("phase"):
+            history_entry["phase"] = phase
+        if result_summary:
+            history_entry["resultSummary"] = result_summary
+        if call_id and not history_entry.get("callId"):
+            history_entry["callId"] = call_id
+
+        if status in _TOOL_SUCCESS_STATUSES:
+            history_entry["success"] = True
+        elif status in _TOOL_FAILURE_STATUSES:
+            history_entry["success"] = False
+        elif event_kind in _TOOL_END_EVENT_KINDS and isinstance(raw_entry.get("success"), bool):
+            history_entry["success"] = bool(raw_entry.get("success"))
+
+    if isinstance(limit, int) and limit > 0:
+        tool_history = tool_history[-limit:]
+
+    tool_success_count = sum(1 for entry in tool_history if entry.get("success") is True)
+    tool_failure_count = sum(1 for entry in tool_history if entry.get("success") is False)
+    tool_call_count = len(tool_history)
+    tool_pending_count = max(0, tool_call_count - tool_success_count - tool_failure_count)
+
+    return {
+        "tool_history": tool_history,
+        "tool_call_count": tool_call_count,
+        "tool_success_count": tool_success_count,
+        "tool_failure_count": tool_failure_count,
+        "tool_pending_count": tool_pending_count,
+        "tool_call_start_count": tool_call_start_count,
+        "tool_call_end_count": tool_call_end_count,
+    }

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -26,6 +26,9 @@ from .representation_contract_vontology_service import (
     ensure_canonical_representation_contract_profiles,
     load_representation_contract_profiles_from_concept_ids,
 )
+from .turn_execution_diagnostic_event_service import (
+    derive_tool_observations_from_diagnostic_events,
+)
 from ..workflows.write_tool_policy import prompt_explicitly_denies_write
 from ..workflows.conversation_turn_stage_model import (
     build_conversation_turn_stage_model_snapshot,
@@ -790,17 +793,23 @@ def _summarise_tool_execution_context(
                 event for event in raw_events if isinstance(event, Mapping)
             ]
 
+    tool_observation_summary = derive_tool_observations_from_diagnostic_events(
+        diagnostic_events
+    )
+    tool_call_start_event_count = _safe_non_negative_int(
+        tool_observation_summary.get("tool_call_start_count")
+    )
+    tool_call_end_event_count = _safe_non_negative_int(
+        tool_observation_summary.get("tool_call_end_count")
+    )
+
     worker_unavailable_event_count = 0
-    tool_call_start_event_count = 0
     tool_plan_stage_event_count = 0
     tool_execute_stage_event_count = 0
     for event in diagnostic_events:
         liveness_reason = (_safe_str(event.get("liveness_reason")) or "").lower()
         if liveness_reason == "worker_unavailable":
             worker_unavailable_event_count += 1
-        event_kind = (_safe_str(event.get("event_kind")) or "").lower()
-        if event_kind == "tool_call_start":
-            tool_call_start_event_count += 1
         stage = (_safe_str(event.get("stage")) or "").lower()
         phase = (_safe_str(event.get("phase")) or "").lower()
         if "tool_plan" in {stage, phase}:
@@ -844,7 +853,11 @@ def _summarise_tool_execution_context(
 
     invocation_count = len(serialised_invocations)
     observed_started_count = max(progress_tools_started, tool_call_start_event_count)
-    observed_executed_count = max(progress_tools_completed, invocation_count)
+    observed_executed_count = max(
+        progress_tools_completed,
+        tool_call_end_event_count,
+        invocation_count,
+    )
 
     failure_codes: list[str] = []
     worker_unavailable_with_tool_expectation = (

--- a/src/backend/workflows/conversation_turn_stage_model.py
+++ b/src/backend/workflows/conversation_turn_stage_model.py
@@ -456,10 +456,19 @@ def build_conversation_turn_stage_path(
     runtime_stages: Sequence[Any],
     workflow_id: str | None = None,
 ) -> dict[str, Any]:
-    """Map a runtime stage sequence into stage catalogue entries."""
+    """Map a runtime stage sequence into stage catalogue entries.
+
+    ``workflow_id`` is treated as a route/mapping hint, not as authoritative
+    proof that every runtime stage belongs to that workflow. The returned root
+    ``workflow_id`` therefore reflects the mapped stage membership when the path
+    yields a single unambiguous workflow, and falls back to the caller-provided
+    hint only when the path itself carries no workflow membership.
+    """
 
     path: list[dict[str, Any]] = []
     unmapped_runtime_stages: list[str] = []
+    observed_workflow_ids: list[str] = []
+    observed_workflow_id_keys: set[str] = set()
     last_dedupe_key: str | None = None
 
     for raw_stage in runtime_stages:
@@ -472,6 +481,13 @@ def build_conversation_turn_stage_path(
             workflow_id=workflow_id,
         )
         if isinstance(resolved, dict):
+            resolved_workflow_id = resolved.get("workflow_id")
+            if isinstance(resolved_workflow_id, str) and resolved_workflow_id.strip():
+                dedupe_workflow_id = resolved_workflow_id.strip()
+                dedupe_workflow_key = dedupe_workflow_id.lower()
+                if dedupe_workflow_key not in observed_workflow_id_keys:
+                    observed_workflow_id_keys.add(dedupe_workflow_key)
+                    observed_workflow_ids.append(dedupe_workflow_id)
             dedupe_key = f"mapped:{resolved.get('stage_id')}:{resolved.get('workflow_id')}"
             if dedupe_key == last_dedupe_key:
                 continue
@@ -511,11 +527,25 @@ def build_conversation_turn_stage_path(
         if normalised_stage not in unmapped_runtime_stages:
             unmapped_runtime_stages.append(normalised_stage)
 
+    root_workflow_id: str | None
+    workflow_id_source: str | None
+    if len(observed_workflow_ids) == 1:
+        root_workflow_id = observed_workflow_ids[0]
+        workflow_id_source = "mapped_stage_consensus"
+    elif observed_workflow_ids:
+        root_workflow_id = None
+        workflow_id_source = "mixed_stage_membership"
+    else:
+        root_workflow_id = workflow_id
+        workflow_id_source = "route_hint" if workflow_id else None
+
     return {
         "schema_version": CONVERSATION_TURN_STAGE_PATH_SCHEMA_VERSION,
         "stage_model_schema_version": CONVERSATION_TURN_STAGE_MODEL_SCHEMA_VERSION,
         "workflow_representation_id": CONVERSATION_TURN_EXECUTION_WORKFLOW_ID,
-        "workflow_id": workflow_id,
+        "workflow_id": root_workflow_id,
+        "workflow_id_source": workflow_id_source,
+        "observed_workflow_ids": observed_workflow_ids,
         "path": path,
         "has_unmapped_runtime_stages": bool(unmapped_runtime_stages),
         "unmapped_runtime_stages": unmapped_runtime_stages,

--- a/tests/backend/test_conversation_turn_stage_model.py
+++ b/tests/backend/test_conversation_turn_stage_model.py
@@ -1,11 +1,93 @@
+import pytest
+
+from src.backend.workflows import conversation_turn_stage_model as stage_model
 from src.backend.workflows.conversation_turn_stage_model import (
     build_conversation_turn_stage_model_snapshot,
     build_conversation_turn_stage_path,
 )
 from src.backend.workflows.definitions import (
     CHAT_BUTTONIFY_WORKFLOW_ID,
+    CHAT_ASSISTANT_WORKFLOW_ID,
     TOOL_CALLING_WORKFLOW_ID,
+    TURN_COMPLETION_GATE_WORKFLOW_ID,
 )
+
+
+@pytest.fixture(autouse=True)
+def _patch_stage_catalogue(monkeypatch: pytest.MonkeyPatch) -> None:
+    specs = (
+        stage_model._StageSpec(
+            stage_id="workflow_discovery",
+            stage_label="Workflow discovery",
+            order=20,
+            stage_kind="non_formal",
+            boundary_type="routing",
+            stage_concept_id="#V#conversation_turn_stage_workflow_discovery",
+            runtime_aliases=("workflow_discovery",),
+        ),
+        stage_model._StageSpec(
+            stage_id="workflow_dispatch",
+            stage_label="Workflow dispatch",
+            order=30,
+            stage_kind="non_formal",
+            boundary_type="routing",
+            stage_concept_id="#V#conversation_turn_stage_workflow_dispatch",
+            runtime_aliases=("workflow_dispatch",),
+        ),
+        stage_model._StageSpec(
+            stage_id="tool_execute",
+            stage_label="Execute tool calls",
+            order=70,
+            stage_kind="formal",
+            boundary_type="execution",
+            stage_concept_id="#V#conversation_turn_stage_tool_execute",
+            workflow_id=TOOL_CALLING_WORKFLOW_ID,
+            workflow_state_id="execute",
+            runtime_aliases=("tool_execute", "execute"),
+        ),
+        stage_model._StageSpec(
+            stage_id="completion_gate",
+            stage_label="Completion gate",
+            order=100,
+            stage_kind="formal",
+            boundary_type="completion_gate",
+            stage_concept_id="#V#conversation_turn_stage_completion_gate",
+            workflow_id=TURN_COMPLETION_GATE_WORKFLOW_ID,
+            workflow_state_id="completion_gate",
+            runtime_aliases=("completion_gate",),
+        ),
+        stage_model._StageSpec(
+            stage_id="buttonify",
+            stage_label="Buttonify output transformation",
+            order=125,
+            stage_kind="non_formal",
+            boundary_type="render",
+            stage_concept_id="#V#conversation_turn_stage_buttonify",
+            workflow_id=CHAT_BUTTONIFY_WORKFLOW_ID,
+            runtime_aliases=("buttonify",),
+        ),
+        stage_model._StageSpec(
+            stage_id="response_finalising",
+            stage_label="Finalising response",
+            order=128,
+            stage_kind="non_formal",
+            boundary_type="postprocess",
+            stage_concept_id="#V#conversation_turn_stage_response_finalising",
+            runtime_aliases=("response_finalising",),
+        ),
+        stage_model._StageSpec(
+            stage_id="completed",
+            stage_label="Completed",
+            order=190,
+            stage_kind="formal",
+            boundary_type="terminal",
+            stage_concept_id="#V#conversation_turn_stage_completed",
+            runtime_aliases=("completed",),
+        ),
+    )
+    alias_index = stage_model._build_alias_index(specs)
+    monkeypatch.setattr(stage_model, "_load_stage_specs", lambda: specs)
+    monkeypatch.setattr(stage_model, "_load_alias_index", lambda: alias_index)
 
 
 def test_stage_model_snapshot_exposes_formal_and_non_formal_stages() -> None:
@@ -82,3 +164,19 @@ def test_stage_path_maps_response_finalising_runtime_stage() -> None:
     assert len(path) == 1
     assert path[0]["stage_id"] == "response_finalising"
     assert path[0]["runtime_stage_normalised"] == "response_finalising"
+
+
+def test_stage_path_prefers_mapped_execution_workflow_over_route_hint() -> None:
+    result = build_conversation_turn_stage_path(
+        runtime_stages=["workflow_dispatch", "tool_execute"],
+        workflow_id=CHAT_ASSISTANT_WORKFLOW_ID,
+    )
+
+    assert result["workflow_id"] == TOOL_CALLING_WORKFLOW_ID
+    assert result["workflow_id_source"] == "mapped_stage_consensus"
+    assert result["observed_workflow_ids"] == [TOOL_CALLING_WORKFLOW_ID]
+    path = result["path"]
+    assert len(path) == 2
+    assert path[0]["stage_id"] == "workflow_dispatch"
+    assert path[1]["stage_id"] == "tool_execute"
+    assert path[1]["workflow_id"] == TOOL_CALLING_WORKFLOW_ID

--- a/tests/backend/test_turn_execution_record_service_execution_summary.py
+++ b/tests/backend/test_turn_execution_record_service_execution_summary.py
@@ -90,3 +90,39 @@ def test_worker_unavailable_with_tool_plan_evidence_emits_tool_failure() -> None
     assert "worker_unavailable_zero_execution" in list(
         summary.get("failure_codes") or []
     )
+
+
+def test_tool_execution_summary_uses_tool_call_end_events_for_executed_count() -> None:
+    summary = _summarise_tool_execution_context(
+        workflow_routing={
+            "workflow_id": "#V#chat_assistant_workflow",
+            "verdict": "fallback",
+        },
+        turn_execution_diagnostics={
+            "latest_progress": {
+                "counters": {"tools_started": 0, "tools_completed": 0},
+                "diagnostic_events": [
+                    {
+                        "status": "tool_call_start",
+                        "event_kind": "tool_call_start",
+                        "phase": "tool_execute",
+                        "tool": "turn_execution_list",
+                        "call_id": "call-1",
+                    },
+                    {
+                        "status": "tool_invoked",
+                        "event_kind": "tool_call_end",
+                        "phase": "tool_execute",
+                        "tool": "turn_execution_list",
+                        "call_id": "call-1",
+                    },
+                ],
+            }
+        },
+        aux_llm_calls=[],
+        serialised_invocations=[],
+    )
+
+    assert summary["tool_route_selected"] is False
+    assert summary["started_count"] == 1
+    assert summary["executed_count"] == 1

--- a/tests/backend/test_von_generate_bare_arxiv_url_integration.py
+++ b/tests/backend/test_von_generate_bare_arxiv_url_integration.py
@@ -18,6 +18,10 @@ from src.backend.integrations.internal_mcp.gateway import (
     MethodDefinition,
 )
 from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+from src.backend.workflows.definitions import (
+    CHAT_ASSISTANT_WORKFLOW_ID,
+    TOOL_CALLING_WORKFLOW_ID,
+)
 from orchestrator_test_harness import (
     _stub_stage_model_snapshot,
     _stub_stage_path,
@@ -236,6 +240,65 @@ def test_generate_bare_arxiv_url_auto_represents_paper(monkeypatch):
     completion_gate = turn_record.get("completion_gate") or {}
     assert completion_gate.get("decision") == "completed"
     assert completion_gate.get("safe_to_claim_completion") is True
+
+
+def test_generate_fallback_route_keeps_route_selection_separate_from_tool_execution(
+    monkeypatch,
+):
+    llm = _LLMSequence(
+        [
+            "fallback",
+            '{"action":"call_tool","tool":"download_paper","payload":{"arxiv_id":"2510.06248"}}',
+            "Downloaded and represented the paper.",
+        ]
+    )
+    app = _make_app(monkeypatch, llm=llm)
+
+    client = app.test_client()
+    response = client.post("/von/generate", json={"prompt": "https://arxiv.org/abs/2510.06248"})
+    assert response.status_code == 200
+
+    body = response.get_json()
+    assert isinstance(body, dict)
+    llm_debug = body.get("llm_debug") or {}
+
+    workflow_routing = llm_debug.get("workflow_routing") or {}
+    assert workflow_routing.get("workflow_id") == CHAT_ASSISTANT_WORKFLOW_ID
+    assert workflow_routing.get("verdict") == "fallback"
+
+    diagnostics = llm_debug.get("turn_execution_diagnostics") or {}
+    assert diagnostics.get("tool_call_count") == 1
+    assert diagnostics.get("tool_success_count") == 1
+    assert diagnostics.get("tool_failure_count") == 0
+    assert diagnostics.get("tool_pending_count") == 0
+
+    tool_history = diagnostics.get("tool_history") or []
+    assert [entry.get("tool") for entry in tool_history] == ["download_paper"]
+    assert all(entry.get("tool") for entry in tool_history)
+
+    workflow_stage_path = diagnostics.get("workflow_stage_path") or {}
+    assert workflow_stage_path.get("workflow_id") != CHAT_ASSISTANT_WORKFLOW_ID
+    assert TOOL_CALLING_WORKFLOW_ID in list(
+        workflow_stage_path.get("observed_workflow_ids") or []
+    )
+    path = workflow_stage_path.get("path") or []
+    tool_execute_entry = next(
+        entry
+        for entry in path
+        if isinstance(entry, dict) and entry.get("stage_id") == "tool_execute"
+    )
+    assert tool_execute_entry.get("workflow_id") == TOOL_CALLING_WORKFLOW_ID
+
+    stage_diagnostics = diagnostics.get("stage_diagnostics") or []
+    tool_stage = next(
+        entry
+        for entry in stage_diagnostics
+        if isinstance(entry, dict) and entry.get("stage_id") == "tool_execute"
+    )
+    assert tool_stage.get("tool_call_count") == 1
+    assert tool_stage.get("tool_success_count") == 1
+    assert tool_stage.get("tool_failure_count") == 0
+    assert tool_stage.get("tool_pending_count") == 0
 
 
 def test_generate_bare_arxiv_url_with_explicit_denial_stays_non_mutating(monkeypatch):


### PR DESCRIPTION
## Summary
- separate route-selection telemetry from execution-stage workflow mapping
- derive tool history and tool counters from concrete tool lifecycle events
- add regression coverage for fallback routing that still executes a tool
- include the related typing fix in knowledge_acquisition_profile_vontology_service.py

## Validation
- pdm run pyright on changed Python files
- pdm run pytest tests/backend/test_conversation_turn_stage_model.py tests/backend/test_turn_execution_record_service_execution_summary.py tests/backend/test_von_generate_bare_arxiv_url_integration.py -q