### PR TITLE
JVNAUTOSCI-1407: implement incremental Jira task import workflow

### DIFF
--- a/docs/engineering/workflow_first_jira_to_von_migration_jvnautosci_1223.md
+++ b/docs/engineering/workflow_first_jira_to_von_migration_jvnautosci_1223.md
@@ -58,3 +58,25 @@ Pilot validation now adds `pilot_validation` to the importer report with:
    - `SUPERSEDED` -> `cancelled`
    - `Won't Fix` -> `cancelled`
    - `SUSPENDED` -> `blocked`
+
+## JVNAUTOSCI-1407 Update (2026-03-09)
+
+The migration path now has a shared incremental runner in
+`src/backend/services/jira_task_migration_runner_service.py` so:
+
+1. `scripts/run_jira_task_migration.py`
+2. the durable workflow `#V#jira_task_incremental_import_workflow`
+3. persisted schedules / ad-hoc workflow instances
+
+all reuse the same discovery, batching, referenced-target repair, and
+reporting logic.
+
+New operational surfaces:
+
+1. Recent-window incremental sync via `--updated-within-hours N`
+2. One-off catch-up via `--min-issue-number` / `--max-issue-number`
+3. Durable workflow action `jira_task_incremental_import.run_sync`
+
+This keeps automation on the canonical Jira proxy -> `task_import_jira_issues`
+gateway path while allowing a persistent schedule to keep importing newly
+appearing Jira tasks without another bespoke sync mechanism.

--- a/scripts/run_jira_task_migration.py
+++ b/scripts/run_jira_task_migration.py
@@ -1,101 +1,58 @@
 from __future__ import annotations
 
 import argparse
-import asyncio
 import json
-from collections import Counter
-from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 import sys
-from typing import Any, Iterator, Mapping, Sequence
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from src.backend.integrations.internal_mcp import build_default_catalogue
-from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
-from src.backend.integrations.internal_mcp.jira_proxy_mcp import get_jira_proxy
-from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
-from src.backend.services.jira_task_import_service import list_imported_jira_issue_keys
-
-DEFAULT_JQL = (
-    "project = JVNAUTOSCI AND issuetype in (Task, Subtask, Epic) "
-    "AND statusCategory != Done ORDER BY key ASC"
+from src.backend.services.jira_task_migration_runner_service import (
+    DEFAULT_JIRA_TASK_MIGRATION_PROJECT_KEY,
+    DEFAULT_JIRA_TASK_MIGRATION_REPORT_PATH,
+    JiraTaskMigrationOptions,
+    run_jira_task_migration_sync,
 )
-DEFAULT_FIELDS = [
-    "summary",
-    "description",
-    "status",
-    "priority",
-    "labels",
-    "project",
-    "duedate",
-    "startdate",
-    "assignee",
-    "creator",
-    "reporter",
-    "parent",
-    "issuelinks",
-    "components",
-    "fixVersions",
-    "customfield_10020",
-    "customfield_10019",
-    "customfield_10027",
-    "customfield_10014",
-    "customfield_10008",
-]
 
 
-@dataclass(frozen=True)
-class MigrationOptions:
-    jql: str
-    project_key: str
-    actor_concept_id: str
-    organisation_concept_id: str | None
-    namespace: str | None
-    batch_size: int
-    passes: int
-    dry_run: bool
-    only_missing: bool
-    import_referenced_targets: bool
-    sync_source_labels: bool
-    source_migrated_label: str
-    report_path: Path
-
-
-def _parse_args() -> MigrationOptions:
+def _parse_args() -> JiraTaskMigrationOptions:
     parser = argparse.ArgumentParser(
         description=(
             "Run the Jira -> Von task migration via paginated Jira discovery plus "
-            "the canonical task_import_jira_issues gateway path."
+            "the canonical task_import_jira_issues gateway path. Supports both "
+            "full current-scope reconciliation and recent-window incremental sync."
         )
     )
-    parser.add_argument("--jql", default=DEFAULT_JQL)
-    parser.add_argument("--project-key", default="JVNAUTOSCI")
+    parser.add_argument("--jql")
+    parser.add_argument(
+        "--project-key",
+        default=DEFAULT_JIRA_TASK_MIGRATION_PROJECT_KEY,
+    )
     parser.add_argument("--actor-concept-id", required=True)
     parser.add_argument("--organisation-concept-id")
     parser.add_argument("--namespace")
     parser.add_argument("--batch-size", type=int, default=50)
+    parser.add_argument("--page-size", type=int, default=100)
     parser.add_argument("--passes", type=int, default=2)
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--only-missing", action="store_true")
     parser.add_argument("--import-referenced-targets", action="store_true")
     parser.add_argument("--sync-source-labels", action="store_true")
     parser.add_argument("--source-migrated-label", default="migrated")
+    parser.add_argument("--updated-within-hours", type=int)
+    parser.add_argument("--include-done", action="store_true")
+    parser.add_argument("--min-issue-number", type=int)
+    parser.add_argument("--max-issue-number", type=int)
     parser.add_argument(
         "--report-path",
-        default="artifacts/jira_task_migration_report.json",
+        default=str(DEFAULT_JIRA_TASK_MIGRATION_REPORT_PATH),
     )
     args = parser.parse_args()
 
-    batch_size = max(1, min(int(args.batch_size), 200))
-    passes = max(1, int(args.passes))
-    project_key = str(args.project_key).strip().upper()
-    return MigrationOptions(
-        jql=str(args.jql).strip(),
-        project_key=project_key,
+    return JiraTaskMigrationOptions(
         actor_concept_id=str(args.actor_concept_id).strip(),
         organisation_concept_id=(
             str(args.organisation_concept_id).strip()
@@ -108,288 +65,39 @@ def _parse_args() -> MigrationOptions:
             if isinstance(args.namespace, str) and args.namespace.strip()
             else None
         ),
-        batch_size=batch_size,
-        passes=passes,
+        project_key=str(args.project_key).strip().upper(),
+        jql=(str(args.jql).strip() if isinstance(args.jql, str) and args.jql.strip() else None),
+        batch_size=int(args.batch_size),
+        page_size=int(args.page_size),
+        passes=int(args.passes),
         dry_run=bool(args.dry_run),
         only_missing=bool(args.only_missing),
         import_referenced_targets=bool(args.import_referenced_targets),
         sync_source_labels=bool(args.sync_source_labels),
         source_migrated_label=str(args.source_migrated_label).strip() or "migrated",
         report_path=Path(args.report_path),
-    )
-
-
-def _iter_batches(items: Sequence[Mapping[str, Any]], batch_size: int) -> Iterator[list[Mapping[str, Any]]]:
-    for start in range(0, len(items), batch_size):
-        yield list(items[start : start + batch_size])
-
-
-def _normalise_issue_key(value: Any) -> str | None:
-    if not isinstance(value, str):
-        return None
-    cleaned = value.strip().upper()
-    return cleaned or None
-
-
-async def _discover_issue_docs(
-    *,
-    jql: str,
-    fields: Sequence[str],
-    page_size: int,
-) -> list[dict[str, Any]]:
-    proxy = await get_jira_proxy()
-    next_page_token: str | None = None
-    issue_docs: list[dict[str, Any]] = []
-
-    while True:
-        payload = await proxy.search(
-            jql=jql,
-            max_results=page_size,
-            next_page_token=next_page_token,
-            fields=list(fields),
-        )
-        raw_issues = payload.get("issues") if isinstance(payload, Mapping) else None
-        next_page_token = (
-            payload.get("nextPageToken") if isinstance(payload, Mapping) else None
-        )
-        if not isinstance(raw_issues, list) or not raw_issues:
-            break
-        issue_docs.extend(item for item in raw_issues if isinstance(item, dict))
-        if not isinstance(next_page_token, str) or not next_page_token.strip():
-            break
-
-    return issue_docs
-
-
-async def _fetch_issue_docs_by_key(issue_keys: Sequence[str]) -> list[dict[str, Any]]:
-    proxy = await get_jira_proxy()
-    issue_docs: list[dict[str, Any]] = []
-    for issue_key in issue_keys:
-        payload = await proxy.get_issue(issue_key=issue_key)
-        if isinstance(payload, dict):
-            issue_docs.append(payload)
-    return issue_docs
-
-
-def _merge_counter(target: Counter[str], source: Mapping[str, Any] | None) -> None:
-    if not isinstance(source, Mapping):
-        return
-    for key, value in source.items():
-        if isinstance(value, bool):
-            target[str(key)] += int(value)
-            continue
-        if isinstance(value, int):
-            target[str(key)] += value
-
-
-def _extract_missing_targets(
-    reports: Sequence[Mapping[str, Any]],
-    *,
-    project_key: str,
-) -> list[str]:
-    missing_targets: set[str] = set()
-    for report in reports:
-        issue_rows = report.get("issues")
-        if not isinstance(issue_rows, list):
-            continue
-        for issue_row in issue_rows:
-            if not isinstance(issue_row, Mapping):
-                continue
-            relation_rows = issue_row.get("relation_results")
-            if not isinstance(relation_rows, list):
-                continue
-            for relation_row in relation_rows:
-                if not isinstance(relation_row, Mapping):
-                    continue
-                if relation_row.get("reason") != "target_issue_not_imported":
-                    continue
-                issue_key = _normalise_issue_key(relation_row.get("target_issue_key"))
-                if (
-                    isinstance(issue_key, str)
-                    and issue_key.startswith(f"{project_key}-")
-                ):
-                    missing_targets.add(issue_key)
-    return sorted(missing_targets)
-
-
-def _build_gateway() -> InternalMCPGateway:
-    return InternalMCPGateway(
-        catalogue=build_default_catalogue(),
-        transport=InternalMCPTransport(),
-        enabled=True,
-    )
-
-
-def _run_import_batches(
-    *,
-    gateway: InternalMCPGateway,
-    issue_docs: Sequence[Mapping[str, Any]],
-    options: MigrationOptions,
-    run_label: str,
-) -> dict[str, Any]:
-    reports: list[dict[str, Any]] = []
-    aggregate_summary: Counter[str] = Counter()
-
-    for pass_index in range(options.passes):
-        for batch_index, batch in enumerate(_iter_batches(issue_docs, options.batch_size), start=1):
-            payload = {
-                "issue_keys": [dict(item) for item in batch if isinstance(item, Mapping)],
-                "dry_run": options.dry_run,
-                "update_existing": True,
-                "include_watchers": False,
-                "namespace": options.namespace,
-                "actor_concept_id": options.actor_concept_id,
-                "organisation_concept_id": options.organisation_concept_id,
-                "auto_resolve_participants": True,
-                "create_missing_participant_concepts": True,
-                "sync_source_labels": options.sync_source_labels,
-                "source_migrated_label": options.source_migrated_label,
-            }
-            result = gateway.invoke("task_import_jira_issues", payload).payload
-            if not isinstance(result, dict) or result.get("success") is not True:
-                raise RuntimeError(
-                    f"{run_label} pass {pass_index + 1} batch {batch_index} failed: {result}"
-                )
-            reports.append(result)
-            _merge_counter(aggregate_summary, result.get("summary"))
-            print(
-                json.dumps(
-                    {
-                        "run": run_label,
-                        "pass": pass_index + 1,
-                        "batch": batch_index,
-                        "batch_issue_count": len(batch),
-                        "summary": result.get("summary"),
-                    }
-                )
-            )
-
-    return {
-        "run_label": run_label,
-        "passes": options.passes,
-        "batch_size": options.batch_size,
-        "batch_count": len(reports),
-        "summary": dict(aggregate_summary),
-        "reports": reports,
-        "missing_target_issue_keys": _extract_missing_targets(
-            reports,
-            project_key=options.project_key,
+        updated_within_hours=(
+            int(args.updated_within_hours)
+            if isinstance(args.updated_within_hours, int)
+            else None
         ),
-    }
-
-
-async def _run(options: MigrationOptions) -> dict[str, Any]:
-    gateway = _build_gateway()
-
-    discovered_issue_docs = await _discover_issue_docs(
-        jql=options.jql,
-        fields=DEFAULT_FIELDS,
-        page_size=100,
+        include_done=bool(args.include_done),
+        min_issue_number=(
+            int(args.min_issue_number)
+            if isinstance(args.min_issue_number, int)
+            else None
+        ),
+        max_issue_number=(
+            int(args.max_issue_number)
+            if isinstance(args.max_issue_number, int)
+            else None
+        ),
     )
-    discovered_by_key = {
-        issue_key: issue_doc
-        for issue_doc in discovered_issue_docs
-        if isinstance(issue_doc, Mapping)
-        for issue_key in [_normalise_issue_key(issue_doc.get("key"))]
-        if isinstance(issue_key, str)
-    }
-    imported_issue_keys = set(
-        list_imported_jira_issue_keys(
-            organisation_concept_id=options.organisation_concept_id,
-            limit=2000,
-        )
-    )
-
-    selected_issue_docs = list(discovered_by_key.values())
-    if options.only_missing:
-        selected_issue_docs = [
-            issue_doc
-            for issue_doc in selected_issue_docs
-            if (
-                issue_key := _normalise_issue_key(issue_doc.get("key"))
-            ) not in imported_issue_keys
-        ]
-
-    report: dict[str, Any] = {
-        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
-        "options": {
-            "jql": options.jql,
-            "project_key": options.project_key,
-            "actor_concept_id": options.actor_concept_id,
-            "organisation_concept_id": options.organisation_concept_id,
-            "namespace": options.namespace,
-            "batch_size": options.batch_size,
-            "passes": options.passes,
-            "dry_run": options.dry_run,
-            "only_missing": options.only_missing,
-            "import_referenced_targets": options.import_referenced_targets,
-            "sync_source_labels": options.sync_source_labels,
-            "source_migrated_label": options.source_migrated_label,
-        },
-        "discovery": {
-            "discovered_issue_count": len(discovered_issue_docs),
-            "selected_issue_count": len(selected_issue_docs),
-            "already_imported_issue_count": len(imported_issue_keys),
-        },
-    }
-
-    main_run = _run_import_batches(
-        gateway=gateway,
-        issue_docs=selected_issue_docs,
-        options=options,
-        run_label="current_scope",
-    )
-    report["current_scope"] = {
-        key: value for key, value in main_run.items() if key != "reports"
-    }
-
-    referenced_target_keys = main_run.get("missing_target_issue_keys") or []
-    if options.import_referenced_targets and referenced_target_keys:
-        target_issue_docs = await _fetch_issue_docs_by_key(referenced_target_keys)
-        referenced_run = _run_import_batches(
-            gateway=gateway,
-            issue_docs=target_issue_docs,
-            options=options,
-            run_label="referenced_targets",
-        )
-        report["referenced_targets"] = {
-            key: value for key, value in referenced_run.items() if key != "reports"
-        }
-
-        # A final current-scope pass repairs links whose targets only became
-        # available after the referenced-target import completed.
-        repair_run = _run_import_batches(
-            gateway=gateway,
-            issue_docs=selected_issue_docs,
-            options=MigrationOptions(
-                jql=options.jql,
-                project_key=options.project_key,
-                actor_concept_id=options.actor_concept_id,
-                organisation_concept_id=options.organisation_concept_id,
-                namespace=options.namespace,
-                batch_size=options.batch_size,
-                passes=1,
-                dry_run=options.dry_run,
-                only_missing=options.only_missing,
-                import_referenced_targets=options.import_referenced_targets,
-                sync_source_labels=options.sync_source_labels,
-                source_migrated_label=options.source_migrated_label,
-                report_path=options.report_path,
-            ),
-            run_label="current_scope_repair",
-        )
-        report["current_scope_repair"] = {
-            key: value for key, value in repair_run.items() if key != "reports"
-        }
-
-    return report
 
 
 def main() -> None:
     options = _parse_args()
-    report = asyncio.run(_run(options))
-    options.report_path.parent.mkdir(parents=True, exist_ok=True)
-    options.report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    report = run_jira_task_migration_sync(options)
     print(json.dumps({"report_path": str(options.report_path), "summary": report}, indent=2))
 
 

--- a/src/backend/services/jira_task_migration_runner_service.py
+++ b/src/backend/services/jira_task_migration_runner_service.py
@@ -1,0 +1,579 @@
+"""Shared Jira task migration runner for bulk, incremental, and repair syncs.
+
+This keeps every Jira->Von task import entry point on the same canonical path:
+1. discover Jira issues via the Jira proxy,
+2. reuse seeded issue documents where possible, and
+3. invoke ``task_import_jira_issues`` through the internal MCP gateway.
+
+The runner supports:
+- full current-scope reconciliation,
+- recent-window incremental sync using ``updated >= -Nh``,
+- one-off recent catch-up by Jira issue-number range, and
+- referenced-target repair passes for linked issues outside the main window.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import Counter
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import re
+from typing import TYPE_CHECKING, Any, Iterator, Mapping, Sequence
+
+from ..integrations.internal_mcp.jira_proxy_mcp import get_jira_proxy
+
+if TYPE_CHECKING:
+    from ..integrations.internal_mcp.gateway import InternalMCPGateway
+
+DEFAULT_JIRA_TASK_MIGRATION_PROJECT_KEY = "JVNAUTOSCI"
+DEFAULT_JIRA_TASK_MIGRATION_BATCH_SIZE = 50
+DEFAULT_JIRA_TASK_MIGRATION_PAGE_SIZE = 100
+DEFAULT_JIRA_TASK_MIGRATION_PASSES = 2
+DEFAULT_JIRA_TASK_MIGRATION_REPORT_PATH = Path(
+    "artifacts/jira_task_migration_report.json"
+)
+DEFAULT_JIRA_TASK_MIGRATION_SOURCE_MIGRATED_LABEL = "migrated"
+DEFAULT_JIRA_TASK_MIGRATION_FIELDS = [
+    "summary",
+    "description",
+    "status",
+    "priority",
+    "labels",
+    "project",
+    "duedate",
+    "startdate",
+    "assignee",
+    "creator",
+    "reporter",
+    "parent",
+    "issuelinks",
+    "components",
+    "fixVersions",
+    "customfield_10020",
+    "customfield_10019",
+    "customfield_10027",
+    "customfield_10014",
+    "customfield_10008",
+]
+
+_ISSUE_KEY_NUMBER_RE = re.compile(r"^[A-Z][A-Z0-9_]*-(\d+)$")
+
+
+@dataclass(frozen=True)
+class JiraTaskMigrationOptions:
+    actor_concept_id: str
+    organisation_concept_id: str | None = None
+    namespace: str | None = None
+    project_key: str = DEFAULT_JIRA_TASK_MIGRATION_PROJECT_KEY
+    jql: str | None = None
+    batch_size: int = DEFAULT_JIRA_TASK_MIGRATION_BATCH_SIZE
+    page_size: int = DEFAULT_JIRA_TASK_MIGRATION_PAGE_SIZE
+    passes: int = DEFAULT_JIRA_TASK_MIGRATION_PASSES
+    dry_run: bool = False
+    only_missing: bool = False
+    import_referenced_targets: bool = False
+    sync_source_labels: bool = False
+    source_migrated_label: str = DEFAULT_JIRA_TASK_MIGRATION_SOURCE_MIGRATED_LABEL
+    report_path: Path | None = DEFAULT_JIRA_TASK_MIGRATION_REPORT_PATH
+    updated_within_hours: int | None = None
+    include_done: bool = False
+    min_issue_number: int | None = None
+    max_issue_number: int | None = None
+
+
+def build_default_jira_task_migration_jql(
+    *,
+    project_key: str,
+    include_done: bool,
+    updated_within_hours: int | None,
+) -> str:
+    """Build the default project-scoped Jira discovery query."""
+
+    project_key_clean = (
+        str(project_key).strip().upper() or DEFAULT_JIRA_TASK_MIGRATION_PROJECT_KEY
+    )
+    clauses = [
+        f"project = {project_key_clean}",
+        "issuetype in (Task, Subtask, Epic)",
+    ]
+    if not include_done:
+        clauses.append("statusCategory != Done")
+    if isinstance(updated_within_hours, int):
+        clauses.append(f"updated >= -{max(1, updated_within_hours)}h")
+        order_by = "updated ASC, key ASC"
+    else:
+        order_by = "key ASC"
+    return " AND ".join(clauses) + f" ORDER BY {order_by}"
+
+
+def _normalise_issue_key(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip().upper()
+    return cleaned or None
+
+
+def _extract_issue_number(issue_key: Any) -> int | None:
+    cleaned = _normalise_issue_key(issue_key)
+    if not cleaned:
+        return None
+    match = _ISSUE_KEY_NUMBER_RE.match(cleaned)
+    if match is None:
+        return None
+    try:
+        return int(match.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def normalise_jira_task_migration_options(
+    options: JiraTaskMigrationOptions,
+) -> JiraTaskMigrationOptions:
+    """Return a bounded, internally consistent options dataclass."""
+
+    actor_concept_id = str(options.actor_concept_id or "").strip()
+    if not actor_concept_id:
+        raise ValueError("actor_concept_id is required")
+
+    project_key = (
+        str(options.project_key or "").strip().upper()
+        or DEFAULT_JIRA_TASK_MIGRATION_PROJECT_KEY
+    )
+    batch_size = max(1, min(int(options.batch_size), 200))
+    page_size = max(1, min(int(options.page_size), 200))
+    passes = max(1, int(options.passes))
+
+    updated_within_hours: int | None = None
+    if isinstance(options.updated_within_hours, int):
+        updated_within_hours = max(1, int(options.updated_within_hours))
+
+    min_issue_number: int | None = None
+    if isinstance(options.min_issue_number, int):
+        min_issue_number = max(1, int(options.min_issue_number))
+
+    max_issue_number: int | None = None
+    if isinstance(options.max_issue_number, int):
+        max_issue_number = max(1, int(options.max_issue_number))
+
+    if (
+        isinstance(min_issue_number, int)
+        and isinstance(max_issue_number, int)
+        and min_issue_number > max_issue_number
+    ):
+        raise ValueError("min_issue_number must be <= max_issue_number")
+
+    jql = str(options.jql or "").strip() or None
+    if jql is None:
+        jql = build_default_jira_task_migration_jql(
+            project_key=project_key,
+            include_done=bool(options.include_done),
+            updated_within_hours=updated_within_hours,
+        )
+
+    organisation_concept_id = (
+        str(options.organisation_concept_id).strip()
+        if isinstance(options.organisation_concept_id, str)
+        and options.organisation_concept_id.strip()
+        else None
+    )
+    namespace = (
+        str(options.namespace).strip()
+        if isinstance(options.namespace, str) and options.namespace.strip()
+        else None
+    )
+    source_migrated_label = (
+        str(options.source_migrated_label or "").strip()
+        or DEFAULT_JIRA_TASK_MIGRATION_SOURCE_MIGRATED_LABEL
+    )
+    report_path = None
+    if options.report_path is not None:
+        report_path = Path(options.report_path)
+
+    return JiraTaskMigrationOptions(
+        actor_concept_id=actor_concept_id,
+        organisation_concept_id=organisation_concept_id,
+        namespace=namespace,
+        project_key=project_key,
+        jql=jql,
+        batch_size=batch_size,
+        page_size=page_size,
+        passes=passes,
+        dry_run=bool(options.dry_run),
+        only_missing=bool(options.only_missing),
+        import_referenced_targets=bool(options.import_referenced_targets),
+        sync_source_labels=bool(options.sync_source_labels),
+        source_migrated_label=source_migrated_label,
+        report_path=report_path,
+        updated_within_hours=updated_within_hours,
+        include_done=bool(options.include_done),
+        min_issue_number=min_issue_number,
+        max_issue_number=max_issue_number,
+    )
+
+
+def _iter_batches(
+    items: Sequence[Mapping[str, Any]],
+    batch_size: int,
+) -> Iterator[list[Mapping[str, Any]]]:
+    for start in range(0, len(items), batch_size):
+        yield list(items[start : start + batch_size])
+
+
+async def _discover_issue_docs(
+    *,
+    jql: str,
+    fields: Sequence[str],
+    page_size: int,
+) -> list[dict[str, Any]]:
+    proxy = await get_jira_proxy()
+    next_page_token: str | None = None
+    issue_docs: list[dict[str, Any]] = []
+
+    while True:
+        payload = await proxy.search(
+            jql=jql,
+            max_results=page_size,
+            next_page_token=next_page_token,
+            fields=list(fields),
+        )
+        raw_issues = payload.get("issues") if isinstance(payload, Mapping) else None
+        next_page_token = (
+            payload.get("nextPageToken") if isinstance(payload, Mapping) else None
+        )
+        if not isinstance(raw_issues, list) or not raw_issues:
+            break
+        issue_docs.extend(item for item in raw_issues if isinstance(item, dict))
+        if not isinstance(next_page_token, str) or not next_page_token.strip():
+            break
+
+    return issue_docs
+
+
+async def _fetch_issue_docs_by_key(
+    issue_keys: Sequence[str],
+    *,
+    fields: Sequence[str],
+) -> list[dict[str, Any]]:
+    proxy = await get_jira_proxy()
+    issue_docs: list[dict[str, Any]] = []
+    for issue_key in issue_keys:
+        payload = await proxy.get_issue(issue_key=issue_key, fields=list(fields))
+        if isinstance(payload, dict):
+            issue_docs.append(payload)
+    return issue_docs
+
+
+def _merge_counter(target: Counter[str], source: Mapping[str, Any] | None) -> None:
+    if not isinstance(source, Mapping):
+        return
+    for key, value in source.items():
+        if isinstance(value, bool):
+            target[str(key)] += int(value)
+            continue
+        if isinstance(value, int):
+            target[str(key)] += value
+
+
+def _extract_missing_targets(
+    reports: Sequence[Mapping[str, Any]],
+    *,
+    project_key: str,
+) -> list[str]:
+    missing_targets: set[str] = set()
+    project_prefix = f"{project_key.strip().upper()}-"
+    for report in reports:
+        issue_rows = report.get("issues")
+        if not isinstance(issue_rows, list):
+            continue
+        for issue_row in issue_rows:
+            if not isinstance(issue_row, Mapping):
+                continue
+            relation_rows = issue_row.get("relation_results")
+            if not isinstance(relation_rows, list):
+                continue
+            for relation_row in relation_rows:
+                if not isinstance(relation_row, Mapping):
+                    continue
+                if relation_row.get("reason") != "target_issue_not_imported":
+                    continue
+                issue_key = _normalise_issue_key(relation_row.get("target_issue_key"))
+                if isinstance(issue_key, str) and issue_key.startswith(project_prefix):
+                    missing_targets.add(issue_key)
+    return sorted(missing_targets)
+
+
+def _build_gateway() -> InternalMCPGateway:
+    from ..integrations.internal_mcp import build_default_catalogue
+    from ..integrations.internal_mcp.gateway import InternalMCPGateway
+    from ..integrations.internal_mcp.transport import InternalMCPTransport
+
+    return InternalMCPGateway(
+        catalogue=build_default_catalogue(),
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+
+
+def _run_import_batches(
+    *,
+    gateway: InternalMCPGateway,
+    issue_docs: Sequence[Mapping[str, Any]],
+    options: JiraTaskMigrationOptions,
+    run_label: str,
+) -> dict[str, Any]:
+    reports: list[dict[str, Any]] = []
+    aggregate_summary: Counter[str] = Counter()
+
+    for pass_index in range(options.passes):
+        for batch in _iter_batches(issue_docs, options.batch_size):
+            payload = {
+                "issue_keys": [dict(item) for item in batch if isinstance(item, Mapping)],
+                "dry_run": options.dry_run,
+                "update_existing": True,
+                "include_watchers": False,
+                "namespace": options.namespace,
+                "actor_concept_id": options.actor_concept_id,
+                "organisation_concept_id": options.organisation_concept_id,
+                "auto_resolve_participants": True,
+                "create_missing_participant_concepts": True,
+                "sync_source_labels": options.sync_source_labels,
+                "source_migrated_label": options.source_migrated_label,
+            }
+            result = gateway.invoke("task_import_jira_issues", payload).payload
+            if not isinstance(result, dict) or result.get("success") is not True:
+                raise RuntimeError(
+                    f"{run_label} pass {pass_index + 1} failed: {result}"
+                )
+            reports.append(result)
+            _merge_counter(aggregate_summary, result.get("summary"))
+
+    return {
+        "run_label": run_label,
+        "passes": options.passes,
+        "batch_size": options.batch_size,
+        "input_issue_count": len(issue_docs),
+        "batch_count": len(reports),
+        "summary": dict(aggregate_summary),
+        "reports": reports,
+        "missing_target_issue_keys": _extract_missing_targets(
+            reports,
+            project_key=options.project_key,
+        ),
+    }
+
+
+def _filter_issue_docs_by_issue_number(
+    issue_docs: Sequence[Mapping[str, Any]],
+    *,
+    min_issue_number: int | None,
+    max_issue_number: int | None,
+) -> tuple[list[Mapping[str, Any]], int]:
+    if min_issue_number is None and max_issue_number is None:
+        return list(issue_docs), 0
+
+    selected: list[Mapping[str, Any]] = []
+    filtered_out_count = 0
+    for issue_doc in issue_docs:
+        issue_number = _extract_issue_number(issue_doc.get("key"))
+        if issue_number is None:
+            filtered_out_count += 1
+            continue
+        if isinstance(min_issue_number, int) and issue_number < min_issue_number:
+            filtered_out_count += 1
+            continue
+        if isinstance(max_issue_number, int) and issue_number > max_issue_number:
+            filtered_out_count += 1
+            continue
+        selected.append(issue_doc)
+    return selected, filtered_out_count
+
+
+def _options_to_report_dict(
+    options: JiraTaskMigrationOptions,
+) -> dict[str, Any]:
+    return {
+        "project_key": options.project_key,
+        "jql": options.jql,
+        "actor_concept_id": options.actor_concept_id,
+        "organisation_concept_id": options.organisation_concept_id,
+        "namespace": options.namespace,
+        "batch_size": options.batch_size,
+        "page_size": options.page_size,
+        "passes": options.passes,
+        "dry_run": options.dry_run,
+        "only_missing": options.only_missing,
+        "import_referenced_targets": options.import_referenced_targets,
+        "sync_source_labels": options.sync_source_labels,
+        "source_migrated_label": options.source_migrated_label,
+        "report_path": str(options.report_path) if options.report_path else None,
+        "updated_within_hours": options.updated_within_hours,
+        "include_done": options.include_done,
+        "min_issue_number": options.min_issue_number,
+        "max_issue_number": options.max_issue_number,
+    }
+
+
+def write_jira_task_migration_report(
+    report: Mapping[str, Any],
+    *,
+    report_path: Path,
+) -> Path:
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    return report_path
+
+
+async def run_jira_task_migration(
+    options: JiraTaskMigrationOptions,
+    *,
+    gateway: InternalMCPGateway | None = None,
+) -> dict[str, Any]:
+    """Run the Jira task migration and return a deterministic summary report."""
+
+    options = normalise_jira_task_migration_options(options)
+    gateway = gateway or _build_gateway()
+
+    discovered_issue_docs = await _discover_issue_docs(
+        jql=str(options.jql),
+        fields=DEFAULT_JIRA_TASK_MIGRATION_FIELDS,
+        page_size=options.page_size,
+    )
+    discovered_by_key = {
+        issue_key: issue_doc
+        for issue_doc in discovered_issue_docs
+        if isinstance(issue_doc, Mapping)
+        for issue_key in [_normalise_issue_key(issue_doc.get("key"))]
+        if isinstance(issue_key, str)
+    }
+    deduplicated_issue_docs = list(discovered_by_key.values())
+
+    candidate_issue_docs, issue_number_filtered_out_count = (
+        _filter_issue_docs_by_issue_number(
+            deduplicated_issue_docs,
+            min_issue_number=options.min_issue_number,
+            max_issue_number=options.max_issue_number,
+        )
+    )
+
+    from .jira_task_import_service import list_imported_jira_issue_keys
+
+    imported_issue_keys = set(
+        list_imported_jira_issue_keys(
+            organisation_concept_id=options.organisation_concept_id,
+            limit=2000,
+        )
+    )
+    already_imported_selected_issue_count = sum(
+        1
+        for issue_doc in candidate_issue_docs
+        if (
+            issue_key := _normalise_issue_key(issue_doc.get("key"))
+        ) in imported_issue_keys
+    )
+
+    selected_issue_docs = list(candidate_issue_docs)
+    if options.only_missing:
+        selected_issue_docs = [
+            issue_doc
+            for issue_doc in candidate_issue_docs
+            if (
+                issue_key := _normalise_issue_key(issue_doc.get("key"))
+            ) not in imported_issue_keys
+        ]
+
+    selection_mode = "explicit_jql"
+    if not options.include_done and options.updated_within_hours is None and not options.only_missing:
+        selection_mode = "current_scope"
+    if options.updated_within_hours is not None:
+        selection_mode = "incremental_recent_window"
+
+    report: dict[str, Any] = {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "options": _options_to_report_dict(options),
+        "discovery": {
+            "selection_mode": selection_mode,
+            "discovered_issue_count": len(discovered_issue_docs),
+            "deduplicated_issue_count": len(deduplicated_issue_docs),
+            "duplicate_issue_count": len(discovered_issue_docs)
+            - len(deduplicated_issue_docs),
+            "issue_number_filtered_out_count": issue_number_filtered_out_count,
+            "candidate_selected_issue_count": len(candidate_issue_docs),
+            "already_imported_issue_count": len(imported_issue_keys),
+            "already_imported_selected_issue_count": already_imported_selected_issue_count,
+            "selected_issue_count": len(selected_issue_docs),
+            "selected_issue_keys_sample": [
+                issue_key
+                for issue_doc in selected_issue_docs[:20]
+                for issue_key in [_normalise_issue_key(issue_doc.get("key"))]
+                if isinstance(issue_key, str)
+            ],
+        },
+    }
+
+    main_run = _run_import_batches(
+        gateway=gateway,
+        issue_docs=selected_issue_docs,
+        options=options,
+        run_label="current_scope",
+    )
+    report["current_scope"] = {
+        key: value for key, value in main_run.items() if key != "reports"
+    }
+
+    referenced_target_keys = main_run.get("missing_target_issue_keys") or []
+    if options.import_referenced_targets and referenced_target_keys:
+        target_issue_docs = await _fetch_issue_docs_by_key(
+            referenced_target_keys,
+            fields=DEFAULT_JIRA_TASK_MIGRATION_FIELDS,
+        )
+        referenced_run = _run_import_batches(
+            gateway=gateway,
+            issue_docs=target_issue_docs,
+            options=options,
+            run_label="referenced_targets",
+        )
+        report["referenced_targets"] = {
+            key: value for key, value in referenced_run.items() if key != "reports"
+        }
+
+        # Repair current-scope links after imported targets become available.
+        repair_run = _run_import_batches(
+            gateway=gateway,
+            issue_docs=selected_issue_docs,
+            options=replace(options, passes=1),
+            run_label="current_scope_repair",
+        )
+        report["current_scope_repair"] = {
+            key: value for key, value in repair_run.items() if key != "reports"
+        }
+
+    if options.report_path is not None:
+        write_jira_task_migration_report(report, report_path=options.report_path)
+
+    return report
+
+
+def run_jira_task_migration_sync(
+    options: JiraTaskMigrationOptions,
+    *,
+    gateway: InternalMCPGateway | None = None,
+) -> dict[str, Any]:
+    """Synchronous wrapper for CLI and durable-workflow callers."""
+
+    return asyncio.run(run_jira_task_migration(options, gateway=gateway))
+
+
+__all__ = [
+    "DEFAULT_JIRA_TASK_MIGRATION_FIELDS",
+    "DEFAULT_JIRA_TASK_MIGRATION_PROJECT_KEY",
+    "DEFAULT_JIRA_TASK_MIGRATION_REPORT_PATH",
+    "JiraTaskMigrationOptions",
+    "build_default_jira_task_migration_jql",
+    "normalise_jira_task_migration_options",
+    "run_jira_task_migration",
+    "run_jira_task_migration_sync",
+    "write_jira_task_migration_report",
+]

--- a/src/backend/workflows/durable/jira_task_incremental_import_workflow.py
+++ b/src/backend/workflows/durable/jira_task_incremental_import_workflow.py
@@ -1,0 +1,215 @@
+"""Durable workflow for scheduled Jira task incremental import (JVNAUTOSCI-1407).
+
+The workflow stays deliberately thin. It delegates the heavy lifting to the
+shared Jira task migration runner so manual CLI runs, ad-hoc workflow
+instances, and scheduled automation all observe the same behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...services.jira_task_migration_runner_service import (
+    DEFAULT_JIRA_TASK_MIGRATION_PROJECT_KEY,
+    JiraTaskMigrationOptions,
+    run_jira_task_migration_sync,
+)
+from ..action_registry import (
+    ActionRegistry,
+    ActionSpec,
+    WorkflowActionRequest,
+    WorkflowActionResult,
+)
+from ..engine import (
+    WorkflowActionInvocation,
+    WorkflowDefinition,
+    WorkflowStateSpec,
+    WorkflowTransitionSpec,
+)
+from ..workflow_registry import WorkflowRegistration
+
+JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID = "#V#jira_task_incremental_import_workflow"
+JIRA_TASK_INCREMENTAL_IMPORT_ACTION_ID = "jira_task_incremental_import.run_sync"
+JIRA_TASK_INCREMENTAL_IMPORT_VERSION = "jira_task_incremental_import.v1"
+
+
+def _clean_text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _context_value(request: WorkflowActionRequest, key: str) -> Any:
+    if key in request.inputs:
+        return request.inputs.get(key)
+    return request.data.get(key)
+
+
+def _build_options_from_request(
+    request: WorkflowActionRequest,
+) -> JiraTaskMigrationOptions:
+    actor_concept_id = _clean_text(_context_value(request, "actor_concept_id"))
+    if not actor_concept_id:
+        raise ValueError("actor_concept_id is required for Jira task import workflow")
+
+    namespace = _clean_text(_context_value(request, "namespace")) or _clean_text(
+        getattr(request.environment, "user_namespace", None)
+    )
+    organisation_concept_id = _clean_text(
+        _context_value(request, "organisation_concept_id")
+    ) or None
+
+    return JiraTaskMigrationOptions(
+        actor_concept_id=actor_concept_id,
+        organisation_concept_id=organisation_concept_id,
+        namespace=namespace or None,
+        project_key=(
+            _clean_text(_context_value(request, "project_key"))
+            or DEFAULT_JIRA_TASK_MIGRATION_PROJECT_KEY
+        ),
+        jql=_clean_text(_context_value(request, "jql")) or None,
+        batch_size=_coerce_int(_context_value(request, "batch_size")) or 50,
+        page_size=_coerce_int(_context_value(request, "page_size")) or 100,
+        passes=_coerce_int(_context_value(request, "passes")) or 1,
+        dry_run=_coerce_bool(_context_value(request, "dry_run"), default=False),
+        only_missing=_coerce_bool(
+            _context_value(request, "only_missing"),
+            default=False,
+        ),
+        import_referenced_targets=_coerce_bool(
+            _context_value(request, "import_referenced_targets"),
+            default=True,
+        ),
+        sync_source_labels=_coerce_bool(
+            _context_value(request, "sync_source_labels"),
+            default=False,
+        ),
+        source_migrated_label=(
+            _clean_text(_context_value(request, "source_migrated_label"))
+            or "migrated"
+        ),
+        report_path=None,
+        updated_within_hours=_coerce_int(
+            _context_value(request, "updated_within_hours")
+        ),
+        include_done=_coerce_bool(
+            _context_value(request, "include_done"),
+            default=False,
+        ),
+        min_issue_number=_coerce_int(
+            _context_value(request, "min_issue_number")
+        ),
+        max_issue_number=_coerce_int(
+            _context_value(request, "max_issue_number")
+        ),
+    )
+
+
+def _handle_run_sync(request: WorkflowActionRequest) -> WorkflowActionResult:
+    report = run_jira_task_migration_sync(_build_options_from_request(request))
+    current_scope = report.get("current_scope")
+    if not isinstance(current_scope, dict):
+        current_scope = {}
+    return WorkflowActionResult(
+        status="success",
+        outputs={
+            "jira_task_migration_result": report,
+            "jira_task_migration_summary": current_scope.get("summary") or {},
+            "jira_task_migration_missing_target_issue_keys": (
+                current_scope.get("missing_target_issue_keys") or []
+            ),
+        },
+    )
+
+
+def build_jira_task_incremental_import_workflow() -> WorkflowDefinition:
+    run_sync = WorkflowStateSpec(
+        state_id="run_sync",
+        actions=(
+            WorkflowActionInvocation(
+                action_id=JIRA_TASK_INCREMENTAL_IMPORT_ACTION_ID,
+                description=(
+                    "Synchronise Jira tasks into Von using the shared migration runner."
+                ),
+            ),
+        ),
+        transitions=(
+            WorkflowTransitionSpec(
+                to_state="failed",
+                condition=lambda ctx: bool(ctx.get("last_action_failed")),
+                reason="sync_failed",
+            ),
+            WorkflowTransitionSpec(
+                to_state="complete",
+                condition=lambda _ctx: True,
+                reason="sync_complete",
+            ),
+        ),
+    )
+
+    complete = WorkflowStateSpec(state_id="complete", terminal=True)
+    failed = WorkflowStateSpec(state_id="failed", terminal=True)
+
+    return WorkflowDefinition(
+        workflow_id=JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID,
+        initial_state="run_sync",
+        states={
+            "run_sync": run_sync,
+            "complete": complete,
+            "failed": failed,
+        },
+        termination_states=("complete", "failed"),
+        purpose=(
+            "Scheduled incremental Jira task import that reuses the canonical "
+            "Jira discovery and task_import_jira_issues gateway path."
+        ),
+    )
+
+
+def get_jira_task_incremental_import_workflow_registration() -> WorkflowRegistration:
+    return WorkflowRegistration(
+        workflow_id=JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID,
+        definition=build_jira_task_incremental_import_workflow(),
+        purpose=(
+            "Background incremental Jira task import using the shared migration runner."
+        ),
+        source="built_in",
+    )
+
+
+def register_jira_task_incremental_import_actions(registry: ActionRegistry) -> None:
+    registry.register_if_absent(
+        ActionSpec(
+            action_id=JIRA_TASK_INCREMENTAL_IMPORT_ACTION_ID,
+            handler=_handle_run_sync,
+            description="Run the shared Jira task incremental import.",
+            side_effects="write",
+        )
+    )
+
+
+__all__ = [
+    "JIRA_TASK_INCREMENTAL_IMPORT_ACTION_ID",
+    "JIRA_TASK_INCREMENTAL_IMPORT_VERSION",
+    "JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID",
+    "build_jira_task_incremental_import_workflow",
+    "get_jira_task_incremental_import_workflow_registration",
+    "register_jira_task_incremental_import_actions",
+]

--- a/src/backend/workflows/durable/registry_factory.py
+++ b/src/backend/workflows/durable/registry_factory.py
@@ -60,6 +60,10 @@ from .entity_identity_resolution_workflow import (
     get_entity_identity_resolution_workflow_registration,
     register_entity_identity_resolution_actions,
 )
+from .jira_task_incremental_import_workflow import (
+    get_jira_task_incremental_import_workflow_registration,
+    register_jira_task_incremental_import_actions,
+)
 from .parent_specificity_concept_dossier_workflow import (
     get_parent_specificity_concept_dossier_workflow_registration,
     register_parent_specificity_concept_dossier_actions,
@@ -445,6 +449,7 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
     registry.register(get_file_copy_upload_handler_workflow_registration())
     registry.register(get_file_copy_interpretation_workflow_registration())
     registry.register(get_entity_identity_resolution_workflow_registration())
+    registry.register(get_jira_task_incremental_import_workflow_registration())
     registry.register(get_parent_specificity_concept_dossier_workflow_registration())
     registry.register(get_parent_specificity_rumination_workflow_registration())
     registry.register(get_workflow_discovery_gap_recovery_workflow_registration())
@@ -586,6 +591,7 @@ def build_durable_action_registry() -> ActionRegistry:
     register_file_copy_upload_handler_actions(registry)
     register_file_copy_interpretation_actions(registry)
     register_entity_identity_resolution_actions(registry)
+    register_jira_task_incremental_import_actions(registry)
     register_parent_specificity_concept_dossier_actions(registry)
     register_parent_specificity_rumination_actions(registry)
     register_workflow_gap_recovery_actions(registry)

--- a/tests/backend/test_jira_task_incremental_import_workflow.py
+++ b/tests/backend/test_jira_task_incremental_import_workflow.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from src.backend.workflows.action_registry import ActionRegistry, WorkflowEnvironment
+from src.backend.workflows.durable import jira_task_incremental_import_workflow as mod
+from src.backend.workflows.engine import WorkflowExecutor
+
+
+def test_incremental_import_workflow_executes_shared_runner(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run(options):
+        captured["options"] = options
+        return {
+            "generated_at_utc": "2026-03-09T00:00:00+00:00",
+            "current_scope": {
+                "summary": {"total_issues": 3, "updated": 3},
+                "missing_target_issue_keys": ["JVNAUTOSCI-1199"],
+            },
+        }
+
+    monkeypatch.setattr(mod, "run_jira_task_migration_sync", _fake_run)
+
+    registration = mod.get_jira_task_incremental_import_workflow_registration()
+    registry = ActionRegistry()
+    mod.register_jira_task_incremental_import_actions(registry)
+
+    result = WorkflowExecutor(registry=registry, max_transitions=5).run(
+        registration.definition,
+        environment=WorkflowEnvironment(
+            llm_client=None,
+            user_namespace="#V#michael_witbrock@university_of_auckland_strong_ai_lab",
+        ),
+        data={
+            "actor_concept_id": "#V#michael_witbrock",
+            "organisation_concept_id": "#V#university_of_auckland_strong_ai_lab",
+            "project_key": "JVNAUTOSCI",
+            "updated_within_hours": 24,
+            "import_referenced_targets": True,
+        },
+    )
+
+    assert result.completed is True
+    assert result.final_state == "complete"
+    assert result.data["jira_task_migration_summary"]["total_issues"] == 3
+    assert result.data["jira_task_migration_missing_target_issue_keys"] == [
+        "JVNAUTOSCI-1199"
+    ]
+    options = captured["options"]
+    assert isinstance(options, mod.JiraTaskMigrationOptions)
+    assert options.actor_concept_id == "#V#michael_witbrock"
+    assert options.namespace == "#V#michael_witbrock@university_of_auckland_strong_ai_lab"
+    assert options.updated_within_hours == 24
+    assert options.import_referenced_targets is True
+
+
+def test_registry_factory_registers_incremental_import_workflow(monkeypatch) -> None:
+    import src.backend.workflows.durable.registry_factory as factory
+
+    monkeypatch.setattr(factory, "discover_workflow_ids", lambda: [])
+    monkeypatch.setattr(
+        factory,
+        "build_workflow_concept_authority_report",
+        lambda registry: {},
+    )
+    monkeypatch.setattr(factory, "_apply_workflow_parity_policy", lambda snapshot: None)
+
+    registry = factory._build_workflow_registry(allow_bootstrap=False)
+    actions = factory.build_durable_action_registry()
+
+    assert registry.get(mod.JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID) is not None
+    assert actions.has(mod.JIRA_TASK_INCREMENTAL_IMPORT_ACTION_ID) is True

--- a/tests/backend/test_jira_task_migration_runner_service.py
+++ b/tests/backend/test_jira_task_migration_runner_service.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+from src.backend.services import jira_task_migration_runner_service as mod
+
+
+class _FakeInvokeResult:
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+        self.duration_ms = 0.0
+
+
+class _FakeGateway:
+    def __init__(self, responses: list[dict]) -> None:
+        self._responses = responses
+        self.calls: list[dict] = []
+
+    def invoke(self, tool_name: str, payload: dict) -> _FakeInvokeResult:
+        self.calls.append({"tool_name": tool_name, "payload": payload})
+        return _FakeInvokeResult(self._responses[len(self.calls) - 1])
+
+
+def test_run_jira_task_migration_filters_recent_catch_up_and_only_missing(
+    monkeypatch,
+) -> None:
+    class _FakeProxy:
+        async def search(
+            self,
+            *,
+            jql: str,
+            max_results=None,
+            next_page_token=None,
+            fields=None,
+        ):
+            assert "statusCategory != Done" in jql
+            assert "ORDER BY key ASC" in jql
+            assert max_results == 100
+            assert next_page_token is None
+            assert isinstance(fields, list)
+            return {
+                "issues": [
+                    {"key": "JVNAUTOSCI-1199", "fields": {"summary": "Old"}},
+                    {"key": "JVNAUTOSCI-1200", "fields": {"summary": "Imported"}},
+                    {"key": "JVNAUTOSCI-1201", "fields": {"summary": "Recent"}},
+                    {"key": "JVNAUTOSCI-1407", "fields": {"summary": "Newest"}},
+                ]
+            }
+
+        async def get_issue(self, *, issue_key: str, fields=None):  # pragma: no cover
+            raise AssertionError(f"unexpected get_issue call for {issue_key}")
+
+    async def _fake_get_jira_proxy():
+        return _FakeProxy()
+
+    monkeypatch.setattr(mod, "get_jira_proxy", _fake_get_jira_proxy)
+    monkeypatch.setattr(
+        "src.backend.services.jira_task_import_service.list_imported_jira_issue_keys",
+        lambda **_kwargs: ["JVNAUTOSCI-1200"],
+    )
+
+    gateway = _FakeGateway(
+        [
+            {
+                "success": True,
+                "summary": {"total_issues": 2, "created": 2},
+                "issues": [],
+            }
+        ]
+    )
+    options = mod.JiraTaskMigrationOptions(
+        actor_concept_id="#V#michael_witbrock",
+        organisation_concept_id="#V#university_of_auckland_strong_ai_lab",
+        namespace="#V#michael_witbrock@university_of_auckland_strong_ai_lab",
+        only_missing=True,
+        min_issue_number=1200,
+        passes=1,
+        report_path=None,
+    )
+
+    report = asyncio.run(
+        mod.run_jira_task_migration(options, gateway=cast(Any, gateway))
+    )
+
+    assert report["discovery"]["discovered_issue_count"] == 4
+    assert report["discovery"]["issue_number_filtered_out_count"] == 1
+    assert report["discovery"]["candidate_selected_issue_count"] == 3
+    assert report["discovery"]["already_imported_selected_issue_count"] == 1
+    assert report["discovery"]["selected_issue_count"] == 2
+    assert report["discovery"]["selected_issue_keys_sample"] == [
+        "JVNAUTOSCI-1201",
+        "JVNAUTOSCI-1407",
+    ]
+    assert len(gateway.calls) == 1
+    assert gateway.calls[0]["tool_name"] == "task_import_jira_issues"
+    issue_keys = gateway.calls[0]["payload"]["issue_keys"]
+    assert [item["key"] for item in issue_keys] == [
+        "JVNAUTOSCI-1201",
+        "JVNAUTOSCI-1407",
+    ]
+
+
+def test_run_jira_task_migration_repairs_missing_referenced_targets(
+    monkeypatch,
+) -> None:
+    get_issue_calls: list[str] = []
+
+    class _FakeProxy:
+        async def search(
+            self,
+            *,
+            jql: str,  # noqa: ARG002
+            max_results=None,  # noqa: ARG002
+            next_page_token=None,  # noqa: ARG002
+            fields=None,  # noqa: ARG002
+        ):
+            return {
+                "issues": [
+                    {"key": "JVNAUTOSCI-1407", "fields": {"summary": "Needs target"}}
+                ]
+            }
+
+        async def get_issue(self, *, issue_key: str, fields=None):  # noqa: ARG002
+            get_issue_calls.append(issue_key)
+            return {"key": issue_key, "fields": {"summary": f"Fetched {issue_key}"}}
+
+    async def _fake_get_jira_proxy():
+        return _FakeProxy()
+
+    monkeypatch.setattr(mod, "get_jira_proxy", _fake_get_jira_proxy)
+    monkeypatch.setattr(
+        "src.backend.services.jira_task_import_service.list_imported_jira_issue_keys",
+        lambda **_kwargs: [],
+    )
+
+    gateway = _FakeGateway(
+        [
+            {
+                "success": True,
+                "summary": {"total_issues": 1, "updated": 1},
+                "issues": [
+                    {
+                        "relation_results": [
+                            {
+                                "reason": "target_issue_not_imported",
+                                "target_issue_key": "JVNAUTOSCI-1199",
+                            }
+                        ]
+                    }
+                ],
+            },
+            {
+                "success": True,
+                "summary": {"total_issues": 1, "created": 1},
+                "issues": [],
+            },
+            {
+                "success": True,
+                "summary": {"total_issues": 1, "updated": 1},
+                "issues": [],
+            },
+        ]
+    )
+    options = mod.JiraTaskMigrationOptions(
+        actor_concept_id="#V#michael_witbrock",
+        organisation_concept_id="#V#university_of_auckland_strong_ai_lab",
+        namespace="#V#michael_witbrock@university_of_auckland_strong_ai_lab",
+        import_referenced_targets=True,
+        report_path=None,
+        passes=1,
+    )
+
+    report = asyncio.run(
+        mod.run_jira_task_migration(options, gateway=cast(Any, gateway))
+    )
+
+    assert report["current_scope"]["missing_target_issue_keys"] == ["JVNAUTOSCI-1199"]
+    assert report["referenced_targets"]["input_issue_count"] == 1
+    assert report["current_scope_repair"]["input_issue_count"] == 1
+    assert get_issue_calls == ["JVNAUTOSCI-1199"]
+    assert len(gateway.calls) == 3
+    assert [item["key"] for item in gateway.calls[0]["payload"]["issue_keys"]] == [
+        "JVNAUTOSCI-1407"
+    ]
+    assert [item["key"] for item in gateway.calls[1]["payload"]["issue_keys"]] == [
+        "JVNAUTOSCI-1199"
+    ]
+    assert [item["key"] for item in gateway.calls[2]["payload"]["issue_keys"]] == [
+        "JVNAUTOSCI-1407"
+    ]


### PR DESCRIPTION
## Summary
- extract the Jira task migration logic into a shared incremental-capable runner service
- add a durable #V#jira_task_incremental_import_workflow that reuses the canonical Jira proxy -> task_import_jira_issues path
- extend the migration CLI with recent-window and issue-number catch-up filters, and document the new operational surfaces

## Validation
- pdm run pyright scripts/run_jira_task_migration.py src/backend/services/jira_task_migration_runner_service.py src/backend/workflows/durable/jira_task_incremental_import_workflow.py src/backend/workflows/durable/registry_factory.py tests/backend/test_jira_task_incremental_import_workflow.py tests/backend/test_jira_task_migration_runner_service.py
- pdm run pytest tests/backend/test_jira_task_incremental_import_workflow.py tests/backend/test_jira_task_migration_runner_service.py tests/backend/test_workflow_registry_factory_parity.py tests/backend/test_internal_mcp_task_parity_tools.py tests/backend/test_e2e_jira_task_migration_workflow.py -q

## Live rollout
- one-off catch-up run imported the missing current-scope issue (JVNAUTOSCI-1407), bringing live non-Done coverage from 468/469 to 469/469
- materialised recurring schedule #V#schedule_f19ae0937ff940888b2dc9450587fec0 for #V#jira_task_incremental_import_workflow