### PR TITLE
fix(orchestrator): resolve pyright emit_progress type-narrowing error

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -9449,6 +9449,9 @@ class InternalMCPChatOrchestrator:
                 )
                 continue
 
+            _progress_cb: Callable[[Mapping[str, Any]], None] | None = (
+                emit_progress if emit_progress is not None else None
+            )
             llm_start = time.perf_counter()
             try:
                 response = self._invoke_with_llm_heartbeat(
@@ -9459,7 +9462,7 @@ class InternalMCPChatOrchestrator:
                     ),
                     stage_name=stage,
                     model_name=model_name,
-                    emit_progress=emit_progress,
+                    emit_progress=_progress_cb,
                     attempt_meta=attempt_meta,
                 )
                 duration_ms = (time.perf_counter() - llm_start) * 1000.0


### PR DESCRIPTION
Fixes a pyright type error at line 9462 in orchestrator.py where `callable()` narrowing widened `emit_progress` to include `(...) -> object` in the union. Uses `is not None` narrowing instead to preserve the declared type exactly.
Also includes the JVNAUTOSCI-1432 fix (arXiv denial override in `_infer_arxiv_acquisition_tool_from_prompt`) from PR #235.