### PR TITLE
JVNAUTOSCI-1445: move URL extraction requirements into the tool workflow

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -219,6 +219,8 @@ class _PromptRequirementEvaluation:
     """Canonical prompt-requirement snapshot shared across routing/execution."""
 
     required_tools: tuple[str, ...] = ()
+    required_url_extraction_tool: str | None = None
+    required_url_extraction_url: str | None = None
     required_fetch_concept_ids: tuple[str, ...] = ()
     required_read_file_copy_ids: tuple[str, ...] = ()
     required_scholarly_representation_file_copy_ids: tuple[str, ...] = ()
@@ -614,6 +616,52 @@ class InternalMCPChatOrchestrator:
     )
     _PROMPT_EXPLICIT_TOOL_CALL_PATTERN = re.compile(
         r"\b(?:call|use|run|invoke|execute)\s+`?([a-z_][a-z0-9_]*(?:_[a-z0-9_]+)+)`?\b",
+        flags=re.IGNORECASE,
+    )
+    _PROMPT_URL_PATTERN = re.compile(r"\bhttps?://[^\s<>()\"']+", re.IGNORECASE)
+    _URL_READING_SHORT_FRAME_TEXTS: frozenset[str] = frozenset(
+        {
+            "read this",
+            "read this page",
+            "read this link",
+            "read this url",
+            "extract this",
+            "extract this page",
+            "extract this link",
+            "analyse this",
+            "analyze this",
+            "inspect this",
+            "review this",
+            "summarise this",
+            "summarize this",
+            "open this",
+            "visit this",
+            "look at this",
+            "check this",
+            "check this out",
+            "what about this",
+            "please read this",
+            "please extract this",
+            "please analyse this",
+            "please analyze this",
+            "please inspect this",
+            "please summarise this",
+            "please summarize this",
+            "please review this",
+            "please open this",
+            "please visit this",
+            "this",
+            "this link",
+            "this url",
+            "this page",
+        }
+    )
+    _URL_READING_INTENT_PATTERN = re.compile(
+        r"\b("
+        r"read|extract|inspect|analyse|analyze|review|open|visit|parse|"
+        r"summaris(?:e|ed|ing)|summariz(?:e|ed|ing)|scrape|crawl|"
+        r"look\s+at|check\s+out|what(?:'s|\s+is)\s+on|what\s+does(?:\s+this)?\s+say"
+        r")\b",
         flags=re.IGNORECASE,
     )
     # Matches natural-language MCP tool-family references such as
@@ -1348,6 +1396,13 @@ class InternalMCPChatOrchestrator:
         # driven by #V#tool_calling_workflow state machine.
         registry.register(
             ActionSpec(
+                action_id="tool_calling.preflight_requirements",
+                handler=self._action_tool_calling_preflight_requirements,
+                description="Derive prompt requirements before tool planning.",
+            )
+        )
+        registry.register(
+            ActionSpec(
                 action_id="tool_calling.plan",
                 handler=self._action_tool_calling_plan,
                 description="Initial LLM call + missing-tool-call recovery.",
@@ -2055,6 +2110,13 @@ class InternalMCPChatOrchestrator:
             if isinstance(required_create_type_name_raw, str)
             else None
         )
+        required_url_extraction_url_raw = data.get("required_prompt_url_extraction_url")
+        required_url_extraction_url = (
+            str(required_url_extraction_url_raw).strip()
+            if isinstance(required_url_extraction_url_raw, str)
+            and str(required_url_extraction_url_raw).strip()
+            else None
+        )
         emit_progress_raw = data.get("emit_progress")
         emit_progress_cb: Callable[[Mapping[str, Any]], None] | None = (
             cast(Callable[[Mapping[str, Any]], None], emit_progress_raw)
@@ -2169,6 +2231,7 @@ class InternalMCPChatOrchestrator:
             missing_required_read_file_copy_ids=missing_required_read_file_copy_ids,
             missing_required_scholarly_representation_file_copy_ids=missing_required_scholarly_file_copy_ids,
             required_create_type_name=required_create_type_name,
+            required_url_extraction_url=required_url_extraction_url,
         )
         if forced:
             import json
@@ -3592,6 +3655,125 @@ class InternalMCPChatOrchestrator:
     #   orchestrator_result (pre-built OrchestratorResult for error exits).
     # ------------------------------------------------------------------
 
+    def _action_tool_calling_preflight_requirements(
+        self, request: Any
+    ) -> WorkflowActionResult:
+        """Materialise workflow-owned prompt requirements before tool planning."""
+
+        data = request.data
+        prompt_for_requirements = data.get("prompt_for_requirements")
+        if (
+            not isinstance(prompt_for_requirements, str)
+            or not prompt_for_requirements.strip()
+        ):
+            prompt_for_requirements = data.get("prompt")
+        prompt_text = (
+            prompt_for_requirements.strip()
+            if isinstance(prompt_for_requirements, str)
+            else ""
+        )
+
+        method_catalogue = data.get("method_catalogue")
+        if not isinstance(method_catalogue, Mapping):
+            try:
+                method_catalogue = self._gateway.describe_methods()
+            except Exception:
+                method_catalogue = None
+
+        augmented_context = data.get("augmented_context")
+        context_messages = (
+            cast(Sequence[Mapping[str, Any]], augmented_context)
+            if isinstance(augmented_context, Sequence)
+            and not isinstance(augmented_context, (str, bytes, bytearray))
+            else None
+        )
+
+        url_requirement = dict(
+            self._derive_url_extraction_requirement(
+                prompt_text,
+                method_catalogue=(
+                    method_catalogue if isinstance(method_catalogue, Mapping) else None
+                ),
+            )
+        )
+        prompt_requirements = self._evaluate_prompt_requirements(
+            prompt_text=prompt_text,
+            method_catalogue=(
+                method_catalogue if isinstance(method_catalogue, Mapping) else None
+            ),
+            context_messages=context_messages,
+            tool_invocations=(),
+            url_requirement=url_requirement,
+        )
+
+        self._store_prompt_requirement_evaluation(data, prompt_requirements)
+        data["prompt_requirement_url_policy"] = dict(url_requirement)
+        if isinstance(method_catalogue, Mapping):
+            data["method_catalogue"] = method_catalogue
+
+        aux_log = data.get("aux_llm_calls")
+        if isinstance(aux_log, list):
+            try:
+                aux_log.append(
+                    {
+                        "type": "prompt_tool_requirements_preflight",
+                        "required_tools": list(prompt_requirements.required_tools),
+                        "required_url_extraction_tool": (
+                            prompt_requirements.required_url_extraction_tool
+                        ),
+                        "required_url_extraction_url": (
+                            prompt_requirements.required_url_extraction_url
+                        ),
+                        "missing_tools": list(prompt_requirements.missing_tools),
+                        "url_requirement": dict(url_requirement),
+                    }
+                )
+            except Exception:
+                pass
+
+        outputs: dict[str, Any] = {
+            "prompt_requirement_url_policy": dict(url_requirement),
+            "required_prompt_tools": list(prompt_requirements.required_tools),
+            "required_prompt_url_extraction_tool": (
+                prompt_requirements.required_url_extraction_tool
+            ),
+            "required_prompt_url_extraction_url": (
+                prompt_requirements.required_url_extraction_url
+            ),
+            "required_prompt_fetch_concept_ids": list(
+                prompt_requirements.required_fetch_concept_ids
+            ),
+            "required_prompt_read_file_copy_ids": list(
+                prompt_requirements.required_read_file_copy_ids
+            ),
+            "required_prompt_scholarly_representation_for_file_copy_ids": list(
+                prompt_requirements.required_scholarly_representation_file_copy_ids
+            ),
+            "required_prompt_create_type_name": (
+                prompt_requirements.required_create_type_name
+            ),
+            "missing_prompt_tools": list(prompt_requirements.missing_tools),
+            "missing_prompt_fetch_concept_ids": list(
+                prompt_requirements.missing_fetch_concept_ids
+            ),
+            "missing_prompt_read_file_copy_ids": list(
+                prompt_requirements.missing_read_file_copy_ids
+            ),
+            "missing_prompt_scholarly_representation_for_file_copy_ids": list(
+                prompt_requirements.missing_scholarly_representation_file_copy_ids
+            ),
+            "missing_tool_call_retry_reason_override": (
+                prompt_requirements.missing_retry_reason
+            ),
+            "prompt_requirements_preflight_completed": True,
+            "result": True,
+        }
+        if isinstance(method_catalogue, Mapping):
+            outputs["method_catalogue"] = method_catalogue
+        if isinstance(aux_log, list):
+            outputs["aux_llm_calls"] = aux_log
+        return WorkflowActionResult(outputs=outputs)
+
     def _action_tool_calling_plan(self, request: Any) -> WorkflowActionResult:
         """Phase 1 of tool calling: initial LLM call + missing-tool-call recovery.
 
@@ -3709,6 +3891,7 @@ class InternalMCPChatOrchestrator:
         prompt_for_requirements = data.get("prompt_for_requirements")
         if not isinstance(prompt_for_requirements, str) or not prompt_for_requirements.strip():
             prompt_for_requirements = prompt
+        prompt_requirement_url_policy = data.get("prompt_requirement_url_policy")
 
         prompt_requirements = self._evaluate_prompt_requirements(
             prompt_text=prompt_for_requirements,
@@ -3719,6 +3902,11 @@ class InternalMCPChatOrchestrator:
             ),
             context_messages=augmented_context,
             tool_invocations=(),
+            url_requirement=(
+                prompt_requirement_url_policy
+                if isinstance(prompt_requirement_url_policy, Mapping)
+                else None
+            ),
         )
         required_prompt_tools = list(prompt_requirements.required_tools)
         required_prompt_fetch_concept_ids = list(
@@ -4781,11 +4969,14 @@ class InternalMCPChatOrchestrator:
 
             prompt_for_requirements = data.get("prompt_for_requirements")
             if not isinstance(prompt_for_requirements, str) or not prompt_for_requirements.strip():
-                prompt_for_requirements = data.get("prompt")
+                prompt_for_requirements = (
+                    data.get("prompt") if isinstance(data.get("prompt"), str) else ""
+                )
 
             invocations_for_requirements = cast(
                 Sequence[Mapping[str, Any]], data.get("invocations") or []
             )
+            prompt_requirement_url_policy = data.get("prompt_requirement_url_policy")
             prompt_requirements = self._evaluate_prompt_requirements(
                 prompt_text=prompt_for_requirements,
                 method_catalogue=(
@@ -4795,6 +4986,11 @@ class InternalMCPChatOrchestrator:
                 ),
                 context_messages=augmented_context,
                 tool_invocations=invocations_for_requirements,
+                url_requirement=(
+                    prompt_requirement_url_policy
+                    if isinstance(prompt_requirement_url_policy, Mapping)
+                    else None
+                ),
             )
             required_prompt_tools = list(prompt_requirements.required_tools)
             required_prompt_fetch_concept_ids = list(
@@ -7417,12 +7613,122 @@ class InternalMCPChatOrchestrator:
         return concept_ids
 
     @classmethod
+    def _extract_prompt_urls(cls, prompt_text: Any) -> list[str]:
+        if not isinstance(prompt_text, str) or not prompt_text.strip():
+            return []
+
+        urls: list[str] = []
+        seen: set[str] = set()
+        for match in cls._PROMPT_URL_PATTERN.finditer(prompt_text):
+            url = str(match.group(0) or "").strip().rstrip(".,;:!?)]}>")
+            if not url:
+                continue
+            key = url.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            urls.append(url)
+        return urls
+
+    @classmethod
+    def _prompt_requests_url_reading(cls, prompt_text: str) -> bool:
+        urls = cls._extract_prompt_urls(prompt_text)
+        if not urls:
+            return False
+
+        lowered = prompt_text.casefold()
+        if cls._URL_READING_INTENT_PATTERN.search(lowered):
+            return True
+
+        prompt_without_urls = prompt_text
+        for url in urls:
+            prompt_without_urls = prompt_without_urls.replace(url, " ")
+        stripped = re.sub(r"\s+", " ", prompt_without_urls).strip(
+            " \t\r\n:;,-()[]{}<>\"'"
+        )
+        return stripped.casefold() in cls._URL_READING_SHORT_FRAME_TEXTS if stripped else True
+
+    @classmethod
+    def _derive_url_extraction_requirement(
+        cls,
+        user_prompt: Any,
+        *,
+        method_catalogue: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]:
+        """Keep URL-reading policy aligned across routing, workflow preflight, and retry."""
+
+        prompt_text = user_prompt if isinstance(user_prompt, str) else ""
+        prompt_urls = cls._extract_prompt_urls(prompt_text)
+        if not prompt_urls:
+            return {
+                "required": False,
+                "url": None,
+                "tool": None,
+                "reason": "no_prompt_url",
+            }
+
+        available_tools: set[str] = set()
+        if isinstance(method_catalogue, Mapping):
+            for tool_name in method_catalogue.keys():
+                if isinstance(tool_name, str) and tool_name.strip():
+                    available_tools.add(tool_name.strip().lower())
+
+        def _tool_available(tool_name: str) -> bool:
+            if not available_tools:
+                return True
+            return tool_name.lower() in available_tools
+
+        allow_default_arxiv_download = bool(
+            cls._extract_arxiv_id_from_text(prompt_text)
+        ) and not prompt_explicitly_denies_write(prompt_text)
+        if cls._infer_arxiv_acquisition_tool_from_prompt(
+            prompt_text,
+            allow_default_download=allow_default_arxiv_download,
+        ):
+            return {
+                "required": False,
+                "url": None,
+                "tool": None,
+                "reason": "arxiv_workflow_preferred",
+            }
+
+        tool_name: str | None = None
+        if _tool_available("resilient_extract_url"):
+            tool_name = "resilient_extract_url"
+        elif _tool_available("extract_url"):
+            tool_name = "extract_url"
+
+        if not tool_name:
+            return {
+                "required": False,
+                "url": prompt_urls[0],
+                "tool": None,
+                "reason": "url_tool_unavailable",
+            }
+
+        if not cls._prompt_requests_url_reading(prompt_text):
+            return {
+                "required": False,
+                "url": prompt_urls[0],
+                "tool": tool_name,
+                "reason": "no_url_reading_intent",
+            }
+
+        return {
+            "required": True,
+            "url": prompt_urls[0],
+            "tool": tool_name,
+            "reason": "url_reading_intent",
+        }
+
+    @classmethod
     def _derive_prompt_tool_requirements(
         cls,
         user_prompt: Any,
         *,
         method_catalogue: Mapping[str, Any] | None = None,
         context_messages: Sequence[Mapping[str, Any]] | None = None,
+        url_requirement: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Derive deterministic prompt requirements for tool recovery."""
 
@@ -7467,10 +7773,6 @@ class InternalMCPChatOrchestrator:
         allow_default_arxiv_download = bool(cls._extract_arxiv_id_from_text(prompt_text)) and not (
             prompt_explicitly_denies_write(prompt_text)
         )
-        has_prompt_url = (
-            isinstance(user_prompt, str)
-            and bool(re.search(r"https?://\S+", user_prompt, re.IGNORECASE))
-        )
 
         seen_required = {
             str(tool_name).strip().lower()
@@ -7492,19 +7794,42 @@ class InternalMCPChatOrchestrator:
         elif preferred_arxiv_tool and not _tool_available(preferred_arxiv_tool):
             preferred_arxiv_tool = None
 
+        url_requirement_map = (
+            dict(url_requirement)
+            if isinstance(url_requirement, Mapping)
+            else dict(
+                cls._derive_url_extraction_requirement(
+                    prompt_text,
+                    method_catalogue=method_catalogue,
+                )
+            )
+        )
+        required_url_extraction_tool = (
+            str(url_requirement_map.get("tool")).strip()
+            if bool(url_requirement_map.get("required"))
+            and isinstance(url_requirement_map.get("tool"), str)
+            and str(url_requirement_map.get("tool")).strip()
+            else None
+        )
+        required_url_extraction_url = (
+            str(url_requirement_map.get("url")).strip()
+            if bool(url_requirement_map.get("required"))
+            and isinstance(url_requirement_map.get("url"), str)
+            and str(url_requirement_map.get("url")).strip()
+            else None
+        )
+
         if preferred_arxiv_tool:
             if preferred_arxiv_tool not in seen_required:
                 required_tools.append(preferred_arxiv_tool)
                 seen_required.add(preferred_arxiv_tool)
-        elif has_prompt_url:
-            url_tool_name: str | None = None
-            if _tool_available("resilient_extract_url"):
-                url_tool_name = "resilient_extract_url"
-            elif _tool_available("extract_url"):
-                url_tool_name = "extract_url"
-            if url_tool_name and url_tool_name not in seen_required:
-                required_tools.append(url_tool_name)
-                seen_required.add(url_tool_name)
+        elif (
+            required_url_extraction_tool
+            and required_url_extraction_url
+            and required_url_extraction_tool not in seen_required
+        ):
+            required_tools.append(required_url_extraction_tool)
+            seen_required.add(required_url_extraction_tool)
         if required_create_type_name and "create_concepts" not in seen_required:
             required_tools.append("create_concepts")
             seen_required.add("create_concepts")
@@ -7533,6 +7858,8 @@ class InternalMCPChatOrchestrator:
 
         return {
             "required_tools": required_tools,
+            "required_url_extraction_tool": required_url_extraction_tool,
+            "required_url_extraction_url": required_url_extraction_url,
             "required_fetch_concept_ids": required_fetch_concept_ids,
             "required_read_file_copy_ids": required_read_file_copy_ids,
             "required_scholarly_representation_for_file_copy_ids": required_scholarly_representation_for_file_copy_ids,
@@ -7700,6 +8027,7 @@ class InternalMCPChatOrchestrator:
         method_catalogue: Mapping[str, Any] | None = None,
         context_messages: Sequence[Mapping[str, Any]] | None = None,
         tool_invocations: Sequence[Mapping[str, Any]] = (),
+        url_requirement: Mapping[str, Any] | None = None,
     ) -> _PromptRequirementEvaluation:
         """Compute prompt-required tools and the still-missing subset once."""
 
@@ -7707,11 +8035,30 @@ class InternalMCPChatOrchestrator:
             prompt_text,
             method_catalogue=method_catalogue,
             context_messages=context_messages,
+            url_requirement=url_requirement,
         )
         required_tools = tuple(
             str(item).strip()
             for item in (prompt_requirement_state.get("required_tools") or [])
             if isinstance(item, str) and str(item).strip()
+        )
+        required_url_extraction_tool_raw = prompt_requirement_state.get(
+            "required_url_extraction_tool"
+        )
+        required_url_extraction_tool = (
+            str(required_url_extraction_tool_raw).strip()
+            if isinstance(required_url_extraction_tool_raw, str)
+            and str(required_url_extraction_tool_raw).strip()
+            else None
+        )
+        required_url_extraction_url_raw = prompt_requirement_state.get(
+            "required_url_extraction_url"
+        )
+        required_url_extraction_url = (
+            str(required_url_extraction_url_raw).strip()
+            if isinstance(required_url_extraction_url_raw, str)
+            and str(required_url_extraction_url_raw).strip()
+            else None
         )
         required_fetch_concept_ids = tuple(
             str(item).strip()
@@ -7774,6 +8121,8 @@ class InternalMCPChatOrchestrator:
 
         return _PromptRequirementEvaluation(
             required_tools=required_tools,
+            required_url_extraction_tool=required_url_extraction_tool,
+            required_url_extraction_url=required_url_extraction_url,
             required_fetch_concept_ids=required_fetch_concept_ids,
             required_read_file_copy_ids=required_read_file_copy_ids,
             required_scholarly_representation_file_copy_ids=required_scholarly_representation_file_copy_ids,
@@ -7799,6 +8148,12 @@ class InternalMCPChatOrchestrator:
         """Persist shared prompt-requirement state into workflow data."""
 
         data["required_prompt_tools"] = list(evaluation.required_tools)
+        data["required_prompt_url_extraction_tool"] = (
+            evaluation.required_url_extraction_tool
+        )
+        data["required_prompt_url_extraction_url"] = (
+            evaluation.required_url_extraction_url
+        )
         data["required_prompt_fetch_concept_ids"] = list(
             evaluation.required_fetch_concept_ids
         )
@@ -16530,6 +16885,7 @@ class InternalMCPChatOrchestrator:
         missing_required_scholarly_representation_file_copy_ids: Sequence[str]
         | None = None,
         required_create_type_name: str | None = None,
+        required_url_extraction_url: str | None = None,
     ) -> list[_ToolCallRequest] | None:
         """Build deterministic tool calls for still-missing explicit requirements."""
 
@@ -16564,6 +16920,27 @@ class InternalMCPChatOrchestrator:
         for tool_name in missing_required_tools:
             name = str(tool_name).strip()
             if not name:
+                continue
+
+            if name in {"resilient_extract_url", "extract_url"}:
+                target_url = (
+                    str(required_url_extraction_url).strip()
+                    if isinstance(required_url_extraction_url, str)
+                    and str(required_url_extraction_url).strip()
+                    else None
+                )
+                if not target_url:
+                    prompt_urls = self._extract_prompt_urls(user_text)
+                    target_url = prompt_urls[0] if prompt_urls else None
+                if not target_url:
+                    continue
+                forced_calls.append(
+                    {
+                        "action": "call_tool",
+                        "tool": name,
+                        "payload": {"url": target_url},
+                    }
+                )
                 continue
 
             if name == "workflow_list_definitions":
@@ -16697,6 +17074,7 @@ class InternalMCPChatOrchestrator:
         missing_required_scholarly_representation_file_copy_ids: Sequence[str]
         | None = None,
         required_create_type_name: str | None = None,
+        required_url_extraction_url: str | None = None,
     ) -> list[_ToolCallRequest] | None:
         """Best-effort deterministic recovery for common missing-tool-call cases.
 
@@ -16751,6 +17129,12 @@ class InternalMCPChatOrchestrator:
                 str(required_create_type_name).strip()
                 if isinstance(required_create_type_name, str)
                 and str(required_create_type_name).strip()
+                else None
+            ),
+            required_url_extraction_url=(
+                str(required_url_extraction_url).strip()
+                if isinstance(required_url_extraction_url, str)
+                and str(required_url_extraction_url).strip()
                 else None
             ),
         )
@@ -19119,11 +19503,16 @@ class InternalMCPChatOrchestrator:
             except Exception:
                 method_catalogue_for_routing = {}
 
+        routing_url_requirement = self._derive_url_extraction_requirement(
+            effective_prompt_for_routing,
+            method_catalogue=method_catalogue_for_routing,
+        )
         routing_prompt_requirements = self._evaluate_prompt_requirements(
             prompt_text=effective_prompt_for_routing,
             method_catalogue=method_catalogue_for_routing,
             context_messages=augmented_context,
             tool_invocations=(),
+            url_requirement=routing_url_requirement,
         )
         prompt_requirements_force_tool_pipeline = (
             routing_prompt_requirements.has_missing_requirements
@@ -19186,6 +19575,12 @@ class InternalMCPChatOrchestrator:
                 "prior_selected_workflow_id": CHAT_ASSISTANT_WORKFLOW_ID,
                 "prior_selector_verdict": None,
                 "required_prompt_tools": list(routing_prompt_requirements.required_tools),
+                "required_prompt_url_extraction_tool": (
+                    routing_prompt_requirements.required_url_extraction_tool
+                ),
+                "required_prompt_url_extraction_url": (
+                    routing_prompt_requirements.required_url_extraction_url
+                ),
                 "missing_prompt_tools": list(routing_prompt_requirements.missing_tools),
                 "required_prompt_fetch_concept_ids": list(
                     routing_prompt_requirements.required_fetch_concept_ids
@@ -19208,6 +19603,7 @@ class InternalMCPChatOrchestrator:
                 "unavailable_required_tools": list(
                     routing_prompt_requirements.unavailable_required_tools
                 ),
+                "prompt_requirement_url_policy": dict(routing_url_requirement),
                 "retry_reason": routing_prompt_requirements.missing_retry_reason,
             }
             aux_llm_calls.append(override_payload)
@@ -19456,10 +19852,10 @@ class InternalMCPChatOrchestrator:
         )
         _TOOL_PIPELINE_ACTION_IDS = frozenset(
             {
-                "tool_calling.plan",
-                "tool_calling.validate",
-                "tool_calling.execute",
-                "tool_calling.backfill",
+                "tool_calling.preflight_requirements",
+                "tool_calling.respond",
+                "turn_execution.critic",
+                "turn_execution.completion_gate",
             }
         )
         _NARRATION_ACTION_IDS = frozenset(
@@ -23889,6 +24285,12 @@ class InternalMCPChatOrchestrator:
                     "required_prompt_tools": list(
                         routing_prompt_requirements.required_tools
                     ),
+                    "required_prompt_url_extraction_tool": (
+                        routing_prompt_requirements.required_url_extraction_tool
+                    ),
+                    "required_prompt_url_extraction_url": (
+                        routing_prompt_requirements.required_url_extraction_url
+                    ),
                     "missing_prompt_tools": list(
                         routing_prompt_requirements.missing_tools
                     ),
@@ -23913,6 +24315,7 @@ class InternalMCPChatOrchestrator:
                     "unavailable_required_tools": list(
                         routing_prompt_requirements.unavailable_required_tools
                     ),
+                    "prompt_requirement_url_policy": dict(routing_url_requirement),
                     "retry_reason": routing_prompt_requirements.missing_retry_reason,
                 },
             )
@@ -24292,6 +24695,7 @@ class InternalMCPChatOrchestrator:
             # Inputs.
             "prompt": prompt,
             "prompt_for_requirements": effective_prompt_for_routing,
+            "prompt_requirement_url_policy": dict(routing_url_requirement),
             "augmented_context": augmented_context,
             "policy_state": policy_state,
             "registry_snapshot": registry_snapshot,

--- a/src/backend/workflows/definitions.py
+++ b/src/backend/workflows/definitions.py
@@ -462,14 +462,33 @@ def build_tool_calling_workflow() -> WorkflowDefinition:
 
     Flow::
 
-        respond ──▸ postcondition_critic ──▸ completion_gate
-             ▲                                      │
-             └──────[completion_gate_repeat_iteration]──────┘
+        preflight_requirements ──▸ respond ──▸ postcondition_critic ──▸ completion_gate
+                                      ▲                                      │
+                                      └──────[completion_gate_repeat_iteration]──────┘
 
     The bounded tool-use loop now lives inside the generic LLM step executor,
-    so the workflow itself only models the ordinary reasoning step plus the
-    postcondition and completion policy stages.
+    so the workflow itself models prompt-requirement preflight, the ordinary
+    reasoning step, and the postcondition and completion policy stages.
     """
+    preflight_requirements = WorkflowStateSpec(
+        state_id="preflight_requirements",
+        actions=(
+            WorkflowActionInvocation(
+                action_id="tool_calling.preflight_requirements",
+                description=(
+                    "Materialise prompt requirements before the tool-calling LLM step."
+                ),
+            ),
+        ),
+        transitions=(
+            WorkflowTransitionSpec(
+                to_state="respond",
+                condition=lambda ctx: True,
+                reason="requirements_preflight_completed",
+            ),
+        ),
+    )
+
     respond = WorkflowStateSpec(
         state_id="respond",
         actions=(
@@ -545,8 +564,9 @@ def build_tool_calling_workflow() -> WorkflowDefinition:
 
     return WorkflowDefinition(
         workflow_id=TOOL_CALLING_WORKFLOW_ID,
-        initial_state="respond",
+        initial_state="preflight_requirements",
         states={
+            "preflight_requirements": preflight_requirements,
             "respond": respond,
             "postcondition_critic": postcondition_critic,
             "completion_gate": completion_gate,
@@ -555,9 +575,9 @@ def build_tool_calling_workflow() -> WorkflowDefinition:
         },
         termination_states=("completed", "failed"),
         purpose=(
-            "Standard tool-calling pipeline implemented as a generic prompt-driven "
-            "LLM step with bounded tool use, followed by postcondition critic and "
-            "completion gate."
+            "Standard tool-calling pipeline with workflow-owned prompt "
+            "requirement preflight, a generic prompt-driven LLM step with "
+            "bounded tool use, and postcondition critic and completion gate."
         ),
     )
 

--- a/src/backend/workflows/llm_step_executor.py
+++ b/src/backend/workflows/llm_step_executor.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 import re
 import time
-from typing import Any, Mapping, MutableMapping, Optional, Sequence
+from typing import Any, Mapping, MutableMapping, Optional, Sequence, cast
 
 from ..services.buttonify_service import (
     parse_buttonify_options_json,
@@ -808,10 +808,30 @@ def execute_llm_step(request: WorkflowActionRequest) -> WorkflowActionResult:
     policy_state, _policy_telemetry = orchestrator._load_workflow_model_policy(None)
     registry_snapshot = get_model_registry_snapshot()
 
-    llm_calls: list[dict[str, Any]] = []
-    aux_llm_calls: list[dict[str, Any]] = []
-    invocations: list[dict[str, Any]] = []
-    tool_messages: list[dict[str, Any]] = []
+    llm_calls = cast(
+        list[dict[str, Any]],
+        request.data.get("llm_calls")
+        if isinstance(request.data.get("llm_calls"), list)
+        else [],
+    )
+    aux_llm_calls = cast(
+        list[dict[str, Any]],
+        request.data.get("aux_llm_calls")
+        if isinstance(request.data.get("aux_llm_calls"), list)
+        else [],
+    )
+    invocations = cast(
+        list[dict[str, Any]],
+        request.data.get("invocations")
+        if isinstance(request.data.get("invocations"), list)
+        else [],
+    )
+    tool_messages = cast(
+        list[dict[str, Any]],
+        request.data.get("tool_messages")
+        if isinstance(request.data.get("tool_messages"), list)
+        else [],
+    )
     selected_models: dict[str, str | None] = {}
 
     def _model_for_stage(inner_stage: str) -> Optional[str]:
@@ -882,6 +902,47 @@ def execute_llm_step(request: WorkflowActionRequest) -> WorkflowActionResult:
         "prompt": rendered_prompt,
         "prompt_for_requirements": request.data.get("prompt_for_requirements")
         or rendered_prompt,
+        "prompt_requirement_url_policy": request.data.get(
+            "prompt_requirement_url_policy"
+        ),
+        "required_prompt_tools": request.data.get("required_prompt_tools") or [],
+        "required_prompt_url_extraction_tool": request.data.get(
+            "required_prompt_url_extraction_tool"
+        ),
+        "required_prompt_url_extraction_url": request.data.get(
+            "required_prompt_url_extraction_url"
+        ),
+        "required_prompt_fetch_concept_ids": (
+            request.data.get("required_prompt_fetch_concept_ids") or []
+        ),
+        "required_prompt_read_file_copy_ids": (
+            request.data.get("required_prompt_read_file_copy_ids") or []
+        ),
+        "required_prompt_scholarly_representation_for_file_copy_ids": (
+            request.data.get(
+                "required_prompt_scholarly_representation_for_file_copy_ids"
+            )
+            or []
+        ),
+        "required_prompt_create_type_name": request.data.get(
+            "required_prompt_create_type_name"
+        ),
+        "missing_prompt_tools": request.data.get("missing_prompt_tools") or [],
+        "missing_prompt_fetch_concept_ids": (
+            request.data.get("missing_prompt_fetch_concept_ids") or []
+        ),
+        "missing_prompt_read_file_copy_ids": (
+            request.data.get("missing_prompt_read_file_copy_ids") or []
+        ),
+        "missing_prompt_scholarly_representation_for_file_copy_ids": (
+            request.data.get(
+                "missing_prompt_scholarly_representation_for_file_copy_ids"
+            )
+            or []
+        ),
+        "missing_tool_call_retry_reason_override": request.data.get(
+            "missing_tool_call_retry_reason_override"
+        ),
         "response": request.data.get("response")
         or request.data.get("current_response")
         or "",

--- a/src/backend/workflows/workflow_concept_authority_service.py
+++ b/src/backend/workflows/workflow_concept_authority_service.py
@@ -627,8 +627,19 @@ _CANONICAL_WORKFLOW_PUBLICATION_SPECS: Dict[str, _CanonicalWorkflowPublicationSp
         ),
     ),
     TOOL_CALLING_WORKFLOW_ID: _CanonicalWorkflowPublicationSpec(
-        initial_state="respond",
+        initial_state="preflight_requirements",
         steps=(
+            _CanonicalStepPublicationSpec(
+                state_id="preflight_requirements",
+                action_id="tool_calling.preflight_requirements",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="respond",
+                        reason="requirements_preflight_completed",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
             _CanonicalStepPublicationSpec(
                 state_id="respond",
                 action_id="tool_calling.respond",

--- a/tests/backend/test_orchestrator_extraction.py
+++ b/tests/backend/test_orchestrator_extraction.py
@@ -1128,6 +1128,45 @@ def test_derive_prompt_tool_requirements_adds_url_extraction_tool_for_current_pr
     assert "resilient_extract_url" in required_tools
 
 
+def test_derive_prompt_tool_requirements_ignores_incidental_urls_without_read_intent():
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=_DummyGateway()  # type: ignore[arg-type]
+    )
+    requirements = orchestrator._derive_prompt_tool_requirements(
+        "Meeting notice: Zoom link https://example.com/join/abc for tomorrow's call.",
+        method_catalogue={
+            "resilient_extract_url": {"description": "resilient URL extraction"},
+            "extract_url": {"description": "URL extraction"},
+        },
+    )
+
+    required_tools = requirements.get("required_tools") or []
+    assert "resilient_extract_url" not in required_tools
+    assert "extract_url" not in required_tools
+    assert requirements.get("required_url_extraction_tool") is None
+    assert requirements.get("required_url_extraction_url") is None
+
+
+def test_infer_required_prompt_tool_retry_tool_calls_forces_url_extraction():
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=_DummyGateway()  # type: ignore[arg-type]
+    )
+
+    forced_calls = orchestrator._infer_required_prompt_tool_retry_tool_calls(
+        user_text="Please read this: https://example.com/report",
+        missing_required_tools=["resilient_extract_url"],
+        required_url_extraction_url="https://example.com/report",
+    )
+
+    assert forced_calls == [
+        {
+            "action": "call_tool",
+            "tool": "resilient_extract_url",
+            "payload": {"url": "https://example.com/report"},
+        }
+    ]
+
+
 def test_derive_missing_prompt_requirements_tracks_missing_fetch_targets():
     orchestrator = InternalMCPChatOrchestrator(
         gateway=_ChecklistPromptToolGateway()  # type: ignore[arg-type]

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -3253,11 +3253,17 @@ def test_plain_response_overridden_when_prompt_requires_tool_verification(monkey
         "describe_methods",
         lambda: {"workflow_list_definitions": {"category": "read"}},
     )
+    monkeypatch.setattr(
+        orchestrator._gateway,
+        "invoke",
+        lambda _tool_name, _payload: _InvokeResult({"workflows": []}),
+    )
 
     llm = _CapturingLLM(
         [
             "plain_response",
             "I inspected workflow definitions.",
+            "Here is what exists.",
         ]
     )
 
@@ -3288,6 +3294,128 @@ def test_plain_response_overridden_when_prompt_requires_tool_verification(monkey
     assert "workflow_list_definitions" in (
         override_entry.get("required_prompt_tools") or []
     )
+
+
+def test_incidental_url_prompt_stays_on_plain_response_path(monkeypatch):
+    orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
+
+    monkeypatch.setattr(
+        orchestrator._gateway,
+        "describe_methods",
+        lambda: {"resilient_extract_url": {"category": "read"}},
+    )
+
+    llm = _CapturingLLM(
+        [
+            "plain_response",
+            "Meeting noted.",
+        ]
+    )
+
+    result = orchestrator.run(
+        prompt="Meeting notice: Zoom link https://example.com/join/abc for tomorrow's call.",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+    )
+
+    assert result.workflow_routing is not None
+    assert result.workflow_routing.workflow_id == CHAT_ASSISTANT_WORKFLOW_ID
+    assert result.workflow_routing.verdict == "plain_response"
+    assert result.tool_invocations == ()
+    assert not any(
+        isinstance(entry, dict)
+        and entry.get("type") == "workflow_selector_override"
+        and entry.get("reason") == "required_prompt_tools_missing_preselector"
+        for entry in result.aux_llm_calls
+    )
+
+
+def test_url_read_prompt_uses_tool_workflow_preflight_and_forces_url_tool(monkeypatch):
+    orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
+
+    gateway_calls: list[tuple[str, dict[str, Any]]] = []
+
+    monkeypatch.setattr(
+        orchestrator._gateway,
+        "describe_methods",
+        lambda: {"resilient_extract_url": {"category": "read"}},
+    )
+
+    def _invoke(tool_name: str, payload: Mapping[str, Any]):
+        gateway_calls.append((tool_name, dict(payload)))
+        return _InvokeResult(
+            {
+                "success": True,
+                "url": payload.get("url"),
+                "title": "Example report",
+                "content": "Example report body",
+            }
+        )
+
+    monkeypatch.setattr(orchestrator._gateway, "invoke", _invoke)
+
+    llm = _CapturingLLM(
+        [
+            "plain_response",
+            "I can help with that.",
+            "Summary after URL extraction.",
+        ]
+    )
+
+    result = orchestrator.run(
+        prompt="Please read this: https://example.com/report",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+    )
+
+    assert result.workflow_routing is not None
+    assert result.workflow_routing.workflow_id == TOOL_CALLING_WORKFLOW_ID
+    assert result.workflow_routing.verdict == "tool_seeking"
+    assert result.workflow_routing.source == "selector_override"
+    extract_call = next(
+        (
+            payload
+            for tool_name, payload in gateway_calls
+            if tool_name == "resilient_extract_url"
+        ),
+        None,
+    )
+    assert extract_call is not None
+    assert extract_call.get("url") == "https://example.com/report"
+    assert any(
+        invocation.get("tool") == "resilient_extract_url"
+        for invocation in result.tool_invocations
+        if isinstance(invocation, dict)
+    )
+
+    preflight_entry = next(
+        (
+            entry
+            for entry in result.aux_llm_calls
+            if isinstance(entry, dict)
+            and entry.get("type") == "prompt_tool_requirements_preflight"
+        ),
+        None,
+    )
+    assert preflight_entry is not None
+    assert preflight_entry.get("required_url_extraction_tool") == "resilient_extract_url"
+
+    retry_entry = next(
+        (
+            entry
+            for entry in result.aux_llm_calls
+            if isinstance(entry, dict)
+            and entry.get("type") == "missing_tool_call_retry"
+            and entry.get("stage") == "response"
+        ),
+        None,
+    )
+    assert retry_entry is not None
+    assert retry_entry.get("mechanism") == "required_tools"
 
 
 def test_write_intent_memory_rehydrates_for_same_session_continuation(monkeypatch):

--- a/tests/backend/test_turn_execution_workflow_definitions.py
+++ b/tests/backend/test_turn_execution_workflow_definitions.py
@@ -16,10 +16,18 @@ from src.backend.workflows.workflow_registry import WorkflowRegistry
 def test_tool_calling_workflow_includes_turn_execution_critic_and_gate() -> None:
     workflow = build_tool_calling_workflow()
 
-    assert workflow.initial_state == "respond"
+    assert workflow.initial_state == "preflight_requirements"
+    assert "preflight_requirements" in workflow.states
     assert "respond" in workflow.states
     assert "postcondition_critic" in workflow.states
     assert "completion_gate" in workflow.states
+
+    preflight = workflow.states["preflight_requirements"]
+    assert preflight.actions[0].action_id == "tool_calling.preflight_requirements"
+    assert any(
+        t.to_state == "respond" and t.reason == "requirements_preflight_completed"
+        for t in preflight.transitions
+    )
 
     respond = workflow.states["respond"]
     assert respond.actions[0].action_id == "tool_calling.respond"


### PR DESCRIPTION
## Summary
- add a workflow-owned 	ool_calling.preflight_requirements step before the tool-calling LLM response step
- derive URL extraction requirements from explicit read/extract intent instead of URL presence alone, and thread that policy through routing, llm-step execution, planning, and deterministic retry forcing
- add regression coverage for incidental links, forced URL extraction, workflow structure, and custom tool-pipeline contract matching

## Validation
- pdm run pyright src/backend/integrations/internal_mcp/orchestrator.py src/backend/workflows/definitions.py src/backend/workflows/workflow_concept_authority_service.py src/backend/workflows/llm_step_executor.py tests/backend/test_orchestrator_extraction.py tests/backend/test_orchestrator_workflow_selector_routing.py tests/backend/test_turn_execution_workflow_definitions.py
- pdm run pytest tests/backend/test_orchestrator_workflow_selector_routing.py::test_plain_response_overridden_when_prompt_requires_tool_verification tests/backend/test_orchestrator_workflow_selector_routing.py::test_incidental_url_prompt_stays_on_plain_response_path tests/backend/test_orchestrator_workflow_selector_routing.py::test_url_read_prompt_uses_tool_workflow_preflight_and_forces_url_tool -q
- pdm run pytest tests/backend/test_orchestrator_workflow_selector_routing.py::test_custom_tool_pipeline_workflow_dispatches_without_id_special_casing -q
- pdm run pytest tests/backend/test_turn_execution_workflow_definitions.py -q
- pdm run pytest tests/backend/test_orchestrator_extraction.py::test_derive_prompt_tool_requirements_adds_url_extraction_tool_for_current_prompt -q
- pdm run pytest tests/backend/test_orchestrator_extraction.py::test_derive_prompt_tool_requirements_ignores_incidental_urls_without_read_intent -q
- pdm run pytest tests/backend/test_orchestrator_extraction.py::test_infer_required_prompt_tool_retry_tool_calls_forces_url_extraction -q
- pdm run pytest tests/backend/test_workflow_concept_authority_service.py::test_bootstrap_publishes_canonical_chat_graphs_with_loader_runtime_parity -q

## Notes
- pdm run pytest tests -m lane_backend_workflows -q and pdm run pytest tests -m lane_backend_mcp -q were both attempted but exceeded the 5 minute command timeout in this environment.