### PR TITLE
JVNAUTOSCI-1419: harden degraded history and workflow monitor

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -17,7 +17,7 @@ import json
 from pathlib import Path
 from dataclasses import asdict, is_dataclass
 from datetime import datetime, timezone
-from typing import Any, Mapping, cast
+from typing import Any, Dict, Mapping, cast
 from ...workflows.durable.registry_factory import build_workflow_registry_read_only
 from ...workflows.durable.startup import get_instance_manager
 from ...workflows.durable.workflow_instance_submission_service import (
@@ -9570,19 +9570,37 @@ def history():
                 exc_info=True,
             )
             return jsonify(
-                {
-                    "history": [],
-                    "segments_returned": 0,
-                    "total_segments": 0,
-                    "has_more_history": False,
-                    "degraded": True,
-                    "retryable": True,
-                    "error": "Chat history temporarily unavailable; please retry.",
-                    "detail": str(e)[:300],
-                }
+                _build_transient_chat_history_payload(
+                    error_message="Chat history temporarily unavailable; please retry.",
+                    exc=e,
+                    fallback_payload={
+                        "history": [],
+                        "segments_returned": 0,
+                        "total_segments": 0,
+                        "has_more_history": False,
+                    },
+                )
             )
         print(f"Error retrieving history: {e}")
         return jsonify({"error": str(e)}), 500
+
+
+def _build_transient_chat_history_payload(
+    *,
+    error_message: str,
+    exc: Exception,
+    fallback_payload: Dict[str, Any],
+) -> Dict[str, Any]:
+    payload = dict(fallback_payload)
+    payload.update(
+        {
+            "degraded": True,
+            "retryable": True,
+            "error": error_message,
+            "detail": str(exc)[:300],
+        }
+    )
+    return payload
 
 
 @von_bp.route("/history/debug", methods=["GET"])
@@ -10108,15 +10126,15 @@ def history_length():
                 exc_info=True,
             )
             return jsonify(
-                {
-                    "history_length": 0,
-                    "session_count": 0,
-                    "authenticated": True,
-                    "degraded": True,
-                    "retryable": True,
-                    "error": "Chat history metrics temporarily unavailable; showing fallback values.",
-                    "detail": str(e)[:300],
-                }
+                _build_transient_chat_history_payload(
+                    error_message="Chat history metrics temporarily unavailable; showing fallback values.",
+                    exc=e,
+                    fallback_payload={
+                        "history_length": 0,
+                        "session_count": 0,
+                        "authenticated": True,
+                    },
+                )
             )
         print(f"Error retrieving history length: {e}")
         return jsonify({"error": str(e)}), 500
@@ -10401,6 +10419,24 @@ def history_sessions():
 
         return jsonify(response_payload)
     except Exception as e:
+        if chat_history_service.is_transient_chat_history_error(e):
+            current_app.logger.warning(
+                "history_sessions degraded due to transient chat history error: %s",
+                e,
+                exc_info=True,
+            )
+            return jsonify(
+                _build_transient_chat_history_payload(
+                    error_message="Conversation list temporarily unavailable; showing fallback state.",
+                    exc=e,
+                    fallback_payload={
+                        "authenticated": True,
+                        "sessions": [],
+                        "active_session_id": session.get("session_id"),
+                        "warnings": ["chat_history_temporarily_unavailable"],
+                    },
+                )
+            )
         current_app.logger.exception("Error retrieving history sessions")
         return jsonify({"error": str(e)}), 500
 

--- a/src/backend/server/routes/workflows_routes.py
+++ b/src/backend/server/routes/workflows_routes.py
@@ -9,6 +9,13 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from flask import Blueprint, jsonify, request
+from pymongo.errors import (
+    AutoReconnect,
+    ConnectionFailure,
+    NetworkTimeout,
+    PyMongoError,
+    ServerSelectionTimeoutError,
+)
 
 from ...db.repositories.concepts_repository import ConceptsRepository
 from ...services.text_value_service import get_texts_for_concept
@@ -57,6 +64,31 @@ _WORKFLOW_DEFINITIONS_REFRESH_LOCKS: Dict[
 _WORKFLOW_DEFINITIONS_CACHE_MAX_ENTRIES = 32
 _WORKFLOW_DEFINITIONS_CACHE_TTL_SECONDS_DEFAULT = 8.0
 _WORKFLOW_DEFINITIONS_REFRESH_RETRY_AFTER_SECONDS_DEFAULT = 1.0
+
+
+def _is_transient_workflow_instances_error(exc: Exception) -> bool:
+    if isinstance(
+        exc,
+        (
+            NetworkTimeout,
+            ServerSelectionTimeoutError,
+            AutoReconnect,
+            ConnectionFailure,
+            PyMongoError,
+        ),
+    ):
+        return True
+    message = str(exc).lower()
+    transient_markers = (
+        "timed out",
+        "no primary",
+        "replicasetnoprimary",
+        "connection pool paused",
+        "server selection timeout",
+        "networktimeout",
+        "temporarily unavailable",
+    )
+    return any(marker in message for marker in transient_markers)
 
 
 def _read_workflow_definitions_cache_ttl_seconds() -> float:
@@ -759,16 +791,40 @@ def api_list_workflow_instances():
             return jsonify({"error": f"Invalid status: {status_str}"}), 400
 
     manager = _get_instance_manager()
-    instances = manager.list_instances(
-        user_id=user_id,
-        org_id=org_id,
-        namespace=namespace,
-        status=status,
-        workflow_id=workflow_id,
-        source_event_type=source_event_type,
-        source_event_id=source_event_id,
-        limit=limit,
-    )
+    try:
+        instances = manager.list_instances(
+            user_id=user_id,
+            org_id=org_id,
+            namespace=namespace,
+            status=status,
+            workflow_id=workflow_id,
+            source_event_type=source_event_type,
+            source_event_id=source_event_id,
+            limit=limit,
+        )
+    except Exception as exc:
+        if _is_transient_workflow_instances_error(exc):
+            logger.warning(
+                "Workflow instances snapshot degraded due to transient store error: %s",
+                exc,
+                exc_info=True,
+            )
+            response = jsonify(
+                {
+                    "items": [],
+                    "count": 0,
+                    "degraded": True,
+                    "retryable": True,
+                    "retry_after_seconds": 2,
+                    "error": "Workflow monitor temporarily unavailable; please retry.",
+                    "detail": str(exc)[:300],
+                }
+            )
+            response.status_code = 503
+            response.headers["Retry-After"] = "2"
+            return response
+        logger.exception("Failed to list workflow instances")
+        return jsonify({"error": str(exc)}), 500
 
     return jsonify(
         {

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -213,6 +213,10 @@ def _read_aggregate(chat_history_coll, pipeline: List[Dict[str, Any]]):
         return chat_history_coll.aggregate(pipeline)
 
 
+def _history_array_expr(field_name: str = "history") -> Dict[str, Any]:
+    return {"$ifNull": [f"${field_name}", []]}
+
+
 def _ensure_chat_history_indexes(collection) -> None:
     global _CHAT_HISTORY_INDEXES_READY
     if _CHAT_HISTORY_INDEXES_READY:
@@ -879,8 +883,13 @@ def get_chat_history_segments(
                     {"$match": query},
                     {
                         "$project": {
-                            "history": {"$slice": ["$history", -history_tail_limit]},
-                            "history_length": {"$size": "$history"},
+                            "history": {
+                                "$slice": [
+                                    _history_array_expr(),
+                                    -history_tail_limit,
+                                ]
+                            },
+                            "history_length": {"$size": _history_array_expr()},
                         }
                     },
                 ]
@@ -1710,7 +1719,7 @@ def get_chat_history_length(
                     "message_count": {
                         "$size": {
                             "$filter": {
-                                "input": {"$ifNull": ["$history", []]},
+                                "input": _history_array_expr(),
                                 "as": "msg",
                                 "cond": {
                                     "$not": {
@@ -1771,7 +1780,7 @@ def get_chat_history_session_count(
                     "message_count": {
                         "$size": {
                             "$filter": {
-                                "input": {"$ifNull": ["$history", []]},
+                                "input": _history_array_expr(),
                                 "as": "msg",
                                 "cond": {
                                     "$not": {
@@ -2291,6 +2300,7 @@ def create_chat_session(
         "created_at": now,
         "updated_at": now,
         "session_name": name,
+        "history": [],
     }
     if isinstance(ns, str) and ns.strip():
         set_on_insert["namespace"] = ns.strip()

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -74,6 +74,21 @@ let activeChatSessionId = null;
 let activeChatSessionName = null;
 let activeChatSessionOwnerId = null;
 let sessionTabsCache = [];
+let displayedHistorySessionId = null;
+const historyLoadState = {
+    degraded: false,
+    message: '',
+    retryable: false,
+    detail: '',
+    sessionId: null
+};
+const historyMetricsState = {
+    degraded: false,
+    message: '',
+    retryable: false,
+    detail: '',
+    lastHealthy: null
+};
 const sessionHistoryCache = new Map();
 let loadingChatSessionId = null;
 const SESSION_TABS_REFRESH_COOLDOWN_MS = 15_000;
@@ -147,7 +162,10 @@ const workflowStatusStreamState = {
     reconnectAttempts: 0,
     reconnectTimeoutId: null,
     items: new Map(),
-    lastSnapshotAt: 0
+    lastSnapshotAt: 0,
+    snapshotError: '',
+    snapshotNotice: '',
+    lastSnapshotPayload: null
 };
 const workflowDefinitionsState = {
     visible: false,
@@ -1212,6 +1230,64 @@ function rehydrateFromCache(scrollableField, cached) {
     });
     updateHistoryBanner();
     return true;
+}
+
+function normaliseHistorySessionId(sessionId) {
+    return (typeof sessionId === 'string' && sessionId.trim())
+        ? sessionId.trim()
+        : null;
+}
+
+function clearHistoryLoadState({ sessionId = null } = {}) {
+    const normalisedSessionId = normaliseHistorySessionId(sessionId);
+    if (
+        normalisedSessionId
+        && historyLoadState.sessionId
+        && historyLoadState.sessionId !== normalisedSessionId
+    ) {
+        return;
+    }
+    historyLoadState.degraded = false;
+    historyLoadState.message = '';
+    historyLoadState.retryable = false;
+    historyLoadState.detail = '';
+    historyLoadState.sessionId = null;
+}
+
+function setHistoryLoadState({
+    sessionId = null,
+    message = '',
+    retryable = false,
+    detail = ''
+} = {}) {
+    historyLoadState.degraded = true;
+    historyLoadState.message = (typeof message === 'string' && message.trim())
+        ? message.trim()
+        : 'Conversation history temporarily unavailable; please retry.';
+    historyLoadState.retryable = Boolean(retryable);
+    historyLoadState.detail = (typeof detail === 'string' && detail.trim())
+        ? detail.trim()
+        : '';
+    historyLoadState.sessionId = normaliseHistorySessionId(sessionId);
+}
+
+function isHistoryLoadStateActiveForSession(sessionId = null) {
+    if (!historyLoadState.degraded) {
+        return false;
+    }
+    const normalisedSessionId = normaliseHistorySessionId(sessionId);
+    if (!normalisedSessionId || !historyLoadState.sessionId) {
+        return historyLoadState.degraded;
+    }
+    return historyLoadState.sessionId === normalisedSessionId;
+}
+
+function shouldPreserveRenderedHistoryForSession(scrollableField, sessionId) {
+    const normalisedSessionId = normaliseHistorySessionId(sessionId);
+    if (!scrollableField || !normalisedSessionId || displayedHistorySessionId !== normalisedSessionId) {
+        return false;
+    }
+    return Boolean(scrollableField.querySelector('.message-container'));
 }
 
 async function refreshToolUseDuringThinkingSetting(force = false) {
@@ -12152,6 +12228,16 @@ function updateHistoryBanner() {
         return;
     }
 
+    const activeHistoryIssue = isHistoryLoadStateActiveForSession(activeChatSessionId);
+    banner.classList.remove('is-warning', 'is-error');
+    if (activeHistoryIssue) {
+        bannerText.textContent = historyLoadState.message;
+        banner.classList.remove('hidden');
+        banner.classList.add(historyLoadState.retryable ? 'is-warning' : 'is-error');
+        loadButton.disabled = true;
+        return;
+    }
+
     const remainingSegments = Math.max(totalHistorySegments - historySegmentsShown, 0);
 
     if (remainingSegments > 0) {
@@ -13729,6 +13815,22 @@ async function refreshChatSessionTabs() {
             return;
         }
 
+        if (data?.degraded === true) {
+            console.warn('[chatTab] Chat session refresh degraded; keeping existing tabs where possible', {
+                status: response.status,
+                data
+            });
+            if (hasCachedTabs) {
+                renderChatSessionTabs(sessionTabsCache, activeChatSessionId);
+                container.hidden = false;
+            } else {
+                _stopChatTabsLoadingTicker();
+                renderChatSessionTabsPlaceholder('error');
+            }
+            setTimeout(() => scheduleChatSessionTabsRefresh(true), 2000);
+            return;
+        }
+
         if (!response.ok) {
             console.warn('[chatTab] Failed to refresh chat sessions (keeping existing tabs)', {
                 status: response.status,
@@ -14594,6 +14696,8 @@ async function switchToChatSession(sessionId) {
     }
 
     scrollableField.innerHTML = '<div class="chat-session-loading">Switching chat…</div>';
+    displayedHistorySessionId = null;
+    clearHistoryLoadState();
     historySegmentsShown = 0;
     totalHistorySegments = 0;
     updateHistoryBanner();
@@ -14679,6 +14783,10 @@ async function switchToChatSession(sessionId) {
             });
             if (!reused) {
                 scrollableField.innerHTML = '';
+                displayedHistorySessionId = null;
+            } else {
+                displayedHistorySessionId = sid;
+                clearHistoryLoadState({ sessionId: sid });
             }
             setChatSessionTabLoading(sid, false);
         } else {
@@ -14695,7 +14803,7 @@ async function switchToChatSession(sessionId) {
                 duration_ms: recentMs,
                 session_id: sid
             });
-            if (!loaded) {
+            if (!loaded && !isHistoryLoadStateActiveForSession(sid)) {
                 scrollableField.innerHTML = '';
             }
 
@@ -14888,17 +14996,55 @@ async function updateHistoryLength() {
         const response = await fetch('/von/history/length', {
             headers: buildChatFetchHeaders()
         });
-        const data = await response.json();
+        const data = await response.json().catch(() => ({}));
 
         if (response.ok) {
-            const historyLength = data.history_length || 0;
+            const historyLength = Number.isFinite(Number(data?.history_length))
+                ? Number(data.history_length)
+                : 0;
             const sessionCount = (typeof data.session_count === 'number') ? data.session_count : null;
             const authenticated = data.authenticated !== undefined ? data.authenticated : true;
             const historyLengthElement = document.getElementById('chat-history-length');
             if (historyLengthElement) {
                 if (!authenticated) {
+                    historyMetricsState.degraded = false;
+                    historyMetricsState.lastHealthy = null;
                     historyLengthElement.textContent = 'History: unauthenticated';
+                    historyLengthElement.title = 'Conversation history unavailable until you log in.';
+                } else if (data?.degraded === true) {
+                    historyMetricsState.degraded = true;
+                    historyMetricsState.message = (typeof data?.error === 'string' && data.error.trim())
+                        ? data.error.trim()
+                        : 'Conversation history metrics temporarily unavailable.';
+                    historyMetricsState.retryable = Boolean(data?.retryable);
+                    historyMetricsState.detail = (typeof data?.detail === 'string' && data.detail.trim())
+                        ? data.detail.trim()
+                        : '';
+                    const contextCount = transcriptTurns.length;
+                    const cached = (
+                        historyMetricsState.lastHealthy
+                        && typeof historyMetricsState.lastHealthy === 'object'
+                    ) ? historyMetricsState.lastHealthy : null;
+                    if (cached) {
+                        const conversationsText = cached.sessionCount === null
+                            ? '- conversations'
+                            : `${cached.sessionCount} conversations`;
+                        historyLengthElement.textContent = `History: ${conversationsText} | this ${contextCount} (stale)`;
+                        historyLengthElement.title = `${historyMetricsState.message} Showing last loaded totals: ${cached.sessionCount ?? '—'} conversations • ${cached.historyLength ?? '—'} messages.`;
+                    } else {
+                        historyLengthElement.textContent = `History: temporarily unavailable | this ${contextCount}`;
+                        historyLengthElement.title = historyMetricsState.message;
+                    }
                 } else {
+                    historyMetricsState.degraded = false;
+                    historyMetricsState.message = '';
+                    historyMetricsState.retryable = false;
+                    historyMetricsState.detail = '';
+                    historyMetricsState.lastHealthy = {
+                        historyLength,
+                        sessionCount,
+                        authenticated: true
+                    };
                     const contextCount = transcriptTurns.length;
                     const conversationsText = (sessionCount === null) ? '- conversations' : `${sessionCount} conversations`;
                     historyLengthElement.textContent = `History: ${conversationsText} | this ${contextCount}`;
@@ -15115,7 +15261,9 @@ async function loadChatHistory(options = {}) {
 
     await _ensureInviteSessionContext();
 
-    const requestedSessionId = activeChatSessionId;
+    const requestedSessionId = normaliseHistorySessionId(activeChatSessionId);
+    clearHistoryLoadState({ sessionId: requestedSessionId });
+    updateHistoryBanner();
     abortActiveHistoryRequest();
     const requestId = ++historyRequestCounter;
     const abortController = new AbortController();
@@ -15157,7 +15305,7 @@ async function loadChatHistory(options = {}) {
             signal: abortController.signal,
             headers: buildChatFetchHeaders()
         });
-        const data = await response.json();
+        const data = await response.json().catch(() => ({}));
 
         if (!activeHistoryRequest || activeHistoryRequest.id !== requestId) {
             return false;
@@ -15166,9 +15314,42 @@ async function loadChatHistory(options = {}) {
             return false;
         }
 
+        const targetSessionId = normaliseHistorySessionId(requestedSessionId || activeChatSessionId);
+        const canPreserveRenderedHistory = shouldPreserveRenderedHistoryForSession(
+            scrollableField,
+            targetSessionId
+        );
+
         console.log(`[chatTab] loadChatHistory response: ok=${response.ok}, segments=${data.segments_returned}, total=${data.total_segments}, history_len=${data.history ? data.history.length : 'undefined'}`);
 
-        if (response.ok && data.history && Array.isArray(data.history)) {
+        if (data?.degraded === true) {
+            const degradedMessage = (typeof data?.error === 'string' && data.error.trim())
+                ? data.error.trim()
+                : 'Conversation history temporarily unavailable; please retry.';
+            setHistoryLoadState({
+                sessionId: targetSessionId,
+                message: degradedMessage,
+                retryable: Boolean(data?.retryable),
+                detail: typeof data?.detail === 'string' ? data.detail : ''
+            });
+            if (!canPreserveRenderedHistory) {
+                scrollableField.innerHTML = `<div class="chat-session-loading">${escapeHtml(degradedMessage)}</div>`;
+                displayedHistorySessionId = null;
+            }
+            console.warn('[chatTab] loadChatHistory degraded', {
+                session_id: targetSessionId,
+                status: response.status,
+                retryable: Boolean(data?.retryable),
+                detail: data?.detail || null
+            });
+            updateHistoryBanner();
+            if (activeHistoryRequest && activeHistoryRequest.id === requestId) {
+                activeHistoryRequest = null;
+            }
+            return false;
+        }
+
+        if (response.ok && Array.isArray(data?.history)) {
             const historyMessages = filterRecentPair
                 ? selectRecentChatPair(data.history)
                 : data.history;
@@ -15188,6 +15369,8 @@ async function loadChatHistory(options = {}) {
                 forceScrollToBottom
             });
 
+            displayedHistorySessionId = targetSessionId;
+            clearHistoryLoadState({ sessionId: targetSessionId });
             updateHistoryBanner();
             const sessionMeta = sessionTabsCache.find(
                 session => String(session?.session_id || '') === String(requestedSessionId || '')
@@ -15205,6 +15388,27 @@ async function loadChatHistory(options = {}) {
             return true;
         }
 
+        if (!response.ok) {
+            const fallbackMessage = (typeof data?.error === 'string' && data.error.trim())
+                ? data.error.trim()
+                : 'Conversation history request failed; please retry.';
+            setHistoryLoadState({
+                sessionId: targetSessionId,
+                message: fallbackMessage,
+                retryable: Boolean(data?.retryable) || response.status >= 500,
+                detail: typeof data?.detail === 'string' ? data.detail : ''
+            });
+            if (!canPreserveRenderedHistory) {
+                scrollableField.innerHTML = `<div class="chat-session-loading">${escapeHtml(fallbackMessage)}</div>`;
+                displayedHistorySessionId = null;
+            }
+            updateHistoryBanner();
+            if (activeHistoryRequest && activeHistoryRequest.id === requestId) {
+                activeHistoryRequest = null;
+            }
+            return false;
+        }
+
         const hasMoreHistory = data?.has_more_history === true;
         const segmentsReturned = Math.max(data?.segments_returned || 0, 0);
         let totalSegments = Math.max(data?.total_segments || segmentsReturned, segmentsReturned);
@@ -15213,6 +15417,8 @@ async function loadChatHistory(options = {}) {
         }
         historySegmentsShown = segmentsReturned;
         totalHistorySegments = totalSegments;
+        displayedHistorySessionId = targetSessionId;
+        clearHistoryLoadState({ sessionId: targetSessionId });
         updateHistoryBanner();
         console.log('No Conversation history to load or empty history');
         if (activeHistoryRequest && activeHistoryRequest.id === requestId) {
@@ -15222,6 +15428,18 @@ async function loadChatHistory(options = {}) {
     } catch (error) {
         if (error?.name === 'AbortError') {
             return false;
+        }
+        const targetSessionId = normaliseHistorySessionId(requestedSessionId || activeChatSessionId);
+        const fallbackMessage = 'Conversation history request failed; please retry.';
+        setHistoryLoadState({
+            sessionId: targetSessionId,
+            message: fallbackMessage,
+            retryable: true,
+            detail: error instanceof Error ? error.message : String(error || '')
+        });
+        if (!shouldPreserveRenderedHistoryForSession(scrollableField, targetSessionId)) {
+            scrollableField.innerHTML = `<div class="chat-session-loading">${escapeHtml(fallbackMessage)}</div>`;
+            displayedHistorySessionId = null;
         }
         console.error('Error loading Conversation history:', error);
         updateHistoryBanner();
@@ -17250,6 +17468,11 @@ function buildWorkflowMonitorExportPayload() {
             show_available: Boolean(workflowDefinitionsState.visible),
             show_designs: Boolean(workflowDefinitionsState.showDesigns),
             loading_available: Boolean(workflowDefinitionsState.loading),
+            active_error: workflowStatusStreamState.snapshotError || null,
+            active_notice: workflowStatusStreamState.snapshotNotice || null,
+            active_last_snapshot_at: workflowStatusStreamState.lastSnapshotAt
+                ? new Date(workflowStatusStreamState.lastSnapshotAt).toISOString()
+                : null,
             available_error: workflowDefinitionsState.error || null,
             available_notice: workflowDefinitionsState.notice || null,
             available_last_fetched_at: workflowDefinitionsState.lastFetchedAt
@@ -17267,7 +17490,8 @@ function buildWorkflowMonitorExportPayload() {
         },
         active_instances_snapshot: {
             count: activeItems.length,
-            items: activeItems
+            items: activeItems,
+            payload: workflowStatusStreamState.lastSnapshotPayload
         },
         diagnostics: {
             parity_counts: parityInventory?.counts || null,
@@ -17308,8 +17532,16 @@ function renderWorkflowStatusList(items) {
     const { body } = getWorkflowStatusElements();
     if (!body) return;
 
+    const bannerParts = [];
+    if (workflowStatusStreamState.snapshotError) {
+        bannerParts.push(`<div class="workflow-status-empty workflow-status-error">${escapeHtml(workflowStatusStreamState.snapshotError)}</div>`);
+    } else if (workflowStatusStreamState.snapshotNotice) {
+        bannerParts.push(`<div class="workflow-status-empty workflow-status-info">${escapeHtml(workflowStatusStreamState.snapshotNotice)}</div>`);
+    }
+    const bannerHtml = bannerParts.join('');
+
     if (!items.length) {
-        body.innerHTML = '<div class="workflow-status-empty">No active workflows</div>';
+        body.innerHTML = bannerHtml || '<div class="workflow-status-empty">No active workflows</div>';
         return;
     }
 
@@ -17383,7 +17615,7 @@ function renderWorkflowStatusList(items) {
         `;
     }).join('');
 
-    body.innerHTML = html;
+    body.innerHTML = `${bannerHtml}${html}`;
 }
 
 function renderWorkflowDefinitionsList(items) {
@@ -17563,13 +17795,40 @@ async function refreshWorkflowStatusSnapshot({ silent = false } = {}) {
     try {
         const resp = await fetch(`/api/workflows/instances?${params.toString()}`,
             { method: 'GET', headers: buildChatFetchHeaders() });
-        if (!resp.ok) {
+        const data = await resp.json().catch(() => null);
+        const payload = (data && typeof data === 'object') ? data : {};
+        if (!resp.ok || payload?.degraded === true) {
+            const hasItems = workflowStatusStreamState.items.size > 0;
+            const detail = (typeof payload?.detail === 'string' && payload.detail.trim())
+                ? payload.detail.trim()
+                : '';
+            const retryable = Boolean(payload?.retryable) || resp.status === 503;
+            workflowStatusStreamState.lastSnapshotPayload = {
+                ...payload,
+                status: resp.status,
+                retryable,
+                degraded: true
+            };
+            if (retryable) {
+                workflowStatusStreamState.snapshotError = '';
+                workflowStatusStreamState.snapshotNotice = hasItems
+                    ? 'Workflow monitor temporarily unavailable; showing last loaded active workflows.'
+                    : 'Workflow monitor temporarily unavailable; please retry.';
+            } else {
+                workflowStatusStreamState.snapshotNotice = '';
+                workflowStatusStreamState.snapshotError = detail
+                    ? `Could not load workflow monitor: ${detail}`
+                    : 'Could not load workflow monitor';
+            }
+            renderWorkflowStatusBody();
             if (!silent) {
-                console.warn('[workflowStatus] Snapshot fetch failed', resp.status);
+                console.warn('[workflowStatus] Snapshot fetch failed', {
+                    status: resp.status,
+                    payload: workflowStatusStreamState.lastSnapshotPayload
+                });
             }
             return;
         }
-        const data = await resp.json();
         const items = Array.isArray(data?.items) ? data.items : [];
         workflowStatusStreamState.items.clear();
         items.forEach((item) => {
@@ -17578,8 +17837,23 @@ async function refreshWorkflowStatusSnapshot({ silent = false } = {}) {
             }
         });
         workflowStatusStreamState.lastSnapshotAt = Date.now();
+        workflowStatusStreamState.snapshotError = '';
+        workflowStatusStreamState.snapshotNotice = '';
+        workflowStatusStreamState.lastSnapshotPayload = payload;
         renderWorkflowStatusBody();
     } catch (err) {
+        const hasItems = workflowStatusStreamState.items.size > 0;
+        workflowStatusStreamState.snapshotError = '';
+        workflowStatusStreamState.snapshotNotice = hasItems
+            ? 'Workflow monitor temporarily unavailable; showing last loaded active workflows.'
+            : 'Workflow monitor temporarily unavailable; please retry.';
+        workflowStatusStreamState.lastSnapshotPayload = {
+            error: 'workflow_status_snapshot_failed',
+            detail: err instanceof Error ? err.message : String(err || 'unknown_error'),
+            retryable: true,
+            degraded: true
+        };
+        renderWorkflowStatusBody();
         if (!silent) {
             console.warn('[workflowStatus] Snapshot fetch failed', err);
         }
@@ -18101,6 +18375,8 @@ async function handleOrgSwitchForChatTab(_detail) {
     activeChatSessionId = null;
     activeChatSessionName = null;
     activeChatSessionOwnerId = null;
+    displayedHistorySessionId = null;
+    clearHistoryLoadState();
 
     // Clear the chat display and show loading state
     const scrollableField = document.getElementById('scrollableField');
@@ -18111,6 +18387,9 @@ async function handleOrgSwitchForChatTab(_detail) {
     closeSharedConversationStream();
     stopWorkflowStatusStream('workflow_stream_stopped_org_switch');
     workflowStatusStreamState.items.clear();
+    workflowStatusStreamState.snapshotError = '';
+    workflowStatusStreamState.snapshotNotice = '';
+    workflowStatusStreamState.lastSnapshotPayload = null;
     renderWorkflowStatusBody();
 
     if (container) {
@@ -21030,6 +21309,16 @@ export function __testOnly_buildWorkflowStatusQuery(opts = {}) {
 export function __testOnly_buildWorkflowStatusStreamQuery() {
     return buildWorkflowStatusStreamQuery().toString();
 }
+export async function __testOnly_refreshWorkflowStatusSnapshot(options = {}) {
+    return refreshWorkflowStatusSnapshot(options);
+}
+export function __testOnly_resetWorkflowStatusState() {
+    workflowStatusStreamState.items.clear();
+    workflowStatusStreamState.lastSnapshotAt = 0;
+    workflowStatusStreamState.snapshotError = '';
+    workflowStatusStreamState.snapshotNotice = '';
+    workflowStatusStreamState.lastSnapshotPayload = null;
+}
 export function __testOnly_renderWorkflowDefinitionsBody(items = []) {
     workflowDefinitionsState.visible = true;
     workflowDefinitionsState.loading = false;
@@ -21061,6 +21350,32 @@ export function __testOnly_resetWorkflowDefinitionsState() {
 }
 export function __testOnly_buildWorkflowMonitorExportPayload() {
     return buildWorkflowMonitorExportPayload();
+}
+export async function __testOnly_loadChatHistory(options = {}) {
+    return loadChatHistory(options);
+}
+export async function __testOnly_refreshChatSessionTabs() {
+    return refreshChatSessionTabs();
+}
+export function __testOnly_setActiveChatSession(sessionId, sessionName = null) {
+    setActiveChatSession(sessionId, sessionName);
+}
+export function __testOnly_setDisplayedHistorySession(sessionId) {
+    displayedHistorySessionId = normaliseHistorySessionId(sessionId);
+}
+export function __testOnly_resetHistoryUiState() {
+    displayedHistorySessionId = null;
+    clearHistoryLoadState();
+    historyMetricsState.degraded = false;
+    historyMetricsState.message = '';
+    historyMetricsState.retryable = false;
+    historyMetricsState.detail = '';
+    historyMetricsState.lastHealthy = null;
+}
+export function __testOnly_setSessionTabsCache(sessions = []) {
+    sessionTabsCache = normaliseConversationSessionViewModels(
+        Array.isArray(sessions) ? sessions : []
+    );
 }
 export function __testOnly_shouldMaintainSharedConversationStreamForInputs(inputs = {}) {
     return shouldMaintainSharedConversationStreamForInputs(inputs);

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -2,11 +2,17 @@ import {
     __testOnly_buildThinkingProgressPresentation,
     __testOnly_buildThinkingDiagnosticsPayload,
     __testOnly_buildWorkflowMonitorExportPayload,
+    __testOnly_loadChatHistory,
     __testOnly_refreshAvailableWorkflowDefinitions,
+    __testOnly_refreshWorkflowStatusSnapshot,
+    __testOnly_resetHistoryUiState,
     __testOnly_resetWorkflowDefinitionsState,
+    __testOnly_resetWorkflowStatusState,
     __testOnly_formatAbsoluteTimestamp,
     __testOnly_formatThinkingEtaText,
     __testOnly_renderWorkflowDefinitionsBody,
+    __testOnly_setActiveChatSession,
+    __testOnly_setDisplayedHistorySession,
     __testOnly_setUnambiguousTimestampTooltip,
     __testOnly_setWorkflowShowDesigns,
     __testOnly_buildWorkflowStatusQuery,
@@ -775,6 +781,199 @@ describe('workflow monitor definitions refresh contention handling', () => {
             'workflow_definitions_fetch_failed'
         );
         expect(exportPayload.definitions_snapshot.payload.status).toBe(500);
+    });
+});
+
+describe('workflow monitor active snapshot degradation handling', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="workflowStatusPanel"></div>
+            <div id="workflowStatusBody"></div>
+            <button id="workflowStatusRefresh"></button>
+            <button id="workflowStatusToggleAvailable"></button>
+            <input id="workflowStatusShowDesigns" type="checkbox" />
+        `;
+        __testOnly_resetWorkflowDefinitionsState();
+        __testOnly_resetWorkflowStatusState();
+    });
+
+    afterEach(() => {
+        delete global.fetch;
+        __testOnly_resetWorkflowDefinitionsState();
+        __testOnly_resetWorkflowStatusState();
+    });
+
+    test('shows retryable snapshot degradation without blanking last loaded active workflows', async () => {
+        global.fetch = jest.fn(() => Promise.resolve({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                items: [
+                    {
+                        instance_id: 'wf-1',
+                        workflow_id: '#V#demo_retry_workflow',
+                        status: 'running',
+                        current_state: 'waiting_for_input',
+                        progress: { current: 1, total: 2 }
+                    }
+                ]
+            })
+        }));
+
+        await __testOnly_refreshWorkflowStatusSnapshot();
+        expect(document.getElementById('workflowStatusBody').textContent).toContain(
+            'demo retry workflow'
+        );
+
+        global.fetch = jest.fn(() => Promise.resolve({
+            ok: false,
+            status: 503,
+            json: async () => ({
+                items: [],
+                count: 0,
+                degraded: true,
+                retryable: true,
+                error: 'Workflow monitor temporarily unavailable; please retry.',
+                detail: 'server selection timeout while reading workflow_instances'
+            })
+        }));
+
+        await __testOnly_refreshWorkflowStatusSnapshot();
+
+        const bodyText = document.getElementById('workflowStatusBody').textContent;
+        expect(bodyText).toContain('Workflow monitor temporarily unavailable');
+        expect(bodyText).toContain('demo retry workflow');
+        const payload = __testOnly_buildWorkflowMonitorExportPayload();
+        expect(payload.monitor_state.active_notice).toContain(
+            'Workflow monitor temporarily unavailable'
+        );
+        expect(payload.active_instances_snapshot.payload.retryable).toBe(true);
+    });
+});
+
+describe('loadChatHistory degraded handling', () => {
+    beforeEach(() => {
+        const { getUserContext, postJson } = require('../apiService.js');
+        getUserContext.mockReturnValue({
+            user_id: '#V#user',
+            org_id: '#V#org',
+            language: 'en-NZ',
+            gmail_profile: null
+        });
+        postJson.mockResolvedValue({ status: 'updated' });
+        document.body.innerHTML = `
+            <div id="scrollableField"><div class="message-container">Kept content</div></div>
+            <div id="historyBanner" class="history-banner hidden">
+                <span id="historyBannerText"></span>
+                <button id="loadOlderHistoryBtn" type="button"></button>
+            </div>
+            <div id="chat-history-length"></div>
+        `;
+        __testOnly_resetHistoryUiState();
+        __testOnly_setActiveChatSession('session-1', 'Session 1');
+    });
+
+    afterEach(() => {
+        delete global.fetch;
+        __testOnly_resetHistoryUiState();
+        __testOnly_setActiveChatSession(null, null);
+    });
+
+    test('preserves rendered history and surfaces a banner when the backend reports degraded history', async () => {
+        __testOnly_setDisplayedHistorySession('session-1');
+        global.fetch = jest.fn((url) => {
+            if (typeof url === 'string' && url.startsWith('/von/api/session/context')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        user_id: '#V#user',
+                        organisation_id: '#V#org',
+                        namespace: '#V#user@org'
+                    })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/history?')) {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({
+                        history: [],
+                        segments_returned: 0,
+                        total_segments: 0,
+                        has_more_history: false,
+                        degraded: true,
+                        retryable: true,
+                        error: 'Chat history temporarily unavailable; please retry.',
+                        detail: 'read circuit open'
+                    })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        history_length: 4,
+                        session_count: 1,
+                        authenticated: true
+                    })
+                });
+            }
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        const loaded = await __testOnly_loadChatHistory({ segments: 1 });
+
+        expect(loaded).toBe(false);
+        expect(document.getElementById('scrollableField').textContent).toContain('Kept content');
+        expect(document.getElementById('historyBanner').classList.contains('hidden')).toBe(false);
+        expect(document.getElementById('historyBannerText').textContent).toContain(
+            'temporarily unavailable'
+        );
+    });
+
+    test('treats genuinely empty history as a successful empty load', async () => {
+        __testOnly_setDisplayedHistorySession('session-1');
+        global.fetch = jest.fn((url) => {
+            if (typeof url === 'string' && url.startsWith('/von/api/session/context')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        user_id: '#V#user',
+                        organisation_id: '#V#org',
+                        namespace: '#V#user@org'
+                    })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/history?')) {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({
+                        history: [],
+                        segments_returned: 0,
+                        total_segments: 0,
+                        has_more_history: false
+                    })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        history_length: 0,
+                        session_count: 1,
+                        authenticated: true
+                    })
+                });
+            }
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        const loaded = await __testOnly_loadChatHistory({ segments: 1 });
+
+        expect(loaded).toBe(true);
+        expect(document.getElementById('scrollableField').textContent).not.toContain('Kept content');
+        expect(document.getElementById('historyBanner').classList.contains('hidden')).toBe(true);
     });
 });
 

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -7026,6 +7026,18 @@ footer {
     font-size: 0.9rem;
 }
 
+.history-banner.is-warning {
+    border-color: #f5d48b;
+    background-color: #fff8e8;
+    color: #92400e;
+}
+
+.history-banner.is-error {
+    border-color: #f2b8b5;
+    background-color: #fff1f2;
+    color: #991b1b;
+}
+
 .history-banner.hidden {
     display: none;
 }

--- a/tests/backend/test_chat_history_service_segments.py
+++ b/tests/backend/test_chat_history_service_segments.py
@@ -14,6 +14,18 @@ class _FakeCollection:
     def __init__(self, docs):
         self._docs = docs
 
+    def _evaluate_expression(self, doc, expr):
+        if isinstance(expr, str) and expr.startswith("$"):
+            return doc.get(expr[1:])
+        if isinstance(expr, dict) and "$ifNull" in expr:
+            args = expr["$ifNull"]
+            if isinstance(args, list) and len(args) == 2:
+                value = self._evaluate_expression(doc, args[0])
+                if value is not None:
+                    return value
+                return self._evaluate_expression(doc, args[1])
+        return expr
+
     def _matches_query(self, doc, query):
         for key, value in query.items():
             if key == "$or":
@@ -76,8 +88,9 @@ class _FakeCollection:
                             if isinstance(slice_spec, list):
                                 if len(slice_spec) == 2:
                                     source, count = slice_spec
-                                    if isinstance(source, str) and source.startswith("$"):
-                                        history = list(doc.get(source[1:]) or [])
+                                    source_value = self._evaluate_expression(doc, source)
+                                    if isinstance(source_value, list):
+                                        history = list(source_value)
                                         if isinstance(count, int):
                                             history = history[count:] if count < 0 else history[:count]
                                         else:
@@ -89,8 +102,9 @@ class _FakeCollection:
                                         history = history[start : start + count]
                                 elif len(slice_spec) == 3:
                                     source, start, count = slice_spec
-                                    if isinstance(source, str) and source.startswith("$"):
-                                        history = list(doc.get(source[1:]) or [])
+                                    source_value = self._evaluate_expression(doc, source)
+                                    if isinstance(source_value, list):
+                                        history = list(source_value)
                                     if isinstance(start, int) and start < 0:
                                         start = len(history) + start
                                     history = history[start : start + count]
@@ -99,13 +113,8 @@ class _FakeCollection:
                             out[key] = history
                             continue
                         if isinstance(spec, dict) and "$size" in spec:
-                            field = spec["$size"]
-                            if isinstance(field, str) and field.startswith("$"):
-                                field_name = field[1:]
-                                target = doc.get(field_name)
-                                out[key] = len(target) if isinstance(target, list) else 0
-                            else:
-                                out[key] = 0
+                            target = self._evaluate_expression(doc, spec["$size"])
+                            out[key] = len(target) if isinstance(target, list) else 0
                             continue
                         if spec in (1, True):
                             out[key] = doc.get(key)
@@ -311,6 +320,35 @@ def test_get_chat_history_segments_reports_truncation(monkeypatch):
 
     assert isinstance(segments, list)
     assert meta["history_truncated"] is True
+
+
+def test_get_chat_history_segments_handles_missing_history_field_with_tail_limit(
+    monkeypatch,
+):
+    from src.backend.services import chat_history_service
+
+    docs = [
+        {
+            "_id": "1",
+            "user_id": "#V#u",
+            "session_id": "s1",
+        }
+    ]
+
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **kwargs: _FakeCollection(docs),
+    )
+
+    result = chat_history_service.get_chat_history_segments(
+        "#V#u",
+        "s1",
+        history_tail_limit=25,
+        return_meta=True,
+    )
+
+    assert result == ([], {"history_truncated": False})
 
 
 def test_get_chat_history_segments_offsets_locations_with_tail_limit(monkeypatch):

--- a/tests/backend/test_chat_history_session_management.py
+++ b/tests/backend/test_chat_history_session_management.py
@@ -47,6 +47,7 @@ def test_create_chat_session_sets_name_and_namespace(monkeypatch):
     doc = stored[("#V#user", "s-1")]
     assert doc["session_name"] == "My chat"
     assert doc["namespace"] == "#V#user@org"
+    assert doc["history"] == []
 
 
 def test_rename_chat_session_updates_name(monkeypatch):

--- a/tests/backend/test_history_sessions_endpoint.py
+++ b/tests/backend/test_history_sessions_endpoint.py
@@ -182,3 +182,49 @@ def test_history_sessions_skips_bad_shared_invite_rows(monkeypatch, app_client):
     assert payload["authenticated"] is True
     assert [s["session_id"] for s in payload["sessions"]] == ["shared-ok"]
     assert "shared_invite_resolution_errors:1" in (payload.get("warnings") or [])
+
+
+def test_history_sessions_returns_degraded_payload_for_transient_history_errors(
+    monkeypatch, app_client
+):
+    _, client = app_client
+    import src.backend.services.chat_history_service as chat_history_service
+
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#u",
+    )
+    monkeypatch.setattr(
+        von_routes,
+        "get_effective_context",
+        lambda *args, **kwargs: {
+            "user_id": "#V#u",
+            "organisation_id": "#V#org",
+            "role": None,
+            "namespace": "#V#u@org",
+            "chat_session_id": None,
+            "source": "test",
+        },
+    )
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "get_chat_history_session_summaries",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            chat_history_service.ChatHistoryServiceError(
+                "read circuit open for 3.0s"
+            )
+        ),
+    )
+
+    response = client.get(
+        "/von/history/sessions?limit=50&summary=light",
+        headers={"X-Von-Window-Session": "ws_test"},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["authenticated"] is True
+    assert payload["degraded"] is True
+    assert payload["retryable"] is True
+    assert payload["sessions"] == []
+    assert "chat_history_temporarily_unavailable" in (payload.get("warnings") or [])

--- a/tests/backend/test_workflows_routes.py
+++ b/tests/backend/test_workflows_routes.py
@@ -6,6 +6,7 @@ import time
 import types
 
 import pytest
+from pymongo.errors import PyMongoError
 
 
 @pytest.fixture()
@@ -686,6 +687,29 @@ def test_trigger_workflow_schedule_route_rejects_unrunnable_workflow(
     assert "workflow_definition_not_registered" in payload["verification"]["preflight"][
         "errors"
     ]
+
+
+def test_list_workflow_instances_returns_retryable_degraded_payload_for_mongo_timeout(
+    monkeypatch, app_client
+):
+    import src.backend.server.routes.workflows_routes as workflows_routes
+
+    manager = types.SimpleNamespace(
+        list_instances=lambda **kwargs: (_ for _ in ()).throw(
+            PyMongoError("server selection timeout while reading workflow_instances")
+        )
+    )
+    monkeypatch.setattr(workflows_routes, "_get_instance_manager", lambda: manager)
+
+    response = app_client.get("/api/workflows/instances")
+
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload["degraded"] is True
+    assert payload["retryable"] is True
+    assert payload["items"] == []
+    assert payload["count"] == 0
+    assert payload["error"] == "Workflow monitor temporarily unavailable; please retry."
 
 
 def test_workflow_definitions_list_uses_short_ttl_cache(monkeypatch, app_client):


### PR DESCRIPTION
## Summary
- harden segmented chat-history reads against session documents that have no `history` field and initialise new chat-session documents with `history: []`
- return explicit degraded/retryable payloads for `/von/history/sessions` and `/api/workflows/instances` instead of silent empty-state or 500 behaviour during transient Mongo failures
- preserve last-known-good chat/workflow UI state while surfacing degraded notices in the chat tab, plus add targeted backend/frontend regression coverage

## Validation
- `pdm run pytest tests/backend/test_chat_history_service_segments.py tests/backend/test_chat_history_session_management.py tests/backend/test_history_sessions_endpoint.py tests/backend/test_workflows_routes.py tests/backend/test_set_chat_session_endpoint.py -q`
- `npx pyright src/backend/server/routes/von_routes.py src/backend/server/routes/workflows_routes.py src/backend/services/chat_history_service.py tests/backend/test_chat_history_service_segments.py tests/backend/test_chat_history_session_management.py tests/backend/test_history_sessions_endpoint.py tests/backend/test_workflows_routes.py`
- `npm test -- --runInBand src/frontend/web/von_interface/static/js/test/chatTab.test.js`
- `pdm run pytest tests/backend/test_chat_history_backfill_endpoint.py tests/backend/test_chat_history_length_resilience.py tests/backend/test_chat_history_rag_namespace.py tests/backend/test_chat_history_segmentation.py tests/backend/test_chat_history_service_segments.py tests/backend/test_chat_history_session_links_service.py tests/backend/test_chat_history_session_management.py tests/backend/test_chat_history_session_summaries_resilience.py tests/backend/test_history_sessions_endpoint.py tests/backend/test_workflows_routes.py -q`
- `pdm run pytest tests/backend/test_parent_specificity_workflows.py tests/backend/test_von_chat_run_timeout.py tests/backend/test_von_diagnostics_export_endpoint.py -q`
- `pdm run pytest tests/backend/test_von_file_upload_endpoint.py tests/backend/test_von_file_upload_scholarly_integration.py -q`
- `pdm run pytest tests/backend/test_von_generate_bare_arxiv_url_integration.py -q`
- `pdm run pytest tests/backend/test_von_generate_context_concept_references.py -q`

## Notes
- `tests/backend/test_von_generate_auxiliary_prompt.py` and `tests/backend/test_von_generate_direct_tool_calls.py` exceeded the environment timeout when run in isolation, so they were not completed in this session.