### PR TITLE
JVNAUTOSCI-1547 Optimise workflow monitor snapshot query

### DIFF
--- a/src/backend/server/routes/workflows_routes.py
+++ b/src/backend/server/routes/workflows_routes.py
@@ -96,6 +96,24 @@ def _is_transient_workflow_instances_error(exc: Exception) -> bool:
     return any(marker in message for marker in transient_markers)
 
 
+def _parse_workflow_instance_status_filters(
+    status_raw: str | None,
+) -> list[WorkflowInstanceStatus]:
+    """Parse and validate workflow instance status filters from query params."""
+    if not isinstance(status_raw, str) or not status_raw.strip():
+        return []
+
+    statuses: list[WorkflowInstanceStatus] = []
+    seen: set[str] = set()
+    for raw_status in status_raw.split(","):
+        value = raw_status.strip().lower()
+        if not value or value in seen:
+            continue
+        statuses.append(WorkflowInstanceStatus(value))
+        seen.add(value)
+    return statuses
+
+
 def _read_workflow_definitions_cache_ttl_seconds() -> float:
     raw = os.getenv(
         "VON_WORKFLOW_DEFINITIONS_CACHE_TTL_SECONDS",
@@ -759,7 +777,7 @@ def api_list_workflow_instances():
     - user_id: Filter by user
     - org_id: Filter by organisation
     - namespace: Filter by namespace
-    - status: Filter by status (pending, running, completed, failed, cancelled, paused)
+    - status: Comma-separated statuses (pending, running, completed, failed, cancelled, paused)
     - workflow_id: Filter by workflow definition
     - source_event_type: Filter by triggering event type
     - source_event_id: Filter by triggering event ID
@@ -776,20 +794,26 @@ def api_list_workflow_instances():
     source_event_id = request.args.get("source_event_id")
     limit = min(int(request.args.get("limit", "50")), 200)
 
-    status: WorkflowInstanceStatus | None = None
-    if status_str:
-        try:
-            status = WorkflowInstanceStatus(status_str.lower())
-        except ValueError:
-            return jsonify({"error": f"Invalid status: {status_str}"}), 400
+    try:
+        statuses = _parse_workflow_instance_status_filters(status_str)
+    except ValueError:
+        valid_statuses = ", ".join(status.value for status in WorkflowInstanceStatus)
+        return (
+            jsonify(
+                {
+                    "error": f"Invalid status: {status_str}. Valid values: {valid_statuses}"
+                }
+            ),
+            400,
+        )
 
     manager = _get_instance_manager()
     try:
-        instances = manager.list_instances(
+        items = manager.list_instance_status_dicts(
             user_id=user_id,
             org_id=org_id,
             namespace=namespace,
-            status=status,
+            status=statuses,
             workflow_id=workflow_id,
             source_event_type=source_event_type,
             source_event_id=source_event_id,
@@ -821,8 +845,8 @@ def api_list_workflow_instances():
 
     return jsonify(
         {
-            "items": [inst.to_status_dict() for inst in instances],
-            "count": len(instances),
+            "items": items,
+            "count": len(items),
         }
     )
 

--- a/src/backend/workflows/durable/instance_manager.py
+++ b/src/backend/workflows/durable/instance_manager.py
@@ -7,6 +7,7 @@ durable workflow instances.
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -37,6 +38,29 @@ WORKFLOW_EVENT_BINDINGS_COLLECTION = "workflow_event_bindings"
 
 # Default lock TTL: 5 minutes
 DEFAULT_LOCK_TTL_SECONDS = 300
+
+_WORKFLOW_INSTANCE_STATUS_SUMMARY_PROJECTION: dict[str, Any] = {
+    "_id": 0,
+    "instance_id": 1,
+    "workflow_id": 1,
+    "status": 1,
+    "current_state": 1,
+    "step_index": 1,
+    "created_at": 1,
+    "started_at": 1,
+    "completed_at": 1,
+    "progress_current": 1,
+    "progress_total": 1,
+    "progress_message": 1,
+    "progress_updated_at": 1,
+    "error": 1,
+    "retry_count": 1,
+    "max_retries": 1,
+    "source_event_type": 1,
+    "source_event_id": 1,
+    "event_idempotency_key": 1,
+    "has_outputs": {"$ne": [{"$ifNull": ["$outputs", None]}, None]},
+}
 
 # Default completed instance TTL: 30 days
 DEFAULT_COMPLETED_TTL_SECONDS = 30 * 24 * 60 * 60
@@ -105,6 +129,16 @@ def _ensure_indexes() -> None:
             instances_coll.create_index(
                 [("org_id", ASCENDING), ("status", ASCENDING)],
                 name="org_status",
+            )
+
+        if "namespace_status_created" not in existing:
+            instances_coll.create_index(
+                [
+                    ("namespace", ASCENDING),
+                    ("status", ASCENDING),
+                    ("created_at", DESCENDING),
+                ],
+                name="namespace_status_created",
             )
 
         # Schedule association
@@ -226,6 +260,89 @@ class WorkflowInstanceManager:
         """Get the workflow_instances collection."""
         db = get_db()
         return db[WORKFLOW_INSTANCES_COLLECTION] if db is not None else None
+
+    @staticmethod
+    def _normalise_status_filter(
+        status: WorkflowInstanceStatus
+        | str
+        | Iterable[WorkflowInstanceStatus | str]
+        | None,
+    ) -> list[str]:
+        if status is None:
+            return []
+        if isinstance(status, WorkflowInstanceStatus):
+            return [status.value]
+        if isinstance(status, str):
+            value = status.strip().lower()
+            return [value] if value else []
+
+        values: list[str] = []
+        for raw_status in status:
+            if isinstance(raw_status, WorkflowInstanceStatus):
+                value = raw_status.value
+            else:
+                value = str(raw_status or "").strip().lower()
+            if value and value not in values:
+                values.append(value)
+        return values
+
+    def _build_instance_list_query(
+        self,
+        *,
+        user_id: str | None = None,
+        org_id: str | None = None,
+        namespace: str | None = None,
+        status: WorkflowInstanceStatus
+        | str
+        | Iterable[WorkflowInstanceStatus | str]
+        | None = None,
+        workflow_id: str | None = None,
+        source_event_type: str | None = None,
+        source_event_id: str | None = None,
+        conversation_session_id: str | None = None,
+        request_id: str | None = None,
+        from_utc: datetime | str | None = None,
+        to_utc: datetime | str | None = None,
+    ) -> dict[str, Any]:
+        """Build the shared query for workflow-instance list operations."""
+        query: dict[str, Any] = {}
+        if user_id:
+            query["user_id"] = user_id
+        if org_id:
+            query["org_id"] = org_id
+        if namespace:
+            query["namespace"] = namespace
+
+        status_values = self._normalise_status_filter(status)
+        if status_values:
+            query["status"] = (
+                status_values[0]
+                if len(status_values) == 1
+                else {"$in": status_values}
+            )
+
+        if workflow_id:
+            query["workflow_id"] = workflow_id
+        if source_event_type:
+            query["source_event_type"] = source_event_type
+        if source_event_id:
+            query["source_event_id"] = source_event_id
+        if conversation_session_id:
+            query["inputs.conversation_session_id"] = conversation_session_id
+        if request_id:
+            query["inputs.turn_id"] = request_id
+
+        created_range: dict[str, Any] = {}
+        from_dt = _parse_datetime_filter(from_utc)
+        to_dt = _parse_datetime_filter(to_utc)
+        if from_dt is not None:
+            created_range["$gte"] = from_dt
+        if to_dt is not None:
+            created_range["$lte"] = to_dt
+        if created_range:
+            query["created_at"] = created_range
+
+        return query
 
     def _get_schedules_collection(self) -> Collection | None:
         """Get the workflow_schedules collection."""
@@ -524,7 +641,10 @@ class WorkflowInstanceManager:
         user_id: str | None = None,
         org_id: str | None = None,
         namespace: str | None = None,
-        status: WorkflowInstanceStatus | str | None = None,
+        status: WorkflowInstanceStatus
+        | str
+        | Iterable[WorkflowInstanceStatus | str]
+        | None = None,
         workflow_id: str | None = None,
         source_event_type: str | None = None,
         source_event_id: str | None = None,
@@ -555,41 +675,68 @@ class WorkflowInstanceManager:
         if coll is None:
             return []
 
-        query: dict[str, Any] = {}
-        if user_id:
-            query["user_id"] = user_id
-        if org_id:
-            query["org_id"] = org_id
-        if namespace:
-            query["namespace"] = namespace
-        if status:
-            status_val = (
-                status.value if isinstance(status, WorkflowInstanceStatus) else status
-            )
-            query["status"] = status_val
-        if workflow_id:
-            query["workflow_id"] = workflow_id
-        if source_event_type:
-            query["source_event_type"] = source_event_type
-        if source_event_id:
-            query["source_event_id"] = source_event_id
-        if conversation_session_id:
-            query["inputs.conversation_session_id"] = conversation_session_id
-        if request_id:
-            query["inputs.turn_id"] = request_id
-
-        created_range: dict[str, Any] = {}
-        from_dt = _parse_datetime_filter(from_utc)
-        to_dt = _parse_datetime_filter(to_utc)
-        if from_dt is not None:
-            created_range["$gte"] = from_dt
-        if to_dt is not None:
-            created_range["$lte"] = to_dt
-        if created_range:
-            query["created_at"] = created_range
-
+        query = self._build_instance_list_query(
+            user_id=user_id,
+            org_id=org_id,
+            namespace=namespace,
+            status=status,
+            workflow_id=workflow_id,
+            source_event_type=source_event_type,
+            source_event_id=source_event_id,
+            conversation_session_id=conversation_session_id,
+            request_id=request_id,
+            from_utc=from_utc,
+            to_utc=to_utc,
+        )
         cursor = coll.find(query).sort("created_at", -1).limit(limit)
         return [WorkflowInstance.from_doc(doc) for doc in cursor]
+
+    def list_instance_status_dicts(
+        self,
+        *,
+        user_id: str | None = None,
+        org_id: str | None = None,
+        namespace: str | None = None,
+        status: WorkflowInstanceStatus
+        | str
+        | Iterable[WorkflowInstanceStatus | str]
+        | None = None,
+        workflow_id: str | None = None,
+        source_event_type: str | None = None,
+        source_event_id: str | None = None,
+        conversation_session_id: str | None = None,
+        request_id: str | None = None,
+        from_utc: datetime | str | None = None,
+        to_utc: datetime | str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """List workflow monitor status cards without hydrating full instances."""
+        coll = self._get_instances_collection()
+        if coll is None:
+            return []
+
+        query = self._build_instance_list_query(
+            user_id=user_id,
+            org_id=org_id,
+            namespace=namespace,
+            status=status,
+            workflow_id=workflow_id,
+            source_event_type=source_event_type,
+            source_event_id=source_event_id,
+            conversation_session_id=conversation_session_id,
+            request_id=request_id,
+            from_utc=from_utc,
+            to_utc=to_utc,
+        )
+        pipeline = [
+            {"$match": query},
+            {"$sort": {"created_at": -1}},
+            {"$limit": limit},
+            {"$project": dict(_WORKFLOW_INSTANCE_STATUS_SUMMARY_PROJECTION)},
+        ]
+        return [
+            WorkflowInstance.status_dict_from_doc(doc) for doc in coll.aggregate(pipeline)
+        ]
 
     # -------------------------------------------------------------------------
     # Locking for distributed workers

--- a/src/backend/workflows/durable/models.py
+++ b/src/backend/workflows/durable/models.py
@@ -40,6 +40,15 @@ class WorkflowInstanceStatus(str, Enum):
             WorkflowInstanceStatus.PAUSED,
         )
 
+    @classmethod
+    def active_values(cls) -> tuple[str, ...]:
+        """Return the active workflow statuses surfaced in the monitor."""
+        return (
+            cls.PENDING.value,
+            cls.RUNNING.value,
+            cls.PAUSED.value,
+        )
+
 
 class ScheduleType(str, Enum):
     """Type of workflow schedule."""
@@ -325,37 +334,79 @@ class WorkflowInstance:
             execution_trace_id=doc.get("execution_trace_id"),
         )
 
-    def to_status_dict(self) -> dict[str, Any]:
-        """Convert to a JSON-serialisable status dict for API responses."""
+    @staticmethod
+    def _status_datetime_to_iso(value: Any) -> str | None:
+        if isinstance(value, datetime):
+            return value.isoformat()
+        if isinstance(value, str):
+            cleaned = value.strip()
+            return cleaned or None
+        return None
+
+    @classmethod
+    def status_dict_from_doc(cls, doc: dict[str, Any]) -> dict[str, Any]:
+        """Convert a persisted document or projection into monitor payload shape."""
+        status_value = doc.get("status")
+        if isinstance(status_value, WorkflowInstanceStatus):
+            status = status_value.value
+        else:
+            status = str(status_value or "")
+
+        has_outputs = doc.get("has_outputs")
+        if not isinstance(has_outputs, bool):
+            has_outputs = doc.get("outputs") is not None
+
         return {
-            "instance_id": self.instance_id,
-            "workflow_id": self.workflow_id,
-            "status": self.status.value,
-            "current_state": self.current_state,
-            "step_index": self.step_index,
-            "created_at": self.created_at.isoformat(),
-            "started_at": self.started_at.isoformat() if self.started_at else None,
-            "completed_at": (
-                self.completed_at.isoformat() if self.completed_at else None
-            ),
+            "instance_id": doc.get("instance_id"),
+            "workflow_id": doc.get("workflow_id"),
+            "status": status,
+            "current_state": doc.get("current_state", ""),
+            "step_index": doc.get("step_index", 0),
+            "created_at": cls._status_datetime_to_iso(doc.get("created_at")),
+            "started_at": cls._status_datetime_to_iso(doc.get("started_at")),
+            "completed_at": cls._status_datetime_to_iso(doc.get("completed_at")),
             "progress": {
-                "current": self.progress_current,
-                "total": self.progress_total,
-                "message": self.progress_message,
-                "updated_at": (
-                    self.progress_updated_at.isoformat()
-                    if self.progress_updated_at
-                    else None
+                "current": doc.get("progress_current"),
+                "total": doc.get("progress_total"),
+                "message": doc.get("progress_message"),
+                "updated_at": cls._status_datetime_to_iso(
+                    doc.get("progress_updated_at")
                 ),
             },
-            "error": self.error,
-            "has_outputs": self.outputs is not None,
-            "retry_count": self.retry_count,
-            "max_retries": self.max_retries,
-            "source_event_type": self.source_event_type,
-            "source_event_id": self.source_event_id,
-            "event_idempotency_key": self.event_idempotency_key,
+            "error": doc.get("error"),
+            "has_outputs": has_outputs,
+            "retry_count": doc.get("retry_count", 0),
+            "max_retries": doc.get("max_retries", 3),
+            "source_event_type": doc.get("source_event_type"),
+            "source_event_id": doc.get("source_event_id"),
+            "event_idempotency_key": doc.get("event_idempotency_key"),
         }
+
+    def to_status_dict(self) -> dict[str, Any]:
+        """Convert to a JSON-serialisable status dict for API responses."""
+        return self.status_dict_from_doc(
+            {
+                "instance_id": self.instance_id,
+                "workflow_id": self.workflow_id,
+                "status": self.status,
+                "current_state": self.current_state,
+                "step_index": self.step_index,
+                "created_at": self.created_at,
+                "started_at": self.started_at,
+                "completed_at": self.completed_at,
+                "progress_current": self.progress_current,
+                "progress_total": self.progress_total,
+                "progress_message": self.progress_message,
+                "progress_updated_at": self.progress_updated_at,
+                "error": self.error,
+                "has_outputs": self.outputs is not None,
+                "retry_count": self.retry_count,
+                "max_retries": self.max_retries,
+                "source_event_type": self.source_event_type,
+                "source_event_id": self.source_event_id,
+                "event_idempotency_key": self.event_idempotency_key,
+            }
+        )
 
 
 @dataclass

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -17027,7 +17027,7 @@ function renderWorkflowEpisodesPopup() {
 async function fetchWorkflowEpisodesSnapshot(workflowId, { limit = 60 } = {}) {
     const cleanWorkflowId = typeof workflowId === 'string' ? workflowId.trim() : '';
     const safeLimit = Math.max(1, Math.min(Number(limit) || 60, 200));
-    const params = buildWorkflowStatusQuery();
+    const params = buildWorkflowStatusQuery({ includeStatusFilter: true });
     params.set('workflow_id', cleanWorkflowId);
     params.set('limit', String(safeLimit));
     const requestQuery = params.toString();
@@ -17846,7 +17846,7 @@ async function refreshWorkflowStatusSnapshot({ silent = false, preserveRetryAtte
     if (!panel) return;
     if (workflowStatusStreamState.loading) return;
 
-    const params = buildWorkflowStatusQuery();
+    const params = buildWorkflowStatusQuery({ includeStatusFilter: true });
     params.set('limit', '50');
 
     if (!preserveRetryAttempt) {

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -936,6 +936,24 @@ describe('workflow monitor active snapshot degradation handling', () => {
         expect(payload.active_instances_snapshot.payload.retry_scheduled_in_ms).toBe(8000);
     });
 
+    test('refreshes the active snapshot with an active-status filter', async () => {
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            headers: { get: () => null },
+            json: async () => ({
+                items: [],
+                count: 0
+            })
+        });
+
+        await __testOnly_refreshWorkflowStatusSnapshot();
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        const requestUrl = new URL(global.fetch.mock.calls[0][0], 'http://localhost');
+        expect(requestUrl.searchParams.get('status')).toBe('pending,running,paused');
+    });
+
     test('shows visible refresh state while an active snapshot request is in flight', async () => {
         let resolveFetch;
         global.fetch = jest.fn(() => new Promise((resolve) => {

--- a/tests/backend/test_durable_workflow_system.py
+++ b/tests/backend/test_durable_workflow_system.py
@@ -657,6 +657,119 @@ class TestWorkflowInstanceManager:
         assert id1 in completed_ids
         assert id2 in pending_ids
 
+    def test_list_instances_accepts_multiple_status_filters(self) -> None:
+        """list_instances() should support multi-status queries."""
+        manager = WorkflowInstanceManager()
+
+        pending_id = manager.create_instance(
+            "#V#test_workflow",
+            user_id="user-1",
+            org_id="org-1",
+            namespace="user-1/org-1",
+        )
+        running_id = manager.create_instance(
+            "#V#test_workflow",
+            user_id="user-1",
+            org_id="org-1",
+            namespace="user-1/org-1",
+        )
+        paused_id = manager.create_instance(
+            "#V#test_workflow",
+            user_id="user-1",
+            org_id="org-1",
+            namespace="user-1/org-1",
+        )
+
+        collection = manager._get_instances_collection()
+        assert collection is not None
+        collection.update_one(
+            {"instance_id": running_id},
+            {
+                "$set": {
+                    "status": WorkflowInstanceStatus.RUNNING.value,
+                    "progress_message": "running",
+                }
+            },
+        )
+        collection.update_one(
+            {"instance_id": paused_id},
+            {
+                "$set": {
+                    "status": WorkflowInstanceStatus.PAUSED.value,
+                    "progress_message": "paused",
+                }
+            },
+        )
+
+        active_instances = manager.list_instances(
+            user_id="user-1",
+            status=[
+                WorkflowInstanceStatus.PENDING,
+                WorkflowInstanceStatus.RUNNING,
+            ],
+        )
+
+        active_ids = {instance.instance_id for instance in active_instances}
+        assert pending_id in active_ids
+        assert running_id in active_ids
+        assert paused_id not in active_ids
+
+    def test_list_instance_status_dicts_returns_summary_payload(self) -> None:
+        """list_instance_status_dicts() should return projected monitor payloads."""
+        manager = WorkflowInstanceManager()
+
+        completed_id = manager.create_instance(
+            "#V#test_workflow",
+            user_id="user-1",
+            org_id="org-1",
+            namespace="user-1/org-1",
+        )
+        active_id = manager.create_instance(
+            "#V#test_workflow",
+            user_id="user-1",
+            org_id="org-1",
+            namespace="user-1/org-1",
+        )
+
+        manager.mark_completed(completed_id, outputs={"result": "done"})
+        collection = manager._get_instances_collection()
+        assert collection is not None
+        collection.update_one(
+            {"instance_id": active_id},
+            {
+                "$set": {
+                    "status": WorkflowInstanceStatus.RUNNING.value,
+                    "progress_message": "running",
+                }
+            },
+        )
+
+        summaries = manager.list_instance_status_dicts(
+            user_id="user-1",
+            status=[WorkflowInstanceStatus.COMPLETED],
+        )
+
+        assert [summary["instance_id"] for summary in summaries] == [completed_id]
+        assert summaries[0]["status"] == WorkflowInstanceStatus.COMPLETED.value
+        assert summaries[0]["has_outputs"] is True
+        assert "workflow_data" not in summaries[0]
+
+    def test_workflow_instance_indexes_include_namespace_status_created(self) -> None:
+        """Workflow instance indexes should cover the monitor namespace/status query."""
+        manager = WorkflowInstanceManager()
+        manager.create_instance(
+            "#V#test_workflow",
+            user_id="user-1",
+            org_id="org-1",
+            namespace="user-1/org-1",
+        )
+
+        collection = manager._get_instances_collection()
+        assert collection is not None
+
+        index_names = {index["name"] for index in collection.list_indexes()}
+        assert "namespace_status_created" in index_names
+
     def test_create_instance_for_event_reuses_existing(self) -> None:
         """create_instance_for_event() should deduplicate by idempotency key."""
         manager = WorkflowInstanceManager()

--- a/tests/backend/test_workflows_routes.py
+++ b/tests/backend/test_workflows_routes.py
@@ -4,6 +4,7 @@ import importlib
 import sys
 import time
 import types
+from typing import cast
 
 import pytest
 from pymongo.errors import PyMongoError
@@ -727,7 +728,7 @@ def test_list_workflow_instances_returns_retryable_degraded_payload_for_mongo_ti
     import src.backend.server.routes.workflows_routes as workflows_routes
 
     manager = types.SimpleNamespace(
-        list_instances=lambda **kwargs: (_ for _ in ()).throw(
+        list_instance_status_dicts=lambda **kwargs: (_ for _ in ()).throw(
             PyMongoError("server selection timeout while reading workflow_instances")
         )
     )
@@ -742,6 +743,78 @@ def test_list_workflow_instances_returns_retryable_degraded_payload_for_mongo_ti
     assert payload["items"] == []
     assert payload["count"] == 0
     assert payload["error"] == "Workflow monitor temporarily unavailable; please retry."
+
+
+def test_list_workflow_instances_accepts_comma_separated_status_filters(
+    monkeypatch, app_client
+):
+    import src.backend.server.routes.workflows_routes as workflows_routes
+
+    captured: dict[str, object] = {}
+
+    def _list_instance_status_dicts(**kwargs):
+        captured.update(kwargs)
+        return [
+            {
+                "instance_id": "inst-1",
+                "workflow_id": "#V#test_workflow",
+                "status": "running",
+                "current_state": "step_a",
+                "step_index": 1,
+                "created_at": "2026-03-20T00:00:00+00:00",
+                "started_at": "2026-03-20T00:00:01+00:00",
+                "completed_at": None,
+                "progress": {
+                    "current": 1,
+                    "total": 3,
+                    "message": "running",
+                    "updated_at": None,
+                },
+                "error": None,
+                "has_outputs": False,
+                "retry_count": 0,
+                "max_retries": 3,
+                "source_event_type": None,
+                "source_event_id": None,
+                "event_idempotency_key": None,
+            }
+        ]
+
+    manager = types.SimpleNamespace(list_instance_status_dicts=_list_instance_status_dicts)
+    monkeypatch.setattr(workflows_routes, "_get_instance_manager", lambda: manager)
+
+    response = app_client.get(
+        "/api/workflows/instances",
+        query_string={
+            "namespace": "#V#user_1@org_1",
+            "status": "pending,running,paused",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["count"] == 1
+    assert payload["items"][0]["instance_id"] == "inst-1"
+    assert captured["namespace"] == "#V#user_1@org_1"
+    statuses = cast(list[workflows_routes.WorkflowInstanceStatus], captured["status"])
+    assert [status.value for status in statuses] == [
+        "pending",
+        "running",
+        "paused",
+    ]
+
+
+def test_list_workflow_instances_rejects_invalid_comma_separated_status_filters(
+    app_client,
+):
+    response = app_client.get(
+        "/api/workflows/instances",
+        query_string={"status": "running,not_a_real_status"},
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert "Invalid status" in payload["error"]
 
 
 def test_workflow_definitions_list_uses_short_ttl_cache(monkeypatch, app_client):


### PR DESCRIPTION
## Summary
- add a lightweight workflow monitor summary query path with shared instance query building
- accept comma-separated status filters on `/api/workflows/instances` and send active statuses from the snapshot fetch
- add targeted backend/frontend regression coverage plus a `namespace/status/created_at` index for the monitor query shape

## Testing
- `pdm run pytest tests/backend/test_durable_workflow_system.py -q`
- `pdm run pytest tests/backend/test_workflows_routes.py -k "list_workflow_instances" -q`
- `npm test -- --runInBand src/frontend/web/von_interface/static/js/test/chatTab.test.js`
- `pdm run pyright src/backend/workflows/durable/models.py src/backend/workflows/durable/instance_manager.py src/backend/server/routes/workflows_routes.py tests/backend/test_durable_workflow_system.py tests/backend/test_workflows_routes.py`
- `npx eslint src/frontend/web/von_interface/static/js/chatTab.js src/frontend/web/von_interface/static/js/test/chatTab.test.js`