### PR TITLE
JVNAUTOSCI-1525 Restore verified workflow submission purity

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -9094,6 +9094,10 @@ def _experiment_emit_learning_signal(**kwargs):
 
 def _experiment_execute_target_workflow(**kwargs):
     from ...workflows.durable import WorkflowInstanceManager
+    from ...workflows.durable.workflow_instance_submission_service import (
+        build_verified_instance_launch_payload,
+        submit_verified_workflow_instance,
+    )
 
     workflow_id = str(kwargs.get("workflow_id") or "").strip()
     if not workflow_id:
@@ -9107,8 +9111,9 @@ def _experiment_execute_target_workflow(**kwargs):
     if not isinstance(workflow_inputs, Mapping):
         workflow_inputs = {}
     manager = WorkflowInstanceManager()
-    instance_id = manager.create_instance(
-        workflow_id,
+    submission = submit_verified_workflow_instance(
+        manager=manager,
+        workflow_id=workflow_id,
         user_id=str(kwargs.get("user_id") or "anonymous").strip() or "anonymous",
         org_id=str(kwargs.get("org_id") or "default").strip() or "default",
         namespace=str(kwargs.get("namespace") or "#V#anonymous@default").strip()
@@ -9116,17 +9121,10 @@ def _experiment_execute_target_workflow(**kwargs):
         inputs=dict(workflow_inputs),
         max_retries=int(kwargs.get("max_retries", 1)),
     )
-    return {
-        "success": True,
-        "workflow_id": workflow_id,
-        "instance_id": instance_id,
-        "workflow_execution": {
-            "workflow_id": workflow_id,
-            "instance_id": instance_id,
-            "launch_mode": "durable_instance",
-            "workflow_inputs": dict(workflow_inputs),
-        },
-    }
+    return build_verified_instance_launch_payload(
+        submission,
+        workflow_inputs=dict(workflow_inputs),
+    )
 
 
 def _experiment_execute_regression_suite(**kwargs):

--- a/src/backend/workflows/durable/testing_workflow_actions.py
+++ b/src/backend/workflows/durable/testing_workflow_actions.py
@@ -350,6 +350,10 @@ def _handle_experiment_execute_target_workflow(
     request: WorkflowActionRequest,
 ) -> WorkflowActionResult:
     from . import WorkflowInstanceManager
+    from .workflow_instance_submission_service import (
+        build_verified_instance_launch_payload,
+        submit_verified_workflow_instance,
+    )
 
     inputs = dict(request.inputs or {})
     actor = _derive_actor_context(request)
@@ -363,9 +367,14 @@ def _handle_experiment_execute_target_workflow(
             outputs={"success": False, "error": "workflow_id_required"},
         )
 
-    workflow_inputs = (
-        dict(inputs.get("workflow_inputs"))
-        if isinstance(inputs.get("workflow_inputs"), Mapping)
+    workflow_inputs_raw = inputs.get("workflow_inputs")
+    workflow_inputs: dict[str, Any] = (
+        {
+            str(key): value
+            for key, value in workflow_inputs_raw.items()
+            if isinstance(key, str) and key.strip()
+        }
+        if isinstance(workflow_inputs_raw, Mapping)
         else {}
     )
     run_id = _safe_str(inputs.get("run_id")) or None
@@ -399,25 +408,26 @@ def _handle_experiment_execute_target_workflow(
         workflow_inputs.setdefault("testing_theory_id", theory_id)
 
     manager = WorkflowInstanceManager()
-    instance_id = manager.create_instance(
-        workflow_id,
+    submission = submit_verified_workflow_instance(
+        manager=manager,
+        workflow_id=workflow_id,
         user_id=actor["user_id"] or "anonymous",
         org_id=actor["org_id"] or "default",
         namespace=actor["namespace"] or "#V#anonymous@default",
         inputs=workflow_inputs,
         max_retries=int(inputs.get("max_retries", 1) or 1),
     )
-    payload = {
-        "success": True,
-        "workflow_id": workflow_id,
-        "instance_id": instance_id,
-        "workflow_execution": {
-            "workflow_id": workflow_id,
-            "instance_id": instance_id,
-            "launch_mode": "durable_instance",
-            "workflow_inputs": workflow_inputs,
-        },
-    }
+    payload = build_verified_instance_launch_payload(
+        submission,
+        workflow_inputs=workflow_inputs,
+    )
+    instance_id = _safe_str(payload.get("instance_id"))
+    if not submission.success or not instance_id:
+        return WorkflowActionResult(
+            status="failed",
+            error=_safe_str(payload.get("error")) or "workflow_submission_failed",
+            outputs=payload,
+        )
 
     if not await_terminal:
         return WorkflowActionResult(status="success", outputs=payload)

--- a/src/backend/workflows/durable/workflow_instance_submission_service.py
+++ b/src/backend/workflows/durable/workflow_instance_submission_service.py
@@ -122,6 +122,38 @@ class WorkflowInstanceSubmissionResult:
         return payload
 
 
+def build_verified_instance_launch_payload(
+    submission: WorkflowInstanceSubmissionResult,
+    *,
+    workflow_inputs: Mapping[str, Any] | None = None,
+    launch_mode: str = "durable_instance",
+) -> Dict[str, Any]:
+    """Add stable workflow-execution payloads without direct instance launches.
+
+    Callers outside the durable submission layer should not need to construct
+    their own instance-launch envelopes, because that encourages bypassing the
+    verified submission pathway and regressing workflow-purity invariants.
+    """
+
+    payload = submission.to_dict()
+    instance_id = (
+        submission.instance_id
+        if isinstance(submission.instance_id, str) and submission.instance_id.strip()
+        else None
+    )
+    if not submission.success or not instance_id:
+        return payload
+
+    payload["workflow_execution"] = {
+        "workflow_id": submission.workflow_id,
+        "instance_id": instance_id,
+        "launch_mode": str(launch_mode or "durable_instance").strip()
+        or "durable_instance",
+        "workflow_inputs": dict(workflow_inputs or {}),
+    }
+    return payload
+
+
 @dataclass(frozen=True)
 class _RunnableVerificationCacheEntry:
     cache_key: str
@@ -989,6 +1021,7 @@ def submit_verified_workflow_instance(
 
 
 __all__ = [
+    "build_verified_instance_launch_payload",
     "WorkflowRunnableVerification",
     "WorkflowInstanceSubmissionResult",
     "verify_workflow_runnable",

--- a/tests/backend/test_internal_mcp_workflow_tools.py
+++ b/tests/backend/test_internal_mcp_workflow_tools.py
@@ -1027,6 +1027,46 @@ def test_workflow_create_instance_normalises_inputs(monkeypatch):
     assert instance.max_retries == 50
 
 
+def test_experiment_execute_target_workflow_uses_verified_submission_path(monkeypatch):
+    manager = _StubWorkflowManager()
+    _patch_submit_verified_instance_success(monkeypatch)
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.WorkflowInstanceManager",
+        lambda: manager,
+    )
+    gateway = _build_gateway()
+
+    payload = gateway.invoke(
+        "experiment_execute_target_workflow",
+        {
+            "workflow_id": "#V#meeting_invitation_testing_workflow",
+            "user_id": "#V#user",
+            "org_id": "#V#org",
+            "namespace": "#V#user@org",
+            "workflow_inputs": {"fixture_id": "fixture-1"},
+            "max_retries": 2,
+        },
+    ).payload
+
+    assert payload.get("success") is True
+    assert payload.get("workflow_id") == "#V#meeting_invitation_testing_workflow"
+    instance_id = payload.get("instance_id")
+    assert isinstance(instance_id, str)
+    assert payload.get("workflow_execution") == {
+        "workflow_id": "#V#meeting_invitation_testing_workflow",
+        "instance_id": instance_id,
+        "launch_mode": "durable_instance",
+        "workflow_inputs": {"fixture_id": "fixture-1"},
+    }
+
+    instance = manager.instances[instance_id]
+    assert instance.user_id == "#V#user"
+    assert instance.org_id == "#V#org"
+    assert instance.namespace == "#V#user@org"
+    assert instance.inputs == {"fixture_id": "fixture-1"}
+    assert instance.max_retries == 2
+
+
 def test_workflow_create_instance_preserves_event_idempotency_submission(monkeypatch):
     manager = _StubWorkflowManager()
     _patch_submit_verified_instance_success(monkeypatch)

--- a/tests/backend/test_testing_workflow_actions.py
+++ b/tests/backend/test_testing_workflow_actions.py
@@ -31,6 +31,43 @@ from src.backend.workflows.durable.testing_workflow_actions import (
 )
 
 
+def _patch_submit_verified_instance_success(monkeypatch, manager: _StubWorkflowManager) -> None:
+    from src.backend.workflows.durable.workflow_instance_submission_service import (
+        WorkflowInstanceSubmissionResult,
+    )
+
+    def _fake_submit_verified_workflow_instance(**kwargs):
+        workflow_id = str(kwargs.get("workflow_id") or "").strip()
+        instance_id = manager.create_instance(
+            workflow_id,
+            user_id=str(kwargs.get("user_id") or "anonymous").strip() or "anonymous",
+            org_id=str(kwargs.get("org_id") or "default").strip() or "default",
+            namespace=str(kwargs.get("namespace") or "#V#anonymous@default").strip()
+            or "#V#anonymous@default",
+            inputs=dict(kwargs.get("inputs") or {}),
+            max_retries=int(kwargs.get("max_retries", 1) or 1),
+        )
+        return WorkflowInstanceSubmissionResult(
+            success=True,
+            workflow_id=workflow_id,
+            status="pending",
+            instance_id=instance_id,
+            verification={
+                "preflight_passed": True,
+                "postflight_passed": True,
+                "runnable_verification_success": True,
+                "preflight": {"errors": []},
+                "postflight": {"errors": []},
+            },
+            created_new=True,
+        )
+
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.workflow_instance_submission_service.submit_verified_workflow_instance",
+        _fake_submit_verified_workflow_instance,
+    )
+
+
 @dataclass
 class _StubWorkflowManager:
     last_call: dict[str, Any] | None = None
@@ -152,6 +189,7 @@ def test_execute_target_workflow_action_launches_durable_instance(monkeypatch):
         "src.backend.workflows.durable.WorkflowInstanceManager",
         lambda: manager,
     )
+    _patch_submit_verified_instance_success(monkeypatch, manager)
 
     registry = ActionRegistry()
     register_testing_workflow_actions(registry)
@@ -212,6 +250,7 @@ def test_execute_target_workflow_action_can_await_terminal_and_record_observatio
         "src.backend.workflows.durable.WorkflowInstanceManager",
         lambda: manager,
     )
+    _patch_submit_verified_instance_success(monkeypatch, manager)
     monkeypatch.setattr(
         mod,
         "record_experiment_observation",

--- a/tests/backend/test_workflow_instance_submission_service.py
+++ b/tests/backend/test_workflow_instance_submission_service.py
@@ -124,10 +124,10 @@ def test_verify_workflow_runnable_rejects_initial_vacuous_step() -> None:
         "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_process_graph",
         return_value=(graph, []),
     ), patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_registry_read_only",
+        "src.backend.workflows.durable.registry_factory.build_workflow_registry_read_only",
         return_value=_make_registry(_make_definition(include_action=False)),
     ), patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_durable_action_registry",
+        "src.backend.workflows.durable.registry_factory.build_durable_action_registry",
         return_value=_make_action_registry(supports_action=True),
     ):
         verification = verify_workflow_runnable("#V#candidate_workflow")
@@ -195,10 +195,10 @@ def test_verify_workflow_runnable_reports_previous_step_context_for_middle_vacui
         "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_process_graph",
         return_value=(graph, []),
     ), patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_registry_read_only",
+        "src.backend.workflows.durable.registry_factory.build_workflow_registry_read_only",
         return_value=_make_registry(definition),
     ), patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_durable_action_registry",
+        "src.backend.workflows.durable.registry_factory.build_durable_action_registry",
         return_value=_make_action_registry(supports_action=True),
     ):
         verification = verify_workflow_runnable("#V#candidate_workflow")
@@ -232,10 +232,10 @@ def test_verify_workflow_runnable_allows_workflows_with_contracts() -> None:
         "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_process_graph",
         return_value=(graph, []),
     ), patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_registry_read_only",
+        "src.backend.workflows.durable.registry_factory.build_workflow_registry_read_only",
         return_value=_make_registry(_make_definition(include_action=True)),
     ), patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_durable_action_registry",
+        "src.backend.workflows.durable.registry_factory.build_durable_action_registry",
         return_value=_make_action_registry(supports_action=True),
     ):
         verification = verify_workflow_runnable("#V#candidate_workflow")
@@ -278,10 +278,10 @@ def test_verify_workflow_runnable_rejects_missing_transition_from_action_state()
         "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_process_graph",
         return_value=(graph, []),
     ), patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_registry_read_only",
+        "src.backend.workflows.durable.registry_factory.build_workflow_registry_read_only",
         return_value=_make_registry(definition),
     ), patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_durable_action_registry",
+        "src.backend.workflows.durable.registry_factory.build_durable_action_registry",
         return_value=_make_action_registry(supports_action=True),
     ):
         verification = verify_workflow_runnable("#V#candidate_workflow")
@@ -331,10 +331,10 @@ def test_verify_workflow_runnable_accepts_shared_conversation_actions_via_fallba
         "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_process_graph",
         return_value=(graph, []),
     ), patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_registry_read_only",
+        "src.backend.workflows.durable.registry_factory.build_workflow_registry_read_only",
         return_value=_make_registry(definition),
     ), patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_durable_action_registry",
+        "src.backend.workflows.durable.registry_factory.build_durable_action_registry",
         return_value=_make_action_registry(supports_action=False, fallback=True),
     ), patch(
         "src.backend.workflows.durable.workflow_instance_submission_service._internal_mcp_method_names",
@@ -371,10 +371,10 @@ def test_verify_workflow_runnable_caches_for_identical_definition() -> None:
         "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_process_graph",
         return_value=(graph, []),
     ) as mock_graph, patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_registry_read_only",
+        "src.backend.workflows.durable.registry_factory.build_workflow_registry_read_only",
         return_value=registry,
     ), patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_durable_action_registry",
+        "src.backend.workflows.durable.registry_factory.build_durable_action_registry",
         return_value=action_registry,
     ), patch(
         "src.backend.workflows.durable.workflow_instance_submission_service._internal_mcp_method_names",
@@ -412,10 +412,10 @@ def test_verify_workflow_runnable_cache_invalidation_forces_recompute() -> None:
         "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_process_graph",
         return_value=(graph, []),
     ) as mock_graph, patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_registry_read_only",
+        "src.backend.workflows.durable.registry_factory.build_workflow_registry_read_only",
         return_value=registry,
     ), patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_durable_action_registry",
+        "src.backend.workflows.durable.registry_factory.build_durable_action_registry",
         return_value=action_registry,
     ), patch(
         "src.backend.workflows.durable.workflow_instance_submission_service._internal_mcp_method_names",
@@ -438,7 +438,7 @@ def test_verify_workflow_runnable_fail_closed_on_registry_exception() -> None:
         workflow_id="#V#candidate_workflow",
     )
     with patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_registry_read_only",
+        "src.backend.workflows.durable.registry_factory.build_workflow_registry_read_only",
         side_effect=RuntimeError("registry unavailable"),
     ):
         verification = verify_workflow_runnable("#V#candidate_workflow")
@@ -499,10 +499,10 @@ def test_verify_workflow_runnable_reports_unresolved_subworkflow_contract() -> N
         "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_process_graph",
         return_value=(graph, []),
     ), patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_registry_read_only",
+        "src.backend.workflows.durable.registry_factory.build_workflow_registry_read_only",
         return_value=_make_registry(parent_definition),
     ), patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_durable_action_registry",
+        "src.backend.workflows.durable.registry_factory.build_durable_action_registry",
         return_value=_make_action_registry(supports_action=True),
     ), patch(
         "src.backend.workflows.durable.workflow_instance_submission_service.load_workflow_definition_from_vontology",
@@ -590,13 +590,13 @@ def test_verify_workflow_runnable_accepts_resolved_subworkflow_contract() -> Non
         "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_process_graph",
         return_value=(graph, []),
     ), patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_workflow_registry_read_only",
+        "src.backend.workflows.durable.registry_factory.build_workflow_registry_read_only",
         return_value=_make_registry(
             parent_definition,
             extra_definitions={"#V#child_workflow": child_definition},
         ),
     ), patch(
-        "src.backend.workflows.durable.workflow_instance_submission_service.build_durable_action_registry",
+        "src.backend.workflows.durable.registry_factory.build_durable_action_registry",
         return_value=_make_action_registry(supports_action=True),
     ), patch(
         "src.backend.workflows.durable.workflow_instance_submission_service.load_workflow_definition_from_vontology",


### PR DESCRIPTION
## Summary
- replace the two reintroduced direct durable-instance launch callsites with verified workflow submission in the internal MCP testing launch paths
- centralise stable `workflow_execution` payload construction in the submission service so callers do not rebuild launch envelopes by hand
- extend regression coverage for the internal MCP gateway path and testing workflow actions, and refresh the stale submission-service mocks that drifted from the current import path

## Validation
- `pdm run python scripts/pytest_lanes.py recommend --git-diff origin/main`
- `pdm run pytest tests/backend/test_testing_workflow_actions.py -q`
- `pdm run pytest tests/backend/test_internal_mcp_workflow_tools.py::test_experiment_execute_target_workflow_uses_verified_submission_path -q`
- `pdm run pytest tests/backend/test_internal_mcp_catalogue_builds.py -q`
- `pdm run pytest tests/backend/test_workflow_instance_submission_service.py -q`
- `pdm run pytest tests/backend/test_workflow_purity_report.py -q`
- `pdm run pytest tests/backend/test_workflow_purity_baseline.py -q`
- `pdm run pyright src/backend/integrations/internal_mcp/catalogue.py src/backend/workflows/durable/testing_workflow_actions.py src/backend/workflows/durable/workflow_instance_submission_service.py tests/backend/test_internal_mcp_workflow_tools.py tests/backend/test_testing_workflow_actions.py tests/backend/test_workflow_instance_submission_service.py`

## Notes
- `JVNAUTOSCI-1525` had already merged previously, but `main` had regressed against its workflow-purity baseline. This PR restores that original acceptance surface.