### PR TITLE
JVNAUTOSCI-1546 Keep retrying workflow monitor while visible

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -160,7 +160,6 @@ const WORKFLOW_STATUS_RECONNECT_MAX_MS = 20000;
 const WORKFLOW_STATUS_SNAPSHOT_FETCH_TIMEOUT_MS = 15000;
 const WORKFLOW_STATUS_SNAPSHOT_RETRY_BASE_MS = 1200;
 const WORKFLOW_STATUS_SNAPSHOT_RETRY_MAX_MS = 8000;
-const WORKFLOW_STATUS_SNAPSHOT_RETRY_MAX_ATTEMPTS = 4;
 const WORKFLOW_STATUS_SNAPSHOT_RETRY_DEFAULT_SECONDS = 2;
 const WORKFLOW_STATUS_INSTANCE_ID_INLINE_MAX_CHARS = 24;
 const workflowStatusStreamState = {
@@ -18072,10 +18071,9 @@ function applyWorkflowStatusSnapshotRetryableState({ payload, response, detail =
         WORKFLOW_STATUS_SNAPSHOT_RETRY_MAX_MS
     );
     const retryDelayMs = Math.max(exponentialDelayMs, retryAfterMs);
-    const shouldRetry = (
-        attempt <= WORKFLOW_STATUS_SNAPSHOT_RETRY_MAX_ATTEMPTS
-        && shouldAutoRefreshWorkflowStatusSnapshot()
-    );
+    // Keep retrying while the monitor remains visible; the capped delay avoids
+    // aggressive polling during extended transient store contention.
+    const shouldRetry = shouldAutoRefreshWorkflowStatusSnapshot();
 
     workflowStatusStreamState.retryAttempt = attempt;
     workflowStatusStreamState.snapshotError = '';

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -901,6 +901,41 @@ describe('workflow monitor active snapshot degradation handling', () => {
         );
     });
 
+    test('keeps retrying retryable active snapshot failures while the monitor stays visible', async () => {
+        let fetchCount = 0;
+        global.fetch = jest.fn(() => {
+            fetchCount += 1;
+            return Promise.resolve({
+                ok: false,
+                status: 503,
+                headers: { get: () => null },
+                json: async () => ({
+                    items: [],
+                    count: 0,
+                    degraded: true,
+                    retryable: true,
+                    error: 'Workflow monitor temporarily unavailable; please retry.',
+                    detail: 'read circuit open'
+                })
+            });
+        });
+
+        await __testOnly_refreshWorkflowStatusSnapshot();
+        expect(fetchCount).toBe(1);
+
+        for (let attempt = 0; attempt < 4; attempt += 1) {
+            jest.runOnlyPendingTimers();
+            await flushMicrotasks();
+        }
+
+        expect(fetchCount).toBe(5);
+        const payload = __testOnly_buildWorkflowMonitorExportPayload();
+        expect(payload.monitor_state.active_notice).toContain('retrying in 8s');
+        expect(payload.monitor_state.active_notice).not.toContain('Press Refresh');
+        expect(payload.active_instances_snapshot.payload.retry_attempt).toBe(5);
+        expect(payload.active_instances_snapshot.payload.retry_scheduled_in_ms).toBe(8000);
+    });
+
     test('shows visible refresh state while an active snapshot request is in flight', async () => {
         let resolveFetch;
         global.fetch = jest.fn(() => new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- remove the active snapshot retry-attempt cap so retryable failures keep retrying while the monitor stays visible
- keep the existing bounded backoff behaviour to avoid aggressive polling during longer contention windows
- add regression coverage for repeated retry scheduling beyond the previous cap

## Testing
- npm test -- --runInBand src/frontend/web/von_interface/static/js/test/chatTab.test.js
- npx eslint src/frontend/web/von_interface/static/js/chatTab.js src/frontend/web/von_interface/static/js/test/chatTab.test.js