### PR TITLE
JVNAUTOSCI-1395 implement remote URL file-copy ingestion

### DIFF
--- a/docs/engineering/blob_store_artefact_source_strategy.md
+++ b/docs/engineering/blob_store_artefact_source_strategy.md
@@ -14,7 +14,10 @@ This document covers `JVNAUTOSCI-883` follow-on scope from `JVNAUTOSCI-879`.
    blob reference, content type, size, and provenance timestamps/source fields).
 3. Retrieval/indexing paths should operate on blob references, not stable local paths.
 4. Filesystem import is supported as a first-class path via `import_local_file_copy`.
-5. Google Drive/Docs ingestion remains optional and is deferred until auth/session
+5. Direct remote URL artefact ingestion is supported as a first-class path via
+   `import_url_file_copy`, with HTTP/HTTPS-only fetch policy, SSRF blocking,
+   bounded download size, and captured response/redirect provenance.
+6. Google Drive/Docs ingestion remains optional and is deferred until auth/session
    lifecycle and export-format policy are fully stabilised.
 
 ## Filesystem Import Path
@@ -28,6 +31,21 @@ This document covers `JVNAUTOSCI-883` follow-on scope from `JVNAUTOSCI-879`.
 
 This provides a stable way to ingest pre-existing local files without relying on
 ephemeral cache paths.
+
+## Remote URL Import Path
+
+`import_url_file_copy` performs:
+
+1. Direct HTTP/HTTPS fetch of a caller-supplied artefact URL.
+2. Fail-closed validation of every hop (scheme, host resolution, redirect target,
+   and maximum size) before bytes are persisted.
+3. Durable upload to the configured blob backend using the same canonical byte
+   ingestion pathway as filesystem import.
+4. Registration of a `#V#computer_file_copy` concept with blob metadata plus
+   recorded URL/response provenance for downstream read/index/interpret flows.
+
+This is the canonical path when the user wants a remote binary artefact stored as
+an addressable file-copy concept rather than extracting page text via `extract_url`.
 
 ## Google Drive/Docs Strategy
 

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -4375,6 +4375,231 @@ def _import_local_file_copy(**kwargs):
         return _run_import()
 
 
+def _import_url_file_copy(**kwargs):
+    from ...security.access_control import get_effective_user_concept_id
+    from ...services.remote_file_copy_ingestion_service import (
+        import_remote_url_file_copy,
+    )
+    from ...services.workflow_event_integration_service import (
+        maybe_launch_file_copy_uploaded_workflow,
+    )
+
+    url = kwargs.get("url")
+    if not isinstance(url, str) or not url.strip():
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameter: url",
+            details={"missing": ["url"]},
+            suggestions=["Provide a direct http or https artefact URL to ingest"],
+        )
+    url = url.strip()
+
+    ns_report = _resolve_rag_namespace_from_kwargs(kwargs)
+    ns_error = _rag_namespace_resolution_error(ns_report)
+    if ns_error is not None:
+        return ns_error
+    ns = ns_report.get("namespace")
+    if not isinstance(ns, str) or not ns.strip():
+        return make_error_response(
+            "namespace_required",
+            "Remote URL file import requires authenticated user context (namespace)",
+            details={"namespace_report": ns_report},
+        )
+    ns = ns.strip()
+
+    filename_raw = kwargs.get("filename")
+    filename = (
+        filename_raw.strip()
+        if isinstance(filename_raw, str) and filename_raw.strip()
+        else None
+    )
+    type_concept_id_raw = kwargs.get("type_concept_id")
+    type_concept_id = (
+        type_concept_id_raw.strip()
+        if isinstance(type_concept_id_raw, str) and type_concept_id_raw.strip()
+        else "#V#computer_file_copy"
+    )
+    source_system_raw = kwargs.get("source_system")
+    source_system = (
+        source_system_raw.strip()
+        if isinstance(source_system_raw, str) and source_system_raw.strip()
+        else "remote_url_import"
+    )
+
+    max_bytes = kwargs.get("max_bytes")
+    if max_bytes is not None:
+        try:
+            max_bytes = int(max_bytes)
+        except (TypeError, ValueError):
+            return make_error_response(
+                "invalid_parameter",
+                "Invalid max_bytes: must be an integer",
+                details={"max_bytes": max_bytes},
+                suggestions=["Provide max_bytes as a positive integer"],
+            )
+        if max_bytes <= 0:
+            return make_error_response(
+                "invalid_parameter",
+                "max_bytes must be positive",
+                details={"max_bytes": max_bytes},
+                suggestions=["Provide max_bytes as a positive integer"],
+            )
+
+    max_redirects = kwargs.get("max_redirects")
+    if max_redirects is not None:
+        try:
+            max_redirects = int(max_redirects)
+        except (TypeError, ValueError):
+            return make_error_response(
+                "invalid_parameter",
+                "Invalid max_redirects: must be an integer",
+                details={"max_redirects": max_redirects},
+                suggestions=["Provide max_redirects as a non-negative integer"],
+            )
+        if max_redirects < 0:
+            return make_error_response(
+                "invalid_parameter",
+                "max_redirects must be zero or greater",
+                details={"max_redirects": max_redirects},
+                suggestions=["Provide max_redirects as zero or a positive integer"],
+            )
+
+    index_in_rag = _coerce_bool_input(kwargs.get("index_in_rag"), default=False)
+
+    def _run_import():
+        user_concept_id = get_effective_user_concept_id()
+        if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+            return make_error_response(
+                "authentication_required",
+                "User authentication required to import remote URL artefacts",
+                suggestions=["Ensure user context is set before calling this tool"],
+            )
+
+        result = import_remote_url_file_copy(
+            url=url,
+            user_concept_id=user_concept_id.strip(),
+            filename=filename,
+            type_concept_id=type_concept_id,
+            source_system=source_system,
+            max_bytes=max_bytes,
+            max_redirects=max_redirects,
+        )
+        if not isinstance(result, dict):
+            return result
+
+        result = dict(result)
+        result.setdefault("namespace", ns)
+        result.update(ns_report)
+
+        if result.get("success") is not True:
+            return result
+
+        file_copy_concept_id = result.get("concept_id")
+        user_scope_concept_id, organisation_concept_id = _resolve_rag_actor_scope_ids(
+            ns_report
+        )
+        if isinstance(file_copy_concept_id, str) and file_copy_concept_id.strip():
+            try:
+                artifact_record_raw = result.get("artifact_record")
+                artifact_record: dict[str, Any] = (
+                    dict(artifact_record_raw)
+                    if isinstance(artifact_record_raw, Mapping)
+                    else {}
+                )
+                response_payload_raw = result.get("response")
+                response_payload: dict[str, Any] = (
+                    dict(response_payload_raw)
+                    if isinstance(response_payload_raw, Mapping)
+                    else {}
+                )
+                response_headers_raw = response_payload.get("headers")
+                response_headers: dict[str, Any] = (
+                    dict(response_headers_raw)
+                    if isinstance(response_headers_raw, Mapping)
+                    else {}
+                )
+                filename_resolution_raw = result.get("filename_resolution")
+                filename_resolution: dict[str, Any] = (
+                    dict(filename_resolution_raw)
+                    if isinstance(filename_resolution_raw, Mapping)
+                    else {}
+                )
+                content_type_resolution_raw = result.get("content_type_resolution")
+                content_type_resolution: dict[str, Any] = (
+                    dict(content_type_resolution_raw)
+                    if isinstance(content_type_resolution_raw, Mapping)
+                    else {}
+                )
+                storage_payload_raw = result.get("storage")
+                storage_payload: dict[str, Any] = (
+                    dict(storage_payload_raw)
+                    if isinstance(storage_payload_raw, Mapping)
+                    else {}
+                )
+                workflow_event_launch = maybe_launch_file_copy_uploaded_workflow(
+                    file_copy_concept_id=file_copy_concept_id.strip(),
+                    uploaded_by_concept_id=user_scope_concept_id,
+                    organisation_concept_id=organisation_concept_id,
+                    namespace=ns,
+                    content_type=str(
+                        (
+                            content_type_resolution.get("effective_content_type")
+                            or response_headers.get("content_type")
+                            or artifact_record.get("content_type")
+                            or ""
+                        )
+                    ).strip()
+                    or None,
+                    original_filename=(
+                        str(filename_resolution.get("original_filename")).strip()
+                        if isinstance(
+                            filename_resolution.get("original_filename"), str
+                        )
+                        and str(filename_resolution.get("original_filename")).strip()
+                        else None
+                    ),
+                    size_bytes=_coerce_int_or_none(
+                        response_payload.get("size_bytes")
+                        or artifact_record.get("size_bytes")
+                        or storage_payload.get("size_bytes")
+                    ),
+                    sha256=(
+                        str(artifact_record.get("sha256")).strip()
+                        if isinstance(artifact_record.get("sha256"), str)
+                        and str(artifact_record.get("sha256")).strip()
+                        else None
+                    ),
+                    blob_uri=(
+                        str(storage_payload.get("uri")).strip()
+                        if isinstance(storage_payload.get("uri"), str)
+                        and str(storage_payload.get("uri")).strip()
+                        else None
+                    ),
+                    uploaded_at_iso=(
+                        str(result.get("uploaded_at")).strip()
+                        if isinstance(result.get("uploaded_at"), str)
+                        and str(result.get("uploaded_at")).strip()
+                        else None
+                    ),
+                    index_in_rag=index_in_rag,
+                )
+            except Exception as exc:
+                workflow_event_launch = {
+                    "success": False,
+                    "triggered": False,
+                    "outcome": "not_triggered",
+                    "event_type": "file_copy.uploaded",
+                    "reason": "workflow_event_launch_failed",
+                    "error": str(exc),
+                }
+            result["workflow_event_launch"] = workflow_event_launch
+
+        return result
+
+    with _with_namespace_actor_override(ns):
+        return _run_import()
+
+
 def _list_recent_screenshots(**kwargs):
     import base64
     import mimetypes
@@ -6785,6 +7010,63 @@ def _import_local_file_copy_output_schema() -> Schema:
         description=(
             "import_local_file_copy output: blob-store registration result with created "
             "#V#computer_file_copy concept and canonical artifact_record."
+        ),
+    )
+
+
+def _import_url_file_copy_input_schema() -> Schema:
+    return Schema(
+        required={
+            "url": str,
+        },
+        optional={
+            "namespace": (str, type(None)),
+            "filename": (str, type(None)),
+            "type_concept_id": (str, type(None)),
+            "source_system": (str, type(None)),
+            "max_bytes": (int, type(None)),
+            "max_redirects": (int, type(None)),
+            "index_in_rag": (bool, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "import_url_file_copy input: direct http/https artefact URL plus namespace "
+            "user@org context; optional filename override, file-copy type, remote fetch "
+            "limits, and workflow-trigger indexing hint."
+        ),
+    )
+
+
+def _import_url_file_copy_output_schema() -> Schema:
+    return Schema(
+        required={},
+        optional={
+            "success": (bool, type(None)),
+            "error": (str, type(None)),
+            "message": (str, type(None)),
+            "concept_id": (str, type(None)),
+            "type_concept_id": (str, type(None)),
+            "uploaded_at": (str, type(None)),
+            "requested_url": (str, type(None)),
+            "final_url": (str, type(None)),
+            "redirect_count": (int, type(None)),
+            "redirects": (list, type(None)),
+            "download_hops": (list, type(None)),
+            "storage": (dict, type(None)),
+            "artifact_record": (dict, type(None)),
+            "response": (dict, type(None)),
+            "filename_resolution": (dict, type(None)),
+            "content_type_resolution": (dict, type(None)),
+            "typing": (dict, type(None)),
+            "typing_result": (dict, type(None)),
+            "workflow_event_launch": (dict, type(None)),
+            "namespace": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "import_url_file_copy output: remote download plus blob-store registration "
+            "result with created #V#computer_file_copy concept, provenance, and "
+            "resolution diagnostics."
         ),
     )
 
@@ -18855,6 +19137,20 @@ def build_default_catalogue() -> MethodCatalogue:
             description=(
                 "Import a local workspace file into the configured blob store and register a "
                 "#V#computer_file_copy concept with canonical provenance metadata."
+            ),
+        ),
+        MethodDefinition(
+            name="import_url_file_copy",
+            handler=_import_url_file_copy,
+            input_schema=_import_url_file_copy_input_schema(),
+            output_schema=_import_url_file_copy_output_schema(),
+            category="write",
+            timeout_sec=45.0,
+            description=(
+                "Fetch a remote artefact directly from an http/https URL, persist its bytes "
+                "to the configured blob store, and register a #V#computer_file_copy concept "
+                "with provenance, MIME, and redirect diagnostics. Use this for binary/file "
+                "ingestion; do not use extract_url when the goal is durable file-copy import."
             ),
         ),
         MethodDefinition(

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -6475,7 +6475,8 @@ class InternalMCPChatOrchestrator:
                 'If user mentions specific dates (2024+, 2025+, "this year", "this month") → USE search_web\n'
                 'If user explicitly says "search", "look up", "find information on" → USE search_web\n'
                 'If user asks "what\'s new", "recent developments", "latest research" → USE search_web\n'
-                "If user provides a URL to analyse or extract content from → USE extract_url (or resilient_extract_url for JS-heavy/blocked pages)\n"
+                "If user provides a URL to analyse or extract page content from → USE extract_url (or resilient_extract_url for JS-heavy/blocked pages)\n"
+                "If user provides a direct file/download URL and wants durable artefact ingestion or file-copy registration → USE import_url_file_copy, not extract_url\n"
                 "If user asks a direct factual question needing verification → USE qna_search\n"
                 "If searching within specific domain/context (e.g., site:example.com) → USE context_search\n"
                 "ARXIV TOOL ROUTING:\n"

--- a/src/backend/services/computer_file_copy_service.py
+++ b/src/backend/services/computer_file_copy_service.py
@@ -750,6 +750,156 @@ def _slugify_concept_id_for_blob_key(concept_id: str) -> str:
     return cleaned or "unknown"
 
 
+def _safe_filename_for_blob_key(original_filename: str | None) -> str:
+    safe_filename = re.sub(
+        r"[^A-Za-z0-9._-]+", "_", str(original_filename or "").strip()
+    ).strip("._")
+    return safe_filename or "file.bin"
+
+
+def import_bytes_file_copy(
+    *,
+    data: bytes,
+    user_concept_id: str,
+    original_filename: str,
+    content_type: str | None = None,
+    type_concept_id: str = "#V#computer_file_copy",
+    source_system: str = "bytes_import",
+    source_identifier: str | None = None,
+    source_uri: str | None = None,
+    blob_key: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Persist bytes durably and register a blob-backed file-copy concept.
+
+    Keep this as the shared ingestion path for any flow that already has the
+    bytes in hand (filesystem imports, remote URL downloads, cached artefacts).
+    """
+
+    if not isinstance(data, (bytes, bytearray)) or not bytes(data):
+        return {"success": False, "error": "empty_file"}
+    if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+        return {"success": False, "error": "missing_user_concept_id"}
+    if not isinstance(original_filename, str) or not original_filename.strip():
+        return {"success": False, "error": "missing_original_filename"}
+
+    data_bytes = bytes(data)
+    user_concept_id = user_concept_id.strip()
+    original_filename = original_filename.strip()
+    content_type = _normalise_optional_text(content_type)
+    source_system = _normalise_optional_text(source_system) or "bytes_import"
+
+    sha256 = hashlib.sha256(data_bytes).hexdigest()
+    size_bytes = len(data_bytes)
+    uploaded_at = _now_utc_iso()
+    user_slug = _slugify_concept_id_for_blob_key(user_concept_id)
+    safe_filename = _safe_filename_for_blob_key(original_filename)
+
+    resolved_blob_key = (
+        blob_key.strip()
+        if isinstance(blob_key, str) and blob_key.strip()
+        else f"imports/{user_slug}/{sha256}/{safe_filename}"
+    )
+
+    persisted_metadata: dict[str, Any] = dict(metadata or {})
+    persisted_metadata.update(
+        {
+            "original_filename": original_filename,
+            "user_concept_id": user_concept_id,
+            "uploaded_at": uploaded_at,
+            "source_system": source_system,
+            "source_identifier": source_identifier,
+            "source_uri": source_uri,
+            "ingested_at": uploaded_at,
+        }
+    )
+
+    try:
+        from .blob_uploads import BlobUploadError, put_bytes_durable
+
+        stored = put_bytes_durable(
+            key=resolved_blob_key,
+            data=data_bytes,
+            content_type=content_type,
+            metadata=persisted_metadata,
+            sha256=sha256,
+            size_bytes=size_bytes,
+        )
+    except BlobUploadError as exc:
+        return {
+            "success": False,
+            "error": "blob_store_upload_failed",
+            "message": str(exc),
+            "blob_key": resolved_blob_key,
+        }
+
+    try:
+        created = create_computer_file_copy_instance(
+            type_concept_id=type_concept_id,
+            user_concept_id=user_concept_id,
+            name=original_filename,
+            sha256=sha256,
+            size_bytes=size_bytes,
+            content_type=content_type,
+            blob_backend=stored.ref.backend,
+            blob_key=stored.ref.key,
+            blob_uri=stored.ref.uri,
+            metadata=persisted_metadata,
+        )
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": "file_copy_register_failed",
+            "message": str(exc),
+            "blob_key": resolved_blob_key,
+        }
+
+    typing_result: dict[str, Any] | None = None
+    typing_persist_result: dict[str, Any] | None = None
+    try:
+        from .file_copy_typing_service import (
+            infer_file_copy_typing,
+            persist_file_copy_typing,
+        )
+
+        typing_result = infer_file_copy_typing(
+            content_type=content_type,
+            original_filename=original_filename,
+            size_bytes=size_bytes,
+        )
+        typing_persist_result = persist_file_copy_typing(
+            file_copy_concept_id=created.concept_id,
+            typing_result=typing_result,
+        )
+    except Exception as exc:
+        typing_persist_result = {
+            "success": False,
+            "typing_persisted": False,
+            "error": "typing_persist_failed",
+            "message": str(exc),
+        }
+
+    artifact_record = build_file_copy_artifact_record(file_copy_concept_id=created.concept_id)
+
+    return {
+        "success": True,
+        "concept_id": created.concept_id,
+        "type_concept_id": created.type_concept_id,
+        "uploaded_at": created.uploaded_at,
+        "storage": {
+            "backend": stored.ref.backend,
+            "key": stored.ref.key,
+            "uri": stored.ref.uri,
+            "content_type": stored.ref.content_type,
+            "size_bytes": stored.ref.size_bytes,
+            "metadata": stored.ref.metadata,
+        },
+        "artifact_record": artifact_record,
+        "typing": typing_persist_result,
+        "typing_result": typing_result,
+    }
+
+
 def import_local_file_copy(
     *,
     local_path: str,
@@ -800,88 +950,26 @@ def import_local_file_copy(
     if not data:
         return {"success": False, "error": "empty_file", "local_path": str(resolved)}
 
-    sha256 = hashlib.sha256(data).hexdigest()
-    size_bytes = len(data)
     original_filename = resolved.name
     content_type, _encoding = mimetypes.guess_type(original_filename)
-    user_slug = _slugify_concept_id_for_blob_key(user_concept_id)
-    safe_filename = re.sub(r"[^A-Za-z0-9._-]+", "_", original_filename).strip("._")
-    safe_filename = safe_filename or "file.bin"
-    uploaded_at = _now_utc_iso()
 
     try:
         resolved_uri = resolved.as_uri()
     except Exception:
         resolved_uri = None
 
-    metadata: dict[str, Any] = {
-        "original_filename": original_filename,
-        "user_concept_id": user_concept_id.strip(),
-        "uploaded_at": uploaded_at,
-        "source_system": source_system,
-        "source_identifier": source_identifier or str(resolved),
-        "source_uri": source_uri or resolved_uri,
-        "ingested_at": uploaded_at,
-    }
-
-    blob_key = f"imports/{user_slug}/{sha256}/{safe_filename}"
-    try:
-        from .blob_uploads import BlobUploadError, put_bytes_durable
-
-        stored = put_bytes_durable(
-            key=blob_key,
-            data=data,
-            content_type=content_type,
-            metadata=metadata,
-            sha256=sha256,
-            size_bytes=size_bytes,
-        )
-    except BlobUploadError as exc:
-        return {
-            "success": False,
-            "error": "blob_store_upload_failed",
-            "message": str(exc),
-            "local_path": str(resolved),
-            "blob_key": blob_key,
-        }
-
-    try:
-        created = create_computer_file_copy_instance(
-            type_concept_id=type_concept_id,
-            user_concept_id=user_concept_id,
-            name=original_filename,
-            sha256=sha256,
-            size_bytes=size_bytes,
-            content_type=content_type,
-            blob_backend=stored.ref.backend,
-            blob_key=stored.ref.key,
-            blob_uri=stored.ref.uri,
-            metadata=metadata,
-        )
-    except Exception as exc:
-        return {
-            "success": False,
-            "error": "file_copy_register_failed",
-            "message": str(exc),
-            "local_path": str(resolved),
-            "blob_key": blob_key,
-        }
-
-    artifact_record = build_file_copy_artifact_record(file_copy_concept_id=created.concept_id)
-
-    return {
-        "success": True,
-        "concept_id": created.concept_id,
-        "type_concept_id": created.type_concept_id,
-        "uploaded_at": created.uploaded_at,
-        "local_path": str(resolved),
-        "storage": {
-            "backend": stored.ref.backend,
-            "key": stored.ref.key,
-            "uri": stored.ref.uri,
-            "content_type": stored.ref.content_type,
-            "size_bytes": stored.ref.size_bytes,
-            "metadata": stored.ref.metadata,
-        },
-        "artifact_record": artifact_record,
-    }
+    result = import_bytes_file_copy(
+        data=data,
+        user_concept_id=user_concept_id,
+        original_filename=original_filename,
+        content_type=content_type,
+        type_concept_id=type_concept_id,
+        source_system=source_system,
+        source_identifier=source_identifier or str(resolved),
+        source_uri=source_uri or resolved_uri,
+        metadata={"local_path": str(resolved)},
+    )
+    if isinstance(result, dict):
+        result = dict(result)
+        result["local_path"] = str(resolved)
+    return result

--- a/src/backend/services/remote_file_copy_ingestion_service.py
+++ b/src/backend/services/remote_file_copy_ingestion_service.py
@@ -1,0 +1,645 @@
+from __future__ import annotations
+
+import ipaddress
+import json
+import mimetypes
+import os
+import socket
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urljoin, urlsplit
+
+import requests
+
+from .computer_file_copy_service import import_bytes_file_copy
+
+_DEFAULT_MAX_BYTES = 25 * 1024 * 1024
+_DEFAULT_MAX_REDIRECTS = 5
+_DEFAULT_CONNECT_TIMEOUT_SECONDS = 10
+_DEFAULT_READ_TIMEOUT_SECONDS = 30
+_DEFAULT_USER_AGENT = "VonRemoteFileCopyIngestion/1.0"
+_REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
+_CAPTURED_RESPONSE_HEADERS: tuple[str, ...] = (
+    "Content-Type",
+    "Content-Length",
+    "Content-Disposition",
+    "ETag",
+    "Last-Modified",
+)
+
+
+def _coerce_configured_int(
+    raw_value: Any,
+    *,
+    default: int,
+    minimum: int,
+    maximum: int,
+) -> int:
+    try:
+        parsed = int(raw_value)
+    except Exception:
+        return default
+    if parsed < minimum:
+        return minimum
+    if parsed > maximum:
+        return maximum
+    return parsed
+
+
+def _configured_max_bytes(override: int | None = None) -> int:
+    if isinstance(override, int) and override > 0:
+        return max(1, override)
+    return _coerce_configured_int(
+        os.getenv("VON_REMOTE_FILE_COPY_MAX_BYTES"),
+        default=_DEFAULT_MAX_BYTES,
+        minimum=1024,
+        maximum=250 * 1024 * 1024,
+    )
+
+
+def _configured_max_redirects(override: int | None = None) -> int:
+    if isinstance(override, int) and override >= 0:
+        return override
+    return _coerce_configured_int(
+        os.getenv("VON_REMOTE_FILE_COPY_MAX_REDIRECTS"),
+        default=_DEFAULT_MAX_REDIRECTS,
+        minimum=0,
+        maximum=20,
+    )
+
+
+def _configured_timeouts() -> tuple[int, int]:
+    connect_timeout = _coerce_configured_int(
+        os.getenv("VON_REMOTE_FILE_COPY_CONNECT_TIMEOUT_SECONDS"),
+        default=_DEFAULT_CONNECT_TIMEOUT_SECONDS,
+        minimum=1,
+        maximum=120,
+    )
+    read_timeout = _coerce_configured_int(
+        os.getenv("VON_REMOTE_FILE_COPY_READ_TIMEOUT_SECONDS"),
+        default=_DEFAULT_READ_TIMEOUT_SECONDS,
+        minimum=1,
+        maximum=300,
+    )
+    return connect_timeout, read_timeout
+
+
+def _safe_filename(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip().strip("\"'")
+    if not cleaned:
+        return None
+    cleaned = cleaned.replace("\\", "/").split("/")[-1].strip()
+    return cleaned or None
+
+
+def _normalise_content_type(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    return cleaned.split(";", 1)[0].strip().lower() or None
+
+
+def _extract_filename_from_content_disposition(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+
+    parts = [segment.strip() for segment in value.split(";") if segment.strip()]
+    params: dict[str, str] = {}
+    for part in parts[1:]:
+        key, sep, raw_val = part.partition("=")
+        if not sep:
+            continue
+        params[key.strip().lower()] = raw_val.strip()
+
+    encoded = params.get("filename*")
+    if isinstance(encoded, str) and encoded:
+        candidate = encoded.strip().strip("\"'")
+        if "''" in candidate:
+            _charset, _lang, encoded_name = candidate.partition("''")
+            candidate = encoded_name
+        return _safe_filename(unquote(candidate))
+
+    plain = params.get("filename")
+    if isinstance(plain, str) and plain:
+        return _safe_filename(plain)
+    return None
+
+
+def _derive_filename_from_url(url: str) -> str | None:
+    parsed = urlsplit(url)
+    candidate = Path(unquote(parsed.path or "")).name
+    return _safe_filename(candidate)
+
+
+def _build_fallback_filename(content_type: str | None) -> str:
+    extension = mimetypes.guess_extension(content_type or "") if content_type else None
+    if extension == ".jpe":
+        extension = ".jpg"
+    if not isinstance(extension, str) or not extension:
+        extension = ".bin"
+    return f"downloaded_file{extension}"
+
+
+def _choose_filename(
+    *,
+    requested_filename: str | None,
+    content_disposition: str | None,
+    final_url: str,
+    content_type: str | None,
+) -> tuple[str, str]:
+    explicit_filename = _safe_filename(requested_filename)
+    if explicit_filename:
+        return explicit_filename, "request.filename"
+
+    disposition_filename = _extract_filename_from_content_disposition(content_disposition)
+    if disposition_filename:
+        return disposition_filename, "response.content_disposition"
+
+    url_filename = _derive_filename_from_url(final_url)
+    if url_filename:
+        return url_filename, "response.final_url"
+
+    return _build_fallback_filename(content_type), "generated.fallback"
+
+
+def _choose_content_type(
+    *,
+    response_content_type: str | None,
+    original_filename: str,
+) -> tuple[str | None, str]:
+    guessed_content_type, _encoding = mimetypes.guess_type(original_filename)
+    guessed_content_type = _normalise_content_type(guessed_content_type)
+    response_content_type = _normalise_content_type(response_content_type)
+
+    if response_content_type and response_content_type not in {
+        "application/octet-stream",
+        "binary/octet-stream",
+    }:
+        return response_content_type, "response.content_type"
+    if guessed_content_type:
+        return guessed_content_type, "filename.extension"
+    if response_content_type:
+        return response_content_type, "response.content_type_generic"
+    return None, "unknown"
+
+
+def _classify_ip_address(value: str) -> tuple[bool, str]:
+    ip = ipaddress.ip_address(value)
+    if ip.is_loopback:
+        return False, "loopback"
+    if ip.is_private:
+        return False, "private"
+    if ip.is_link_local:
+        return False, "link_local"
+    if ip.is_multicast:
+        return False, "multicast"
+    if ip.is_reserved:
+        return False, "reserved"
+    if ip.is_unspecified:
+        return False, "unspecified"
+    return True, "public"
+
+
+def _validate_remote_target(url: str) -> dict[str, Any]:
+    parsed = urlsplit(url)
+    scheme = (parsed.scheme or "").strip().lower()
+    if scheme not in {"http", "https"}:
+        return {
+            "success": False,
+            "error": "unsupported_url_scheme",
+            "message": "Remote artefact ingestion only supports http and https URLs.",
+            "url": url,
+            "scheme": scheme or None,
+        }
+    if parsed.username or parsed.password:
+        return {
+            "success": False,
+            "error": "url_credentials_not_allowed",
+            "message": "Remote artefact ingestion does not allow embedded URL credentials.",
+            "url": url,
+        }
+
+    hostname = parsed.hostname
+    if not isinstance(hostname, str) or not hostname.strip():
+        return {
+            "success": False,
+            "error": "missing_remote_host",
+            "message": "Remote artefact ingestion requires a URL host.",
+            "url": url,
+        }
+
+    hostname = hostname.strip().lower().rstrip(".")
+    if hostname in {"localhost", "localhost.localdomain"}:
+        return {
+            "success": False,
+            "error": "blocked_private_host",
+            "message": "Localhost targets are not allowed for remote artefact ingestion.",
+            "url": url,
+            "host": hostname,
+        }
+
+    try:
+        addrinfo = socket.getaddrinfo(
+            hostname,
+            parsed.port or (443 if scheme == "https" else 80),
+            type=socket.SOCK_STREAM,
+            proto=socket.IPPROTO_TCP,
+        )
+    except socket.gaierror as exc:
+        return {
+            "success": False,
+            "error": "host_resolution_failed",
+            "message": f"Could not resolve remote host '{hostname}': {exc}",
+            "url": url,
+            "host": hostname,
+        }
+
+    resolved_addresses: list[str] = []
+    blocked_addresses: list[dict[str, str]] = []
+    for _family, _socktype, _proto, _canonname, sockaddr in addrinfo:
+        if not isinstance(sockaddr, tuple) or not sockaddr:
+            continue
+        address = str(sockaddr[0]).strip()
+        if not address or address in resolved_addresses:
+            continue
+        resolved_addresses.append(address)
+        try:
+            allowed, reason = _classify_ip_address(address)
+        except ValueError:
+            blocked_addresses.append({"address": address, "reason": "invalid_ip"})
+            continue
+        if not allowed:
+            blocked_addresses.append({"address": address, "reason": reason})
+
+    if not resolved_addresses:
+        return {
+            "success": False,
+            "error": "host_resolution_failed",
+            "message": f"Remote host '{hostname}' did not resolve to any addresses.",
+            "url": url,
+            "host": hostname,
+        }
+
+    if blocked_addresses:
+        return {
+            "success": False,
+            "error": "blocked_private_host",
+            "message": "Remote artefact ingestion blocked a non-public destination.",
+            "url": url,
+            "host": hostname,
+            "resolved_addresses": resolved_addresses,
+            "blocked_addresses": blocked_addresses,
+        }
+
+    return {
+        "success": True,
+        "url": url,
+        "host": hostname,
+        "resolved_addresses": resolved_addresses,
+    }
+
+
+def _create_requests_session() -> requests.Session:
+    session = requests.Session()
+    session.trust_env = False
+    return session
+
+
+def download_remote_file_copy_bytes(
+    *,
+    url: str,
+    filename: str | None = None,
+    max_bytes: int | None = None,
+    max_redirects: int | None = None,
+) -> dict[str, Any]:
+    """Fetch a remote artefact with SSRF and size guardrails."""
+
+    if not isinstance(url, str) or not url.strip():
+        return {
+            "success": False,
+            "error": "missing_url",
+            "message": "Provide a remote URL to import.",
+        }
+
+    requested_url = url.strip()
+    resolved_max_bytes = _configured_max_bytes(max_bytes)
+    resolved_max_redirects = _configured_max_redirects(max_redirects)
+    connect_timeout, read_timeout = _configured_timeouts()
+    current_url = requested_url
+    redirects: list[dict[str, Any]] = []
+    hops: list[dict[str, Any]] = []
+
+    session = _create_requests_session()
+    try:
+        for _hop_index in range(resolved_max_redirects + 1):
+            validation = _validate_remote_target(current_url)
+            if not validation.get("success"):
+                failure = dict(validation)
+                failure["requested_url"] = requested_url
+                failure["redirects"] = redirects
+                failure["hops"] = hops
+                return failure
+            hops.append(
+                {
+                    "url": current_url,
+                    "host": validation.get("host"),
+                    "resolved_addresses": validation.get("resolved_addresses"),
+                }
+            )
+
+            try:
+                response = session.get(
+                    current_url,
+                    stream=True,
+                    allow_redirects=False,
+                    timeout=(connect_timeout, read_timeout),
+                    headers={
+                        "User-Agent": os.getenv(
+                            "VON_REMOTE_FILE_COPY_USER_AGENT", _DEFAULT_USER_AGENT
+                        ),
+                        "Accept": "*/*",
+                    },
+                )
+            except requests.RequestException as exc:
+                return {
+                    "success": False,
+                    "error": "remote_request_failed",
+                    "message": f"Remote artefact request failed: {exc}",
+                    "requested_url": requested_url,
+                    "final_url": current_url,
+                    "redirects": redirects,
+                    "hops": hops,
+                }
+
+            try:
+                status_code = int(response.status_code)
+            except Exception:
+                status_code = 0
+
+            try:
+                location = response.headers.get("Location")
+                if (
+                    status_code in _REDIRECT_STATUS_CODES
+                    and isinstance(location, str)
+                    and location.strip()
+                ):
+                    if len(redirects) >= resolved_max_redirects:
+                        return {
+                            "success": False,
+                            "error": "too_many_redirects",
+                            "message": "Remote artefact ingestion exceeded the redirect limit.",
+                            "requested_url": requested_url,
+                            "final_url": current_url,
+                            "redirects": redirects,
+                            "hops": hops,
+                            "status_code": status_code,
+                        }
+
+                    next_url = urljoin(current_url, location.strip())
+                    redirects.append(
+                        {
+                            "status_code": status_code,
+                            "from_url": current_url,
+                            "to_url": next_url,
+                        }
+                    )
+                    current_url = next_url
+                    continue
+
+                if status_code < 200 or status_code >= 300:
+                    return {
+                        "success": False,
+                        "error": "remote_http_error",
+                        "message": f"Remote artefact request returned HTTP {status_code}.",
+                        "requested_url": requested_url,
+                        "final_url": current_url,
+                        "status_code": status_code,
+                        "redirects": redirects,
+                        "hops": hops,
+                    }
+
+                content_length_raw = response.headers.get("Content-Length")
+                content_length: int | None = None
+                if isinstance(content_length_raw, str) and content_length_raw.strip():
+                    try:
+                        content_length = int(content_length_raw.strip())
+                    except ValueError:
+                        content_length = None
+                if isinstance(content_length, int) and content_length > resolved_max_bytes:
+                    return {
+                        "success": False,
+                        "error": "remote_file_too_large",
+                        "message": "Remote artefact exceeds the configured maximum size.",
+                        "requested_url": requested_url,
+                        "final_url": current_url,
+                        "status_code": status_code,
+                        "content_length": content_length,
+                        "max_bytes": resolved_max_bytes,
+                        "redirects": redirects,
+                        "hops": hops,
+                    }
+
+                captured_headers = {
+                    key.lower().replace("-", "_"): response.headers.get(key)
+                    for key in _CAPTURED_RESPONSE_HEADERS
+                    if response.headers.get(key) is not None
+                }
+
+                data = bytearray()
+                for chunk in response.iter_content(chunk_size=64 * 1024):
+                    if not chunk:
+                        continue
+                    data.extend(chunk)
+                    if len(data) > resolved_max_bytes:
+                        return {
+                            "success": False,
+                            "error": "remote_file_too_large",
+                            "message": "Remote artefact exceeded the configured maximum size while downloading.",
+                            "requested_url": requested_url,
+                            "final_url": current_url,
+                            "status_code": status_code,
+                            "size_bytes": len(data),
+                            "max_bytes": resolved_max_bytes,
+                            "redirects": redirects,
+                            "hops": hops,
+                        }
+
+                if not data:
+                    return {
+                        "success": False,
+                        "error": "empty_remote_file",
+                        "message": "Remote artefact response contained no bytes.",
+                        "requested_url": requested_url,
+                        "final_url": current_url,
+                        "status_code": status_code,
+                        "redirects": redirects,
+                        "hops": hops,
+                    }
+
+                response_content_type = _normalise_content_type(
+                    response.headers.get("Content-Type")
+                )
+                content_disposition = response.headers.get("Content-Disposition")
+                original_filename, filename_source = _choose_filename(
+                    requested_filename=filename,
+                    content_disposition=content_disposition,
+                    final_url=str(response.url or current_url),
+                    content_type=response_content_type,
+                )
+                effective_content_type, content_type_source = _choose_content_type(
+                    response_content_type=response_content_type,
+                    original_filename=original_filename,
+                )
+
+                return {
+                    "success": True,
+                    "requested_url": requested_url,
+                    "final_url": str(response.url or current_url),
+                    "redirects": redirects,
+                    "redirect_count": len(redirects),
+                    "hops": hops,
+                    "status_code": status_code,
+                    "size_bytes": len(data),
+                    "data": bytes(data),
+                    "original_filename": original_filename,
+                    "filename_source": filename_source,
+                    "response_content_type": response_content_type,
+                    "content_type": effective_content_type,
+                    "content_type_source": content_type_source,
+                    "response_headers": captured_headers,
+                }
+            finally:
+                response.close()
+
+        return {
+            "success": False,
+            "error": "too_many_redirects",
+            "message": "Remote artefact ingestion exceeded the redirect limit.",
+            "requested_url": requested_url,
+            "final_url": current_url,
+            "redirects": redirects,
+            "hops": hops,
+        }
+    finally:
+        session.close()
+
+
+def import_remote_url_file_copy(
+    *,
+    url: str,
+    user_concept_id: str,
+    filename: str | None = None,
+    type_concept_id: str = "#V#computer_file_copy",
+    source_system: str = "remote_url_import",
+    max_bytes: int | None = None,
+    max_redirects: int | None = None,
+) -> dict[str, Any]:
+    """Download a remote artefact, persist it durably, and register a file copy."""
+
+    download_result = download_remote_file_copy_bytes(
+        url=url,
+        filename=filename,
+        max_bytes=max_bytes,
+        max_redirects=max_redirects,
+    )
+    if not download_result.get("success"):
+        return download_result
+
+    response_headers = (
+        dict(download_result.get("response_headers") or {})
+        if isinstance(download_result.get("response_headers"), dict)
+        else {}
+    )
+    redirects = (
+        list(download_result.get("redirects") or [])
+        if isinstance(download_result.get("redirects"), list)
+        else []
+    )
+    import_result = import_bytes_file_copy(
+        data=bytes(download_result["data"]),
+        user_concept_id=user_concept_id,
+        original_filename=str(download_result["original_filename"]),
+        content_type=download_result.get("content_type"),
+        type_concept_id=type_concept_id,
+        source_system=source_system,
+        source_identifier=str(download_result["requested_url"]),
+        source_uri=str(download_result["final_url"]),
+        metadata={
+            "requested_url": str(download_result["requested_url"]),
+            "final_url": str(download_result["final_url"]),
+            "filename_source": str(download_result.get("filename_source") or ""),
+            "content_type_source": str(download_result.get("content_type_source") or ""),
+            "response_status_code": str(download_result.get("status_code") or ""),
+            "response_content_type": response_headers.get("content_type"),
+            "response_content_disposition": response_headers.get(
+                "content_disposition"
+            ),
+            "response_etag": response_headers.get("etag"),
+            "response_last_modified": response_headers.get("last_modified"),
+            "redirect_count": len(redirects),
+            "redirect_chain_json": json.dumps(redirects, ensure_ascii=False),
+        },
+    )
+    if not import_result.get("success"):
+        merged_failure = dict(import_result)
+        merged_failure.update(
+            {
+                "requested_url": download_result.get("requested_url"),
+                "final_url": download_result.get("final_url"),
+                "redirects": redirects,
+                "redirect_count": len(redirects),
+                "response": {
+                    "status_code": download_result.get("status_code"),
+                    "size_bytes": download_result.get("size_bytes"),
+                    "headers": response_headers,
+                },
+                "filename_resolution": {
+                    "original_filename": download_result.get("original_filename"),
+                    "source": download_result.get("filename_source"),
+                },
+                "content_type_resolution": {
+                    "effective_content_type": download_result.get("content_type"),
+                    "response_content_type": download_result.get(
+                        "response_content_type"
+                    ),
+                    "source": download_result.get("content_type_source"),
+                },
+            }
+        )
+        return merged_failure
+
+    result = dict(import_result)
+    result.update(
+        {
+            "requested_url": download_result.get("requested_url"),
+            "final_url": download_result.get("final_url"),
+            "redirects": redirects,
+            "redirect_count": len(redirects),
+            "response": {
+                "status_code": download_result.get("status_code"),
+                "size_bytes": download_result.get("size_bytes"),
+                "headers": response_headers,
+            },
+            "filename_resolution": {
+                "original_filename": download_result.get("original_filename"),
+                "source": download_result.get("filename_source"),
+            },
+            "content_type_resolution": {
+                "effective_content_type": download_result.get("content_type"),
+                "response_content_type": download_result.get("response_content_type"),
+                "source": download_result.get("content_type_source"),
+            },
+            "download_hops": download_result.get("hops"),
+        }
+    )
+    return result
+
+
+__all__ = [
+    "download_remote_file_copy_bytes",
+    "import_remote_url_file_copy",
+]

--- a/src/backend/services/tool_metadata_service.py
+++ b/src/backend/services/tool_metadata_service.py
@@ -408,6 +408,11 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
         "category": "vontology",
         "display_template": "Imported local file",
     },
+    "import_url_file_copy": {
+        "salience": "medium",
+        "category": "vontology",
+        "display_template": "Imported URL file",
+    },
     "generate_concept_description": {
         "salience": "medium",
         "category": "vontology",

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -60,6 +60,7 @@ _WRITE_TOOL_NAMES = {
     "delete_text_relation",
     "download_paper",
     "finalise_cached_paper",
+    "import_url_file_copy",
     "gmail_modify_labels",
     "issue_write",
     "jira_add_attachment",

--- a/src/backend/workflows/write_tool_policy.py
+++ b/src/backend/workflows/write_tool_policy.py
@@ -56,6 +56,7 @@ _ADDITIVE_LOW_RISK_WRITE_TOOLS: frozenset[str] = frozenset(
         "upsert_singleton_text_relation",
         "download_paper",
         "finalise_cached_paper",
+        "import_url_file_copy",
         "create_task",
         "assign_task",
         "workflow_create_instance",

--- a/tests/backend/test_computer_file_copy_artifact_ingestion.py
+++ b/tests/backend/test_computer_file_copy_artifact_ingestion.py
@@ -121,3 +121,68 @@ def test_import_local_file_copy_rejects_path_outside_allowed_root(tmp_path):
 
     assert result["success"] is False
     assert result["error"] == "path_outside_allowed_root"
+
+
+def test_import_bytes_file_copy_persists_typing(monkeypatch):
+    from src.backend.services import computer_file_copy_service as svc
+    from src.backend.services.blob_store import BlobRef
+    from src.backend.services.blob_uploads import StoredBytes
+
+    monkeypatch.setattr(
+        "src.backend.services.blob_uploads.put_bytes_durable",
+        lambda **kwargs: StoredBytes(
+            ref=BlobRef(
+                backend="local",
+                key=str(kwargs["key"]),
+                uri=f"local://{kwargs['key']}",
+                content_type=kwargs.get("content_type"),
+                size_bytes=len(kwargs["data"]),
+                metadata=dict(kwargs.get("metadata") or {}),
+            ),
+            sha256="typed123",
+            size_bytes=len(kwargs["data"]),
+        ),
+    )
+
+    class _Record:
+        concept_id = "#V#typed_file_copy"
+        type_concept_id = "#V#computer_file_copy"
+        uploaded_at = "2026-01-01T00:00:00+00:00"
+
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.create_computer_file_copy_instance",
+        lambda **_kwargs: _Record(),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.build_file_copy_artifact_record",
+        lambda **_kwargs: {"artifact_id": "#V#typed_file_copy", "sha256": "typed123"},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.file_copy_typing_service.infer_file_copy_typing",
+        lambda **_kwargs: {
+            "success": True,
+            "detected_type_concept_ids": ["#V#mspowerpoint_pptx_computer_file_copy"],
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.file_copy_typing_service.persist_file_copy_typing",
+        lambda **_kwargs: {"success": True, "typing_persisted": True},
+    )
+
+    result = svc.import_bytes_file_copy(
+        data=b"pptx-bytes",
+        user_concept_id="#V#user",
+        original_filename="deck.pptx",
+        content_type="application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        source_system="remote_url_import",
+        source_identifier="https://example.com/deck.pptx",
+        source_uri="https://cdn.example.com/deck.pptx",
+    )
+
+    assert result["success"] is True
+    assert result["concept_id"] == "#V#typed_file_copy"
+    assert result["storage"]["key"].endswith("/deck.pptx")
+    assert result["typing"]["typing_persisted"] is True
+    assert result["typing_result"]["detected_type_concept_ids"] == [
+        "#V#mspowerpoint_pptx_computer_file_copy"
+    ]

--- a/tests/backend/test_file_copy_ingestion_mcp_tools.py
+++ b/tests/backend/test_file_copy_ingestion_mcp_tools.py
@@ -86,6 +86,84 @@ def test_import_local_file_copy_uses_authenticated_context(monkeypatch):
     assert result["namespace"] == "#V#user@org"
 
 
+def test_import_url_file_copy_uses_authenticated_context_and_triggers_workflow(
+    monkeypatch,
+):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#user",
+    )
+    monkeypatch.setattr(
+        "src.backend.services.remote_file_copy_ingestion_service.import_remote_url_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "concept_id": "#V#imported_url_file",
+            "type_concept_id": "#V#computer_file_copy",
+            "uploaded_at": "2026-03-08T00:00:00+00:00",
+            "artifact_record": {
+                "artifact_id": "#V#imported_url_file",
+                "sha256": "deadbeef",
+                "size_bytes": 12,
+            },
+            "storage": {
+                "backend": "swift",
+                "key": "imports/user/hash/paper.pdf",
+                "uri": "swift://bucket/imports/user/hash/paper.pdf",
+                "size_bytes": 12,
+            },
+            "response": {
+                "status_code": 200,
+                "size_bytes": 12,
+                "headers": {"content_type": "application/pdf"},
+            },
+            "filename_resolution": {
+                "original_filename": "paper.pdf",
+                "source": "response.content_disposition",
+            },
+            "content_type_resolution": {
+                "effective_content_type": "application/pdf",
+                "source": "response.content_type",
+            },
+        },
+    )
+
+    workflow_calls: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        "src.backend.services.workflow_event_integration_service.maybe_launch_file_copy_uploaded_workflow",
+        lambda **kwargs: workflow_calls.append(dict(kwargs))
+        or {"success": True, "triggered": True, "event_type": "file_copy.uploaded"},
+    )
+
+    result = cat._import_url_file_copy(
+        url="https://example.com/paper.pdf",
+        namespace="#V#user@org",
+        index_in_rag=True,
+    )
+
+    assert result["success"] is True
+    assert result["concept_id"] == "#V#imported_url_file"
+    assert result["namespace"] == "#V#user@org"
+    assert result["workflow_event_launch"]["triggered"] is True
+    assert workflow_calls == [
+        {
+            "file_copy_concept_id": "#V#imported_url_file",
+            "uploaded_by_concept_id": "#V#user",
+            "organisation_concept_id": "#V#org",
+            "namespace": "#V#user@org",
+            "content_type": "application/pdf",
+            "original_filename": "paper.pdf",
+            "size_bytes": 12,
+            "sha256": "deadbeef",
+            "blob_uri": "swift://bucket/imports/user/hash/paper.pdf",
+            "uploaded_at_iso": "2026-03-08T00:00:00+00:00",
+            "index_in_rag": True,
+        }
+    ]
+
+
 def test_interpret_file_copy_persists_image_interpretation(monkeypatch):
     from src.backend.integrations.internal_mcp import catalogue as cat
 
@@ -114,6 +192,10 @@ def test_interpret_file_copy_persists_image_interpretation(monkeypatch):
             "content_text": "OCR text from screenshot",
             "content_length": 24,
         },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.relationship_write_service.add_relationship",
+        lambda **_kwargs: {"success": True, "forward_modified": True},
     )
 
     writes: list[dict[str, object]] = []
@@ -607,6 +689,10 @@ def test_interpret_file_copy_includes_pdf_diagram_analysis(monkeypatch):
             ],
             "errors": [],
         },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.relationship_write_service.add_relationship",
+        lambda **_kwargs: {"success": True, "forward_modified": True},
     )
     monkeypatch.setattr(
         "src.backend.services.arxiv_paper_link_service.materialise_scholarly_representation_for_file_copy",

--- a/tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py
+++ b/tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py
@@ -62,6 +62,10 @@ def test_file_copy_ingestion_tools_gateway_invoke(monkeypatch):
         },
     )
     monkeypatch.setattr(
+        "src.backend.services.relationship_write_service.add_relationship",
+        lambda **_kwargs: {"success": True, "forward_modified": True},
+    )
+    monkeypatch.setattr(
         "src.backend.services.text_value_service.upsert_singleton_text_relation",
         lambda **_kwargs: {"relation_id": "rel-test"},
     )
@@ -183,6 +187,61 @@ def test_interpret_file_copy_gateway_asserts_docx_subtype(monkeypatch):
             "target": "#V#msword_docx_computer_file_copy",
         }
     ]
+
+
+def test_import_url_file_copy_gateway_invoke(monkeypatch):
+    gateway = _build_gateway()
+
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#user",
+    )
+    monkeypatch.setattr(
+        "src.backend.services.remote_file_copy_ingestion_service.import_remote_url_file_copy",
+        lambda **_kwargs: {
+            "success": True,
+            "concept_id": "#V#imported_url_file_gateway",
+            "type_concept_id": "#V#computer_file_copy",
+            "uploaded_at": "2026-03-08T00:00:00+00:00",
+            "artifact_record": {
+                "artifact_id": "#V#imported_url_file_gateway",
+                "sha256": "feedface",
+                "size_bytes": 24,
+            },
+            "storage": {
+                "backend": "swift",
+                "key": "imports/user/hash/deck.pptx",
+                "uri": "swift://bucket/imports/user/hash/deck.pptx",
+                "size_bytes": 24,
+            },
+            "response": {
+                "status_code": 200,
+                "size_bytes": 24,
+                "headers": {"content_type": "application/octet-stream"},
+            },
+            "filename_resolution": {
+                "original_filename": "deck.pptx",
+                "source": "response.content_disposition",
+            },
+            "content_type_resolution": {
+                "effective_content_type": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                "source": "filename.extension",
+            },
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.workflow_event_integration_service.maybe_launch_file_copy_uploaded_workflow",
+        lambda **_kwargs: {"success": True, "triggered": True},
+    )
+
+    payload = gateway.invoke(
+        "import_url_file_copy",
+        {"url": "https://example.com/deck.pptx", "namespace": "#V#user@org"},
+    ).payload
+
+    assert payload.get("success") is True
+    assert payload.get("concept_id") == "#V#imported_url_file_gateway"
+    assert payload.get("workflow_event_launch", {}).get("triggered") is True
 
 
 def test_interpret_file_copy_gateway_fails_closed_on_unverified_person_representation(
@@ -446,6 +505,10 @@ def test_interpret_file_copy_gateway_returns_pdf_diagram_candidates(monkeypatch)
             "page_summaries": [{"page_number": 1, "diagram_candidate": True}],
             "errors": [],
         },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.relationship_write_service.add_relationship",
+        lambda **_kwargs: {"success": True, "forward_modified": True},
     )
     monkeypatch.setattr(
         "src.backend.services.arxiv_paper_link_service.materialise_scholarly_representation_for_file_copy",

--- a/tests/backend/test_remote_file_copy_ingestion_service.py
+++ b/tests/backend/test_remote_file_copy_ingestion_service.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+
+class _StubResponse:
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        headers: dict[str, str] | None = None,
+        body_chunks: list[bytes] | None = None,
+        url: str | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.headers = dict(headers or {})
+        self._body_chunks = list(body_chunks or [])
+        self.url = url or "https://example.com/file.bin"
+        self.closed = False
+
+    def iter_content(self, chunk_size: int = 0):
+        del chunk_size
+        yield from self._body_chunks
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _StubSession:
+    def __init__(self, responses: list[_StubResponse]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, object]] = []
+        self.closed = False
+
+    def get(self, url: str, **kwargs):
+        self.calls.append({"url": url, "kwargs": dict(kwargs)})
+        if not self._responses:
+            raise AssertionError("No stubbed responses remaining")
+        return self._responses.pop(0)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_download_remote_file_copy_bytes_follows_redirect_and_inferrs_mime(
+    monkeypatch,
+):
+    from src.backend.services import remote_file_copy_ingestion_service as svc
+
+    monkeypatch.setattr(
+        svc,
+        "_validate_remote_target",
+        lambda url: {
+            "success": True,
+            "url": url,
+            "host": "example.com",
+            "resolved_addresses": ["198.51.100.20"],
+        },
+    )
+
+    redirect_response = _StubResponse(
+        status_code=302,
+        headers={"Location": "https://cdn.example.com/files/deck"},
+        url="https://example.com/download",
+    )
+    final_response = _StubResponse(
+        status_code=200,
+        headers={
+            "Content-Type": "application/octet-stream",
+            "Content-Disposition": 'attachment; filename="deck.pptx"',
+            "Content-Length": "11",
+            "ETag": "abc123",
+        },
+        body_chunks=[b"hello ", b"world"],
+        url="https://cdn.example.com/files/deck",
+    )
+    session = _StubSession([redirect_response, final_response])
+    monkeypatch.setattr(svc, "_create_requests_session", lambda: session)
+
+    result = svc.download_remote_file_copy_bytes(url="https://example.com/download")
+
+    assert result["success"] is True
+    assert result["redirect_count"] == 1
+    assert result["redirects"] == [
+        {
+            "status_code": 302,
+            "from_url": "https://example.com/download",
+            "to_url": "https://cdn.example.com/files/deck",
+        }
+    ]
+    assert result["final_url"] == "https://cdn.example.com/files/deck"
+    assert result["original_filename"] == "deck.pptx"
+    assert result["filename_source"] == "response.content_disposition"
+    assert (
+        result["content_type"]
+        == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    )
+    assert result["content_type_source"] == "filename.extension"
+    assert result["response_headers"]["etag"] == "abc123"
+    assert redirect_response.closed is True
+    assert final_response.closed is True
+    assert session.closed is True
+
+
+def test_download_remote_file_copy_bytes_blocks_private_host(monkeypatch):
+    from src.backend.services import remote_file_copy_ingestion_service as svc
+
+    session = _StubSession([])
+    monkeypatch.setattr(svc, "_create_requests_session", lambda: session)
+    monkeypatch.setattr(
+        "socket.getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (0, 0, 0, "", ("10.0.0.5", 443)),
+        ],
+    )
+
+    result = svc.download_remote_file_copy_bytes(url="https://files.example.com/data.pdf")
+
+    assert result["success"] is False
+    assert result["error"] == "blocked_private_host"
+    assert result["host"] == "files.example.com"
+    assert session.calls == []
+    assert session.closed is True
+
+
+def test_download_remote_file_copy_bytes_rejects_oversized_response(monkeypatch):
+    from src.backend.services import remote_file_copy_ingestion_service as svc
+
+    monkeypatch.setattr(
+        svc,
+        "_validate_remote_target",
+        lambda url: {
+            "success": True,
+            "url": url,
+            "host": "example.com",
+            "resolved_addresses": ["198.51.100.20"],
+        },
+    )
+    large_response = _StubResponse(
+        status_code=200,
+        headers={
+            "Content-Type": "application/pdf",
+            "Content-Length": "99",
+        },
+        body_chunks=[b"unused"],
+        url="https://example.com/big.pdf",
+    )
+    session = _StubSession([large_response])
+    monkeypatch.setattr(svc, "_create_requests_session", lambda: session)
+
+    result = svc.download_remote_file_copy_bytes(
+        url="https://example.com/big.pdf",
+        max_bytes=10,
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "remote_file_too_large"
+    assert result["content_length"] == 99
+    assert result["max_bytes"] == 10
+    assert large_response.closed is True
+    assert session.closed is True
+
+
+def test_import_remote_url_file_copy_persists_download_provenance(monkeypatch):
+    from src.backend.services import remote_file_copy_ingestion_service as svc
+
+    monkeypatch.setattr(
+        svc,
+        "download_remote_file_copy_bytes",
+        lambda **_kwargs: {
+            "success": True,
+            "requested_url": "https://example.com/paper",
+            "final_url": "https://cdn.example.com/paper.pdf",
+            "redirects": [
+                {
+                    "status_code": 302,
+                    "from_url": "https://example.com/paper",
+                    "to_url": "https://cdn.example.com/paper.pdf",
+                }
+            ],
+            "hops": [{"url": "https://example.com/paper", "host": "example.com"}],
+            "status_code": 200,
+            "size_bytes": 7,
+            "data": b"pdfdata",
+            "original_filename": "paper.pdf",
+            "filename_source": "response.content_disposition",
+            "response_content_type": "application/pdf",
+            "content_type": "application/pdf",
+            "content_type_source": "response.content_type",
+            "response_headers": {
+                "content_type": "application/pdf",
+                "content_disposition": 'attachment; filename="paper.pdf"',
+            },
+        },
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_import_bytes_file_copy(**kwargs):
+        captured.update(kwargs)
+        return {
+            "success": True,
+            "concept_id": "#V#imported_remote_file",
+            "type_concept_id": "#V#computer_file_copy",
+            "uploaded_at": "2026-03-08T00:00:00+00:00",
+            "storage": {"backend": "swift", "key": "imports/user/hash/paper.pdf", "uri": "swift://bucket/imports/user/hash/paper.pdf", "size_bytes": 7},
+            "artifact_record": {"artifact_id": "#V#imported_remote_file"},
+            "typing": {"typing_persisted": True},
+            "typing_result": {"detected_type_concept_ids": ["#V#pdf_computer_file_copy"]},
+        }
+
+    monkeypatch.setattr(svc, "import_bytes_file_copy", _fake_import_bytes_file_copy)
+
+    result = svc.import_remote_url_file_copy(
+        url="https://example.com/paper",
+        user_concept_id="#V#user",
+    )
+
+    assert result["success"] is True
+    assert captured["original_filename"] == "paper.pdf"
+    assert captured["source_identifier"] == "https://example.com/paper"
+    assert captured["source_uri"] == "https://cdn.example.com/paper.pdf"
+    metadata = captured["metadata"]
+    assert isinstance(metadata, dict)
+    assert metadata["response_status_code"] == "200"
+    assert metadata["redirect_count"] == 1
+    assert result["response"]["status_code"] == 200
+    assert result["response"]["size_bytes"] == 7
+    assert result["filename_resolution"]["source"] == "response.content_disposition"
+    assert result["content_type_resolution"]["effective_content_type"] == "application/pdf"

--- a/tests/backend/test_write_tool_policy.py
+++ b/tests/backend/test_write_tool_policy.py
@@ -22,6 +22,10 @@ def test_classify_write_tool_risk_covers_policy_classes():
         classify_write_tool_risk("jira_create_issue")
         == WRITE_RISK_EXTERNAL_NON_VONTOLOGY
     )
+    assert (
+        classify_write_tool_risk("import_url_file_copy")
+        == WRITE_RISK_ADDITIVE_LOW_RISK
+    )
 
 
 def test_bare_arxiv_url_allows_additive_download_by_default():


### PR DESCRIPTION
## Summary
- add `import_url_file_copy` as a durable internal MCP path for direct HTTP/HTTPS artefact ingestion
- reuse the shared byte-ingestion/file-copy registration path and persist typing/provenance metadata
- add SSRF, redirect, and bounded-size guardrails plus targeted regression coverage

## Validation
- `pdm run pytest tests/backend/test_computer_file_copy_artifact_ingestion.py tests/backend/test_remote_file_copy_ingestion_service.py tests/backend/test_file_copy_ingestion_mcp_tools.py tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py tests/backend/test_write_tool_policy.py -q`
- `pdm run pyright src/backend/integrations/internal_mcp/catalogue.py src/backend/integrations/internal_mcp/orchestrator.py src/backend/services/computer_file_copy_service.py src/backend/services/remote_file_copy_ingestion_service.py src/backend/services/tool_metadata_service.py src/backend/services/turn_execution_record_service.py src/backend/workflows/write_tool_policy.py tests/backend/test_computer_file_copy_artifact_ingestion.py tests/backend/test_remote_file_copy_ingestion_service.py tests/backend/test_file_copy_ingestion_mcp_tools.py tests/backend/test_internal_mcp_file_copy_ingestion_gateway.py tests/backend/test_write_tool_policy.py`