### PR TITLE
JVNAUTOSCI-1533 finish workflow authority convergence

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -1,7 +1,7 @@
 # Von Workflow Language (VWL) Manual
 
 Status: Draft (current implementation-aligned)
-Last updated: 2026-03-15 (Pacific/Auckland)
+Last updated: 2026-03-18 (Pacific/Auckland)
 Audience: Human engineers and AI agents
 
 ## 1. Purpose and Scope
@@ -258,19 +258,40 @@ Compilation flow:
 Important deterministic ordering:
 
 - Generated branch precedence for implicit branch links is:
-  Explicit declarative `conditions` listed on the step are evaluated first, in
+- Explicit declarative `conditions` listed on the step are evaluated first, in
   stored order.
-  - `on_failure`
-  - `on_unknown`
-  - `on_approval_required`
-  - `on_break`
-  - `on_continue`
-  - `on_true`/`on_false`
-  - `next_step`
+- `on_failure`
+- `on_unknown`
+- `on_approval_required`
+- `on_break`
+- `on_continue`
+- `on_true`/`on_false`
+- `next_step`
 
 `on_failure` and `on_unknown` compile to context-flag conditions (`last_action_failed`, `last_action_unknown`).
 `on_approval_required` compiles to a context-flag condition (`approval_required == true`).
 `on_break`/`on_continue` compile to control-signal conditions (`last_control_signal == break|continue`).
+
+### 6.1 Runtime Registry Authority
+
+Production runtime registry construction is now read-only with respect to
+workflow authority:
+
+- the runtime registry MUST discover already-materialised workflow concepts from
+  Vontology and load definitions from Vontology on demand;
+- the runtime registry MUST NOT publish or materialise authoritative workflow
+  graphs from Python workflow-definition helpers during normal startup or route
+  selection;
+- Python workflow-definition modules MAY remain for test support, publication
+  repair, or action registration, but they are not production registration
+  authority;
+- workflow parity/purity checks are expected to fail closed on drift by default,
+  and authoritative routing text is expected to come from `source=vontology`
+  workflows with non-empty narrative text.
+- authoritative selector prompts for workflow routing MUST also come from
+  Vontology prompt concepts; missing or malformed selector prompts MUST fail
+  closed with explicit diagnostics instead of regenerating a code-authored
+  ranker prompt.
 
 ## 7. Execution Semantics
 
@@ -336,6 +357,10 @@ For live chat progress payloads used by workflow-aware thinking-card rendering:
 - workflow discovery SHOULD emit an explicit completion payload even when zero workflows match, so the UI can render a visible "no applicable workflow found" step rather than silently omitting discovery outcome;
 - live workflow-dispatch progress SHOULD expose `selected_workflow_id` and SHOULD expose a human-readable `selected_workflow_name` when available;
 - selector metadata such as `workflow_selector_verdict` and `workflow_selector_source` SHOULD be preserved in the live payload so the UI can explain why a workflow route was chosen;
+- selector fail-closed diagnostics such as `selector_prompt_unavailable` or
+  `selector_prompt_missing_candidate_list` SHOULD remain visible in live payloads
+  and traces when authoritative routing prompt content is unavailable or
+  malformed;
 - tool history and tool success/failure/pending counters SHOULD be derived from concrete tool lifecycle events (`tool_call_start` / terminal tool events) rather than route-selection metadata such as `workflow_task`;
 - thinking-card step labels SHOULD prefer canonical workflow-stage labels (for example `Workflow discovery`, `Workflow dispatch`, `Plan tool calls`) over transport/internal labels such as `orchestrator_start`.
 
@@ -622,7 +647,7 @@ This enables workflow authors to declare expected context variables and their de
 
 ### 10.4 File-Copy Upload Routing Workflows (JVNAUTOSCI-1309)
 
-Built-in workflow IDs:
+Canonical workflow IDs:
 
 - `#V#file_copy_upload_classification_workflow`
 - `#V#file_copy_upload_handler_workflow`
@@ -643,15 +668,9 @@ Safety semantics:
 
 Event-launch semantics:
 
-- `file_copy.uploaded` launches use a single selected workflow strategy (`#V#file_copy_upload_handler_workflow` by default) to avoid duplicate uncontrolled launches.
-- Default event bindings are bootstrapped idempotently; conflicting bindings are not overwritten.
+- `file_copy.uploaded` launches resolve through persisted workflow event bindings; the canonical production route is a single enabled binding to `#V#file_copy_upload_handler_workflow` to avoid duplicate uncontrolled launches.
+- Production runtime no longer bootstraps default `file_copy.uploaded` bindings from Python. Missing bindings MUST surface explicit `workflow_not_configured` diagnostics instead of silently recreating authority at runtime.
 - Operators should resolve obsolete `file_copy.uploaded` routes through workflow binding governance (`workflow_list_event_bindings`, `workflow_set_event_binding_enabled`, `workflow_delete_event_binding`) rather than by adding Python-side routing switches.
-
-Current implementation caveat (JVNAUTOSCI-1415):
-
-- the upload-classification scholarly default still points at `#V#integration_scholarly_paper_representation_workflow` in code (`src/backend/workflows/durable/file_copy_upload_classification_workflow.py`);
-- that ID is not currently a Vontology concept, while `#V#scholarly_paper_representation_workflow` does exist as a Vontology workflow concept;
-- until `JVNAUTOSCI-1415` aligns these identities, treat the upload scholarly target as an implementation split rather than a clean single-source workflow authority.
 
 ### 10.5 PDF Diagram-Aware Organisation Extraction (JVNAUTOSCI-1017)
 
@@ -945,6 +964,11 @@ Operational cadence controls include:
 - `workflow_trigger_schedule`
 
 These tools are the default operational control surface for VWL runtime behaviour.
+Workflow instance and schedule creation paths canonicalise namespace context to
+`#V#user@org` (or `#V#user` when no organisation scope exists) via the
+namespace service. Legacy slash-form inputs may still be accepted on read/query
+surfaces or normalised at write boundaries for compatibility, but new
+authoritative workflow launches must not emit fresh `user/org` namespaces.
 
 ## 15. Conformance Checklist for Workflow Authors
 

--- a/orchestrator_test_harness.py
+++ b/orchestrator_test_harness.py
@@ -9,6 +9,11 @@ from src.backend.integrations.internal_mcp.orchestrator import (
     InternalMCPChatOrchestrator,
     _WorkflowModelPolicyState,
 )
+from workflow_test_support import (
+    TEST_WORKFLOW_SELECTOR_PROMPT_ID,
+    TEST_WORKFLOW_SELECTOR_PROMPT_TEMPLATE,
+    render_test_prompt_template,
+)
 
 
 def _stub_stage_model_snapshot() -> dict[str, Any]:
@@ -232,6 +237,11 @@ def build_db_independent_orchestrator(
     )
 
     original_render_prompt = orchestrator._prompt_templates.render_prompt
+    selector_prompt_ids = {
+        str(item).strip()
+        for item in (orchestrator._TURN_SELECTOR_PROMPTS or ())
+        if isinstance(item, str) and str(item).strip()
+    }
 
     def _render_prompt_with_narration_fallback(
         prompt_ids: Any,
@@ -240,6 +250,23 @@ def build_db_independent_orchestrator(
         variables: Any = None,
         max_chars: Any = None,
     ) -> Any:
+        requested_prompt_ids = [
+            str(item).strip()
+            for item in (prompt_ids or ())
+            if isinstance(item, str) and str(item).strip()
+        ]
+        if requested_prompt_ids and any(
+            item in selector_prompt_ids for item in requested_prompt_ids
+        ):
+            return SimpleNamespace(
+                text=render_test_prompt_template(
+                    TEST_WORKFLOW_SELECTOR_PROMPT_TEMPLATE,
+                    dict(variables or {}),
+                ),
+                prompt_id=requested_prompt_ids[0] or TEST_WORKFLOW_SELECTOR_PROMPT_ID,
+                variables=dict(variables or {}),
+                truncated=False,
+            )
         if not prompt_ids and not fallback:
             return SimpleNamespace(
                 text=(

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -10011,6 +10011,7 @@ def _workflow_delete_event_binding(**kwargs):
 
 def _workflow_create_instance(**kwargs):
     """Create a new durable workflow instance."""
+    from ...services.namespace_service import resolve_canonical_namespace
     from ...workflows.durable import WorkflowInstanceManager
     from ...workflows.durable.workflow_instance_submission_service import (
         submit_verified_workflow_instance,
@@ -10040,11 +10041,12 @@ def _workflow_create_instance(**kwargs):
         if isinstance(org_id_raw, str) and org_id_raw.strip()
         else "default"
     )
-    namespace = (
-        namespace_raw.strip()
-        if isinstance(namespace_raw, str) and namespace_raw.strip()
-        else f"{user_id}/{org_id}"
-    )
+    namespace = resolve_canonical_namespace(namespace_raw, user_id, org_id)
+    if not namespace:
+        return make_error_response(
+            "invalid_namespace",
+            "namespace must be canonical or derivable from user_id/org_id",
+        )
     inputs = inputs_raw if isinstance(inputs_raw, dict) else {}
     try:
         max_retries = int(max_retries_raw)
@@ -10073,6 +10075,7 @@ def _workflow_create_instance(**kwargs):
 
 def _workflow_list_instances(**kwargs):
     """List workflow instances with filters."""
+    from ...services.namespace_service import coerce_namespace
     from ...workflows.durable import WorkflowInstanceManager, WorkflowInstanceStatus
 
     user_id = kwargs.get("user_id")
@@ -10086,11 +10089,9 @@ def _workflow_list_instances(**kwargs):
     request_id = kwargs.get("request_id") or kwargs.get("turn_id")
     from_utc = kwargs.get("from_utc")
     to_utc = kwargs.get("to_utc")
-    namespace = (
-        namespace_raw.strip()
-        if isinstance(namespace_raw, str) and namespace_raw.strip()
-        else None
-    )
+    namespace = coerce_namespace(namespace_raw)
+    if namespace is None and isinstance(namespace_raw, str) and namespace_raw.strip():
+        namespace = namespace_raw.strip()
     try:
         limit = int(kwargs.get("limit", 50))
     except (TypeError, ValueError):
@@ -10255,6 +10256,7 @@ def _workflow_retry_instance(**kwargs):
 def _workflow_create_schedule(**kwargs):
     """Create a new workflow schedule."""
     from datetime import datetime, timezone
+    from ...services.namespace_service import resolve_canonical_namespace
     from ...workflows.durable import (
         WorkflowInstanceManager,
         WorkflowSchedule,
@@ -10271,7 +10273,12 @@ def _workflow_create_schedule(**kwargs):
 
     user_id = kwargs.get("user_id", "anonymous")
     org_id = kwargs.get("org_id", "default")
-    namespace = kwargs.get("namespace", f"{user_id}/{org_id}")
+    namespace = resolve_canonical_namespace(kwargs.get("namespace"), user_id, org_id)
+    if not namespace:
+        return make_error_response(
+            "invalid_namespace",
+            "namespace must be canonical or derivable from user_id/org_id",
+        )
     default_inputs = kwargs.get("default_inputs", {})
     description = kwargs.get("description")
 

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -19927,7 +19927,29 @@ class InternalMCPChatOrchestrator:
                         reasoning=str(selector_policy.get("reasoning") or ""),
                         selection_metadata=selector_policy,
                     )
+                elif not selector_prompt.prompt_text:
+                    _emit_progress_local(
+                        {
+                            "status": "thinking",
+                            "stage": "workflow_dispatch",
+                            "phase": "workflow_dispatch",
+                            "phase_label": "Workflow selection unavailable",
+                            "workflow_selector_verdict": (
+                                selector_prompt.prompt_failure_reason
+                                or "selector_prompt_unavailable"
+                            ),
+                            "workflow_match_count": len(discovered_matches),
+                            "workflow_candidate_count": len(selector_candidate_matches)
+                            + len(excluded_discovered_matches),
+                        }
+                    )
+                    selector_selection = (
+                        self._workflow_selector.resolve_prompt_unavailable_selection(
+                            selection_prompt=selector_prompt,
+                        )
+                    )
                 else:
+                    selector_prompt_text = selector_prompt.prompt_text
                     selector_response_text, classifier_model, selector_candidate = (
                         self._run_llm_with_fallbacks(
                             stage="workflow_dispatch",
@@ -19936,7 +19958,7 @@ class InternalMCPChatOrchestrator:
                             context=[
                                 {
                                     "role": "system",
-                                    "content": selector_prompt.prompt_text,
+                                    "content": selector_prompt_text,
                                 }
                             ],
                             default_client=llm_client,
@@ -19954,7 +19976,7 @@ class InternalMCPChatOrchestrator:
                     selector_selection = self._workflow_selector.resolve_selection(
                         raw_response=selector_response_text,
                         prompt_id=selector_prompt.prompt_id,
-                        prompt_used=selector_prompt.prompt_text,
+                        prompt_used=selector_prompt_text,
                         discovered_workflow_ids=selector_prompt.discovered_workflow_ids,
                     )
                 routing_duration_ms = (time.perf_counter() - selector_start) * 1000.0
@@ -20024,6 +20046,20 @@ class InternalMCPChatOrchestrator:
                         "routing_duration_ms": routing_duration_ms,
                         "confidence_score": selector_selection.confidence_score,
                         "reasoning": selector_selection.reasoning,
+                        "prompt_failure_reason": (
+                            selector_selection.selection_metadata.get(
+                                "prompt_failure_reason"
+                            )
+                            if isinstance(selector_selection.selection_metadata, Mapping)
+                            else None
+                        ),
+                        "prompt_failure_detail": (
+                            selector_selection.selection_metadata.get(
+                                "prompt_failure_detail"
+                            )
+                            if isinstance(selector_selection.selection_metadata, Mapping)
+                            else None
+                        ),
                         "policy_guidance_mode": selector_policy.get("guidance_mode"),
                         "policy_snapshot_id": selector_policy.get("snapshot_id"),
                         "policy_candidate_scores": list(
@@ -20059,6 +20095,20 @@ class InternalMCPChatOrchestrator:
                         "routing_duration_ms": routing_duration_ms,
                         "confidence_score": selector_selection.confidence_score,
                         "reasoning": selector_selection.reasoning,
+                        "prompt_failure_reason": (
+                            selector_selection.selection_metadata.get(
+                                "prompt_failure_reason"
+                            )
+                            if isinstance(selector_selection.selection_metadata, Mapping)
+                            else None
+                        ),
+                        "prompt_failure_detail": (
+                            selector_selection.selection_metadata.get(
+                                "prompt_failure_detail"
+                            )
+                            if isinstance(selector_selection.selection_metadata, Mapping)
+                            else None
+                        ),
                         "policy_guidance_mode": selector_policy.get("guidance_mode"),
                         "policy_snapshot_id": selector_policy.get("snapshot_id"),
                         "policy_candidate_scores": list(

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -5779,17 +5779,29 @@ def onboard_new_member():
             or "anonymous"
         )
 
+        from ...services.namespace_service import resolve_canonical_namespace
+
         requested_namespace = data.get("namespace")
         if not isinstance(requested_namespace, str) or not requested_namespace.strip():
             requested_namespace = None
-        namespace = namespace_resolution.get("namespace") or requested_namespace
+        namespace = resolve_canonical_namespace(
+            namespace_resolution.get("namespace") or requested_namespace,
+            user_id,
+            org_id if org_id != "default" else None,
+        )
         if not isinstance(namespace, str) or not namespace.strip():
-            if isinstance(user_id, str) and user_id.startswith("#V#"):
-                namespace = _derive_namespace_for_user_org(
-                    user_id, org_id if org_id != "default" else None
-                )
-            if not isinstance(namespace, str) or not namespace.strip():
-                namespace = f"{user_id}/{org_id}"
+            return (
+                jsonify(
+                    {
+                        "error": "namespace_resolution_failed",
+                        "message": (
+                            "Workflow launch namespace must be canonical or "
+                            "derivable from authenticated user/org context."
+                        ),
+                    }
+                ),
+                400,
+            )
 
         manager = get_instance_manager()
         attempt_payloads: list[dict[str, Any]] = []

--- a/src/backend/server/routes/workflows_routes.py
+++ b/src/backend/server/routes/workflows_routes.py
@@ -25,6 +25,10 @@ from ...services.workflow_episode_service import (
     get_workflow_usage_aggregates_for_workflows,
     list_workflow_use_episodes,
 )
+from ...services.namespace_service import (
+    coerce_namespace,
+    resolve_canonical_namespace,
+)
 from ...workflows.trace_store import (
     get_workflow_execution_trace,
     list_recent_workflow_execution_traces,
@@ -724,9 +728,9 @@ def api_create_workflow_instance():
     Request body:
     {
         "workflow_id": "#V#example_workflow",
-        "user_id": "user-123",
-        "org_id": "org-456",
-        "namespace": "user-123/org-456",
+        "user_id": "#V#user_123",
+        "org_id": "#V#org_456",
+        "namespace": "#V#user_123@org_456",
         "inputs": {"param1": "value1"},
         "max_retries": 3
     }
@@ -739,7 +743,20 @@ def api_create_workflow_instance():
 
     user_id = data.get("user_id", "anonymous")
     org_id = data.get("org_id", "default")
-    namespace = data.get("namespace", f"{user_id}/{org_id}")
+    namespace = resolve_canonical_namespace(
+        data.get("namespace"),
+        user_id,
+        org_id,
+    )
+    if not namespace:
+        return (
+            jsonify(
+                {
+                    "error": "namespace must be canonical or derivable from user_id/org_id",
+                }
+            ),
+            400,
+        )
     inputs = data.get("inputs", {})
     max_retries = data.get("max_retries", 3)
 
@@ -778,7 +795,9 @@ def api_list_workflow_instances():
     """
     user_id = request.args.get("user_id")
     org_id = request.args.get("org_id")
-    namespace = request.args.get("namespace")
+    namespace = coerce_namespace(request.args.get("namespace")) or request.args.get(
+        "namespace"
+    )
     status_str = request.args.get("status")
     workflow_id = request.args.get("workflow_id")
     source_event_type = request.args.get("source_event_type")
@@ -1065,9 +1084,9 @@ def api_create_workflow_schedule():
     Request body:
     {
         "workflow_id": "#V#example_workflow",
-        "user_id": "user-123",
-        "org_id": "org-456",
-        "namespace": "user-123/org-456",
+        "user_id": "#V#user_123",
+        "org_id": "#V#org_456",
+        "namespace": "#V#user_123@org_456",
         "schedule_type": "interval" | "cron" | "once",
         "interval_seconds": 3600,  // for interval type
         "cron_expression": "0 9 * * 1-5",  // for cron type
@@ -1084,7 +1103,20 @@ def api_create_workflow_schedule():
 
     user_id = data.get("user_id", "anonymous")
     org_id = data.get("org_id", "default")
-    namespace = data.get("namespace", f"{user_id}/{org_id}")
+    namespace = resolve_canonical_namespace(
+        data.get("namespace"),
+        user_id,
+        org_id,
+    )
+    if not namespace:
+        return (
+            jsonify(
+                {
+                    "error": "namespace must be canonical or derivable from user_id/org_id",
+                }
+            ),
+            400,
+        )
     default_inputs = data.get("default_inputs", {})
     description = data.get("description")
 

--- a/src/backend/services/identity_resolution_schedule_bootstrap_service.py
+++ b/src/backend/services/identity_resolution_schedule_bootstrap_service.py
@@ -13,6 +13,7 @@ import os
 import threading
 from typing import Any
 
+from .namespace_service import coerce_namespace, derive_namespace_for_actor
 from ..workflows.durable.models import ScheduleType, WorkflowSchedule
 from ..workflows.durable.startup import get_instance_manager
 from ..workflows.durable.entity_identity_resolution_workflow import (
@@ -66,9 +67,14 @@ def _desired_schedule_config() -> dict[str, Any]:
     org_id = str(
         os.getenv("VON_IDENTITY_RESOLUTION_SCHEDULE_ORG_ID", "#V#default")
     ).strip() or "#V#default"
-    namespace = str(
-        os.getenv("VON_IDENTITY_RESOLUTION_SCHEDULE_NAMESPACE", f"{user_id}/{org_id}")
-    ).strip() or f"{user_id}/{org_id}"
+    namespace_override = coerce_namespace(
+        os.getenv("VON_IDENTITY_RESOLUTION_SCHEDULE_NAMESPACE")
+    )
+    namespace = (
+        namespace_override
+        or derive_namespace_for_actor(user_id, org_id)
+        or "#V#system"
+    )
 
     interval_seconds = _coerce_int(
         os.getenv("VON_IDENTITY_RESOLUTION_SCHEDULE_INTERVAL_SECONDS"),

--- a/src/backend/services/namespace_service.py
+++ b/src/backend/services/namespace_service.py
@@ -9,7 +9,7 @@ Example: #V#michael_witbrock@sail
 """
 
 import re
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 
 def derive_namespace(
@@ -45,6 +45,98 @@ def derive_namespace(
         return f"#V#{user_id}@{org_id}"
     else:
         return f"#V#{user_id}"
+
+
+def concept_id_to_namespace_slug(value: Any) -> Optional[str]:
+    """Return a namespace slug from a concept ID or already-slugged value."""
+
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    if cleaned.startswith("#V#"):
+        cleaned = cleaned[3:]
+    cleaned = cleaned.strip()
+    return cleaned or None
+
+
+def derive_namespace_for_actor(
+    user_id: Any,
+    org_id: Any = None,
+) -> Optional[str]:
+    """Derive a canonical namespace from concept IDs or namespace slugs."""
+
+    user_slug = concept_id_to_namespace_slug(user_id)
+    if not user_slug:
+        return None
+    org_slug = concept_id_to_namespace_slug(org_id)
+    try:
+        return derive_namespace(user_slug, org_slug)
+    except ValueError:
+        return None
+
+
+def coerce_namespace(value: Any) -> Optional[str]:
+    """Normalise common namespace encodings to canonical ``#V#user@org`` form."""
+
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+
+    if cleaned.startswith("#V#"):
+        body = cleaned[3:].strip()
+        if not body:
+            return None
+        if "@" in body:
+            user_raw, org_raw = body.split("@", 1)
+            return derive_namespace_for_actor(user_raw, org_raw)
+        if "/" in body:
+            user_raw, org_raw = body.split("/", 1)
+            return derive_namespace_for_actor(user_raw, org_raw)
+        return derive_namespace_for_actor(body)
+
+    if "@" in cleaned:
+        user_raw, org_raw = cleaned.split("@", 1)
+        return derive_namespace_for_actor(user_raw, org_raw)
+    if "/" in cleaned:
+        user_raw, org_raw = cleaned.split("/", 1)
+        return derive_namespace_for_actor(user_raw, org_raw)
+    return derive_namespace_for_actor(cleaned)
+
+
+def resolve_canonical_namespace(
+    namespace: Any,
+    user_id: Any = None,
+    org_id: Any = None,
+    *,
+    preserve_explicit: bool = False,
+) -> Optional[str]:
+    """Prefer canonical explicit namespace text, otherwise derive from actor IDs.
+
+    This helper lets workflow write paths converge on one authoritative namespace
+    derivation pathway while still allowing bounded compatibility for legacy read
+    surfaces or explicit caller-provided opaque identifiers when requested.
+    """
+
+    cleaned_explicit = None
+    if isinstance(namespace, str):
+        cleaned_explicit = namespace.strip() or None
+
+    canonical = coerce_namespace(cleaned_explicit)
+    if canonical:
+        return canonical
+
+    derived = derive_namespace_for_actor(user_id, org_id)
+    if derived:
+        return derived
+
+    if preserve_explicit:
+        return cleaned_explicit
+
+    return None
 
 
 def parse_namespace(namespace: str) -> Dict[str, Optional[str]]:

--- a/src/backend/services/parent_specificity_schedule_bootstrap_service.py
+++ b/src/backend/services/parent_specificity_schedule_bootstrap_service.py
@@ -8,6 +8,7 @@ import os
 import threading
 from typing import Any
 
+from .namespace_service import coerce_namespace, derive_namespace_for_actor
 from ..workflows.durable.models import ScheduleType, WorkflowSchedule
 from ..workflows.durable.startup import get_instance_manager
 from ..workflows.durable.parent_specificity_rumination_workflow import (
@@ -69,12 +70,14 @@ def _desired_schedule_config() -> dict[str, Any]:
     org_id = str(
         os.getenv("VON_PARENT_SPECIFICITY_SCHEDULE_ORG_ID", "#V#default")
     ).strip() or "#V#default"
-    namespace = str(
-        os.getenv(
-            "VON_PARENT_SPECIFICITY_SCHEDULE_NAMESPACE",
-            f"{user_id}/{org_id}",
-        )
-    ).strip() or f"{user_id}/{org_id}"
+    namespace_override = coerce_namespace(
+        os.getenv("VON_PARENT_SPECIFICITY_SCHEDULE_NAMESPACE")
+    )
+    namespace = (
+        namespace_override
+        or derive_namespace_for_actor(user_id, org_id)
+        or "#V#system"
+    )
 
     interval_seconds = _coerce_int(
         os.getenv("VON_PARENT_SPECIFICITY_SCHEDULE_INTERVAL_SECONDS"),

--- a/src/backend/services/workflow_discovery_service.py
+++ b/src/backend/services/workflow_discovery_service.py
@@ -67,6 +67,9 @@ EXECUTABILITY_WORKFLOW_STEP_PARTIALLY_VACUOUS = "workflow_step_partially_vacuous
 EXECUTABILITY_WORKFLOW_STEP_COMPLETELY_VACUOUS = (
     "workflow_step_completely_vacuous"
 )
+ROUTING_EXCLUSION_MISSING_AUTHORITATIVE_PURPOSE = (
+    "missing_authoritative_purpose"
+)
 
 _EXECUTABILITY_REASON_PRIORITY = {
     EXECUTABILITY_EXECUTABLE_NOW: 2,
@@ -775,6 +778,22 @@ def _compute_candidate_confidence(match: WorkflowMatch) -> float:
     return min(1.0, round(score, 3))
 
 
+def _has_authoritative_routing_text(concept_id: str) -> bool:
+    """Return whether the workflow exposes authoritative Vontology narrative text."""
+
+    if not isinstance(concept_id, str) or not concept_id.strip():
+        return False
+
+    try:
+        from ..workflows.vontology_loader import resolve_workflow_narrative_text
+
+        narrative_text, _source = resolve_workflow_narrative_text(concept_id)
+    except Exception:
+        return False
+
+    return isinstance(narrative_text, str) and bool(narrative_text.strip())
+
+
 def _annotate_and_rank_candidates(
     matches: List[WorkflowMatch],
     *,
@@ -786,14 +805,22 @@ def _annotate_and_rank_candidates(
         is_executable, reason, detail = _classify_workflow_concept_executability(
             match.concept_id
         )
+        has_authoritative_text = _has_authoritative_routing_text(match.concept_id)
         match.is_executable = bool(is_executable)
         match.executability_reason = reason
         match.executability_detail = detail
         # Discovery-level policy baseline: only executable candidates are
         # considered safe before orchestrator-level policy checks are applied.
-        match.is_policy_safe = bool(is_executable)
-        match.routing_eligible = bool(is_executable)
-        match.routing_exclusion_reason = None if is_executable else reason
+        match.is_policy_safe = bool(is_executable and has_authoritative_text)
+        match.routing_eligible = bool(is_executable and has_authoritative_text)
+        if not is_executable:
+            match.routing_exclusion_reason = reason
+        elif not has_authoritative_text:
+            match.routing_exclusion_reason = (
+                ROUTING_EXCLUSION_MISSING_AUTHORITATIVE_PURPOSE
+            )
+        else:
+            match.routing_exclusion_reason = None
         match.confidence_score = _compute_candidate_confidence(match)
         annotated.append(match)
 

--- a/src/backend/services/workflow_episode_service.py
+++ b/src/backend/services/workflow_episode_service.py
@@ -48,7 +48,9 @@ def _namespace_equivalents(namespace: str | None) -> list[str]:
 
     Workflow episodes have historically used both ``user/org`` and
     ``#V#user@org`` forms. The monitor should treat these as equivalent when
-    querying episodes, while still remaining namespace-scoped.
+    querying episodes, while still remaining namespace-scoped. New workflow
+    launches should emit canonical namespaces; this helper is read-side
+    compatibility for historical data only.
     """
     clean_namespace = _safe_str(namespace)
     if clean_namespace is None:

--- a/src/backend/services/workflow_event_integration_service.py
+++ b/src/backend/services/workflow_event_integration_service.py
@@ -18,6 +18,11 @@ from .feature_flags import (
     get_durable_workflows_enabled,
     get_event_workflow_integration_enabled,
 )
+from .namespace_service import (
+    concept_id_to_namespace_slug,
+    coerce_namespace,
+    derive_namespace_for_actor,
+)
 from ..workflows.durable.models import EventWorkflowBinding
 from ..workflows.durable.startup import get_instance_manager
 from ..workflows.durable.workflow_instance_submission_service import (
@@ -68,24 +73,21 @@ def _build_event_idempotency_key(
 
 
 def _build_namespace(user_id: str | None, org_id: str | None) -> str:
-    safe_user = (user_id or "anonymous").strip() or "anonymous"
-    safe_org = (org_id or "").strip()
+    safe_user = concept_id_to_namespace_slug(user_id) or "anonymous"
+    safe_org = concept_id_to_namespace_slug(org_id)
 
-    # Prefer user-only namespace when org context is unknown.
-    # Historical user/default placeholders made monitor scoping opaque and
-    # prevented reliable namespace filtering once org-scoped namespaces landed.
+    namespace = derive_namespace_for_actor(safe_user, safe_org)
+    if namespace:
+        return namespace
+
+    # Keep the fallback canonical even if upstream identifiers are malformed.
     if safe_org:
-        return f"{safe_user}/{safe_org}"
-    if safe_user != "anonymous":
-        return safe_user
-    return "anonymous/default"
+        return f"#V#{safe_user}@{safe_org}"
+    return f"#V#{safe_user}"
 
 
 def _normalise_namespace_override(namespace: str | None) -> str | None:
-    if not isinstance(namespace, str):
-        return None
-    cleaned = namespace.strip()
-    return cleaned or None
+    return coerce_namespace(namespace)
 
 
 def _derive_actor_context_from_namespace(

--- a/src/backend/workflows/durable/workflow_instance_submission_service.py
+++ b/src/backend/workflows/durable/workflow_instance_submission_service.py
@@ -33,6 +33,7 @@ from ...services.feature_flags import (
     get_durable_workflows_enabled,
     get_event_workflow_integration_enabled,
 )
+from ...services.namespace_service import resolve_canonical_namespace
 from ..engine import WorkflowDefinition
 from ..vontology_loader import (
     build_workflow_process_graph,
@@ -865,6 +866,33 @@ def submit_verified_workflow_instance(
 
     workflow_id = str(workflow_id or "").strip()
     inputs_payload = dict(inputs or {})
+    canonical_namespace = resolve_canonical_namespace(namespace, user_id, org_id)
+    if not canonical_namespace:
+        return WorkflowInstanceSubmissionResult(
+            success=False,
+            workflow_id=workflow_id,
+            status="rejected_preflight",
+            instance_id=None,
+            error_code="invalid_namespace",
+            error=(
+                "Workflow instance namespace could not be resolved to canonical "
+                "Vontology form."
+            ),
+            verification={
+                "runnable_verification_success": False,
+                "preflight_passed": False,
+                "postflight_passed": False,
+                "preflight": {
+                    "workflow_id": workflow_id,
+                    "runnable_verification_success": False,
+                    "errors": ["invalid_namespace"],
+                    "warnings": [],
+                },
+                "postflight": None,
+                "namespace_resolution_error": "invalid_namespace",
+            },
+            created_new=None,
+        )
     preflight = verify_workflow_runnable(workflow_id)
     verification_payload = _build_submission_verification_payload(
         preflight=preflight,
@@ -900,7 +928,7 @@ def submit_verified_workflow_instance(
             workflow_id=workflow_id,
             user_id=user_id,
             org_id=org_id,
-            namespace=namespace,
+            namespace=canonical_namespace,
             event_idempotency_key=str(event_idempotency_key).strip(),
             source_event_type=str(source_event_type).strip(),
             source_event_id=str(source_event_id).strip(),
@@ -913,7 +941,7 @@ def submit_verified_workflow_instance(
             workflow_id,
             user_id=user_id,
             org_id=org_id,
-            namespace=namespace,
+            namespace=canonical_namespace,
             inputs=inputs_payload,
             schedule_id=schedule_id,
             max_retries=max_retries,

--- a/src/backend/workflows/workflow_selector.py
+++ b/src/backend/workflows/workflow_selector.py
@@ -26,34 +26,16 @@ from src.backend.services.workflow_selection_policy_service import (
 from .workflow_registry import WorkflowRegistry
 
 
-# -----------------------------------------------------------------------
-# RAG-first ranker prompt (Phase 2 default)
-# -----------------------------------------------------------------------
-
-_DEFAULT_RANKER_PROMPT = (
-    "You are a workflow router.  Given the user's request and a set of "
-    "candidate workflows, select the single best workflow.\n\n"
-    "Return a JSON object with exactly these fields:\n"
-    '- "workflow_id": the concept_id of the best workflow '
-    "(e.g. #V#tool_calling_workflow)\n"
-    '- "confidence": a float between 0.0 and 1.0 indicating selection '
-    "confidence\n"
-    '- "reasoning": a brief explanation (1-2 sentences) of why this '
-    "workflow fits\n\n"
-    "Rules:\n"
-    "- Choose the workflow whose capabilities best match the user's intent.\n"
-    "- If the request requires tools, data retrieval, file operations, API "
-    "calls, or knowledge-base mutations, prefer a tool-calling or "
-    "specialised workflow.\n"
-    "- If the request is a simple greeting, question, or acknowledgement "
-    "that needs no external data, choose the chat assistant workflow.\n"
-    "- Canonical artefact identifiers and URLs (arXiv IDs, DOIs, file "
-    "references) usually require a tool-calling or specialised workflow.\n"
-    "- Set confidence to 1.0 when the match is unambiguous, lower when "
-    "multiple workflows could apply.\n\n"
-    "User request:\n{turn_text}\n\n"
-    "Candidate workflows:\n{candidate_list}\n"
+# Fail closed if the authoritative selector prompt cannot be resolved from
+# Vontology or omits the required routing context variables.
+SELECTOR_PROMPT_UNAVAILABLE_REASON = "selector_prompt_unavailable"
+SELECTOR_PROMPT_RENDER_ERROR_REASON = "selector_prompt_render_error"
+SELECTOR_PROMPT_MISSING_CANDIDATE_LIST_REASON = (
+    "selector_prompt_missing_candidate_list"
 )
+SELECTOR_PROMPT_MISSING_TURN_TEXT_REASON = "selector_prompt_missing_turn_text"
+SELECTOR_FAIL_CLOSED_SOURCE = "selector_fail_closed"
+
 
 @dataclass(frozen=True)
 class WorkflowSelection:
@@ -72,9 +54,11 @@ class WorkflowSelection:
 @dataclass(frozen=True)
 class WorkflowSelectionPrompt:
     prompt_id: Optional[str]
-    prompt_text: str
+    prompt_text: str | None
     discovered_workflow_ids: tuple[str, ...] = ()
     policy_recommendation: Mapping[str, Any] = field(default_factory=dict)
+    prompt_failure_reason: str | None = None
+    prompt_failure_detail: str | None = None
 
 
 class WorkflowSelector:
@@ -91,13 +75,11 @@ class WorkflowSelector:
         prompt_service: PromptTemplateService,
         default_workflow_id: str = "#V#chat_assistant_workflow",
         classifier_prompt_ids: Sequence[str] = ("#V#chat_turn_classifier_prompt",),
-        fallback_prompt: str | None = None,
     ) -> None:
         self._registry = registry
         self._prompt_service = prompt_service
         self._default_workflow_id = default_workflow_id
         self._classifier_prompt_ids = tuple(classifier_prompt_ids)
-        self._fallback_prompt = fallback_prompt or _DEFAULT_RANKER_PROMPT
     _JSON_SELECTION_KEYS = (
         "workflow_id",
         "workflow",
@@ -143,9 +125,34 @@ class WorkflowSelector:
             turn_text=turn_text,
             discovered_workflows=discovered_workflows,
         )
+        prompt_text = selection_prompt.prompt_text
+        selection_policy = (
+            dict(selection_prompt.policy_recommendation)
+            if isinstance(selection_prompt.policy_recommendation, Mapping)
+            else {}
+        )
+        if (
+            isinstance(selection_policy.get("recommended_workflow_id"), str)
+            and selection_policy.get("guidance_mode") == "direct"
+        ):
+            return self.resolve_policy_selection(
+                workflow_id=str(selection_policy.get("recommended_workflow_id")),
+                prompt_id=selection_prompt.prompt_id,
+                prompt_used=selection_prompt.prompt_text,
+                discovered_workflow_ids=selection_prompt.discovered_workflow_ids,
+                confidence_score=float(
+                    selection_policy.get("confidence_score", 0.0)
+                ),
+                reasoning=str(selection_policy.get("reasoning") or ""),
+                selection_metadata=selection_policy,
+            )
+        if not prompt_text:
+            return self.resolve_prompt_unavailable_selection(
+                selection_prompt=selection_prompt,
+            )
         response = llm_client.generate(
             prompt="Select workflow",
-            context=[{"role": "system", "content": selection_prompt.prompt_text}],
+            context=[{"role": "system", "content": prompt_text}],
             model=model,
         )
         return self.resolve_selection(
@@ -256,30 +263,52 @@ class WorkflowSelector:
 
         candidate_list = "\n".join(candidate_lines)
 
-        # Try Vontology prompt template first, then fall back.
-        prompt = self._prompt_service.render_prompt(
-            self._classifier_prompt_ids,
-            variables={"turn_text": turn_text, "candidate_list": candidate_list},
-            fallback=self._fallback_prompt,
-            max_chars=6000,
-        )
-        prompt_id = prompt.prompt_id if prompt else None
-        prompt_text = prompt.text if prompt else self._fallback_prompt
-
-        # If the rendered prompt doesn't contain the candidate list
-        # (e.g. because the Vontology template doesn't have the
-        # {candidate_list} variable), append it.
-        if "{candidate_list}" in prompt_text:
-            prompt_text = prompt_text.replace("{candidate_list}", candidate_list)
-        elif candidate_list and candidate_list not in prompt_text:
-            prompt_text = _DEFAULT_RANKER_PROMPT.format(
-                turn_text=turn_text,
-                candidate_list=candidate_list,
+        try:
+            prompt = self._prompt_service.render_prompt(
+                self._classifier_prompt_ids,
+                variables={"turn_text": turn_text, "candidate_list": candidate_list},
+                fallback=None,
+                max_chars=6000,
             )
-            prompt_id = None  # Using fallback ranker prompt.
+        except Exception as exc:
+            return WorkflowSelectionPrompt(
+                prompt_id=None,
+                prompt_text=None,
+                discovered_workflow_ids=tuple(candidate_ids),
+                policy_recommendation=policy_recommendation,
+                prompt_failure_reason=SELECTOR_PROMPT_RENDER_ERROR_REASON,
+                prompt_failure_detail=str(exc),
+            )
+
+        if prompt is None or not isinstance(prompt.text, str) or not prompt.text.strip():
+            return WorkflowSelectionPrompt(
+                prompt_id=None,
+                prompt_text=None,
+                discovered_workflow_ids=tuple(candidate_ids),
+                policy_recommendation=policy_recommendation,
+                prompt_failure_reason=SELECTOR_PROMPT_UNAVAILABLE_REASON,
+            )
+
+        prompt_text = prompt.text.strip()
+        if candidate_list and candidate_list not in prompt_text:
+            return WorkflowSelectionPrompt(
+                prompt_id=prompt.prompt_id,
+                prompt_text=prompt_text,
+                discovered_workflow_ids=tuple(candidate_ids),
+                policy_recommendation=policy_recommendation,
+                prompt_failure_reason=SELECTOR_PROMPT_MISSING_CANDIDATE_LIST_REASON,
+            )
+        if turn_text and turn_text not in prompt_text:
+            return WorkflowSelectionPrompt(
+                prompt_id=prompt.prompt_id,
+                prompt_text=prompt_text,
+                discovered_workflow_ids=tuple(candidate_ids),
+                policy_recommendation=policy_recommendation,
+                prompt_failure_reason=SELECTOR_PROMPT_MISSING_TURN_TEXT_REASON,
+            )
 
         return WorkflowSelectionPrompt(
-            prompt_id=prompt_id,
+            prompt_id=prompt.prompt_id,
             prompt_text=prompt_text,
             discovered_workflow_ids=tuple(candidate_ids),
             policy_recommendation=policy_recommendation,
@@ -414,6 +443,39 @@ class WorkflowSelector:
             reasoning=str(reasoning or ""),
             selection_source="policy_direct",
             selection_metadata=dict(selection_metadata or {}),
+        )
+
+    def resolve_prompt_unavailable_selection(
+        self,
+        *,
+        selection_prompt: WorkflowSelectionPrompt,
+    ) -> WorkflowSelection:
+        """Return an explicit fail-closed selection when prompt authority is missing."""
+
+        failure_reason = (
+            selection_prompt.prompt_failure_reason or SELECTOR_PROMPT_UNAVAILABLE_REASON
+        )
+        selection_metadata: dict[str, Any] = {
+            "prompt_failure_reason": failure_reason,
+        }
+        if (
+            isinstance(selection_prompt.prompt_failure_detail, str)
+            and selection_prompt.prompt_failure_detail
+        ):
+            selection_metadata["prompt_failure_detail"] = (
+                selection_prompt.prompt_failure_detail
+            )
+        return WorkflowSelection(
+            workflow_id=self._default_workflow_id,
+            verdict=failure_reason,
+            prompt_id=selection_prompt.prompt_id,
+            prompt_used=selection_prompt.prompt_text,
+            raw_response="",
+            discovered_workflow_ids=selection_prompt.discovered_workflow_ids,
+            confidence_score=0.0,
+            reasoning=failure_reason,
+            selection_source=SELECTOR_FAIL_CLOSED_SOURCE,
+            selection_metadata=selection_metadata,
         )
 
     # ------------------------------------------------------------------

--- a/tests/backend/test_identity_resolution_schedule_bootstrap_service.py
+++ b/tests/backend/test_identity_resolution_schedule_bootstrap_service.py
@@ -63,7 +63,7 @@ def test_bootstrap_reuses_existing_matching_schedule(monkeypatch) -> None:
         interval_seconds=interval_seconds,
         user_id="#V#system",
         org_id="#V#default",
-        namespace="#V#system/#V#default",
+        namespace="#V#system@default",
         default_inputs={
             "managed_schedule_key": mod.IDENTITY_RESOLUTION_SCHEDULE_MANAGED_KEY,
         },
@@ -96,7 +96,7 @@ def test_bootstrap_disables_mismatch_and_recreates(monkeypatch) -> None:
         interval_seconds=1800,
         user_id="#V#system",
         org_id="#V#default",
-        namespace="#V#system/#V#default",
+        namespace="#V#system@default",
         default_inputs={
             "managed_schedule_key": mod.IDENTITY_RESOLUTION_SCHEDULE_MANAGED_KEY,
         },
@@ -115,3 +115,34 @@ def test_bootstrap_disables_mismatch_and_recreates(monkeypatch) -> None:
     assert report["created_count"] == 1
     assert report["disabled_count"] == 1
     assert (mismatched.schedule_id, False) in fake.enabled_updates
+
+
+def test_bootstrap_recreates_legacy_namespace_schedule(monkeypatch) -> None:
+    from src.backend.services import identity_resolution_schedule_bootstrap_service as mod
+
+    _reset_bootstrap_state(mod)
+    legacy = WorkflowSchedule.create_interval(
+        mod.ENTITY_IDENTITY_RESOLUTION_WORKFLOW_ID,
+        interval_seconds=21600,
+        user_id="#V#system",
+        org_id="#V#default",
+        namespace="#V#system/#V#default",
+        default_inputs={
+            "managed_schedule_key": mod.IDENTITY_RESOLUTION_SCHEDULE_MANAGED_KEY,
+        },
+        description="managed",
+    )
+    legacy.enabled = True
+
+    fake = _FakeManager([legacy])
+    monkeypatch.setattr(mod, "get_instance_manager", lambda: fake)
+    monkeypatch.setenv("VON_IDENTITY_RESOLUTION_SCHEDULE_ENABLE", "1")
+    monkeypatch.setenv("VON_IDENTITY_RESOLUTION_SCHEDULE_INTERVAL_SECONDS", "21600")
+
+    report = mod.ensure_identity_resolution_background_schedule()
+
+    assert report["success"] is True
+    assert report["created_count"] == 1
+    assert report["disabled_count"] == 1
+    assert (legacy.schedule_id, False) in fake.enabled_updates
+    assert fake.created[0].namespace == "#V#system@default"

--- a/tests/backend/test_internal_mcp_workflow_tools.py
+++ b/tests/backend/test_internal_mcp_workflow_tools.py
@@ -30,6 +30,7 @@ def _build_gateway() -> InternalMCPGateway:
 
 def _patch_submit_verified_instance_success(monkeypatch) -> None:
     """Make success-path tests independent of external workflow authority state."""
+    from src.backend.services.namespace_service import resolve_canonical_namespace
     from src.backend.workflows.durable.workflow_instance_submission_service import (
         WorkflowInstanceSubmissionResult,
     )
@@ -40,9 +41,11 @@ def _patch_submit_verified_instance_success(monkeypatch) -> None:
         user_id = str(kwargs.get("user_id") or "anonymous").strip() or "anonymous"
         org_id = str(kwargs.get("org_id") or "default").strip() or "default"
         namespace = (
-            str(kwargs.get("namespace") or f"{user_id}/{org_id}").strip()
-            or f"{user_id}/{org_id}"
+            resolve_canonical_namespace(kwargs.get("namespace"), user_id, org_id)
+            or str(kwargs.get("namespace") or "").strip()
         )
+        if not namespace:
+            raise AssertionError("workflow test helper expected canonical namespace")
         inputs = kwargs.get("inputs")
         max_retries_raw = kwargs.get("max_retries", 3)
         try:
@@ -695,7 +698,7 @@ def test_workflow_create_list_get_instance_gateway_paths(monkeypatch):
     assert detail.get("success") is True
     assert detail.get("instance_id") == instance_id
     assert detail.get("workflow_id") == workflow_id
-    assert detail.get("namespace") == "#V#user/#V#org"
+    assert detail.get("namespace") == "#V#user@org"
     assert detail.get("inputs") == {"seed": "value"}
 
 
@@ -1172,6 +1175,7 @@ def test_workflow_schedule_gateway_tools_integrate_with_scheduler(monkeypatch):
     assert create_result.get("success") is True
     schedule_id = create_result.get("schedule_id")
     assert isinstance(schedule_id, str)
+    assert manager.schedules[schedule_id].namespace == "#V#user@org"
 
     scheduler = WorkflowScheduler(manager, check_interval_seconds=0.01)  # type: ignore[arg-type]
     scheduler._process_due_schedules()
@@ -1181,6 +1185,7 @@ def test_workflow_schedule_gateway_tools_integrate_with_scheduler(monkeypatch):
     assert metrics["due_schedules_seen_total"] == 1
     assert len(manager.instances) == 1
     assert manager.instances[0]["schedule_id"] == schedule_id
+    assert manager.instances[0]["namespace"] == "#V#user@org"
 
     trigger_result = gateway.invoke(
         "workflow_trigger_schedule",
@@ -1218,6 +1223,7 @@ def test_workflow_schedule_execute_checkpoint_fail_retry_resume(monkeypatch):
     assert created_schedule.get("success") is True
     schedule_id = created_schedule.get("schedule_id")
     assert isinstance(schedule_id, str)
+    assert manager.schedules[schedule_id].namespace == "#V#user@org"
 
     scheduler = WorkflowScheduler(manager, check_interval_seconds=0.01)  # type: ignore[arg-type]
     scheduler._process_due_schedules()

--- a/tests/backend/test_namespace_service.py
+++ b/tests/backend/test_namespace_service.py
@@ -7,17 +7,21 @@ Tests namespace derivation, parsing, and validation for composite user@org names
 import pytest
 import sys
 from pathlib import Path
+from typing import Any, cast
 
 # Add parent directory to path to enable imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from src.backend.services.namespace_service import (
+    coerce_namespace,
     derive_namespace,
+    derive_namespace_for_actor,
     parse_namespace,
     is_org_scoped,
     get_user_id,
     get_org_id,
     normalize_namespace,
+    resolve_canonical_namespace,
 )
 
 
@@ -67,7 +71,7 @@ class TestDeriveNamespace:
     def test_none_user_id(self):
         """Test that None user_id raises ValueError."""
         with pytest.raises(ValueError, match="user_id is required"):
-            derive_namespace(None)
+            derive_namespace(cast(Any, None))
 
 
 class TestParseNamespace:
@@ -106,7 +110,7 @@ class TestParseNamespace:
     def test_parse_none_namespace(self):
         """Test that None namespace raises ValueError."""
         with pytest.raises(ValueError, match="Invalid namespace"):
-            parse_namespace(None)
+            parse_namespace(cast(Any, None))
 
     def test_parse_empty_string(self):
         """Test that empty string namespace raises ValueError."""
@@ -182,6 +186,35 @@ class TestNormalizeNamespace:
         """Test that normalising invalid namespace raises ValueError."""
         with pytest.raises(ValueError):
             normalize_namespace("invalid")
+
+
+class TestCompatibilityNormalisation:
+    """Tests for compatibility helpers used at workflow write boundaries."""
+
+    def test_coerce_legacy_slash_namespace(self):
+        assert coerce_namespace("#V#user_alpha/#V#org_beta") == "#V#user_alpha@org_beta"
+
+    def test_derive_namespace_for_actor_accepts_concept_ids(self):
+        assert (
+            derive_namespace_for_actor("#V#user_alpha", "#V#org_beta")
+            == "#V#user_alpha@org_beta"
+        )
+
+    def test_resolve_canonical_namespace_prefers_explicit_canonicalised_value(self):
+        assert (
+            resolve_canonical_namespace(
+                "#V#user_alpha/#V#org_beta",
+                "#V#different_user",
+                "#V#different_org",
+            )
+            == "#V#user_alpha@org_beta"
+        )
+
+    def test_resolve_canonical_namespace_derives_from_actor_when_missing(self):
+        assert (
+            resolve_canonical_namespace(None, "#V#user_alpha", "#V#org_beta")
+            == "#V#user_alpha@org_beta"
+        )
 
 
 class TestEdgeCases:

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -2649,6 +2649,68 @@ def test_selector_fires_without_presenter_mode(monkeypatch):
     assert selector_entry["verdict"] == "rag_selected"
 
 
+def test_selector_prompt_unavailable_fails_closed_without_selector_llm(monkeypatch):
+    """Missing authoritative selector prompt should skip selector LLM dispatch."""
+
+    orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
+    original_render_prompt = orchestrator._prompt_templates.render_prompt
+
+    def _render_without_selector_prompt(
+        prompt_ids: Any,
+        *,
+        fallback: Any = None,
+        variables: Any = None,
+        max_chars: Any = None,
+    ) -> Any:
+        requested_prompt_ids = {
+            str(item).strip()
+            for item in (prompt_ids or ())
+            if isinstance(item, str) and str(item).strip()
+        }
+        if requested_prompt_ids.intersection(orchestrator._TURN_SELECTOR_PROMPTS):
+            return None
+        return original_render_prompt(
+            prompt_ids,
+            fallback=fallback,
+            variables=variables,
+            max_chars=max_chars,
+        )
+
+    monkeypatch.setattr(
+        orchestrator._prompt_templates,
+        "render_prompt",
+        _render_without_selector_prompt,
+    )
+
+    llm = _CapturingLLM(
+        [
+            "I'll help with that.",
+        ]
+    )
+
+    result = orchestrator.run(
+        prompt="hello",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+    )
+
+    assert len(llm.calls) == 1
+    assert all(call["prompt"] != "Select workflow" for call in llm.calls)
+    assert result.response_text == "I'll help with that."
+
+    selector_entry = next(
+        e
+        for e in result.aux_llm_calls
+        if isinstance(e, dict) and e.get("type") == "workflow_selector"
+    )
+    assert selector_entry["workflow_id"] == CHAT_ASSISTANT_WORKFLOW_ID
+    assert selector_entry["verdict"] == "selector_prompt_unavailable"
+    assert selector_entry["selection_source"] == "selector_fail_closed"
+    assert selector_entry["prompt_failure_reason"] == "selector_prompt_unavailable"
+
+
 # ---------------------------------------------------------------------------
 # JVNAUTOSCI-922 Phase 1.3: Discovered workflows in selector prompt.
 # ---------------------------------------------------------------------------

--- a/tests/backend/test_parent_specificity_schedule_bootstrap_service.py
+++ b/tests/backend/test_parent_specificity_schedule_bootstrap_service.py
@@ -61,7 +61,7 @@ def test_bootstrap_reuses_existing_matching_schedule(monkeypatch) -> None:
         interval_seconds=14400,
         user_id="#V#system",
         org_id="#V#default",
-        namespace="#V#system/#V#default",
+        namespace="#V#system@default",
         default_inputs={
             "managed_schedule_key": mod.PARENT_SPECIFICITY_SCHEDULE_MANAGED_KEY,
             "scan_limit": 24,
@@ -95,7 +95,7 @@ def test_bootstrap_disables_mismatch_and_recreates(monkeypatch) -> None:
         interval_seconds=1800,
         user_id="#V#system",
         org_id="#V#default",
-        namespace="#V#system/#V#default",
+        namespace="#V#system@default",
         default_inputs={
             "managed_schedule_key": mod.PARENT_SPECIFICITY_SCHEDULE_MANAGED_KEY,
             "scan_limit": 12,
@@ -118,3 +118,38 @@ def test_bootstrap_disables_mismatch_and_recreates(monkeypatch) -> None:
     assert report["created_count"] == 1
     assert report["disabled_count"] == 1
     assert (mismatched.schedule_id, False) in fake.enabled_updates
+
+
+def test_bootstrap_recreates_legacy_namespace_schedule(monkeypatch) -> None:
+    from src.backend.services import parent_specificity_schedule_bootstrap_service as mod
+
+    _reset_bootstrap_state(mod)
+    legacy = WorkflowSchedule.create_interval(
+        mod.PARENT_SPECIFICITY_RUMINATION_WORKFLOW_ID,
+        interval_seconds=14400,
+        user_id="#V#system",
+        org_id="#V#default",
+        namespace="#V#system/#V#default",
+        default_inputs={
+            "managed_schedule_key": mod.PARENT_SPECIFICITY_SCHEDULE_MANAGED_KEY,
+            "scan_limit": 24,
+            "max_mutations_per_run": 4,
+            "min_confidence": 0.92,
+            "reanalyse_after_hours": 168,
+        },
+        description="managed",
+    )
+    legacy.enabled = True
+
+    fake = _FakeManager([legacy])
+    monkeypatch.setattr(mod, "get_instance_manager", lambda: fake)
+    monkeypatch.setenv("VON_PARENT_SPECIFICITY_SCHEDULE_ENABLE", "1")
+    monkeypatch.setenv("VON_PARENT_SPECIFICITY_SCHEDULE_INTERVAL_SECONDS", "14400")
+
+    report = mod.ensure_parent_specificity_background_schedule()
+
+    assert report["success"] is True
+    assert report["created_count"] == 1
+    assert report["disabled_count"] == 1
+    assert (legacy.schedule_id, False) in fake.enabled_updates
+    assert fake.created[0].namespace == "#V#system@default"

--- a/tests/backend/test_workflow_discovery_service.py
+++ b/tests/backend/test_workflow_discovery_service.py
@@ -24,6 +24,7 @@ from src.backend.services.workflow_discovery_service import (
     EXECUTABILITY_WORKFLOW_STEP_PARTIALLY_VACUOUS,
     EXECUTABILITY_WORKFLOW_STEP_INTEGRITY,
     EXECUTABILITY_NON_EXECUTABLE_DESIGN_ARTIFACT,
+    ROUTING_EXCLUSION_MISSING_AUTHORITATIVE_PURPOSE,
     WORKFLOW_TYPE_IDS,
     WorkflowDiscoveryResult,
     WorkflowMatch,
@@ -377,11 +378,15 @@ class TestDiscoverWorkflows:
         "src.backend.services.workflow_discovery_service._search_workflows_vontology"
     )
     @patch(
+        "src.backend.services.workflow_discovery_service._has_authoritative_routing_text"
+    )
+    @patch(
         "src.backend.services.workflow_discovery_service._classify_workflow_concept_executability"
     )
     def test_mixed_candidates_expose_reason_codes_and_routing_subset(
         self,
         mock_classify: MagicMock,
+        mock_has_authoritative_text: MagicMock,
         mock_vontology: MagicMock,
         mock_semantic: MagicMock,
     ) -> None:
@@ -406,6 +411,7 @@ class TestDiscoverWorkflows:
             )
 
         mock_classify.side_effect = _classify
+        mock_has_authoritative_text.side_effect = lambda concept_id: concept_id == "#V#wf_exec"
 
         with patch(
             "src.backend.services.workflow_discovery_service._enrich_workflow_matches",
@@ -429,11 +435,16 @@ class TestDiscoverWorkflows:
         "src.backend.services.workflow_discovery_service._search_workflows_vontology"
     )
     @patch(
+        "src.backend.services.workflow_discovery_service._has_authoritative_routing_text",
+        return_value=True,
+    )
+    @patch(
         "src.backend.services.workflow_discovery_service._classify_workflow_concept_executability"
     )
     def test_allow_non_executable_override_keeps_mixed_routing_candidates(
         self,
         mock_classify: MagicMock,
+        mock_has_authoritative_text: MagicMock,
         mock_vontology: MagicMock,
         mock_semantic: MagicMock,
     ) -> None:
@@ -563,6 +574,40 @@ class TestDiscoverWorkflowsForTurn:
         assert "Scholarly paper file copy" in fallback_queries
         assert "PDF file copy" in fallback_queries
         assert "route_hint=scholarly" in result.query
+
+    @patch("src.backend.services.workflow_discovery_service._enrich_workflow_matches")
+    @patch("src.backend.services.workflow_discovery_service._has_authoritative_routing_text")
+    @patch("src.backend.services.workflow_discovery_service._classify_workflow_concept_executability")
+    @patch("src.backend.services.workflow_discovery_service._search_workflows_name_fallback")
+    @patch("src.backend.services.workflow_discovery_service._search_workflows_vontology")
+    @patch("src.backend.services.workflow_discovery_service._search_workflows_semantic")
+    def test_textless_fallback_match_is_visible_but_not_routing_eligible(
+        self,
+        mock_semantic: MagicMock,
+        mock_vontology: MagicMock,
+        mock_name_fallback: MagicMock,
+        mock_classify: MagicMock,
+        mock_has_authoritative_text: MagicMock,
+        mock_enrich: MagicMock,
+    ) -> None:
+        mock_semantic.return_value = [
+            WorkflowMatch("#V#textless_candidate", "Textless candidate", relevance_score=0.86)
+        ]
+        mock_vontology.return_value = []
+        mock_name_fallback.return_value = []
+        mock_classify.return_value = (True, EXECUTABILITY_EXECUTABLE_NOW, None)
+        mock_has_authoritative_text.return_value = False
+        mock_enrich.side_effect = lambda matches: matches
+
+        result = discover_workflows("Represent the uploaded paper now", max_results=1)
+
+        assert len(result.matches) == 1
+        assert result.matches[0].routing_eligible is False
+        assert (
+            result.matches[0].routing_exclusion_reason
+            == ROUTING_EXCLUSION_MISSING_AUTHORITATIVE_PURPOSE
+        )
+        assert result.routing_matches == []
 
     @patch("src.backend.services.workflow_discovery_service._enrich_workflow_matches")
     @patch("src.backend.services.workflow_discovery_service._search_workflows_name_fallback")

--- a/tests/backend/test_workflow_event_integration_service.py
+++ b/tests/backend/test_workflow_event_integration_service.py
@@ -155,7 +155,7 @@ def test_launch_event_workflow_creates_instance_when_configured(
     assert called_args.kwargs["workflow_id"] == "#V#task_event_workflow"
     assert called_args.kwargs["source_event_type"] == EVENT_TYPE_TASK_CREATED
     assert called_args.kwargs["source_event_id"] == "task-1"
-    assert called_args.kwargs["namespace"] == "#V#user_alice/#V#org_nao"
+    assert called_args.kwargs["namespace"] == "#V#user_alice@org_nao"
     assert called_args.kwargs["event_idempotency_key"].startswith(
         "evt:task.created:",
     )
@@ -462,6 +462,44 @@ def test_launch_event_workflow_uses_namespace_override_for_tenancy(
     assert result["success"] is True
     assert result["triggered"] is True
 
+    called_args = mock_submit.call_args
+    assert called_args is not None
+    assert called_args.kwargs["user_id"] == "#V#user_alice"
+    assert called_args.kwargs["org_id"] == "#V#org_nao"
+    assert called_args.kwargs["namespace"] == "#V#user_alice@org_nao"
+
+
+@patch("src.backend.services.workflow_event_integration_service.get_instance_manager")
+def test_launch_event_workflow_normalises_legacy_namespace_override(
+    mock_get_instance_manager: MagicMock,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("VON_EVENT_WORKFLOW_INTEGRATION_ENABLE", "1")
+    monkeypatch.setenv("VON_DURABLE_WORKFLOWS_ENABLE", "1")
+
+    mock_manager = MagicMock()
+    mock_get_instance_manager.return_value = mock_manager
+
+    with patch(
+        "src.backend.services.workflow_event_integration_service.submit_verified_workflow_instance",
+        return_value=_submission_result(
+            workflow_id="#V#task_event_workflow",
+            instance_id="instance-ns-legacy",
+            created_new=True,
+        ),
+    ) as mock_submit:
+        result = launch_event_workflow(
+            event_type=EVENT_TYPE_TASK_CREATED,
+            event_id="task-legacy-namespace",
+            user_id=None,
+            org_id=None,
+            namespace="#V#user_alice/#V#org_nao",
+            workflow_id="#V#task_event_workflow",
+            inputs={"task_concept_id": "#V#task_99"},
+        )
+
+    assert result["success"] is True
+    assert result["triggered"] is True
     called_args = mock_submit.call_args
     assert called_args is not None
     assert called_args.kwargs["user_id"] == "#V#user_alice"

--- a/tests/backend/test_workflow_instance_submission_service.py
+++ b/tests/backend/test_workflow_instance_submission_service.py
@@ -637,6 +637,10 @@ def test_submit_verified_workflow_instance_uses_event_idempotent_creation() -> N
     assert result.verification["runnable_verification_success"] is True
     manager.create_instance_for_event.assert_called_once()
     manager.create_instance.assert_not_called()
+    assert (
+        manager.create_instance_for_event.call_args.kwargs["namespace"]
+        == "#V#user_alice@org_nao"
+    )
     assert mock_verify.call_count == 2
 
 
@@ -669,4 +673,27 @@ def test_submit_verified_workflow_instance_preserves_idempotent_reuse_without_po
     manager.create_instance_for_event.assert_called_once()
     manager.create_instance.assert_not_called()
     manager.mark_failed.assert_not_called()
+    assert (
+        manager.create_instance_for_event.call_args.kwargs["namespace"]
+        == "#V#user_alice@org_nao"
+    )
     mock_verify.assert_called_once_with("#V#candidate_workflow")
+
+
+def test_submit_verified_workflow_instance_rejects_unresolvable_namespace() -> None:
+    manager = MagicMock()
+
+    result = submit_verified_workflow_instance(
+        manager=manager,
+        workflow_id="#V#candidate_workflow",
+        user_id="user-1",
+        org_id="org-1",
+        namespace="user-1/org-1",
+        inputs={"seed": "abc-123"},
+    )
+
+    assert result.success is False
+    assert result.status == "rejected_preflight"
+    assert result.error_code == "invalid_namespace"
+    manager.create_instance_for_event.assert_not_called()
+    manager.create_instance.assert_not_called()

--- a/tests/backend/test_workflow_selector_phase3.py
+++ b/tests/backend/test_workflow_selector_phase3.py
@@ -14,7 +14,7 @@ import json
 
 import pytest
 
-from src.backend.services.prompt_template_service import PromptTemplateService
+import src.backend.services.workflow_selection_policy_service as policy_module
 from src.backend.services.workflow_selection_experience import (
     SelectionExperienceTuple,
     get_recent_experiences,
@@ -27,7 +27,10 @@ from src.backend.workflows.workflow_selector import (
     WorkflowSelection,
     WorkflowSelector,
 )
-from workflow_test_support import build_test_conversation_turn_registry
+from workflow_test_support import (
+    build_test_conversation_turn_registry,
+    build_test_prompt_service,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -42,11 +45,17 @@ def _build_registry() -> WorkflowRegistry:
 def _build_selector(*, default_workflow_id=None) -> WorkflowSelector:
     kwargs: dict = {
         "registry": _build_registry(),
-        "prompt_service": PromptTemplateService(),
+        "prompt_service": build_test_prompt_service(),
     }
     if default_workflow_id is not None:
         kwargs["default_workflow_id"] = default_workflow_id
     return WorkflowSelector(**kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _disable_learned_policy(monkeypatch: pytest.MonkeyPatch):
+    policy_module.clear_live_selection_policy()
+    monkeypatch.setattr(policy_module, "get_live_selection_policy", lambda: None)
 
 
 _TOOL_WORKFLOW = "#V#tool_calling_workflow"
@@ -251,6 +260,7 @@ class TestEnhancedPrompt:
                 },
             ],
         )
+        assert prompt.prompt_text is not None
         assert "JSON" in prompt.prompt_text
         assert "confidence" in prompt.prompt_text
         assert "reasoning" in prompt.prompt_text
@@ -264,6 +274,7 @@ class TestEnhancedPrompt:
                 {"concept_id": _TOOL_WORKFLOW, "name": "Tools", "description": "Tools."},
             ],
         )
+        assert prompt.prompt_text is not None
         assert _CHAT_WORKFLOW in prompt.prompt_text
         assert _TOOL_WORKFLOW in prompt.prompt_text
 

--- a/tests/backend/test_workflow_selector_phase4.py
+++ b/tests/backend/test_workflow_selector_phase4.py
@@ -8,7 +8,6 @@ import pytest
 import src.backend.db.mongo_client as mongo_client_module
 import src.backend.services.workflow_selection_experience as experience_module
 import src.backend.services.workflow_selection_policy_service as policy_module
-from src.backend.services.prompt_template_service import PromptTemplateService
 from src.backend.workflows import WorkflowRegistry
 from src.backend.workflows.definitions import (
     CHAT_ASSISTANT_WORKFLOW_ID,
@@ -20,7 +19,10 @@ from test_orchestrator_workflow_selector_routing import (
     _CapturingLLM,
     _build_orchestrator,
 )
-from workflow_test_support import build_test_conversation_turn_registry
+from workflow_test_support import (
+    build_test_conversation_turn_registry,
+    build_test_prompt_service,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -82,7 +84,7 @@ def _build_selector() -> WorkflowSelector:
     registry = build_test_conversation_turn_registry()
     return WorkflowSelector(
         registry=registry,
-        prompt_service=PromptTemplateService(),
+        prompt_service=build_test_prompt_service(),
     )
 
 
@@ -92,7 +94,7 @@ def _build_rag_first_orchestrator(
     orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
     orchestrator._workflow_selector = WorkflowSelector(
         registry=orchestrator._workflow_registry,
-        prompt_service=PromptTemplateService(),
+        prompt_service=build_test_prompt_service(),
         classifier_prompt_ids=orchestrator._TURN_SELECTOR_PROMPTS,
         default_workflow_id=CHAT_ASSISTANT_WORKFLOW_ID,
     )

--- a/tests/backend/test_workflow_selector_rag_first.py
+++ b/tests/backend/test_workflow_selector_rag_first.py
@@ -13,14 +13,17 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from src.backend.services.prompt_template_service import PromptTemplateService
+import src.backend.services.workflow_selection_policy_service as policy_module
 from src.backend.workflows import WorkflowRegistry
 from src.backend.workflows.workflow_selector import (
     WorkflowSelection,
     WorkflowSelectionPrompt,
     WorkflowSelector,
 )
-from workflow_test_support import build_test_conversation_turn_registry
+from workflow_test_support import (
+    build_test_conversation_turn_registry,
+    build_test_prompt_service,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -35,11 +38,17 @@ def _build_registry() -> WorkflowRegistry:
 def _build_selector(*, default_workflow_id=None) -> WorkflowSelector:
     kwargs: dict = {
         "registry": _build_registry(),
-        "prompt_service": PromptTemplateService(),
+        "prompt_service": build_test_prompt_service(),
     }
     if default_workflow_id is not None:
         kwargs["default_workflow_id"] = default_workflow_id
     return WorkflowSelector(**kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _disable_learned_policy(monkeypatch: pytest.MonkeyPatch):
+    policy_module.clear_live_selection_policy()
+    monkeypatch.setattr(policy_module, "get_live_selection_policy", lambda: None)
 
 
 # ---------------------------------------------------------------------------
@@ -149,6 +158,7 @@ class TestRagFirstPrompt:
             ],
         )
         assert isinstance(prompt, WorkflowSelectionPrompt)
+        assert prompt.prompt_text is not None
         assert "#V#tool_calling_workflow" in prompt.prompt_text
         assert "#V#chat_assistant_workflow" in prompt.prompt_text
         assert "Tool Calling" in prompt.prompt_text
@@ -163,6 +173,7 @@ class TestRagFirstPrompt:
             turn_text="hello",
             discovered_workflows=[],
         )
+        assert prompt.prompt_text is not None
         assert "#V#chat_assistant_workflow" in prompt.prompt_text
         assert len(prompt.discovered_workflow_ids) == 1
 
@@ -177,7 +188,57 @@ class TestRagFirstPrompt:
                 },
             ],
         )
+        assert prompt.prompt_text is not None
         assert "What is the meaning of life?" in prompt.prompt_text
+
+    def test_prompt_missing_candidate_list_fails_closed(self):
+        selector = WorkflowSelector(
+            registry=_build_registry(),
+            prompt_service=build_test_prompt_service(
+                prompt_text="Route this turn:\n{turn_text}\n",
+            ),
+        )
+
+        prompt = selector.prepare_selection_prompt(
+            turn_text="Find arXiv papers about transformers",
+            discovered_workflows=[
+                {
+                    "concept_id": "#V#tool_calling_workflow",
+                    "name": "Tool Calling",
+                    "description": "General-purpose tool-calling pipeline.",
+                }
+            ],
+        )
+
+        assert prompt.prompt_failure_reason == "selector_prompt_missing_candidate_list"
+        assert prompt.prompt_text is not None
+
+    def test_select_workflow_prompt_unavailable_fails_closed_without_selector_llm(self):
+        selector = WorkflowSelector(
+            registry=_build_registry(),
+            prompt_service=build_test_prompt_service(prompt_text=None),
+            default_workflow_id="#V#chat_assistant_workflow",
+        )
+        mock_llm = MagicMock()
+
+        result = selector.select_workflow(
+            llm_client=mock_llm,
+            model="test-model",
+            turn_text="Find papers about AI",
+            discovered_workflows=[
+                {
+                    "concept_id": "#V#tool_calling_workflow",
+                    "name": "Tool Calling",
+                    "description": "General-purpose tool pipeline.",
+                }
+            ],
+        )
+
+        assert isinstance(result, WorkflowSelection)
+        assert result.workflow_id == "#V#chat_assistant_workflow"
+        assert result.verdict == "selector_prompt_unavailable"
+        assert result.selection_source == "selector_fail_closed"
+        mock_llm.generate.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/test_workflows_routes.py
+++ b/tests/backend/test_workflows_routes.py
@@ -618,9 +618,9 @@ def test_create_workflow_instance_route_rejects_unrunnable_workflow(
         "/api/workflows/instances",
         json={
             "workflow_id": "#V#non_runnable_workflow",
-            "user_id": "user-1",
-            "org_id": "org-1",
-            "namespace": "user-1/org-1",
+            "user_id": "#V#user_1",
+            "org_id": "#V#org_1",
+            "namespace": "#V#user_1/#V#org_1",
             "inputs": {"seed": "value"},
         },
     )
@@ -645,9 +645,9 @@ def test_trigger_workflow_schedule_route_rejects_unrunnable_workflow(
     schedule = types.SimpleNamespace(
         schedule_id="#V#schedule_test_1",
         workflow_id="#V#non_runnable_workflow",
-        user_id="user-1",
-        org_id="org-1",
-        namespace="user-1/org-1",
+        user_id="#V#user_1",
+        org_id="#V#org_1",
+        namespace="#V#user_1@org_1",
         default_inputs={"seed": "value"},
     )
 
@@ -687,6 +687,38 @@ def test_trigger_workflow_schedule_route_rejects_unrunnable_workflow(
     assert "workflow_definition_not_registered" in payload["verification"]["preflight"][
         "errors"
     ]
+
+
+def test_create_workflow_schedule_route_canonicalises_legacy_namespace(
+    monkeypatch, app_client
+):
+    import src.backend.server.routes.workflows_routes as workflows_routes
+
+    captured: dict[str, object] = {}
+
+    def _create_schedule(schedule):
+        captured["schedule"] = schedule
+        return schedule.schedule_id
+
+    manager = types.SimpleNamespace(create_schedule=_create_schedule)
+    monkeypatch.setattr(workflows_routes, "_get_instance_manager", lambda: manager)
+
+    response = app_client.post(
+        "/api/workflows/schedules",
+        json={
+            "workflow_id": "#V#alpha_workflow",
+            "user_id": "#V#user_1",
+            "org_id": "#V#org_1",
+            "namespace": "#V#user_1/#V#org_1",
+            "schedule_type": "interval",
+            "interval_seconds": 60,
+            "default_inputs": {"seed": "value"},
+        },
+    )
+
+    assert response.status_code == 201
+    schedule = captured["schedule"]
+    assert getattr(schedule, "namespace", None) == "#V#user_1@org_1"
 
 
 def test_list_workflow_instances_returns_retryable_degraded_payload_for_mongo_timeout(

--- a/tests/backend/workflow_test_support.py
+++ b/tests/backend/workflow_test_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import cast
 from typing import Any
 
@@ -211,6 +212,59 @@ AUTHORITATIVE_FILE_COPY_WORKFLOW_IDS: tuple[str, ...] = (
     FILE_COPY_UPLOAD_HANDLER_WORKFLOW_ID,
     FILE_COPY_INTERPRETATION_WORKFLOW_ID,
 )
+
+TEST_WORKFLOW_SELECTOR_PROMPT_ID = "#V#chat_turn_classifier_prompt"
+TEST_WORKFLOW_SELECTOR_PROMPT_TEMPLATE = (
+    "You are a workflow router. Given the user's request and the candidate "
+    "workflows below, select the single best workflow.\n\n"
+    "Return JSON with fields workflow_id, confidence, and reasoning.\n\n"
+    "User request:\n{turn_text}\n\n"
+    "Candidate workflows:\n{candidate_list}\n"
+)
+
+
+def render_test_prompt_template(
+    template: str,
+    variables: dict[str, Any] | None = None,
+) -> str:
+    rendered = str(template)
+    for key, value in dict(variables or {}).items():
+        rendered = rendered.replace("{" + str(key) + "}", str(value))
+    return rendered
+
+
+def build_test_prompt_service(
+    *,
+    prompt_text: str | None = TEST_WORKFLOW_SELECTOR_PROMPT_TEMPLATE,
+    prompt_id: str = TEST_WORKFLOW_SELECTOR_PROMPT_ID,
+    error: Exception | None = None,
+) -> Any:
+    class _TestPromptService:
+        def render_prompt(
+            self,
+            concept_ids: Any,
+            *,
+            variables: Any = None,
+            fallback: Any = None,
+            max_chars: Any = None,
+        ) -> Any:
+            _ = (concept_ids, fallback, max_chars)
+            if error is not None:
+                raise error
+            if prompt_text is None:
+                return None
+            rendered = render_test_prompt_template(
+                prompt_text,
+                dict(variables or {}),
+            )
+            return SimpleNamespace(
+                prompt_id=prompt_id,
+                text=rendered,
+                variables=dict(variables or {}),
+                truncated=False,
+            )
+
+    return _TestPromptService()
 
 
 def build_test_conversation_turn_registry() -> WorkflowRegistry:


### PR DESCRIPTION
## Summary
- remove the remaining production selector-prompt authority fallback and fail closed when selector prompt content is unavailable
- canonicalise workflow namespace emission at shared submission and schedule-creation boundaries while preserving legacy read compatibility
- update VWL documentation and add regression coverage for selector, workflow creation, event integration, and schedule call paths

## Validation
- `pdm run python scripts/pytest_lanes.py recommend --git-diff origin/main`
- `pdm run pytest tests/backend/test_namespace_service.py -q`
- `pdm run pytest tests/backend/test_workflow_instance_submission_service.py -q`
- `pdm run pytest tests/backend/test_workflows_routes.py -q`
- `pdm run pytest tests/backend/test_internal_mcp_workflow_tools.py -q -k workflow_create_list_get_instance_gateway_paths`
- `pdm run pytest tests/backend/test_internal_mcp_workflow_tools.py -q -k workflow_schedule_gateway_tools_integrate_with_scheduler`
- `pdm run pytest tests/backend/test_internal_mcp_workflow_tools.py -q -k workflow_list_instances_supports_turn_and_date_filters`
- `pdm run pytest tests/backend/test_internal_mcp_workflow_tools.py -q -k workflow_create_instance_normalises_inputs`
- `pdm run pytest tests/backend/test_internal_mcp_workflow_tools.py -q -k workflow_create_instance_rejects_unrunnable_workflow`
- `pdm run pytest tests/backend/test_workflow_event_integration_service.py -q`
- `pdm run pytest tests/backend/test_identity_resolution_schedule_bootstrap_service.py -q`
- `pdm run pytest tests/backend/test_parent_specificity_schedule_bootstrap_service.py -q`
- `pdm run pytest tests/backend/test_workflow_discovery_service.py -q`
- `pdm run pytest tests/backend/test_workflow_selector_rag_first.py -q`
- `pdm run pytest tests/backend/test_workflow_selector_phase3.py -q`
- `pdm run pytest tests/backend/test_workflow_selector_phase4.py -q`
- `pdm run pytest tests/backend/test_orchestrator_workflow_selector_routing.py -q -k "selector_prompt_unavailable_fails_closed_without_selector_llm or selector_fires_without_presenter_mode or selector_receives_discovered_workflows or non_executable_discovered_workflow_filtered_by_default or non_executable_discovered_workflow_can_be_overridden"`
- `pdm run pyright orchestrator_test_harness.py src/backend/integrations/internal_mcp/catalogue.py src/backend/integrations/internal_mcp/orchestrator.py src/backend/server/routes/von_routes.py src/backend/server/routes/workflows_routes.py src/backend/services/identity_resolution_schedule_bootstrap_service.py src/backend/services/namespace_service.py src/backend/services/parent_specificity_schedule_bootstrap_service.py src/backend/services/workflow_discovery_service.py src/backend/services/workflow_episode_service.py src/backend/services/workflow_event_integration_service.py src/backend/workflows/durable/workflow_instance_submission_service.py src/backend/workflows/workflow_selector.py tests/backend/test_identity_resolution_schedule_bootstrap_service.py tests/backend/test_internal_mcp_workflow_tools.py tests/backend/test_namespace_service.py tests/backend/test_orchestrator_workflow_selector_routing.py tests/backend/test_parent_specificity_schedule_bootstrap_service.py tests/backend/test_workflow_discovery_service.py tests/backend/test_workflow_event_integration_service.py tests/backend/test_workflow_instance_submission_service.py tests/backend/test_workflow_selector_phase3.py tests/backend/test_workflow_selector_phase4.py tests/backend/test_workflow_selector_rag_first.py tests/backend/test_workflows_routes.py tests/backend/workflow_test_support.py`

## Notes
- `scripts/workflow_purity_report.py` timed out in the interactive worktree, so closure is based on the targeted call-path validation plus the already-zero checked-in purity baseline from JVNAUTOSCI-1532, not on a fresh live purity-report run in this session.