### PR TITLE
JVNAUTOSCI-1534 Make workflow purity reporting deterministic

### DIFF
--- a/src/backend/workflows/durable/registry_factory.py
+++ b/src/backend/workflows/durable/registry_factory.py
@@ -573,10 +573,31 @@ def _register_python_defined_workflows(registry: WorkflowRegistry) -> None:
     return None
 
 
-def build_workflow_purity_registry_snapshot() -> WorkflowRegistry:
-    """Build the actual runtime registry path for workflow-purity checks."""
+def _build_workflow_purity_source_snapshot() -> WorkflowRegistry:
+    """Build a deterministic registry snapshot for purity reporting.
 
-    return build_workflow_registry_read_only()
+    The workflow-purity report is a regression gate over code-authored runtime
+    authority surfaces. It must stay usable in standalone operator runs even if
+    live Vontology discovery or authoritative graph loading is slow. Keep this
+    snapshot intentionally DB-free and limited to code-registered workflow
+    sources only.
+    """
+
+    registry = WorkflowRegistry()
+    _register_python_defined_workflows(registry)
+    return registry
+
+
+def build_workflow_purity_registry_snapshot() -> WorkflowRegistry:
+    """Build the registry snapshot used by standalone workflow-purity checks.
+
+    This intentionally excludes live workflow discovery, authoritative graph
+    loading, and deferred registry diagnostics. Those paths are valuable for
+    runtime parity checks, but they make the purity report unsuitable as a fast
+    operator-visible regression gate.
+    """
+
+    return _build_workflow_purity_source_snapshot()
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/workflows/workflow_purity_report.py
+++ b/src/backend/workflows/workflow_purity_report.py
@@ -231,9 +231,16 @@ def _collect_registry_sources(registry: Any | None) -> dict[str, Any]:
     for workflow_id in workflow_ids:
         source = "unknown"
         try:
-            registration = registry.get_registration(workflow_id)
-            if registration is not None:
-                source = str(getattr(registration, "source", "") or "").strip() or "unknown"
+            get_source = getattr(registry, "get_registration_source", None)
+            if callable(get_source):
+                source = str(get_source(workflow_id, resolve_lazy=False) or "").strip() or "unknown"
+            else:
+                registration = registry.get_registration(workflow_id)
+                if registration is not None:
+                    source = (
+                        str(getattr(registration, "source", "") or "").strip()
+                        or "unknown"
+                    )
         except Exception:
             source = "unknown"
         source_by_workflow_id[workflow_id] = source

--- a/src/backend/workflows/workflow_registry.py
+++ b/src/backend/workflows/workflow_registry.py
@@ -218,6 +218,42 @@ class WorkflowRegistry:
             return reg
         return self._resolve_lazy(workflow_id)
 
+    def get_registration_source(
+        self,
+        workflow_id: str,
+        *,
+        resolve_lazy: bool = False,
+    ) -> str | None:
+        """Return the registration source for *workflow_id*.
+
+        Introspection/reporting call paths often need source metadata without
+        triggering lazy definition resolution. By default this consults eager
+        registrations first, then lazy placeholders, and only resolves lazily
+        when ``resolve_lazy`` is explicitly requested.
+        """
+
+        reg = self._workflows.get(workflow_id)
+        if reg is not None:
+            source = reg.source
+            if isinstance(source, str) and source.strip():
+                return source.strip()
+            return None
+
+        lazy = self._lazy.get(workflow_id)
+        if lazy is not None and not resolve_lazy:
+            source = lazy.source
+            if isinstance(source, str) and source.strip():
+                return source.strip()
+            return None
+
+        resolved = self._resolve_lazy(workflow_id) if resolve_lazy else None
+        if resolved is None:
+            return None
+        source = resolved.source
+        if isinstance(source, str) and source.strip():
+            return source.strip()
+        return None
+
     def all_workflow_ids(self) -> Iterable[str]:
         """Return all known workflow IDs (both eager and lazy)."""
         ids = set(self._workflows.keys())

--- a/tests/backend/test_workflow_purity_baseline.py
+++ b/tests/backend/test_workflow_purity_baseline.py
@@ -1,5 +1,6 @@
 import json
 
+from src.backend.workflows.durable import registry_factory
 from src.backend.workflows.durable.registry_factory import (
     build_workflow_purity_registry_snapshot,
 )
@@ -23,3 +24,22 @@ def test_workflow_purity_baseline_has_no_regression() -> None:
         "Workflow purity counters regressed relative to the checked-in baseline.\n"
         f"{json.dumps(report, indent=2, sort_keys=True)}"
     )
+
+
+def test_workflow_purity_registry_snapshot_skips_live_vontology_resolution(
+    monkeypatch,
+) -> None:
+    def _unexpected(*args, **kwargs):
+        raise AssertionError("purity snapshot must not call live Vontology helpers")
+
+    monkeypatch.setattr(
+        registry_factory,
+        "_build_expected_authoritative_workflow_report",
+        _unexpected,
+    )
+    monkeypatch.setattr(registry_factory, "discover_workflow_ids", _unexpected)
+    monkeypatch.setattr(registry_factory, "_launch_deferred_registry_work", _unexpected)
+
+    registry = build_workflow_purity_registry_snapshot()
+
+    assert list(registry.all_workflow_ids()) == []

--- a/tests/backend/test_workflow_purity_report.py
+++ b/tests/backend/test_workflow_purity_report.py
@@ -4,6 +4,10 @@ from pathlib import Path
 from src.backend.services.workflow_capability_service import (
     BUILTIN_WORKFLOW_CAPABILITIES,
 )
+from src.backend.workflows.workflow_registry import (
+    LazyWorkflowRegistration,
+    WorkflowRegistry,
+)
 from src.backend.workflows.workflow_purity_report import (
     build_workflow_purity_report,
 )
@@ -221,3 +225,54 @@ def test_build_workflow_purity_report_flags_baseline_regressions(tmp_path: Path)
         "delta": 1,
     }
     assert "builtin_capability_override_count" not in comparison["increased_counters"]
+
+
+def test_build_workflow_purity_report_does_not_resolve_lazy_registrations(
+    tmp_path: Path,
+) -> None:
+    baseline_path = tmp_path / "tests" / "backend" / "fixtures" / "workflow_purity_baseline.json"
+    baseline_path.parent.mkdir(parents=True, exist_ok=True)
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "workflow_purity_baseline.v1",
+                "counters": {
+                    "built_in_registration_count": 0,
+                    "remaining_python_workflow_family_count": 0,
+                    "direct_instance_create_callsite_count": 0,
+                    "env_event_binding_count": 0,
+                    "legacy_selector_mode_count": 0,
+                    "builtin_capability_override_count": len(
+                        BUILTIN_WORKFLOW_CAPABILITIES
+                    ),
+                    "non_vontology_discoverable_workflow_count": 0,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loader_calls: list[str] = []
+
+    def _unexpected_loader(workflow_id: str):
+        loader_calls.append(workflow_id)
+        raise AssertionError("purity reporting must not resolve lazy workflow definitions")
+
+    registry = WorkflowRegistry(definition_loader=_unexpected_loader)
+    registry.register_lazy(
+        LazyWorkflowRegistration(
+            workflow_id="#V#lazy_vontology_workflow",
+            source="vontology",
+        )
+    )
+
+    report = build_workflow_purity_report(
+        registry=registry,
+        project_root=tmp_path,
+        baseline_path=baseline_path,
+    )
+
+    assert loader_calls == []
+    assert report["details"]["registry_source_counts"] == {"vontology": 1}
+    assert report["counters"]["built_in_registration_count"] == 0
+    assert report["counters"]["non_vontology_discoverable_workflow_count"] == 0


### PR DESCRIPTION
## Summary
- replace the workflow-purity registry snapshot with a lean DB-free code-authority snapshot
- add non-resolving workflow registration source introspection to avoid lazy Vontology definition loads in purity reporting
- add regression tests covering the standalone purity path and lazy-source introspection

## Validation
- pdm run pytest tests/backend/test_workflow_purity_report.py -q
- pdm run pytest tests/backend/test_workflow_purity_baseline.py -q
- pdm run pytest tests/backend/test_workflow_registry_factory_parity.py -q
- pdm run pytest tests/backend/test_workflow_registry_lazy_loading.py -q
- pdm run pyright src/backend/workflows/durable/registry_factory.py src/backend/workflows/workflow_purity_report.py src/backend/workflows/workflow_registry.py tests/backend/test_workflow_purity_baseline.py tests/backend/test_workflow_purity_report.py
- ./.venv/Scripts/python.exe ./scripts/workflow_purity_report.py