### PR TITLE
fix(JVNAUTOSCI-1426): translate internal GitHub proxy tool names

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -13704,6 +13704,7 @@ def _github_clean_text(value: Any) -> str | None:
 def _github_normalise_response(
     *,
     tool_name: str,
+    proxy_tool_name: str,
     raw_result: Any,
     proxy_stats: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
@@ -13717,17 +13718,86 @@ def _github_normalise_response(
         payload = {"success": True, "result": raw_result}
 
     payload.setdefault("tool", tool_name)
+    if proxy_tool_name != tool_name:
+        payload.setdefault("proxy_tool", proxy_tool_name)
     if isinstance(proxy_stats, Mapping):
         payload.setdefault("proxy_stats", dict(proxy_stats))
     return payload
 
 
+def _github_resolve_proxy_call(
+    tool_name: str,
+    arguments: Mapping[str, Any],
+) -> tuple[str, dict[str, Any]] | dict[str, Any]:
+    # Internal tool names mirror Von's `github_*` surface, while the external
+    # `@modelcontextprotocol/server-github` server exposes mostly unprefixed
+    # names.  Resolve the translation once here so handlers stay simple.
+    proxy_arguments = dict(arguments)
+
+    if tool_name == "github_pull_request_read":
+        method = _github_clean_text(proxy_arguments.pop("method"))
+        method_map = {
+            "get": "get_pull_request",
+            "get_files": "get_pull_request_files",
+            "get_status": "get_pull_request_status",
+            "get_comments": "get_pull_request_comments",
+            "get_reviews": "get_pull_request_reviews",
+        }
+        proxy_tool_name = method_map.get(method or "")
+        if proxy_tool_name is None:
+            return make_error_response(
+                "unsupported_operation",
+                "Configured GitHub MCP server does not support this "
+                f"github_pull_request_read method: {method!r}",
+                details={
+                    "tool": tool_name,
+                    "method": method,
+                    "supported_methods": sorted(method_map),
+                },
+                suggestions=[
+                    "Use one of: get, get_files, get_status, get_comments, get_reviews",
+                    "If you need other pull-request reads, extend the proxy-tool mapping first",
+                ],
+            )
+        return proxy_tool_name, proxy_arguments
+
+    if tool_name == "github_issue_read":
+        method = _github_clean_text(proxy_arguments.pop("method"))
+        method_map = {"get": "get_issue"}
+        proxy_tool_name = method_map.get(method or "")
+        if proxy_tool_name is None:
+            return make_error_response(
+                "unsupported_operation",
+                "Configured GitHub MCP server does not support this "
+                f"github_issue_read method: {method!r}",
+                details={
+                    "tool": tool_name,
+                    "method": method,
+                    "supported_methods": sorted(method_map),
+                },
+                suggestions=[
+                    "Use method=get for the current GitHub MCP server version",
+                    "If you need richer issue reads, add an explicit translation for the target tool",
+                ],
+            )
+        return proxy_tool_name, proxy_arguments
+
+    if tool_name.startswith("github_"):
+        return tool_name.removeprefix("github_"), proxy_arguments
+    return tool_name, proxy_arguments
+
+
 def _github_invoke_proxy_tool(tool_name: str, arguments: Mapping[str, Any]) -> dict[str, Any]:
     from .github_proxy_mcp import GitHubProxyError, get_github_proxy
 
+    resolved_call = _github_resolve_proxy_call(tool_name, arguments)
+    if isinstance(resolved_call, dict):
+        return resolved_call
+    proxy_tool_name, proxy_arguments = resolved_call
+
     async def _async_call():
         proxy = await get_github_proxy()
-        result = await proxy.call_tool(tool_name, dict(arguments))
+        result = await proxy.call_tool(proxy_tool_name, proxy_arguments)
         return result, proxy.get_stats()
 
     try:
@@ -13737,7 +13807,12 @@ def _github_invoke_proxy_tool(tool_name: str, arguments: Mapping[str, Any]) -> d
         return make_error_response(
             "github_proxy_error",
             error_message,
-            details={"exception_type": "GitHubProxyError", "tool": tool_name, "message": error_message},
+            details={
+                "exception_type": "GitHubProxyError",
+                "tool": tool_name,
+                "proxy_tool": proxy_tool_name,
+                "message": error_message,
+            },
             suggestions=[
                 "Check GitHub MCP connectivity, command args, and token configuration",
                 "If using VS Code, ensure GITHUB_PERSONAL_ACCESS_TOKEN is set in .env "
@@ -13748,12 +13823,17 @@ def _github_invoke_proxy_tool(tool_name: str, arguments: Mapping[str, Any]) -> d
         return make_error_response(
             "github_proxy_error",
             f"GitHub proxy invocation failed: {exc}",
-            details={"exception_type": type(exc).__name__, "tool": tool_name},
+            details={
+                "exception_type": type(exc).__name__,
+                "tool": tool_name,
+                "proxy_tool": proxy_tool_name,
+            },
             suggestions=["Check GitHub MCP server availability"],
         )
 
     return _github_normalise_response(
         tool_name=tool_name,
+        proxy_tool_name=proxy_tool_name,
         raw_result=raw_result,
         proxy_stats=proxy_stats if isinstance(proxy_stats, Mapping) else None,
     )

--- a/tests/backend/test_internal_mcp_github_tools.py
+++ b/tests/backend/test_internal_mcp_github_tools.py
@@ -8,6 +8,7 @@ from src.backend.integrations.internal_mcp.catalogue import (
     _github_create_branch,
     _github_create_pull_request,
     _github_get_file_contents,
+    _github_issue_read,
     _github_search_code,
     build_default_catalogue,
 )
@@ -82,7 +83,7 @@ def test_github_get_file_contents_success_through_gateway_invoke(monkeypatch) ->
 
     class _FakeProxy:
         async def call_tool(self, tool_name: str, arguments: dict):
-            assert tool_name == "github_get_file_contents"
+            assert tool_name == "get_file_contents"
             assert arguments["owner"] == "Strong-AI-Lab"
             assert arguments["repo"] == "Von"
             return {
@@ -91,7 +92,7 @@ def test_github_get_file_contents_success_through_gateway_invoke(monkeypatch) ->
             }
 
         async def list_tools(self):
-            return [{"name": "github_get_file_contents"}]
+            return [{"name": "get_file_contents"}]
 
         def get_stats(self):
             return {"call_count": 1, "error_count": 0}
@@ -115,6 +116,8 @@ def test_github_get_file_contents_success_through_gateway_invoke(monkeypatch) ->
     )
     payload = result.payload
     assert payload.get("success") is True
+    assert payload.get("tool") == "github_get_file_contents"
+    assert payload.get("proxy_tool") == "get_file_contents"
     assert payload.get("path") == "README.md"
 
 
@@ -153,6 +156,68 @@ def test_github_proxy_error_through_gateway_invoke(monkeypatch) -> None:
     payload = result.payload
     assert payload.get("success") is False
     assert payload.get("error_code") == "github_proxy_error"
+    assert payload.get("error_details", {}).get("proxy_tool") == "get_file_contents"
+
+
+def test_github_pull_request_read_translates_supported_methods(monkeypatch) -> None:
+    from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
+    from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+
+    class _FakeProxy:
+        async def call_tool(self, tool_name: str, arguments: dict):
+            assert tool_name == "get_pull_request_status"
+            assert arguments == {
+                "owner": "Strong-AI-Lab",
+                "repo": "Von",
+                "pullNumber": 42,
+            }
+            return {"state": "success"}
+
+        async def list_tools(self):
+            return [{"name": "get_pull_request_status"}]
+
+        def get_stats(self):
+            return {"call_count": 1, "error_count": 0}
+
+    async def _fake_get_github_proxy():
+        return _FakeProxy()
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.github_proxy_mcp.get_github_proxy",
+        _fake_get_github_proxy,
+    )
+
+    gateway = InternalMCPGateway(
+        catalogue=build_default_catalogue(),
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+    result = gateway.invoke(
+        "github_pull_request_read",
+        {
+            "owner": "Strong-AI-Lab",
+            "repo": "Von",
+            "pullNumber": 42,
+            "method": "get_status",
+        },
+    )
+    payload = result.payload
+
+    assert payload.get("success") is True
+    assert payload.get("tool") == "github_pull_request_read"
+    assert payload.get("proxy_tool") == "get_pull_request_status"
+    assert payload.get("state") == "success"
+
+
+def test_github_issue_read_rejects_unsupported_methods() -> None:
+    result = _github_issue_read(
+        owner="Strong-AI-Lab",
+        repo="Von",
+        issue_number=7,
+        method="get_comments",
+    )
+    assert result.get("success") is False
+    assert result.get("error_code") == "unsupported_operation"
 
 
 def test_github_create_pull_request_success_through_gateway_invoke(monkeypatch) -> None:
@@ -161,13 +226,13 @@ def test_github_create_pull_request_success_through_gateway_invoke(monkeypatch) 
 
     class _FakeProxy:
         async def call_tool(self, tool_name: str, arguments: dict):
-            assert tool_name == "github_create_pull_request"
+            assert tool_name == "create_pull_request"
             assert arguments["owner"] == "Strong-AI-Lab"
             assert arguments["repo"] == "Von"
             return {"number": 42, "html_url": "https://example.test/pr/42"}
 
         async def list_tools(self):
-            return [{"name": "github_create_pull_request"}]
+            return [{"name": "create_pull_request"}]
 
         def get_stats(self):
             return {"call_count": 1, "error_count": 0}
@@ -201,6 +266,7 @@ def test_github_create_pull_request_success_through_gateway_invoke(monkeypatch) 
     assert payload.get("success") is True
     assert payload.get("executed") is True
     assert payload.get("action") == "create_pull_request"
+    assert payload.get("proxy_tool") == "create_pull_request"
 
 
 def test_github_build_env_prefers_repo_dotenv_token(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- translate Von internal \\github_*\\ tool names to the external \\@modelcontextprotocol/server-github\\ tool names before invoking the proxy
- preserve the internal tool name in responses while surfacing the translated external \\proxy_tool\\ for diagnostics
- route supported \\github_pull_request_read\\ modes to the matching external read tool and reject unsupported \\github_issue_read\\ modes clearly

## Verification
- \\pdm run pytest tests/backend/test_internal_mcp_github_tools.py -q\\
- \\pdm run pyright src/backend/integrations/internal_mcp/catalogue.py tests/backend/test_internal_mcp_github_tools.py\\
- \\pdm run pytest tests/backend/test_workflow_introspection_maintenance_workflow.py -q\\
- \\pdm run pytest tests/backend/test_mcp_proxy_base_transport_recovery.py -q\\
- live smoke via \\InternalMCPGateway.invoke('github_get_file_contents', ...)\\ against \\Strong-AI-Lab/Von\\ succeeded after the fix

## Notes
- \\pdm run pytest tests -m lane_backend_mcp -q\\ exceeded the available command timeout twice, so verification used the directly impacted suites plus a live gateway smoke instead.