### PR TITLE
JVNAUTOSCI-1549: harden workflow discovery and handoff telemetry

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -358,6 +358,8 @@ For live chat progress payloads used by workflow-aware thinking-card rendering:
 - `workflow_stage_path.workflow_id` SHOULD represent the mapped execution-stage consensus when the observed stage path yields one unambiguous workflow, and SHOULD fall back to the selected-route hint only when the stage path itself carries no workflow membership;
 - `workflow_stage_path.observed_workflow_ids` SHOULD expose the workflow IDs actually observed in the mapped stage path so route selection (`selected_workflow_id`) and execution-stage membership can be compared without ambiguity;
 - workflow discovery SHOULD emit an explicit completion payload even when zero workflows match, so the UI can render a visible "no applicable workflow found" step rather than silently omitting discovery outcome;
+- workflow discovery payloads SHOULD remain explicit even when both routing matches and near-match candidates are empty, so selector fallback, gap-recovery, and turn-execution diagnostics can distinguish "discovery ran and found nothing" from "discovery did not run";
+- the authoritative workflow-capability search substrate SHOULD self-populate from Vontology-authored workflow descriptions when deferred startup indexing is not yet ready, rather than silently collapsing routed turns to builtin-only selector candidates;
 - live workflow-dispatch progress SHOULD expose `selected_workflow_id` and SHOULD expose a human-readable `selected_workflow_name` when available;
 - selector metadata such as `workflow_selector_verdict` and `workflow_selector_source` SHOULD be preserved in the live payload so the UI can explain why a workflow route was chosen;
 - selector fail-closed diagnostics such as `selector_prompt_unavailable` or
@@ -374,6 +376,7 @@ For workflow-governed conversation turns:
 - completion safety MUST be determined by completion-gate outputs, not by whether a response text was produced;
 - if `completion_gate_safe_to_claim_completion=false`, the orchestrator MUST NOT surface the turn as `completed`;
 - unresolved required effects or inconclusive mutation/representation verification MUST produce `follow_up_required` or `failed`, with explicit blocking effect IDs and failure codes preserved in diagnostics;
+- once tool-pipeline contract resolution succeeds, the runtime MUST either emit a `workflow_handoff` start boundary or emit a more local failed handoff boundary with blocker reason/error metadata; `tool_dispatch_not_started` alone is not a sufficient terminal explanation when a narrower root cause is available;
 - UI/progress surfaces MUST derive terminal state from authoritative completion status (`completed`, `follow_up_required`, `failed`, `cancelled`) rather than from liveness/heartbeat signals.
 
 ### 7.4 Workflow Episode Continuation and Repair Semantics (JVNAUTOSCI-1380)

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -25705,128 +25705,195 @@ class InternalMCPChatOrchestrator:
                 "preferred_workflow_id": selected_workflow_id_text,
             },
         )
-        tc_env = WorkflowEnvironment(
-            llm_client=llm_client,
-            gateway=self._gateway,
-            model=model,
-            user_namespace=user_namespace,
-            auxiliary_system_prompt=auxiliary_system_prompt,
-            max_tool_invocations=self._max_tool_invocations,
-            max_tool_result_chars=self._max_tool_result_chars,
-            max_tool_result_field_chars=self._max_tool_result_field_chars,
-            default_gmail_profile=gmail_profile or self._default_gmail_profile,
-        )
-        auto_proceed_minimal_imposition_enabled = (
-            self._get_auto_proceed_minimal_imposition_enabled()
-        )
+        tool_pipeline_handoff_started = False
         try:
-            aux_llm_calls.append(
-                {
-                    "type": "auto_proceed_minimal_imposition_setting",
-                    "enabled": bool(auto_proceed_minimal_imposition_enabled),
-                    "source": "settings",
-                }
+            tc_env = WorkflowEnvironment(
+                llm_client=llm_client,
+                gateway=self._gateway,
+                model=model,
+                user_namespace=user_namespace,
+                auxiliary_system_prompt=auxiliary_system_prompt,
+                max_tool_invocations=self._max_tool_invocations,
+                max_tool_result_chars=self._max_tool_result_chars,
+                max_tool_result_field_chars=self._max_tool_result_field_chars,
+                default_gmail_profile=gmail_profile or self._default_gmail_profile,
             )
-        except Exception:
-            pass
+            auto_proceed_minimal_imposition_enabled = (
+                self._get_auto_proceed_minimal_imposition_enabled()
+            )
+            try:
+                aux_llm_calls.append(
+                    {
+                        "type": "auto_proceed_minimal_imposition_setting",
+                        "enabled": bool(auto_proceed_minimal_imposition_enabled),
+                        "source": "settings",
+                    }
+                )
+            except Exception:
+                pass
 
-        routing_info_payload = asdict(routing_info) if routing_info is not None else None
-        tc_data: dict[str, Any] = {
-            # Inputs.
-            "prompt": prompt,
-            "prompt_for_requirements": effective_prompt_for_routing,
-            "prompt_requirement_url_policy": dict(routing_url_requirement),
-            "augmented_context": augmented_context,
-            "policy_state": policy_state,
-            "registry_snapshot": registry_snapshot,
-            "user_concept_id": user_concept_id,
-            "org_concept_id": org_concept_id,
-            "conversation_session_id": conversation_session_id,
-            "turn_id": turn_id,
-            "recent_user_prompts": recent_user_prompts,
-            "write_intent_context_reused": bool(
-                isinstance(write_intent_rehydrate_telemetry, Mapping)
-                and write_intent_rehydrate_telemetry.get("reused")
-            ),
-            "gmail_profile": gmail_profile or self._default_gmail_profile,
-            "workflow_discovery_result": workflow_discovery_result,
-            "workflow_routing": routing_info_payload,
-            "auto_proceed_minimal_imposition_enabled": bool(
-                auto_proceed_minimal_imposition_enabled
-            ),
-            "workflow_episode_source": "chat_turn_workflow",
-            "workflow_episode_stage": "tool_calling",
-            # Closures from run().
-            "model_for_stage": _model_for_stage,
-            "record_llm_call": _record_llm_call,
-            "emit_progress": _emit_progress_local,
-            "emit_phase_transition": _emit_phase_transition_local,
-            "check_cancellation": _check_cancellation_local,
-            "build_parse_error_result": _build_tool_call_parse_error_result,
-            "build_validation_error_result": _build_tool_call_validation_error_result,
-            # Shared mutable state.
-            "aux_llm_calls": aux_llm_calls,
-            "llm_calls": llm_calls,
-            "invocations": [],
-            "tool_messages": [],
-            # Inter-handler state initialised here; handlers override.
-            "iteration_count": 0,
-            "allowed_write_tools": set(),
-            # Shared missing-tool-call retry budget for the full turn across
-            # both planning and backfill recovery passes.
-            "missing_tool_call_retry_attempts": 0,
-            "missing_tool_call_retry_budget": int(
-                self._max_missing_tool_call_retries_per_turn
-            ),
-            # Completion-gate repeat-until-complete loop settings.
-            "completion_gate_repeat_iteration": False,
-            "completion_gate_loop_retry_reason": None,
-            "completion_gate_loop_stop_reason": None,
-            "completion_gate_loop_attempts": 0,
-            "completion_gate_loop_max_attempts": int(
-                self._completion_gate_loop_max_attempts
-            ),
-            "completion_gate_loop_started_monotonic": float(time.monotonic()),
-            "completion_gate_loop_elapsed_ms": 0,
-            "completion_gate_loop_max_elapsed_ms": int(
-                self._completion_gate_loop_max_elapsed_ms
-            ),
-            "completion_gate_loop_no_progress_streak": 0,
-            "completion_gate_loop_no_progress_limit": int(
-                self._completion_gate_loop_no_progress_limit
-            ),
-            "completion_gate_loop_stall_events": 0,
-            "completion_gate_loop_stall_elapsed_ms": 0,
-            "completion_gate_loop_stall_max_elapsed_ms": int(
-                self._completion_gate_loop_stall_max_elapsed_ms
-            ),
-            "completion_gate_loop_stall_started_monotonic": None,
-            "completion_gate_loop_last_invocation_count": 0,
-            "completion_gate_loop_last_blocking_signature": "",
-            "completion_gate_escalation_signal": False,
-            "completion_gate_escalation_reason": None,
-        }
+            routing_info_payload = (
+                asdict(routing_info) if routing_info is not None else None
+            )
+            tc_data: dict[str, Any] = {
+                # Inputs.
+                "prompt": prompt,
+                "prompt_for_requirements": effective_prompt_for_routing,
+                "prompt_requirement_url_policy": dict(routing_url_requirement),
+                "augmented_context": augmented_context,
+                "policy_state": policy_state,
+                "registry_snapshot": registry_snapshot,
+                "user_concept_id": user_concept_id,
+                "org_concept_id": org_concept_id,
+                "conversation_session_id": conversation_session_id,
+                "turn_id": turn_id,
+                "recent_user_prompts": recent_user_prompts,
+                "write_intent_context_reused": bool(
+                    isinstance(write_intent_rehydrate_telemetry, Mapping)
+                    and write_intent_rehydrate_telemetry.get("reused")
+                ),
+                "gmail_profile": gmail_profile or self._default_gmail_profile,
+                "workflow_discovery_result": workflow_discovery_result,
+                "workflow_routing": routing_info_payload,
+                "auto_proceed_minimal_imposition_enabled": bool(
+                    auto_proceed_minimal_imposition_enabled
+                ),
+                "workflow_episode_source": "chat_turn_workflow",
+                "workflow_episode_stage": "tool_calling",
+                # Closures from run().
+                "model_for_stage": _model_for_stage,
+                "record_llm_call": _record_llm_call,
+                "emit_progress": _emit_progress_local,
+                "emit_phase_transition": _emit_phase_transition_local,
+                "check_cancellation": _check_cancellation_local,
+                "build_parse_error_result": _build_tool_call_parse_error_result,
+                "build_validation_error_result": _build_tool_call_validation_error_result,
+                # Shared mutable state.
+                "aux_llm_calls": aux_llm_calls,
+                "llm_calls": llm_calls,
+                "invocations": [],
+                "tool_messages": [],
+                # Inter-handler state initialised here; handlers override.
+                "iteration_count": 0,
+                "allowed_write_tools": set(),
+                # Shared missing-tool-call retry budget for the full turn across
+                # both planning and backfill recovery passes.
+                "missing_tool_call_retry_attempts": 0,
+                "missing_tool_call_retry_budget": int(
+                    self._max_missing_tool_call_retries_per_turn
+                ),
+                # Completion-gate repeat-until-complete loop settings.
+                "completion_gate_repeat_iteration": False,
+                "completion_gate_loop_retry_reason": None,
+                "completion_gate_loop_stop_reason": None,
+                "completion_gate_loop_attempts": 0,
+                "completion_gate_loop_max_attempts": int(
+                    self._completion_gate_loop_max_attempts
+                ),
+                "completion_gate_loop_started_monotonic": float(time.monotonic()),
+                "completion_gate_loop_elapsed_ms": 0,
+                "completion_gate_loop_max_elapsed_ms": int(
+                    self._completion_gate_loop_max_elapsed_ms
+                ),
+                "completion_gate_loop_no_progress_streak": 0,
+                "completion_gate_loop_no_progress_limit": int(
+                    self._completion_gate_loop_no_progress_limit
+                ),
+                "completion_gate_loop_stall_events": 0,
+                "completion_gate_loop_stall_elapsed_ms": 0,
+                "completion_gate_loop_stall_max_elapsed_ms": int(
+                    self._completion_gate_loop_stall_max_elapsed_ms
+                ),
+                "completion_gate_loop_stall_started_monotonic": None,
+                "completion_gate_loop_last_invocation_count": 0,
+                "completion_gate_loop_last_blocking_signature": "",
+                "completion_gate_escalation_signal": False,
+                "completion_gate_escalation_reason": None,
+            }
 
-        _emit_dispatch_boundary(
-            boundary="workflow_handoff",
-            status="started",
-            selected_execution_mode="tool_pipeline",
-            selected_workflow_id=selected_workflow_id_text,
-            dispatch_workflow_id=tool_dispatch_workflow_id,
-        )
-        tc_result = self.execute_workflow(
-            tool_dispatch_workflow_id,
-            data=tc_data,
-            llm_client=llm_client,
-            model=model,
-            user_namespace=user_namespace,
-            auxiliary_system_prompt=auxiliary_system_prompt,
-            trace=trace if trace_enabled else None,
-            environment=tc_env,
-            conversation_session_id=conversation_session_id,
-            turn_id=turn_id,
-            episode_source="chat_turn_workflow",
-        )
+            _emit_dispatch_boundary(
+                boundary="workflow_handoff",
+                status="started",
+                selected_execution_mode="tool_pipeline",
+                selected_workflow_id=selected_workflow_id_text,
+                dispatch_workflow_id=tool_dispatch_workflow_id,
+            )
+            tool_pipeline_handoff_started = True
+            tc_result = self.execute_workflow(
+                tool_dispatch_workflow_id,
+                data=tc_data,
+                llm_client=llm_client,
+                model=model,
+                user_namespace=user_namespace,
+                auxiliary_system_prompt=auxiliary_system_prompt,
+                trace=trace if trace_enabled else None,
+                environment=tc_env,
+                conversation_session_id=conversation_session_id,
+                turn_id=turn_id,
+                episode_source="chat_turn_workflow",
+            )
+        except Exception as exc:
+            failure_reason = (
+                "tool_pipeline_execution_exception"
+                if tool_pipeline_handoff_started
+                else "tool_pipeline_setup_exception"
+            )
+            if not tool_pipeline_handoff_started:
+                _emit_dispatch_boundary(
+                    boundary="workflow_handoff",
+                    status="failed",
+                    selected_execution_mode="tool_pipeline",
+                    selected_workflow_id=selected_workflow_id_text,
+                    dispatch_workflow_id=tool_dispatch_workflow_id,
+                    extra={
+                        "reason": failure_reason,
+                        "error_class": type(exc).__name__,
+                        "error": str(exc),
+                    },
+                )
+            _emit_dispatch_boundary(
+                boundary="workflow_terminal",
+                status="failed",
+                selected_execution_mode="tool_pipeline",
+                selected_workflow_id=selected_workflow_id_text,
+                dispatch_workflow_id=tool_dispatch_workflow_id,
+                completed=False,
+                extra={
+                    "reason": failure_reason,
+                    "error_class": type(exc).__name__,
+                    "error": str(exc),
+                },
+            )
+            self._logger.warning(
+                "[mcp_orchestrator] Tool-pipeline %s for %s failed: %s",
+                "execution" if tool_pipeline_handoff_started else "setup",
+                tool_dispatch_workflow_id,
+                exc,
+                exc_info=True,
+            )
+            result = OrchestratorResult(
+                response_text=(
+                    "I attempted to use tools but the tool-pipeline handoff failed "
+                    "before tool execution could begin. Please try again or report "
+                    "this issue."
+                ),
+                extra_messages=(),
+                tool_invocations=(),
+                aux_llm_calls=tuple(aux_llm_calls),
+                llm_calls=tuple(llm_calls),
+                llm_usage=_aggregate_usage_total(),
+                orchestrator_duration_ms=_orchestrator_duration_ms(),
+                workflow_routing=routing_info,
+                render_plan=_result_render_plan(),
+            )
+            _finalise_selection_experience_record(
+                result=result,
+                outcome="failed",
+                final_state=failure_reason,
+                completed=False,
+            )
+            _persist_trace(status="completed")
+            return result
         if tc_result is None:
             _emit_dispatch_boundary(
                 boundary="workflow_terminal",

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -242,6 +242,8 @@ _TOOL_EXECUTION_FAILURE_REASON_MAP = {
     "missing_tool_call_parse_error": "Tool call parsing failed before any tool execution occurred.",
     "missing_tool_call_retry_exhausted": "Tool-call recovery exhausted retries without executing a tool.",
     "missing_tool_call_unresolved": "Tool-calling was selected but no executable tool call was produced.",
+    "tool_pipeline_setup_exception": "Tool-pipeline setup failed before the first action could start.",
+    "tool_pipeline_execution_exception": "Tool-pipeline execution failed before the first tool action completed.",
 }
 
 _REPRESENTATION_CONTRACT_SCHEMA_VERSION = "required_effects_contract.v1"
@@ -1194,6 +1196,12 @@ def build_workflow_routing_diagnostics(
             "workflow_handoff_started": bool(
                 execution_summary_payload.get("workflow_handoff_started")
             ),
+            "workflow_handoff_failure_reason": _safe_str(
+                execution_summary_payload.get("workflow_handoff_failure_reason")
+            ),
+            "workflow_handoff_failure_error_class": _safe_str(
+                execution_summary_payload.get("workflow_handoff_failure_error_class")
+            ),
             "dispatch_terminal_status": _safe_str(
                 execution_summary_payload.get("dispatch_terminal_status")
             ),
@@ -1207,6 +1215,12 @@ def build_workflow_routing_diagnostics(
                     bool,
                 )
                 else None
+            ),
+            "dispatch_terminal_failure_reason": _safe_str(
+                execution_summary_payload.get("dispatch_terminal_failure_reason")
+            ),
+            "dispatch_terminal_failure_error_class": _safe_str(
+                execution_summary_payload.get("dispatch_terminal_failure_error_class")
             ),
             "tool_route_selected": bool(
                 execution_summary_payload.get("tool_route_selected")
@@ -1522,9 +1536,13 @@ def _summarise_tool_execution_context(
     contract_resolution_status = ""
     execution_mode_selected_explicitly = False
     workflow_handoff_started = False
+    workflow_handoff_failure_reason = ""
+    workflow_handoff_failure_error_class = ""
     dispatch_terminal_status = ""
     dispatch_terminal_final_state = ""
     dispatch_terminal_completed: bool | None = None
+    dispatch_terminal_failure_reason = ""
+    dispatch_terminal_failure_error_class = ""
     for entry in aux_llm_calls or ():
         if not isinstance(entry, Mapping):
             continue
@@ -1560,6 +1578,11 @@ def _summarise_tool_execution_context(
             contract_resolution_status = status
         elif boundary == "workflow_handoff" and status == "started":
             workflow_handoff_started = True
+        elif boundary == "workflow_handoff" and status == "failed":
+            workflow_handoff_failure_reason = _safe_str(event.get("reason")) or ""
+            workflow_handoff_failure_error_class = (
+                _safe_str(event.get("error_class")) or ""
+            )
         elif boundary == "workflow_terminal":
             if status:
                 dispatch_terminal_status = status
@@ -1569,6 +1592,13 @@ def _summarise_tool_execution_context(
             completed_value = event.get("completed")
             if isinstance(completed_value, bool):
                 dispatch_terminal_completed = completed_value
+            if status == "failed":
+                dispatch_terminal_failure_reason = (
+                    _safe_str(event.get("reason")) or ""
+                )
+                dispatch_terminal_failure_error_class = (
+                    _safe_str(event.get("error_class")) or ""
+                )
 
     invocation_count = len(serialised_invocations)
     observed_started_count = max(progress_tools_started, tool_call_start_event_count)
@@ -1615,6 +1645,8 @@ def _summarise_tool_execution_context(
     ):
         failure_codes.append("missing_tool_call_unresolved")
     if tool_route_selected and observed_executed_count <= 0:
+        if workflow_handoff_failure_reason:
+            failure_codes.append(workflow_handoff_failure_reason)
         if contract_resolution_status == "missing":
             failure_codes.append("tool_dispatch_contract_unresolved")
         if dispatch_terminal_status == "missing":
@@ -1624,8 +1656,12 @@ def _summarise_tool_execution_context(
         elif not workflow_handoff_started and selected_execution_mode == "tool_pipeline":
             failure_codes.append("tool_dispatch_not_started")
         elif workflow_handoff_started and observed_started_count <= 0:
+            if dispatch_terminal_failure_reason:
+                failure_codes.append(dispatch_terminal_failure_reason)
             failure_codes.append("tool_dispatch_handoff_zero_execution")
         elif dispatch_terminal_status == "failed":
+            if dispatch_terminal_failure_reason:
+                failure_codes.append(dispatch_terminal_failure_reason)
             failure_codes.append("tool_dispatch_failed_before_tool_execution")
 
     deduped_failure_codes: list[str] = []
@@ -1671,9 +1707,17 @@ def _summarise_tool_execution_context(
         "dispatch_event_count": len(dispatch_boundary_events),
         "contract_resolution_status": contract_resolution_status or None,
         "workflow_handoff_started": workflow_handoff_started,
+        "workflow_handoff_failure_reason": workflow_handoff_failure_reason or None,
+        "workflow_handoff_failure_error_class": (
+            workflow_handoff_failure_error_class or None
+        ),
         "dispatch_terminal_status": dispatch_terminal_status or None,
         "dispatch_terminal_final_state": dispatch_terminal_final_state or None,
         "dispatch_terminal_completed": dispatch_terminal_completed,
+        "dispatch_terminal_failure_reason": dispatch_terminal_failure_reason or None,
+        "dispatch_terminal_failure_error_class": (
+            dispatch_terminal_failure_error_class or None
+        ),
         "last_successful_boundary": last_successful_boundary or None,
         "planned_count": planned_count,
         "started_count": observed_started_count,

--- a/src/backend/services/workflow_capability_service.py
+++ b/src/backend/services/workflow_capability_service.py
@@ -55,14 +55,54 @@ _STOP_WORDS = frozenset({
     "of", "with", "by", "is", "was", "are", "were", "be", "been", "being",
     "it", "its", "this", "that", "from", "as", "not", "no", "do", "does",
 })
+_CAPABILITY_INDEX_REBUILD_MIN_INTERVAL_SECONDS = 30.0
+
+_INDEX_REBUILD_LOCK = Lock()
+_INDEX_REBUILD_STATE: Dict[str, float | int] = {
+    "last_attempt_monotonic": 0.0,
+    "last_success_monotonic": 0.0,
+    "last_built_size": 0,
+}
+
+
+def _normalise_token_variants(token: str) -> List[str]:
+    """Return stable lexical variants for simple singular/plural matching."""
+    cleaned = str(token or "").strip().lower()
+    if not cleaned:
+        return []
+
+    variants = [cleaned]
+    singular = cleaned
+    if cleaned.endswith("ies") and len(cleaned) > 4:
+        singular = cleaned[:-3] + "y"
+    elif (
+        (cleaned.endswith("es") and len(cleaned) > 4 and cleaned[-3:-2] in {"s", "x", "z"})
+        or cleaned.endswith(("ches", "shes"))
+    ):
+        singular = cleaned[:-2]
+    elif (
+        cleaned.endswith("s")
+        and len(cleaned) > 4
+        and not cleaned.endswith(("ss", "us", "is"))
+    ):
+        singular = cleaned[:-1]
+
+    singular = singular.strip()
+    if singular and singular not in variants:
+        variants.append(singular)
+
+    return variants
 
 
 def _tokenise(text: str) -> List[str]:
     """Tokenise text into lowercase terms, filtering stop words."""
-    return [
-        tok for tok in _TOKENISE_RE.findall(text.lower())
-        if tok not in _STOP_WORDS and len(tok) > 1
-    ]
+    tokens: list[str] = []
+    for raw_token in _TOKENISE_RE.findall(text.lower()):
+        for token in _normalise_token_variants(raw_token):
+            if token in _STOP_WORDS or len(token) <= 1:
+                continue
+            tokens.append(token)
+    return tokens
 
 
 @dataclass
@@ -428,8 +468,100 @@ def get_workflow_capability_index() -> WorkflowCapabilityIndex:
         return _global_index
 
 
+def ensure_workflow_capability_index_populated(
+    *,
+    force_refresh: bool = False,
+) -> WorkflowCapabilityIndex:
+    """Build the shared capability index on demand from authoritative workflows.
+
+    Workflow discovery can run before deferred registry background work has
+    populated the search substrate. Building on demand keeps routed turns from
+    silently degrading to builtin-only candidates.
+    """
+
+    index = get_workflow_capability_index()
+    if index.size > 0 and not force_refresh:
+        return index
+
+    now = time.monotonic()
+    with _INDEX_REBUILD_LOCK:
+        index = get_workflow_capability_index()
+        if index.size > 0 and not force_refresh:
+            return index
+
+        last_attempt = float(_INDEX_REBUILD_STATE.get("last_attempt_monotonic", 0.0))
+        if (
+            not force_refresh
+            and last_attempt > 0.0
+            and (now - last_attempt) < _CAPABILITY_INDEX_REBUILD_MIN_INTERVAL_SECONDS
+        ):
+            return index
+
+        _INDEX_REBUILD_STATE["last_attempt_monotonic"] = now
+
+        try:
+            from ..workflows.durable.registry_factory import (
+                build_durable_workflow_registry_read_only,
+            )
+            from ..workflows.vontology_loader import batch_fetch_workflow_purposes
+            from ..workflows.workflow_registry import LazyWorkflowRegistration
+
+            registry = build_durable_workflow_registry_read_only(defer_parity_work=True)
+            lazy_ids = list(registry.lazy_workflow_ids())
+            if lazy_ids:
+                purposes = batch_fetch_workflow_purposes(lazy_ids)
+                for workflow_id, purpose in purposes.items():
+                    registration = registry.peek_registration(workflow_id)
+                    if (
+                        isinstance(registration, LazyWorkflowRegistration)
+                        and not registration.purpose
+                        and isinstance(purpose, str)
+                        and purpose.strip()
+                    ):
+                        registration.purpose = purpose.strip()
+
+            if force_refresh:
+                reset_workflow_capability_index()
+                index = get_workflow_capability_index()
+
+            count = index.index_from_registry(registry)
+            _INDEX_REBUILD_STATE["last_success_monotonic"] = time.monotonic()
+            _INDEX_REBUILD_STATE["last_built_size"] = count
+            logger.info(
+                "[workflow_capability_index] On-demand build completed with %d entries.",
+                count,
+            )
+        except Exception as exc:
+            logger.warning("workflow_capability_index_on_demand_build_failed: %s", exc)
+
+        return get_workflow_capability_index()
+
+
+def search_workflow_capabilities(
+    query: str,
+    *,
+    max_results: int = 10,
+    min_score: float = 0.0,
+) -> List[WorkflowCapabilityMatch]:
+    """Search workflow capabilities, rebuilding the index on bounded misses."""
+
+    index = ensure_workflow_capability_index_populated()
+    results = index.search(query, max_results=max_results, min_score=min_score)
+    if results:
+        return results
+
+    refreshed = ensure_workflow_capability_index_populated(force_refresh=True)
+    if refreshed is index and refreshed.size == 0:
+        return []
+    return refreshed.search(query, max_results=max_results, min_score=min_score)
+
+
 def reset_workflow_capability_index() -> None:
     """Reset the global index.  Intended for tests."""
     global _global_index
     with _global_index_lock:
         _global_index = None
+    with _INDEX_REBUILD_LOCK:
+        _INDEX_REBUILD_STATE["last_attempt_monotonic"] = 0.0
+        _INDEX_REBUILD_STATE["last_success_monotonic"] = 0.0
+        _INDEX_REBUILD_STATE["last_built_size"] = 0

--- a/src/backend/services/workflow_discovery_service.py
+++ b/src/backend/services/workflow_discovery_service.py
@@ -34,7 +34,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from .file_copy_reference_service import extract_file_copy_concept_ids_from_text
 from .file_copy_typing_service import build_file_copy_typing_context
 from .arxiv_paper_link_service import extract_arxiv_id_candidates
-from .workflow_capability_service import get_workflow_capability_index
+from .workflow_capability_service import search_workflow_capabilities
 
 logger = logging.getLogger(__name__)
 
@@ -922,11 +922,11 @@ def _search_workflow_capabilities(
     fallback paths.
     """
     try:
-        index = get_workflow_capability_index()
-        if index.size == 0:
-            return []
-
-        cap_matches = index.search(query, max_results=limit, min_score=0.01)
+        cap_matches = search_workflow_capabilities(
+            query,
+            max_results=limit,
+            min_score=0.01,
+        )
         results: list[WorkflowMatch] = []
         for cap in cap_matches:
             results.append(
@@ -1122,7 +1122,7 @@ def discover_workflows_for_turn(
         max_results: Maximum workflows to return
 
     Returns:
-        Dict with workflow suggestions or None if no matches
+        Dict with workflow suggestions or None if the input is too short
     """
     if not user_input or len(user_input.strip()) < 5:
         # Skip very short inputs
@@ -1140,18 +1140,6 @@ def discover_workflows_for_turn(
             max_results=max_results,
             allow_non_executable=effective_allow_non_executable,
         )
-
-        # Return candidate payloads even when routing-eligible matches are empty.
-        # The caller needs visibility into near matches and exclusion reasons,
-        # not just the final dispatchable subset.
-        routing_matches = (
-            result.routing_matches
-            if isinstance(result.routing_matches, list)
-            else result.matches
-        )
-        if not routing_matches and not result.matches:
-            return None
-
         return result.to_dict()
 
     except Exception as e:

--- a/tests/backend/test_orchestrator_tool_pipeline_handoff_failure.py
+++ b/tests/backend/test_orchestrator_tool_pipeline_handoff_failure.py
@@ -1,0 +1,99 @@
+"""Focused regression tests for tool-pipeline handoff failure telemetry."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional, Sequence, cast
+
+import src.backend.services.workflow_selection_policy_service as policy_module
+from src.backend.integrations.internal_mcp.orchestrator import (
+    InternalMCPChatOrchestrator,
+)
+from src.backend.workflows.definitions import TOOL_CALLING_WORKFLOW_ID
+from orchestrator_test_harness import build_db_independent_orchestrator
+
+
+class _StubGateway:
+    enabled = True
+
+    def describe_methods(self) -> dict[str, Any]:
+        return {
+            "renderer_resolve_applicability": {"category": "read"},
+        }
+
+    def invoke(self, _tool_name: str, _payload: Mapping[str, Any]):
+        raise AssertionError("Gateway should not be invoked in this test")
+
+
+class _CapturingLLM:
+    """Test double that returns canned responses and records calls."""
+
+    def __init__(self, responses: Sequence[str]):
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    def generate(
+        self,
+        prompt: str,
+        context: Optional[Sequence[Mapping[str, Any]]] = None,
+        model=None,
+    ):
+        self.calls.append(
+            {"prompt": prompt, "context": list(context or []), "model": model}
+        )
+        if not self._responses:
+            raise AssertionError("LLM called more times than expected")
+        return self._responses.pop(0)
+
+
+def _build_orchestrator(monkeypatch) -> InternalMCPChatOrchestrator:
+    return build_db_independent_orchestrator(
+        monkeypatch,
+        gateway=cast(Any, _StubGateway()),
+        selector_enabled=True,
+        max_tool_invocations=1,
+    )
+
+
+def test_tool_pipeline_setup_failure_emits_local_handoff_boundary(monkeypatch):
+    monkeypatch.setattr(policy_module, "get_live_selection_policy", lambda: None)
+    orchestrator = _build_orchestrator(monkeypatch)
+
+    def _raise_setup_failure() -> bool:
+        raise RuntimeError("settings unavailable")
+
+    monkeypatch.setattr(
+        orchestrator,
+        "_get_auto_proceed_minimal_imposition_enabled",
+        _raise_setup_failure,
+    )
+
+    llm = _CapturingLLM([TOOL_CALLING_WORKFLOW_ID])
+
+    result = orchestrator.run(
+        prompt="Use tools to inspect the workflow runtime.",
+        context=[],
+        llm_client=llm,
+        model=None,
+        user_namespace="#V#user",
+    )
+
+    assert "tool-pipeline handoff failed before tool execution could begin" in (
+        result.response_text
+    )
+    dispatch_boundaries = [
+        entry
+        for entry in result.aux_llm_calls
+        if isinstance(entry, dict) and entry.get("type") == "workflow_dispatch_boundary"
+    ]
+    assert [entry.get("boundary") for entry in dispatch_boundaries[-2:]] == [
+        "workflow_handoff",
+        "workflow_terminal",
+    ]
+    assert dispatch_boundaries[-2].get("status") == "failed"
+    assert dispatch_boundaries[-2].get("reason") == "tool_pipeline_setup_exception"
+    assert dispatch_boundaries[-2].get("error_class") == "RuntimeError"
+    assert dispatch_boundaries[-1].get("status") == "failed"
+    assert dispatch_boundaries[-1].get("reason") == "tool_pipeline_setup_exception"
+    assert result.workflow_routing is not None
+    assert result.workflow_routing.routing_duration_ms is not None
+    assert result.workflow_routing.routing_duration_ms >= 0

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -4064,9 +4064,6 @@ def test_routing_duration_ms_in_aux_llm_calls(monkeypatch):
     assert selector_entry["routing_duration_ms"] >= 0
 
     # Also check WorkflowRoutingInfo has timing.
-    assert result.workflow_routing is not None
-    assert result.workflow_routing.routing_duration_ms is not None
-    assert result.workflow_routing.routing_duration_ms >= 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/test_turn_execution_record_service_execution_summary.py
+++ b/tests/backend/test_turn_execution_record_service_execution_summary.py
@@ -157,6 +157,69 @@ def test_tool_execution_summary_marks_missing_dispatch_boundary_after_tool_selec
     assert "tool_dispatch_boundary_missing" in list(summary.get("failure_codes") or [])
 
 
+def test_tool_execution_summary_preserves_local_handoff_failure_reason() -> None:
+    summary = _summarise_tool_execution_context(
+        workflow_routing={
+            "workflow_id": "#V#tool_calling_workflow",
+            "verdict": "rag_selected",
+        },
+        turn_execution_diagnostics={
+            "latest_progress": {
+                "counters": {"tools_started": 0, "tools_completed": 0},
+                "diagnostic_events": [],
+            }
+        },
+        aux_llm_calls=[
+            {
+                "type": "workflow_dispatch_boundary",
+                "boundary": "execution_mode_selected",
+                "status": "selected",
+                "selected_execution_mode": "tool_pipeline",
+                "selected_workflow_id": "#V#tool_calling_workflow",
+            },
+            {
+                "type": "workflow_dispatch_boundary",
+                "boundary": "contract_resolution",
+                "status": "resolved",
+                "selected_execution_mode": "tool_pipeline",
+                "selected_workflow_id": "#V#tool_calling_workflow",
+                "dispatch_workflow_id": "#V#tool_calling_workflow",
+            },
+            {
+                "type": "workflow_dispatch_boundary",
+                "boundary": "workflow_handoff",
+                "status": "failed",
+                "selected_execution_mode": "tool_pipeline",
+                "selected_workflow_id": "#V#tool_calling_workflow",
+                "dispatch_workflow_id": "#V#tool_calling_workflow",
+                "reason": "tool_pipeline_setup_exception",
+                "error_class": "RuntimeError",
+            },
+            {
+                "type": "workflow_dispatch_boundary",
+                "boundary": "workflow_terminal",
+                "status": "failed",
+                "selected_execution_mode": "tool_pipeline",
+                "selected_workflow_id": "#V#tool_calling_workflow",
+                "dispatch_workflow_id": "#V#tool_calling_workflow",
+                "reason": "tool_pipeline_setup_exception",
+                "error_class": "RuntimeError",
+                "completed": False,
+            },
+        ],
+        serialised_invocations=[],
+    )
+
+    assert summary["workflow_handoff_started"] is False
+    assert summary["workflow_handoff_failure_reason"] == "tool_pipeline_setup_exception"
+    assert summary["dispatch_terminal_failure_reason"] == "tool_pipeline_setup_exception"
+    assert summary["failure_codes"] == [
+        "tool_pipeline_setup_exception",
+        "tool_dispatch_not_started",
+    ]
+    assert summary["last_successful_boundary"] == "workflow_terminal"
+
+
 def test_build_workflow_routing_diagnostics_preserves_selector_exchange_and_dispatch_events() -> None:
     diagnostics = build_workflow_routing_diagnostics(
         workflow_discovery={
@@ -407,3 +470,95 @@ def test_build_workflow_routing_diagnostics_preserves_selector_exchange_and_disp
         "tool_dispatch_not_started"
     )
     assert diagnostics["dispatch"]["last_successful_boundary"] == "contract_resolution"
+
+
+def test_build_workflow_routing_diagnostics_preserves_local_handoff_failure_details() -> None:
+    diagnostics = build_workflow_routing_diagnostics(
+        workflow_discovery={"query": "Run the testing workflow", "matches": [], "candidates": []},
+        workflow_routing={
+            "workflow_id": "#V#tool_calling_workflow",
+            "verdict": "rag_selected",
+            "source": "selector",
+        },
+        turn_execution_diagnostics={
+            "latest_progress": {
+                "counters": {"tools_started": 0, "tools_completed": 0},
+                "diagnostic_events": [],
+            }
+        },
+        aux_llm_calls=[
+            {
+                "type": "workflow_dispatch_boundary",
+                "boundary": "execution_mode_selected",
+                "status": "selected",
+                "selected_execution_mode": "tool_pipeline",
+                "selected_workflow_id": "#V#tool_calling_workflow",
+            },
+            {
+                "type": "workflow_dispatch_boundary",
+                "boundary": "contract_resolution",
+                "status": "resolved",
+                "selected_execution_mode": "tool_pipeline",
+                "selected_workflow_id": "#V#tool_calling_workflow",
+                "dispatch_workflow_id": "#V#tool_calling_workflow",
+            },
+            {
+                "type": "workflow_dispatch_boundary",
+                "boundary": "workflow_handoff",
+                "status": "failed",
+                "selected_execution_mode": "tool_pipeline",
+                "selected_workflow_id": "#V#tool_calling_workflow",
+                "dispatch_workflow_id": "#V#tool_calling_workflow",
+                "reason": "tool_pipeline_setup_exception",
+                "error_class": "RuntimeError",
+            },
+            {
+                "type": "workflow_dispatch_boundary",
+                "boundary": "workflow_terminal",
+                "status": "failed",
+                "selected_execution_mode": "tool_pipeline",
+                "selected_workflow_id": "#V#tool_calling_workflow",
+                "dispatch_workflow_id": "#V#tool_calling_workflow",
+                "reason": "tool_pipeline_setup_exception",
+                "error_class": "RuntimeError",
+                "completed": False,
+            },
+        ],
+        execution_summary={
+            "tool_route_selected": True,
+            "selected_execution_mode": "tool_pipeline",
+            "dispatch_workflow_id": "#V#tool_calling_workflow",
+            "dispatch_event_count": 4,
+            "contract_resolution_status": "resolved",
+            "workflow_handoff_started": False,
+            "workflow_handoff_failure_reason": "tool_pipeline_setup_exception",
+            "workflow_handoff_failure_error_class": "RuntimeError",
+            "dispatch_terminal_status": "failed",
+            "dispatch_terminal_final_state": None,
+            "dispatch_terminal_completed": False,
+            "dispatch_terminal_failure_reason": "tool_pipeline_setup_exception",
+            "dispatch_terminal_failure_error_class": "RuntimeError",
+            "planned_count": 1,
+            "started_count": 0,
+            "executed_count": 0,
+            "zero_tools_executed": True,
+            "failure_codes": [
+                "tool_pipeline_setup_exception",
+                "tool_dispatch_not_started",
+            ],
+            "last_successful_boundary": "workflow_terminal",
+        },
+    )
+
+    assert diagnostics["dispatch"]["workflow_handoff_failure_reason"] == (
+        "tool_pipeline_setup_exception"
+    )
+    assert diagnostics["dispatch"]["workflow_handoff_failure_error_class"] == (
+        "RuntimeError"
+    )
+    assert diagnostics["dispatch"]["dispatch_terminal_failure_reason"] == (
+        "tool_pipeline_setup_exception"
+    )
+    assert diagnostics["dispatch"]["zero_execution_primary_failure_code"] == (
+        "tool_pipeline_setup_exception"
+    )

--- a/tests/backend/test_workflow_capability_service.py
+++ b/tests/backend/test_workflow_capability_service.py
@@ -20,6 +20,7 @@ from src.backend.services.workflow_capability_service import (
     build_workflow_capability_text,
     get_workflow_capability_index,
     reset_workflow_capability_index,
+    search_workflow_capabilities,
 )
 from workflow_test_support import build_test_conversation_turn_registry
 
@@ -49,6 +50,12 @@ class TestTokenise:
         # Single-char tokens should be excluded.
         assert "b" not in tokens
         assert "c" not in tokens
+
+    def test_simple_plural_forms_normalise_to_singular_variants(self):
+        tokens = _tokenise("testing workflows tools queries")
+        assert "workflow" in tokens
+        assert "tool" in tokens
+        assert "query" in tokens
 
 
 # ---------------------------------------------------------------------------
@@ -254,6 +261,22 @@ class TestPurposeDrivenCapabilities:
         top = results[0]
         assert top.workflow_id == "#V#tool_calling_workflow"
 
+    def test_plural_query_matches_singular_workflow_capability_text(self):
+        index = WorkflowCapabilityIndex()
+        index.index_workflow(
+            "#V#meeting_invitation_testing_workflow",
+            (
+                "Testing workflow for meeting invitation experiments that prepares "
+                "an experiment spec and executes the candidate workflow."
+            ),
+            metadata={"name": "Meeting invitation testing workflow"},
+        )
+
+        results = index.search("use Testing Workflows tools for experiments")
+
+        assert results
+        assert results[0].workflow_id == "#V#meeting_invitation_testing_workflow"
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -302,3 +325,29 @@ class TestSingleton:
         reset_workflow_capability_index()
         idx2 = get_workflow_capability_index()
         assert idx1 is not idx2
+
+
+def test_search_workflow_capabilities_populates_empty_index_from_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reset_workflow_capability_index()
+    registry = build_test_conversation_turn_registry()
+
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.registry_factory.build_durable_workflow_registry_read_only",
+        lambda defer_parity_work=False: registry,
+    )
+    monkeypatch.setattr(
+        "src.backend.workflows.vontology_loader.batch_fetch_workflow_purposes",
+        lambda workflow_ids: {},
+    )
+
+    results = search_workflow_capabilities(
+        "general tool-calling workflows for external APIs",
+        max_results=5,
+        min_score=0.01,
+    )
+
+    assert any(
+        result.workflow_id == "#V#tool_calling_workflow" for result in results
+    )

--- a/tests/backend/test_workflow_creation_workflow.py
+++ b/tests/backend/test_workflow_creation_workflow.py
@@ -16,6 +16,7 @@ from src.backend.services.text_value_service import (
 from src.backend.services.workflow_discovery_service import (
     EXECUTABILITY_EXECUTABLE_NOW,
     WORKFLOW_CREATION_WORKFLOW_ID as DISCOVERY_WORKFLOW_CREATION_WORKFLOW_ID,
+    WorkflowMatch,
     discover_workflows,
     discover_workflows_for_turn,
 )
@@ -84,6 +85,28 @@ PHD_STUDENT_WORKFLOW_REQUEST_PROMPT = (
 @pytest.fixture(autouse=True)
 def _reset_mock_db(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VON_USE_MOCK_DB", "1")
+
+    def _stub_capability_search(query: str, *args: Any, **kwargs: Any):
+        text = str(query or "").lower()
+        if "create a workflow from this description request" in text:
+            return [
+                WorkflowMatch(
+                    concept_id=DISCOVERY_WORKFLOW_CREATION_WORKFLOW_ID,
+                    name="Von Workflow Creation Workflow",
+                    description=(
+                        "Create and verify executable workflows from a workflow "
+                        "description/request."
+                    ),
+                    relevance_score=1.0,
+                    match_source="capability_index",
+                )
+            ]
+        return []
+
+    monkeypatch.setattr(
+        "src.backend.services.workflow_discovery_service._search_workflow_capabilities",
+        _stub_capability_search,
+    )
     authority_service.clear_workflow_type_resolution_cache()
 
     from src.backend.services.workflow_discovery_service import (
@@ -392,6 +415,10 @@ def test_workflow_creation_request_is_discoverable_for_turn_routing() -> None:
                 else (False, "graph_incomplete", "not_used")
             ),
         ),
+        patch(
+            "src.backend.services.workflow_discovery_service._has_authoritative_routing_text",
+            return_value=True,
+        ),
     ):
         query = (
             "Please create a workflow from this description request for scholarly "
@@ -449,6 +476,10 @@ def test_workflow_creation_request_routes_and_executes_end_to_end() -> None:
                 if concept_id == DISCOVERY_WORKFLOW_CREATION_WORKFLOW_ID
                 else (False, "graph_incomplete", "not_used")
             ),
+        ),
+        patch(
+            "src.backend.services.workflow_discovery_service._has_authoritative_routing_text",
+            return_value=True,
         ),
     ):
         wrapped = discover_workflows_for_turn(query, max_results=5)
@@ -683,6 +714,10 @@ def test_text_only_phd_student_request_routes_create_execute_end_to_end() -> Non
                 if concept_id == DISCOVERY_WORKFLOW_CREATION_WORKFLOW_ID
                 else (False, "graph_incomplete", "not_used")
             ),
+        ),
+        patch(
+            "src.backend.services.workflow_discovery_service._has_authoritative_routing_text",
+            return_value=True,
         ),
     ):
         wrapped = discover_workflows_for_turn(query, max_results=5)

--- a/tests/backend/test_workflow_discovery_service.py
+++ b/tests/backend/test_workflow_discovery_service.py
@@ -46,6 +46,15 @@ def _use_mock_db(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VON_USE_MOCK_DB", "1")
 
 
+@pytest.fixture(autouse=True)
+def _stub_capability_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep unit discovery tests focused on discovery logic, not registry rebuilds."""
+    monkeypatch.setattr(
+        "src.backend.services.workflow_discovery_service._search_workflow_capabilities",
+        lambda *args, **kwargs: [],
+    )
+
+
 class TestWorkflowMatch:
     """Unit tests for WorkflowMatch dataclass."""
 
@@ -488,11 +497,17 @@ class TestDiscoverWorkflowsForTurn:
         assert result is None
 
     @patch("src.backend.services.workflow_discovery_service.discover_workflows")
-    def test_returns_none_when_no_matches(self, mock_discover: MagicMock) -> None:
-        """Should return None when discover_workflows finds no matches."""
+    def test_returns_structured_empty_payload_when_no_matches(
+        self, mock_discover: MagicMock
+    ) -> None:
+        """Wrapper should preserve an attempted zero-match discovery result."""
         mock_discover.return_value = WorkflowDiscoveryResult(matches=[])
         result = discover_workflows_for_turn("test query input")
-        assert result is None
+        assert result is not None
+        assert result["match_count"] == 0
+        assert result["candidate_count"] == 0
+        assert result["matches"] == []
+        assert result["candidates"] == []
 
     @patch("src.backend.services.workflow_discovery_service.discover_workflows")
     def test_returns_candidate_payload_when_only_non_routing_candidates_exist(


### PR DESCRIPTION
## Summary
- self-populate the workflow capability index on demand and retry bounded misses so workflow discovery still sees authoritative Vontology workflows before deferred startup indexing completes
- preserve explicit zero-match discovery payloads and propagate local tool-pipeline handoff failure reasons into dispatch telemetry and turn-execution summaries
- add focused regression coverage for capability search, discovery consumers, workflow-creation routing, and tool-pipeline handoff failures

## Validation
- `pdm run pytest tests/backend/test_workflow_capability_service.py -q`
- `pdm run pytest tests/backend/test_workflow_discovery_service.py -q`
- `pdm run pytest tests/backend/test_turn_execution_record_service_execution_summary.py -q`
- `pdm run pytest tests/backend/test_orchestrator_tool_pipeline_handoff_failure.py -q`
- `pdm run pytest tests/backend/test_workflow_creation_workflow.py -k "test_workflow_creation_request_is_discoverable_for_turn_routing" -q`
- `pdm run pyright src/backend/integrations/internal_mcp/orchestrator.py src/backend/services/turn_execution_record_service.py src/backend/services/workflow_capability_service.py src/backend/services/workflow_discovery_service.py tests/backend/test_orchestrator_workflow_selector_routing.py tests/backend/test_turn_execution_record_service_execution_summary.py tests/backend/test_workflow_capability_service.py tests/backend/test_workflow_creation_workflow.py tests/backend/test_workflow_discovery_service.py tests/backend/test_orchestrator_tool_pipeline_handoff_failure.py`
