### PR TITLE
JVNAUTOSCI-1548 Harden introspection workflow recovery

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -10230,6 +10230,9 @@ def _workflow_create_instance(**kwargs):
     namespace_raw = kwargs.get("namespace")
     inputs_raw = kwargs.get("inputs", {})
     max_retries_raw = kwargs.get("max_retries", 3)
+    source_event_type_raw = kwargs.get("source_event_type")
+    source_event_id_raw = kwargs.get("source_event_id")
+    event_idempotency_key_raw = kwargs.get("event_idempotency_key")
 
     user_id = (
         user_id_raw.strip()
@@ -10247,6 +10250,22 @@ def _workflow_create_instance(**kwargs):
             "invalid_namespace",
             "namespace must be canonical or derivable from user_id/org_id",
         )
+    source_event_type = (
+        source_event_type_raw.strip()
+        if isinstance(source_event_type_raw, str) and source_event_type_raw.strip()
+        else None
+    )
+    source_event_id = (
+        source_event_id_raw.strip()
+        if isinstance(source_event_id_raw, str) and source_event_id_raw.strip()
+        else None
+    )
+    event_idempotency_key = (
+        event_idempotency_key_raw.strip()
+        if isinstance(event_idempotency_key_raw, str)
+        and event_idempotency_key_raw.strip()
+        else None
+    )
     inputs = inputs_raw if isinstance(inputs_raw, dict) else {}
     try:
         max_retries = int(max_retries_raw)
@@ -10264,6 +10283,9 @@ def _workflow_create_instance(**kwargs):
             namespace=namespace,
             inputs=inputs if isinstance(inputs, dict) else {},
             max_retries=max_retries,
+            source_event_type=source_event_type,
+            source_event_id=source_event_id,
+            event_idempotency_key=event_idempotency_key,
         )
         return submission.to_dict()
     except Exception as e:
@@ -21697,6 +21719,9 @@ def build_default_catalogue() -> MethodCatalogue:
                     "namespace": (str, type(None)),
                     "inputs": (dict, type(None)),
                     "max_retries": int,
+                    "source_event_type": (str, type(None)),
+                    "source_event_id": (str, type(None)),
+                    "event_idempotency_key": (str, type(None)),
                 },
                 allow_unknown=True,
                 description="Create a durable workflow instance.",

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -5858,6 +5859,33 @@ class InternalMCPChatOrchestrator:
                 if prompt_text
                 else str(decision_reason or "")[:500]
             )
+            source_event_type = "turn_execution.completion_gate"
+            if request_id:
+                source_event_id = request_id
+            else:
+                identity_seed = "|".join(
+                    part
+                    for part in (
+                        conversation_session_id,
+                        selected_workflow_id,
+                        incident_text,
+                    )
+                    if isinstance(part, str) and part.strip()
+                )
+                identity_digest = hashlib.sha256(
+                    identity_seed.encode("utf-8")
+                ).hexdigest()[:16]
+                session_component = conversation_session_id or "sessionless"
+                source_event_id = f"{session_component}:{identity_digest}"
+            event_idempotency_key = (
+                "orchestrator.workflow_introspection_autotrigger:"
+                f"{self._WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID}:"
+                f"{source_event_type}:{source_event_id}"
+            )
+            if selected_workflow_id:
+                event_idempotency_key = (
+                    f"{event_idempotency_key}:workflow:{selected_workflow_id}"
+                )
             try:
                 create_payload = {
                     "workflow_id": self._WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID,
@@ -5865,6 +5893,9 @@ class InternalMCPChatOrchestrator:
                     "user_id": user_concept_id or "anonymous",
                     "org_id": org_concept_id or "default",
                     "max_retries": 1,
+                    "source_event_type": source_event_type,
+                    "source_event_id": source_event_id,
+                    "event_idempotency_key": event_idempotency_key,
                     "inputs": {
                         "namespace": namespace,
                         "request_id": request_id,
@@ -5886,6 +5917,9 @@ class InternalMCPChatOrchestrator:
                     "status": payload.get("status"),
                     "error": payload.get("error"),
                     "error_code": payload.get("error_code"),
+                    "source_event_type": source_event_type,
+                    "source_event_id": source_event_id,
+                    "event_idempotency_key": event_idempotency_key,
                     "workflow_id": self._WORKFLOW_INTROSPECTION_MAINTENANCE_WORKFLOW_ID,
                 }
                 data["workflow_introspection_autotriggered"] = ok

--- a/src/backend/workflows/durable/startup.py
+++ b/src/backend/workflows/durable/startup.py
@@ -181,7 +181,7 @@ def stop_worker_and_scheduler(timeout: float = 30.0) -> None:
 def recover_orphaned_instances(
     worker_id: str | None = None,
     *,
-    max_stale_hours: int = 24,
+    max_stale_hours: int | None = None,
 ) -> int:
     """Recover instances that were orphaned during previous shutdown.
 
@@ -190,7 +190,8 @@ def recover_orphaned_instances(
 
     Args:
         worker_id: Worker ID for logging (informational only).
-        max_stale_hours: Maximum age of instances to recover.
+        max_stale_hours: Optional maximum age of instances to recover. When
+            omitted, recover all expired running instances regardless of age.
 
     Returns:
         Number of instances recovered.
@@ -206,15 +207,17 @@ def recover_orphaned_instances(
 
     coll = db[WORKFLOW_INSTANCES_COLLECTION]
     now = datetime.now(timezone.utc)
-    stale_cutoff = now - timedelta(hours=max_stale_hours)
-
     # Find running instances with expired locks
+    query: dict[str, Any] = {
+        "status": WorkflowInstanceStatus.RUNNING.value,
+        "lock_expires_at": {"$lt": now},
+    }
+    if isinstance(max_stale_hours, int) and max_stale_hours > 0:
+        stale_cutoff = now - timedelta(hours=max_stale_hours)
+        query["started_at"] = {"$gt": stale_cutoff}
+
     result = coll.update_many(
-        {
-            "status": WorkflowInstanceStatus.RUNNING.value,
-            "lock_expires_at": {"$lt": now},
-            "started_at": {"$gt": stale_cutoff},  # Don't recover very old instances
-        },
+        query,
         {
             "$set": {
                 "status": WorkflowInstanceStatus.PAUSED.value,

--- a/src/backend/workflows/durable/worker.py
+++ b/src/backend/workflows/durable/worker.py
@@ -243,6 +243,34 @@ class DurableWorkflowWorker:
             instance.workflow_id,
         )
 
+        def _best_effort_mark_failed(
+            *,
+            error: str,
+            error_step: str | None = None,
+            increment_retry: bool = True,
+        ) -> None:
+            try:
+                self._instance_manager.mark_failed(
+                    instance_id,
+                    error=error,
+                    error_step=error_step,
+                    increment_retry=increment_retry,
+                )
+            except Exception:
+                logger.exception(
+                    "[durable_worker] Failed to persist FAILED status for %s",
+                    instance_id,
+                )
+
+        def _best_effort_release_lock() -> None:
+            try:
+                self._instance_manager.release_lock(instance_id, self._worker_id)
+            except Exception:
+                logger.exception(
+                    "[durable_worker] Failed to release lock for %s",
+                    instance_id,
+                )
+
         try:
             # Notify started
             if self._on_instance_started:
@@ -255,8 +283,7 @@ class DurableWorkflowWorker:
             definition = self._definition_loader(instance.workflow_id)
             if definition is None:
                 error = f"workflow_definition_not_found:{instance.workflow_id}"
-                self._instance_manager.mark_failed(
-                    instance_id,
+                _best_effort_mark_failed(
                     error=error,
                     increment_retry=False,
                 )
@@ -294,8 +321,7 @@ class DurableWorkflowWorker:
                 logger.info("[durable_worker] Instance %s was cancelled", instance_id)
 
             else:
-                self._instance_manager.mark_failed(
-                    instance_id,
+                _best_effort_mark_failed(
                     error=result.error or "unknown_error",
                     error_step=result.final_state,
                 )
@@ -314,8 +340,7 @@ class DurableWorkflowWorker:
             logger.exception(
                 "[durable_worker] Unexpected error processing %s", instance_id
             )
-            self._instance_manager.mark_failed(
-                instance_id,
+            _best_effort_mark_failed(
                 error=f"worker_exception:{e}",
             )
             if self._on_instance_failed:
@@ -325,10 +350,11 @@ class DurableWorkflowWorker:
                     pass
 
         finally:
-            # Release lock and remove from tracking
-            self._instance_manager.release_lock(instance_id, self._worker_id)
             with self._lock:
                 self._current_instances.pop(instance_id, None)
+            # Stop heartbeat extension before best-effort unlock so a dead worker
+            # thread cannot keep a stale RUNNING row alive after teardown starts.
+            _best_effort_release_lock()
 
     def _heartbeat_loop(self) -> None:
         """Periodically extend locks on active instances."""

--- a/tests/backend/test_durable_workflow_system.py
+++ b/tests/backend/test_durable_workflow_system.py
@@ -25,6 +25,7 @@ from src.backend.workflows.durable.scheduler import (
     _calculate_next_cron_run,
     WorkflowScheduler,
 )
+from src.backend.workflows.durable.startup import recover_orphaned_instances
 from src.backend.workflows.durable.vontology_schedule_repository import (
     CTX_ENABLED_BOOL,
     CTX_NEXT_RUN_EPOCH_MS,
@@ -1148,6 +1149,74 @@ class TestWorkflowInstanceManager:
         # So reset_for_retry should fail
         success = manager.reset_for_retry(instance_id)
         assert success is False  # 1 < 1 is False, can't retry
+
+    def test_recover_orphaned_instances_recovers_old_expired_running_rows(self) -> None:
+        """Startup recovery should pause expired running rows regardless of age."""
+        manager = WorkflowInstanceManager()
+        instance_id = manager.create_instance(
+            "#V#test_workflow",
+            user_id="user-1",
+            org_id="org-1",
+            namespace="user-1/org-1",
+        )
+        claimed = manager.find_and_claim_instance("worker-1")
+        assert claimed is not None
+
+        collection = manager._get_instances_collection()
+        assert collection is not None
+        old_started_at = datetime.now(timezone.utc) - timedelta(days=14)
+        expired_lock_at = datetime.now(timezone.utc) - timedelta(hours=2)
+        collection.update_one(
+            {"instance_id": instance_id},
+            {
+                "$set": {
+                    "started_at": old_started_at,
+                    "lock_expires_at": expired_lock_at,
+                }
+            },
+        )
+
+        recovered = recover_orphaned_instances()
+
+        assert recovered == 1
+        instance = manager.get_instance(instance_id)
+        assert instance is not None
+        assert instance.status == WorkflowInstanceStatus.PAUSED
+        assert instance.locked_by is None
+        assert instance.lock_expires_at is None
+
+    def test_recover_orphaned_instances_honours_optional_stale_cutoff(self) -> None:
+        """Explicit stale-age limits should still support bounded recovery sweeps."""
+        manager = WorkflowInstanceManager()
+        instance_id = manager.create_instance(
+            "#V#test_workflow",
+            user_id="user-1",
+            org_id="org-1",
+            namespace="user-1/org-1",
+        )
+        claimed = manager.find_and_claim_instance("worker-1")
+        assert claimed is not None
+
+        collection = manager._get_instances_collection()
+        assert collection is not None
+        old_started_at = datetime.now(timezone.utc) - timedelta(days=14)
+        expired_lock_at = datetime.now(timezone.utc) - timedelta(hours=2)
+        collection.update_one(
+            {"instance_id": instance_id},
+            {
+                "$set": {
+                    "started_at": old_started_at,
+                    "lock_expires_at": expired_lock_at,
+                }
+            },
+        )
+
+        recovered = recover_orphaned_instances(max_stale_hours=24)
+
+        assert recovered == 0
+        instance = manager.get_instance(instance_id)
+        assert instance is not None
+        assert instance.status == WorkflowInstanceStatus.RUNNING
 
 
 class TestScheduleManagement:

--- a/tests/backend/test_durable_workflow_worker.py
+++ b/tests/backend/test_durable_workflow_worker.py
@@ -1,0 +1,98 @@
+"""Focused worker regression tests for stale-running recovery hardening."""
+
+from __future__ import annotations
+
+from threading import Thread
+from types import SimpleNamespace
+from typing import Any, cast
+
+from src.backend.workflows.action_registry import ActionRegistry
+from src.backend.workflows.durable.models import (
+    WorkflowInstance,
+    WorkflowInstanceStatus,
+)
+from src.backend.workflows.durable.worker import DurableWorkflowWorker
+
+
+class _WorkerManagerStub:
+    def __init__(self) -> None:
+        self.release_lock_calls: list[tuple[str, str]] = []
+        self.mark_failed_calls: list[dict[str, Any]] = []
+        self.release_lock_error: Exception | None = None
+        self.mark_failed_error: Exception | None = None
+
+    def release_lock(self, instance_id: str, worker_id: str) -> bool:
+        self.release_lock_calls.append((instance_id, worker_id))
+        if self.release_lock_error is not None:
+            raise self.release_lock_error
+        return True
+
+    def mark_failed(self, instance_id: str, **kwargs: Any) -> bool:
+        call = {"instance_id": instance_id}
+        call.update(kwargs)
+        self.mark_failed_calls.append(call)
+        if self.mark_failed_error is not None:
+            raise self.mark_failed_error
+        return True
+
+
+def _build_instance() -> WorkflowInstance:
+    instance = WorkflowInstance.create(
+        "#V#workflow_introspection_maintenance_workflow",
+        user_id="#V#user",
+        org_id="#V#org",
+        namespace="#V#user@org",
+    )
+    instance.status = WorkflowInstanceStatus.RUNNING
+    return instance
+
+
+def test_worker_cleanup_removes_tracking_even_if_release_lock_fails() -> None:
+    manager = _WorkerManagerStub()
+    manager.release_lock_error = RuntimeError("mongo_timeout")
+    worker = DurableWorkflowWorker(
+        worker_id="worker-1548",
+        instance_manager=manager,  # type: ignore[arg-type]
+        registry=ActionRegistry(),
+        definition_loader=lambda _workflow_id: None,
+    )
+    instance = _build_instance()
+    worker._current_instances[instance.instance_id] = Thread()
+
+    worker._process_instance(instance)
+
+    assert instance.instance_id not in worker._current_instances
+    assert manager.release_lock_calls == [(instance.instance_id, "worker-1548")]
+    assert manager.mark_failed_calls
+    assert manager.mark_failed_calls[0]["increment_retry"] is False
+
+
+def test_worker_swallows_mark_failed_errors_during_exception_path() -> None:
+    manager = _WorkerManagerStub()
+    manager.mark_failed_error = RuntimeError("mongo_timeout")
+    worker = DurableWorkflowWorker(
+        worker_id="worker-1548",
+        instance_manager=manager,  # type: ignore[arg-type]
+        registry=ActionRegistry(),
+        definition_loader=cast(
+            Any,
+            lambda _workflow_id: SimpleNamespace(workflow_id=_workflow_id),
+        ),
+    )
+    instance = _build_instance()
+    worker._current_instances[instance.instance_id] = Thread()
+    worker._executor = cast(
+        Any,
+        SimpleNamespace(
+            run_durable=lambda *args, **kwargs: (_ for _ in ()).throw(
+                RuntimeError("executor blew up")
+            )
+        ),
+    )
+
+    worker._process_instance(instance)
+
+    assert instance.instance_id not in worker._current_instances
+    assert manager.release_lock_calls == [(instance.instance_id, "worker-1548")]
+    assert manager.mark_failed_calls
+    assert manager.mark_failed_calls[0]["error"].startswith("worker_exception:")

--- a/tests/backend/test_internal_mcp_workflow_tools.py
+++ b/tests/backend/test_internal_mcp_workflow_tools.py
@@ -53,21 +53,49 @@ def _patch_submit_verified_instance_success(monkeypatch) -> None:
             max_retries = int(max_retries_raw)
         except (TypeError, ValueError):
             max_retries = 3
-
-        instance_id = manager.create_instance(
-            workflow_id,
-            user_id=user_id,
-            org_id=org_id,
-            namespace=namespace,
-            inputs=dict(inputs) if isinstance(inputs, dict) else {},
-            max_retries=max_retries,
-            schedule_id=kwargs.get("schedule_id"),
-        )
+        source_event_type = kwargs.get("source_event_type")
+        source_event_id = kwargs.get("source_event_id")
+        event_idempotency_key = kwargs.get("event_idempotency_key")
+        if (
+            isinstance(source_event_type, str)
+            and source_event_type.strip()
+            and isinstance(source_event_id, str)
+            and source_event_id.strip()
+            and isinstance(event_idempotency_key, str)
+            and event_idempotency_key.strip()
+        ):
+            instance_id, created_new = manager.create_instance_for_event(
+                workflow_id=workflow_id,
+                user_id=user_id,
+                org_id=org_id,
+                namespace=namespace,
+                event_idempotency_key=event_idempotency_key.strip(),
+                source_event_type=source_event_type.strip(),
+                source_event_id=source_event_id.strip(),
+                inputs=dict(inputs) if isinstance(inputs, dict) else {},
+                schedule_id=kwargs.get("schedule_id"),
+                max_retries=max_retries,
+            )
+            status = "created" if created_new else "reused"
+        else:
+            instance_id = manager.create_instance(
+                workflow_id,
+                user_id=user_id,
+                org_id=org_id,
+                namespace=namespace,
+                inputs=dict(inputs) if isinstance(inputs, dict) else {},
+                max_retries=max_retries,
+                schedule_id=kwargs.get("schedule_id"),
+                source_event_type=source_event_type,
+                source_event_id=source_event_id,
+                event_idempotency_key=event_idempotency_key,
+            )
+            status = "created"
 
         return WorkflowInstanceSubmissionResult(
             success=True,
             workflow_id=workflow_id,
-            status="created",
+            status=status,
             instance_id=instance_id,
             verification={
                 "preflight_passed": True,
@@ -129,6 +157,7 @@ class _StubInstance:
         self.max_retries = max_retries
         self.source_event_type: str | None = None
         self.source_event_id: str | None = None
+        self.event_idempotency_key: str | None = None
         self.created_at = datetime.now(timezone.utc)
 
     def to_status_dict(self) -> dict[str, object]:
@@ -145,6 +174,7 @@ class _StubInstance:
 class _StubWorkflowManager:
     def __init__(self) -> None:
         self.instances: dict[str, _StubInstance] = {}
+        self._event_index: dict[str, str] = {}
         self._counter = 0
         self.bindings: dict[tuple[str, str], EventWorkflowBinding] = {}
 
@@ -157,7 +187,7 @@ class _StubWorkflowManager:
         namespace: str,
         inputs: dict[str, object] | None = None,
         max_retries: int = 3,
-        **_kwargs,
+        **kwargs,
     ) -> str:
         self._counter += 1
         instance_id = f"#V#wf_instance_{self._counter}"
@@ -170,7 +200,53 @@ class _StubWorkflowManager:
             inputs=dict(inputs or {}),
             max_retries=max_retries,
         )
+        instance = self.instances[instance_id]
+        source_event_type = kwargs.get("source_event_type")
+        source_event_id = kwargs.get("source_event_id")
+        event_idempotency_key = kwargs.get("event_idempotency_key")
+        if isinstance(source_event_type, str) and source_event_type.strip():
+            instance.source_event_type = source_event_type.strip()
+        if isinstance(source_event_id, str) and source_event_id.strip():
+            instance.source_event_id = source_event_id.strip()
+        if (
+            isinstance(event_idempotency_key, str)
+            and event_idempotency_key.strip()
+        ):
+            instance.event_idempotency_key = event_idempotency_key.strip()
         return instance_id
+
+    def create_instance_for_event(
+        self,
+        workflow_id: str,
+        *,
+        user_id: str,
+        org_id: str,
+        namespace: str,
+        event_idempotency_key: str,
+        source_event_type: str,
+        source_event_id: str,
+        inputs: dict[str, object] | None = None,
+        schedule_id: str | None = None,
+        max_retries: int = 3,
+    ) -> tuple[str, bool]:
+        existing_instance_id = self._event_index.get(event_idempotency_key)
+        if isinstance(existing_instance_id, str):
+            return existing_instance_id, False
+
+        instance_id = self.create_instance(
+            workflow_id,
+            user_id=user_id,
+            org_id=org_id,
+            namespace=namespace,
+            inputs=inputs,
+            max_retries=max_retries,
+            schedule_id=schedule_id,
+            source_event_type=source_event_type,
+            source_event_id=source_event_id,
+            event_idempotency_key=event_idempotency_key,
+        )
+        self._event_index[event_idempotency_key] = instance_id
+        return instance_id, True
 
     def list_instances(
         self,
@@ -949,6 +1025,46 @@ def test_workflow_create_instance_normalises_inputs(monkeypatch):
     assert instance.namespace == "#V#explicit_ns"
     assert instance.inputs == {}
     assert instance.max_retries == 50
+
+
+def test_workflow_create_instance_preserves_event_idempotency_submission(monkeypatch):
+    manager = _StubWorkflowManager()
+    _patch_submit_verified_instance_success(monkeypatch)
+    workflow_id = "#V#enrichment_workflow"
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.WorkflowInstanceManager",
+        lambda: manager,
+    )
+    gateway = _build_gateway()
+
+    payload = {
+        "workflow_id": workflow_id,
+        "user_id": "#V#user",
+        "org_id": "#V#org",
+        "namespace": "#V#user@org",
+        "source_event_type": "turn_execution.completion_gate",
+        "source_event_id": "req-1548",
+        "event_idempotency_key": "evt:turn_execution.completion_gate:req-1548",
+        "inputs": {"request_id": "req-1548"},
+    }
+
+    created = gateway.invoke("workflow_create_instance", payload).payload
+    reused = gateway.invoke("workflow_create_instance", payload).payload
+
+    assert created.get("success") is True
+    assert reused.get("success") is True
+    assert created.get("instance_id") == reused.get("instance_id")
+    assert reused.get("status") == "reused"
+
+    instance_id = created.get("instance_id")
+    assert isinstance(instance_id, str)
+    instance = manager.instances[instance_id]
+    assert instance.source_event_type == "turn_execution.completion_gate"
+    assert instance.source_event_id == "req-1548"
+    assert (
+        instance.event_idempotency_key
+        == "evt:turn_execution.completion_gate:req-1548"
+    )
 
 
 def test_workflow_create_instance_rejects_unrunnable_workflow(monkeypatch):

--- a/tests/backend/test_orchestrator_turn_execution_gate.py
+++ b/tests/backend/test_orchestrator_turn_execution_gate.py
@@ -832,6 +832,11 @@ def test_turn_completion_gate_autotriggers_workflow_introspection(monkeypatch) -
     assert payload.get("workflow_id") == (
         "#V#workflow_introspection_maintenance_workflow"
     )
+    assert payload.get("source_event_type") == "turn_execution.completion_gate"
+    assert payload.get("source_event_id") == "req-introspection-1"
+    event_idempotency_key = payload.get("event_idempotency_key")
+    assert isinstance(event_idempotency_key, str)
+    assert "req-introspection-1" in event_idempotency_key
     inputs = payload.get("inputs")
     assert isinstance(inputs, dict)
     assert inputs.get("request_id") == "req-introspection-1"


### PR DESCRIPTION
## Summary
- thread source-event provenance and event idempotency through workflow_create_instance
- make the completion-gate introspection autotrigger submit a deterministic per-turn idempotency key
- harden durable worker teardown and startup orphan recovery so stale unning rows do not accumulate after store failures
- add regression coverage for idempotent submissions, stale-orphan recovery, and worker cleanup

## Validation
- pdm run pytest tests/backend/test_orchestrator_turn_execution_gate.py -k autotriggers_workflow_introspection -q
- pdm run pytest tests/backend/test_internal_mcp_workflow_tools.py -k event_idempotency_submission -q
- pdm run pytest tests/backend/test_durable_workflow_system.py -k "recover_orphaned_instances or create_instance_for_event_reuses_existing or list_instances_by_source_event_filters" -q
- pdm run pytest tests/backend/test_durable_workflow_worker.py -q
- pdm run pytest tests/backend/test_internal_mcp_catalogue_builds.py -q
- pdm run pytest tests/backend/test_utils_flask_orchestrator_startup.py -q
- pdm run pyright src/backend/integrations/internal_mcp/catalogue.py src/backend/integrations/internal_mcp/orchestrator.py src/backend/workflows/durable/startup.py src/backend/workflows/durable/worker.py tests/backend/test_durable_workflow_system.py tests/backend/test_internal_mcp_workflow_tools.py tests/backend/test_orchestrator_turn_execution_gate.py tests/backend/test_durable_workflow_worker.py

## Notes
- 	ests/backend/test_orchestrator_durable_instance_telemetry.py timed out during collection/startup even when split to single tests, so it was not validated in this run.