### PR TITLE
JVNAUTOSCI-1410 Fix live progress visibility and bare arXiv routing

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -18861,7 +18861,31 @@ class InternalMCPChatOrchestrator:
                 # Place immediately after the main instruction message.
                 augmented_context.insert(1, {"role": "system", "content": hint.strip()})
 
-        selected_workflow_id = CHAT_ASSISTANT_WORKFLOW_ID
+        method_catalogue_for_routing: Mapping[str, Any] = {}
+        describe_methods_for_routing = getattr(self._gateway, "describe_methods", None)
+        if callable(describe_methods_for_routing):
+            try:
+                described_methods = describe_methods_for_routing()
+                if isinstance(described_methods, Mapping):
+                    method_catalogue_for_routing = described_methods
+            except Exception:
+                method_catalogue_for_routing = {}
+
+        routing_prompt_requirements = self._evaluate_prompt_requirements(
+            prompt_text=effective_prompt_for_routing,
+            method_catalogue=method_catalogue_for_routing,
+            context_messages=augmented_context,
+            tool_invocations=(),
+        )
+        prompt_requirements_force_tool_pipeline = (
+            routing_prompt_requirements.has_missing_requirements
+        )
+
+        selected_workflow_id = (
+            TOOL_CALLING_WORKFLOW_ID
+            if prompt_requirements_force_tool_pipeline
+            else CHAT_ASSISTANT_WORKFLOW_ID
+        )
         presenter_mode_requested = False
         if context:
             for msg in context:
@@ -18897,6 +18921,50 @@ class InternalMCPChatOrchestrator:
             )
 
         routing_info: WorkflowRoutingInfo | None = None
+        if prompt_requirements_force_tool_pipeline:
+            routing_info = WorkflowRoutingInfo(
+                workflow_id=TOOL_CALLING_WORKFLOW_ID,
+                verdict="tool_seeking",
+                prompt_id=None,
+                discovered_workflow_ids=(),
+                source="selector_override",
+            )
+            override_payload = {
+                "type": "workflow_selector_override",
+                "reason": "required_prompt_tools_missing_preselector",
+                "selected_workflow_id": TOOL_CALLING_WORKFLOW_ID,
+                "excluded_workflow_ids": [CHAT_ASSISTANT_WORKFLOW_ID],
+                "excluded_selector_verdicts": ["selector_skipped"],
+                "prior_selected_workflow_id": CHAT_ASSISTANT_WORKFLOW_ID,
+                "prior_selector_verdict": None,
+                "required_prompt_tools": list(routing_prompt_requirements.required_tools),
+                "missing_prompt_tools": list(routing_prompt_requirements.missing_tools),
+                "required_prompt_fetch_concept_ids": list(
+                    routing_prompt_requirements.required_fetch_concept_ids
+                ),
+                "missing_prompt_fetch_concept_ids": list(
+                    routing_prompt_requirements.missing_fetch_concept_ids
+                ),
+                "required_prompt_read_file_copy_ids": list(
+                    routing_prompt_requirements.required_read_file_copy_ids
+                ),
+                "missing_prompt_read_file_copy_ids": list(
+                    routing_prompt_requirements.missing_read_file_copy_ids
+                ),
+                "required_prompt_scholarly_representation_for_file_copy_ids": list(
+                    routing_prompt_requirements.required_scholarly_representation_file_copy_ids
+                ),
+                "missing_prompt_scholarly_representation_for_file_copy_ids": list(
+                    routing_prompt_requirements.missing_scholarly_representation_file_copy_ids
+                ),
+                "unavailable_required_tools": list(
+                    routing_prompt_requirements.unavailable_required_tools
+                ),
+                "retry_reason": routing_prompt_requirements.missing_retry_reason,
+            }
+            aux_llm_calls.append(override_payload)
+            if trace_enabled and trace is not None:
+                trace.metadata["workflow_selector_override"] = dict(override_payload)
 
         def _resolve_selected_workflow_name(workflow_id: str | None) -> str | None:
             clean_workflow_id = (
@@ -18929,7 +18997,11 @@ class InternalMCPChatOrchestrator:
                 else clean_workflow_id
             )
 
-        if user_namespace and self._workflow_selector.enabled():
+        if (
+            not prompt_requirements_force_tool_pipeline
+            and user_namespace
+            and self._workflow_selector.enabled()
+        ):
             _emit_progress_local(
                 {
                     "status": "phase_transition",
@@ -19144,15 +19216,6 @@ class InternalMCPChatOrchestrator:
             and selected_workflow_id_text
             and selected_workflow_id_text.lower() == selector_verdict
         )
-        method_catalogue_for_routing: Mapping[str, Any] = {}
-        describe_methods_for_routing = getattr(self._gateway, "describe_methods", None)
-        if callable(describe_methods_for_routing):
-            try:
-                described_methods = describe_methods_for_routing()
-                if isinstance(described_methods, Mapping):
-                    method_catalogue_for_routing = described_methods
-            except Exception:
-                method_catalogue_for_routing = {}
         write_tool_candidates_for_routing = sorted(
             {
                 str(tool_name).strip()
@@ -23451,12 +23514,9 @@ class InternalMCPChatOrchestrator:
         #   2. custom_workflow — execute selected discovered workflow
         #   3. tool_pipeline   — execute registry workflow matching tool contract
         # ----------------------------------------------------------------
-        routing_prompt_requirements = self._evaluate_prompt_requirements(
-            prompt_text=effective_prompt_for_routing,
-            method_catalogue=method_catalogue_for_routing,
-            context_messages=augmented_context,
-            tool_invocations=(),
-        )
+        # This was already evaluated before workflow selection so prompt-required
+        # tools can dominate routing deterministically, even when selector output
+        # is noisy or unavailable.
         selected_uses_tool_pipeline_contract = _workflow_matches_action_contract(
             selected_workflow_id_text,
             required_action_ids=_TOOL_PIPELINE_ACTION_IDS,
@@ -23746,7 +23806,7 @@ class InternalMCPChatOrchestrator:
         # to build tool context, inject write-policy, or run the
         # plan→validate→execute→backfill pipeline.  This saves an LLM
         # round-trip worth of system prompt tokens and reduces latency.
-        if selector_verdict == "plain_response":
+        if selector_verdict == "plain_response" and not selected_uses_tool_pipeline_contract:
             _emit_phase_transition_local(
                 self.PHASE_PLAIN_RESPONSE,
                 extra=workflow_dispatch_progress,

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -69,6 +69,11 @@ from ...services.turn_execution_diagnostic_event_service import (
 from ...services.runtime_code_version_service import (
     get_runtime_code_version_info,
 )
+from ...services.tool_progress_store_service import (
+    delete_tool_progress_state,
+    fetch_tool_progress_state,
+    store_tool_progress_state,
+)
 from ...services.turn_execution_record_service import build_turn_execution_record
 from ...workflows import (
     CHAT_BUTTONIFY_WORKFLOW_ID,
@@ -2063,10 +2068,20 @@ def _prune_tool_progress() -> None:
             _TOOL_PROGRESS.pop(key, None)
 
 
+def _cache_tool_progress_state(
+    scope_key: str, request_id: str, payload: Mapping[str, Any]
+) -> dict[str, Any]:
+    cached = dict(payload)
+    with _TOOL_PROGRESS_LOCK:
+        _TOOL_PROGRESS[(scope_key, request_id)] = cached
+    return cached
+
+
 def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) -> None:
     _prune_tool_progress()
     now_epoch = time.time()
     now_utc = _now_utc_iso()
+    merged: dict[str, Any]
     with _TOOL_PROGRESS_LOCK:
         key = (scope_key, request_id)
         existing = _TOOL_PROGRESS.get(key)
@@ -2325,9 +2340,25 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
         merged["updated_at_epoch"] = now_epoch
         _TOOL_PROGRESS[key] = merged
 
+    try:
+        store_tool_progress_state(
+            scope_key=scope_key,
+            request_id=request_id,
+            payload=merged,
+            ttl_seconds=_TOOL_PROGRESS_TTL_SEC,
+        )
+    except Exception:
+        pass
+
 
 def _get_tool_progress(scope_key: str, request_id: str) -> dict[str, Any] | None:
     _prune_tool_progress()
+    try:
+        persisted = fetch_tool_progress_state(scope_key=scope_key, request_id=request_id)
+    except Exception:
+        persisted = None
+    if isinstance(persisted, dict):
+        return dict(_cache_tool_progress_state(scope_key, request_id, persisted))
     with _TOOL_PROGRESS_LOCK:
         value = _TOOL_PROGRESS.get((scope_key, request_id))
         return dict(value) if isinstance(value, dict) else None
@@ -2350,6 +2381,10 @@ def _snapshot_tool_progress_for_request(
 def _clear_tool_progress(scope_key: str, request_id: str) -> None:
     with _TOOL_PROGRESS_LOCK:
         _TOOL_PROGRESS.pop((scope_key, request_id), None)
+    try:
+        delete_tool_progress_state(scope_key=scope_key, request_id=request_id)
+    except Exception:
+        pass
 
 
 @von_bp.route("/progress/<request_id>", methods=["GET"])

--- a/src/backend/services/tool_progress_store_service.py
+++ b/src/backend/services/tool_progress_store_service.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import copy
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping
+
+from src.backend.db.mongo_client import get_db
+
+logger = logging.getLogger(__name__)
+
+TOOL_PROGRESS_STATE_COLLECTION_NAME = "tool_progress_state"
+
+_indexes_ensured = False
+
+
+def _get_collection():
+    try:
+        db = get_db()
+    except Exception as exc:  # pragma: no cover - environment dependent
+        logger.debug("[tool_progress_store] Failed to resolve DB: %s", exc)
+        return None
+    if db is None:
+        return None
+    return db[TOOL_PROGRESS_STATE_COLLECTION_NAME]
+
+
+def _ensure_indexes() -> None:
+    global _indexes_ensured
+    if _indexes_ensured:
+        return
+
+    coll = _get_collection()
+    if coll is None:
+        return
+
+    try:
+        coll.create_index(
+            [("scope_key", 1), ("request_id", 1)],
+            unique=True,
+            name="scope_request_unique",
+        )
+        coll.create_index([("request_id", 1)], name="request_id_1")
+        coll.create_index([("updated_at", -1)], name="updated_at_-1")
+        # TTL based on the stored expiry timestamp. Mongo ignores documents that do
+        # not have this field, so local-memory fallback still works cleanly.
+        coll.create_index(
+            [("expires_at", 1)],
+            expireAfterSeconds=0,
+            name="expires_at_ttl",
+        )
+    except Exception as exc:  # pragma: no cover - DB backend dependent
+        logger.debug("[tool_progress_store] Index creation skipped/failed: %s", exc)
+    finally:
+        _indexes_ensured = True
+
+
+def store_tool_progress_state(
+    *,
+    scope_key: str,
+    request_id: str,
+    payload: Mapping[str, Any],
+    ttl_seconds: int,
+) -> bool:
+    if not isinstance(scope_key, str) or not scope_key.strip():
+        return False
+    if not isinstance(request_id, str) or not request_id.strip():
+        return False
+    if not isinstance(payload, Mapping):
+        return False
+
+    coll = _get_collection()
+    if coll is None:
+        return False
+
+    _ensure_indexes()
+
+    now = datetime.now(timezone.utc)
+    expires_at = now + timedelta(seconds=max(1, int(ttl_seconds)))
+    stored_payload = copy.deepcopy(dict(payload))
+
+    try:
+        coll.update_one(
+            {"scope_key": scope_key.strip(), "request_id": request_id.strip()},
+            {
+                "$set": {
+                    "scope_key": scope_key.strip(),
+                    "request_id": request_id.strip(),
+                    "status": stored_payload.get("status"),
+                    "stage": stored_payload.get("stage"),
+                    "updated_at": now,
+                    "expires_at": expires_at,
+                    "payload": stored_payload,
+                }
+            },
+            upsert=True,
+        )
+        return True
+    except Exception as exc:  # pragma: no cover - DB backend dependent
+        logger.debug(
+            "[tool_progress_store] Failed to persist progress scope=%s request=%s: %s",
+            scope_key,
+            request_id,
+            exc,
+        )
+        return False
+
+
+def fetch_tool_progress_state(
+    *,
+    scope_key: str,
+    request_id: str,
+) -> dict[str, Any] | None:
+    if not isinstance(scope_key, str) or not scope_key.strip():
+        return None
+    if not isinstance(request_id, str) or not request_id.strip():
+        return None
+
+    coll = _get_collection()
+    if coll is None:
+        return None
+
+    _ensure_indexes()
+
+    try:
+        doc = coll.find_one(
+            {"scope_key": scope_key.strip(), "request_id": request_id.strip()},
+            {"_id": 0, "payload": 1},
+        )
+    except Exception as exc:  # pragma: no cover - DB backend dependent
+        logger.debug(
+            "[tool_progress_store] Failed to fetch progress scope=%s request=%s: %s",
+            scope_key,
+            request_id,
+            exc,
+        )
+        return None
+
+    if not isinstance(doc, Mapping):
+        return None
+    payload = doc.get("payload")
+    if not isinstance(payload, Mapping):
+        return None
+    return copy.deepcopy(dict(payload))
+
+
+def delete_tool_progress_state(*, scope_key: str, request_id: str) -> bool:
+    coll = _get_collection()
+    if coll is None:
+        return False
+
+    try:
+        result = coll.delete_one(
+            {"scope_key": scope_key.strip(), "request_id": request_id.strip()}
+        )
+        return bool(getattr(result, "deleted_count", 0))
+    except Exception as exc:  # pragma: no cover - DB backend dependent
+        logger.debug(
+            "[tool_progress_store] Failed to delete progress scope=%s request=%s: %s",
+            scope_key,
+            request_id,
+            exc,
+        )
+        return False
+
+
+def clear_tool_progress_documents_for_tests() -> None:
+    """Best-effort test helper to clear persisted progress state."""
+
+    coll = _get_collection()
+    if coll is None:
+        return
+    try:
+        coll.delete_many({})
+    except Exception as exc:  # pragma: no cover - DB backend dependent
+        logger.debug("[tool_progress_store] Failed to clear test progress docs: %s", exc)

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -3280,7 +3280,7 @@ def test_plain_response_overridden_when_prompt_requires_tool_verification(monkey
             for entry in result.aux_llm_calls
             if isinstance(entry, dict)
             and entry.get("type") == "workflow_selector_override"
-            and entry.get("reason") == "required_prompt_tools_missing"
+            and entry.get("reason") == "required_prompt_tools_missing_preselector"
         ),
         None,
     )
@@ -3497,7 +3497,9 @@ def test_write_intent_memory_rehydrates_for_low_risk_confirm_structure_prompt(
     assert gate_entry.get("continuation_context_reused") is True
 
 
-def test_selector_receives_authoritative_workflow_continuation_context(monkeypatch):
+def test_preselected_tool_planner_receives_authoritative_workflow_continuation_context(
+    monkeypatch,
+):
     orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
 
     monkeypatch.setattr(
@@ -3548,17 +3550,18 @@ def test_selector_receives_authoritative_workflow_continuation_context(monkeypat
 
     assert result.workflow_routing is not None
     assert result.workflow_routing.verdict == "tool_seeking"
+    assert result.workflow_routing.source == "selector_override"
 
-    selector_context = llm.calls[0]["context"] or []
-    selector_prompt = "\n".join(
+    planner_context = llm.calls[0]["context"] or []
+    planner_prompt_context = "\n".join(
         str(message.get("content") or "")
-        for message in selector_context
+        for message in planner_context
         if isinstance(message, dict)
     )
-    assert "ACTIVE WORKFLOW CONTINUATION CONTEXT" in selector_prompt
-    assert "#V#scholarly_paper_representation_workflow" in selector_prompt
-    assert "#V#uploaded_file_copy_abc123" in selector_prompt
-    assert "Please proceed." in selector_prompt
+    assert llm.calls[0]["prompt"] == "Please proceed."
+    assert "ACTIVE WORKFLOW CONTINUATION CONTEXT" in planner_prompt_context
+    assert "#V#scholarly_paper_representation_workflow" in planner_prompt_context
+    assert "#V#uploaded_file_copy_abc123" in planner_prompt_context
 
     continuation_entry = next(
         (

--- a/tests/backend/test_tool_progress_liveness.py
+++ b/tests/backend/test_tool_progress_liveness.py
@@ -1,6 +1,17 @@
 """Tests for generate() tool-progress liveness telemetry (JVNAUTOSCI-1103)."""
 
+import os
+
+from flask import Flask
+
 import src.backend.server.routes.von_routes as von_routes
+from src.backend.services.tool_progress_store_service import (
+    clear_tool_progress_documents_for_tests,
+)
+
+
+_ORIGINAL_USE_MOCK_DB = os.environ.get("VON_USE_MOCK_DB")
+_ORIGINAL_DB_NAME = os.environ.get("VON_DB_NAME")
 
 
 def _set_clock(monkeypatch, start: float = 1000.0):
@@ -12,14 +23,25 @@ def _set_clock(monkeypatch, start: float = 1000.0):
 def _clear_progress_state() -> None:
     with von_routes._TOOL_PROGRESS_LOCK:
         von_routes._TOOL_PROGRESS.clear()
+    clear_tool_progress_documents_for_tests()
 
 
 def setup_function() -> None:
+    os.environ["VON_USE_MOCK_DB"] = "1"
+    os.environ["VON_DB_NAME"] = "test_von_db"
     _clear_progress_state()
 
 
 def teardown_function() -> None:
     _clear_progress_state()
+    if _ORIGINAL_USE_MOCK_DB is None:
+        os.environ.pop("VON_USE_MOCK_DB", None)
+    else:
+        os.environ["VON_USE_MOCK_DB"] = _ORIGINAL_USE_MOCK_DB
+    if _ORIGINAL_DB_NAME is None:
+        os.environ.pop("VON_DB_NAME", None)
+    else:
+        os.environ["VON_DB_NAME"] = _ORIGINAL_DB_NAME
 
 
 def test_heartbeat_updates_sequence_and_keeps_stage(monkeypatch) -> None:
@@ -57,6 +79,50 @@ def test_heartbeat_updates_sequence_and_keeps_stage(monkeypatch) -> None:
     assert heartbeat["idle_ms"] >= int(
         von_routes._TOOL_PROGRESS_HEARTBEAT_INTERVAL_SEC * 1000
     )
+
+
+def test_progress_endpoint_reads_persisted_state_after_local_cache_miss(
+    monkeypatch,
+) -> None:
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.register_blueprint(von_routes.von_bp, url_prefix="/von")
+
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#test_user",
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_show_tool_use_during_thinking",
+        lambda: True,
+    )
+
+    scope_key = "user:#V#test_user"
+    von_routes._set_tool_progress(
+        scope_key,
+        "req-persisted",
+        {
+            "status": "thinking",
+            "phase": "workflow_dispatch",
+            "phase_label": "Selecting workflow",
+            "request_id": "req-persisted",
+            "goal_label": "https://arxiv.org/abs/2602.20478",
+        },
+    )
+
+    with von_routes._TOOL_PROGRESS_LOCK:
+        von_routes._TOOL_PROGRESS.clear()
+
+    client = app.test_client()
+    response = client.get("/von/progress/req-persisted")
+    assert response.status_code == 200
+
+    body = response.get_json()
+    assert isinstance(body, dict)
+    assert body.get("request_id") == "req-persisted"
+    assert body.get("stage") == "workflow_dispatch"
+    assert body.get("phase_label") == "Selecting workflow"
+    assert body.get("goal_label") == "https://arxiv.org/abs/2602.20478"
 
 
 def test_missing_heartbeat_marks_request_stalled(monkeypatch) -> None:

--- a/tests/backend/test_von_generate_bare_arxiv_url_integration.py
+++ b/tests/backend/test_von_generate_bare_arxiv_url_integration.py
@@ -192,7 +192,6 @@ def _make_app(
 def test_generate_bare_arxiv_url_auto_represents_paper(monkeypatch):
     llm = _LLMSequence(
         [
-            "plain_response",
             '{"action":"call_tool","tool":"download_paper","payload":{"arxiv_id":"2510.06248"}}',
             "Downloaded and represented the paper.",
         ]
@@ -210,6 +209,7 @@ def test_generate_bare_arxiv_url_auto_represents_paper(monkeypatch):
     workflow_routing = llm_debug.get("workflow_routing") or {}
     assert workflow_routing.get("workflow_id") == "#V#tool_calling_workflow"
     assert workflow_routing.get("verdict") == "tool_seeking"
+    assert workflow_routing.get("source") == "selector_override"
 
     tool_invocations = llm_debug.get("tool_invocations") or []
     download_records = [
@@ -245,9 +245,10 @@ def test_generate_bare_arxiv_url_auto_represents_paper(monkeypatch):
     completion_gate = turn_record.get("completion_gate") or {}
     assert completion_gate.get("decision") == "completed"
     assert completion_gate.get("safe_to_claim_completion") is True
+    assert len(llm.calls) == 2
 
 
-def test_generate_invalid_selector_verdict_still_routes_bare_arxiv_to_tool_pipeline(
+def test_generate_bare_arxiv_url_recovers_from_noisy_initial_tool_plan_output(
     monkeypatch,
 ):
     llm = _LLMSequence(
@@ -273,13 +274,16 @@ def test_generate_invalid_selector_verdict_still_routes_bare_arxiv_to_tool_pipel
     assert workflow_routing.get("source") == "selector_override"
 
     diagnostics = llm_debug.get("turn_execution_diagnostics") or {}
-    assert diagnostics.get("tool_call_count") == 1
-    assert diagnostics.get("tool_success_count") == 1
+    assert diagnostics.get("tool_call_count") == 2
+    assert diagnostics.get("tool_success_count") == 2
     assert diagnostics.get("tool_failure_count") == 0
     assert diagnostics.get("tool_pending_count") == 0
 
     tool_history = diagnostics.get("tool_history") or []
-    assert [entry.get("tool") for entry in tool_history] == ["download_paper"]
+    assert [entry.get("tool") for entry in tool_history] == [
+        "download_paper",
+        "download_paper",
+    ]
     assert all(entry.get("tool") for entry in tool_history)
 
     workflow_stage_path = diagnostics.get("workflow_stage_path") or {}
@@ -301,10 +305,11 @@ def test_generate_invalid_selector_verdict_still_routes_bare_arxiv_to_tool_pipel
         for entry in stage_diagnostics
         if isinstance(entry, dict) and entry.get("stage_id") == "tool_execute"
     )
-    assert tool_stage.get("tool_call_count") == 1
-    assert tool_stage.get("tool_success_count") == 1
+    assert tool_stage.get("tool_call_count") == 2
+    assert tool_stage.get("tool_success_count") == 2
     assert tool_stage.get("tool_failure_count") == 0
     assert tool_stage.get("tool_pending_count") == 0
+    assert len(llm.calls) == 3
 
 
 def test_generate_bare_arxiv_url_without_selector_still_forces_tool_pipeline_routing(


### PR DESCRIPTION
## Summary
- persist tool-progress state in Mongo so `/von/progress/<request_id>` remains visible across workers/processes
- force tool-calling routing up front when prompt requirements already imply missing required tools, including bare arXiv URLs
- update routing and integration regressions to reflect the stronger preselector contract and the noisy-initial-plan retry path

## Validation
- `pdm run pyright src/backend/services/tool_progress_store_service.py src/backend/server/routes/von_routes.py src/backend/integrations/internal_mcp/orchestrator.py tests/backend/test_tool_progress_liveness.py tests/backend/test_von_generate_bare_arxiv_url_integration.py tests/backend/test_orchestrator_workflow_selector_routing.py tests/backend/test_orchestrator_missing_tool_call_retry_arxiv.py tests/backend/test_write_tool_policy.py`
- `$env:VON_DB_NAME='test_von_db'; pdm run pytest tests/backend/test_tool_progress_liveness.py tests/backend/test_von_generate_bare_arxiv_url_integration.py tests/backend/test_write_tool_policy.py -q`
- `$env:VON_DB_NAME='test_von_db'; pdm run pytest tests/backend/test_orchestrator_workflow_selector_routing.py -q`

## Notes
- `tests/backend/test_orchestrator_missing_tool_call_retry_arxiv.py::test_missing_tool_call_retry_forces_download_paper_over_list_papers` still timed out locally even with a 5-minute timeout, so I am not claiming that specific adjacent regression as revalidated here.
- Full `lane_backend_routes` and `lane_backend_mcp` runs also exceeded the command timeout in this environment, so validation stayed focused on the impacted call paths above.