### PR TITLE
JVNAUTOSCI-1408 Harden selector routing for required tools

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -203,6 +203,33 @@ class _OntologyPreflightResult:
 
 
 @dataclass(frozen=True)
+class _PromptRequirementEvaluation:
+    """Canonical prompt-requirement snapshot shared across routing/execution."""
+
+    required_tools: tuple[str, ...] = ()
+    required_fetch_concept_ids: tuple[str, ...] = ()
+    required_read_file_copy_ids: tuple[str, ...] = ()
+    required_scholarly_representation_file_copy_ids: tuple[str, ...] = ()
+    required_create_type_name: str | None = None
+    unavailable_required_tools: tuple[str, ...] = ()
+    scholarly_representation_intent: bool = False
+    missing_tools: tuple[str, ...] = ()
+    missing_fetch_concept_ids: tuple[str, ...] = ()
+    missing_read_file_copy_ids: tuple[str, ...] = ()
+    missing_scholarly_representation_file_copy_ids: tuple[str, ...] = ()
+    missing_retry_reason: str | None = None
+
+    @property
+    def has_missing_requirements(self) -> bool:
+        return bool(
+            self.missing_tools
+            or self.missing_fetch_concept_ids
+            or self.missing_read_file_copy_ids
+            or self.missing_scholarly_representation_file_copy_ids
+        )
+
+
+@dataclass(frozen=True)
 class _WorkflowModelPolicyState:
     enabled: bool
     policy: Mapping[str, Any] | None
@@ -3652,58 +3679,30 @@ class InternalMCPChatOrchestrator:
         if not isinstance(prompt_for_requirements, str) or not prompt_for_requirements.strip():
             prompt_for_requirements = prompt
 
-        prompt_requirement_state = self._derive_prompt_tool_requirements(
-            prompt_for_requirements,
+        prompt_requirements = self._evaluate_prompt_requirements(
+            prompt_text=prompt_for_requirements,
             method_catalogue=(
                 method_catalogue_for_requirements
                 if isinstance(method_catalogue_for_requirements, Mapping)
                 else None
             ),
             context_messages=augmented_context,
+            tool_invocations=(),
         )
-        required_prompt_tools = list(
-            cast(list[str], prompt_requirement_state.get("required_tools") or [])
-        )
+        required_prompt_tools = list(prompt_requirements.required_tools)
         required_prompt_fetch_concept_ids = list(
-            cast(
-                list[str],
-                prompt_requirement_state.get("required_fetch_concept_ids") or [],
-            )
+            prompt_requirements.required_fetch_concept_ids
         )
         required_prompt_read_file_copy_ids = list(
-            cast(
-                list[str],
-                prompt_requirement_state.get("required_read_file_copy_ids") or [],
-            )
+            prompt_requirements.required_read_file_copy_ids
         )
         required_prompt_scholarly_representation_file_copy_ids = list(
-            cast(
-                list[str],
-                prompt_requirement_state.get(
-                    "required_scholarly_representation_for_file_copy_ids"
-                )
-                or [],
-            )
-        )
-        required_prompt_create_type_name_raw = prompt_requirement_state.get(
-            "required_create_type_name"
+            prompt_requirements.required_scholarly_representation_file_copy_ids
         )
         required_prompt_create_type_name = (
-            str(required_prompt_create_type_name_raw).strip()
-            if isinstance(required_prompt_create_type_name_raw, str)
-            else None
+            prompt_requirements.required_create_type_name
         )
-        data["required_prompt_tools"] = list(required_prompt_tools)
-        data["required_prompt_fetch_concept_ids"] = list(
-            required_prompt_fetch_concept_ids
-        )
-        data["required_prompt_read_file_copy_ids"] = list(
-            required_prompt_read_file_copy_ids
-        )
-        data["required_prompt_scholarly_representation_for_file_copy_ids"] = list(
-            required_prompt_scholarly_representation_file_copy_ids
-        )
-        data["required_prompt_create_type_name"] = required_prompt_create_type_name
+        self._store_prompt_requirement_evaluation(data, prompt_requirements)
 
         # Emit planning phase.
         if callable(emit_phase_transition):
@@ -3813,40 +3812,16 @@ class InternalMCPChatOrchestrator:
 
         # Missing-tool-call recovery.
         if not has_valid_tool_call:
-            (
-                missing_prompt_tools,
-                missing_prompt_fetch_concept_ids,
-                missing_prompt_read_file_copy_ids,
-                missing_prompt_scholarly_representation_file_copy_ids,
-            ) = (
-                self._derive_missing_prompt_requirements(
-                    required_tools=required_prompt_tools,
-                    required_fetch_concept_ids=required_prompt_fetch_concept_ids,
-                    required_read_file_copy_ids=required_prompt_read_file_copy_ids,
-                    required_scholarly_representation_for_file_copy_ids=required_prompt_scholarly_representation_file_copy_ids,
-                    tool_invocations=(),
-                )
+            missing_prompt_tools = list(prompt_requirements.missing_tools)
+            missing_prompt_fetch_concept_ids = list(
+                prompt_requirements.missing_fetch_concept_ids
             )
-            data["missing_prompt_fetch_concept_ids"] = list(
-                missing_prompt_fetch_concept_ids
+            missing_prompt_read_file_copy_ids = list(
+                prompt_requirements.missing_read_file_copy_ids
             )
-            data["missing_prompt_read_file_copy_ids"] = list(
-                missing_prompt_read_file_copy_ids
+            missing_prompt_scholarly_representation_file_copy_ids = list(
+                prompt_requirements.missing_scholarly_representation_file_copy_ids
             )
-            data["missing_prompt_scholarly_representation_for_file_copy_ids"] = list(
-                missing_prompt_scholarly_representation_file_copy_ids
-            )
-            missing_retry_reason = self._build_missing_prompt_retry_reason(
-                missing_tools=missing_prompt_tools,
-                missing_fetch_concept_ids=missing_prompt_fetch_concept_ids,
-                missing_read_file_copy_ids=missing_prompt_read_file_copy_ids,
-                missing_scholarly_representation_file_copy_ids=missing_prompt_scholarly_representation_file_copy_ids,
-            )
-            data["missing_prompt_tools"] = list(missing_prompt_tools)
-            if missing_retry_reason:
-                data["missing_tool_call_retry_reason_override"] = missing_retry_reason
-            else:
-                data.pop("missing_tool_call_retry_reason_override", None)
 
             recovery_data = self._run_missing_tool_call_recovery_workflow(
                 request=request,
@@ -4692,96 +4667,43 @@ class InternalMCPChatOrchestrator:
             if not isinstance(prompt_for_requirements, str) or not prompt_for_requirements.strip():
                 prompt_for_requirements = data.get("prompt")
 
-            prompt_requirement_state = self._derive_prompt_tool_requirements(
-                prompt_for_requirements,
+            invocations_for_requirements = cast(
+                Sequence[Mapping[str, Any]], data.get("invocations") or []
+            )
+            prompt_requirements = self._evaluate_prompt_requirements(
+                prompt_text=prompt_for_requirements,
                 method_catalogue=(
                     method_catalogue_for_requirements
                     if isinstance(method_catalogue_for_requirements, Mapping)
                     else None
                 ),
                 context_messages=augmented_context,
+                tool_invocations=invocations_for_requirements,
             )
-            required_prompt_tools = list(
-                cast(list[str], prompt_requirement_state.get("required_tools") or [])
-            )
+            required_prompt_tools = list(prompt_requirements.required_tools)
             required_prompt_fetch_concept_ids = list(
-                cast(
-                    list[str],
-                    prompt_requirement_state.get("required_fetch_concept_ids") or [],
-                )
+                prompt_requirements.required_fetch_concept_ids
             )
             required_prompt_read_file_copy_ids = list(
-                cast(
-                    list[str],
-                    prompt_requirement_state.get("required_read_file_copy_ids") or [],
-                )
+                prompt_requirements.required_read_file_copy_ids
             )
             required_prompt_scholarly_representation_file_copy_ids = list(
-                cast(
-                    list[str],
-                    prompt_requirement_state.get(
-                        "required_scholarly_representation_for_file_copy_ids"
-                    )
-                    or [],
-                )
-            )
-            required_prompt_create_type_name_raw = prompt_requirement_state.get(
-                "required_create_type_name"
+                prompt_requirements.required_scholarly_representation_file_copy_ids
             )
             required_prompt_create_type_name = (
-                str(required_prompt_create_type_name_raw).strip()
-                if isinstance(required_prompt_create_type_name_raw, str)
-                else None
+                prompt_requirements.required_create_type_name
             )
-            data["required_prompt_tools"] = list(required_prompt_tools)
-            data["required_prompt_fetch_concept_ids"] = list(
-                required_prompt_fetch_concept_ids
+            missing_prompt_tools = list(prompt_requirements.missing_tools)
+            missing_prompt_fetch_concept_ids = list(
+                prompt_requirements.missing_fetch_concept_ids
             )
-            data["required_prompt_read_file_copy_ids"] = list(
-                required_prompt_read_file_copy_ids
+            missing_prompt_read_file_copy_ids = list(
+                prompt_requirements.missing_read_file_copy_ids
             )
-            data["required_prompt_scholarly_representation_for_file_copy_ids"] = list(
-                required_prompt_scholarly_representation_file_copy_ids
+            missing_prompt_scholarly_representation_file_copy_ids = list(
+                prompt_requirements.missing_scholarly_representation_file_copy_ids
             )
-            data["required_prompt_create_type_name"] = required_prompt_create_type_name
-
-            invocations_for_requirements = cast(
-                Sequence[Mapping[str, Any]], data.get("invocations") or []
-            )
-            (
-                missing_prompt_tools,
-                missing_prompt_fetch_concept_ids,
-                missing_prompt_read_file_copy_ids,
-                missing_prompt_scholarly_representation_file_copy_ids,
-            ) = (
-                self._derive_missing_prompt_requirements(
-                    required_tools=required_prompt_tools,
-                    required_fetch_concept_ids=required_prompt_fetch_concept_ids,
-                    required_read_file_copy_ids=required_prompt_read_file_copy_ids,
-                    required_scholarly_representation_for_file_copy_ids=required_prompt_scholarly_representation_file_copy_ids,
-                    tool_invocations=invocations_for_requirements,
-                )
-            )
-            data["missing_prompt_tools"] = list(missing_prompt_tools)
-            data["missing_prompt_fetch_concept_ids"] = list(
-                missing_prompt_fetch_concept_ids
-            )
-            data["missing_prompt_read_file_copy_ids"] = list(
-                missing_prompt_read_file_copy_ids
-            )
-            data["missing_prompt_scholarly_representation_for_file_copy_ids"] = list(
-                missing_prompt_scholarly_representation_file_copy_ids
-            )
-            missing_retry_reason = self._build_missing_prompt_retry_reason(
-                missing_tools=missing_prompt_tools,
-                missing_fetch_concept_ids=missing_prompt_fetch_concept_ids,
-                missing_read_file_copy_ids=missing_prompt_read_file_copy_ids,
-                missing_scholarly_representation_file_copy_ids=missing_prompt_scholarly_representation_file_copy_ids,
-            )
-            if missing_retry_reason:
-                data["missing_tool_call_retry_reason_override"] = missing_retry_reason
-            else:
-                data.pop("missing_tool_call_retry_reason_override", None)
+            self._store_prompt_requirement_evaluation(data, prompt_requirements)
 
             if isinstance(aux_llm_calls, list) and required_prompt_tools:
                 try:
@@ -7614,6 +7536,140 @@ class InternalMCPChatOrchestrator:
         if not details:
             return None
         return "prompt requested tool(s) not yet invoked: " + "; ".join(details)
+
+    @classmethod
+    def _evaluate_prompt_requirements(
+        cls,
+        *,
+        prompt_text: str,
+        method_catalogue: Mapping[str, Any] | None = None,
+        context_messages: Sequence[Mapping[str, Any]] | None = None,
+        tool_invocations: Sequence[Mapping[str, Any]] = (),
+    ) -> _PromptRequirementEvaluation:
+        """Compute prompt-required tools and the still-missing subset once."""
+
+        prompt_requirement_state = cls._derive_prompt_tool_requirements(
+            prompt_text,
+            method_catalogue=method_catalogue,
+            context_messages=context_messages,
+        )
+        required_tools = tuple(
+            str(item).strip()
+            for item in (prompt_requirement_state.get("required_tools") or [])
+            if isinstance(item, str) and str(item).strip()
+        )
+        required_fetch_concept_ids = tuple(
+            str(item).strip()
+            for item in (
+                prompt_requirement_state.get("required_fetch_concept_ids") or []
+            )
+            if isinstance(item, str) and str(item).strip()
+        )
+        required_read_file_copy_ids = tuple(
+            str(item).strip()
+            for item in (
+                prompt_requirement_state.get("required_read_file_copy_ids") or []
+            )
+            if isinstance(item, str) and str(item).strip()
+        )
+        required_scholarly_representation_file_copy_ids = tuple(
+            str(item).strip()
+            for item in (
+                prompt_requirement_state.get(
+                    "required_scholarly_representation_for_file_copy_ids"
+                )
+                or []
+            )
+            if isinstance(item, str) and str(item).strip()
+        )
+        required_create_type_name_raw = prompt_requirement_state.get(
+            "required_create_type_name"
+        )
+        required_create_type_name = (
+            str(required_create_type_name_raw).strip()
+            if isinstance(required_create_type_name_raw, str)
+            and str(required_create_type_name_raw).strip()
+            else None
+        )
+        unavailable_required_tools = tuple(
+            str(item).strip()
+            for item in (
+                prompt_requirement_state.get("unavailable_required_tools") or []
+            )
+            if isinstance(item, str) and str(item).strip()
+        )
+        (
+            missing_tools,
+            missing_fetch_concept_ids,
+            missing_read_file_copy_ids,
+            missing_scholarly_representation_file_copy_ids,
+        ) = cls._derive_missing_prompt_requirements(
+            required_tools=required_tools,
+            required_fetch_concept_ids=required_fetch_concept_ids,
+            required_read_file_copy_ids=required_read_file_copy_ids,
+            required_scholarly_representation_for_file_copy_ids=required_scholarly_representation_file_copy_ids,
+            tool_invocations=tool_invocations,
+        )
+        missing_retry_reason = cls._build_missing_prompt_retry_reason(
+            missing_tools=missing_tools,
+            missing_fetch_concept_ids=missing_fetch_concept_ids,
+            missing_read_file_copy_ids=missing_read_file_copy_ids,
+            missing_scholarly_representation_file_copy_ids=missing_scholarly_representation_file_copy_ids,
+        )
+
+        return _PromptRequirementEvaluation(
+            required_tools=required_tools,
+            required_fetch_concept_ids=required_fetch_concept_ids,
+            required_read_file_copy_ids=required_read_file_copy_ids,
+            required_scholarly_representation_file_copy_ids=required_scholarly_representation_file_copy_ids,
+            required_create_type_name=required_create_type_name,
+            unavailable_required_tools=unavailable_required_tools,
+            scholarly_representation_intent=bool(
+                prompt_requirement_state.get("scholarly_representation_intent")
+            ),
+            missing_tools=tuple(missing_tools),
+            missing_fetch_concept_ids=tuple(missing_fetch_concept_ids),
+            missing_read_file_copy_ids=tuple(missing_read_file_copy_ids),
+            missing_scholarly_representation_file_copy_ids=tuple(
+                missing_scholarly_representation_file_copy_ids
+            ),
+            missing_retry_reason=missing_retry_reason,
+        )
+
+    @staticmethod
+    def _store_prompt_requirement_evaluation(
+        data: MutableMapping[str, Any],
+        evaluation: _PromptRequirementEvaluation,
+    ) -> None:
+        """Persist shared prompt-requirement state into workflow data."""
+
+        data["required_prompt_tools"] = list(evaluation.required_tools)
+        data["required_prompt_fetch_concept_ids"] = list(
+            evaluation.required_fetch_concept_ids
+        )
+        data["required_prompt_read_file_copy_ids"] = list(
+            evaluation.required_read_file_copy_ids
+        )
+        data["required_prompt_scholarly_representation_for_file_copy_ids"] = list(
+            evaluation.required_scholarly_representation_file_copy_ids
+        )
+        data["required_prompt_create_type_name"] = evaluation.required_create_type_name
+        data["missing_prompt_tools"] = list(evaluation.missing_tools)
+        data["missing_prompt_fetch_concept_ids"] = list(
+            evaluation.missing_fetch_concept_ids
+        )
+        data["missing_prompt_read_file_copy_ids"] = list(
+            evaluation.missing_read_file_copy_ids
+        )
+        data["missing_prompt_scholarly_representation_for_file_copy_ids"] = list(
+            evaluation.missing_scholarly_representation_file_copy_ids
+        )
+        if evaluation.missing_retry_reason:
+            data["missing_tool_call_retry_reason_override"] = (
+                evaluation.missing_retry_reason
+            )
+        else:
+            data.pop("missing_tool_call_retry_reason_override", None)
 
     @classmethod
     def _validate_completion_claims(
@@ -23395,7 +23451,33 @@ class InternalMCPChatOrchestrator:
         #   2. custom_workflow — execute selected discovered workflow
         #   3. tool_pipeline   — execute registry workflow matching tool contract
         # ----------------------------------------------------------------
-        if selector_verdict == "plain_response" and mutative_intent_requires_tool_routing:
+        routing_prompt_requirements = self._evaluate_prompt_requirements(
+            prompt_text=effective_prompt_for_routing,
+            method_catalogue=method_catalogue_for_routing,
+            context_messages=augmented_context,
+            tool_invocations=(),
+        )
+        selected_uses_tool_pipeline_contract = _workflow_matches_action_contract(
+            selected_workflow_id_text,
+            required_action_ids=_TOOL_PIPELINE_ACTION_IDS,
+        )
+
+        def _force_tool_pipeline_routing(
+            *,
+            reason: str,
+            excluded_selector_verdicts: Sequence[str],
+            extra_payload: Mapping[str, Any] | None = None,
+        ) -> None:
+            nonlocal selected_workflow_id
+            nonlocal selected_workflow_id_text
+            nonlocal selector_verdict
+            nonlocal selector_requests_narration
+            nonlocal selector_requests_custom_workflow
+            nonlocal routing_info
+            nonlocal selected_uses_tool_pipeline_contract
+
+            prior_selected_workflow_id = selected_workflow_id_text
+            prior_selector_verdict = selector_verdict or None
             excluded_workflow_ids = sorted(
                 {
                     CHAT_ASSISTANT_WORKFLOW_ID,
@@ -23407,142 +23489,99 @@ class InternalMCPChatOrchestrator:
             selector_verdict = "tool_seeking"
             selector_requests_narration = False
             selector_requests_custom_workflow = False
+            selected_uses_tool_pipeline_contract = True
+
+            prompt_id = None
+            discovered_workflow_ids: tuple[str, ...] = ()
+            routing_duration_ms = None
             if isinstance(routing_info, WorkflowRoutingInfo):
-                routing_info = WorkflowRoutingInfo(
-                    workflow_id=TOOL_CALLING_WORKFLOW_ID,
-                    verdict="tool_seeking",
-                    prompt_id=routing_info.prompt_id,
-                    discovered_workflow_ids=routing_info.discovered_workflow_ids,
-                    routing_duration_ms=routing_info.routing_duration_ms,
-                    source="selector_override",
-                )
+                prompt_id = routing_info.prompt_id
+                discovered_workflow_ids = routing_info.discovered_workflow_ids
+                routing_duration_ms = routing_info.routing_duration_ms
+            routing_info = WorkflowRoutingInfo(
+                workflow_id=TOOL_CALLING_WORKFLOW_ID,
+                verdict="tool_seeking",
+                prompt_id=prompt_id,
+                discovered_workflow_ids=discovered_workflow_ids,
+                routing_duration_ms=routing_duration_ms,
+                source="selector_override",
+            )
+
             override_payload: dict[str, Any] = {
                 "type": "workflow_selector_override",
-                "reason": "mutative_intent_requires_tool_pipeline",
+                "reason": reason,
                 "selected_workflow_id": TOOL_CALLING_WORKFLOW_ID,
                 "excluded_workflow_ids": excluded_workflow_ids,
-                "excluded_selector_verdicts": ["plain_response"],
-                "write_policy_reason": write_routing_policy_reason,
-                "write_tool_candidate_count": len(write_tool_candidates_for_routing),
-                "write_tool_candidates": write_tool_candidates_for_routing[:12],
+                "excluded_selector_verdicts": list(excluded_selector_verdicts),
+                "prior_selected_workflow_id": prior_selected_workflow_id,
+                "prior_selector_verdict": prior_selector_verdict,
             }
+            if extra_payload:
+                override_payload.update(dict(extra_payload))
             aux_llm_calls.append(override_payload)
             if trace_enabled and trace is not None:
                 trace.metadata["workflow_selector_override"] = dict(override_payload)
 
-        if selector_verdict == "plain_response":
-            plain_requirement_state = self._derive_prompt_tool_requirements(
-                effective_prompt_for_routing,
-                method_catalogue=method_catalogue_for_routing,
-                context_messages=augmented_context,
-            )
-            required_prompt_tools = list(
-                cast(list[str], plain_requirement_state.get("required_tools") or [])
-            )
-            required_prompt_fetch_concept_ids = list(
-                cast(
-                    list[str],
-                    plain_requirement_state.get("required_fetch_concept_ids") or [],
-                )
-            )
-            required_prompt_read_file_copy_ids = list(
-                cast(
-                    list[str],
-                    plain_requirement_state.get("required_read_file_copy_ids") or [],
-                )
-            )
-            required_prompt_scholarly_representation_file_copy_ids = list(
-                cast(
-                    list[str],
-                    plain_requirement_state.get(
-                        "required_scholarly_representation_for_file_copy_ids"
-                    )
-                    or [],
-                )
-            )
-            unavailable_required_tools = list(
-                cast(
-                    list[str],
-                    plain_requirement_state.get("unavailable_required_tools") or [],
-                )
-            )
-            (
-                missing_prompt_tools,
-                missing_prompt_fetch_concept_ids,
-                missing_prompt_read_file_copy_ids,
-                missing_prompt_scholarly_representation_file_copy_ids,
-            ) = self._derive_missing_prompt_requirements(
-                required_tools=required_prompt_tools,
-                required_fetch_concept_ids=required_prompt_fetch_concept_ids,
-                required_read_file_copy_ids=required_prompt_read_file_copy_ids,
-                required_scholarly_representation_for_file_copy_ids=required_prompt_scholarly_representation_file_copy_ids,
-                tool_invocations=(),
-            )
-            missing_retry_reason = self._build_missing_prompt_retry_reason(
-                missing_tools=missing_prompt_tools,
-                missing_fetch_concept_ids=missing_prompt_fetch_concept_ids,
-                missing_read_file_copy_ids=missing_prompt_read_file_copy_ids,
-                missing_scholarly_representation_file_copy_ids=missing_prompt_scholarly_representation_file_copy_ids,
+        if (
+            selector_verdict == "plain_response"
+            and mutative_intent_requires_tool_routing
+            and not selected_uses_tool_pipeline_contract
+        ):
+            _force_tool_pipeline_routing(
+                reason="mutative_intent_requires_tool_pipeline",
+                excluded_selector_verdicts=["plain_response"],
+                extra_payload={
+                    "write_policy_reason": write_routing_policy_reason,
+                    "write_tool_candidate_count": len(
+                        write_tool_candidates_for_routing
+                    ),
+                    "write_tool_candidates": write_tool_candidates_for_routing[:12],
+                },
             )
 
-            if (
-                missing_prompt_tools
-                or missing_prompt_fetch_concept_ids
-                or missing_prompt_read_file_copy_ids
-                or missing_prompt_scholarly_representation_file_copy_ids
-            ):
-                excluded_workflow_ids = sorted(
-                    {
-                        CHAT_ASSISTANT_WORKFLOW_ID,
-                        selected_workflow_id_text or CHAT_ASSISTANT_WORKFLOW_ID,
-                    }
-                )
-                selected_workflow_id = TOOL_CALLING_WORKFLOW_ID
-                selected_workflow_id_text = TOOL_CALLING_WORKFLOW_ID
-                selector_verdict = "tool_seeking"
-                selector_requests_narration = False
-                selector_requests_custom_workflow = False
-                if isinstance(routing_info, WorkflowRoutingInfo):
-                    routing_info = WorkflowRoutingInfo(
-                        workflow_id=TOOL_CALLING_WORKFLOW_ID,
-                        verdict="tool_seeking",
-                        prompt_id=routing_info.prompt_id,
-                        discovered_workflow_ids=routing_info.discovered_workflow_ids,
-                        routing_duration_ms=routing_info.routing_duration_ms,
-                        source="selector_override",
-                    )
-                override_payload = {
-                    "type": "workflow_selector_override",
-                    "reason": "required_prompt_tools_missing",
-                    "selected_workflow_id": TOOL_CALLING_WORKFLOW_ID,
-                    "excluded_workflow_ids": excluded_workflow_ids,
-                    "excluded_selector_verdicts": ["plain_response"],
-                    "required_prompt_tools": list(required_prompt_tools),
-                    "missing_prompt_tools": list(missing_prompt_tools),
+        if (
+            routing_prompt_requirements.has_missing_requirements
+            and not selected_uses_tool_pipeline_contract
+        ):
+            excluded_selector_verdicts: list[str] = []
+            if selector_verdict:
+                excluded_selector_verdicts.append(selector_verdict)
+            elif routing_info is None:
+                excluded_selector_verdicts.append("no_selector_verdict")
+            _force_tool_pipeline_routing(
+                reason="required_prompt_tools_missing",
+                excluded_selector_verdicts=excluded_selector_verdicts,
+                extra_payload={
+                    "required_prompt_tools": list(
+                        routing_prompt_requirements.required_tools
+                    ),
+                    "missing_prompt_tools": list(
+                        routing_prompt_requirements.missing_tools
+                    ),
                     "required_prompt_fetch_concept_ids": list(
-                        required_prompt_fetch_concept_ids
+                        routing_prompt_requirements.required_fetch_concept_ids
                     ),
                     "missing_prompt_fetch_concept_ids": list(
-                        missing_prompt_fetch_concept_ids
+                        routing_prompt_requirements.missing_fetch_concept_ids
                     ),
                     "required_prompt_read_file_copy_ids": list(
-                        required_prompt_read_file_copy_ids
+                        routing_prompt_requirements.required_read_file_copy_ids
                     ),
                     "missing_prompt_read_file_copy_ids": list(
-                        missing_prompt_read_file_copy_ids
+                        routing_prompt_requirements.missing_read_file_copy_ids
                     ),
                     "required_prompt_scholarly_representation_for_file_copy_ids": list(
-                        required_prompt_scholarly_representation_file_copy_ids
+                        routing_prompt_requirements.required_scholarly_representation_file_copy_ids
                     ),
                     "missing_prompt_scholarly_representation_for_file_copy_ids": list(
-                        missing_prompt_scholarly_representation_file_copy_ids
+                        routing_prompt_requirements.missing_scholarly_representation_file_copy_ids
                     ),
-                    "unavailable_required_tools": list(unavailable_required_tools),
-                    "retry_reason": missing_retry_reason,
-                }
-                aux_llm_calls.append(override_payload)
-                if trace_enabled and trace is not None:
-                    trace.metadata["workflow_selector_override"] = dict(override_payload)
+                    "unavailable_required_tools": list(
+                        routing_prompt_requirements.unavailable_required_tools
+                    ),
+                    "retry_reason": routing_prompt_requirements.missing_retry_reason,
+                },
+            )
 
         selected_workflow_name = _resolve_selected_workflow_name(
             selected_workflow_id_text
@@ -23701,11 +23740,6 @@ class InternalMCPChatOrchestrator:
                 workflow_routing=base_result.workflow_routing,
                 render_plan=base_result.render_plan,
             )
-
-        selected_uses_tool_pipeline_contract = _workflow_matches_action_contract(
-            selected_workflow_id_text,
-            required_action_ids=_TOOL_PIPELINE_ACTION_IDS,
-        )
 
         # Tier 1: Plain response — skip tool-calling overhead entirely.
         # When the classifier says "plain_response", there is no need

--- a/src/backend/workflows/workflow_selector.py
+++ b/src/backend/workflows/workflow_selector.py
@@ -12,7 +12,9 @@ user's intent matches.
 
 from __future__ import annotations
 
+import json
 import os
+import re
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional, Sequence
 
@@ -22,9 +24,13 @@ from .workflow_registry import WorkflowRegistry
 
 
 _DEFAULT_CLASSIFIER_PROMPT = (
-    "You are a router that selects a workflow for the next assistant turn.\n"
-    "Pick ONE of: plain_response, tool_seeking, summarisation, narration.\n"
-    "Reply with only the label. Treat tool-seeking as any case where tools or MCP calls are expected.\n"
+    "You are a workflow router for the next assistant turn.\n"
+    "Return exactly one routing label and nothing else.\n"
+    "Allowed labels: plain_response, tool_seeking, summarisation, narration.\n"
+    "Do not return prose, JSON, punctuation, explanations, code fences, or more than one label.\n"
+    "Choose tool_seeking whenever satisfying the request likely requires tools, MCP calls, retrieval, downloads, reads, searches, file access, or additive knowledge-base mutations.\n"
+    "Canonical artefact identifiers and URLs usually imply tool_seeking when acting on the artefact is needed, including bare arXiv URLs or arXiv IDs.\n"
+    "Choose plain_response only for direct conversational replies that do not need tools.\n"
     "User+assistant turn so far:\n"
     "{turn_text}\n"
 )
@@ -80,6 +86,22 @@ class WorkflowSelector:
         self._verdict_mapping = dict(verdict_mapping)
         self._classifier_prompt_ids = tuple(classifier_prompt_ids)
         self._fallback_prompt = fallback_prompt
+
+    _STATIC_SELECTOR_VERDICTS = (
+        "plain_response",
+        "tool_seeking",
+        "summarisation",
+        "narration",
+    )
+    _JSON_SELECTION_KEYS = (
+        "workflow_id",
+        "workflow",
+        "verdict",
+        "label",
+        "route",
+        "selection",
+    )
+    _CANDIDATE_BOUNDARY_STRIP = " \t\r\n`'\".,;:!?()[]{}<>"
 
     def enabled(self) -> bool:
         """Check whether the workflow selector is enabled.
@@ -178,26 +200,31 @@ class WorkflowSelector:
         discovered_workflow_ids: Sequence[str] = (),
     ) -> WorkflowSelection:
         """Resolve a raw classifier response into a workflow selection."""
-        verdict = str(raw_response or "").strip().lower()
+        verdict = self._extract_candidate_label(
+            raw_response=raw_response,
+            discovered_workflow_ids=discovered_workflow_ids,
+        )
+        verdict_lookup = verdict.lower()
+        resolved_verdict = verdict
         discovered_ids = tuple(
             item for item in discovered_workflow_ids if isinstance(item, str) and item
         )
+        discovered_lookup = {item.lower(): item for item in discovered_ids}
 
         # Resolve verdict → workflow_id.
         # 1. Check static verdict mapping.
-        workflow_id = self._verdict_mapping.get(verdict)
+        workflow_id = self._verdict_mapping.get(verdict_lookup)
 
         # 2. Check if the verdict is a discovered workflow concept_id.
-        if not workflow_id and verdict in {d.lower() for d in discovered_ids}:
-            # Normalise to the original casing from the discovered list.
-            for d in discovered_ids:
-                if d.lower() == verdict:
-                    workflow_id = d
-                    break
+        discovered_match = discovered_lookup.get(verdict_lookup)
+        if not workflow_id and discovered_match:
+            workflow_id = discovered_match
+            resolved_verdict = discovered_match
 
         # 3. Fallback to plain_response mapping.
         if not workflow_id:
             workflow_id = self._verdict_mapping.get("plain_response")
+            resolved_verdict = "plain_response"
 
         if not isinstance(workflow_id, str):
             workflow_id = ""
@@ -211,12 +238,91 @@ class WorkflowSelector:
                 workflow_id = (
                     fallback_id if isinstance(fallback_id, str) else workflow_id
                 )
+                resolved_verdict = "plain_response"
 
         return WorkflowSelection(
             workflow_id=workflow_id or "",
-            verdict=verdict or "",
+            verdict=resolved_verdict or "",
             prompt_id=prompt_id,
             prompt_used=prompt_used,
             raw_response=str(raw_response or ""),
             discovered_workflow_ids=tuple(discovered_ids),
         )
+
+    @classmethod
+    def _extract_candidate_label(
+        cls,
+        *,
+        raw_response: Any,
+        discovered_workflow_ids: Sequence[str] = (),
+    ) -> str:
+        raw_text = str(raw_response or "")
+        discovered_ids = tuple(
+            item for item in discovered_workflow_ids if isinstance(item, str) and item
+        )
+        discovered_lookup = {item.lower(): item for item in discovered_ids}
+
+        snippets: list[str] = []
+        stripped = raw_text.strip()
+        if stripped:
+            snippets.append(stripped)
+            snippets.extend(
+                line.strip() for line in stripped.splitlines() if isinstance(line, str)
+            )
+
+        json_candidate = cls._extract_json_candidate(raw_text)
+        if json_candidate:
+            snippets.insert(0, json_candidate)
+
+        for snippet in snippets:
+            normalised = cls._normalise_candidate(snippet)
+            if normalised in cls._STATIC_SELECTOR_VERDICTS:
+                return normalised
+            discovered_match = discovered_lookup.get(normalised)
+            if discovered_match:
+                return discovered_match
+
+        lowered = raw_text.lower()
+        for workflow_id in discovered_ids:
+            if workflow_id.lower() in lowered:
+                return workflow_id
+
+        static_match = cls._extract_static_verdict_from_text(lowered)
+        if static_match:
+            return static_match
+
+        return cls._normalise_candidate(raw_text)
+
+    @classmethod
+    def _extract_json_candidate(cls, raw_text: str) -> str | None:
+        stripped = raw_text.strip()
+        if not stripped:
+            return None
+        try:
+            parsed = json.loads(stripped)
+        except Exception:
+            return None
+        if isinstance(parsed, str):
+            return parsed
+        if isinstance(parsed, Mapping):
+            for key in cls._JSON_SELECTION_KEYS:
+                value = parsed.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value
+        return None
+
+    @classmethod
+    def _extract_static_verdict_from_text(cls, lowered_text: str) -> str | None:
+        best_match: tuple[int, str] | None = None
+        for verdict in cls._STATIC_SELECTOR_VERDICTS:
+            match = re.search(rf"\b{re.escape(verdict)}\b", lowered_text)
+            if not match:
+                continue
+            position = match.start()
+            if best_match is None or position < best_match[0]:
+                best_match = (position, verdict)
+        return best_match[1] if best_match is not None else None
+
+    @classmethod
+    def _normalise_candidate(cls, value: str) -> str:
+        return str(value or "").strip().strip(cls._CANDIDATE_BOUNDARY_STRIP).lower()

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -3674,6 +3674,84 @@ def test_selector_can_be_disabled_via_env(monkeypatch):
     assert not orchestrator._workflow_selector.enabled()
 
 
+def test_selector_resolve_selection_extracts_static_verdict_from_free_form_output():
+    registry = MagicMock()
+    registry.all_workflow_ids.return_value = {
+        CHAT_ASSISTANT_WORKFLOW_ID,
+        TOOL_CALLING_WORKFLOW_ID,
+    }
+    selector = WorkflowSelector(
+        registry=registry,
+        prompt_service=MagicMock(),
+        verdict_mapping={
+            "plain_response": CHAT_ASSISTANT_WORKFLOW_ID,
+            "tool_seeking": TOOL_CALLING_WORKFLOW_ID,
+        },
+    )
+
+    selection = selector.resolve_selection(
+        raw_response='{"verdict":"tool_seeking"}',
+        prompt_id=None,
+        prompt_used=None,
+        discovered_workflow_ids=(),
+    )
+
+    assert selection.verdict == "tool_seeking"
+    assert selection.workflow_id == TOOL_CALLING_WORKFLOW_ID
+
+
+def test_selector_resolve_selection_extracts_discovered_workflow_from_free_form_output():
+    registry = MagicMock()
+    registry.all_workflow_ids.return_value = {
+        CHAT_ASSISTANT_WORKFLOW_ID,
+        TOOL_CALLING_WORKFLOW_ID,
+    }
+    selector = WorkflowSelector(
+        registry=registry,
+        prompt_service=MagicMock(),
+        verdict_mapping={
+            "plain_response": CHAT_ASSISTANT_WORKFLOW_ID,
+            "tool_seeking": TOOL_CALLING_WORKFLOW_ID,
+        },
+    )
+
+    selection = selector.resolve_selection(
+        raw_response=f"Use {TODO_REFRESH_WORKFLOW_ID} for this request.",
+        prompt_id=None,
+        prompt_used=None,
+        discovered_workflow_ids=(TODO_REFRESH_WORKFLOW_ID,),
+    )
+
+    assert selection.verdict == TODO_REFRESH_WORKFLOW_ID
+    assert selection.workflow_id == TODO_REFRESH_WORKFLOW_ID
+
+
+def test_selector_resolve_selection_invalid_output_falls_back_to_plain_response():
+    registry = MagicMock()
+    registry.all_workflow_ids.return_value = {
+        CHAT_ASSISTANT_WORKFLOW_ID,
+        TOOL_CALLING_WORKFLOW_ID,
+    }
+    selector = WorkflowSelector(
+        registry=registry,
+        prompt_service=MagicMock(),
+        verdict_mapping={
+            "plain_response": CHAT_ASSISTANT_WORKFLOW_ID,
+            "tool_seeking": TOOL_CALLING_WORKFLOW_ID,
+        },
+    )
+
+    selection = selector.resolve_selection(
+        raw_response="I am not sure.",
+        prompt_id=None,
+        prompt_used=None,
+        discovered_workflow_ids=(),
+    )
+
+    assert selection.verdict == "plain_response"
+    assert selection.workflow_id == CHAT_ASSISTANT_WORKFLOW_ID
+
+
 # ---------------------------------------------------------------------------
 # JVNAUTOSCI-825: Routing info absent when selector disabled.
 # ---------------------------------------------------------------------------
@@ -3699,19 +3777,6 @@ def test_no_routing_info_when_selector_disabled(monkeypatch):
 def test_discovery_miss_invokes_gap_recovery_after_plain_fallback(monkeypatch):
     orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
 
-    monkeypatch.setattr(
-        orchestrator._workflow_selector,
-        "select_workflow",
-        lambda **_kwargs: WorkflowSelection(
-            workflow_id=CHAT_ASSISTANT_WORKFLOW_ID,
-            verdict="plain_response",
-            prompt_id=None,
-            prompt_used=None,
-            raw_response="plain_response",
-            discovered_workflow_ids=(),
-        ),
-    )
-
     recovery_calls: list[tuple[str, Mapping[str, Any]]] = []
 
     def _fake_execute_workflow(workflow_id: str, **kwargs):
@@ -3734,7 +3799,7 @@ def test_discovery_miss_invokes_gap_recovery_after_plain_fallback(monkeypatch):
 
     monkeypatch.setattr(orchestrator, "execute_workflow", _fake_execute_workflow)
 
-    llm = _CapturingLLM(["Fallback response."])
+    llm = _CapturingLLM(["plain_response", "Fallback response."])
     result = orchestrator.run(
         prompt="Handle this missing workflow.",
         context=[],
@@ -3775,19 +3840,6 @@ def test_custom_workflow_result_preserves_messages_and_invocations(monkeypatch):
     monkeypatch.setenv("VON_WORKFLOW_SELECTOR_ALLOW_POLICY_UNSAFE", "1")
 
     monkeypatch.setattr(
-        orchestrator._workflow_selector,
-        "select_workflow",
-        lambda **_kwargs: WorkflowSelection(
-            workflow_id=selected_workflow_id,
-            verdict=selected_workflow_id,
-            prompt_id=None,
-            prompt_used=None,
-            raw_response=selected_workflow_id,
-            discovered_workflow_ids=(selected_workflow_id,),
-        ),
-    )
-
-    monkeypatch.setattr(
         orchestrator,
         "execute_workflow",
         lambda workflow_id, **_kwargs: (
@@ -3808,7 +3860,7 @@ def test_custom_workflow_result_preserves_messages_and_invocations(monkeypatch):
     result = orchestrator.run(
         prompt="Use the discovered workflow.",
         context=[],
-        llm_client=_CapturingLLM([]),
+        llm_client=_CapturingLLM([selected_workflow_id]),
         model=None,
         user_namespace="#V#user",
         workflow_discovery_result={

--- a/tests/backend/test_von_generate_bare_arxiv_url_integration.py
+++ b/tests/backend/test_von_generate_bare_arxiv_url_integration.py
@@ -119,7 +119,12 @@ def _build_gateway(monkeypatch) -> InternalMCPGateway:
     return gateway
 
 
-def _make_app(monkeypatch, *, llm: _LLMSequence) -> Flask:
+def _make_app(
+    monkeypatch,
+    *,
+    llm: _LLMSequence,
+    selector_enabled: bool = True,
+) -> Flask:
     from src.backend.server.routes.von_routes import von_bp
 
     monkeypatch.setenv("VON_WORKFLOW_DISCOVERY_ENABLE", "0")
@@ -170,7 +175,7 @@ def _make_app(monkeypatch, *, llm: _LLMSequence) -> Flask:
     orchestrator = build_db_independent_orchestrator(
         monkeypatch,
         gateway=gateway,
-        selector_enabled=True,
+        selector_enabled=selector_enabled,
         max_tool_invocations=1,
     )
 
@@ -242,12 +247,12 @@ def test_generate_bare_arxiv_url_auto_represents_paper(monkeypatch):
     assert completion_gate.get("safe_to_claim_completion") is True
 
 
-def test_generate_fallback_route_keeps_route_selection_separate_from_tool_execution(
+def test_generate_invalid_selector_verdict_still_routes_bare_arxiv_to_tool_pipeline(
     monkeypatch,
 ):
     llm = _LLMSequence(
         [
-            "fallback",
+            "I would route this as plain_response.",
             '{"action":"call_tool","tool":"download_paper","payload":{"arxiv_id":"2510.06248"}}',
             "Downloaded and represented the paper.",
         ]
@@ -263,8 +268,9 @@ def test_generate_fallback_route_keeps_route_selection_separate_from_tool_execut
     llm_debug = body.get("llm_debug") or {}
 
     workflow_routing = llm_debug.get("workflow_routing") or {}
-    assert workflow_routing.get("workflow_id") == CHAT_ASSISTANT_WORKFLOW_ID
-    assert workflow_routing.get("verdict") == "fallback"
+    assert workflow_routing.get("workflow_id") == TOOL_CALLING_WORKFLOW_ID
+    assert workflow_routing.get("verdict") == "tool_seeking"
+    assert workflow_routing.get("source") == "selector_override"
 
     diagnostics = llm_debug.get("turn_execution_diagnostics") or {}
     assert diagnostics.get("tool_call_count") == 1
@@ -277,7 +283,7 @@ def test_generate_fallback_route_keeps_route_selection_separate_from_tool_execut
     assert all(entry.get("tool") for entry in tool_history)
 
     workflow_stage_path = diagnostics.get("workflow_stage_path") or {}
-    assert workflow_stage_path.get("workflow_id") != CHAT_ASSISTANT_WORKFLOW_ID
+    assert workflow_stage_path.get("workflow_id") == TOOL_CALLING_WORKFLOW_ID
     assert TOOL_CALLING_WORKFLOW_ID in list(
         workflow_stage_path.get("observed_workflow_ids") or []
     )
@@ -299,6 +305,36 @@ def test_generate_fallback_route_keeps_route_selection_separate_from_tool_execut
     assert tool_stage.get("tool_success_count") == 1
     assert tool_stage.get("tool_failure_count") == 0
     assert tool_stage.get("tool_pending_count") == 0
+
+
+def test_generate_bare_arxiv_url_without_selector_still_forces_tool_pipeline_routing(
+    monkeypatch,
+):
+    llm = _LLMSequence(
+        [
+            '{"action":"call_tool","tool":"download_paper","payload":{"arxiv_id":"2510.06248"}}',
+            "Downloaded and represented the paper.",
+        ]
+    )
+    app = _make_app(monkeypatch, llm=llm, selector_enabled=False)
+
+    client = app.test_client()
+    response = client.post("/von/generate", json={"prompt": "https://arxiv.org/abs/2510.06248"})
+    assert response.status_code == 200
+
+    body = response.get_json()
+    assert isinstance(body, dict)
+    llm_debug = body.get("llm_debug") or {}
+
+    workflow_routing = llm_debug.get("workflow_routing") or {}
+    assert workflow_routing.get("workflow_id") == TOOL_CALLING_WORKFLOW_ID
+    assert workflow_routing.get("verdict") == "tool_seeking"
+    assert workflow_routing.get("source") == "selector_override"
+
+    diagnostics = llm_debug.get("turn_execution_diagnostics") or {}
+    assert diagnostics.get("tool_call_count") == 1
+    assert diagnostics.get("tool_success_count") == 1
+    assert diagnostics.get("tool_pending_count") == 0
 
 
 def test_generate_bare_arxiv_url_with_explicit_denial_stays_non_mutating(monkeypatch):


### PR DESCRIPTION
## Summary
- harden workflow selector parsing and fallback normalisation so imperfect classifier outputs still resolve deterministically
- route prompt-required tools to the tool pipeline even when selector verdict quality is poor or the selector is disabled
- update arXiv and routing regressions to assert the hardened behaviour

## Root cause
The selector path relied on an exact raw label match. When the classifier emitted blank, invalid, or free-form output, the effective workflow fallback and the selector verdict could diverge. Separately, deterministic prompt-required tool routing still depended too heavily on selector state, so bare arXiv turns could bypass the required `download_paper` obligation before tool execution.

## Validation
- `pdm run pyright src/backend/integrations/internal_mcp/orchestrator.py src/backend/workflows/workflow_selector.py tests/backend/test_orchestrator_workflow_selector_routing.py tests/backend/test_von_generate_bare_arxiv_url_integration.py`
- `$env:VON_DB_NAME='test_von_db'; pdm run pytest tests/backend/test_von_generate_bare_arxiv_url_integration.py tests/backend/test_orchestrator_workflow_selector_routing.py -q`
- `$env:VON_DB_NAME='test_von_db'; pdm run pytest tests/backend/test_internal_mcp_orchestrator_preflight.py::test_instruction_message_uses_internal_guardrail_wording_without_budget_leak -q`

## Notes
- `#V#chat_turn_classifier_prompt` was materialised in Vontology with canonical `hasContent` text so the live selector is no longer missing its prompt concept.
- `tests/backend/test_orchestrator_missing_tool_call_retry_arxiv.py::test_missing_tool_call_retry_forces_download_paper_over_list_papers` did not complete within the local timeout window here, so I am not claiming that broader file as revalidated in this environment.