### PR TITLE
JVNAUTOSCI-1413 canonicalise live progress history

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -113,6 +113,7 @@ _TOOL_PROGRESS_TERMINAL_PHASES = {
     "terminated",
 }
 _TOOL_PROGRESS_DIAGNOSTIC_EVENT_LIMIT = 80
+_TOOL_PROGRESS_PHASE_HISTORY_LIMIT = 80
 
 _ONBOARDING_WORKFLOW_IDS_ENV = "VON_NEW_MEMBER_ONBOARDING_WORKFLOW_IDS"
 _ONBOARDING_WORKFLOW_KEYWORDS = ("onboard", "onboarding")
@@ -484,25 +485,25 @@ def _serialise_tool_progress_state(
     if workflow_stage_path is None:
         workflow_stage_path = _build_live_workflow_stage_path(payload)
     payload["workflow_stage_path"] = workflow_stage_path
+    diagnostic_events = [
+        cast(dict[str, Any], entry)
+        for entry in payload.get("diagnostic_events", [])
+        if isinstance(entry, dict)
+    ]
+    phase_history = _extract_phase_history_from_progress_state(
+        payload,
+        diagnostic_events=diagnostic_events,
+    )
     workflow_discovery = payload.get("workflow_discovery")
     if isinstance(workflow_discovery, Mapping):
         payload["workflow_discovery"] = _normalise_workflow_discovery_progress_payload(
             workflow_discovery
         )
-    payload["stage_diagnostics"] = _build_turn_execution_stage_diagnostics(
-        diagnostic_events=[
-            cast(dict[str, Any], entry)
-            for entry in payload.get("diagnostic_events", [])
-            if isinstance(entry, dict)
-        ],
+    tool_history = _derive_tool_history_from_diagnostic_events(diagnostic_events)
+    stage_diagnostics = _build_turn_execution_stage_diagnostics(
+        diagnostic_events=diagnostic_events,
         workflow_stage_path=workflow_stage_path,
-        tool_history=_derive_tool_history_from_diagnostic_events(
-            [
-                cast(dict[str, Any], entry)
-                for entry in payload.get("diagnostic_events", [])
-                if isinstance(entry, dict)
-            ]
-        ),
+        tool_history=tool_history,
         tool_observation_summary=_extract_tool_observation_summary_from_progress(payload),
         workflow_discovery=(
             cast(dict[str, Any], payload["workflow_discovery"])
@@ -511,7 +512,19 @@ def _serialise_tool_progress_state(
         ),
         latest_progress=payload,
     )
+    payload["phase_history"] = phase_history
+    payload["progress_events"] = _build_progress_events_from_phase_history(
+        phase_history,
+        latest_progress=payload,
+    )
+    payload["stage_diagnostics"] = stage_diagnostics
+    payload["activity_history"] = _build_activity_history_from_phase_history(
+        phase_history,
+        stage_diagnostics=stage_diagnostics,
+        latest_progress=payload,
+    )
     payload.pop("_workflow_runtime_stages", None)
+    payload.pop("_phase_history", None)
     payload.pop("_stage_summaries", None)
 
     return payload
@@ -821,6 +834,230 @@ def _derive_phase_history_from_diagnostic_events(
         last_phase = phase
 
     return phase_history[-_TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT :]
+
+
+def _normalise_phase_history_entries(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+
+    normalised: list[dict[str, Any]] = []
+    for raw_entry in value:
+        if not isinstance(raw_entry, Mapping):
+            continue
+
+        phase = _progress_str(raw_entry.get("phase")) or _progress_str(raw_entry.get("stage"))
+        if not phase:
+            continue
+
+        timestamp = _progress_number(raw_entry.get("timestamp"))
+        at_utc = _progress_str(raw_entry.get("at_utc"))
+        if timestamp is None and at_utc:
+            timestamp = _iso_utc_to_epoch_ms(at_utc)
+        if timestamp is None:
+            continue
+
+        stage_id = _canonicalise_live_runtime_stage(phase) or phase
+        phase_label = (
+            _progress_str(raw_entry.get("phaseLabel"))
+            or _progress_str(raw_entry.get("phase_label"))
+            or _progress_str(raw_entry.get("stage_label"))
+            or _default_stage_label(stage_id)
+        )
+        normalised.append(
+            {
+                "phase": phase,
+                "phaseLabel": phase_label,
+                "timestamp": int(max(0.0, timestamp)),
+                "at_utc": at_utc,
+                "sequence_no": int(max(0.0, _progress_number(raw_entry.get("sequence_no")) or 0))
+                or None,
+            }
+        )
+
+    return normalised[-_TOOL_PROGRESS_PHASE_HISTORY_LIMIT :]
+
+
+def _append_preserved_phase_history_entry(
+    entries: list[dict[str, Any]],
+    *,
+    phase: str | None,
+    phase_label: str | None,
+    timestamp_ms: int,
+    at_utc: str | None,
+    sequence_no: int | None,
+) -> list[dict[str, Any]]:
+    clean_phase = _progress_str(phase)
+    if not clean_phase:
+        return entries
+
+    updated = [dict(entry) for entry in entries if isinstance(entry, Mapping)]
+    clean_stage_id = _canonicalise_live_runtime_stage(clean_phase) or clean_phase
+    clean_phase_label = _progress_str(phase_label) or _default_stage_label(clean_stage_id)
+    clean_timestamp = int(max(0, timestamp_ms))
+    clean_sequence_no = int(max(0, sequence_no)) if isinstance(sequence_no, int) else None
+
+    if updated:
+        last_entry = updated[-1]
+        last_phase = _progress_str(last_entry.get("phase"))
+        if last_phase == clean_phase:
+            if not _progress_str(last_entry.get("phaseLabel")):
+                last_entry["phaseLabel"] = clean_phase_label
+            if not _progress_str(last_entry.get("at_utc")) and at_utc:
+                last_entry["at_utc"] = at_utc
+            if _progress_number(last_entry.get("timestamp")) is None:
+                last_entry["timestamp"] = clean_timestamp
+            if clean_sequence_no is not None and _progress_number(
+                last_entry.get("sequence_no")
+            ) is None:
+                last_entry["sequence_no"] = clean_sequence_no
+            return updated[-_TOOL_PROGRESS_PHASE_HISTORY_LIMIT :]
+
+    updated.append(
+        {
+            "phase": clean_phase,
+            "phaseLabel": clean_phase_label,
+            "timestamp": clean_timestamp,
+            "at_utc": at_utc,
+            "sequence_no": clean_sequence_no,
+        }
+    )
+    return updated[-_TOOL_PROGRESS_PHASE_HISTORY_LIMIT :]
+
+
+def _extract_phase_history_from_progress_state(
+    progress_state: Mapping[str, Any] | None,
+    *,
+    diagnostic_events: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    if isinstance(progress_state, Mapping):
+        preserved_entries = _normalise_phase_history_entries(progress_state.get("_phase_history"))
+        if preserved_entries:
+            return preserved_entries
+
+        payload_entries = _normalise_phase_history_entries(progress_state.get("phase_history"))
+        if payload_entries:
+            return payload_entries
+
+    return _derive_phase_history_from_diagnostic_events(diagnostic_events or [])
+
+
+def _build_progress_events_from_phase_history(
+    phase_history: list[dict[str, Any]],
+    *,
+    latest_progress: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    if not phase_history:
+        return []
+
+    latest_payload = latest_progress if isinstance(latest_progress, Mapping) else {}
+    latest_stage = _canonicalise_live_runtime_stage(
+        _progress_str(latest_payload.get("phase")) or _progress_str(latest_payload.get("stage"))
+    )
+    latest_status = _progress_str(latest_payload.get("status"))
+    latest_liveness_state = _progress_str(latest_payload.get("liveness_state"))
+    latest_idle_ms = _progress_number(latest_payload.get("idle_ms"))
+    latest_subtask = _progress_str(latest_payload.get("subtask")) or _progress_str(
+        latest_payload.get("tool")
+    ) or _progress_str(latest_payload.get("workflow_task"))
+    goal_label = _normalise_progress_goal_label(latest_payload.get("goal_label"))
+
+    progress_events: list[dict[str, Any]] = []
+    for index, entry in enumerate(phase_history):
+        phase = _progress_str(entry.get("phase"))
+        if not phase:
+            continue
+        stage_id = _canonicalise_live_runtime_stage(phase) or phase
+        is_latest = index == len(phase_history) - 1
+        progress_events.append(
+            {
+                "at_utc": _progress_str(entry.get("at_utc")),
+                "status": latest_status if is_latest and latest_status else "phase_transition",
+                "stage": stage_id,
+                "sequence_no": _progress_number(entry.get("sequence_no")),
+                "liveness_state": latest_liveness_state
+                if is_latest and latest_liveness_state
+                else "active",
+                "idle_ms": int(max(0.0, latest_idle_ms))
+                if is_latest and latest_idle_ms is not None
+                else 0,
+                "subtask": latest_subtask if is_latest and latest_subtask else None,
+                "goal_label": goal_label,
+            }
+        )
+
+    if latest_stage and progress_events:
+        progress_events[-1]["stage"] = latest_stage
+
+    return progress_events[-_TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT :]
+
+
+def _build_activity_history_from_phase_history(
+    phase_history: list[dict[str, Any]],
+    *,
+    stage_diagnostics: list[dict[str, Any]],
+    latest_progress: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    if not phase_history:
+        return []
+
+    latest_payload = latest_progress if isinstance(latest_progress, Mapping) else {}
+    latest_stage = _canonicalise_live_runtime_stage(
+        _progress_str(latest_payload.get("phase")) or _progress_str(latest_payload.get("stage"))
+    )
+    latest_status = (_progress_str(latest_payload.get("status")) or "").lower()
+    stage_diagnostic_map = {
+        _canonicalise_live_runtime_stage(entry.get("stage_id")) or _progress_str(entry.get("stage_id")): entry
+        for entry in stage_diagnostics
+        if isinstance(entry, Mapping)
+    }
+
+    activity_history: list[dict[str, Any]] = []
+    for index, entry in enumerate(phase_history):
+        phase = _progress_str(entry.get("phase"))
+        if not phase:
+            continue
+        stage_id = _canonicalise_live_runtime_stage(phase) or phase
+        stage_diagnostic = stage_diagnostic_map.get(stage_id) or {}
+        is_latest = index == len(phase_history) - 1
+        state = "success"
+        if is_latest:
+            if latest_status in {"error", "failed", "cancelled"}:
+                state = "failure"
+            else:
+                state = "pending"
+
+        activity_history.append(
+            {
+                "sequenceNo": _progress_number(entry.get("sequence_no")),
+                "atUtc": _progress_str(entry.get("at_utc")),
+                "stage": stage_id,
+                "status": _progress_str(stage_diagnostic.get("latest_status"))
+                or ("heartbeat" if is_latest and latest_status == "heartbeat" else "phase_transition"),
+                "eventKind": "phase_transition",
+                "label": _progress_str(entry.get("phaseLabel"))
+                or _progress_str(stage_diagnostic.get("stage_label"))
+                or _default_stage_label(stage_id),
+                "detail": _progress_str(stage_diagnostic.get("latest_result_summary"))
+                or _progress_str(stage_diagnostic.get("latest_error")),
+                "detailHtml": "",
+                "state": state,
+                "isLowLevel": False,
+                "groupCount": 1,
+                "subtask": (
+                    _progress_str(latest_payload.get("subtask"))
+                    or _progress_str(latest_payload.get("tool"))
+                    or _progress_str(latest_payload.get("workflow_task"))
+                )
+                if is_latest
+                else None,
+                "model": _progress_str(latest_payload.get("model")) if is_latest else None,
+            }
+        )
+
+    if latest_stage and activity_history:
+        activity_history[-1]["stage"] = latest_stage
+
+    return activity_history[-_TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT :]
 
 
 def _derive_tool_history_from_diagnostic_events(
@@ -1303,7 +1540,10 @@ def _build_turn_execution_diagnostics(
     if effective_request_id is None and isinstance(latest_progress, dict):
         effective_request_id = _progress_str(latest_progress.get("request_id"))
 
-    phase_history = _derive_phase_history_from_diagnostic_events(diagnostic_events)
+    phase_history = _extract_phase_history_from_progress_state(
+        latest_progress,
+        diagnostic_events=diagnostic_events,
+    )
     runtime_stages = [entry.get("phase") for entry in phase_history]
     selected_workflow_id = (
         _progress_str(latest_progress.get("selected_workflow_id"))
@@ -1349,6 +1589,15 @@ def _build_turn_execution_diagnostics(
         workflow_discovery=workflow_payload,
         latest_progress=latest_progress,
     )
+    progress_events = _build_progress_events_from_phase_history(
+        phase_history,
+        latest_progress=latest_progress,
+    )
+    activity_history = _build_activity_history_from_phase_history(
+        phase_history,
+        stage_diagnostics=stage_diagnostics,
+        latest_progress=latest_progress,
+    )
 
     return {
         "generated_at_utc": _progress_str(generated_at_utc) or _now_utc_iso(),
@@ -1358,9 +1607,8 @@ def _build_turn_execution_diagnostics(
         "elapsed_ms": elapsed_ms_value,
         "prompt_preview": prompt_preview,
         "latest_progress": latest_progress,
-        "progress_events": _normalise_progress_events_from_diagnostic_events(
-            diagnostic_events
-        ),
+        "progress_events": progress_events,
+        "activity_history": activity_history,
         "phase_history": phase_history,
         "tool_history": tool_history,
         "tool_call_count": int(_progress_number(tool_observation_summary.get("tool_call_count")) or 0),
@@ -2373,6 +2621,17 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
             _progress_str(merged.get("phase")) or _progress_str(merged.get("stage")),
         )
         merged["_workflow_runtime_stages"] = runtime_stages
+        phase_history = _normalise_phase_history_entries(existing.get("_phase_history"))
+        phase_history = _append_preserved_phase_history_entry(
+            phase_history,
+            phase=_progress_str(merged.get("phase")) or _progress_str(merged.get("stage")),
+            phase_label=_progress_str(merged.get("phase_label"))
+            or _progress_str(merged.get("stage_label")),
+            timestamp_ms=int(now_epoch * 1000.0),
+            at_utc=now_utc,
+            sequence_no=sequence_no,
+        )
+        merged["_phase_history"] = phase_history
         merged["workflow_stage_path"] = _build_live_workflow_stage_path_from_runtime_stages(
             runtime_stages,
             _progress_str(merged.get("selected_workflow_id")),

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -617,6 +617,8 @@ const THINKING_CARD_TOGGLE_ARIA_LABEL_EXPANDED = 'Collapse thinking details';
 const THINKING_CARD_TOGGLE_ARIA_LABEL_COLLAPSED = 'Expand thinking details';
 const THINKING_ACTIVITY_LOW_LEVEL_EVENT_KINDS = new Set(['llm_call_chunk', 'heartbeat']);
 const THINKING_DIAGNOSTIC_DETAILS_SELECTOR = 'details[data-thinking-diagnostic-key]';
+const THINKING_DIAGNOSTICS_EXPORT_EVENT_LIMIT = 40;
+const THINKING_DIAGNOSTICS_EXPORT_PHASE_HISTORY_LIMIT = 80;
 const THINKING_TERMINAL_PROGRESS_STATUSES = new Set([
     'completed',
     'complete',
@@ -972,6 +974,15 @@ function cloneThinkingToolHistory(history) {
         .map((entry) => ({ ...entry }));
 }
 
+function cloneThinkingStructuredHistory(history) {
+    if (!Array.isArray(history)) {
+        return [];
+    }
+    return history
+        .filter((entry) => entry && typeof entry === 'object')
+        .map((entry) => ({ ...entry }));
+}
+
 function getCanonicalThinkingToolHistory(request) {
     if (!request || typeof request !== 'object') {
         return [];
@@ -999,6 +1010,36 @@ function syncThinkingToolHistoryFromProgress(request, progress) {
     return true;
 }
 
+function syncThinkingCanonicalHistoriesFromProgress(request, progress) {
+    if (!request || typeof request !== 'object' || !progress || typeof progress !== 'object') {
+        return false;
+    }
+
+    let updated = false;
+
+    if (Array.isArray(progress.phase_history)) {
+        request.phaseHistory = cloneThinkingStructuredHistory(progress.phase_history);
+        updated = true;
+    }
+
+    if (Array.isArray(progress.progress_events)) {
+        request.progressEvents = cloneThinkingStructuredHistory(progress.progress_events);
+        updated = true;
+    }
+
+    if (Array.isArray(progress.activity_history)) {
+        request.activityHistory = cloneThinkingStructuredHistory(progress.activity_history);
+        updated = true;
+    }
+
+    if (Array.isArray(progress.stage_diagnostics)) {
+        request.stageDiagnostics = cloneThinkingStructuredHistory(progress.stage_diagnostics);
+        updated = true;
+    }
+
+    return updated;
+}
+
 function createThinkingCardHistorySnapshot(request) {
     if (!request || typeof request !== 'object') {
         return null;
@@ -1009,6 +1050,12 @@ function createThinkingCardHistorySnapshot(request) {
         : null;
     const activityHistory = Array.isArray(request.activityHistory)
         ? request.activityHistory.map((entry) => ({ ...entry }))
+        : [];
+    const progressEvents = Array.isArray(request.progressEvents)
+        ? request.progressEvents.map((entry) => ({ ...entry }))
+        : [];
+    const phaseHistory = Array.isArray(request.phaseHistory)
+        ? request.phaseHistory.map((entry) => ({ ...entry }))
         : [];
     const toolHistory = getCanonicalThinkingToolHistory(request);
     const workflowDiscovery = (request.workflowDiscovery && typeof request.workflowDiscovery === 'object')
@@ -1039,6 +1086,9 @@ function createThinkingCardHistorySnapshot(request) {
                 : []
         }
         : null;
+    const stageDiagnostics = Array.isArray(request.stageDiagnostics)
+        ? request.stageDiagnostics.map((entry) => ({ ...entry }))
+        : [];
 
     const effectiveProgressForTerminal = latestProgress || { status: 'completed' };
     const completedDisplayState = reduceThinkingCardDisplayState(
@@ -1048,9 +1098,12 @@ function createThinkingCardHistorySnapshot(request) {
 
     return {
         activityHistory,
+        progressEvents,
+        phaseHistory,
         toolUseProgressHistory: toolHistory,
         workflowDiscovery,
         workflowStagePath,
+        stageDiagnostics,
         latestProgress,
         expandedThinkingDiagnosticKeys: request.expandedThinkingDiagnosticKeys instanceof Set
             ? Array.from(request.expandedThinkingDiagnosticKeys)
@@ -1464,6 +1517,10 @@ export function __testOnly_updateThinkingCardMeta(request, progress) {
     updateThinkingCardMeta(request, progress);
 }
 
+export function __testOnly_syncThinkingCanonicalHistoriesFromProgress(request, progress) {
+    return syncThinkingCanonicalHistoriesFromProgress(request, progress);
+}
+
 function updateThinkingCardStatusBadge(progress) {
     const badgeEl = document.getElementById('thinkingCardStatusBadge');
     if (!badgeEl) {
@@ -1573,8 +1630,10 @@ function recordToolUseHistory(request, progress) {
         request.phaseHistory = [];
     }
 
+    const hasCanonicalPhaseHistory = Array.isArray(progress.phase_history);
+
     // Record phase transitions (JVNAUTOSCI-984).
-    if (phase && status === 'phase_transition') {
+    if (!hasCanonicalPhaseHistory && phase && status === 'phase_transition') {
         const lastPhase = request.phaseHistory.length
             ? request.phaseHistory[request.phaseHistory.length - 1]
             : null;
@@ -2692,7 +2751,7 @@ function buildToolHistoryDiagnosticsHTML(entry) {
 }
 
 function buildThinkingStageDiagnosticsSnapshot(request) {
-    return buildThinkingWorkflowStageRows(request)
+    const workflowRows = buildThinkingWorkflowStageRows(request)
         .map((entry) => ({
             stage_id: entry.stageId || null,
             label: entry.label || null,
@@ -2701,6 +2760,65 @@ function buildThinkingStageDiagnosticsSnapshot(request) {
             diagnostics: entry.diagnosticData || null
         }))
         .filter((entry) => entry.stage_id || entry.label);
+
+    const preservedEntries = Array.isArray(request?.stageDiagnostics)
+        ? request.stageDiagnostics
+            .map((entry) => normaliseThinkingStageDiagnosticSnapshotEntry(entry))
+            .filter((entry) => entry && (entry.stage_id || entry.label))
+        : [];
+
+    if (workflowRows.length === 0) {
+        return preservedEntries;
+    }
+    if (preservedEntries.length === 0) {
+        return workflowRows;
+    }
+
+    const mergedRows = workflowRows.map((entry) => ({ ...entry }));
+    const seenStageKeys = new Set(
+        mergedRows
+            .map((entry) => normaliseThinkingActivityString(entry.stage_id || entry.label))
+            .filter(Boolean)
+    );
+
+    for (const entry of preservedEntries) {
+        const stageKey = normaliseThinkingActivityString(entry.stage_id || entry.label);
+        if (!stageKey || seenStageKeys.has(stageKey)) {
+            continue;
+        }
+        mergedRows.push({ ...entry });
+        seenStageKeys.add(stageKey);
+    }
+
+    return mergedRows;
+}
+
+function normaliseThinkingStageDiagnosticSnapshotEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const stageId = normaliseThinkingActivityString(entry.stage_id || entry.stageId);
+    const label = normaliseThinkingActivityString(entry.label || entry.stage_label || entry.stageLabel)
+        || formatThinkingActivityFallbackLabel(stageId)
+        || null;
+    const detail = normaliseThinkingActivityString(entry.detail) || null;
+    const state = normaliseThinkingActivityString(entry.state) || null;
+    const diagnostics = (entry.diagnostics && typeof entry.diagnostics === 'object')
+        ? { ...entry.diagnostics }
+        : null;
+
+    if (!stageId && !label) {
+        return null;
+    }
+
+    return {
+        stage_id: stageId,
+        label,
+        detail,
+        state,
+        diagnostics
+    };
 }
 
 function buildWorkflowStageDetailPresentation(stageId, request) {
@@ -2887,11 +3005,28 @@ function buildThinkingWorkflowStageRows(request) {
     const path = Array.isArray(workflowStagePath?.path)
         ? workflowStagePath.path.filter((entry) => entry && typeof entry === 'object')
         : [];
+    const preservedRows = Array.isArray(request?.stageDiagnostics)
+        ? request.stageDiagnostics
+            .map((entry) => normaliseThinkingStageDiagnosticSnapshotEntry(entry))
+            .filter((entry) => entry && (entry.stage_id || entry.label))
+            .map((entry) => ({
+                stageId: entry.stage_id,
+                label: entry.label || formatThinkingActivityFallbackLabel(entry.stage_id) || 'Workflow step',
+                detail: entry.detail || '',
+                detailHtml: '',
+                state: entry.state || null,
+                diagnosticKey: buildThinkingDiagnosticKey('stage', entry.stage_id || entry.label),
+                diagnosticData: entry.diagnostics || null
+            }))
+        : [];
 
     const workflowDiscovery = (request.workflowDiscovery && typeof request.workflowDiscovery === 'object')
         ? request.workflowDiscovery
         : null;
     if (path.length === 0) {
+        if (preservedRows.length > 0) {
+            return preservedRows;
+        }
         if (workflowDiscovery) {
             const diagnosticData = buildThinkingWorkflowStageDiagnosticData(
                 'workflow_discovery',
@@ -2923,7 +3058,7 @@ function buildThinkingWorkflowStageRows(request) {
     const latestIsTerminal = isTerminalThinkingProgress(latestProgress);
     const latestIsFailure = latestStatus === 'error' || latestStatus === 'failed';
 
-    return path.map((entry, index) => {
+    const stageRows = path.map((entry, index) => {
         const stageId = normaliseThinkingActivityString(entry.stage_id || entry.runtime_stage_normalised);
         const stageLabel = normaliseThinkingActivityString(entry.stage_label)
             || formatThinkingActivityFallbackLabel(stageId)
@@ -2960,6 +3095,28 @@ function buildThinkingWorkflowStageRows(request) {
             diagnosticData
         };
     });
+
+    if (preservedRows.length === 0) {
+        return stageRows;
+    }
+
+    const mergedRows = stageRows.map((entry) => ({ ...entry }));
+    const seenStageKeys = new Set(
+        mergedRows
+            .map((entry) => normaliseThinkingActivityString(entry.stageId || entry.label))
+            .filter(Boolean)
+    );
+
+    for (const entry of preservedRows) {
+        const stageKey = normaliseThinkingActivityString(entry.stageId || entry.label);
+        if (!stageKey || seenStageKeys.has(stageKey)) {
+            continue;
+        }
+        mergedRows.push({ ...entry });
+        seenStageKeys.add(stageKey);
+    }
+
+    return mergedRows;
 }
 
 function renderThinkingWorkflowStageHistoryHTML(request) {
@@ -3298,20 +3455,23 @@ function startToolUseProgressPolling(request) {
                 type: 'progress_update',
                 progress
             });
-            if (!Array.isArray(request.progressEvents)) {
-                request.progressEvents = [];
-            }
-            request.progressEvents.push({
-                at_utc: new Date().toISOString(),
-                status: progress?.status || null,
-                stage: progress?.stage || progress?.phase || null,
-                sequence_no: progress?.sequence_no || null,
-                liveness_state: progress?.liveness_state || null,
-                idle_ms: progress?.activity_idle_ms ?? progress?.idle_ms ?? null,
-                subtask: progress?.subtask || progress?.tool || progress?.workflow_task || null
-            });
-            if (request.progressEvents.length > 60) {
-                request.progressEvents = request.progressEvents.slice(-60);
+            syncThinkingCanonicalHistoriesFromProgress(request, progress);
+            if (!Array.isArray(progress?.progress_events)) {
+                if (!Array.isArray(request.progressEvents)) {
+                    request.progressEvents = [];
+                }
+                request.progressEvents.push({
+                    at_utc: new Date().toISOString(),
+                    status: progress?.status || null,
+                    stage: progress?.stage || progress?.phase || null,
+                    sequence_no: progress?.sequence_no || null,
+                    liveness_state: progress?.liveness_state || null,
+                    idle_ms: progress?.activity_idle_ms ?? progress?.idle_ms ?? null,
+                    subtask: progress?.subtask || progress?.tool || progress?.workflow_task || null
+                });
+                if (request.progressEvents.length > 60) {
+                    request.progressEvents = request.progressEvents.slice(-60);
+                }
             }
 
             poll.consecutiveNotFound = 0;
@@ -3319,9 +3479,11 @@ function startToolUseProgressPolling(request) {
             setLoadingIndicatorText(formatToolUseProgressText(progress, request));
             updateThinkingCardMeta(request, progress);
             recordToolUseHistory(request, progress);
-            request.activityHistory = normaliseThinkingActivityHistory(progress?.diagnostic_events);
-            if (request.activityHistory.length > 80) {
-                request.activityHistory = request.activityHistory.slice(-80);
+            if (!Array.isArray(progress?.activity_history)) {
+                request.activityHistory = normaliseThinkingActivityHistory(progress?.diagnostic_events);
+                if (request.activityHistory.length > 80) {
+                    request.activityHistory = request.activityHistory.slice(-80);
+                }
             }
 
             if (progress.workflow_stage_path && typeof progress.workflow_stage_path === 'object') {
@@ -3332,9 +3494,6 @@ function startToolUseProgressPolling(request) {
             // including explicit no-match payloads.
             if (progress.workflow_discovery && typeof progress.workflow_discovery === 'object') {
                 request.workflowDiscovery = progress.workflow_discovery;
-            }
-            if (Array.isArray(progress.stage_diagnostics)) {
-                request.stageDiagnostics = progress.stage_diagnostics;
             }
 
             setLoadingIndicatorDetailHtml(renderThinkingCardBodyHTML(request));
@@ -18533,10 +18692,16 @@ function buildThinkingDiagnosticsPayload(request) {
         elapsed_ms: elapsedMs,
         prompt_preview: typeof request.promptRaw === 'string' ? request.promptRaw.slice(0, 1000) : null,
         latest_progress: request.latestProgress || null,
-        activity_history: Array.isArray(request.activityHistory) ? request.activityHistory.slice(-40) : [],
-        progress_events: Array.isArray(request.progressEvents) ? request.progressEvents.slice(-40) : [],
-        phase_history: Array.isArray(request.phaseHistory) ? request.phaseHistory.slice(-40) : [],
-        tool_history: getCanonicalThinkingToolHistory(request).slice(-40),
+        activity_history: Array.isArray(request.activityHistory)
+            ? request.activityHistory.slice(-THINKING_DIAGNOSTICS_EXPORT_EVENT_LIMIT)
+            : [],
+        progress_events: Array.isArray(request.progressEvents)
+            ? request.progressEvents.slice(-THINKING_DIAGNOSTICS_EXPORT_EVENT_LIMIT)
+            : [],
+        phase_history: Array.isArray(request.phaseHistory)
+            ? request.phaseHistory.slice(-THINKING_DIAGNOSTICS_EXPORT_PHASE_HISTORY_LIMIT)
+            : [],
+        tool_history: getCanonicalThinkingToolHistory(request).slice(-THINKING_DIAGNOSTICS_EXPORT_EVENT_LIMIT),
         workflow_discovery: request.workflowDiscovery || null,
         workflow_stage_path: request.workflowStagePath || null,
         stage_diagnostics: buildThinkingStageDiagnosticsSnapshot(request)
@@ -19077,6 +19242,8 @@ async function handleSendPrompt(options = {}) {
         workflowStagePath: null,
         latestProgress: null,
         progressEvents: [],
+        phaseHistory: [],
+        stageDiagnostics: [],
         thinkingCardDisplayState: reduceThinkingCardDisplayState(null, { type: 'reset_for_active' })
     };
     activeChatRequest = request;

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -34,6 +34,7 @@ import {
     __testOnly_renderThinkingCardBodyHTML,
     __testOnly_bindConceptSelectionClicks,
     __testOnly_updateThinkingCardMeta,
+    __testOnly_syncThinkingCanonicalHistoriesFromProgress,
     __testOnly_resetChatConceptMetaCaches,
     formatChatTimestamp,
     sendMessage
@@ -1171,6 +1172,97 @@ describe('thinking activity history normalisation', () => {
                 })
             })
         ]);
+    });
+
+    test('syncs canonical preserved histories from progress payloads', () => {
+        const phaseHistory = Array.from({ length: 45 }, (_, index) => ({
+            phase: `phase_${index}`,
+            phaseLabel: `Phase ${index}`,
+            timestamp: index + 1
+        }));
+        const request = {
+            activityHistory: [{ label: 'Stale row' }],
+            progressEvents: [{ stage: 'stale_stage' }],
+            phaseHistory: [{ phase: 'stale_phase' }],
+            stageDiagnostics: [{ stage_id: 'stale_stage' }]
+        };
+        const progress = {
+            phase_history: phaseHistory,
+            progress_events: [
+                { stage: 'context_build', status: 'phase_transition' },
+                { stage: 'response_finalising', status: 'heartbeat' }
+            ],
+            activity_history: [
+                { stage: 'context_build', label: 'Build context', state: 'success' },
+                { stage: 'response_finalising', label: 'Finalising response', state: 'pending' }
+            ],
+            stage_diagnostics: [
+                { stage_id: 'context_build', stage_label: 'Build context' },
+                { stage_id: 'response_finalising', stage_label: 'Finalising response' }
+            ]
+        };
+
+        expect(__testOnly_syncThinkingCanonicalHistoriesFromProgress(request, progress)).toBe(true);
+        expect(request.phaseHistory).toEqual(progress.phase_history);
+        expect(request.progressEvents).toEqual(progress.progress_events);
+        expect(request.activityHistory).toEqual(progress.activity_history);
+        expect(request.stageDiagnostics).toEqual(progress.stage_diagnostics);
+
+        const diagnosticsPayload = __testOnly_buildThinkingDiagnosticsPayload({
+            ...request,
+            latestProgress: progress,
+            clientRequestId: 'req-canonical',
+            promptRaw: 'https://arxiv.org/abs/2602.20478'
+        });
+        expect(diagnosticsPayload.phase_history).toEqual(progress.phase_history);
+        expect(diagnosticsPayload.progress_events).toEqual(progress.progress_events);
+        expect(diagnosticsPayload.activity_history).toEqual(progress.activity_history);
+        expect(diagnosticsPayload.stage_diagnostics).toEqual([
+            expect.objectContaining({ stage_id: 'context_build' }),
+            expect.objectContaining({ stage_id: 'response_finalising' })
+        ]);
+        expect(diagnosticsPayload.phase_history).toHaveLength(45);
+        expect(diagnosticsPayload.phase_history[0]).toEqual(expect.objectContaining({ phase: 'phase_0' }));
+    });
+
+    test('renders preserved stage diagnostics when workflow stage path is absent', () => {
+        const html = __testOnly_renderThinkingCardBodyHTML({
+            latestProgress: {
+                status: 'heartbeat',
+                stage: 'response_finalising'
+            },
+            stageDiagnostics: [
+                {
+                    stage_id: 'context_build',
+                    label: 'Build context',
+                    detail: 'Initialising request context',
+                    state: 'success',
+                    diagnostics: {
+                        stage_id: 'context_build',
+                        stage_label: 'Build context',
+                        stage_event_count: 2,
+                        latest_status: 'thinking'
+                    }
+                },
+                {
+                    stage_id: 'response_finalising',
+                    label: 'Finalising response',
+                    detail: 'Persisting conversation history',
+                    state: 'pending',
+                    diagnostics: {
+                        stage_id: 'response_finalising',
+                        stage_label: 'Finalising response',
+                        stage_event_count: 1,
+                        latest_status: 'heartbeat'
+                    }
+                }
+            ]
+        });
+
+        expect(html).toContain('Build context');
+        expect(html).toContain('Initialising request context');
+        expect(html).toContain('Finalising response');
+        expect(html).toContain('Persisting conversation history');
     });
 
     test('renders canonical workflow stages with selected workflow details', () => {

--- a/tests/backend/test_tool_progress_liveness.py
+++ b/tests/backend/test_tool_progress_liveness.py
@@ -809,6 +809,28 @@ def test_live_stage_path_and_stage_diagnostics_survive_long_finalising_heartbeat
     assert stage_diagnostics[2].get("event_count") == (
         von_routes._TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT + 11
     )
+    phase_history = snapshot.get("phase_history")
+    assert isinstance(phase_history, list)
+    assert [entry.get("phase") for entry in phase_history] == [
+        "context_build",
+        "workflow_discovery",
+        "response_finalising",
+    ]
+    progress_events = snapshot.get("progress_events")
+    assert isinstance(progress_events, list)
+    assert [entry.get("stage") for entry in progress_events] == [
+        "context_build",
+        "workflow_discovery",
+        "response_finalising",
+    ]
+    activity_history = snapshot.get("activity_history")
+    assert isinstance(activity_history, list)
+    assert [entry.get("stage") for entry in activity_history] == [
+        "context_build",
+        "workflow_discovery",
+        "response_finalising",
+    ]
+    assert activity_history[-1].get("state") == "pending"
 
     diagnostics = von_routes._build_turn_execution_diagnostics(
         request_id="req-stage-tail",
@@ -827,6 +849,41 @@ def test_live_stage_path_and_stage_diagnostics_survive_long_finalising_heartbeat
     diagnostics_stage_diagnostics = diagnostics.get("stage_diagnostics")
     assert isinstance(diagnostics_stage_diagnostics, list)
     assert [entry.get("stage_id") for entry in diagnostics_stage_diagnostics] == [
+        "context_build",
+        "workflow_discovery",
+        "response_finalising",
+    ]
+    diagnostics_phase_history = diagnostics.get("phase_history")
+    assert isinstance(diagnostics_phase_history, list)
+    assert [entry.get("phase") for entry in diagnostics_phase_history] == [
+        "context_build",
+        "workflow_discovery",
+        "response_finalising",
+    ]
+    diagnostics_progress_events = diagnostics.get("progress_events")
+    assert isinstance(diagnostics_progress_events, list)
+    assert [entry.get("stage") for entry in diagnostics_progress_events] == [
+        "context_build",
+        "workflow_discovery",
+        "response_finalising",
+    ]
+    diagnostics_activity_history = diagnostics.get("activity_history")
+    assert isinstance(diagnostics_activity_history, list)
+    assert [entry.get("stage") for entry in diagnostics_activity_history] == [
+        "context_build",
+        "workflow_discovery",
+        "response_finalising",
+    ]
+    diagnostics_timing = diagnostics.get("timing_breakdown")
+    assert isinstance(diagnostics_timing, dict)
+    diagnostics_stage_rows = diagnostics_timing.get("stages")
+    assert isinstance(diagnostics_stage_rows, list)
+    diagnostics_stage_names = [
+        entry.get("stage")
+        for entry in diagnostics_stage_rows
+        if isinstance(entry, dict)
+    ]
+    assert diagnostics_stage_names[:3] == [
         "context_build",
         "workflow_discovery",
         "response_finalising",


### PR DESCRIPTION
## Summary
- preserve canonical phase, activity, and progress histories in live diagnostics instead of rebuilding from the truncated event tail
- keep frontend thinking-card exports and stage rendering aligned with preserved backend histories and stage diagnostics
- add long-tail retention regressions for backend diagnostics and frontend thinking-card behaviour

## Validation
- `pdm run pyright src/backend/server/routes/von_routes.py tests/backend/test_tool_progress_liveness.py`
- `$env:VON_DB_NAME=''test_von_db''; pdm run pytest tests/backend/test_tool_progress_liveness.py tests/backend/test_von_generate_bare_arxiv_url_integration.py tests/backend/test_von_diagnostics_export_endpoint.py tests/backend/test_von_generate_direct_tool_calls.py -q`
- `npm test -- src/frontend/web/von_interface/static/js/test/chatTab.test.js --runInBand`
