### PR TITLE
JVNAUTOSCI-1523 enforce strict Vontology workflow authority

### DIFF
--- a/docs/engineering/workflow_authoritative_publication_process.md
+++ b/docs/engineering/workflow_authoritative_publication_process.md
@@ -91,6 +91,16 @@ startup under the `workflow_purity` logger key. The counters currently include:
 6. `builtin_capability_override_count`
 7. `non_vontology_discoverable_workflow_count`
 
+Parity enforcement now defaults to `fail`, not `warn`. Production startup should
+raise on authority drift unless a developer explicitly relaxes
+`VON_WORKFLOW_PARITY_ENFORCEMENT` for bounded local diagnostics.
+
+The runtime registry must also keep bootstrap-only workflow families separate
+from production registration authority. Python definitions that remain for
+bootstrap/test support, such as the file-copy family during convergence, may be
+used to publish or repair authoritative Vontology graphs, but they must not be
+counted as discoverable production registrations.
+
 Capability indexing now also fails closed for routing: the workflow capability
 index should only index `source=vontology` workflows with non-empty
 authoritative narrative text. Non-authoritative registrations and textless

--- a/orchestrator_test_harness.py
+++ b/orchestrator_test_harness.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -118,9 +119,6 @@ def build_db_independent_orchestrator(
 
     env_val = "1" if selector_enabled else "0"
     monkeypatch.setenv("VON_CHAT_WORKFLOW_SELECTOR_ENABLED", env_val)
-    # Default to legacy selector mode in the harness — RAG-first routing
-    # is tested separately in test_workflow_selector_rag_first.py.
-    monkeypatch.setenv("VON_WORKFLOW_RAG_FIRST_ROUTING", "0")
 
     from src.backend.workflows import WorkflowRegistry
     from src.backend.workflows.action_registry import ActionRegistry
@@ -226,6 +224,36 @@ def build_db_independent_orchestrator(
     monkeypatch.setattr(
         "src.backend.services.turn_execution_record_service.build_conversation_turn_stage_path",
         _stub_stage_path,
+    )
+
+    original_render_prompt = orchestrator._prompt_templates.render_prompt
+
+    def _render_prompt_with_narration_fallback(
+        prompt_ids: Any,
+        *,
+        fallback: Any = None,
+        variables: Any = None,
+        max_chars: Any = None,
+    ) -> Any:
+        if not prompt_ids and not fallback:
+            return SimpleNamespace(
+                text=(
+                    "Produce a concise spoken summary of the on-screen content. "
+                    "Return only the spoken talk track."
+                ),
+                prompt_id="#V#test_narration_prompt",
+            )
+        return original_render_prompt(
+            prompt_ids,
+            fallback=fallback,
+            variables=variables,
+            max_chars=max_chars,
+        )
+
+    monkeypatch.setattr(
+        orchestrator._prompt_templates,
+        "render_prompt",
+        _render_prompt_with_narration_fallback,
     )
 
     return orchestrator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,12 +178,12 @@ geo = [
 include = ["src"]
 executionEnvironments = [
     # Use project root so that top-level package name 'src' resolves.
-    { root = ".", extraPaths = ["src"] }
+    { root = ".", extraPaths = ["src", "tests/backend"] }
 ]
 typeCheckingMode = "basic"
 reportMissingImports = true
 reportMissingTypeStubs = false
-extraPaths = ["src"]
+extraPaths = ["src", "tests/backend"]
 stubPath = "typings"
 venvPath = "."
 venv = ".venv"

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -1098,27 +1098,13 @@ class InternalMCPChatOrchestrator:
         self._workflow_executor = WorkflowExecutor(
             registry=self._action_registry, max_transitions=50
         )
-        # JVNAUTOSCI-1424 Phase 2: RAG-first routing support.
-        # The selector uses RAG-first candidate matching by default.
-        # Set VON_WORKFLOW_RAG_FIRST_ROUTING=0 to fall back to the legacy
-        # static verdict taxonomy during rollback.
-        rag_first = os.getenv("VON_WORKFLOW_RAG_FIRST_ROUTING", "1").strip().lower() not in {
-            "0", "false", "off",
-        }
+        # JVNAUTOSCI-1521: production routing now has one selector path.
         selector_kwargs: dict[str, Any] = {
             "registry": self._workflow_registry,
             "prompt_service": self._prompt_templates,
             "classifier_prompt_ids": self._TURN_SELECTOR_PROMPTS,
+            "default_workflow_id": CHAT_ASSISTANT_WORKFLOW_ID,
         }
-        if rag_first:
-            selector_kwargs["default_workflow_id"] = CHAT_ASSISTANT_WORKFLOW_ID
-        else:
-            selector_kwargs["verdict_mapping"] = {
-                "plain_response": CHAT_ASSISTANT_WORKFLOW_ID,
-                "tool_seeking": TOOL_CALLING_WORKFLOW_ID,
-                "summarisation": TOOL_CALLING_WORKFLOW_ID,
-                "narration": CHAT_NARRATION_WORKFLOW_ID,
-            }
         self._workflow_selector = WorkflowSelector(**selector_kwargs)
         self._last_base_system_prompt_telemetry: dict[str, Any] | None = None
 
@@ -1654,13 +1640,9 @@ class InternalMCPChatOrchestrator:
             if isinstance(required_prompt_create_type_name_raw, str)
             else ""
         )
-        allow_semantic_retry = bool(
-            missing_prompt_tools
-            or missing_prompt_fetch_concept_ids
-            or missing_prompt_read_file_copy_ids
-            or missing_prompt_scholarly_file_copy_ids
-            or required_prompt_create_type_name
-        )
+        # Keep heuristic/classifier retry available for ordinary "I'll do it
+        # now" tool promises as well as explicit prompt-requirement failures.
+        allow_semantic_retry = True
         retries_remaining_before = max(0, retry_budget - retry_attempts)
         data["missing_tool_call_retry_attempts"] = retry_attempts
         data["missing_tool_call_retry_budget"] = retry_budget
@@ -2645,6 +2627,8 @@ class InternalMCPChatOrchestrator:
             user_namespace=environment.user_namespace,
             auxiliary_system_prompt=environment.auxiliary_system_prompt,
             max_tool_invocations=environment.max_tool_invocations,
+            max_tool_result_chars=environment.max_tool_result_chars,
+            max_tool_result_field_chars=environment.max_tool_result_field_chars,
             default_gmail_profile=(
                 data.get("gmail_profile") or environment.default_gmail_profile
             ),
@@ -9193,6 +9177,7 @@ class InternalMCPChatOrchestrator:
             seen_values.add(candidate_value)
             if not _exists(candidate_value):
                 continue
+            return candidate_value, strategy
         return None, None
 
     def _is_write_tool(
@@ -12150,12 +12135,45 @@ class InternalMCPChatOrchestrator:
                 preview_str = (
                     preview_str[: self._max_tool_result_chars] + "\n... [truncated]"
                 )
-            result["payload"] = {
+            truncated_payload = {
                 "_truncated": True,
                 "_original_chars": len(encoded),
                 "_preview": preview_str,
             }
-            return json.dumps(result, default=str)
+            result["payload"] = truncated_payload
+            encoded_truncated = json.dumps(result, default=str)
+            if len(encoded_truncated) <= self._max_tool_result_chars:
+                return encoded_truncated
+
+            # The preview string itself is JSON-escaped again inside the final
+            # envelope, so trim against the encoded envelope size rather than
+            # only the raw preview size.
+            for _ in range(3):
+                overflow = len(encoded_truncated) - self._max_tool_result_chars
+                if overflow <= 0:
+                    return encoded_truncated
+                current_preview = str(truncated_payload.get("_preview") or "")
+                if not current_preview:
+                    break
+                clip_to = max(0, len(current_preview) - overflow - 64)
+                if clip_to >= len(current_preview):
+                    break
+                next_preview = current_preview[:clip_to].rstrip()
+                if next_preview:
+                    next_preview += "\n... [truncated]"
+                truncated_payload["_preview"] = next_preview
+                encoded_truncated = json.dumps(result, default=str)
+                if len(encoded_truncated) <= self._max_tool_result_chars:
+                    return encoded_truncated
+
+            result["payload"] = {
+                "_truncated": True,
+                "_original_chars": len(encoded),
+            }
+            encoded_minimal = json.dumps(result, default=str)
+            if len(encoded_minimal) <= self._max_tool_result_chars:
+                return encoded_minimal
+            return encoded_minimal[: self._max_tool_result_chars]
         except Exception:
             # Fallback to manual coercion if payload is not JSON serialisable
             safe_payload = result.get("payload")
@@ -14142,6 +14160,17 @@ class InternalMCPChatOrchestrator:
             payload["errors"].append("rag_namespace_missing")
             return payload
 
+        try:
+            described_methods = self._gateway.describe_methods()
+        except Exception:
+            described_methods = {}
+        if not (
+            isinstance(described_methods, Mapping)
+            and "search_knowledge_base" in described_methods
+        ):
+            payload["errors"].append("rag_search_tool_unavailable")
+            return payload
+
         rag_payload = {
             "query": query,
             "namespace": namespace,
@@ -14498,6 +14527,8 @@ class InternalMCPChatOrchestrator:
             user_namespace=user_namespace,
             auxiliary_system_prompt=None,
             max_tool_invocations=None,
+            max_tool_result_chars=self._max_tool_result_chars,
+            max_tool_result_field_chars=self._max_tool_result_field_chars,
             default_gmail_profile=self._default_gmail_profile,
         )
 
@@ -18561,6 +18592,8 @@ class InternalMCPChatOrchestrator:
             user_namespace=user_namespace,
             auxiliary_system_prompt=auxiliary_system_prompt,
             max_tool_invocations=self._max_tool_invocations,
+            max_tool_result_chars=self._max_tool_result_chars,
+            max_tool_result_field_chars=self._max_tool_result_field_chars,
             default_gmail_profile=self._default_gmail_profile,
         )
         try:
@@ -19665,17 +19698,70 @@ class InternalMCPChatOrchestrator:
         # ----------------------------------------------------------------
         discovered_matches: list[dict[str, Any]] = []
         excluded_discovered_matches: list[dict[str, Any]] = []
+
+        def _build_selector_default_candidates() -> list[dict[str, Any]]:
+            candidate_ids = (
+                CHAT_ASSISTANT_WORKFLOW_ID,
+                TOOL_CALLING_WORKFLOW_ID,
+                CHAT_NARRATION_WORKFLOW_ID,
+            )
+            candidates: list[dict[str, Any]] = []
+            for workflow_id in candidate_ids:
+                registration = self._workflow_registry.get_registration(workflow_id)
+                if registration is None:
+                    continue
+                name = workflow_id[3:] if workflow_id.startswith("#V#") else workflow_id
+                name = name.replace("_", " ").strip().title() or workflow_id
+                description = str(getattr(registration, "purpose", "") or "").strip()
+                candidates.append(
+                    {
+                        "concept_id": workflow_id,
+                        "name": name,
+                        "description": description,
+                        "is_executable": True,
+                        "executability_reason": "executable_now",
+                        "is_policy_safe": True,
+                        "routing_eligible": True,
+                        "routing_exclusion_reason": None,
+                    }
+                )
+            return candidates
+
+        def _merge_selector_candidates(
+            primary: Sequence[Mapping[str, Any]],
+            secondary: Sequence[Mapping[str, Any]],
+        ) -> list[dict[str, Any]]:
+            merged: list[dict[str, Any]] = []
+            seen_ids: set[str] = set()
+            for source in (primary, secondary):
+                for item in source:
+                    if not isinstance(item, Mapping):
+                        continue
+                    concept_id = str(item.get("concept_id") or "").strip()
+                    if not concept_id:
+                        continue
+                    dedupe_key = concept_id.lower()
+                    if dedupe_key in seen_ids:
+                        continue
+                    seen_ids.add(dedupe_key)
+                    merged.append(dict(item))
+            return merged
+
         if isinstance(workflow_discovery_result, Mapping):
             discovered_matches, excluded_discovered_matches = (
                 self._prepare_selector_discovered_matches(workflow_discovery_result)
             )
+        selector_candidate_matches = _merge_selector_candidates(
+            _build_selector_default_candidates(),
+            discovered_matches,
+        )
 
         routing_info: WorkflowRoutingInfo | None = None
         selection_experience_id: str | None = None
         if prompt_requirements_force_tool_pipeline:
             routing_info = WorkflowRoutingInfo(
                 workflow_id=TOOL_CALLING_WORKFLOW_ID,
-                verdict="tool_seeking",
+                verdict="tool_contract_preselected",
                 prompt_id=None,
                 discovered_workflow_ids=(),
                 source="selector_override",
@@ -19733,7 +19819,7 @@ class InternalMCPChatOrchestrator:
             if not clean_workflow_id:
                 return None
 
-            for match in (*discovered_matches, *excluded_discovered_matches):
+            for match in (*selector_candidate_matches, *excluded_discovered_matches):
                 if not isinstance(match, Mapping):
                     continue
                 match_id = match.get("concept_id")
@@ -19768,14 +19854,14 @@ class InternalMCPChatOrchestrator:
                     "phase_label": "Selecting workflow",
                     "subtask": "Choose the best workflow for this turn",
                     "workflow_match_count": len(discovered_matches),
-                    "workflow_candidate_count": len(discovered_matches)
+                    "workflow_candidate_count": len(selector_candidate_matches)
                     + len(excluded_discovered_matches),
                 }
             )
             selector_start = time.perf_counter()
             selector_prompt = self._workflow_selector.prepare_selection_prompt(
                 turn_text=effective_prompt_for_routing,
-                discovered_workflows=discovered_matches or None,
+                discovered_workflows=selector_candidate_matches or None,
             )
             selector_policy = (
                 dict(selector_prompt.policy_recommendation)
@@ -19809,7 +19895,7 @@ class InternalMCPChatOrchestrator:
                 payload.setdefault("workflow_match_count", len(discovered_matches))
                 payload.setdefault(
                     "workflow_candidate_count",
-                    len(discovered_matches) + len(excluded_discovered_matches),
+                    len(selector_candidate_matches) + len(excluded_discovered_matches),
                 )
                 _emit_progress_local(payload)
 
@@ -19827,7 +19913,7 @@ class InternalMCPChatOrchestrator:
                             "phase": "workflow_dispatch",
                             "phase_label": "Applying learned workflow policy",
                             "workflow_match_count": len(discovered_matches),
-                            "workflow_candidate_count": len(discovered_matches)
+                            "workflow_candidate_count": len(selector_candidate_matches)
                             + len(excluded_discovered_matches),
                         }
                     )
@@ -19913,7 +19999,7 @@ class InternalMCPChatOrchestrator:
                         "workflow_task": selector_selection.workflow_id
                         or selector_selection.verdict,
                         "workflow_match_count": len(discovered_matches),
-                        "workflow_candidate_count": len(discovered_matches)
+                        "workflow_candidate_count": len(selector_candidate_matches)
                         + len(excluded_discovered_matches),
                         "workflow_selection_rationale": selection_rationale,
                     }
@@ -19933,7 +20019,7 @@ class InternalMCPChatOrchestrator:
                         "discovered_workflow_ids": list(
                             selector_selection.discovered_workflow_ids
                         ),
-                        "discovery_candidate_count": len(discovered_matches)
+                        "discovery_candidate_count": len(selector_candidate_matches)
                         + len(excluded_discovered_matches),
                         "discovery_excluded_count": len(excluded_discovered_matches),
                         "routing_duration_ms": routing_duration_ms,
@@ -19963,7 +20049,7 @@ class InternalMCPChatOrchestrator:
                         "discovered_workflow_ids": list(
                             selector_selection.discovered_workflow_ids
                         ),
-                        "discovery_candidate_count": len(discovered_matches)
+                        "discovery_candidate_count": len(selector_candidate_matches)
                         + len(excluded_discovered_matches),
                         "discovery_excluded_count": len(excluded_discovered_matches),
                         "excluded_discovered_workflow_ids": [
@@ -20011,7 +20097,7 @@ class InternalMCPChatOrchestrator:
                 selected_workflow_id = CHAT_ASSISTANT_WORKFLOW_ID
                 routing_info = WorkflowRoutingInfo(
                     workflow_id=CHAT_ASSISTANT_WORKFLOW_ID,
-                    verdict="fallback",
+                    verdict="selector_exception",
                     prompt_id=None,
                     discovered_workflow_ids=(),
                     source="default",
@@ -20019,7 +20105,7 @@ class InternalMCPChatOrchestrator:
                 )
                 selection_rationale = _derive_workflow_selection_rationale(
                     selected_workflow_id=CHAT_ASSISTANT_WORKFLOW_ID,
-                    selector_verdict="fallback",
+                    selector_verdict="selector_exception",
                     selector_source="default",
                     candidate_workflow_ids=(),
                     explicit_reasoning="selector_exception",
@@ -20030,7 +20116,7 @@ class InternalMCPChatOrchestrator:
                         "stage": "workflow_dispatch",
                         "phase": "workflow_dispatch",
                         "phase_label": "Workflow selection fallback",
-                        "workflow_selector_verdict": "fallback",
+                        "workflow_selector_verdict": "selector_exception",
                         "selected_workflow_id": CHAT_ASSISTANT_WORKFLOW_ID,
                         "selected_workflow_name": _resolve_selected_workflow_name(
                             CHAT_ASSISTANT_WORKFLOW_ID
@@ -20049,7 +20135,7 @@ class InternalMCPChatOrchestrator:
                         query=effective_prompt_for_routing[:500],
                         candidate_workflow_ids=(),
                         selected_workflow_id=CHAT_ASSISTANT_WORKFLOW_ID,
-                        verdict="fallback",
+                        verdict="selector_exception",
                         selection_source="default",
                         selection_metadata={"selector_error": str(exc)},
                         confidence_score=0.0,
@@ -20061,9 +20147,53 @@ class InternalMCPChatOrchestrator:
                 except Exception:
                     pass
 
-        _STATIC_SELECTOR_VERDICTS = frozenset(
-            {"plain_response", "tool_seeking", "summarisation", "narration", "fallback"}
-        )
+        def _workflow_action_ids(workflow_id: str | None) -> set[str]:
+            if not isinstance(workflow_id, str) or not workflow_id.strip():
+                return set()
+            workflow_def = self._workflow_registry.get(workflow_id.strip())
+            if workflow_def is None:
+                return set()
+            action_ids: set[str] = set()
+            for state in workflow_def.states.values():
+                for action in state.actions:
+                    action_id = str(action.action_id or "").strip()
+                    if action_id:
+                        action_ids.add(action_id)
+            return action_ids
+
+        def _workflow_matches_action_contract(
+            workflow_id: str | None,
+            *,
+            required_action_ids: frozenset[str],
+        ) -> bool:
+            action_ids = _workflow_action_ids(workflow_id)
+            return bool(action_ids) and required_action_ids.issubset(action_ids)
+
+        def _resolve_workflow_id_for_action_contract(
+            *,
+            required_action_ids: frozenset[str],
+            preferred_workflow_id: str | None = None,
+        ) -> str | None:
+            preferred = (
+                preferred_workflow_id.strip()
+                if isinstance(preferred_workflow_id, str)
+                and preferred_workflow_id.strip()
+                else None
+            )
+            if preferred and _workflow_matches_action_contract(
+                preferred, required_action_ids=required_action_ids
+            ):
+                return preferred
+            for workflow_id in self._workflow_registry.all_workflow_ids():
+                candidate = str(workflow_id).strip()
+                if not candidate:
+                    continue
+                if _workflow_matches_action_contract(
+                    candidate, required_action_ids=required_action_ids
+                ):
+                    return candidate
+            return None
+
         _TOOL_PIPELINE_ACTION_IDS = frozenset(
             {
                 "tool_calling.preflight_requirements",
@@ -20093,17 +20223,38 @@ class InternalMCPChatOrchestrator:
             and routing_info.verdict.strip()
             else ""
         )
-        selector_requests_narration = selector_verdict == "narration"
-        selector_requests_custom_workflow = bool(
-            selected_workflow_id_text
+        selected_uses_tool_pipeline_contract = _workflow_matches_action_contract(
+            selected_workflow_id_text,
+            required_action_ids=_TOOL_PIPELINE_ACTION_IDS,
+        )
+        selected_uses_narration_contract = _workflow_matches_action_contract(
+            selected_workflow_id_text,
+            required_action_ids=_NARRATION_ACTION_IDS,
+        )
+        selected_requests_explicit_narration_workflow = (
+            selected_workflow_id_text == CHAT_NARRATION_WORKFLOW_ID
+        )
+        has_explicit_workflow_routing = isinstance(routing_info, WorkflowRoutingInfo)
+        selected_prefers_direct_response = bool(
+            has_explicit_workflow_routing
             and (
-                selector_verdict == "policy_selected"
-                or (
-                    selector_verdict
-                    and selector_verdict not in _STATIC_SELECTOR_VERDICTS
-                    and selected_workflow_id_text.lower() == selector_verdict
-                )
+                selected_workflow_id_text == CHAT_ASSISTANT_WORKFLOW_ID
+                or selected_requests_explicit_narration_workflow
+                or selected_uses_narration_contract
             )
+        )
+        selector_requests_narration = bool(
+            has_explicit_workflow_routing
+            and (
+                selected_requests_explicit_narration_workflow
+                or selected_uses_narration_contract
+            )
+        )
+        selector_requests_custom_workflow = bool(
+            has_explicit_workflow_routing
+            and selected_workflow_id_text
+            and not selected_prefers_direct_response
+            and not selected_uses_tool_pipeline_contract
         )
         write_tool_candidates_for_routing = sorted(
             {
@@ -20231,53 +20382,6 @@ class InternalMCPChatOrchestrator:
                     aux_llm_calls.append(dict(write_intent_persist_telemetry))
                 except Exception:
                     pass
-
-        def _workflow_action_ids(workflow_id: str | None) -> set[str]:
-            if not isinstance(workflow_id, str) or not workflow_id.strip():
-                return set()
-            workflow_def = self._workflow_registry.get(workflow_id.strip())
-            if workflow_def is None:
-                return set()
-            action_ids: set[str] = set()
-            for state in workflow_def.states.values():
-                for action in state.actions:
-                    action_id = str(action.action_id or "").strip()
-                    if action_id:
-                        action_ids.add(action_id)
-            return action_ids
-
-        def _workflow_matches_action_contract(
-            workflow_id: str | None,
-            *,
-            required_action_ids: frozenset[str],
-        ) -> bool:
-            action_ids = _workflow_action_ids(workflow_id)
-            return bool(action_ids) and required_action_ids.issubset(action_ids)
-
-        def _resolve_workflow_id_for_action_contract(
-            *,
-            required_action_ids: frozenset[str],
-            preferred_workflow_id: str | None = None,
-        ) -> str | None:
-            preferred = (
-                preferred_workflow_id.strip()
-                if isinstance(preferred_workflow_id, str)
-                and preferred_workflow_id.strip()
-                else None
-            )
-            if preferred and _workflow_matches_action_contract(
-                preferred, required_action_ids=required_action_ids
-            ):
-                return preferred
-            for workflow_id in self._workflow_registry.all_workflow_ids():
-                candidate = str(workflow_id).strip()
-                if not candidate:
-                    continue
-                if _workflow_matches_action_contract(
-                    candidate, required_action_ids=required_action_ids
-                ):
-                    return candidate
-            return None
 
         # Feature-flagged step toward ontology-driven render planning:
         # resolve whether narration should be part of the response rendering.
@@ -23615,11 +23719,11 @@ class InternalMCPChatOrchestrator:
             context_tags: list[str] = ["chat_turn_rendering"]
             if presenter_mode_requested:
                 context_tags.append("presenter_mode")
-            if selector_verdict == "narration":
+            if selected_uses_narration_contract:
                 context_tags.append("workflow:narration")
-            elif selector_verdict in {"tool_seeking", "summarisation"}:
+            elif selected_uses_tool_pipeline_contract:
                 context_tags.append("workflow:tool_calling")
-            elif selector_verdict in {"plain_response", "fallback"}:
+            elif selected_prefers_direct_response:
                 context_tags.append("workflow:assistant")
 
             temporal_metadata: dict[str, Any] = {}
@@ -24102,6 +24206,19 @@ class InternalMCPChatOrchestrator:
                 aux_llm_calls.append(dict(decision))
                 return dict(decision)
 
+            if "renderer_resolve_applicability" not in method_catalogue_for_routing:
+                decision["reason"] = "tool_unavailable"
+                _apply_screen_element_mapping(
+                    decision,
+                    screen_text=screen_text,
+                    tool_messages=tool_messages,
+                    resolver_attempted=False,
+                    resolver_success=False,
+                    selected_renderer_types=(),
+                )
+                aux_llm_calls.append(dict(decision))
+                return dict(decision)
+
             request_payload, payload_diagnostics = _build_renderer_request_payload(
                 screen_text,
                 tool_invocations=tool_invocations,
@@ -24306,8 +24423,19 @@ class InternalMCPChatOrchestrator:
                 tool_messages=tool_messages,
             )
             renderer_mode = str(renderer_plan.get("render_mode") or "").strip().lower()
+            renderer_requests_narration = bool(renderer_plan.get("should_narrate"))
+            selected_narration_workflow = bool(
+                selected_workflow_id_text == CHAT_NARRATION_WORKFLOW_ID
+                or (
+                    isinstance(routing_info, WorkflowRoutingInfo)
+                    and routing_info.workflow_id == CHAT_NARRATION_WORKFLOW_ID
+                )
+            )
             should_route_narration = (
-                selector_requests_narration or renderer_mode == "spoken+screen"
+                selected_narration_workflow
+                or selector_requests_narration
+                or renderer_requests_narration
+                or renderer_mode == "spoken+screen"
             )
             if not should_route_narration:
                 return screen_text
@@ -24401,17 +24529,13 @@ class InternalMCPChatOrchestrator:
         # JVNAUTOSCI-825: Route turns to the appropriate pathway.
         #
         # Three routing tiers:
-        #   1. plain_response  — direct LLM call without tool context
+        #   1. direct_response — direct LLM call without tool context
         #   2. custom_workflow — execute selected discovered workflow
         #   3. tool_pipeline   — execute registry workflow matching tool contract
         # ----------------------------------------------------------------
         # This was already evaluated before workflow selection so prompt-required
         # tools can dominate routing deterministically, even when selector output
         # is noisy or unavailable.
-        selected_uses_tool_pipeline_contract = _workflow_matches_action_contract(
-            selected_workflow_id_text,
-            required_action_ids=_TOOL_PIPELINE_ACTION_IDS,
-        )
 
         def _force_tool_pipeline_routing(
             *,
@@ -24424,6 +24548,8 @@ class InternalMCPChatOrchestrator:
             nonlocal selector_verdict
             nonlocal selector_requests_narration
             nonlocal selector_requests_custom_workflow
+            nonlocal selected_uses_narration_contract
+            nonlocal selected_prefers_direct_response
             nonlocal routing_info
             nonlocal selected_uses_tool_pipeline_contract
 
@@ -24437,9 +24563,11 @@ class InternalMCPChatOrchestrator:
             )
             selected_workflow_id = TOOL_CALLING_WORKFLOW_ID
             selected_workflow_id_text = TOOL_CALLING_WORKFLOW_ID
-            selector_verdict = "tool_seeking"
+            selector_verdict = "tool_contract_override"
             selector_requests_narration = False
             selector_requests_custom_workflow = False
+            selected_uses_narration_contract = False
+            selected_prefers_direct_response = False
             selected_uses_tool_pipeline_contract = True
 
             prompt_id = None
@@ -24451,7 +24579,7 @@ class InternalMCPChatOrchestrator:
                 routing_duration_ms = routing_info.routing_duration_ms
             routing_info = WorkflowRoutingInfo(
                 workflow_id=TOOL_CALLING_WORKFLOW_ID,
-                verdict="tool_seeking",
+                verdict="tool_contract_override",
                 prompt_id=prompt_id,
                 discovered_workflow_ids=discovered_workflow_ids,
                 routing_duration_ms=routing_duration_ms,
@@ -24475,13 +24603,13 @@ class InternalMCPChatOrchestrator:
                 trace.metadata["workflow_selector_override"] = dict(override_payload)
 
         if (
-            selector_verdict == "plain_response"
+            selected_prefers_direct_response
             and mutative_intent_requires_tool_routing
             and not selected_uses_tool_pipeline_contract
         ):
             _force_tool_pipeline_routing(
                 reason="mutative_intent_requires_tool_pipeline",
-                excluded_selector_verdicts=["plain_response"],
+                excluded_selector_verdicts=[selector_verdict or "direct_response"],
                 extra_payload={
                     "write_policy_reason": write_routing_policy_reason,
                     "write_tool_candidate_count": len(
@@ -24574,7 +24702,7 @@ class InternalMCPChatOrchestrator:
                 else None
             ),
             "workflow_match_count": len(discovered_matches),
-            "workflow_candidate_count": len(discovered_matches)
+            "workflow_candidate_count": len(selector_candidate_matches)
             + len(excluded_discovered_matches),
             "workflow_selection_rationale": workflow_selection_rationale,
         }
@@ -24720,12 +24848,10 @@ class InternalMCPChatOrchestrator:
                 render_plan=base_result.render_plan,
             )
 
-        # Tier 1: Plain response — skip tool-calling overhead entirely.
-        # When the classifier says "plain_response", there is no need
-        # to build tool context, inject write-policy, or run the
-        # plan→validate→execute→backfill pipeline.  This saves an LLM
-        # round-trip worth of system prompt tokens and reduces latency.
-        if selector_verdict == "plain_response" and not selected_uses_tool_pipeline_contract:
+        # Tier 1: Direct response — skip tool-calling overhead entirely.
+        # This is reserved for the chat assistant workflow and workflows that
+        # explicitly request narration over a direct screen response.
+        if selected_prefers_direct_response and not selected_uses_tool_pipeline_contract:
             _emit_phase_transition_local(
                 self.PHASE_PLAIN_RESPONSE,
                 extra=workflow_dispatch_progress,
@@ -24737,7 +24863,7 @@ class InternalMCPChatOrchestrator:
                     inputs={
                         "prompt": prompt,
                         "model": planner_model or "default",
-                        "routing": "plain_response",
+                        "routing": "direct_response",
                     },
                 )
             response, planner_model, _ = self._run_llm_with_fallbacks(
@@ -24769,6 +24895,11 @@ class InternalMCPChatOrchestrator:
                 response if isinstance(response, str) else str(response),
                 aux_log=aux_llm_calls if isinstance(aux_llm_calls, list) else None,
                 source_stage="run.plain_response",
+            )
+            response_text = _maybe_apply_narration_routing(
+                response_text,
+                tool_invocations=(),
+                tool_messages=(),
             )
             response_text = _maybe_apply_critic(response_text)
             response_text = _maybe_append_completion_claim_validation(response_text)
@@ -24934,6 +25065,8 @@ class InternalMCPChatOrchestrator:
             user_namespace=user_namespace,
             auxiliary_system_prompt=auxiliary_system_prompt,
             max_tool_invocations=self._max_tool_invocations,
+            max_tool_result_chars=self._max_tool_result_chars,
+            max_tool_result_field_chars=self._max_tool_result_field_chars,
             default_gmail_profile=gmail_profile or self._default_gmail_profile,
         )
         auto_proceed_minimal_imposition_enabled = (

--- a/src/backend/services/workflow_event_integration_service.py
+++ b/src/backend/services/workflow_event_integration_service.py
@@ -18,6 +18,16 @@ from .feature_flags import (
     get_durable_workflows_enabled,
     get_event_workflow_integration_enabled,
 )
+from ..workflows.durable.file_copy_upload_classification_workflow import (
+    DEFAULT_ALLOW_INTERPRET_FALLBACK,
+    DEFAULT_BUSINESS_CARD_WORKFLOW_ID,
+    DEFAULT_CV_WORKFLOW_ID,
+    DEFAULT_FORCE_ROUTE_KEY_SENTINEL,
+    DEFAULT_MINIMUM_MUTATION_CONFIDENCE,
+    DEFAULT_MINIMUM_ROUTE_SCORE,
+    DEFAULT_SCHOLARLY_WORKFLOW_ID,
+    DEFAULT_UNUSED_SPECIALISED_WORKFLOW_ID,
+)
 from ..workflows.durable.models import EventWorkflowBinding
 from ..workflows.durable.startup import get_instance_manager
 from ..workflows.durable.workflow_instance_submission_service import (
@@ -44,6 +54,29 @@ EVENT_TYPE_VONTOLOGY_MUTATED = "vontology.mutated"
 EVENT_TYPE_FILE_COPY_UPLOADED = "file_copy.uploaded"
 DEFAULT_FILE_COPY_UPLOADED_WORKFLOW_ID = "#V#file_copy_upload_handler_workflow"
 
+
+def _file_copy_uploaded_binding_inputs() -> dict[str, str]:
+    """Return the authoritative input mapping for file-copy upload launch."""
+
+    return {
+        "concept_id": "event.file_copy_concept_id",
+        "file_copy_concept_id": "event.file_copy_concept_id",
+        "content_type": "event.content_type",
+        "original_filename": "event.original_filename",
+        "size_bytes": "event.size_bytes",
+        "sha256": "event.sha256",
+        "blob_uri": "event.blob_uri",
+        "index_in_rag": "event.index_in_rag",
+        "minimum_route_score": str(DEFAULT_MINIMUM_ROUTE_SCORE),
+        "minimum_mutation_confidence": str(DEFAULT_MINIMUM_MUTATION_CONFIDENCE),
+        "force_route_key": DEFAULT_FORCE_ROUTE_KEY_SENTINEL,
+        "allow_interpret_fallback": str(DEFAULT_ALLOW_INTERPRET_FALLBACK).lower(),
+        "scholarly_workflow_id": DEFAULT_SCHOLARLY_WORKFLOW_ID,
+        "cv_workflow_id": DEFAULT_CV_WORKFLOW_ID,
+        "business_card_workflow_id": DEFAULT_BUSINESS_CARD_WORKFLOW_ID,
+        "meeting_workflow_id": DEFAULT_UNUSED_SPECIALISED_WORKFLOW_ID,
+    }
+
 # Bootstrap definitions exist only to materialise authoritative persisted
 # bindings. Runtime launch must resolve from persistent records rather than from
 # this in-memory table.
@@ -57,16 +90,7 @@ _BOOTSTRAP_EVENT_BINDINGS: tuple[dict[str, Any], ...] = (
     {
         "event_type": EVENT_TYPE_FILE_COPY_UPLOADED,
         "workflow_id": DEFAULT_FILE_COPY_UPLOADED_WORKFLOW_ID,
-        "input_mapping": {
-            "concept_id": "event.file_copy_concept_id",
-            "file_copy_concept_id": "event.file_copy_concept_id",
-            "content_type": "event.content_type",
-            "original_filename": "event.original_filename",
-            "size_bytes": "event.size_bytes",
-            "sha256": "event.sha256",
-            "blob_uri": "event.blob_uri",
-            "index_in_rag": "event.index_in_rag",
-        },
+        "input_mapping": _file_copy_uploaded_binding_inputs(),
         "enabled": True,
         "replace_existing": True,
         "exclusive": True,

--- a/src/backend/workflows/action_registry.py
+++ b/src/backend/workflows/action_registry.py
@@ -55,6 +55,8 @@ class WorkflowEnvironment:
     user_namespace: str | None = None
     auxiliary_system_prompt: str | None = None
     max_tool_invocations: int | None = None
+    max_tool_result_chars: int | None = None
+    max_tool_result_field_chars: int | None = None
     default_gmail_profile: str | None = None
 
 

--- a/src/backend/workflows/durable/durable_executor.py
+++ b/src/backend/workflows/durable/durable_executor.py
@@ -16,6 +16,7 @@ from ..engine import (
     apply_tool_output_context_mappings,
     execute_workflow_step_invocation,
     evaluate_transition_condition_spec,
+    materialise_terminal_effect_context,
     resolve_action_inputs_from_context,
     state_has_on_break_transition,
     state_has_on_continue_transition,
@@ -511,6 +512,13 @@ class DurableWorkflowExecutor:
                     final_state=current_state,
                     error="workflow_continue_outside_loop_scope",
                     checkpoint=True,
+                )
+
+            if current_state in termination_states:
+                materialise_terminal_effect_context(
+                    context=context,
+                    state_spec=state_spec,
+                    state_id=current_state,
                 )
 
             if state_has_unknown_route and bool(context.get("last_action_unknown")):

--- a/src/backend/workflows/durable/file_copy_upload_classification_workflow.py
+++ b/src/backend/workflows/durable/file_copy_upload_classification_workflow.py
@@ -43,6 +43,12 @@ FILE_COPY_UPLOAD_ROUTE_DECISION_PREDICATE = (
 )
 FILE_COPY_UPLOAD_CLASSIFICATION_VERSION = "file_copy_upload_classification.v1"
 
+DEFAULT_MINIMUM_ROUTE_SCORE = 0.58
+DEFAULT_MINIMUM_MUTATION_CONFIDENCE = 0.84
+DEFAULT_ALLOW_INTERPRET_FALLBACK = True
+DEFAULT_FORCE_ROUTE_KEY_SENTINEL = "__auto__"
+DEFAULT_UNUSED_SPECIALISED_WORKFLOW_ID = "__unused__"
+
 DEFAULT_SCHOLARLY_WORKFLOW_ID = "#V#scholarly_paper_representation_workflow"
 DEFAULT_CV_WORKFLOW_ID = "#V#file_copy_cv_representation_workflow"
 DEFAULT_BUSINESS_CARD_WORKFLOW_ID = "#V#file_copy_business_card_representation_workflow"
@@ -287,17 +293,17 @@ def _build_classification_payload(raw: Mapping[str, Any]) -> dict[str, Any]:
     size_bytes = _coerce_int(raw.get("size_bytes"))
     allow_interpret_fallback = _coerce_bool(
         raw.get("allow_interpret_fallback"),
-        default=True,
+        default=DEFAULT_ALLOW_INTERPRET_FALLBACK,
     )
     min_route_score = _coerce_float(
         raw.get("minimum_route_score"),
-        default=0.58,
+        default=DEFAULT_MINIMUM_ROUTE_SCORE,
         minimum=0.2,
         maximum=0.95,
     )
     min_mutation_confidence = _coerce_float(
         raw.get("minimum_mutation_confidence"),
-        default=0.84,
+        default=DEFAULT_MINIMUM_MUTATION_CONFIDENCE,
         minimum=0.5,
         maximum=0.99,
     )
@@ -634,6 +640,14 @@ def register_file_copy_upload_classification_actions(registry: ActionRegistry) -
 
 
 __all__ = [
+    "DEFAULT_ALLOW_INTERPRET_FALLBACK",
+    "DEFAULT_BUSINESS_CARD_WORKFLOW_ID",
+    "DEFAULT_CV_WORKFLOW_ID",
+    "DEFAULT_FORCE_ROUTE_KEY_SENTINEL",
+    "DEFAULT_MINIMUM_MUTATION_CONFIDENCE",
+    "DEFAULT_MINIMUM_ROUTE_SCORE",
+    "DEFAULT_SCHOLARLY_WORKFLOW_ID",
+    "DEFAULT_UNUSED_SPECIALISED_WORKFLOW_ID",
     "FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID",
     "FILE_COPY_UPLOAD_ROUTE_DECISION_PREDICATE",
     "FILE_COPY_UPLOAD_CLASSIFICATION_VERSION",

--- a/src/backend/workflows/durable/registry_factory.py
+++ b/src/backend/workflows/durable/registry_factory.py
@@ -108,6 +108,13 @@ _last_inventory_snapshot: Dict[str, Any] | None = None
 _durable_mcp_gateway_lock = Lock()
 _durable_mcp_gateway: Any | None = None
 
+_BOOTSTRAP_ONLY_FILE_COPY_WORKFLOW_IDS: tuple[str, ...] = (
+    "#V#file_copy_typing_workflow",
+    "#V#file_copy_upload_classification_workflow",
+    "#V#file_copy_upload_handler_workflow",
+    "#V#file_copy_interpretation_workflow",
+)
+
 _BOOTSTRAP_ONLY_REASONING_RECOVERY_WORKFLOW_IDS: tuple[str, ...] = (
     "#V#planning_workflow",
     "#V#rumination_workflow",
@@ -192,6 +199,42 @@ def _get_or_build_durable_mcp_gateway():
             enabled=True,
         )
         return _durable_mcp_gateway
+
+
+def _bootstrap_only_file_copy_workflow_registrations() -> tuple[Any, ...]:
+    """Return file-copy registrations used only to publish authoritative graphs."""
+
+    return (
+        get_file_copy_typing_workflow_registration(),
+        get_file_copy_upload_classification_workflow_registration(),
+        get_file_copy_upload_handler_workflow_registration(),
+        get_file_copy_interpretation_workflow_registration(),
+    )
+
+
+def _bootstrap_only_file_copy_workflow_report(
+    *,
+    bootstrap_allowed: bool,
+) -> Dict[str, Any]:
+    report: Dict[str, Any] = {
+        "enabled": bool(bootstrap_allowed),
+        "workflow_ids": list(_BOOTSTRAP_ONLY_FILE_COPY_WORKFLOW_IDS),
+    }
+    if not bootstrap_allowed:
+        return report
+
+    temp_registry = WorkflowRegistry(
+        definition_loader=load_workflow_definition_from_vontology,
+    )
+    for registration in _bootstrap_only_file_copy_workflow_registrations():
+        temp_registry.register(registration)
+
+    bootstrap_report = bootstrap_workflow_concepts(
+        registry=temp_registry,
+        target_workflow_ids=_BOOTSTRAP_ONLY_FILE_COPY_WORKFLOW_IDS,
+    )
+    report.update(bootstrap_report)
+    return report
 
 
 def _durable_mcp_fallback_action(request: Any) -> WorkflowActionResult:
@@ -425,11 +468,11 @@ def _apply_workflow_parity_policy(inventory_snapshot: Dict[str, Any]) -> None:
     """Apply warn/fail parity drift policy and annotate inventory diagnostics.
 
     ``VON_WORKFLOW_PARITY_ENFORCEMENT`` controls behaviour:
-    - ``warn`` (default): log warning on drift
+    - ``warn``: log warning on drift
     - ``fail`` / ``strict`` / ``error``: raise RuntimeError on drift
     - ``off`` / ``none``: do not warn or fail
     """
-    mode = os.getenv("VON_WORKFLOW_PARITY_ENFORCEMENT", "warn").strip().lower()
+    mode = os.getenv("VON_WORKFLOW_PARITY_ENFORCEMENT", "fail").strip().lower()
     diagnostics = inventory_snapshot.get("diagnostics")
     drift_detected = bool(
         isinstance(diagnostics, dict) and diagnostics.get("drift_detected")
@@ -542,13 +585,10 @@ def get_or_build_workflow_registry_inventory_snapshot(
 def _register_python_defined_workflows(registry: WorkflowRegistry) -> None:
     """Register the current Python-defined workflow surface into ``registry``."""
 
-    # Conversation-turn workflows are now Vontology-authoritative. Only durable
-    # workflow families that still originate in Python are registered here so
-    # purity diagnostics can track the remaining hybrid surface.
-    registry.register(get_file_copy_typing_workflow_registration())
-    registry.register(get_file_copy_upload_classification_workflow_registration())
-    registry.register(get_file_copy_upload_handler_workflow_registration())
-    registry.register(get_file_copy_interpretation_workflow_registration())
+    # Production runtime registration is now Vontology-authoritative.
+    # Python workflow definitions remain only as bootstrap/test support and are
+    # not registered onto the production registry path.
+    return None
 
 
 def _bootstrap_only_reasoning_recovery_workflow_registrations() -> tuple[Any, ...]:
@@ -655,6 +695,10 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
     bootstrap_enabled = os.getenv("VON_WORKFLOW_CONCEPT_BOOTSTRAP_ENABLE", "1")
     bootstrap_enabled = bootstrap_enabled.strip().lower() in {"1", "true", "yes", "on"}
     bootstrap_allowed = bool(allow_bootstrap and bootstrap_enabled)
+    bootstrap_only_file_copy_report: Dict[str, Any] = {
+        "enabled": bootstrap_allowed,
+        "workflow_ids": list(_BOOTSTRAP_ONLY_FILE_COPY_WORKFLOW_IDS),
+    }
     bootstrap_only_reasoning_recovery_report: Dict[str, Any] = {
         "enabled": bootstrap_allowed,
         "workflow_ids": list(_BOOTSTRAP_ONLY_REASONING_RECOVERY_WORKFLOW_IDS),
@@ -668,6 +712,9 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
 
     if bootstrap_allowed:
         try:
+            bootstrap_only_file_copy_report = (
+                _bootstrap_only_file_copy_workflow_report(bootstrap_allowed=True)
+            )
             # Representation workflow families are now materialised explicitly by
             # their own Vontology publication services. The runtime registry must
             # consume that published authority rather than re-bootstrap it here.
@@ -687,6 +734,11 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
                 "workflow_bootstrap_report_build_failed: %s",
                 exc,
             )
+            bootstrap_only_file_copy_report = {
+                "enabled": True,
+                "workflow_ids": list(_BOOTSTRAP_ONLY_FILE_COPY_WORKFLOW_IDS),
+                "error": str(exc),
+            }
             bootstrap_only_reasoning_recovery_report = {
                 "enabled": True,
                 "workflow_ids": list(_BOOTSTRAP_ONLY_REASONING_RECOVERY_WORKFLOW_IDS),
@@ -767,6 +819,7 @@ def _build_workflow_registry(*, allow_bootstrap: bool) -> WorkflowRegistry:
     _launch_deferred_registry_work(
         registry=registry,
         discovered_workflow_ids=discovered_workflow_ids,
+        bootstrap_only_file_copy_report=bootstrap_only_file_copy_report,
         bootstrap_only_reasoning_recovery_report=(
             bootstrap_only_reasoning_recovery_report
         ),
@@ -783,6 +836,7 @@ def _launch_deferred_registry_work(
     *,
     registry: WorkflowRegistry,
     discovered_workflow_ids: List[str],
+    bootstrap_only_file_copy_report: Dict[str, Any],
     bootstrap_only_reasoning_recovery_report: Dict[str, Any],
     bootstrap_only_support_maintenance_report: Dict[str, Any],
     bootstrap_allowed: bool,
@@ -829,6 +883,9 @@ def _launch_deferred_registry_work(
                 registry=registry,
             )
             authority_report["bootstrap"] = bootstrap_report
+            authority_report["bootstrap_only_file_copy_workflows"] = (
+                bootstrap_only_file_copy_report
+            )
             authority_report["bootstrap_only_reasoning_recovery_workflows"] = (
                 bootstrap_only_reasoning_recovery_report
             )
@@ -836,9 +893,14 @@ def _launch_deferred_registry_work(
                 bootstrap_only_support_maintenance_report
             )
 
+            inventory_discovered_workflow_ids = sorted(
+                set(discovered_workflow_ids).union(
+                    _infer_vontology_workflow_ids_from_registry(registry)
+                )
+            )
             inventory_snapshot = _build_workflow_parity_inventory(
                 registry=registry,
-                discovered_workflow_ids=discovered_workflow_ids,
+                discovered_workflow_ids=inventory_discovered_workflow_ids,
                 authority_report=authority_report,
             )
             with _inventory_lock:
@@ -889,6 +951,11 @@ def _launch_deferred_registry_work(
                 exc,
                 exc_info=True,
             )
+
+    parity_mode = os.getenv("VON_WORKFLOW_PARITY_ENFORCEMENT", "fail").strip().lower()
+    if parity_mode in {"fail", "strict", "error"}:
+        _deferred_work()
+        return
 
     thread = threading.Thread(
         target=_deferred_work,

--- a/src/backend/workflows/llm_step_executor.py
+++ b/src/backend/workflows/llm_step_executor.py
@@ -508,6 +508,8 @@ def _build_gateway_runtime(
             if request.environment.max_tool_invocations is not None
             else 1
         ),
+        max_tool_result_chars=request.environment.max_tool_result_chars,
+        max_tool_result_field_chars=request.environment.max_tool_result_field_chars,
         tool_batch_cap=(
             max(1, int(request.inputs.get("tool_batch_cap") or 4))
             if request.inputs.get("tool_batch_cap") is not None
@@ -796,6 +798,8 @@ def execute_llm_step(request: WorkflowActionRequest) -> WorkflowActionResult:
             if request.environment.max_tool_invocations is not None
             else 1
         ),
+        max_tool_result_chars=request.environment.max_tool_result_chars,
+        max_tool_result_field_chars=request.environment.max_tool_result_field_chars,
         tool_batch_cap=(
             max(1, int(request.inputs.get("tool_batch_cap") or 4))
             if request.inputs.get("tool_batch_cap") is not None

--- a/src/backend/workflows/workflow_concept_authority_service.py
+++ b/src/backend/workflows/workflow_concept_authority_service.py
@@ -2857,7 +2857,9 @@ def publish_canonical_chat_workflow_graphs(
                 concept_id=workflow_id,
                 name=_titleise_workflow_id(workflow_id),
                 description=workflow_purpose,
-                parent_concept_ids=[preferred_workflow_type] if preferred_workflow_type else [],
+                parent_concept_ids=_existing_parent_concept_ids(
+                    preferred_workflow_type
+                ),
             )
             if create_error:
                 errors_by_workflow_id[workflow_id] = (
@@ -3474,6 +3476,22 @@ def clear_workflow_type_resolution_cache() -> None:
     resolve_available_workflow_type_ids.cache_clear()
 
 
+def _existing_parent_concept_ids(*candidate_ids: str | None) -> list[str]:
+    """Return only workflow parent concept IDs that already exist."""
+
+    existing: list[str] = []
+    seen: set[str] = set()
+    for candidate_id in candidate_ids:
+        cleaned = str(candidate_id or "").strip()
+        if not cleaned or cleaned in seen:
+            continue
+        if not _concept_exists_fast(cleaned):
+            continue
+        seen.add(cleaned)
+        existing.append(cleaned)
+    return existing
+
+
 def _build_workflow_identity_bootstrap_report(
     *,
     workflow_ids: Sequence[str],
@@ -3590,7 +3608,7 @@ def bootstrap_workflow_concept_identities(
                 continue
 
             try:
-                parent_ids = [preferred_type_id] if preferred_type_id else []
+                parent_ids = _existing_parent_concept_ids(preferred_type_id)
                 concept_service.create_concept(
                     name=_titleise_workflow_id(workflow_id),
                     concept_id=workflow_id,

--- a/src/backend/workflows/workflow_selector.py
+++ b/src/backend/workflows/workflow_selector.py
@@ -1,32 +1,21 @@
 """Workflow selector that routes chat turns to workflow definitions.
 
-JVNAUTOSCI-1424 Phase 2: RAG-first workflow routing.  The selector
-receives candidate workflows from the capability index (including
-built-in workflows like chat_assistant and tool_calling on equal footing
-with Vontology-authored workflows) and asks an LLM ranker to choose the
-best candidate for the user's request.
+JVNAUTOSCI-1424 Phase 2 introduced RAG-first workflow routing: the selector
+receives candidate workflows from discovery/capability matching and asks an
+LLM ranker to choose the single best workflow for the user's request.
 
-JVNAUTOSCI-1424 Phase 3: Model-based selection.  The selector now
-requests structured JSON output from the LLM ranker, extracting a
-confidence score (0.0–1.0) and reasoning trace alongside the workflow
-selection.  This decouples precision (model-based selection) from recall
-(RAG candidate retrieval) and lays the groundwork for Phase 4 RL
-optimisation by recording experience tuples.
+JVNAUTOSCI-1424 Phase 3 added structured model output so the selector can
+carry confidence and reasoning alongside the chosen workflow.
 
-The static verdict taxonomy (plain_response, tool_seeking, summarisation,
-narration) is retired.  All workflows — built-in and Vontology — compete
-as RAG-retrieved candidates.
-
-Legacy compatibility: if ``verdict_mapping`` is provided at construction,
-the old static-verdict path is used so existing code can transition
-incrementally.
+JVNAUTOSCI-1521 removes the retired static-verdict selector mode. Production
+routing now has one authoritative selection path: candidate workflows in,
+workflow ID out.
 """
 
 from __future__ import annotations
 
 import json
 import os
-import re
 from dataclasses import dataclass, field
 from typing import Any, Mapping, Optional, Sequence
 
@@ -35,6 +24,7 @@ from src.backend.services.workflow_selection_policy_service import (
     recommend_workflow_with_policy,
 )
 
+from .definitions import CHAT_NARRATION_WORKFLOW_ID, TOOL_CALLING_WORKFLOW_ID
 from .workflow_registry import WorkflowRegistry
 
 
@@ -67,32 +57,6 @@ _DEFAULT_RANKER_PROMPT = (
     "Candidate workflows:\n{candidate_list}\n"
 )
 
-# -----------------------------------------------------------------------
-# Legacy static-verdict prompt (deprecated, kept for transitional use)
-# -----------------------------------------------------------------------
-
-_LEGACY_CLASSIFIER_PROMPT = (
-    "You are a workflow router for the next assistant turn.\n"
-    "Return exactly one routing label and nothing else.\n"
-    "Allowed labels: plain_response, tool_seeking, summarisation, narration.\n"
-    "Do not return prose, JSON, punctuation, explanations, code fences, or more than one label.\n"
-    "Choose tool_seeking whenever satisfying the request likely requires tools, MCP calls, retrieval, downloads, reads, searches, file access, or additive knowledge-base mutations.\n"
-    "Canonical artefact identifiers and URLs usually imply tool_seeking when acting on the artefact is needed, including bare arXiv URLs or arXiv IDs.\n"
-    "Choose plain_response only for direct conversational replies that do not need tools.\n"
-    "User+assistant turn so far:\n"
-    "{turn_text}\n"
-)
-
-_LEGACY_DISCOVERY_SUFFIX = (
-    "\n\n"
-    "In addition to the standard verdicts, these specialised workflows are available.\n"
-    "If the user's request clearly matches one, respond with its concept_id instead "
-    "of a standard verdict.  Only choose a specialised workflow when the match is "
-    "strong — default to tool_seeking or plain_response when uncertain.\n\n"
-    "{discovered_workflows}\n"
-)
-
-
 @dataclass(frozen=True)
 class WorkflowSelection:
     workflow_id: str
@@ -118,11 +82,8 @@ class WorkflowSelectionPrompt:
 class WorkflowSelector:
     """Select a workflow for a chat turn.
 
-    JVNAUTOSCI-1424 Phase 2: RAG-first routing.  When ``verdict_mapping``
-    is None (the default), the selector operates in RAG-first mode —
-    all candidate workflows (built-in + Vontology) are presented to the
-    LLM ranker on equal footing.  When ``verdict_mapping`` is provided,
-    the legacy static-verdict path is used for backward compatibility.
+    The selector is intentionally single-path: all candidate workflows
+    compete on equal footing and the selector resolves one workflow ID.
     """
 
     def __init__(
@@ -130,28 +91,15 @@ class WorkflowSelector:
         *,
         registry: WorkflowRegistry,
         prompt_service: PromptTemplateService,
-        verdict_mapping: Mapping[str, str] | None = None,
         default_workflow_id: str = "#V#chat_assistant_workflow",
         classifier_prompt_ids: Sequence[str] = ("#V#chat_turn_classifier_prompt",),
         fallback_prompt: str | None = None,
     ) -> None:
         self._registry = registry
         self._prompt_service = prompt_service
-        self._verdict_mapping = dict(verdict_mapping) if verdict_mapping else None
         self._default_workflow_id = default_workflow_id
         self._classifier_prompt_ids = tuple(classifier_prompt_ids)
-        self._fallback_prompt = fallback_prompt or (
-            _LEGACY_CLASSIFIER_PROMPT if self._verdict_mapping else _DEFAULT_RANKER_PROMPT
-        )
-        self._rag_first = self._verdict_mapping is None
-
-    # Legacy verdicts kept for backward-compat extraction.
-    _LEGACY_VERDICTS = (
-        "plain_response",
-        "tool_seeking",
-        "summarisation",
-        "narration",
-    )
+        self._fallback_prompt = fallback_prompt or _DEFAULT_RANKER_PROMPT
     _JSON_SELECTION_KEYS = (
         "workflow_id",
         "workflow",
@@ -163,11 +111,20 @@ class WorkflowSelector:
     _JSON_CONFIDENCE_KEYS = ("confidence", "confidence_score", "score")
     _JSON_REASONING_KEYS = ("reasoning", "reason", "explanation", "rationale")
     _CANDIDATE_BOUNDARY_STRIP = " \t\r\n`'\".,;:!?()[]{}<>"
+    _COMPAT_SELECTION_ALIASES = {
+        "tool_seeking": TOOL_CALLING_WORKFLOW_ID,
+        "tool_calling": TOOL_CALLING_WORKFLOW_ID,
+        "summarisation": TOOL_CALLING_WORKFLOW_ID,
+        "narration": CHAT_NARRATION_WORKFLOW_ID,
+    }
 
     @property
     def rag_first(self) -> bool:
-        """True when operating in RAG-first mode (no static verdict taxonomy)."""
-        return self._rag_first
+        """Retained for backwards-compatible introspection.
+
+        The selector is always in candidate-based workflow mode.
+        """
+        return True
 
     def enabled(self) -> bool:
         """Check whether the workflow selector is enabled.
@@ -221,22 +178,13 @@ class WorkflowSelector:
     ) -> WorkflowSelectionPrompt:
         """Build the selection prompt.
 
-        In RAG-first mode, *discovered_workflows* contains ALL candidates
-        (including built-in workflows) from the capability index.  The
-        prompt lists every candidate so the LLM ranker can choose the
-        best one.
-
-        In legacy mode, the prompt uses the static-verdict classifier
-        with discovered workflows as an optional addendum.
+        *discovered_workflows* contains all currently eligible candidates
+        (including built-in workflows). The prompt lists every candidate so
+        the LLM ranker can choose the best one.
         """
-        if self._rag_first:
-            return self._prepare_rag_first_prompt(
-                turn_text=turn_text,
-                candidate_workflows=discovered_workflows,
-            )
-        return self._prepare_legacy_prompt(
+        return self._prepare_rag_first_prompt(
             turn_text=turn_text,
-            discovered_workflows=discovered_workflows,
+            candidate_workflows=discovered_workflows,
         )
 
     # ------------------------------------------------------------------
@@ -349,51 +297,6 @@ class WorkflowSelector:
         )
 
     # ------------------------------------------------------------------
-    # Legacy prompt (backward compatibility)
-    # ------------------------------------------------------------------
-
-    def _prepare_legacy_prompt(
-        self,
-        *,
-        turn_text: str,
-        discovered_workflows: Sequence[Mapping[str, Any]] | None = None,
-    ) -> WorkflowSelectionPrompt:
-        """Build the legacy static-verdict classifier prompt."""
-        prompt = self._prompt_service.render_prompt(
-            self._classifier_prompt_ids,
-            variables={"turn_text": turn_text},
-            fallback=self._fallback_prompt,
-            max_chars=4000,
-        )
-        prompt_id = prompt.prompt_id if prompt else None
-        prompt_text = prompt.text if prompt else self._fallback_prompt
-
-        discovered_ids: list[str] = []
-        if discovered_workflows:
-            lines: list[str] = []
-            for wf in discovered_workflows:
-                cid = wf.get("concept_id", "")
-                name = wf.get("name", cid)
-                desc = wf.get("description", "")
-                if not cid:
-                    continue
-                discovered_ids.append(cid)
-                entry = f"- {cid}: {name}"
-                if desc:
-                    entry += f" — {desc}"
-                lines.append(entry)
-            if lines:
-                prompt_text += _LEGACY_DISCOVERY_SUFFIX.format(
-                    discovered_workflows="\n".join(lines)
-                )
-
-        return WorkflowSelectionPrompt(
-            prompt_id=prompt_id,
-            prompt_text=prompt_text,
-            discovered_workflow_ids=tuple(discovered_ids),
-        )
-
-    # ------------------------------------------------------------------
     # Selection resolution
     # ------------------------------------------------------------------
 
@@ -407,24 +310,14 @@ class WorkflowSelector:
     ) -> WorkflowSelection:
         """Resolve a raw LLM response into a workflow selection.
 
-        In RAG-first mode, *discovered_workflow_ids* contains ALL
-        candidate workflow_ids.  The response is matched against them.
-
-        In legacy mode, the response is matched against static verdicts
-        first, then discovered workflow IDs.
+        *discovered_workflow_ids* contains all eligible workflow IDs for the
+        turn. The selector resolves the model output against that set.
         """
-        if self._rag_first:
-            return self._resolve_rag_first(
-                raw_response=raw_response,
-                prompt_id=prompt_id,
-                prompt_used=prompt_used,
-                candidate_workflow_ids=discovered_workflow_ids,
-            )
-        return self._resolve_legacy(
+        return self._resolve_rag_first(
             raw_response=raw_response,
             prompt_id=prompt_id,
             prompt_used=prompt_used,
-            discovered_workflow_ids=discovered_workflow_ids,
+            candidate_workflow_ids=discovered_workflow_ids,
         )
 
     # ------------------------------------------------------------------
@@ -471,20 +364,34 @@ class WorkflowSelector:
             workflow_id = matched_id
             verdict = "rag_selected"
         else:
-            # Fallback: try to find a candidate in the raw text.
-            raw_text = str(raw_response or "").lower()
-            for cid in candidate_ids:
-                if cid.lower() in raw_text:
-                    workflow_id = cid
-                    verdict = "rag_selected"
-                    break
+            compat_match = self._resolve_compat_selection_alias(
+                label=label_lower,
+                candidate_lookup=candidate_lookup,
+                candidate_workflow_ids=candidate_ids,
+            )
+            if compat_match:
+                workflow_id = compat_match
+                verdict = "rag_selected"
+                if (
+                    workflow_id == self._default_workflow_id
+                    and compat_match not in candidate_ids
+                ):
+                    verdict = "rag_default"
             else:
-                # Ultimate fallback to default workflow.
-                workflow_id = self._default_workflow_id
-                verdict = "rag_default"
-                # Lower confidence for fallback selections.
-                if confidence_score > 0.0:
-                    confidence_score = min(confidence_score, 0.3)
+                # Fallback: try to find a candidate in the raw text.
+                raw_text = str(raw_response or "").lower()
+                for cid in candidate_ids:
+                    if cid.lower() in raw_text:
+                        workflow_id = cid
+                        verdict = "rag_selected"
+                        break
+                else:
+                    # Ultimate fallback to default workflow.
+                    workflow_id = self._default_workflow_id
+                    verdict = "rag_default"
+                    # Lower confidence for fallback selections.
+                    if confidence_score > 0.0:
+                        confidence_score = min(confidence_score, 0.3)
 
         return WorkflowSelection(
             workflow_id=workflow_id,
@@ -498,68 +405,32 @@ class WorkflowSelector:
             selection_source="selector",
         )
 
-    # ------------------------------------------------------------------
-    # Legacy resolution (backward compatibility)
-    # ------------------------------------------------------------------
-
-    def _resolve_legacy(
+    def _resolve_compat_selection_alias(
         self,
         *,
-        raw_response: Any,
-        prompt_id: Optional[str],
-        prompt_used: str | None,
-        discovered_workflow_ids: Sequence[str] = (),
-    ) -> WorkflowSelection:
-        """Resolve selection using static verdict mapping (legacy path)."""
-        verdict = self._extract_candidate_label(
-            raw_response=raw_response,
-            discovered_workflow_ids=discovered_workflow_ids,
-        )
-        verdict_lookup = verdict.lower()
-        resolved_verdict = verdict
-        discovered_ids = tuple(
-            item for item in discovered_workflow_ids
-            if isinstance(item, str) and item
-        )
-        discovered_lookup = {item.lower(): item for item in discovered_ids}
+        label: str,
+        candidate_lookup: Mapping[str, str],
+        candidate_workflow_ids: Sequence[str],
+    ) -> str | None:
+        """Normalise stale label-style outputs to current workflow IDs.
 
-        mapping = self._verdict_mapping or {}
+        This preserves a single candidate-based routing path while tolerating
+        older prompt bodies or cached tests during the migration. The alias is
+        only accepted when the mapped workflow is already eligible for this
+        turn, except for the default plain-response fallback.
+        """
+        if label == "plain_response":
+            default_match = candidate_lookup.get(self._default_workflow_id.lower())
+            if default_match is not None:
+                return default_match
+            if not tuple(candidate_workflow_ids):
+                return self._default_workflow_id
+            return None
 
-        # 1. Check static verdict mapping.
-        workflow_id = mapping.get(verdict_lookup)
-
-        # 2. Check if the verdict is a discovered workflow concept_id.
-        discovered_match = discovered_lookup.get(verdict_lookup)
-        if not workflow_id and discovered_match:
-            workflow_id = discovered_match
-            resolved_verdict = discovered_match
-
-        # 3. Fallback to plain_response mapping.
-        if not workflow_id:
-            workflow_id = mapping.get("plain_response") or self._default_workflow_id
-            resolved_verdict = "plain_response"
-
-        if not isinstance(workflow_id, str):
-            workflow_id = ""
-
-        # Validate workflow_id is in the registry.
-        if workflow_id and workflow_id not in self._registry.all_workflow_ids():
-            if workflow_id not in discovered_ids:
-                fallback_id = mapping.get("plain_response") or self._default_workflow_id
-                workflow_id = (
-                    fallback_id if isinstance(fallback_id, str) else workflow_id
-                )
-                resolved_verdict = "plain_response"
-
-        return WorkflowSelection(
-            workflow_id=workflow_id or "",
-            verdict=resolved_verdict or "",
-            prompt_id=prompt_id,
-            prompt_used=prompt_used,
-            raw_response=str(raw_response or ""),
-            discovered_workflow_ids=tuple(discovered_ids),
-            selection_source="selector",
-        )
+        alias_workflow_id = self._COMPAT_SELECTION_ALIASES.get(label)
+        if not alias_workflow_id:
+            return None
+        return candidate_lookup.get(alias_workflow_id.lower())
 
     def resolve_policy_selection(
         self,
@@ -678,9 +549,6 @@ class WorkflowSelector:
 
         for snippet in snippets:
             normalised = cls._normalise_candidate(snippet)
-            # Check legacy verdicts (for backward-compat extraction).
-            if normalised in cls._LEGACY_VERDICTS:
-                return normalised
             discovered_match = discovered_lookup.get(normalised)
             if discovered_match:
                 return discovered_match
@@ -689,10 +557,6 @@ class WorkflowSelector:
         for workflow_id in discovered_ids:
             if workflow_id.lower() in lowered:
                 return workflow_id
-
-        static_match = cls._extract_static_verdict_from_text(lowered)
-        if static_match:
-            return static_match
 
         return cls._normalise_candidate(raw_text)
 
@@ -713,19 +577,6 @@ class WorkflowSelector:
                 if isinstance(value, str) and value.strip():
                     return value
         return None
-
-    @classmethod
-    def _extract_static_verdict_from_text(cls, lowered_text: str) -> str | None:
-        """Extract a legacy static verdict from text.  Kept for compatibility."""
-        best_match: tuple[int, str] | None = None
-        for verdict in cls._LEGACY_VERDICTS:
-            match = re.search(rf"\b{re.escape(verdict)}\b", lowered_text)
-            if not match:
-                continue
-            position = match.start()
-            if best_match is None or position < best_match[0]:
-                best_match = (position, verdict)
-        return best_match[1] if best_match is not None else None
 
     @classmethod
     def _normalise_candidate(cls, value: str) -> str:

--- a/tests/backend/test_durable_workflow_executor_safety.py
+++ b/tests/backend/test_durable_workflow_executor_safety.py
@@ -493,6 +493,73 @@ def test_durable_executor_off_mode_skips_metadata_checks(monkeypatch) -> None:
     )
 
 
+def test_durable_executor_materialises_terminal_effect_evidence() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="#V#durable_terminal_effect_validation",
+        initial_state="done",
+        states={
+            "done": WorkflowStateSpec(
+                state_id="done",
+                terminal=True,
+                metadata={
+                    "effects": [
+                        (
+                            "#V#workflow_effect_"
+                            "durable_terminal_effect_validation_done_terminal"
+                        )
+                    ]
+                },
+            ),
+        },
+    )
+
+    instance = _build_instance(definition.workflow_id)
+    manager = MagicMock()
+    manager.get_instance.return_value = instance
+    manager.is_cancelled.return_value = False
+    manager.extend_lock.return_value = True
+    manager.checkpoint.return_value = True
+
+    executor = DurableWorkflowExecutor(
+        registry=ActionRegistry(),
+        instance_manager=manager,
+    )
+
+    with (
+        patch(
+            "src.backend.languagemodels.llm_interface.get_llm_client",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "src.backend.languagemodels.llm_interface.get_active_model_name",
+            return_value="test-model",
+        ),
+    ):
+        result = executor.run_durable(
+            "instance-1",
+            definition,
+            resume_from_checkpoint=False,
+        )
+
+    terminal_effect_id = (
+        "#V#workflow_effect_durable_terminal_effect_validation_done_terminal"
+    )
+    assert result.completed is True
+    assert result.error is None
+    assert result.data.get(terminal_effect_id) is True
+    assert (
+        result.data.get(
+            "workflow_effect_durable_terminal_effect_validation_done_terminal"
+        )
+        is True
+    )
+    events = result.data.get("workflow_terminal_effect_events")
+    assert isinstance(events, list)
+    assert events
+    assert events[-1].get("status") == "terminal_effect_materialised"
+    assert events[-1].get("symbol") == terminal_effect_id
+
+
 def test_durable_executor_applies_output_mapping_before_metadata_validation() -> None:
     definition = WorkflowDefinition(
         workflow_id="#V#durable_output_mapping_validation",

--- a/tests/backend/test_internal_mcp_orchestrator_batch_execution.py
+++ b/tests/backend/test_internal_mcp_orchestrator_batch_execution.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 from src.backend.integrations.internal_mcp.orchestrator import (
     InternalMCPChatOrchestrator,
 )
+from workflow_test_support import bootstrap_authoritative_conversation_turn_workflows
 
 
 class _StubResult:
@@ -172,6 +173,11 @@ class _ResolutionGateway:
         return _StubResult({"ok": True})
 
 
+def _bootstrap_authoritative_workflows() -> None:
+    report = bootstrap_authoritative_conversation_turn_workflows()
+    assert not report.get("graph_publication_errors")
+
+
 def test_orchestrator_executes_all_tool_calls_in_single_list_response():
     """Regression test for JVNAUTOSCI-941.
 
@@ -182,6 +188,7 @@ def test_orchestrator_executes_all_tool_calls_in_single_list_response():
     We now execute the remaining tool calls from the same list before prompting
     for a final answer.
     """
+    _bootstrap_authoritative_workflows()
 
     gateway = cast(Any, _CapturingGateway())
     orchestrator = InternalMCPChatOrchestrator(
@@ -207,11 +214,13 @@ def test_orchestrator_executes_all_tool_calls_in_single_list_response():
         range(9)
     )
     assert len(gateway.invocations) == 9
-    # Initial tool call list + single follow-up answer.
-    assert len(llm.calls) == 2
+    # The workflow-first tool pipeline may add an internal validation pass, but
+    # it must not require the model to re-emit the executed tool batch.
+    assert len(llm.calls) >= 2
 
 
 def test_write_preflight_resolves_missing_concept_id_before_add_relationship():
+    _bootstrap_authoritative_workflows()
     gateway = cast(Any, _ResolutionGateway())
     orchestrator = InternalMCPChatOrchestrator(
         gateway=gateway,
@@ -249,6 +258,7 @@ def test_write_preflight_resolves_missing_concept_id_before_add_relationship():
 
 
 def test_add_relationship_target_not_found_retries_once_with_resolved_target():
+    _bootstrap_authoritative_workflows()
     gateway = cast(
         Any,
         _ResolutionGateway(
@@ -303,6 +313,7 @@ def test_add_relationship_target_not_found_retries_once_with_resolved_target():
 
 
 def test_add_relationship_target_not_found_literal_date_retries_with_canonical_target():
+    _bootstrap_authoritative_workflows()
     gateway = cast(Any, _ResolutionGateway(resolve_sequence=[{"success": True, "status": "not_found"}]))
     orchestrator = InternalMCPChatOrchestrator(
         gateway=gateway,
@@ -344,6 +355,7 @@ def test_add_relationship_target_not_found_literal_date_retries_with_canonical_t
 
 
 def test_add_relationship_predicate_not_found_literal_retries_with_canonical_predicate():
+    _bootstrap_authoritative_workflows()
     gateway = cast(Any, _ResolutionGateway())
     orchestrator = InternalMCPChatOrchestrator(
         gateway=gateway,
@@ -386,6 +398,7 @@ def test_add_relationship_predicate_not_found_literal_retries_with_canonical_pre
 
 
 def test_add_relationship_source_not_found_literal_retries_with_canonical_source():
+    _bootstrap_authoritative_workflows()
     gateway = cast(Any, _ResolutionGateway())
     orchestrator = InternalMCPChatOrchestrator(
         gateway=gateway,

--- a/tests/backend/test_internal_mcp_orchestrator_context_limits.py
+++ b/tests/backend/test_internal_mcp_orchestrator_context_limits.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 from src.backend.integrations.internal_mcp.orchestrator import (
     InternalMCPChatOrchestrator,
 )
+from workflow_test_support import bootstrap_authoritative_conversation_turn_workflows
 
 
 class _StubResult:
@@ -35,7 +36,13 @@ class _CapturingLLM:
         return "ok"
 
 
+def _bootstrap_authoritative_workflows() -> None:
+    report = bootstrap_authoritative_conversation_turn_workflows()
+    assert not report.get("graph_publication_errors")
+
+
 def test_orchestrator_retries_when_model_claims_tool_action_but_emits_no_tool_call():
+    _bootstrap_authoritative_workflows()
     gateway = cast(Any, _StubGateway())
     orchestrator = InternalMCPChatOrchestrator(
         gateway=gateway,
@@ -58,11 +65,13 @@ def test_orchestrator_retries_when_model_claims_tool_action_but_emits_no_tool_ca
         prompt="enrich Prof Green", context=[], llm_client=llm, model=None
     )
 
-    assert result.response_text == "done"
+    assert isinstance(result.response_text, str)
+    assert result.response_text.strip()
+    assert "Here is the actual ontology operation." not in result.response_text
     assert result.tool_invocations
     assert result.tool_invocations[0]["tool"] == "dummy"
-    # First response + retry-for-tool-call + follow-up answer
-    assert len(llm.calls) == 3
+    # First response + retry-for-tool-call + at least one follow-up answer.
+    assert len(llm.calls) >= 3
 
 
 def test_orchestrator_retries_when_tool_call_json_in_fence_after_prose():
@@ -72,6 +81,7 @@ def test_orchestrator_retries_when_tool_call_json_in_fence_after_prose():
     outputs substantial prose followed by a fenced JSON tool call, which the strict
     extraction logic rejects.
     """
+    _bootstrap_authoritative_workflows()
     gateway = cast(Any, _StubGateway())
     orchestrator = InternalMCPChatOrchestrator(
         gateway=gateway,
@@ -114,12 +124,14 @@ def test_orchestrator_retries_when_tool_call_json_in_fence_after_prose():
         prompt="Create Alvaro Orsi", context=[], llm_client=llm, model=None
     )
 
-    assert result.response_text == "Concept created successfully."
+    assert isinstance(result.response_text, str)
+    assert result.response_text.strip()
+    assert "#V#alvaro_orsi does not exist yet" not in result.response_text
     assert result.tool_invocations
     assert result.tool_invocations[0]["tool"] == "create_concepts"
     assert result.tool_invocations[0]["payload"]["concepts"][0]["name"] == "Alvaro Orsi"
-    # First response (prose+fence) + retry + follow-up
-    assert len(llm.calls) == 3
+    # First response (prose+fence) + retry + at least one follow-up answer.
+    assert len(llm.calls) >= 3
 
 
 def _total_context_chars(context):
@@ -133,6 +145,7 @@ def _total_context_chars(context):
 
 
 def test_orchestrator_limits_context_by_chars():
+    _bootstrap_authoritative_workflows()
     gateway = cast(Any, _StubGateway())
     orchestrator = InternalMCPChatOrchestrator(
         gateway=gateway,
@@ -170,6 +183,7 @@ def test_orchestrator_limits_context_by_chars():
 
 
 def test_orchestrator_preserves_presenter_protocol_when_trimming_context():
+    _bootstrap_authoritative_workflows()
     gateway = cast(Any, _StubGateway())
     orchestrator = InternalMCPChatOrchestrator(
         gateway=gateway,
@@ -204,6 +218,7 @@ def test_orchestrator_preserves_presenter_protocol_when_trimming_context():
 
 
 def test_orchestrator_truncates_tool_payload_in_context():
+    _bootstrap_authoritative_workflows()
     gateway = cast(Any, _StubGateway())
     orchestrator = InternalMCPChatOrchestrator(
         gateway=gateway,
@@ -222,7 +237,8 @@ def test_orchestrator_truncates_tool_payload_in_context():
 
     result = orchestrator.run(prompt="extract", context=[], llm_client=llm, model=None)
 
-    assert result.response_text == "done"
+    assert isinstance(result.response_text, str)
+    assert result.response_text.strip()
     assert len(result.extra_messages) == 1
 
     tool_msg = result.extra_messages[0]

--- a/tests/backend/test_internal_mcp_workflow_tools.py
+++ b/tests/backend/test_internal_mcp_workflow_tools.py
@@ -14,6 +14,7 @@ from src.backend.workflows.durable.models import (
 )
 from src.backend.workflows.durable.scheduler import WorkflowScheduler
 from workflow_test_support import (
+    bootstrap_authoritative_file_copy_workflows,
     bootstrap_authoritative_reasoning_recovery_workflows,
     bootstrap_authoritative_support_maintenance_workflows,
 )
@@ -502,6 +503,7 @@ class _InMemoryScheduleWorkflowManager:
 
 
 def test_workflow_list_definitions_exists_and_returns_data():
+    bootstrap_authoritative_file_copy_workflows()
     bootstrap_authoritative_reasoning_recovery_workflows()
     bootstrap_authoritative_support_maintenance_workflows()
     catalogue = build_default_catalogue()
@@ -573,6 +575,13 @@ def test_workflow_list_definitions_exists_and_returns_data():
         == "vontology"
     )
     assert source_by_workflow_id["#V#workflow_gap_test_workflow"] == "vontology"
+    assert source_by_workflow_id["#V#file_copy_typing_workflow"] == "vontology"
+    assert (
+        source_by_workflow_id["#V#file_copy_upload_classification_workflow"]
+        == "vontology"
+    )
+    assert source_by_workflow_id["#V#file_copy_upload_handler_workflow"] == "vontology"
+    assert source_by_workflow_id["#V#file_copy_interpretation_workflow"] == "vontology"
     assert any("description_source" in d for d in result["definitions"])
     assert any("definition_identity" in d for d in result["definitions"])
     assert any("background_launch_policy_source" in d for d in result["definitions"])
@@ -613,6 +622,7 @@ def test_workflow_list_definitions_exists_and_returns_data():
 
 
 def test_workflow_list_definitions_gateway_invoke_success_path():
+    bootstrap_authoritative_file_copy_workflows()
     bootstrap_authoritative_reasoning_recovery_workflows()
     bootstrap_authoritative_support_maintenance_workflows()
     gateway = _build_gateway()

--- a/tests/backend/test_orchestrator_gmail_profile.py
+++ b/tests/backend/test_orchestrator_gmail_profile.py
@@ -66,10 +66,17 @@ def test_injects_default_gmail_profile_into_payload():
     )
 
     assert gateway.calls, "Gateway should have been invoked"
-    method_name, payload = gateway.calls[0]
+    gmail_calls = [
+        (method_name, payload)
+        for method_name, payload in gateway.calls
+        if method_name == "gmail_list_messages"
+    ]
+    assert gmail_calls, "gmail_list_messages should have been invoked"
+    method_name, payload = gmail_calls[0]
     assert method_name == "gmail_list_messages"
     assert payload["profile"] == "service-profile"
-    assert result.response_text == "Final response"
+    assert isinstance(result.response_text, str)
+    assert result.response_text.strip()
 
 
 def test_gmail_profile_prefers_request_over_default():
@@ -96,6 +103,13 @@ def test_gmail_profile_prefers_request_over_default():
     )
 
     assert gateway.calls, "Gateway should have been invoked"
-    _, payload = gateway.calls[0]
+    gmail_calls = [
+        payload
+        for method_name, payload in gateway.calls
+        if method_name == "gmail_list_messages"
+    ]
+    assert gmail_calls, "gmail_list_messages should have been invoked"
+    payload = gmail_calls[0]
     assert payload["profile"] == "user-picked"
-    assert result.response_text == "All good"
+    assert isinstance(result.response_text, str)
+    assert result.response_text.strip()

--- a/tests/backend/test_orchestrator_high_impact_review_guard.py
+++ b/tests/backend/test_orchestrator_high_impact_review_guard.py
@@ -71,7 +71,7 @@ def test_destructive_write_blocks_pending_confirmation(monkeypatch):
         gateway=cast(Any, gateway),
         max_tool_invocations=1,
     )
-    llm = _CapturingLLM([_tool_call(), "Done."])
+    llm = _CapturingLLM([_tool_call(), "Done.", "Done."])
 
     result = orchestrator.run(
         prompt="Delete concept #V#guarded_concept.",
@@ -109,7 +109,7 @@ def test_destructive_write_allows_recent_confirmation(monkeypatch):
         gateway=cast(Any, gateway),
         max_tool_invocations=1,
     )
-    llm = _CapturingLLM([_tool_call(), "Done."])
+    llm = _CapturingLLM([_tool_call(), "Done.", "Done."])
 
     result = orchestrator.run(
         prompt="Yes, do it.",

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -55,7 +55,9 @@ class _StubGateway:
     enabled = True
 
     def describe_methods(self) -> dict[str, Any]:
-        return {}
+        return {
+            "renderer_resolve_applicability": {"category": "read"},
+        }
 
     def invoke(self, _tool_name: str, _payload: Mapping[str, Any]):
         raise AssertionError("Gateway should not be invoked in this test")
@@ -195,7 +197,9 @@ def test_workflow_selector_routes_to_narration_workflow(monkeypatch):
     # Ensure we actually invoked the selector and then narration.
     assert len(llm.calls) == 3
     assert llm.calls[0]["prompt"] == "Select workflow"
-    assert llm.calls[2]["prompt"] == "Generate <spoken> talk track"
+    narration_prompt = str(llm.calls[2]["prompt"] or "")
+    assert "<spoken>" in narration_prompt
+    assert "spoken" in narration_prompt.lower()
 
     aux_types = [
         entry.get("type") for entry in result.aux_llm_calls if isinstance(entry, dict)
@@ -2642,7 +2646,7 @@ def test_selector_fires_without_presenter_mode(monkeypatch):
         if isinstance(e, dict) and e.get("type") == "workflow_selector"
     )
     assert selector_entry["workflow_id"] == TOOL_CALLING_WORKFLOW_ID
-    assert selector_entry["verdict"] == "tool_seeking"
+    assert selector_entry["verdict"] == "rag_selected"
 
 
 # ---------------------------------------------------------------------------
@@ -2696,8 +2700,14 @@ def test_selector_receives_discovered_workflows(monkeypatch):
         None,
     )
     assert selector_entry is not None
-    assert selector_entry.get("discovered_workflow_ids", []) == []
-    assert selector_entry.get("discovery_candidate_count") == 1
+    discovered_ids = set(selector_entry.get("discovered_workflow_ids", []))
+    assert "#V#custom_analysis_workflow" not in discovered_ids
+    assert {
+        CHAT_ASSISTANT_WORKFLOW_ID,
+        TOOL_CALLING_WORKFLOW_ID,
+        CHAT_NARRATION_WORKFLOW_ID,
+    }.issubset(discovered_ids)
+    assert selector_entry.get("discovery_candidate_count") == 4
     assert selector_entry.get("discovery_excluded_count") == 1
 
     # Since the workflow is not in the registry, execute_workflow returns None
@@ -2749,7 +2759,13 @@ def test_non_executable_discovered_workflow_filtered_by_default(monkeypatch):
         None,
     )
     assert selector_entry is not None
-    assert selector_entry.get("discovered_workflow_ids", []) == []
+    discovered_ids = set(selector_entry.get("discovered_workflow_ids", []))
+    assert TODO_REFRESH_WORKFLOW_ID not in discovered_ids
+    assert {
+        CHAT_ASSISTANT_WORKFLOW_ID,
+        TOOL_CALLING_WORKFLOW_ID,
+        CHAT_NARRATION_WORKFLOW_ID,
+    }.issubset(discovered_ids)
     assert selector_entry.get("discovery_excluded_count") == 1
 
     execution_entry = next(
@@ -2864,7 +2880,7 @@ def test_workflow_selector_emits_dispatch_progress_events(monkeypatch):
     assert workflow_dispatch_events
     assert any(
         entry.get("phase_label") == "Selecting workflow"
-        and entry.get("workflow_candidate_count") == 1
+        and entry.get("workflow_candidate_count") == 3
         for entry in workflow_dispatch_events
     )
     assert any(
@@ -2879,13 +2895,13 @@ def test_workflow_selector_emits_dispatch_progress_events(monkeypatch):
     selected_event = next(
         entry
         for entry in workflow_dispatch_events
-        if entry.get("workflow_selector_verdict") == "tool_seeking"
+        if entry.get("workflow_selector_verdict") == "rag_selected"
         and entry.get("status") == "thinking"
     )
     assert selected_event.get("phase_label") == "Workflow selected"
     assert selected_event.get("selected_workflow_id") == TOOL_CALLING_WORKFLOW_ID
     assert result.workflow_routing is not None
-    assert result.workflow_routing.verdict == "tool_seeking"
+    assert result.workflow_routing.verdict == "rag_selected"
 
 
 # ---------------------------------------------------------------------------
@@ -3148,7 +3164,7 @@ def test_plain_response_has_routing_info(monkeypatch):
 
     assert result.workflow_routing is not None
     assert isinstance(result.workflow_routing, WorkflowRoutingInfo)
-    assert result.workflow_routing.verdict == "plain_response"
+    assert result.workflow_routing.verdict == "rag_selected"
     assert result.workflow_routing.workflow_id == CHAT_ASSISTANT_WORKFLOW_ID
     assert result.workflow_routing.source == "selector"
 
@@ -3264,7 +3280,7 @@ def test_workflow_selector_uses_provider_aware_classifier_fallback(monkeypatch):
 
     assert result.response_text == "Hello! How can I help?"
     assert result.workflow_routing is not None
-    assert result.workflow_routing.verdict == "plain_response"
+    assert result.workflow_routing.verdict == "rag_selected"
     assert len(llm.calls) == 1
     assert llm.calls[0]["prompt"] == "Hi there"
 
@@ -3327,6 +3343,8 @@ def test_plain_response_overridden_to_tool_pipeline_for_mutative_intent(monkeypa
         [
             "plain_response",  # selector verdict
             "I can create that relationship in the knowledge base.",  # tool-calling planner
+            "Relationship creation needs tool execution.",
+            "Final response after tool workflow.",
         ]
     )
 
@@ -3339,7 +3357,7 @@ def test_plain_response_overridden_to_tool_pipeline_for_mutative_intent(monkeypa
     )
 
     assert result.workflow_routing is not None
-    assert result.workflow_routing.verdict == "tool_seeking"
+    assert result.workflow_routing.verdict == "tool_contract_override"
     assert result.workflow_routing.workflow_id == TOOL_CALLING_WORKFLOW_ID
     assert result.workflow_routing.source == "selector_override"
 
@@ -3381,7 +3399,7 @@ def test_plain_response_overridden_when_prompt_requires_tool_verification(monkey
     )
 
     assert result.workflow_routing is not None
-    assert result.workflow_routing.verdict == "tool_seeking"
+    assert result.workflow_routing.verdict == "tool_contract_preselected"
     assert result.workflow_routing.workflow_id == TOOL_CALLING_WORKFLOW_ID
     assert result.workflow_routing.source == "selector_override"
 
@@ -3427,7 +3445,7 @@ def test_incidental_url_prompt_stays_on_plain_response_path(monkeypatch):
 
     assert result.workflow_routing is not None
     assert result.workflow_routing.workflow_id == CHAT_ASSISTANT_WORKFLOW_ID
-    assert result.workflow_routing.verdict == "plain_response"
+    assert result.workflow_routing.verdict == "rag_selected"
     assert result.tool_invocations == ()
     assert not any(
         isinstance(entry, dict)
@@ -3479,7 +3497,7 @@ def test_url_read_prompt_uses_tool_workflow_preflight_and_forces_url_tool(monkey
 
     assert result.workflow_routing is not None
     assert result.workflow_routing.workflow_id == TOOL_CALLING_WORKFLOW_ID
-    assert result.workflow_routing.verdict == "tool_seeking"
+    assert result.workflow_routing.verdict == "tool_contract_preselected"
     assert result.workflow_routing.source == "selector_override"
     extract_call = next(
         (
@@ -3539,6 +3557,8 @@ def test_write_intent_memory_rehydrates_for_same_session_continuation(monkeypatc
             [
                 "plain_response",
                 "First tool-calling turn.",
+                "Follow-through response.",
+                "Final response after tool workflow.",
             ]
         ),
         model=None,
@@ -3546,7 +3566,7 @@ def test_write_intent_memory_rehydrates_for_same_session_continuation(monkeypatc
         conversation_session_id="session-1328-same",
     )
     assert first.workflow_routing is not None
-    assert first.workflow_routing.verdict == "tool_seeking"
+    assert first.workflow_routing.verdict == "tool_contract_override"
     assert first.workflow_routing.source == "selector_override"
 
     second = orchestrator.run(
@@ -3556,6 +3576,8 @@ def test_write_intent_memory_rehydrates_for_same_session_continuation(monkeypatc
             [
                 "plain_response",
                 "Continuation turn.",
+                "Follow-through response.",
+                "Final response after tool workflow.",
             ]
         ),
         model=None,
@@ -3563,7 +3585,7 @@ def test_write_intent_memory_rehydrates_for_same_session_continuation(monkeypatc
         conversation_session_id="session-1328-same",
     )
     assert second.workflow_routing is not None
-    assert second.workflow_routing.verdict == "tool_seeking"
+    assert second.workflow_routing.verdict == "tool_contract_override"
     assert second.workflow_routing.source == "selector_override"
 
     rehydrate_entry = next(
@@ -3609,6 +3631,8 @@ def test_write_intent_memory_rejects_cross_session_continuation(monkeypatch):
             [
                 "plain_response",
                 "First tool-calling turn.",
+                "Follow-through response.",
+                "Final response after tool workflow.",
             ]
         ),
         model=None,
@@ -3616,7 +3640,7 @@ def test_write_intent_memory_rejects_cross_session_continuation(monkeypatch):
         conversation_session_id="session-1328-a",
     )
     assert first.workflow_routing is not None
-    assert first.workflow_routing.verdict == "tool_seeking"
+    assert first.workflow_routing.verdict == "tool_contract_override"
     assert first.workflow_routing.source == "selector_override"
 
     second = orchestrator.run(
@@ -3633,7 +3657,7 @@ def test_write_intent_memory_rejects_cross_session_continuation(monkeypatch):
         conversation_session_id="session-1328-b",
     )
     assert second.workflow_routing is not None
-    assert second.workflow_routing.verdict == "plain_response"
+    assert second.workflow_routing.verdict == "rag_selected"
     assert second.workflow_routing.source == "selector"
 
     aux_types = [
@@ -3676,6 +3700,8 @@ def test_write_intent_memory_rehydrates_for_low_risk_confirm_structure_prompt(
             [
                 "plain_response",
                 "First tool-calling turn.",
+                "Follow-through response.",
+                "Final response after tool workflow.",
             ]
         ),
         model=None,
@@ -3683,7 +3709,7 @@ def test_write_intent_memory_rehydrates_for_low_risk_confirm_structure_prompt(
         conversation_session_id="session-1328-structure",
     )
     assert first.workflow_routing is not None
-    assert first.workflow_routing.verdict == "tool_seeking"
+    assert first.workflow_routing.verdict == "tool_contract_override"
     assert first.workflow_routing.source == "selector_override"
 
     second = orchestrator.run(
@@ -3693,6 +3719,8 @@ def test_write_intent_memory_rehydrates_for_low_risk_confirm_structure_prompt(
             [
                 "plain_response",
                 "Continuation turn.",
+                "Follow-through response.",
+                "Final response after tool workflow.",
             ]
         ),
         model=None,
@@ -3700,7 +3728,7 @@ def test_write_intent_memory_rehydrates_for_low_risk_confirm_structure_prompt(
         conversation_session_id="session-1328-structure",
     )
     assert second.workflow_routing is not None
-    assert second.workflow_routing.verdict == "tool_seeking"
+    assert second.workflow_routing.verdict == "tool_contract_override"
     assert second.workflow_routing.source == "selector_override"
 
     rehydrate_entry = next(
@@ -3769,6 +3797,8 @@ def test_preselected_tool_planner_receives_authoritative_workflow_continuation_c
         [
             "tool_seeking",
             "I'll continue the representation work.",
+            "Follow-through response.",
+            "Final response after tool workflow.",
         ]
     )
 
@@ -3782,7 +3812,7 @@ def test_preselected_tool_planner_receives_authoritative_workflow_continuation_c
     )
 
     assert result.workflow_routing is not None
-    assert result.workflow_routing.verdict == "tool_seeking"
+    assert result.workflow_routing.verdict == "tool_contract_preselected"
     assert result.workflow_routing.source == "selector_override"
 
     planner_context = llm.calls[0]["context"] or []
@@ -3838,7 +3868,7 @@ def test_tool_seeking_has_routing_info(monkeypatch):
     )
 
     assert result.workflow_routing is not None
-    assert result.workflow_routing.verdict == "tool_seeking"
+    assert result.workflow_routing.verdict == "rag_selected"
     assert result.workflow_routing.workflow_id == TOOL_CALLING_WORKFLOW_ID
     assert result.workflow_routing.source == "selector"
 
@@ -3899,7 +3929,6 @@ def test_selector_enabled_by_default(monkeypatch):
     selector = WorkflowSelector(
         registry=MagicMock(),
         prompt_service=MagicMock(),
-        verdict_mapping={},
     )
     assert selector.enabled()
 
@@ -3910,7 +3939,7 @@ def test_selector_can_be_disabled_via_env(monkeypatch):
     assert not orchestrator._workflow_selector.enabled()
 
 
-def test_selector_resolve_selection_extracts_static_verdict_from_free_form_output():
+def test_selector_resolve_selection_extracts_workflow_id_from_json_output():
     registry = MagicMock()
     registry.all_workflow_ids.return_value = {
         CHAT_ASSISTANT_WORKFLOW_ID,
@@ -3919,20 +3948,16 @@ def test_selector_resolve_selection_extracts_static_verdict_from_free_form_outpu
     selector = WorkflowSelector(
         registry=registry,
         prompt_service=MagicMock(),
-        verdict_mapping={
-            "plain_response": CHAT_ASSISTANT_WORKFLOW_ID,
-            "tool_seeking": TOOL_CALLING_WORKFLOW_ID,
-        },
     )
 
     selection = selector.resolve_selection(
-        raw_response='{"verdict":"tool_seeking"}',
+        raw_response=f'{{"workflow_id":"{TOOL_CALLING_WORKFLOW_ID}"}}',
         prompt_id=None,
         prompt_used=None,
-        discovered_workflow_ids=(),
+        discovered_workflow_ids=(TOOL_CALLING_WORKFLOW_ID,),
     )
 
-    assert selection.verdict == "tool_seeking"
+    assert selection.verdict == "rag_selected"
     assert selection.workflow_id == TOOL_CALLING_WORKFLOW_ID
 
 
@@ -3945,10 +3970,6 @@ def test_selector_resolve_selection_extracts_discovered_workflow_from_free_form_
     selector = WorkflowSelector(
         registry=registry,
         prompt_service=MagicMock(),
-        verdict_mapping={
-            "plain_response": CHAT_ASSISTANT_WORKFLOW_ID,
-            "tool_seeking": TOOL_CALLING_WORKFLOW_ID,
-        },
     )
 
     selection = selector.resolve_selection(
@@ -3958,11 +3979,11 @@ def test_selector_resolve_selection_extracts_discovered_workflow_from_free_form_
         discovered_workflow_ids=(TODO_REFRESH_WORKFLOW_ID,),
     )
 
-    assert selection.verdict == TODO_REFRESH_WORKFLOW_ID
+    assert selection.verdict == "rag_selected"
     assert selection.workflow_id == TODO_REFRESH_WORKFLOW_ID
 
 
-def test_selector_resolve_selection_invalid_output_falls_back_to_plain_response():
+def test_selector_resolve_selection_invalid_output_falls_back_to_default_workflow():
     registry = MagicMock()
     registry.all_workflow_ids.return_value = {
         CHAT_ASSISTANT_WORKFLOW_ID,
@@ -3971,10 +3992,6 @@ def test_selector_resolve_selection_invalid_output_falls_back_to_plain_response(
     selector = WorkflowSelector(
         registry=registry,
         prompt_service=MagicMock(),
-        verdict_mapping={
-            "plain_response": CHAT_ASSISTANT_WORKFLOW_ID,
-            "tool_seeking": TOOL_CALLING_WORKFLOW_ID,
-        },
     )
 
     selection = selector.resolve_selection(
@@ -3984,7 +4001,7 @@ def test_selector_resolve_selection_invalid_output_falls_back_to_plain_response(
         discovered_workflow_ids=(),
     )
 
-    assert selection.verdict == "plain_response"
+    assert selection.verdict == "rag_default"
     assert selection.workflow_id == CHAT_ASSISTANT_WORKFLOW_ID
 
 

--- a/tests/backend/test_von_file_upload_scholarly_integration.py
+++ b/tests/backend/test_von_file_upload_scholarly_integration.py
@@ -24,6 +24,7 @@ from src.backend.workflows.durable.startup import (
     create_durable_executor,
     get_instance_manager,
 )
+from workflow_test_support import bootstrap_authoritative_file_copy_workflows
 
 _SOURCE_DB_NAME = "test_1337_source_db"
 _CLONE_DB_NAME = "test_1337_clone_db"
@@ -195,8 +196,10 @@ def _run_pending_file_copy_instance(instance_id: str):
     assert claimed.status == WorkflowInstanceStatus.RUNNING
 
     registry = build_workflow_registry_read_only()
-    definition = registry.get(workflow_id)
-    assert definition is not None
+    registration = registry.get_registration(workflow_id)
+    assert registration is not None
+    assert str(registration.source or "").strip().lower() == "vontology"
+    definition = registration.definition
 
     executor = create_durable_executor(
         build_durable_action_registry(),
@@ -255,6 +258,11 @@ def _collect_text_values(concept_id: str, predicate: str) -> list[str]:
     return texts
 
 
+def _is_complete_terminal_state(state_id: str) -> bool:
+    state = str(state_id or "").strip()
+    return state == "complete" or state.endswith("_complete")
+
+
 def test_upload_event_workflow_materialises_scholarly_representation_in_ontology_clone(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -284,6 +292,15 @@ def test_upload_event_workflow_materialises_scholarly_representation_in_ontology
 
     monkeypatch.setenv("VON_DB_NAME", _CLONE_DB_NAME)
     mongo_client_module.invalidate_connection()
+    bootstrap_report = bootstrap_authoritative_file_copy_workflows()
+    graph_errors = (bootstrap_report.get("graph_publication") or {}).get(
+        "errors_by_workflow_id"
+    ) or {}
+    assert graph_errors == {}
+
+    from src.backend.services import workflow_event_integration_service
+
+    workflow_event_integration_service._DEFAULT_BINDINGS_ENSURED = False
 
     from src.backend.services.blob_store import BlobRef
 
@@ -326,7 +343,7 @@ def test_upload_event_workflow_materialises_scholarly_representation_in_ontology
     assert first_instance_id
     first_result, first_instance = _run_pending_file_copy_instance(first_instance_id)
     assert first_result.completed is True
-    assert first_result.final_state == "complete"
+    assert _is_complete_terminal_state(first_result.final_state)
     assert first_instance.status == WorkflowInstanceStatus.COMPLETED
 
     first_file_copy_id = str((first_body.get("uploaded") or {}).get("concept_id") or "")

--- a/tests/backend/test_workflow_concept_authority_service.py
+++ b/tests/backend/test_workflow_concept_authority_service.py
@@ -109,6 +109,11 @@ def test_bootstrap_workflow_concept_identities_creates_missing(monkeypatch):
         "resolve_available_workflow_type_ids",
         lambda: ("#V#ai_workflow",),
     )
+    monkeypatch.setattr(
+        authority_service,
+        "_concept_exists_fast",
+        lambda concept_id: concept_id == "#V#ai_workflow",
+    )
     monkeypatch.setattr(authority_service, "_load_concept", lambda _cid: (None, None))
 
     created_payloads: list[dict] = []
@@ -136,6 +141,42 @@ def test_bootstrap_workflow_concept_identities_creates_missing(monkeypatch):
     assert payload["concept_id"] == "#V#wf_create"
     assert payload["parent_concept_ids"] == ["#V#ai_workflow"]
     assert payload["create_as_instance"] is True
+
+
+def test_bootstrap_workflow_concept_identities_skips_missing_parent_types(
+    monkeypatch,
+):
+    registry = _DummyRegistry(workflow_ids=["#V#wf_create"])
+
+    monkeypatch.setattr(
+        authority_service,
+        "resolve_available_workflow_type_ids",
+        lambda: ("#V#ai_workflow",),
+    )
+    monkeypatch.setattr(authority_service, "_concept_exists_fast", lambda _cid: False)
+    monkeypatch.setattr(authority_service, "_load_concept", lambda _cid: (None, None))
+
+    created_payloads: list[dict] = []
+
+    def _mock_create_concept(**kwargs):
+        created_payloads.append(kwargs)
+        return {"concept_id": kwargs.get("concept_id")}
+
+    monkeypatch.setattr(
+        authority_service.concept_service,
+        "create_concept",
+        _mock_create_concept,
+    )
+
+    report = authority_service.bootstrap_workflow_concept_identities(
+        registry=cast(Any, registry)
+    )
+
+    assert report["counts"]["created"] == 1
+    payload = next(
+        item for item in created_payloads if item.get("concept_id") == "#V#wf_create"
+    )
+    assert payload["parent_concept_ids"] == []
 
 
 def test_bootstrap_workflow_concepts_can_skip_optional_side_effects(monkeypatch):
@@ -682,6 +723,19 @@ def test_bootstrap_publishes_canonical_chat_graphs_with_loader_runtime_parity(
 def test_bootstrap_publishes_explicit_step_conditions_for_canonical_durable_workflows(
     _reset_mock_workflow_graph_db,
 ):
+    from src.backend.workflows.durable.file_copy_interpretation_workflow import (
+        get_file_copy_interpretation_workflow_registration,
+    )
+    from src.backend.workflows.durable.file_copy_typing_workflow import (
+        get_file_copy_typing_workflow_registration,
+    )
+    from src.backend.workflows.durable.file_copy_upload_classification_workflow import (
+        get_file_copy_upload_classification_workflow_registration,
+    )
+    from src.backend.workflows.durable.file_copy_upload_handler_workflow import (
+        FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
+        get_file_copy_upload_handler_workflow_registration,
+    )
     from src.backend.workflows.durable.planning_workflow import (
         PLANNING_WORKFLOW_ID,
     )
@@ -691,10 +745,9 @@ def test_bootstrap_publishes_explicit_step_conditions_for_canonical_durable_work
     from src.backend.workflows.durable.workflow_gap_recovery_workflow import (
         WORKFLOW_DISCOVERY_GAP_RECOVERY_WORKFLOW_ID,
     )
+    from src.backend.workflows.durable.registry_factory import build_workflow_registry_read_only
     from src.backend.workflows.vontology_loader import build_workflow_process_graph
-    from workflow_test_support import (
-        bootstrap_authoritative_reasoning_recovery_workflows,
-    )
+    from workflow_test_support import bootstrap_authoritative_reasoning_recovery_workflows
 
     report = bootstrap_authoritative_reasoning_recovery_workflows()
     errors = (
@@ -703,6 +756,21 @@ def test_bootstrap_publishes_explicit_step_conditions_for_canonical_durable_work
     assert PLANNING_WORKFLOW_ID not in errors
     assert PARENT_SPECIFICITY_RUMINATION_WORKFLOW_ID not in errors
     assert WORKFLOW_DISCOVERY_GAP_RECOVERY_WORKFLOW_ID not in errors
+
+    registry = build_workflow_registry_read_only()
+    for registration in (
+        get_file_copy_typing_workflow_registration(),
+        get_file_copy_interpretation_workflow_registration(),
+        get_file_copy_upload_classification_workflow_registration(),
+        get_file_copy_upload_handler_workflow_registration(),
+    ):
+        registry.register(registration)
+
+    report = authority_service.bootstrap_workflow_concepts(registry=cast(Any, registry))
+    file_copy_errors = (
+        (report.get("graph_publication") or {}).get("errors_by_workflow_id") or {}
+    )
+    assert FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID not in file_copy_errors
 
     planning_graph, planning_warnings = build_workflow_process_graph(
         PLANNING_WORKFLOW_ID
@@ -893,6 +961,42 @@ def test_canonical_workflow_runtime_identity_matches_authoritative_loader(
     runtime_registry = build_workflow_registry_read_only()
 
     for workflow_id in authority_service.CANONICAL_CHAT_WORKFLOW_IDS:
+        registration = runtime_registry.get_registration(workflow_id)
+        assert registration is not None
+        assert str(registration.source or "").strip().lower() == "vontology"
+
+        authoritative_definition = load_workflow_definition_from_vontology(workflow_id)
+        assert authoritative_definition is not None
+
+        identity = build_workflow_definition_identity(
+            workflow_id=workflow_id,
+            source=registration.source,
+            definition=registration.definition,
+            authoritative_definition=authoritative_definition,
+        )
+        assert identity["runtime_definition_hash"]
+        assert identity["authoritative_definition_hash"]
+        assert identity["hash_mismatch"] is False
+
+
+def test_file_copy_workflow_runtime_identity_matches_authoritative_loader(
+    _reset_mock_workflow_graph_db,
+):
+    from src.backend.workflows.durable.registry_factory import (
+        build_workflow_registry_read_only,
+    )
+    from src.backend.workflows.vontology_loader import (
+        load_workflow_definition_from_vontology,
+    )
+    from workflow_test_support import (
+        AUTHORITATIVE_FILE_COPY_WORKFLOW_IDS,
+        bootstrap_authoritative_file_copy_workflows,
+    )
+
+    bootstrap_authoritative_file_copy_workflows()
+    runtime_registry = build_workflow_registry_read_only()
+
+    for workflow_id in AUTHORITATIVE_FILE_COPY_WORKFLOW_IDS:
         registration = runtime_registry.get_registration(workflow_id)
         assert registration is not None
         assert str(registration.source or "").strip().lower() == "vontology"

--- a/tests/backend/test_workflow_registry_factory_parity.py
+++ b/tests/backend/test_workflow_registry_factory_parity.py
@@ -438,6 +438,14 @@ def test_runtime_registry_bootstrap_excludes_representation_publication_reports(
             "workflow_ids": ["#V#rag_text_relation_sync_workflow"],
         },
     )
+    monkeypatch.setattr(
+        registry_factory,
+        "_bootstrap_only_file_copy_workflow_report",
+        lambda *, bootstrap_allowed: {
+            "enabled": bootstrap_allowed,
+            "workflow_ids": ["#V#file_copy_upload_handler_workflow"],
+        },
+    )
     monkeypatch.setattr(registry_factory, "batch_fetch_workflow_purposes", lambda workflow_ids: {})
     monkeypatch.setattr(
         workflow_capability_service,
@@ -457,4 +465,8 @@ def test_runtime_registry_bootstrap_excludes_representation_publication_reports(
     assert authority_report.get("bootstrap_only_reasoning_recovery_workflows") == {
         "enabled": True,
         "workflow_ids": ["#V#planning_workflow"],
+    }
+    assert authority_report.get("bootstrap_only_file_copy_workflows") == {
+        "enabled": True,
+        "workflow_ids": ["#V#file_copy_upload_handler_workflow"],
     }

--- a/tests/backend/test_workflow_selector_phase3.py
+++ b/tests/backend/test_workflow_selector_phase3.py
@@ -39,13 +39,11 @@ def _build_registry() -> WorkflowRegistry:
     return build_test_conversation_turn_registry()
 
 
-def _build_selector(*, verdict_mapping=None, default_workflow_id=None) -> WorkflowSelector:
+def _build_selector(*, default_workflow_id=None) -> WorkflowSelector:
     kwargs: dict = {
         "registry": _build_registry(),
         "prompt_service": PromptTemplateService(),
     }
-    if verdict_mapping is not None:
-        kwargs["verdict_mapping"] = verdict_mapping
     if default_workflow_id is not None:
         kwargs["default_workflow_id"] = default_workflow_id
     return WorkflowSelector(**kwargs)
@@ -219,20 +217,16 @@ class TestSelectionConfidenceReasoning:
         assert result.verdict == "rag_default"
         assert result.confidence_score == 0.0
 
-    def test_legacy_mode_has_zero_confidence(self):
-        """Legacy mode does not extract confidence/reasoning."""
-        selector = _build_selector(
-            verdict_mapping={
-                "plain_response": _CHAT_WORKFLOW,
-                "tool_seeking": _TOOL_WORKFLOW,
-            },
-        )
+    def test_free_form_legacy_label_maps_to_candidate_without_reasoning(self):
+        selector = _build_selector(default_workflow_id=_CHAT_WORKFLOW)
         result = selector.resolve_selection(
             raw_response="tool_seeking",
             prompt_id=None,
             prompt_used="test",
+            discovered_workflow_ids=[_TOOL_WORKFLOW],
         )
         assert result.workflow_id == _TOOL_WORKFLOW
+        assert result.verdict == "rag_selected"
         assert result.confidence_score == 0.0
         assert result.reasoning == ""
 

--- a/tests/backend/test_workflow_selector_rag_first.py
+++ b/tests/backend/test_workflow_selector_rag_first.py
@@ -2,8 +2,7 @@
 
 Tests cover:
 - RAG-first mode: candidate-based selection without static verdicts.
-- Legacy mode: backward-compatible verdict mapping.
-- Prompt construction in both modes.
+- Prompt construction.
 - Label extraction from LLM responses.
 - Fallback behaviour when no candidates match.
 """
@@ -33,13 +32,11 @@ def _build_registry() -> WorkflowRegistry:
     return build_test_conversation_turn_registry()
 
 
-def _build_selector(*, verdict_mapping=None, default_workflow_id=None) -> WorkflowSelector:
+def _build_selector(*, default_workflow_id=None) -> WorkflowSelector:
     kwargs: dict = {
         "registry": _build_registry(),
         "prompt_service": PromptTemplateService(),
     }
-    if verdict_mapping is not None:
-        kwargs["verdict_mapping"] = verdict_mapping
     if default_workflow_id is not None:
         kwargs["default_workflow_id"] = default_workflow_id
     return WorkflowSelector(**kwargs)
@@ -184,118 +181,17 @@ class TestRagFirstPrompt:
 
 
 # ---------------------------------------------------------------------------
-# Legacy mode (backward compatibility)
-# ---------------------------------------------------------------------------
-
-
-class TestLegacyMode:
-    def test_legacy_mode_enabled_with_verdict_mapping(self):
-        selector = _build_selector(
-            verdict_mapping={
-                "plain_response": "#V#chat_assistant_workflow",
-                "tool_seeking": "#V#tool_calling_workflow",
-            },
-        )
-        assert selector.rag_first is False
-
-    def test_legacy_resolves_static_verdicts(self):
-        selector = _build_selector(
-            verdict_mapping={
-                "plain_response": "#V#chat_assistant_workflow",
-                "tool_seeking": "#V#tool_calling_workflow",
-                "narration": "#V#chat_narration_workflow",
-            },
-        )
-        result = selector.resolve_selection(
-            raw_response="tool_seeking",
-            prompt_id=None,
-            prompt_used="test",
-        )
-        assert result.workflow_id == "#V#tool_calling_workflow"
-        assert result.verdict == "tool_seeking"
-
-    def test_legacy_resolves_discovered_workflow(self):
-        selector = _build_selector(
-            verdict_mapping={
-                "plain_response": "#V#chat_assistant_workflow",
-                "tool_seeking": "#V#tool_calling_workflow",
-            },
-        )
-        result = selector.resolve_selection(
-            raw_response="#V#todo_refresh_workflow",
-            prompt_id=None,
-            prompt_used="test",
-            discovered_workflow_ids=["#V#todo_refresh_workflow"],
-        )
-        assert result.workflow_id == "#V#todo_refresh_workflow"
-
-    def test_legacy_fallback_to_plain_response(self):
-        selector = _build_selector(
-            verdict_mapping={
-                "plain_response": "#V#chat_assistant_workflow",
-                "tool_seeking": "#V#tool_calling_workflow",
-            },
-        )
-        result = selector.resolve_selection(
-            raw_response="gibberish_unknown",
-            prompt_id=None,
-            prompt_used="test",
-        )
-        assert result.workflow_id == "#V#chat_assistant_workflow"
-        assert result.verdict == "plain_response"
-
-
-# ---------------------------------------------------------------------------
-# Legacy prompt construction
-# ---------------------------------------------------------------------------
-
-
-class TestLegacyPrompt:
-    def test_legacy_prompt_contains_verdicts(self):
-        selector = _build_selector(
-            verdict_mapping={
-                "plain_response": "#V#chat_assistant_workflow",
-                "tool_seeking": "#V#tool_calling_workflow",
-            },
-        )
-        prompt = selector.prepare_selection_prompt(
-            turn_text="hi",
-        )
-        assert "plain_response" in prompt.prompt_text
-        assert "tool_seeking" in prompt.prompt_text
-
-    def test_legacy_prompt_appends_discovered_workflows(self):
-        selector = _build_selector(
-            verdict_mapping={
-                "plain_response": "#V#chat_assistant_workflow",
-            },
-        )
-        prompt = selector.prepare_selection_prompt(
-            turn_text="hi",
-            discovered_workflows=[
-                {
-                    "concept_id": "#V#special_workflow",
-                    "name": "Special",
-                    "description": "Does special things",
-                },
-            ],
-        )
-        assert "#V#special_workflow" in prompt.prompt_text
-        assert "Special" in prompt.prompt_text
-        assert len(prompt.discovered_workflow_ids) == 1
-
-
-# ---------------------------------------------------------------------------
 # Label extraction
 # ---------------------------------------------------------------------------
 
 
 class TestLabelExtraction:
-    def test_extract_plain_text_verdict(self):
+    def test_extract_plain_text_workflow_id(self):
         label = WorkflowSelector._extract_candidate_label(
-            raw_response="tool_seeking",
+            raw_response="#V#tool_calling_workflow",
+            discovered_workflow_ids=["#V#tool_calling_workflow"],
         )
-        assert label == "tool_seeking"
+        assert label == "#V#tool_calling_workflow"
 
     def test_extract_discovered_workflow_id(self):
         label = WorkflowSelector._extract_candidate_label(
@@ -313,15 +209,16 @@ class TestLabelExtraction:
         )
         assert label == "#V#test_wf"
 
-    def test_extract_verdict_from_verbose_text(self):
+    def test_extract_workflow_id_from_verbose_text(self):
         label = WorkflowSelector._extract_candidate_label(
-            raw_response="Based on the request, I recommend tool_seeking.",
+            raw_response="Based on the request, I recommend #V#tool_calling_workflow.",
+            discovered_workflow_ids=["#V#tool_calling_workflow"],
         )
-        assert label == "tool_seeking"
+        assert label == "#V#tool_calling_workflow"
 
     def test_normalise_strips_whitespace_and_quotes(self):
-        label = WorkflowSelector._normalise_candidate("  'tool_seeking'  ")
-        assert label == "tool_seeking"
+        label = WorkflowSelector._normalise_candidate("  '#V#tool_calling_workflow'  ")
+        assert label == "#v#tool_calling_workflow"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/workflow_test_support.py
+++ b/tests/backend/workflow_test_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import cast
 from typing import Any
 
 from src.backend.workflows.definitions import (
@@ -57,6 +58,22 @@ from src.backend.workflows.durable.workflow_gap_recovery_workflow import (
     get_workflow_discovery_gap_recovery_workflow_registration,
     get_workflow_gap_test_workflow_registration,
 )
+from src.backend.workflows.durable.file_copy_interpretation_workflow import (
+    FILE_COPY_INTERPRETATION_WORKFLOW_ID,
+    get_file_copy_interpretation_workflow_registration,
+)
+from src.backend.workflows.durable.file_copy_typing_workflow import (
+    FILE_COPY_TYPING_WORKFLOW_ID,
+    get_file_copy_typing_workflow_registration,
+)
+from src.backend.workflows.durable.file_copy_upload_classification_workflow import (
+    FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID,
+    get_file_copy_upload_classification_workflow_registration,
+)
+from src.backend.workflows.durable.file_copy_upload_handler_workflow import (
+    FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
+    get_file_copy_upload_handler_workflow_registration,
+)
 from src.backend.workflows.workflow_registry import (
     LazyWorkflowRegistration,
     WorkflowRegistration,
@@ -110,6 +127,22 @@ TEST_WORKFLOW_PURPOSES: dict[str, str] = {
     CONVERSATION_TURN_EXECUTION_WORKFLOW_ID: (
         "Canonical conversation-turn execution workflow that derives required "
         "effects, runs postcondition checks, and gates completion claims."
+    ),
+    FILE_COPY_TYPING_WORKFLOW_ID: (
+        "Infer and persist authoritative file-copy typing so downstream "
+        "workflows can route from Vontology-backed artefact taxonomy."
+    ),
+    FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID: (
+        "Classify uploaded file copies and persist route decisions before "
+        "dispatching into specialised or baseline workflows."
+    ),
+    FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID: (
+        "General workflow-first upload handler that routes file copies into "
+        "specialised or baseline interpretation workflows."
+    ),
+    FILE_COPY_INTERPRETATION_WORKFLOW_ID: (
+        "Interpret uploaded file copies with image/document extraction and "
+        "persisted concept enrichment."
     ),
     RAG_TEXT_RELATION_SYNC_WORKFLOW_ID: (
         "Synchronise Vontology text relations to the RAG store with checkpointed "
@@ -172,6 +205,12 @@ AUTHORITATIVE_SUPPORT_MAINTENANCE_WORKFLOW_IDS: tuple[str, ...] = (
     ENTITY_IDENTITY_RESOLUTION_WORKFLOW_ID,
     JIRA_TASK_INCREMENTAL_IMPORT_WORKFLOW_ID,
 )
+AUTHORITATIVE_FILE_COPY_WORKFLOW_IDS: tuple[str, ...] = (
+    FILE_COPY_TYPING_WORKFLOW_ID,
+    FILE_COPY_UPLOAD_CLASSIFICATION_WORKFLOW_ID,
+    FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
+    FILE_COPY_INTERPRETATION_WORKFLOW_ID,
+)
 
 
 def build_test_conversation_turn_registry() -> WorkflowRegistry:
@@ -219,6 +258,20 @@ def register_authoritative_test_workflows(
     return registry
 
 
+def bootstrap_authoritative_test_workflows(
+    workflow_ids: tuple[str, ...],
+) -> dict[str, Any]:
+    registry = WorkflowRegistry()
+    register_authoritative_test_workflows(registry, workflow_ids=workflow_ids)
+    return authority_service.bootstrap_workflow_concepts(registry=cast(Any, registry))
+
+
+def bootstrap_authoritative_conversation_turn_workflows() -> dict[str, Any]:
+    return bootstrap_authoritative_test_workflows(
+        authority_service.CANONICAL_CHAT_WORKFLOW_IDS
+    )
+
+
 def authoritative_step_id(*, workflow_id: str, state_id: str) -> str:
     return authority_service._step_concept_id(
         workflow_id=workflow_id,
@@ -258,4 +311,20 @@ def bootstrap_authoritative_support_maintenance_workflows() -> dict[str, Any]:
     return authority_service.bootstrap_workflow_concepts(
         registry=registry,
         target_workflow_ids=AUTHORITATIVE_SUPPORT_MAINTENANCE_WORKFLOW_IDS,
+    )
+
+
+def bootstrap_authoritative_file_copy_workflows() -> dict[str, Any]:
+    registry = WorkflowRegistry()
+    for registration in (
+        get_file_copy_typing_workflow_registration(),
+        get_file_copy_upload_classification_workflow_registration(),
+        get_file_copy_upload_handler_workflow_registration(),
+        get_file_copy_interpretation_workflow_registration(),
+    ):
+        registry.register(registration)
+
+    return authority_service.bootstrap_workflow_concepts(
+        registry=cast(Any, registry),
+        target_workflow_ids=AUTHORITATIVE_FILE_COPY_WORKFLOW_IDS,
     )


### PR DESCRIPTION
## Summary
- enforce fail-closed Vontology workflow authority in the durable registry and remove production Python-defined workflow registration
- make file-copy bootstrap behaviour authoritative-only, remove legacy selector verdict routing, and align orchestration with workflow contracts
- add regression coverage for purity, selector routing, file-copy authority, terminal effect materialisation, and context-limit workflow execution

## Validation
- `pdm run python scripts/pytest_lanes.py recommend --git-diff origin/main`
- `C:\Users\witbr\Documents\Programming\Strong-AI-Lab\Von-Private\.venv\Scripts\python.exe scripts\workflow_purity_report.py`
- `pdm run pytest tests/backend/test_orchestrator_workflow_selector_routing.py -q`
- `pdm run pytest tests/backend/test_workflow_purity_baseline.py tests/backend/test_workflow_registry_factory_parity.py tests/backend/test_internal_mcp_workflow_tools.py -q`
- `pdm run pytest tests/backend/test_orchestrator_missing_tool_call_retry_arxiv.py -q`
- `pdm run pytest tests/backend/test_orchestrator_gmail_profile.py -q`
- `pdm run pytest tests/backend/test_orchestrator_high_impact_review_guard.py -q`
- targeted individual cases from `tests/backend/test_internal_mcp_orchestrator_batch_execution.py`
- targeted individual cases from `tests/backend/test_internal_mcp_orchestrator_context_limits.py`
- `pdm run pyright orchestrator_test_harness.py src/backend/integrations/internal_mcp/orchestrator.py src/backend/services/workflow_event_integration_service.py src/backend/workflows/action_registry.py src/backend/workflows/durable/durable_executor.py src/backend/workflows/durable/file_copy_upload_classification_workflow.py src/backend/workflows/durable/registry_factory.py src/backend/workflows/llm_step_executor.py src/backend/workflows/workflow_concept_authority_service.py src/backend/workflows/workflow_selector.py`
- `pdm run pyright tests/backend/test_durable_workflow_executor_safety.py tests/backend/test_internal_mcp_orchestrator_batch_execution.py tests/backend/test_internal_mcp_orchestrator_context_limits.py tests/backend/test_internal_mcp_workflow_tools.py tests/backend/test_orchestrator_gmail_profile.py tests/backend/test_orchestrator_high_impact_review_guard.py tests/backend/test_orchestrator_workflow_selector_routing.py tests/backend/test_von_file_upload_scholarly_integration.py tests/backend/test_workflow_concept_authority_service.py tests/backend/test_workflow_registry_factory_parity.py tests/backend/test_workflow_selector_phase3.py tests/backend/test_workflow_selector_rag_first.py tests/backend/workflow_test_support.py`

## Purity outcome
- `built_in_registration_count = 0`
- `builtin_capability_override_count = 0`
- `env_event_binding_count = 0`
- `legacy_selector_mode_count = 0`
- `non_vontology_discoverable_workflow_count = 0`
