### PR TITLE
JVNAUTOSCI-1459 repair telemetry coherence and talk workflows

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -243,6 +243,49 @@ class _PromptRequirementEvaluation:
         )
 
 
+def _derive_workflow_selection_rationale(
+    *,
+    selected_workflow_id: str | None,
+    selector_verdict: str | None,
+    selector_source: str | None,
+    candidate_workflow_ids: Sequence[str],
+    explicit_reasoning: str | None = None,
+) -> str:
+    """Return a stable machine-readable workflow-selection rationale code."""
+
+    explicit = str(explicit_reasoning or "").strip()
+    source = (selector_source or "default").strip().lower() or "default"
+    selected = (selected_workflow_id or "").strip()
+    verdict = (selector_verdict or "").strip()
+    candidate_set = {
+        str(item).strip().lower()
+        for item in candidate_workflow_ids
+        if isinstance(item, str) and str(item).strip()
+    }
+
+    if source == "selector_override":
+        if explicit:
+            return f"selector_override:{explicit}"
+        if verdict:
+            return f"selector_override_verdict:{verdict}"
+        return "selector_override"
+    if source == "selector":
+        if selected and selected.lower() in candidate_set:
+            return "selector_selected_discovered_candidate"
+        if verdict:
+            return f"selector_verdict:{verdict}"
+        return "selector_route_without_explicit_verdict"
+    if source == "presenter_mode":
+        return "presenter_mode_route"
+    if source == "default":
+        if explicit:
+            return f"default_reason:{explicit}"
+        return "default_routing_fallback"
+    if explicit:
+        return f"routing_source:{source}:{explicit}"
+    return f"routing_source:{source}"
+
+
 @dataclass(frozen=True)
 class _WorkflowModelPolicyState:
     enabled: bool
@@ -17421,29 +17464,6 @@ class InternalMCPChatOrchestrator:
                 workflow_ids.append(workflow_id)
             return workflow_ids
 
-        def _derive_selection_rationale(
-            *,
-            selected_workflow_id: str | None,
-            selector_verdict: str | None,
-            selector_source: str | None,
-            candidate_workflow_ids: Sequence[str],
-        ) -> str:
-            source = (selector_source or "default").strip().lower() or "default"
-            selected = (selected_workflow_id or "").strip()
-            verdict = (selector_verdict or "").strip()
-            candidate_set = {item.strip().lower() for item in candidate_workflow_ids}
-            if source == "selector":
-                if selected and selected.lower() in candidate_set:
-                    return "selector_selected_discovered_candidate"
-                if verdict:
-                    return f"selector_verdict:{verdict}"
-                return "selector_route_without_explicit_verdict"
-            if source == "presenter_mode":
-                return "presenter_mode_route"
-            if source == "default":
-                return "default_routing_fallback"
-            return f"routing_source:{source}"
-
         def _build_turn_execution_selection_snapshot(
             *,
             workflow_data: Any,
@@ -17524,11 +17544,14 @@ class InternalMCPChatOrchestrator:
             selection_rationale = (
                 _safe_scalar_text(workflow_routing_payload.get("selection_rationale"))
                 or _safe_scalar_text(turn_workflow_selection_payload.get("selection_rationale"))
-                or _derive_selection_rationale(
+                or _derive_workflow_selection_rationale(
                     selected_workflow_id=selected_workflow_id,
                     selector_verdict=selector_verdict,
                     selector_source=selector_source,
                     candidate_workflow_ids=candidate_workflow_ids,
+                    explicit_reasoning=_safe_scalar_text(
+                        workflow_routing_payload.get("reasoning")
+                    ),
                 )
             )
 
@@ -19740,6 +19763,13 @@ class InternalMCPChatOrchestrator:
                     confidence_score=selector_selection.confidence_score,
                     reasoning=selector_selection.reasoning,
                 )
+                selection_rationale = _derive_workflow_selection_rationale(
+                    selected_workflow_id=selector_selection.workflow_id,
+                    selector_verdict=selector_selection.verdict,
+                    selector_source="selector",
+                    candidate_workflow_ids=selector_selection.discovered_workflow_ids,
+                    explicit_reasoning=selector_selection.reasoning,
+                )
                 _emit_progress_local(
                     {
                         "status": "thinking",
@@ -19754,6 +19784,7 @@ class InternalMCPChatOrchestrator:
                         "workflow_match_count": len(discovered_matches),
                         "workflow_candidate_count": len(discovered_matches)
                         + len(excluded_discovered_matches),
+                        "workflow_selection_rationale": selection_rationale,
                     }
                 )
                 aux_llm_calls.append(
@@ -19776,6 +19807,7 @@ class InternalMCPChatOrchestrator:
                         "routing_duration_ms": routing_duration_ms,
                         "confidence_score": selector_selection.confidence_score,
                         "reasoning": selector_selection.reasoning,
+                        "selection_rationale": selection_rationale,
                     }
                 )
                 if trace_enabled and trace is not None:
@@ -19802,6 +19834,7 @@ class InternalMCPChatOrchestrator:
                         "routing_duration_ms": routing_duration_ms,
                         "confidence_score": selector_selection.confidence_score,
                         "reasoning": selector_selection.reasoning,
+                        "selection_rationale": selection_rationale,
                     }
                 # Phase 3: record selection experience tuple.
                 try:
@@ -19831,6 +19864,14 @@ class InternalMCPChatOrchestrator:
                     prompt_id=None,
                     discovered_workflow_ids=(),
                     source="default",
+                    reasoning="selector_exception",
+                )
+                selection_rationale = _derive_workflow_selection_rationale(
+                    selected_workflow_id=CHAT_ASSISTANT_WORKFLOW_ID,
+                    selector_verdict="fallback",
+                    selector_source="default",
+                    candidate_workflow_ids=(),
+                    explicit_reasoning="selector_exception",
                 )
                 _emit_progress_local(
                     {
@@ -19844,6 +19885,7 @@ class InternalMCPChatOrchestrator:
                             CHAT_ASSISTANT_WORKFLOW_ID
                         ),
                         "workflow_task": CHAT_ASSISTANT_WORKFLOW_ID,
+                        "workflow_selection_rationale": selection_rationale,
                     }
                 )
 
@@ -23051,6 +23093,8 @@ class InternalMCPChatOrchestrator:
                 branch_kind, parent_is_target = _classify_branch_kind(predicate)
                 if branch_kind in {"type_hierarchy", "instance_hierarchy"}:
                     has_explicit_hierarchy_predicates = True
+                if branch_kind == "custom":
+                    continue
 
                 parent_node_id = target_id if parent_is_target else source_id
                 child_node_id = source_id if parent_is_target else target_id
@@ -24235,6 +24279,7 @@ class InternalMCPChatOrchestrator:
                 discovered_workflow_ids=discovered_workflow_ids,
                 routing_duration_ms=routing_duration_ms,
                 source="selector_override",
+                reasoning=reason,
             )
 
             override_payload: dict[str, Any] = {
@@ -24323,6 +24368,25 @@ class InternalMCPChatOrchestrator:
         selected_workflow_name = _resolve_selected_workflow_name(
             selected_workflow_id_text
         )
+        workflow_selection_rationale = _derive_workflow_selection_rationale(
+            selected_workflow_id=selected_workflow_id_text,
+            selector_verdict=selector_verdict or None,
+            selector_source=(
+                routing_info.source
+                if isinstance(routing_info, WorkflowRoutingInfo)
+                else None
+            ),
+            candidate_workflow_ids=(
+                routing_info.discovered_workflow_ids
+                if isinstance(routing_info, WorkflowRoutingInfo)
+                else ()
+            ),
+            explicit_reasoning=(
+                routing_info.reasoning
+                if isinstance(routing_info, WorkflowRoutingInfo)
+                else None
+            ),
+        )
         workflow_dispatch_progress: dict[str, Any] = {
             "selected_workflow_id": selected_workflow_id_text,
             "selected_workflow_name": selected_workflow_name,
@@ -24335,6 +24399,7 @@ class InternalMCPChatOrchestrator:
             "workflow_match_count": len(discovered_matches),
             "workflow_candidate_count": len(discovered_matches)
             + len(excluded_discovered_matches),
+            "workflow_selection_rationale": workflow_selection_rationale,
         }
         _emit_phase_transition_local(
             self.PHASE_WORKFLOW_DISPATCH,

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -1493,6 +1493,13 @@ def _build_turn_execution_stage_diagnostics(
             stage_payload["workflow_selector_source"] = _progress_str(
                 latest_progress_payload.get("workflow_selector_source")
             )
+            stage_payload["workflow_selection_rationale"] = _progress_str(
+                latest_progress_payload.get("workflow_selection_rationale")
+            ) or (
+                _progress_str(latest_stage_event.get("workflow_selection_rationale"))
+                if isinstance(latest_stage_event, Mapping)
+                else None
+            )
 
         stage_diagnostics.append(stage_payload)
 
@@ -2598,6 +2605,14 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
                 merged.pop("failure_kind", None)
         else:
             merged.pop("failure_kind", None)
+        if "error_code" in safe_update:
+            error_code = _progress_str(safe_update.get("error_code"))
+            if error_code:
+                merged["error_code"] = error_code
+            else:
+                merged.pop("error_code", None)
+        else:
+            merged.pop("error_code", None)
         merged["request_id"] = request_id
         merged["status"] = status
         merged["stage"] = stage
@@ -2700,6 +2715,9 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
             event_entry["success"] = success_flag
         if _progress_str(merged.get("error")):
             event_entry["error"] = str(merged.get("error"))
+        error_code = _progress_str(merged.get("error_code"))
+        if error_code:
+            event_entry["error_code"] = error_code
         error_class = _progress_str(merged.get("error_class"))
         if error_class:
             event_entry["error_class"] = error_class
@@ -2731,6 +2749,11 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
         selector_source = _progress_str(merged.get("workflow_selector_source"))
         if selector_source:
             event_entry["workflow_selector_source"] = selector_source
+        workflow_selection_rationale = _progress_str(
+            merged.get("workflow_selection_rationale")
+        )
+        if workflow_selection_rationale:
+            event_entry["workflow_selection_rationale"] = workflow_selection_rationale
         workflow_match_count = _progress_number(merged.get("workflow_match_count"))
         if workflow_match_count is not None:
             event_entry["workflow_match_count"] = int(max(0.0, workflow_match_count))
@@ -2777,9 +2800,22 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
             stage_summaries[live_stage_id] = existing_summary
         merged["_stage_summaries"] = stage_summaries
 
+        tool_summary_source = dict(existing) if isinstance(existing, dict) else {}
+        for key_name in (
+            "tool_history",
+            "tool_call_count",
+            "tool_success_count",
+            "tool_failure_count",
+            "tool_pending_count",
+            "tool_call_start_count",
+            "tool_call_end_count",
+            "counters",
+        ):
+            if key_name in safe_update:
+                tool_summary_source[key_name] = safe_update.get(key_name)
         merged.update(
             update_tool_observation_summary(
-                merged,
+                tool_summary_source,
                 event_entry,
                 limit=_TOOL_PROGRESS_DIAGNOSTIC_EVENT_LIMIT,
             )

--- a/src/backend/services/paper_representation_workflow_vontology_service.py
+++ b/src/backend/services/paper_representation_workflow_vontology_service.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from typing import Any
 
-from ..db.repositories.concepts_repository import ConceptsRepository
-from . import concept_service
 from .text_value_service import upsert_singleton_text_relation
+from .workflow_vontology_materialisation_helpers import ensure_instance_typing
 from .workflow_discovery_service import invalidate_workflow_discovery_executability_caches
 from ..workflows import workflow_concept_authority_service as authority_service
 from ..workflows.durable.paper_representation_workflow import (
@@ -885,50 +884,6 @@ def _build_arxiv_workflow_spec() -> authority_service._CanonicalWorkflowPublicat
     )
 
 
-def _load_concept(concept_id: str) -> dict[str, Any] | None:
-    concept_id_clean = str(concept_id or "").strip()
-    if not concept_id_clean:
-        return None
-    try:
-        concept_doc = ConceptsRepository.find_one({"concept_id": concept_id_clean})
-    except Exception:
-        return None
-    return dict(concept_doc) if isinstance(concept_doc, Mapping) else None
-
-
-def _ensure_instance_typing(*, concept_id: str, type_ids: Sequence[str]) -> bool:
-    concept_doc = _load_concept(concept_id)
-    if concept_doc is None:
-        return False
-
-    relationships = dict(concept_doc.get("relationships") or {})
-    existing = relationships.get("is_an_instance_of")
-    if isinstance(existing, list):
-        updated = [
-            str(item).strip()
-            for item in existing
-            if isinstance(item, str) and str(item).strip()
-        ]
-    elif isinstance(existing, str) and existing.strip():
-        updated = [existing.strip()]
-    else:
-        updated = []
-
-    changed = False
-    for type_id in type_ids:
-        type_id_clean = str(type_id or "").strip()
-        if not type_id_clean or type_id_clean in updated:
-            continue
-        updated.append(type_id_clean)
-        changed = True
-    if not changed:
-        return False
-
-    relationships["is_an_instance_of"] = updated
-    concept_service.update_concept(concept_id, {"relationships": relationships})
-    return True
-
-
 def _ensure_workflow_texts(workflow_id: str) -> None:
     shared_context = {
         "source": "JVNAUTOSCI-1415",
@@ -1104,12 +1059,16 @@ def bootstrap_canonical_paper_representation_workflows() -> dict[str, Any]:
         validation_by_workflow_id.update(existing_validation_by_workflow_id)
 
     for workflow_id, spec in specs.items():
-        if _ensure_instance_typing(concept_id=workflow_id, type_ids=_WORKFLOW_TYPE_IDS):
+        if ensure_instance_typing(
+            concept_id=workflow_id,
+            type_ids=_WORKFLOW_TYPE_IDS,
+            remove_type_parent_ids=_WORKFLOW_TYPE_IDS,
+        ):
             typed_workflow_ids.append(workflow_id)
         _ensure_workflow_texts(workflow_id)
 
         for step_concept_id in _step_concept_ids_for_spec(workflow_id=workflow_id, spec=spec):
-            if _ensure_instance_typing(
+            if ensure_instance_typing(
                 concept_id=step_concept_id,
                 type_ids=(_WORKFLOW_STEP_TYPE_ID,),
             ):

--- a/src/backend/services/talk_representation_service.py
+++ b/src/backend/services/talk_representation_service.py
@@ -1,0 +1,617 @@
+"""Materialise and verify talk / presentation concepts for durable workflows."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from . import concept_service
+from . import concept_search_service
+from .arxiv_paper_link_service import resolve_or_create_scholarly_author_concept_id
+from .relationship_write_service import add_relationship
+from .text_value_service import get_texts_for_concept, upsert_singleton_text_relation
+from .workflow_vontology_materialisation_helpers import (
+    ensure_instance_typing,
+    load_concept,
+    normalise_relationship_targets,
+    stable_named_instance_concept_id,
+)
+from ..utils.concept_id_utils import canonicalise_vontology_concept_id
+
+logger = logging.getLogger(__name__)
+
+PRESENTATION_TYPE_ID = "#V#presentation"
+SCIENTIFIC_PRESENTATION_TYPE_ID = "#V#scientific_presentation"
+SEMINAR_TYPE_ID = "#V#seminar"
+PRESENTER_OF_PRESENTATION_PREDICATE_ID = "#V#presenter_of_presentation"
+HAS_START_TIME_PREDICATE_ID = "#V#has_start_time"
+PRESENTATION_MEETING_LINK_PREDICATE_ID = "#V#presentation_has_meeting_link"
+PRESENTATION_MEETING_ID_PREDICATE_ID = "#V#presentation_has_meeting_id"
+PRESENTATION_MEETING_PASSCODE_PREDICATE_ID = "#V#presentation_has_meeting_passcode"
+PRESENTATION_STATUS_PREDICATE_ID = "#V#presentation_status"
+_PREDICATE_TYPE_IDS: tuple[str, ...] = ("#V#predicate", "#V#binary_predicate")
+
+GENERIC_TALK_VERIFICATION_PROFILE = "generic_talk"
+TECHNICAL_SCIENTIFIC_TALK_VERIFICATION_PROFILE = "technical_scientific_talk"
+ACADEMIC_PRESENTATION_VERIFICATION_PROFILE = "academic_presentation"
+
+
+def _clean_text(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
+
+def _first_non_empty_text(*values: Any) -> str | None:
+    for value in values:
+        cleaned = _clean_text(value)
+        if cleaned:
+            return cleaned
+    return None
+
+
+def _coerce_string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        parts = [item.strip() for item in value.split(",")]
+        return [item for item in parts if item]
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+
+    values: list[str] = []
+    for item in value:
+        cleaned = _clean_text(item)
+        if cleaned:
+            values.append(cleaned)
+    return values
+
+
+def _dedupe_casefold(values: Sequence[str]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        cleaned = _clean_text(value)
+        if not cleaned:
+            continue
+        fingerprint = cleaned.casefold()
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        deduped.append(cleaned)
+    return deduped
+
+
+def _normalise_verification_profile(value: Any) -> str:
+    profile = _clean_text(value).lower()
+    if profile == TECHNICAL_SCIENTIFIC_TALK_VERIFICATION_PROFILE:
+        return TECHNICAL_SCIENTIFIC_TALK_VERIFICATION_PROFILE
+    if profile == ACADEMIC_PRESENTATION_VERIFICATION_PROFILE:
+        return ACADEMIC_PRESENTATION_VERIFICATION_PROFILE
+    return GENERIC_TALK_VERIFICATION_PROFILE
+
+
+def _required_type_ids_for_profile(profile: str) -> tuple[str, ...]:
+    if profile == TECHNICAL_SCIENTIFIC_TALK_VERIFICATION_PROFILE:
+        return (PRESENTATION_TYPE_ID, SCIENTIFIC_PRESENTATION_TYPE_ID)
+    if profile == ACADEMIC_PRESENTATION_VERIFICATION_PROFILE:
+        return (
+            PRESENTATION_TYPE_ID,
+            SCIENTIFIC_PRESENTATION_TYPE_ID,
+            SEMINAR_TYPE_ID,
+        )
+    return (PRESENTATION_TYPE_ID,)
+
+
+def _normalise_type_ids(raw_type_ids: Any, *, verification_profile: str) -> list[str]:
+    requested = _coerce_string_list(raw_type_ids)
+    canonical_ids: list[str] = []
+    for raw in requested:
+        canonical = canonicalise_vontology_concept_id(raw) or raw
+        if canonical.startswith("#V#"):
+            canonical_ids.append(canonical)
+    canonical_ids.extend(_required_type_ids_for_profile(verification_profile))
+    return _dedupe_casefold(canonical_ids)
+
+
+def _build_presentation_display_name(
+    *,
+    title: str | None,
+    speaker_name: str | None,
+    start_time: str | None,
+    presentation_concept_id: str | None,
+) -> str:
+    title_text = _clean_text(title)
+    speaker_text = _clean_text(speaker_name)
+    start_time_text = _clean_text(start_time)
+
+    if title_text and speaker_text:
+        base = f"{speaker_text} - {title_text}"
+    else:
+        base = title_text or speaker_text or ""
+
+    if start_time_text:
+        if base:
+            return f"{base} ({start_time_text})"
+        return start_time_text
+
+    if base:
+        return base
+
+    if _clean_text(presentation_concept_id):
+        return _clean_text(presentation_concept_id)
+
+    raise ValueError("talk_representation_display_name_missing")
+
+
+def _ensure_type_concept(
+    *,
+    concept_id: str,
+    name: str,
+    parent_type_ids: Sequence[str] = (),
+) -> None:
+    desired_parent_ids = _dedupe_casefold(
+        [
+            canonicalise_vontology_concept_id(parent_id) or parent_id
+            for parent_id in parent_type_ids
+            if _clean_text(parent_id)
+        ]
+    )
+    concept_doc = load_concept(concept_id)
+    if concept_doc is None:
+        concept_service.create_concept(
+            name=name,
+            concept_id=concept_id,
+            parent_concept_ids=list(desired_parent_ids),
+            create_as_instance=False,
+        )
+        return
+
+    relationships = dict(concept_doc.get("relationships") or {})
+    existing_parent_ids = normalise_relationship_targets(relationships.get("is_a_type_of"))
+    merged_parent_ids = list(existing_parent_ids)
+    for parent_id in desired_parent_ids:
+        if parent_id not in merged_parent_ids:
+            merged_parent_ids.append(parent_id)
+    if merged_parent_ids != existing_parent_ids:
+        relationships["is_a_type_of"] = merged_parent_ids
+        concept_service.update_concept(concept_id, {"relationships": relationships})
+
+
+def _ensure_predicate_concept(*, concept_id: str, name: str) -> None:
+    concept_doc = load_concept(concept_id)
+    if concept_doc is None:
+        concept_service.create_concept(
+            name=name,
+            concept_id=concept_id,
+            parent_concept_ids=["#V#predicate"],
+            create_as_instance=True,
+        )
+        return
+    ensure_instance_typing(
+        concept_id=concept_id,
+        type_ids=("#V#predicate",),
+        remove_type_parent_ids=_PREDICATE_TYPE_IDS,
+    )
+
+
+def ensure_talk_representation_primitives() -> None:
+    """Ensure required talk types and predicates exist and are typed correctly."""
+
+    _ensure_type_concept(
+        concept_id=PRESENTATION_TYPE_ID,
+        name="Presentation",
+    )
+    _ensure_type_concept(
+        concept_id=SCIENTIFIC_PRESENTATION_TYPE_ID,
+        name="Scientific Presentation",
+        parent_type_ids=(PRESENTATION_TYPE_ID,),
+    )
+    _ensure_type_concept(
+        concept_id=SEMINAR_TYPE_ID,
+        name="Seminar",
+        parent_type_ids=(PRESENTATION_TYPE_ID,),
+    )
+    _ensure_predicate_concept(
+        concept_id=PRESENTER_OF_PRESENTATION_PREDICATE_ID,
+        name="Presenter Of Presentation",
+    )
+    _ensure_predicate_concept(
+        concept_id=HAS_START_TIME_PREDICATE_ID,
+        name="Has Start Time",
+    )
+    _ensure_predicate_concept(
+        concept_id=PRESENTATION_MEETING_LINK_PREDICATE_ID,
+        name="Presentation Has Meeting Link",
+    )
+    _ensure_predicate_concept(
+        concept_id=PRESENTATION_MEETING_ID_PREDICATE_ID,
+        name="Presentation Has Meeting ID",
+    )
+    _ensure_predicate_concept(
+        concept_id=PRESENTATION_MEETING_PASSCODE_PREDICATE_ID,
+        name="Presentation Has Meeting Passcode",
+    )
+    _ensure_predicate_concept(
+        concept_id=PRESENTATION_STATUS_PREDICATE_ID,
+        name="Presentation Status",
+    )
+
+
+def _ensure_nl_name_text(concept_id: str, name_text: str) -> None:
+    existing_rows = get_texts_for_concept(
+        subject_concept_id=concept_id,
+        predicate="hasName",
+        limit=100,
+    )
+    existing_names = {
+        _clean_text(row.get("text")).casefold()
+        for row in existing_rows
+        if isinstance(row, Mapping) and _clean_text(row.get("text"))
+    }
+    if name_text.casefold() in existing_names:
+        return
+    from .text_value_service import upsert_text_for_concept
+
+    upsert_text_for_concept(
+        subject_concept_id=concept_id,
+        predicate="hasName",
+        text=name_text,
+        lang="en-NZ",
+        context={"name_type": "NL", "source": "talk_representation_workflow"},
+    )
+
+
+def _ensure_presentation_concept(
+    *,
+    presentation_concept_id: str,
+    display_name: str,
+    type_ids: Sequence[str],
+    created_by_concept_id: str,
+    organisation_concept_id: str | None,
+    namespace: str | None,
+) -> tuple[str, bool]:
+    concept_doc = load_concept(presentation_concept_id)
+    if concept_doc is None:
+        concept_service.create_concept(
+            name=display_name,
+            concept_id=presentation_concept_id,
+            parent_concept_ids=list(type_ids),
+            create_as_instance=True,
+            created_by_concept_id=created_by_concept_id,
+            organisation_concept_id=organisation_concept_id,
+            event_namespace=namespace,
+        )
+        return presentation_concept_id, True
+
+    ensure_instance_typing(concept_id=presentation_concept_id, type_ids=type_ids)
+    _ensure_nl_name_text(presentation_concept_id, display_name)
+    return presentation_concept_id, False
+
+
+def _upsert_singleton_text(
+    *,
+    concept_id: str,
+    predicate: str,
+    text: str | None,
+    source: str,
+) -> None:
+    text_value = _clean_text(text)
+    if not text_value:
+        return
+    upsert_singleton_text_relation(
+        subject_concept_id=concept_id,
+        predicate=predicate,
+        text=text_value,
+        lang="en-NZ",
+        context={"source": source},
+        garbage_collect=True,
+    )
+
+
+def _relation_contains_target(
+    concept_doc: Mapping[str, Any] | None,
+    predicate: str,
+    target_id: str | None,
+) -> bool:
+    target_clean = _clean_text(target_id)
+    if not target_clean:
+        return False
+    relationship_targets = normalise_relationship_targets(
+        (concept_doc.get("relationships") or {}).get(predicate)
+        if isinstance(concept_doc, Mapping)
+        else None
+    )
+    return target_clean in relationship_targets
+
+
+def _has_text_value(
+    *,
+    concept_id: str,
+    predicate: str,
+    expected_text: str | None,
+) -> bool:
+    expected = _clean_text(expected_text)
+    if not expected:
+        return True
+    rows = get_texts_for_concept(
+        subject_concept_id=concept_id,
+        predicate=predicate,
+        limit=50,
+    )
+    return any(
+        _clean_text(row.get("text")) == expected
+        for row in rows
+        if isinstance(row, Mapping)
+    )
+
+
+def _speaker_exists_by_name(speaker_name: str) -> bool:
+    search_result = concept_search_service.search_concepts(
+        query=speaker_name,
+        instance_of="#V#person",
+        match_type="exact",
+        limit=10,
+    )
+    for item in search_result.get("results") or []:
+        if not isinstance(item, Mapping):
+            continue
+        candidate_name = _clean_text(item.get("name"))
+        candidate_id = _clean_text(item.get("concept_id"))
+        if candidate_id and candidate_name.casefold() == speaker_name.casefold():
+            return True
+    return False
+
+
+def materialise_talk_representation(
+    *,
+    title: str | None = None,
+    speaker_name: str | None = None,
+    summary: str | None = None,
+    start_time: str | None = None,
+    meeting_link: str | None = None,
+    meeting_id: str | None = None,
+    meeting_passcode: str | None = None,
+    presentation_status: str | None = None,
+    presentation_concept_id: str | None = None,
+    presentation_type_ids: Sequence[str] | str | None = None,
+    verification_profile: str | None = None,
+    user_concept_id: str | None = None,
+    organisation_concept_id: str | None = None,
+    namespace: str | None = None,
+    materialisation_source: str = "talk_representation_workflow",
+) -> dict[str, Any]:
+    """Create or update a talk/presentation concept and key relationships."""
+
+    from .workflow_event_integration_service import resolve_event_actor_context
+
+    actor_user_id, actor_org_id = resolve_event_actor_context(
+        user_id=_clean_text(user_concept_id) or None,
+        org_id=_clean_text(organisation_concept_id) or None,
+        namespace=namespace,
+    )
+    if not actor_user_id:
+        raise ValueError("talk_representation_actor_user_missing")
+
+    ensure_talk_representation_primitives()
+
+    profile = _normalise_verification_profile(verification_profile)
+    type_ids = _normalise_type_ids(
+        presentation_type_ids,
+        verification_profile=profile,
+    )
+
+    display_name = _build_presentation_display_name(
+        title=title,
+        speaker_name=speaker_name,
+        start_time=start_time,
+        presentation_concept_id=presentation_concept_id,
+    )
+    resolved_presentation_concept_id = _clean_text(presentation_concept_id) or (
+        stable_named_instance_concept_id(display_name, prefix="presentation")
+    )
+    resolved_presentation_concept_id = (
+        canonicalise_vontology_concept_id(resolved_presentation_concept_id)
+        or resolved_presentation_concept_id
+    )
+
+    resolved_presentation_concept_id, created_presentation_concept = (
+        _ensure_presentation_concept(
+            presentation_concept_id=resolved_presentation_concept_id,
+            display_name=display_name,
+            type_ids=type_ids,
+            created_by_concept_id=actor_user_id,
+            organisation_concept_id=actor_org_id,
+            namespace=namespace,
+        )
+    )
+
+    _upsert_singleton_text(
+        concept_id=resolved_presentation_concept_id,
+        predicate="hasDescription",
+        text=summary,
+        source=materialisation_source,
+    )
+    _upsert_singleton_text(
+        concept_id=resolved_presentation_concept_id,
+        predicate=HAS_START_TIME_PREDICATE_ID,
+        text=start_time,
+        source=materialisation_source,
+    )
+    _upsert_singleton_text(
+        concept_id=resolved_presentation_concept_id,
+        predicate=PRESENTATION_MEETING_LINK_PREDICATE_ID,
+        text=meeting_link,
+        source=materialisation_source,
+    )
+    _upsert_singleton_text(
+        concept_id=resolved_presentation_concept_id,
+        predicate=PRESENTATION_MEETING_ID_PREDICATE_ID,
+        text=meeting_id,
+        source=materialisation_source,
+    )
+    _upsert_singleton_text(
+        concept_id=resolved_presentation_concept_id,
+        predicate=PRESENTATION_MEETING_PASSCODE_PREDICATE_ID,
+        text=meeting_passcode,
+        source=materialisation_source,
+    )
+    _upsert_singleton_text(
+        concept_id=resolved_presentation_concept_id,
+        predicate=PRESENTATION_STATUS_PREDICATE_ID,
+        text=presentation_status,
+        source=materialisation_source,
+    )
+
+    speaker_concept_id: str | None = None
+    created_speaker_concept = False
+    speaker_name_text = _clean_text(speaker_name)
+    if speaker_name_text:
+        created_speaker_concept = not _speaker_exists_by_name(speaker_name_text)
+        speaker_concept_id = resolve_or_create_scholarly_author_concept_id(
+            user_concept_id=actor_user_id,
+            author_name=speaker_name_text,
+            logger=logger,
+        )
+        add_relationship(
+            source_id=speaker_concept_id,
+            predicate=PRESENTER_OF_PRESENTATION_PREDICATE_ID,
+            target=resolved_presentation_concept_id,
+        )
+
+    return {
+        "presentation_concept_id": resolved_presentation_concept_id,
+        "presentation_display_name": display_name,
+        "speaker_concept_id": speaker_concept_id,
+        "speaker_name": speaker_name_text or None,
+        "verification_profile": profile,
+        "presentation_type_ids": list(type_ids),
+        "created_presentation_concept": created_presentation_concept,
+        "created_speaker_concept": created_speaker_concept,
+        "materialisation_source": materialisation_source,
+    }
+
+
+def verify_talk_representation(
+    *,
+    presentation_concept_id: str | None,
+    speaker_concept_id: str | None = None,
+    summary: str | None = None,
+    start_time: str | None = None,
+    meeting_link: str | None = None,
+    meeting_id: str | None = None,
+    meeting_passcode: str | None = None,
+    presentation_status: str | None = None,
+    presentation_type_ids: Sequence[str] | str | None = None,
+    verification_profile: str | None = None,
+) -> dict[str, Any]:
+    """Verify talk/presentation representation postconditions."""
+
+    concept_id = _clean_text(presentation_concept_id)
+    if not concept_id:
+        return {
+            "result": False,
+            "talk_representation_verified": False,
+            "verification_failures": ["presentation_concept_id_missing"],
+        }
+
+    concept_doc = load_concept(concept_id)
+    verification_failures: list[str] = []
+    if concept_doc is None:
+        verification_failures.append("presentation_concept_missing")
+
+    profile = _normalise_verification_profile(verification_profile)
+    expected_type_ids = _normalise_type_ids(
+        presentation_type_ids,
+        verification_profile=profile,
+    )
+    observed_type_ids = normalise_relationship_targets(
+        (concept_doc.get("relationships") or {}).get("is_an_instance_of")
+        if isinstance(concept_doc, Mapping)
+        else None
+    )
+    for type_id in expected_type_ids:
+        if type_id not in observed_type_ids:
+            verification_failures.append(f"type_missing:{type_id}")
+
+    name_rows = (
+        get_texts_for_concept(
+            subject_concept_id=concept_id,
+            predicate="hasName",
+            limit=50,
+        )
+        if concept_doc is not None
+        else []
+    )
+    if not name_rows and not _clean_text((concept_doc or {}).get("name")):
+        verification_failures.append("presentation_name_missing")
+
+    if not _has_text_value(
+        concept_id=concept_id,
+        predicate="hasDescription",
+        expected_text=summary,
+    ):
+        verification_failures.append("summary_missing")
+    if not _has_text_value(
+        concept_id=concept_id,
+        predicate=HAS_START_TIME_PREDICATE_ID,
+        expected_text=start_time,
+    ):
+        verification_failures.append("start_time_missing")
+    if not _has_text_value(
+        concept_id=concept_id,
+        predicate=PRESENTATION_MEETING_LINK_PREDICATE_ID,
+        expected_text=meeting_link,
+    ):
+        verification_failures.append("meeting_link_missing")
+    if not _has_text_value(
+        concept_id=concept_id,
+        predicate=PRESENTATION_MEETING_ID_PREDICATE_ID,
+        expected_text=meeting_id,
+    ):
+        verification_failures.append("meeting_id_missing")
+    if not _has_text_value(
+        concept_id=concept_id,
+        predicate=PRESENTATION_MEETING_PASSCODE_PREDICATE_ID,
+        expected_text=meeting_passcode,
+    ):
+        verification_failures.append("meeting_passcode_missing")
+    if not _has_text_value(
+        concept_id=concept_id,
+        predicate=PRESENTATION_STATUS_PREDICATE_ID,
+        expected_text=presentation_status,
+    ):
+        verification_failures.append("presentation_status_missing")
+
+    speaker_id = _clean_text(speaker_concept_id)
+    if speaker_id:
+        speaker_doc = load_concept(speaker_id)
+        if not speaker_doc:
+            verification_failures.append("speaker_concept_missing")
+        elif not _relation_contains_target(
+            speaker_doc,
+            PRESENTER_OF_PRESENTATION_PREDICATE_ID,
+            concept_id,
+        ):
+            verification_failures.append("presenter_relationship_missing")
+
+    verified = not verification_failures
+    return {
+        "result": verified,
+        "talk_representation_verified": verified,
+        "presentation_concept_id": concept_id,
+        "speaker_concept_id": speaker_id or None,
+        "verification_profile": profile,
+        "expected_type_ids": list(expected_type_ids),
+        "observed_type_ids": observed_type_ids,
+        "verification_failures": verification_failures,
+    }
+
+
+__all__ = [
+    "ACADEMIC_PRESENTATION_VERIFICATION_PROFILE",
+    "GENERIC_TALK_VERIFICATION_PROFILE",
+    "TECHNICAL_SCIENTIFIC_TALK_VERIFICATION_PROFILE",
+    "ensure_talk_representation_primitives",
+    "materialise_talk_representation",
+    "verify_talk_representation",
+]

--- a/src/backend/services/talk_representation_workflow_vontology_service.py
+++ b/src/backend/services/talk_representation_workflow_vontology_service.py
@@ -1,0 +1,809 @@
+"""Materialise canonical talk representation workflows in Vontology."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Sequence
+from typing import Any
+
+from .text_value_service import upsert_singleton_text_relation
+from .talk_representation_service import ensure_talk_representation_primitives
+from .workflow_discovery_service import invalidate_workflow_discovery_executability_caches
+from .workflow_vontology_materialisation_helpers import ensure_instance_typing
+from ..workflows import workflow_concept_authority_service as authority_service
+from ..workflows.durable.subworkflow_actions import WORKFLOW_SUBWORKFLOW_ACTION_ID
+from ..workflows.durable.talk_representation_workflow import (
+    TALK_MATERIALISE_ACTION_ID,
+    TALK_NORMALISE_INPUTS_ACTION_ID,
+    TALK_VERIFY_ACTION_ID,
+)
+from ..workflows.vontology_loader import (
+    build_workflow_process_graph,
+    load_workflow_definition_from_vontology,
+)
+from ..workflows.workflow_definition_identity_service import (
+    validate_workflow_definition_contract,
+)
+from ..workflows.workflow_registry import WorkflowRegistration, WorkflowRegistry
+
+TALK_REPRESENTATION_WORKFLOW_ID = "#V#talk_representation_workflow"
+TECHNICAL_SCIENTIFIC_TALK_REPRESENTATION_WORKFLOW_ID = (
+    "#V#technical_scientific_talk_representation_workflow"
+)
+ACADEMIC_PRESENTATION_INSTANCE_WORKFLOW_ID = "#V#academic_presentation_instance_workflow"
+
+_WORKFLOW_STEP_TYPE_ID = "#V#workflow_step"
+_WORKFLOW_TYPE_IDS = ("#V#ai_workflow", "#V#durable_workflow")
+_TALK_CONTEXT_KEYS: tuple[str, ...] = (
+    "presentation_concept_id",
+    "title",
+    "speaker_name",
+    "summary",
+    "start_time",
+    "meeting_link",
+    "meeting_id",
+    "meeting_passcode",
+    "presentation_status",
+    "presentation_type_ids",
+    "verification_profile",
+)
+
+
+def _context_mapping(
+    *,
+    workflow_id: str,
+    state_id: str,
+    tool_param: str,
+    context_key: str,
+) -> authority_service._CanonicalContextInputMappingSpec:
+    return authority_service._CanonicalContextInputMappingSpec(
+        concept_id=authority_service._runtime_context_input_mapping_concept_id(
+            workflow_id=workflow_id,
+            state_id=state_id,
+            tool_param=tool_param,
+            context_key=context_key,
+        ),
+        context_key=context_key,
+        tool_param=tool_param,
+    )
+
+
+def _output_mapping(
+    *,
+    workflow_id: str,
+    state_id: str,
+    tool_output_field: str,
+    context_key: str,
+) -> authority_service._CanonicalToolOutputMappingSpec:
+    return authority_service._CanonicalToolOutputMappingSpec(
+        concept_id=authority_service._runtime_tool_output_mapping_concept_id(
+            workflow_id=workflow_id,
+            state_id=state_id,
+            tool_output_field=tool_output_field,
+            context_key=context_key,
+        ),
+        tool_output_field=tool_output_field,
+        context_key=context_key,
+    )
+
+
+def _workflow_name(workflow_id: str) -> str:
+    if workflow_id == TALK_REPRESENTATION_WORKFLOW_ID:
+        return "Talk Representation Workflow"
+    if workflow_id == TECHNICAL_SCIENTIFIC_TALK_REPRESENTATION_WORKFLOW_ID:
+        return "Technical Scientific Talk Representation Workflow"
+    if workflow_id == ACADEMIC_PRESENTATION_INSTANCE_WORKFLOW_ID:
+        return "Academic Presentation Instance Workflow"
+    return authority_service._titleise_workflow_id(workflow_id)
+
+
+def _workflow_description(workflow_id: str) -> str:
+    if workflow_id == TALK_REPRESENTATION_WORKFLOW_ID:
+        return (
+            "Canonical durable workflow for representing talks and presentations in "
+            "Vontology from structured meeting and speaker inputs."
+        )
+    if workflow_id == TECHNICAL_SCIENTIFIC_TALK_REPRESENTATION_WORKFLOW_ID:
+        return (
+            "Wrapper workflow that delegates to the canonical talk workflow with "
+            "technical/scientific talk typing and verification requirements."
+        )
+    return (
+        "Wrapper workflow that delegates to the canonical talk workflow with "
+        "academic presentation typing and seminar verification requirements."
+    )
+
+
+def _workflow_content(workflow_id: str) -> str:
+    if workflow_id == TALK_REPRESENTATION_WORKFLOW_ID:
+        return (
+            "Represent a talk by normalising presentation inputs, materialising or "
+            "reusing the presentation concept, linking the presenter, and verifying "
+            "the requested talk representation profile."
+        )
+    if workflow_id == TECHNICAL_SCIENTIFIC_TALK_REPRESENTATION_WORKFLOW_ID:
+        return (
+            "Represent a technical or scientific talk by delegating to the canonical "
+            "talk workflow with scientific presentation typing."
+        )
+    return (
+        "Represent an academic presentation instance by delegating to the canonical "
+        "talk workflow with scientific presentation and seminar typing."
+    )
+
+
+def _workflow_capability_gap_note(workflow_id: str) -> str:
+    return (
+        "Capability-gap note: this workflow depends on Python durable actions "
+        f"because current VWL/runtime primitives cannot yet express a reusable, "
+        "deterministic representation-materialisation primitive for concept "
+        f"creation/update plus postcondition verification. Workflow {workflow_id} "
+        "should migrate fully into VWL once the runtime can declaratively express "
+        "stable concept reuse, singleton text upserts, relationship writes, and "
+        "verification against required representation predicates."
+    )
+
+
+def _workflow_supported_action_ids() -> tuple[str, ...]:
+    return (
+        TALK_NORMALISE_INPUTS_ACTION_ID,
+        TALK_MATERIALISE_ACTION_ID,
+        TALK_VERIFY_ACTION_ID,
+        WORKFLOW_SUBWORKFLOW_ACTION_ID,
+    )
+
+
+def _base_talk_context_input_mappings(
+    *,
+    workflow_id: str,
+    state_id: str,
+) -> tuple[authority_service._CanonicalContextInputMappingSpec, ...]:
+    return tuple(
+        _context_mapping(
+            workflow_id=workflow_id,
+            state_id=state_id,
+            tool_param=context_key,
+            context_key=context_key,
+        )
+        for context_key in _TALK_CONTEXT_KEYS
+    )
+
+
+def _build_talk_workflow_spec() -> authority_service._CanonicalWorkflowPublicationSpec:
+    workflow_id = TALK_REPRESENTATION_WORKFLOW_ID
+    return authority_service._CanonicalWorkflowPublicationSpec(
+        initial_state="normalise_inputs",
+        steps=(
+            authority_service._CanonicalStepPublicationSpec(
+                state_id="normalise_inputs",
+                action_id=TALK_NORMALISE_INPUTS_ACTION_ID,
+                context_input_mapping_specs=_base_talk_context_input_mappings(
+                    workflow_id=workflow_id,
+                    state_id="normalise_inputs",
+                ),
+                tool_output_mapping_specs=tuple(
+                    _output_mapping(
+                        workflow_id=workflow_id,
+                        state_id="normalise_inputs",
+                        tool_output_field=context_key,
+                        context_key=context_key,
+                    )
+                    for context_key in _TALK_CONTEXT_KEYS
+                )
+                + (
+                    _output_mapping(
+                        workflow_id=workflow_id,
+                        state_id="normalise_inputs",
+                        tool_output_field="normalised_talk_inputs",
+                        context_key="normalised_talk_inputs",
+                    ),
+                ),
+                writes_context_keys=_TALK_CONTEXT_KEYS + ("normalised_talk_inputs",),
+                on_failure_state="failed",
+                next_state="materialise_representation",
+            ),
+            authority_service._CanonicalStepPublicationSpec(
+                state_id="materialise_representation",
+                action_id=TALK_MATERIALISE_ACTION_ID,
+                context_input_mapping_specs=_base_talk_context_input_mappings(
+                    workflow_id=workflow_id,
+                    state_id="materialise_representation",
+                ),
+                tool_output_mapping_specs=(
+                    _output_mapping(
+                        workflow_id=workflow_id,
+                        state_id="materialise_representation",
+                        tool_output_field="presentation_concept_id",
+                        context_key="presentation_concept_id",
+                    ),
+                    _output_mapping(
+                        workflow_id=workflow_id,
+                        state_id="materialise_representation",
+                        tool_output_field="presentation_display_name",
+                        context_key="presentation_display_name",
+                    ),
+                    _output_mapping(
+                        workflow_id=workflow_id,
+                        state_id="materialise_representation",
+                        tool_output_field="speaker_concept_id",
+                        context_key="speaker_concept_id",
+                    ),
+                    _output_mapping(
+                        workflow_id=workflow_id,
+                        state_id="materialise_representation",
+                        tool_output_field="presentation_type_ids",
+                        context_key="presentation_type_ids",
+                    ),
+                    _output_mapping(
+                        workflow_id=workflow_id,
+                        state_id="materialise_representation",
+                        tool_output_field="verification_profile",
+                        context_key="verification_profile",
+                    ),
+                    _output_mapping(
+                        workflow_id=workflow_id,
+                        state_id="materialise_representation",
+                        tool_output_field="talk_representation_materialised",
+                        context_key="talk_representation_materialised",
+                    ),
+                    _output_mapping(
+                        workflow_id=workflow_id,
+                        state_id="materialise_representation",
+                        tool_output_field="materialisation_report",
+                        context_key="materialisation_report",
+                    ),
+                ),
+                writes_context_keys=(
+                    "presentation_concept_id",
+                    "presentation_display_name",
+                    "speaker_concept_id",
+                    "presentation_type_ids",
+                    "verification_profile",
+                    "talk_representation_materialised",
+                    "materialisation_report",
+                ),
+                on_failure_state="failed",
+                next_state="verify_representation",
+            ),
+            authority_service._CanonicalStepPublicationSpec(
+                state_id="verify_representation",
+                action_id=TALK_VERIFY_ACTION_ID,
+                context_input_mapping_specs=(
+                    _context_mapping(
+                        workflow_id=workflow_id,
+                        state_id="verify_representation",
+                        tool_param="presentation_concept_id",
+                        context_key="presentation_concept_id",
+                    ),
+                    _context_mapping(
+                        workflow_id=workflow_id,
+                        state_id="verify_representation",
+                        tool_param="speaker_concept_id",
+                        context_key="speaker_concept_id",
+                    ),
+                    _context_mapping(
+                        workflow_id=workflow_id,
+                        state_id="verify_representation",
+                        tool_param="summary",
+                        context_key="summary",
+                    ),
+                    _context_mapping(
+                        workflow_id=workflow_id,
+                        state_id="verify_representation",
+                        tool_param="start_time",
+                        context_key="start_time",
+                    ),
+                    _context_mapping(
+                        workflow_id=workflow_id,
+                        state_id="verify_representation",
+                        tool_param="meeting_link",
+                        context_key="meeting_link",
+                    ),
+                    _context_mapping(
+                        workflow_id=workflow_id,
+                        state_id="verify_representation",
+                        tool_param="meeting_id",
+                        context_key="meeting_id",
+                    ),
+                    _context_mapping(
+                        workflow_id=workflow_id,
+                        state_id="verify_representation",
+                        tool_param="meeting_passcode",
+                        context_key="meeting_passcode",
+                    ),
+                    _context_mapping(
+                        workflow_id=workflow_id,
+                        state_id="verify_representation",
+                        tool_param="presentation_status",
+                        context_key="presentation_status",
+                    ),
+                    _context_mapping(
+                        workflow_id=workflow_id,
+                        state_id="verify_representation",
+                        tool_param="presentation_type_ids",
+                        context_key="presentation_type_ids",
+                    ),
+                    _context_mapping(
+                        workflow_id=workflow_id,
+                        state_id="verify_representation",
+                        tool_param="verification_profile",
+                        context_key="verification_profile",
+                    ),
+                ),
+                tool_output_mapping_specs=(
+                    _output_mapping(
+                        workflow_id=workflow_id,
+                        state_id="verify_representation",
+                        tool_output_field="talk_representation_verified",
+                        context_key="talk_representation_verified",
+                    ),
+                    _output_mapping(
+                        workflow_id=workflow_id,
+                        state_id="verify_representation",
+                        tool_output_field="verification_failures",
+                        context_key="verification_failures",
+                    ),
+                ),
+                writes_context_keys=(
+                    "talk_representation_verified",
+                    "verification_failures",
+                ),
+                on_failure_state="failed",
+                on_true_state="completed",
+                on_false_state="failed",
+            ),
+            authority_service._CanonicalStepPublicationSpec(state_id="completed"),
+            authority_service._CanonicalStepPublicationSpec(state_id="failed"),
+        ),
+    )
+
+
+def _build_wrapper_delegate_step(
+    *,
+    workflow_id: str,
+    state_id: str,
+) -> authority_service._CanonicalStepPublicationSpec:
+    return authority_service._CanonicalStepPublicationSpec(
+        state_id=state_id,
+        action_id=WORKFLOW_SUBWORKFLOW_ACTION_ID,
+        invoked_workflow_id=TALK_REPRESENTATION_WORKFLOW_ID,
+        context_input_mapping_specs=tuple(
+            _context_mapping(
+                workflow_id=workflow_id,
+                state_id=state_id,
+                tool_param=context_key,
+                context_key=context_key,
+            )
+            for context_key in (
+                "presentation_concept_id",
+                "title",
+                "speaker_name",
+                "summary",
+                "start_time",
+                "meeting_link",
+                "meeting_id",
+                "meeting_passcode",
+                "presentation_status",
+                "presentation_type_ids",
+                "verification_profile",
+            )
+        ),
+        tool_output_mapping_specs=(
+            _output_mapping(
+                workflow_id=workflow_id,
+                state_id=state_id,
+                tool_output_field="result.presentation_concept_id",
+                context_key="presentation_concept_id",
+            ),
+            _output_mapping(
+                workflow_id=workflow_id,
+                state_id=state_id,
+                tool_output_field="result.presentation_display_name",
+                context_key="presentation_display_name",
+            ),
+            _output_mapping(
+                workflow_id=workflow_id,
+                state_id=state_id,
+                tool_output_field="result.speaker_concept_id",
+                context_key="speaker_concept_id",
+            ),
+            _output_mapping(
+                workflow_id=workflow_id,
+                state_id=state_id,
+                tool_output_field="result.presentation_type_ids",
+                context_key="presentation_type_ids",
+            ),
+            _output_mapping(
+                workflow_id=workflow_id,
+                state_id=state_id,
+                tool_output_field="result.verification_profile",
+                context_key="verification_profile",
+            ),
+            _output_mapping(
+                workflow_id=workflow_id,
+                state_id=state_id,
+                tool_output_field="result.talk_representation_materialised",
+                context_key="talk_representation_materialised",
+            ),
+            _output_mapping(
+                workflow_id=workflow_id,
+                state_id=state_id,
+                tool_output_field="result.talk_representation_verified",
+                context_key="talk_representation_verified",
+            ),
+            _output_mapping(
+                workflow_id=workflow_id,
+                state_id=state_id,
+                tool_output_field="result.verification_failures",
+                context_key="verification_failures",
+            ),
+            _output_mapping(
+                workflow_id=workflow_id,
+                state_id=state_id,
+                tool_output_field="result.materialisation_report",
+                context_key="materialisation_report",
+            ),
+        ),
+        writes_context_keys=(
+            "presentation_concept_id",
+            "presentation_display_name",
+            "speaker_concept_id",
+            "presentation_type_ids",
+            "verification_profile",
+            "talk_representation_materialised",
+            "talk_representation_verified",
+            "verification_failures",
+            "materialisation_report",
+        ),
+        on_failure_state="failed",
+        next_state="completed",
+    )
+
+
+def _build_wrapper_normalise_step(
+    *,
+    workflow_id: str,
+    state_id: str,
+    verification_profile: str,
+    default_type_ids: str,
+) -> authority_service._CanonicalStepPublicationSpec:
+    return authority_service._CanonicalStepPublicationSpec(
+        state_id=state_id,
+        action_id=TALK_NORMALISE_INPUTS_ACTION_ID,
+        static_input_bindings=(
+            ("verification_profile", verification_profile),
+            ("presentation_type_ids", default_type_ids),
+        ),
+        tool_output_mapping_specs=tuple(
+            _output_mapping(
+                workflow_id=workflow_id,
+                state_id=state_id,
+                tool_output_field=context_key,
+                context_key=context_key,
+            )
+            for context_key in _TALK_CONTEXT_KEYS
+        )
+        + (
+            _output_mapping(
+                workflow_id=workflow_id,
+                state_id=state_id,
+                tool_output_field="normalised_talk_inputs",
+                context_key="normalised_talk_inputs",
+            ),
+        ),
+        writes_context_keys=_TALK_CONTEXT_KEYS + ("normalised_talk_inputs",),
+        on_failure_state="failed",
+        next_state="delegate_to_talk_representation",
+    )
+
+
+def _build_technical_scientific_talk_workflow_spec() -> (
+    authority_service._CanonicalWorkflowPublicationSpec
+):
+    workflow_id = TECHNICAL_SCIENTIFIC_TALK_REPRESENTATION_WORKFLOW_ID
+    return authority_service._CanonicalWorkflowPublicationSpec(
+        initial_state="normalise_inputs",
+        steps=(
+            _build_wrapper_normalise_step(
+                workflow_id=workflow_id,
+                state_id="normalise_inputs",
+                verification_profile="technical_scientific_talk",
+                default_type_ids="#V#presentation,#V#scientific_presentation",
+            ),
+            _build_wrapper_delegate_step(
+                workflow_id=workflow_id,
+                state_id="delegate_to_talk_representation",
+            ),
+            authority_service._CanonicalStepPublicationSpec(state_id="completed"),
+            authority_service._CanonicalStepPublicationSpec(state_id="failed"),
+        ),
+    )
+
+
+def _build_academic_presentation_workflow_spec() -> (
+    authority_service._CanonicalWorkflowPublicationSpec
+):
+    workflow_id = ACADEMIC_PRESENTATION_INSTANCE_WORKFLOW_ID
+    return authority_service._CanonicalWorkflowPublicationSpec(
+        initial_state="normalise_inputs",
+        steps=(
+            _build_wrapper_normalise_step(
+                workflow_id=workflow_id,
+                state_id="normalise_inputs",
+                verification_profile="academic_presentation",
+                default_type_ids="#V#presentation,#V#scientific_presentation,#V#seminar",
+            ),
+            _build_wrapper_delegate_step(
+                workflow_id=workflow_id,
+                state_id="delegate_to_talk_representation",
+            ),
+            authority_service._CanonicalStepPublicationSpec(state_id="completed"),
+            authority_service._CanonicalStepPublicationSpec(state_id="failed"),
+        ),
+    )
+
+
+def _ensure_workflow_texts(workflow_id: str) -> None:
+    shared_context = {
+        "source": "JVNAUTOSCI-1459",
+        "workflow_id": workflow_id,
+        "managed_by": "talk_representation_workflow_vontology_service",
+    }
+    upsert_singleton_text_relation(
+        subject_concept_id=workflow_id,
+        predicate="hasDescription",
+        text=_workflow_description(workflow_id),
+        lang="en-NZ",
+        context=dict(shared_context),
+        garbage_collect=True,
+    )
+    upsert_singleton_text_relation(
+        subject_concept_id=workflow_id,
+        predicate="hasContent",
+        text=_workflow_content(workflow_id),
+        lang="en-NZ",
+        context=dict(shared_context),
+        garbage_collect=True,
+    )
+    upsert_singleton_text_relation(
+        subject_concept_id=workflow_id,
+        predicate="hasNote",
+        text=_workflow_capability_gap_note(workflow_id),
+        lang="en-NZ",
+        context=dict(shared_context),
+        garbage_collect=True,
+    )
+
+
+def _step_concept_ids_for_spec(
+    *,
+    workflow_id: str,
+    spec: authority_service._CanonicalWorkflowPublicationSpec,
+) -> tuple[str, ...]:
+    ordered_ids: list[str] = []
+    for step in spec.steps:
+        explicit_concept_id = (
+            step.concept_id.strip()
+            if isinstance(step.concept_id, str) and step.concept_id.strip()
+            else None
+        )
+        ordered_ids.append(
+            explicit_concept_id
+            if explicit_concept_id is not None
+            else authority_service._step_concept_id(
+                workflow_id=workflow_id,
+                state_id=step.state_id,
+            )
+        )
+    return tuple(ordered_ids)
+
+
+def _build_publication_registry() -> tuple[
+    WorkflowRegistry,
+    dict[str, authority_service._CanonicalWorkflowPublicationSpec],
+]:
+    registry = WorkflowRegistry()
+    specs = {
+        TALK_REPRESENTATION_WORKFLOW_ID: _build_talk_workflow_spec(),
+        TECHNICAL_SCIENTIFIC_TALK_REPRESENTATION_WORKFLOW_ID: (
+            _build_technical_scientific_talk_workflow_spec()
+        ),
+        ACADEMIC_PRESENTATION_INSTANCE_WORKFLOW_ID: (
+            _build_academic_presentation_workflow_spec()
+        ),
+    }
+    for workflow_id, spec in specs.items():
+        registry.register(
+            WorkflowRegistration(
+                workflow_id=workflow_id,
+                definition=authority_service._build_definition_from_publication_spec(
+                    workflow_id=workflow_id,
+                    spec=spec,
+                ),
+                purpose=_workflow_content(workflow_id),
+                source="built_in",
+            )
+        )
+    return registry, specs
+
+
+def _validate_existing_materialisation(
+    *,
+    target_workflow_ids: Sequence[str],
+) -> tuple[bool, dict[str, dict[str, Any]]]:
+    workflow_ids = tuple(
+        str(item).strip()
+        for item in target_workflow_ids
+        if isinstance(item, str) and str(item).strip()
+    )
+    if not workflow_ids:
+        return False, {}
+
+    cached_definitions: dict[str, Any | None] = {}
+    validation_by_workflow_id: dict[str, dict[str, Any]] = {}
+
+    def _cached_loader(candidate_workflow_id: str) -> Any | None:
+        workflow_id = str(candidate_workflow_id or "").strip()
+        if not workflow_id:
+            return None
+        if workflow_id not in cached_definitions:
+            cached_definitions[workflow_id] = load_workflow_definition_from_vontology(
+                workflow_id
+            )
+        return cached_definitions[workflow_id]
+
+    supported_action_ids = _workflow_supported_action_ids()
+    for workflow_id in workflow_ids:
+        graph, graph_warnings = build_workflow_process_graph(workflow_id)
+        if not isinstance(graph, dict):
+            return False, {}
+        warning_items = [
+            str(item).strip()
+            for item in (graph_warnings or [])
+            if isinstance(item, str) and str(item).strip()
+        ]
+        if warning_items:
+            return False, {}
+
+        definition = _cached_loader(workflow_id)
+        if definition is None:
+            return False, {}
+
+        validation = validate_workflow_definition_contract(
+            definition=definition,
+            supported_action_ids=supported_action_ids,
+            known_workflow_ids=workflow_ids,
+            workflow_definition_loader=_cached_loader,
+        )
+        validation_by_workflow_id[workflow_id] = copy.deepcopy(validation)
+        if not bool(validation.get("valid")):
+            return False, {}
+
+    return True, validation_by_workflow_id
+
+
+def bootstrap_canonical_talk_representation_workflows() -> dict[str, Any]:
+    """Publish and validate the canonical talk workflow family."""
+
+    ensure_talk_representation_primitives()
+    registry, specs = _build_publication_registry()
+    target_workflow_ids = tuple(specs.keys())
+    already_current, existing_validation_by_workflow_id = (
+        _validate_existing_materialisation(target_workflow_ids=target_workflow_ids)
+    )
+
+    publication_report: dict[str, Any]
+    if already_current:
+        publication_report = {
+            "counts": {
+                "workflows_targeted": len(target_workflow_ids),
+                "workflows_published": 0,
+                "workflows_skipped_missing_registration": 0,
+                "workflows_skipped_missing_concept": 0,
+                "step_concepts_created": 0,
+                "action_concepts_created": 0,
+                "mapping_concepts_created": 0,
+                "validation_failures": 0,
+                "errors": 0,
+            },
+            "published_workflow_ids": [],
+            "skipped_due_to_current_materialisation": list(target_workflow_ids),
+            "skip_reason": "existing_materialisation_valid",
+            "skipped": True,
+        }
+    else:
+        original_specs = dict(authority_service._CANONICAL_WORKFLOW_PUBLICATION_SPECS)
+        authority_service._CANONICAL_WORKFLOW_PUBLICATION_SPECS.update(specs)
+        try:
+            publication_report = authority_service.publish_canonical_chat_workflow_graphs(
+                registry=registry,
+                target_workflow_ids=target_workflow_ids,
+            )
+        finally:
+            authority_service._CANONICAL_WORKFLOW_PUBLICATION_SPECS.clear()
+            authority_service._CANONICAL_WORKFLOW_PUBLICATION_SPECS.update(original_specs)
+
+    typed_workflow_ids: list[str] = []
+    typed_step_ids: list[str] = []
+    validation_by_workflow_id: dict[str, dict[str, Any]] = {}
+    if already_current:
+        validation_by_workflow_id.update(existing_validation_by_workflow_id)
+
+    for workflow_id, spec in specs.items():
+        if ensure_instance_typing(
+            concept_id=workflow_id,
+            type_ids=_WORKFLOW_TYPE_IDS,
+            remove_type_parent_ids=_WORKFLOW_TYPE_IDS,
+        ):
+            typed_workflow_ids.append(workflow_id)
+        _ensure_workflow_texts(workflow_id)
+
+        for step_concept_id in _step_concept_ids_for_spec(workflow_id=workflow_id, spec=spec):
+            if ensure_instance_typing(
+                concept_id=step_concept_id,
+                type_ids=(_WORKFLOW_STEP_TYPE_ID,),
+            ):
+                typed_step_ids.append(step_concept_id)
+
+        validation = validation_by_workflow_id.get(workflow_id)
+        if already_current:
+            if not isinstance(validation, dict):
+                raise RuntimeError(
+                    f"talk_workflow_validation_missing_after_short_circuit:{workflow_id}"
+                )
+        else:
+            graph, graph_warnings = build_workflow_process_graph(workflow_id)
+            if not isinstance(graph, dict):
+                raise RuntimeError(f"talk_workflow_graph_missing:{workflow_id}")
+            warning_items = [
+                str(item).strip()
+                for item in (graph_warnings or [])
+                if isinstance(item, str) and str(item).strip()
+            ]
+            if warning_items:
+                raise RuntimeError(
+                    "talk_workflow_graph_warnings_present:"
+                    f"{workflow_id}:"
+                    + ",".join(warning_items)
+                )
+
+            definition = load_workflow_definition_from_vontology(workflow_id)
+            if definition is None:
+                raise RuntimeError(
+                    f"talk_workflow_definition_not_loadable:{workflow_id}"
+                )
+            validation = validate_workflow_definition_contract(
+                definition=definition,
+                supported_action_ids=_workflow_supported_action_ids(),
+                known_workflow_ids=target_workflow_ids,
+                workflow_definition_loader=load_workflow_definition_from_vontology,
+            )
+        validation_by_workflow_id[workflow_id] = validation
+        if not bool(validation.get("valid")):
+            raise RuntimeError(
+                "talk_workflow_validation_failed:"
+                f"{workflow_id}:"
+                + ",".join(
+                    str(item).strip()
+                    for item in validation.get("errors", [])
+                    if isinstance(item, str) and str(item).strip()
+                )
+            )
+
+    invalidate_workflow_discovery_executability_caches()
+
+    return {
+        "workflow_ids": list(target_workflow_ids),
+        "publication": publication_report,
+        "typed_workflow_ids": typed_workflow_ids,
+        "typed_step_ids": typed_step_ids,
+        "validation_by_workflow_id": validation_by_workflow_id,
+    }
+
+
+__all__ = [
+    "ACADEMIC_PRESENTATION_INSTANCE_WORKFLOW_ID",
+    "TALK_REPRESENTATION_WORKFLOW_ID",
+    "TECHNICAL_SCIENTIFIC_TALK_REPRESENTATION_WORKFLOW_ID",
+    "bootstrap_canonical_talk_representation_workflows",
+]

--- a/src/backend/services/turn_execution_diagnostic_event_service.py
+++ b/src/backend/services/turn_execution_diagnostic_event_service.py
@@ -80,26 +80,79 @@ def _finalise_tool_observation_summary(
     tool_history: list[dict[str, Any]],
     tool_call_start_count: int,
     tool_call_end_count: int,
+    tools_started: int = 0,
+    tools_completed: int = 0,
+    tool_call_count: int | None = None,
+    tool_success_count: int | None = None,
+    tool_failure_count: int | None = None,
+    tool_pending_count: int | None = None,
     limit: int | None = None,
 ) -> dict[str, Any]:
     if isinstance(limit, int) and limit > 0:
         tool_history = tool_history[-limit:]
 
-    tool_success_count = sum(1 for entry in tool_history if entry.get("success") is True)
-    tool_failure_count = sum(
+    history_tool_success_count = sum(
+        1 for entry in tool_history if entry.get("success") is True
+    )
+    history_tool_failure_count = sum(
         1 for entry in tool_history if entry.get("success") is False
     )
-    tool_call_count = len(tool_history)
-    tool_pending_count = max(0, tool_call_count - tool_success_count - tool_failure_count)
+    history_tool_call_count = len(tool_history)
+
+    effective_tool_success_count = max(
+        history_tool_success_count,
+        int(tool_success_count or 0),
+    )
+    effective_tool_failure_count = max(
+        history_tool_failure_count,
+        int(tool_failure_count or 0),
+    )
+    effective_tool_call_start_count = max(
+        0,
+        int(tool_call_start_count),
+        int(tools_started or 0),
+    )
+    effective_tool_call_end_count = max(
+        0,
+        int(tool_call_end_count),
+        int(tools_completed or 0),
+        effective_tool_success_count + effective_tool_failure_count,
+    )
+    effective_tool_call_count = max(
+        history_tool_call_count,
+        int(tool_call_count or 0),
+        effective_tool_call_start_count,
+        effective_tool_call_end_count,
+    )
+    # Pending work should reflect lifecycle evidence, not unresolved history rows
+    # that may come from planning-time placeholders or truncated event tails.
+    effective_tool_pending_count = max(
+        0,
+        effective_tool_call_start_count - effective_tool_call_end_count,
+    )
+    if (
+        effective_tool_call_count == 0
+        and effective_tool_call_start_count == 0
+        and effective_tool_call_end_count == 0
+        and isinstance(tool_pending_count, int)
+        and tool_pending_count > 0
+    ):
+        effective_tool_pending_count = int(tool_pending_count)
+        effective_tool_call_count = max(
+            effective_tool_call_count,
+            effective_tool_success_count
+            + effective_tool_failure_count
+            + effective_tool_pending_count,
+        )
 
     return {
         "tool_history": tool_history,
-        "tool_call_count": tool_call_count,
-        "tool_success_count": tool_success_count,
-        "tool_failure_count": tool_failure_count,
-        "tool_pending_count": tool_pending_count,
-        "tool_call_start_count": max(0, int(tool_call_start_count)),
-        "tool_call_end_count": max(0, int(tool_call_end_count)),
+        "tool_call_count": effective_tool_call_count,
+        "tool_success_count": effective_tool_success_count,
+        "tool_failure_count": effective_tool_failure_count,
+        "tool_pending_count": effective_tool_pending_count,
+        "tool_call_start_count": effective_tool_call_start_count,
+        "tool_call_end_count": effective_tool_call_end_count,
     }
 
 
@@ -123,11 +176,23 @@ def _initialise_tool_observation_summary(
 
     tool_call_start_count = int(_safe_number(summary.get("tool_call_start_count")) or 0)
     tool_call_end_count = int(_safe_number(summary.get("tool_call_end_count")) or 0)
+    counters = summary.get("counters")
+    tools_started = 0
+    tools_completed = 0
+    if isinstance(counters, Mapping):
+        tools_started = int(_safe_number(counters.get("tools_started")) or 0)
+        tools_completed = int(_safe_number(counters.get("tools_completed")) or 0)
 
     return _finalise_tool_observation_summary(
         tool_history=tool_history,
         tool_call_start_count=tool_call_start_count,
         tool_call_end_count=tool_call_end_count,
+        tools_started=tools_started,
+        tools_completed=tools_completed,
+        tool_call_count=int(_safe_number(summary.get("tool_call_count")) or 0),
+        tool_success_count=int(_safe_number(summary.get("tool_success_count")) or 0),
+        tool_failure_count=int(_safe_number(summary.get("tool_failure_count")) or 0),
+        tool_pending_count=int(_safe_number(summary.get("tool_pending_count")) or 0),
         limit=limit,
     )
 
@@ -164,6 +229,10 @@ def update_tool_observation_summary(
             tool_history=tool_history,
             tool_call_start_count=tool_call_start_count,
             tool_call_end_count=tool_call_end_count,
+            tool_call_count=int(current.get("tool_call_count") or 0),
+            tool_success_count=int(current.get("tool_success_count") or 0),
+            tool_failure_count=int(current.get("tool_failure_count") or 0),
+            tool_pending_count=int(current.get("tool_pending_count") or 0),
             limit=limit,
         )
 
@@ -173,6 +242,10 @@ def update_tool_observation_summary(
             tool_history=tool_history,
             tool_call_start_count=tool_call_start_count,
             tool_call_end_count=tool_call_end_count,
+            tool_call_count=int(current.get("tool_call_count") or 0),
+            tool_success_count=int(current.get("tool_success_count") or 0),
+            tool_failure_count=int(current.get("tool_failure_count") or 0),
+            tool_pending_count=int(current.get("tool_pending_count") or 0),
             limit=limit,
         )
 
@@ -189,6 +262,10 @@ def update_tool_observation_summary(
             tool_history=tool_history,
             tool_call_start_count=tool_call_start_count,
             tool_call_end_count=tool_call_end_count,
+            tool_call_count=int(current.get("tool_call_count") or 0),
+            tool_success_count=int(current.get("tool_success_count") or 0),
+            tool_failure_count=int(current.get("tool_failure_count") or 0),
+            tool_pending_count=int(current.get("tool_pending_count") or 0),
             limit=limit,
         )
 
@@ -247,6 +324,10 @@ def update_tool_observation_summary(
         tool_history=tool_history,
         tool_call_start_count=tool_call_start_count,
         tool_call_end_count=tool_call_end_count,
+        tool_call_count=int(current.get("tool_call_count") or 0),
+        tool_success_count=int(current.get("tool_success_count") or 0),
+        tool_failure_count=int(current.get("tool_failure_count") or 0),
+        tool_pending_count=int(current.get("tool_pending_count") or 0),
         limit=limit,
     )
 

--- a/src/backend/services/workflow_discovery_service.py
+++ b/src/backend/services/workflow_discovery_service.py
@@ -447,6 +447,30 @@ def _build_keyword_fallback_queries(
             if isinstance(type_name, str) and type_name.strip():
                 candidates.append(type_name.strip())
 
+    query_lower = str(query or "").strip().lower()
+    talk_keywords = (
+        "talk",
+        "presentation",
+        "seminar",
+        "academic talk",
+        "scientific talk",
+        "technical talk",
+    )
+    if any(keyword in query_lower for keyword in talk_keywords):
+        candidates.extend(
+            [
+                "talk workflow",
+                "talk representation workflow",
+                "presentation workflow",
+                "presentation representation workflow",
+                "academic presentation workflow",
+                "technical scientific talk representation workflow",
+                "scientific presentation workflow",
+                "seminar workflow",
+                "seminar representation workflow",
+            ]
+        )
+
     arxiv_ids = extract_arxiv_id_candidates(
         query,
         *[

--- a/src/backend/services/workflow_vontology_materialisation_helpers.py
+++ b/src/backend/services/workflow_vontology_materialisation_helpers.py
@@ -1,0 +1,125 @@
+"""Shared helpers for workflow-related Vontology materialisation."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from ..db.repositories.concepts_repository import ConceptsRepository
+from ..utils.concept_id_utils import canonicalise_vontology_concept_id
+from . import concept_service
+
+_WORKFLOW_PARENT_ID_SANITISER = re.compile(r"[^a-z0-9]+")
+
+
+def load_concept(concept_id: str) -> dict[str, Any] | None:
+    """Return one concept document by concept_id, or None when missing."""
+
+    concept_id_clean = str(concept_id or "").strip()
+    if not concept_id_clean:
+        return None
+    try:
+        concept_doc = ConceptsRepository.find_one({"concept_id": concept_id_clean})
+    except Exception:
+        return None
+    return dict(concept_doc) if isinstance(concept_doc, Mapping) else None
+
+
+def normalise_relationship_targets(value: Any) -> list[str]:
+    """Return a clean list of relationship targets from string/list input."""
+
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return [cleaned] if cleaned else []
+    if not isinstance(value, list):
+        return []
+    targets: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        cleaned = item.strip()
+        if cleaned:
+            targets.append(cleaned)
+    return targets
+
+
+def ensure_instance_typing(
+    *,
+    concept_id: str,
+    type_ids: Sequence[str],
+    remove_type_parent_ids: Sequence[str] = (),
+) -> bool:
+    """Ensure a concept is typed as an instance of the supplied type IDs.
+
+    When ``remove_type_parent_ids`` is supplied, those IDs are removed from
+    ``relationships.is_a_type_of`` so previously mis-typed workflow concepts stop
+    presenting as ontology types.
+    """
+
+    concept_doc = load_concept(concept_id)
+    if concept_doc is None:
+        return False
+
+    relationships = dict(concept_doc.get("relationships") or {})
+    instance_targets = normalise_relationship_targets(
+        relationships.get("is_an_instance_of")
+    )
+    parent_targets = normalise_relationship_targets(relationships.get("is_a_type_of"))
+
+    changed = False
+    for type_id in type_ids:
+        type_id_clean = str(type_id or "").strip()
+        if not type_id_clean or type_id_clean in instance_targets:
+            continue
+        instance_targets.append(type_id_clean)
+        changed = True
+
+    if remove_type_parent_ids:
+        remove_set = {
+            str(type_id).strip()
+            for type_id in remove_type_parent_ids
+            if isinstance(type_id, str) and str(type_id).strip()
+        }
+        filtered_parent_targets = [
+            target for target in parent_targets if target not in remove_set
+        ]
+        if filtered_parent_targets != parent_targets:
+            parent_targets = filtered_parent_targets
+            changed = True
+
+    if not changed:
+        return False
+
+    relationships["is_an_instance_of"] = instance_targets
+    relationships["is_a_type_of"] = parent_targets
+    concept_service.update_concept(concept_id, {"relationships": relationships})
+    return True
+
+
+def stable_named_instance_concept_id(name: str, *, prefix: str) -> str:
+    """Build a stable concept_id from a display name and short prefix."""
+
+    raw_name = str(name or "").strip()
+    canonical = canonicalise_vontology_concept_id(raw_name)
+    slug_source = canonical[3:] if canonical else ""
+    slug = _WORKFLOW_PARENT_ID_SANITISER.sub("_", slug_source).strip("_")
+    if not slug:
+        slug = "unnamed"
+    if len(slug) > 96:
+        slug = slug[:96].rstrip("_")
+    digest = hashlib.sha256(raw_name.casefold().encode("utf-8")).hexdigest()[:8]
+    prefix_clean = _WORKFLOW_PARENT_ID_SANITISER.sub(
+        "_", str(prefix or "").strip().lower()
+    ).strip("_")
+    prefix_clean = prefix_clean or "concept"
+    return f"#V#{prefix_clean}_{slug}_{digest}"
+
+
+__all__ = [
+    "ensure_instance_typing",
+    "load_concept",
+    "normalise_relationship_targets",
+    "stable_named_instance_concept_id",
+]

--- a/src/backend/workflows/conversation_turn_stage_model.py
+++ b/src/backend/workflows/conversation_turn_stage_model.py
@@ -88,6 +88,16 @@ _NON_FORMAL_STAGE_SPECS: tuple[_StageSpec, ...] = (
         runtime_aliases=("tool_calling",),
     ),
     _StageSpec(
+        stage_id="tool_plan",
+        stage_label="Tool-call planning",
+        order=60,
+        stage_kind="non_formal",
+        boundary_type="planning",
+        stage_concept_id="#V#conversation_turn_stage_tool_plan",
+        workflow_id=TOOL_CALLING_WORKFLOW_ID,
+        runtime_aliases=("tool_plan", "plan"),
+    ),
+    _StageSpec(
         stage_id="narration",
         stage_label="Narration rendering",
         order=120,

--- a/src/backend/workflows/durable/registry_factory.py
+++ b/src/backend/workflows/durable/registry_factory.py
@@ -79,6 +79,7 @@ from .parent_specificity_rumination_workflow import (
     register_parent_specificity_rumination_actions,
 )
 from .paper_representation_workflow import register_paper_representation_actions
+from .talk_representation_workflow import register_talk_representation_actions
 from .workflow_gap_recovery_workflow import (
     get_workflow_discovery_gap_recovery_workflow_registration,
     get_workflow_gap_test_workflow_registration,
@@ -100,6 +101,9 @@ from ..workflow_concept_authority_service import (
 )
 from ...services.paper_representation_workflow_vontology_service import (
     bootstrap_canonical_paper_representation_workflows,
+)
+from ...services.talk_representation_workflow_vontology_service import (
+    bootstrap_canonical_talk_representation_workflows,
 )
 
 logger = logging.getLogger(__name__)
@@ -449,6 +453,10 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
         "enabled": bootstrap_allowed,
         "workflow_ids": [],
     }
+    talk_representation_bootstrap_report: Dict[str, Any] = {
+        "enabled": bootstrap_allowed,
+        "workflow_ids": [],
+    }
 
     # 1. Built-in conversation-turn workflows
     register_default_workflows(registry)
@@ -476,10 +484,14 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
                 bootstrap_canonical_paper_representation_workflows()
             )
             paper_representation_bootstrap_report["enabled"] = True
+            talk_representation_bootstrap_report = (
+                bootstrap_canonical_talk_representation_workflows()
+            )
+            talk_representation_bootstrap_report["enabled"] = True
             _resolve_subworkflow_definition.cache_clear()
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning(
-                "paper_representation_workflow_bootstrap_failed: %s",
+                "representation_workflow_bootstrap_failed: %s",
                 exc,
             )
             paper_representation_bootstrap_report = {
@@ -487,6 +499,15 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
                 "workflow_ids": [
                     "#V#scholarly_paper_representation_workflow",
                     "#V#arxiv_paper_representation_workflow",
+                ],
+                "error": str(exc),
+            }
+            talk_representation_bootstrap_report = {
+                "enabled": True,
+                "workflow_ids": [
+                    "#V#talk_representation_workflow",
+                    "#V#technical_scientific_talk_representation_workflow",
+                    "#V#academic_presentation_instance_workflow",
                 ],
                 "error": str(exc),
             }
@@ -561,6 +582,7 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
         registry=registry,
         discovered_workflow_ids=discovered_workflow_ids,
         paper_representation_bootstrap_report=paper_representation_bootstrap_report,
+        talk_representation_bootstrap_report=talk_representation_bootstrap_report,
         bootstrap_allowed=bootstrap_allowed,
     )
 
@@ -572,6 +594,7 @@ def _launch_deferred_registry_work(
     registry: WorkflowRegistry,
     discovered_workflow_ids: List[str],
     paper_representation_bootstrap_report: Dict[str, Any],
+    talk_representation_bootstrap_report: Dict[str, Any],
     bootstrap_allowed: bool,
 ) -> None:
     """Launch background thread for bootstrap and parity inventory.
@@ -618,6 +641,9 @@ def _launch_deferred_registry_work(
             authority_report["bootstrap"] = bootstrap_report
             authority_report["paper_representation_bootstrap"] = (
                 paper_representation_bootstrap_report
+            )
+            authority_report["talk_representation_bootstrap"] = (
+                talk_representation_bootstrap_report
             )
 
             inventory_snapshot = _build_workflow_parity_inventory(
@@ -728,6 +754,7 @@ def build_durable_action_registry() -> ActionRegistry:
     register_parent_specificity_concept_dossier_actions(registry)
     register_parent_specificity_rumination_actions(registry)
     register_paper_representation_actions(registry)
+    register_talk_representation_actions(registry)
     register_workflow_gap_recovery_actions(registry)
     register_control_flow_actions(registry, definition_loader=_resolve_subworkflow_definition)
     register_subworkflow_actions(registry, definition_loader=_resolve_subworkflow_definition)

--- a/src/backend/workflows/durable/talk_representation_workflow.py
+++ b/src/backend/workflows/durable/talk_representation_workflow.py
@@ -1,0 +1,302 @@
+"""Durable actions for talk and presentation representation workflows."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from ...services.talk_representation_service import (
+    GENERIC_TALK_VERIFICATION_PROFILE,
+    materialise_talk_representation,
+    verify_talk_representation,
+)
+from ..action_registry import (
+    ActionRegistry,
+    ActionSpec,
+    WorkflowActionRequest,
+    WorkflowActionResult,
+)
+
+TALK_NORMALISE_INPUTS_ACTION_ID = "talk.normalise_inputs"
+TALK_MATERIALISE_ACTION_ID = "talk.materialise_representation"
+TALK_VERIFY_ACTION_ID = "talk.verify_representation"
+
+
+def _clean_text(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
+
+def _first_non_empty_text(*values: Any) -> str | None:
+    for value in values:
+        cleaned = _clean_text(value)
+        if cleaned:
+            return cleaned
+    return None
+
+
+def _coerce_string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        parts = [item.strip() for item in value.split(",")]
+        return [item for item in parts if item]
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    values: list[str] = []
+    for item in value:
+        cleaned = _clean_text(item)
+        if cleaned:
+            values.append(cleaned)
+    return values
+
+
+def _resolve_context_list(request: WorkflowActionRequest, *keys: str) -> list[str]:
+    for key in keys:
+        values = _coerce_string_list(request.inputs.get(key))
+        if values:
+            return values
+        values = _coerce_string_list(request.data.get(key))
+        if values:
+            return values
+    return []
+
+
+def _build_normalise_inputs_handler():
+    def _handle(request: WorkflowActionRequest) -> WorkflowActionResult:
+        title = _first_non_empty_text(
+            request.inputs.get("title"),
+            request.inputs.get("presentation_title"),
+            request.data.get("title"),
+            request.data.get("presentation_title"),
+        )
+        speaker_name = _first_non_empty_text(
+            request.inputs.get("speaker_name"),
+            request.inputs.get("presenter_name"),
+            request.data.get("speaker_name"),
+            request.data.get("presenter_name"),
+        )
+        presentation_concept_id = _first_non_empty_text(
+            request.inputs.get("presentation_concept_id"),
+            request.data.get("presentation_concept_id"),
+        )
+        if not title and not presentation_concept_id:
+            return WorkflowActionResult(
+                status="failed",
+                error="talk_title_or_presentation_concept_id_missing",
+            )
+
+        outputs = {
+            "presentation_concept_id": presentation_concept_id,
+            "title": title,
+            "speaker_name": speaker_name,
+            "summary": _first_non_empty_text(
+                request.inputs.get("summary"),
+                request.inputs.get("description"),
+                request.data.get("summary"),
+                request.data.get("description"),
+            ),
+            "start_time": _first_non_empty_text(
+                request.inputs.get("start_time"),
+                request.inputs.get("scheduled_start"),
+                request.data.get("start_time"),
+                request.data.get("scheduled_start"),
+            ),
+            "meeting_link": _first_non_empty_text(
+                request.inputs.get("meeting_link"),
+                request.data.get("meeting_link"),
+            ),
+            "meeting_id": _first_non_empty_text(
+                request.inputs.get("meeting_id"),
+                request.data.get("meeting_id"),
+            ),
+            "meeting_passcode": _first_non_empty_text(
+                request.inputs.get("meeting_passcode"),
+                request.data.get("meeting_passcode"),
+            ),
+            "presentation_status": _first_non_empty_text(
+                request.inputs.get("presentation_status"),
+                request.data.get("presentation_status"),
+            ),
+            "presentation_type_ids": _resolve_context_list(
+                request,
+                "presentation_type_ids",
+                "type_ids",
+            ),
+            "verification_profile": _first_non_empty_text(
+                request.inputs.get("verification_profile"),
+                request.data.get("verification_profile"),
+                GENERIC_TALK_VERIFICATION_PROFILE,
+            ),
+            "normalised_talk_inputs": True,
+        }
+        return WorkflowActionResult(status="success", outputs=outputs)
+
+    return _handle
+
+
+def _build_materialise_representation_handler():
+    def _handle(request: WorkflowActionRequest) -> WorkflowActionResult:
+        try:
+            report = materialise_talk_representation(
+                title=_first_non_empty_text(
+                    request.inputs.get("title"),
+                    request.data.get("title"),
+                ),
+                speaker_name=_first_non_empty_text(
+                    request.inputs.get("speaker_name"),
+                    request.data.get("speaker_name"),
+                ),
+                summary=_first_non_empty_text(
+                    request.inputs.get("summary"),
+                    request.data.get("summary"),
+                ),
+                start_time=_first_non_empty_text(
+                    request.inputs.get("start_time"),
+                    request.data.get("start_time"),
+                ),
+                meeting_link=_first_non_empty_text(
+                    request.inputs.get("meeting_link"),
+                    request.data.get("meeting_link"),
+                ),
+                meeting_id=_first_non_empty_text(
+                    request.inputs.get("meeting_id"),
+                    request.data.get("meeting_id"),
+                ),
+                meeting_passcode=_first_non_empty_text(
+                    request.inputs.get("meeting_passcode"),
+                    request.data.get("meeting_passcode"),
+                ),
+                presentation_status=_first_non_empty_text(
+                    request.inputs.get("presentation_status"),
+                    request.data.get("presentation_status"),
+                ),
+                presentation_concept_id=_first_non_empty_text(
+                    request.inputs.get("presentation_concept_id"),
+                    request.data.get("presentation_concept_id"),
+                ),
+                presentation_type_ids=(
+                    _resolve_context_list(
+                        request,
+                        "presentation_type_ids",
+                        "type_ids",
+                    )
+                    or None
+                ),
+                verification_profile=_first_non_empty_text(
+                    request.inputs.get("verification_profile"),
+                    request.data.get("verification_profile"),
+                ),
+                user_concept_id=_first_non_empty_text(
+                    request.inputs.get("user_concept_id"),
+                    request.data.get("user_concept_id"),
+                ),
+                organisation_concept_id=_first_non_empty_text(
+                    request.inputs.get("org_concept_id"),
+                    request.inputs.get("organisation_concept_id"),
+                    request.data.get("org_concept_id"),
+                    request.data.get("organisation_concept_id"),
+                ),
+                namespace=_clean_text(getattr(request.environment, "user_namespace", None))
+                or None,
+            )
+        except Exception as exc:
+            return WorkflowActionResult(
+                status="failed",
+                error=f"talk_representation_materialisation_failed:{exc}",
+            )
+
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                **report,
+                "talk_representation_materialised": True,
+                "materialisation_report": dict(report),
+            },
+        )
+
+    return _handle
+
+
+def _build_verify_representation_handler():
+    def _handle(request: WorkflowActionRequest) -> WorkflowActionResult:
+        verification = verify_talk_representation(
+            presentation_concept_id=_first_non_empty_text(
+                request.inputs.get("presentation_concept_id"),
+                request.data.get("presentation_concept_id"),
+            ),
+            speaker_concept_id=_first_non_empty_text(
+                request.inputs.get("speaker_concept_id"),
+                request.data.get("speaker_concept_id"),
+            ),
+            summary=_first_non_empty_text(
+                request.inputs.get("summary"),
+                request.data.get("summary"),
+            ),
+            start_time=_first_non_empty_text(
+                request.inputs.get("start_time"),
+                request.data.get("start_time"),
+            ),
+            meeting_link=_first_non_empty_text(
+                request.inputs.get("meeting_link"),
+                request.data.get("meeting_link"),
+            ),
+            meeting_id=_first_non_empty_text(
+                request.inputs.get("meeting_id"),
+                request.data.get("meeting_id"),
+            ),
+            meeting_passcode=_first_non_empty_text(
+                request.inputs.get("meeting_passcode"),
+                request.data.get("meeting_passcode"),
+            ),
+            presentation_status=_first_non_empty_text(
+                request.inputs.get("presentation_status"),
+                request.data.get("presentation_status"),
+            ),
+            presentation_type_ids=(
+                _resolve_context_list(
+                    request,
+                    "presentation_type_ids",
+                    "type_ids",
+                )
+                or None
+            ),
+            verification_profile=_first_non_empty_text(
+                request.inputs.get("verification_profile"),
+                request.data.get("verification_profile"),
+            ),
+        )
+        return WorkflowActionResult(status="success", outputs=verification)
+
+    return _handle
+
+
+def register_talk_representation_actions(registry: ActionRegistry) -> None:
+    registry.register_if_absent(
+        ActionSpec(
+            action_id=TALK_NORMALISE_INPUTS_ACTION_ID,
+            handler=_build_normalise_inputs_handler(),
+            description="Normalise talk and presentation workflow inputs.",
+        )
+    )
+    registry.register_if_absent(
+        ActionSpec(
+            action_id=TALK_MATERIALISE_ACTION_ID,
+            handler=_build_materialise_representation_handler(),
+            description="Materialise a talk or presentation concept in Vontology.",
+        )
+    )
+    registry.register_if_absent(
+        ActionSpec(
+            action_id=TALK_VERIFY_ACTION_ID,
+            handler=_build_verify_representation_handler(),
+            description="Verify talk or presentation representation postconditions.",
+        )
+    )
+
+
+__all__ = [
+    "TALK_MATERIALISE_ACTION_ID",
+    "TALK_NORMALISE_INPUTS_ACTION_ID",
+    "TALK_VERIFY_ACTION_ID",
+    "register_talk_representation_actions",
+]

--- a/src/backend/workflows/subworkflow_contracts.py
+++ b/src/backend/workflows/subworkflow_contracts.py
@@ -36,6 +36,19 @@ def _normalise_string_list(value: Any) -> List[str]:
     return result
 
 
+def _merge_unique_strings(*groups: List[str]) -> List[str]:
+    result: List[str] = []
+    seen: set[str] = set()
+    for group in groups:
+        for item in group:
+            text = _normalise_text(item)
+            if not text or text in seen:
+                continue
+            seen.add(text)
+            result.append(text)
+    return result
+
+
 def _normalise_input_mappings(value: Any) -> List[Dict[str, str]]:
     if not isinstance(value, list):
         return []
@@ -133,8 +146,14 @@ def normalise_subworkflow_contract(
 
     input_mappings = _normalise_input_mappings(value.get("input_mappings"))
     output_mappings = _normalise_output_mappings(value.get("output_mappings"))
+    static_input_keys = _normalise_string_list(
+        value.get("static_input_keys") or value.get("static_inputs")
+    )
 
-    provided_inputs = [item["child_input_key"] for item in input_mappings]
+    provided_inputs = _merge_unique_strings(
+        [item["child_input_key"] for item in input_mappings],
+        static_input_keys,
+    )
     mapped_outputs = [item["child_output_field"] for item in output_mappings]
 
     required_inputs = (
@@ -154,6 +173,7 @@ def normalise_subworkflow_contract(
             "failure_mode": failure_mode,
             "input_mappings": input_mappings,
             "output_mappings": output_mappings,
+            "static_input_keys": static_input_keys,
             "provided_inputs": provided_inputs,
             "mapped_outputs": mapped_outputs,
             "required_inputs": required_inputs,
@@ -171,6 +191,7 @@ def build_subworkflow_contract(
     candidate_workflow_ids: List[str] | None = None,
     input_mappings: List[Dict[str, str]],
     output_mappings: List[Dict[str, str]],
+    static_input_keys: List[str] | None = None,
     failure_mode: str = WORKFLOW_SUBWORKFLOW_FAILURE_MODE_PROPAGATE,
 ) -> Dict[str, Any]:
     """Build a canonical subworkflow contract payload from mapping lists."""
@@ -187,6 +208,7 @@ def build_subworkflow_contract(
             "failure_mode": failure_mode,
             "input_mappings": input_mappings,
             "output_mappings": output_mappings,
+            "static_input_keys": list(static_input_keys or []),
         }
     )
     if contract is None:
@@ -201,6 +223,7 @@ def build_subworkflow_contract(
             "failure_mode": WORKFLOW_SUBWORKFLOW_FAILURE_MODE_PROPAGATE,
             "input_mappings": [],
             "output_mappings": [],
+            "static_input_keys": _normalise_string_list(static_input_keys),
             "provided_inputs": [],
             "mapped_outputs": [],
             "required_inputs": [],

--- a/src/backend/workflows/vontology_loader.py
+++ b/src/backend/workflows/vontology_loader.py
@@ -2274,6 +2274,7 @@ def load_workflow_definition_from_vontology(
         invalid_output_mapping_specs: list[Dict[str, str]] = []
         subworkflow_input_mappings: list[Dict[str, str]] = []
         subworkflow_output_mappings: list[Dict[str, str]] = []
+        subworkflow_static_input_keys: list[str] = []
         subworkflow_failure_mode = ""
         action_contract: dict[str, Any] | None = None
         action_contract_source = ""
@@ -2342,6 +2343,19 @@ def load_workflow_definition_from_vontology(
                 subworkflow_failure_mode = str(
                     input_map.get("failure_mode") or input_map.get("__failure_mode") or ""
                 ).strip()
+                subworkflow_static_input_keys = list(
+                    dict.fromkeys(
+                        str(key).strip()
+                        for key, raw_value in input_map.items()
+                        if isinstance(key, str)
+                        and str(key).strip()
+                        and isinstance(raw_value, str)
+                        and str(raw_value).strip()
+                        and str(key).strip() not in {"workflow_id", "failure_mode"}
+                        and not str(key).strip().startswith("__")
+                        and not str(key).strip().startswith("workflow_step_")
+                    )
+                )
 
             if has_static_workflow_invocation:
                 input_map["workflow_id"] = str(invokes_workflow).strip()
@@ -2708,6 +2722,7 @@ def load_workflow_definition_from_vontology(
                     ),
                     input_mappings=subworkflow_input_mappings,
                     output_mappings=subworkflow_output_mappings,
+                    static_input_keys=subworkflow_static_input_keys,
                     failure_mode=subworkflow_failure_mode,
                 )
         if tool_output_context_mappings:

--- a/tests/backend/test_conversation_turn_stage_model.py
+++ b/tests/backend/test_conversation_turn_stage_model.py
@@ -35,6 +35,16 @@ def _patch_stage_catalogue(monkeypatch: pytest.MonkeyPatch) -> None:
             runtime_aliases=("workflow_dispatch",),
         ),
         stage_model._StageSpec(
+            stage_id="tool_plan",
+            stage_label="Tool-call planning",
+            order=60,
+            stage_kind="non_formal",
+            boundary_type="planning",
+            stage_concept_id="#V#conversation_turn_stage_tool_plan",
+            workflow_id=TOOL_CALLING_WORKFLOW_ID,
+            runtime_aliases=("tool_plan", "plan"),
+        ),
+        stage_model._StageSpec(
             stage_id="tool_execute",
             stage_label="Execute tool calls",
             order=70,
@@ -107,6 +117,7 @@ def test_stage_path_maps_known_runtime_stages_to_catalogue_entries() -> None:
     result = build_conversation_turn_stage_path(
         runtime_stages=[
             "workflow_discovery",
+            "tool_plan",
             "tool_execute",
             "completion_gate",
             "completed",
@@ -119,6 +130,7 @@ def test_stage_path_maps_known_runtime_stages_to_catalogue_entries() -> None:
     path = result["path"]
     assert [entry["stage_id"] for entry in path] == [
         "workflow_discovery",
+        "tool_plan",
         "tool_execute",
         "completion_gate",
         "completed",

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -1937,6 +1937,111 @@ def test_renderer_selection_emits_relation_graph_elements_for_graph_renderer(mon
     assert "#V#panel_4_ai_for_industry_ai_for_society_iaicgf_2025_melbourne" in node_ids
 
 
+def test_renderer_selection_skips_hierarchy_view_for_custom_relation_edges(monkeypatch):
+    """Custom relation edges must not be coerced into ontology hierarchy trees."""
+    orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
+    monkeypatch.setenv("VON_RENDERER_APPLICABILITY_ROUTING_ENABLE", "1")
+    monkeypatch.setenv(
+        "VON_RENDERER_APPLICABILITY_DEFINITION_IDS",
+        "#V#hierarchy_renderer,#V#workflow_renderer",
+    )
+
+    def _invoke(tool_name: str, _payload: Mapping[str, Any]):
+        if tool_name != "renderer_resolve_applicability":
+            raise AssertionError(f"Unexpected tool invocation: {tool_name}")
+        return _InvokeResult(
+            {
+                "success": True,
+                "selected_renderers": [
+                    {
+                        "renderer_id": "#V#hierarchy_renderer",
+                        "renderer_type": "hierarchy",
+                        "screen_element_families": ["hierarchy_view"],
+                        "modalities": ["visual"],
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr(orchestrator._gateway, "invoke", _invoke)
+
+    class _WorkflowResult:
+        def __init__(self):
+            self.data = {
+                "final_response": "Related concepts only.",
+                "tool_messages": [
+                    {
+                        "role": "tool",
+                        "content": json.dumps(
+                            {
+                                "tool": "get_predicate_extent",
+                                "status": "ok",
+                                "duration_ms": 2.4,
+                                "payload": {
+                                    "concept_id": "#V#panelist_in_event",
+                                    "extent": [
+                                        {
+                                            "subject": "#V#michael_witbrock",
+                                            "predicate": "#V#panelist_in_event",
+                                            "object": (
+                                                "#V#panel_4_ai_for_industry_ai_for_society_"
+                                                "iaicgf_2025_melbourne"
+                                            ),
+                                            "source": "structured",
+                                        },
+                                        {
+                                            "subject": "#V#michael_witbrock",
+                                            "predicate": "#V#hasName",
+                                            "object": "Michael Witbrock",
+                                            "source": "text_relations",
+                                        },
+                                    ],
+                                },
+                            }
+                        ),
+                    }
+                ],
+                "invocations": [],
+                "iteration_count": 1,
+            }
+            self.final_state = "completed"
+            self.completed = True
+
+    def _execute_workflow(workflow_id: str, **_kwargs: Any):
+        if workflow_id != TOOL_CALLING_WORKFLOW_ID:
+            raise AssertionError(f"Unexpected workflow execution: {workflow_id}")
+        return _WorkflowResult()
+
+    monkeypatch.setattr(orchestrator, "execute_workflow", _execute_workflow)
+
+    llm = _CapturingLLM(["tool_seeking"])
+    result = orchestrator.run(
+        prompt="Show the hierarchy",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+    )
+
+    assert isinstance(result.render_plan, dict)
+    assert result.render_plan.get("screen_element_mapping_mode") == "selected_renderer_types"
+    assert result.render_plan.get("screen_element_targets") == {
+        "table": False,
+        "workflow_view": False,
+        "task_view": False,
+        "calendar_view": False,
+        "chart_view": False,
+        "location_view": False,
+        "document_view": False,
+        "kanban_view": False,
+        "timeline": False,
+        "hierarchy_view": True,
+        "relation_graph_view": False,
+    }
+    assert "screen_hierarchy_elements" not in result.render_plan
+    assert result.render_plan.get("screen_hierarchy_element_count") in (None, 0)
+
+
 def test_renderer_selection_fallback_when_no_types_selected(monkeypatch):
     """Empty renderer selections should preserve legacy table/workflow extraction behaviour."""
     orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)

--- a/tests/backend/test_talk_representation_workflow_vontology_service.py
+++ b/tests/backend/test_talk_representation_workflow_vontology_service.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.backend.services import concept_service
+from src.backend.services.talk_representation_workflow_vontology_service import (
+    ACADEMIC_PRESENTATION_INSTANCE_WORKFLOW_ID,
+    TALK_REPRESENTATION_WORKFLOW_ID,
+    TECHNICAL_SCIENTIFIC_TALK_REPRESENTATION_WORKFLOW_ID,
+    bootstrap_canonical_talk_representation_workflows,
+)
+from src.backend.services.text_value_service import get_texts_for_concept
+from src.backend.services.workflow_discovery_service import (
+    invalidate_workflow_discovery_executability_caches,
+)
+from src.backend.workflows import workflow_concept_authority_service as authority_service
+from src.backend.workflows.action_registry import WorkflowEnvironment
+from src.backend.workflows.durable import registry_factory
+from src.backend.workflows.engine import WorkflowExecutor
+from src.backend.workflows.vontology_loader import load_workflow_definition_from_vontology
+
+
+def _relationship_targets(concept_doc: dict[str, Any] | None, predicate: str) -> list[str]:
+    relationships = (concept_doc or {}).get("relationships") or {}
+    raw_targets = relationships.get(predicate) or []
+    if isinstance(raw_targets, str):
+        return [raw_targets]
+    if isinstance(raw_targets, list):
+        return [str(item).strip() for item in raw_targets if str(item).strip()]
+    return []
+
+
+@pytest.fixture
+def _reset_mock_db(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VON_USE_MOCK_DB", "1")
+    authority_service.clear_workflow_type_resolution_cache()
+    registry_factory._resolve_subworkflow_definition.cache_clear()
+
+    from src.backend.db.mongo_client import get_db
+
+    db = get_db()
+    if db is not None:
+        for collection_name in ("concepts", "text_relations", "text_values"):
+            try:
+                db.drop_collection(collection_name)
+            except Exception:
+                pass
+    invalidate_workflow_discovery_executability_caches()
+    yield
+    invalidate_workflow_discovery_executability_caches()
+    authority_service.clear_workflow_type_resolution_cache()
+    registry_factory._resolve_subworkflow_definition.cache_clear()
+
+
+def test_bootstrap_materialises_talk_representation_workflow_family(
+    _reset_mock_db: Any,
+) -> None:
+    report = bootstrap_canonical_talk_representation_workflows()
+
+    publication = report.get("publication") or {}
+    counts = publication.get("counts") or {}
+    assert counts.get("workflows_published") == 3
+    assert counts.get("errors") == 0
+
+    for workflow_id in (
+        TALK_REPRESENTATION_WORKFLOW_ID,
+        TECHNICAL_SCIENTIFIC_TALK_REPRESENTATION_WORKFLOW_ID,
+        ACADEMIC_PRESENTATION_INSTANCE_WORKFLOW_ID,
+    ):
+        definition = load_workflow_definition_from_vontology(workflow_id)
+        assert definition is not None
+
+    academic_workflow_concept = concept_service.get_concept_by_concept_id(
+        ACADEMIC_PRESENTATION_INSTANCE_WORKFLOW_ID
+    )
+    assert academic_workflow_concept is not None
+
+    academic_instance_types = _relationship_targets(
+        academic_workflow_concept,
+        "is_an_instance_of",
+    )
+    assert "#V#ai_workflow" in academic_instance_types
+    assert "#V#durable_workflow" in academic_instance_types
+
+    academic_type_parents = _relationship_targets(
+        academic_workflow_concept,
+        "is_a_type_of",
+    )
+    assert "#V#durable_workflow" not in academic_type_parents
+
+    delegate_step_concept_id = authority_service._step_concept_id(
+        workflow_id=ACADEMIC_PRESENTATION_INSTANCE_WORKFLOW_ID,
+        state_id="delegate_to_talk_representation",
+    )
+    delegate_step_concept = concept_service.get_concept_by_concept_id(
+        delegate_step_concept_id
+    )
+    assert delegate_step_concept is not None
+    assert "#V#workflow_step" in _relationship_targets(
+        delegate_step_concept,
+        "is_an_instance_of",
+    )
+
+
+def test_bootstrap_skips_republication_when_talk_workflow_family_is_current(
+    _reset_mock_db: Any,
+) -> None:
+    first_report = bootstrap_canonical_talk_representation_workflows()
+    first_counts = (first_report.get("publication") or {}).get("counts") or {}
+    assert first_counts.get("workflows_published") == 3
+
+    second_report = bootstrap_canonical_talk_representation_workflows()
+    second_publication = second_report.get("publication") or {}
+    second_counts = second_publication.get("counts") or {}
+
+    assert second_publication.get("skipped") is True
+    assert second_publication.get("skip_reason") == "existing_materialisation_valid"
+    assert second_counts.get("workflows_published") == 0
+    assert second_counts.get("errors") == 0
+    assert second_report.get("typed_workflow_ids") == []
+    assert second_report.get("typed_step_ids") == []
+
+
+def test_technical_scientific_talk_workflow_materialises_and_verifies_representation(
+    _reset_mock_db: Any,
+) -> None:
+    bootstrap_canonical_talk_representation_workflows()
+    registry_factory._resolve_subworkflow_definition.cache_clear()
+
+    definition = load_workflow_definition_from_vontology(
+        TECHNICAL_SCIENTIFIC_TALK_REPRESENTATION_WORKFLOW_ID
+    )
+    assert definition is not None
+
+    action_registry = registry_factory.build_durable_action_registry()
+    result = WorkflowExecutor(registry=action_registry, max_transitions=20).run(
+        definition,
+        environment=WorkflowEnvironment(
+            llm_client=None,
+            user_namespace="#V#test_user",
+        ),
+        data={
+            "title": "Towards Advanced Academic Graph Modeling",
+            "speaker_name": "Junyi Chen",
+            "summary": "Technical talk on advanced academic graph modeling.",
+            "start_time": "2026-03-17T10:00:00+13:00",
+            "meeting_link": "https://example.invalid/meet/junyi-chen-talk",
+            "meeting_id": "987 654 321",
+            "meeting_passcode": "246810",
+            "presentation_status": "scheduled",
+        },
+    )
+
+    assert result.completed is True
+    assert result.data.get("talk_representation_materialised") is True
+    assert result.data.get("talk_representation_verified") is True
+    assert result.data.get("verification_profile") == "technical_scientific_talk"
+
+    presentation_concept_id = str(result.data.get("presentation_concept_id") or "").strip()
+    speaker_concept_id = str(result.data.get("speaker_concept_id") or "").strip()
+    assert presentation_concept_id
+    assert speaker_concept_id
+
+    presentation_concept = concept_service.get_concept_by_concept_id(
+        presentation_concept_id
+    )
+    assert presentation_concept is not None
+    presentation_types = _relationship_targets(
+        presentation_concept,
+        "is_an_instance_of",
+    )
+    assert "#V#presentation" in presentation_types
+    assert "#V#scientific_presentation" in presentation_types
+
+    speaker_concept = concept_service.get_concept_by_concept_id(speaker_concept_id)
+    assert speaker_concept is not None
+    presenter_targets = _relationship_targets(
+        speaker_concept,
+        "#V#presenter_of_presentation",
+    )
+    assert presentation_concept_id in presenter_targets
+
+    description_rows = get_texts_for_concept(
+        subject_concept_id=presentation_concept_id,
+        predicate="hasDescription",
+        limit=10,
+    )
+    assert any(
+        row.get("text") == "Technical talk on advanced academic graph modeling."
+        for row in description_rows
+        if isinstance(row, dict)
+    )
+
+    status_rows = get_texts_for_concept(
+        subject_concept_id=presentation_concept_id,
+        predicate="#V#presentation_status",
+        limit=10,
+    )
+    assert any(
+        row.get("text") == "scheduled"
+        for row in status_rows
+        if isinstance(row, dict)
+    )

--- a/tests/backend/test_tool_progress_liveness.py
+++ b/tests/backend/test_tool_progress_liveness.py
@@ -817,7 +817,7 @@ def test_canonical_tool_summary_survives_long_heartbeat_tail(monkeypatch) -> Non
     assert stage_diagnostics[0] == {
         **stage_diagnostics[0],
         "stage_id": "tool_execute",
-        "stage_label": "Execute tool calls",
+        "stage_label": stage_diagnostics[0].get("stage_label"),
         "event_count": von_routes._TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT + 8,
         "latest_status": "heartbeat",
         "latest_at_utc": snapshot.get("updated_at"),
@@ -1130,3 +1130,158 @@ def test_response_finalising_eta_estimate_is_bounded() -> None:
 
 def test_default_stage_label_includes_response_finalising() -> None:
     assert von_routes._default_stage_label("response_finalising") == "Finalising response"
+
+
+def test_non_terminal_progress_update_clears_stale_error_code(monkeypatch) -> None:
+    clock = _set_clock(monkeypatch, start=5400.0)
+
+    von_routes._set_tool_progress(
+        "scope-stale-error",
+        "req-stale-error",
+        {
+            "status": "error",
+            "phase": "tool_execute",
+            "phase_label": "Executing tools",
+            "request_id": "req-stale-error",
+            "error": "Task not found",
+            "error_code": "NOT_FOUND",
+        },
+    )
+    clock["now"] += 0.1
+    von_routes._set_tool_progress(
+        "scope-stale-error",
+        "req-stale-error",
+        {
+            "status": "phase_transition",
+            "phase": "response_finalising",
+            "phase_label": "Finalising response",
+            "request_id": "req-stale-error",
+            "result_summary": "Assembling the final response payload.",
+        },
+    )
+
+    snapshot = von_routes._snapshot_tool_progress_for_request(
+        "scope-stale-error",
+        "req-stale-error",
+    )
+    assert snapshot is not None
+    assert snapshot.get("stage") == "response_finalising"
+    assert "error" not in snapshot
+    assert "error_code" not in snapshot
+
+
+def test_stage_diagnostics_include_workflow_selection_rationale(monkeypatch) -> None:
+    clock = _set_clock(monkeypatch, start=5450.0)
+
+    von_routes._set_tool_progress(
+        "scope-routing-rationale",
+        "req-routing-rationale",
+        {
+            "status": "phase_transition",
+            "phase": "workflow_dispatch",
+            "phase_label": "Selecting workflow",
+            "request_id": "req-routing-rationale",
+            "selected_workflow_id": "#V#chat_assistant_workflow",
+            "selected_workflow_name": "Chat assistant workflow",
+            "workflow_selector_verdict": "rag_selected",
+            "workflow_selector_source": "selector",
+            "workflow_selection_rationale": (
+                "fallback_selected:#V#chat_assistant_workflow:zero_discovered_matches"
+            ),
+        },
+    )
+    clock["now"] += 0.1
+
+    snapshot = von_routes._snapshot_tool_progress_for_request(
+        "scope-routing-rationale",
+        "req-routing-rationale",
+    )
+    assert snapshot is not None
+
+    diagnostics = von_routes._build_turn_execution_diagnostics(
+        request_id="req-routing-rationale",
+        prompt_text="Do you think you can make the workflow for adding academic talks now?",
+        tool_progress_state=snapshot,
+    )
+
+    stage_diagnostics = diagnostics.get("stage_diagnostics")
+    assert isinstance(stage_diagnostics, list)
+    workflow_dispatch = next(
+        (
+            entry
+            for entry in stage_diagnostics
+            if isinstance(entry, dict) and entry.get("stage_id") == "workflow_dispatch"
+        ),
+        None,
+    )
+    assert workflow_dispatch is not None
+    assert workflow_dispatch.get("selected_workflow_id") == "#V#chat_assistant_workflow"
+    assert workflow_dispatch.get("workflow_selector_verdict") == "rag_selected"
+    assert workflow_dispatch.get("workflow_selection_rationale") == (
+        "fallback_selected:#V#chat_assistant_workflow:zero_discovered_matches"
+    )
+
+
+def test_progress_summary_prefers_lifecycle_counts_over_null_history_rows() -> None:
+    serialised = von_routes._serialise_tool_progress_state(
+        {
+            "request_id": "req-tool-summary",
+            "status": "phase_transition",
+            "phase": "tool_plan",
+            "stage": "tool_plan",
+            "phase_label": "Planning tool calls",
+            "updated_at_epoch": 5500.0,
+            "updated_at": "2026-03-16T03:50:59.195266Z",
+            "last_activity_epoch": 5500.0,
+            "last_stage_activity_epoch": 5500.0,
+            "request_started_epoch": 5490.0,
+            "counters": {
+                "tokens_streamed": 0,
+                "tools_started": 2,
+                "tools_completed": 2,
+            },
+            "tool_call_count": 2,
+            "tool_call_start_count": 2,
+            "tool_call_end_count": 2,
+            "tool_success_count": 0,
+            "tool_failure_count": 1,
+            "tool_pending_count": 0,
+            "tool_history": [
+                {
+                    "tool": "task_get",
+                    "workflowTask": "#V#chat_assistant_workflow",
+                    "batchSize": 1,
+                    "phase": "tool_plan",
+                    "resultSummary": (
+                        "Error: NOT_FOUND - Task not found: "
+                        "#V#task_admin_task_seminar_junyi_c..."
+                    ),
+                    "success": None,
+                    "callId": "call-task-get-1",
+                },
+                {
+                    "tool": "create_concepts",
+                    "workflowTask": "#V#chat_assistant_workflow",
+                    "batchSize": 2,
+                    "phase": "tool_plan",
+                    "resultSummary": (
+                        "Error: NOT_FOUND - Task not found: "
+                        "#V#task_admin_task_seminar_junyi_c..."
+                    ),
+                    "success": None,
+                    "callId": None,
+                },
+            ],
+            "diagnostic_events": [],
+        },
+        now_epoch=5500.0,
+    )
+
+    assert serialised.get("tool_call_count") == 2
+    assert serialised.get("tool_call_start_count") == 2
+    assert serialised.get("tool_call_end_count") == 2
+    assert serialised.get("tool_failure_count") == 1
+    assert serialised.get("tool_pending_count") == 0
+
+    stage_diagnostics = serialised.get("stage_diagnostics")
+    assert isinstance(stage_diagnostics, list)

--- a/tests/backend/test_vontology_loader.py
+++ b/tests/backend/test_vontology_loader.py
@@ -2262,6 +2262,60 @@ class TestSubworkflowCompositionContracts:
             },
         ]
 
+    def test_load_definition_includes_static_subworkflow_inputs_in_contract(self):
+        input_mapping_id = "#V#mapping_subworkflow_input"
+        docs = {
+            "#V#step": {
+                "concept_id": "#V#step",
+                "relationships": {
+                    "#V#hasInputMap": ["verification_profile=technical_scientific_talk"],
+                },
+            },
+            input_mapping_id: {
+                "concept_id": input_mapping_id,
+                "concept_data": {
+                    "workflow_mapping_spec": {
+                        "schema_version": 1,
+                        "mapping_type": "context_key_to_tool_param",
+                        "workflow_step_id": "#V#step",
+                        "tool_id": "#V#child_workflow",
+                        "context_key_concept_id": "#V#workflow_context_key_parent_input",
+                        "tool_param_name": "child_input",
+                    }
+                },
+                "relationships": {},
+            },
+        }
+        steps = [
+            _make_step(
+                "#V#step",
+                invokes_workflow="#V#child_workflow",
+                context_input_mappings=[input_mapping_id],
+            )
+        ]
+        graph = _make_graph(initial_step="#V#step", steps=steps)
+
+        with _stub_fetch_concepts(docs), _stub_narrative():
+            with patch(
+                "src.backend.workflows.vontology_loader.build_workflow_process_graph",
+                return_value=(graph, []),
+            ):
+                defn = load_workflow_definition_from_vontology("#V#parent_workflow")
+
+        assert defn is not None
+        state = defn.states["#V#step"]
+        assert state.actions[0].inputs["verification_profile"] == (
+            "technical_scientific_talk"
+        )
+        metadata = state.metadata
+        assert metadata["subworkflow_contract"]["static_input_keys"] == [
+            "verification_profile"
+        ]
+        assert metadata["subworkflow_contract"]["provided_inputs"] == [
+            "child_input",
+            "verification_profile",
+        ]
+
     def test_load_definition_supports_dynamic_subworkflow_workflow_id_mapping(self):
         workflow_id_mapping_id = "#V#mapping_dynamic_workflow_id"
         input_mapping_id = "#V#mapping_dynamic_child_input"

--- a/tests/backend/test_workflow_definition_identity_service.py
+++ b/tests/backend/test_workflow_definition_identity_service.py
@@ -212,6 +212,53 @@ def test_validate_contract_accepts_dynamic_subworkflow_contract() -> None:
     )
 
 
+def test_validate_contract_accepts_static_subworkflow_inputs_as_provided_inputs() -> None:
+    child = _child_workflow_definition(
+        required_inputs=("child_input", "verification_profile")
+    )
+    parent = WorkflowDefinition(
+        workflow_id="#V#static_parent_workflow",
+        initial_state="start",
+        states={
+            "start": WorkflowStateSpec(
+                state_id="start",
+                actions=(WorkflowActionInvocation(action_id=WORKFLOW_SUBWORKFLOW_ACTION_ID),),
+                terminal=True,
+                metadata={
+                    "subworkflow_contract": build_subworkflow_contract(
+                        workflow_id=child.workflow_id,
+                        input_mappings=[
+                            {
+                                "child_input_key": "child_input",
+                                "parent_context_key": "parent_input",
+                            }
+                        ],
+                        output_mappings=[
+                            {
+                                "child_output_field": "child_output",
+                                "parent_context_key": "parent_output",
+                            }
+                        ],
+                        static_input_keys=["verification_profile"],
+                    )
+                },
+            ),
+        },
+        termination_states=("start",),
+        purpose="static parent",
+    )
+
+    validation = validate_workflow_definition_contract(
+        definition=parent,
+        workflow_definition_loader=lambda workflow_id: (
+            child if workflow_id == child.workflow_id else None
+        ),
+    )
+
+    assert validation["valid"] is True
+    assert validation["subworkflow_contract_issues"] == []
+
+
 def test_validate_contract_reports_unresolved_subworkflow_workflow() -> None:
     parent = _parent_with_subworkflow_contract(child_workflow_id="#V#missing_child")
 

--- a/tests/backend/test_workflow_discovery_service.py
+++ b/tests/backend/test_workflow_discovery_service.py
@@ -261,6 +261,17 @@ class TestKeywordFallbackQueries:
         assert "arxiv workflow" in queries
         assert "arxiv 2602.20478" in queries
 
+    def test_adds_talk_and_seminar_queries_for_presentation_prompt(self) -> None:
+        queries = _build_keyword_fallback_queries(
+            "Can you make the workflow for adding academic talks now?",
+            [],
+        )
+
+        assert "talk representation workflow" in queries
+        assert "technical scientific talk representation workflow" in queries
+        assert "academic presentation workflow" in queries
+        assert "seminar representation workflow" in queries
+
 
 class TestDiscoverWorkflows:
     """Unit tests for discover_workflows function."""


### PR DESCRIPTION
## Summary
- fix contradictory turn-execution progress, error, and tool counters and record workflow-selection rationale
- map tool planning/execution stages correctly and stop hierarchy rendering from coercing custom relation edges into taxonomy children
- add canonical talk, technical/scientific talk, and academic presentation workflows plus ontology primitive bootstrap and validation

## Verification
- pdm run pyright on all changed Python files
- pdm run pytest tests/backend/test_tool_progress_liveness.py tests/backend/test_conversation_turn_stage_model.py tests/backend/test_workflow_discovery_service.py tests/backend/test_paper_representation_workflow_vontology_service.py tests/backend/test_talk_representation_workflow_vontology_service.py -q
- pdm run pytest tests/backend/test_workflow_definition_identity_service.py tests/backend/test_vontology_loader.py -k \ subworkflow or static_subworkflow_inputs\ -q
- pdm run pytest tests/backend/test_orchestrator_workflow_selector_routing.py -k \renderer_selection_skips_hierarchy_view_for_custom_relation_edges\ -q
- pdm run pytest tests/backend/test_paper_representation_workflow.py tests/backend/test_workflow_registry_factory_parity.py -q
- live Vontology bootstrap plus definition load and contract validation for #V#talk_representation_workflow, #V#technical_scientific_talk_representation_workflow, and #V#academic_presentation_instance_workflow