### PR TITLE
JVNAUTOSCI-1519 externalise event launch authority to persisted bindings

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -9860,7 +9860,7 @@ def _workflow_bind_event(**kwargs):
 
 
 def _workflow_list_event_bindings(**kwargs):
-    """List event -> workflow bindings (persistent + optional env fallback)."""
+    """List authoritative persisted event -> workflow bindings."""
 
     from ...services.workflow_event_integration_service import (
         build_event_workflow_binding_diagnostics,
@@ -9869,7 +9869,6 @@ def _workflow_list_event_bindings(**kwargs):
 
     event_type = kwargs.get("event_type")
     enabled_only = kwargs.get("enabled_only", False)
-    include_env_fallback = kwargs.get("include_env_fallback", True)
     try:
         limit = int(kwargs.get("limit", 100))
     except (TypeError, ValueError):
@@ -9880,13 +9879,10 @@ def _workflow_list_event_bindings(**kwargs):
         event_type = None
     if not isinstance(enabled_only, bool):
         enabled_only = bool(enabled_only)
-    if not isinstance(include_env_fallback, bool):
-        include_env_fallback = bool(include_env_fallback)
 
     bindings = list_event_workflow_bindings(
         event_type=event_type,
         enabled_only=enabled_only,
-        include_env_fallback=include_env_fallback,
         limit=limit,
     )
     diagnostics = build_event_workflow_binding_diagnostics(bindings)
@@ -16136,7 +16132,6 @@ def _chat_introspect(
         )
 
         event_workflow_bindings_detailed = list_event_workflow_bindings(
-            include_env_fallback=True,
             limit=200,
         )
     except Exception:
@@ -21018,7 +21013,6 @@ def build_default_catalogue() -> MethodCatalogue:
                 optional={
                     "event_type": (str, type(None)),
                     "enabled_only": bool,
-                    "include_env_fallback": bool,
                     "limit": int,
                 },
                 allow_unknown=True,
@@ -21037,8 +21031,7 @@ def build_default_catalogue() -> MethodCatalogue:
             ),
             category="read",
             description=(
-                "List event bindings from persistent storage, with optional environment fallback "
-                "entries for legacy compatibility."
+                "List authoritative persisted event bindings from workflow storage."
             ),
         ),
         MethodDefinition(

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -2860,7 +2860,7 @@
         },
         {
             "name": "workflow_list_event_bindings",
-            "description": "List event bindings from persistent storage, with optional environment fallback entries for legacy compatibility.",
+            "description": "List authoritative persisted event bindings from workflow storage.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -2871,9 +2871,6 @@
                         ]
                     },
                     "enabled_only": {
-                        "type": "boolean"
-                    },
-                    "include_env_fallback": {
                         "type": "boolean"
                     },
                     "limit": {

--- a/src/backend/services/workflow_event_integration_service.py
+++ b/src/backend/services/workflow_event_integration_service.py
@@ -44,17 +44,10 @@ EVENT_TYPE_VONTOLOGY_MUTATED = "vontology.mutated"
 EVENT_TYPE_FILE_COPY_UPLOADED = "file_copy.uploaded"
 DEFAULT_FILE_COPY_UPLOADED_WORKFLOW_ID = "#V#file_copy_upload_handler_workflow"
 
-# Backward-compatible environment wiring (legacy/system bootstrap).
-EVENT_WORKFLOW_ID_ENV_MAP: dict[str, str] = {
-    EVENT_TYPE_TASK_CREATED: "VON_EVENT_TASK_CREATED_WORKFLOW_ID",
-    EVENT_TYPE_TASK_STATUS_CHANGED: "VON_EVENT_TASK_STATUS_CHANGED_WORKFLOW_ID",
-    EVENT_TYPE_EFFORT_UNIT_COMPLETED: "VON_EVENT_EFFORT_UNIT_COMPLETED_WORKFLOW_ID",
-    EVENT_TYPE_DIRECT_MESSAGE_CREATED: "VON_EVENT_DIRECT_MESSAGE_WORKFLOW_ID",
-    EVENT_TYPE_TYPE_CREATED: "VON_EVENT_TYPE_CREATED_WORKFLOW_ID",
-    EVENT_TYPE_FILE_COPY_UPLOADED: "VON_EVENT_FILE_COPY_UPLOADED_WORKFLOW_ID",
-}
-
-_DEFAULT_EVENT_BINDINGS: tuple[dict[str, Any], ...] = (
+# Bootstrap definitions exist only to materialise authoritative persisted
+# bindings. Runtime launch must resolve from persistent records rather than from
+# this in-memory table.
+_BOOTSTRAP_EVENT_BINDINGS: tuple[dict[str, Any], ...] = (
     {
         "event_type": EVENT_TYPE_TYPE_CREATED,
         "workflow_id": "#V#salient_predicate_governance_workflow",
@@ -79,6 +72,11 @@ _DEFAULT_EVENT_BINDINGS: tuple[dict[str, Any], ...] = (
         "exclusive": True,
     },
 )
+_BOOTSTRAP_EVENT_TYPES = frozenset(
+    str(item.get("event_type") or "").strip()
+    for item in _BOOTSTRAP_EVENT_BINDINGS
+    if isinstance(item, dict)
+)
 
 _DEFAULT_BINDINGS_ENSURED = False
 
@@ -92,15 +90,6 @@ def _task_status_trigger_values() -> set[str]:
     if values:
         return values
     return {"in_progress", "completed", "blocked", "cancelled"}
-
-
-def _workflow_id_for_event(event_type: str) -> str | None:
-    env_name = EVENT_WORKFLOW_ID_ENV_MAP.get(event_type)
-    if not env_name:
-        return None
-
-    workflow_id = os.getenv(env_name, "").strip()
-    return workflow_id or None
 
 
 def _build_event_idempotency_key(
@@ -236,11 +225,10 @@ def _normalise_event_binding_mapping(
 
 
 def ensure_default_event_bindings() -> dict[str, Any]:
-    """Best-effort bootstrap of default event bindings.
+    """Best-effort bootstrap of canonical persisted event bindings.
 
-    This is intentionally idempotent and conflict-safe:
-    - Existing equivalent bindings are treated as unchanged.
-    - Existing conflicting bindings are left untouched (no override).
+    This materialises authoritative records only. Runtime launch must still
+    resolve from persisted bindings after this function returns.
     """
 
     global _DEFAULT_BINDINGS_ENSURED
@@ -293,7 +281,7 @@ def ensure_default_event_bindings() -> dict[str, Any]:
                 "skipped_conflicts": 0,
             }
 
-        for binding in _DEFAULT_EVENT_BINDINGS:
+        for binding in _BOOTSTRAP_EVENT_BINDINGS:
             try:
                 _saved_binding, created, updated = manager.upsert_event_binding(
                     event_type=binding["event_type"],
@@ -443,7 +431,6 @@ def build_event_workflow_binding_diagnostics(
                 "disabled_binding_ids": [],
                 "workflow_ids": [],
                 "persistent_count": 0,
-                "environment_count": 0,
             },
         )
         binding_id = str(binding.get("binding_id") or "").strip()
@@ -462,8 +449,6 @@ def build_event_workflow_binding_diagnostics(
             else:
                 if binding_id:
                     group["disabled_binding_ids"].append(binding_id)
-        elif source == "environment":
-            group["environment_count"] += 1
 
     diagnostics: list[dict[str, Any]] = []
     for event_type in sorted(grouped):
@@ -471,7 +456,6 @@ def build_event_workflow_binding_diagnostics(
         enabled_count = len(group["enabled_binding_ids"])
         disabled_count = len(group["disabled_binding_ids"])
         persistent_count = int(group["persistent_count"])
-        environment_count = int(group["environment_count"])
         severity = ""
         reason_code = ""
         hint = ""
@@ -496,13 +480,6 @@ def build_event_workflow_binding_diagnostics(
                 "Disabled historical bindings remain for this event. Delete them when "
                 "they are no longer needed for audit or rollback."
             )
-        elif environment_count > 0 and persistent_count > 0:
-            severity = "info"
-            reason_code = "persistent_bindings_override_environment"
-            hint = (
-                "Persistent bindings exist alongside environment fallback wiring. "
-                "Persistent bindings are authoritative for normal operation."
-            )
         if not reason_code:
             continue
         diagnostics.append(
@@ -514,7 +491,6 @@ def build_event_workflow_binding_diagnostics(
                 "persistent_count": persistent_count,
                 "enabled_binding_count": enabled_count,
                 "disabled_binding_count": disabled_count,
-                "environment_binding_count": environment_count,
                 "binding_ids": list(group["binding_ids"]),
                 "enabled_binding_ids": list(group["enabled_binding_ids"]),
                 "disabled_binding_ids": list(group["disabled_binding_ids"]),
@@ -529,59 +505,19 @@ def list_event_workflow_bindings(
     *,
     event_type: str | None = None,
     enabled_only: bool = False,
-    include_env_fallback: bool = True,
     limit: int = 200,
 ) -> list[dict[str, Any]]:
-    """Return event-workflow bindings for introspection and diagnostics."""
+    """Return persisted event-workflow bindings for introspection and diagnostics."""
 
     bindings = _fetch_persistent_bindings(
         event_type=event_type,
         enabled_only=enabled_only,
         limit=limit,
     )
-    seen_pairs = {
-        (str(b.get("event_type") or ""), str(b.get("workflow_id") or ""))
-        for b in bindings
-    }
 
-    if include_env_fallback:
-        event_keys = (
-            [event_type]
-            if isinstance(event_type, str) and event_type.strip()
-            else list(EVENT_WORKFLOW_ID_ENV_MAP.keys())
-        )
-        for key in event_keys:
-            if not isinstance(key, str) or not key.strip():
-                continue
-            workflow_id = _workflow_id_for_event(key)
-            if not workflow_id:
-                continue
-            pair = (key, workflow_id)
-            if pair in seen_pairs:
-                continue
-            seen_pairs.add(pair)
-            bindings.append(
-                {
-                    "binding_id": None,
-                    "event_type": key,
-                    "workflow_id": workflow_id,
-                    "input_mapping": {},
-                    "enabled": True,
-                    "created_at": None,
-                    "updated_at": None,
-                    "created_by": None,
-                    "updated_by": None,
-                    "revision": None,
-                    "source": "environment",
-                }
-            )
-
-    def _sort_key(item: dict[str, Any]) -> tuple[str, int, str]:
-        source = str(item.get("source") or "")
-        source_rank = 0 if source == "persistent" else 1
+    def _sort_key(item: dict[str, Any]) -> tuple[str, str]:
         return (
             str(item.get("event_type") or ""),
-            source_rank,
             str(item.get("workflow_id") or ""),
         )
 
@@ -592,7 +528,6 @@ def _resolve_bindings_for_event(event_type: str) -> list[dict[str, Any]]:
     all_bindings = list_event_workflow_bindings(
         event_type=event_type,
         enabled_only=True,
-        include_env_fallback=True,
         limit=200,
     )
     return [
@@ -600,6 +535,36 @@ def _resolve_bindings_for_event(event_type: str) -> list[dict[str, Any]]:
         for binding in all_bindings
         if str(binding.get("event_type") or "").strip() == event_type
     ]
+
+
+def _supports_bootstrap_event_bindings(event_type: str) -> bool:
+    return str(event_type or "").strip() in _BOOTSTRAP_EVENT_TYPES
+
+
+def _ensure_bootstrap_event_bindings_for(
+    event_type: str,
+) -> dict[str, Any] | None:
+    if not _supports_bootstrap_event_bindings(event_type):
+        return None
+    return ensure_default_event_bindings()
+
+
+def _annotate_bootstrap_launch_result(
+    launch_result: dict[str, Any],
+    *,
+    bootstrap_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not isinstance(launch_result, dict):
+        return launch_result
+    if isinstance(bootstrap_report, dict):
+        launch_result["event_binding_bootstrap"] = bootstrap_report
+        # Keep the historical field for callers that already read it.
+        launch_result["default_binding_bootstrap"] = bootstrap_report
+    workflow_id = str(launch_result.get("workflow_id") or "").strip()
+    if workflow_id:
+        launch_result["selected_workflow_id"] = workflow_id
+    launch_result["launch_strategy"] = "resolved_persistent_bindings"
+    return launch_result
 
 
 def _extract_path_value(payload: dict[str, Any], path: str) -> tuple[bool, Any]:
@@ -1117,11 +1082,10 @@ def launch_event_workflow(
         resolved_bindings = _resolve_bindings_for_event(event_type)
 
     if not resolved_bindings:
-        env_name = EVENT_WORKFLOW_ID_ENV_MAP.get(event_type)
         hint = (
-            "Register an event binding using workflow_bind_event, or configure "
-            f"{env_name} with a workflow concept ID."
-            if env_name
+            "Materialise the canonical persisted event binding for this event, or "
+            "register an event binding using workflow_bind_event."
+            if _supports_bootstrap_event_bindings(event_type)
             else "Register an event binding using workflow_bind_event for this event type."
         )
         return {
@@ -1130,7 +1094,6 @@ def launch_event_workflow(
             "outcome": "not_triggered",
             "event_type": event_type,
             "reason": "workflow_not_configured",
-            "workflow_id_env": env_name,
             "hint": hint,
         }
 
@@ -1323,9 +1286,6 @@ def maybe_launch_task_status_workflow(
             "triggered": False,
             "outcome": "not_triggered",
             "event_type": EVENT_TYPE_TASK_STATUS_CHANGED,
-            "workflow_id_env": EVENT_WORKFLOW_ID_ENV_MAP.get(
-                EVENT_TYPE_TASK_STATUS_CHANGED
-            ),
             "reason": "status_not_configured_for_trigger",
             "hint": "Update VON_EVENT_TASK_STATUS_TRIGGER_VALUES to include this status if a trigger is expected.",
         }
@@ -1433,7 +1393,8 @@ def maybe_launch_type_created_workflow(
 ) -> dict[str, Any]:
     """Launch workflow(s) bound to type.created for new type concepts."""
 
-    return launch_event_workflow(
+    bootstrap_report = _ensure_bootstrap_event_bindings_for(EVENT_TYPE_TYPE_CREATED)
+    launch_result = launch_event_workflow(
         event_type=EVENT_TYPE_TYPE_CREATED,
         event_id=str(type_concept_id),
         user_id=created_by_concept_id,
@@ -1449,6 +1410,10 @@ def maybe_launch_type_created_workflow(
             "type_concept_id": type_concept_id,
             "parent_type_ids": list(parent_type_ids or []),
         },
+    )
+    return _annotate_bootstrap_launch_result(
+        launch_result,
+        bootstrap_report=bootstrap_report,
     )
 
 
@@ -1569,10 +1534,8 @@ def maybe_launch_file_copy_uploaded_workflow(
             "hint": "Provide file_copy_concept_id for upload-event workflow launch.",
         }
 
-    ensure_report = ensure_default_event_bindings()
-    selected_workflow_id = (
-        _workflow_id_for_event(EVENT_TYPE_FILE_COPY_UPLOADED)
-        or DEFAULT_FILE_COPY_UPLOADED_WORKFLOW_ID
+    bootstrap_report = _ensure_bootstrap_event_bindings_for(
+        EVENT_TYPE_FILE_COPY_UPLOADED
     )
     launch_result = launch_event_workflow(
         event_type=EVENT_TYPE_FILE_COPY_UPLOADED,
@@ -1580,7 +1543,6 @@ def maybe_launch_file_copy_uploaded_workflow(
         user_id=uploaded_by_concept_id,
         org_id=organisation_concept_id,
         namespace=namespace,
-        workflow_id=selected_workflow_id,
         event_payload={
             "concept_id": concept_id,
             "file_copy_concept_id": concept_id,
@@ -1604,8 +1566,7 @@ def maybe_launch_file_copy_uploaded_workflow(
             "index_in_rag": bool(index_in_rag),
         },
     )
-    if isinstance(launch_result, dict):
-        launch_result["default_binding_bootstrap"] = ensure_report
-        launch_result["selected_workflow_id"] = selected_workflow_id
-        launch_result["launch_strategy"] = "single_selected_binding"
-    return launch_result
+    return _annotate_bootstrap_launch_result(
+        launch_result,
+        bootstrap_report=bootstrap_report,
+    )

--- a/tests/backend/test_event_binding_authority_guardrails.py
+++ b/tests/backend/test_event_binding_authority_guardrails.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(relative_path: str) -> str:
+    return (PROJECT_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_runtime_event_binding_authority_has_no_env_fallback() -> None:
+    service_text = _read("src/backend/services/workflow_event_integration_service.py")
+    assert "EVENT_WORKFLOW_ID_ENV_MAP" not in service_text
+    assert "_workflow_id_for_event(" not in service_text
+
+
+def test_event_binding_tools_no_longer_advertise_env_fallback() -> None:
+    catalogue_text = _read("src/backend/integrations/internal_mcp/catalogue.py")
+    manifest_text = _read("src/backend/mcp_server/vontology_mcp.json")
+
+    assert "include_env_fallback" not in catalogue_text
+    assert "environment fallback" not in catalogue_text.lower()
+    assert "include_env_fallback" not in manifest_text
+    assert "environment fallback" not in manifest_text.lower()

--- a/tests/backend/test_workflow_event_integration_service.py
+++ b/tests/backend/test_workflow_event_integration_service.py
@@ -17,11 +17,13 @@ from src.backend.services.workflow_event_integration_service import (
     EVENT_TYPE_EFFORT_UNIT_COMPLETED,
     EVENT_TYPE_FILE_COPY_UPLOADED,
     EVENT_TYPE_TASK_CREATED,
+    EVENT_TYPE_TYPE_CREATED,
     EVENT_TYPE_VONTOLOGY_MUTATED,
     ensure_default_event_bindings,
     launch_event_workflow,
     maybe_launch_effort_unit_completed_workflow,
     maybe_launch_file_copy_uploaded_workflow,
+    maybe_launch_type_created_workflow,
     maybe_launch_vontology_mutation_workflow,
     maybe_launch_task_status_workflow,
 )
@@ -85,10 +87,12 @@ def test_launch_event_workflow_durable_gate_disables_trigger(monkeypatch) -> Non
     assert "hint" in result
 
 
-def test_launch_event_workflow_requires_configured_workflow(monkeypatch) -> None:
+def test_launch_event_workflow_ignores_legacy_env_fallback_without_persisted_binding(
+    monkeypatch,
+) -> None:
     monkeypatch.setenv("VON_EVENT_WORKFLOW_INTEGRATION_ENABLE", "1")
     monkeypatch.setenv("VON_DURABLE_WORKFLOWS_ENABLE", "1")
-    monkeypatch.delenv("VON_EVENT_TASK_CREATED_WORKFLOW_ID", raising=False)
+    monkeypatch.setenv("VON_EVENT_TASK_CREATED_WORKFLOW_ID", "#V#legacy_env_workflow")
 
     result = launch_event_workflow(
         event_type=EVENT_TYPE_TASK_CREATED,
@@ -102,8 +106,9 @@ def test_launch_event_workflow_requires_configured_workflow(monkeypatch) -> None
     assert result["outcome"] == "not_triggered"
     assert result["event_type"] == EVENT_TYPE_TASK_CREATED
     assert result["reason"] == "workflow_not_configured"
-    assert result["workflow_id_env"] == "VON_EVENT_TASK_CREATED_WORKFLOW_ID"
     assert "hint" in result
+    assert "workflow_bind_event" in result["hint"]
+    assert "workflow_id_env" not in result
 
 
 @patch("src.backend.services.workflow_event_integration_service.get_instance_manager")
@@ -113,7 +118,6 @@ def test_launch_event_workflow_creates_instance_when_configured(
 ) -> None:
     monkeypatch.setenv("VON_EVENT_WORKFLOW_INTEGRATION_ENABLE", "1")
     monkeypatch.setenv("VON_DURABLE_WORKFLOWS_ENABLE", "1")
-    monkeypatch.setenv("VON_EVENT_TASK_CREATED_WORKFLOW_ID", "#V#task_event_workflow")
 
     mock_manager = MagicMock()
     mock_get_instance_manager.return_value = mock_manager
@@ -131,6 +135,7 @@ def test_launch_event_workflow_creates_instance_when_configured(
             event_id="task-1",
             user_id="#V#user_alice",
             org_id="#V#org_nao",
+            workflow_id="#V#task_event_workflow",
             inputs={"task_concept_id": "#V#task_1"},
         )
 
@@ -165,7 +170,6 @@ def test_launch_event_workflow_reports_reused_idempotent_instance(
 ) -> None:
     monkeypatch.setenv("VON_EVENT_WORKFLOW_INTEGRATION_ENABLE", "1")
     monkeypatch.setenv("VON_DURABLE_WORKFLOWS_ENABLE", "1")
-    monkeypatch.setenv("VON_EVENT_TASK_CREATED_WORKFLOW_ID", "#V#task_event_workflow")
 
     mock_manager = MagicMock()
     mock_get_instance_manager.return_value = mock_manager
@@ -183,6 +187,7 @@ def test_launch_event_workflow_reports_reused_idempotent_instance(
             event_id="task-1",
             user_id="#V#user_alice",
             org_id="#V#org_nao",
+            workflow_id="#V#task_event_workflow",
             inputs={"task_concept_id": "#V#task_1"},
         )
 
@@ -347,28 +352,12 @@ def test_build_event_workflow_binding_diagnostics_reports_operator_actions() -> 
         enabled=False,
         actor="test",
     )
-    persistent_with_env = EventWorkflowBinding.create(
-        event_type="vontology.mutated",
-        workflow_id="#V#vontology_mutation_governance_workflow",
-        input_mapping={"concept_id": "event.concept_id"},
-        enabled=True,
-        actor="test",
-    )
-
     bindings = [
         {**multiple_enabled_a.to_status_dict(), "source": "persistent"},
         {**multiple_enabled_b.to_status_dict(), "source": "persistent"},
         {**disabled_only.to_status_dict(), "source": "persistent"},
         {**historical_enabled.to_status_dict(), "source": "persistent"},
         {**historical_disabled.to_status_dict(), "source": "persistent"},
-        {**persistent_with_env.to_status_dict(), "source": "persistent"},
-        {
-            "binding_id": "env:vontology.mutated",
-            "event_type": "vontology.mutated",
-            "workflow_id": "#V#env_fallback_workflow",
-            "enabled": True,
-            "source": "environment",
-        },
     ]
 
     diagnostics = workflow_event_service.build_event_workflow_binding_diagnostics(
@@ -382,11 +371,24 @@ def test_build_event_workflow_binding_diagnostics_reports_operator_actions() -> 
     assert by_event["task.created"]["severity"] == "warning"
     assert by_event["concept.updated"]["reason_code"] == "historical_bindings_present"
     assert by_event["concept.updated"]["severity"] == "info"
-    assert (
-        by_event["vontology.mutated"]["reason_code"]
-        == "persistent_bindings_override_environment"
+
+
+@patch("src.backend.services.workflow_event_integration_service.get_instance_manager")
+def test_list_event_workflow_bindings_excludes_env_fallback_entries(
+    mock_get_instance_manager: MagicMock,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("VON_EVENT_TASK_CREATED_WORKFLOW_ID", "#V#legacy_env_workflow")
+    mock_manager = MagicMock()
+    mock_manager.list_event_bindings.return_value = []
+    mock_get_instance_manager.return_value = mock_manager
+
+    bindings = workflow_event_service.list_event_workflow_bindings(
+        event_type=EVENT_TYPE_TASK_CREATED,
+        limit=20,
     )
-    assert by_event["vontology.mutated"]["environment_binding_count"] == 1
+
+    assert bindings == []
 
 
 @patch("src.backend.services.workflow_event_integration_service.get_instance_manager")
@@ -541,7 +543,6 @@ def test_launch_event_workflow_uses_user_only_namespace_when_org_unknown(
 ) -> None:
     monkeypatch.setenv("VON_EVENT_WORKFLOW_INTEGRATION_ENABLE", "1")
     monkeypatch.setenv("VON_DURABLE_WORKFLOWS_ENABLE", "1")
-    monkeypatch.setenv("VON_EVENT_TASK_CREATED_WORKFLOW_ID", "#V#task_event_workflow")
 
     mock_manager = MagicMock()
     mock_get_instance_manager.return_value = mock_manager
@@ -559,6 +560,7 @@ def test_launch_event_workflow_uses_user_only_namespace_when_org_unknown(
             event_id="task-namespace-user-only",
             user_id="#V#user_alice",
             org_id=None,
+            workflow_id="#V#task_event_workflow",
             inputs={"task_concept_id": "#V#task_99"},
         )
 
@@ -577,7 +579,6 @@ def test_launch_event_workflow_blocks_when_cadence_window_is_active(
 ) -> None:
     monkeypatch.setenv("VON_EVENT_WORKFLOW_INTEGRATION_ENABLE", "1")
     monkeypatch.setenv("VON_DURABLE_WORKFLOWS_ENABLE", "1")
-    monkeypatch.setenv("VON_EVENT_TASK_CREATED_WORKFLOW_ID", "#V#task_event_workflow")
 
     now = datetime.now(timezone.utc)
     mock_manager = MagicMock()
@@ -604,12 +605,13 @@ def test_launch_event_workflow_blocks_when_cadence_window_is_active(
                 "text_relation:#V#hasBackgroundLaunchPolicyJson",
             ),
         ):
-            result = launch_event_workflow(
-                event_type=EVENT_TYPE_TASK_CREATED,
-                event_id="task-cadence-1",
-                user_id="#V#user_alice",
-                org_id="#V#org_nao",
-            )
+                result = launch_event_workflow(
+                    event_type=EVENT_TYPE_TASK_CREATED,
+                    event_id="task-cadence-1",
+                    user_id="#V#user_alice",
+                    org_id="#V#org_nao",
+                    workflow_id="#V#task_event_workflow",
+                )
 
     assert result["success"] is True
     assert result["triggered"] is False
@@ -630,7 +632,6 @@ def test_launch_event_workflow_idempotent_reuse_takes_precedence_over_cadence(
 ) -> None:
     monkeypatch.setenv("VON_EVENT_WORKFLOW_INTEGRATION_ENABLE", "1")
     monkeypatch.setenv("VON_DURABLE_WORKFLOWS_ENABLE", "1")
-    monkeypatch.setenv("VON_EVENT_TASK_CREATED_WORKFLOW_ID", "#V#task_event_workflow")
 
     now = datetime.now(timezone.utc)
     mock_manager = MagicMock()
@@ -659,12 +660,13 @@ def test_launch_event_workflow_idempotent_reuse_takes_precedence_over_cadence(
             "text_relation:#V#hasBackgroundLaunchPolicyJson",
         ),
     ):
-        result = launch_event_workflow(
-            event_type=EVENT_TYPE_TASK_CREATED,
-            event_id="task-cadence-existing",
-            user_id="#V#user_alice",
-            org_id="#V#org_nao",
-        )
+            result = launch_event_workflow(
+                event_type=EVENT_TYPE_TASK_CREATED,
+                event_id="task-cadence-existing",
+                user_id="#V#user_alice",
+                org_id="#V#org_nao",
+                workflow_id="#V#task_event_workflow",
+            )
 
     assert result["success"] is True
     assert result["triggered"] is False
@@ -713,7 +715,11 @@ def test_maybe_launch_file_copy_uploaded_workflow_emits_upload_event(
     mock_launch_event_workflow: MagicMock,
 ) -> None:
     mock_ensure_default_event_bindings.return_value = {"success": True, "ensured": True}
-    mock_launch_event_workflow.return_value = {"success": True, "triggered": True}
+    mock_launch_event_workflow.return_value = {
+        "success": True,
+        "triggered": True,
+        "workflow_id": DEFAULT_FILE_COPY_UPLOADED_WORKFLOW_ID,
+    }
 
     result = maybe_launch_file_copy_uploaded_workflow(
         file_copy_concept_id="#V#uploaded_file_copy_123",
@@ -730,8 +736,9 @@ def test_maybe_launch_file_copy_uploaded_workflow_emits_upload_event(
 
     assert result["success"] is True
     assert result["triggered"] is True
+    assert result["event_binding_bootstrap"]["ensured"] is True
     assert result["default_binding_bootstrap"]["ensured"] is True
-    assert result["launch_strategy"] == "single_selected_binding"
+    assert result["launch_strategy"] == "resolved_persistent_bindings"
     assert result["selected_workflow_id"] == DEFAULT_FILE_COPY_UPLOADED_WORKFLOW_ID
     mock_ensure_default_event_bindings.assert_called_once()
 
@@ -739,9 +746,45 @@ def test_maybe_launch_file_copy_uploaded_workflow_emits_upload_event(
     assert called_args is not None
     assert called_args.kwargs["event_type"] == EVENT_TYPE_FILE_COPY_UPLOADED
     assert called_args.kwargs["event_id"] == "#V#uploaded_file_copy_123"
-    assert called_args.kwargs["workflow_id"] == DEFAULT_FILE_COPY_UPLOADED_WORKFLOW_ID
+    assert "workflow_id" not in called_args.kwargs
     assert called_args.kwargs["inputs"]["file_copy_concept_id"] == "#V#uploaded_file_copy_123"
     assert called_args.kwargs["inputs"]["index_in_rag"] is True
+
+
+@patch("src.backend.services.workflow_event_integration_service.launch_event_workflow")
+@patch(
+    "src.backend.services.workflow_event_integration_service.ensure_default_event_bindings"
+)
+def test_maybe_launch_type_created_workflow_bootstraps_and_defers_to_persisted_binding(
+    mock_ensure_default_event_bindings: MagicMock,
+    mock_launch_event_workflow: MagicMock,
+) -> None:
+    mock_ensure_default_event_bindings.return_value = {"success": True, "ensured": True}
+    mock_launch_event_workflow.return_value = {
+        "success": True,
+        "triggered": True,
+        "workflow_id": "#V#salient_predicate_governance_workflow",
+    }
+
+    result = maybe_launch_type_created_workflow(
+        type_concept_id="#V#new_type",
+        created_by_concept_id="#V#user_alice",
+        organisation_concept_id="#V#org_nao",
+        parent_type_ids=["#V#supertype"],
+    )
+
+    assert result["success"] is True
+    assert result["triggered"] is True
+    assert result["event_binding_bootstrap"]["ensured"] is True
+    assert result["selected_workflow_id"] == "#V#salient_predicate_governance_workflow"
+    assert result["launch_strategy"] == "resolved_persistent_bindings"
+    mock_ensure_default_event_bindings.assert_called_once()
+
+    called_args = mock_launch_event_workflow.call_args
+    assert called_args is not None
+    assert called_args.kwargs["event_type"] == EVENT_TYPE_TYPE_CREATED
+    assert "workflow_id" not in called_args.kwargs
+    assert called_args.kwargs["inputs"]["type_concept_id"] == "#V#new_type"
 
 
 @patch("src.backend.services.workflow_event_integration_service.launch_event_workflow")


### PR DESCRIPTION
## Summary
- remove runtime environment/default fallback authority from workflow event launch resolution
- keep bootstrap flows only as persisted-binding materialisation, then defer launch selection to authoritative stored bindings
- add gateway/schema/test guardrails so event binding inspection and execution stay persisted-binding-only

## Validation
- pdm run pytest tests/backend/test_workflow_event_integration_service.py -q
- pdm run pytest tests/backend/test_event_binding_authority_guardrails.py tests/backend/test_internal_mcp_workflow_tools.py::test_workflow_bind_event_and_list_event_bindings_gateway_paths tests/backend/test_internal_mcp_workflow_tools.py::test_workflow_event_binding_enable_disable_and_delete_gateway_paths tests/backend/test_mcp_stdio_server_exposes_workflow_tools.py -q
- pdm run pytest tests/backend/test_internal_mcp_catalogue_builds.py tests/backend/test_pytest_lane_catalogue.py tests/backend/test_catalogue_download_paper_prefers_finalise.py tests/backend/test_catalogue_resilient_extract_url.py -q
- pdm run python scripts/pytest_lanes.py recommend --git-diff origin/main
- pdm run pyright src/backend/integrations/internal_mcp/catalogue.py src/backend/services/workflow_event_integration_service.py tests/backend/test_workflow_event_integration_service.py tests/backend/test_event_binding_authority_guardrails.py