### PR TITLE
JVNAUTOSCI-1528 migrate support workflows to Vontology authority

### DIFF
--- a/src/backend/workflows/durable/registry_factory.py
+++ b/src/backend/workflows/durable/registry_factory.py
@@ -122,6 +122,13 @@ _BOOTSTRAP_ONLY_REASONING_RECOVERY_WORKFLOW_IDS: tuple[str, ...] = (
     "#V#workflow_discovery_gap_recovery_workflow",
     "#V#workflow_gap_test_workflow",
 )
+_BOOTSTRAP_ONLY_SUPPORT_MAINTENANCE_WORKFLOW_IDS: tuple[str, ...] = (
+    "#V#rag_text_relation_sync_workflow",
+    "#V#enrichment_workflow",
+    "#V#workflow_introspection_maintenance_workflow",
+    "#V#entity_identity_resolution_workflow",
+    "#V#jira_task_incremental_import_workflow",
+)
 
 
 def _utc_now_iso() -> str:
@@ -544,15 +551,10 @@ def _register_python_defined_workflows(registry: WorkflowRegistry) -> None:
     # Conversation-turn workflows are now Vontology-authoritative. Only durable
     # workflow families that still originate in Python are registered here so
     # purity diagnostics can track the remaining hybrid surface.
-    registry.register(get_rag_sync_workflow_registration())
-    registry.register(get_enrichment_workflow_registration())
-    registry.register(get_workflow_introspection_maintenance_registration())
     registry.register(get_file_copy_typing_workflow_registration())
     registry.register(get_file_copy_upload_classification_workflow_registration())
     registry.register(get_file_copy_upload_handler_workflow_registration())
     registry.register(get_file_copy_interpretation_workflow_registration())
-    registry.register(get_entity_identity_resolution_workflow_registration())
-    registry.register(get_jira_task_incremental_import_workflow_registration())
 
 
 def _bootstrap_only_reasoning_recovery_workflow_registrations() -> tuple[Any, ...]:
@@ -588,6 +590,43 @@ def _bootstrap_only_reasoning_recovery_workflow_report(
     bootstrap_report = bootstrap_workflow_concepts(
         registry=temp_registry,
         target_workflow_ids=_BOOTSTRAP_ONLY_REASONING_RECOVERY_WORKFLOW_IDS,
+    )
+    report.update(bootstrap_report)
+    return report
+
+
+def _bootstrap_only_support_maintenance_workflow_registrations() -> tuple[Any, ...]:
+    """Return maintenance registrations used only to publish authoritative graphs."""
+
+    return (
+        get_rag_sync_workflow_registration(),
+        get_enrichment_workflow_registration(),
+        get_workflow_introspection_maintenance_registration(),
+        get_entity_identity_resolution_workflow_registration(),
+        get_jira_task_incremental_import_workflow_registration(),
+    )
+
+
+def _bootstrap_only_support_maintenance_workflow_report(
+    *,
+    bootstrap_allowed: bool,
+) -> Dict[str, Any]:
+    report: Dict[str, Any] = {
+        "enabled": bool(bootstrap_allowed),
+        "workflow_ids": list(_BOOTSTRAP_ONLY_SUPPORT_MAINTENANCE_WORKFLOW_IDS),
+    }
+    if not bootstrap_allowed:
+        return report
+
+    temp_registry = WorkflowRegistry(
+        definition_loader=load_workflow_definition_from_vontology,
+    )
+    for registration in _bootstrap_only_support_maintenance_workflow_registrations():
+        temp_registry.register(registration)
+
+    bootstrap_report = bootstrap_workflow_concepts(
+        registry=temp_registry,
+        target_workflow_ids=_BOOTSTRAP_ONLY_SUPPORT_MAINTENANCE_WORKFLOW_IDS,
     )
     report.update(bootstrap_report)
     return report
@@ -634,6 +673,10 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
         "enabled": bootstrap_allowed,
         "workflow_ids": list(_BOOTSTRAP_ONLY_REASONING_RECOVERY_WORKFLOW_IDS),
     }
+    bootstrap_only_support_maintenance_report: Dict[str, Any] = {
+        "enabled": bootstrap_allowed,
+        "workflow_ids": list(_BOOTSTRAP_ONLY_SUPPORT_MAINTENANCE_WORKFLOW_IDS),
+    }
 
     _register_python_defined_workflows(registry)
 
@@ -649,6 +692,11 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
             talk_representation_bootstrap_report["enabled"] = True
             bootstrap_only_reasoning_recovery_report = (
                 _bootstrap_only_reasoning_recovery_workflow_report(
+                    bootstrap_allowed=True
+                )
+            )
+            bootstrap_only_support_maintenance_report = (
+                _bootstrap_only_support_maintenance_workflow_report(
                     bootstrap_allowed=True
                 )
             )
@@ -673,6 +721,16 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
                     "#V#technical_scientific_talk_representation_workflow",
                     "#V#academic_presentation_instance_workflow",
                 ],
+                "error": str(exc),
+            }
+            bootstrap_only_reasoning_recovery_report = {
+                "enabled": True,
+                "workflow_ids": list(_BOOTSTRAP_ONLY_REASONING_RECOVERY_WORKFLOW_IDS),
+                "error": str(exc),
+            }
+            bootstrap_only_support_maintenance_report = {
+                "enabled": True,
+                "workflow_ids": list(_BOOTSTRAP_ONLY_SUPPORT_MAINTENANCE_WORKFLOW_IDS),
                 "error": str(exc),
             }
 
@@ -750,6 +808,9 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
         bootstrap_only_reasoning_recovery_report=(
             bootstrap_only_reasoning_recovery_report
         ),
+        bootstrap_only_support_maintenance_report=(
+            bootstrap_only_support_maintenance_report
+        ),
         bootstrap_allowed=bootstrap_allowed,
     )
 
@@ -763,6 +824,7 @@ def _launch_deferred_registry_work(
     paper_representation_bootstrap_report: Dict[str, Any],
     talk_representation_bootstrap_report: Dict[str, Any],
     bootstrap_only_reasoning_recovery_report: Dict[str, Any],
+    bootstrap_only_support_maintenance_report: Dict[str, Any],
     bootstrap_allowed: bool,
 ) -> None:
     """Launch background thread for bootstrap and parity inventory.
@@ -815,6 +877,9 @@ def _launch_deferred_registry_work(
             )
             authority_report["bootstrap_only_reasoning_recovery_workflows"] = (
                 bootstrap_only_reasoning_recovery_report
+            )
+            authority_report["bootstrap_only_support_maintenance_workflows"] = (
+                bootstrap_only_support_maintenance_report
             )
 
             inventory_snapshot = _build_workflow_parity_inventory(

--- a/src/backend/workflows/workflow_concept_authority_service.py
+++ b/src/backend/workflows/workflow_concept_authority_service.py
@@ -139,6 +139,15 @@ PARENT_SPECIFICITY_DOSSIER_WORKFLOW_ID = (
 PARENT_SPECIFICITY_RUMINATION_WORKFLOW_ID = (
     "#V#parent_specificity_rumination_workflow"
 )
+RAG_TEXT_RELATION_SYNC_WORKFLOW_ID = "#V#rag_text_relation_sync_workflow"
+ENRICHMENT_WORKFLOW_ID = "#V#enrichment_workflow"
+WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID = (
+    "#V#workflow_introspection_maintenance_workflow"
+)
+ENTITY_IDENTITY_RESOLUTION_WORKFLOW_ID = "#V#entity_identity_resolution_workflow"
+JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID = (
+    "#V#jira_task_incremental_import_workflow"
+)
 PLANNING_WORKFLOW_ID = "#V#planning_workflow"
 RUMINATION_WORKFLOW_ID = "#V#rumination_workflow"
 
@@ -170,10 +179,15 @@ CANONICAL_CHAT_WORKFLOW_IDS: tuple[str, ...] = (
 
 # Additional built-in workflows that should be published when registered.
 CANONICAL_DURABLE_WORKFLOW_IDS: tuple[str, ...] = (
+    RAG_TEXT_RELATION_SYNC_WORKFLOW_ID,
+    ENRICHMENT_WORKFLOW_ID,
     FILE_COPY_TYPING_WORKFLOW_ID,
     FILE_COPY_INTERPRETATION_WORKFLOW_ID,
     FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID,
     FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
+    WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID,
+    ENTITY_IDENTITY_RESOLUTION_WORKFLOW_ID,
+    JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID,
     PLANNING_WORKFLOW_ID,
     PARENT_SPECIFICITY_DOSSIER_WORKFLOW_ID,
     PARENT_SPECIFICITY_RUMINATION_WORKFLOW_ID,
@@ -1447,6 +1461,337 @@ _CANONICAL_WORKFLOW_PUBLICATION_SPECS: Dict[str, _CanonicalWorkflowPublicationSp
                 state_id="complete",
                 action_id="rumination.finalise",
             ),
+            _CanonicalStepPublicationSpec(state_id="failed"),
+        ),
+    ),
+    RAG_TEXT_RELATION_SYNC_WORKFLOW_ID: _CanonicalWorkflowPublicationSpec(
+        initial_state="collect",
+        steps=(
+            _CanonicalStepPublicationSpec(
+                state_id="collect",
+                action_id="rag_sync.collect_docs",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="batch",
+                        reason="docs_collected",
+                        condition_spec={
+                            "kind": "context_flag",
+                            "key": "collected_docs",
+                            "expected": True,
+                        },
+                    ),
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="complete",
+                        reason="no_docs_to_sync",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="batch",
+                action_id="rag_sync.prepare_batch",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="upsert",
+                        reason="batch_prepared",
+                        condition_spec={
+                            "kind": "context_flag",
+                            "key": "current_batch",
+                            "expected": True,
+                        },
+                    ),
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="complete",
+                        reason="all_batches_processed",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="upsert",
+                action_id="rag_sync.upsert_batch",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="batch",
+                        reason="more_batches",
+                        condition_spec={
+                            "kind": "context_flag",
+                            "key": "has_more_batches",
+                            "expected": True,
+                        },
+                    ),
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="complete",
+                        reason="all_batches_done",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="complete",
+                action_id="rag_sync.finalise",
+            ),
+            _CanonicalStepPublicationSpec(state_id="failed"),
+        ),
+    ),
+    ENRICHMENT_WORKFLOW_ID: _CanonicalWorkflowPublicationSpec(
+        initial_state="collect",
+        steps=(
+            _CanonicalStepPublicationSpec(
+                state_id="collect",
+                action_id="enrichment.collect_candidates",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="batch",
+                        reason="candidates_found",
+                        condition_spec={
+                            "kind": "context_flag",
+                            "key": "candidate_ids",
+                            "expected": True,
+                        },
+                    ),
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="complete",
+                        reason="no_candidates",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="batch",
+                action_id="enrichment.prepare_batch",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="generate",
+                        reason="batch_ready",
+                        condition_spec={
+                            "kind": "context_flag",
+                            "key": "current_batch",
+                            "expected": True,
+                        },
+                    ),
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="complete",
+                        reason="all_processed",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="generate",
+                action_id="enrichment.process_batch",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="batch",
+                        reason="more_batches_pending",
+                        condition_spec={
+                            "kind": "context_flag",
+                            "key": "has_more_batches",
+                            "expected": True,
+                        },
+                    ),
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="complete",
+                        reason="processing_complete",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="complete",
+                action_id="enrichment.finalise",
+            ),
+            _CanonicalStepPublicationSpec(state_id="failed"),
+        ),
+    ),
+    WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID: _CanonicalWorkflowPublicationSpec(
+        initial_state="assess",
+        steps=(
+            _CanonicalStepPublicationSpec(
+                state_id="assess",
+                action_id="workflow_introspection.assess_context",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="failed",
+                        reason="on_failure",
+                        condition_spec={
+                            "kind": "context_flag",
+                            "key": "last_action_failed",
+                            "expected": True,
+                        },
+                    ),
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="diagnose",
+                        reason="evidence_ready",
+                        condition_spec={
+                            "kind": "context_flag",
+                            "key": "maintenance_evidence",
+                            "expected": True,
+                        },
+                    ),
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="failed",
+                        reason="missing_evidence",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="diagnose",
+                action_id="workflow_introspection.diagnose_conflation",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="failed",
+                        reason="on_failure",
+                        condition_spec={
+                            "kind": "context_flag",
+                            "key": "last_action_failed",
+                            "expected": True,
+                        },
+                    ),
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="plan",
+                        reason="diagnosis_ready",
+                        condition_spec={
+                            "kind": "context_flag",
+                            "key": "maintenance_diagnosis",
+                            "expected": True,
+                        },
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="plan",
+                action_id="workflow_introspection.plan_repairs",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="failed",
+                        reason="on_failure",
+                        condition_spec={
+                            "kind": "context_flag",
+                            "key": "last_action_failed",
+                            "expected": True,
+                        },
+                    ),
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="apply",
+                        reason="planned",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="apply",
+                action_id="workflow_introspection.apply_repairs",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="failed",
+                        reason="on_failure",
+                        condition_spec={
+                            "kind": "context_flag",
+                            "key": "last_action_failed",
+                            "expected": True,
+                        },
+                    ),
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="verify",
+                        reason="applied_or_skipped",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="verify",
+                action_id="workflow_introspection.verify_repairs",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="failed",
+                        reason="on_failure",
+                        condition_spec={
+                            "kind": "context_flag",
+                            "key": "last_action_failed",
+                            "expected": True,
+                        },
+                    ),
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="complete",
+                        reason="verified_or_noop",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="complete",
+                action_id="workflow_introspection.finalise",
+            ),
+            _CanonicalStepPublicationSpec(state_id="failed"),
+        ),
+    ),
+    ENTITY_IDENTITY_RESOLUTION_WORKFLOW_ID: _CanonicalWorkflowPublicationSpec(
+        initial_state="scan",
+        steps=(
+            _CanonicalStepPublicationSpec(
+                state_id="scan",
+                action_id="identity_resolution.scan_candidates",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="apply",
+                        reason="recommendations_ready",
+                        condition_spec={
+                            "kind": "context_flag",
+                            "key": "duplicate_recommendations",
+                            "expected": True,
+                        },
+                    ),
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="complete",
+                        reason="nothing_to_apply",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="apply",
+                action_id="identity_resolution.apply_resolutions",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="complete",
+                        reason="apply_complete",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(
+                state_id="complete",
+                action_id="identity_resolution.finalise",
+            ),
+            _CanonicalStepPublicationSpec(state_id="failed"),
+        ),
+    ),
+    JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID: _CanonicalWorkflowPublicationSpec(
+        initial_state="run_sync",
+        steps=(
+            _CanonicalStepPublicationSpec(
+                state_id="run_sync",
+                action_id="jira_task_incremental_import.run_sync",
+                conditional_transitions=(
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="failed",
+                        reason="sync_failed",
+                        condition_spec={
+                            "kind": "context_flag",
+                            "key": "last_action_failed",
+                            "expected": True,
+                        },
+                    ),
+                    _CanonicalConditionalTransitionPublicationSpec(
+                        to_state="complete",
+                        reason="sync_complete",
+                        condition_spec={"kind": "always"},
+                    ),
+                ),
+            ),
+            _CanonicalStepPublicationSpec(state_id="complete"),
             _CanonicalStepPublicationSpec(state_id="failed"),
         ),
     ),

--- a/tests/backend/fixtures/workflow_purity_baseline.json
+++ b/tests/backend/fixtures/workflow_purity_baseline.json
@@ -1,14 +1,14 @@
 {
   "counters": {
-    "built_in_registration_count": 9,
+    "built_in_registration_count": 4,
     "builtin_capability_override_count": 0,
     "direct_instance_create_callsite_count": 4,
     "env_event_binding_count": 0,
     "legacy_selector_mode_count": 1,
-    "non_vontology_discoverable_workflow_count": 9,
+    "non_vontology_discoverable_workflow_count": 4,
     "remaining_python_workflow_family_count": 16
   },
-  "generated_at_utc": "2026-03-17T21:34:31.301998+00:00",
+  "generated_at_utc": "2026-03-17T22:54:02.832635+00:00",
   "report_schema_version": "workflow_purity_report.v1",
   "schema_version": "workflow_purity_baseline.v1"
 }

--- a/tests/backend/test_enrichment_workflow.py
+++ b/tests/backend/test_enrichment_workflow.py
@@ -409,16 +409,21 @@ class TestEnrichmentRegistration:
         from src.backend.workflows.durable.enrichment_workflow import (
             ENRICHMENT_WORKFLOW_ID,
         )
+        from workflow_test_support import (
+            bootstrap_authoritative_support_maintenance_workflows,
+        )
+
+        bootstrap_authoritative_support_maintenance_workflows()
 
         with (
             patch(
                 "src.backend.workflows.durable.registry_factory.discover_workflow_ids",
-                return_value=[],
+                return_value=[ENRICHMENT_WORKFLOW_ID],
             ),
         ):
             from src.backend.workflows.durable.registry_factory import (
-                build_workflow_registry,
+                _build_workflow_registry,
             )
 
-            registry = build_workflow_registry()
+            registry = _build_workflow_registry(allow_bootstrap=False)
             assert ENRICHMENT_WORKFLOW_ID in registry.all_workflow_ids()

--- a/tests/backend/test_internal_mcp_workflow_tools.py
+++ b/tests/backend/test_internal_mcp_workflow_tools.py
@@ -13,7 +13,10 @@ from src.backend.workflows.durable.models import (
     WorkflowInstanceStatus,
 )
 from src.backend.workflows.durable.scheduler import WorkflowScheduler
-from workflow_test_support import bootstrap_authoritative_reasoning_recovery_workflows
+from workflow_test_support import (
+    bootstrap_authoritative_reasoning_recovery_workflows,
+    bootstrap_authoritative_support_maintenance_workflows,
+)
 
 
 def _build_gateway() -> InternalMCPGateway:
@@ -500,6 +503,7 @@ class _InMemoryScheduleWorkflowManager:
 
 def test_workflow_list_definitions_exists_and_returns_data():
     bootstrap_authoritative_reasoning_recovery_workflows()
+    bootstrap_authoritative_support_maintenance_workflows()
     catalogue = build_default_catalogue()
     methods = catalogue.list_methods()
     assert "workflow_list_definitions" in methods
@@ -523,6 +527,9 @@ def test_workflow_list_definitions_exists_and_returns_data():
     # (rag_sync_workflow is registered in build_durable_workflow_registry)
     assert "#V#rag_text_relation_sync_workflow" in def_ids
     assert "#V#enrichment_workflow" in def_ids
+    assert "#V#workflow_introspection_maintenance_workflow" in def_ids
+    assert "#V#entity_identity_resolution_workflow" in def_ids
+    assert "#V#jira_task_incremental_import_workflow" in def_ids
     assert "#V#planning_workflow" in def_ids
     assert "#V#rumination_workflow" in def_ids
     assert "#V#parent_specificity_concept_dossier_workflow" in def_ids
@@ -537,6 +544,20 @@ def test_workflow_list_definitions_exists_and_returns_data():
         item["workflow_id"]: str(item.get("source") or "").strip().lower()
         for item in result["definitions"]
     }
+    assert source_by_workflow_id["#V#rag_text_relation_sync_workflow"] == "vontology"
+    assert source_by_workflow_id["#V#enrichment_workflow"] == "vontology"
+    assert (
+        source_by_workflow_id["#V#workflow_introspection_maintenance_workflow"]
+        == "vontology"
+    )
+    assert (
+        source_by_workflow_id["#V#entity_identity_resolution_workflow"]
+        == "vontology"
+    )
+    assert (
+        source_by_workflow_id["#V#jira_task_incremental_import_workflow"]
+        == "vontology"
+    )
     assert source_by_workflow_id["#V#planning_workflow"] == "vontology"
     assert source_by_workflow_id["#V#rumination_workflow"] == "vontology"
     assert (
@@ -593,6 +614,7 @@ def test_workflow_list_definitions_exists_and_returns_data():
 
 def test_workflow_list_definitions_gateway_invoke_success_path():
     bootstrap_authoritative_reasoning_recovery_workflows()
+    bootstrap_authoritative_support_maintenance_workflows()
     gateway = _build_gateway()
     result = gateway.invoke("workflow_list_definitions", {"limit": 10})
     payload = result.payload

--- a/tests/backend/test_jira_task_incremental_import_workflow.py
+++ b/tests/backend/test_jira_task_incremental_import_workflow.py
@@ -55,8 +55,16 @@ def test_incremental_import_workflow_executes_shared_runner(monkeypatch) -> None
 
 def test_registry_factory_registers_incremental_import_workflow(monkeypatch) -> None:
     import src.backend.workflows.durable.registry_factory as factory
+    from workflow_test_support import (
+        bootstrap_authoritative_support_maintenance_workflows,
+    )
 
-    monkeypatch.setattr(factory, "discover_workflow_ids", lambda: [])
+    bootstrap_authoritative_support_maintenance_workflows()
+    monkeypatch.setattr(
+        factory,
+        "discover_workflow_ids",
+        lambda: [mod.JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID],
+    )
     monkeypatch.setattr(
         factory,
         "build_workflow_concept_authority_report",

--- a/tests/backend/test_workflow_concept_authority_service.py
+++ b/tests/backend/test_workflow_concept_authority_service.py
@@ -979,6 +979,172 @@ def test_build_workflow_registry_bootstraps_reasoning_recovery_family_from_vonto
         assert str(registration.source or "").strip().lower() == "vontology"
 
 
+def test_bootstrap_publishes_explicit_step_conditions_for_support_maintenance_workflows(
+    _reset_mock_workflow_graph_db,
+):
+    from src.backend.workflows.durable.workflow_introspection_maintenance_workflow import (
+        WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID,
+    )
+    from src.backend.workflows.durable.jira_task_incremental_import_workflow import (
+        JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID,
+    )
+    from src.backend.workflows.vontology_loader import build_workflow_process_graph
+    from workflow_test_support import (
+        bootstrap_authoritative_support_maintenance_workflows,
+    )
+
+    report = bootstrap_authoritative_support_maintenance_workflows()
+    errors = (
+        (report.get("graph_publication") or {}).get("errors_by_workflow_id") or {}
+    )
+    assert WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID not in errors
+    assert JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID not in errors
+
+    maintenance_graph, maintenance_warnings = build_workflow_process_graph(
+        WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID
+    )
+    assert maintenance_graph is not None
+    assert maintenance_warnings == []
+    assert _graph_step_control_flow_conditions(
+        graph=maintenance_graph,
+        workflow_id=WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID,
+        state_id="assess",
+    ) == [
+        {
+            "to": authority_service._step_concept_id(
+                workflow_id=WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID,
+                state_id="failed",
+            ),
+            "reason": "on_failure",
+            "condition": {
+                "kind": "context_flag",
+                "key": "last_action_failed",
+                "expected": True,
+            },
+        },
+        {
+            "to": authority_service._step_concept_id(
+                workflow_id=WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID,
+                state_id="diagnose",
+            ),
+            "reason": "evidence_ready",
+            "condition": {
+                "kind": "context_flag",
+                "key": "maintenance_evidence",
+                "expected": True,
+            },
+        },
+        {
+            "to": authority_service._step_concept_id(
+                workflow_id=WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID,
+                state_id="failed",
+            ),
+            "reason": "missing_evidence",
+            "condition": {"kind": "always"},
+        },
+    ]
+
+    jira_graph, jira_warnings = build_workflow_process_graph(
+        JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID
+    )
+    assert jira_graph is not None
+    assert jira_warnings == []
+    assert _graph_step_control_flow_conditions(
+        graph=jira_graph,
+        workflow_id=JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID,
+        state_id="run_sync",
+    ) == [
+        {
+            "to": authority_service._step_concept_id(
+                workflow_id=JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID,
+                state_id="failed",
+            ),
+            "reason": "sync_failed",
+            "condition": {
+                "kind": "context_flag",
+                "key": "last_action_failed",
+                "expected": True,
+            },
+        },
+        {
+            "to": authority_service._step_concept_id(
+                workflow_id=JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID,
+                state_id="complete",
+            ),
+            "reason": "sync_complete",
+            "condition": {"kind": "always"},
+        },
+    ]
+
+
+def test_support_maintenance_workflow_runtime_identity_matches_authoritative_loader(
+    _reset_mock_workflow_graph_db,
+):
+    from src.backend.workflows.durable.registry_factory import (
+        build_workflow_registry_read_only,
+    )
+    from src.backend.workflows.vontology_loader import (
+        load_workflow_definition_from_vontology,
+    )
+    from workflow_test_support import (
+        AUTHORITATIVE_SUPPORT_MAINTENANCE_WORKFLOW_IDS,
+        bootstrap_authoritative_support_maintenance_workflows,
+    )
+
+    bootstrap_authoritative_support_maintenance_workflows()
+    runtime_registry = build_workflow_registry_read_only()
+
+    for workflow_id in AUTHORITATIVE_SUPPORT_MAINTENANCE_WORKFLOW_IDS:
+        registration = runtime_registry.get_registration(workflow_id)
+        assert registration is not None
+        assert str(registration.source or "").strip().lower() == "vontology"
+
+        authoritative_definition = load_workflow_definition_from_vontology(workflow_id)
+        assert authoritative_definition is not None
+
+        identity = build_workflow_definition_identity(
+            workflow_id=workflow_id,
+            source=registration.source,
+            definition=registration.definition,
+            authoritative_definition=authoritative_definition,
+        )
+        assert identity["runtime_definition_hash"]
+        assert identity["authoritative_definition_hash"]
+        assert identity["hash_mismatch"] is False
+
+
+def test_build_workflow_registry_bootstraps_support_maintenance_family_from_vontology(
+    _reset_mock_workflow_graph_db,
+    monkeypatch,
+):
+    from src.backend.db.mongo_client import get_db
+    from src.backend.services.workflow_discovery_service import (
+        invalidate_workflow_discovery_executability_caches,
+    )
+    from src.backend.workflows.durable.registry_factory import build_workflow_registry
+    from workflow_test_support import AUTHORITATIVE_SUPPORT_MAINTENANCE_WORKFLOW_IDS
+
+    monkeypatch.setenv("VON_USE_MOCK_DB", "1")
+    monkeypatch.setenv("VON_DB_NAME", "test_von_db")
+    authority_service.clear_workflow_type_resolution_cache()
+
+    db = get_db()
+    if db is not None:
+        for collection_name in ("concepts", "text_relations", "text_values"):
+            try:
+                db.drop_collection(collection_name)
+            except Exception:
+                pass
+
+    invalidate_workflow_discovery_executability_caches()
+    registry = build_workflow_registry()
+
+    for workflow_id in AUTHORITATIVE_SUPPORT_MAINTENANCE_WORKFLOW_IDS:
+        registration = registry.get_registration(workflow_id)
+        assert registration is not None
+        assert str(registration.source or "").strip().lower() == "vontology"
+
+
 def test_publish_canonical_graphs_reports_validation_failures(
     _reset_mock_workflow_graph_db,
     monkeypatch,

--- a/tests/backend/test_workflow_introspection_maintenance_workflow.py
+++ b/tests/backend/test_workflow_introspection_maintenance_workflow.py
@@ -373,15 +373,20 @@ def test_registered_in_registry_factory():
         WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID,
     )
     from src.backend.workflows.durable.registry_factory import (
+        _build_workflow_registry,
         build_durable_action_registry,
-        build_workflow_registry,
     )
+    from workflow_test_support import (
+        bootstrap_authoritative_support_maintenance_workflows,
+    )
+
+    bootstrap_authoritative_support_maintenance_workflows()
 
     with patch(
         "src.backend.workflows.durable.registry_factory.discover_workflow_ids",
-        return_value=[],
+        return_value=[WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID],
     ):
-        workflow_registry = build_workflow_registry()
+        workflow_registry = _build_workflow_registry(allow_bootstrap=False)
         assert WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID in workflow_registry.all_workflow_ids()
 
     action_registry = build_durable_action_registry()

--- a/tests/backend/workflow_test_support.py
+++ b/tests/backend/workflow_test_support.py
@@ -31,6 +31,26 @@ from src.backend.workflows.durable.rumination_workflow import (
     RUMINATION_WORKFLOW_ID,
     get_rumination_workflow_registration,
 )
+from src.backend.workflows.durable.rag_sync_workflow import (
+    RAG_TEXT_RELATION_SYNC_WORKFLOW_ID,
+    get_rag_sync_workflow_registration,
+)
+from src.backend.workflows.durable.enrichment_workflow import (
+    ENRICHMENT_WORKFLOW_ID,
+    get_enrichment_workflow_registration,
+)
+from src.backend.workflows.durable.workflow_introspection_maintenance_workflow import (
+    WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID,
+    get_workflow_introspection_maintenance_registration,
+)
+from src.backend.workflows.durable.entity_identity_resolution_workflow import (
+    ENTITY_IDENTITY_RESOLUTION_WORKFLOW_ID,
+    get_entity_identity_resolution_workflow_registration,
+)
+from src.backend.workflows.durable.jira_task_incremental_import_workflow import (
+    JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID,
+    get_jira_task_incremental_import_workflow_registration,
+)
 from src.backend.workflows.durable.workflow_gap_recovery_workflow import (
     WORKFLOW_DISCOVERY_GAP_RECOVERY_WORKFLOW_ID,
     WORKFLOW_GAP_TEST_WORKFLOW_ID,
@@ -91,6 +111,26 @@ TEST_WORKFLOW_PURPOSES: dict[str, str] = {
         "Canonical conversation-turn execution workflow that derives required "
         "effects, runs postcondition checks, and gates completion claims."
     ),
+    RAG_TEXT_RELATION_SYNC_WORKFLOW_ID: (
+        "Synchronise Vontology text relations to the RAG store with checkpointed "
+        "batch upserts."
+    ),
+    ENRICHMENT_WORKFLOW_ID: (
+        "Generate missing text relations for concepts using a parameterised "
+        "enrichment workflow."
+    ),
+    WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID: (
+        "Diagnose workflow and prompt incidents, plan bounded repairs, and verify "
+        "maintenance outcomes."
+    ),
+    ENTITY_IDENTITY_RESOLUTION_WORKFLOW_ID: (
+        "Detect duplicate entities, apply confidence-scored resolutions, and "
+        "summarise identity-maintenance results."
+    ),
+    JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID: (
+        "Synchronise Jira tasks into Von via the shared incremental migration "
+        "runner."
+    ),
     PLANNING_WORKFLOW_ID: (
         "Forward inference workflow that proposes concrete, validated next "
         "actions including tool calls and workflow invocations."
@@ -124,6 +164,13 @@ AUTHORITATIVE_REASONING_RECOVERY_WORKFLOW_IDS: tuple[str, ...] = (
     PARENT_SPECIFICITY_RUMINATION_WORKFLOW_ID,
     WORKFLOW_DISCOVERY_GAP_RECOVERY_WORKFLOW_ID,
     WORKFLOW_GAP_TEST_WORKFLOW_ID,
+)
+AUTHORITATIVE_SUPPORT_MAINTENANCE_WORKFLOW_IDS: tuple[str, ...] = (
+    RAG_TEXT_RELATION_SYNC_WORKFLOW_ID,
+    ENRICHMENT_WORKFLOW_ID,
+    WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID,
+    ENTITY_IDENTITY_RESOLUTION_WORKFLOW_ID,
+    JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID,
 )
 
 
@@ -194,4 +241,21 @@ def bootstrap_authoritative_reasoning_recovery_workflows() -> dict[str, Any]:
     return authority_service.bootstrap_workflow_concepts(
         registry=registry,
         target_workflow_ids=AUTHORITATIVE_REASONING_RECOVERY_WORKFLOW_IDS,
+    )
+
+
+def bootstrap_authoritative_support_maintenance_workflows() -> dict[str, Any]:
+    registry = WorkflowRegistry()
+    for registration in (
+        get_rag_sync_workflow_registration(),
+        get_enrichment_workflow_registration(),
+        get_workflow_introspection_maintenance_registration(),
+        get_entity_identity_resolution_workflow_registration(),
+        get_jira_task_incremental_import_workflow_registration(),
+    ):
+        registry.register(registration)
+
+    return authority_service.bootstrap_workflow_concepts(
+        registry=registry,
+        target_workflow_ids=AUTHORITATIVE_SUPPORT_MAINTENANCE_WORKFLOW_IDS,
     )


### PR DESCRIPTION
## Summary
- publish canonical authority specs for the remaining support and maintenance workflow family
- remove that family from production Python registration and bootstrap it as Vontology-authoritative instead
- update registry, MCP, authority, and workflow tests to assert `source=vontology` and refresh the workflow-purity baseline

## Testing
- `C:\Users\witbr\Documents\Programming\Strong-AI-Lab\Von\.venv\Scripts\python.exe -m pytest tests/backend/test_enrichment_workflow.py -q`
- `C:\Users\witbr\Documents\Programming\Strong-AI-Lab\Von\.venv\Scripts\python.exe -m pytest tests/backend/test_internal_mcp_workflow_tools.py -q`
- `C:\Users\witbr\Documents\Programming\Strong-AI-Lab\Von\.venv\Scripts\python.exe -m pytest tests/backend/test_jira_task_incremental_import_workflow.py -q`
- `C:\Users\witbr\Documents\Programming\Strong-AI-Lab\Von\.venv\Scripts\python.exe -m pytest tests/backend/test_workflow_concept_authority_service.py -k "canonical_chat_graphs_with_loader_runtime_parity or explicit_step_conditions_for_support_maintenance_workflows or support_maintenance_workflow_runtime_identity_matches_authoritative_loader or build_workflow_registry_bootstraps_support_maintenance_family_from_vontology" -q`
- `C:\Users\witbr\Documents\Programming\Strong-AI-Lab\Von\.venv\Scripts\python.exe -m pytest tests/backend/test_workflow_introspection_maintenance_workflow.py -q`
- `C:\Users\witbr\Documents\Programming\Strong-AI-Lab\Von\.venv\Scripts\python.exe -m pytest tests/backend/test_entity_identity_resolution_workflow.py -q`
- `C:\Users\witbr\Documents\Programming\Strong-AI-Lab\Von\.venv\Scripts\python.exe -m pytest tests/backend/test_rag_sync_workflow.py -q`
- `C:\Users\witbr\Documents\Programming\Strong-AI-Lab\Von\.venv\Scripts\python.exe -m pytest tests/backend/test_rag_text_relation_sync_service.py -q`
- `C:\Users\witbr\Documents\Programming\Strong-AI-Lab\Von\.venv\Scripts\python.exe -m pytest tests/backend/test_workflow_registry_factory_parity.py -q`
- `C:\Users\witbr\Documents\Programming\Strong-AI-Lab\Von\.venv\Scripts\python.exe -m pytest tests/backend/test_workflow_purity_baseline.py -q`
- `C:\Users\witbr\Documents\Programming\Strong-AI-Lab\Von\.venv\Scripts\pyright.exe src/backend/workflows/durable/registry_factory.py src/backend/workflows/workflow_concept_authority_service.py tests/backend/test_enrichment_workflow.py tests/backend/test_internal_mcp_workflow_tools.py tests/backend/test_jira_task_incremental_import_workflow.py tests/backend/test_workflow_concept_authority_service.py tests/backend/test_workflow_introspection_maintenance_workflow.py tests/backend/workflow_test_support.py`