### PR TITLE
JVNAUTOSCI-1529 Retire representation built-in bootstrap path

### DIFF
--- a/docs/engineering/workflow_authoritative_publication_process.md
+++ b/docs/engineering/workflow_authoritative_publication_process.md
@@ -18,6 +18,13 @@ Use the existing canonical pathway in `src/backend/workflows/workflow_concept_au
 
 `publish_canonical_chat_workflow_graphs(...)` now applies strict post-publication validation before a workflow is counted as published.
 
+For explicit Vontology-authored workflow families such as paper/talk
+representation, use `publish_canonical_chat_workflow_graphs(...)` with explicit
+publication specs/definitions/purposes rather than creating temporary
+`source="built_in"` runtime registrations. The runtime registry must consume the
+published Vontology authority; it must not materialise those families on the
+production registry path.
+
 ## Strict Validation Gates
 
 `validate_workflow_definition_contract(...)` in `src/backend/workflows/workflow_definition_identity_service.py` enforces:

--- a/src/backend/services/paper_representation_workflow_vontology_service.py
+++ b/src/backend/services/paper_representation_workflow_vontology_service.py
@@ -27,7 +27,6 @@ from ..workflows.vontology_loader import (
 from ..workflows.workflow_definition_identity_service import (
     validate_workflow_definition_contract,
 )
-from ..workflows.workflow_registry import WorkflowRegistration, WorkflowRegistry
 
 SCHOLARLY_PAPER_REPRESENTATION_WORKFLOW_ID = "#V#scholarly_paper_representation_workflow"
 ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID = "#V#arxiv_paper_representation_workflow"
@@ -931,28 +930,22 @@ def _step_concept_ids_for_spec(
     return tuple(ordered_ids)
 
 
-def _build_publication_registry() -> tuple[
-    WorkflowRegistry,
-    dict[str, authority_service._CanonicalWorkflowPublicationSpec],
+def _build_publication_specs() -> dict[
+    str,
+    authority_service._CanonicalWorkflowPublicationSpec,
 ]:
-    registry = WorkflowRegistry()
-    specs = {
+    return {
         SCHOLARLY_PAPER_REPRESENTATION_WORKFLOW_ID: _build_scholarly_workflow_spec(),
         ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID: _build_arxiv_workflow_spec(),
     }
-    for workflow_id, spec in specs.items():
-        registry.register(
-            WorkflowRegistration(
-                workflow_id=workflow_id,
-                definition=authority_service._build_definition_from_publication_spec(
-                    workflow_id=workflow_id,
-                    spec=spec,
-                ),
-                purpose=_workflow_content(workflow_id),
-                source="built_in",
-            )
-        )
-    return registry, specs
+
+
+def _build_publication_purposes(workflow_ids: Sequence[str]) -> dict[str, str]:
+    return {
+        workflow_id: _workflow_content(workflow_id)
+        for workflow_id in workflow_ids
+        if isinstance(workflow_id, str) and workflow_id.strip()
+    }
 
 
 def _validate_existing_materialisation(
@@ -1015,8 +1008,12 @@ def _validate_existing_materialisation(
 def bootstrap_canonical_paper_representation_workflows() -> dict[str, Any]:
     """Publish and validate the canonical scholarly-paper workflow family."""
 
-    registry, specs = _build_publication_registry()
+    specs = _build_publication_specs()
     target_workflow_ids = tuple(specs.keys())
+    publication_definitions = authority_service._build_definition_map_from_publication_specs(
+        specs
+    )
+    publication_purposes = _build_publication_purposes(target_workflow_ids)
     already_current, existing_validation_by_workflow_id = (
         _validate_existing_materialisation(target_workflow_ids=target_workflow_ids)
     )
@@ -1041,16 +1038,12 @@ def bootstrap_canonical_paper_representation_workflows() -> dict[str, Any]:
             "skipped": True,
         }
     else:
-        original_specs = dict(authority_service._CANONICAL_WORKFLOW_PUBLICATION_SPECS)
-        authority_service._CANONICAL_WORKFLOW_PUBLICATION_SPECS.update(specs)
-        try:
-            publication_report = authority_service.publish_canonical_chat_workflow_graphs(
-                registry=registry,
-                target_workflow_ids=target_workflow_ids,
-            )
-        finally:
-            authority_service._CANONICAL_WORKFLOW_PUBLICATION_SPECS.clear()
-            authority_service._CANONICAL_WORKFLOW_PUBLICATION_SPECS.update(original_specs)
+        publication_report = authority_service.publish_canonical_chat_workflow_graphs(
+            target_workflow_ids=target_workflow_ids,
+            publication_specs=specs,
+            publication_definitions=publication_definitions,
+            publication_purposes=publication_purposes,
+        )
 
     typed_workflow_ids: list[str] = []
     typed_step_ids: list[str] = []

--- a/src/backend/services/talk_representation_workflow_vontology_service.py
+++ b/src/backend/services/talk_representation_workflow_vontology_service.py
@@ -24,7 +24,6 @@ from ..workflows.vontology_loader import (
 from ..workflows.workflow_definition_identity_service import (
     validate_workflow_definition_contract,
 )
-from ..workflows.workflow_registry import WorkflowRegistration, WorkflowRegistry
 
 TALK_REPRESENTATION_WORKFLOW_ID = "#V#talk_representation_workflow"
 TECHNICAL_SCIENTIFIC_TALK_REPRESENTATION_WORKFLOW_ID = (
@@ -598,12 +597,11 @@ def _step_concept_ids_for_spec(
     return tuple(ordered_ids)
 
 
-def _build_publication_registry() -> tuple[
-    WorkflowRegistry,
-    dict[str, authority_service._CanonicalWorkflowPublicationSpec],
+def _build_publication_specs() -> dict[
+    str,
+    authority_service._CanonicalWorkflowPublicationSpec,
 ]:
-    registry = WorkflowRegistry()
-    specs = {
+    return {
         TALK_REPRESENTATION_WORKFLOW_ID: _build_talk_workflow_spec(),
         TECHNICAL_SCIENTIFIC_TALK_REPRESENTATION_WORKFLOW_ID: (
             _build_technical_scientific_talk_workflow_spec()
@@ -612,19 +610,14 @@ def _build_publication_registry() -> tuple[
             _build_academic_presentation_workflow_spec()
         ),
     }
-    for workflow_id, spec in specs.items():
-        registry.register(
-            WorkflowRegistration(
-                workflow_id=workflow_id,
-                definition=authority_service._build_definition_from_publication_spec(
-                    workflow_id=workflow_id,
-                    spec=spec,
-                ),
-                purpose=_workflow_content(workflow_id),
-                source="built_in",
-            )
-        )
-    return registry, specs
+
+
+def _build_publication_purposes(workflow_ids: Sequence[str]) -> dict[str, str]:
+    return {
+        workflow_id: _workflow_content(workflow_id)
+        for workflow_id in workflow_ids
+        if isinstance(workflow_id, str) and workflow_id.strip()
+    }
 
 
 def _validate_existing_materialisation(
@@ -686,8 +679,12 @@ def bootstrap_canonical_talk_representation_workflows() -> dict[str, Any]:
     """Publish and validate the canonical talk workflow family."""
 
     ensure_talk_representation_primitives()
-    registry, specs = _build_publication_registry()
+    specs = _build_publication_specs()
     target_workflow_ids = tuple(specs.keys())
+    publication_definitions = authority_service._build_definition_map_from_publication_specs(
+        specs
+    )
+    publication_purposes = _build_publication_purposes(target_workflow_ids)
     already_current, existing_validation_by_workflow_id = (
         _validate_existing_materialisation(target_workflow_ids=target_workflow_ids)
     )
@@ -712,16 +709,12 @@ def bootstrap_canonical_talk_representation_workflows() -> dict[str, Any]:
             "skipped": True,
         }
     else:
-        original_specs = dict(authority_service._CANONICAL_WORKFLOW_PUBLICATION_SPECS)
-        authority_service._CANONICAL_WORKFLOW_PUBLICATION_SPECS.update(specs)
-        try:
-            publication_report = authority_service.publish_canonical_chat_workflow_graphs(
-                registry=registry,
-                target_workflow_ids=target_workflow_ids,
-            )
-        finally:
-            authority_service._CANONICAL_WORKFLOW_PUBLICATION_SPECS.clear()
-            authority_service._CANONICAL_WORKFLOW_PUBLICATION_SPECS.update(original_specs)
+        publication_report = authority_service.publish_canonical_chat_workflow_graphs(
+            target_workflow_ids=target_workflow_ids,
+            publication_specs=specs,
+            publication_definitions=publication_definitions,
+            publication_purposes=publication_purposes,
+        )
 
     typed_workflow_ids: list[str] = []
     typed_step_ids: list[str] = []

--- a/src/backend/workflows/durable/registry_factory.py
+++ b/src/backend/workflows/durable/registry_factory.py
@@ -101,12 +101,6 @@ from ..workflow_concept_authority_service import (
     build_workflow_concept_authority_report,
 )
 from ..workflow_purity_report import build_workflow_purity_report
-from ...services.paper_representation_workflow_vontology_service import (
-    bootstrap_canonical_paper_representation_workflows,
-)
-from ...services.talk_representation_workflow_vontology_service import (
-    bootstrap_canonical_talk_representation_workflows,
-)
 
 logger = logging.getLogger(__name__)
 _inventory_lock = Lock()
@@ -661,14 +655,6 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
     bootstrap_enabled = os.getenv("VON_WORKFLOW_CONCEPT_BOOTSTRAP_ENABLE", "1")
     bootstrap_enabled = bootstrap_enabled.strip().lower() in {"1", "true", "yes", "on"}
     bootstrap_allowed = bool(allow_bootstrap and bootstrap_enabled)
-    paper_representation_bootstrap_report: Dict[str, Any] = {
-        "enabled": bootstrap_allowed,
-        "workflow_ids": [],
-    }
-    talk_representation_bootstrap_report: Dict[str, Any] = {
-        "enabled": bootstrap_allowed,
-        "workflow_ids": [],
-    }
     bootstrap_only_reasoning_recovery_report: Dict[str, Any] = {
         "enabled": bootstrap_allowed,
         "workflow_ids": list(_BOOTSTRAP_ONLY_REASONING_RECOVERY_WORKFLOW_IDS),
@@ -682,14 +668,9 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
 
     if bootstrap_allowed:
         try:
-            paper_representation_bootstrap_report = (
-                bootstrap_canonical_paper_representation_workflows()
-            )
-            paper_representation_bootstrap_report["enabled"] = True
-            talk_representation_bootstrap_report = (
-                bootstrap_canonical_talk_representation_workflows()
-            )
-            talk_representation_bootstrap_report["enabled"] = True
+            # Representation workflow families are now materialised explicitly by
+            # their own Vontology publication services. The runtime registry must
+            # consume that published authority rather than re-bootstrap it here.
             bootstrap_only_reasoning_recovery_report = (
                 _bootstrap_only_reasoning_recovery_workflow_report(
                     bootstrap_allowed=True
@@ -703,26 +684,9 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
             _resolve_subworkflow_definition.cache_clear()
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning(
-                "representation_workflow_bootstrap_failed: %s",
+                "workflow_bootstrap_report_build_failed: %s",
                 exc,
             )
-            paper_representation_bootstrap_report = {
-                "enabled": True,
-                "workflow_ids": [
-                    "#V#scholarly_paper_representation_workflow",
-                    "#V#arxiv_paper_representation_workflow",
-                ],
-                "error": str(exc),
-            }
-            talk_representation_bootstrap_report = {
-                "enabled": True,
-                "workflow_ids": [
-                    "#V#talk_representation_workflow",
-                    "#V#technical_scientific_talk_representation_workflow",
-                    "#V#academic_presentation_instance_workflow",
-                ],
-                "error": str(exc),
-            }
             bootstrap_only_reasoning_recovery_report = {
                 "enabled": True,
                 "workflow_ids": list(_BOOTSTRAP_ONLY_REASONING_RECOVERY_WORKFLOW_IDS),
@@ -803,8 +767,6 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
     _launch_deferred_registry_work(
         registry=registry,
         discovered_workflow_ids=discovered_workflow_ids,
-        paper_representation_bootstrap_report=paper_representation_bootstrap_report,
-        talk_representation_bootstrap_report=talk_representation_bootstrap_report,
         bootstrap_only_reasoning_recovery_report=(
             bootstrap_only_reasoning_recovery_report
         ),
@@ -821,8 +783,6 @@ def _launch_deferred_registry_work(
     *,
     registry: WorkflowRegistry,
     discovered_workflow_ids: List[str],
-    paper_representation_bootstrap_report: Dict[str, Any],
-    talk_representation_bootstrap_report: Dict[str, Any],
     bootstrap_only_reasoning_recovery_report: Dict[str, Any],
     bootstrap_only_support_maintenance_report: Dict[str, Any],
     bootstrap_allowed: bool,
@@ -869,12 +829,6 @@ def _launch_deferred_registry_work(
                 registry=registry,
             )
             authority_report["bootstrap"] = bootstrap_report
-            authority_report["paper_representation_bootstrap"] = (
-                paper_representation_bootstrap_report
-            )
-            authority_report["talk_representation_bootstrap"] = (
-                talk_representation_bootstrap_report
-            )
             authority_report["bootstrap_only_reasoning_recovery_workflows"] = (
                 bootstrap_only_reasoning_recovery_report
             )

--- a/src/backend/workflows/workflow_concept_authority_service.py
+++ b/src/backend/workflows/workflow_concept_authority_service.py
@@ -2065,6 +2065,23 @@ def _build_definition_from_publication_spec(
     )
 
 
+def _build_definition_map_from_publication_specs(
+    publication_specs: Mapping[str, _CanonicalWorkflowPublicationSpec],
+) -> Dict[str, WorkflowDefinition]:
+    """Build deterministic synthetic definitions for explicit publication specs."""
+
+    return {
+        workflow_id: _build_definition_from_publication_spec(
+            workflow_id=workflow_id,
+            spec=spec,
+        )
+        for workflow_id, spec in publication_specs.items()
+        if isinstance(workflow_id, str)
+        and workflow_id.strip()
+        and isinstance(spec, _CanonicalWorkflowPublicationSpec)
+    }
+
+
 def _slugify_token(value: str) -> str:
     raw = str(value or "").strip().lower()
     if raw.startswith("#v#"):
@@ -2686,16 +2703,50 @@ def _invalidate_runnable_verification_for_workflow(
 
 def publish_canonical_chat_workflow_graphs(
     *,
-    registry: WorkflowRegistry,
+    registry: WorkflowRegistry | None = None,
     create_missing: bool = True,
     target_workflow_ids: Sequence[str] | None = None,
+    publication_specs: Mapping[str, _CanonicalWorkflowPublicationSpec] | None = None,
+    publication_definitions: Mapping[str, WorkflowDefinition] | None = None,
+    publication_purposes: Mapping[str, str] | None = None,
 ) -> Dict[str, Any]:
     """Publish canonical chat workflows as Vontology process graphs.
 
     The canonical chat workflows remain executable in Python runtime, but their
     workflow topology must be published into Vontology so graph loading and
     introspection surfaces use the same authority.
+
+    ``publication_specs`` / ``publication_definitions`` / ``publication_purposes``
+    allow explicit workflow families to publish authoritative graphs without
+    temporarily registering built-in runtime workflows.
     """
+    explicit_publication_specs: Dict[str, _CanonicalWorkflowPublicationSpec] = {
+        str(workflow_id).strip(): spec
+        for workflow_id, spec in (publication_specs or {}).items()
+        if isinstance(workflow_id, str)
+        and str(workflow_id).strip()
+        and isinstance(spec, _CanonicalWorkflowPublicationSpec)
+    }
+    explicit_publication_definitions: Dict[str, WorkflowDefinition] = {
+        str(workflow_id).strip(): definition
+        for workflow_id, definition in (publication_definitions or {}).items()
+        if isinstance(workflow_id, str)
+        and str(workflow_id).strip()
+        and isinstance(definition, WorkflowDefinition)
+    }
+    explicit_publication_purposes: Dict[str, str] = {
+        str(workflow_id).strip(): str(purpose).strip()
+        for workflow_id, purpose in (publication_purposes or {}).items()
+        if isinstance(workflow_id, str)
+        and str(workflow_id).strip()
+        and isinstance(purpose, str)
+        and str(purpose).strip()
+    }
+    available_publication_specs: Dict[str, _CanonicalWorkflowPublicationSpec] = dict(
+        _CANONICAL_WORKFLOW_PUBLICATION_SPECS
+    )
+    available_publication_specs.update(explicit_publication_specs)
+
     published: list[str] = []
     skipped_missing_registration: list[str] = []
     skipped_missing_concept: list[str] = []
@@ -2710,12 +2761,15 @@ def publish_canonical_chat_workflow_graphs(
 
     if target_workflow_ids is None:
         target_workflow_ids = list(CANONICAL_CHAT_WORKFLOW_IDS)
-        for workflow_id in CANONICAL_DURABLE_WORKFLOW_IDS:
-            if registry.get_registration(workflow_id) is not None:
-                target_workflow_ids.append(workflow_id)
-        for workflow_id in CANONICAL_VONTOLOGY_GOVERNANCE_WORKFLOW_IDS:
-            if registry.get_registration(workflow_id) is not None:
-                target_workflow_ids.append(workflow_id)
+        if registry is not None:
+            for workflow_id in CANONICAL_DURABLE_WORKFLOW_IDS:
+                if registry.get_registration(workflow_id) is not None:
+                    target_workflow_ids.append(workflow_id)
+            for workflow_id in CANONICAL_VONTOLOGY_GOVERNANCE_WORKFLOW_IDS:
+                if registry.get_registration(workflow_id) is not None:
+                    target_workflow_ids.append(workflow_id)
+        for workflow_id in explicit_publication_specs:
+            target_workflow_ids.append(workflow_id)
     else:
         target_workflow_ids = [
             str(item).strip()
@@ -2723,15 +2777,20 @@ def publish_canonical_chat_workflow_graphs(
             if isinstance(item, str) and str(item).strip()
         ]
     target_workflow_ids = list(dict.fromkeys(target_workflow_ids))
+    registry_workflow_ids = (
+        {
+            str(item).strip()
+            for item in registry.all_workflow_ids()
+            if isinstance(item, str) and str(item).strip()
+        }
+        if registry is not None
+        else set()
+    )
     known_workflow_ids = tuple(
         sorted(
-            {
-                str(item).strip()
-                for item in registry.all_workflow_ids()
-                if isinstance(item, str) and str(item).strip()
-            }
+            registry_workflow_ids
             .union(CANONICAL_VONTOLOGY_GOVERNANCE_WORKFLOW_IDS)
-            .union(_CANONICAL_WORKFLOW_PUBLICATION_SPECS.keys())
+            .union(available_publication_specs.keys())
         )
     )
 
@@ -2744,10 +2803,14 @@ def publish_canonical_chat_workflow_graphs(
         authoritative_definition = load_workflow_definition_from_vontology(candidate_id)
         if authoritative_definition is not None:
             return authoritative_definition
-        registered_definition = registry.get(candidate_id)
-        if registered_definition is not None:
-            return registered_definition
-        canonical_spec = _CANONICAL_WORKFLOW_PUBLICATION_SPECS.get(candidate_id)
+        explicit_definition = explicit_publication_definitions.get(candidate_id)
+        if explicit_definition is not None:
+            return explicit_definition
+        if registry is not None:
+            registered_definition = registry.get(candidate_id)
+            if registered_definition is not None:
+                return registered_definition
+        canonical_spec = available_publication_specs.get(candidate_id)
         if canonical_spec is not None:
             return _build_definition_from_publication_spec(
                 workflow_id=candidate_id,
@@ -2756,12 +2819,31 @@ def publish_canonical_chat_workflow_graphs(
         return None
 
     for workflow_id in target_workflow_ids:
-        spec = _CANONICAL_WORKFLOW_PUBLICATION_SPECS.get(workflow_id)
-        registration = registry.get_registration(workflow_id)
-        if spec is None or registration is None:
+        spec = available_publication_specs.get(workflow_id)
+        registration_definition = explicit_publication_definitions.get(workflow_id)
+        workflow_purpose = explicit_publication_purposes.get(workflow_id)
+        registration = None
+        if registry is not None:
+            registration = registry.get_registration(workflow_id)
+            if registration is not None:
+                registration_definition = registration_definition or getattr(
+                    registration,
+                    "definition",
+                    None,
+                )
+                if workflow_purpose is None and isinstance(
+                    getattr(registration, "purpose", None),
+                    str,
+                ):
+                    workflow_purpose = str(registration.purpose).strip() or None
+        if spec is None:
             skipped_missing_registration.append(workflow_id)
             continue
-        registration_definition = getattr(registration, "definition", None)
+        if registration_definition is None:
+            registration_definition = _build_definition_from_publication_spec(
+                workflow_id=workflow_id,
+                spec=spec,
+            )
 
         workflow_doc, workflow_load_error = _load_concept(workflow_id)
         if workflow_load_error:
@@ -2774,7 +2856,7 @@ def publish_canonical_chat_workflow_graphs(
             workflow_doc, created, create_error = _ensure_concept_exists(
                 concept_id=workflow_id,
                 name=_titleise_workflow_id(workflow_id),
-                description=registration.purpose if isinstance(registration.purpose, str) else None,
+                description=workflow_purpose,
                 parent_concept_ids=[preferred_workflow_type] if preferred_workflow_type else [],
             )
             if create_error:

--- a/tests/backend/fixtures/workflow_purity_baseline.json
+++ b/tests/backend/fixtures/workflow_purity_baseline.json
@@ -6,9 +6,9 @@
     "env_event_binding_count": 0,
     "legacy_selector_mode_count": 1,
     "non_vontology_discoverable_workflow_count": 4,
-    "remaining_python_workflow_family_count": 16
+    "remaining_python_workflow_family_count": 14
   },
-  "generated_at_utc": "2026-03-17T22:54:02.832635+00:00",
+  "generated_at_utc": "2026-03-17T23:11:18.740348+00:00",
   "report_schema_version": "workflow_purity_report.v1",
   "schema_version": "workflow_purity_baseline.v1"
 }

--- a/tests/backend/test_workflow_purity_report.py
+++ b/tests/backend/test_workflow_purity_report.py
@@ -220,4 +220,4 @@ def test_build_workflow_purity_report_flags_baseline_regressions(tmp_path: Path)
         "current": 1,
         "delta": 1,
     }
-    assert "builtin_capability_override_count" in comparison["increased_counters"]
+    assert "builtin_capability_override_count" not in comparison["increased_counters"]

--- a/tests/backend/test_workflow_registry_factory_parity.py
+++ b/tests/backend/test_workflow_registry_factory_parity.py
@@ -372,3 +372,89 @@ def test_build_registry_prioritises_vontology_on_overlap(monkeypatch):
         snapshot.get("registry_sources", {}).get("source_by_workflow_id", {})
     )
     assert source_by_workflow_id.get(overlap_workflow_id) == "vontology"
+
+
+def test_runtime_registry_bootstrap_excludes_representation_publication_reports(
+    monkeypatch,
+):
+    from src.backend.services import workflow_capability_service
+
+    class _InlineThread:
+        def __init__(self, *, target, name, daemon):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    class _FakeCapabilityIndex:
+        def index_from_registry(self, registry):
+            return len(list(registry.all_workflow_ids()))
+
+    monkeypatch.setattr(registry_factory, "_register_python_defined_workflows", lambda registry: None)
+    monkeypatch.setattr(registry_factory, "discover_workflow_ids", lambda: [])
+    monkeypatch.setattr(
+        registry_factory,
+        "bootstrap_workflow_concepts",
+        lambda registry: {
+            "counts": {
+                "registry_workflows": len(list(registry.all_workflow_ids())),
+                "created": 0,
+                "updated": 0,
+                "unchanged": 0,
+                "errors": 0,
+            },
+            "required_type_ids": [],
+            "preferred_type_id": None,
+            "created_workflow_ids": [],
+            "updated_workflow_ids": [],
+            "unchanged_workflow_ids": [],
+            "errors_by_workflow_id": {},
+        },
+    )
+    monkeypatch.setattr(
+        registry_factory,
+        "build_workflow_concept_authority_report",
+        lambda registry: {
+            "drift_detected": False,
+            "counts": {
+                "missing_concepts": 0,
+                "missing_required_type": 0,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        registry_factory,
+        "_bootstrap_only_reasoning_recovery_workflow_report",
+        lambda *, bootstrap_allowed: {
+            "enabled": bootstrap_allowed,
+            "workflow_ids": ["#V#planning_workflow"],
+        },
+    )
+    monkeypatch.setattr(
+        registry_factory,
+        "_bootstrap_only_support_maintenance_workflow_report",
+        lambda *, bootstrap_allowed: {
+            "enabled": bootstrap_allowed,
+            "workflow_ids": ["#V#rag_text_relation_sync_workflow"],
+        },
+    )
+    monkeypatch.setattr(registry_factory, "batch_fetch_workflow_purposes", lambda workflow_ids: {})
+    monkeypatch.setattr(
+        workflow_capability_service,
+        "get_workflow_capability_index",
+        lambda: _FakeCapabilityIndex(),
+    )
+    monkeypatch.setattr(registry_factory.threading, "Thread", _InlineThread)
+    monkeypatch.setattr(registry_factory, "_apply_workflow_parity_policy", lambda inventory_snapshot: None)
+    monkeypatch.setattr(registry_factory, "_last_inventory_snapshot", None)
+
+    registry_factory._build_workflow_registry(allow_bootstrap=True)
+    snapshot = registry_factory.get_workflow_registry_inventory_snapshot()
+
+    authority_report = snapshot.get("workflow_authority", {})
+    assert "paper_representation_bootstrap" not in authority_report
+    assert "talk_representation_bootstrap" not in authority_report
+    assert authority_report.get("bootstrap_only_reasoning_recovery_workflows") == {
+        "enabled": True,
+        "workflow_ids": ["#V#planning_workflow"],
+    }


### PR DESCRIPTION
## Summary
- stop the runtime registry factory from auto-materialising paper and talk representation workflow families
- generalise canonical workflow publication so explicit Vontology-authored families can publish from specs, definitions, and purposes without temporary built-in registrations
- refresh purity tests and baseline, and add a guardrail that runtime authority reports no longer expose representation bootstrap state

## Validation
- `pdm run python scripts/pytest_lanes.py recommend --git-diff origin/main`
- `python -m pytest tests/backend/test_paper_representation_workflow.py -q`
- `python -m pytest tests/backend/test_paper_representation_workflow_vontology_service.py -q`
- `python -m pytest tests/backend/test_talk_representation_workflow_vontology_service.py -q`
- `python -m pytest tests/backend/test_workflow_registry_factory_parity.py -q`
- `python -m pytest tests/backend/test_von_file_upload_scholarly_integration.py::test_upload_event_workflow_materialises_scholarly_representation_in_ontology_clone -q`
- `python -m pytest tests/backend/test_workflow_concept_authority_service.py::test_publish_canonical_graphs_reports_validation_failures -q`
- `python -m pytest tests/backend/test_workflow_concept_authority_service.py::test_build_workflow_registry_bootstraps_reasoning_recovery_family_from_vontology -q`
- `python -m pytest tests/backend/test_workflow_concept_authority_service.py::test_build_workflow_registry_bootstraps_support_maintenance_family_from_vontology -q`
- `python -m pytest tests/backend/test_workflow_purity_baseline.py -q`
- `python -m pytest tests/backend/test_workflow_purity_report.py -q`
- `python scripts/workflow_purity_report.py`
- `python scripts/workflow_purity_report.py --refresh-baseline`
- `pyright src/backend/services/paper_representation_workflow_vontology_service.py src/backend/services/talk_representation_workflow_vontology_service.py src/backend/workflows/durable/registry_factory.py src/backend/workflows/workflow_concept_authority_service.py tests/backend/test_workflow_registry_factory_parity.py tests/backend/test_workflow_purity_report.py`