### PR TITLE
JVNAUTOSCI-1406 Stamp diagnostics with runtime code version

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -65,6 +65,9 @@ from ...services.response_transformation_telemetry import (
 from ...services.turn_execution_diagnostic_event_service import (
     derive_tool_observations_from_diagnostic_events,
 )
+from ...services.runtime_code_version_service import (
+    get_runtime_code_version_info,
+)
 from ...services.turn_execution_record_service import build_turn_execution_record
 from ...workflows import (
     CHAT_BUTTONIFY_WORKFLOW_ID,
@@ -1058,6 +1061,8 @@ def _build_turn_execution_diagnostics(
     generated_at_utc: str | None = None,
     llm_calls: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
+    code_version_details = get_runtime_code_version_info()
+
     prompt_preview = (
         prompt_text[:_TURN_EXECUTION_DIAGNOSTICS_PROMPT_PREVIEW_LIMIT]
         if isinstance(prompt_text, str)
@@ -1134,6 +1139,8 @@ def _build_turn_execution_diagnostics(
     return {
         "generated_at_utc": _progress_str(generated_at_utc) or _now_utc_iso(),
         "request_id": effective_request_id,
+        "code_version": _progress_str(code_version_details.get("version")),
+        "code_version_details": code_version_details,
         "elapsed_ms": elapsed_ms_value,
         "prompt_preview": prompt_preview,
         "latest_progress": latest_progress,
@@ -2947,6 +2954,16 @@ def _finalise_llm_debug_info(
 ) -> dict[str, Any]:
     if not isinstance(llm_debug_info, dict):
         return llm_debug_info
+
+    code_version_details = get_runtime_code_version_info()
+    llm_debug_info["code_version"] = _progress_str(code_version_details.get("version"))
+    llm_debug_info["code_version_details"] = code_version_details
+    diagnostics_payload = llm_debug_info.get("turn_execution_diagnostics")
+    if isinstance(diagnostics_payload, dict):
+        diagnostics_payload["code_version"] = _progress_str(
+            code_version_details.get("version")
+        )
+        diagnostics_payload["code_version_details"] = code_version_details
 
     workflow_discovery_payload = workflow_discovery
     if workflow_discovery_payload is None:

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -62,6 +62,11 @@ from ..services.annotation_extraction_service import (
     prompt_concept_health_status,
     PROMPT_CONCEPT_ID,
 )
+from ..services.runtime_code_version_service import (
+    DEFAULT_APP_VERSION,
+    get_runtime_code_version,
+    get_runtime_code_version_info,
+)
 from ..services.google_oauth_config import (
     google_oauth_strict_startup_enabled,
     validate_google_oauth_startup_or_raise,
@@ -77,8 +82,8 @@ from ..services.settings_service import (
     get_internal_mcp_tool_batch_cap,
 )
 
-# Define a version string
-APP_VERSION = "v20250421_1015_backend"  # Updated version
+# Legacy fallback version string retained for backwards compatibility.
+APP_VERSION = DEFAULT_APP_VERSION
 
 
 # --- Durable Workflow System Globals ---
@@ -609,12 +614,15 @@ def create_flask_app(
 
     # --- Log App Version ---
     # Use app.logger if available, otherwise print
+    runtime_code_version = get_runtime_code_version()
     try:
         app.logger.setLevel(logging.INFO)  # Ensure INFO level is logged
-        app.logger.info(f"--- Flask App Initializing - Version: {APP_VERSION} ---")
+        app.logger.info(
+            f"--- Flask App Initializing - Version: {runtime_code_version} ---"
+        )
     except Exception:
         print(
-            f"--- Flask App Initializing - Version: {APP_VERSION} ---"
+            f"--- Flask App Initializing - Version: {runtime_code_version} ---"
         )  # Fallback print
 
     # Internal MCP gateway bootstrap (disabled by default until flag flipped)
@@ -970,10 +978,12 @@ def create_flask_app(
         # do not cancel server work. If a DB call hangs, it can occupy Waitress
         # threads and block *all* endpoints (including /health) for minutes.
         rag_pending_count = None
+        version_info = get_runtime_code_version_info()
 
         return jsonify(
             status="healthy",
-            version=APP_VERSION,
+            version=version_info.get("version"),
+            version_details=version_info,
             pid=os.getpid(),
             start_time=app.config["SERVER_START_TIME"],
             local_ip=local_ip,
@@ -2414,9 +2424,12 @@ def create_flask_app(
         except Exception as exc:  # pragma: no cover - defensive
             search_proxy_stats = {"error": str(exc)}
 
+        version_info = get_runtime_code_version_info()
+
         diag = {
             "status": "ok",
-            "version": APP_VERSION,
+            "version": version_info.get("version"),
+            "version_details": version_info,
             "pid": os.getpid(),
             "rss_mb": rss_mb,
             "thread_count": thread_count,
@@ -2554,7 +2567,7 @@ def create_flask_app(
     @app.route("/api/version")
     def get_version():
         """API endpoint to get the version of the app."""
-        return jsonify(version=APP_VERSION)
+        return jsonify(get_runtime_code_version_info())
 
     # --- Graceful Shutdown Endpoint (admin) ---
     @app.route("/admin/shutdown", methods=["POST"])

--- a/src/backend/services/runtime_code_version_service.py
+++ b/src/backend/services/runtime_code_version_service.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+RUNTIME_CODE_VERSION_SCHEMA_VERSION = "runtime_code_version.v1"
+DEFAULT_APP_VERSION = "v20250421_1015_backend"
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_GIT_TIMEOUT_SECONDS = 2.0
+
+
+def _clean_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _parse_optional_bool(value: object) -> bool | None:
+    cleaned = _clean_text(value)
+    if cleaned is None:
+        return None
+    lowered = cleaned.lower()
+    if lowered in {"1", "true", "yes", "y", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "n", "off"}:
+        return False
+    return None
+
+
+def _run_git_command(*args: str) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=_REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except Exception:
+        return None
+
+    cleaned = completed.stdout.strip()
+    return cleaned or None
+
+
+@lru_cache(maxsize=1)
+def get_runtime_code_version_info() -> dict[str, Any]:
+    env_version = _clean_text(
+        os.getenv("VON_BUILD_VERSION") or os.getenv("VON_CODE_VERSION")
+    )
+    env_commit = _clean_text(
+        os.getenv("VON_BUILD_COMMIT") or os.getenv("VON_GIT_COMMIT")
+    )
+    env_branch = _clean_text(
+        os.getenv("VON_BUILD_BRANCH") or os.getenv("VON_GIT_BRANCH")
+    )
+    env_dirty = _parse_optional_bool(
+        os.getenv("VON_BUILD_DIRTY") or os.getenv("VON_GIT_DIRTY")
+    )
+
+    if env_version is not None:
+        git_short_commit = env_commit[:12] if env_commit else None
+        return {
+            "schema_version": RUNTIME_CODE_VERSION_SCHEMA_VERSION,
+            "version": env_version,
+            "source": "env",
+            "legacy_app_version": DEFAULT_APP_VERSION,
+            "git_commit": env_commit,
+            "git_short_commit": git_short_commit,
+            "git_branch": env_branch,
+            "git_dirty": env_dirty,
+        }
+
+    git_commit = _run_git_command("rev-parse", "HEAD")
+    git_short_commit = _run_git_command("rev-parse", "--short=12", "HEAD")
+    git_branch = _run_git_command("rev-parse", "--abbrev-ref", "HEAD")
+    git_status = _run_git_command("status", "--porcelain", "--untracked-files=no")
+    git_dirty = bool(git_status.strip()) if isinstance(git_status, str) else None
+
+    if git_short_commit is not None:
+        version = f"{DEFAULT_APP_VERSION}+g{git_short_commit}"
+        if git_dirty is True:
+            version = f"{version}.dirty"
+        return {
+            "schema_version": RUNTIME_CODE_VERSION_SCHEMA_VERSION,
+            "version": version,
+            "source": "git",
+            "legacy_app_version": DEFAULT_APP_VERSION,
+            "git_commit": git_commit,
+            "git_short_commit": git_short_commit,
+            "git_branch": git_branch,
+            "git_dirty": git_dirty,
+        }
+
+    return {
+        "schema_version": RUNTIME_CODE_VERSION_SCHEMA_VERSION,
+        "version": DEFAULT_APP_VERSION,
+        "source": "static",
+        "legacy_app_version": DEFAULT_APP_VERSION,
+        "git_commit": None,
+        "git_short_commit": None,
+        "git_branch": None,
+        "git_dirty": None,
+    }
+
+
+def get_runtime_code_version() -> str:
+    return str(get_runtime_code_version_info().get("version") or DEFAULT_APP_VERSION)
+
+
+def clear_runtime_code_version_cache() -> None:
+    get_runtime_code_version_info.cache_clear()

--- a/tests/backend/test_runtime_code_version_endpoint.py
+++ b/tests/backend/test_runtime_code_version_endpoint.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+_VERSION_INFO = {
+    "schema_version": "runtime_code_version.v1",
+    "version": "test-version+gfeedbeef",
+    "source": "test",
+    "legacy_app_version": "legacy-test-version",
+    "git_commit": "feedbeeffeedbeeffeedbeeffeedbeeffeedbeef",
+    "git_short_commit": "feedbeef",
+    "git_branch": "test-branch",
+    "git_dirty": False,
+}
+
+
+def _install_google_oauth_stubs() -> None:
+    fake_flow_module = types.ModuleType("google_auth_oauthlib.flow")
+
+    class _DummyFlow:
+        def __init__(self, *args, **kwargs):
+            self.credentials = types.SimpleNamespace(id_token="dummy-token")
+            self.redirect_uri = kwargs.get("redirect_uri")
+            self.client_config = {"web": {"redirect_uris": [self.redirect_uri]}}
+
+        @classmethod
+        def from_client_config(cls, *args, **kwargs):
+            return cls(**kwargs)
+
+        def authorization_url(self, *args, **kwargs):
+            return "https://auth.example", "state-token"
+
+        def fetch_token(self, *args, **kwargs):
+            return None
+
+    fake_flow_module.Flow = _DummyFlow  # type: ignore[attr-defined]
+    sys.modules["google_auth_oauthlib"] = types.ModuleType("google_auth_oauthlib")
+    sys.modules["google_auth_oauthlib"].flow = fake_flow_module  # type: ignore[attr-defined]
+    sys.modules["google_auth_oauthlib.flow"] = fake_flow_module
+
+    fake_id_token_module = types.ModuleType("google.oauth2.id_token")
+    fake_id_token_module.verify_oauth2_token = lambda *args, **kwargs: {  # type: ignore[attr-defined]
+        "sub": "dummy-user"
+    }
+
+    fake_credentials_module = types.ModuleType("google.oauth2.credentials")
+
+    class _DummyCredentials:
+        def __init__(self, id_token: str = "dummy-token"):
+            self.id_token = id_token
+
+    fake_credentials_module.Credentials = _DummyCredentials  # type: ignore[attr-defined]
+
+    fake_service_account_module = types.ModuleType("google.oauth2.service_account")
+
+    class _DummyServiceAccountCredentials:
+        def __init__(self, *args, **kwargs):
+            self.project_id = kwargs.get("project_id")
+
+    fake_service_account_module.Credentials = _DummyServiceAccountCredentials  # type: ignore[attr-defined]
+
+    fake_oauth2_package = types.ModuleType("google.oauth2")
+    fake_oauth2_package.id_token = fake_id_token_module  # type: ignore[attr-defined]
+    fake_oauth2_package.credentials = fake_credentials_module  # type: ignore[attr-defined]
+    fake_oauth2_package.service_account = fake_service_account_module  # type: ignore[attr-defined]
+
+    sys.modules["google.oauth2"] = fake_oauth2_package
+    sys.modules["google.oauth2.id_token"] = fake_id_token_module
+    sys.modules["google.oauth2.credentials"] = fake_credentials_module
+    sys.modules["google.oauth2.service_account"] = fake_service_account_module
+
+
+@pytest.fixture
+def app_client(monkeypatch):
+    _install_google_oauth_stubs()
+
+    import src.backend.server.utils_flask as utils_flask
+
+    monkeypatch.setattr(utils_flask, "ensure_monitor_started", lambda: None)
+    monkeypatch.setattr(
+        utils_flask,
+        "prompt_concept_health_status",
+        lambda: {"available": True, "source_field": "stub"},
+    )
+    monkeypatch.setattr(
+        utils_flask,
+        "get_runtime_code_version_info",
+        lambda: dict(_VERSION_INFO),
+    )
+    monkeypatch.setattr(
+        utils_flask,
+        "get_runtime_code_version",
+        lambda: str(_VERSION_INFO["version"]),
+    )
+
+    app = utils_flask.create_flask_app(
+        list_models_func=lambda: ["dummy-model"],
+        generate_func=lambda prompt, context, model: "ok",
+    )
+    app.config["TESTING"] = True
+
+    with app.test_client() as client:
+        yield app, client
+
+
+def test_api_version_returns_structured_runtime_code_version(app_client):
+    _, client = app_client
+
+    resp = client.get("/api/version")
+
+    assert resp.status_code == 200
+    assert resp.get_json() == _VERSION_INFO

--- a/tests/backend/test_von_generate_llm_debug_stored_context.py
+++ b/tests/backend/test_von_generate_llm_debug_stored_context.py
@@ -1,6 +1,17 @@
 import pytest
 from flask import Flask
 
+_VERSION_INFO = {
+    "schema_version": "runtime_code_version.v1",
+    "version": "test-version+gabcd1234",
+    "source": "test",
+    "legacy_app_version": "legacy-test-version",
+    "git_commit": "abcd1234abcd1234abcd1234abcd1234abcd1234",
+    "git_short_commit": "abcd1234",
+    "git_branch": "test-branch",
+    "git_dirty": False,
+}
+
 
 class _StubLLM:
     def __init__(self):
@@ -24,6 +35,10 @@ def app(monkeypatch):
     monkeypatch.setattr(
         "src.backend.server.routes.von_routes.get_active_model_name",
         lambda: "test-model",
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_runtime_code_version_info",
+        lambda: dict(_VERSION_INFO),
     )
 
     monkeypatch.setattr(
@@ -87,6 +102,10 @@ def test_generate_debug_stored_context_uses_persisted_history_for_authenticated_
     assert isinstance(diagnostics, dict)
     assert diagnostics.get("request_id") == body.get("request_id")
     assert diagnostics.get("prompt_preview") == "Hello"
+    assert llm_debug.get("code_version") == _VERSION_INFO["version"]
+    assert llm_debug.get("code_version_details") == _VERSION_INFO
+    assert diagnostics.get("code_version") == _VERSION_INFO["version"]
+    assert diagnostics.get("code_version_details") == _VERSION_INFO
     assert isinstance(diagnostics.get("progress_events"), list)
     assert isinstance(diagnostics.get("phase_history"), list)
     assert isinstance(diagnostics.get("tool_history"), list)


### PR DESCRIPTION
## Summary
- add a central runtime code version service that resolves version metadata from env overrides or git state
- stamp llm_debug and turn_execution_diagnostics payloads with code_version and code_version_details
- expose the same structured version metadata from `/api/version`, `/health`, and `/diag`
- add regression coverage for the structured version endpoint and stored-context llm_debug diagnostics

## Validation
- `pdm run pyright src/backend/services/runtime_code_version_service.py src/backend/server/routes/von_routes.py src/backend/server/utils_flask.py tests/backend/test_von_generate_llm_debug_stored_context.py tests/backend/test_runtime_code_version_endpoint.py`
- `pdm run pytest tests/backend/test_runtime_code_version_endpoint.py tests/backend/test_von_generate_llm_debug_stored_context.py tests/backend/test_tool_progress_liveness.py tests/backend/test_von_generate_bare_arxiv_url_integration.py -q`

## Baseline note
- `tests/backend/test_utils_flask_orchestrator_startup.py::test_create_flask_app_defers_orchestrator_initialisation`
- `tests/backend/test_von_generate_auxiliary_prompt.py`

Those three tests also fail on `origin/main`, so they were treated as pre-existing baseline issues rather than regressions from this change.