### PR TITLE
JVNAUTOSCI-1518 route durable launches through verified submission

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -18313,6 +18313,9 @@ class InternalMCPChatOrchestrator:
         ):
             try:
                 from ...workflows.durable import WorkflowInstanceManager
+                from ...workflows.durable.workflow_instance_submission_service import (
+                    submit_verified_workflow_instance,
+                )
 
                 durable_instance_manager = WorkflowInstanceManager()
                 source_event_type = (
@@ -18328,10 +18331,8 @@ class InternalMCPChatOrchestrator:
                         f"{workflow_id}:{source_event_type}:{source_event_id}:"
                         f"{str(resolved_stage or '').strip()}"
                     )
-                    (
-                        durable_instance_id,
-                        durable_instance_created_new,
-                    ) = durable_instance_manager.create_instance_for_event(
+                    submission = submit_verified_workflow_instance(
+                        manager=durable_instance_manager,
                         workflow_id=workflow_id,
                         user_id=resolved_user_id,
                         org_id=resolved_org_id,
@@ -18343,15 +18344,25 @@ class InternalMCPChatOrchestrator:
                         max_retries=0,
                     )
                 else:
-                    durable_instance_id = durable_instance_manager.create_instance(
-                        workflow_id,
+                    submission = submit_verified_workflow_instance(
+                        manager=durable_instance_manager,
+                        workflow_id=workflow_id,
                         user_id=resolved_user_id,
                         org_id=resolved_org_id,
                         namespace=resolved_namespace,
                         inputs=_build_durable_inputs_snapshot(),
                         max_retries=0,
                     )
-                    durable_instance_created_new = True
+                if not submission.success or not submission.instance_id:
+                    raise RuntimeError(
+                        submission.error
+                        or (
+                            "Verified durable workflow submission failed "
+                            f"for {workflow_id}"
+                        )
+                    )
+                durable_instance_id = submission.instance_id
+                durable_instance_created_new = submission.created_new
             except Exception as exc:
                 self._logger.warning(
                     "[workflow_instance_telemetry] Failed to create durable instance "

--- a/src/backend/services/rag_text_relation_sync_service.py
+++ b/src/backend/services/rag_text_relation_sync_service.py
@@ -529,6 +529,9 @@ def submit_durable_rag_sync(
         from ..workflows.durable.rag_sync_workflow import (
             RAG_TEXT_RELATION_SYNC_WORKFLOW_ID,
         )
+        from ..workflows.durable.workflow_instance_submission_service import (
+            submit_verified_workflow_instance,
+        )
 
         instance_manager = get_instance_manager()
 
@@ -545,20 +548,34 @@ def submit_durable_rag_sync(
         if concept_ids:
             inputs["concept_ids"] = list(concept_ids)
 
-        # Create and submit the instance
-        instance_id = instance_manager.create_instance(
-            RAG_TEXT_RELATION_SYNC_WORKFLOW_ID,
+        submission = submit_verified_workflow_instance(
+            manager=instance_manager,
+            workflow_id=RAG_TEXT_RELATION_SYNC_WORKFLOW_ID,
             user_id=user_id,
             org_id=org_id,
             namespace=namespace,
             inputs=inputs,
         )
+        if not submission.success:
+            return {
+                "success": False,
+                "workflow_id": RAG_TEXT_RELATION_SYNC_WORKFLOW_ID,
+                "namespace": namespace,
+                "error": str(submission.error or "workflow_submission_failed"),
+                "error_code": submission.error_code,
+                "verification": dict(submission.verification),
+                "submission_status": submission.status,
+                "instance_id": submission.instance_id,
+            }
 
         return {
             "success": True,
-            "instance_id": instance_id,
+            "instance_id": submission.instance_id,
             "workflow_id": RAG_TEXT_RELATION_SYNC_WORKFLOW_ID,
             "namespace": namespace,
+            "verification": dict(submission.verification),
+            "submission_status": submission.status,
+            "created_new": submission.created_new,
         }
 
     except Exception as exc:

--- a/src/backend/services/workflow_event_integration_service.py
+++ b/src/backend/services/workflow_event_integration_service.py
@@ -20,6 +20,9 @@ from .feature_flags import (
 )
 from ..workflows.durable.models import EventWorkflowBinding
 from ..workflows.durable.startup import get_instance_manager
+from ..workflows.durable.workflow_instance_submission_service import (
+    submit_verified_workflow_instance,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -967,8 +970,9 @@ def _launch_single_event_binding(
         }
 
     instance_create_started = perf_counter()
-    instance_id, created_new = manager.create_instance_for_event(
-        resolved_workflow_id,
+    submission = submit_verified_workflow_instance(
+        manager=manager,
+        workflow_id=resolved_workflow_id,
         user_id=(user_id or "anonymous"),
         org_id=(org_id or "default"),
         namespace=namespace,
@@ -981,6 +985,32 @@ def _launch_single_event_binding(
         (perf_counter() - instance_create_started) * 1000.0,
         3,
     )
+    if not submission.success:
+        return {
+            "success": False,
+            "triggered": False,
+            "outcome": "not_triggered",
+            "reason": str(submission.error_code or "workflow_submission_failed"),
+            "hint": str(
+                submission.error
+                or "Verified workflow submission rejected this event launch."
+            ),
+            "workflow_id": resolved_workflow_id,
+            "instance_id": submission.instance_id,
+            "event_type": event_type,
+            "event_id": safe_event_id,
+            "idempotency_key": event_idempotency_key,
+            "idempotent_reused": False,
+            "verification": dict(submission.verification),
+            "submission_status": submission.status,
+            "launch_check_timings_ms": {
+                **launch_check_timings_ms,
+                "total_ms": round((perf_counter() - launch_checks_started) * 1000.0, 3),
+            },
+        }
+
+    instance_id = submission.instance_id
+    created_new = submission.created_new is not False
 
     logger.info(
         "[workflow_event] %s event=%s workflow=%s instance=%s created_new=%s",
@@ -1009,6 +1039,8 @@ def _launch_single_event_binding(
         "event_id": safe_event_id,
         "idempotency_key": event_idempotency_key,
         "idempotent_reused": not created_new,
+        "verification": dict(submission.verification),
+        "submission_status": submission.status,
         "cadence_policy": cadence_gate.get("policy"),
         "cadence_policy_source": cadence_gate.get("policy_source"),
         "launch_check_timings_ms": {

--- a/src/backend/workflows/durable/workflow_instance_submission_service.py
+++ b/src/backend/workflows/durable/workflow_instance_submission_service.py
@@ -103,6 +103,7 @@ class WorkflowInstanceSubmissionResult:
     status: str
     instance_id: str | None
     verification: Mapping[str, Any]
+    created_new: bool | None = None
     error_code: str | None = None
     error: str | None = None
 
@@ -115,6 +116,8 @@ class WorkflowInstanceSubmissionResult:
         }
         if isinstance(self.instance_id, str) and self.instance_id:
             payload["instance_id"] = self.instance_id
+        if isinstance(self.created_new, bool):
+            payload["created_new"] = self.created_new
         if isinstance(self.error_code, str) and self.error_code:
             payload["error_code"] = self.error_code
         if isinstance(self.error, str) and self.error:
@@ -861,6 +864,7 @@ def submit_verified_workflow_instance(
     """Create a durable workflow instance only when runnable verification passes."""
 
     workflow_id = str(workflow_id or "").strip()
+    inputs_payload = dict(inputs or {})
     preflight = verify_workflow_runnable(workflow_id)
     verification_payload = _build_submission_verification_payload(
         preflight=preflight,
@@ -879,27 +883,53 @@ def submit_verified_workflow_instance(
                 "instance was not created."
             ),
             verification=verification_payload,
+            created_new=None,
         )
 
-    instance_id = manager.create_instance(
-        workflow_id,
-        user_id=user_id,
-        org_id=org_id,
-        namespace=namespace,
-        inputs=dict(inputs or {}),
-        schedule_id=schedule_id,
-        max_retries=max_retries,
-        source_event_type=source_event_type,
-        source_event_id=source_event_id,
-        event_idempotency_key=event_idempotency_key,
+    use_event_idempotency_submission = all(
+        isinstance(value, str) and value.strip()
+        for value in (
+            source_event_type,
+            source_event_id,
+            event_idempotency_key,
+        )
     )
+    created_new = True
+    if use_event_idempotency_submission:
+        instance_id, created_new = manager.create_instance_for_event(
+            workflow_id=workflow_id,
+            user_id=user_id,
+            org_id=org_id,
+            namespace=namespace,
+            event_idempotency_key=str(event_idempotency_key).strip(),
+            source_event_type=str(source_event_type).strip(),
+            source_event_id=str(source_event_id).strip(),
+            inputs=inputs_payload,
+            schedule_id=schedule_id,
+            max_retries=max_retries,
+        )
+    else:
+        instance_id = manager.create_instance(
+            workflow_id,
+            user_id=user_id,
+            org_id=org_id,
+            namespace=namespace,
+            inputs=inputs_payload,
+            schedule_id=schedule_id,
+            max_retries=max_retries,
+            source_event_type=source_event_type,
+            source_event_id=source_event_id,
+            event_idempotency_key=event_idempotency_key,
+        )
 
-    postflight = verify_workflow_runnable(workflow_id)
+    # Idempotent event reuse should not retroactively fail a previously created
+    # instance if the workflow definition drifts after the original launch.
+    postflight = preflight if not created_new else verify_workflow_runnable(workflow_id)
     verification_payload = _build_submission_verification_payload(
         preflight=preflight,
         postflight=postflight,
     )
-    if not postflight.runnable_verification_success:
+    if created_new and not postflight.runnable_verification_success:
         manager.mark_failed(
             instance_id,
             error=f"workflow_postflight_not_runnable:{workflow_id}",
@@ -916,14 +946,16 @@ def submit_verified_workflow_instance(
                 "instance marked failed."
             ),
             verification=verification_payload,
+            created_new=True,
         )
 
     return WorkflowInstanceSubmissionResult(
         success=True,
         workflow_id=workflow_id,
-        status="pending",
+        status="pending" if created_new else "reused",
         instance_id=instance_id,
         verification=verification_payload,
+        created_new=created_new,
     )
 
 

--- a/tests/backend/test_durable_submission_guardrails.py
+++ b/tests/backend/test_durable_submission_guardrails.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import re
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_ROOT = PROJECT_ROOT / "src" / "backend"
+DIRECT_CREATE_PATTERN = re.compile(r"\.create_instance(?:_for_event)?\(")
+
+# JVNAUTOSCI-1518: user-facing durable launches must route through the verified
+# submission service. These internals remain the only allowed direct callers.
+ALLOWED_DIRECT_CREATE_CALLSITES = {
+    "src/backend/workflows/durable/durable_executor.py",
+    "src/backend/workflows/durable/instance_manager.py",
+    "src/backend/workflows/durable/workflow_instance_submission_service.py",
+}
+
+
+def test_direct_durable_instance_creation_is_restricted_to_authoritative_paths() -> None:
+    offenders: list[str] = []
+    for path in sorted(BACKEND_ROOT.rglob("*.py")):
+        relative_path = path.relative_to(PROJECT_ROOT).as_posix()
+        if not DIRECT_CREATE_PATTERN.search(path.read_text(encoding="utf-8")):
+            continue
+        if relative_path not in ALLOWED_DIRECT_CREATE_CALLSITES:
+            offenders.append(relative_path)
+
+    assert offenders == [], (
+        "Direct durable instance creation bypasses the verified submission pathway. "
+        "Route user-facing launches through "
+        "workflow_instance_submission_service.submit_verified_workflow_instance(). "
+        f"Offending files: {offenders}"
+    )

--- a/tests/backend/test_orchestrator_durable_instance_telemetry.py
+++ b/tests/backend/test_orchestrator_durable_instance_telemetry.py
@@ -8,6 +8,9 @@ import pytest
 from src.backend.integrations.internal_mcp.orchestrator import (
     InternalMCPChatOrchestrator,
 )
+from src.backend.workflows.durable.workflow_instance_submission_service import (
+    WorkflowInstanceSubmissionResult,
+)
 from src.backend.workflows import (
     WorkflowDefinition,
     WorkflowStateSpec,
@@ -64,11 +67,71 @@ def _build_orchestrator() -> InternalMCPChatOrchestrator:
     return InternalMCPChatOrchestrator(gateway=cast(Any, _DummyGateway()))
 
 
+def _patch_submit_verified_instance(monkeypatch) -> None:
+    def _fake_submit_verified_workflow_instance(**kwargs: Any):
+        manager = kwargs["manager"]
+        workflow_id = str(kwargs.get("workflow_id") or "").strip()
+        inputs = kwargs.get("inputs")
+        source_event_type = kwargs.get("source_event_type")
+        source_event_id = kwargs.get("source_event_id")
+        event_idempotency_key = kwargs.get("event_idempotency_key")
+        if (
+            isinstance(source_event_type, str)
+            and source_event_type.strip()
+            and isinstance(source_event_id, str)
+            and source_event_id.strip()
+            and isinstance(event_idempotency_key, str)
+            and event_idempotency_key.strip()
+        ):
+            instance_id, created_new = manager.create_instance_for_event(
+                workflow_id=workflow_id,
+                user_id=str(kwargs.get("user_id") or "anonymous"),
+                org_id=str(kwargs.get("org_id") or "default"),
+                namespace=str(kwargs.get("namespace") or "anonymous/default"),
+                event_idempotency_key=event_idempotency_key,
+                source_event_type=source_event_type,
+                source_event_id=source_event_id,
+                inputs=dict(inputs or {}),
+                max_retries=int(kwargs.get("max_retries", 3) or 0),
+            )
+            status = "pending" if created_new else "reused"
+        else:
+            instance_id = manager.create_instance(
+                workflow_id,
+                user_id=str(kwargs.get("user_id") or "anonymous"),
+                org_id=str(kwargs.get("org_id") or "default"),
+                namespace=str(kwargs.get("namespace") or "anonymous/default"),
+                inputs=dict(inputs or {}),
+                max_retries=int(kwargs.get("max_retries", 3) or 0),
+            )
+            created_new = True
+            status = "pending"
+
+        return WorkflowInstanceSubmissionResult(
+            success=True,
+            workflow_id=workflow_id,
+            status=status,
+            instance_id=instance_id,
+            verification={
+                "preflight_passed": True,
+                "postflight_passed": True,
+                "runnable_verification_success": True,
+            },
+            created_new=created_new,
+        )
+
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.workflow_instance_submission_service.submit_verified_workflow_instance",
+        _fake_submit_verified_workflow_instance,
+    )
+
+
 def test_execute_workflow_persists_completed_durable_instance_with_turn_summary(
     monkeypatch,
 ) -> None:
     orchestrator = _build_orchestrator()
     fake_manager = _FakeWorkflowInstanceManager()
+    _patch_submit_verified_instance(monkeypatch)
 
     monkeypatch.setattr(
         "src.backend.workflows.durable.WorkflowInstanceManager",
@@ -234,6 +297,7 @@ def test_execute_workflow_marks_durable_instance_failed_on_exception(
 ) -> None:
     orchestrator = _build_orchestrator()
     fake_manager = _FakeWorkflowInstanceManager()
+    _patch_submit_verified_instance(monkeypatch)
 
     monkeypatch.setattr(
         "src.backend.workflows.durable.WorkflowInstanceManager",
@@ -294,6 +358,7 @@ def test_execute_workflow_materialises_terminal_effect_evidence_on_gateway_path(
 ) -> None:
     orchestrator = _build_orchestrator()
     fake_manager = _FakeWorkflowInstanceManager()
+    _patch_submit_verified_instance(monkeypatch)
 
     monkeypatch.setattr(
         "src.backend.workflows.durable.WorkflowInstanceManager",

--- a/tests/backend/test_rag_sync_workflow.py
+++ b/tests/backend/test_rag_sync_workflow.py
@@ -267,17 +267,33 @@ class TestSubmitDurableRagSync:
         from src.backend.workflows.durable.instance_manager import (
             WorkflowInstanceManager,
         )
+        from src.backend.workflows.durable.workflow_instance_submission_service import (
+            WorkflowInstanceSubmissionResult,
+        )
 
         # Enable workflows and mock the startup module
         with patch.dict(os.environ, {"VON_DURABLE_WORKFLOWS_ENABLE": "1"}):
             # Mock the instance manager
             mock_manager = MagicMock(spec=WorkflowInstanceManager)
-            mock_manager.create_instance.return_value = "test-instance-id"
 
             with patch(
                 "src.backend.workflows.durable.startup.get_instance_manager",
                 return_value=mock_manager,
-            ):
+            ), patch(
+                "src.backend.workflows.durable.workflow_instance_submission_service.submit_verified_workflow_instance",
+                return_value=WorkflowInstanceSubmissionResult(
+                    success=True,
+                    workflow_id="#V#rag_text_relation_sync_workflow",
+                    status="pending",
+                    instance_id="test-instance-id",
+                    verification={
+                        "preflight_passed": True,
+                        "postflight_passed": True,
+                        "runnable_verification_success": True,
+                    },
+                    created_new=True,
+                ),
+            ) as mock_submit:
                 # Import after patching
                 from src.backend.services.rag_text_relation_sync_service import (
                     submit_durable_rag_sync,
@@ -295,9 +311,11 @@ class TestSubmitDurableRagSync:
         assert result["success"] is True
         assert result["instance_id"] == "test-instance-id"
         assert result["namespace"] == "#V#test"
+        assert result["created_new"] is True
+        assert result["submission_status"] == "pending"
+        assert result["verification"]["runnable_verification_success"] is True
 
-        # Verify create_instance was called
-        mock_manager.create_instance.assert_called_once()
+        mock_submit.assert_called_once()
 
 
 class TestWorkflowRegistration:

--- a/tests/backend/test_workflow_event_integration_service.py
+++ b/tests/backend/test_workflow_event_integration_service.py
@@ -8,6 +8,9 @@ from unittest.mock import MagicMock, patch
 
 from src.backend.services import workflow_event_integration_service as workflow_event_service
 from src.backend.workflows.durable.models import EventWorkflowBinding
+from src.backend.workflows.durable.workflow_instance_submission_service import (
+    WorkflowInstanceSubmissionResult,
+)
 from src.backend.services.workflow_event_integration_service import (
     DEFAULT_FILE_COPY_UPLOADED_WORKFLOW_ID,
     EVENT_TYPE_CONCEPT_UPDATED,
@@ -22,6 +25,26 @@ from src.backend.services.workflow_event_integration_service import (
     maybe_launch_vontology_mutation_workflow,
     maybe_launch_task_status_workflow,
 )
+
+
+def _submission_result(
+    *,
+    workflow_id: str,
+    instance_id: str,
+    created_new: bool,
+) -> WorkflowInstanceSubmissionResult:
+    return WorkflowInstanceSubmissionResult(
+        success=True,
+        workflow_id=workflow_id,
+        status="pending" if created_new else "reused",
+        instance_id=instance_id,
+        verification={
+            "preflight_passed": True,
+            "postflight_passed": True,
+            "runnable_verification_success": True,
+        },
+        created_new=created_new,
+    )
 
 
 def test_launch_event_workflow_integration_flag_disables_trigger(monkeypatch) -> None:
@@ -93,16 +116,23 @@ def test_launch_event_workflow_creates_instance_when_configured(
     monkeypatch.setenv("VON_EVENT_TASK_CREATED_WORKFLOW_ID", "#V#task_event_workflow")
 
     mock_manager = MagicMock()
-    mock_manager.create_instance_for_event.return_value = ("instance-123", True)
     mock_get_instance_manager.return_value = mock_manager
 
-    result = launch_event_workflow(
-        event_type=EVENT_TYPE_TASK_CREATED,
-        event_id="task-1",
-        user_id="#V#user_alice",
-        org_id="#V#org_nao",
-        inputs={"task_concept_id": "#V#task_1"},
-    )
+    with patch(
+        "src.backend.services.workflow_event_integration_service.submit_verified_workflow_instance",
+        return_value=_submission_result(
+            workflow_id="#V#task_event_workflow",
+            instance_id="instance-123",
+            created_new=True,
+        ),
+    ) as mock_submit:
+        result = launch_event_workflow(
+            event_type=EVENT_TYPE_TASK_CREATED,
+            event_id="task-1",
+            user_id="#V#user_alice",
+            org_id="#V#org_nao",
+            inputs={"task_concept_id": "#V#task_1"},
+        )
 
     assert result["success"] is True
     assert result["triggered"] is True
@@ -117,9 +147,9 @@ def test_launch_event_workflow_creates_instance_when_configured(
     assert "instance_create_ms" in timings
     assert "total_ms" in timings
 
-    called_args = mock_manager.create_instance_for_event.call_args
+    called_args = mock_submit.call_args
     assert called_args is not None
-    assert called_args.args[0] == "#V#task_event_workflow"
+    assert called_args.kwargs["workflow_id"] == "#V#task_event_workflow"
     assert called_args.kwargs["source_event_type"] == EVENT_TYPE_TASK_CREATED
     assert called_args.kwargs["source_event_id"] == "task-1"
     assert called_args.kwargs["namespace"] == "#V#user_alice/#V#org_nao"
@@ -138,16 +168,23 @@ def test_launch_event_workflow_reports_reused_idempotent_instance(
     monkeypatch.setenv("VON_EVENT_TASK_CREATED_WORKFLOW_ID", "#V#task_event_workflow")
 
     mock_manager = MagicMock()
-    mock_manager.create_instance_for_event.return_value = ("instance-123", False)
     mock_get_instance_manager.return_value = mock_manager
 
-    result = launch_event_workflow(
-        event_type=EVENT_TYPE_TASK_CREATED,
-        event_id="task-1",
-        user_id="#V#user_alice",
-        org_id="#V#org_nao",
-        inputs={"task_concept_id": "#V#task_1"},
-    )
+    with patch(
+        "src.backend.services.workflow_event_integration_service.submit_verified_workflow_instance",
+        return_value=_submission_result(
+            workflow_id="#V#task_event_workflow",
+            instance_id="instance-123",
+            created_new=False,
+        ),
+    ) as mock_submit:
+        result = launch_event_workflow(
+            event_type=EVENT_TYPE_TASK_CREATED,
+            event_id="task-1",
+            user_id="#V#user_alice",
+            org_id="#V#org_nao",
+            inputs={"task_concept_id": "#V#task_1"},
+        )
 
     assert result["success"] is True
     assert result["triggered"] is False
@@ -163,6 +200,7 @@ def test_launch_event_workflow_reports_reused_idempotent_instance(
     assert result["reused_count"] == 1
     assert result["success_count"] == 1
     assert result["failure_count"] == 0
+    assert mock_submit.call_args is not None
 
 
 def test_maybe_launch_task_status_workflow_skips_unconfigured_status(monkeypatch) -> None:
@@ -372,23 +410,30 @@ def test_launch_event_workflow_uses_persistent_binding_input_mapping(
     )
     mock_manager = MagicMock()
     mock_manager.list_event_bindings.return_value = [binding]
-    mock_manager.create_instance_for_event.return_value = ("instance-999", True)
     mock_get_instance_manager.return_value = mock_manager
 
-    result = launch_event_workflow(
-        event_type="type.created",
-        event_id="#V#my_new_type",
-        user_id="#V#user_alice",
-        org_id="#V#org_nao",
-        inputs={"seed": "abc-123"},
-        event_payload={"concept_id": "#V#my_new_type"},
-    )
+    with patch(
+        "src.backend.services.workflow_event_integration_service.submit_verified_workflow_instance",
+        return_value=_submission_result(
+            workflow_id="#V#salient_predicate_governance_workflow",
+            instance_id="instance-999",
+            created_new=True,
+        ),
+    ) as mock_submit:
+        result = launch_event_workflow(
+            event_type="type.created",
+            event_id="#V#my_new_type",
+            user_id="#V#user_alice",
+            org_id="#V#org_nao",
+            inputs={"seed": "abc-123"},
+            event_payload={"concept_id": "#V#my_new_type"},
+        )
 
     assert result["success"] is True
     assert result["triggered"] is True
     assert result["workflow_id"] == "#V#salient_predicate_governance_workflow"
 
-    called_args = mock_manager.create_instance_for_event.call_args
+    called_args = mock_submit.call_args
     assert called_args is not None
     workflow_inputs = called_args.kwargs["inputs"]
     assert workflow_inputs["type_concept_id"] == "#V#my_new_type"
@@ -416,20 +461,27 @@ def test_launch_event_workflow_resolves_braced_event_mapping_expression(
     )
     mock_manager = MagicMock()
     mock_manager.list_event_bindings.return_value = [binding]
-    mock_manager.create_instance_for_event.return_value = ("instance-1000", True)
     mock_get_instance_manager.return_value = mock_manager
 
-    result = launch_event_workflow(
-        event_type="type.created",
-        event_id="#V#my_new_type",
-        user_id="#V#user_alice",
-        org_id="#V#org_nao",
-        event_payload={"concept_id": "#V#my_new_type"},
-    )
+    with patch(
+        "src.backend.services.workflow_event_integration_service.submit_verified_workflow_instance",
+        return_value=_submission_result(
+            workflow_id="#V#salient_predicate_governance_workflow",
+            instance_id="instance-1000",
+            created_new=True,
+        ),
+    ) as mock_submit:
+        result = launch_event_workflow(
+            event_type="type.created",
+            event_id="#V#my_new_type",
+            user_id="#V#user_alice",
+            org_id="#V#org_nao",
+            event_payload={"concept_id": "#V#my_new_type"},
+        )
 
     assert result["success"] is True
     assert result["triggered"] is True
-    called_args = mock_manager.create_instance_for_event.call_args
+    called_args = mock_submit.call_args
     assert called_args is not None
     workflow_inputs = called_args.kwargs["inputs"]
     assert workflow_inputs["target_type_id"] == "#V#my_new_type"
@@ -453,22 +505,29 @@ def test_launch_event_workflow_uses_namespace_override_for_tenancy(
     )
     mock_manager = MagicMock()
     mock_manager.list_event_bindings.return_value = [binding]
-    mock_manager.create_instance_for_event.return_value = ("instance-ns-1", True)
     mock_get_instance_manager.return_value = mock_manager
 
-    result = launch_event_workflow(
-        event_type="type.created",
-        event_id="#V#my_new_type",
-        user_id=None,
-        org_id=None,
-        namespace="#V#user_alice@org_nao",
-        event_payload={"concept_id": "#V#my_new_type"},
-    )
+    with patch(
+        "src.backend.services.workflow_event_integration_service.submit_verified_workflow_instance",
+        return_value=_submission_result(
+            workflow_id="#V#salient_predicate_governance_workflow",
+            instance_id="instance-ns-1",
+            created_new=True,
+        ),
+    ) as mock_submit:
+        result = launch_event_workflow(
+            event_type="type.created",
+            event_id="#V#my_new_type",
+            user_id=None,
+            org_id=None,
+            namespace="#V#user_alice@org_nao",
+            event_payload={"concept_id": "#V#my_new_type"},
+        )
 
     assert result["success"] is True
     assert result["triggered"] is True
 
-    called_args = mock_manager.create_instance_for_event.call_args
+    called_args = mock_submit.call_args
     assert called_args is not None
     assert called_args.kwargs["user_id"] == "#V#user_alice"
     assert called_args.kwargs["org_id"] == "#V#org_nao"
@@ -485,21 +544,28 @@ def test_launch_event_workflow_uses_user_only_namespace_when_org_unknown(
     monkeypatch.setenv("VON_EVENT_TASK_CREATED_WORKFLOW_ID", "#V#task_event_workflow")
 
     mock_manager = MagicMock()
-    mock_manager.create_instance_for_event.return_value = ("instance-user-only", True)
     mock_get_instance_manager.return_value = mock_manager
 
-    result = launch_event_workflow(
-        event_type=EVENT_TYPE_TASK_CREATED,
-        event_id="task-namespace-user-only",
-        user_id="#V#user_alice",
-        org_id=None,
-        inputs={"task_concept_id": "#V#task_99"},
-    )
+    with patch(
+        "src.backend.services.workflow_event_integration_service.submit_verified_workflow_instance",
+        return_value=_submission_result(
+            workflow_id="#V#task_event_workflow",
+            instance_id="instance-user-only",
+            created_new=True,
+        ),
+    ) as mock_submit:
+        result = launch_event_workflow(
+            event_type=EVENT_TYPE_TASK_CREATED,
+            event_id="task-namespace-user-only",
+            user_id="#V#user_alice",
+            org_id=None,
+            inputs={"task_concept_id": "#V#task_99"},
+        )
 
     assert result["success"] is True
     assert result["triggered"] is True
 
-    called_args = mock_manager.create_instance_for_event.call_args
+    called_args = mock_submit.call_args
     assert called_args is not None
     assert called_args.kwargs["namespace"] == "#V#user_alice"
 
@@ -523,24 +589,27 @@ def test_launch_event_workflow_blocks_when_cadence_window_is_active(
     mock_get_instance_manager.return_value = mock_manager
 
     with patch(
-        "src.backend.services.workflow_event_integration_service._workflow_background_launch_policy_for_id",
-        return_value=(
-            {
-                "schema_version": "workflow_background_launch_policy.v1",
-                "enabled": True,
-                "min_interval_seconds": 300,
-                "scope": "global_per_server",
-                "applies_to_sources": ["event"],
-            },
-            "text_relation:#V#hasBackgroundLaunchPolicyJson",
-        ),
-    ):
-        result = launch_event_workflow(
-            event_type=EVENT_TYPE_TASK_CREATED,
-            event_id="task-cadence-1",
-            user_id="#V#user_alice",
-            org_id="#V#org_nao",
-        )
+        "src.backend.services.workflow_event_integration_service.submit_verified_workflow_instance",
+    ) as mock_submit:
+        with patch(
+            "src.backend.services.workflow_event_integration_service._workflow_background_launch_policy_for_id",
+            return_value=(
+                {
+                    "schema_version": "workflow_background_launch_policy.v1",
+                    "enabled": True,
+                    "min_interval_seconds": 300,
+                    "scope": "global_per_server",
+                    "applies_to_sources": ["event"],
+                },
+                "text_relation:#V#hasBackgroundLaunchPolicyJson",
+            ),
+        ):
+            result = launch_event_workflow(
+                event_type=EVENT_TYPE_TASK_CREATED,
+                event_id="task-cadence-1",
+                user_id="#V#user_alice",
+                org_id="#V#org_nao",
+            )
 
     assert result["success"] is True
     assert result["triggered"] is False
@@ -550,6 +619,7 @@ def test_launch_event_workflow_blocks_when_cadence_window_is_active(
     assert isinstance(retry_after_seconds, int)
     assert retry_after_seconds > 0
     assert result.get("cadence_policy_source") == "text_relation:#V#hasBackgroundLaunchPolicyJson"
+    mock_submit.assert_not_called()
     mock_manager.create_instance_for_event.assert_not_called()
 
 
@@ -575,6 +645,8 @@ def test_launch_event_workflow_idempotent_reuse_takes_precedence_over_cadence(
     mock_get_instance_manager.return_value = mock_manager
 
     with patch(
+        "src.backend.services.workflow_event_integration_service.submit_verified_workflow_instance",
+    ) as mock_submit, patch(
         "src.backend.services.workflow_event_integration_service._workflow_background_launch_policy_for_id",
         return_value=(
             {
@@ -600,6 +672,7 @@ def test_launch_event_workflow_idempotent_reuse_takes_precedence_over_cadence(
     assert result["reason"] == "idempotent_reuse"
     assert result["idempotent_reused"] is True
     assert result["instance_id"] == "instance-existing"
+    mock_submit.assert_not_called()
     mock_manager.create_instance_for_event.assert_not_called()
 
 

--- a/tests/backend/test_workflow_instance_submission_service.py
+++ b/tests/backend/test_workflow_instance_submission_service.py
@@ -4,7 +4,9 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from src.backend.workflows.durable.workflow_instance_submission_service import (
+    WorkflowRunnableVerification,
     invalidate_workflow_runnable_verification_cache,
+    submit_verified_workflow_instance,
     verify_workflow_runnable,
 )
 from src.backend.workflows.engine import (
@@ -78,6 +80,25 @@ def _make_action_registry(*, supports_action: bool, fallback: bool = False) -> M
     else:
         registry.has.return_value = False
     return registry
+
+
+def _make_verification(
+    *,
+    workflow_id: str = "#V#candidate_workflow",
+    runnable: bool = True,
+) -> WorkflowRunnableVerification:
+    return WorkflowRunnableVerification(
+        workflow_id=workflow_id,
+        conceptual_representation_success=runnable,
+        executable_registration_success=runnable,
+        runnable_verification_success=runnable,
+        fallback_action_routing_enabled=False,
+        discovered_action_ids=(),
+        unsupported_action_ids=(),
+        integrity_issues=(),
+        warnings=(),
+        errors=(),
+    )
 
 
 def test_verify_workflow_runnable_rejects_initial_vacuous_step() -> None:
@@ -586,3 +607,66 @@ def test_verify_workflow_runnable_accepts_resolved_subworkflow_contract() -> Non
     assert verification.runnable_verification_success is True
     assert "workflow_subworkflow_unresolved" not in verification.errors
     assert "workflow_subworkflow_contract_mismatch" not in verification.errors
+
+
+def test_submit_verified_workflow_instance_uses_event_idempotent_creation() -> None:
+    manager = MagicMock()
+    manager.create_instance_for_event.return_value = ("instance-evt-1", True)
+    verification = _make_verification()
+
+    with patch(
+        "src.backend.workflows.durable.workflow_instance_submission_service.verify_workflow_runnable",
+        side_effect=[verification, verification],
+    ) as mock_verify:
+        result = submit_verified_workflow_instance(
+            manager=manager,
+            workflow_id="#V#candidate_workflow",
+            user_id="#V#user_alice",
+            org_id="#V#org_nao",
+            namespace="#V#user_alice/#V#org_nao",
+            inputs={"seed": "abc-123"},
+            source_event_type="task.created",
+            source_event_id="task-1",
+            event_idempotency_key="evt:task.created:task-1",
+        )
+
+    assert result.success is True
+    assert result.instance_id == "instance-evt-1"
+    assert result.created_new is True
+    assert result.status == "pending"
+    assert result.verification["runnable_verification_success"] is True
+    manager.create_instance_for_event.assert_called_once()
+    manager.create_instance.assert_not_called()
+    assert mock_verify.call_count == 2
+
+
+def test_submit_verified_workflow_instance_preserves_idempotent_reuse_without_postflight_failure() -> None:
+    manager = MagicMock()
+    manager.create_instance_for_event.return_value = ("instance-evt-existing", False)
+    verification = _make_verification()
+
+    with patch(
+        "src.backend.workflows.durable.workflow_instance_submission_service.verify_workflow_runnable",
+        return_value=verification,
+    ) as mock_verify:
+        result = submit_verified_workflow_instance(
+            manager=manager,
+            workflow_id="#V#candidate_workflow",
+            user_id="#V#user_alice",
+            org_id="#V#org_nao",
+            namespace="#V#user_alice/#V#org_nao",
+            inputs={"seed": "abc-123"},
+            source_event_type="task.created",
+            source_event_id="task-1",
+            event_idempotency_key="evt:task.created:task-1",
+        )
+
+    assert result.success is True
+    assert result.instance_id == "instance-evt-existing"
+    assert result.created_new is False
+    assert result.status == "reused"
+    assert result.verification["postflight_passed"] is True
+    manager.create_instance_for_event.assert_called_once()
+    manager.create_instance.assert_not_called()
+    manager.mark_failed.assert_not_called()
+    mock_verify.assert_called_once_with("#V#candidate_workflow")


### PR DESCRIPTION
## Summary
- route event-driven, RAG sync, and orchestrator durable instance creation through `submit_verified_workflow_instance`
- preserve idempotent event reuse semantics while surfacing verification telemetry and `created_new` metadata
- add guardrail and regression tests to prevent new direct `create_instance*` bypasses outside authoritative internals

## Validation
- `pdm run python scripts/pytest_lanes.py recommend --git-diff origin/main`
- `pdm run pytest tests/backend/test_workflow_instance_submission_service.py -q`
- `pdm run pytest tests/backend/test_workflow_event_integration_service.py -q`
- `pdm run pytest tests/backend/test_rag_sync_workflow.py -q`
- `pdm run pytest tests/backend/test_rag_text_relation_sync_service.py -q`
- `pdm run pytest tests/backend/test_orchestrator_durable_instance_telemetry.py::test_execute_workflow_persists_completed_durable_instance_with_turn_summary -q`
- `pdm run pytest tests/backend/test_orchestrator_durable_instance_telemetry.py::test_execute_workflow_marks_durable_instance_failed_on_exception -q`
- `pdm run pytest tests/backend/test_orchestrator_durable_instance_telemetry.py::test_execute_workflow_materialises_terminal_effect_evidence_on_gateway_path -q`
- `pdm run pytest tests/backend/test_internal_mcp_workflow_tools.py::test_workflow_create_list_get_instance_gateway_paths tests/backend/test_internal_mcp_workflow_tools.py::test_workflow_create_instance_normalises_inputs tests/backend/test_internal_mcp_workflow_tools.py::test_workflow_create_instance_rejects_unrunnable_workflow tests/backend/test_workflows_routes.py::test_create_workflow_instance_route_rejects_unrunnable_workflow tests/backend/test_workflows_routes.py::test_trigger_workflow_schedule_route_rejects_unrunnable_workflow -q`
- `pdm run pytest tests/backend/test_durable_submission_guardrails.py -q`
- `pdm run pyright $(git diff --name-only -- '*.py')`