### PR TITLE
JVNAUTOSCI-1458 Use shared copied-state feedback for diagnostics button

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -1604,6 +1604,10 @@ export function __testOnly_setThinkingState(isThinking, request, options) {
     return setThinkingState(isThinking, request, options);
 }
 
+export async function __testOnly_copyActiveThinkingDiagnostics(button = null, request = null) {
+    return copyActiveThinkingDiagnostics(button, request);
+}
+
 function updateThinkingCardStatusBadge(progress) {
     const badgeEl = document.getElementById('thinkingCardStatusBadge');
     if (!badgeEl) {
@@ -19027,7 +19031,14 @@ function setThinkingState(isThinking, request = activeChatRequest, options = {})
         copyDiagnosticsButton.setAttribute('aria-hidden', (isThinking || preserveFinishedCard) ? 'false' : 'true');
         if (!isThinking && !preserveFinishedCard) {
             copyDiagnosticsButton.textContent = 'Copy diagnostics';
-            copyDiagnosticsButton.classList.remove('success-feedback', 'error-feedback');
+            copyDiagnosticsButton.setAttribute('title', 'Copy diagnostics');
+            copyDiagnosticsButton.setAttribute('aria-label', 'Copy diagnostics');
+            copyDiagnosticsButton.classList.remove(
+                'success-feedback',
+                'error-feedback',
+                'copy-json-copied',
+                'copy-json-copy-failed'
+            );
         }
     }
 
@@ -19383,25 +19394,24 @@ function retryActiveChatRequest() {
     }, 0);
 }
 
-async function copyActiveThinkingDiagnostics(button = null) {
-    if (!activeChatRequest) {
+async function copyActiveThinkingDiagnostics(button = null, requestOverride = null) {
+    const request = requestOverride || activeChatRequest;
+    if (!request) {
         return false;
     }
-    const payload = buildThinkingDiagnosticsPayload(activeChatRequest);
+    const payload = buildThinkingDiagnosticsPayload(request);
     if (!payload) {
         return false;
     }
 
     const text = JSON.stringify(payload, null, 2);
-    const copied = await copyTextToClipboard(text);
-
-    if (button) {
-        const original = button.dataset.originalText || button.textContent || 'Copy diagnostics';
-        button.dataset.originalText = original;
-        indicateClipboardResult(button, original, copied);
+    if (button instanceof HTMLButtonElement) {
+        return copyJsonTextWithButtonFeedback(button, text, {
+            fallbackLabel: 'Copy diagnostics'
+        });
     }
 
-    return copied;
+    return copyTextToClipboard(text);
 }
 
 function ensureAbortButtonBound() {

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -36,6 +36,7 @@ import {
     __testOnly_showNewSharedMessagesIndicator,
     __testOnly_updateScrollToEndButtonVisibility,
     __testOnly_reduceThinkingCardDisplayState,
+    __testOnly_copyActiveThinkingDiagnostics,
     __testOnly_setThinkingState,
     __testOnly_normaliseThinkingActivityHistory,
     __testOnly_renderThinkingCardBodyHTML,
@@ -2299,6 +2300,7 @@ describe('thinking card toggle accessibility', () => {
 
 describe('copy diagnostics button visibility on preserved finished card', () => {
     beforeEach(() => {
+        jest.useFakeTimers();
         document.body.innerHTML = `
             <div id="scrollableField"></div>
             <div class="thinking-card-wrapper" id="thinkingCardWrapper" aria-hidden="true">
@@ -2325,6 +2327,7 @@ describe('copy diagnostics button visibility on preserved finished card', () => 
     });
 
     afterEach(() => {
+        jest.useRealTimers();
         jest.restoreAllMocks();
     });
 
@@ -2352,18 +2355,53 @@ describe('copy diagnostics button visibility on preserved finished card', () => 
         const copyBtn = document.getElementById('copyThinkingDiagnosticsButton');
 
         // Simulate a successful copy feedback state
-        copyBtn.textContent = 'Copied!';
-        copyBtn.classList.add('success-feedback');
+        copyBtn.textContent = '✓ Copied';
+        copyBtn.classList.add('copy-json-copied');
+        copyBtn.setAttribute('title', 'Copied to clipboard');
+        copyBtn.setAttribute('aria-label', 'Copied to clipboard');
 
         // Preserved finished card should keep the feedback text
         __testOnly_setThinkingState(false, {}, { preserveFinishedCard: true });
-        expect(copyBtn.textContent).toBe('Copied!');
-        expect(copyBtn.classList.contains('success-feedback')).toBe(true);
+        expect(copyBtn.textContent).toBe('✓ Copied');
+        expect(copyBtn.classList.contains('copy-json-copied')).toBe(true);
 
         // Full dismissal should reset
         __testOnly_setThinkingState(false, {});
         expect(copyBtn.textContent).toBe('Copy diagnostics');
+        expect(copyBtn.getAttribute('title')).toBe('Copy diagnostics');
+        expect(copyBtn.getAttribute('aria-label')).toBe('Copy diagnostics');
+        expect(copyBtn.classList.contains('copy-json-copied')).toBe(false);
+    });
+
+    test('copy diagnostics button uses shared copied-state feedback after success (JVNAUTOSCI-1458)', async () => {
+        const copyBtn = document.getElementById('copyThinkingDiagnosticsButton');
+        const writeText = jest.fn().mockResolvedValue(undefined);
+        Object.assign(navigator, {
+            clipboard: { writeText }
+        });
+
+        const copied = await __testOnly_copyActiveThinkingDiagnostics(copyBtn, {
+            clientRequestId: 'request-1458',
+            promptRaw: 'diagnose this',
+            thinkingStartedAtMs: Date.now() - 250,
+            latestProgress: null,
+            activityHistory: [],
+            progressEvents: [],
+            phaseHistory: [],
+            workflowDiscovery: null,
+            workflowStagePath: null
+        });
+
+        expect(copied).toBe(true);
+        expect(copyBtn.textContent).toBe('✓ Copied');
+        expect(copyBtn.classList.contains('copy-json-copied')).toBe(true);
         expect(copyBtn.classList.contains('success-feedback')).toBe(false);
+        expect(copyBtn.getAttribute('title')).toBe('Copied to clipboard');
+        expect(copyBtn.getAttribute('aria-label')).toBe('Copied to clipboard');
+
+        jest.advanceTimersByTime(2300);
+        expect(copyBtn.textContent).toBe('Copy diagnostics');
+        expect(copyBtn.classList.contains('copy-json-copied')).toBe(false);
     });
 });
 

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -6648,6 +6648,28 @@ footer {
     background: #fee2e2;
 }
 
+.thinking-card-action.copy-json-copied {
+    color: #1e3a8a;
+    border-color: #93c5fd;
+    background: #dbeafe;
+}
+
+.thinking-card-action.copy-json-copied:hover {
+    background: #bfdbfe;
+    border-color: #60a5fa;
+}
+
+.thinking-card-action.copy-json-copy-failed {
+    color: #991b1b;
+    border-color: #fca5a5;
+    background: #fee2e2;
+}
+
+.thinking-card-action.copy-json-copy-failed:hover {
+    background: #fecaca;
+    border-color: #f87171;
+}
+
 .thinking-card-toggle {
     width: 22px;
     height: 22px;


### PR DESCRIPTION
## Summary
- route the thinking-card diagnostics button through the shared JSON copy feedback helper
- apply the shared copied/error visual treatment to thinking-card actions so success becomes the lighter copied-state instead of the legacy green success state
- add regression coverage for diagnostics-button copied-state behaviour and reset semantics

## Validation
- `npx jest src/frontend/web/von_interface/static/js/test/chatTab.test.js src/frontend/web/von_interface/static/js/test/copyJsonButtonState.test.js --runInBand`
- `npx pyright src/frontend/web/von_interface/static/js/chatTab.js src/frontend/web/von_interface/static/js/test/chatTab.test.js` *(not a meaningful repo signal here; pyright mis-parses these frontend ES-module JS files from line 1 and reports broad syntax noise unrelated to this change)*