### PR TITLE
feat(JVNAUTOSCI-1452): make VWL step execution LLM-first

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -110,6 +110,12 @@ Canonical graph families include:
 - a raw executable action ID such as `workflow_control.context_set`, or
 - a concept-backed action contract, typically an instance of `#V#workflow_action_contract`.
 
+Semantic rule:
+
+- `invokesAction` is the deterministic execution target for a step; it is not, by itself, evidence that the step is an ordinary reasoning step.
+- Prompt-bearing reasoning steps MUST compile as `llm` execution-mode steps, even when they also expose an underlying `action_id` for traceability or publication.
+- Genuinely deterministic and reliable steps SHOULD remain explicit deterministic or control executions rather than being wrapped in LLM reasoning.
+
 When a workflow step points at an action-contract concept, the concept SHOULD carry the machine-readable contract in both:
 
 - `concept_data.workflow_action_contract`
@@ -137,10 +143,15 @@ A VWL program is a workflow concept graph:
 - Workflow node (concept ID, usually an instance of `#V#ai_workflow` or `#V#durable_workflow`).
 - Step nodes linked via `hasStep`.
 - One initial step via `hasInitialStep` (or inferred first step if absent).
-- Per-step invocation target:
+- Per-step execution contract:
+  - `llm` for ordinary prompt-driven reasoning,
+  - `deterministic` for explicit reliable tool/action execution,
+  - `control` for workflow control primitives,
+  - `subworkflow` for child workflow invocation.
+- Per-step deterministic/subworkflow target:
   - tool/action (`invokesAction` or `workflow_step_invokes_tool`), or
   - subworkflow (`invokesWorkflow`).
-- Optional per-step prompt contract link:
+- Optional per-step prompt contract link, required for KB-authored prompt-bearing LLM steps:
   - `workflow_step_uses_llm_prompt` (legacy aliases accepted for compatibility).
 - Per-step control flow links:
   - `next`
@@ -155,6 +166,12 @@ A VWL program is a workflow concept graph:
   - `reason` stable branch label
   - `condition` transition-condition spec
 - Optional metadata and mapping contracts.
+
+Compilation rule:
+
+- If a step carries a prompt contract and is intended to perform ordinary reasoning, the loader MUST compile it as execution mode `llm`.
+- A prompt-bearing executable step compiled as `deterministic` is semantically contradictory and MUST fail workflow validation unless it is an explicitly documented deterministic exception.
+- `WorkflowActionInvocation` is now the compiled step execution contract surface. In addition to `action_id`/`inputs`, it carries first-class `execution_mode`, `prompt_contract`, `llm_policy`, `validation_policy`, and `subworkflow_id`.
 
 ### 4.1 Workflow Publication Lifecycle
 
@@ -262,7 +279,7 @@ Runtime execution model (`WorkflowExecutor`):
 0. Initialise declared workflow variables from `definition.metadata["variable_declarations"]` — only for keys not already present in the caller-supplied context.
 1. Enter current state.
 2. Run pre-action metadata validation (unless validation mode disables enforcement).
-3. Execute actions in state order.
+3. Execute actions in state order according to their compiled execution mode.
 4. Merge action outputs into context for non-failure outcomes.
 5. Apply tool-output-to-context mappings.
 6. Emit canonical step-result envelope for each executed action.
@@ -290,6 +307,14 @@ Control-signal keys:
 - `last_control_signal` (`none|break|continue|return|error`)
 - `last_control_signal_scope`
 - boolean convenience flags (`last_control_signal_break`, `last_control_signal_continue`, `last_control_signal_return`, `last_control_signal_error`)
+
+Step execution dispatch:
+
+- `llm` steps execute through the generic LLM step executor. Prompt resolution, bounded tool use, structured validation, and tool-policy enforcement happen inside that runtime path.
+- `deterministic` steps execute via the deterministic action registry and MCP fallback bridge.
+- `control` steps are deterministic executions reserved for workflow control and validation primitives.
+- `subworkflow` steps invoke a child workflow and map its outputs back into the parent context.
+- The current canonical tool-calling workflow no longer models plan/validate/execute/backfill as separate VWL states. Ordinary tool-augmented reasoning happens inside a single prompt-driven `llm` step, with critic/completion policy stages remaining explicit.
 
 ### 7.1 Thinking-Card Progress Terminal Precedence (JVNAUTOSCI-1316)
 
@@ -1022,7 +1047,15 @@ Validation and fail-closed behaviour:
 - unavailable tools or agent profiles follow the declared validation policy (`warn` or `fail`),
 - stable merged prompt state is carried in workflow-state metadata as `prompt_contract`,
 - runtime diagnostics are attached to action inputs as `__prompt_resolution_diagnostics`,
+- the compiled action/step contract carries the prompt contract as a first-class field; prompt-bearing steps MUST NOT depend on hidden `__prompt_contract` input passthrough,
 - fail-policy violations reject workflow loading with deterministic `workflow_prompt_contract_invalid` errors.
+
+LLM policy and model-selection notes:
+
+- compiled `llm` steps MAY carry first-class `llm_policy` fields such as `prompt_candidates`, `selected_prompt_id`, `allowed_tools`, `tool_resolution_priority`, `prompt_text_context_key`, `response_contract_text`, and `selection_policy`;
+- `selection_policy` currently distinguishes declared intent such as `fixed`, `adaptive`, and `bandit`, and the runtime records the chosen policy in the step envelope even when the concrete model candidate set is resolved through stage policy and enabled-model settings;
+- runtime model candidate discovery is sourced from `enabled_llms` settings (global, organisation, or user scope as applicable), with `active_llm` retained as the fallback/default model when no enabled-model list is present;
+- multiple enabled LLMs are therefore part of the canonical VWL execution substrate, not a UI-only convenience.
 
 ### 16.6 External SKILL Interoperability
 

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -15747,7 +15747,10 @@ def _settings_get_public(
     """
 
     from src.backend.server.routes.settings_routes import get_all_settings_data
-    from src.backend.services.settings_service import resolve_llm_setting
+    from src.backend.services.settings_service import (
+        resolve_enabled_llm_settings,
+        resolve_llm_setting,
+    )
 
     settings = get_all_settings_data() or {}
     try:
@@ -15757,6 +15760,13 @@ def _settings_get_public(
         )
     except Exception:
         settings["resolved_llm"] = None
+    try:
+        settings["enabled_llms"] = resolve_enabled_llm_settings(
+            user_concept_id=user_concept_id,
+            org_concept_id=organisation_concept_id,
+        )
+    except Exception:
+        settings["enabled_llms"] = []
 
     return {"success": True, "settings": settings}
 
@@ -15788,6 +15798,7 @@ def _chat_introspect(
     )
     from src.backend.services.settings_service import (
         get_setting,
+        resolve_enabled_llm_settings,
         resolve_llm_setting,
     )
 
@@ -15951,6 +15962,14 @@ def _chat_introspect(
     except Exception:
         resolved_llm = None
     resolved_llm = _sanitise_for_introspection(resolved_llm)
+    try:
+        enabled_llms = resolve_enabled_llm_settings(
+            user_concept_id=namespace,
+            org_concept_id=organisation_concept_id,
+        )
+    except Exception:
+        enabled_llms = []
+    enabled_llms = _sanitise_for_introspection(enabled_llms)
 
     configured_openai_api_key_env_var = None
     try:
@@ -16143,6 +16162,7 @@ def _chat_introspect(
         "active_model_name": active_model_name,
         "active_llm": resolved_llm,  # Resolved LLM shape with sensitive keys redacted to booleans.
         "resolved_llm": resolved_llm,
+        "enabled_llms": enabled_llms,
         # Backwards-compatible fields.
         "prompt_concept_ids": list(behaviour_prompt_concept_ids),
         "prompt_concepts": prompt_concepts,
@@ -18748,6 +18768,7 @@ def build_default_catalogue() -> MethodCatalogue:
                     "active_model_name": (str, type(None)),
                     "active_llm": (dict, type(None)),
                     "resolved_llm": (dict, type(None)),
+                    "enabled_llms": list,
                     "prompt_concept_ids": list,
                     "prompt_concepts": list,
                     "prompt_count": int,

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -467,6 +467,7 @@ class InternalMCPChatOrchestrator:
     _BASE_SYSTEM_PROMPT_TYPE_ID = "#V#von_chat_base_system_prompt"
     _CURRENT_BASE_SYSTEM_PROMPT_TYPE_ID = "#V#current_von_base_system_prompt"
     _MISSING_TOOL_CALL_ACTION_ID = "#V#detect_missing_tool_call_action"
+    _MISSING_TOOL_CALL_RETRY_ACTION_ID = "#V#retry_missing_tool_call_action"
     _PREFLIGHT_PREDICATE_TYPE_ID = "#V#conversation_preflight_predicate"
     _PREFLIGHT_TYPE_TYPE_ID = "#V#conversation_preflight_type"
     _PREFLIGHT_CACHE_TTL_SECONDS = 120
@@ -1235,7 +1236,7 @@ class InternalMCPChatOrchestrator:
                 action_id="missing_tool_call.retry",
                 handler=self._action_missing_tool_call_retry,
                 description="Run retry prompt to elicit tool-call JSON.",
-                concept_id=self._MISSING_TOOL_CALL_ACTION_ID,
+                concept_id=self._MISSING_TOOL_CALL_RETRY_ACTION_ID,
             )
         )
         registry.register(
@@ -3698,6 +3699,12 @@ class InternalMCPChatOrchestrator:
         if isinstance(method_catalogue_for_requirements, Mapping):
             data["method_catalogue"] = method_catalogue_for_requirements
 
+        allowed_tool_names = {
+            str(tool_name).strip().lower()
+            for tool_name in (data.get("llm_allowed_tools") or [])
+            if isinstance(tool_name, str) and str(tool_name).strip()
+        }
+
         prompt_for_requirements = data.get("prompt_for_requirements")
         if not isinstance(prompt_for_requirements, str) or not prompt_for_requirements.strip():
             prompt_for_requirements = prompt
@@ -3759,6 +3766,14 @@ class InternalMCPChatOrchestrator:
                         else None
                     )
                 )
+                if allowed_tool_names:
+                    tool_definitions = [
+                        definition
+                        for definition in tool_definitions
+                        if isinstance(getattr(definition, "name", None), str)
+                        and getattr(definition, "name").strip().lower()
+                        in allowed_tool_names
+                    ]
                 llm_response, tool_call_model, _ = self._run_llm_with_tools_fallbacks(
                     stage="tool_call",
                     prompt=prompt,
@@ -4029,6 +4044,11 @@ class InternalMCPChatOrchestrator:
         preflight = self._preflight_tool_calls(
             cast(list, tool_calls),
             method_catalogue,
+            allowed_tool_names=set(
+                str(tool_name).strip().lower()
+                for tool_name in (data.get("llm_allowed_tools") or [])
+                if isinstance(tool_name, str) and str(tool_name).strip()
+            ),
             user_namespace=env.user_namespace,
             selected_gmail_profile=gmail_profile,
             conversation_session_id=conversation_session_id,
@@ -4073,6 +4093,11 @@ class InternalMCPChatOrchestrator:
                 preflight = self._preflight_tool_calls(
                     repaired_calls,
                     method_catalogue,
+                    allowed_tool_names=set(
+                        str(tool_name).strip().lower()
+                        for tool_name in (data.get("llm_allowed_tools") or [])
+                        if isinstance(tool_name, str) and str(tool_name).strip()
+                    ),
                     user_namespace=env.user_namespace,
                     selected_gmail_profile=gmail_profile,
                     conversation_session_id=conversation_session_id,
@@ -4257,6 +4282,11 @@ class InternalMCPChatOrchestrator:
             for item in (data.get("write_policy_requires_confirmation") or [])
             if isinstance(item, str) and str(item).strip()
         }
+        allowed_tool_names = {
+            str(tool_name).strip().lower()
+            for tool_name in (data.get("llm_allowed_tools") or [])
+            if isinstance(tool_name, str) and str(tool_name).strip()
+        }
         turn_id = data.get("turn_id")
 
         for tool_request in tool_calls:
@@ -4267,6 +4297,7 @@ class InternalMCPChatOrchestrator:
 
             if not isinstance(tool_name, str):
                 continue
+            tool_name_key = tool_name.strip().lower()
             if not isinstance(payload, dict):
                 payload = dict(payload) if isinstance(payload, Mapping) else {}
             else:
@@ -4285,9 +4316,46 @@ class InternalMCPChatOrchestrator:
                         "tool_calls_remaining": max(
                             0, max_tool_invocations - iteration_count
                         ),
-                        "call_id": call_id,
-                    }
+                            "call_id": call_id,
+                        }
+                    )
+
+            if allowed_tool_names and tool_name_key not in allowed_tool_names:
+                message = (
+                    f"Tool '{tool_name}' is not allowed for this workflow step."
                 )
+                tool_payload = self._format_tool_result(
+                    tool_name, None, None, "error", message
+                )
+                blocked_record = {
+                    "tool": tool_name,
+                    "payload": dict(payload),
+                    "error": message,
+                    "blocked": True,
+                    "blocked_reason": "tool_not_allowed_for_llm_step",
+                }
+                if call_id:
+                    blocked_record["call_id"] = call_id
+                invocations.append(blocked_record)
+                if callable(emit_progress):
+                    emit_progress(
+                        {
+                            "status": "tool_blocked",
+                            "tool": tool_name,
+                            "batch_size": current_batch_size,
+                            "tool_calls_done": iteration_count,
+                            "tool_calls_cap": int(max_tool_invocations),
+                            "tool_calls_remaining": max(
+                                0, max_tool_invocations - iteration_count
+                            ),
+                            "call_id": call_id,
+                            "error": message,
+                            "blocked_reason": "tool_not_allowed_for_llm_step",
+                        }
+                    )
+                augmented_context.append({"role": "tool", "content": tool_payload})
+                tool_messages.append({"role": "tool", "content": tool_payload})
+                continue
 
             # Write-policy gate.
             tool_category = tool_categories.get(tool_name)
@@ -8363,11 +8431,45 @@ class InternalMCPChatOrchestrator:
         default_model: Optional[str],
         policy_state: _WorkflowModelPolicyState,
         registry_snapshot: Mapping[str, Any] | None = None,
+        user_concept_id: Optional[str] = None,
+        org_concept_id: Optional[str] = None,
     ) -> list[_ModelCandidate]:
         candidates: list[_ModelCandidate] = []
+        enabled_candidates: list[_ModelCandidate] = []
+        try:
+            from src.backend.services.settings_service import (
+                resolve_enabled_llm_settings,
+            )
+
+            enabled_entries = resolve_enabled_llm_settings(
+                user_concept_id=user_concept_id,
+                org_concept_id=org_concept_id,
+            )
+        except Exception:
+            enabled_entries = []
+
+        for entry in enabled_entries:
+            if not isinstance(entry, Mapping):
+                continue
+            provider = str(entry.get("provider") or "").strip().lower() or None
+            model = str(entry.get("model") or "").strip() or None
+            host = str(entry.get("host") or "").strip() or None
+            if not provider or not model:
+                continue
+            raw = f"{provider}:{model}"
+            enabled_candidates.append(
+                _ModelCandidate(
+                    provider=provider,
+                    model=model,
+                    raw=raw,
+                    source="enabled_settings",
+                    host=host,
+                )
+            )
 
         if not policy_state.enabled or not policy_state.policy:
-            return [
+            candidates.extend(enabled_candidates)
+            candidates.append(
                 _ModelCandidate(
                     provider=None,
                     model=default_model,
@@ -8375,65 +8477,61 @@ class InternalMCPChatOrchestrator:
                     source="active_llm",
                     host=None,
                 )
-            ]
-
-        stages = None
-        if policy_state.policy and isinstance(
-            policy_state.policy.get("stages"), Mapping
-        ):
-            stages = policy_state.policy.get("stages")
-
-        stage_config = None
-        if isinstance(stages, Mapping):
-            stage_config = stages.get(stage)
-
-        primary = None
-        fallback = None
-        if isinstance(stage_config, Mapping):
-            primary = stage_config.get("primary")
-            fallback = stage_config.get("fallback")
-
-        primary = self._resolve_registry_model_candidate(primary, registry_snapshot)
-        fallback = (
-            [
-                self._resolve_registry_model_candidate(item, registry_snapshot)
-                for item in fallback
-            ]
-            if isinstance(fallback, list)
-            else fallback
-        )
-
-        primary_candidate = self._parse_policy_model_candidate(primary)
-        if primary_candidate:
-            candidates.append(primary_candidate)
-
-        if isinstance(fallback, list):
-            for item in fallback:
-                fallback_candidate = self._parse_policy_model_candidate(item)
-                if fallback_candidate:
-                    candidates.append(fallback_candidate)
-
-        # Always include active LLM as last resort.
-        candidates.append(
-            _ModelCandidate(
-                provider=None,
-                model=default_model,
-                raw="active_llm",
-                source="active_llm",
-                host=None,
             )
-        )
+        else:
+            stages = None
+            if policy_state.policy and isinstance(
+                policy_state.policy.get("stages"), Mapping
+            ):
+                stages = policy_state.policy.get("stages")
 
-        # De-duplicate by provider+model+host+source
-        seen: set[tuple[str | None, str | None, str | None, str]] = set()
+            stage_config = None
+            if isinstance(stages, Mapping):
+                stage_config = stages.get(stage)
+
+            primary = None
+            fallback = None
+            if isinstance(stage_config, Mapping):
+                primary = stage_config.get("primary")
+                fallback = stage_config.get("fallback")
+
+            primary = self._resolve_registry_model_candidate(primary, registry_snapshot)
+            fallback = (
+                [
+                    self._resolve_registry_model_candidate(item, registry_snapshot)
+                    for item in fallback
+                ]
+                if isinstance(fallback, list)
+                else fallback
+            )
+
+            primary_candidate = self._parse_policy_model_candidate(primary)
+            if primary_candidate:
+                candidates.append(primary_candidate)
+
+            if isinstance(fallback, list):
+                for item in fallback:
+                    fallback_candidate = self._parse_policy_model_candidate(item)
+                    if fallback_candidate:
+                        candidates.append(fallback_candidate)
+
+            candidates.extend(enabled_candidates)
+            candidates.append(
+                _ModelCandidate(
+                    provider=None,
+                    model=default_model,
+                    raw="active_llm",
+                    source="active_llm",
+                    host=None,
+                )
+            )
+
+        # De-duplicate by provider+model+host so the same model does not appear
+        # multiple times merely because it was sourced from settings and active_llm.
+        seen: set[tuple[str | None, str | None, str | None]] = set()
         unique: list[_ModelCandidate] = []
         for candidate in candidates:
-            key = (
-                candidate.provider,
-                candidate.model,
-                candidate.host,
-                candidate.source,
-            )
+            key = (candidate.provider, candidate.model, candidate.host)
             if key in seen:
                 continue
             seen.add(key)
@@ -8970,15 +9068,16 @@ class InternalMCPChatOrchestrator:
         default_model: Optional[str],
         policy_state: _WorkflowModelPolicyState,
         registry_snapshot: Mapping[str, Any] | None = None,
+        user_concept_id: Optional[str] = None,
+        org_concept_id: Optional[str] = None,
     ) -> Optional[str]:
-        if not policy_state.enabled:
-            return default_model
-
         candidates = self._stage_model_candidates(
             stage=stage,
             default_model=default_model,
             policy_state=policy_state,
             registry_snapshot=registry_snapshot,
+            user_concept_id=user_concept_id,
+            org_concept_id=org_concept_id,
         )
 
         for candidate in candidates:
@@ -9342,6 +9441,8 @@ class InternalMCPChatOrchestrator:
             default_model=default_model,
             policy_state=policy_state,
             registry_snapshot=registry_snapshot,
+            user_concept_id=user_concept_id,
+            org_concept_id=org_concept_id,
         )
 
         errors: list[Mapping[str, Any]] = []
@@ -9633,6 +9734,8 @@ class InternalMCPChatOrchestrator:
             default_model=default_model,
             policy_state=policy_state,
             registry_snapshot=registry_snapshot,
+            user_concept_id=user_concept_id,
+            org_concept_id=org_concept_id,
         )
 
         errors: list[Mapping[str, Any]] = []
@@ -10967,6 +11070,7 @@ class InternalMCPChatOrchestrator:
         tool_calls: list[_ToolCallRequest],
         method_catalogue: Mapping[str, Any],
         *,
+        allowed_tool_names: set[str] | None,
         user_namespace: str | None,
         selected_gmail_profile: str | None,
         conversation_session_id: str | None = None,
@@ -10991,10 +11095,15 @@ class InternalMCPChatOrchestrator:
             if not isinstance(tool_name, str):
                 errors.append("Tool name must be a string.")
                 continue
+            tool_name_key = tool_name.strip().lower()
 
             if enforce_availability and tool_name not in available_tools:
                 tool_unavailable.append(tool_name)
                 errors.append(f"Tool '{tool_name}' is not available.")
+                continue
+            if allowed_tool_names and tool_name_key not in allowed_tool_names:
+                tool_unavailable.append(tool_name)
+                errors.append(f"Tool '{tool_name}' is not allowed for this workflow step.")
                 continue
 
             if not isinstance(payload, MutableMapping):
@@ -18642,6 +18751,8 @@ class InternalMCPChatOrchestrator:
                 default_model=model,
                 policy_state=policy_state,
                 registry_snapshot=registry_snapshot,
+                user_concept_id=user_concept_id,
+                org_concept_id=org_concept_id,
             )
 
         def _summarise_tool_messages_for_critic(

--- a/src/backend/server/routes/settings_routes.py
+++ b/src/backend/server/routes/settings_routes.py
@@ -27,8 +27,11 @@ from ...services.settings_service import (
     get_active_ollama_host,
     set_active_ollama_host,
     resolve_llm_setting,
+    resolve_enabled_llm_settings,
     set_user_llm_setting,
     set_org_llm_setting,
+    set_user_enabled_llm_settings,
+    set_org_enabled_llm_settings,
     get_disable_remote_ollama_scan,
     get_show_tool_use_during_thinking,
     set_disable_remote_ollama_scan,
@@ -675,6 +678,10 @@ def get_all_settings():
             user_concept_id=user_concept_id, org_concept_id=org_concept_id
         )
         settings["resolved_llm"] = resolved
+        settings["enabled_llms"] = resolve_enabled_llm_settings(
+            user_concept_id=user_concept_id,
+            org_concept_id=org_concept_id,
+        )
         return jsonify(settings), 200
     except Exception as e:
         current_app.logger.error(f"Error retrieving all settings: {e}", exc_info=True)
@@ -695,6 +702,9 @@ def save_all_settings():
 
     try:
         resolved_llm = None
+        resolved_enabled_llms = None
+        llm_scope = None
+        llm_scope_concept_id = None
         if "disable_write_tool_conservatism" in data:
             if not _is_admin_or_owner_session():
                 return (
@@ -746,6 +756,8 @@ def save_all_settings():
             scope = llm_data.get("scope")  # required: user or organisation
             concept_id = llm_data.get("concept_id")
             if scope in ("user", "organisation") and concept_id and provider and model:
+                llm_scope = scope
+                llm_scope_concept_id = concept_id
                 ok = (
                     set_user_llm_setting(concept_id, provider, model)
                     if scope == "user"
@@ -793,6 +805,53 @@ def save_all_settings():
                     ),
                     400,
                 )
+
+        if "enabled_llms" in data:
+            enabled_entries = data.get("enabled_llms")
+            if not isinstance(enabled_entries, list):
+                return (
+                    jsonify(
+                        {
+                            "status": "error",
+                            "message": "enabled_llms must be a list of provider/model entries.",
+                        }
+                    ),
+                    400,
+                )
+            if not (llm_scope and llm_scope_concept_id):
+                return (
+                    jsonify(
+                        {
+                            "status": "error",
+                            "message": (
+                                "Saving enabled_llms requires active_llm scope and concept_id "
+                                "in the same request."
+                            ),
+                        }
+                    ),
+                    400,
+                )
+            ok = (
+                set_user_enabled_llm_settings(llm_scope_concept_id, enabled_entries)
+                if llm_scope == "user"
+                else set_org_enabled_llm_settings(llm_scope_concept_id, enabled_entries)
+            )
+            if not ok:
+                return (
+                    jsonify(
+                        {
+                            "status": "error",
+                            "message": "Failed to persist enabled_llms.",
+                        }
+                    ),
+                    500,
+                )
+            resolved_enabled_llms = resolve_enabled_llm_settings(
+                user_concept_id=llm_scope_concept_id if llm_scope == "user" else None,
+                org_concept_id=(
+                    llm_scope_concept_id if llm_scope == "organisation" else None
+                ),
+            )
 
         if "openai_api_key_env_var" in data and data["openai_api_key_env_var"]:
             env_var = data["openai_api_key_env_var"]
@@ -873,6 +932,7 @@ def save_all_settings():
                     "status": "success",
                     "message": "Settings updated successfully.",
                     "resolved_llm": resolved_llm,
+                    "enabled_llms": resolved_enabled_llms,
                 }
             ),
             200,

--- a/src/backend/services/model_registry_service.py
+++ b/src/backend/services/model_registry_service.py
@@ -6,7 +6,7 @@ import json
 import logging
 from typing import Any, Mapping, Optional, Sequence
 
-from .settings_service import resolve_llm_setting
+from .settings_service import resolve_enabled_llm_settings, resolve_llm_setting
 
 logger = logging.getLogger(__name__)
 
@@ -406,28 +406,54 @@ def _build_registry_from_settings() -> Mapping[str, Any]:
     except Exception:
         pass
 
-    active = (
-        resolve_llm_setting(
-            user_concept_id=user_concept_id, org_concept_id=org_concept_id
-        )
-        or {}
-    )
-    provider = active.get("provider") if isinstance(active, dict) else None
-    model = active.get("model") if isinstance(active, dict) else None
-    locality = "external"
-    if isinstance(provider, str) and provider.lower() == "ollama":
-        locality = "local"
-
     models = []
-    if isinstance(model, str) and model.strip():
+    enabled = resolve_enabled_llm_settings(
+        user_concept_id=user_concept_id,
+        org_concept_id=org_concept_id,
+    )
+    for entry in enabled:
+        if not isinstance(entry, Mapping):
+            continue
+        provider = entry.get("provider")
+        model = entry.get("model")
+        locality = "external"
+        if isinstance(provider, str) and provider.lower() == "ollama":
+            locality = "local"
+        if not isinstance(model, str) or not model.strip():
+            continue
         models.append(
             {
                 "model_id": model.strip(),
                 "provider": provider or "unknown",
                 "locality": locality,
                 "source": "settings",
+                "scope": entry.get("scope"),
+                "host": entry.get("host"),
             }
         )
+
+    if not models:
+        active = (
+            resolve_llm_setting(
+                user_concept_id=user_concept_id, org_concept_id=org_concept_id
+            )
+            or {}
+        )
+        provider = active.get("provider") if isinstance(active, dict) else None
+        model = active.get("model") if isinstance(active, dict) else None
+        locality = "external"
+        if isinstance(provider, str) and provider.lower() == "ollama":
+            locality = "local"
+        if isinstance(model, str) and model.strip():
+            models.append(
+                {
+                    "model_id": model.strip(),
+                    "provider": provider or "unknown",
+                    "locality": locality,
+                    "source": "settings",
+                    "scope": active.get("scope") if isinstance(active, Mapping) else None,
+                }
+            )
 
     return {
         "source": "settings",

--- a/src/backend/services/settings_service.py
+++ b/src/backend/services/settings_service.py
@@ -1,7 +1,7 @@
 import logging
 import json
 import os
-from typing import Any, Optional, Dict, List
+from typing import Any, Optional, Dict, List, Mapping, Sequence
 from pymongo.results import UpdateResult
 from pymongo.errors import OperationFailure
 from datetime import datetime, timezone
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 # --- Setting Names ---
 # REFACTORING_NOTE: Consolidating to a single setting for the active LLM.
 ACTIVE_LLM_SETTING_NAME = "active_llm"
+ENABLED_LLMS_SETTING_NAME = "enabled_llms"
 OPENAI_ENV_VAR_SETTING_NAME = "openai_api_key_env_var"
 # Setting has been removed as it's a flawed concept for multi-user applications.
 # The user's identity is managed via the session.
@@ -65,6 +66,58 @@ REQUIRE_HUMAN_REVIEW_FOR_HIGH_IMPACT_KB_WRITES_SETTING_NAME = (
 # Prefixes for contextual (scoped) LLM settings (Phase 2 scaffold)
 _ACTIVE_LLM_USER_PREFIX = f"{ACTIVE_LLM_SETTING_NAME}:user:"
 _ACTIVE_LLM_ORG_PREFIX = f"{ACTIVE_LLM_SETTING_NAME}:org:"
+_ENABLED_LLMS_USER_PREFIX = f"{ENABLED_LLMS_SETTING_NAME}:user:"
+_ENABLED_LLMS_ORG_PREFIX = f"{ENABLED_LLMS_SETTING_NAME}:org:"
+
+
+def _normalise_llm_setting_entry(raw: Any) -> dict[str, str] | None:
+    if not isinstance(raw, dict):
+        return None
+    provider = str(raw.get("provider") or "").strip().lower()
+    model = str(raw.get("model") or "").strip()
+    if not provider or not model:
+        return None
+    normalised: dict[str, str] = {
+        "provider": provider,
+        "model": model,
+    }
+    host = str(raw.get("host") or "").strip()
+    if host:
+        normalised["host"] = host
+    return normalised
+
+
+def _dedupe_llm_setting_entries(
+    entries: Sequence[Mapping[str, Any]],
+) -> list[dict[str, str]]:
+    deduped: list[dict[str, str]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for entry in entries:
+        provider = str(entry.get("provider") or "").strip().lower()
+        model = str(entry.get("model") or "").strip()
+        host = str(entry.get("host") or "").strip()
+        if not provider or not model:
+            continue
+        key = (provider, model, host)
+        if key in seen:
+            continue
+        seen.add(key)
+        payload = {"provider": provider, "model": model}
+        if host:
+            payload["host"] = host
+        deduped.append(payload)
+    return deduped
+
+
+def _normalise_llm_setting_list(raw: Any) -> list[dict[str, str]]:
+    if not isinstance(raw, list):
+        return []
+    entries: list[dict[str, str]] = []
+    for item in raw:
+        entry = _normalise_llm_setting_entry(item)
+        if entry is not None:
+            entries.append(entry)
+    return _dedupe_llm_setting_entries(entries)
 
 
 def get_setting(setting_name: str) -> Any:
@@ -356,16 +409,80 @@ def _build_org_llm_setting_name(org_concept_id: str) -> str:
     return f"{_ACTIVE_LLM_ORG_PREFIX}{org_concept_id}"
 
 
+def _build_user_enabled_llm_setting_name(user_concept_id: str) -> str:
+    return f"{_ENABLED_LLMS_USER_PREFIX}{user_concept_id}"
+
+
+def _build_org_enabled_llm_setting_name(org_concept_id: str) -> str:
+    return f"{_ENABLED_LLMS_ORG_PREFIX}{org_concept_id}"
+
+
+def _merge_primary_into_enabled_llms(
+    *,
+    primary: Mapping[str, Any] | None,
+    enabled: Sequence[Mapping[str, Any]] | None,
+) -> list[dict[str, str]]:
+    merged = list(enabled or [])
+    primary_entry = _normalise_llm_setting_entry(primary)
+    if primary_entry is None:
+        return _dedupe_llm_setting_entries(merged)
+    return _dedupe_llm_setting_entries([primary_entry, *merged])
+
+
+def set_user_enabled_llm_settings(
+    user_concept_id: str,
+    entries: Sequence[Mapping[str, Any]],
+) -> bool:
+    if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+        logger.error("set_user_enabled_llm_settings requires a non-empty user_concept_id")
+        return False
+    normalised = _normalise_llm_setting_list(list(entries))
+    return update_setting(_build_user_enabled_llm_setting_name(user_concept_id), normalised)
+
+
+def get_user_enabled_llm_settings(user_concept_id: str) -> list[dict[str, str]]:
+    if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+        return []
+    raw = get_setting(_build_user_enabled_llm_setting_name(user_concept_id))
+    return _normalise_llm_setting_list(raw)
+
+
+def set_org_enabled_llm_settings(
+    org_concept_id: str,
+    entries: Sequence[Mapping[str, Any]],
+) -> bool:
+    if not isinstance(org_concept_id, str) or not org_concept_id.strip():
+        logger.error("set_org_enabled_llm_settings requires a non-empty org_concept_id")
+        return False
+    normalised = _normalise_llm_setting_list(list(entries))
+    return update_setting(_build_org_enabled_llm_setting_name(org_concept_id), normalised)
+
+
+def get_org_enabled_llm_settings(org_concept_id: str) -> list[dict[str, str]]:
+    if not isinstance(org_concept_id, str) or not org_concept_id.strip():
+        return []
+    raw = get_setting(_build_org_enabled_llm_setting_name(org_concept_id))
+    return _normalise_llm_setting_list(raw)
+
+
 def set_user_llm_setting(user_concept_id: str, provider: str, model_name: str) -> bool:
     if not all(
         isinstance(x, str) and x for x in (user_concept_id, provider, model_name)
     ):
         logger.error("set_user_llm_setting requires non-empty string arguments")
         return False
-    return update_setting(
+    ok = update_setting(
         _build_user_llm_setting_name(user_concept_id),
         {"provider": provider, "model": model_name},
     )
+    if not ok:
+        return False
+    merged_enabled = _merge_primary_into_enabled_llms(
+        primary={"provider": provider, "model": model_name},
+        enabled=get_user_enabled_llm_settings(user_concept_id),
+    )
+    set_user_enabled_llm_settings(user_concept_id, merged_enabled)
+    return True
 
 
 def get_user_llm_setting(user_concept_id: str):
@@ -384,10 +501,18 @@ def set_org_llm_setting(org_concept_id: str, provider: str, model_name: str) -> 
     ):
         logger.error("set_org_llm_setting requires non-empty string arguments")
         return False
-    return update_setting(
+    ok = update_setting(
         _build_org_llm_setting_name(org_concept_id),
         {"provider": provider, "model": model_name},
     )
+    if not ok:
+        return False
+    merged_enabled = _merge_primary_into_enabled_llms(
+        primary={"provider": provider, "model": model_name},
+        enabled=get_org_enabled_llm_settings(org_concept_id),
+    )
+    set_org_enabled_llm_settings(org_concept_id, merged_enabled)
+    return True
 
 
 def get_org_llm_setting(org_concept_id: str):
@@ -421,6 +546,51 @@ def resolve_llm_setting(
                 "organisation_concept_id": org_concept_id,
             }
     return None
+
+
+def resolve_enabled_llm_settings(
+    user_concept_id: str | None = None,
+    org_concept_id: str | None = None,
+) -> list[dict[str, str]]:
+    """Resolve ordered enabled LLM candidates with precedence user > organisation.
+
+    The first item is always the effective primary selection for backwards
+    compatibility. Additional items represent scope-local enabled alternatives.
+    """
+
+    if user_concept_id:
+        user_primary = get_user_llm_setting(user_concept_id)
+        user_enabled = _merge_primary_into_enabled_llms(
+            primary=user_primary,
+            enabled=get_user_enabled_llm_settings(user_concept_id),
+        )
+        if user_enabled:
+            return [
+                {
+                    **entry,
+                    "scope": "user",
+                    "user_concept_id": user_concept_id,
+                }
+                for entry in user_enabled
+            ]
+
+    if org_concept_id:
+        org_primary = get_org_llm_setting(org_concept_id)
+        org_enabled = _merge_primary_into_enabled_llms(
+            primary=org_primary,
+            enabled=get_org_enabled_llm_settings(org_concept_id),
+        )
+        if org_enabled:
+            return [
+                {
+                    **entry,
+                    "scope": "organisation",
+                    "organisation_concept_id": org_concept_id,
+                }
+                for entry in org_enabled
+            ]
+
+    return []
 
 
 # --- Deprecated compatibility layer (tests still reference these) ---

--- a/src/backend/workflows/action_registry.py
+++ b/src/backend/workflows/action_registry.py
@@ -67,6 +67,10 @@ class WorkflowActionRequest:
     trace: Any | None = None
     action_target_id: str | None = None
     contract_concept_id: str | None = None
+    execution_mode: str | None = None
+    prompt_contract: Mapping[str, Any] | None = None
+    llm_policy: Mapping[str, Any] | None = None
+    validation_policy: Mapping[str, Any] | None = None
 
 
 @dataclass

--- a/src/backend/workflows/conversation_turn_stage_model.py
+++ b/src/backend/workflows/conversation_turn_stage_model.py
@@ -175,33 +175,12 @@ _FORMAL_STAGE_PROFILE_BY_ACTION_ID: dict[str, _DerivedFormalStageProfile] = {
         boundary_type="policy",
         runtime_aliases=("write_policy",),
     ),
-    "tool_calling.plan": _DerivedFormalStageProfile(
-        stage_id="tool_plan",
-        stage_label="Plan tool calls",
-        order=50,
-        boundary_type="execution",
-        runtime_aliases=("tool_plan", "plan"),
-    ),
-    "tool_calling.validate": _DerivedFormalStageProfile(
-        stage_id="tool_validate",
-        stage_label="Validate tool calls",
-        order=60,
-        boundary_type="execution",
-        runtime_aliases=("validate",),
-    ),
-    "tool_calling.execute": _DerivedFormalStageProfile(
+    "tool_calling.respond": _DerivedFormalStageProfile(
         stage_id="tool_execute",
-        stage_label="Execute tool calls",
+        stage_label="Prompt-driven tool execution",
         order=70,
         boundary_type="execution",
-        runtime_aliases=("tool_execute", "execute"),
-    ),
-    "tool_calling.backfill": _DerivedFormalStageProfile(
-        stage_id="screen_backfill",
-        stage_label="Summarise/backfill response",
-        order=80,
-        boundary_type="execution",
-        runtime_aliases=("screen_backfill", "backfill"),
+        runtime_aliases=("tool_execute", "respond"),
     ),
     "turn_execution.critic": _DerivedFormalStageProfile(
         stage_id="postcondition_critic",

--- a/src/backend/workflows/definitions.py
+++ b/src/backend/workflows/definitions.py
@@ -9,6 +9,7 @@ from .engine import (
     WorkflowDefinition,
     WorkflowStateSpec,
     WorkflowTransitionSpec,
+    WORKFLOW_STEP_EXECUTION_MODE_LLM,
 )
 from .workflow_registry import WorkflowRegistration, WorkflowRegistry
 
@@ -134,7 +135,33 @@ def build_chat_narration_workflow() -> WorkflowDefinition:
 
     render = WorkflowStateSpec(
         state_id="render_narration",
-        actions=(WorkflowActionInvocation(action_id="narration.render"),),
+        actions=(
+            WorkflowActionInvocation(
+                action_id="narration.render",
+                execution_mode=WORKFLOW_STEP_EXECUTION_MODE_LLM,
+                llm_policy={
+                    "tool_mode": "none",
+                    "policy_stage": "narration",
+                    "prompt_text_context_key": "narration_prompt_text",
+                    "response_contract_text": (
+                        "Return ONLY one block: <spoken>...</spoken>. "
+                        "Do not include <screen>. Do not include code blocks. "
+                        "Use New Zealand English spelling."
+                    ),
+                    "context_fields": [
+                        {"label": "User message", "context_key": "user_prompt"},
+                        {
+                            "label": (
+                                "On-screen content (do not read verbatim if long; "
+                                "summarise)"
+                            ),
+                            "context_key": "screen_text",
+                        },
+                    ],
+                },
+                validation_policy={"output_format": "narration_spoken_xml"},
+            ),
+        ),
         transitions=(
             _transition_if_flag_set(
                 "narration_rendered",
@@ -218,7 +245,25 @@ def build_chat_buttonify_workflow() -> WorkflowDefinition:
 
     extract = WorkflowStateSpec(
         state_id="extract_options",
-        actions=(WorkflowActionInvocation(action_id="buttonify.extract_options"),),
+        actions=(
+            WorkflowActionInvocation(
+                action_id="buttonify.extract_options",
+                execution_mode=WORKFLOW_STEP_EXECUTION_MODE_LLM,
+                llm_policy={
+                    "tool_mode": "none",
+                    "policy_stage": "buttonify",
+                    "prompt_text_context_key": "buttonify_prompt_text",
+                    "context_fields": [
+                        {"label": "User message", "context_key": "user_prompt"},
+                        {
+                            "label": "Assistant response",
+                            "context_key": "screen_text",
+                        },
+                    ],
+                },
+                validation_policy={"output_format": "buttonify_options_json"},
+            ),
+        ),
         transitions=(
             WorkflowTransitionSpec(
                 to_state="completed",
@@ -413,114 +458,40 @@ def build_concept_suggestion_preflight_workflow() -> WorkflowDefinition:
 
 
 def build_tool_calling_workflow() -> WorkflowDefinition:
-    """Workflow wrapping the standard tool-calling pipeline.
+    """Workflow wrapping the standard prompt-driven tool-calling pipeline.
 
     Flow::
 
-        plan  ──[tool_calls_present]──▸  validate
-          │                                  │
-          └──[direct_response]──▸ completed   ├──[tool_calls_present]──▸ execute ──▸ backfill
-                                              │                                       │
-                                              └──[no tools]──▸ completed               ├──[more_tool_calls]──▸ validate  (loop)
-                                                                                       └──[done]──▸ completed
+        respond ──▸ postcondition_critic ──▸ completion_gate
+             ▲                                      │
+             └──────[completion_gate_repeat_iteration]──────┘
 
-    This expresses the same logic currently inline in ``orchestrator.run()``
-    (LLM call → missing-tool-call recovery → preflight → tool execution →
-    screen backfill) as a declarative workflow so that it can participate in
-    workflow selection alongside narration, todo refresh, etc.
-
-    The execute handler processes **one batch** of tool calls (respecting
-    ``tool_batch_cap``).  Overflow batches and chained tool calls from the
-    backfill LLM response re-enter via ``validate``.
-
-    See JVNAUTOSCI-922 Phase 2.
+    The bounded tool-use loop now lives inside the generic LLM step executor,
+    so the workflow itself only models the ordinary reasoning step plus the
+    postcondition and completion policy stages.
     """
-    plan = WorkflowStateSpec(
-        state_id="plan",
+    respond = WorkflowStateSpec(
+        state_id="respond",
         actions=(
             WorkflowActionInvocation(
-                action_id="tool_calling.plan",
-                description="Generate tool calls via LLM (structured or legacy).",
+                action_id="tool_calling.respond",
+                description=(
+                    "Run bounded prompt-driven response generation with optional "
+                    "tool use via the generic LLM step executor."
+                ),
+                execution_mode=WORKFLOW_STEP_EXECUTION_MODE_LLM,
+                llm_policy={
+                    "tool_mode": "allowed",
+                    "policy_stage": "tool_call",
+                    "prompt_text_context_key": "prompt",
+                },
             ),
         ),
         transitions=(
-            _transition_if_flag_set(
-                "tool_calls_present",
-                to_state="validate",
-                reason="tool_calls_found",
-            ),
-            # No tool calls found (or error with pre-built result) still flows
-            # through turn-execution critic + completion gate.
             WorkflowTransitionSpec(
                 to_state="postcondition_critic",
                 condition=lambda ctx: True,
-                reason="direct_response",
-            ),
-        ),
-    )
-
-    validate = WorkflowStateSpec(
-        state_id="validate",
-        actions=(
-            WorkflowActionInvocation(
-                action_id="tool_calling.validate",
-                description="Preflight validation, coercion, and repair of tool calls.",
-            ),
-        ),
-        transitions=(
-            _transition_if_flag_set(
-                "tool_calls_validated",
-                to_state="execute",
-                reason="validation_passed",
-            ),
-            # Validation errors must still pass through critic + completion gate
-            # so unresolved required effects cannot be marked as safely complete.
-            WorkflowTransitionSpec(
-                to_state="postcondition_critic",
-                condition=lambda ctx: True,
-                reason="validation_error",
-            ),
-        ),
-    )
-
-    execute = WorkflowStateSpec(
-        state_id="execute",
-        actions=(
-            WorkflowActionInvocation(
-                action_id="tool_calling.execute",
-                description="Execute tool-call batch against MCP gateway.",
-            ),
-        ),
-        transitions=(
-            # Execute always transitions to backfill (even on errors, the
-            # backfill summariser can explain what went wrong).
-            WorkflowTransitionSpec(
-                to_state="backfill",
-                condition=lambda ctx: True,
-                reason="batch_executed",
-            ),
-        ),
-    )
-
-    backfill = WorkflowStateSpec(
-        state_id="backfill",
-        actions=(
-            WorkflowActionInvocation(
-                action_id="tool_calling.backfill",
-                description="Summariser LLM call; detect chained tool calls.",
-            ),
-        ),
-        transitions=(
-            # Chained tool calls from the summariser response
-            _transition_if_flag_set(
-                "more_tool_calls",
-                to_state="validate",
-                reason="chained_tool_calls",
-            ),
-            WorkflowTransitionSpec(
-                to_state="postcondition_critic",
-                condition=lambda ctx: True,
-                reason="backfill_done",
+                reason="response_ready",
             ),
         ),
     )
@@ -553,7 +524,7 @@ def build_tool_calling_workflow() -> WorkflowDefinition:
         transitions=(
             _transition_if_flag_set(
                 "completion_gate_repeat_iteration",
-                to_state="plan",
+                to_state="respond",
                 reason="completion_gate_repeat_iteration",
             ),
             _transition_if_flag_set(
@@ -574,12 +545,9 @@ def build_tool_calling_workflow() -> WorkflowDefinition:
 
     return WorkflowDefinition(
         workflow_id=TOOL_CALLING_WORKFLOW_ID,
-        initial_state="plan",
+        initial_state="respond",
         states={
-            "plan": plan,
-            "validate": validate,
-            "execute": execute,
-            "backfill": backfill,
+            "respond": respond,
             "postcondition_critic": postcondition_critic,
             "completion_gate": completion_gate,
             "completed": completed,
@@ -587,8 +555,9 @@ def build_tool_calling_workflow() -> WorkflowDefinition:
         },
         termination_states=("completed", "failed"),
         purpose=(
-            "Standard tool-calling pipeline: plan → validate → execute → backfill "
-            "→ postcondition critic → completion gate."
+            "Standard tool-calling pipeline implemented as a generic prompt-driven "
+            "LLM step with bounded tool use, followed by postcondition critic and "
+            "completion gate."
         ),
     )
 

--- a/src/backend/workflows/durable/durable_executor.py
+++ b/src/backend/workflows/durable/durable_executor.py
@@ -14,6 +14,7 @@ from typing import Any, Mapping
 from ..engine import (
     WorkflowDefinition,
     apply_tool_output_context_mappings,
+    execute_workflow_step_invocation,
     evaluate_transition_condition_spec,
     resolve_action_inputs_from_context,
     state_has_on_break_transition,
@@ -173,6 +174,7 @@ class DurableWorkflowExecutor:
             get_active_model_name,
             get_llm_client,
         )
+        from .registry_factory import _get_or_build_durable_mcp_gateway
 
         llm_client = get_llm_client(
             user_concept_id=instance.user_id,
@@ -180,6 +182,7 @@ class DurableWorkflowExecutor:
         )
         environment = WorkflowEnvironment(
             llm_client=llm_client,
+            gateway=_get_or_build_durable_mcp_gateway(),
             model=get_active_model_name(),
             user_namespace=instance.namespace,
         )
@@ -379,20 +382,22 @@ class DurableWorkflowExecutor:
             context_before_actions = dict(context)
             for action in state_spec.actions:
                 context_before_action = dict(context)
+                action_target_id = action.target_id
                 resolved_inputs = resolve_action_inputs_from_context(
                     action_inputs=action.inputs,
                     context=context,
                 )
-                result = self._registry.execute(
-                    action.action_id,
-                    inputs=resolved_inputs,
+                result = execute_workflow_step_invocation(
+                    registry=self._registry,
+                    action=action,
+                    resolved_inputs=resolved_inputs,
                     context=context,
                     env=environment,
                     trace=trace,
                 )
 
                 trace.record_action(
-                    action_id=action.action_id,
+                    action_id=action_target_id,
                     inputs=resolved_inputs,
                     outputs=result.outputs,
                     status=result.status,
@@ -412,13 +417,13 @@ class DurableWorkflowExecutor:
                         metadata=state_spec.metadata,
                         action_outputs=result.outputs,
                         state_id=current_state,
-                        action_id=action.action_id,
+                        action_id=action_target_id,
                     )
 
                 step_envelope = build_step_result_envelope(
                     workflow_id=definition.workflow_id,
                     state_id=current_state,
-                    action_id=action.action_id,
+                    action_id=action_target_id,
                     action_status=result.status,
                     action_outcome=action_outcome,
                     action_error=result.error,
@@ -435,7 +440,7 @@ class DurableWorkflowExecutor:
                         "status": "control_signal",
                         "workflow_id": definition.workflow_id,
                         "state_id": current_state,
-                        "action_id": action.action_id,
+                        "action_id": action_target_id,
                         "control_signal": step_envelope["control_signal"],
                         "control_signal_scope": step_envelope.get(
                             "control_signal_scope"
@@ -462,7 +467,7 @@ class DurableWorkflowExecutor:
                         final_state=current_state,
                         error=error,
                         checkpoint=True,
-                        error_step=action.action_id,
+                        error_step=action_target_id,
                     )
                 if action_outcome == WORKFLOW_ACTION_OUTCOME_UNKNOWN:
                     if state_has_unknown_route:
@@ -476,7 +481,7 @@ class DurableWorkflowExecutor:
                         final_state=current_state,
                         error=error,
                         checkpoint=True,
-                        error_step=action.action_id,
+                        error_step=action_target_id,
                     )
 
                 control_signal = get_last_control_signal(context)

--- a/src/backend/workflows/durable/planning_workflow.py
+++ b/src/backend/workflows/durable/planning_workflow.py
@@ -31,6 +31,7 @@ from ..engine import (
     WorkflowDefinition,
     WorkflowStateSpec,
     WorkflowTransitionSpec,
+    WORKFLOW_STEP_EXECUTION_MODE_LLM,
 )
 from ..workflow_registry import WorkflowRegistration
 
@@ -360,6 +361,7 @@ def _handle_assess_context(request: WorkflowActionRequest) -> WorkflowActionResu
             "planning_context": planning_context,
             "planning_inventory": planning_inventory,
             "planning_diagnostics": planning_diagnostics,
+            "planning_prompt_text": _resolve_planning_prompt(context),
             "planning_trace": trace,
         }
     )
@@ -679,6 +681,28 @@ def build_planning_workflow() -> WorkflowDefinition:
             WorkflowActionInvocation(
                 action_id="planning.infer_plan",
                 description="Infer forward actions from context and inventory.",
+                execution_mode=WORKFLOW_STEP_EXECUTION_MODE_LLM,
+                llm_policy={
+                    "tool_mode": "none",
+                    "policy_stage": "planning",
+                    "prompt_text_context_key": "planning_prompt_text",
+                    "response_contract_text": "Return JSON only.",
+                    "context_fields": [
+                        {
+                            "label": "Planning input (JSON)",
+                            "context_key": "planning_context",
+                        },
+                        {
+                            "label": "Available execution inventory (JSON)",
+                            "context_key": "planning_inventory",
+                        },
+                        {
+                            "label": "Context summary",
+                            "context_key": "context_summary",
+                        },
+                    ],
+                },
+                validation_policy={"output_format": "planning_plan_json"},
             ),
         ),
         transitions=(

--- a/src/backend/workflows/engine.py
+++ b/src/backend/workflows/engine.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
+from typing import Any, Callable, Dict, List, Mapping, MutableMapping, Optional, Sequence
 
 from .action_registry import (
     ActionRegistry,
@@ -80,6 +80,25 @@ WORKFLOW_IDEMPOTENCY_RECORDS_KEY = "workflow_idempotency_records"
 WORKFLOW_RETRY_POLICY_SCHEMA_VERSION = "workflow_step_retry_policy.v1"
 WORKFLOW_APPROVAL_GATE_SCHEMA_VERSION = "workflow_step_approval_gate.v1"
 WORKFLOW_IDEMPOTENCY_POLICY_SCHEMA_VERSION = "workflow_step_idempotency_policy.v1"
+WORKFLOW_STEP_EXECUTION_MODE_LLM = "llm"
+WORKFLOW_STEP_EXECUTION_MODE_DETERMINISTIC = "deterministic"
+WORKFLOW_STEP_EXECUTION_MODE_SUBWORKFLOW = "subworkflow"
+WORKFLOW_STEP_EXECUTION_MODE_CONTROL = "control"
+WORKFLOW_STEP_EXECUTION_MODES = frozenset(
+    {
+        WORKFLOW_STEP_EXECUTION_MODE_LLM,
+        WORKFLOW_STEP_EXECUTION_MODE_DETERMINISTIC,
+        WORKFLOW_STEP_EXECUTION_MODE_SUBWORKFLOW,
+        WORKFLOW_STEP_EXECUTION_MODE_CONTROL,
+    }
+)
+
+
+def normalise_workflow_step_execution_mode(value: Any) -> str:
+    raw = str(value or "").strip().lower()
+    if raw in WORKFLOW_STEP_EXECUTION_MODES:
+        return raw
+    return WORKFLOW_STEP_EXECUTION_MODE_DETERMINISTIC
 
 
 def _extract_context_binding_symbol(value: Any) -> str | None:
@@ -422,6 +441,55 @@ def _apply_action_result_context(
         return_payload=return_payload,
     )
     return action_outcome
+
+
+def execute_workflow_step_invocation(
+    *,
+    registry: ActionRegistry,
+    action: WorkflowActionInvocation,
+    resolved_inputs: MutableMapping[str, Any],
+    context: Dict[str, Any],
+    env: WorkflowEnvironment,
+    trace: WorkflowExecutionTrace | None = None,
+) -> WorkflowActionResult:
+    if action.execution_mode == WORKFLOW_STEP_EXECUTION_MODE_LLM:
+        from .llm_step_executor import execute_llm_step
+        from .action_registry import WorkflowActionRequest
+
+        request = WorkflowActionRequest(
+            action_id=action.target_id,
+            inputs=resolved_inputs,
+            environment=env,
+            data=context,
+            trace=trace,
+            action_target_id=action.target_id,
+            contract_concept_id=action.contract_concept_id,
+            execution_mode=action.execution_mode,
+            prompt_contract=(
+                dict(action.prompt_contract)
+                if isinstance(action.prompt_contract, Mapping)
+                else None
+            ),
+            llm_policy=(
+                dict(action.llm_policy)
+                if isinstance(action.llm_policy, Mapping)
+                else None
+            ),
+            validation_policy=(
+                dict(action.validation_policy)
+                if isinstance(action.validation_policy, Mapping)
+                else None
+            ),
+        )
+        return execute_llm_step(request)
+
+    return registry.execute(
+        action.target_id,
+        inputs=resolved_inputs,
+        context=context,
+        env=env,
+        trace=trace,
+    )
 
 
 def _resolve_condition_path_key(condition_spec: Mapping[str, Any]) -> str:
@@ -846,10 +914,61 @@ def build_transition_condition(
 
 @dataclass(frozen=True)
 class WorkflowActionInvocation:
-    action_id: str
+    action_id: str | None = None
     inputs: Mapping[str, Any] = field(default_factory=dict)
     description: str | None = None
     contract_concept_id: str | None = None
+    execution_mode: str = WORKFLOW_STEP_EXECUTION_MODE_DETERMINISTIC
+    prompt_contract: Mapping[str, Any] | None = None
+    llm_policy: Mapping[str, Any] | None = None
+    validation_policy: Mapping[str, Any] | None = None
+    subworkflow_id: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "execution_mode",
+            normalise_workflow_step_execution_mode(self.execution_mode),
+        )
+
+    @property
+    def is_llm_step(self) -> bool:
+        return self.execution_mode == WORKFLOW_STEP_EXECUTION_MODE_LLM
+
+    @property
+    def is_subworkflow_step(self) -> bool:
+        return self.execution_mode == WORKFLOW_STEP_EXECUTION_MODE_SUBWORKFLOW
+
+    @property
+    def target_id(self) -> str:
+        action_id = str(self.action_id or "").strip()
+        if action_id:
+            return action_id
+        subworkflow_id = str(self.subworkflow_id or "").strip()
+        if subworkflow_id:
+            return subworkflow_id
+        prompt_contract = (
+            self.prompt_contract
+            if isinstance(self.prompt_contract, Mapping)
+            else {}
+        )
+        resolved_prompt_id = str(
+            prompt_contract.get("resolved_prompt_concept_id") or ""
+        ).strip()
+        if resolved_prompt_id:
+            return f"llm_prompt:{resolved_prompt_id}"
+        requested_prompt_ids = prompt_contract.get("requested_prompt_concept_ids") or []
+        if isinstance(requested_prompt_ids, Sequence) and not isinstance(
+            requested_prompt_ids, str
+        ):
+            for prompt_id in requested_prompt_ids:
+                candidate = str(prompt_id or "").strip()
+                if candidate:
+                    return f"llm_prompt:{candidate}"
+        return f"workflow_step.{self.execution_mode}"
+
+
+WorkflowStepExecutionSpec = WorkflowActionInvocation
 
 
 @dataclass(frozen=True)
@@ -1325,6 +1444,7 @@ class WorkflowExecutor:
                 retry_requested = False
                 for action in state_spec.actions:
                     context_before_action = dict(context)
+                    action_target_id = action.target_id
                     resolved_inputs = resolve_action_inputs_from_context(
                         action_inputs=action.inputs,
                         context=context,
@@ -1340,7 +1460,7 @@ class WorkflowExecutor:
                             idempotency_key = _build_idempotency_key(
                                 workflow_id=definition.workflow_id,
                                 state_id=current_state,
-                                action_id=action.action_id,
+                                action_id=action_target_id,
                                 context=context,
                                 idempotency_policy=idempotency_policy,
                             )
@@ -1378,12 +1498,12 @@ class WorkflowExecutor:
                         )
                         action_outcome = _apply_action_result_context(
                             context=context,
-                            action_id=action.action_id,
+                            action_id=action_target_id,
                             result=result,
                         )
                         if trace is not None:
                             trace.record_action(
-                                action_id=action.action_id,
+                                action_id=action_target_id,
                                 inputs=resolved_inputs,
                                 outputs=result.outputs,
                                 status=result.status,
@@ -1398,13 +1518,13 @@ class WorkflowExecutor:
                                 metadata=state_spec.metadata,
                                 action_outputs=cached_outputs,
                                 state_id=current_state,
-                                action_id=action.action_id,
+                                action_id=action_target_id,
                             )
                         idempotency_event = {
                             "status": "idempotent_reuse",
                             "workflow_id": definition.workflow_id,
                             "state_id": current_state,
-                            "action_id": action.action_id,
+                            "action_id": action_target_id,
                             "idempotency_key": idempotency_key,
                         }
                         _append_context_event(
@@ -1439,7 +1559,7 @@ class WorkflowExecutor:
                                 "status": "approval_gate_checked",
                                 "workflow_id": definition.workflow_id,
                                 "state_id": current_state,
-                                "action_id": action.action_id,
+                                "action_id": action_target_id,
                                 "approval_context_key": approval_gate.get(
                                     "approval_context_key"
                                 ),
@@ -1473,16 +1593,17 @@ class WorkflowExecutor:
                             context["approval_required"] = False
                             context["approval_state"] = "approved"
 
-                        result = self._registry.execute(
-                            action.action_id,
-                            inputs=resolved_inputs,
+                        result = execute_workflow_step_invocation(
+                            registry=self._registry,
+                            action=action,
+                            resolved_inputs=resolved_inputs,
                             context=context,
                             env=environment,
                             trace=trace,
                         )
                         if trace is not None:
                             trace.record_action(
-                                action_id=action.action_id,
+                                action_id=action_target_id,
                                 inputs=resolved_inputs,
                                 outputs=result.outputs,
                                 status=result.status,
@@ -1501,7 +1622,7 @@ class WorkflowExecutor:
                                 metadata=state_spec.metadata,
                                 action_outputs=result.outputs,
                                 state_id=current_state,
-                                action_id=action.action_id,
+                                action_id=action_target_id,
                             )
                             if (
                                 idempotency_policy is not None
@@ -1518,7 +1639,7 @@ class WorkflowExecutor:
                                     "status": "idempotent_recorded",
                                     "workflow_id": definition.workflow_id,
                                     "state_id": current_state,
-                                    "action_id": action.action_id,
+                                    "action_id": action_target_id,
                                     "idempotency_key": idempotency_key,
                                 }
                                 _append_context_event(
@@ -1535,7 +1656,7 @@ class WorkflowExecutor:
                     step_envelope = build_step_result_envelope(
                         workflow_id=definition.workflow_id,
                         state_id=current_state,
-                        action_id=action.action_id,
+                        action_id=action_target_id,
                         action_status=result.status,
                         action_outcome=action_outcome,
                         action_error=result.error,
@@ -1555,7 +1676,7 @@ class WorkflowExecutor:
                             "status": "control_signal",
                             "workflow_id": definition.workflow_id,
                             "state_id": current_state,
-                            "action_id": action.action_id,
+                            "action_id": action_target_id,
                             "control_signal": step_envelope["control_signal"],
                             "control_signal_scope": step_envelope.get(
                                 "control_signal_scope"
@@ -1582,7 +1703,7 @@ class WorkflowExecutor:
                             "status": "retry_scheduled",
                             "workflow_id": definition.workflow_id,
                             "state_id": current_state,
-                            "action_id": action.action_id,
+                            "action_id": action_target_id,
                             "attempt_number": state_attempt,
                             "next_attempt_number": state_attempt + 1,
                             "delay_ms": delay_ms,

--- a/src/backend/workflows/llm_step_executor.py
+++ b/src/backend/workflows/llm_step_executor.py
@@ -1,0 +1,1030 @@
+"""Generic prompt-driven LLM step execution for VWL.
+
+This module makes prompt-bearing workflow steps executable without requiring a
+bespoke Python handler per reasoning step. Deterministic tool execution and
+write-policy enforcement are delegated to the existing internal MCP
+orchestrator machinery when a gateway is available.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from typing import Any, Mapping, MutableMapping, Optional, Sequence
+
+from ..services.buttonify_service import (
+    parse_buttonify_options_json,
+    sanitise_buttonify_options,
+)
+from ..services.prompt_template_service import PromptTemplateService
+from .action_registry import WorkflowActionRequest, WorkflowActionResult
+
+_SPOKEN_BLOCK_RE = re.compile(
+    r"<spoken>\s*(.*?)\s*</spoken>",
+    flags=re.DOTALL | re.IGNORECASE,
+)
+
+
+def _context_string(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    return str(value or "").strip()
+
+
+def _serialise_prompt_context_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    try:
+        return json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True)
+    except Exception:
+        return str(value)
+
+
+def _coerce_prompt_id_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return [cleaned] if cleaned else []
+    if not isinstance(value, Sequence) or isinstance(value, (bytes, bytearray)):
+        return []
+    items: list[str] = []
+    for raw in value:
+        if not isinstance(raw, str):
+            continue
+        cleaned = raw.strip()
+        if cleaned:
+            items.append(cleaned)
+    return items
+
+
+def _coerce_context_messages(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    rows: list[dict[str, str]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        role = _context_string(item.get("role")) or "user"
+        content = _context_string(item.get("content"))
+        if not content:
+            continue
+        rows.append({"role": role, "content": content})
+    return rows
+
+
+def _resolve_user_context_ids(
+    context: Mapping[str, Any],
+) -> tuple[str | None, str | None]:
+    user_concept_id = _context_string(context.get("user_concept_id")) or None
+    org_concept_id = (
+        _context_string(context.get("org_concept_id"))
+        or _context_string(context.get("organisation_concept_id"))
+        or None
+    )
+    return user_concept_id, org_concept_id
+
+
+def _resolve_prompt_from_policy_context(
+    *,
+    llm_policy: Mapping[str, Any],
+    context: Mapping[str, Any],
+    prompt_service: PromptTemplateService,
+) -> tuple[str | None, str | None, Mapping[str, Any], str | None]:
+    prompt_id_context_key = _context_string(llm_policy.get("prompt_id_context_key"))
+    prompt_text_context_key = _context_string(llm_policy.get("prompt_text_context_key"))
+    prompt_concept_id_context_key = _context_string(
+        llm_policy.get("prompt_concept_id_context_key")
+    )
+    prompt_candidates_context_key = _context_string(
+        llm_policy.get("prompt_candidates_context_key")
+    )
+
+    prompt_id = (
+        _context_string(context.get(prompt_id_context_key))
+        if prompt_id_context_key
+        else None
+    )
+    prompt_text = (
+        _context_string(context.get(prompt_text_context_key))
+        if prompt_text_context_key
+        else ""
+    )
+    if prompt_text:
+        return prompt_id or None, prompt_text, {}, "context.prompt_text"
+
+    prompt_candidate_ids: list[str] = []
+    if prompt_concept_id_context_key:
+        candidate = _context_string(context.get(prompt_concept_id_context_key))
+        if candidate:
+            prompt_candidate_ids.append(candidate)
+    if prompt_candidates_context_key:
+        prompt_candidate_ids.extend(
+            _coerce_prompt_id_list(context.get(prompt_candidates_context_key))
+        )
+    prompt_candidate_ids = list(dict.fromkeys(prompt_candidate_ids))
+    if not prompt_candidate_ids:
+        return None, None, {}, None
+
+    rendered = prompt_service.render_prompt(
+        prompt_candidate_ids,
+        variables=context,
+        fallback=None,
+        max_chars=24000,
+    )
+    if rendered is None:
+        return None, None, {}, "context.prompt_candidates_unavailable"
+    return rendered.prompt_id, rendered.text, dict(rendered.variables), "context.prompt"
+
+
+def _resolve_prompt_render(
+    *,
+    prompt_contract: Mapping[str, Any] | None,
+    llm_policy: Mapping[str, Any] | None,
+    context: Mapping[str, Any],
+) -> tuple[str | None, str | None, Mapping[str, Any], str | None]:
+    prompt_service = PromptTemplateService(default_max_chars=24000)
+    llm_policy_map = dict(llm_policy) if isinstance(llm_policy, Mapping) else {}
+
+    policy_prompt_id, policy_prompt_text, policy_variables, policy_source = (
+        _resolve_prompt_from_policy_context(
+            llm_policy=llm_policy_map,
+            context=context,
+            prompt_service=prompt_service,
+        )
+    )
+    if isinstance(policy_prompt_text, str) and policy_prompt_text.strip():
+        return (
+            policy_prompt_id,
+            policy_prompt_text,
+            dict(policy_variables),
+            policy_source,
+        )
+
+    prompt_contract_map = (
+        prompt_contract if isinstance(prompt_contract, Mapping) else {}
+    )
+    requested_prompt_ids = (
+        prompt_contract_map.get("requested_prompt_concept_ids") or []
+    )
+    prompt_candidates = (
+        list(requested_prompt_ids) if isinstance(requested_prompt_ids, list) else []
+    )
+    fallback_prompt = _context_string(prompt_contract_map.get("prompt_text")) or None
+    if prompt_candidates or fallback_prompt:
+        rendered = prompt_service.render_prompt(
+            prompt_candidates,
+            variables=context,
+            fallback=fallback_prompt,
+            max_chars=24000,
+        )
+        if rendered is not None:
+            return (
+                rendered.prompt_id,
+                rendered.text,
+                dict(rendered.variables),
+                "prompt_contract",
+            )
+
+    static_prompt_candidates = _coerce_prompt_id_list(
+        llm_policy_map.get("prompt_candidates")
+    )
+    static_fallback_prompt = _context_string(llm_policy_map.get("prompt_text")) or None
+    if static_prompt_candidates or static_fallback_prompt:
+        rendered = prompt_service.render_prompt(
+            static_prompt_candidates,
+            variables=context,
+            fallback=static_fallback_prompt,
+            max_chars=24000,
+        )
+        if rendered is not None:
+            return (
+                rendered.prompt_id,
+                rendered.text,
+                dict(rendered.variables),
+                "llm_policy",
+            )
+
+    return None, None, {}, None
+
+
+def _compose_llm_prompt(
+    *,
+    base_prompt: str,
+    llm_policy: Mapping[str, Any],
+    context: Mapping[str, Any],
+) -> str:
+    sections: list[str] = []
+
+    prefix_text = _context_string(
+        llm_policy.get("prompt_prefix_text") or llm_policy.get("system_preamble")
+    )
+    if prefix_text:
+        sections.append(prefix_text)
+
+    prompt_text = _context_string(base_prompt)
+    if prompt_text:
+        sections.append(prompt_text)
+
+    response_contract_text = _context_string(llm_policy.get("response_contract_text"))
+    if response_contract_text:
+        sections.append(response_contract_text)
+
+    raw_context_fields = llm_policy.get("context_fields")
+    if isinstance(raw_context_fields, Sequence) and not isinstance(
+        raw_context_fields, (str, bytes, bytearray)
+    ):
+        for item in raw_context_fields:
+            if not isinstance(item, Mapping):
+                continue
+            context_key = _context_string(item.get("context_key"))
+            if not context_key:
+                continue
+            value = context.get(context_key)
+            value_text = _serialise_prompt_context_value(value)
+            if not value_text:
+                continue
+            label = _context_string(item.get("label")) or context_key.replace("_", " ")
+            sections.append(f"{label}:\n{value_text}")
+
+    return "\n\n".join(section for section in sections if section).strip()
+
+
+def _validation_output_format(validation_policy: Mapping[str, Any]) -> str:
+    for key in ("output_format", "format", "validator"):
+        value = _context_string(validation_policy.get(key))
+        if value:
+            return value.lower()
+    return ""
+
+
+def _coerce_spoken_text(text: Any) -> str | None:
+    raw = _context_string(text)
+    if not raw:
+        return None
+
+    match = _SPOKEN_BLOCK_RE.search(raw)
+    if match:
+        raw = _context_string(match.group(1))
+
+    raw = re.sub(r"</?spoken>", "", raw, flags=re.IGNORECASE)
+    raw = re.sub(r"</?screen>", "", raw, flags=re.IGNORECASE)
+    raw = re.sub(r"```.*?```", "", raw, flags=re.DOTALL)
+    raw = raw.replace("`", "").strip()
+    return raw or None
+
+
+def _build_planning_outputs(
+    *,
+    response_text: str,
+    request: WorkflowActionRequest,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    from .durable.planning_workflow import (
+        _append_trace_event,
+        _coerce_planning_actions,
+        _coerce_str_list,
+        _extract_json_payload,
+    )
+
+    parsed_payload, parse_mode = _extract_json_payload(response_text)
+    if not isinstance(parsed_payload, Mapping):
+        return (
+            {},
+            {
+                "status": "failed",
+                "reason": f"planning_json_parse_failed:{parse_mode}",
+                "parse_mode": parse_mode,
+            },
+        )
+
+    actions = _coerce_planning_actions(parsed_payload.get("actions"))
+    assumptions = _coerce_str_list(parsed_payload.get("assumptions"))
+    raw_planning_context = request.data.get("planning_context")
+    planning_context = (
+        {
+            str(key): value
+            for key, value in raw_planning_context.items()
+            if isinstance(key, str)
+        }
+        if isinstance(raw_planning_context, Mapping)
+        else {}
+    )
+    planning_goal = (
+        _context_string(parsed_payload.get("goal"))
+        or _context_string(planning_context.get("goal"))
+        or None
+    )
+    trace = _append_trace_event(
+        request.data,
+        stage="infer",
+        event="plan_inferred",
+        details={
+            "parse_mode": parse_mode,
+            "actions_count": len(actions),
+        },
+    )
+
+    raw_planning_diagnostics = request.data.get("planning_diagnostics")
+    diagnostics = (
+        {
+            str(key): value
+            for key, value in raw_planning_diagnostics.items()
+            if isinstance(key, str)
+        }
+        if isinstance(raw_planning_diagnostics, Mapping)
+        else {}
+    )
+    diagnostics["inference"] = {
+        "parse_mode": parse_mode,
+        "actions_count": len(actions),
+        "assumptions_count": len(assumptions),
+        "response_preview": response_text[:300],
+    }
+
+    return (
+        {
+            "planning_goal": planning_goal,
+            "planning_assumptions": assumptions,
+            "planning_actions": actions,
+            "planning_raw_plan": dict(parsed_payload),
+            "planning_trace": trace,
+            "planning_diagnostics": diagnostics,
+        },
+        {
+            "status": "success",
+            "parse_mode": parse_mode,
+            "actions_count": len(actions),
+        },
+    )
+
+
+def _apply_validation_policy(
+    *,
+    request: WorkflowActionRequest,
+    response_text: str,
+    prompt_id: str | None,
+    selected_model: str | None,
+    validation_policy: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not isinstance(validation_policy, Mapping):
+        return ({}, {"status": "skipped"})
+
+    output_format = _validation_output_format(validation_policy)
+    if not output_format:
+        return ({}, {"status": "skipped"})
+
+    if output_format == "narration_spoken_xml":
+        spoken = _coerce_spoken_text(response_text) or _coerce_spoken_text(
+            request.data.get("screen_text")
+        )
+        return (
+            {
+                "narration_rendered": bool(spoken),
+                "narration_spoken": spoken,
+                "narration_raw_response": response_text,
+                "result": bool(spoken),
+            },
+            {
+                "status": "success" if spoken else "failed",
+                "output_format": output_format,
+                "spoken_present": bool(spoken),
+            },
+        )
+
+    if output_format == "buttonify_options_json":
+        options = sanitise_buttonify_options(parse_buttonify_options_json(response_text))
+        status = "success" if options else "no_op"
+        return (
+            {
+                "buttonify_status": status,
+                "buttonify_options": options,
+                "buttonify_source": "llm" if options else "none",
+                "buttonify_prompt_id": _context_string(
+                    request.data.get("buttonify_prompt_id")
+                )
+                or prompt_id,
+                "buttonify_prompt_truncated": bool(
+                    request.data.get("buttonify_prompt_truncated")
+                ),
+                "buttonify_prompt_available": bool(
+                    request.data.get("buttonify_prompt_available", True)
+                ),
+                "buttonify_prompt_error": request.data.get("buttonify_prompt_error"),
+                "buttonify_model_used": selected_model,
+                "buttonify_model_attempted": True,
+                "buttonify_error_class": None,
+                "buttonify_suppression_reason": None if options else "no_candidates",
+                "result": bool(options),
+            },
+            {
+                "status": status,
+                "output_format": output_format,
+                "options_count": len(options),
+            },
+        )
+
+    if output_format == "planning_plan_json":
+        return _build_planning_outputs(response_text=response_text, request=request)
+
+    return (
+        {"llm_step_validation_unhandled": output_format},
+        {
+            "status": "skipped",
+            "output_format": output_format,
+            "reason": "validation_handler_unavailable",
+        },
+    )
+
+
+def _append_llm_call(
+    bucket: MutableMapping[str, Any],
+    *,
+    call_type: str,
+    stage: str,
+    model_name: str | None,
+    provider: str | None = None,
+    candidate: Mapping[str, Any] | None = None,
+    duration_ms: float | None = None,
+    note: str | None = None,
+) -> None:
+    llm_calls = bucket.get("llm_calls")
+    if not isinstance(llm_calls, list):
+        llm_calls = []
+        bucket["llm_calls"] = llm_calls
+    entry: dict[str, Any] = {
+        "type": call_type,
+        "stage": stage,
+        "model_name": model_name,
+    }
+    if provider:
+        entry["provider"] = provider
+    if isinstance(candidate, Mapping):
+        entry["candidate"] = dict(candidate)
+    if duration_ms is not None:
+        entry["duration_ms"] = duration_ms
+    if note:
+        entry["note"] = note
+    llm_calls.append(entry)
+
+
+def _tool_mode(llm_policy: Mapping[str, Any]) -> str:
+    raw = _context_string(llm_policy.get("tool_mode")).lower()
+    if raw in {"allowed", "tool_augmented", "tools"}:
+        return "allowed"
+    if raw in {"none", "disabled", "off"}:
+        return "none"
+    if "allowed_tools" in llm_policy or "required_tools" in llm_policy:
+        return "allowed"
+    return "none"
+
+
+def _llm_stage(llm_policy: Mapping[str, Any], request: WorkflowActionRequest) -> str:
+    policy_stage = _context_string(llm_policy.get("policy_stage"))
+    if policy_stage:
+        return policy_stage
+    action_id = _context_string(request.action_id)
+    if action_id:
+        return action_id
+    return "llm_step"
+
+
+def _build_gateway_runtime(
+    request: WorkflowActionRequest,
+) -> tuple[Any, Any, Mapping[str, Any], str | None, str | None]:
+    from ..integrations.internal_mcp.orchestrator import InternalMCPChatOrchestrator
+    from ..services.model_registry_service import get_model_registry_snapshot
+
+    gateway = request.environment.gateway
+    if gateway is None:
+        raise RuntimeError("workflow_llm_step_gateway_unavailable")
+
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=gateway,
+        max_tool_invocations=(
+            int(request.environment.max_tool_invocations)
+            if request.environment.max_tool_invocations is not None
+            else 1
+        ),
+        tool_batch_cap=(
+            max(1, int(request.inputs.get("tool_batch_cap") or 4))
+            if request.inputs.get("tool_batch_cap") is not None
+            else 4
+        ),
+        default_gmail_profile=request.environment.default_gmail_profile,
+    )
+    user_concept_id, org_concept_id = _resolve_user_context_ids(request.data)
+    policy_state, _policy_telemetry = orchestrator._load_workflow_model_policy(None)
+    registry_snapshot = get_model_registry_snapshot()
+    return orchestrator, policy_state, registry_snapshot, user_concept_id, org_concept_id
+
+
+def _build_result(
+    *,
+    request: WorkflowActionRequest,
+    response_text: str,
+    prompt_id: str | None,
+    prompt_source: str | None,
+    rendered_variables: Mapping[str, Any],
+    llm_policy_map: Mapping[str, Any],
+    validation_policy_map: Mapping[str, Any],
+    selected_model: str | None,
+    selected_candidate: Mapping[str, Any] | None,
+    tool_invocations: Sequence[Mapping[str, Any]],
+    tool_messages: Sequence[Mapping[str, Any]],
+    llm_calls: Sequence[Mapping[str, Any]],
+    aux_llm_calls: Sequence[Mapping[str, Any]],
+) -> WorkflowActionResult:
+    validated_outputs, validation_summary = _apply_validation_policy(
+        request=request,
+        response_text=response_text,
+        prompt_id=prompt_id,
+        selected_model=selected_model,
+        validation_policy=validation_policy_map,
+    )
+
+    llm_step_envelope = {
+        "execution_mode": "llm",
+        "action_id": request.action_id,
+        "selected_prompt_id": prompt_id,
+        "selected_prompt_source": prompt_source,
+        "selected_model": selected_model,
+        "selected_model_candidate": (
+            dict(selected_candidate) if isinstance(selected_candidate, Mapping) else None
+        ),
+        "tool_invocations": list(tool_invocations),
+        "tool_messages": list(tool_messages),
+        "rendered_prompt_variables": dict(rendered_variables),
+        "selection_policy": _context_string(llm_policy_map.get("selection_policy"))
+        or "adaptive",
+        "allowed_tools": list(llm_policy_map.get("allowed_tools") or []),
+        "llm_calls": list(llm_calls),
+        "aux_llm_calls": list(aux_llm_calls),
+        "validation": validation_summary,
+        "completion_reason": (
+            "tool_augmented_response" if tool_invocations else "direct_llm_response"
+        ),
+    }
+
+    outputs = {
+        "final_response": response_text,
+        "llm_step_response": response_text,
+        "llm_step_envelope": llm_step_envelope,
+        "tool_invocations": list(tool_invocations),
+        "tool_messages": list(tool_messages),
+        "llm_calls": list(llm_calls),
+        "aux_llm_calls": list(aux_llm_calls),
+    }
+    outputs.update(validated_outputs)
+    return WorkflowActionResult(outputs=outputs)
+
+
+def _run_direct_llm_step(
+    *,
+    request: WorkflowActionRequest,
+    stage: str,
+    prompt_id: str | None,
+    prompt_source: str | None,
+    rendered_prompt: str,
+    rendered_variables: Mapping[str, Any],
+    llm_policy_map: Mapping[str, Any],
+    validation_policy_map: Mapping[str, Any],
+) -> WorkflowActionResult:
+    llm_client = request.environment.llm_client
+    if llm_client is None or not hasattr(llm_client, "generate"):
+        return WorkflowActionResult(
+            status="failed",
+            error="workflow_llm_step_client_unavailable",
+        )
+
+    context_messages = _coerce_context_messages(
+        request.data.get(_context_string(llm_policy_map.get("context_messages_context_key")))
+    )
+    model_name = request.environment.model
+    start = time.perf_counter()
+    response = llm_client.generate(
+        rendered_prompt,
+        context=context_messages or None,
+        model=model_name,
+    )
+    duration_ms = (time.perf_counter() - start) * 1000.0
+    _append_llm_call(
+        request.data,
+        call_type="llm.generate",
+        stage=stage,
+        model_name=model_name,
+        duration_ms=duration_ms,
+        note="generic_llm_step_direct",
+    )
+
+    response_text = response if isinstance(response, str) else str(response)
+    return _build_result(
+        request=request,
+        response_text=response_text,
+        prompt_id=prompt_id,
+        prompt_source=prompt_source,
+        rendered_variables=rendered_variables,
+        llm_policy_map=llm_policy_map,
+        validation_policy_map=validation_policy_map,
+        selected_model=model_name,
+        selected_candidate=None,
+        tool_invocations=(),
+        tool_messages=(),
+        llm_calls=request.data.get("llm_calls") or [],
+        aux_llm_calls=request.data.get("aux_llm_calls") or [],
+    )
+
+
+def _run_gateway_llm_step_no_tools(
+    *,
+    request: WorkflowActionRequest,
+    stage: str,
+    prompt_id: str | None,
+    prompt_source: str | None,
+    rendered_prompt: str,
+    rendered_variables: Mapping[str, Any],
+    llm_policy_map: Mapping[str, Any],
+    validation_policy_map: Mapping[str, Any],
+) -> WorkflowActionResult:
+    orchestrator, policy_state, registry_snapshot, user_concept_id, org_concept_id = (
+        _build_gateway_runtime(request)
+    )
+    llm_calls: list[dict[str, Any]] = []
+    aux_llm_calls: list[dict[str, Any]] = []
+    emit_progress = (
+        request.data.get("emit_progress")
+        if callable(request.data.get("emit_progress"))
+        else None
+    )
+
+    def _record_llm_call(
+        *,
+        call_type: str,
+        model_name: str | None,
+        duration_ms: float | None,
+        usage: Mapping[str, Any] | None = None,
+        note: str | None = None,
+        stage: str | None = None,
+        provider: str | None = None,
+        candidate: Mapping[str, Any] | None = None,
+    ) -> None:
+        entry: dict[str, Any] = {
+            "type": call_type,
+            "model_name": model_name,
+            "duration_ms": duration_ms,
+            "stage": stage,
+        }
+        if usage:
+            entry["usage"] = dict(usage)
+        if note:
+            entry["note"] = note
+        if provider:
+            entry["provider"] = provider
+        if isinstance(candidate, Mapping):
+            entry["candidate"] = dict(candidate)
+        llm_calls.append(entry)
+
+    response_text, selected_model, selected_candidate = (
+        orchestrator._run_llm_with_fallbacks(
+            stage=stage,
+            prompt=rendered_prompt,
+            context=_coerce_context_messages(
+                request.data.get(
+                    _context_string(llm_policy_map.get("context_messages_context_key"))
+                )
+            ),
+            default_client=request.environment.llm_client,
+            default_model=request.environment.model,
+            policy_state=policy_state,
+            registry_snapshot=registry_snapshot,
+            user_concept_id=user_concept_id,
+            org_concept_id=org_concept_id,
+            llm_calls_log=llm_calls,
+            aux_log=aux_llm_calls,
+            record_llm_call=_record_llm_call,
+            emit_progress=emit_progress,
+        )
+    )
+
+    return _build_result(
+        request=request,
+        response_text=response_text,
+        prompt_id=prompt_id,
+        prompt_source=prompt_source,
+        rendered_variables=rendered_variables,
+        llm_policy_map=llm_policy_map,
+        validation_policy_map=validation_policy_map,
+        selected_model=selected_model,
+        selected_candidate=selected_candidate,
+        tool_invocations=(),
+        tool_messages=(),
+        llm_calls=llm_calls,
+        aux_llm_calls=aux_llm_calls,
+    )
+
+
+def execute_llm_step(request: WorkflowActionRequest) -> WorkflowActionResult:
+    """Execute a generic LLM workflow step."""
+
+    llm_policy_map = (
+        dict(request.llm_policy) if isinstance(request.llm_policy, Mapping) else {}
+    )
+    validation_policy_map = (
+        dict(request.validation_policy)
+        if isinstance(request.validation_policy, Mapping)
+        else {}
+    )
+
+    prompt_id, base_prompt_text, rendered_variables, prompt_source = (
+        _resolve_prompt_render(
+            prompt_contract=request.prompt_contract,
+            llm_policy=llm_policy_map,
+            context=request.data,
+        )
+    )
+    if not isinstance(base_prompt_text, str) or not base_prompt_text.strip():
+        return WorkflowActionResult(
+            status="failed",
+            error="workflow_llm_step_prompt_render_failed",
+        )
+
+    rendered_prompt = _compose_llm_prompt(
+        base_prompt=base_prompt_text,
+        llm_policy=llm_policy_map,
+        context=request.data,
+    )
+    if not rendered_prompt:
+        return WorkflowActionResult(
+            status="failed",
+            error="workflow_llm_step_prompt_render_failed",
+        )
+
+    stage = _llm_stage(llm_policy_map, request)
+    if not request.environment.gateway:
+        return _run_direct_llm_step(
+            request=request,
+            stage=stage,
+            prompt_id=prompt_id,
+            prompt_source=prompt_source,
+            rendered_prompt=rendered_prompt,
+            rendered_variables=rendered_variables,
+            llm_policy_map=llm_policy_map,
+            validation_policy_map=validation_policy_map,
+        )
+
+    if _tool_mode(llm_policy_map) != "allowed":
+        return _run_gateway_llm_step_no_tools(
+            request=request,
+            stage=stage,
+            prompt_id=prompt_id,
+            prompt_source=prompt_source,
+            rendered_prompt=rendered_prompt,
+            rendered_variables=rendered_variables,
+            llm_policy_map=llm_policy_map,
+            validation_policy_map=validation_policy_map,
+        )
+
+    from ..integrations.internal_mcp.orchestrator import InternalMCPChatOrchestrator
+    from ..services.model_registry_service import get_model_registry_snapshot
+
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=request.environment.gateway,
+        max_tool_invocations=(
+            int(request.environment.max_tool_invocations)
+            if request.environment.max_tool_invocations is not None
+            else 1
+        ),
+        tool_batch_cap=(
+            max(1, int(request.inputs.get("tool_batch_cap") or 4))
+            if request.inputs.get("tool_batch_cap") is not None
+            else 4
+        ),
+        default_gmail_profile=request.environment.default_gmail_profile,
+    )
+
+    user_concept_id, org_concept_id = _resolve_user_context_ids(request.data)
+    policy_state, _policy_telemetry = orchestrator._load_workflow_model_policy(None)
+    registry_snapshot = get_model_registry_snapshot()
+
+    llm_calls: list[dict[str, Any]] = []
+    aux_llm_calls: list[dict[str, Any]] = []
+    invocations: list[dict[str, Any]] = []
+    tool_messages: list[dict[str, Any]] = []
+    selected_models: dict[str, str | None] = {}
+
+    def _model_for_stage(inner_stage: str) -> Optional[str]:
+        model_name = orchestrator._select_model_for_stage(
+            stage=inner_stage,
+            default_model=request.environment.model,
+            policy_state=policy_state,
+            registry_snapshot=registry_snapshot,
+            user_concept_id=user_concept_id,
+            org_concept_id=org_concept_id,
+        )
+        selected_models[inner_stage] = model_name
+        return model_name
+
+    def _record_llm_call(
+        *,
+        call_type: str,
+        model_name: str | None,
+        duration_ms: float | None,
+        usage: Mapping[str, Any] | None = None,
+        note: str | None = None,
+        stage: str | None = None,
+        provider: str | None = None,
+        candidate: Mapping[str, Any] | None = None,
+    ) -> None:
+        entry: dict[str, Any] = {
+            "type": call_type,
+            "model_name": model_name,
+            "duration_ms": duration_ms,
+            "stage": stage,
+        }
+        if usage:
+            entry["usage"] = dict(usage)
+        if note:
+            entry["note"] = note
+        if provider:
+            entry["provider"] = provider
+        if isinstance(candidate, Mapping):
+            entry["candidate"] = dict(candidate)
+        llm_calls.append(entry)
+
+    def _build_simple_error_result(
+        kind: str,
+        payload: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "kind": kind,
+            "response_text": _context_string(payload.get("message"))
+            or _context_string(payload.get("error"))
+            or kind,
+            "details": dict(payload),
+        }
+
+    method_catalogue = request.environment.gateway.describe_methods()
+    allowed_tools_raw = llm_policy_map.get("allowed_tools")
+    allowed_tools = (
+        [
+            str(tool_name).strip()
+            for tool_name in allowed_tools_raw
+            if str(tool_name).strip()
+        ]
+        if isinstance(allowed_tools_raw, Sequence)
+        and not isinstance(allowed_tools_raw, (str, bytes, bytearray))
+        else None
+    )
+
+    shared_data: dict[str, Any] = {
+        "prompt": rendered_prompt,
+        "prompt_for_requirements": request.data.get("prompt_for_requirements")
+        or rendered_prompt,
+        "response": request.data.get("response")
+        or request.data.get("current_response")
+        or "",
+        "current_response": request.data.get("current_response") or "",
+        "augmented_context": _coerce_context_messages(
+            request.data.get("augmented_context")
+        ),
+        "policy_state": policy_state,
+        "registry_snapshot": registry_snapshot,
+        "user_concept_id": user_concept_id,
+        "org_concept_id": org_concept_id,
+        "conversation_session_id": request.data.get("conversation_session_id"),
+        "turn_id": request.data.get("turn_id"),
+        "recent_user_prompts": request.data.get("recent_user_prompts") or [],
+        "gmail_profile": request.data.get("gmail_profile")
+        or request.environment.default_gmail_profile,
+        "workflow_episode_source": request.data.get("workflow_episode_source")
+        or "workflow_step",
+        "workflow_episode_stage": request.data.get("workflow_episode_stage") or stage,
+        "model_for_stage": _model_for_stage,
+        "record_llm_call": _record_llm_call,
+        "emit_progress": (
+            request.data.get("emit_progress")
+            if callable(request.data.get("emit_progress"))
+            else None
+        ),
+        "emit_phase_transition": (
+            request.data.get("emit_phase_transition")
+            if callable(request.data.get("emit_phase_transition"))
+            else None
+        ),
+        "check_cancellation": (
+            request.data.get("check_cancellation")
+            if callable(request.data.get("check_cancellation"))
+            else None
+        ),
+        "build_parse_error_result": lambda error: _build_simple_error_result(
+            "tool_call_parse_error",
+            {
+                "error": getattr(error, "message", None) or str(error),
+                "raw_response": getattr(error, "raw_response", None),
+            },
+        ),
+        "build_validation_error_result": lambda errors, warnings, unavailable, **kwargs: _build_simple_error_result(
+            "tool_call_validation_error",
+            {
+                "message": "; ".join(
+                    [*list(errors or []), *list(warnings or [])]
+                )
+                or "tool validation failed",
+                "errors": list(errors or []),
+                "warnings": list(warnings or []),
+                "unavailable": list(unavailable or []),
+                **kwargs,
+            },
+        ),
+        "aux_llm_calls": aux_llm_calls,
+        "llm_calls": llm_calls,
+        "invocations": invocations,
+        "tool_messages": tool_messages,
+        "iteration_count": 0,
+        "allowed_write_tools": set(),
+        "missing_tool_call_retry_attempts": 0,
+        "missing_tool_call_retry_budget": int(
+            getattr(orchestrator, "_max_missing_tool_call_retries_per_turn", 1)
+        ),
+        "llm_allowed_tools": allowed_tools,
+        "method_catalogue": method_catalogue,
+    }
+
+    plan_request = WorkflowActionRequest(
+        action_id=request.action_id,
+        inputs={},
+        environment=request.environment,
+        data=shared_data,
+        trace=request.trace,
+        action_target_id=request.action_target_id,
+        contract_concept_id=request.contract_concept_id,
+    )
+    plan_result = orchestrator._action_tool_calling_plan(plan_request)
+    shared_data.update(plan_result.outputs)
+    if plan_result.status == "failed":
+        return plan_result
+
+    while bool(shared_data.get("tool_calls_present")):
+        validate_result = orchestrator._action_tool_calling_validate(plan_request)
+        shared_data.update(validate_result.outputs)
+        if validate_result.status == "failed":
+            return validate_result
+        if not shared_data.get("tool_calls_validated"):
+            break
+
+        execute_result = orchestrator._action_tool_calling_execute(plan_request)
+        shared_data.update(execute_result.outputs)
+        if execute_result.status == "failed":
+            return execute_result
+
+        backfill_result = orchestrator._action_tool_calling_backfill(plan_request)
+        shared_data.update(backfill_result.outputs)
+        if backfill_result.status == "failed":
+            return backfill_result
+        if not shared_data.get("more_tool_calls"):
+            break
+
+    orchestrator_result = shared_data.get("orchestrator_result")
+    if isinstance(orchestrator_result, Mapping):
+        response_text = _context_string(orchestrator_result.get("response_text"))
+    else:
+        response_text = _context_string(
+            shared_data.get("final_response")
+            or shared_data.get("current_response")
+            or shared_data.get("response")
+        )
+
+    selected_model = (
+        selected_models.get("tool_call")
+        or selected_models.get("summariser")
+        or request.environment.model
+    )
+    selected_candidate = None
+    for entry in reversed(llm_calls):
+        if not isinstance(entry, Mapping):
+            continue
+        candidate = entry.get("candidate")
+        if isinstance(candidate, Mapping):
+            selected_candidate = candidate
+            break
+
+    return _build_result(
+        request=request,
+        response_text=response_text,
+        prompt_id=prompt_id,
+        prompt_source=prompt_source,
+        rendered_variables=rendered_variables,
+        llm_policy_map=llm_policy_map,
+        validation_policy_map=validation_policy_map,
+        selected_model=selected_model,
+        selected_candidate=selected_candidate,
+        tool_invocations=invocations,
+        tool_messages=tool_messages,
+        llm_calls=llm_calls,
+        aux_llm_calls=aux_llm_calls,
+    )
+
+
+__all__ = ["execute_llm_step"]

--- a/src/backend/workflows/prompt_metadata_resolution.py
+++ b/src/backend/workflows/prompt_metadata_resolution.py
@@ -150,6 +150,7 @@ _PROMPT_VARIABLE_RE = re.compile(r"{([A-Za-z0-9_]+)}")
 class WorkflowPromptResolution:
     requested_prompt_concept_ids: tuple[str, ...] = ()
     resolved_prompt_concept_id: str | None = None
+    prompt_text: str | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
     diagnostics: Mapping[str, Any] = field(default_factory=dict)
 
@@ -645,6 +646,7 @@ def resolve_workflow_prompt_metadata(
     return WorkflowPromptResolution(
         requested_prompt_concept_ids=requested_prompt_ids,
         resolved_prompt_concept_id=selected_prompt_id,
+        prompt_text=prompt_text,
         metadata=merged_metadata,
         diagnostics=diagnostics,
     )
@@ -664,6 +666,8 @@ def build_workflow_prompt_contract(
         )
     if resolution.resolved_prompt_concept_id:
         contract["resolved_prompt_concept_id"] = resolution.resolved_prompt_concept_id
+    if isinstance(resolution.prompt_text, str) and resolution.prompt_text.strip():
+        contract["prompt_text"] = resolution.prompt_text
     if resolution.metadata:
         contract["metadata"] = dict(resolution.metadata)
     return contract

--- a/src/backend/workflows/vontology_loader.py
+++ b/src/backend/workflows/vontology_loader.py
@@ -31,11 +31,16 @@ from .engine import (
     WorkflowDefinition,
     WorkflowStateSpec,
     WorkflowActionInvocation,
+    WORKFLOW_STEP_EXECUTION_MODE_CONTROL,
+    WORKFLOW_STEP_EXECUTION_MODE_DETERMINISTIC,
+    WORKFLOW_STEP_EXECUTION_MODE_LLM,
+    WORKFLOW_STEP_EXECUTION_MODE_SUBWORKFLOW,
     WorkflowTransitionSpec,
     _normalise_approval_gate_spec,
     _normalise_idempotency_policy_spec,
     _normalise_retry_policy_spec,
     build_transition_condition,
+    normalise_workflow_step_execution_mode,
 )
 
 logger = logging.getLogger(__name__)
@@ -876,6 +881,119 @@ def _extract_step_prompt_resolution_config(
         normalise_prompt_metadata_defaults(defaults_raw),
         normalise_prompt_validation_policy(policy_raw),
     )
+
+
+_WORKFLOW_STEP_EXECUTION_MODE_INPUT_KEYS: tuple[str, ...] = (
+    "execution_mode",
+    "__execution_mode",
+    "workflow_step_execution_mode",
+    "step_execution_mode",
+)
+_WORKFLOW_STEP_LLM_POLICY_INPUT_KEYS: tuple[str, ...] = (
+    "llm_policy",
+    "__llm_policy",
+    "workflow_step_llm_policy",
+)
+_WORKFLOW_STEP_VALIDATION_POLICY_INPUT_KEYS: tuple[str, ...] = (
+    "validation_policy",
+    "__validation_policy",
+    "workflow_step_validation_policy",
+)
+
+
+def _extract_step_execution_mode(input_map: Dict[str, Any]) -> str | None:
+    for key in _WORKFLOW_STEP_EXECUTION_MODE_INPUT_KEYS:
+        if key not in input_map:
+            continue
+        return normalise_workflow_step_execution_mode(input_map.pop(key))
+    return None
+
+
+def _extract_step_llm_policy(
+    *,
+    input_map: Dict[str, Any],
+    prompt_contract: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    policy: dict[str, Any] = {}
+    raw_policy: Any = None
+    for key in _WORKFLOW_STEP_LLM_POLICY_INPUT_KEYS:
+        if key not in input_map:
+            continue
+        raw_policy = input_map.pop(key)
+        break
+
+    if isinstance(raw_policy, Mapping):
+        policy.update(dict(raw_policy))
+    elif isinstance(raw_policy, str) and raw_policy.strip():
+        try:
+            parsed = json.loads(raw_policy)
+        except Exception:
+            parsed = None
+        if isinstance(parsed, Mapping):
+            policy.update(dict(parsed))
+
+    prompt_contract_map = (
+        prompt_contract if isinstance(prompt_contract, Mapping) else {}
+    )
+    prompt_metadata = prompt_contract_map.get("metadata")
+    prompt_metadata_map = (
+        prompt_metadata if isinstance(prompt_metadata, Mapping) else {}
+    )
+
+    requested_prompt_ids = prompt_contract_map.get("requested_prompt_concept_ids")
+    if isinstance(requested_prompt_ids, list) and requested_prompt_ids:
+        policy.setdefault("prompt_candidates", list(requested_prompt_ids))
+    resolved_prompt_id = str(
+        prompt_contract_map.get("resolved_prompt_concept_id") or ""
+    ).strip()
+    if resolved_prompt_id:
+        policy.setdefault("selected_prompt_id", resolved_prompt_id)
+    prompt_text = str(prompt_contract_map.get("prompt_text") or "").strip()
+    if prompt_text:
+        policy.setdefault("prompt_text", prompt_text)
+
+    allowed_tools = prompt_metadata_map.get("allowed_tools")
+    if isinstance(allowed_tools, list) and allowed_tools:
+        policy.setdefault("allowed_tools", list(allowed_tools))
+    tool_priority = prompt_metadata_map.get("tool_resolution_priority")
+    if isinstance(tool_priority, list) and tool_priority:
+        policy.setdefault("tool_resolution_priority", list(tool_priority))
+    model_preference = prompt_metadata_map.get("model_preference")
+    if isinstance(model_preference, str) and model_preference.strip():
+        policy.setdefault("model_preference", model_preference.strip())
+    agent_profiles = prompt_metadata_map.get("agent_profile_ids")
+    if isinstance(agent_profiles, list) and agent_profiles:
+        policy.setdefault("agent_profile_ids", list(agent_profiles))
+
+    selection_policy = str(policy.get("selection_policy") or "").strip().lower()
+    if selection_policy not in {"fixed", "adaptive", "bandit"}:
+        policy["selection_policy"] = "adaptive"
+
+    return policy
+
+
+def _extract_step_validation_policy(
+    input_map: Dict[str, Any],
+) -> dict[str, Any] | None:
+    raw_policy: Any = None
+    for key in _WORKFLOW_STEP_VALIDATION_POLICY_INPUT_KEYS:
+        if key not in input_map:
+            continue
+        raw_policy = input_map.pop(key)
+        break
+
+    policy: dict[str, Any] = {}
+    if isinstance(raw_policy, Mapping):
+        policy.update(dict(raw_policy))
+    elif isinstance(raw_policy, str) and raw_policy.strip():
+        try:
+            parsed = json.loads(raw_policy)
+        except Exception:
+            parsed = None
+        if isinstance(parsed, Mapping):
+            policy.update(dict(parsed))
+
+    return policy or None
 
 
 def _extract_tool_output_mapping(
@@ -2159,7 +2277,8 @@ def load_workflow_definition_from_vontology(
         subworkflow_failure_mode = ""
         action_contract: dict[str, Any] | None = None
         action_contract_source = ""
-        if invocation_action_id:
+        step_has_prompt_contract = isinstance(step.get("prompt_contract"), Mapping)
+        if invocation_action_id or step_has_prompt_contract:
             # Read input mapping from Vontology (hasInputMap relationships).
             doc = step_docs.get(step_id, {})
             step_rels = doc.get("relationships") or {}
@@ -2167,6 +2286,7 @@ def load_workflow_definition_from_vontology(
                 step_rels = {}
             input_map = _parse_step_input_map(step_rels)
             _extract_step_prompt_resolution_config(input_map)
+            configured_execution_mode = _extract_step_execution_mode(input_map)
             prompt_contract = (
                 dict(step.get("prompt_contract"))
                 if isinstance(step.get("prompt_contract"), Mapping)
@@ -2227,12 +2347,48 @@ def load_workflow_definition_from_vontology(
                 input_map["workflow_id"] = str(invokes_workflow).strip()
                 input_map["__parent_workflow_id"] = str(workflow_id or "").strip()
                 input_map["__parent_state_id"] = str(step_id or "").strip()
-            if prompt_contract:
-                input_map["__prompt_contract"] = prompt_contract
             if prompt_resolution_diagnostics:
                 input_map["__prompt_resolution_diagnostics"] = (
                     prompt_resolution_diagnostics
                 )
+
+            execution_mode = configured_execution_mode
+            if not execution_mode:
+                if has_static_workflow_invocation:
+                    execution_mode = WORKFLOW_STEP_EXECUTION_MODE_SUBWORKFLOW
+                elif prompt_contract:
+                    if str(invocation_action_id or "").strip().startswith(
+                        "workflow_control."
+                    ):
+                        execution_mode = WORKFLOW_STEP_EXECUTION_MODE_CONTROL
+                    else:
+                        execution_mode = WORKFLOW_STEP_EXECUTION_MODE_LLM
+                elif str(invocation_action_id or "").strip().startswith(
+                    "workflow_control."
+                ):
+                    execution_mode = WORKFLOW_STEP_EXECUTION_MODE_CONTROL
+                else:
+                    execution_mode = WORKFLOW_STEP_EXECUTION_MODE_DETERMINISTIC
+
+            llm_policy = (
+                _extract_step_llm_policy(
+                    input_map=input_map,
+                    prompt_contract=prompt_contract,
+                )
+                if execution_mode == WORKFLOW_STEP_EXECUTION_MODE_LLM
+                else None
+            )
+            validation_policy = _extract_step_validation_policy(input_map)
+            if (
+                validation_policy is None
+                and isinstance(prompt_contract, Mapping)
+                and prompt_contract.get("validation_policy")
+            ):
+                validation_policy = {
+                    "prompt_validation_policy": str(
+                        prompt_contract.get("validation_policy") or ""
+                    ).strip()
+                }
 
             actions.append(
                 WorkflowActionInvocation(
@@ -2244,6 +2400,15 @@ def load_workflow_definition_from_vontology(
                         else None
                     )
                     or None,
+                    execution_mode=execution_mode,
+                    prompt_contract=prompt_contract,
+                    llm_policy=llm_policy,
+                    validation_policy=validation_policy,
+                    subworkflow_id=(
+                        str(invokes_workflow or "").strip() or None
+                        if execution_mode == WORKFLOW_STEP_EXECUTION_MODE_SUBWORKFLOW
+                        else None
+                    ),
                 )
             )
 
@@ -2490,6 +2655,31 @@ def load_workflow_definition_from_vontology(
             step_metadata["checkpoint_policy"] = checkpoint_policy
         if prompt_contract:
             step_metadata["prompt_contract"] = prompt_contract
+        action_execution_modes = [
+            str(getattr(action, "execution_mode", "") or "").strip()
+            for action in actions
+            if str(getattr(action, "execution_mode", "") or "").strip()
+        ]
+        if action_execution_modes:
+            step_metadata["execution_modes"] = action_execution_modes
+            if len(action_execution_modes) == 1:
+                step_metadata["execution_mode"] = action_execution_modes[0]
+        llm_policies = []
+        for action in actions:
+            raw_llm_policy = getattr(action, "llm_policy", None)
+            if not isinstance(raw_llm_policy, Mapping):
+                continue
+            llm_policies.append(
+                {
+                    str(key): value
+                    for key, value in raw_llm_policy.items()
+                    if isinstance(key, str)
+                }
+            )
+        if llm_policies:
+            step_metadata["llm_policies"] = llm_policies
+            if len(llm_policies) == 1:
+                step_metadata["llm_policy"] = llm_policies[0]
         if action_contract:
             step_metadata["action_contract"] = action_contract
         action_contract_source = step.get("action_contract_source")

--- a/src/backend/workflows/workflow_concept_authority_service.py
+++ b/src/backend/workflows/workflow_concept_authority_service.py
@@ -254,6 +254,9 @@ class _CanonicalStepPublicationSpec:
     concept_id: str | None = None
     action_id: str | None = None
     action_concept_id: str | None = None
+    execution_mode: str | None = None
+    llm_policy: Mapping[str, Any] | None = None
+    validation_policy: Mapping[str, Any] | None = None
     invoked_workflow_id: str | None = None
     static_input_bindings: tuple[tuple[str, str], ...] = ()
     context_input_mappings: tuple[str, ...] = ()
@@ -289,6 +292,9 @@ class _CanonicalWorkflowPublicationSpec:
 
 @dataclass(frozen=True)
 class _RuntimeStepPublicationDetails:
+    execution_mode: str | None = None
+    llm_policy: Mapping[str, Any] | None = None
+    validation_policy: Mapping[str, Any] | None = None
     invoked_workflow_id: str | None = None
     static_input_bindings: tuple[tuple[str, str], ...] = ()
     context_input_mapping_specs: tuple[_CanonicalContextInputMappingSpec, ...] = ()
@@ -388,6 +394,28 @@ _CANONICAL_WORKFLOW_PUBLICATION_SPECS: Dict[str, _CanonicalWorkflowPublicationSp
             _CanonicalStepPublicationSpec(
                 state_id="render_narration",
                 action_id="narration.render",
+                execution_mode="llm",
+                llm_policy={
+                    "tool_mode": "none",
+                    "policy_stage": "narration",
+                    "prompt_text_context_key": "narration_prompt_text",
+                    "response_contract_text": (
+                        "Return ONLY one block: <spoken>...</spoken>. "
+                        "Do not include <screen>. Do not include code blocks. "
+                        "Use New Zealand English spelling."
+                    ),
+                    "context_fields": [
+                        {"label": "User message", "context_key": "user_prompt"},
+                        {
+                            "label": (
+                                "On-screen content (do not read verbatim if long; "
+                                "summarise)"
+                            ),
+                            "context_key": "screen_text",
+                        },
+                    ],
+                },
+                validation_policy={"output_format": "narration_spoken_xml"},
                 conditional_transitions=(
                     _CanonicalConditionalTransitionPublicationSpec(
                         to_state="emit_audio",
@@ -455,6 +483,20 @@ _CANONICAL_WORKFLOW_PUBLICATION_SPECS: Dict[str, _CanonicalWorkflowPublicationSp
             _CanonicalStepPublicationSpec(
                 state_id="extract_options",
                 action_id="buttonify.extract_options",
+                execution_mode="llm",
+                llm_policy={
+                    "tool_mode": "none",
+                    "policy_stage": "buttonify",
+                    "prompt_text_context_key": "buttonify_prompt_text",
+                    "context_fields": [
+                        {"label": "User message", "context_key": "user_prompt"},
+                        {
+                            "label": "Assistant response",
+                            "context_key": "screen_text",
+                        },
+                    ],
+                },
+                validation_policy={"output_format": "buttonify_options_json"},
                 conditional_transitions=(
                     _CanonicalConditionalTransitionPublicationSpec(
                         to_state="completed",
@@ -585,72 +627,21 @@ _CANONICAL_WORKFLOW_PUBLICATION_SPECS: Dict[str, _CanonicalWorkflowPublicationSp
         ),
     ),
     TOOL_CALLING_WORKFLOW_ID: _CanonicalWorkflowPublicationSpec(
-        initial_state="plan",
+        initial_state="respond",
         steps=(
             _CanonicalStepPublicationSpec(
-                state_id="plan",
-                action_id="tool_calling.plan",
+                state_id="respond",
+                action_id="tool_calling.respond",
+                execution_mode="llm",
+                llm_policy={
+                    "tool_mode": "allowed",
+                    "policy_stage": "tool_call",
+                    "prompt_text_context_key": "prompt",
+                },
                 conditional_transitions=(
-                    _CanonicalConditionalTransitionPublicationSpec(
-                        to_state="validate",
-                        reason="tool_calls_found",
-                        condition_spec={
-                            "kind": "context_flag",
-                            "key": "tool_calls_present",
-                        },
-                    ),
                     _CanonicalConditionalTransitionPublicationSpec(
                         to_state="postcondition_critic",
-                        reason="direct_response",
-                        condition_spec={"kind": "always"},
-                    ),
-                ),
-            ),
-            _CanonicalStepPublicationSpec(
-                state_id="validate",
-                action_id="tool_calling.validate",
-                conditional_transitions=(
-                    _CanonicalConditionalTransitionPublicationSpec(
-                        to_state="execute",
-                        reason="validation_passed",
-                        condition_spec={
-                            "kind": "context_flag",
-                            "key": "tool_calls_validated",
-                        },
-                    ),
-                    _CanonicalConditionalTransitionPublicationSpec(
-                        to_state="postcondition_critic",
-                        reason="validation_error",
-                        condition_spec={"kind": "always"},
-                    ),
-                ),
-            ),
-            _CanonicalStepPublicationSpec(
-                state_id="execute",
-                action_id="tool_calling.execute",
-                conditional_transitions=(
-                    _CanonicalConditionalTransitionPublicationSpec(
-                        to_state="backfill",
-                        reason="batch_executed",
-                        condition_spec={"kind": "always"},
-                    ),
-                ),
-            ),
-            _CanonicalStepPublicationSpec(
-                state_id="backfill",
-                action_id="tool_calling.backfill",
-                conditional_transitions=(
-                    _CanonicalConditionalTransitionPublicationSpec(
-                        to_state="validate",
-                        reason="chained_tool_calls",
-                        condition_spec={
-                            "kind": "context_flag",
-                            "key": "more_tool_calls",
-                        },
-                    ),
-                    _CanonicalConditionalTransitionPublicationSpec(
-                        to_state="postcondition_critic",
-                        reason="backfill_done",
+                        reason="response_ready",
                         condition_spec={"kind": "always"},
                     ),
                 ),
@@ -671,7 +662,7 @@ _CANONICAL_WORKFLOW_PUBLICATION_SPECS: Dict[str, _CanonicalWorkflowPublicationSp
                 action_id="turn_execution.completion_gate",
                 conditional_transitions=(
                     _CanonicalConditionalTransitionPublicationSpec(
-                        to_state="plan",
+                        to_state="respond",
                         reason="completion_gate_repeat_iteration",
                         condition_spec={
                             "kind": "context_flag",
@@ -1515,6 +1506,17 @@ def _build_definition_from_publication_spec(
                         and step.action_concept_id.strip()
                         else None
                     ),
+                    execution_mode=step.execution_mode or "deterministic",
+                    llm_policy=(
+                        dict(step.llm_policy)
+                        if isinstance(step.llm_policy, Mapping)
+                        else None
+                    ),
+                    validation_policy=(
+                        dict(step.validation_policy)
+                        if isinstance(step.validation_policy, Mapping)
+                        else None
+                    ),
                 ),
             )
             if isinstance(step.action_id, str) and step.action_id.strip()
@@ -1788,8 +1790,21 @@ def _extract_runtime_step_publication_details(
     )
     static_input_bindings: list[tuple[str, str]] = []
     context_input_mapping_specs: list[_CanonicalContextInputMappingSpec] = []
+    execution_mode: str | None = None
+    llm_policy: Mapping[str, Any] | None = None
+    validation_policy: Mapping[str, Any] | None = None
 
     for action in actions:
+        execution_mode = str(getattr(action, "execution_mode", "") or "").strip() or execution_mode
+        action_llm_policy = getattr(action, "llm_policy", None)
+        if isinstance(action_llm_policy, Mapping) and not isinstance(llm_policy, Mapping):
+            llm_policy = dict(action_llm_policy)
+        action_validation_policy = getattr(action, "validation_policy", None)
+        if isinstance(action_validation_policy, Mapping) and not isinstance(
+            validation_policy,
+            Mapping,
+        ):
+            validation_policy = dict(action_validation_policy)
         inputs = getattr(action, "inputs", None)
         if not isinstance(inputs, Mapping):
             continue
@@ -1865,6 +1880,13 @@ def _extract_runtime_step_publication_details(
             ]
 
     return _RuntimeStepPublicationDetails(
+        execution_mode=execution_mode or None,
+        llm_policy=dict(llm_policy) if isinstance(llm_policy, Mapping) else None,
+        validation_policy=(
+            dict(validation_policy)
+            if isinstance(validation_policy, Mapping)
+            else None
+        ),
         invoked_workflow_id=invoked_workflow_id or None,
         static_input_bindings=tuple(dict.fromkeys(static_input_bindings)),
         context_input_mapping_specs=tuple(
@@ -2429,6 +2451,29 @@ def publish_canonical_chat_workflow_graphs(
                 and step.invoked_workflow_id.strip()
                 else runtime_details.invoked_workflow_id
             )
+            execution_mode = (
+                step.execution_mode.strip()
+                if isinstance(step.execution_mode, str) and step.execution_mode.strip()
+                else runtime_details.execution_mode
+            )
+            llm_policy = (
+                dict(step.llm_policy)
+                if isinstance(step.llm_policy, Mapping)
+                else (
+                    dict(runtime_details.llm_policy)
+                    if isinstance(runtime_details.llm_policy, Mapping)
+                    else None
+                )
+            )
+            validation_policy = (
+                dict(step.validation_policy)
+                if isinstance(step.validation_policy, Mapping)
+                else (
+                    dict(runtime_details.validation_policy)
+                    if isinstance(runtime_details.validation_policy, Mapping)
+                    else None
+                )
+            )
             static_input_bindings = (
                 step.static_input_bindings
                 if step.static_input_bindings
@@ -2524,6 +2569,32 @@ def publish_canonical_chat_workflow_graphs(
                     and isinstance(value, str)
                     and value.strip()
                 ]
+            runtime_input_maps = list(
+                step_relationships.get(_CANONICAL_GRAPH_PREDICATES["hasInputMap"]) or []
+            )
+            if isinstance(execution_mode, str) and execution_mode.strip():
+                runtime_input_maps.append(
+                    "workflow_step_execution_mode="
+                    f"{execution_mode.strip()}"
+                )
+            if isinstance(llm_policy, Mapping) and llm_policy:
+                runtime_input_maps.append(
+                    "workflow_step_llm_policy="
+                    + json.dumps(dict(llm_policy), ensure_ascii=True, sort_keys=True)
+                )
+            if isinstance(validation_policy, Mapping) and validation_policy:
+                runtime_input_maps.append(
+                    "workflow_step_validation_policy="
+                    + json.dumps(
+                        dict(validation_policy),
+                        ensure_ascii=True,
+                        sort_keys=True,
+                    )
+                )
+            if runtime_input_maps:
+                step_relationships[_CANONICAL_GRAPH_PREDICATES["hasInputMap"]] = (
+                    list(dict.fromkeys(item for item in runtime_input_maps if item))
+                )
             if context_input_mapping_specs:
                 if not isinstance(mapping_target_id, str) or not mapping_target_id.strip():
                     errors_by_workflow_id[workflow_id] = (

--- a/src/backend/workflows/workflow_definition_identity_service.py
+++ b/src/backend/workflows/workflow_definition_identity_service.py
@@ -231,7 +231,11 @@ def collect_workflow_action_ids(definition: Any) -> tuple[str, ...]:
         actions_raw = getattr(state_spec, "actions", ())
         actions = actions_raw if _is_sequence_like(actions_raw) else ()
         for action in actions:
-            action_id = str(getattr(action, "action_id", "") or "").strip()
+            action_id = str(
+                getattr(action, "action_id", None)
+                or getattr(action, "target_id", "")
+                or ""
+            ).strip()
             if action_id:
                 action_ids.add(action_id)
     return tuple(sorted(action_ids))
@@ -719,19 +723,44 @@ def validate_workflow_definition_contract(
         metadata = dict(metadata_raw) if isinstance(metadata_raw, Mapping) else {}
         actions_raw = getattr(state_spec, "actions", ())
         action_objects = actions_raw if _is_sequence_like(actions_raw) else ()
-        action_specs: list[tuple[str, Mapping[str, Any]]] = []
+        action_specs: list[dict[str, Any]] = []
         for action in action_objects:
             action_id = str(getattr(action, "action_id", "") or "").strip()
-            if not action_id:
-                continue
+            target_id = str(getattr(action, "target_id", "") or "").strip()
+            execution_mode = str(getattr(action, "execution_mode", "") or "").strip()
             action_inputs_raw = getattr(action, "inputs", {})
             action_inputs = (
                 dict(action_inputs_raw)
                 if isinstance(action_inputs_raw, Mapping)
                 else {}
             )
-            action_specs.append((action_id, action_inputs))
-        actions = [action_id for action_id, _ in action_specs]
+            prompt_contract_raw = getattr(action, "prompt_contract", None)
+            action_specs.append(
+                {
+                    "action_id": action_id,
+                    "target_id": target_id,
+                    "execution_mode": execution_mode,
+                    "inputs": action_inputs,
+                    "prompt_contract": (
+                        dict(prompt_contract_raw)
+                        if isinstance(prompt_contract_raw, Mapping)
+                        else {}
+                    ),
+                }
+            )
+        executable_actions = [
+            spec for spec in action_specs if str(spec.get("target_id") or "").strip()
+        ]
+        actions = [
+            str(spec.get("action_id") or spec.get("target_id") or "").strip()
+            for spec in executable_actions
+            if str(spec.get("action_id") or spec.get("target_id") or "").strip()
+        ]
+        llm_actions = [
+            spec
+            for spec in executable_actions
+            if str(spec.get("execution_mode") or "").strip().lower() == "llm"
+        ]
         is_terminal_state = bool(getattr(state_spec, "terminal", False)) or (
             state_id in termination_states
         )
@@ -821,11 +850,19 @@ def validate_workflow_definition_contract(
         resolved_prompt_concept_id = str(
             prompt_contract.get("resolved_prompt_concept_id") or ""
         ).strip()
-        if prompt_contract and not actions:
+        if prompt_contract and not executable_actions:
             prompt_contract_issues.append(
                 {
                     "state_id": state_id,
                     "reason_code": "prompt_contract_without_action",
+                    "severity": "error",
+                }
+            )
+        if prompt_contract and executable_actions and not llm_actions:
+            prompt_contract_issues.append(
+                {
+                    "state_id": state_id,
+                    "reason_code": "prompt_contract_not_compiled_as_llm_step",
                     "severity": "error",
                 }
             )
@@ -838,10 +875,27 @@ def validate_workflow_definition_contract(
                     "requested_prompt_concept_ids": requested_prompt_concept_ids,
                 }
             )
-        for action_id, action_inputs in action_specs:
+        for action_spec in action_specs:
+            action_id = str(
+                action_spec.get("action_id") or action_spec.get("target_id") or ""
+            ).strip()
+            raw_action_inputs = action_spec.get("inputs")
+            action_inputs: dict[str, Any] = (
+                {
+                    str(key): value
+                    for key, value in raw_action_inputs.items()
+                    if isinstance(key, str)
+                }
+                if isinstance(raw_action_inputs, Mapping)
+                else {}
+            )
             raw_prompt_diagnostics = action_inputs.get("__prompt_resolution_diagnostics")
-            prompt_diagnostics: Mapping[str, Any] = (
-                raw_prompt_diagnostics
+            prompt_diagnostics: dict[str, Any] = (
+                {
+                    str(key): value
+                    for key, value in raw_prompt_diagnostics.items()
+                    if isinstance(key, str)
+                }
                 if isinstance(raw_prompt_diagnostics, Mapping)
                 else {}
             )

--- a/src/frontend/web/von_interface/static/js/settingsPage.js
+++ b/src/frontend/web/von_interface/static/js/settingsPage.js
@@ -71,6 +71,7 @@ let runtimeAbortController = null;
 let runtimeStatusInFlight = false;
 let backgroundTaskUnsubscribe = null;
 let gmailProfileStatusInFlight = false;
+let currentResolvedLlm = null;
 
 let __vonIsAdminOrOwner = false;
 let availableGmailProfiles = [];
@@ -159,6 +160,47 @@ function resolveActiveLlmScopeContext() {
   }
 
   return { scope: null, conceptId: null };
+}
+
+function buildEnabledLlmSelections() {
+  const selections = [];
+  const openaiModelSelect = document.getElementById('openaiModelSelect');
+  const ollamaModelSelect = document.getElementById('globalModelSelect');
+
+  const openaiModel = openaiModelSelect?.value;
+  if (openaiModel) {
+    selections.push({ provider: 'openai', model: openaiModel });
+  }
+
+  const ollamaOption = ollamaModelSelect?.selectedOptions?.[0];
+  const ollamaModel = ollamaOption ? (ollamaOption.dataset.modelName || ollamaModelSelect?.value) : ollamaModelSelect?.value;
+  if (ollamaModel) {
+    const selection = { provider: 'ollama', model: ollamaModel };
+    const hostUrl = ollamaOption?.dataset?.hostUrl || null;
+    if (hostUrl) selection.host = hostUrl;
+    selections.push(selection);
+  }
+
+  return selections;
+}
+
+function resolveActiveLlmFromSelections(enabledLlms, preferredProvider = null) {
+  if (!Array.isArray(enabledLlms) || !enabledLlms.length) return null;
+
+  const matchesCurrent = enabledLlms.find((entry) =>
+    currentResolvedLlm
+    && entry?.provider === currentResolvedLlm.provider
+    && entry?.model === currentResolvedLlm.model
+    && (entry?.host || null) === (currentResolvedLlm.host || null)
+  );
+  if (matchesCurrent) return { ...matchesCurrent };
+
+  if (preferredProvider) {
+    const preferred = enabledLlms.find((entry) => entry?.provider === preferredProvider);
+    if (preferred) return { ...preferred };
+  }
+
+  return { ...enabledLlms[0] };
 }
 
 async function _fetchSessionContextForRole() {
@@ -1781,13 +1823,24 @@ async function loadAndDisplaySettings() {
     // Extract current model information from resolved_llm (respects user > org > global precedence)
     // Falls back to active_llm for backwards compatibility
     const effectiveLlm = settings.resolved_llm || settings.active_llm;
+    currentResolvedLlm = effectiveLlm || null;
+    const enabledLlms = Array.isArray(settings.enabled_llms) ? settings.enabled_llms : [];
     let currentOllamaModel = null;
     let currentOpenAIModel = null;
 
+    for (const entry of enabledLlms) {
+      if (!entry || typeof entry !== 'object') continue;
+      if (entry.provider === 'ollama' && entry.model) {
+        currentOllamaModel = entry.model;
+      } else if (entry.provider === 'openai' && entry.model) {
+        currentOpenAIModel = entry.model;
+      }
+    }
+
     if (effectiveLlm) {
-      if (effectiveLlm.provider === 'ollama') {
+      if (!currentOllamaModel && effectiveLlm.provider === 'ollama') {
         currentOllamaModel = effectiveLlm.model;
-      } else if (effectiveLlm.provider === 'openai') {
+      } else if (!currentOpenAIModel && effectiveLlm.provider === 'openai') {
         currentOpenAIModel = effectiveLlm.model;
       }
     }
@@ -2233,37 +2286,10 @@ async function saveAllSettings(changedProvider = null) {
   const ollamaModelSelect = document.getElementById('globalModelSelect');
   const openaiModelSelect = document.getElementById('openaiModelSelect');
   const { scope: llmScope, conceptId: llmConceptId } = resolveActiveLlmScopeContext();
+  const enabledLlms = buildEnabledLlmSelections();
+  let activeLlm = resolveActiveLlmFromSelections(enabledLlms, changedProvider);
 
-  let activeLlm = null;
-
-  if (changedProvider === 'openai') {
-    activeLlm = { provider: 'openai', model: openaiModelSelect.value };
-    // Clear the other dropdown to avoid confusion
-    ollamaModelSelect.value = '';
-  } else if (changedProvider === 'ollama') {
-    // Extract both the model name and host URL from the selected option
-    const selectedOption = ollamaModelSelect.selectedOptions[0];
-    const modelName = selectedOption ? selectedOption.dataset.modelName : ollamaModelSelect.value;
-    const hostUrl = selectedOption ? selectedOption.dataset.hostUrl : null;
-    activeLlm = { provider: 'ollama', model: modelName, host: hostUrl };
-    // Clear the other dropdown
-    openaiModelSelect.value = '';
-  } else {
-    // If no specific provider changed (e.g., user change), determine the active one
-    const openaiModel = openaiModelSelect?.value;
-    const ollamaModel = ollamaModelSelect?.value;
-    if (openaiModel) {
-      activeLlm = { provider: 'openai', model: openaiModel };
-    } else if (ollamaModel) {
-      // Extract both the model name and host URL from the selected option
-      const selectedOption = ollamaModelSelect.selectedOptions[0];
-      const modelName = selectedOption ? selectedOption.dataset.modelName : ollamaModel;
-      const hostUrl = selectedOption ? selectedOption.dataset.hostUrl : null;
-      activeLlm = { provider: 'ollama', model: modelName, host: hostUrl };
-    }
-  }
-
-  if (activeLlm && (!llmScope || !llmConceptId)) {
+  if (enabledLlms.length && (!llmScope || !llmConceptId)) {
     showStatusMessage(
       'settingsStatusMessage',
       'Select a current user or organisation before changing the model.',
@@ -2280,6 +2306,7 @@ async function saveAllSettings(changedProvider = null) {
   // We now persist user/org/language only in localStorage; do not send to backend
   const settings = {
     active_llm: activeLlm,
+    enabled_llms: enabledLlms,
     openai_api_key_env_var: document.getElementById('openaiApiKeyEnvVar')?.value,
     preload_vontology_tree: !!document.getElementById('preloadVontologyTreeToggle')?.checked,
     fetch_counts_on_load: !!document.getElementById('fetchCountsOnLoadToggle')?.checked,
@@ -2330,6 +2357,10 @@ async function saveAllSettings(changedProvider = null) {
       )
     ) {
       throw new Error('Model change did not take effect for the current context.');
+    }
+
+    if (payload?.resolved_llm) {
+      currentResolvedLlm = payload.resolved_llm;
     }
 
     showStatusMessage('settingsStatusMessage', payload.message || 'Settings saved successfully!');

--- a/tests/backend/test_turn_execution_workflow_definitions.py
+++ b/tests/backend/test_turn_execution_workflow_definitions.py
@@ -9,29 +9,25 @@ from src.backend.workflows.definitions import (
     build_tool_calling_workflow,
     register_default_workflows,
 )
+from src.backend.workflows.engine import WORKFLOW_STEP_EXECUTION_MODE_LLM
 from src.backend.workflows.workflow_registry import WorkflowRegistry
 
 
 def test_tool_calling_workflow_includes_turn_execution_critic_and_gate() -> None:
     workflow = build_tool_calling_workflow()
 
+    assert workflow.initial_state == "respond"
+    assert "respond" in workflow.states
     assert "postcondition_critic" in workflow.states
     assert "completion_gate" in workflow.states
 
-    plan = workflow.states["plan"]
+    respond = workflow.states["respond"]
+    assert respond.actions[0].action_id == "tool_calling.respond"
+    assert respond.actions[0].execution_mode == WORKFLOW_STEP_EXECUTION_MODE_LLM
     assert any(
-        t.to_state == "postcondition_critic" and t.reason == "direct_response"
-        for t in plan.transitions
+        t.to_state == "postcondition_critic" and t.reason == "response_ready"
+        for t in respond.transitions
     )
-
-    validate = workflow.states["validate"]
-    assert any(
-        t.to_state == "postcondition_critic" and t.reason == "validation_error"
-        for t in validate.transitions
-    )
-
-    backfill = workflow.states["backfill"]
-    assert any(t.to_state == "postcondition_critic" for t in backfill.transitions)
 
     postcondition_critic = workflow.states["postcondition_critic"]
     assert postcondition_critic.actions[0].action_id == "turn_execution.critic"
@@ -40,7 +36,7 @@ def test_tool_calling_workflow_includes_turn_execution_critic_and_gate() -> None
     completion_gate = workflow.states["completion_gate"]
     assert completion_gate.actions[0].action_id == "turn_execution.completion_gate"
     assert any(
-        t.to_state == "plan" and t.reason == "completion_gate_repeat_iteration"
+        t.to_state == "respond" and t.reason == "completion_gate_repeat_iteration"
         for t in completion_gate.transitions
     )
     assert any(t.to_state == "completed" for t in completion_gate.transitions)

--- a/tests/backend/test_vontology_loader.py
+++ b/tests/backend/test_vontology_loader.py
@@ -22,6 +22,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from src.backend.workflows.engine import (
+    WORKFLOW_STEP_EXECUTION_MODE_LLM,
     WorkflowActionInvocation,
     WorkflowDefinition,
     WorkflowStateSpec,
@@ -589,7 +590,9 @@ class TestWorkflowPromptContracts:
         assert step["prompt_contract"]["metadata"]["prompt_variables"] == ["issue_key"]
         assert step["prompt_resolution_diagnostics"]["status"] == "ok"
 
-    def test_load_workflow_definition_carries_prompt_contract_into_action_inputs(self):
+    def test_load_workflow_definition_carries_prompt_contract_into_llm_step_metadata(
+        self,
+    ):
         steps = [
             {
                 **_make_step(
@@ -637,13 +640,24 @@ class TestWorkflowPromptContracts:
         assert prompt_state.metadata["prompt_contract"]["resolved_prompt_concept_id"] == (
             "#V#issue_prompt"
         )
-        action_inputs = prompt_state.actions[0].inputs
+        action = prompt_state.actions[0]
+        action_inputs = action.inputs
         assert action_inputs["ticket_id"] == "JVNAUTOSCI-1358"
         assert "__prompt_defaults" not in action_inputs
-        assert action_inputs["__prompt_contract"]["metadata"]["prompt_name"] == (
+        assert "__prompt_contract" not in action_inputs
+        assert action_inputs["__prompt_resolution_diagnostics"]["status"] == "warning"
+        assert action.execution_mode == WORKFLOW_STEP_EXECUTION_MODE_LLM
+        assert action.prompt_contract is not None
+        assert action.prompt_contract["metadata"]["prompt_name"] == "Issue fixer"
+        assert action.llm_policy is not None
+        assert action.llm_policy["selected_prompt_id"] == "#V#issue_prompt"
+        assert action.llm_policy["selection_policy"] == "adaptive"
+        assert action.validation_policy == {
+            "prompt_validation_policy": "warn"
+        }
+        assert prompt_state.metadata["prompt_contract"]["metadata"]["prompt_name"] == (
             "Issue fixer"
         )
-        assert action_inputs["__prompt_resolution_diagnostics"]["status"] == "warning"
 
 
 class TestWorkflowBackgroundLaunchPolicyResolution:
@@ -2392,7 +2406,7 @@ class TestMetadataCarrythrough:
         assert meta["writes_variables"] == ["task_id"]
 
     def test_empty_metadata_when_no_annotations(self):
-        """Steps without annotations should have empty metadata."""
+        """Steps without annotations should still expose execution-mode metadata."""
         steps = [_make_step("#V#step", invokes_action="act")]
         graph = _make_graph(initial_step="#V#step", steps=steps)
 
@@ -2404,7 +2418,10 @@ class TestMetadataCarrythrough:
                 defn = load_workflow_definition_from_vontology("#V#test_workflow")
 
         assert defn is not None
-        assert defn.states["#V#step"].metadata == {}
+        assert defn.states["#V#step"].metadata == {
+            "execution_mode": "deterministic",
+            "execution_modes": ["deterministic"],
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/test_workflow_definition_identity_service.py
+++ b/tests/backend/test_workflow_definition_identity_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from src.backend.workflows.engine import (
+    WORKFLOW_STEP_EXECUTION_MODE_LLM,
     WorkflowActionInvocation,
     WorkflowDefinition,
     WorkflowStateSpec,
@@ -410,6 +411,7 @@ def test_validate_contract_keeps_prompt_contract_warnings_non_blocking() -> None
                 actions=(
                     WorkflowActionInvocation(
                         action_id="llm.action",
+                        execution_mode=WORKFLOW_STEP_EXECUTION_MODE_LLM,
                         inputs={
                             "__prompt_resolution_diagnostics": {
                                 "errors": [],


### PR DESCRIPTION
Implements JVNAUTOSCI-1452. This changes VWL step compilation and execution to be LLM-first for ordinary reasoning steps, preserves deterministic/control/subworkflow exceptions, adds the generic LLM step executor, supports multi-enabled LLM settings for runtime model selection, migrates the canonical planning/narration/buttonify/tool-calling workflows, updates publication/validation surfaces, and refreshes the workflow manual and regression tests.