### PR TITLE
JVNAUTOSCI-1405 Fix post-download completion telemetry

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -9126,7 +9126,7 @@ class InternalMCPChatOrchestrator:
                 _coerce_float_env("VON_LLM_HEARTBEAT_INTERVAL_SEC", 5.0),
             ),
         )
-        if stage_name == "screen_backfill":
+        if stage_name in {"screen_backfill", "summariser", "summarizer"}:
             timeout_sec = max(
                 0.0,
                 _coerce_float_env("VON_SCREEN_BACKFILL_LLM_TIMEOUT_SEC", 180.0),

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -64,6 +64,7 @@ from ...services.response_transformation_telemetry import (
 )
 from ...services.turn_execution_diagnostic_event_service import (
     derive_tool_observations_from_diagnostic_events,
+    update_tool_observation_summary,
 )
 from ...services.runtime_code_version_service import (
     get_runtime_code_version_info,
@@ -747,6 +748,61 @@ def _derive_tool_history_from_diagnostic_events(
     )
 
 
+def _extract_tool_observation_summary_from_progress(
+    progress_state: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not isinstance(progress_state, Mapping):
+        return None
+
+    has_tool_history = isinstance(progress_state.get("tool_history"), list)
+    has_tool_counts = any(
+        key in progress_state
+        for key in (
+            "tool_call_count",
+            "tool_success_count",
+            "tool_failure_count",
+            "tool_pending_count",
+            "tool_call_start_count",
+            "tool_call_end_count",
+        )
+    )
+    if not has_tool_history and not has_tool_counts:
+        return None
+
+    return update_tool_observation_summary(
+        progress_state,
+        None,
+        limit=_TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT,
+    )
+
+
+def _extract_workflow_stage_path_from_progress(
+    progress_state: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not isinstance(progress_state, Mapping):
+        return None
+
+    raw_stage_path = progress_state.get("workflow_stage_path")
+    if not isinstance(raw_stage_path, Mapping):
+        return None
+
+    raw_path = raw_stage_path.get("path")
+    if not isinstance(raw_path, list):
+        return None
+
+    path = [
+        dict(entry)
+        for entry in raw_path
+        if isinstance(entry, Mapping)
+    ]
+    if not path:
+        return None
+
+    stage_path = dict(raw_stage_path)
+    stage_path["path"] = path
+    return stage_path
+
+
 def _latest_event_timestamp_ms(events: list[dict[str, Any]]) -> int | None:
     for entry in reversed(events):
         timestamp = _iso_utc_to_epoch_ms(entry.get("at_utc"))
@@ -1004,6 +1060,16 @@ def _build_turn_execution_stage_diagnostics(
                 if isinstance(latest_stage_event, Mapping)
                 else None
             ),
+            "latest_result_summary": (
+                _progress_str(latest_stage_event.get("result_summary"))
+                if isinstance(latest_stage_event, Mapping)
+                else None
+            ),
+            "latest_error": (
+                _progress_str(latest_stage_event.get("error"))
+                if isinstance(latest_stage_event, Mapping)
+                else None
+            ),
         }
 
         if stage_id == "workflow_discovery" and isinstance(workflow_discovery, Mapping):
@@ -1103,10 +1169,12 @@ def _build_turn_execution_diagnostics(
         if isinstance(latest_progress, dict)
         else None
     )
-    workflow_stage_path = build_conversation_turn_stage_path(
-        runtime_stages=runtime_stages,
-        workflow_id=selected_workflow_id,
-    )
+    workflow_stage_path = _extract_workflow_stage_path_from_progress(latest_progress)
+    if workflow_stage_path is None:
+        workflow_stage_path = build_conversation_turn_stage_path(
+            runtime_stages=runtime_stages,
+            workflow_id=selected_workflow_id,
+        )
     llm_call_entries = [
         cast(dict[str, Any], entry)
         for entry in (llm_calls or [])
@@ -1116,6 +1184,11 @@ def _build_turn_execution_diagnostics(
         diagnostic_events,
         limit=_TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT,
     )
+    progress_tool_observation_summary = _extract_tool_observation_summary_from_progress(
+        latest_progress
+    )
+    if progress_tool_observation_summary is not None:
+        tool_observation_summary = progress_tool_observation_summary
     tool_history = [
         cast(dict[str, Any], entry)
         for entry in (tool_observation_summary.get("tool_history") or [])
@@ -2165,6 +2238,9 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
             "liveness_reason": liveness.get("liveness_reason"),
             "stall_detected": liveness.get("stall_detected"),
         }
+        call_id = _progress_str(safe_update.get("call_id"))
+        if call_id:
+            event_entry["call_id"] = call_id
         duration_ms = _progress_number(safe_update.get("duration_ms"))
         if duration_ms is not None:
             event_entry["duration_ms"] = int(max(0.0, duration_ms))
@@ -2225,6 +2301,13 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
             event_entry,
         ]
         merged["diagnostic_events"] = trimmed_events
+        merged.update(
+            update_tool_observation_summary(
+                merged,
+                event_entry,
+                limit=_TOOL_PROGRESS_DIAGNOSTIC_EVENT_LIMIT,
+            )
+        )
         merged["diagnostic_summary"] = {
             "request_id": request_id,
             "event_count": len(trimmed_events),

--- a/src/backend/services/turn_execution_diagnostic_event_service.py
+++ b/src/backend/services/turn_execution_diagnostic_event_service.py
@@ -35,93 +35,60 @@ def _normalise_batch_size(value: Any) -> int | float | None:
     return float(raw_value)
 
 
-def derive_tool_observations_from_diagnostic_events(
-    events: Sequence[Mapping[str, Any]] | None,
+def _empty_tool_observation_summary() -> dict[str, Any]:
+    return {
+        "tool_history": [],
+        "tool_call_count": 0,
+        "tool_success_count": 0,
+        "tool_failure_count": 0,
+        "tool_pending_count": 0,
+        "tool_call_start_count": 0,
+        "tool_call_end_count": 0,
+    }
+
+
+def _normalise_tool_history_entry(entry: Mapping[str, Any]) -> dict[str, Any] | None:
+    tool_name = _safe_str(entry.get("tool"))
+    if not tool_name:
+        return None
+
+    workflow_task = _safe_str(entry.get("workflowTask")) or _safe_str(
+        entry.get("workflow_task")
+    )
+    phase = _safe_str(entry.get("phase"))
+    result_summary = _safe_str(entry.get("resultSummary")) or _safe_str(
+        entry.get("result_summary")
+    )
+    call_id = _safe_str(entry.get("callId")) or _safe_str(entry.get("call_id"))
+    success = entry.get("success")
+
+    return {
+        "tool": tool_name,
+        "workflowTask": workflow_task or "",
+        "batchSize": _normalise_batch_size(
+            entry.get("batchSize") if "batchSize" in entry else entry.get("batch_size")
+        ),
+        "phase": phase or "",
+        "resultSummary": result_summary or "",
+        "success": success if isinstance(success, bool) else None,
+        "callId": call_id,
+    }
+
+
+def _finalise_tool_observation_summary(
     *,
+    tool_history: list[dict[str, Any]],
+    tool_call_start_count: int,
+    tool_call_end_count: int,
     limit: int | None = None,
 ) -> dict[str, Any]:
-    """Derive tool history and counts from concrete tool lifecycle events only."""
-
-    tool_history: list[dict[str, Any]] = []
-    history_indexes_by_key: dict[str, list[int]] = {}
-    tool_call_start_count = 0
-    tool_call_end_count = 0
-
-    for raw_entry in events or ():
-        if not isinstance(raw_entry, Mapping):
-            continue
-
-        tool_name = _safe_str(raw_entry.get("tool"))
-        if not tool_name:
-            continue
-
-        status = (_safe_str(raw_entry.get("status")) or "").lower()
-        event_kind = (_safe_str(raw_entry.get("event_kind")) or "").lower()
-        is_tool_start = status in _TOOL_START_STATUSES or event_kind in _TOOL_START_EVENT_KINDS
-        is_tool_terminal = (
-            status in _TOOL_SUCCESS_STATUSES
-            or status in _TOOL_FAILURE_STATUSES
-            or event_kind in _TOOL_END_EVENT_KINDS
-        )
-        if not is_tool_start and not is_tool_terminal:
-            continue
-
-        if is_tool_start:
-            tool_call_start_count += 1
-        if is_tool_terminal:
-            tool_call_end_count += 1
-
-        batch_size = _normalise_batch_size(raw_entry.get("batch_size"))
-        call_id = _safe_str(raw_entry.get("call_id"))
-        phase = _safe_str(raw_entry.get("phase")) or _safe_str(raw_entry.get("stage")) or ""
-        result_summary = _safe_str(raw_entry.get("result_summary")) or ""
-        workflow_task = _safe_str(raw_entry.get("workflow_task")) or ""
-        key = call_id or f"{tool_name.lower()}::{batch_size!r}"
-
-        history_index: int | None = None
-        for candidate_index in reversed(history_indexes_by_key.get(key, [])):
-            candidate_entry = tool_history[candidate_index]
-            if candidate_entry.get("success") is None:
-                history_index = candidate_index
-                break
-
-        if history_index is None:
-            tool_history.append(
-                {
-                    "tool": tool_name,
-                    "workflowTask": workflow_task,
-                    "batchSize": batch_size,
-                    "phase": phase,
-                    "resultSummary": result_summary,
-                    "success": None,
-                    "callId": call_id,
-                }
-            )
-            history_index = len(tool_history) - 1
-            history_indexes_by_key.setdefault(key, []).append(history_index)
-
-        history_entry = tool_history[history_index]
-        if workflow_task and not history_entry.get("workflowTask"):
-            history_entry["workflowTask"] = workflow_task
-        if phase and not history_entry.get("phase"):
-            history_entry["phase"] = phase
-        if result_summary:
-            history_entry["resultSummary"] = result_summary
-        if call_id and not history_entry.get("callId"):
-            history_entry["callId"] = call_id
-
-        if status in _TOOL_SUCCESS_STATUSES:
-            history_entry["success"] = True
-        elif status in _TOOL_FAILURE_STATUSES:
-            history_entry["success"] = False
-        elif event_kind in _TOOL_END_EVENT_KINDS and isinstance(raw_entry.get("success"), bool):
-            history_entry["success"] = bool(raw_entry.get("success"))
-
     if isinstance(limit, int) and limit > 0:
         tool_history = tool_history[-limit:]
 
     tool_success_count = sum(1 for entry in tool_history if entry.get("success") is True)
-    tool_failure_count = sum(1 for entry in tool_history if entry.get("success") is False)
+    tool_failure_count = sum(
+        1 for entry in tool_history if entry.get("success") is False
+    )
     tool_call_count = len(tool_history)
     tool_pending_count = max(0, tool_call_count - tool_success_count - tool_failure_count)
 
@@ -131,6 +98,168 @@ def derive_tool_observations_from_diagnostic_events(
         "tool_success_count": tool_success_count,
         "tool_failure_count": tool_failure_count,
         "tool_pending_count": tool_pending_count,
-        "tool_call_start_count": tool_call_start_count,
-        "tool_call_end_count": tool_call_end_count,
+        "tool_call_start_count": max(0, int(tool_call_start_count)),
+        "tool_call_end_count": max(0, int(tool_call_end_count)),
     }
+
+
+def _initialise_tool_observation_summary(
+    summary: Mapping[str, Any] | None,
+    *,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    if not isinstance(summary, Mapping):
+        return _empty_tool_observation_summary()
+
+    raw_history = summary.get("tool_history")
+    tool_history: list[dict[str, Any]] = []
+    if isinstance(raw_history, list):
+        for entry in raw_history:
+            if not isinstance(entry, Mapping):
+                continue
+            normalised_entry = _normalise_tool_history_entry(entry)
+            if normalised_entry is not None:
+                tool_history.append(normalised_entry)
+
+    tool_call_start_count = int(_safe_number(summary.get("tool_call_start_count")) or 0)
+    tool_call_end_count = int(_safe_number(summary.get("tool_call_end_count")) or 0)
+
+    return _finalise_tool_observation_summary(
+        tool_history=tool_history,
+        tool_call_start_count=tool_call_start_count,
+        tool_call_end_count=tool_call_end_count,
+        limit=limit,
+    )
+
+
+def update_tool_observation_summary(
+    summary: Mapping[str, Any] | None,
+    event: Mapping[str, Any] | None,
+    *,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Incrementally apply a tool lifecycle event to a canonical summary."""
+
+    current = _initialise_tool_observation_summary(summary, limit=limit)
+    tool_history = [
+        dict(entry)
+        for entry in current.get("tool_history", [])
+        if isinstance(entry, Mapping)
+    ]
+    history_indexes_by_key: dict[str, list[int]] = {}
+    for index, entry in enumerate(tool_history):
+        tool_name = _safe_str(entry.get("tool"))
+        if not tool_name:
+            continue
+        batch_size = _normalise_batch_size(entry.get("batchSize"))
+        call_id = _safe_str(entry.get("callId"))
+        key = call_id or f"{tool_name.lower()}::{batch_size!r}"
+        history_indexes_by_key.setdefault(key, []).append(index)
+
+    tool_call_start_count = int(current.get("tool_call_start_count") or 0)
+    tool_call_end_count = int(current.get("tool_call_end_count") or 0)
+
+    if not isinstance(event, Mapping):
+        return _finalise_tool_observation_summary(
+            tool_history=tool_history,
+            tool_call_start_count=tool_call_start_count,
+            tool_call_end_count=tool_call_end_count,
+            limit=limit,
+        )
+
+    tool_name = _safe_str(event.get("tool"))
+    if not tool_name:
+        return _finalise_tool_observation_summary(
+            tool_history=tool_history,
+            tool_call_start_count=tool_call_start_count,
+            tool_call_end_count=tool_call_end_count,
+            limit=limit,
+        )
+
+    status = (_safe_str(event.get("status")) or "").lower()
+    event_kind = (_safe_str(event.get("event_kind")) or "").lower()
+    is_tool_start = status in _TOOL_START_STATUSES or event_kind in _TOOL_START_EVENT_KINDS
+    is_tool_terminal = (
+        status in _TOOL_SUCCESS_STATUSES
+        or status in _TOOL_FAILURE_STATUSES
+        or event_kind in _TOOL_END_EVENT_KINDS
+    )
+    if not is_tool_start and not is_tool_terminal:
+        return _finalise_tool_observation_summary(
+            tool_history=tool_history,
+            tool_call_start_count=tool_call_start_count,
+            tool_call_end_count=tool_call_end_count,
+            limit=limit,
+        )
+
+    if is_tool_start:
+        tool_call_start_count += 1
+    if is_tool_terminal:
+        tool_call_end_count += 1
+
+    batch_size = _normalise_batch_size(event.get("batch_size"))
+    call_id = _safe_str(event.get("call_id"))
+    phase = _safe_str(event.get("phase")) or _safe_str(event.get("stage")) or ""
+    result_summary = _safe_str(event.get("result_summary")) or ""
+    workflow_task = _safe_str(event.get("workflow_task")) or ""
+    key = call_id or f"{tool_name.lower()}::{batch_size!r}"
+
+    history_index: int | None = None
+    for candidate_index in reversed(history_indexes_by_key.get(key, [])):
+        candidate_entry = tool_history[candidate_index]
+        if candidate_entry.get("success") is None:
+            history_index = candidate_index
+            break
+
+    if history_index is None:
+        tool_history.append(
+            {
+                "tool": tool_name,
+                "workflowTask": workflow_task,
+                "batchSize": batch_size,
+                "phase": phase,
+                "resultSummary": result_summary,
+                "success": None,
+                "callId": call_id,
+            }
+        )
+        history_index = len(tool_history) - 1
+        history_indexes_by_key.setdefault(key, []).append(history_index)
+
+    history_entry = tool_history[history_index]
+    if workflow_task and not history_entry.get("workflowTask"):
+        history_entry["workflowTask"] = workflow_task
+    if phase and not history_entry.get("phase"):
+        history_entry["phase"] = phase
+    if result_summary:
+        history_entry["resultSummary"] = result_summary
+    if call_id and not history_entry.get("callId"):
+        history_entry["callId"] = call_id
+
+    if status in _TOOL_SUCCESS_STATUSES:
+        history_entry["success"] = True
+    elif status in _TOOL_FAILURE_STATUSES:
+        history_entry["success"] = False
+    elif event_kind in _TOOL_END_EVENT_KINDS and isinstance(event.get("success"), bool):
+        history_entry["success"] = bool(event.get("success"))
+
+    return _finalise_tool_observation_summary(
+        tool_history=tool_history,
+        tool_call_start_count=tool_call_start_count,
+        tool_call_end_count=tool_call_end_count,
+        limit=limit,
+    )
+
+
+def derive_tool_observations_from_diagnostic_events(
+    events: Sequence[Mapping[str, Any]] | None,
+    *,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Derive tool history and counts from concrete tool lifecycle events only."""
+    summary = _empty_tool_observation_summary()
+    for raw_entry in events or ():
+        if not isinstance(raw_entry, Mapping):
+            continue
+        summary = update_tool_observation_summary(summary, raw_entry, limit=limit)
+    return summary

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -963,6 +963,42 @@ function toggleThinkingCardExpanded(request = getThinkingCardDisplayRequest()) {
     applyThinkingCardDisplayStateUpdate(request, { type: 'manual_toggle' });
 }
 
+function cloneThinkingToolHistory(history) {
+    if (!Array.isArray(history)) {
+        return [];
+    }
+    return history
+        .filter((entry) => entry && typeof entry === 'object')
+        .map((entry) => ({ ...entry }));
+}
+
+function getCanonicalThinkingToolHistory(request) {
+    if (!request || typeof request !== 'object') {
+        return [];
+    }
+
+    const latestProgress = (request.latestProgress && typeof request.latestProgress === 'object')
+        ? request.latestProgress
+        : null;
+    if (latestProgress && Array.isArray(latestProgress.tool_history)) {
+        return cloneThinkingToolHistory(latestProgress.tool_history);
+    }
+
+    return cloneThinkingToolHistory(request.toolUseProgressHistory);
+}
+
+function syncThinkingToolHistoryFromProgress(request, progress) {
+    if (!request || typeof request !== 'object' || !progress || typeof progress !== 'object') {
+        return false;
+    }
+    if (!Array.isArray(progress.tool_history)) {
+        return false;
+    }
+
+    request.toolUseProgressHistory = cloneThinkingToolHistory(progress.tool_history);
+    return true;
+}
+
 function createThinkingCardHistorySnapshot(request) {
     if (!request || typeof request !== 'object') {
         return null;
@@ -974,9 +1010,7 @@ function createThinkingCardHistorySnapshot(request) {
     const activityHistory = Array.isArray(request.activityHistory)
         ? request.activityHistory.map((entry) => ({ ...entry }))
         : [];
-    const toolHistory = Array.isArray(request.toolUseProgressHistory)
-        ? request.toolUseProgressHistory.map((entry) => ({ ...entry }))
-        : [];
+    const toolHistory = getCanonicalThinkingToolHistory(request);
     const workflowDiscovery = (request.workflowDiscovery && typeof request.workflowDiscovery === 'object')
         ? {
             ...request.workflowDiscovery,
@@ -1395,6 +1429,10 @@ export function __testOnly_buildThinkingProgressPresentation(progress, request =
     return buildThinkingProgressPresentation(progress, request);
 }
 
+export function __testOnly_buildThinkingDiagnosticsPayload(request = null) {
+    return buildThinkingDiagnosticsPayload(request);
+}
+
 export function __testOnly_formatThinkingEtaText(progress) {
     return formatThinkingEtaText(progress);
 }
@@ -1544,6 +1582,11 @@ function recordToolUseHistory(request, progress) {
                 timestamp: Date.now(),
             });
         }
+    }
+
+    const syncedCanonicalHistory = syncThinkingToolHistoryFromProgress(request, progress);
+    if (syncedCanonicalHistory) {
+        return;
     }
 
     // Original tool/task tracking.
@@ -1949,7 +1992,7 @@ function renderToolHistoryHTML(request) {
         return '';
     }
 
-    const toolHistory = Array.isArray(request.toolUseProgressHistory) ? request.toolUseProgressHistory : [];
+    const toolHistory = getCanonicalThinkingToolHistory(request);
 
     if (toolHistory.length === 0) {
         return '';
@@ -2379,11 +2422,7 @@ function buildThinkingWorkflowStageDiagnosticData(stageId, stageLabel, request) 
     const latestProgress = (request?.latestProgress && typeof request.latestProgress === 'object')
         ? request.latestProgress
         : null;
-    const toolHistory = Array.isArray(request?.toolUseProgressHistory)
-        ? request.toolUseProgressHistory
-            .filter((entry) => entry && typeof entry === 'object')
-            .map((entry) => ({ ...entry }))
-        : [];
+    const toolHistory = getCanonicalThinkingToolHistory(request);
 
     const data = {
         stage_id: cleanStageId,
@@ -2746,11 +2785,9 @@ function buildWorkflowStageDetailPresentation(stageId, request) {
     }
 
     if (cleanStageId === 'tool_execute') {
-        const toolNames = Array.isArray(request?.toolUseProgressHistory)
-            ? request.toolUseProgressHistory
-                .map((entry) => normaliseThinkingActivityString(entry?.tool || entry?.workflowTask))
-                .filter(Boolean)
-            : [];
+        const toolNames = getCanonicalThinkingToolHistory(request)
+            .map((entry) => normaliseThinkingActivityString(entry?.tool || entry?.workflowTask))
+            .filter(Boolean);
         const uniqueToolNames = [...new Set(toolNames)];
         if (uniqueToolNames.length > 0) {
             const preview = uniqueToolNames.slice(0, 3).join(', ');
@@ -18348,7 +18385,7 @@ function buildThinkingDiagnosticsPayload(request) {
         activity_history: Array.isArray(request.activityHistory) ? request.activityHistory.slice(-40) : [],
         progress_events: Array.isArray(request.progressEvents) ? request.progressEvents.slice(-40) : [],
         phase_history: Array.isArray(request.phaseHistory) ? request.phaseHistory.slice(-40) : [],
-        tool_history: Array.isArray(request.toolUseProgressHistory) ? request.toolUseProgressHistory.slice(-40) : [],
+        tool_history: getCanonicalThinkingToolHistory(request).slice(-40),
         workflow_discovery: request.workflowDiscovery || null,
         workflow_stage_path: request.workflowStagePath || null,
         stage_diagnostics: buildThinkingStageDiagnosticsSnapshot(request)

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -1,5 +1,6 @@
 import {
     __testOnly_buildThinkingProgressPresentation,
+    __testOnly_buildThinkingDiagnosticsPayload,
     __testOnly_buildWorkflowMonitorExportPayload,
     __testOnly_refreshAvailableWorkflowDefinitions,
     __testOnly_resetWorkflowDefinitionsState,
@@ -1119,6 +1120,57 @@ describe('thinking activity history normalisation', () => {
         });
         expect(fallbackHtml).toContain('fetch_concept');
         expect(fallbackHtml).toContain('Fetched');
+    });
+
+    test('prefers canonical latest progress tool history over stale local tool history', () => {
+        const request = {
+            toolUseProgressHistory: [{
+                tool: 'download_paper',
+                resultSummary: 'Downloaded: 2510.06018',
+                success: null
+            }],
+            latestProgress: {
+                tool_history: [{
+                    tool: 'download_paper',
+                    resultSummary: 'Downloaded: 2510.06018',
+                    success: true
+                }],
+                tool_call_count: 1,
+                tool_success_count: 1,
+                tool_failure_count: 0,
+                tool_pending_count: 0
+            },
+            workflowStagePath: {
+                path: [
+                    { stage_id: 'tool_execute', stage_label: 'Execute tool calls' }
+                ]
+            }
+        };
+
+        const html = __testOnly_renderThinkingCardBodyHTML(request);
+        expect(html).toContain('download_paper');
+        expect(html).toContain('Downloaded: 2510.06018');
+        expect(html).toContain('thinking-card-tool-status success');
+
+        const diagnosticsPayload = __testOnly_buildThinkingDiagnosticsPayload(request);
+        expect(diagnosticsPayload.tool_history).toEqual([
+            expect.objectContaining({
+                tool: 'download_paper',
+                resultSummary: 'Downloaded: 2510.06018',
+                success: true
+            })
+        ]);
+        expect(diagnosticsPayload.stage_diagnostics).toEqual([
+            expect.objectContaining({
+                stage_id: 'tool_execute',
+                diagnostics: expect.objectContaining({
+                    tool_call_count: 1,
+                    tool_success_count: 1,
+                    tool_failure_count: 0,
+                    tool_pending_count: 0
+                })
+            })
+        ]);
     });
 
     test('renders canonical workflow stages with selected workflow details', () => {

--- a/tests/backend/test_orchestrator_model_fallback_execution.py
+++ b/tests/backend/test_orchestrator_model_fallback_execution.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import time
 from typing import Any, Mapping, cast
+
+import pytest
 
 from src.backend.integrations.internal_mcp.orchestrator import (
     InternalMCPChatOrchestrator,
@@ -223,3 +226,31 @@ def test_probe_model_candidate_reachability_uses_failure_cooldown_cache(
     assert second.get("cooldown_hit") is True
     assert second.get("cached") is True
     assert request_calls["count"] == 1
+
+
+def test_invoke_with_llm_heartbeat_uses_backfill_timeout_for_summariser(
+    monkeypatch,
+) -> None:
+    orchestrator = object.__new__(InternalMCPChatOrchestrator)
+    monkeypatch.setenv("VON_LLM_HEARTBEAT_INTERVAL_SEC", "1")
+    monkeypatch.setenv("VON_SCREEN_BACKFILL_LLM_TIMEOUT_SEC", "1")
+    monkeypatch.delenv("VON_LLM_CALL_TIMEOUT_SEC", raising=False)
+
+    progress_events: list[dict[str, Any]] = []
+
+    def _slow_call() -> str:
+        time.sleep(2.0)
+        return "done"
+
+    with pytest.raises(TimeoutError, match=r"stage=summariser"):
+        orchestrator._invoke_with_llm_heartbeat(
+            call=_slow_call,
+            stage_name="summariser",
+            model_name="gpt-test",
+            emit_progress=lambda payload: progress_events.append(dict(payload)),
+        )
+
+    assert progress_events, "expected heartbeat progress before timeout"
+    assert progress_events[-1]["status"] == "heartbeat"
+    assert progress_events[-1]["stage"] == "summariser"
+    assert progress_events[-1]["liveness_reason"] == "llm_call_pending"

--- a/tests/backend/test_tool_progress_liveness.py
+++ b/tests/backend/test_tool_progress_liveness.py
@@ -497,6 +497,120 @@ def test_turn_execution_diagnostics_rebuilds_phase_and_tool_history(monkeypatch)
     assert first_llm.get("duration_ms") == 125
 
 
+def test_canonical_tool_summary_survives_long_heartbeat_tail(monkeypatch) -> None:
+    clock = _set_clock(monkeypatch, start=5200.0)
+
+    von_routes._set_tool_progress(
+        "scope-heartbeat-tail",
+        "req-heartbeat-tail",
+        {
+            "status": "phase_transition",
+            "phase": "tool_execute",
+            "phase_label": "Executing tools",
+            "request_id": "req-heartbeat-tail",
+        },
+    )
+    clock["now"] += 0.1
+    von_routes._set_tool_progress(
+        "scope-heartbeat-tail",
+        "req-heartbeat-tail",
+        {
+            "status": "tool_call_start",
+            "phase": "tool_execute",
+            "tool": "download_paper",
+            "batch_size": 1,
+            "call_id": "call-download-paper",
+            "request_id": "req-heartbeat-tail",
+        },
+    )
+    clock["now"] += 0.1
+    von_routes._set_tool_progress(
+        "scope-heartbeat-tail",
+        "req-heartbeat-tail",
+        {
+            "status": "tool_invoked",
+            "phase": "tool_execute",
+            "tool": "download_paper",
+            "batch_size": 1,
+            "call_id": "call-download-paper",
+            "result_summary": "Downloaded: 2510.06018",
+            "request_id": "req-heartbeat-tail",
+        },
+    )
+
+    for _ in range(von_routes._TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT + 5):
+        clock["now"] += float(von_routes._TOOL_PROGRESS_HEARTBEAT_INTERVAL_SEC)
+        von_routes._set_tool_progress(
+            "scope-heartbeat-tail",
+            "req-heartbeat-tail",
+            {
+                "status": "heartbeat",
+                "request_id": "req-heartbeat-tail",
+            },
+        )
+
+    snapshot = von_routes._snapshot_tool_progress_for_request(
+        "scope-heartbeat-tail",
+        "req-heartbeat-tail",
+    )
+    assert snapshot is not None
+
+    diagnostic_events = snapshot.get("diagnostic_events")
+    assert isinstance(diagnostic_events, list)
+    assert len(diagnostic_events) == von_routes._TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT
+    assert all(event.get("status") != "tool_invoked" for event in diagnostic_events)
+
+    assert snapshot.get("tool_call_count") == 1
+    assert snapshot.get("tool_success_count") == 1
+    assert snapshot.get("tool_failure_count") == 0
+    assert snapshot.get("tool_pending_count") == 0
+    tool_history = snapshot.get("tool_history")
+    assert isinstance(tool_history, list)
+    assert tool_history == [
+        {
+            "tool": "download_paper",
+            "workflowTask": "",
+            "batchSize": 1,
+            "phase": "tool_execute",
+            "resultSummary": "Downloaded: 2510.06018",
+            "success": True,
+            "callId": "call-download-paper",
+        }
+    ]
+
+    diagnostics = von_routes._build_turn_execution_diagnostics(
+        request_id="req-heartbeat-tail",
+        prompt_text="https://arxiv.org/abs/2510.06018 represent that paper",
+        tool_progress_state=snapshot,
+    )
+    assert diagnostics["tool_call_count"] == 1
+    assert diagnostics["tool_success_count"] == 1
+    assert diagnostics["tool_failure_count"] == 0
+    assert diagnostics["tool_pending_count"] == 0
+    assert diagnostics["tool_history"] == tool_history
+
+    stage_diagnostics = diagnostics.get("stage_diagnostics")
+    assert isinstance(stage_diagnostics, list)
+    assert len(stage_diagnostics) == 1
+    assert stage_diagnostics[0] == {
+        **stage_diagnostics[0],
+        "stage_id": "tool_execute",
+        "stage_label": "Execute tool calls",
+        "event_count": von_routes._TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT,
+        "latest_status": "heartbeat",
+        "latest_at_utc": snapshot.get("updated_at"),
+        "latest_result_summary": "Downloaded: 2510.06018",
+        "latest_error": None,
+        "tool_call_count": 1,
+        "tool_success_count": 1,
+        "tool_failure_count": 0,
+        "tool_pending_count": 0,
+        "tool_call_start_count": 1,
+        "tool_call_end_count": 1,
+        "tool_history": tool_history,
+    }
+
+
 def test_turn_execution_diagnostics_stage_path_fallback_for_unknown_phase(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- persist canonical tool history and counts in live tool-progress state instead of reconstructing them only from the truncated diagnostic event tail
- prefer canonical workflow stage path and tool summary in turn-execution diagnostics and keep latest result and error fields on stage diagnostics
- apply the backfill timeout to summariser LLM calls and update thinking-card consumers and tests to prefer canonical backend tool history

## Validation
- `python -m pytest tests/backend/test_tool_progress_liveness.py -q`
- `python -m pytest tests/backend/test_orchestrator_model_fallback_execution.py::test_invoke_with_llm_heartbeat_uses_backfill_timeout_for_summariser -q`
- `python -m pytest tests/backend/test_von_generate_bare_arxiv_url_integration.py::test_generate_bare_arxiv_url_auto_represents_paper tests/backend/test_von_diagnostics_export_endpoint.py -q`

## Notes
- `test_orchestrator_model_fallback_execution.py::test_run_llm_with_fallbacks_records_attempt_chain_and_fallback_metadata` also times out on `main` in this environment, so it was treated as a baseline suite issue rather than a regression from this change.
- Frontend Jest validation is currently blocked in this environment because the local Babel preset/tooling install is incomplete (`@babel/preset-env` missing).