### PR TITLE
JVNAUTOSCI-1236: harden Jira task migration execution

### DIFF
--- a/docs/engineering/workflow_first_jira_to_von_migration_jvnautosci_1223.md
+++ b/docs/engineering/workflow_first_jira_to_von_migration_jvnautosci_1223.md
@@ -11,6 +11,12 @@ This slice adds workflow-first execution coverage for Jira->Von task migration b
 
 The runtime path is MCP-first and uses existing tooling (`jira_search`, `task_import_jira_issues`) rather than bespoke orchestration code.
 
+## Execution Surface
+
+For live project-scale execution, use `scripts/run_jira_task_migration.py`. It pages Jira discovery with `jira_search`, reuses the returned issue documents when calling `task_import_jira_issues`, and can optionally import missing JVNAUTOSCI referenced targets before a final repair pass.
+
+This keeps the migration on the canonical Jira/Von MCP path while avoiding the earlier per-issue refetch bottleneck that made a single large project run operationally unreliable.
+
 ## Project-Level Parity Findings
 
 `task_import_jira_issues` now emits `project_parity` in the migration report. The report is deterministic and grouped by Jira project key.

--- a/scripts/run_jira_task_migration.py
+++ b/scripts/run_jira_task_migration.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+from typing import Any, Iterator, Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.backend.integrations.internal_mcp import build_default_catalogue
+from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
+from src.backend.integrations.internal_mcp.jira_proxy_mcp import get_jira_proxy
+from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+from src.backend.services.jira_task_import_service import list_imported_jira_issue_keys
+
+DEFAULT_JQL = (
+    "project = JVNAUTOSCI AND issuetype in (Task, Subtask, Epic) "
+    "AND statusCategory != Done ORDER BY key ASC"
+)
+DEFAULT_FIELDS = [
+    "summary",
+    "description",
+    "status",
+    "priority",
+    "labels",
+    "project",
+    "duedate",
+    "startdate",
+    "assignee",
+    "creator",
+    "reporter",
+    "parent",
+    "issuelinks",
+    "components",
+    "fixVersions",
+    "customfield_10020",
+    "customfield_10019",
+    "customfield_10027",
+    "customfield_10014",
+    "customfield_10008",
+]
+
+
+@dataclass(frozen=True)
+class MigrationOptions:
+    jql: str
+    project_key: str
+    actor_concept_id: str
+    organisation_concept_id: str | None
+    namespace: str | None
+    batch_size: int
+    passes: int
+    dry_run: bool
+    only_missing: bool
+    import_referenced_targets: bool
+    sync_source_labels: bool
+    source_migrated_label: str
+    report_path: Path
+
+
+def _parse_args() -> MigrationOptions:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the Jira -> Von task migration via paginated Jira discovery plus "
+            "the canonical task_import_jira_issues gateway path."
+        )
+    )
+    parser.add_argument("--jql", default=DEFAULT_JQL)
+    parser.add_argument("--project-key", default="JVNAUTOSCI")
+    parser.add_argument("--actor-concept-id", required=True)
+    parser.add_argument("--organisation-concept-id")
+    parser.add_argument("--namespace")
+    parser.add_argument("--batch-size", type=int, default=50)
+    parser.add_argument("--passes", type=int, default=2)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--only-missing", action="store_true")
+    parser.add_argument("--import-referenced-targets", action="store_true")
+    parser.add_argument("--sync-source-labels", action="store_true")
+    parser.add_argument("--source-migrated-label", default="migrated")
+    parser.add_argument(
+        "--report-path",
+        default="artifacts/jira_task_migration_report.json",
+    )
+    args = parser.parse_args()
+
+    batch_size = max(1, min(int(args.batch_size), 200))
+    passes = max(1, int(args.passes))
+    project_key = str(args.project_key).strip().upper()
+    return MigrationOptions(
+        jql=str(args.jql).strip(),
+        project_key=project_key,
+        actor_concept_id=str(args.actor_concept_id).strip(),
+        organisation_concept_id=(
+            str(args.organisation_concept_id).strip()
+            if isinstance(args.organisation_concept_id, str)
+            and args.organisation_concept_id.strip()
+            else None
+        ),
+        namespace=(
+            str(args.namespace).strip()
+            if isinstance(args.namespace, str) and args.namespace.strip()
+            else None
+        ),
+        batch_size=batch_size,
+        passes=passes,
+        dry_run=bool(args.dry_run),
+        only_missing=bool(args.only_missing),
+        import_referenced_targets=bool(args.import_referenced_targets),
+        sync_source_labels=bool(args.sync_source_labels),
+        source_migrated_label=str(args.source_migrated_label).strip() or "migrated",
+        report_path=Path(args.report_path),
+    )
+
+
+def _iter_batches(items: Sequence[Mapping[str, Any]], batch_size: int) -> Iterator[list[Mapping[str, Any]]]:
+    for start in range(0, len(items), batch_size):
+        yield list(items[start : start + batch_size])
+
+
+def _normalise_issue_key(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip().upper()
+    return cleaned or None
+
+
+async def _discover_issue_docs(
+    *,
+    jql: str,
+    fields: Sequence[str],
+    page_size: int,
+) -> list[dict[str, Any]]:
+    proxy = await get_jira_proxy()
+    next_page_token: str | None = None
+    issue_docs: list[dict[str, Any]] = []
+
+    while True:
+        payload = await proxy.search(
+            jql=jql,
+            max_results=page_size,
+            next_page_token=next_page_token,
+            fields=list(fields),
+        )
+        raw_issues = payload.get("issues") if isinstance(payload, Mapping) else None
+        next_page_token = (
+            payload.get("nextPageToken") if isinstance(payload, Mapping) else None
+        )
+        if not isinstance(raw_issues, list) or not raw_issues:
+            break
+        issue_docs.extend(item for item in raw_issues if isinstance(item, dict))
+        if not isinstance(next_page_token, str) or not next_page_token.strip():
+            break
+
+    return issue_docs
+
+
+async def _fetch_issue_docs_by_key(issue_keys: Sequence[str]) -> list[dict[str, Any]]:
+    proxy = await get_jira_proxy()
+    issue_docs: list[dict[str, Any]] = []
+    for issue_key in issue_keys:
+        payload = await proxy.get_issue(issue_key=issue_key)
+        if isinstance(payload, dict):
+            issue_docs.append(payload)
+    return issue_docs
+
+
+def _merge_counter(target: Counter[str], source: Mapping[str, Any] | None) -> None:
+    if not isinstance(source, Mapping):
+        return
+    for key, value in source.items():
+        if isinstance(value, bool):
+            target[str(key)] += int(value)
+            continue
+        if isinstance(value, int):
+            target[str(key)] += value
+
+
+def _extract_missing_targets(
+    reports: Sequence[Mapping[str, Any]],
+    *,
+    project_key: str,
+) -> list[str]:
+    missing_targets: set[str] = set()
+    for report in reports:
+        issue_rows = report.get("issues")
+        if not isinstance(issue_rows, list):
+            continue
+        for issue_row in issue_rows:
+            if not isinstance(issue_row, Mapping):
+                continue
+            relation_rows = issue_row.get("relation_results")
+            if not isinstance(relation_rows, list):
+                continue
+            for relation_row in relation_rows:
+                if not isinstance(relation_row, Mapping):
+                    continue
+                if relation_row.get("reason") != "target_issue_not_imported":
+                    continue
+                issue_key = _normalise_issue_key(relation_row.get("target_issue_key"))
+                if (
+                    isinstance(issue_key, str)
+                    and issue_key.startswith(f"{project_key}-")
+                ):
+                    missing_targets.add(issue_key)
+    return sorted(missing_targets)
+
+
+def _build_gateway() -> InternalMCPGateway:
+    return InternalMCPGateway(
+        catalogue=build_default_catalogue(),
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+
+
+def _run_import_batches(
+    *,
+    gateway: InternalMCPGateway,
+    issue_docs: Sequence[Mapping[str, Any]],
+    options: MigrationOptions,
+    run_label: str,
+) -> dict[str, Any]:
+    reports: list[dict[str, Any]] = []
+    aggregate_summary: Counter[str] = Counter()
+
+    for pass_index in range(options.passes):
+        for batch_index, batch in enumerate(_iter_batches(issue_docs, options.batch_size), start=1):
+            payload = {
+                "issue_keys": [dict(item) for item in batch if isinstance(item, Mapping)],
+                "dry_run": options.dry_run,
+                "update_existing": True,
+                "include_watchers": False,
+                "namespace": options.namespace,
+                "actor_concept_id": options.actor_concept_id,
+                "organisation_concept_id": options.organisation_concept_id,
+                "auto_resolve_participants": True,
+                "create_missing_participant_concepts": True,
+                "sync_source_labels": options.sync_source_labels,
+                "source_migrated_label": options.source_migrated_label,
+            }
+            result = gateway.invoke("task_import_jira_issues", payload).payload
+            if not isinstance(result, dict) or result.get("success") is not True:
+                raise RuntimeError(
+                    f"{run_label} pass {pass_index + 1} batch {batch_index} failed: {result}"
+                )
+            reports.append(result)
+            _merge_counter(aggregate_summary, result.get("summary"))
+            print(
+                json.dumps(
+                    {
+                        "run": run_label,
+                        "pass": pass_index + 1,
+                        "batch": batch_index,
+                        "batch_issue_count": len(batch),
+                        "summary": result.get("summary"),
+                    }
+                )
+            )
+
+    return {
+        "run_label": run_label,
+        "passes": options.passes,
+        "batch_size": options.batch_size,
+        "batch_count": len(reports),
+        "summary": dict(aggregate_summary),
+        "reports": reports,
+        "missing_target_issue_keys": _extract_missing_targets(
+            reports,
+            project_key=options.project_key,
+        ),
+    }
+
+
+async def _run(options: MigrationOptions) -> dict[str, Any]:
+    gateway = _build_gateway()
+
+    discovered_issue_docs = await _discover_issue_docs(
+        jql=options.jql,
+        fields=DEFAULT_FIELDS,
+        page_size=100,
+    )
+    discovered_by_key = {
+        issue_key: issue_doc
+        for issue_doc in discovered_issue_docs
+        if isinstance(issue_doc, Mapping)
+        for issue_key in [_normalise_issue_key(issue_doc.get("key"))]
+        if isinstance(issue_key, str)
+    }
+    imported_issue_keys = set(
+        list_imported_jira_issue_keys(
+            organisation_concept_id=options.organisation_concept_id,
+            limit=2000,
+        )
+    )
+
+    selected_issue_docs = list(discovered_by_key.values())
+    if options.only_missing:
+        selected_issue_docs = [
+            issue_doc
+            for issue_doc in selected_issue_docs
+            if (
+                issue_key := _normalise_issue_key(issue_doc.get("key"))
+            ) not in imported_issue_keys
+        ]
+
+    report: dict[str, Any] = {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "options": {
+            "jql": options.jql,
+            "project_key": options.project_key,
+            "actor_concept_id": options.actor_concept_id,
+            "organisation_concept_id": options.organisation_concept_id,
+            "namespace": options.namespace,
+            "batch_size": options.batch_size,
+            "passes": options.passes,
+            "dry_run": options.dry_run,
+            "only_missing": options.only_missing,
+            "import_referenced_targets": options.import_referenced_targets,
+            "sync_source_labels": options.sync_source_labels,
+            "source_migrated_label": options.source_migrated_label,
+        },
+        "discovery": {
+            "discovered_issue_count": len(discovered_issue_docs),
+            "selected_issue_count": len(selected_issue_docs),
+            "already_imported_issue_count": len(imported_issue_keys),
+        },
+    }
+
+    main_run = _run_import_batches(
+        gateway=gateway,
+        issue_docs=selected_issue_docs,
+        options=options,
+        run_label="current_scope",
+    )
+    report["current_scope"] = {
+        key: value for key, value in main_run.items() if key != "reports"
+    }
+
+    referenced_target_keys = main_run.get("missing_target_issue_keys") or []
+    if options.import_referenced_targets and referenced_target_keys:
+        target_issue_docs = await _fetch_issue_docs_by_key(referenced_target_keys)
+        referenced_run = _run_import_batches(
+            gateway=gateway,
+            issue_docs=target_issue_docs,
+            options=options,
+            run_label="referenced_targets",
+        )
+        report["referenced_targets"] = {
+            key: value for key, value in referenced_run.items() if key != "reports"
+        }
+
+        # A final current-scope pass repairs links whose targets only became
+        # available after the referenced-target import completed.
+        repair_run = _run_import_batches(
+            gateway=gateway,
+            issue_docs=selected_issue_docs,
+            options=MigrationOptions(
+                jql=options.jql,
+                project_key=options.project_key,
+                actor_concept_id=options.actor_concept_id,
+                organisation_concept_id=options.organisation_concept_id,
+                namespace=options.namespace,
+                batch_size=options.batch_size,
+                passes=1,
+                dry_run=options.dry_run,
+                only_missing=options.only_missing,
+                import_referenced_targets=options.import_referenced_targets,
+                sync_source_labels=options.sync_source_labels,
+                source_migrated_label=options.source_migrated_label,
+                report_path=options.report_path,
+            ),
+            run_label="current_scope_repair",
+        )
+        report["current_scope_repair"] = {
+            key: value for key, value in repair_run.items() if key != "reports"
+        }
+
+    return report
+
+
+def main() -> None:
+    options = _parse_args()
+    report = asyncio.run(_run(options))
+    options.report_path.parent.mkdir(parents=True, exist_ok=True)
+    options.report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps({"report_path": str(options.report_path), "summary": report}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backend/db/mongo_client.py
+++ b/src/backend/db/mongo_client.py
@@ -661,6 +661,31 @@ def get_concepts_collection() -> Collection | None:
                 concepts_coll.create_index(
                     [("names.text", ASCENDING)], name="names.text_1"
                 )
+            # Task import and incremental Jira sync rely on exact Jira issue-key
+            # lookups plus organisation-scoped replays.
+            if "task_jira_external_id_lookup" not in existing_indexes:
+                concepts_coll.create_index(
+                    [
+                        ("relationships.is_an_instance_of", ASCENDING),
+                        (
+                            "metadata.external_references.jira.external_id",
+                            ASCENDING,
+                        ),
+                    ],
+                    name="task_jira_external_id_lookup",
+                )
+            if "task_jira_external_id_org_lookup" not in existing_indexes:
+                concepts_coll.create_index(
+                    [
+                        ("relationships.is_an_instance_of", ASCENDING),
+                        ("metadata.organisation_concept_id", ASCENDING),
+                        (
+                            "metadata.external_references.jira.external_id",
+                            ASCENDING,
+                        ),
+                    ],
+                    name="task_jira_external_id_org_lookup",
+                )
 
             # Timestamp indexes
             if "timestamps.created_at_-1" not in existing_indexes:

--- a/src/backend/db/repositories/concepts_repository.py
+++ b/src/backend/db/repositories/concepts_repository.py
@@ -202,6 +202,16 @@ class ConceptsRepository:
         cursor = coll.aggregate(pipeline_with_access)
         return _AccessControlledCursor(cursor)
 
+    @staticmethod
+    def distinct(field: str, filter: Optional[Dict[str, Any]] = None) -> List[Any]:
+        """Return distinct values for a field while preserving concept access control."""
+
+        coll = ConceptsRepository.collection()
+        if coll is None:
+            return []
+        query = apply_concept_query_filter(filter or {})
+        return list(coll.distinct(field, query))
+
     # Relationship helpers
     @staticmethod
     def _ensure_relationship_array(concept_id: str, rel_kind: str) -> bool:

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -16480,13 +16480,40 @@ def _task_search(**kwargs):
         return make_error_response("UNEXPECTED_ERROR", f"Unexpected error: {exc}")
 
 
-def _normalise_issue_keys_input(raw_issue_keys: Any) -> list[str]:
+def _clone_seeded_jira_issue_doc(
+    raw_issue: Mapping[str, Any],
+    *,
+    issue_key: str,
+) -> dict[str, Any] | None:
+    fields = raw_issue.get("fields")
+    if not isinstance(fields, Mapping):
+        return None
+
+    seeded_issue = dict(raw_issue)
+    seeded_issue["key"] = issue_key
+    seeded_issue["fields"] = dict(fields)
+
+    for optional_key in ("watchers", "watcher", "watches", "changelog"):
+        optional_value = raw_issue.get(optional_key)
+        if isinstance(optional_value, Mapping):
+            seeded_issue[optional_key] = dict(optional_value)
+        elif isinstance(optional_value, list):
+            seeded_issue[optional_key] = list(optional_value)
+
+    return seeded_issue
+
+
+def _normalise_issue_keys_input(
+    raw_issue_keys: Any,
+) -> tuple[list[str], dict[str, dict[str, Any]]]:
     if not isinstance(raw_issue_keys, list):
-        return []
+        return [], {}
     seen: set[str] = set()
     result: list[str] = []
+    seeded_issue_docs: dict[str, dict[str, Any]] = {}
     for raw in raw_issue_keys:
         cleaned: str | None = None
+        seeded_issue_doc: dict[str, Any] | None = None
         if isinstance(raw, str):
             cleaned = raw.strip().upper()
         elif isinstance(raw, Mapping):
@@ -16495,13 +16522,20 @@ def _normalise_issue_keys_input(raw_issue_keys: Any) -> list[str]:
                 if isinstance(value, str) and value.strip():
                     cleaned = value.strip().upper()
                     break
+            if isinstance(cleaned, str) and cleaned:
+                seeded_issue_doc = _clone_seeded_jira_issue_doc(
+                    raw,
+                    issue_key=cleaned,
+                )
         if not isinstance(cleaned, str):
             continue
         if not cleaned or cleaned in seen:
             continue
         seen.add(cleaned)
         result.append(cleaned)
-    return result
+        if isinstance(seeded_issue_doc, dict):
+            seeded_issue_docs[cleaned] = seeded_issue_doc
+    return result, seeded_issue_docs
 
 
 def _coerce_bool_input(value: Any, *, default: bool) -> bool:
@@ -16558,7 +16592,7 @@ def _task_import_jira_issues(**kwargs):
         resolve_event_actor_context,
     )
 
-    issue_keys = _normalise_issue_keys_input(kwargs.get("issue_keys"))
+    issue_keys, seeded_issue_docs = _normalise_issue_keys_input(kwargs.get("issue_keys"))
     jql = kwargs.get("jql")
     backfill_existing_imports = _coerce_bool_input(
         kwargs.get("backfill_existing_imports"),
@@ -16702,16 +16736,27 @@ def _task_import_jira_issues(**kwargs):
 
         issue_docs: list[dict[str, Any]] = []
         for issue_key in discovered_keys:
-            try:
-                issue_doc = await proxy.get_issue(issue_key=issue_key)
-            except Exception as exc:
-                fetch_errors.append(
-                    {
-                        "issue_key": issue_key,
-                        "error": f"{type(exc).__name__}: {exc}",
-                    }
-                )
-                continue
+            seeded_issue_doc = seeded_issue_docs.get(issue_key)
+            issue_doc: dict[str, Any] | None = None
+            if isinstance(seeded_issue_doc, Mapping):
+                issue_doc = dict(seeded_issue_doc)
+                issue_doc["key"] = issue_key
+                raw_fields = issue_doc.get("fields")
+                if isinstance(raw_fields, Mapping):
+                    issue_doc["fields"] = dict(raw_fields)
+            else:
+                try:
+                    fetched_issue_doc = await proxy.get_issue(issue_key=issue_key)
+                except Exception as exc:
+                    fetch_errors.append(
+                        {
+                            "issue_key": issue_key,
+                            "error": f"{type(exc).__name__}: {exc}",
+                        }
+                    )
+                    continue
+                if isinstance(fetched_issue_doc, dict):
+                    issue_doc = fetched_issue_doc
 
             if not isinstance(issue_doc, dict):
                 fetch_errors.append(

--- a/src/backend/services/jira_task_import_service.py
+++ b/src/backend/services/jira_task_import_service.py
@@ -925,7 +925,12 @@ def list_imported_jira_issue_keys(
     organisation_concept_id: str | None = None,
     limit: int = 2000,
 ) -> list[str]:
-    """Return Jira issue keys already linked via task external_references."""
+    """Return Jira issue keys already linked via task external_references.
+
+    This intentionally uses a distinct-value query rather than a sorted scan of
+    task documents. Full-document scans were operationally unreliable for
+    project-scale migration checkpoints and incremental sync runs.
+    """
 
     try:
         bounded_limit = max(1, min(int(limit), 2000))
@@ -947,50 +952,20 @@ def list_imported_jira_issue_keys(
             {f"metadata.{TASK_METADATA_KEY_ORGANISATION}": None},
         ]
 
-    keys: list[str] = []
-    seen: set[str] = set()
-    skip = 0
-    batch_size = min(max(200, bounded_limit), 1000)
-    projection = {
-        f"metadata.{TASK_METADATA_KEY_EXTERNAL_REFERENCES}.{_JIRA_SOURCE_SYSTEM}": 1,
-    }
+    raw_values = ConceptsRepository.distinct(
+        f"metadata.{TASK_METADATA_KEY_EXTERNAL_REFERENCES}.{_JIRA_SOURCE_SYSTEM}.external_id",
+        query,
+    )
 
-    while len(keys) < bounded_limit:
-        docs = list(
-            ConceptsRepository.find(
-                query,
-                projection=projection,
-                sort=[("updated_at", -1), ("concept_id", 1)],
-                skip=skip,
-                limit=min(batch_size, max(1, bounded_limit - len(keys))),
-            )
-        )
-        if not docs:
-            break
-        skip += len(docs)
-        for doc in docs:
-            if not isinstance(doc, Mapping):
-                continue
-            metadata = doc.get("metadata")
-            if not isinstance(metadata, Mapping):
-                continue
-            external_references = metadata.get(TASK_METADATA_KEY_EXTERNAL_REFERENCES)
-            if not isinstance(external_references, Mapping):
-                continue
-            jira_reference = external_references.get(_JIRA_SOURCE_SYSTEM)
-            if not isinstance(jira_reference, Mapping):
-                continue
-            raw_issue_key = jira_reference.get("external_id") or jira_reference.get(
-                "issue_key"
-            )
-            issue_key = _normalise_issue_key(raw_issue_key)
-            if not issue_key or issue_key in seen:
-                continue
-            seen.add(issue_key)
-            keys.append(issue_key)
-            if len(keys) >= bounded_limit:
-                break
-    return keys
+    unique_keys = sorted(
+        {
+            issue_key
+            for raw_value in raw_values
+            for issue_key in [_normalise_issue_key(raw_value)]
+            if isinstance(issue_key, str) and issue_key
+        }
+    )
+    return unique_keys[:bounded_limit]
 
 
 _PARITY_CLASS_MUST_FIX = "must_fix"

--- a/tests/backend/test_internal_mcp_task_parity_tools.py
+++ b/tests/backend/test_internal_mcp_task_parity_tools.py
@@ -212,6 +212,66 @@ def test_task_import_jira_issues_gateway_accepts_issue_objects_from_discovery(mo
     _assert_schema_conformance(gateway, "task_import_jira_issues", payload)
 
 
+def test_task_import_jira_issues_gateway_reuses_seeded_issue_documents(monkeypatch):
+    gateway = _build_gateway()
+    fetched_issue_keys: list[str] = []
+
+    class _FakeProxy:
+        async def get_issue(self, *, issue_key: str, fields=None):  # noqa: ARG002
+            fetched_issue_keys.append(issue_key)
+            return {
+                "key": issue_key,
+                "fields": {
+                    "summary": "Fetched issue",
+                    "status": {"name": "To Do"},
+                    "priority": {"name": "Medium"},
+                    "project": {"key": "JVNAUTOSCI", "name": "JVNAUTOSCI Project"},
+                    "issuelinks": [],
+                },
+            }
+
+    async def _fake_get_jira_proxy():
+        return _FakeProxy()
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.jira_proxy_mcp.get_jira_proxy",
+        _fake_get_jira_proxy,
+    )
+
+    payload = gateway.invoke(
+        "task_import_jira_issues",
+        {
+            "issue_keys": [
+                {
+                    "key": "JVNAUTOSCI-3004",
+                    "fields": {
+                        "summary": "Seeded issue",
+                        "description": {
+                            "type": "doc",
+                            "version": 1,
+                            "content": [
+                                {
+                                    "type": "paragraph",
+                                    "content": [{"type": "text", "text": "Desc"}],
+                                }
+                            ],
+                        },
+                        "status": {"name": "To Do"},
+                        "priority": {"name": "Medium"},
+                        "project": {"key": "JVNAUTOSCI", "name": "JVNAUTOSCI Project"},
+                        "issuelinks": [],
+                    },
+                }
+            ],
+            "dry_run": True,
+        },
+    ).payload
+    assert payload.get("success") is True
+    assert payload.get("summary", {}).get("total_issues") == 1
+    assert fetched_issue_keys == []
+    _assert_schema_conformance(gateway, "task_import_jira_issues", payload)
+
+
 def test_task_import_jira_issues_gateway_syncs_migrated_label_on_write(monkeypatch):
     gateway = _build_gateway()
     _patch_task_import_write_path(monkeypatch)

--- a/tests/backend/test_jira_task_import_service.py
+++ b/tests/backend/test_jira_task_import_service.py
@@ -429,57 +429,31 @@ def test_import_jira_issues_preserves_participant_concepts_from_account_map(monk
 
 
 def test_list_imported_jira_issue_keys_scans_repository_with_org_and_legacy_scope(monkeypatch):
-    docs = [
-        {
-            "metadata": {
-                "external_references": {
-                    "jira": {"external_id": "JVNAUTOSCI-301"},
-                },
-                "organisation_concept_id": "#V#sail_org",
-            }
-        },
-        {
-            "metadata": {
-                "external_references": {
-                    "jira": {"external_id": "JVNAUTOSCI-302"},
-                },
-                "organisation_concept_id": None,
-            }
-        },
-        {
-            "metadata": {
-                "external_references": {
-                    "jira": {"external_id": "JVNAUTOSCI-301"},
-                },
-                "organisation_concept_id": None,
-            }
-        },
+    raw_keys = [
+        "JVNAUTOSCI-301",
+        "JVNAUTOSCI-302",
+        "jvnautosci-301",
+        "  JVNAUTOSCI-303  ",
+        None,
     ]
     captured_queries: list[dict[str, Any]] = []
 
-    def _fake_find(
-        query: dict[str, Any],
-        projection=None,  # noqa: ARG001
-        sort=None,  # noqa: ARG001
-        skip: int = 0,
-        limit: int = 0,
+    def _fake_distinct(
+        field: str,
+        query: dict[str, Any] | None = None,
     ):
-        captured_queries.append(query)
-        rows = list(docs)
-        if skip:
-            rows = rows[skip:]
-        if limit:
-            rows = rows[:limit]
-        return rows
+        assert field == "metadata.external_references.jira.external_id"
+        captured_queries.append(query or {})
+        return list(raw_keys)
 
-    monkeypatch.setattr(import_service.ConceptsRepository, "find", _fake_find)
+    monkeypatch.setattr(import_service.ConceptsRepository, "distinct", _fake_distinct)
 
     keys = import_service.list_imported_jira_issue_keys(
         organisation_concept_id="#V#sail_org",
         limit=10,
     )
 
-    assert keys == ["JVNAUTOSCI-301", "JVNAUTOSCI-302"]
+    assert keys == ["JVNAUTOSCI-301", "JVNAUTOSCI-302", "JVNAUTOSCI-303"]
     assert captured_queries
     assert "$or" in captured_queries[0]
     assert {


### PR DESCRIPTION
## Summary
- add a live migration runner that pages Jira discovery and reuses seeded issue documents when importing into Von
- harden imported-issue lookup for project-scale runs with repository distinct queries and task/Jira key indexes
- document the execution surface and cover seeded-document reuse plus distinct lookup behaviour in tests

## Validation
- pdm run pyright src/backend/db/mongo_client.py src/backend/db/repositories/concepts_repository.py src/backend/integrations/internal_mcp/catalogue.py src/backend/services/jira_task_import_service.py tests/backend/test_internal_mcp_task_parity_tools.py tests/backend/test_jira_task_import_service.py scripts/run_jira_task_migration.py
- $env:VON_DB_NAME='test_von_db'; pdm run pytest tests/backend/test_internal_mcp_task_parity_tools.py tests/backend/test_e2e_jira_task_migration_workflow.py tests/backend/test_jira_task_import_service.py tests/backend/test_internal_mcp_catalogue_builds.py tests/backend/test_pytest_lane_catalogue.py -q

## Live migration
- current non-Done JVNAUTOSCI Task/Subtask/Epic scope: 469 discovered, 469 represented after completion pass
- created 282 missing current-scope tasks, imported 53 referenced target issues, repaired 122 source tasks for relation completeness
- rerun idempotence check selected 0 current-scope issues
- follow-up automation task created: JVNAUTOSCI-1407