### PR TITLE
JVNAUTOSCI-1423: Persist user chat message to history immediately on receipt

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -6091,6 +6091,37 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                     request_id,
                 )
 
+    # ------------------------------------------------------------------
+    # JVNAUTOSCI-1423: Persist user message to chat history immediately,
+    # BEFORE orchestrator/LLM work begins.  This guarantees the user's
+    # message is recorded even if the downstream turn crashes or stalls.
+    # Downstream paths must NOT re-persist the user message.
+    # ------------------------------------------------------------------
+    _user_message_persisted_early = False
+    if history_user_id:
+        try:
+            _add_chat_history_message(
+                user_id=history_user_id,
+                session_id=session_id,
+                message={
+                    "role": "user",
+                    "content": prompt_text,
+                    "author_user_id": user_concept_id,
+                },
+                namespace=user_namespace,
+                organisation_concept_id=org_concept_id,
+                role_in_org=role_in_org,
+            )
+            _user_message_persisted_early = True
+        except Exception as early_persist_exc:
+            current_app.logger.warning(
+                "[EARLY_PERSIST] Failed to persist user message early "
+                "for session_id=%s request_id=%s: %s",
+                session_id,
+                request_id,
+                early_persist_exc,
+            )
+
     if show_tool_use_progress:
         try:
             max_calls = int(get_internal_mcp_max_tool_invocations())
@@ -6859,7 +6890,9 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                 tool_messages = []
 
             # Persist messages in history/context.
-            if user_id_for_history:
+            # NOTE: User message already persisted early (JVNAUTOSCI-1423).
+            # Fallback: persist here if early persist failed.
+            if not _user_message_persisted_early and user_id_for_history:
                 _add_chat_history_message(
                     user_id=user_id_for_history,
                     session_id=session_id,
@@ -7041,19 +7074,22 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                             ]
 
                     # Skip LLM generation for direct tool calls
+                    # NOTE: User message already persisted early (JVNAUTOSCI-1423).
                     if history_user_id:
-                        _add_chat_history_message(
-                            user_id=history_user_id,
-                            session_id=session_id,
-                            message={
-                                "role": "user",
-                                "content": prompt_text,
-                                "author_user_id": user_concept_id,
-                            },
-                            namespace=user_namespace,
-                            organisation_concept_id=org_concept_id,
-                            role_in_org=role_in_org,
-                        )
+                        # Fallback: persist here if early persist failed.
+                        if not _user_message_persisted_early:
+                            _add_chat_history_message(
+                                user_id=history_user_id,
+                                session_id=session_id,
+                                message={
+                                    "role": "user",
+                                    "content": prompt_text,
+                                    "author_user_id": user_concept_id,
+                                },
+                                namespace=user_namespace,
+                                organisation_concept_id=org_concept_id,
+                                role_in_org=role_in_org,
+                            )
                         for tool_msg in _truncate_large_tool_results(
                             tool_messages, max_tool_content_chars=5000
                         ):
@@ -7499,22 +7535,24 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                             )
 
                             # Phase 4: Persist to chat history
+                            # NOTE: User message already persisted early (JVNAUTOSCI-1423).
                             if bg_history_user_id:
                                 try:
-                                    # Store user message
-                                    _add_chat_history_message(
-                                        user_id=bg_history_user_id,
-                                        session_id=bg_session_id,
-                                        message={
-                                            "role": "user",
-                                            "content": prompt_text,
-                                            "author_user_id": bg_user_concept_id,
-                                            "background_task_id": request_id,
-                                        },
-                                        namespace=bg_user_namespace,
-                                        organisation_concept_id=bg_org_concept_id,
-                                        role_in_org=bg_role_in_org,
-                                    )
+                                    # Fallback: persist user message here if early persist failed.
+                                    if not _user_message_persisted_early:
+                                        _add_chat_history_message(
+                                            user_id=bg_history_user_id,
+                                            session_id=bg_session_id,
+                                            message={
+                                                "role": "user",
+                                                "content": prompt_text,
+                                                "author_user_id": bg_user_concept_id,
+                                                "background_task_id": request_id,
+                                            },
+                                            namespace=bg_user_namespace,
+                                            organisation_concept_id=bg_org_concept_id,
+                                            role_in_org=bg_role_in_org,
+                                        )
                                     # Store tool messages
                                     tool_messages = [
                                         dict(msg) for msg in result.extra_messages
@@ -7544,7 +7582,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                                         role_in_org=bg_role_in_org,
                                     )
                                 except Exception as hist_exc:
-                                    _logger.warning(
+                                    current_app.logger.warning(
                                         "[background] Failed to persist history: %s",
                                         hist_exc,
                                     )
@@ -9237,18 +9275,21 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
         )
 
         if history_user_id:
-            _add_chat_history_message(
-                user_id=history_user_id,
-                session_id=session_id,
-                message={
-                    "role": "user",
-                    "content": prompt_text,
-                    "author_user_id": user_concept_id,
-                },
-                namespace=user_namespace,
-                organisation_concept_id=org_concept_id,
-                role_in_org=role_in_org,
-            )
+            # NOTE: User message already persisted early (JVNAUTOSCI-1423).
+            # Fallback: persist here if early persist failed.
+            if not _user_message_persisted_early:
+                _add_chat_history_message(
+                    user_id=history_user_id,
+                    session_id=session_id,
+                    message={
+                        "role": "user",
+                        "content": prompt_text,
+                        "author_user_id": user_concept_id,
+                    },
+                    namespace=user_namespace,
+                    organisation_concept_id=org_concept_id,
+                    role_in_org=role_in_org,
+                )
             for tool_msg in truncated_tool_messages:
                 _add_chat_history_message(
                     user_id=history_user_id,

--- a/tests/backend/test_von_generate_early_user_message_persist.py
+++ b/tests/backend/test_von_generate_early_user_message_persist.py
@@ -1,0 +1,206 @@
+"""Tests for JVNAUTOSCI-1423: early user message persistence.
+
+Verifies that the user message is persisted to chat history immediately
+after the chat-history lookup, BEFORE orchestrator/LLM work begins.
+"""
+
+import pytest
+from flask import Flask
+
+_VERSION_INFO = {
+    "schema_version": "runtime_code_version.v1",
+    "version": "test-version+gabcd1234",
+    "source": "test",
+    "legacy_app_version": "legacy-test-version",
+    "git_commit": "abcd1234abcd1234abcd1234abcd1234abcd1234",
+    "git_short_commit": "abcd1234",
+    "git_branch": "test-branch",
+    "git_dirty": False,
+}
+
+
+class _StubLLM:
+    def __init__(self):
+        self.calls = []
+
+    def generate(self, prompt, context, model):
+        self.calls.append({"prompt": prompt, "context": list(context), "model": model})
+        return "test response"
+
+
+class _MessageRecorder:
+    """Records add_message_to_history calls in order."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def __call__(self, *args, **kwargs):
+        # Positional: user_id, session_id, message
+        entry = {}
+        if len(args) >= 3:
+            entry["user_id"] = args[0]
+            entry["session_id"] = args[1]
+            entry["message"] = args[2]
+        elif len(args) >= 1:
+            entry["user_id"] = args[0]
+        entry.update(kwargs)
+        self.calls.append(entry)
+
+    @property
+    def user_message_calls(self) -> list[dict]:
+        return [
+            c for c in self.calls
+            if isinstance(c.get("message"), dict) and c["message"].get("role") == "user"
+        ]
+
+    @property
+    def assistant_message_calls(self) -> list[dict]:
+        return [
+            c for c in self.calls
+            if isinstance(c.get("message"), dict) and c["message"].get("role") == "assistant"
+        ]
+
+
+@pytest.fixture()
+def recorder():
+    return _MessageRecorder()
+
+
+@pytest.fixture()
+def app(monkeypatch, recorder):
+    from src.backend.server.routes.von_routes import von_bp
+
+    llm = _StubLLM()
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_llm_client",
+        lambda **_kwargs: llm,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_active_model_name",
+        lambda: "test-model",
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_runtime_code_version_info",
+        lambda: dict(_VERSION_INFO),
+    )
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#test_user",
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.chat_history_service.add_message_to_history",
+        recorder,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.chat_history_service.get_chat_history",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
+        lambda _user_id, **_kwargs: [],
+    )
+
+    flask_app = Flask(__name__)
+    flask_app.secret_key = "test-secret"
+    flask_app.register_blueprint(von_bp, url_prefix="/von")
+    flask_app.config["CONTEXT"] = []
+    flask_app.config["INTERNAL_MCP_ORCHESTRATOR"] = None
+    flask_app.config["INTERNAL_MCP_GATEWAY"] = None
+
+    return flask_app
+
+
+def test_user_message_persisted_exactly_once(app, recorder):
+    """User message must appear exactly once in history calls — the early persist."""
+    client = app.test_client()
+
+    resp = client.post("/von/generate", json={"prompt": "Hello early persist"})
+    assert resp.status_code == 200
+
+    user_calls = recorder.user_message_calls
+    assert len(user_calls) == 1, (
+        f"Expected exactly 1 user-message persist call, got {len(user_calls)}: "
+        f"{[c['message'] for c in user_calls]}"
+    )
+    assert user_calls[0]["message"]["content"] == "Hello early persist"
+    assert user_calls[0]["message"]["role"] == "user"
+
+
+def test_user_message_persisted_before_assistant(app, recorder):
+    """User message must be persisted before the assistant response."""
+    client = app.test_client()
+
+    resp = client.post("/von/generate", json={"prompt": "Order test"})
+    assert resp.status_code == 200
+
+    all_calls = recorder.calls
+    user_indices = [
+        i for i, c in enumerate(all_calls)
+        if isinstance(c.get("message"), dict) and c["message"].get("role") == "user"
+    ]
+    assistant_indices = [
+        i for i, c in enumerate(all_calls)
+        if isinstance(c.get("message"), dict) and c["message"].get("role") == "assistant"
+    ]
+
+    assert len(user_indices) >= 1, "No user message persist call found"
+    assert len(assistant_indices) >= 1, "No assistant message persist call found"
+    assert user_indices[0] < assistant_indices[0], (
+        f"User message (index {user_indices[0]}) must come before "
+        f"assistant message (index {assistant_indices[0]})"
+    )
+
+
+def test_early_persist_failure_falls_back_to_downstream(app, monkeypatch, recorder):
+    """If early persist fails, the downstream path should still persist the user message."""
+    call_count = {"early": 0}
+
+    original_recorder_call = recorder.__call__
+
+    def _fail_on_first_user(*args, **kwargs):
+        msg = args[2] if len(args) >= 3 else kwargs.get("message", {})
+        if isinstance(msg, dict) and msg.get("role") == "user":
+            call_count["early"] += 1
+            if call_count["early"] == 1:
+                raise RuntimeError("Simulated early persist failure")
+        original_recorder_call(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.chat_history_service.add_message_to_history",
+        _fail_on_first_user,
+    )
+
+    client = app.test_client()
+    resp = client.post("/von/generate", json={"prompt": "Fallback test"})
+    assert resp.status_code == 200
+
+    # The first attempt failed, but fallback should have retried
+    assert call_count["early"] >= 2, (
+        f"Expected at least 2 user-message persist attempts (1 early fail + 1 fallback), "
+        f"got {call_count['early']}"
+    )
+
+
+def test_user_message_contains_author_user_id(app, recorder):
+    """Early-persisted user message must include the author_user_id field."""
+    client = app.test_client()
+
+    resp = client.post("/von/generate", json={"prompt": "Author check"})
+    assert resp.status_code == 200
+
+    user_calls = recorder.user_message_calls
+    assert len(user_calls) >= 1
+    assert user_calls[0]["message"].get("author_user_id") == "#V#test_user"
+
+
+def test_assistant_message_still_persisted(app, recorder):
+    """Assistant response must still be persisted after early user persist."""
+    client = app.test_client()
+
+    resp = client.post("/von/generate", json={"prompt": "Assistant check"})
+    assert resp.status_code == 200
+
+    assistant_calls = recorder.assistant_message_calls
+    assert len(assistant_calls) >= 1, "No assistant message was persisted"
+    assert assistant_calls[0]["message"]["content"] == "test response"


### PR DESCRIPTION
## Changes

Persists the user's chat message to MongoDB history **immediately** after the chat-history lookup completes, **before** any orchestrator/LLM work begins. This ensures the message is recorded even if the downstream turn crashes or stalls.

### Implementation
- Early persistence inserted after chat-history lookup, before orchestrator/LLM call
- Duplicate user-message persistence removed from all 4 downstream paths:
  - Main sync path
  - Background mode path
  - RAG counts fastpath
  - Direct tool fastpath
- Graceful fallback: if early persist fails, downstream paths still persist the user message
- Fixed \_logger\ -> \current_app.logger\ in exception handlers (from JVNAUTOSCI-1422)

### Tests
5 new tests in \	est_von_generate_early_user_message_persist.py\:
- User message persisted exactly once
- User message persisted before assistant
- Early persist failure falls back to downstream
- User message contains author_user_id
- Assistant message still persisted