### PR TITLE
fix(github-proxy): resolve JVNAUTOSCI-1426 token poisoning and error message loss

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -13729,11 +13729,16 @@ def _github_invoke_proxy_tool(tool_name: str, arguments: Mapping[str, Any]) -> d
     try:
         raw_result, proxy_stats = _run_async_compat(_async_call)
     except GitHubProxyError as exc:
+        error_message = str(exc)
         return make_error_response(
             "github_proxy_error",
-            str(exc),
-            details={"exception_type": "GitHubProxyError", "tool": tool_name},
-            suggestions=["Check GitHub MCP connectivity, command args, and token configuration"],
+            error_message,
+            details={"exception_type": "GitHubProxyError", "tool": tool_name, "message": error_message},
+            suggestions=[
+                "Check GitHub MCP connectivity, command args, and token configuration",
+                "If using VS Code, ensure GITHUB_PERSONAL_ACCESS_TOKEN is set in .env "
+                "(VS Code may override GITHUB_TOKEN with its own Copilot auth token)",
+            ],
         )
     except Exception as exc:  # pragma: no cover - defensive
         return make_error_response(

--- a/src/backend/integrations/internal_mcp/github_proxy_mcp.py
+++ b/src/backend/integrations/internal_mcp/github_proxy_mcp.py
@@ -105,6 +105,18 @@ def _build_github_env() -> Dict[str, str]:
         token[:12] if len(token) > 12 else "***",
     )
 
+    # GITHUB_TOKEN / GH_TOKEN are low-priority fallbacks that VS Code may
+    # have set to its own Copilot auth token (insufficient scopes for the
+    # GitHub MCP server).  Warn so operators can add a proper PAT to .env.
+    if resolved_key in ("GITHUB_TOKEN", "GH_TOKEN"):
+        logger.warning(
+            "%s Token resolved from %s — this may be a VS Code Copilot token "
+            "with insufficient scopes. Set GITHUB_PERSONAL_ACCESS_TOKEN in "
+            ".env for reliable GitHub API access.",
+            _LOG_TAG,
+            resolved_key,
+        )
+
     # Populate common token keys used by GitHub MCP server variants.
     env["GITHUB_PERSONAL_ACCESS_TOKEN"] = token
     env["GITHUB_TOKEN"] = token

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -7196,6 +7196,12 @@ class InternalMCPChatOrchestrator:
         if not cls._extract_arxiv_id_from_text(prompt_text):
             return None
 
+        # Explicit denial overrides all artefact-intent tokens — the denial
+        # phrase itself contains words like "download"/"store" that would
+        # otherwise register as positive intent.
+        if prompt_explicitly_denies_write(prompt_text):
+            return None
+
         lowered = prompt_text.lower()
         if any(token in lowered for token in ("finalise", "finalize", "cached")):
             return "finalise_cached_paper"
@@ -11702,6 +11708,9 @@ class InternalMCPChatOrchestrator:
             error_msg = payload.get("error", "")
             error_code = payload.get("error_code")
             if error_code:
+                if isinstance(error_msg, str) and error_msg:
+                    short_msg = error_msg[:50] + "..." if len(error_msg) > 50 else error_msg
+                    return f"Error: {error_code} \u2014 {short_msg}"
                 return f"Error: {error_code}"
             if isinstance(error_msg, str) and error_msg:
                 short = error_msg[:50] + "..." if len(error_msg) > 50 else error_msg

--- a/src/workflows/von/main.py
+++ b/src/workflows/von/main.py
@@ -161,6 +161,8 @@ _apply_dotenv_overrides(
         # (VS Code may set GITHUB_TOKEN to its own Copilot auth token).
         "GITHUB_PERSONAL_ACCESS_TOKEN",
         "GITHUB_VON_TOKEN",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
     }
 )
 


### PR DESCRIPTION
## Summary
Fixes JVNAUTOSCI-1426: GitHub proxy tools failing with `github_proxy_error` due to VS Code Copilot token poisoning.

## Changes
1. **main.py**: Added `GITHUB_TOKEN` and `GH_TOKEN` to `_apply_dotenv_overrides()` so `.env` always wins over VS Code injected Copilot auth token
2. **orchestrator.py**: `_extract_result_summary()` now surfaces actual error message alongside error_code (was showing only 'Error: github_proxy_error')
3. **github_proxy_mcp.py**: Added `logger.warning` when token resolves from `GITHUB_TOKEN`/`GH_TOKEN` (keys vulnerable to VS Code Copilot token injection)
4. **catalogue.py**: Enhanced proxy error response with original error message in details dict and VS Code-specific troubleshooting suggestion

## Testing
- All 7 existing GitHub proxy tests pass
- Pyright: 0 errors on all 4 changed files