### PR TITLE
JVNAUTOSCI-1428 gate local Ollama fallback probes

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -26,6 +26,7 @@ from typing import (
     Sequence,
     TypedDict,
 )
+from urllib.parse import urlparse
 
 from .gateway import InternalMCPGateway, MethodDefinition
 from .schemas import (
@@ -9187,6 +9188,25 @@ class InternalMCPChatOrchestrator:
         return f"http://{host}:11434"
 
     @staticmethod
+    def _is_local_ollama_probe_host(host: str) -> bool:
+        try:
+            parsed = urlparse(host)
+        except Exception:
+            return False
+        hostname = str(parsed.hostname or "").strip().lower()
+        return hostname in {"localhost", "127.0.0.1", "::1"}
+
+    def _ollama_probe_timeout_ms(self, *, host: str) -> int:
+        default_timeout_ms = 200 if self._is_local_ollama_probe_host(host) else 1200
+        return self._coerce_int(
+            None,
+            env_var="VON_INTERNAL_MCP_OLLAMA_PROBE_TIMEOUT_MS",
+            default=default_timeout_ms,
+            min_value=100,
+            max_value=10000,
+        )
+
+    @staticmethod
     def _provider_probe_cache_key(*, provider: str, host: str | None = None) -> str:
         provider_key = str(provider or "").strip().lower()
         host_key = str(host or "").strip().lower()
@@ -9265,15 +9285,10 @@ class InternalMCPChatOrchestrator:
         }:
             return None
 
-        timeout_ms = self._coerce_int(
-            None,
-            env_var="VON_INTERNAL_MCP_OLLAMA_PROBE_TIMEOUT_MS",
-            default=1200,
-            min_value=100,
-            max_value=10000,
-        )
         host = self._normalise_ollama_probe_host(telemetry.get("host"))
+        timeout_ms = self._ollama_probe_timeout_ms(host=host)
         probe_url = f"{host}/api/tags"
+        probe_start = time.perf_counter()
         cooldown_seconds = max(0, int(self._provider_probe_cooldown_seconds))
         if cooldown_seconds > 0:
             cached = self._provider_probe_cache_get(provider=provider, host=host)
@@ -9297,6 +9312,7 @@ class InternalMCPChatOrchestrator:
                     cached_payload.setdefault("provider", provider)
                     cached_payload.setdefault("host", host)
                     cached_payload.setdefault("probe_url", probe_url)
+                    cached_payload.setdefault("probe_timeout_ms", int(timeout_ms))
                     cached_payload["cached"] = True
                     cached_payload["cooldown_hit"] = True
                     cached_payload["cooldown_seconds"] = cooldown_seconds
@@ -9304,9 +9320,14 @@ class InternalMCPChatOrchestrator:
                         max(0.0, (float(cooldown_seconds) - age_seconds) * 1000.0)
                     )
                     cached_payload["cache_age_ms"] = int(age_seconds * 1000.0)
+                    cached_payload["cached_result_duration_ms"] = int(
+                        max(0.0, float(cached_payload.get("duration_ms") or 0.0))
+                    )
+                    cached_payload["duration_ms"] = int(
+                        (time.perf_counter() - probe_start) * 1000.0
+                    )
                     return cached_payload
 
-        probe_start = time.perf_counter()
         try:
             http_response = requests.get(
                 probe_url,

--- a/tests/backend/test_orchestrator_model_fallback_execution.py
+++ b/tests/backend/test_orchestrator_model_fallback_execution.py
@@ -42,10 +42,18 @@ def _policy_state() -> _WorkflowModelPolicyState:
     )
 
 
+def _bare_orchestrator() -> InternalMCPChatOrchestrator:
+    orchestrator = object.__new__(InternalMCPChatOrchestrator)
+    orchestrator._provider_probe_cache = {}
+    orchestrator._provider_probe_cache_max_entries = 32
+    orchestrator._provider_probe_cooldown_seconds = 0
+    return orchestrator
+
+
 def test_run_llm_with_fallbacks_records_attempt_chain_and_fallback_metadata(
     monkeypatch,
 ) -> None:
-    orchestrator = InternalMCPChatOrchestrator(gateway=cast(Any, _StubGateway()))
+    orchestrator = _bare_orchestrator()
     ollama_candidate = _ModelCandidate(
         provider="ollama",
         model="granite3.3:2b",
@@ -191,7 +199,7 @@ def test_run_llm_with_fallbacks_records_attempt_chain_and_fallback_metadata(
 def test_probe_model_candidate_reachability_uses_failure_cooldown_cache(
     monkeypatch,
 ) -> None:
-    orchestrator = InternalMCPChatOrchestrator(gateway=cast(Any, _StubGateway()))
+    orchestrator = _bare_orchestrator()
     orchestrator._provider_probe_cooldown_seconds = 120
 
     request_calls = {"count": 0}
@@ -202,6 +210,7 @@ def test_probe_model_candidate_reachability_uses_failure_cooldown_cache(
 
     def _fake_get(*_args: Any, **_kwargs: Any) -> _FailingResponse:
         request_calls["count"] += 1
+        time.sleep(0.02)
         return _FailingResponse()
 
     monkeypatch.setattr(
@@ -225,7 +234,56 @@ def test_probe_model_candidate_reachability_uses_failure_cooldown_cache(
     assert second.get("reachable") is False
     assert second.get("cooldown_hit") is True
     assert second.get("cached") is True
+    assert second.get("cached_result_duration_ms") == first.get("duration_ms")
+    assert isinstance(first.get("duration_ms"), int)
+    assert isinstance(second.get("duration_ms"), int)
+    assert second["duration_ms"] < first["duration_ms"]
     assert request_calls["count"] == 1
+
+
+def test_probe_model_candidate_reachability_uses_shorter_timeout_for_local_ollama(
+    monkeypatch,
+) -> None:
+    orchestrator = _bare_orchestrator()
+    seen_timeouts: dict[str, float] = {}
+
+    class _SuccessfulResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+    def _fake_get(url: str, *_args: Any, **kwargs: Any) -> _SuccessfulResponse:
+        seen_timeouts[url] = float(kwargs["timeout"])
+        return _SuccessfulResponse()
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.orchestrator.requests.get",
+        _fake_get,
+    )
+
+    local_probe = orchestrator._probe_model_candidate_reachability(
+        telemetry={"provider": "ollama", "host": "http://localhost:11434"}
+    )
+    remote_probe = orchestrator._probe_model_candidate_reachability(
+        telemetry={"provider": "ollama", "host": "http://10.0.0.8:11434"}
+    )
+
+    assert local_probe is not None
+    assert local_probe["provider"] == "ollama"
+    assert local_probe["host"] == "http://localhost:11434"
+    assert local_probe["probe_url"] == "http://localhost:11434/api/tags"
+    assert local_probe["probe_timeout_ms"] == 200
+    assert local_probe["reachable"] is True
+    assert isinstance(local_probe["duration_ms"], int)
+
+    assert remote_probe is not None
+    assert remote_probe["provider"] == "ollama"
+    assert remote_probe["host"] == "http://10.0.0.8:11434"
+    assert remote_probe["probe_url"] == "http://10.0.0.8:11434/api/tags"
+    assert remote_probe["probe_timeout_ms"] == 1200
+    assert remote_probe["reachable"] is True
+    assert isinstance(remote_probe["duration_ms"], int)
+    assert seen_timeouts["http://localhost:11434/api/tags"] == pytest.approx(0.2)
+    assert seen_timeouts["http://10.0.0.8:11434/api/tags"] == pytest.approx(1.2)
 
 
 def test_invoke_with_llm_heartbeat_uses_backfill_timeout_for_summariser(


### PR DESCRIPTION
## Summary
- reduce the default Ollama reachability probe timeout to 200ms for local hosts while keeping 1200ms for non-local hosts
- preserve cached failure duration separately so cooldown hits report near-zero reuse time instead of replaying the original timeout
- add targeted regressions for cooldown-cache telemetry and local-vs-remote timeout selection, using a lightweight orchestrator fixture to avoid unrelated startup cost in the test file

## Verification
- `pdm run pyright src/backend/integrations/internal_mcp/orchestrator.py tests/backend/test_orchestrator_model_fallback_execution.py`
- `pdm run pytest tests/backend/test_orchestrator_model_fallback_execution.py -q`
- `pdm run pytest tests/backend/test_orchestrator_workflow_selector_routing.py::test_workflow_selector_uses_provider_aware_classifier_fallback -q`
- `pdm run pytest tests/backend/test_tool_progress_liveness.py::test_progress_clears_stale_error_on_subsequent_success -q`
- attempted `pdm run pytest tests -m lane_backend_mcp -q` but it exceeded the agent timeout in this environment