### PR TITLE
feat(JVNAUTOSCI-1446): make workflow creation VWL-native

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -103,6 +103,33 @@ Canonical graph families include:
 - `workflowStepMapsToolOutputFieldToContextKey`
 - `hasWorkflowVariable`
 
+### 3.4 Action-Contract Concepts
+
+`invokesAction` MAY point to either:
+
+- a raw executable action ID such as `workflow_control.context_set`, or
+- a concept-backed action contract, typically an instance of `#V#workflow_action_contract`.
+
+When a workflow step points at an action-contract concept, the concept SHOULD carry the machine-readable contract in both:
+
+- `concept_data.workflow_action_contract`
+- `#V#hasWorkflowActionContractJson` text (primary `en-NZ`)
+
+The canonical payload schema is `workflow_action_contract.v1` and includes:
+
+- `concept_id`
+- `action_id`
+- `description`
+- optional `input_schema`
+- optional `output_schema`
+- optional `side_effects`
+- optional `postconditions`
+
+Runtime rule:
+
+- the loader MUST resolve the concept-backed target to its underlying executable `action_id`;
+- the original concept target MUST remain available as the step's contract concept for introspection, validation, and publication repair.
+
 ## 4. VWL Program Model
 
 A VWL program is a workflow concept graph:
@@ -128,6 +155,31 @@ A VWL program is a workflow concept graph:
   - `reason` stable branch label
   - `condition` transition-condition spec
 - Optional metadata and mapping contracts.
+
+### 4.1 Workflow Publication Lifecycle
+
+Workflow authoring MAY attach explicit publication lifecycle metadata to a workflow concept. This is the current mechanism used by the workflow-creation workflow to keep drafts loadable but non-routable until validation and final publish complete.
+
+Canonical storage:
+
+- `concept_data.workflow_publication_lifecycle`
+- `#V#hasWorkflowLifecycleJson` text (primary `en-NZ`)
+
+Canonical schema: `workflow_publication_lifecycle.v1`
+
+Current phases:
+
+- `draft`
+- `validated`
+- `validation_failed`
+- `draft_failed_completion_gate`
+- `published`
+
+Current routing/discovery rule:
+
+- workflows with explicit lifecycle metadata where `published=false` MUST remain loadable for validation and repair;
+- those workflows MUST NOT be returned by workflow discovery or treated as executable for routing;
+- only workflows with `published=true`, or workflows with no explicit lifecycle metadata, are discoverable.
 
 ## 5. Condition Language (Transition Expressions)
 
@@ -176,6 +228,8 @@ Compilation flow:
 2. Build process graph (`build_workflow_process_graph`):
    - collect steps,
    - resolve invocation target,
+   - resolve optional action-contract metadata,
+   - resolve optional publication lifecycle metadata,
    - resolve control-flow edges,
    - capture metadata and mapping references.
 3. Compile into runtime state machine (`load_workflow_definition_from_vontology`):

--- a/src/backend/services/workflow_discovery_service.py
+++ b/src/backend/services/workflow_discovery_service.py
@@ -61,6 +61,7 @@ SEARCH_TIMEOUT_SECONDS = 0.5
 EXECUTABILITY_EXECUTABLE_NOW = "executable_now"
 EXECUTABILITY_GRAPH_INCOMPLETE = "graph_incomplete"
 EXECUTABILITY_NON_EXECUTABLE_DESIGN_ARTIFACT = "non_executable_design_artifact"
+EXECUTABILITY_DRAFT_NOT_PUBLISHED = "draft_not_published"
 EXECUTABILITY_WORKFLOW_STEP_INTEGRITY = "workflow_step_integrity_issue"
 EXECUTABILITY_WORKFLOW_STEP_PARTIALLY_VACUOUS = "workflow_step_partially_vacuous"
 EXECUTABILITY_WORKFLOW_STEP_COMPLETELY_VACUOUS = (
@@ -71,6 +72,7 @@ _EXECUTABILITY_REASON_PRIORITY = {
     EXECUTABILITY_EXECUTABLE_NOW: 2,
     EXECUTABILITY_GRAPH_INCOMPLETE: 1,
     EXECUTABILITY_NON_EXECUTABLE_DESIGN_ARTIFACT: 0,
+    EXECUTABILITY_DRAFT_NOT_PUBLISHED: 1,
     EXECUTABILITY_WORKFLOW_STEP_INTEGRITY: 1,
     EXECUTABILITY_WORKFLOW_STEP_PARTIALLY_VACUOUS: 1,
     EXECUTABILITY_WORKFLOW_STEP_COMPLETELY_VACUOUS: 1,
@@ -636,9 +638,26 @@ def _classify_workflow_concept_executability(
     try:
         from ..workflows.vontology_loader import (
             build_workflow_process_graph,
-            load_workflow_definition_from_vontology,
             detect_vacuous_workflow_steps,
+            load_workflow_definition_from_vontology,
+            resolve_workflow_publication_lifecycle,
         )
+
+        publication_lifecycle, publication_lifecycle_source = (
+            resolve_workflow_publication_lifecycle(concept_id)
+        )
+        if (
+            isinstance(publication_lifecycle, Mapping)
+            and publication_lifecycle.get("published") is False
+        ):
+            phase = str(publication_lifecycle.get("phase") or "draft").strip() or "draft"
+            detail = f"workflow_not_published:phase={phase}"
+            if (
+                isinstance(publication_lifecycle_source, str)
+                and publication_lifecycle_source
+            ):
+                detail = f"{detail}:source={publication_lifecycle_source}"
+            return (False, EXECUTABILITY_DRAFT_NOT_PUBLISHED, detail)
 
         graph, warnings = build_workflow_process_graph(concept_id)
         warning_items = [

--- a/src/backend/workflows/action_registry.py
+++ b/src/backend/workflows/action_registry.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Mapping, Optional
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence
 
 from .execution_contracts import (
     WORKFLOW_CONTROL_SIGNAL_ERROR,
@@ -65,6 +65,8 @@ class WorkflowActionRequest:
     environment: WorkflowEnvironment
     data: Dict[str, Any]
     trace: Any | None = None
+    action_target_id: str | None = None
+    contract_concept_id: str | None = None
 
 
 @dataclass
@@ -91,13 +93,17 @@ class ActionSpec:
     description: str | None = None
     concept_id: str | None = None
     input_schema: Mapping[str, Any] | None = None
+    output_schema: Mapping[str, Any] | None = None
     side_effects: str | None = None
+    postconditions: Sequence[str] = ()
 
 
 def _apply_action_outcome_context(
     *,
     context: Dict[str, Any],
-    action_id: str,
+    action_target_id: str,
+    resolved_action_id: str | None,
+    contract_concept_id: str | None,
     result: WorkflowActionResult,
 ) -> None:
     """Stamp canonical action outcome flags into workflow context.
@@ -107,7 +113,12 @@ def _apply_action_outcome_context(
     and durable) observes identical post-action state.
     """
     outcome = normalise_action_outcome(result.status)
-    context["last_action_id"] = action_id
+    context["last_action_id"] = action_target_id
+    context["last_action_target_id"] = action_target_id
+    context["last_action_registry_action_id"] = (
+        resolved_action_id or action_target_id
+    )
+    context["last_action_contract_concept_id"] = contract_concept_id
     context["last_action_status"] = result.status
     context["last_action_outcome"] = outcome
     context["last_action_succeeded"] = outcome == WORKFLOW_ACTION_OUTCOME_SUCCESS
@@ -144,6 +155,7 @@ class ActionRegistry:
 
     def __init__(self) -> None:
         self._actions: Dict[str, ActionSpec] = {}
+        self._actions_by_concept_id: Dict[str, ActionSpec] = {}
         self._fallback_handler: (
             Callable[[WorkflowActionRequest], WorkflowActionResult] | None
         ) = None
@@ -155,7 +167,17 @@ class ActionRegistry:
             raise TypeError("spec must be an ActionSpec")
         if spec.action_id in self._actions:
             raise ValueError(f"action already registered: {spec.action_id}")
+        concept_id = str(spec.concept_id or "").strip()
+        if concept_id:
+            existing = self._actions_by_concept_id.get(concept_id)
+            if existing is not None and existing.action_id != spec.action_id:
+                raise ValueError(
+                    "action concept already registered: "
+                    f"{concept_id} -> {existing.action_id}"
+                )
         self._actions[spec.action_id] = spec
+        if concept_id:
+            self._actions_by_concept_id[concept_id] = spec
 
     def register_if_absent(self, spec: ActionSpec) -> bool:
         """Register *spec* only if its ``action_id`` is not already present.
@@ -166,7 +188,17 @@ class ActionRegistry:
             raise TypeError("spec must be an ActionSpec")
         if spec.action_id in self._actions:
             return False
+        concept_id = str(spec.concept_id or "").strip()
+        if concept_id:
+            existing = self._actions_by_concept_id.get(concept_id)
+            if existing is not None and existing.action_id != spec.action_id:
+                raise ValueError(
+                    "action concept already registered: "
+                    f"{concept_id} -> {existing.action_id}"
+                )
         self._actions[spec.action_id] = spec
+        if concept_id:
+            self._actions_by_concept_id[concept_id] = spec
         return True
 
     def merge(self, other: "ActionRegistry", *, overwrite: bool = False) -> None:
@@ -181,6 +213,9 @@ class ActionRegistry:
         for action_id, spec in other._actions.items():
             if overwrite or action_id not in self._actions:
                 self._actions[action_id] = spec
+                concept_id = str(spec.concept_id or "").strip()
+                if concept_id:
+                    self._actions_by_concept_id[concept_id] = spec
 
     def set_fallback_handler(
         self,
@@ -204,9 +239,26 @@ class ActionRegistry:
     def get(self, action_id: str) -> ActionSpec | None:
         return self._actions.get(action_id)
 
+    def get_by_concept_id(self, concept_id: str) -> ActionSpec | None:
+        return self._actions_by_concept_id.get(concept_id)
+
+    def resolve_action_spec(self, action_target_id: str) -> ActionSpec | None:
+        target = str(action_target_id or "").strip()
+        if not target:
+            return None
+        spec = self.get(target)
+        if spec is not None:
+            return spec
+        if target.startswith("#V#"):
+            return self.get_by_concept_id(target)
+        return None
+
     def has(self, action_id: str) -> bool:
         """Return True if *action_id* is registered."""
         return action_id in self._actions
+
+    def has_action_target(self, action_target_id: str) -> bool:
+        return self.resolve_action_spec(action_target_id) is not None
 
     def all_action_ids(self) -> list[str]:
         """Return all registered action IDs."""
@@ -221,27 +273,38 @@ class ActionRegistry:
         env: WorkflowEnvironment,
         trace: Any | None = None,
     ) -> WorkflowActionResult:
-        spec = self.get(action_id)
+        action_target_id = str(action_id or "").strip()
+        spec = self.resolve_action_spec(action_target_id)
         handler: Callable[[WorkflowActionRequest], WorkflowActionResult] | None = (
             spec.handler if spec is not None else self._fallback_handler
         )
         if handler is None:
             result = WorkflowActionResult(
-                status="failed", error=f"action_not_registered:{action_id}"
+                status="failed", error=f"action_not_registered:{action_target_id}"
             )
             _apply_action_outcome_context(
                 context=context,
-                action_id=action_id,
+                action_target_id=action_target_id,
+                resolved_action_id=None,
+                contract_concept_id=None,
                 result=result,
             )
             return result
+        resolved_action_id = (
+            str(spec.action_id or "").strip() if spec is not None else action_target_id
+        )
+        contract_concept_id = (
+            str(spec.concept_id or "").strip() if spec is not None else None
+        ) or None
         try:
             request = WorkflowActionRequest(
-                action_id=action_id,
+                action_id=resolved_action_id or action_target_id,
                 inputs=inputs,
                 environment=env,
                 data=context,
                 trace=trace,
+                action_target_id=action_target_id or None,
+                contract_concept_id=contract_concept_id,
             )
             raw_result = handler(request)
             if isinstance(raw_result, WorkflowActionResult):
@@ -251,7 +314,7 @@ class ActionRegistry:
                     status="failed",
                     error=(
                         "invalid_action_result_type:"
-                        f"{action_id}:{type(raw_result).__name__}"
+                        f"{action_target_id}:{type(raw_result).__name__}"
                     ),
                 )
         except Exception as exc:
@@ -259,7 +322,9 @@ class ActionRegistry:
 
         _apply_action_outcome_context(
             context=context,
-            action_id=action_id,
+            action_target_id=action_target_id,
+            resolved_action_id=resolved_action_id or action_target_id,
+            contract_concept_id=contract_concept_id,
             result=result,
         )
         return result

--- a/src/backend/workflows/durable/workflow_creation_workflow.py
+++ b/src/backend/workflows/durable/workflow_creation_workflow.py
@@ -23,58 +23,35 @@ from ..action_registry import (
 )
 from ..engine import WorkflowEnvironment, WorkflowExecutor
 from ..vontology_loader import discover_workflow_ids, load_workflow_definition_from_vontology
+from ..workflow_creation_contracts import (
+    WORKFLOW_CREATION_ACTION_ASSERT_PHD_STUDENT_RELATIONSHIPS,
+    WORKFLOW_CREATION_ACTION_CONTRACT_BY_ACTION_ID,
+    WORKFLOW_CREATION_ACTION_CREATE_STEP_CONCEPTS,
+    WORKFLOW_CREATION_ACTION_CREATE_WORKFLOW_TYPE,
+    WORKFLOW_CREATION_ACTION_DESIGN_STRUCTURE,
+    WORKFLOW_CREATION_ACTION_EMIT_MARKER,
+    WORKFLOW_CREATION_ACTION_ESTABLISH_RELATIONSHIPS,
+    WORKFLOW_CREATION_ACTION_FINALISE,
+    WORKFLOW_CREATION_ACTION_GROUND_PHD_STUDENT_TEXT,
+    WORKFLOW_CREATION_ACTION_IDENTIFY_NEED,
+    WORKFLOW_CREATION_ACTION_RESOLVE_PHD_STUDENT_CANDIDATE,
+    WORKFLOW_CREATION_ACTION_RESOLVE_SCHOLARLY_AUTHORS,
+    WORKFLOW_CREATION_ACTION_VERIFY_DISCOVERABILITY,
+    WORKFLOW_CREATION_STEP_CREATE_STEP_CONCEPTS,
+    WORKFLOW_CREATION_STEP_CREATE_WORKFLOW_TYPE,
+    WORKFLOW_CREATION_STEP_DESIGN_STRUCTURE,
+    WORKFLOW_CREATION_STEP_DOCUMENT_IN_JIRA,
+    WORKFLOW_CREATION_STEP_ESTABLISH_RELATIONSHIPS,
+    WORKFLOW_CREATION_STEP_IDENTIFY_NEED,
+    WORKFLOW_CREATION_STEP_VERIFY_DISCOVERABILITY,
+    WORKFLOW_CREATION_WORKFLOW_ID,
+    workflow_creation_action_target,
+)
 from ..workflow_definition_identity_service import (
     collect_workflow_action_ids,
     validate_workflow_definition_contract,
 )
 from .workflow_gap_recovery_workflow import register_workflow_gap_recovery_actions
-
-WORKFLOW_CREATION_WORKFLOW_ID = "#V#von_workflow_creation_workflow"
-
-WORKFLOW_CREATION_STEP_IDENTIFY_NEED = "#V#workflow_creation_step_identify_need"
-WORKFLOW_CREATION_STEP_DESIGN_STRUCTURE = "#V#workflow_creation_step_design_structure"
-WORKFLOW_CREATION_STEP_CREATE_WORKFLOW_TYPE = (
-    "#V#workflow_creation_step_create_workflow_type"
-)
-WORKFLOW_CREATION_STEP_CREATE_STEP_CONCEPTS = (
-    "#V#workflow_creation_step_create_step_concepts"
-)
-WORKFLOW_CREATION_STEP_ESTABLISH_RELATIONSHIPS = (
-    "#V#workflow_creation_step_establish_relationships"
-)
-WORKFLOW_CREATION_STEP_VERIFY_DISCOVERABILITY = (
-    "#V#workflow_creation_step_verify_discoverability"
-)
-WORKFLOW_CREATION_STEP_DOCUMENT_IN_JIRA = "#V#workflow_creation_step_document_in_jira"
-
-WORKFLOW_CREATION_ACTION_IDENTIFY_NEED = "workflow_creation.identify_need"
-WORKFLOW_CREATION_ACTION_DESIGN_STRUCTURE = "workflow_creation.design_structure"
-WORKFLOW_CREATION_ACTION_CREATE_WORKFLOW_TYPE = (
-    "workflow_creation.create_workflow_type"
-)
-WORKFLOW_CREATION_ACTION_CREATE_STEP_CONCEPTS = (
-    "workflow_creation.create_step_concepts"
-)
-WORKFLOW_CREATION_ACTION_ESTABLISH_RELATIONSHIPS = (
-    "workflow_creation.establish_relationships"
-)
-WORKFLOW_CREATION_ACTION_VERIFY_DISCOVERABILITY = (
-    "workflow_creation.verify_discoverability"
-)
-WORKFLOW_CREATION_ACTION_FINALISE = "workflow_creation.finalise"
-WORKFLOW_CREATION_ACTION_EMIT_MARKER = "workflow_creation.emit_marker"
-WORKFLOW_CREATION_ACTION_RESOLVE_SCHOLARLY_AUTHORS = (
-    "workflow_creation.resolve_scholarly_authors"
-)
-WORKFLOW_CREATION_ACTION_RESOLVE_PHD_STUDENT_CANDIDATE = (
-    "workflow_creation.resolve_phd_student_candidate"
-)
-WORKFLOW_CREATION_ACTION_ASSERT_PHD_STUDENT_RELATIONSHIPS = (
-    "workflow_creation.assert_phd_student_relationships"
-)
-WORKFLOW_CREATION_ACTION_GROUND_PHD_STUDENT_TEXT = (
-    "workflow_creation.ground_phd_student_text"
-)
 
 WORKFLOW_CONTEXT_KEY_VALIDATED_TYPE_NAME = "#V#workflow_context_key_validated_type_name"
 DEFAULT_WORKFLOW_PARENT_TYPE_ID = "#V#ai_workflow"
@@ -87,6 +64,15 @@ DEFAULT_PREDICATE_TYPE_ID = "#V#predicate"
 DEFAULT_AUTHORED_BY_PREDICATE_ID = "#V#authored_by"
 DEFAULT_SUPERVISED_BY_PREDICATE_ID = "#V#supervised_by"
 DEFAULT_RESEARCHES_PREDICATE_ID = "#V#researches"
+WORKFLOW_GRAPH_PREDICATE_HAS_INITIAL_STEP = "#V#hasInitialStep"
+WORKFLOW_GRAPH_PREDICATE_HAS_STEP = "#V#hasStep"
+WORKFLOW_GRAPH_PREDICATE_INVOKES_ACTION = "#V#invokesAction"
+WORKFLOW_GRAPH_PREDICATE_HAS_INPUT_MAP = "#V#hasInputMap"
+WORKFLOW_GRAPH_PREDICATE_NEXT_STEP = "#V#nextStep"
+WORKFLOW_GRAPH_PREDICATE_ON_TRUE_NEXT_STEP = "#V#onTrueNextStep"
+WORKFLOW_GRAPH_PREDICATE_ON_FALSE_NEXT_STEP = "#V#onFalseNextStep"
+WORKFLOW_GRAPH_PREDICATE_ON_FAILURE_NEXT_STEP = "#V#onFailureNextStep"
+WORKFLOW_GRAPH_PREDICATE_ON_UNKNOWN_NEXT_STEP = "#V#onUnknownNextStep"
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 _WORKFLOW_CREATION_INTENT_RE = re.compile(
     r"\b(create|build|generate)\b[\s\w]{0,80}\bworkflow\b",
@@ -105,6 +91,8 @@ WORKFLOW_CREATION_AUTONOMY_POLICY_VALUE = "only_when_vital_info_missing"
 WORKFLOW_CREATION_SYNTHESIS_POLICY_MISSING_ERROR = (
     "workflow_creation_synthesis_policy_missing"
 )
+WORKFLOW_PUBLICATION_LIFECYCLE_SCHEMA_VERSION = "workflow_publication_lifecycle.v1"
+WORKFLOW_PUBLICATION_LIFECYCLE_TEXT_PREDICATE = "#V#hasWorkflowLifecycleJson"
 
 
 def _clean_text(value: Any) -> str:
@@ -1177,6 +1165,43 @@ def _add_contract_output(
     return payload
 
 
+def _write_workflow_publication_lifecycle(
+    *,
+    workflow_id: str,
+    phase: str,
+    published: bool,
+    validation_passed: bool | None = None,
+    postconditions_verified: bool | None = None,
+    optional_test_instance_id: str | None = None,
+    last_error: str | None = None,
+) -> None:
+    phase_text = _clean_text(phase) or "draft"
+    payload: dict[str, Any] = {
+        "schema_version": WORKFLOW_PUBLICATION_LIFECYCLE_SCHEMA_VERSION,
+        "phase": phase_text,
+        "published": bool(published),
+    }
+    if validation_passed is not None:
+        payload["validation_passed"] = bool(validation_passed)
+    if postconditions_verified is not None:
+        payload["postconditions_verified"] = bool(postconditions_verified)
+    if isinstance(optional_test_instance_id, str) and optional_test_instance_id.strip():
+        payload["optional_test_instance_id"] = optional_test_instance_id.strip()
+    if isinstance(last_error, str) and last_error.strip():
+        payload["last_error"] = last_error.strip()
+
+    concept_service.update_concept(
+        workflow_id,
+        {"concept_data.workflow_publication_lifecycle": payload},
+    )
+    upsert_text_for_concept(
+        subject_concept_id=workflow_id,
+        predicate=WORKFLOW_PUBLICATION_LIFECYCLE_TEXT_PREDICATE,
+        text=json.dumps(payload, sort_keys=True),
+        lang="en-NZ",
+    )
+
+
 def _handle_identify_need(request: WorkflowActionRequest) -> WorkflowActionResult:
     spec = _normalise_workflow_spec(request.data)
     parent_type_id = str(spec.get("parent_type_id") or DEFAULT_WORKFLOW_PARENT_TYPE_ID)
@@ -1218,6 +1243,13 @@ def _handle_create_workflow_type(request: WorkflowActionRequest) -> WorkflowActi
         name=workflow_name,
         parent_type_id=parent_type_id,
         description=workflow_description or None,
+    )
+    _write_workflow_publication_lifecycle(
+        workflow_id=workflow_id,
+        phase="draft",
+        published=False,
+        validation_passed=False,
+        postconditions_verified=False,
     )
 
     outputs = _add_contract_output(
@@ -1265,6 +1297,8 @@ def _handle_create_step_concepts(request: WorkflowActionRequest) -> WorkflowActi
 
 
 def _handle_establish_relationships(request: WorkflowActionRequest) -> WorkflowActionResult:
+    from .. import workflow_concept_authority_service as workflow_authority_service
+
     spec = _normalise_workflow_spec(request.data)
     parent_type_id = str(spec.get("parent_type_id") or DEFAULT_WORKFLOW_PARENT_TYPE_ID)
     workflow_id = str(spec["workflow_id"])
@@ -1289,28 +1323,47 @@ def _handle_establish_relationships(request: WorkflowActionRequest) -> WorkflowA
         )
 
     workflow_relationships = dict(workflow_doc.get("relationships") or {})
+    for key in (
+        WORKFLOW_GRAPH_PREDICATE_HAS_INITIAL_STEP,
+        "hasInitialStep",
+        "has_initial_step",
+        WORKFLOW_GRAPH_PREDICATE_HAS_STEP,
+        "hasStep",
+        "has_step",
+    ):
+        workflow_relationships.pop(key, None)
     ordered_step_ids = [
         state_to_step_id.get(str(row.get("state_key") or ""))
         for row in (spec.get("steps") or [])
         if isinstance(row, Mapping)
     ]
     ordered_step_ids = [item for item in ordered_step_ids if isinstance(item, str)]
-    workflow_relationships["hasInitialStep"] = [initial_step_id]
-    workflow_relationships["hasStep"] = ordered_step_ids
+    workflow_relationships[WORKFLOW_GRAPH_PREDICATE_HAS_INITIAL_STEP] = [
+        initial_step_id
+    ]
+    workflow_relationships[WORKFLOW_GRAPH_PREDICATE_HAS_STEP] = ordered_step_ids
     concept_service.update_concept(workflow_id, {"relationships": workflow_relationships})
 
     graph_keys = {
+        WORKFLOW_GRAPH_PREDICATE_INVOKES_ACTION,
         "invokesAction",
         "workflow_step_invokes_tool",
+        WORKFLOW_GRAPH_PREDICATE_HAS_INPUT_MAP,
         "hasInputMap",
         "has_input_map",
+        WORKFLOW_GRAPH_PREDICATE_NEXT_STEP,
         "nextStep",
         "next_step",
+        WORKFLOW_GRAPH_PREDICATE_ON_TRUE_NEXT_STEP,
         "onTrueNextStep",
+        WORKFLOW_GRAPH_PREDICATE_ON_FALSE_NEXT_STEP,
         "onFalseNextStep",
+        WORKFLOW_GRAPH_PREDICATE_ON_FAILURE_NEXT_STEP,
         "onFailureNextStep",
+        WORKFLOW_GRAPH_PREDICATE_ON_UNKNOWN_NEXT_STEP,
         "onUnknownNextStep",
     }
+    action_contract_concept_ids: list[str] = []
 
     for row in spec.get("steps") or []:
         if not isinstance(row, Mapping):
@@ -1330,11 +1383,33 @@ def _handle_establish_relationships(request: WorkflowActionRequest) -> WorkflowA
 
         action_id = _clean_text(row.get("action_id"))
         if action_id:
-            relationships["invokesAction"] = [action_id]
+            action_target = action_id
+            if action_id in WORKFLOW_CREATION_ACTION_CONTRACT_BY_ACTION_ID:
+                (
+                    resolved_action_concept_id,
+                    _created_action_concept,
+                    action_concept_error,
+                ) = workflow_authority_service.ensure_workflow_action_contract_concept(
+                    action_id=action_id
+                )
+                if action_concept_error:
+                    return WorkflowActionResult(
+                        status="failed",
+                        error=(
+                            "workflow_creation_action_contract_failed:"
+                            f"{step_id}:{action_id}:{action_concept_error}"
+                        ),
+                    )
+                if resolved_action_concept_id:
+                    action_target = resolved_action_concept_id
+                    action_contract_concept_ids.append(resolved_action_concept_id)
+            relationships[WORKFLOW_GRAPH_PREDICATE_INVOKES_ACTION] = [
+                workflow_creation_action_target(action_target) or action_target
+            ]
 
         inputs = row.get("inputs")
         if isinstance(inputs, Mapping) and inputs:
-            relationships["hasInputMap"] = [
+            relationships[WORKFLOW_GRAPH_PREDICATE_HAS_INPUT_MAP] = [
                 f"{key}={value}"
                 for key, value in sorted(inputs.items(), key=lambda item: item[0])
             ]
@@ -1343,31 +1418,39 @@ def _handle_establish_relationships(request: WorkflowActionRequest) -> WorkflowA
         if next_state_key:
             target_step_id = state_to_step_id.get(next_state_key)
             if target_step_id:
-                relationships["nextStep"] = [target_step_id]
+                relationships[WORKFLOW_GRAPH_PREDICATE_NEXT_STEP] = [target_step_id]
 
         on_true_state_key = _clean_text(row.get("on_true_state_key"))
         if on_true_state_key:
             target_step_id = state_to_step_id.get(on_true_state_key)
             if target_step_id:
-                relationships["onTrueNextStep"] = [target_step_id]
+                relationships[WORKFLOW_GRAPH_PREDICATE_ON_TRUE_NEXT_STEP] = [
+                    target_step_id
+                ]
 
         on_false_state_key = _clean_text(row.get("on_false_state_key"))
         if on_false_state_key:
             target_step_id = state_to_step_id.get(on_false_state_key)
             if target_step_id:
-                relationships["onFalseNextStep"] = [target_step_id]
+                relationships[WORKFLOW_GRAPH_PREDICATE_ON_FALSE_NEXT_STEP] = [
+                    target_step_id
+                ]
 
         on_failure_state_key = _clean_text(row.get("on_failure_state_key"))
         if on_failure_state_key:
             target_step_id = state_to_step_id.get(on_failure_state_key)
             if target_step_id:
-                relationships["onFailureNextStep"] = [target_step_id]
+                relationships[WORKFLOW_GRAPH_PREDICATE_ON_FAILURE_NEXT_STEP] = [
+                    target_step_id
+                ]
 
         on_unknown_state_key = _clean_text(row.get("on_unknown_state_key"))
         if on_unknown_state_key:
             target_step_id = state_to_step_id.get(on_unknown_state_key)
             if target_step_id:
-                relationships["onUnknownNextStep"] = [target_step_id]
+                relationships[WORKFLOW_GRAPH_PREDICATE_ON_UNKNOWN_NEXT_STEP] = [
+                    target_step_id
+                ]
 
         concept_service.update_concept(step_id, {"relationships": relationships})
 
@@ -1376,6 +1459,9 @@ def _handle_establish_relationships(request: WorkflowActionRequest) -> WorkflowA
             "workflow_creation_spec": spec,
             "workflow_structure_written": True,
             "workflow_concept_id": workflow_id,
+            "workflow_action_contract_concept_ids": list(
+                dict.fromkeys(action_contract_concept_ids)
+            ),
         },
         validated_type_name=parent_type_id,
     )
@@ -1918,6 +2004,9 @@ def _build_verification_registry(environment: WorkflowEnvironment) -> ActionRegi
             action_id=WORKFLOW_CREATION_ACTION_EMIT_MARKER,
             handler=_handle_emit_marker,
             description="Emit a deterministic marker key/value into workflow context.",
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_EMIT_MARKER
+            ),
         )
     )
     registry.register_if_absent(
@@ -1927,6 +2016,9 @@ def _build_verification_registry(environment: WorkflowEnvironment) -> ActionRegi
             description=(
                 "Resolve scholarly-work authors against existing person concepts "
                 "and create/link missing people."
+            ),
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_RESOLVE_SCHOLARLY_AUTHORS
             ),
         )
     )
@@ -1938,6 +2030,9 @@ def _build_verification_registry(environment: WorkflowEnvironment) -> ActionRegi
                 "Resolve a PhD-student candidate concept from text/profile data "
                 "with fail-closed ambiguity diagnostics."
             ),
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_RESOLVE_PHD_STUDENT_CANDIDATE
+            ),
         )
     )
     registry.register_if_absent(
@@ -1948,6 +2043,9 @@ def _build_verification_registry(environment: WorkflowEnvironment) -> ActionRegi
                 "Assert core person/student/research relationships for the resolved "
                 "PhD student concept."
             ),
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_ASSERT_PHD_STUDENT_RELATIONSHIPS
+            ),
         )
     )
     registry.register_if_absent(
@@ -1956,6 +2054,9 @@ def _build_verification_registry(environment: WorkflowEnvironment) -> ActionRegi
             handler=_handle_ground_phd_student_text,
             description=(
                 "Ground source text and provenance on the resolved PhD student concept."
+            ),
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_GROUND_PHD_STUDENT_TEXT
             ),
         )
     )
@@ -2020,7 +2121,7 @@ def _handle_verify_discoverability(request: WorkflowActionRequest) -> WorkflowAc
     parent_type_id = str(spec.get("parent_type_id") or DEFAULT_WORKFLOW_PARENT_TYPE_ID)
     workflow_id = str(spec["workflow_id"])
     discovered = set(discover_workflow_ids())
-    discoverable = workflow_id in discovered
+    discoverable_before_publish = workflow_id in discovered
     definition = load_workflow_definition_from_vontology(workflow_id)
     if definition is None:
         outputs = _add_contract_output(
@@ -2029,9 +2130,17 @@ def _handle_verify_discoverability(request: WorkflowActionRequest) -> WorkflowAc
                 "required_effects_declared": bool(spec.get("required_effects")),
                 "structural_validation_passed": False,
                 "postconditions_verified": False,
-                "workflow_discoverable": discoverable,
+                "workflow_discoverable_before_publish": discoverable_before_publish,
             },
             validated_type_name=parent_type_id,
+        )
+        _write_workflow_publication_lifecycle(
+            workflow_id=workflow_id,
+            phase="validation_failed",
+            published=False,
+            validation_passed=False,
+            postconditions_verified=False,
+            last_error=f"workflow_definition_not_loadable:{workflow_id}",
         )
         return WorkflowActionResult(
             status="failed",
@@ -2051,7 +2160,7 @@ def _handle_verify_discoverability(request: WorkflowActionRequest) -> WorkflowAc
         known_workflow_ids=discovered,
         workflow_definition_loader=load_workflow_definition_from_vontology,
     )
-    structural_validation_passed = bool(contract.get("valid")) and discoverable
+    structural_validation_passed = bool(contract.get("valid"))
 
     postconditions_verified = False
     optional_test_instance_id: str | None = None
@@ -2090,6 +2199,18 @@ def _handle_verify_discoverability(request: WorkflowActionRequest) -> WorkflowAc
         )
 
     required_effects_declared = bool(spec.get("required_effects"))
+    all_verified = (
+        required_effects_declared and structural_validation_passed and postconditions_verified
+    )
+    _write_workflow_publication_lifecycle(
+        workflow_id=workflow_id,
+        phase="validated" if all_verified else "validation_failed",
+        published=False,
+        validation_passed=structural_validation_passed,
+        postconditions_verified=postconditions_verified,
+        optional_test_instance_id=optional_test_instance_id,
+        last_error=None if all_verified else "workflow_creation_verification_failed",
+    )
     outputs = _add_contract_output(
         outputs={
             "workflow_creation_spec": spec,
@@ -2099,15 +2220,13 @@ def _handle_verify_discoverability(request: WorkflowActionRequest) -> WorkflowAc
             "structural_validation_passed": structural_validation_passed,
             "postconditions_verified": postconditions_verified,
             "optional_test_instance_id": optional_test_instance_id,
-            "workflow_discoverable": discoverable,
+            "workflow_discoverable_before_publish": discoverable_before_publish,
             "contract_validation": contract,
         },
         validated_type_name=parent_type_id,
     )
 
-    if not (
-        required_effects_declared and structural_validation_passed and postconditions_verified
-    ):
+    if not all_verified:
         return WorkflowActionResult(
             status="failed",
             error="workflow_creation_verification_failed",
@@ -2119,22 +2238,40 @@ def _handle_verify_discoverability(request: WorkflowActionRequest) -> WorkflowAc
 def _handle_finalise(request: WorkflowActionRequest) -> WorkflowActionResult:
     spec = _normalise_workflow_spec(request.data)
     parent_type_id = str(spec.get("parent_type_id") or DEFAULT_WORKFLOW_PARENT_TYPE_ID)
+    workflow_id = str(
+        request.data.get("workflow_concept_id") or spec.get("workflow_id") or ""
+    ).strip()
     required_effects_declared = bool(request.data.get("required_effects_declared"))
     structural_validation_passed = bool(request.data.get("structural_validation_passed"))
     postconditions_verified = bool(request.data.get("postconditions_verified"))
     all_verified = (
         required_effects_declared and structural_validation_passed and postconditions_verified
     )
+    if workflow_id:
+        _write_workflow_publication_lifecycle(
+            workflow_id=workflow_id,
+            phase="published" if all_verified else "draft_failed_completion_gate",
+            published=all_verified,
+            validation_passed=structural_validation_passed,
+            postconditions_verified=postconditions_verified,
+            optional_test_instance_id=(
+                str(request.data.get("optional_test_instance_id") or "").strip() or None
+            ),
+            last_error=(
+                None if all_verified else "workflow_creation_completion_gate_failed"
+            ),
+        )
+    discoverable = workflow_id in set(discover_workflow_ids()) if workflow_id else False
 
     summary = {
-        "workflow_concept_id": request.data.get("workflow_concept_id")
-        or spec.get("workflow_id"),
+        "workflow_concept_id": workflow_id or spec.get("workflow_id"),
         "parent_concept_id_used": request.data.get("parent_concept_id_used")
         or parent_type_id,
         "required_effects_declared": required_effects_declared,
         "structural_validation_passed": structural_validation_passed,
         "postconditions_verified": postconditions_verified,
         "optional_test_instance_id": request.data.get("optional_test_instance_id"),
+        "workflow_discoverable": discoverable,
     }
     outputs = _add_contract_output(outputs=summary, validated_type_name=parent_type_id)
     outputs["response_text"] = (
@@ -2183,6 +2320,21 @@ def _handle_emit_marker(request: WorkflowActionRequest) -> WorkflowActionResult:
     )
 
 
+def _workflow_creation_action_spec_kwargs(action_id: str) -> dict[str, Any]:
+    definition = WORKFLOW_CREATION_ACTION_CONTRACT_BY_ACTION_ID.get(
+        str(action_id or "").strip()
+    )
+    if definition is None:
+        return {}
+    return {
+        "concept_id": definition.concept_id,
+        "input_schema": definition.input_schema,
+        "output_schema": definition.output_schema,
+        "side_effects": definition.side_effects,
+        "postconditions": definition.postconditions,
+    }
+
+
 def register_workflow_creation_actions(registry: ActionRegistry) -> None:
     """Register action handlers required by ``#V#von_workflow_creation_workflow``."""
 
@@ -2191,41 +2343,65 @@ def register_workflow_creation_actions(registry: ActionRegistry) -> None:
             action_id=WORKFLOW_CREATION_ACTION_IDENTIFY_NEED,
             handler=_handle_identify_need,
             description="Normalise workflow creation request/specification.",
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_IDENTIFY_NEED
+            ),
         ),
         ActionSpec(
             action_id=WORKFLOW_CREATION_ACTION_DESIGN_STRUCTURE,
             handler=_handle_design_structure,
             description="Design a deterministic workflow structure.",
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_DESIGN_STRUCTURE
+            ),
         ),
         ActionSpec(
             action_id=WORKFLOW_CREATION_ACTION_CREATE_WORKFLOW_TYPE,
             handler=_handle_create_workflow_type,
             description="Create or update workflow concept and parent typing.",
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_CREATE_WORKFLOW_TYPE
+            ),
         ),
         ActionSpec(
             action_id=WORKFLOW_CREATION_ACTION_CREATE_STEP_CONCEPTS,
             handler=_handle_create_step_concepts,
             description="Create step concepts for the target workflow graph.",
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_CREATE_STEP_CONCEPTS
+            ),
         ),
         ActionSpec(
             action_id=WORKFLOW_CREATION_ACTION_ESTABLISH_RELATIONSHIPS,
             handler=_handle_establish_relationships,
             description="Write workflow graph relationships (initial/step/transition/action).",
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_ESTABLISH_RELATIONSHIPS
+            ),
         ),
         ActionSpec(
             action_id=WORKFLOW_CREATION_ACTION_VERIFY_DISCOVERABILITY,
             handler=_handle_verify_discoverability,
             description="Verify created workflow discoverability, contract validity, and postconditions.",
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_VERIFY_DISCOVERABILITY
+            ),
         ),
         ActionSpec(
             action_id=WORKFLOW_CREATION_ACTION_FINALISE,
             handler=_handle_finalise,
             description="Apply completion gate for workflow creation.",
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_FINALISE
+            ),
         ),
         ActionSpec(
             action_id=WORKFLOW_CREATION_ACTION_EMIT_MARKER,
             handler=_handle_emit_marker,
             description="Emit deterministic marker output for created workflow tasks.",
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_EMIT_MARKER
+            ),
         ),
         ActionSpec(
             action_id=WORKFLOW_CREATION_ACTION_RESOLVE_SCHOLARLY_AUTHORS,
@@ -2233,6 +2409,9 @@ def register_workflow_creation_actions(registry: ActionRegistry) -> None:
             description=(
                 "Resolve scholarly-work authors by reusing verified person concepts "
                 "or creating missing person concepts, then assert authorship links."
+            ),
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_RESOLVE_SCHOLARLY_AUTHORS
             ),
         ),
         ActionSpec(
@@ -2242,6 +2421,9 @@ def register_workflow_creation_actions(registry: ActionRegistry) -> None:
                 "Resolve a PhD-student candidate concept from text/profile data "
                 "with fail-closed ambiguity diagnostics."
             ),
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_RESOLVE_PHD_STUDENT_CANDIDATE
+            ),
         ),
         ActionSpec(
             action_id=WORKFLOW_CREATION_ACTION_ASSERT_PHD_STUDENT_RELATIONSHIPS,
@@ -2250,12 +2432,18 @@ def register_workflow_creation_actions(registry: ActionRegistry) -> None:
                 "Assert core person/student/research relationships for the resolved "
                 "PhD student concept."
             ),
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_ASSERT_PHD_STUDENT_RELATIONSHIPS
+            ),
         ),
         ActionSpec(
             action_id=WORKFLOW_CREATION_ACTION_GROUND_PHD_STUDENT_TEXT,
             handler=_handle_ground_phd_student_text,
             description=(
                 "Ground source text and provenance on the resolved PhD student concept."
+            ),
+            **_workflow_creation_action_spec_kwargs(
+                WORKFLOW_CREATION_ACTION_GROUND_PHD_STUDENT_TEXT
             ),
         ),
     )

--- a/src/backend/workflows/engine.py
+++ b/src/backend/workflows/engine.py
@@ -849,6 +849,7 @@ class WorkflowActionInvocation:
     action_id: str
     inputs: Mapping[str, Any] = field(default_factory=dict)
     description: str | None = None
+    contract_concept_id: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/backend/workflows/vontology_loader.py
+++ b/src/backend/workflows/vontology_loader.py
@@ -26,6 +26,7 @@ from .subworkflow_contracts import (
     WORKFLOW_SUBWORKFLOW_ACTION_ID,
     build_subworkflow_contract,
 )
+from .workflow_action_contracts import resolve_workflow_action_target
 from .engine import (
     WorkflowDefinition,
     WorkflowStateSpec,
@@ -191,6 +192,21 @@ WORKFLOW_DESCRIPTION_SOURCE_DEFINITION = "definition.purpose"
 WORKFLOW_BACKGROUND_LAUNCH_POLICY_SOURCE_NONE = "none"
 WORKFLOW_BACKGROUND_LAUNCH_POLICY_SCHEMA_VERSION = (
     "workflow_background_launch_policy.v1"
+)
+WORKFLOW_PUBLICATION_LIFECYCLE_SOURCE_NONE = "none"
+WORKFLOW_PUBLICATION_LIFECYCLE_SCHEMA_VERSION = (
+    "workflow_publication_lifecycle.v1"
+)
+WORKFLOW_PUBLICATION_LIFECYCLE_CONCEPT_DATA_KEY = "workflow_publication_lifecycle"
+WORKFLOW_PUBLICATION_LIFECYCLE_TEXT_PREDICATE_PRECEDENCE: Tuple[
+    Tuple[str, ...], ...
+] = (
+    (
+        "#V#hasWorkflowLifecycleJson",
+        "hasWorkflowLifecycleJson",
+        "#V#has_workflow_lifecycle_json",
+        "has_workflow_lifecycle_json",
+    ),
 )
 WORKFLOW_STEP_RETRY_POLICY_TEXT_PREDICATE_PRECEDENCE: Tuple[Tuple[str, ...], ...] = (
     (
@@ -931,20 +947,10 @@ def _normalise_invoked_action_target(raw_target: str) -> str | None:
 
     if not isinstance(raw_target, str):
         return None
-    target = raw_target.strip()
-    if not target:
-        return None
-
-    if target.startswith("#V#"):
-        token = target[3:].strip()
-        if token.endswith("_tool"):
-            token = token[: -len("_tool")]
-        elif token.endswith(" tool"):
-            token = token[: -len(" tool")]
-        token = token.strip()
-        return token or None
-
-    return target
+    resolved_action_id, _contract_payload, _contract_source = (
+        resolve_workflow_action_target(raw_target)
+    )
+    return resolved_action_id
 
 
 def _normalise_invoked_workflow_target(raw_target: str) -> str | None:
@@ -1262,6 +1268,98 @@ def _parse_json_object_text_value(text_value: Any) -> dict[str, Any] | None:
     return None
 
 
+def _normalise_workflow_publication_lifecycle(
+    value: Any,
+) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+
+    phase = _normalise_non_empty_text(value.get("phase")) or "published"
+    published_raw = value.get("published")
+    if isinstance(published_raw, bool):
+        published = published_raw
+    else:
+        published = phase not in {
+            "draft",
+            "validated",
+            "validation_failed",
+            "draft_failed_completion_gate",
+        }
+
+    payload: dict[str, Any] = {
+        "schema_version": (
+            _normalise_non_empty_text(value.get("schema_version"))
+            or WORKFLOW_PUBLICATION_LIFECYCLE_SCHEMA_VERSION
+        ),
+        "phase": phase,
+        "published": bool(published),
+    }
+    for key in ("validation_passed", "postconditions_verified"):
+        raw_flag = value.get(key)
+        if isinstance(raw_flag, bool):
+            payload[key] = raw_flag
+    optional_test_instance_id = _normalise_non_empty_text(
+        value.get("optional_test_instance_id")
+    )
+    if optional_test_instance_id:
+        payload["optional_test_instance_id"] = optional_test_instance_id
+    last_error = _normalise_non_empty_text(value.get("last_error"))
+    if last_error:
+        payload["last_error"] = last_error
+    return payload
+
+
+def resolve_workflow_publication_lifecycle(
+    workflow_id: str,
+    workflow_doc: Mapping[str, Any] | None = None,
+) -> tuple[dict[str, Any] | None, str]:
+    """Resolve explicit workflow publication lifecycle metadata.
+
+    Draft workflows must remain loadable so the workflow-creation authoring flow
+    can validate them before publication, but discovery/routing should ignore
+    workflows whose lifecycle explicitly says ``published=false``.
+    """
+
+    workflow_id_text = _normalise_non_empty_text(workflow_id)
+    if not workflow_id_text:
+        return None, WORKFLOW_PUBLICATION_LIFECYCLE_SOURCE_NONE
+
+    concept_doc = workflow_doc if isinstance(workflow_doc, Mapping) else None
+    if concept_doc is None:
+        try:
+            raw_doc = ConceptsRepository.find_one(
+                {"concept_id": workflow_id_text},
+                {"concept_id": 1, "concept_data": 1},
+            )
+        except Exception:
+            raw_doc = None
+        if isinstance(raw_doc, Mapping):
+            concept_doc = raw_doc
+
+    concept_data = (
+        concept_doc.get("concept_data") if isinstance(concept_doc, Mapping) else None
+    )
+    if isinstance(concept_data, Mapping):
+        raw_lifecycle = concept_data.get(
+            WORKFLOW_PUBLICATION_LIFECYCLE_CONCEPT_DATA_KEY
+        )
+        if isinstance(raw_lifecycle, Mapping):
+            normalised = _normalise_workflow_publication_lifecycle(raw_lifecycle)
+            if normalised is not None:
+                return normalised, "concept_data"
+
+    lifecycle, lifecycle_source = _resolve_policy_from_text_relations(
+        concept_id=workflow_id_text,
+        predicate_precedence=WORKFLOW_PUBLICATION_LIFECYCLE_TEXT_PREDICATE_PRECEDENCE,
+        normaliser=_normalise_workflow_publication_lifecycle,
+    )
+    if lifecycle is not None:
+        return lifecycle, lifecycle_source or WORKFLOW_PUBLICATION_LIFECYCLE_SOURCE_NONE
+    if isinstance(lifecycle_source, str) and lifecycle_source:
+        return None, lifecycle_source
+    return None, WORKFLOW_PUBLICATION_LIFECYCLE_SOURCE_NONE
+
+
 def _resolve_policy_from_text_relations(
     *,
     concept_id: str,
@@ -1502,7 +1600,7 @@ def build_workflow_process_graph(
 
     workflow_doc = ConceptsRepository.find_one(
         {"concept_id": workflow_id},
-        {"concept_id": 1, "name": 1, "relationships": 1},
+        {"concept_id": 1, "name": 1, "relationships": 1, "concept_data": 1},
     )
     if not workflow_doc:
         return None, ["workflow_concept_not_found"]
@@ -1515,6 +1613,25 @@ def build_workflow_process_graph(
         resolve_workflow_long_horizon_policies(workflow_id)
     )
     warnings.extend(workflow_policy_warnings)
+    publication_lifecycle, publication_lifecycle_source = (
+        resolve_workflow_publication_lifecycle(workflow_id, workflow_doc)
+    )
+    if publication_lifecycle is not None:
+        workflow_runtime_policies["publication_lifecycle"] = publication_lifecycle
+    if (
+        isinstance(publication_lifecycle_source, str)
+        and publication_lifecycle_source
+        and publication_lifecycle_source != WORKFLOW_PUBLICATION_LIFECYCLE_SOURCE_NONE
+    ):
+        if publication_lifecycle is not None:
+            workflow_runtime_policies["publication_lifecycle_source"] = (
+                publication_lifecycle_source
+            )
+        else:
+            warnings.append(
+                "workflow_publication_lifecycle_invalid:"
+                f"{workflow_id}:{publication_lifecycle_source}"
+            )
 
     legacy_aliases: set[str] = set()
 
@@ -1614,7 +1731,10 @@ def build_workflow_process_graph(
             step_rels,
             invokes_action_candidates,
         )
-        invokes_action = _normalise_invoked_action_target(invokes_action_raw or "")
+        invokes_action_target = _normalise_non_empty_text(invokes_action_raw)
+        invokes_action, action_contract_payload, action_contract_source = (
+            resolve_workflow_action_target(str(invokes_action_raw or ""))
+        )
         _record_legacy_alias_use(
             legacy_aliases=legacy_aliases,
             canonical_predicate=WORKFLOW_GRAPH_PREDICATE_ALIASES["invokesAction"][0],
@@ -1885,6 +2005,7 @@ def build_workflow_process_graph(
                 "step_id": step_id,
                 "name": doc.get("name"),
                 "invokes_action": invokes_action,
+                "invokes_action_target": invokes_action_target,
                 "invokes_workflow": invokes_workflow,
                 "preconditions": preconditions,
                 "effects": effects,
@@ -1899,6 +2020,10 @@ def build_workflow_process_graph(
                 "control_flow": control_flow,
             }
         )
+        if action_contract_payload:
+            step_items[-1]["action_contract"] = action_contract_payload
+        if action_contract_source:
+            step_items[-1]["action_contract_source"] = action_contract_source
 
         _edge(step_id, "nextStep", next_step)
         _edge(step_id, "onTrueNextStep", on_true)
@@ -2032,6 +2157,8 @@ def load_workflow_definition_from_vontology(
         subworkflow_input_mappings: list[Dict[str, str]] = []
         subworkflow_output_mappings: list[Dict[str, str]] = []
         subworkflow_failure_mode = ""
+        action_contract: dict[str, Any] | None = None
+        action_contract_source = ""
         if invocation_action_id:
             # Read input mapping from Vontology (hasInputMap relationships).
             doc = step_docs.get(step_id, {})
@@ -2043,6 +2170,11 @@ def load_workflow_definition_from_vontology(
             prompt_contract = (
                 dict(step.get("prompt_contract"))
                 if isinstance(step.get("prompt_contract"), Mapping)
+                else None
+            )
+            action_contract = (
+                dict(step.get("action_contract"))
+                if isinstance(step.get("action_contract"), Mapping)
                 else None
             )
             prompt_resolution_diagnostics = (
@@ -2106,6 +2238,12 @@ def load_workflow_definition_from_vontology(
                 WorkflowActionInvocation(
                     action_id=invocation_action_id,
                     inputs=input_map if input_map else {},
+                    contract_concept_id=(
+                        str(action_contract.get("concept_id") or "").strip()
+                        if isinstance(action_contract, Mapping)
+                        else None
+                    )
+                    or None,
                 )
             )
 
@@ -2352,6 +2490,11 @@ def load_workflow_definition_from_vontology(
             step_metadata["checkpoint_policy"] = checkpoint_policy
         if prompt_contract:
             step_metadata["prompt_contract"] = prompt_contract
+        if action_contract:
+            step_metadata["action_contract"] = action_contract
+        action_contract_source = step.get("action_contract_source")
+        if isinstance(action_contract_source, str) and action_contract_source.strip():
+            step_metadata["action_contract_source"] = action_contract_source.strip()
         if is_subworkflow_action:
             workflow_target = str(invokes_workflow or "").strip()
             workflow_id_context_key = ""
@@ -2547,7 +2690,33 @@ def discover_workflow_ids() -> List[str]:
         except Exception as e:
             logger.warning(f"Error querying workflows by type: {e}")
 
-    return sorted(candidates)
+    if not candidates:
+        return []
+
+    lifecycle_docs: dict[str, dict[str, Any]] = {}
+    try:
+        lifecycle_cursor = ConceptsRepository.find(
+            {"concept_id": {"$in": sorted(candidates)}},
+            {"concept_id": 1, "concept_data": 1},
+        )
+        for doc in lifecycle_cursor:
+            concept_id = doc.get("concept_id")
+            if isinstance(concept_id, str) and concept_id.strip():
+                lifecycle_docs[concept_id.strip()] = dict(doc)
+    except Exception as e:
+        logger.warning(f"Error querying workflow publication lifecycle: {e}")
+
+    discoverable_candidates: set[str] = set()
+    for concept_id in candidates:
+        lifecycle, _source = resolve_workflow_publication_lifecycle(
+            concept_id,
+            lifecycle_docs.get(concept_id),
+        )
+        if isinstance(lifecycle, Mapping) and lifecycle.get("published") is False:
+            continue
+        discoverable_candidates.add(concept_id)
+
+    return sorted(discoverable_candidates)
 
 
 def batch_fetch_workflow_purposes(

--- a/src/backend/workflows/workflow_action_contracts.py
+++ b/src/backend/workflows/workflow_action_contracts.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from typing import Any, Mapping, Sequence
+
+from ..db.repositories.concepts_repository import ConceptsRepository
+from ..services.text_value_service import get_texts_for_concept
+
+WORKFLOW_ACTION_CONTRACT_TYPE_ID = "#V#workflow_action_contract"
+WORKFLOW_ACTION_CONTRACT_SCHEMA_VERSION = "workflow_action_contract.v1"
+WORKFLOW_ACTION_CONTRACT_SPEC_CONCEPT_DATA_KEY = "workflow_action_contract"
+WORKFLOW_ACTION_CONTRACT_TEXT_PREDICATE_PRECEDENCE: tuple[tuple[str, ...], ...] = (
+    (
+        "#V#hasWorkflowActionContractJson",
+        "hasWorkflowActionContractJson",
+        "#V#has_workflow_action_contract_json",
+        "has_workflow_action_contract_json",
+    ),
+)
+
+
+def _normalise_non_empty_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _normalise_optional_object(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    return dict(value)
+
+
+def _normalise_optional_text_list(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return ()
+    values: list[str] = []
+    for item in value:
+        text = _normalise_non_empty_text(item)
+        if text:
+            values.append(text)
+    return tuple(dict.fromkeys(values))
+
+
+def build_workflow_action_contract_payload(
+    *,
+    concept_id: str,
+    action_id: str,
+    description: str | None = None,
+    input_schema: Mapping[str, Any] | None = None,
+    output_schema: Mapping[str, Any] | None = None,
+    side_effects: str | None = None,
+    postconditions: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": WORKFLOW_ACTION_CONTRACT_SCHEMA_VERSION,
+        "concept_id": str(concept_id).strip(),
+        "action_id": str(action_id).strip(),
+    }
+    description_text = _normalise_non_empty_text(description)
+    if description_text:
+        payload["description"] = description_text
+    input_schema_object = _normalise_optional_object(input_schema)
+    if input_schema_object:
+        payload["input_schema"] = input_schema_object
+    output_schema_object = _normalise_optional_object(output_schema)
+    if output_schema_object:
+        payload["output_schema"] = output_schema_object
+    side_effects_text = _normalise_non_empty_text(side_effects)
+    if side_effects_text:
+        payload["side_effects"] = side_effects_text
+    postcondition_values = _normalise_optional_text_list(postconditions or ())
+    if postcondition_values:
+        payload["postconditions"] = list(postcondition_values)
+    return payload
+
+
+def normalise_workflow_action_contract_payload(
+    payload: Mapping[str, Any],
+    *,
+    fallback_concept_id: str | None = None,
+) -> dict[str, Any] | None:
+    if not isinstance(payload, Mapping):
+        return None
+
+    action_id = _normalise_non_empty_text(
+        payload.get("action_id") or payload.get("registry_action_id")
+    )
+    if not action_id:
+        return None
+
+    concept_id = _normalise_non_empty_text(payload.get("concept_id"))
+    if not concept_id:
+        concept_id = _normalise_non_empty_text(fallback_concept_id)
+    if not concept_id:
+        return None
+
+    schema_version = _normalise_non_empty_text(payload.get("schema_version"))
+    if not schema_version:
+        schema_version = WORKFLOW_ACTION_CONTRACT_SCHEMA_VERSION
+
+    normalised = build_workflow_action_contract_payload(
+        concept_id=concept_id,
+        action_id=action_id,
+        description=_normalise_non_empty_text(payload.get("description")),
+        input_schema=_normalise_optional_object(payload.get("input_schema")),
+        output_schema=_normalise_optional_object(payload.get("output_schema")),
+        side_effects=_normalise_non_empty_text(payload.get("side_effects")),
+        postconditions=_normalise_optional_text_list(payload.get("postconditions")),
+    )
+    normalised["schema_version"] = schema_version
+    return normalised
+
+
+def _parse_json_object_text_value(text_value: Any) -> dict[str, Any] | None:
+    text = _normalise_non_empty_text(text_value)
+    if not text:
+        return None
+    try:
+        parsed = json.loads(text)
+    except Exception:
+        return None
+    if not isinstance(parsed, Mapping):
+        return None
+    return dict(parsed)
+
+
+@lru_cache(maxsize=2048)
+def _resolve_action_contract_payload_cached(
+    concept_id: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    concept_id_text = _normalise_non_empty_text(concept_id)
+    if not concept_id_text:
+        return None, None
+
+    try:
+        texts = get_texts_for_concept(concept_id_text)
+    except Exception:
+        texts = []
+
+    if isinstance(texts, list):
+        for predicate_aliases in WORKFLOW_ACTION_CONTRACT_TEXT_PREDICATE_PRECEDENCE:
+            for item in texts:
+                if not isinstance(item, Mapping):
+                    continue
+                predicate = _normalise_non_empty_text(item.get("predicate"))
+                if predicate not in predicate_aliases:
+                    continue
+                parsed = _parse_json_object_text_value(item.get("text"))
+                if parsed is None:
+                    continue
+                normalised = normalise_workflow_action_contract_payload(
+                    parsed,
+                    fallback_concept_id=concept_id_text,
+                )
+                if normalised is not None:
+                    return normalised, f"text_relation:{predicate}"
+
+    concept_doc = ConceptsRepository.find_one(
+        {"concept_id": concept_id_text},
+        {"concept_id": 1, "concept_data": 1},
+    )
+    concept_data = concept_doc.get("concept_data") if isinstance(concept_doc, Mapping) else None
+    if isinstance(concept_data, Mapping):
+        parsed = concept_data.get(WORKFLOW_ACTION_CONTRACT_SPEC_CONCEPT_DATA_KEY)
+        if isinstance(parsed, Mapping):
+            normalised = normalise_workflow_action_contract_payload(
+                parsed,
+                fallback_concept_id=concept_id_text,
+            )
+            if normalised is not None:
+                return normalised, "concept_data"
+
+    return None, None
+
+
+def resolve_workflow_action_contract_payload(
+    concept_id: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    concept_id_text = _normalise_non_empty_text(concept_id)
+    if not concept_id_text or not concept_id_text.startswith("#V#"):
+        return None, None
+    return _resolve_action_contract_payload_cached(concept_id_text)
+
+
+def resolve_workflow_action_target(
+    raw_target: str,
+) -> tuple[str | None, dict[str, Any] | None, str | None]:
+    target = _normalise_non_empty_text(raw_target)
+    if not target:
+        return None, None, None
+
+    if target.startswith("#V#"):
+        contract_payload, contract_source = resolve_workflow_action_contract_payload(
+            target
+        )
+        if contract_payload is not None:
+            resolved_action_id = _normalise_non_empty_text(
+                contract_payload.get("action_id")
+            )
+            if resolved_action_id:
+                return resolved_action_id, contract_payload, contract_source
+
+        token = target[3:].strip()
+        if token.endswith("_tool"):
+            token = token[: -len("_tool")]
+        elif token.endswith(" tool"):
+            token = token[: -len(" tool")]
+        token = token.strip()
+        return token or None, None, contract_source
+
+    return target, None, None
+
+
+def invalidate_workflow_action_contract_resolution_cache() -> None:
+    _resolve_action_contract_payload_cached.cache_clear()
+
+
+__all__ = [
+    "WORKFLOW_ACTION_CONTRACT_SCHEMA_VERSION",
+    "WORKFLOW_ACTION_CONTRACT_SPEC_CONCEPT_DATA_KEY",
+    "WORKFLOW_ACTION_CONTRACT_TEXT_PREDICATE_PRECEDENCE",
+    "WORKFLOW_ACTION_CONTRACT_TYPE_ID",
+    "build_workflow_action_contract_payload",
+    "invalidate_workflow_action_contract_resolution_cache",
+    "normalise_workflow_action_contract_payload",
+    "resolve_workflow_action_contract_payload",
+    "resolve_workflow_action_target",
+]

--- a/src/backend/workflows/workflow_concept_authority_service.py
+++ b/src/backend/workflows/workflow_concept_authority_service.py
@@ -8,6 +8,7 @@ provides one canonical pathway to:
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from dataclasses import dataclass
@@ -18,6 +19,7 @@ from ..db.repositories.concepts_repository import ConceptsRepository
 from ..services import concept_service
 from ..services.concept_service import ConceptNotFoundError
 from ..services.effort_unit_ontology_service import ensure_effort_unit_ontology
+from ..services.text_value_service import upsert_text_for_concept
 from .definitions import (
     CHAT_ASSISTANT_WORKFLOW_ID,
     CHAT_BUTTONIFY_WORKFLOW_ID,
@@ -71,6 +73,38 @@ from .vontology_loader import (
     build_workflow_process_graph,
     load_workflow_definition_from_vontology,
 )
+from .workflow_action_contracts import (
+    WORKFLOW_ACTION_CONTRACT_SPEC_CONCEPT_DATA_KEY,
+    WORKFLOW_ACTION_CONTRACT_TEXT_PREDICATE_PRECEDENCE,
+    WORKFLOW_ACTION_CONTRACT_TYPE_ID,
+    build_workflow_action_contract_payload,
+    invalidate_workflow_action_contract_resolution_cache,
+)
+from .workflow_creation_contracts import (
+    WORKFLOW_CREATION_ACTION_CONCEPT_CREATE_STEP_CONCEPTS,
+    WORKFLOW_CREATION_ACTION_CONCEPT_CREATE_WORKFLOW_TYPE,
+    WORKFLOW_CREATION_ACTION_CONCEPT_DESIGN_STRUCTURE,
+    WORKFLOW_CREATION_ACTION_CONCEPT_ESTABLISH_RELATIONSHIPS,
+    WORKFLOW_CREATION_ACTION_CONCEPT_FINALISE,
+    WORKFLOW_CREATION_ACTION_CONCEPT_IDENTIFY_NEED,
+    WORKFLOW_CREATION_ACTION_CONCEPT_VERIFY_DISCOVERABILITY,
+    WORKFLOW_CREATION_ACTION_CONTRACT_BY_ACTION_ID,
+    WORKFLOW_CREATION_ACTION_CREATE_STEP_CONCEPTS,
+    WORKFLOW_CREATION_ACTION_CREATE_WORKFLOW_TYPE,
+    WORKFLOW_CREATION_ACTION_DESIGN_STRUCTURE,
+    WORKFLOW_CREATION_ACTION_ESTABLISH_RELATIONSHIPS,
+    WORKFLOW_CREATION_ACTION_FINALISE,
+    WORKFLOW_CREATION_ACTION_IDENTIFY_NEED,
+    WORKFLOW_CREATION_ACTION_VERIFY_DISCOVERABILITY,
+    WORKFLOW_CREATION_STEP_CREATE_STEP_CONCEPTS,
+    WORKFLOW_CREATION_STEP_CREATE_WORKFLOW_TYPE,
+    WORKFLOW_CREATION_STEP_DESIGN_STRUCTURE,
+    WORKFLOW_CREATION_STEP_DOCUMENT_IN_JIRA,
+    WORKFLOW_CREATION_STEP_ESTABLISH_RELATIONSHIPS,
+    WORKFLOW_CREATION_STEP_IDENTIFY_NEED,
+    WORKFLOW_CREATION_STEP_VERIFY_DISCOVERABILITY,
+    WORKFLOW_CREATION_WORKFLOW_ID,
+)
 from .engine import (
     WorkflowActionInvocation,
     WorkflowDefinition,
@@ -106,39 +140,6 @@ PARENT_SPECIFICITY_RUMINATION_WORKFLOW_ID = (
     "#V#parent_specificity_rumination_workflow"
 )
 RUMINATION_WORKFLOW_ID = "#V#rumination_workflow"
-WORKFLOW_CREATION_WORKFLOW_ID = "#V#von_workflow_creation_workflow"
-
-WORKFLOW_CREATION_STEP_IDENTIFY_NEED = "#V#workflow_creation_step_identify_need"
-WORKFLOW_CREATION_STEP_DESIGN_STRUCTURE = "#V#workflow_creation_step_design_structure"
-WORKFLOW_CREATION_STEP_CREATE_WORKFLOW_TYPE = (
-    "#V#workflow_creation_step_create_workflow_type"
-)
-WORKFLOW_CREATION_STEP_CREATE_STEP_CONCEPTS = (
-    "#V#workflow_creation_step_create_step_concepts"
-)
-WORKFLOW_CREATION_STEP_ESTABLISH_RELATIONSHIPS = (
-    "#V#workflow_creation_step_establish_relationships"
-)
-WORKFLOW_CREATION_STEP_VERIFY_DISCOVERABILITY = (
-    "#V#workflow_creation_step_verify_discoverability"
-)
-WORKFLOW_CREATION_STEP_DOCUMENT_IN_JIRA = "#V#workflow_creation_step_document_in_jira"
-
-WORKFLOW_CREATION_ACTION_IDENTIFY_NEED = "workflow_creation.identify_need"
-WORKFLOW_CREATION_ACTION_DESIGN_STRUCTURE = "workflow_creation.design_structure"
-WORKFLOW_CREATION_ACTION_CREATE_WORKFLOW_TYPE = (
-    "workflow_creation.create_workflow_type"
-)
-WORKFLOW_CREATION_ACTION_CREATE_STEP_CONCEPTS = (
-    "workflow_creation.create_step_concepts"
-)
-WORKFLOW_CREATION_ACTION_ESTABLISH_RELATIONSHIPS = (
-    "workflow_creation.establish_relationships"
-)
-WORKFLOW_CREATION_ACTION_VERIFY_DISCOVERABILITY = (
-    "workflow_creation.verify_discoverability"
-)
-WORKFLOW_CREATION_ACTION_FINALISE = "workflow_creation.finalise"
 
 
 # Ordered from preferred canonical type to legacy fallbacks.
@@ -252,6 +253,7 @@ class _CanonicalStepPublicationSpec:
     state_id: str
     concept_id: str | None = None
     action_id: str | None = None
+    action_concept_id: str | None = None
     invoked_workflow_id: str | None = None
     static_input_bindings: tuple[tuple[str, str], ...] = ()
     context_input_mappings: tuple[str, ...] = ()
@@ -1387,42 +1389,49 @@ _CANONICAL_WORKFLOW_PUBLICATION_SPECS: Dict[str, _CanonicalWorkflowPublicationSp
                 state_id=WORKFLOW_CREATION_STEP_IDENTIFY_NEED,
                 concept_id=WORKFLOW_CREATION_STEP_IDENTIFY_NEED,
                 action_id=WORKFLOW_CREATION_ACTION_IDENTIFY_NEED,
+                action_concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_IDENTIFY_NEED,
                 next_state=WORKFLOW_CREATION_STEP_DESIGN_STRUCTURE,
             ),
             _CanonicalStepPublicationSpec(
                 state_id=WORKFLOW_CREATION_STEP_DESIGN_STRUCTURE,
                 concept_id=WORKFLOW_CREATION_STEP_DESIGN_STRUCTURE,
                 action_id=WORKFLOW_CREATION_ACTION_DESIGN_STRUCTURE,
+                action_concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_DESIGN_STRUCTURE,
                 next_state=WORKFLOW_CREATION_STEP_CREATE_WORKFLOW_TYPE,
             ),
             _CanonicalStepPublicationSpec(
                 state_id=WORKFLOW_CREATION_STEP_CREATE_WORKFLOW_TYPE,
                 concept_id=WORKFLOW_CREATION_STEP_CREATE_WORKFLOW_TYPE,
                 action_id=WORKFLOW_CREATION_ACTION_CREATE_WORKFLOW_TYPE,
+                action_concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_CREATE_WORKFLOW_TYPE,
                 next_state=WORKFLOW_CREATION_STEP_CREATE_STEP_CONCEPTS,
             ),
             _CanonicalStepPublicationSpec(
                 state_id=WORKFLOW_CREATION_STEP_CREATE_STEP_CONCEPTS,
                 concept_id=WORKFLOW_CREATION_STEP_CREATE_STEP_CONCEPTS,
                 action_id=WORKFLOW_CREATION_ACTION_CREATE_STEP_CONCEPTS,
+                action_concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_CREATE_STEP_CONCEPTS,
                 next_state=WORKFLOW_CREATION_STEP_ESTABLISH_RELATIONSHIPS,
             ),
             _CanonicalStepPublicationSpec(
                 state_id=WORKFLOW_CREATION_STEP_ESTABLISH_RELATIONSHIPS,
                 concept_id=WORKFLOW_CREATION_STEP_ESTABLISH_RELATIONSHIPS,
                 action_id=WORKFLOW_CREATION_ACTION_ESTABLISH_RELATIONSHIPS,
+                action_concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_ESTABLISH_RELATIONSHIPS,
                 next_state=WORKFLOW_CREATION_STEP_VERIFY_DISCOVERABILITY,
             ),
             _CanonicalStepPublicationSpec(
                 state_id=WORKFLOW_CREATION_STEP_VERIFY_DISCOVERABILITY,
                 concept_id=WORKFLOW_CREATION_STEP_VERIFY_DISCOVERABILITY,
                 action_id=WORKFLOW_CREATION_ACTION_VERIFY_DISCOVERABILITY,
+                action_concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_VERIFY_DISCOVERABILITY,
                 next_state=WORKFLOW_CREATION_STEP_DOCUMENT_IN_JIRA,
             ),
             _CanonicalStepPublicationSpec(
                 state_id=WORKFLOW_CREATION_STEP_DOCUMENT_IN_JIRA,
                 concept_id=WORKFLOW_CREATION_STEP_DOCUMENT_IN_JIRA,
                 action_id=WORKFLOW_CREATION_ACTION_FINALISE,
+                action_concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_FINALISE,
             ),
         ),
     ),
@@ -1500,6 +1509,12 @@ def _build_definition_from_publication_spec(
                 WorkflowActionInvocation(
                     action_id=step.action_id,
                     inputs=action_inputs,
+                    contract_concept_id=(
+                        step.action_concept_id.strip()
+                        if isinstance(step.action_concept_id, str)
+                        and step.action_concept_id.strip()
+                        else None
+                    ),
                 ),
             )
             if isinstance(step.action_id, str) and step.action_id.strip()
@@ -2077,6 +2092,130 @@ def _ensure_concept_exists(
     return created_doc, True, None
 
 
+def _ensure_type_concept_exists(
+    *,
+    concept_id: str,
+    name: str,
+    description: str | None = None,
+) -> tuple[Dict[str, Any] | None, bool, str | None]:
+    existing_doc, load_error = _load_concept(concept_id)
+    if load_error:
+        return None, False, f"lookup_failed:{load_error}"
+    if existing_doc is not None:
+        return existing_doc, False, None
+
+    try:
+        concept_service.create_concept(
+            name=name,
+            concept_id=concept_id,
+            description=description,
+            create_as_instance=False,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        error_text = str(exc)
+        if "E11000" in error_text or "duplicate key" in error_text.lower():
+            recovered_doc, recovered_error = _load_concept(concept_id)
+            if recovered_error:
+                return None, False, f"lookup_after_duplicate_failed:{recovered_error}"
+            if recovered_doc is not None:
+                return recovered_doc, False, None
+        return None, False, f"create_failed:{exc}"
+
+    created_doc, created_error = _load_concept(concept_id)
+    if created_error:
+        return None, False, f"lookup_after_create_failed:{created_error}"
+    return created_doc, True, None
+
+
+def _ensure_workflow_action_contract_concept(
+    *,
+    action_id: str,
+) -> tuple[str | None, bool, str | None]:
+    definition = WORKFLOW_CREATION_ACTION_CONTRACT_BY_ACTION_ID.get(
+        str(action_id or "").strip()
+    )
+    if definition is None:
+        return None, False, "action_contract_definition_missing"
+
+    _type_doc, _type_created, type_error = _ensure_type_concept_exists(
+        concept_id=WORKFLOW_ACTION_CONTRACT_TYPE_ID,
+        name="Workflow Action Contract",
+        description=(
+            "Canonical action or tool contract concept used by VWL-authored "
+            "workflow steps."
+        ),
+    )
+    if type_error:
+        return None, False, f"action_contract_type_failed:{type_error}"
+
+    concept_doc, created, create_error = _ensure_concept_exists(
+        concept_id=definition.concept_id,
+        name=definition.name,
+        description=definition.description,
+        parent_concept_ids=[WORKFLOW_ACTION_CONTRACT_TYPE_ID],
+    )
+    if create_error:
+        return None, False, create_error
+
+    payload = build_workflow_action_contract_payload(
+        concept_id=definition.concept_id,
+        action_id=definition.action_id,
+        description=definition.description,
+        input_schema=definition.input_schema,
+        output_schema=definition.output_schema,
+        side_effects=definition.side_effects,
+        postconditions=definition.postconditions,
+    )
+    existing_payload = (
+        ((concept_doc or {}).get("concept_data") or {}).get(
+            WORKFLOW_ACTION_CONTRACT_SPEC_CONCEPT_DATA_KEY
+        )
+        if isinstance(concept_doc, Mapping)
+        else None
+    )
+    if existing_payload != payload:
+        try:
+            concept_service.update_concept(
+                definition.concept_id,
+                {
+                    (
+                        "concept_data."
+                        f"{WORKFLOW_ACTION_CONTRACT_SPEC_CONCEPT_DATA_KEY}"
+                    ): payload
+                },
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            return None, created, f"action_contract_update_failed:{exc}"
+
+    predicate = WORKFLOW_ACTION_CONTRACT_TEXT_PREDICATE_PRECEDENCE[0][0]
+    try:
+        upsert_text_for_concept(
+            subject_concept_id=definition.concept_id,
+            predicate=predicate,
+            text=json.dumps(payload, sort_keys=True),
+            lang="en-NZ",
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        return None, created, f"action_contract_text_upsert_failed:{exc}"
+
+    invalidate_workflow_action_contract_resolution_cache()
+    return definition.concept_id, created, None
+
+
+def ensure_workflow_action_contract_concept(
+    *,
+    action_id: str,
+) -> tuple[str | None, bool, str | None]:
+    """Ensure a canonical workflow action-contract concept exists.
+
+    This is the reusable VWL authoring primitive used both by canonical
+    publication repair and by the workflow-creation workflow when it authors
+    new Vontology workflow graphs that bind to concept-backed actions.
+    """
+
+    return _ensure_workflow_action_contract_concept(action_id=action_id)
+
+
 def _invalidate_runnable_verification_for_workflow(
     workflow_id: str,
     *,
@@ -2314,6 +2453,31 @@ def publish_canonical_chat_workflow_graphs(
                 if step.tool_output_mapping_specs
                 else runtime_details.tool_output_mapping_specs
             )
+            action_concept_id = (
+                step.action_concept_id.strip()
+                if isinstance(step.action_concept_id, str)
+                and step.action_concept_id.strip()
+                else None
+            )
+            if (
+                isinstance(step.action_id, str)
+                and step.action_id.strip()
+                and step.action_id.strip() in WORKFLOW_CREATION_ACTION_CONTRACT_BY_ACTION_ID
+            ):
+                resolved_action_concept_id, created_action_concept, action_concept_error = (
+                    _ensure_workflow_action_contract_concept(
+                        action_id=step.action_id.strip()
+                    )
+                )
+                if action_concept_error:
+                    errors_by_workflow_id[workflow_id] = (
+                        f"action_contract_failed:{step.state_id}:{action_concept_error}"
+                    )
+                    step_update_failed = True
+                    break
+                action_concept_id = action_concept_id or resolved_action_concept_id
+                if created_action_concept and resolved_action_concept_id:
+                    created_action_concept_ids.append(resolved_action_concept_id)
             tool_output_context_mapping_ids = (
                 tuple(
                     item.strip()
@@ -2332,7 +2496,9 @@ def publish_canonical_chat_workflow_graphs(
                 else runtime_details.writes_context_keys
             )
             mapping_target_id = (
-                invoked_workflow_id if invoked_workflow_id else step.action_id
+                invoked_workflow_id
+                if invoked_workflow_id
+                else (action_concept_id or step.action_id)
             )
             if (
                 isinstance(step.action_id, str)
@@ -2343,7 +2509,7 @@ def publish_canonical_chat_workflow_graphs(
                 )
             ):
                 step_relationships[_CANONICAL_GRAPH_PREDICATES["invokesAction"]] = [
-                    step.action_id.strip()
+                    action_concept_id or step.action_id.strip()
                 ]
             if invoked_workflow_id:
                 step_relationships[

--- a/src/backend/workflows/workflow_creation_contracts.py
+++ b/src/backend/workflows/workflow_creation_contracts.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+WORKFLOW_CREATION_WORKFLOW_ID = "#V#von_workflow_creation_workflow"
+
+WORKFLOW_CREATION_STEP_IDENTIFY_NEED = "#V#workflow_creation_step_identify_need"
+WORKFLOW_CREATION_STEP_DESIGN_STRUCTURE = "#V#workflow_creation_step_design_structure"
+WORKFLOW_CREATION_STEP_CREATE_WORKFLOW_TYPE = (
+    "#V#workflow_creation_step_create_workflow_type"
+)
+WORKFLOW_CREATION_STEP_CREATE_STEP_CONCEPTS = (
+    "#V#workflow_creation_step_create_step_concepts"
+)
+WORKFLOW_CREATION_STEP_ESTABLISH_RELATIONSHIPS = (
+    "#V#workflow_creation_step_establish_relationships"
+)
+WORKFLOW_CREATION_STEP_VERIFY_DISCOVERABILITY = (
+    "#V#workflow_creation_step_verify_discoverability"
+)
+WORKFLOW_CREATION_STEP_DOCUMENT_IN_JIRA = "#V#workflow_creation_step_document_in_jira"
+
+WORKFLOW_CREATION_ACTION_IDENTIFY_NEED = "workflow_authoring.identify_need"
+WORKFLOW_CREATION_ACTION_DESIGN_STRUCTURE = "workflow_authoring.design_structure"
+WORKFLOW_CREATION_ACTION_CREATE_WORKFLOW_TYPE = (
+    "workflow_authoring.create_workflow_type"
+)
+WORKFLOW_CREATION_ACTION_CREATE_STEP_CONCEPTS = (
+    "workflow_authoring.create_step_concepts"
+)
+WORKFLOW_CREATION_ACTION_ESTABLISH_RELATIONSHIPS = (
+    "workflow_authoring.establish_relationships"
+)
+WORKFLOW_CREATION_ACTION_VERIFY_DISCOVERABILITY = (
+    "workflow_authoring.verify_discoverability"
+)
+WORKFLOW_CREATION_ACTION_FINALISE = "workflow_authoring.finalise"
+WORKFLOW_CREATION_ACTION_EMIT_MARKER = "workflow_authoring.emit_marker"
+WORKFLOW_CREATION_ACTION_RESOLVE_SCHOLARLY_AUTHORS = (
+    "workflow_authoring.resolve_scholarly_authors"
+)
+WORKFLOW_CREATION_ACTION_RESOLVE_PHD_STUDENT_CANDIDATE = (
+    "workflow_authoring.resolve_phd_student_candidate"
+)
+WORKFLOW_CREATION_ACTION_ASSERT_PHD_STUDENT_RELATIONSHIPS = (
+    "workflow_authoring.assert_phd_student_relationships"
+)
+WORKFLOW_CREATION_ACTION_GROUND_PHD_STUDENT_TEXT = (
+    "workflow_authoring.ground_phd_student_text"
+)
+
+WORKFLOW_CREATION_ACTION_CONCEPT_IDENTIFY_NEED = (
+    "#V#workflow_authoring_action_identify_need"
+)
+WORKFLOW_CREATION_ACTION_CONCEPT_DESIGN_STRUCTURE = (
+    "#V#workflow_authoring_action_design_structure"
+)
+WORKFLOW_CREATION_ACTION_CONCEPT_CREATE_WORKFLOW_TYPE = (
+    "#V#workflow_authoring_action_create_workflow_type"
+)
+WORKFLOW_CREATION_ACTION_CONCEPT_CREATE_STEP_CONCEPTS = (
+    "#V#workflow_authoring_action_create_step_concepts"
+)
+WORKFLOW_CREATION_ACTION_CONCEPT_ESTABLISH_RELATIONSHIPS = (
+    "#V#workflow_authoring_action_establish_relationships"
+)
+WORKFLOW_CREATION_ACTION_CONCEPT_VERIFY_DISCOVERABILITY = (
+    "#V#workflow_authoring_action_verify_discoverability"
+)
+WORKFLOW_CREATION_ACTION_CONCEPT_FINALISE = (
+    "#V#workflow_authoring_action_finalise"
+)
+WORKFLOW_CREATION_ACTION_CONCEPT_EMIT_MARKER = (
+    "#V#workflow_authoring_action_emit_marker"
+)
+WORKFLOW_CREATION_ACTION_CONCEPT_RESOLVE_SCHOLARLY_AUTHORS = (
+    "#V#workflow_authoring_action_resolve_scholarly_authors"
+)
+WORKFLOW_CREATION_ACTION_CONCEPT_RESOLVE_PHD_STUDENT_CANDIDATE = (
+    "#V#workflow_authoring_action_resolve_phd_student_candidate"
+)
+WORKFLOW_CREATION_ACTION_CONCEPT_ASSERT_PHD_STUDENT_RELATIONSHIPS = (
+    "#V#workflow_authoring_action_assert_phd_student_relationships"
+)
+WORKFLOW_CREATION_ACTION_CONCEPT_GROUND_PHD_STUDENT_TEXT = (
+    "#V#workflow_authoring_action_ground_phd_student_text"
+)
+
+
+def _object_schema(*, properties: Mapping[str, Any], required: tuple[str, ...] = ()) -> dict[str, Any]:
+    schema = {
+        "type": "object",
+        "additionalProperties": True,
+        "properties": dict(properties),
+    }
+    if required:
+        schema["required"] = list(required)
+    return schema
+
+
+@dataclass(frozen=True)
+class WorkflowCreationActionContractDefinition:
+    action_id: str
+    concept_id: str
+    name: str
+    description: str
+    input_schema: Mapping[str, Any] | None = None
+    output_schema: Mapping[str, Any] | None = None
+    side_effects: str | None = None
+    postconditions: tuple[str, ...] = ()
+
+
+WORKFLOW_CREATION_ACTION_CONTRACT_DEFINITIONS: tuple[
+    WorkflowCreationActionContractDefinition,
+    ...,
+] = (
+    WorkflowCreationActionContractDefinition(
+        action_id=WORKFLOW_CREATION_ACTION_IDENTIFY_NEED,
+        concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_IDENTIFY_NEED,
+        name="Workflow authoring identify need",
+        description="Normalise a workflow-authoring request into deterministic workflow state.",
+        input_schema=_object_schema(
+            properties={
+                "prompt": {"type": "string"},
+                "workflow_spec": {"type": "object"},
+                "parent_type_id": {"type": "string"},
+            }
+        ),
+        output_schema=_object_schema(
+            properties={
+                "workflow_creation_spec": {"type": "object"},
+                "required_effects_declared": {"type": "boolean"},
+                "parent_concept_id_used": {"type": "string"},
+            },
+            required=("workflow_creation_spec", "required_effects_declared"),
+        ),
+        side_effects="None. Pure normalisation and contract shaping.",
+        postconditions=("workflow_creation_spec_normalised",),
+    ),
+    WorkflowCreationActionContractDefinition(
+        action_id=WORKFLOW_CREATION_ACTION_DESIGN_STRUCTURE,
+        concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_DESIGN_STRUCTURE,
+        name="Workflow authoring design structure",
+        description="Summarise the normalised workflow structure and declared step count.",
+        input_schema=_object_schema(
+            properties={"workflow_creation_spec": {"type": "object"}},
+            required=("workflow_creation_spec",),
+        ),
+        output_schema=_object_schema(
+            properties={
+                "workflow_creation_spec": {"type": "object"},
+                "workflow_creation_step_count": {"type": "integer"},
+            },
+            required=("workflow_creation_spec", "workflow_creation_step_count"),
+        ),
+        side_effects="None. Uses existing workflow state only.",
+        postconditions=("workflow_step_count_available",),
+    ),
+    WorkflowCreationActionContractDefinition(
+        action_id=WORKFLOW_CREATION_ACTION_CREATE_WORKFLOW_TYPE,
+        concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_CREATE_WORKFLOW_TYPE,
+        name="Workflow authoring ensure workflow concept",
+        description="Create or update the draft workflow concept and its parent typing.",
+        input_schema=_object_schema(
+            properties={"workflow_creation_spec": {"type": "object"}},
+            required=("workflow_creation_spec",),
+        ),
+        output_schema=_object_schema(
+            properties={
+                "workflow_concept_id": {"type": "string"},
+                "parent_concept_id_used": {"type": "string"},
+            },
+            required=("workflow_concept_id", "parent_concept_id_used"),
+        ),
+        side_effects="Creates or updates the target workflow concept and draft lifecycle metadata.",
+        postconditions=("workflow_concept_exists", "workflow_lifecycle_is_draft"),
+    ),
+    WorkflowCreationActionContractDefinition(
+        action_id=WORKFLOW_CREATION_ACTION_CREATE_STEP_CONCEPTS,
+        concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_CREATE_STEP_CONCEPTS,
+        name="Workflow authoring ensure step concepts",
+        description="Create or update step concepts for the authored workflow graph.",
+        input_schema=_object_schema(
+            properties={"workflow_creation_spec": {"type": "object"}},
+            required=("workflow_creation_spec",),
+        ),
+        output_schema=_object_schema(
+            properties={"workflow_step_concept_ids": {"type": "array"}},
+            required=("workflow_step_concept_ids",),
+        ),
+        side_effects="Creates or updates workflow-step concepts declared in the authoring spec.",
+        postconditions=("workflow_step_concepts_exist",),
+    ),
+    WorkflowCreationActionContractDefinition(
+        action_id=WORKFLOW_CREATION_ACTION_ESTABLISH_RELATIONSHIPS,
+        concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_ESTABLISH_RELATIONSHIPS,
+        name="Workflow authoring write workflow graph",
+        description="Write structural workflow graph relationships and action bindings.",
+        input_schema=_object_schema(
+            properties={"workflow_creation_spec": {"type": "object"}},
+            required=("workflow_creation_spec",),
+        ),
+        output_schema=_object_schema(
+            properties={
+                "workflow_structure_written": {"type": "boolean"},
+                "workflow_concept_id": {"type": "string"},
+                "workflow_action_contract_concept_ids": {"type": "array"},
+            },
+            required=("workflow_structure_written", "workflow_concept_id"),
+        ),
+        side_effects="Writes hasInitialStep, hasStep, transition edges, input maps, and invokesAction bindings.",
+        postconditions=(
+            "workflow_graph_written_to_draft",
+            "workflow_action_contract_concepts_materialised",
+        ),
+    ),
+    WorkflowCreationActionContractDefinition(
+        action_id=WORKFLOW_CREATION_ACTION_VERIFY_DISCOVERABILITY,
+        concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_VERIFY_DISCOVERABILITY,
+        name="Workflow authoring verify publication",
+        description="Validate authored workflow structure, execute a test instance, and update draft validation state.",
+        input_schema=_object_schema(
+            properties={"workflow_creation_spec": {"type": "object"}},
+            required=("workflow_creation_spec",),
+        ),
+        output_schema=_object_schema(
+            properties={
+                "structural_validation_passed": {"type": "boolean"},
+                "postconditions_verified": {"type": "boolean"},
+                "optional_test_instance_id": {"type": "string"},
+                "workflow_discoverable_before_publish": {"type": "boolean"},
+            },
+            required=("structural_validation_passed", "postconditions_verified"),
+        ),
+        side_effects="Runs structural validation and a bounded test execution against the draft workflow.",
+        postconditions=("draft_validation_state_recorded",),
+    ),
+    WorkflowCreationActionContractDefinition(
+        action_id=WORKFLOW_CREATION_ACTION_FINALISE,
+        concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_FINALISE,
+        name="Workflow authoring completion gate",
+        description="Promote a validated draft workflow to published state only when all authoring gates pass.",
+        input_schema=_object_schema(
+            properties={
+                "workflow_concept_id": {"type": "string"},
+                "required_effects_declared": {"type": "boolean"},
+                "structural_validation_passed": {"type": "boolean"},
+                "postconditions_verified": {"type": "boolean"},
+            }
+        ),
+        output_schema=_object_schema(
+            properties={
+                "workflow_concept_id": {"type": "string"},
+                "workflow_discoverable": {"type": "boolean"},
+                "response_text": {"type": "string"},
+            },
+            required=("workflow_concept_id", "workflow_discoverable", "response_text"),
+        ),
+        side_effects="Updates workflow lifecycle state to published or a failed draft outcome.",
+        postconditions=("workflow_completion_gate_enforced",),
+    ),
+    WorkflowCreationActionContractDefinition(
+        action_id=WORKFLOW_CREATION_ACTION_EMIT_MARKER,
+        concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_EMIT_MARKER,
+        name="Workflow authoring emit marker",
+        description="Emit a deterministic marker value into workflow context for postcondition probes.",
+        input_schema=_object_schema(
+            properties={
+                "marker_key": {"type": "string"},
+                "marker_value": {},
+            }
+        ),
+        output_schema=_object_schema(
+            properties={"marker_output": {"type": "object"}},
+        ),
+        side_effects="None. Updates workflow context only.",
+        postconditions=("marker_context_written",),
+    ),
+    WorkflowCreationActionContractDefinition(
+        action_id=WORKFLOW_CREATION_ACTION_RESOLVE_SCHOLARLY_AUTHORS,
+        concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_RESOLVE_SCHOLARLY_AUTHORS,
+        name="Workflow authoring resolve scholarly authors",
+        description="Resolve scholarly authors against existing person concepts and create/link missing people.",
+        side_effects="Creates or updates person concepts and authorship links when grounded evidence supports them.",
+        postconditions=("scholarly_author_resolution_completed",),
+    ),
+    WorkflowCreationActionContractDefinition(
+        action_id=WORKFLOW_CREATION_ACTION_RESOLVE_PHD_STUDENT_CANDIDATE,
+        concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_RESOLVE_PHD_STUDENT_CANDIDATE,
+        name="Workflow authoring resolve PhD student candidate",
+        description="Resolve a PhD-student candidate concept from provided text/profile data.",
+        side_effects="May create or reuse a candidate concept, with fail-closed ambiguity reporting.",
+        postconditions=("phd_student_candidate_resolved_or_failed_closed",),
+    ),
+    WorkflowCreationActionContractDefinition(
+        action_id=WORKFLOW_CREATION_ACTION_ASSERT_PHD_STUDENT_RELATIONSHIPS,
+        concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_ASSERT_PHD_STUDENT_RELATIONSHIPS,
+        name="Workflow authoring assert PhD student relationships",
+        description="Assert core person, student, and research relationships for the resolved candidate.",
+        side_effects="Creates or updates supported PhD student relationships in Vontology.",
+        postconditions=("phd_student_relationships_asserted",),
+    ),
+    WorkflowCreationActionContractDefinition(
+        action_id=WORKFLOW_CREATION_ACTION_GROUND_PHD_STUDENT_TEXT,
+        concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_GROUND_PHD_STUDENT_TEXT,
+        name="Workflow authoring ground PhD student text",
+        description="Attach source text and provenance to the resolved PhD student concept.",
+        side_effects="Writes grounded text and provenance to the resolved concept.",
+        postconditions=("phd_student_text_grounded",),
+    ),
+)
+
+WORKFLOW_CREATION_ACTION_CONTRACT_BY_ACTION_ID: dict[
+    str,
+    WorkflowCreationActionContractDefinition,
+] = {
+    item.action_id: item for item in WORKFLOW_CREATION_ACTION_CONTRACT_DEFINITIONS
+}
+WORKFLOW_CREATION_ACTION_ID_BY_CONCEPT_ID: dict[str, str] = {
+    item.concept_id: item.action_id for item in WORKFLOW_CREATION_ACTION_CONTRACT_DEFINITIONS
+}
+WORKFLOW_CREATION_ACTION_CONCEPT_ID_BY_ACTION_ID: dict[str, str] = {
+    item.action_id: item.concept_id for item in WORKFLOW_CREATION_ACTION_CONTRACT_DEFINITIONS
+}
+
+
+def workflow_creation_action_contract_definition(
+    action_id: str,
+) -> WorkflowCreationActionContractDefinition | None:
+    return WORKFLOW_CREATION_ACTION_CONTRACT_BY_ACTION_ID.get(str(action_id or "").strip())
+
+
+def workflow_creation_action_contract_concept_id(action_id: str) -> str | None:
+    return WORKFLOW_CREATION_ACTION_CONCEPT_ID_BY_ACTION_ID.get(
+        str(action_id or "").strip()
+    )
+
+
+def workflow_creation_action_target(action_id: str) -> str | None:
+    action_id_text = str(action_id or "").strip()
+    if not action_id_text:
+        return None
+    return (
+        workflow_creation_action_contract_concept_id(action_id_text)
+        or action_id_text
+    )
+
+
+__all__ = [
+    "WORKFLOW_CREATION_ACTION_ASSERT_PHD_STUDENT_RELATIONSHIPS",
+    "WORKFLOW_CREATION_ACTION_CONCEPT_ASSERT_PHD_STUDENT_RELATIONSHIPS",
+    "WORKFLOW_CREATION_ACTION_CONCEPT_CREATE_STEP_CONCEPTS",
+    "WORKFLOW_CREATION_ACTION_CONCEPT_CREATE_WORKFLOW_TYPE",
+    "WORKFLOW_CREATION_ACTION_CONCEPT_DESIGN_STRUCTURE",
+    "WORKFLOW_CREATION_ACTION_CONCEPT_EMIT_MARKER",
+    "WORKFLOW_CREATION_ACTION_CONCEPT_ESTABLISH_RELATIONSHIPS",
+    "WORKFLOW_CREATION_ACTION_CONCEPT_FINALISE",
+    "WORKFLOW_CREATION_ACTION_CONCEPT_GROUND_PHD_STUDENT_TEXT",
+    "WORKFLOW_CREATION_ACTION_CONCEPT_IDENTIFY_NEED",
+    "WORKFLOW_CREATION_ACTION_CONCEPT_RESOLVE_PHD_STUDENT_CANDIDATE",
+    "WORKFLOW_CREATION_ACTION_CONCEPT_RESOLVE_SCHOLARLY_AUTHORS",
+    "WORKFLOW_CREATION_ACTION_CONCEPT_VERIFY_DISCOVERABILITY",
+    "WORKFLOW_CREATION_ACTION_CONTRACT_BY_ACTION_ID",
+    "WORKFLOW_CREATION_ACTION_CONTRACT_DEFINITIONS",
+    "WORKFLOW_CREATION_ACTION_CREATE_STEP_CONCEPTS",
+    "WORKFLOW_CREATION_ACTION_CREATE_WORKFLOW_TYPE",
+    "WORKFLOW_CREATION_ACTION_DESIGN_STRUCTURE",
+    "WORKFLOW_CREATION_ACTION_EMIT_MARKER",
+    "WORKFLOW_CREATION_ACTION_ESTABLISH_RELATIONSHIPS",
+    "WORKFLOW_CREATION_ACTION_FINALISE",
+    "WORKFLOW_CREATION_ACTION_GROUND_PHD_STUDENT_TEXT",
+    "WORKFLOW_CREATION_ACTION_IDENTIFY_NEED",
+    "WORKFLOW_CREATION_ACTION_RESOLVE_PHD_STUDENT_CANDIDATE",
+    "WORKFLOW_CREATION_ACTION_RESOLVE_SCHOLARLY_AUTHORS",
+    "WORKFLOW_CREATION_ACTION_VERIFY_DISCOVERABILITY",
+    "WORKFLOW_CREATION_STEP_CREATE_STEP_CONCEPTS",
+    "WORKFLOW_CREATION_STEP_CREATE_WORKFLOW_TYPE",
+    "WORKFLOW_CREATION_STEP_DESIGN_STRUCTURE",
+    "WORKFLOW_CREATION_STEP_DOCUMENT_IN_JIRA",
+    "WORKFLOW_CREATION_STEP_ESTABLISH_RELATIONSHIPS",
+    "WORKFLOW_CREATION_STEP_IDENTIFY_NEED",
+    "WORKFLOW_CREATION_STEP_VERIFY_DISCOVERABILITY",
+    "WORKFLOW_CREATION_WORKFLOW_ID",
+    "WorkflowCreationActionContractDefinition",
+    "workflow_creation_action_contract_concept_id",
+    "workflow_creation_action_contract_definition",
+    "workflow_creation_action_target",
+]

--- a/tests/backend/test_vontology_loader.py
+++ b/tests/backend/test_vontology_loader.py
@@ -15,6 +15,7 @@ including:
 
 from __future__ import annotations
 
+import json
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch, MagicMock
 
@@ -40,7 +41,16 @@ from src.backend.workflows.vontology_loader import (
     resolve_workflow_description,
     resolve_workflow_long_horizon_policies,
     resolve_workflow_narrative_text,
+    resolve_workflow_publication_lifecycle,
     resolve_workflow_step_runtime_policies,
+)
+from src.backend.workflows.workflow_action_contracts import (
+    build_workflow_action_contract_payload,
+    invalidate_workflow_action_contract_resolution_cache,
+)
+from src.backend.workflows.workflow_creation_contracts import (
+    WORKFLOW_CREATION_ACTION_CONCEPT_EMIT_MARKER,
+    WORKFLOW_CREATION_ACTION_EMIT_MARKER,
 )
 from src.backend.workflows.subworkflow_contracts import (
     WORKFLOW_SUBWORKFLOW_ACTION_ID,
@@ -197,6 +207,117 @@ class TestNormaliseInvokedActionTarget:
             _normalise_invoked_action_target("#V#fetch_concept_tool")
             == "fetch_concept"
         )
+
+    def test_action_contract_concept_resolves_to_registry_action_id(self):
+        payload = build_workflow_action_contract_payload(
+            concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_EMIT_MARKER,
+            action_id=WORKFLOW_CREATION_ACTION_EMIT_MARKER,
+            description="Emit marker contract",
+        )
+
+        with patch(
+            "src.backend.workflows.workflow_action_contracts.get_texts_for_concept",
+            return_value=[
+                {
+                    "predicate": "#V#hasWorkflowActionContractJson",
+                    "text": json.dumps(payload, sort_keys=True),
+                }
+            ],
+        ), patch(
+            "src.backend.workflows.workflow_action_contracts.ConceptsRepository.find_one",
+            return_value=None,
+        ):
+            assert (
+                _normalise_invoked_action_target(
+                    WORKFLOW_CREATION_ACTION_CONCEPT_EMIT_MARKER
+                )
+                == WORKFLOW_CREATION_ACTION_EMIT_MARKER
+            )
+
+
+class TestWorkflowPublicationLifecycleResolution:
+    def test_resolve_publication_lifecycle_prefers_concept_data(self):
+        lifecycle, source = resolve_workflow_publication_lifecycle(
+            "#V#demo_workflow",
+            {
+                "concept_id": "#V#demo_workflow",
+                "concept_data": {
+                    "workflow_publication_lifecycle": {
+                        "phase": "validated",
+                        "published": False,
+                    }
+                },
+            },
+        )
+
+        assert lifecycle is not None
+        assert lifecycle["phase"] == "validated"
+        assert lifecycle["published"] is False
+        assert source == "concept_data"
+
+
+class TestWorkflowActionContractGraphLoading:
+    def test_build_graph_preserves_action_contract_metadata(self):
+        workflow_doc = {
+            "concept_id": "#V#contract_workflow",
+            "relationships": {
+                "#V#hasInitialStep": ["#V#step_a"],
+                "#V#hasStep": ["#V#step_a"],
+            },
+            "concept_data": {},
+        }
+        step_docs = {
+            "#V#step_a": {
+                "concept_id": "#V#step_a",
+                "name": "Step A",
+                "relationships": {
+                    "#V#invokesAction": [WORKFLOW_CREATION_ACTION_CONCEPT_EMIT_MARKER]
+                },
+            }
+        }
+        payload = build_workflow_action_contract_payload(
+            concept_id=WORKFLOW_CREATION_ACTION_CONCEPT_EMIT_MARKER,
+            action_id=WORKFLOW_CREATION_ACTION_EMIT_MARKER,
+            description="Emit marker contract",
+        )
+        invalidate_workflow_action_contract_resolution_cache()
+
+        def _fake_find_one(query, *_args, **_kwargs):
+            if isinstance(query, dict) and query.get("concept_id") == "#V#contract_workflow":
+                return workflow_doc
+            return None
+
+        with patch(
+            "src.backend.workflows.vontology_loader.ConceptsRepository.find_one",
+            side_effect=_fake_find_one,
+        ), patch(
+            "src.backend.workflows.vontology_loader._fetch_concepts_by_id",
+            return_value=step_docs,
+        ), patch(
+            "src.backend.workflows.vontology_loader.resolve_workflow_long_horizon_policies",
+            return_value=({}, []),
+        ), patch(
+            "src.backend.workflows.workflow_action_contracts.get_texts_for_concept",
+            return_value=[
+                {
+                    "predicate": "#V#hasWorkflowActionContractJson",
+                    "text": json.dumps(payload, sort_keys=True),
+                }
+            ],
+        ):
+            graph, warnings = build_workflow_process_graph("#V#contract_workflow")
+
+        assert graph is not None
+        assert warnings == []
+        steps = graph.get("steps") or []
+        assert len(steps) == 1
+        step = steps[0]
+        assert step["invokes_action"] == WORKFLOW_CREATION_ACTION_EMIT_MARKER
+        assert (
+            step["invokes_action_target"]
+            == WORKFLOW_CREATION_ACTION_CONCEPT_EMIT_MARKER
+        )
+        assert step["action_contract"]["action_id"] == WORKFLOW_CREATION_ACTION_EMIT_MARKER
 
 
 class TestFetchConceptProjection:
@@ -2404,6 +2525,13 @@ class TestDiscoverWorkflowIds:
                     for item in query["$or"]
                 ):
                     return [{"concept_id": "#V#wf_canonical"}]
+            if isinstance(query, dict) and isinstance(query.get("concept_id"), dict):
+                return [
+                    {
+                        "concept_id": "#V#wf_canonical",
+                        "concept_data": {},
+                    }
+                ]
             return []
 
         with patch(
@@ -2450,6 +2578,17 @@ class TestDiscoverWorkflowIds:
                             },
                         },
                     ]
+            if isinstance(query, dict) and isinstance(query.get("concept_id"), dict):
+                return [
+                    {
+                        "concept_id": "#V#wf_alpha",
+                        "concept_data": {},
+                    },
+                    {
+                        "concept_id": "#V#wf_zeta",
+                        "concept_data": {},
+                    },
+                ]
             return []
 
         with patch(
@@ -2462,6 +2601,52 @@ class TestDiscoverWorkflowIds:
             workflow_ids = discover_workflow_ids()
 
         assert workflow_ids == ["#V#wf_alpha", "#V#wf_zeta"]
+
+    def test_excludes_explicitly_unpublished_draft_workflows(self):
+        def _fake_find(query, *_args, **_kwargs):
+            if isinstance(query, dict) and isinstance(query.get("$or"), list):
+                if any(
+                    isinstance(item, dict)
+                    and "relationships.#V#hasInitialStep" in item
+                    for item in query["$or"]
+                ):
+                    return [
+                        {"concept_id": "#V#wf_published"},
+                        {"concept_id": "#V#wf_draft"},
+                    ]
+            if isinstance(query, dict) and isinstance(query.get("concept_id"), dict):
+                return [
+                    {
+                        "concept_id": "#V#wf_published",
+                        "concept_data": {
+                            "workflow_publication_lifecycle": {
+                                "phase": "published",
+                                "published": True,
+                            }
+                        },
+                    },
+                    {
+                        "concept_id": "#V#wf_draft",
+                        "concept_data": {
+                            "workflow_publication_lifecycle": {
+                                "phase": "validated",
+                                "published": False,
+                            }
+                        },
+                    },
+                ]
+            return []
+
+        with patch(
+            "src.backend.workflows.vontology_loader.ConceptsRepository.find",
+            side_effect=_fake_find,
+        ), patch(
+            "src.backend.workflows.vontology_loader._discover_workflow_type_family_ids",
+            return_value=set(),
+        ):
+            workflow_ids = discover_workflow_ids()
+
+        assert workflow_ids == ["#V#wf_published"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/test_workflow_creation_workflow.py
+++ b/tests/backend/test_workflow_creation_workflow.py
@@ -26,6 +26,7 @@ from src.backend.workflows.durable.workflow_creation_workflow import (
     WORKFLOW_CONTEXT_KEY_VALIDATED_TYPE_NAME,
     WORKFLOW_CREATION_ACTION_CREATE_STEP_CONCEPTS,
     WORKFLOW_CREATION_ACTION_CREATE_WORKFLOW_TYPE,
+    WORKFLOW_CREATION_ACTION_RESOLVE_SCHOLARLY_AUTHORS,
     WORKFLOW_CREATION_ACTION_DESIGN_STRUCTURE,
     WORKFLOW_CREATION_ACTION_EMIT_MARKER,
     WORKFLOW_CREATION_ACTION_ESTABLISH_RELATIONSHIPS,
@@ -39,7 +40,23 @@ from src.backend.workflows.durable.workflow_creation_workflow import (
     WORKFLOW_CREATION_WORKFLOW_ID,
 )
 from src.backend.workflows.engine import WorkflowExecutor
-from src.backend.workflows.vontology_loader import load_workflow_definition_from_vontology
+from src.backend.workflows.vontology_loader import (
+    build_workflow_process_graph,
+    discover_workflow_ids,
+    load_workflow_definition_from_vontology,
+    resolve_workflow_publication_lifecycle,
+)
+from src.backend.workflows.workflow_creation_contracts import (
+    WORKFLOW_CREATION_ACTION_CONCEPT_CREATE_STEP_CONCEPTS,
+    WORKFLOW_CREATION_ACTION_CONCEPT_CREATE_WORKFLOW_TYPE,
+    WORKFLOW_CREATION_ACTION_CONCEPT_DESIGN_STRUCTURE,
+    WORKFLOW_CREATION_ACTION_CONCEPT_EMIT_MARKER,
+    WORKFLOW_CREATION_ACTION_CONCEPT_ESTABLISH_RELATIONSHIPS,
+    WORKFLOW_CREATION_ACTION_CONCEPT_FINALISE,
+    WORKFLOW_CREATION_ACTION_CONCEPT_IDENTIFY_NEED,
+    WORKFLOW_CREATION_ACTION_CONCEPT_RESOLVE_SCHOLARLY_AUTHORS,
+    WORKFLOW_CREATION_ACTION_CONCEPT_VERIFY_DISCOVERABILITY,
+)
 from src.backend.workflows.workflow_definition_identity_service import (
     collect_workflow_action_ids,
 )
@@ -188,6 +205,15 @@ def test_publish_repair_adds_executable_actions_to_workflow_creation_workflow() 
     assert WORKFLOW_CREATION_WORKFLOW_ID in (
         report.get("published_workflow_ids") or []
     )
+    assert set(report.get("created_action_concept_ids") or []) == {
+        WORKFLOW_CREATION_ACTION_CONCEPT_IDENTIFY_NEED,
+        WORKFLOW_CREATION_ACTION_CONCEPT_DESIGN_STRUCTURE,
+        WORKFLOW_CREATION_ACTION_CONCEPT_CREATE_WORKFLOW_TYPE,
+        WORKFLOW_CREATION_ACTION_CONCEPT_CREATE_STEP_CONCEPTS,
+        WORKFLOW_CREATION_ACTION_CONCEPT_ESTABLISH_RELATIONSHIPS,
+        WORKFLOW_CREATION_ACTION_CONCEPT_VERIFY_DISCOVERABILITY,
+        WORKFLOW_CREATION_ACTION_CONCEPT_FINALISE,
+    }
 
     repaired = load_workflow_definition_from_vontology(WORKFLOW_CREATION_WORKFLOW_ID)
     assert repaired is not None
@@ -199,6 +225,43 @@ def test_publish_repair_adds_executable_actions_to_workflow_creation_workflow() 
     assert WORKFLOW_CREATION_ACTION_ESTABLISH_RELATIONSHIPS in action_ids
     assert WORKFLOW_CREATION_ACTION_VERIFY_DISCOVERABILITY in action_ids
     assert WORKFLOW_CREATION_ACTION_FINALISE in action_ids
+
+    graph, warnings = build_workflow_process_graph(WORKFLOW_CREATION_WORKFLOW_ID)
+    assert graph is not None
+    assert warnings == []
+    step_targets = {
+        str(step.get("step_id")): str(step.get("invokes_action_target") or "")
+        for step in (graph.get("steps") or [])
+        if isinstance(step, dict)
+    }
+    assert (
+        step_targets.get("#V#workflow_creation_step_identify_need")
+        == WORKFLOW_CREATION_ACTION_CONCEPT_IDENTIFY_NEED
+    )
+    assert (
+        step_targets.get("#V#workflow_creation_step_design_structure")
+        == WORKFLOW_CREATION_ACTION_CONCEPT_DESIGN_STRUCTURE
+    )
+    assert (
+        step_targets.get("#V#workflow_creation_step_create_workflow_type")
+        == WORKFLOW_CREATION_ACTION_CONCEPT_CREATE_WORKFLOW_TYPE
+    )
+    assert (
+        step_targets.get("#V#workflow_creation_step_create_step_concepts")
+        == WORKFLOW_CREATION_ACTION_CONCEPT_CREATE_STEP_CONCEPTS
+    )
+    assert (
+        step_targets.get("#V#workflow_creation_step_establish_relationships")
+        == WORKFLOW_CREATION_ACTION_CONCEPT_ESTABLISH_RELATIONSHIPS
+    )
+    assert (
+        step_targets.get("#V#workflow_creation_step_verify_discoverability")
+        == WORKFLOW_CREATION_ACTION_CONCEPT_VERIFY_DISCOVERABILITY
+    )
+    assert (
+        step_targets.get("#V#workflow_creation_step_document_in_jira")
+        == WORKFLOW_CREATION_ACTION_CONCEPT_FINALISE
+    )
 
 
 def test_workflow_creation_actions_individual_then_end_to_end() -> None:
@@ -228,16 +291,15 @@ def test_workflow_creation_actions_individual_then_end_to_end() -> None:
         "workflow_spec": _workflow_spec(target_workflow_id, marker_key, marker_value),
     }
 
-    individual_actions = (
+    pre_publication_actions = (
         WORKFLOW_CREATION_ACTION_IDENTIFY_NEED,
         WORKFLOW_CREATION_ACTION_DESIGN_STRUCTURE,
         WORKFLOW_CREATION_ACTION_CREATE_WORKFLOW_TYPE,
         WORKFLOW_CREATION_ACTION_CREATE_STEP_CONCEPTS,
         WORKFLOW_CREATION_ACTION_ESTABLISH_RELATIONSHIPS,
         WORKFLOW_CREATION_ACTION_VERIFY_DISCOVERABILITY,
-        WORKFLOW_CREATION_ACTION_FINALISE,
     )
-    for action_id in individual_actions:
+    for action_id in pre_publication_actions:
         result = action_registry.execute(
             action_id,
             inputs={},
@@ -251,6 +313,30 @@ def test_workflow_creation_actions_individual_then_end_to_end() -> None:
     assert context.get("required_effects_declared") is True
     assert context.get("structural_validation_passed") is True
     assert context.get("postconditions_verified") is True
+    lifecycle_before_publish, lifecycle_source_before_publish = (
+        resolve_workflow_publication_lifecycle(target_workflow_id)
+    )
+    assert lifecycle_before_publish is not None
+    assert lifecycle_before_publish.get("phase") == "validated"
+    assert lifecycle_before_publish.get("published") is False
+    assert lifecycle_source_before_publish in {"concept_data", "text_relation:#V#hasWorkflowLifecycleJson"}
+    assert target_workflow_id not in set(discover_workflow_ids())
+
+    finalise_result = action_registry.execute(
+        WORKFLOW_CREATION_ACTION_FINALISE,
+        inputs={},
+        context=context,
+        env=env,
+    )
+    assert finalise_result.outcome == "success", finalise_result.error
+    context.update(finalise_result.outputs)
+    lifecycle_after_publish, _lifecycle_source_after_publish = (
+        resolve_workflow_publication_lifecycle(target_workflow_id)
+    )
+    assert lifecycle_after_publish is not None
+    assert lifecycle_after_publish.get("phase") == "published"
+    assert lifecycle_after_publish.get("published") is True
+    assert target_workflow_id in set(discover_workflow_ids())
 
     workflow_creation_definition = load_workflow_definition_from_vontology(
         WORKFLOW_CREATION_WORKFLOW_ID
@@ -484,8 +570,27 @@ def test_text_only_scholarly_request_synthesises_non_blocking_workflow() -> None
     assert generated_definition is not None
     action_ids = set(collect_workflow_action_ids(generated_definition))
     assert "request_user_input" not in action_ids
-    assert "workflow_creation.emit_marker" in action_ids
-    assert "workflow_creation.resolve_scholarly_authors" in action_ids
+    assert WORKFLOW_CREATION_ACTION_EMIT_MARKER in action_ids
+    assert WORKFLOW_CREATION_ACTION_RESOLVE_SCHOLARLY_AUTHORS in action_ids
+
+    generated_graph, generated_warnings = build_workflow_process_graph(
+        "#V#integration_scholarly_paper_representation_workflow"
+    )
+    assert generated_graph is not None
+    assert generated_warnings == []
+    generated_step_targets = {
+        str(step.get("invokes_action")): str(step.get("invokes_action_target") or "")
+        for step in (generated_graph.get("steps") or [])
+        if isinstance(step, dict) and isinstance(step.get("invokes_action"), str)
+    }
+    assert (
+        generated_step_targets.get(WORKFLOW_CREATION_ACTION_EMIT_MARKER)
+        == WORKFLOW_CREATION_ACTION_CONCEPT_EMIT_MARKER
+    )
+    assert (
+        generated_step_targets.get(WORKFLOW_CREATION_ACTION_RESOLVE_SCHOLARLY_AUTHORS)
+        == WORKFLOW_CREATION_ACTION_CONCEPT_RESOLVE_SCHOLARLY_AUTHORS
+    )
 
     _ensure_type("#V#scholarly_article", "Scholarly Article")
     _ensure_type("#V#person", "Person")

--- a/tests/backend/test_workflow_discovery_service.py
+++ b/tests/backend/test_workflow_discovery_service.py
@@ -17,6 +17,7 @@ import pytest
 from src.backend.services.workflow_discovery_service import (
     DEFAULT_MAX_RESULTS,
     DEFAULT_RELEVANCE_THRESHOLD,
+    EXECUTABILITY_DRAFT_NOT_PUBLISHED,
     EXECUTABILITY_EXECUTABLE_NOW,
     EXECUTABILITY_GRAPH_INCOMPLETE,
     EXECUTABILITY_WORKFLOW_STEP_COMPLETELY_VACUOUS,
@@ -661,6 +662,25 @@ def test_classify_workflow_treats_partial_vacuous_steps_as_non_executable() -> N
     assert "count=1" in str(detail)
     assert "total=2" in str(detail)
     assert "first_step=#V#identify" in str(detail)
+
+
+def test_classify_workflow_treats_unpublished_draft_as_non_executable() -> None:
+    _classify_workflow_concept_executability.cache_clear()
+
+    with patch(
+        "src.backend.workflows.vontology_loader.resolve_workflow_publication_lifecycle",
+        return_value=(
+            {"phase": "validated", "published": False},
+            "concept_data",
+        ),
+    ):
+        is_executable, reason, detail = _classify_workflow_concept_executability(
+            "#V#wf_draft"
+        )
+
+    assert is_executable is False
+    assert reason == EXECUTABILITY_DRAFT_NOT_PUBLISHED
+    assert detail == "workflow_not_published:phase=validated:source=concept_data"
 
 
 def test_classify_workflow_treats_completely_vacuous_steps_as_non_executable() -> None:


### PR DESCRIPTION
## Summary
- add first-class workflow action-contract concepts and contract-aware action resolution
- add authored workflow publication lifecycle semantics so drafts stay loadable but undiscoverable until publish
- migrate workflow-creation authoring to concept-backed workflow_authoring actions and canonical graph predicates
- update tests and the VWL manual, and materialise the workflow-creation graph/action contracts in Vontology

## Validation
- pdm run pyright src/backend/workflows/action_registry.py src/backend/workflows/durable/workflow_creation_workflow.py src/backend/workflows/engine.py src/backend/workflows/vontology_loader.py src/backend/workflows/workflow_concept_authority_service.py src/backend/workflows/workflow_action_contracts.py src/backend/workflows/workflow_creation_contracts.py src/backend/services/workflow_discovery_service.py tests/backend/test_workflow_creation_workflow.py tests/backend/test_vontology_loader.py tests/backend/test_workflow_discovery_service.py
- pdm run pytest tests/backend/test_vontology_loader.py tests/backend/test_workflow_concept_authority_service.py tests/backend/test_workflow_creation_workflow.py tests/backend/test_workflow_discovery_service.py -q
- pdm run pytest tests -m lane_backend_workflows -q

## Vontology materialisation
- republished #V#von_workflow_creation_workflow into von_db
- ensured all workflow_authoring action-contract concepts exist
- updated the workflow capability-gap note on #V#von_workflow_creation_workflow