### PR TITLE
JVNAUTOSCI-1414 stabilise anonymous progress lookup

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -199,6 +199,10 @@ if _TOOL_PROGRESS_WAITING_THRESHOLD_SEC >= _TOOL_PROGRESS_STALL_THRESHOLD_SEC:
         _TOOL_PROGRESS_WAITING_THRESHOLD_SEC + _TOOL_PROGRESS_HEARTBEAT_INTERVAL_SEC
     )
 
+_TOOL_PROGRESS_WINDOW_SCOPE_PREFIX = "anon:window:"
+_TOOL_PROGRESS_SESSION_SCOPE_PREFIX = "anon:session:"
+_WINDOW_SESSION_HEADER_NAME = "X-Von-Window-Session"
+
 
 def _now_utc_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -1795,11 +1799,23 @@ def _slugify_concept_id_for_key(concept_id: str) -> str:
     return cleaned or "unknown"
 
 
+def _normalise_tool_progress_window_session_id(value: Any) -> str | None:
+    clean_value = _progress_str(value)
+    if not clean_value:
+        return None
+    if len(clean_value) > 200:
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9._:-]+", clean_value):
+        return None
+    return clean_value
+
+
 def _get_tool_progress_scope_key() -> str:
     """Return a stable scope key for tool-progress lookup.
 
     - Authenticated: scope is user concept id
-    - Unauthenticated: scope is a session-scoped random token
+    - Unauthenticated: scope is the stable window-session header when present,
+      otherwise a legacy Flask-session random token
     """
 
     user_concept_id = None
@@ -1813,10 +1829,16 @@ def _get_tool_progress_scope_key() -> str:
     if isinstance(user_concept_id, str) and user_concept_id.strip():
         return f"user:{user_concept_id.strip()}"
 
+    window_session_id = _normalise_tool_progress_window_session_id(
+        request.headers.get(_WINDOW_SESSION_HEADER_NAME)
+    )
+    if window_session_id:
+        return f"{_TOOL_PROGRESS_WINDOW_SCOPE_PREFIX}{window_session_id}"
+
     if "tool_progress_scope" not in session:
         session["tool_progress_scope"] = secrets.token_urlsafe(16)
 
-    return f"anon:{session.get('tool_progress_scope')}"
+    return f"{_TOOL_PROGRESS_SESSION_SCOPE_PREFIX}{session.get('tool_progress_scope')}"
 
 
 @von_bp.route("/api/files/upload", methods=["POST"])

--- a/tests/backend/test_tool_progress_liveness.py
+++ b/tests/backend/test_tool_progress_liveness.py
@@ -154,6 +154,116 @@ def test_progress_endpoint_pending_response_includes_explanatory_payload(
     assert "No live progress state is visible yet" in str(body.get("result_summary"))
 
 
+def test_progress_endpoint_uses_window_session_scope_for_anonymous_requests(
+    monkeypatch,
+) -> None:
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.register_blueprint(von_routes.von_bp, url_prefix="/von")
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_show_tool_use_during_thinking",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: None,
+    )
+
+    window_session_id = "ws_progress_visibility_race"
+    with app.test_request_context(
+        "/von/generate",
+        headers={"X-Von-Window-Session": window_session_id},
+    ):
+        scope_key = von_routes._get_tool_progress_scope_key()
+
+    assert scope_key == f"anon:window:{window_session_id}"
+
+    von_routes._set_tool_progress(
+        scope_key,
+        "req-window-scope",
+        {
+            "status": "thinking",
+            "phase": "workflow_discovery",
+            "phase_label": "Searching for workflows",
+            "request_id": "req-window-scope",
+            "goal_label": "https://arxiv.org/abs/2602.20478",
+        },
+    )
+
+    with von_routes._TOOL_PROGRESS_LOCK:
+        von_routes._TOOL_PROGRESS.clear()
+
+    client = app.test_client()
+    with client.session_transaction() as flask_session:
+        flask_session["tool_progress_scope"] = "legacy_cookie_scope"
+
+    response = client.get(
+        "/von/progress/req-window-scope",
+        headers={"X-Von-Window-Session": window_session_id},
+    )
+    assert response.status_code == 200
+
+    body = response.get_json()
+    assert isinstance(body, dict)
+    assert body.get("request_id") == "req-window-scope"
+    assert body.get("stage") == "workflow_discovery"
+    assert body.get("phase_label") == "Searching for workflows"
+    assert body.get("goal_label") == "https://arxiv.org/abs/2602.20478"
+
+
+def test_progress_endpoint_retains_legacy_session_scope_without_window_header(
+    monkeypatch,
+) -> None:
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.register_blueprint(von_routes.von_bp, url_prefix="/von")
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_show_tool_use_during_thinking",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: None,
+    )
+
+    client = app.test_client()
+    with client.session_transaction() as flask_session:
+        flask_session["tool_progress_scope"] = "legacy_cookie_scope"
+
+    with app.test_request_context("/von/generate"):
+        from flask import session as request_session
+
+        request_session["tool_progress_scope"] = "legacy_cookie_scope"
+        scope_key = von_routes._get_tool_progress_scope_key()
+
+    assert scope_key == "anon:session:legacy_cookie_scope"
+
+    von_routes._set_tool_progress(
+        scope_key,
+        "req-legacy-scope",
+        {
+            "status": "thinking",
+            "phase": "context_build",
+            "phase_label": "Building context",
+            "request_id": "req-legacy-scope",
+        },
+    )
+
+    with von_routes._TOOL_PROGRESS_LOCK:
+        von_routes._TOOL_PROGRESS.clear()
+
+    response = client.get("/von/progress/req-legacy-scope")
+    assert response.status_code == 200
+
+    body = response.get_json()
+    assert isinstance(body, dict)
+    assert body.get("request_id") == "req-legacy-scope"
+    assert body.get("stage") == "context_build"
+    assert body.get("phase_label") == "Building context"
+
+
 def test_response_finalising_payload_includes_useful_detail() -> None:
     payload = von_routes._build_response_finalising_tool_progress_payload(
         request_id="req-finalise",


### PR DESCRIPTION
## Summary
- derive anonymous tool-progress scope from the stable X-Von-Window-Session header before falling back to the legacy Flask-session token
- keep legacy no-header clients working via the old session token path
- add regressions for the anonymous progress visibility race and the legacy fallback path

## Validation
- `pdm run pyright src/backend/server/routes/von_routes.py tests/backend/test_tool_progress_liveness.py`
- `$env:VON_DB_NAME=''test_von_db''; pdm run pytest tests/backend/test_tool_progress_liveness.py tests/backend/test_von_generate_bare_arxiv_url_integration.py tests/backend/test_von_diagnostics_export_endpoint.py -q`
