### PR TITLE
JVNAUTOSCI-1520 Fail closed on workflow capability text

### DIFF
--- a/docs/engineering/workflow_authoritative_publication_process.md
+++ b/docs/engineering/workflow_authoritative_publication_process.md
@@ -91,6 +91,11 @@ startup under the `workflow_purity` logger key. The counters currently include:
 6. `builtin_capability_override_count`
 7. `non_vontology_discoverable_workflow_count`
 
+Capability indexing now also fails closed for routing: the workflow capability
+index should only index `source=vontology` workflows with non-empty
+authoritative narrative text. Non-authoritative registrations and textless
+workflows must be skipped rather than receiving guessed fallback routing prose.
+
 The checked-in CI baseline lives at:
 
 - `tests/backend/fixtures/workflow_purity_baseline.json`

--- a/src/backend/services/workflow_capability_service.py
+++ b/src/backend/services/workflow_capability_service.py
@@ -11,8 +11,8 @@ Architecture:
       capability documents.  Fast to build, zero external dependencies,
       supports hybrid keyword + relevance matching.
     - ``index_from_registry()``: Indexes all workflows from a registry
-      (both eager and lazy) using purpose metadata and fallback name-derived
-      descriptions only when Vontology metadata is absent.
+      (both eager and lazy) using authoritative Vontology narrative text and
+      skipping non-authoritative or textless workflows.
 
 The dedicated namespace isolates workflow routing from general concept search,
 enabling independent tuning and scaling as the workflow catalogue grows.
@@ -140,49 +140,77 @@ class WorkflowCapabilityIndex:
     def index_from_registry(self, registry: Any) -> int:
         """Index all workflows from a ``WorkflowRegistry``.
 
-        Uses authoritative registry ``purpose`` metadata when available and
-        falls back to an ID-derived description only when no narrative text
-        is available.
+        Only indexes workflows whose routing text is already authoritative:
+        Vontology-sourced registrations with non-empty narrative text.
+        Non-authoritative registrations and textless workflows are skipped so
+        discovery fails closed instead of routing on guessed fallback prose.
 
         Returns the number of workflows indexed.
         """
         count = 0
+        skipped_non_authoritative = 0
+        skipped_missing_purpose = 0
+
+        def _index_candidate(
+            *,
+            workflow_id: str,
+            purpose: Any,
+            source: Any,
+        ) -> None:
+            nonlocal count
+            nonlocal skipped_non_authoritative
+            nonlocal skipped_missing_purpose
+
+            text, reason = _resolve_authoritative_capability_text(
+                workflow_id=workflow_id,
+                source=source,
+                purpose=purpose,
+            )
+            if text is None:
+                if reason == "non_authoritative_source":
+                    skipped_non_authoritative += 1
+                elif reason == "missing_authoritative_purpose":
+                    skipped_missing_purpose += 1
+                return
+
+            self.index_workflow(
+                workflow_id,
+                text,
+                metadata={
+                    "name": _workflow_id_to_name(workflow_id),
+                    "source": str(source or "unknown"),
+                    "purpose": _normalise_capability_text(purpose),
+                },
+            )
+            count += 1
+
         # Eager registrations.
         for wid in list(registry.eager_workflow_ids()):
             reg = registry._workflows.get(wid)  # type: ignore[attr-defined]
-            purpose = (reg.purpose if reg else None) or ""
-            text = BUILTIN_WORKFLOW_CAPABILITIES.get(wid) or purpose
-            if not text:
-                text = _workflow_id_to_description(wid)
-            name = _workflow_id_to_name(wid)
-            source = (reg.source if reg else None) or "unknown"
-            self.index_workflow(
-                wid, text,
-                metadata={"name": name, "source": source, "purpose": purpose},
+            _index_candidate(
+                workflow_id=wid,
+                purpose=(reg.purpose if reg else None),
+                source=(reg.source if reg else None),
             )
-            count += 1
 
         # Lazy registrations (metadata only, no definition load).
         for wid in list(registry.lazy_workflow_ids()):
             lazy = registry._lazy.get(wid)  # type: ignore[attr-defined]
-            purpose = (lazy.purpose if lazy else None) or ""
-            text = BUILTIN_WORKFLOW_CAPABILITIES.get(wid) or purpose
-            if not text:
-                text = _workflow_id_to_description(wid)
-            name = _workflow_id_to_name(wid)
-            source = (lazy.source if lazy else None) or "unknown"
-            self.index_workflow(
-                wid, text,
-                metadata={"name": name, "source": source, "purpose": purpose},
+            _index_candidate(
+                workflow_id=wid,
+                purpose=(lazy.purpose if lazy else None),
+                source=(lazy.source if lazy else None),
             )
-            count += 1
 
         logger.info(
             "[workflow_capability_index] Indexed %d workflows "
-            "(%d eager, %d lazy)",
+            "(%d eager, %d lazy), skipped_non_authoritative=%d "
+            "skipped_missing_authoritative_text=%d",
             count,
             len(list(registry.eager_workflow_ids())),
             len(list(registry.lazy_workflow_ids())),
+            skipped_non_authoritative,
+            skipped_missing_purpose,
         )
         return count
 
@@ -312,6 +340,32 @@ def _workflow_id_to_description(workflow_id: str) -> str:
     """Derive a minimal fallback description from a workflow ID."""
     name = _workflow_id_to_name(workflow_id)
     return f"{name} workflow."
+
+
+def _normalise_capability_text(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
+
+def _resolve_authoritative_capability_text(
+    *,
+    workflow_id: str,
+    source: Any,
+    purpose: Any,
+) -> tuple[str | None, str]:
+    """Return authoritative routing text or a deterministic skip reason."""
+
+    _ = workflow_id
+    source_token = str(source or "").strip().lower()
+    if source_token != "vontology":
+        return None, "non_authoritative_source"
+
+    purpose_text = _normalise_capability_text(purpose)
+    if not purpose_text:
+        return None, "missing_authoritative_purpose"
+
+    return purpose_text, "authoritative_purpose"
 
 
 def build_workflow_capability_text(

--- a/tests/backend/test_workflow_capability_service.py
+++ b/tests/backend/test_workflow_capability_service.py
@@ -184,7 +184,7 @@ class TestIndexFromRegistry:
         results = index.search("research papers key insights")
         assert any(r.workflow_id == "#V#test_lazy_wf" for r in results)
 
-    def test_lazy_without_purpose_uses_fallback(self):
+    def test_lazy_without_purpose_is_skipped(self):
         from src.backend.workflows import WorkflowRegistry
         from src.backend.workflows.workflow_registry import LazyWorkflowRegistration
 
@@ -196,10 +196,37 @@ class TestIndexFromRegistry:
         registry.register_lazy(lazy)
         index = WorkflowCapabilityIndex()
         count = index.index_from_registry(registry)
-        assert count >= 1
-        # Even without purpose, the ID-derived name should be searchable.
+        assert count == 0
         results = index.search("entity resolution")
-        assert any(r.workflow_id == "#V#entity_resolution_workflow" for r in results)
+        assert all(r.workflow_id != "#V#entity_resolution_workflow" for r in results)
+
+    def test_non_vontology_registration_is_skipped(self):
+        from src.backend.workflows import WorkflowRegistry
+        from src.backend.workflows.workflow_registry import WorkflowRegistration
+        from src.backend.workflows.engine import WorkflowDefinition, WorkflowStateSpec
+
+        registry = WorkflowRegistry()
+        definition = WorkflowDefinition(
+            workflow_id="#V#built_in_workflow",
+            initial_state="start",
+            states={"start": WorkflowStateSpec(state_id="start", terminal=True)},
+            termination_states=("start",),
+            purpose="Built-in workflow purpose text",
+        )
+        registry.register(
+            WorkflowRegistration(
+                workflow_id="#V#built_in_workflow",
+                definition=definition,
+                purpose="Built-in workflow purpose text",
+                source="built_in",
+            )
+        )
+
+        index = WorkflowCapabilityIndex()
+        count = index.index_from_registry(registry)
+
+        assert count == 0
+        assert index.search("workflow purpose text") == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make the workflow capability index fail closed on non-authoritative routing text by indexing only `source=vontology` workflows with non-empty narrative text
- stop capability discovery from routing on ID-derived fallback prose for textless workflows or on built-in registration prose for non-authoritative workflows
- update capability-index tests and documentation to match the new workflow-authoritative routing policy

## Validation
- `pdm run python scripts/pytest_lanes.py recommend --git-diff origin/main`
- `python -m pytest tests/backend/test_workflow_capability_service.py -q`
- `python -m pytest tests/backend/test_workflow_discovery_service.py -q`
- `python -m pytest tests/backend/test_workflow_selector_rag_first.py -q`
- `python -m pytest tests/backend/test_workflow_purity_baseline.py -q`
- `python scripts/workflow_purity_report.py`
- `pyright src/backend/services/workflow_capability_service.py tests/backend/test_workflow_capability_service.py`