### PR TITLE
JVNAUTOSCI-1527 migrate reasoning recovery workflows to Vontology authority

### DIFF
--- a/src/backend/workflows/durable/registry_factory.py
+++ b/src/backend/workflows/durable/registry_factory.py
@@ -114,6 +114,15 @@ _last_inventory_snapshot: Dict[str, Any] | None = None
 _durable_mcp_gateway_lock = Lock()
 _durable_mcp_gateway: Any | None = None
 
+_BOOTSTRAP_ONLY_REASONING_RECOVERY_WORKFLOW_IDS: tuple[str, ...] = (
+    "#V#planning_workflow",
+    "#V#rumination_workflow",
+    "#V#parent_specificity_concept_dossier_workflow",
+    "#V#parent_specificity_rumination_workflow",
+    "#V#workflow_discovery_gap_recovery_workflow",
+    "#V#workflow_gap_test_workflow",
+)
+
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -537,8 +546,6 @@ def _register_python_defined_workflows(registry: WorkflowRegistry) -> None:
     # purity diagnostics can track the remaining hybrid surface.
     registry.register(get_rag_sync_workflow_registration())
     registry.register(get_enrichment_workflow_registration())
-    registry.register(get_rumination_workflow_registration())
-    registry.register(get_planning_workflow_registration())
     registry.register(get_workflow_introspection_maintenance_registration())
     registry.register(get_file_copy_typing_workflow_registration())
     registry.register(get_file_copy_upload_classification_workflow_registration())
@@ -546,10 +553,44 @@ def _register_python_defined_workflows(registry: WorkflowRegistry) -> None:
     registry.register(get_file_copy_interpretation_workflow_registration())
     registry.register(get_entity_identity_resolution_workflow_registration())
     registry.register(get_jira_task_incremental_import_workflow_registration())
-    registry.register(get_parent_specificity_concept_dossier_workflow_registration())
-    registry.register(get_parent_specificity_rumination_workflow_registration())
-    registry.register(get_workflow_discovery_gap_recovery_workflow_registration())
-    registry.register(get_workflow_gap_test_workflow_registration())
+
+
+def _bootstrap_only_reasoning_recovery_workflow_registrations() -> tuple[Any, ...]:
+    """Return actual registrations used only to publish authoritative graphs."""
+
+    return (
+        get_planning_workflow_registration(),
+        get_rumination_workflow_registration(),
+        get_parent_specificity_concept_dossier_workflow_registration(),
+        get_parent_specificity_rumination_workflow_registration(),
+        get_workflow_discovery_gap_recovery_workflow_registration(),
+        get_workflow_gap_test_workflow_registration(),
+    )
+
+
+def _bootstrap_only_reasoning_recovery_workflow_report(
+    *,
+    bootstrap_allowed: bool,
+) -> Dict[str, Any]:
+    report: Dict[str, Any] = {
+        "enabled": bool(bootstrap_allowed),
+        "workflow_ids": list(_BOOTSTRAP_ONLY_REASONING_RECOVERY_WORKFLOW_IDS),
+    }
+    if not bootstrap_allowed:
+        return report
+
+    temp_registry = WorkflowRegistry(
+        definition_loader=load_workflow_definition_from_vontology,
+    )
+    for registration in _bootstrap_only_reasoning_recovery_workflow_registrations():
+        temp_registry.register(registration)
+
+    bootstrap_report = bootstrap_workflow_concepts(
+        registry=temp_registry,
+        target_workflow_ids=_BOOTSTRAP_ONLY_REASONING_RECOVERY_WORKFLOW_IDS,
+    )
+    report.update(bootstrap_report)
+    return report
 
 
 def build_workflow_purity_registry_snapshot() -> WorkflowRegistry:
@@ -589,6 +630,10 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
         "enabled": bootstrap_allowed,
         "workflow_ids": [],
     }
+    bootstrap_only_reasoning_recovery_report: Dict[str, Any] = {
+        "enabled": bootstrap_allowed,
+        "workflow_ids": list(_BOOTSTRAP_ONLY_REASONING_RECOVERY_WORKFLOW_IDS),
+    }
 
     _register_python_defined_workflows(registry)
 
@@ -602,6 +647,11 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
                 bootstrap_canonical_talk_representation_workflows()
             )
             talk_representation_bootstrap_report["enabled"] = True
+            bootstrap_only_reasoning_recovery_report = (
+                _bootstrap_only_reasoning_recovery_workflow_report(
+                    bootstrap_allowed=True
+                )
+            )
             _resolve_subworkflow_definition.cache_clear()
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning(
@@ -697,6 +747,9 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
         discovered_workflow_ids=discovered_workflow_ids,
         paper_representation_bootstrap_report=paper_representation_bootstrap_report,
         talk_representation_bootstrap_report=talk_representation_bootstrap_report,
+        bootstrap_only_reasoning_recovery_report=(
+            bootstrap_only_reasoning_recovery_report
+        ),
         bootstrap_allowed=bootstrap_allowed,
     )
 
@@ -709,6 +762,7 @@ def _launch_deferred_registry_work(
     discovered_workflow_ids: List[str],
     paper_representation_bootstrap_report: Dict[str, Any],
     talk_representation_bootstrap_report: Dict[str, Any],
+    bootstrap_only_reasoning_recovery_report: Dict[str, Any],
     bootstrap_allowed: bool,
 ) -> None:
     """Launch background thread for bootstrap and parity inventory.
@@ -758,6 +812,9 @@ def _launch_deferred_registry_work(
             )
             authority_report["talk_representation_bootstrap"] = (
                 talk_representation_bootstrap_report
+            )
+            authority_report["bootstrap_only_reasoning_recovery_workflows"] = (
+                bootstrap_only_reasoning_recovery_report
             )
 
             inventory_snapshot = _build_workflow_parity_inventory(

--- a/src/backend/workflows/workflow_concept_authority_service.py
+++ b/src/backend/workflows/workflow_concept_authority_service.py
@@ -139,6 +139,7 @@ PARENT_SPECIFICITY_DOSSIER_WORKFLOW_ID = (
 PARENT_SPECIFICITY_RUMINATION_WORKFLOW_ID = (
     "#V#parent_specificity_rumination_workflow"
 )
+PLANNING_WORKFLOW_ID = "#V#planning_workflow"
 RUMINATION_WORKFLOW_ID = "#V#rumination_workflow"
 
 
@@ -173,6 +174,7 @@ CANONICAL_DURABLE_WORKFLOW_IDS: tuple[str, ...] = (
     FILE_COPY_INTERPRETATION_WORKFLOW_ID,
     FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID,
     FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
+    PLANNING_WORKFLOW_ID,
     PARENT_SPECIFICITY_DOSSIER_WORKFLOW_ID,
     PARENT_SPECIFICITY_RUMINATION_WORKFLOW_ID,
     WORKFLOW_DISCOVERY_GAP_RECOVERY_WORKFLOW_ID,
@@ -1353,6 +1355,70 @@ _CANONICAL_WORKFLOW_PUBLICATION_SPECS: Dict[str, _CanonicalWorkflowPublicationSp
                 ),
             ),
             _CanonicalStepPublicationSpec(state_id="complete"),
+            _CanonicalStepPublicationSpec(state_id="failed"),
+        ),
+    ),
+    PLANNING_WORKFLOW_ID: _CanonicalWorkflowPublicationSpec(
+        initial_state="assess",
+        steps=(
+            _CanonicalStepPublicationSpec(
+                state_id="assess",
+                action_id="planning.assess_context",
+                on_failure_state="failed",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="infer",
+                        reason="context_ready",
+                        condition_spec={
+                            "kind": "context_exists",
+                            "key": "planning_context",
+                            "expected": True,
+                        },
+                    ),
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="failed",
+                        reason="missing_context",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="infer",
+                action_id="planning.infer_plan",
+                on_failure_state="failed",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="validate",
+                        reason="plan_inferred",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="validate",
+                action_id="planning.validate_plan",
+                on_failure_state="failed",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="complete",
+                        reason="validated",
+                        condition_spec={
+                            "kind": "context_exists",
+                            "key": "planning_validation",
+                            "expected": True,
+                        },
+                    ),
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="failed",
+                        reason="validation_missing",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="complete",
+                action_id="planning.finalise",
+            ),
             _CanonicalStepPublicationSpec(state_id="failed"),
         ),
     ),

--- a/tests/backend/fixtures/workflow_purity_baseline.json
+++ b/tests/backend/fixtures/workflow_purity_baseline.json
@@ -1,14 +1,14 @@
 {
   "counters": {
-    "built_in_registration_count": 15,
+    "built_in_registration_count": 9,
     "builtin_capability_override_count": 0,
     "direct_instance_create_callsite_count": 4,
     "env_event_binding_count": 0,
     "legacy_selector_mode_count": 1,
-    "non_vontology_discoverable_workflow_count": 15,
+    "non_vontology_discoverable_workflow_count": 9,
     "remaining_python_workflow_family_count": 16
   },
-  "generated_at_utc": "2026-03-17T12:23:42.397123+00:00",
+  "generated_at_utc": "2026-03-17T21:34:31.301998+00:00",
   "report_schema_version": "workflow_purity_report.v1",
   "schema_version": "workflow_purity_baseline.v1"
 }

--- a/tests/backend/test_internal_mcp_workflow_tools.py
+++ b/tests/backend/test_internal_mcp_workflow_tools.py
@@ -13,6 +13,7 @@ from src.backend.workflows.durable.models import (
     WorkflowInstanceStatus,
 )
 from src.backend.workflows.durable.scheduler import WorkflowScheduler
+from workflow_test_support import bootstrap_authoritative_reasoning_recovery_workflows
 
 
 def _build_gateway() -> InternalMCPGateway:
@@ -498,6 +499,7 @@ class _InMemoryScheduleWorkflowManager:
 
 
 def test_workflow_list_definitions_exists_and_returns_data():
+    bootstrap_authoritative_reasoning_recovery_workflows()
     catalogue = build_default_catalogue()
     methods = catalogue.list_methods()
     assert "workflow_list_definitions" in methods
@@ -522,12 +524,34 @@ def test_workflow_list_definitions_exists_and_returns_data():
     assert "#V#rag_text_relation_sync_workflow" in def_ids
     assert "#V#enrichment_workflow" in def_ids
     assert "#V#planning_workflow" in def_ids
+    assert "#V#rumination_workflow" in def_ids
+    assert "#V#parent_specificity_concept_dossier_workflow" in def_ids
+    assert "#V#parent_specificity_rumination_workflow" in def_ids
     assert "#V#file_copy_typing_workflow" in def_ids
     assert "#V#file_copy_upload_classification_workflow" in def_ids
     assert "#V#file_copy_upload_handler_workflow" in def_ids
     assert "#V#file_copy_interpretation_workflow" in def_ids
     assert "#V#workflow_discovery_gap_recovery_workflow" in def_ids
     assert "#V#workflow_gap_test_workflow" in def_ids
+    source_by_workflow_id = {
+        item["workflow_id"]: str(item.get("source") or "").strip().lower()
+        for item in result["definitions"]
+    }
+    assert source_by_workflow_id["#V#planning_workflow"] == "vontology"
+    assert source_by_workflow_id["#V#rumination_workflow"] == "vontology"
+    assert (
+        source_by_workflow_id["#V#parent_specificity_concept_dossier_workflow"]
+        == "vontology"
+    )
+    assert (
+        source_by_workflow_id["#V#parent_specificity_rumination_workflow"]
+        == "vontology"
+    )
+    assert (
+        source_by_workflow_id["#V#workflow_discovery_gap_recovery_workflow"]
+        == "vontology"
+    )
+    assert source_by_workflow_id["#V#workflow_gap_test_workflow"] == "vontology"
     assert any("description_source" in d for d in result["definitions"])
     assert any("definition_identity" in d for d in result["definitions"])
     assert any("background_launch_policy_source" in d for d in result["definitions"])
@@ -568,6 +592,7 @@ def test_workflow_list_definitions_exists_and_returns_data():
 
 
 def test_workflow_list_definitions_gateway_invoke_success_path():
+    bootstrap_authoritative_reasoning_recovery_workflows()
     gateway = _build_gateway()
     result = gateway.invoke("workflow_list_definitions", {"limit": 10})
     payload = result.payload

--- a/tests/backend/test_workflow_concept_authority_service.py
+++ b/tests/backend/test_workflow_concept_authority_service.py
@@ -682,134 +682,56 @@ def test_bootstrap_publishes_canonical_chat_graphs_with_loader_runtime_parity(
 def test_bootstrap_publishes_explicit_step_conditions_for_canonical_durable_workflows(
     _reset_mock_workflow_graph_db,
 ):
-    from src.backend.workflows.durable.file_copy_upload_handler_workflow import (
-        FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
+    from src.backend.workflows.durable.planning_workflow import (
+        PLANNING_WORKFLOW_ID,
     )
     from src.backend.workflows.durable.parent_specificity_rumination_workflow import (
         PARENT_SPECIFICITY_RUMINATION_WORKFLOW_ID,
-    )
-    from src.backend.workflows.durable.registry_factory import (
-        build_workflow_registry_read_only,
     )
     from src.backend.workflows.durable.workflow_gap_recovery_workflow import (
         WORKFLOW_DISCOVERY_GAP_RECOVERY_WORKFLOW_ID,
     )
     from src.backend.workflows.vontology_loader import build_workflow_process_graph
+    from workflow_test_support import (
+        bootstrap_authoritative_reasoning_recovery_workflows,
+    )
 
-    registry = build_workflow_registry_read_only()
-
-    report = authority_service.bootstrap_workflow_concepts(registry=cast(Any, registry))
+    report = bootstrap_authoritative_reasoning_recovery_workflows()
     errors = (
         (report.get("graph_publication") or {}).get("errors_by_workflow_id") or {}
     )
-    assert FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID not in errors
+    assert PLANNING_WORKFLOW_ID not in errors
     assert PARENT_SPECIFICITY_RUMINATION_WORKFLOW_ID not in errors
     assert WORKFLOW_DISCOVERY_GAP_RECOVERY_WORKFLOW_ID not in errors
 
-    file_copy_graph, file_copy_warnings = build_workflow_process_graph(
-        FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID
+    planning_graph, planning_warnings = build_workflow_process_graph(
+        PLANNING_WORKFLOW_ID
     )
-    assert file_copy_graph is not None
-    assert file_copy_warnings == []
+    assert planning_graph is not None
+    assert planning_warnings == []
     assert _graph_step_control_flow_conditions(
-        graph=file_copy_graph,
-        workflow_id=FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
-        state_id="classify",
+        graph=planning_graph,
+        workflow_id=PLANNING_WORKFLOW_ID,
+        state_id="assess",
     ) == [
         {
             "to": authority_service._step_concept_id(
-                workflow_id=FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
-                state_id="fail_closed",
+                workflow_id=PLANNING_WORKFLOW_ID,
+                state_id="infer",
             ),
-            "reason": "fail_closed_selected",
+            "reason": "context_ready",
             "condition": {
-                "kind": "context_flag",
-                "key": "upload_fail_closed",
+                "kind": "context_exists",
+                "key": "planning_context",
                 "expected": True,
             },
         },
         {
             "to": authority_service._step_concept_id(
-                workflow_id=FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
-                state_id="specialised",
+                workflow_id=PLANNING_WORKFLOW_ID,
+                state_id="failed",
             ),
-            "reason": "specialised_route_selected",
-            "condition": {
-                "kind": "all",
-                "conditions": [
-                    {
-                        "kind": "context_value_equals",
-                        "key": "upload_route_mode",
-                        "value": "specialised",
-                    },
-                    {
-                        "kind": "context_exists",
-                        "key": "upload_target_workflow_id",
-                        "expected": True,
-                    },
-                    {
-                        "kind": "not",
-                        "condition": {
-                            "kind": "context_value_equals",
-                            "key": "upload_target_workflow_id",
-                            "value": "",
-                        },
-                    },
-                ],
-            },
-        },
-        {
-            "to": authority_service._step_concept_id(
-                workflow_id=FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
-                state_id="interpret",
-            ),
-            "reason": "interpret_route_selected",
-            "condition": {
-                "kind": "context_value_equals",
-                "key": "upload_route_mode",
-                "value": "interpret",
-            },
-        },
-        {
-            "to": authority_service._step_concept_id(
-                workflow_id=FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
-                state_id="noop",
-            ),
-            "reason": "noop_route_selected",
-            "condition": {
-                "kind": "context_value_equals",
-                "key": "upload_route_mode",
-                "value": "noop",
-            },
-        },
-        {
-            "to": authority_service._step_concept_id(
-                workflow_id=FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
-                state_id="interpret",
-            ),
-            "reason": "fallback_interpret_default",
-            "condition": {
-                "kind": "any",
-                "conditions": [
-                    {
-                        "kind": "context_exists",
-                        "key": "upload_allow_interpret_fallback",
-                        "expected": False,
-                    },
-                    {
-                        "kind": "context_flag",
-                        "key": "upload_allow_interpret_fallback",
-                        "expected": True,
-                    },
-                ],
-            },
-        },
-        {
-            "to": authority_service._step_concept_id(
-                workflow_id=FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
-                state_id="noop",
-            ),
-            "reason": "fallback_noop_default",
+            "reason": "missing_context",
             "condition": {"kind": "always"},
         },
     ]
@@ -987,6 +909,74 @@ def test_canonical_workflow_runtime_identity_matches_authoritative_loader(
         assert identity["runtime_definition_hash"]
         assert identity["authoritative_definition_hash"]
         assert identity["hash_mismatch"] is False
+
+
+def test_reasoning_recovery_workflow_runtime_identity_matches_authoritative_loader(
+    _reset_mock_workflow_graph_db,
+):
+    from src.backend.workflows.durable.registry_factory import (
+        build_workflow_registry_read_only,
+    )
+    from src.backend.workflows.vontology_loader import (
+        load_workflow_definition_from_vontology,
+    )
+    from workflow_test_support import (
+        AUTHORITATIVE_REASONING_RECOVERY_WORKFLOW_IDS,
+        bootstrap_authoritative_reasoning_recovery_workflows,
+    )
+
+    bootstrap_authoritative_reasoning_recovery_workflows()
+    runtime_registry = build_workflow_registry_read_only()
+
+    for workflow_id in AUTHORITATIVE_REASONING_RECOVERY_WORKFLOW_IDS:
+        registration = runtime_registry.get_registration(workflow_id)
+        assert registration is not None
+        assert str(registration.source or "").strip().lower() == "vontology"
+
+        authoritative_definition = load_workflow_definition_from_vontology(workflow_id)
+        assert authoritative_definition is not None
+
+        identity = build_workflow_definition_identity(
+            workflow_id=workflow_id,
+            source=registration.source,
+            definition=registration.definition,
+            authoritative_definition=authoritative_definition,
+        )
+        assert identity["runtime_definition_hash"]
+        assert identity["authoritative_definition_hash"]
+        assert identity["hash_mismatch"] is False
+
+
+def test_build_workflow_registry_bootstraps_reasoning_recovery_family_from_vontology(
+    _reset_mock_workflow_graph_db,
+    monkeypatch,
+):
+    from src.backend.db.mongo_client import get_db
+    from src.backend.services.workflow_discovery_service import (
+        invalidate_workflow_discovery_executability_caches,
+    )
+    from src.backend.workflows.durable.registry_factory import build_workflow_registry
+    from workflow_test_support import AUTHORITATIVE_REASONING_RECOVERY_WORKFLOW_IDS
+
+    monkeypatch.setenv("VON_USE_MOCK_DB", "1")
+    monkeypatch.setenv("VON_DB_NAME", "test_von_db")
+    authority_service.clear_workflow_type_resolution_cache()
+
+    db = get_db()
+    if db is not None:
+        for collection_name in ("concepts", "text_relations", "text_values"):
+            try:
+                db.drop_collection(collection_name)
+            except Exception:
+                pass
+
+    invalidate_workflow_discovery_executability_caches()
+    registry = build_workflow_registry()
+
+    for workflow_id in AUTHORITATIVE_REASONING_RECOVERY_WORKFLOW_IDS:
+        registration = registry.get_registration(workflow_id)
+        assert registration is not None
+        assert str(registration.source or "").strip().lower() == "vontology"
 
 
 def test_publish_canonical_graphs_reports_validation_failures(

--- a/tests/backend/test_workflow_gap_recovery_workflow.py
+++ b/tests/backend/test_workflow_gap_recovery_workflow.py
@@ -240,9 +240,11 @@ def test_workflow_gap_recovery_workflows_publish_authoritatively(monkeypatch) ->
     from src.backend.services.workflow_discovery_service import (
         invalidate_workflow_discovery_executability_caches,
     )
-    from src.backend.workflows import workflow_concept_authority_service as authority_service
-    from src.backend.workflows.durable.registry_factory import (
-        build_workflow_registry_read_only,
+    from src.backend.workflows import (
+        workflow_concept_authority_service as authority_service,
+    )
+    from workflow_test_support import (
+        bootstrap_authoritative_reasoning_recovery_workflows,
     )
 
     monkeypatch.setenv("VON_USE_MOCK_DB", "1")
@@ -258,8 +260,7 @@ def test_workflow_gap_recovery_workflows_publish_authoritatively(monkeypatch) ->
                 pass
 
     invalidate_workflow_discovery_executability_caches()
-    registry = build_workflow_registry_read_only()
-    report = authority_service.bootstrap_workflow_concepts(registry=cast(Any, registry))
+    report = bootstrap_authoritative_reasoning_recovery_workflows()
     graph_publication = report.get("graph_publication") or {}
     published_ids = set(graph_publication.get("published_workflow_ids") or [])
     errors_by_workflow_id = graph_publication.get("errors_by_workflow_id") or {}

--- a/tests/backend/workflow_test_support.py
+++ b/tests/backend/workflow_test_support.py
@@ -15,6 +15,28 @@ from src.backend.workflows.definitions import (
     TURN_COMPLETION_GATE_WORKFLOW_ID,
     WRITE_TOOL_POLICY_WORKFLOW_ID,
 )
+from src.backend.workflows.durable.parent_specificity_concept_dossier_workflow import (
+    PARENT_SPECIFICITY_DOSSIER_WORKFLOW_ID,
+    get_parent_specificity_concept_dossier_workflow_registration,
+)
+from src.backend.workflows.durable.parent_specificity_rumination_workflow import (
+    PARENT_SPECIFICITY_RUMINATION_WORKFLOW_ID,
+    get_parent_specificity_rumination_workflow_registration,
+)
+from src.backend.workflows.durable.planning_workflow import (
+    PLANNING_WORKFLOW_ID,
+    get_planning_workflow_registration,
+)
+from src.backend.workflows.durable.rumination_workflow import (
+    RUMINATION_WORKFLOW_ID,
+    get_rumination_workflow_registration,
+)
+from src.backend.workflows.durable.workflow_gap_recovery_workflow import (
+    WORKFLOW_DISCOVERY_GAP_RECOVERY_WORKFLOW_ID,
+    WORKFLOW_GAP_TEST_WORKFLOW_ID,
+    get_workflow_discovery_gap_recovery_workflow_registration,
+    get_workflow_gap_test_workflow_registration,
+)
 from src.backend.workflows.workflow_registry import (
     LazyWorkflowRegistration,
     WorkflowRegistration,
@@ -69,7 +91,40 @@ TEST_WORKFLOW_PURPOSES: dict[str, str] = {
         "Canonical conversation-turn execution workflow that derives required "
         "effects, runs postcondition checks, and gates completion claims."
     ),
+    PLANNING_WORKFLOW_ID: (
+        "Forward inference workflow that proposes concrete, validated next "
+        "actions including tool calls and workflow invocations."
+    ),
+    RUMINATION_WORKFLOW_ID: (
+        "Proactive knowledge quality orchestrator that assesses ontology gaps "
+        "and dispatches enrichment work."
+    ),
+    PARENT_SPECIFICITY_DOSSIER_WORKFLOW_ID: (
+        "Gather multilingual dossier evidence for parent-specificity taxonomy "
+        "analysis."
+    ),
+    PARENT_SPECIFICITY_RUMINATION_WORKFLOW_ID: (
+        "Review parent candidates using dossier evidence and apply or defer "
+        "taxonomy refinements."
+    ),
+    WORKFLOW_DISCOVERY_GAP_RECOVERY_WORKFLOW_ID: (
+        "Recover from workflow discovery misses by analysing the gap, creating "
+        "candidate workflows, and optionally testing them."
+    ),
+    WORKFLOW_GAP_TEST_WORKFLOW_ID: (
+        "Run and assess a candidate workflow against explicit workflow-gap "
+        "acceptance requirements."
+    ),
 }
+
+AUTHORITATIVE_REASONING_RECOVERY_WORKFLOW_IDS: tuple[str, ...] = (
+    PLANNING_WORKFLOW_ID,
+    RUMINATION_WORKFLOW_ID,
+    PARENT_SPECIFICITY_DOSSIER_WORKFLOW_ID,
+    PARENT_SPECIFICITY_RUMINATION_WORKFLOW_ID,
+    WORKFLOW_DISCOVERY_GAP_RECOVERY_WORKFLOW_ID,
+    WORKFLOW_GAP_TEST_WORKFLOW_ID,
+)
 
 
 def build_test_conversation_turn_registry() -> WorkflowRegistry:
@@ -121,4 +176,22 @@ def authoritative_step_id(*, workflow_id: str, state_id: str) -> str:
     return authority_service._step_concept_id(
         workflow_id=workflow_id,
         state_id=state_id,
+    )
+
+
+def bootstrap_authoritative_reasoning_recovery_workflows() -> dict[str, Any]:
+    registry = WorkflowRegistry()
+    for registration in (
+        get_planning_workflow_registration(),
+        get_rumination_workflow_registration(),
+        get_parent_specificity_concept_dossier_workflow_registration(),
+        get_parent_specificity_rumination_workflow_registration(),
+        get_workflow_discovery_gap_recovery_workflow_registration(),
+        get_workflow_gap_test_workflow_registration(),
+    ):
+        registry.register(registration)
+
+    return authority_service.bootstrap_workflow_concepts(
+        registry=registry,
+        target_workflow_ids=AUTHORITATIVE_REASONING_RECOVERY_WORKFLOW_IDS,
     )


### PR DESCRIPTION
## Summary
- add the missing canonical planning workflow publication spec and include the planning/rumination/parent-specificity/gap-recovery family in the authority service durable set
- publish that family through a bootstrap-only registry path before discovery and remove its production Python graph registrations from the runtime registry
- add authoritative bootstrap helpers and regression coverage for MCP definition listing, registry bootstrap, workflow-gap publication, runtime identity parity, and the refreshed workflow-purity baseline

## Validation
- `pdm run pytest tests/backend/test_internal_mcp_workflow_tools.py -q`
- `pdm run pytest tests/backend/test_workflow_gap_recovery_workflow.py -q`
- `pdm run pytest tests/backend/test_workflow_registry_factory_parity.py -q`
- `pdm run pytest tests/backend/test_workflow_purity_baseline.py -q`
- `pdm run pytest tests/backend/test_workflow_concept_authority_service.py -q`
- `pdm run pyright src/backend/workflows/durable/registry_factory.py src/backend/workflows/workflow_concept_authority_service.py tests/backend/test_internal_mcp_workflow_tools.py tests/backend/test_workflow_concept_authority_service.py tests/backend/test_workflow_gap_recovery_workflow.py tests/backend/workflow_test_support.py`
- `C:\Users\witbr\Documents\Programming\Strong-AI-Lab\Von-Private\.venv\Scripts\python.exe scripts\workflow_purity_report.py`
- `C:\Users\witbr\Documents\Programming\Strong-AI-Lab\Von-Private\.venv\Scripts\python.exe scripts\workflow_purity_report.py --refresh-baseline`