### PR TITLE
Implement JVNAUTOSCI-1433 workflow selection policy training

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -18960,6 +18960,72 @@ class InternalMCPChatOrchestrator:
         def _orchestrator_duration_ms() -> float:
             return (time.perf_counter() - orchestrator_start) * 1000.0
 
+        def _finalise_selection_experience_record(
+            *,
+            result: OrchestratorResult,
+            outcome: str,
+            final_state: str | None = None,
+            completed: bool | None = None,
+            retry_attempts: int = 0,
+            completion_gate_repeat_attempts: int = 0,
+        ) -> None:
+            if not isinstance(selection_experience_id, str) or not selection_experience_id:
+                return
+
+            usage = result.llm_usage if isinstance(result.llm_usage, Mapping) else {}
+            safe_outcome = str(outcome or "").strip() or "unknown"
+            prompt_tokens = usage.get("prompt_tokens")
+            completion_tokens = usage.get("completion_tokens")
+            total_tokens = usage.get("total_tokens")
+            outcome_payload = {
+                "selected_workflow_id": (
+                    routing_info.workflow_id
+                    if isinstance(routing_info, WorkflowRoutingInfo)
+                    else None
+                ),
+                "final_state": final_state,
+                "completed": bool(completed) if completed is not None else None,
+                "retry_attempts": max(0, int(retry_attempts)),
+                "completion_gate_repeat_attempts": max(
+                    0, int(completion_gate_repeat_attempts)
+                ),
+                "orchestrator_duration_ms": float(
+                    result.orchestrator_duration_ms
+                    if isinstance(result.orchestrator_duration_ms, (int, float))
+                    else _orchestrator_duration_ms()
+                ),
+                "prompt_tokens": int(prompt_tokens)
+                if isinstance(prompt_tokens, int)
+                else 0,
+                "completion_tokens": int(completion_tokens)
+                if isinstance(completion_tokens, int)
+                else 0,
+                "total_tokens": int(total_tokens)
+                if isinstance(total_tokens, int)
+                else 0,
+                "workflow_gap_recovery_applied": any(
+                    isinstance(entry, Mapping)
+                    and entry.get("type") == "workflow_gap_recovery"
+                    and entry.get("status") == "applied"
+                    for entry in result.aux_llm_calls
+                ),
+            }
+            if safe_outcome == "follow_up_required":
+                outcome_payload["completion_gate_requires_follow_up"] = True
+
+            try:
+                from ...services.workflow_selection_experience import (
+                    finalise_selection_experience,
+                )
+
+                finalise_selection_experience(
+                    experience_id=selection_experience_id,
+                    outcome=safe_outcome,
+                    outcome_metadata=outcome_payload,
+                )
+            except Exception:
+                pass
+
         def _build_tool_call_parse_error_result(
             tool_call_parse_error: ToolCallParsingError,
             *,
@@ -19581,6 +19647,7 @@ class InternalMCPChatOrchestrator:
             )
 
         routing_info: WorkflowRoutingInfo | None = None
+        selection_experience_id: str | None = None
         if prompt_requirements_force_tool_pipeline:
             routing_info = WorkflowRoutingInfo(
                 workflow_id=TOOL_CALLING_WORKFLOW_ID,
@@ -19686,6 +19753,11 @@ class InternalMCPChatOrchestrator:
                 turn_text=effective_prompt_for_routing,
                 discovered_workflows=discovered_matches or None,
             )
+            selector_policy = (
+                dict(selector_prompt.policy_recommendation)
+                if isinstance(selector_prompt.policy_recommendation, Mapping)
+                else {}
+            )
 
             def _emit_selector_progress(info: Mapping[str, Any]) -> None:
                 payload = dict(info)
@@ -19718,36 +19790,71 @@ class InternalMCPChatOrchestrator:
                 _emit_progress_local(payload)
 
             try:
-                selector_response_text, classifier_model, selector_candidate = (
-                    self._run_llm_with_fallbacks(
-                        stage="workflow_dispatch",
-                        policy_stage="classifier",
-                        prompt="Select workflow",
-                        context=[
-                            {
-                                "role": "system",
-                                "content": selector_prompt.prompt_text,
-                            }
-                        ],
-                        default_client=llm_client,
-                        default_model=model,
-                        policy_state=policy_state,
-                        registry_snapshot=registry_snapshot,
-                        user_concept_id=user_concept_id,
-                        org_concept_id=org_concept_id,
-                        llm_calls_log=llm_calls,
-                        aux_log=aux_llm_calls,
-                        record_llm_call=_record_llm_call,
-                        emit_progress=_emit_selector_progress,
+                classifier_model = None
+                selector_candidate = None
+                if (
+                    isinstance(selector_policy.get("recommended_workflow_id"), str)
+                    and selector_policy.get("guidance_mode") == "direct"
+                ):
+                    _emit_progress_local(
+                        {
+                            "status": "thinking",
+                            "stage": "workflow_dispatch",
+                            "phase": "workflow_dispatch",
+                            "phase_label": "Applying learned workflow policy",
+                            "workflow_match_count": len(discovered_matches),
+                            "workflow_candidate_count": len(discovered_matches)
+                            + len(excluded_discovered_matches),
+                        }
                     )
-                )
-                selector_selection = self._workflow_selector.resolve_selection(
-                    raw_response=selector_response_text,
-                    prompt_id=selector_prompt.prompt_id,
-                    prompt_used=selector_prompt.prompt_text,
-                    discovered_workflow_ids=selector_prompt.discovered_workflow_ids,
-                )
+                    selector_selection = self._workflow_selector.resolve_policy_selection(
+                        workflow_id=str(selector_policy.get("recommended_workflow_id")),
+                        prompt_id=selector_prompt.prompt_id,
+                        prompt_used=selector_prompt.prompt_text,
+                        discovered_workflow_ids=selector_prompt.discovered_workflow_ids,
+                        confidence_score=float(
+                            selector_policy.get("confidence_score", 0.0)
+                        ),
+                        reasoning=str(selector_policy.get("reasoning") or ""),
+                        selection_metadata=selector_policy,
+                    )
+                else:
+                    selector_response_text, classifier_model, selector_candidate = (
+                        self._run_llm_with_fallbacks(
+                            stage="workflow_dispatch",
+                            policy_stage="classifier",
+                            prompt="Select workflow",
+                            context=[
+                                {
+                                    "role": "system",
+                                    "content": selector_prompt.prompt_text,
+                                }
+                            ],
+                            default_client=llm_client,
+                            default_model=model,
+                            policy_state=policy_state,
+                            registry_snapshot=registry_snapshot,
+                            user_concept_id=user_concept_id,
+                            org_concept_id=org_concept_id,
+                            llm_calls_log=llm_calls,
+                            aux_log=aux_llm_calls,
+                            record_llm_call=_record_llm_call,
+                            emit_progress=_emit_selector_progress,
+                        )
+                    )
+                    selector_selection = self._workflow_selector.resolve_selection(
+                        raw_response=selector_response_text,
+                        prompt_id=selector_prompt.prompt_id,
+                        prompt_used=selector_prompt.prompt_text,
+                        discovered_workflow_ids=selector_prompt.discovered_workflow_ids,
+                    )
                 routing_duration_ms = (time.perf_counter() - selector_start) * 1000.0
+                selection_source = (
+                    selector_selection.selection_source
+                    if isinstance(selector_selection.selection_source, str)
+                    and selector_selection.selection_source.strip()
+                    else "selector"
+                )
                 selected_workflow_name = _resolve_selected_workflow_name(
                     selector_selection.workflow_id
                 )
@@ -19759,14 +19866,14 @@ class InternalMCPChatOrchestrator:
                     prompt_id=selector_selection.prompt_id,
                     discovered_workflow_ids=selector_selection.discovered_workflow_ids,
                     routing_duration_ms=routing_duration_ms,
-                    source="selector",
+                    source=selection_source,
                     confidence_score=selector_selection.confidence_score,
                     reasoning=selector_selection.reasoning,
                 )
                 selection_rationale = _derive_workflow_selection_rationale(
                     selected_workflow_id=selector_selection.workflow_id,
                     selector_verdict=selector_selection.verdict,
-                    selector_source="selector",
+                    selector_source=selection_source,
                     candidate_workflow_ids=selector_selection.discovered_workflow_ids,
                     explicit_reasoning=selector_selection.reasoning,
                 )
@@ -19792,6 +19899,7 @@ class InternalMCPChatOrchestrator:
                         "type": "workflow_selector",
                         "workflow_id": selector_selection.workflow_id,
                         "verdict": selector_selection.verdict,
+                        "selection_source": selection_source,
                         "prompt_id": selector_selection.prompt_id,
                         "policy_stage": "classifier",
                         "model_name": classifier_model,
@@ -19807,6 +19915,13 @@ class InternalMCPChatOrchestrator:
                         "routing_duration_ms": routing_duration_ms,
                         "confidence_score": selector_selection.confidence_score,
                         "reasoning": selector_selection.reasoning,
+                        "policy_guidance_mode": selector_policy.get("guidance_mode"),
+                        "policy_snapshot_id": selector_policy.get("snapshot_id"),
+                        "policy_candidate_scores": list(
+                            selector_policy.get("candidate_scores", ())
+                        )
+                        if isinstance(selector_policy.get("candidate_scores"), list)
+                        else None,
                         "selection_rationale": selection_rationale,
                     }
                 )
@@ -19814,6 +19929,7 @@ class InternalMCPChatOrchestrator:
                     trace.metadata["workflow_selector"] = {
                         "workflow_id": selector_selection.workflow_id,
                         "verdict": selector_selection.verdict,
+                        "selection_source": selection_source,
                         "prompt_id": selector_selection.prompt_id,
                         "policy_stage": "classifier",
                         "model_name": classifier_model,
@@ -19834,14 +19950,22 @@ class InternalMCPChatOrchestrator:
                         "routing_duration_ms": routing_duration_ms,
                         "confidence_score": selector_selection.confidence_score,
                         "reasoning": selector_selection.reasoning,
+                        "policy_guidance_mode": selector_policy.get("guidance_mode"),
+                        "policy_snapshot_id": selector_policy.get("snapshot_id"),
+                        "policy_candidate_scores": list(
+                            selector_policy.get("candidate_scores", ())
+                        )
+                        if isinstance(selector_policy.get("candidate_scores"), list)
+                        else None,
                         "selection_rationale": selection_rationale,
                     }
-                # Phase 3: record selection experience tuple.
+                # Phase 4: record selection experience tuple for later outcome
+                # finalisation and policy training.
                 try:
                     from ...services.workflow_selection_experience import (
                         record_selection_experience,
                     )
-                    record_selection_experience(
+                    selection_experience = record_selection_experience(
                         turn_id=str(turn_id or ""),
                         query=effective_prompt_for_routing[:500],
                         candidate_workflow_ids=list(
@@ -19849,11 +19973,14 @@ class InternalMCPChatOrchestrator:
                         ),
                         selected_workflow_id=selector_selection.workflow_id,
                         verdict=selector_selection.verdict,
+                        selection_source=selection_source,
+                        selection_metadata=selector_selection.selection_metadata,
                         confidence_score=selector_selection.confidence_score,
                         reasoning=selector_selection.reasoning,
                         model_name=str(classifier_model or ""),
                         routing_duration_ms=routing_duration_ms,
                     )
+                    selection_experience_id = selection_experience.experience_id
                 except Exception:
                     pass  # Best-effort; never block routing.
             except Exception as exc:
@@ -19888,6 +20015,27 @@ class InternalMCPChatOrchestrator:
                         "workflow_selection_rationale": selection_rationale,
                     }
                 )
+                try:
+                    from ...services.workflow_selection_experience import (
+                        record_selection_experience,
+                    )
+
+                    selection_experience = record_selection_experience(
+                        turn_id=str(turn_id or ""),
+                        query=effective_prompt_for_routing[:500],
+                        candidate_workflow_ids=(),
+                        selected_workflow_id=CHAT_ASSISTANT_WORKFLOW_ID,
+                        verdict="fallback",
+                        selection_source="default",
+                        selection_metadata={"selector_error": str(exc)},
+                        confidence_score=0.0,
+                        reasoning="selector_exception",
+                        model_name="",
+                        routing_duration_ms=0.0,
+                    )
+                    selection_experience_id = selection_experience.experience_id
+                except Exception:
+                    pass
 
         _STATIC_SELECTOR_VERDICTS = frozenset(
             {"plain_response", "tool_seeking", "summarisation", "narration", "fallback"}
@@ -19923,10 +20071,15 @@ class InternalMCPChatOrchestrator:
         )
         selector_requests_narration = selector_verdict == "narration"
         selector_requests_custom_workflow = bool(
-            selector_verdict
-            and selector_verdict not in _STATIC_SELECTOR_VERDICTS
-            and selected_workflow_id_text
-            and selected_workflow_id_text.lower() == selector_verdict
+            selected_workflow_id_text
+            and (
+                selector_verdict == "policy_selected"
+                or (
+                    selector_verdict
+                    and selector_verdict not in _STATIC_SELECTOR_VERDICTS
+                    and selected_workflow_id_text.lower() == selector_verdict
+                )
+            )
         )
         write_tool_candidates_for_routing = sorted(
             {
@@ -24607,6 +24760,12 @@ class InternalMCPChatOrchestrator:
                 render_plan=_result_render_plan(),
             )
             result = _maybe_apply_workflow_gap_recovery(result)
+            _finalise_selection_experience_record(
+                result=result,
+                outcome="completed",
+                final_state="plain_response",
+                completed=True,
+            )
             _persist_trace(status="completed")
             return result
 
@@ -24684,6 +24843,12 @@ class InternalMCPChatOrchestrator:
                         render_plan=_result_render_plan(),
                     )
                     result = _maybe_apply_workflow_gap_recovery(result)
+                    _finalise_selection_experience_record(
+                        result=result,
+                        outcome="completed" if wf_result.completed else "failed",
+                        final_state=wf_result.final_state,
+                        completed=wf_result.completed,
+                    )
                     _persist_trace(status="completed")
                     return result
                 self._logger.warning(
@@ -24728,6 +24893,12 @@ class InternalMCPChatOrchestrator:
                 orchestrator_duration_ms=_orchestrator_duration_ms(),
                 workflow_routing=routing_info,
                 render_plan=_result_render_plan(),
+            )
+            _finalise_selection_experience_record(
+                result=result,
+                outcome="failed",
+                final_state="tool_workflow_unavailable",
+                completed=False,
             )
             _persist_trace(status="completed")
             return result
@@ -24859,14 +25030,34 @@ class InternalMCPChatOrchestrator:
                 orchestrator_duration_ms=_orchestrator_duration_ms(),
                 workflow_routing=routing_info,
             )
+            _finalise_selection_experience_record(
+                result=result,
+                outcome="failed",
+                final_state="tool_workflow_missing",
+                completed=False,
+            )
             _persist_trace(status="completed")
             return result
 
         # Unpack the workflow result.
         if tc_result.data.get("orchestrator_result") is not None:
             # Handler produced a pre-built OrchestratorResult (error case).
+            prebuilt_result = tc_result.data["orchestrator_result"]
+            if isinstance(prebuilt_result, OrchestratorResult):
+                _finalise_selection_experience_record(
+                    result=prebuilt_result,
+                    outcome="failed",
+                    final_state=tc_result.final_state,
+                    completed=tc_result.completed,
+                    retry_attempts=int(
+                        tc_result.data.get("missing_tool_call_retry_attempts", 0)
+                    ),
+                    completion_gate_repeat_attempts=int(
+                        tc_result.data.get("completion_gate_loop_attempts", 0)
+                    ),
+                )
             _persist_trace(status="completed")
-            return tc_result.data["orchestrator_result"]
+            return prebuilt_result
 
         final_response = tc_result.data.get("final_response", "")
         if not isinstance(final_response, str):
@@ -24936,6 +25127,24 @@ class InternalMCPChatOrchestrator:
             render_plan=_result_render_plan(),
         )
         result = _maybe_apply_workflow_gap_recovery(result)
+        _finalise_selection_experience_record(
+            result=result,
+            outcome=(
+                "completed"
+                if gate_safe_to_claim_completion and not gate_requires_follow_up
+                else "follow_up_required"
+                if tc_result.completed
+                else "failed"
+            ),
+            final_state=tc_result.final_state,
+            completed=tc_result.completed,
+            retry_attempts=int(
+                tc_result.data.get("missing_tool_call_retry_attempts", 0)
+            ),
+            completion_gate_repeat_attempts=int(
+                tc_result.data.get("completion_gate_loop_attempts", 0)
+            ),
+        )
         _persist_trace(status=terminal_trace_status)
         return result
 

--- a/src/backend/services/workflow_selection_experience.py
+++ b/src/backend/services/workflow_selection_experience.py
@@ -1,55 +1,167 @@
-"""Process-local workflow selection experience buffer.
+"""Workflow selection experience capture for Phase 3 and Phase 4.
 
-JVNAUTOSCI-1424 Phase 3:  Records selection decisions (workflow chosen,
-confidence, reasoning, candidates offered) in a bounded ring buffer so
-that Phase 4 RL training has a warm-start dataset of experience tuples.
-
-The buffer is process-local and thread-safe.  A snapshot function
-exposes the current experience data for telemetry endpoints and offline
-export.  Aggregate counters give a quick overview of selection quality
-without iterating the full buffer.
+Phase 3 introduced a process-local ring buffer so selector decisions could be
+inspected after routing. Phase 4 extends that record into a proper learning
+signal: decisions are persisted durably, finalised with execution outcomes, and
+scored with a compact reward function that the learned routing policy can reuse.
 """
 
 from __future__ import annotations
 
 import copy
+import logging
+import re
+import uuid
 from collections import deque
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 from threading import Lock
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from pymongo import ASCENDING, DESCENDING
+from pymongo.errors import OperationFailure
+
+from ..db.mongo_client import get_db
+
+logger = logging.getLogger(__name__)
+
+SELECTION_EXPERIENCES_COLLECTION = "workflow_selection_experiences"
+_DEFAULT_BUFFER_SIZE = 500
+_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_:-]{1,31}")
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _utcnow_iso() -> str:
+    return _utcnow().isoformat()
+
+
+def _safe_str(value: Any, *, limit: int | None = None) -> str:
+    if isinstance(value, str):
+        text = value.strip()
+    elif value is None:
+        text = ""
+    else:
+        text = str(value).strip()
+    if limit is not None:
+        return text[:limit]
+    return text
+
+
+def _coerce_float(
+    value: Any,
+    *,
+    default: float = 0.0,
+    minimum: float | None = None,
+    maximum: float | None = None,
+) -> float:
+    try:
+        parsed = float(value)
+    except Exception:
+        parsed = default
+    if minimum is not None:
+        parsed = max(minimum, parsed)
+    if maximum is not None:
+        parsed = min(maximum, parsed)
+    return parsed
+
+
+def _coerce_int(
+    value: Any,
+    *,
+    default: int = 0,
+    minimum: int | None = None,
+) -> int:
+    try:
+        parsed = int(value)
+    except Exception:
+        parsed = default
+    if minimum is not None:
+        parsed = max(minimum, parsed)
+    return parsed
+
+
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return False
+
+
+def _clone_mapping(value: Mapping[str, Any] | None) -> Dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): copy.deepcopy(val) for key, val in value.items()}
+
+
+def _normalise_workflow_ids(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(_safe_str(value) for value in values if _safe_str(value))
+
+
+def extract_selection_query_tokens(
+    query: str,
+    *,
+    limit: int = 24,
+) -> tuple[str, ...]:
+    """Extract a stable, bounded token set from selector input text."""
+    clean_query = _safe_str(query, limit=500).lower()
+    if not clean_query:
+        return ()
+
+    tokens: list[str] = []
+    seen: set[str] = set()
+    for match in _TOKEN_RE.findall(clean_query):
+        if match in seen:
+            continue
+        seen.add(match)
+        tokens.append(match)
+        if len(tokens) >= limit:
+            break
+    return tuple(tokens)
+
+
+def _normalise_outcome(outcome: Any) -> str | None:
+    clean = _safe_str(outcome).lower().replace(" ", "_")
+    return clean or None
+
+
+def _outcome_is_success(outcome: str | None) -> bool:
+    return outcome in {"completed", "success"}
 
 
 @dataclass(frozen=True)
 class SelectionExperienceTuple:
-    """One recorded selection decision (immutable experience tuple).
+    """One recorded workflow-selection experience tuple."""
 
-    Fields mirror the orchestrator's auxiliary LLM‐call record so the
-    buffer can be reconciled against telemetry traces.
-    """
-
+    experience_id: str
     timestamp: str
     turn_id: str = ""
     query: str = ""
+    query_tokens: tuple[str, ...] = ()
     candidate_workflow_ids: tuple[str, ...] = ()
     candidate_count: int = 0
     selected_workflow_id: str = ""
     verdict: str = ""
+    selection_source: str = "selector"
+    selection_metadata: Dict[str, Any] = field(default_factory=dict)
     confidence_score: float = 0.0
     reasoning: str = ""
     model_name: str = ""
     routing_duration_ms: float = 0.0
-    # Outcome populated asynchronously after execution completes.
     outcome: Optional[str] = None
     outcome_metadata: Dict[str, Any] = field(default_factory=dict)
+    reward: Optional[float] = None
+    reward_breakdown: Dict[str, float] = field(default_factory=dict)
+    completed_at: str | None = None
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
 
-
-# -----------------------------------------------------------------------
-# Aggregate counters
-# -----------------------------------------------------------------------
 
 @dataclass
 class _SelectionAggregates:
@@ -58,19 +170,285 @@ class _SelectionAggregates:
     rag_default: int = 0
     legacy: int = 0
     fallback: int = 0
+    policy_direct: int = 0
     confidence_sum: float = 0.0
     confidence_count: int = 0
+    completed_count: int = 0
+    successful_outcomes: int = 0
+    reward_sum: float = 0.0
+    reward_count: int = 0
 
-
-# -----------------------------------------------------------------------
-# Global ring-buffer singleton
-# -----------------------------------------------------------------------
-
-_DEFAULT_BUFFER_SIZE = 500
 
 _lock = Lock()
 _buffer: deque[SelectionExperienceTuple] = deque(maxlen=_DEFAULT_BUFFER_SIZE)
 _aggregates = _SelectionAggregates()
+_indexes_ensured = False
+
+
+def _serialise_for_storage(entry: SelectionExperienceTuple) -> Dict[str, Any]:
+    payload = entry.to_dict()
+    payload["query_tokens"] = list(entry.query_tokens)
+    payload["candidate_workflow_ids"] = list(entry.candidate_workflow_ids)
+    return payload
+
+
+def _coerce_experience_tuple(payload: Mapping[str, Any]) -> SelectionExperienceTuple | None:
+    experience_id = _safe_str(payload.get("experience_id"))
+    timestamp = _safe_str(payload.get("timestamp"))
+    if not experience_id or not timestamp:
+        return None
+
+    return SelectionExperienceTuple(
+        experience_id=experience_id,
+        timestamp=timestamp,
+        turn_id=_safe_str(payload.get("turn_id")),
+        query=_safe_str(payload.get("query"), limit=500),
+        query_tokens=tuple(
+            _safe_str(item)
+            for item in (payload.get("query_tokens") or [])
+            if _safe_str(item)
+        ),
+        candidate_workflow_ids=tuple(
+            _safe_str(item)
+            for item in (payload.get("candidate_workflow_ids") or [])
+            if _safe_str(item)
+        ),
+        candidate_count=_coerce_int(payload.get("candidate_count"), minimum=0),
+        selected_workflow_id=_safe_str(payload.get("selected_workflow_id")),
+        verdict=_safe_str(payload.get("verdict")),
+        selection_source=_safe_str(payload.get("selection_source")) or "selector",
+        selection_metadata=_clone_mapping(payload.get("selection_metadata")),
+        confidence_score=_coerce_float(
+            payload.get("confidence_score"),
+            minimum=0.0,
+            maximum=1.0,
+        ),
+        reasoning=_safe_str(payload.get("reasoning"), limit=500),
+        model_name=_safe_str(payload.get("model_name")),
+        routing_duration_ms=_coerce_float(
+            payload.get("routing_duration_ms"),
+            minimum=0.0,
+        ),
+        outcome=_normalise_outcome(payload.get("outcome")),
+        outcome_metadata=_clone_mapping(payload.get("outcome_metadata")),
+        reward=(
+            _coerce_float(payload.get("reward"))
+            if payload.get("reward") is not None
+            else None
+        ),
+        reward_breakdown={
+            _safe_str(key): _coerce_float(value)
+            for key, value in _clone_mapping(payload.get("reward_breakdown")).items()
+        },
+        completed_at=_safe_str(payload.get("completed_at")) or None,
+    )
+
+
+def _ensure_indexes() -> None:
+    global _indexes_ensured
+    if _indexes_ensured:
+        return
+
+    db = get_db()
+    if db is None:
+        return
+
+    coll = db[SELECTION_EXPERIENCES_COLLECTION]
+    try:
+        existing = [idx.get("name") for idx in coll.list_indexes()]
+        if "experience_id_unique" not in existing:
+            coll.create_index(
+                [("experience_id", ASCENDING)],
+                unique=True,
+                name="experience_id_unique",
+            )
+        if "workflow_timestamp_desc" not in existing:
+            coll.create_index(
+                [("selected_workflow_id", ASCENDING), ("timestamp", DESCENDING)],
+                name="workflow_timestamp_desc",
+            )
+        if "turn_timestamp_desc" not in existing:
+            coll.create_index(
+                [("turn_id", ASCENDING), ("timestamp", DESCENDING)],
+                name="turn_timestamp_desc",
+            )
+        if "reward_timestamp_desc" not in existing:
+            coll.create_index(
+                [("reward", DESCENDING), ("timestamp", DESCENDING)],
+                name="reward_timestamp_desc",
+            )
+    except OperationFailure as exc:
+        logger.warning(
+            "[workflow_selection_experience] index creation partially failed: %s",
+            exc,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "[workflow_selection_experience] could not create indexes: %s",
+            exc,
+        )
+    else:
+        _indexes_ensured = True
+
+
+def _get_collection():
+    _ensure_indexes()
+    db = get_db()
+    if db is None:
+        return None
+    return db[SELECTION_EXPERIENCES_COLLECTION]
+
+
+def _persist_entry(entry: SelectionExperienceTuple) -> None:
+    coll = _get_collection()
+    if coll is None:
+        return
+    payload = _serialise_for_storage(entry)
+    coll.update_one(
+        {"experience_id": entry.experience_id},
+        {
+            "$set": payload,
+            "$setOnInsert": {"created_at": entry.timestamp},
+        },
+        upsert=True,
+    )
+
+
+def _find_buffer_index_locked(experience_id: str) -> int | None:
+    for index, entry in enumerate(_buffer):
+        if entry.experience_id == experience_id:
+            return index
+    return None
+
+
+def _register_entry_locked(entry: SelectionExperienceTuple) -> None:
+    _aggregates.total += 1
+    if entry.verdict == "rag_selected":
+        _aggregates.rag_selected += 1
+    elif entry.verdict == "rag_default":
+        _aggregates.rag_default += 1
+    elif entry.verdict == "fallback":
+        _aggregates.fallback += 1
+    else:
+        _aggregates.legacy += 1
+    if entry.selection_source == "policy_direct":
+        _aggregates.policy_direct += 1
+    if entry.confidence_score > 0.0:
+        _aggregates.confidence_sum += entry.confidence_score
+        _aggregates.confidence_count += 1
+    _register_outcome_metrics_locked(entry)
+
+
+def _register_outcome_metrics_locked(entry: SelectionExperienceTuple) -> None:
+    if entry.outcome is not None:
+        _aggregates.completed_count += 1
+        if _outcome_is_success(entry.outcome):
+            _aggregates.successful_outcomes += 1
+    if entry.reward is not None:
+        _aggregates.reward_sum += float(entry.reward)
+        _aggregates.reward_count += 1
+
+
+def _unregister_outcome_metrics_locked(entry: SelectionExperienceTuple) -> None:
+    if entry.outcome is not None:
+        _aggregates.completed_count = max(0, _aggregates.completed_count - 1)
+        if _outcome_is_success(entry.outcome):
+            _aggregates.successful_outcomes = max(
+                0, _aggregates.successful_outcomes - 1
+            )
+    if entry.reward is not None:
+        _aggregates.reward_sum -= float(entry.reward)
+        _aggregates.reward_count = max(0, _aggregates.reward_count - 1)
+
+
+def compute_selection_reward(
+    *,
+    outcome: str | None,
+    confidence_score: float = 0.0,
+    routing_duration_ms: float = 0.0,
+    outcome_metadata: Mapping[str, Any] | None = None,
+    selection_metadata: Mapping[str, Any] | None = None,
+) -> tuple[float, Dict[str, float]]:
+    """Compute a compact reward signal from execution telemetry."""
+
+    clean_outcome = _normalise_outcome(outcome)
+    safe_outcome_metadata = _clone_mapping(outcome_metadata)
+    safe_selection_metadata = _clone_mapping(selection_metadata)
+
+    duration_ms = _coerce_float(
+        safe_outcome_metadata.get("orchestrator_duration_ms", routing_duration_ms),
+        minimum=0.0,
+    )
+    retry_attempts = _coerce_int(
+        safe_outcome_metadata.get("retry_attempts"),
+        minimum=0,
+    ) + _coerce_int(
+        safe_outcome_metadata.get("completion_gate_repeat_attempts"),
+        minimum=0,
+    )
+    total_tokens = _coerce_int(
+        safe_outcome_metadata.get("total_tokens"),
+        minimum=0,
+    )
+    confidence = _coerce_float(
+        confidence_score,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    follow_up_required = _coerce_bool(
+        safe_outcome_metadata.get("completion_gate_requires_follow_up")
+    )
+    exploration_bonus = _coerce_float(
+        safe_selection_metadata.get("selected_exploration_bonus"),
+        minimum=0.0,
+        maximum=0.25,
+    )
+
+    if clean_outcome in {"completed", "success"}:
+        completion_signal = 1.0
+    elif clean_outcome in {"follow_up_required", "partial"} or follow_up_required:
+        completion_signal = 0.35
+    elif clean_outcome in {"failed", "terminated", "error", "selection_failed"}:
+        completion_signal = -0.75
+    else:
+        completion_signal = 0.0
+
+    if duration_ms <= 1500.0:
+        efficiency_signal = 0.2
+    elif duration_ms <= 5000.0:
+        efficiency_signal = 0.1
+    elif duration_ms >= 15000.0:
+        efficiency_signal = -0.15
+    else:
+        efficiency_signal = 0.0
+
+    retry_penalty = -0.08 * min(retry_attempts, 4)
+    cost_penalty = -0.2 * min(total_tokens / 8000.0, 1.0)
+    if completion_signal > 0.5:
+        calibration_signal = 0.2 * confidence
+    elif completion_signal < 0.0:
+        calibration_signal = -0.3 * confidence
+    else:
+        calibration_signal = -0.1 * confidence
+
+    reward = (
+        completion_signal
+        + efficiency_signal
+        + retry_penalty
+        + cost_penalty
+        + calibration_signal
+        + exploration_bonus
+    )
+    reward = round(max(-1.5, min(1.5, reward)), 4)
+    breakdown = {
+        "completion_signal": round(completion_signal, 4),
+        "efficiency_signal": round(efficiency_signal, 4),
+        "retry_penalty": round(retry_penalty, 4),
+        "cost_penalty": round(cost_penalty, 4),
+        "calibration_signal": round(calibration_signal, 4),
+        "exploration_bonus": round(exploration_bonus, 4),
+    }
+    return reward, breakdown
 
 
 def record_selection_experience(
@@ -80,68 +458,215 @@ def record_selection_experience(
     candidate_workflow_ids: Sequence[str] = (),
     selected_workflow_id: str = "",
     verdict: str = "",
+    selection_source: str = "selector",
+    selection_metadata: Mapping[str, Any] | None = None,
     confidence_score: float = 0.0,
     reasoning: str = "",
     model_name: str = "",
     routing_duration_ms: float = 0.0,
 ) -> SelectionExperienceTuple:
-    """Append a selection experience tuple to the global ring buffer."""
-    entry = SelectionExperienceTuple(
-        timestamp=datetime.now(timezone.utc).isoformat(),
-        turn_id=str(turn_id or ""),
-        query=str(query or "")[:500],  # Cap query length.
-        candidate_workflow_ids=tuple(
-            str(cid) for cid in candidate_workflow_ids if cid
+    """Append and persist a workflow-selection experience tuple."""
+
+    experience = SelectionExperienceTuple(
+        experience_id=f"wse_{uuid.uuid4().hex[:24]}",
+        timestamp=_utcnow_iso(),
+        turn_id=_safe_str(turn_id),
+        query=_safe_str(query, limit=500),
+        query_tokens=extract_selection_query_tokens(query),
+        candidate_workflow_ids=_normalise_workflow_ids(candidate_workflow_ids),
+        candidate_count=len(_normalise_workflow_ids(candidate_workflow_ids)),
+        selected_workflow_id=_safe_str(selected_workflow_id),
+        verdict=_safe_str(verdict),
+        selection_source=_safe_str(selection_source) or "selector",
+        selection_metadata=_clone_mapping(selection_metadata),
+        confidence_score=_coerce_float(
+            confidence_score,
+            minimum=0.0,
+            maximum=1.0,
         ),
-        candidate_count=len(
-            [cid for cid in candidate_workflow_ids if cid]
-        ),
-        selected_workflow_id=str(selected_workflow_id or ""),
-        verdict=str(verdict or ""),
-        confidence_score=max(0.0, min(1.0, float(confidence_score))),
-        reasoning=str(reasoning or "")[:500],  # Cap reasoning length.
-        model_name=str(model_name or ""),
-        routing_duration_ms=float(routing_duration_ms or 0.0),
+        reasoning=_safe_str(reasoning, limit=500),
+        model_name=_safe_str(model_name),
+        routing_duration_ms=_coerce_float(routing_duration_ms, minimum=0.0),
     )
 
     with _lock:
-        _buffer.append(entry)
-        _aggregates.total += 1
-        if verdict == "rag_selected":
-            _aggregates.rag_selected += 1
-        elif verdict == "rag_default":
-            _aggregates.rag_default += 1
-        elif verdict == "fallback":
-            _aggregates.fallback += 1
-        else:
-            _aggregates.legacy += 1
-        if confidence_score > 0.0:
-            _aggregates.confidence_sum += entry.confidence_score
-            _aggregates.confidence_count += 1
+        _buffer.append(experience)
+        _register_entry_locked(experience)
 
-    return entry
+    try:
+        _persist_entry(experience)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "[workflow_selection_experience] could not persist %s: %s",
+            experience.experience_id,
+            exc,
+        )
+    return experience
+
+
+def get_selection_experience(experience_id: str) -> SelectionExperienceTuple | None:
+    clean_experience_id = _safe_str(experience_id)
+    if not clean_experience_id:
+        return None
+
+    with _lock:
+        for entry in _buffer:
+            if entry.experience_id == clean_experience_id:
+                return entry
+
+    coll = _get_collection()
+    if coll is None:
+        return None
+    payload = coll.find_one({"experience_id": clean_experience_id}, {"_id": 0})
+    if not isinstance(payload, Mapping):
+        return None
+    return _coerce_experience_tuple(payload)
+
+
+def finalise_selection_experience(
+    *,
+    experience_id: str,
+    outcome: str,
+    outcome_metadata: Mapping[str, Any] | None = None,
+    reward: float | None = None,
+    reward_breakdown: Mapping[str, float] | None = None,
+    retrain_policy: bool = True,
+) -> SelectionExperienceTuple | None:
+    """Attach execution outcome and reward to a previously recorded decision."""
+
+    existing = get_selection_experience(experience_id)
+    if existing is None:
+        return None
+
+    safe_outcome_metadata = _clone_mapping(outcome_metadata)
+    resolved_reward = reward
+    resolved_breakdown = (
+        {
+            _safe_str(key): _coerce_float(value)
+            for key, value in reward_breakdown.items()
+        }
+        if isinstance(reward_breakdown, Mapping)
+        else None
+    )
+    if resolved_reward is None or resolved_breakdown is None:
+        resolved_reward, resolved_breakdown = compute_selection_reward(
+            outcome=outcome,
+            confidence_score=existing.confidence_score,
+            routing_duration_ms=existing.routing_duration_ms,
+            outcome_metadata=safe_outcome_metadata,
+            selection_metadata=existing.selection_metadata,
+        )
+
+    updated = replace(
+        existing,
+        outcome=_normalise_outcome(outcome),
+        outcome_metadata=safe_outcome_metadata,
+        reward=_coerce_float(resolved_reward),
+        reward_breakdown=dict(resolved_breakdown),
+        completed_at=_utcnow_iso(),
+    )
+
+    with _lock:
+        buffer_index = _find_buffer_index_locked(existing.experience_id)
+        if buffer_index is not None:
+            prior = _buffer[buffer_index]
+            _unregister_outcome_metrics_locked(prior)
+            _buffer[buffer_index] = updated
+            _register_outcome_metrics_locked(updated)
+        else:
+            _register_outcome_metrics_locked(updated)
+
+    try:
+        _persist_entry(updated)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "[workflow_selection_experience] could not persist finalised %s: %s",
+            updated.experience_id,
+            exc,
+        )
+
+    if retrain_policy:
+        try:
+            from .workflow_selection_policy_service import refresh_live_selection_policy
+
+            refresh_live_selection_policy()
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.warning(
+                "[workflow_selection_experience] could not refresh live policy: %s",
+                exc,
+            )
+
+    return updated
+
+
+def list_selection_experiences(
+    *,
+    limit: int = 100,
+    completed_only: bool = False,
+) -> List[SelectionExperienceTuple]:
+    """List recent workflow-selection experiences from durable storage when available."""
+
+    coll = _get_collection()
+    if coll is None:
+        with _lock:
+            entries = list(_buffer)
+        entries.reverse()
+        if completed_only:
+            entries = [entry for entry in entries if entry.outcome is not None]
+        return entries[: max(1, min(limit, 1000))]
+
+    query: Dict[str, Any] = {}
+    if completed_only:
+        query["outcome"] = {"$ne": None}
+
+    safe_limit = max(1, min(limit, 5000))
+    cursor = coll.find(query, {"_id": 0}).sort("timestamp", DESCENDING).limit(safe_limit)
+    entries: list[SelectionExperienceTuple] = []
+    for payload in cursor:
+        if isinstance(payload, Mapping):
+            entry = _coerce_experience_tuple(payload)
+            if entry is not None:
+                entries.append(entry)
+    return entries
 
 
 def get_selection_experience_snapshot() -> Dict[str, Any]:
-    """Return a deep copy of aggregates and recent experience tuples."""
+    """Return a deep copy of process-local aggregates and recent experiences."""
+
     with _lock:
-        entries = [e.to_dict() for e in _buffer]
-        agg = copy.copy(_aggregates)
+        entries = [entry.to_dict() for entry in _buffer]
+        aggregates = copy.copy(_aggregates)
 
     avg_confidence = (
-        round(agg.confidence_sum / agg.confidence_count, 4)
-        if agg.confidence_count > 0
+        round(aggregates.confidence_sum / aggregates.confidence_count, 4)
+        if aggregates.confidence_count > 0
+        else 0.0
+    )
+    avg_reward = (
+        round(aggregates.reward_sum / aggregates.reward_count, 4)
+        if aggregates.reward_count > 0
+        else 0.0
+    )
+    success_rate = (
+        round(aggregates.successful_outcomes / aggregates.completed_count, 4)
+        if aggregates.completed_count > 0
         else 0.0
     )
     return {
         "aggregates": {
-            "total_selections": agg.total,
-            "rag_selected": agg.rag_selected,
-            "rag_default": agg.rag_default,
-            "legacy": agg.legacy,
-            "fallback": agg.fallback,
+            "total_selections": aggregates.total,
+            "rag_selected": aggregates.rag_selected,
+            "rag_default": aggregates.rag_default,
+            "legacy": aggregates.legacy,
+            "fallback": aggregates.fallback,
+            "policy_direct": aggregates.policy_direct,
             "avg_confidence": avg_confidence,
-            "confidence_sample_count": agg.confidence_count,
+            "confidence_sample_count": aggregates.confidence_count,
+            "completed_count": aggregates.completed_count,
+            "successful_outcomes": aggregates.successful_outcomes,
+            "success_rate": success_rate,
+            "avg_reward": avg_reward,
+            "reward_sample_count": aggregates.reward_count,
         },
         "recent_experiences": entries,
         "buffer_capacity": _buffer.maxlen or _DEFAULT_BUFFER_SIZE,
@@ -152,15 +677,16 @@ def get_recent_experiences(
     *,
     limit: int = 20,
 ) -> List[Dict[str, Any]]:
-    """Return the most recent *limit* experience tuples (newest first)."""
+    """Return the most recent experience tuples (newest first)."""
     with _lock:
         recent = list(_buffer)
     recent.reverse()
-    return [e.to_dict() for e in recent[:limit]]
+    return [entry.to_dict() for entry in recent[: max(1, min(limit, 200))]]
 
 
 def reset_selection_experience() -> None:
-    """Clear the experience buffer and aggregates (for testing)."""
+    """Clear process-local experience state and best-effort durable test data."""
+
     with _lock:
         _buffer.clear()
         _aggregates.total = 0
@@ -168,5 +694,31 @@ def reset_selection_experience() -> None:
         _aggregates.rag_default = 0
         _aggregates.legacy = 0
         _aggregates.fallback = 0
+        _aggregates.policy_direct = 0
         _aggregates.confidence_sum = 0.0
         _aggregates.confidence_count = 0
+        _aggregates.completed_count = 0
+        _aggregates.successful_outcomes = 0
+        _aggregates.reward_sum = 0.0
+        _aggregates.reward_count = 0
+
+    coll = _get_collection()
+    if coll is not None:
+        try:
+            coll.delete_many({})
+        except Exception:  # pragma: no cover - best effort
+            pass
+
+
+__all__ = [
+    "SelectionExperienceTuple",
+    "compute_selection_reward",
+    "extract_selection_query_tokens",
+    "finalise_selection_experience",
+    "get_recent_experiences",
+    "get_selection_experience",
+    "get_selection_experience_snapshot",
+    "list_selection_experiences",
+    "record_selection_experience",
+    "reset_selection_experience",
+]

--- a/src/backend/services/workflow_selection_policy_service.py
+++ b/src/backend/services/workflow_selection_policy_service.py
@@ -1,0 +1,499 @@
+"""Learned policy support for workflow selection.
+
+The Phase 3 selector already finds a relevant candidate set. Phase 4 adds a
+lightweight learned policy on top of that recall step: selector experiences are
+converted into workflow-level reward priors, token-level affinity signals, and
+UCB-style exploration bonuses that can reorder or occasionally short-circuit the
+candidate list when evidence is strong.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Any, Dict, Mapping, Sequence
+
+from .workflow_selection_experience import (
+    SelectionExperienceTuple,
+    extract_selection_query_tokens,
+    list_selection_experiences,
+)
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_str(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _coerce_float(value: Any, *, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+def _coerce_candidate_workflows(
+    candidate_workflows: Sequence[Mapping[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for item in candidate_workflows or ():
+        workflow_id = _safe_str(item.get("concept_id") or item.get("workflow_id"))
+        if not workflow_id:
+            continue
+        rows.append(
+            {
+                "concept_id": workflow_id,
+                "name": _safe_str(item.get("name")) or workflow_id,
+                "description": _safe_str(item.get("description")),
+            }
+        )
+    return rows
+
+
+@dataclass(frozen=True)
+class WorkflowSelectionPolicySnapshot:
+    snapshot_id: str
+    created_at: str
+    experience_count: int
+    completed_experience_count: int
+    overall_average_reward: float
+    workflow_stats: Dict[str, Dict[str, float]]
+    token_stats: Dict[str, Dict[str, Dict[str, float]]]
+    config: Dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+_DEFAULT_CONFIG: dict[str, float] = {
+    "minimum_completed_experiences": 6.0,
+    "reward_weight": 0.6,
+    "token_weight": 0.4,
+    "exploration_weight": 0.18,
+    "cold_start_bonus": 0.12,
+    "max_tokens_per_workflow": 48.0,
+    "direct_selection_min_attempts": 3.0,
+    "direct_selection_min_margin": 0.18,
+    "direct_selection_min_average_reward": 0.2,
+}
+
+_policy_lock = Lock()
+_live_policy_snapshot: WorkflowSelectionPolicySnapshot | None = None
+
+
+def _coerce_experience_sequence(
+    experiences: Sequence[SelectionExperienceTuple | Mapping[str, Any]] | None,
+) -> list[SelectionExperienceTuple]:
+    result: list[SelectionExperienceTuple] = []
+    for item in experiences or ():
+        if isinstance(item, SelectionExperienceTuple):
+            result.append(item)
+    return result
+
+
+def clear_live_selection_policy() -> None:
+    global _live_policy_snapshot
+    with _policy_lock:
+        _live_policy_snapshot = None
+
+
+def set_live_selection_policy(
+    snapshot: WorkflowSelectionPolicySnapshot | None,
+) -> WorkflowSelectionPolicySnapshot | None:
+    global _live_policy_snapshot
+    with _policy_lock:
+        _live_policy_snapshot = snapshot
+    return snapshot
+
+
+def get_live_selection_policy() -> WorkflowSelectionPolicySnapshot | None:
+    with _policy_lock:
+        snapshot = _live_policy_snapshot
+    if snapshot is not None:
+        return snapshot
+    return refresh_live_selection_policy()
+
+
+def train_selection_policy(
+    *,
+    experiences: Sequence[SelectionExperienceTuple | Mapping[str, Any]] | None = None,
+    config_overrides: Mapping[str, float] | None = None,
+) -> WorkflowSelectionPolicySnapshot | None:
+    """Train a lightweight reward-guided routing policy from stored experiences."""
+
+    config = dict(_DEFAULT_CONFIG)
+    if isinstance(config_overrides, Mapping):
+        for key, value in config_overrides.items():
+            config[_safe_str(key)] = _coerce_float(value, default=config.get(key, 0.0))
+
+    if experiences is None:
+        items = list_selection_experiences(limit=5000, completed_only=True)
+    else:
+        items = _coerce_experience_sequence(experiences)
+
+    completed = [
+        item
+        for item in items
+        if item.reward is not None and _safe_str(item.selected_workflow_id)
+    ]
+    if len(completed) < int(config["minimum_completed_experiences"]):
+        return None
+
+    overall_average_reward = sum(float(item.reward or 0.0) for item in completed) / len(
+        completed
+    )
+    workflow_totals: dict[str, dict[str, float]] = {}
+    token_totals: dict[str, dict[str, dict[str, float]]] = {}
+
+    for entry in completed:
+        workflow_id = _safe_str(entry.selected_workflow_id)
+        if not workflow_id:
+            continue
+
+        workflow_bucket = workflow_totals.setdefault(
+            workflow_id,
+            {"attempts": 0.0, "reward_sum": 0.0, "successes": 0.0},
+        )
+        workflow_bucket["attempts"] += 1.0
+        workflow_bucket["reward_sum"] += float(entry.reward or 0.0)
+        if entry.outcome in {"completed", "success"}:
+            workflow_bucket["successes"] += 1.0
+
+        tokens = entry.query_tokens or extract_selection_query_tokens(entry.query)
+        per_workflow_tokens = token_totals.get(workflow_id)
+        if per_workflow_tokens is None:
+            per_workflow_tokens = {}
+            token_totals[workflow_id] = per_workflow_tokens
+        for token in tokens:
+            token_metrics = per_workflow_tokens.setdefault(
+                token,
+                {"count": 0.0, "reward_sum": 0.0},
+            )
+            token_metrics["count"] += 1.0
+            token_metrics["reward_sum"] += float(entry.reward or 0.0)
+
+    workflow_stats: dict[str, dict[str, float]] = {}
+    token_stats: dict[str, dict[str, dict[str, float]]] = {}
+    max_tokens_per_workflow = max(1, int(config["max_tokens_per_workflow"]))
+
+    for workflow_id, bucket in workflow_totals.items():
+        attempts = max(1.0, bucket["attempts"])
+        average_reward = bucket["reward_sum"] / attempts
+        success_rate = bucket["successes"] / attempts
+        workflow_stats[workflow_id] = {
+            "attempts": float(attempts),
+            "average_reward": round(average_reward, 6),
+            "success_rate": round(success_rate, 6),
+        }
+
+        ranked_tokens = sorted(
+            token_totals.get(workflow_id, {}).items(),
+            key=lambda item: (
+                -(item[1]["count"] * abs((item[1]["reward_sum"] / max(1.0, item[1]["count"])) - overall_average_reward)),
+                -item[1]["count"],
+                item[0],
+            ),
+        )
+        token_bucket: dict[str, dict[str, float]] = {}
+        for token, stats in ranked_tokens[:max_tokens_per_workflow]:
+            count = max(1.0, stats["count"])
+            token_bucket[token] = {
+                "count": float(count),
+                "average_reward": round(stats["reward_sum"] / count, 6),
+            }
+        token_stats[workflow_id] = token_bucket
+
+    return WorkflowSelectionPolicySnapshot(
+        snapshot_id=f"wsp_{_utcnow_iso().replace(':', '').replace('-', '')}",
+        created_at=_utcnow_iso(),
+        experience_count=len(items),
+        completed_experience_count=len(completed),
+        overall_average_reward=round(overall_average_reward, 6),
+        workflow_stats=workflow_stats,
+        token_stats=token_stats,
+        config={key: round(value, 6) for key, value in config.items()},
+    )
+
+
+def refresh_live_selection_policy(
+    *,
+    experiences: Sequence[SelectionExperienceTuple | Mapping[str, Any]] | None = None,
+    config_overrides: Mapping[str, float] | None = None,
+) -> WorkflowSelectionPolicySnapshot | None:
+    snapshot = train_selection_policy(
+        experiences=experiences,
+        config_overrides=config_overrides,
+    )
+    return set_live_selection_policy(snapshot)
+
+
+def rank_policy_candidates(
+    *,
+    turn_text: str,
+    candidate_workflows: Sequence[Mapping[str, Any]] | None,
+    snapshot: WorkflowSelectionPolicySnapshot | None = None,
+) -> list[dict[str, Any]]:
+    """Rank candidate workflows using learned reward priors and exploration."""
+
+    rows = _coerce_candidate_workflows(candidate_workflows)
+    if not rows:
+        return []
+
+    policy = snapshot if snapshot is not None else get_live_selection_policy()
+    if policy is None:
+        return [
+            {
+                "workflow_id": row["concept_id"],
+                "score": 0.0,
+                "average_reward": 0.0,
+                "token_signal": 0.0,
+                "exploration_bonus": 0.0,
+                "attempts": 0,
+                "rank": index + 1,
+                "reasoning": "No learned selection policy available yet.",
+            }
+            for index, row in enumerate(rows)
+        ]
+
+    tokens = extract_selection_query_tokens(turn_text)
+    total_completed = max(1.0, float(policy.completed_experience_count))
+    scores: list[dict[str, Any]] = []
+    for row in rows:
+        workflow_id = row["concept_id"]
+        workflow_stats = policy.workflow_stats.get(workflow_id, {})
+        attempts = max(0.0, _coerce_float(workflow_stats.get("attempts"), default=0.0))
+        average_reward = _coerce_float(
+            workflow_stats.get("average_reward"),
+            default=policy.overall_average_reward,
+        )
+        token_entries = policy.token_stats.get(workflow_id, {})
+        matching_token_rewards = [
+            _coerce_float(token_entries[token]["average_reward"])
+            for token in tokens
+            if token in token_entries
+        ]
+        token_signal = (
+            sum(matching_token_rewards) / len(matching_token_rewards)
+            if matching_token_rewards
+            else average_reward
+        )
+        exploration_bonus = _coerce_float(
+            policy.config.get("exploration_weight", _DEFAULT_CONFIG["exploration_weight"])
+        ) * math.sqrt(math.log(total_completed + 1.0) / (attempts + 1.0))
+        if attempts <= 0.0:
+            exploration_bonus += _coerce_float(
+                policy.config.get("cold_start_bonus", _DEFAULT_CONFIG["cold_start_bonus"])
+            )
+
+        score = (
+            _coerce_float(
+                policy.config.get("reward_weight", _DEFAULT_CONFIG["reward_weight"])
+            )
+            * average_reward
+            + _coerce_float(
+                policy.config.get("token_weight", _DEFAULT_CONFIG["token_weight"])
+            )
+            * token_signal
+            + exploration_bonus
+        )
+        reasoning_bits = [
+            f"reward prior {average_reward:.2f}",
+            f"evidence {int(attempts)}",
+            f"exploration {exploration_bonus:.2f}",
+        ]
+        if matching_token_rewards:
+            reasoning_bits.append(
+                "token affinity "
+                + ", ".join(token for token in tokens if token in token_entries)
+            )
+        scores.append(
+            {
+                "workflow_id": workflow_id,
+                "score": round(score, 6),
+                "average_reward": round(average_reward, 6),
+                "token_signal": round(token_signal, 6),
+                "exploration_bonus": round(exploration_bonus, 6),
+                "attempts": int(attempts),
+                "reasoning": "; ".join(reasoning_bits),
+            }
+        )
+
+    scores.sort(
+        key=lambda item: (
+            -_coerce_float(item["score"]),
+            -_coerce_float(item["average_reward"]),
+            item["workflow_id"],
+        )
+    )
+    for index, score in enumerate(scores, start=1):
+        score["rank"] = index
+    return scores
+
+
+def recommend_workflow_with_policy(
+    *,
+    turn_text: str,
+    candidate_workflows: Sequence[Mapping[str, Any]] | None,
+    snapshot: WorkflowSelectionPolicySnapshot | None = None,
+) -> dict[str, Any]:
+    """Return policy guidance for selector candidate ordering or direct selection."""
+
+    scores = rank_policy_candidates(
+        turn_text=turn_text,
+        candidate_workflows=candidate_workflows,
+        snapshot=snapshot,
+    )
+    policy = snapshot if snapshot is not None else get_live_selection_policy()
+    if not scores or policy is None:
+        return {
+            "policy_active": False,
+            "guidance_mode": "none",
+            "candidate_scores": scores,
+            "ranked_candidate_ids": [item["workflow_id"] for item in scores],
+        }
+
+    top_score = scores[0]
+    second_score_value = _coerce_float(scores[1]["score"]) if len(scores) > 1 else -1.0
+    margin = _coerce_float(top_score["score"]) - second_score_value
+    minimum_attempts = int(
+        _coerce_float(
+            policy.config.get(
+                "direct_selection_min_attempts",
+                _DEFAULT_CONFIG["direct_selection_min_attempts"],
+            )
+        )
+    )
+    minimum_margin = _coerce_float(
+        policy.config.get(
+            "direct_selection_min_margin",
+            _DEFAULT_CONFIG["direct_selection_min_margin"],
+        )
+    )
+    minimum_average_reward = _coerce_float(
+        policy.config.get(
+            "direct_selection_min_average_reward",
+            _DEFAULT_CONFIG["direct_selection_min_average_reward"],
+        )
+    )
+    direct_selection = (
+        int(top_score["attempts"]) >= minimum_attempts
+        and margin >= minimum_margin
+        and _coerce_float(top_score["average_reward"]) >= minimum_average_reward
+    )
+    confidence = min(
+        0.98,
+        max(
+            0.0,
+            0.55 + max(0.0, margin) * 0.8 + min(int(top_score["attempts"]), 12) * 0.02,
+        ),
+    )
+    reasoning = (
+        f"Learned policy prefers {top_score['workflow_id']} "
+        f"(margin {margin:.2f}; {top_score['reasoning']})."
+    )
+    return {
+        "policy_active": True,
+        "guidance_mode": "direct" if direct_selection else "prompt_guidance",
+        "recommended_workflow_id": top_score["workflow_id"],
+        "confidence_score": round(confidence, 6),
+        "reasoning": reasoning,
+        "snapshot_id": policy.snapshot_id,
+        "candidate_scores": scores,
+        "ranked_candidate_ids": [item["workflow_id"] for item in scores],
+        "selected_workflow_attempts": int(top_score["attempts"]),
+        "selected_exploration_bonus": _coerce_float(top_score["exploration_bonus"]),
+    }
+
+
+def evaluate_selection_policy(
+    *,
+    benchmark_cases: Sequence[Mapping[str, Any]],
+    snapshot: WorkflowSelectionPolicySnapshot | None = None,
+) -> dict[str, Any]:
+    """Evaluate the learned policy against held-out benchmark cases."""
+
+    policy = snapshot if snapshot is not None else get_live_selection_policy()
+    if policy is None:
+        return {
+            "policy_accuracy": 0.0,
+            "baseline_accuracy": 0.0,
+            "accuracy_improvement": 0.0,
+            "case_count": 0,
+            "cases": [],
+        }
+
+    case_results: list[dict[str, Any]] = []
+    baseline_correct = 0
+    policy_correct = 0
+
+    for case in benchmark_cases:
+        expected_workflow_id = _safe_str(case.get("expected_workflow_id"))
+        candidate_workflows = _coerce_candidate_workflows(case.get("candidate_workflows"))
+        if not expected_workflow_id or not candidate_workflows:
+            continue
+        recommendation = recommend_workflow_with_policy(
+            turn_text=_safe_str(case.get("turn_text")),
+            candidate_workflows=candidate_workflows,
+            snapshot=policy,
+        )
+        baseline_workflow_id = _safe_str(case.get("baseline_workflow_id"))
+        if not baseline_workflow_id:
+            baseline_workflow_id = candidate_workflows[0]["concept_id"]
+        policy_workflow_id = _safe_str(recommendation.get("recommended_workflow_id"))
+
+        baseline_hit = baseline_workflow_id == expected_workflow_id
+        policy_hit = policy_workflow_id == expected_workflow_id
+        baseline_correct += 1 if baseline_hit else 0
+        policy_correct += 1 if policy_hit else 0
+        case_results.append(
+            {
+                "turn_text": _safe_str(case.get("turn_text")),
+                "expected_workflow_id": expected_workflow_id,
+                "baseline_workflow_id": baseline_workflow_id,
+                "policy_workflow_id": policy_workflow_id,
+                "baseline_hit": baseline_hit,
+                "policy_hit": policy_hit,
+            }
+        )
+
+    case_count = len(case_results)
+    if case_count == 0:
+        return {
+            "policy_accuracy": 0.0,
+            "baseline_accuracy": 0.0,
+            "accuracy_improvement": 0.0,
+            "case_count": 0,
+            "cases": [],
+        }
+
+    baseline_accuracy = baseline_correct / case_count
+    policy_accuracy = policy_correct / case_count
+    return {
+        "policy_accuracy": round(policy_accuracy, 6),
+        "baseline_accuracy": round(baseline_accuracy, 6),
+        "accuracy_improvement": round(policy_accuracy - baseline_accuracy, 6),
+        "case_count": case_count,
+        "cases": case_results,
+    }
+
+
+__all__ = [
+    "WorkflowSelectionPolicySnapshot",
+    "clear_live_selection_policy",
+    "evaluate_selection_policy",
+    "get_live_selection_policy",
+    "rank_policy_candidates",
+    "recommend_workflow_with_policy",
+    "refresh_live_selection_policy",
+    "set_live_selection_policy",
+    "train_selection_policy",
+]

--- a/src/backend/workflows/workflow_selector.py
+++ b/src/backend/workflows/workflow_selector.py
@@ -27,10 +27,13 @@ from __future__ import annotations
 import json
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Mapping, Optional, Sequence
 
 from src.backend.services.prompt_template_service import PromptTemplateService
+from src.backend.services.workflow_selection_policy_service import (
+    recommend_workflow_with_policy,
+)
 
 from .workflow_registry import WorkflowRegistry
 
@@ -100,6 +103,8 @@ class WorkflowSelection:
     discovered_workflow_ids: tuple[str, ...] = ()
     confidence_score: float = 0.0
     reasoning: str = ""
+    selection_source: str = "selector"
+    selection_metadata: Mapping[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -107,6 +112,7 @@ class WorkflowSelectionPrompt:
     prompt_id: Optional[str]
     prompt_text: str
     discovered_workflow_ids: tuple[str, ...] = ()
+    policy_recommendation: Mapping[str, Any] = field(default_factory=dict)
 
 
 class WorkflowSelector:
@@ -245,20 +251,63 @@ class WorkflowSelector:
     ) -> WorkflowSelectionPrompt:
         """Build the RAG-first ranker prompt from candidate workflows."""
         candidate_ids: list[str] = []
-        candidate_lines: list[str] = []
+        candidate_entries: list[dict[str, str]] = []
 
         if candidate_workflows:
             for wf in candidate_workflows:
                 cid = str(wf.get("concept_id") or "").strip()
                 if not cid:
                     continue
-                candidate_ids.append(cid)
-                name = wf.get("name", cid)
-                desc = wf.get("description", "")
-                entry = f"- {cid}: {name}"
-                if desc:
-                    entry += f" — {desc}"
-                candidate_lines.append(entry)
+                candidate_entries.append(
+                    {
+                        "concept_id": cid,
+                        "name": str(wf.get("name") or cid),
+                        "description": str(wf.get("description") or ""),
+                    }
+                )
+
+        policy_recommendation = recommend_workflow_with_policy(
+            turn_text=turn_text,
+            candidate_workflows=candidate_entries,
+        )
+        ranked_candidate_ids = tuple(
+            str(item)
+            for item in policy_recommendation.get("ranked_candidate_ids", ())
+            if isinstance(item, str) and item
+        )
+        if ranked_candidate_ids:
+            entry_lookup = {
+                item["concept_id"]: item for item in candidate_entries if item.get("concept_id")
+            }
+            reordered_entries: list[dict[str, str]] = []
+            for workflow_id in ranked_candidate_ids:
+                entry = entry_lookup.pop(workflow_id, None)
+                if entry is not None:
+                    reordered_entries.append(entry)
+            reordered_entries.extend(entry_lookup.values())
+            candidate_entries = reordered_entries
+
+        policy_score_lookup = {
+            str(item.get("workflow_id")): item
+            for item in policy_recommendation.get("candidate_scores", ())
+            if isinstance(item, Mapping) and isinstance(item.get("workflow_id"), str)
+        }
+        candidate_lines: list[str] = []
+        for entry_row in candidate_entries:
+            cid = entry_row["concept_id"]
+            candidate_ids.append(cid)
+            entry = f"- {cid}: {entry_row['name']}"
+            if entry_row["description"]:
+                entry += f" — {entry_row['description']}"
+            policy_score = policy_score_lookup.get(cid)
+            if policy_score is not None and policy_recommendation.get("policy_active"):
+                entry += (
+                    " "
+                    f"[policy prior {float(policy_score.get('average_reward', 0.0)):.2f}; "
+                    f"exploration {float(policy_score.get('exploration_bonus', 0.0)):.2f}; "
+                    f"evidence {int(policy_score.get('attempts', 0))}]"
+                )
+            candidate_lines.append(entry)
 
         # If no candidates were provided (e.g. empty capability index),
         # inject the default workflow as the sole candidate.
@@ -296,6 +345,7 @@ class WorkflowSelector:
             prompt_id=prompt_id,
             prompt_text=prompt_text,
             discovered_workflow_ids=tuple(candidate_ids),
+            policy_recommendation=policy_recommendation,
         )
 
     # ------------------------------------------------------------------
@@ -445,6 +495,7 @@ class WorkflowSelector:
             discovered_workflow_ids=candidate_ids,
             confidence_score=confidence_score,
             reasoning=reasoning,
+            selection_source="selector",
         )
 
     # ------------------------------------------------------------------
@@ -507,6 +558,43 @@ class WorkflowSelector:
             prompt_used=prompt_used,
             raw_response=str(raw_response or ""),
             discovered_workflow_ids=tuple(discovered_ids),
+            selection_source="selector",
+        )
+
+    def resolve_policy_selection(
+        self,
+        *,
+        workflow_id: str,
+        prompt_id: Optional[str],
+        prompt_used: str | None,
+        discovered_workflow_ids: Sequence[str] = (),
+        confidence_score: float = 0.0,
+        reasoning: str = "",
+        selection_metadata: Mapping[str, Any] | None = None,
+    ) -> WorkflowSelection:
+        """Resolve a direct learned-policy recommendation into a selection."""
+
+        candidate_ids = tuple(
+            item for item in discovered_workflow_ids if isinstance(item, str) and item
+        )
+        clean_workflow_id = str(workflow_id or "").strip()
+        if clean_workflow_id not in candidate_ids:
+            clean_workflow_id = self._default_workflow_id
+            verdict = "rag_default"
+        else:
+            verdict = "policy_selected"
+
+        return WorkflowSelection(
+            workflow_id=clean_workflow_id,
+            verdict=verdict,
+            prompt_id=prompt_id,
+            prompt_used=prompt_used,
+            raw_response=f"policy::{clean_workflow_id}",
+            discovered_workflow_ids=candidate_ids,
+            confidence_score=max(0.0, min(1.0, float(confidence_score))),
+            reasoning=str(reasoning or ""),
+            selection_source="policy_direct",
+            selection_metadata=dict(selection_metadata or {}),
         )
 
     # ------------------------------------------------------------------

--- a/tests/backend/test_workflow_selector_phase4.py
+++ b/tests/backend/test_workflow_selector_phase4.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+
+import src.backend.db.mongo_client as mongo_client_module
+import src.backend.services.workflow_selection_experience as experience_module
+import src.backend.services.workflow_selection_policy_service as policy_module
+from src.backend.services.prompt_template_service import PromptTemplateService
+from src.backend.workflows import WorkflowRegistry, register_default_workflows
+from src.backend.workflows.definitions import (
+    CHAT_ASSISTANT_WORKFLOW_ID,
+    TODO_REFRESH_WORKFLOW_ID,
+    TOOL_CALLING_WORKFLOW_ID,
+)
+from src.backend.workflows.workflow_selector import WorkflowSelector
+from test_orchestrator_workflow_selector_routing import (
+    _CapturingLLM,
+    _build_orchestrator,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_phase4_selection_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[None, None, None]:
+    monkeypatch.setenv("VON_USE_MOCK_DB", "1")
+    mongo_client_module.close_connection()
+    db = mongo_client_module.get_db()
+    if db is not None:
+        try:
+            db.drop_collection("workflow_selection_experiences")
+        except Exception:
+            pass
+    experience_module.reset_selection_experience()
+    policy_module.clear_live_selection_policy()
+    yield
+    experience_module.reset_selection_experience()
+    policy_module.clear_live_selection_policy()
+    mongo_client_module.close_connection()
+
+
+def _record_completed_example(
+    *,
+    query: str,
+    workflow_id: str,
+    outcome: str,
+    confidence_score: float = 0.9,
+    duration_ms: float = 1200.0,
+    total_tokens: int = 900,
+    selection_source: str = "selector",
+) -> None:
+    entry = experience_module.record_selection_experience(
+        turn_id=f"turn::{query}::{workflow_id}::{outcome}::{confidence_score}",
+        query=query,
+        candidate_workflow_ids=[CHAT_ASSISTANT_WORKFLOW_ID, TODO_REFRESH_WORKFLOW_ID],
+        selected_workflow_id=workflow_id,
+        verdict="rag_selected" if workflow_id else "fallback",
+        selection_source=selection_source,
+        selection_metadata={"selected_exploration_bonus": 0.05},
+        confidence_score=confidence_score,
+        reasoning="Phase 4 training example.",
+        model_name="phase4-test-model",
+        routing_duration_ms=12.0,
+    )
+    experience_module.finalise_selection_experience(
+        experience_id=entry.experience_id,
+        outcome=outcome,
+        outcome_metadata={
+            "orchestrator_duration_ms": duration_ms,
+            "total_tokens": total_tokens,
+            "retry_attempts": 0,
+        },
+        retrain_policy=False,
+    )
+
+
+def _build_selector() -> WorkflowSelector:
+    registry = WorkflowRegistry()
+    register_default_workflows(registry)
+    return WorkflowSelector(
+        registry=registry,
+        prompt_service=PromptTemplateService(),
+    )
+
+
+def _build_rag_first_orchestrator(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
+    orchestrator._workflow_selector = WorkflowSelector(
+        registry=orchestrator._workflow_registry,
+        prompt_service=PromptTemplateService(),
+        classifier_prompt_ids=orchestrator._TURN_SELECTOR_PROMPTS,
+        default_workflow_id=CHAT_ASSISTANT_WORKFLOW_ID,
+    )
+    return orchestrator
+
+
+def test_selection_experience_finalisation_persists_outcome_and_reward() -> None:
+    entry = experience_module.record_selection_experience(
+        turn_id="turn-phase4-persist",
+        query="Refresh my Jira todo list",
+        candidate_workflow_ids=[CHAT_ASSISTANT_WORKFLOW_ID, TODO_REFRESH_WORKFLOW_ID],
+        selected_workflow_id=TODO_REFRESH_WORKFLOW_ID,
+        verdict="policy_selected",
+        selection_source="policy_direct",
+        selection_metadata={"selected_exploration_bonus": 0.12},
+        confidence_score=0.91,
+        reasoning="Historical reward prior strongly favours the Jira refresh workflow.",
+        model_name="policy::unit-test",
+        routing_duration_ms=10.0,
+    )
+
+    finalised = experience_module.finalise_selection_experience(
+        experience_id=entry.experience_id,
+        outcome="completed",
+        outcome_metadata={
+            "orchestrator_duration_ms": 900,
+            "total_tokens": 750,
+            "retry_attempts": 1,
+        },
+        retrain_policy=False,
+    )
+
+    assert finalised is not None
+    assert finalised.outcome == "completed"
+    assert finalised.reward is not None
+    assert finalised.reward > 0.5
+    assert finalised.reward_breakdown["completion_signal"] > 0.0
+
+    persisted = experience_module.list_selection_experiences(limit=5)
+    assert len(persisted) == 1
+    assert persisted[0].experience_id == entry.experience_id
+    assert persisted[0].outcome == "completed"
+
+    snapshot = experience_module.get_selection_experience_snapshot()
+    assert snapshot["aggregates"]["total_selections"] == 1
+    assert snapshot["aggregates"]["completed_count"] == 1
+    assert snapshot["aggregates"]["reward_sample_count"] == 1
+    assert snapshot["aggregates"]["policy_direct"] == 1
+
+
+def test_policy_training_improves_held_out_benchmark_cases() -> None:
+    for _ in range(4):
+        _record_completed_example(
+            query="Refresh my Jira todo list",
+            workflow_id=TODO_REFRESH_WORKFLOW_ID,
+            outcome="completed",
+            confidence_score=0.92,
+            duration_ms=800,
+            total_tokens=650,
+        )
+        _record_completed_example(
+            query="Refresh my Jira todo list",
+            workflow_id=CHAT_ASSISTANT_WORKFLOW_ID,
+            outcome="failed",
+            confidence_score=0.88,
+            duration_ms=3500,
+            total_tokens=2200,
+        )
+        _record_completed_example(
+            query="Hello there",
+            workflow_id=CHAT_ASSISTANT_WORKFLOW_ID,
+            outcome="completed",
+            confidence_score=0.86,
+            duration_ms=700,
+            total_tokens=420,
+        )
+        _record_completed_example(
+            query="Hello there",
+            workflow_id=TODO_REFRESH_WORKFLOW_ID,
+            outcome="failed",
+            confidence_score=0.82,
+            duration_ms=2600,
+            total_tokens=1800,
+        )
+
+    snapshot = policy_module.refresh_live_selection_policy()
+    assert snapshot is not None
+
+    evaluation = policy_module.evaluate_selection_policy(
+        snapshot=snapshot,
+        benchmark_cases=[
+            {
+                "turn_text": "Refresh my Jira todo list",
+                "candidate_workflows": [
+                    {"concept_id": CHAT_ASSISTANT_WORKFLOW_ID, "name": "Chat assistant"},
+                    {"concept_id": TODO_REFRESH_WORKFLOW_ID, "name": "Todo refresh"},
+                ],
+                "baseline_workflow_id": CHAT_ASSISTANT_WORKFLOW_ID,
+                "expected_workflow_id": TODO_REFRESH_WORKFLOW_ID,
+            },
+            {
+                "turn_text": "Refresh my Jira tasks",
+                "candidate_workflows": [
+                    {"concept_id": CHAT_ASSISTANT_WORKFLOW_ID, "name": "Chat assistant"},
+                    {"concept_id": TODO_REFRESH_WORKFLOW_ID, "name": "Todo refresh"},
+                ],
+                "baseline_workflow_id": CHAT_ASSISTANT_WORKFLOW_ID,
+                "expected_workflow_id": TODO_REFRESH_WORKFLOW_ID,
+            },
+            {
+                "turn_text": "Hello there",
+                "candidate_workflows": [
+                    {"concept_id": TODO_REFRESH_WORKFLOW_ID, "name": "Todo refresh"},
+                    {"concept_id": CHAT_ASSISTANT_WORKFLOW_ID, "name": "Chat assistant"},
+                ],
+                "baseline_workflow_id": TODO_REFRESH_WORKFLOW_ID,
+                "expected_workflow_id": CHAT_ASSISTANT_WORKFLOW_ID,
+            },
+            {
+                "turn_text": "Say hello to the user",
+                "candidate_workflows": [
+                    {"concept_id": TODO_REFRESH_WORKFLOW_ID, "name": "Todo refresh"},
+                    {"concept_id": CHAT_ASSISTANT_WORKFLOW_ID, "name": "Chat assistant"},
+                ],
+                "baseline_workflow_id": TODO_REFRESH_WORKFLOW_ID,
+                "expected_workflow_id": CHAT_ASSISTANT_WORKFLOW_ID,
+            },
+        ],
+    )
+
+    assert evaluation["case_count"] == 4
+    assert evaluation["baseline_accuracy"] == 0.0
+    assert evaluation["policy_accuracy"] == 1.0
+    assert evaluation["accuracy_improvement"] > 0.0
+
+
+def test_selector_uses_policy_guidance_for_candidate_ordering_and_direct_selection() -> None:
+    for _ in range(4):
+        _record_completed_example(
+            query="Refresh my Jira todo list",
+            workflow_id=TODO_REFRESH_WORKFLOW_ID,
+            outcome="completed",
+            confidence_score=0.94,
+            duration_ms=820,
+            total_tokens=650,
+        )
+        _record_completed_example(
+            query="Refresh my Jira todo list",
+            workflow_id=CHAT_ASSISTANT_WORKFLOW_ID,
+            outcome="failed",
+            confidence_score=0.88,
+            duration_ms=3200,
+            total_tokens=2100,
+        )
+
+    snapshot = policy_module.refresh_live_selection_policy()
+    assert snapshot is not None
+
+    selector = _build_selector()
+    prompt = selector.prepare_selection_prompt(
+        turn_text="Refresh my Jira todo list",
+        discovered_workflows=[
+            {"concept_id": CHAT_ASSISTANT_WORKFLOW_ID, "name": "Chat assistant"},
+            {"concept_id": TODO_REFRESH_WORKFLOW_ID, "name": "Todo refresh"},
+        ],
+    )
+
+    assert prompt.discovered_workflow_ids[0] == TODO_REFRESH_WORKFLOW_ID
+    assert prompt.policy_recommendation["policy_active"] is True
+    assert prompt.policy_recommendation["guidance_mode"] == "direct"
+    assert (
+        prompt.policy_recommendation["recommended_workflow_id"]
+        == TODO_REFRESH_WORKFLOW_ID
+    )
+
+    resolved = selector.resolve_policy_selection(
+        workflow_id=prompt.policy_recommendation["recommended_workflow_id"],
+        prompt_id=prompt.prompt_id,
+        prompt_used=prompt.prompt_text,
+        discovered_workflow_ids=prompt.discovered_workflow_ids,
+        confidence_score=prompt.policy_recommendation["confidence_score"],
+        reasoning=prompt.policy_recommendation["reasoning"],
+        selection_metadata=prompt.policy_recommendation,
+    )
+    assert resolved.workflow_id == TODO_REFRESH_WORKFLOW_ID
+    assert resolved.verdict == "policy_selected"
+    assert resolved.selection_source == "policy_direct"
+
+
+def test_orchestrator_can_route_via_direct_policy_without_selector_llm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for _ in range(4):
+        _record_completed_example(
+            query="Refresh my Jira todo list",
+            workflow_id=TODO_REFRESH_WORKFLOW_ID,
+            outcome="completed",
+            confidence_score=0.95,
+            duration_ms=780,
+            total_tokens=620,
+        )
+        _record_completed_example(
+            query="Refresh my Jira todo list",
+            workflow_id=TOOL_CALLING_WORKFLOW_ID,
+            outcome="failed",
+            confidence_score=0.86,
+            duration_ms=4200,
+            total_tokens=2400,
+        )
+
+    snapshot = policy_module.refresh_live_selection_policy()
+    assert snapshot is not None
+
+    orchestrator = _build_rag_first_orchestrator(monkeypatch)
+    llm = _CapturingLLM([])
+    discovery_result = {
+        "matches": [
+            {
+                "concept_id": TOOL_CALLING_WORKFLOW_ID,
+                "name": "Tool calling workflow",
+                "description": "General tool pipeline.",
+                "is_executable": True,
+                "executability_reason": "executable_now",
+            },
+            {
+                "concept_id": TODO_REFRESH_WORKFLOW_ID,
+                "name": "Todo refresh workflow",
+                "description": "Refreshes the user's Jira todo list.",
+                "is_executable": True,
+                "executability_reason": "executable_now",
+            },
+        ],
+        "match_count": 2,
+    }
+
+    result = orchestrator.run(
+        prompt="Refresh my Jira todo list",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+        workflow_discovery_result=discovery_result,
+    )
+
+    assert llm.calls == []
+    assert result.workflow_routing is not None
+    assert result.workflow_routing.workflow_id == TODO_REFRESH_WORKFLOW_ID
+    assert result.workflow_routing.source == "policy_direct"
+
+    selector_entry = next(
+        (
+            entry
+            for entry in result.aux_llm_calls
+            if isinstance(entry, dict) and entry.get("type") == "workflow_selector"
+        ),
+        None,
+    )
+    assert selector_entry is not None
+    assert selector_entry.get("selection_source") == "policy_direct"
+    assert selector_entry.get("policy_guidance_mode") == "direct"
+
+    recent = experience_module.get_recent_experiences(limit=1)
+    assert recent[0]["selected_workflow_id"] == TODO_REFRESH_WORKFLOW_ID
+    assert recent[0]["outcome"] == "completed"


### PR DESCRIPTION
## Summary
- persist workflow-selection experiences with completion outcomes and reward breakdowns
- add a lightweight learned policy layer that ranks candidates and can short-circuit selector LLM calls when confidence is strong
- wire the orchestrator to record/finalise selection outcomes and add Phase 4 regression coverage

## Validation
- `pdm run pyright src/backend/integrations/internal_mcp/orchestrator.py src/backend/services/workflow_selection_experience.py src/backend/services/workflow_selection_policy_service.py src/backend/workflows/workflow_selector.py tests/backend/test_workflow_selector_phase4.py`
- `pdm run pytest tests/backend/test_workflow_selector_phase3.py tests/backend/test_workflow_selector_phase4.py tests/backend/test_workflow_selector_rag_first.py -q`
- `pdm run pytest tests/backend/test_orchestrator_workflow_selector_routing.py::test_selector_fires_without_presenter_mode tests/backend/test_orchestrator_workflow_selector_routing.py::test_selector_receives_discovered_workflows tests/backend/test_orchestrator_workflow_selector_routing.py::test_non_executable_discovered_workflow_filtered_by_default tests/backend/test_orchestrator_workflow_selector_routing.py::test_non_standard_workflow_routes_via_execute_workflow tests/backend/test_orchestrator_workflow_selector_routing.py::test_custom_tool_pipeline_workflow_dispatches_without_id_special_casing tests/backend/test_orchestrator_workflow_selector_routing.py::test_plain_response_skips_tool_calling tests/backend/test_orchestrator_workflow_selector_routing.py::test_tool_seeking_has_routing_info tests/backend/test_orchestrator_workflow_selector_routing.py::test_routing_duration_ms_in_aux_llm_calls -q`

## Notes
- `tests/backend/test_orchestrator_durable_instance_telemetry.py` and `tests/backend/test_internal_mcp_orchestrator_preflight.py` exceeded the interactive timeout window in this session without surfacing concrete failures.