### PR TITLE
JVNAUTOSCI-1556 Generic workflow launch input resolution

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -410,6 +410,7 @@ Per-state metadata keys currently used:
 - `writes_context_keys`
 - `context_input_mappings`
 - `tool_output_context_mappings`
+- `launch_input_contract`
 - `subworkflow_contract`
 - `invokes_workflow`
 - `retry_policy`
@@ -434,6 +435,7 @@ Workflow-level long-horizon policy payloads are stored as singleton text relatio
 
 - `#V#hasWorkflowPlanStatePolicyJson`
 - `#V#hasWorkflowCompletionGateJson`
+- `#V#hasWorkflowLaunchInputContractJson`
 
 Current schema versions:
 
@@ -443,6 +445,7 @@ Current schema versions:
 - `workflow_step_checkpoint_policy.v1`
 - `workflow_plan_state_policy.v1`
 - `workflow_completion_gate.v1`
+- `workflow_launch_input_contract.v1`
 
 Normative semantics:
 
@@ -452,7 +455,9 @@ Normative semantics:
 - destructive or otherwise high-risk approval-gated states SHOULD provide an explicit `on_approval_required` route to a blocked terminal or escalation state;
 - checkpoint policies update the shared runtime plan-state artefact rather than introducing workflow-specific Python persistence logic;
 - plan-state items support `pending|in_progress|blocked|done` statuses, bounded checkpoint history, periodic summary snapshots, resumable cursor snapshots, and resume telemetry;
-- completion gates MUST fail closed before terminal success when required plan items or required context keys are not satisfied.
+- completion gates MUST fail closed before terminal success when required plan items or required context keys are not satisfied;
+- launch input contracts MAY map invocation-context values into workflow context keys before the initial state executes;
+- launch input contracts MUST remain declarative, so reusable extractors such as quoted-text extraction or workflow-ID list extraction are configured in metadata rather than hard-coded for specific workflow IDs.
 
 Validation phases:
 

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -66,7 +66,10 @@ from ...workflows.conversation_turn_stage_model import (
     build_conversation_turn_stage_model_snapshot,
     build_conversation_turn_stage_path,
 )
-from ...workflows.engine import WorkflowExecutor
+from ...workflows.engine import WorkflowExecutor, WorkflowResult
+from ...workflows.workflow_launch_input_contracts import (
+    resolve_workflow_launch_inputs,
+)
 from ...workflows.vontology_loader import load_workflow_definition_from_vontology
 from ...workflows.workflow_selector import WorkflowSelector
 from ...workflows.durable.registry_factory import (
@@ -17529,6 +17532,7 @@ class InternalMCPChatOrchestrator:
         workflow_registration = None
         workflow_definition_for_identity = None
         workflow_definition_identity: dict[str, Any] | None = None
+        workflow_def = None
         try:
             from ...workflows.workflow_definition_identity_service import (
                 build_workflow_definition_identity,
@@ -17540,6 +17544,7 @@ class InternalMCPChatOrchestrator:
                 if workflow_registration is not None
                 else self._workflow_registry.get(workflow_id)
             )
+            workflow_def = workflow_definition_for_identity
             workflow_source = (
                 str(getattr(workflow_registration, "source", "") or "").strip()
                 if workflow_registration is not None
@@ -17559,6 +17564,7 @@ class InternalMCPChatOrchestrator:
             workflow_registration = None
             workflow_definition_for_identity = None
             workflow_definition_identity = None
+            workflow_def = None
 
         def _safe_scalar_text(value: Any) -> str | None:
             if not isinstance(value, str):
@@ -18312,6 +18318,88 @@ class InternalMCPChatOrchestrator:
         durable_instance_id: str | None = None
         durable_instance_created_new: bool | None = None
 
+        if workflow_def is None:
+            try:
+                workflow_def = self._workflow_registry.get(workflow_id)
+            except Exception:
+                workflow_def = None
+
+        if workflow_def is not None:
+            workflow_metadata = getattr(workflow_def, "metadata", None)
+            launch_contract = (
+                workflow_metadata.get("launch_input_contract")
+                if isinstance(workflow_metadata, Mapping)
+                else None
+            )
+            launch_contract_source = (
+                workflow_metadata.get("launch_input_contract_source")
+                if isinstance(workflow_metadata, Mapping)
+                else None
+            )
+            launch_resolution = resolve_workflow_launch_inputs(
+                workflow_id=workflow_id,
+                contract=launch_contract if isinstance(launch_contract, Mapping) else None,
+                inputs=data,
+                contract_source=(
+                    str(launch_contract_source).strip()
+                    if isinstance(launch_contract_source, str)
+                    and launch_contract_source.strip()
+                    else None
+                ),
+            )
+            for key, value in launch_resolution.resolved_inputs.items():
+                if key not in data:
+                    data[key] = value
+            data["workflow_launch_input_resolution"] = dict(
+                launch_resolution.diagnostics
+            )
+
+            unresolved_required_inputs = tuple(
+                item
+                for item in launch_resolution.unresolved_required_inputs
+                if isinstance(item, str) and item.strip()
+            )
+            if unresolved_required_inputs:
+                initial_state = (
+                    str(getattr(workflow_def, "initial_state", "") or "").strip() or None
+                )
+                failing_action_id: str | None = None
+                initial_states = getattr(workflow_def, "states", None)
+                if initial_state and isinstance(initial_states, Mapping):
+                    initial_state_spec = initial_states.get(initial_state)
+                    actions = getattr(initial_state_spec, "actions", None)
+                    if isinstance(actions, Sequence) and actions:
+                        first_action = actions[0]
+                        failing_action_id = _safe_scalar_text(
+                            getattr(first_action, "action_id", None)
+                            or getattr(first_action, "target_id", None)
+                        )
+                diagnostics_payload = dict(launch_resolution.diagnostics)
+                diagnostics_payload["failing_state_id"] = initial_state
+                diagnostics_payload["failing_action_id"] = failing_action_id
+                data["workflow_launch_input_resolution"] = diagnostics_payload
+                message = (
+                    f"Workflow {workflow_id} could not start because required launch "
+                    "inputs were unresolved: "
+                    + ", ".join(unresolved_required_inputs)
+                    + "."
+                )
+                if failing_action_id:
+                    message += f" Initial action: {failing_action_id}."
+                return WorkflowResult(
+                    data={
+                        "response_text": message,
+                        "summary": message,
+                        "workflow_launch_input_resolution": diagnostics_payload,
+                    },
+                    completed=False,
+                    final_state=initial_state or "workflow_launch_input_resolution",
+                    error=(
+                        "workflow_launch_input_resolution_failed:"
+                        + ",".join(unresolved_required_inputs)
+                    ),
+                )
+
         def _build_durable_inputs_snapshot() -> dict[str, Any]:
             prompt = data.get("prompt")
             prompt_preview = prompt[:1000] if isinstance(prompt, str) else None
@@ -18330,6 +18418,9 @@ class InternalMCPChatOrchestrator:
                     data.get("workflow_discovery_result")
                 ),
                 "workflow_definition_identity": workflow_definition_identity,
+                "workflow_launch_input_resolution": _safe_mapping_snapshot(
+                    data.get("workflow_launch_input_resolution")
+                ),
                 # Canonical per-turn contract persisted at workflow start.
                 "turn_execution_contract": _build_turn_execution_contract_snapshot(data),
             }
@@ -18398,6 +18489,13 @@ class InternalMCPChatOrchestrator:
             if isinstance(workflow_discovery, Mapping):
                 payload["workflow_discovery_result"] = _safe_mapping_snapshot(
                     workflow_discovery
+                )
+            workflow_launch_input_resolution = workflow_data.get(
+                "workflow_launch_input_resolution"
+            )
+            if isinstance(workflow_launch_input_resolution, Mapping):
+                payload["workflow_launch_input_resolution"] = _safe_mapping_snapshot(
+                    workflow_launch_input_resolution
                 )
 
             turn_execution_outcome = _build_turn_execution_outcome(
@@ -18687,6 +18785,8 @@ class InternalMCPChatOrchestrator:
         workflow_def = (
             workflow_definition_for_identity
             if workflow_definition_for_identity is not None
+            else workflow_def
+            if workflow_def is not None
             else self._workflow_registry.get(workflow_id)
         )
         if workflow_def is None:
@@ -25517,6 +25617,24 @@ class InternalMCPChatOrchestrator:
                     data={
                         "prompt": prompt,
                         "augmented_context": augmented_context,
+                        "workflow_routing": (
+                            asdict(routing_info)
+                            if isinstance(routing_info, WorkflowRoutingInfo)
+                            else None
+                        ),
+                        "workflow_discovery_result": (
+                            dict(workflow_discovery_result)
+                            if isinstance(workflow_discovery_result, Mapping)
+                            else None
+                        ),
+                        "selected_workflow_id": selected_workflow_id_text,
+                        "selected_workflow_name": selected_workflow_name,
+                        "workflow_selector_verdict": selector_verdict or None,
+                        "workflow_selector_source": (
+                            routing_info.source
+                            if isinstance(routing_info, WorkflowRoutingInfo)
+                            else None
+                        ),
                         "user_concept_id": user_concept_id,
                         "org_concept_id": org_concept_id,
                         "gmail_profile": gmail_profile or self._default_gmail_profile,

--- a/src/backend/services/testing_workflow_vontology_service.py
+++ b/src/backend/services/testing_workflow_vontology_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import json
 from collections.abc import Sequence
 from typing import Any
 
@@ -821,6 +822,55 @@ def _ensure_workflow_texts(workflow_id: str) -> None:
     )
 
 
+def _workflow_launch_input_contract(workflow_id: str) -> dict[str, Any] | None:
+    if workflow_id != MEETING_INVITATION_TESTING_WORKFLOW_ID:
+        return None
+    return {
+        "schema_version": "workflow_launch_input_contract.v1",
+        "required_inputs": ["invitation_text"],
+        "input_mappings": [
+            {
+                "target_context_key": "invitation_text",
+                "source_expression": "inputs.prompt",
+                "extractor": "first_quoted_text",
+                "required": True,
+                "description": (
+                    "Extract the invitation specimen from the quoted user prompt "
+                    "before preparing the experiment spec."
+                ),
+            },
+            {
+                "target_context_key": "candidate_workflow_ids",
+                "source_expression": "inputs.workflow_discovery_result.matches",
+                "extractor": "workflow_id_list",
+                "required": False,
+                "description": (
+                    "Carry discovered candidate workflow IDs into the experiment "
+                    "context when they are available."
+                ),
+            },
+        ],
+    }
+
+
+def _ensure_workflow_launch_contract(workflow_id: str) -> None:
+    contract = _workflow_launch_input_contract(workflow_id)
+    if contract is None:
+        return
+    upsert_singleton_text_relation(
+        subject_concept_id=workflow_id,
+        predicate="#V#hasWorkflowLaunchInputContractJson",
+        text=json.dumps(contract, ensure_ascii=True, sort_keys=True),
+        lang="en-NZ",
+        context={
+            "source": "JVNAUTOSCI-1556",
+            "workflow_id": workflow_id,
+            "managed_by": _MANAGED_BY,
+        },
+        garbage_collect=True,
+    )
+
+
 def _ensure_step_notes(
     *,
     workflow_id: str,
@@ -916,6 +966,7 @@ def bootstrap_canonical_testing_workflows() -> dict[str, Any]:
             ):
                 typed_workflow_ids.append(workflow_id)
             _ensure_workflow_texts(workflow_id)
+            _ensure_workflow_launch_contract(workflow_id)
             _ensure_step_notes(workflow_id=workflow_id, spec=spec)
 
             for step_concept_id in _step_concept_ids_for_spec(

--- a/src/backend/workflows/vontology_loader.py
+++ b/src/backend/workflows/vontology_loader.py
@@ -26,6 +26,9 @@ from .subworkflow_contracts import (
     WORKFLOW_SUBWORKFLOW_ACTION_ID,
     build_subworkflow_contract,
 )
+from .workflow_launch_input_contracts import (
+    normalise_workflow_launch_input_contract,
+)
 from .workflow_action_contracts import resolve_workflow_action_target
 from .engine import (
     WorkflowDefinition,
@@ -297,6 +300,17 @@ WORKFLOW_COMPLETION_GATE_TEXT_PREDICATE_PRECEDENCE: Tuple[
         "hasWorkflowCompletionGateJson",
         "#V#has_workflow_completion_gate_json",
         "has_workflow_completion_gate_json",
+    ),
+)
+WORKFLOW_LAUNCH_INPUT_CONTRACT_SOURCE_NONE = "none"
+WORKFLOW_LAUNCH_INPUT_CONTRACT_TEXT_PREDICATE_PRECEDENCE: Tuple[
+    Tuple[str, ...], ...
+] = (
+    (
+        "#V#hasWorkflowLaunchInputContractJson",
+        "hasWorkflowLaunchInputContractJson",
+        "#V#has_workflow_launch_input_contract_json",
+        "has_workflow_launch_input_contract_json",
     ),
 )
 WORKFLOW_BACKGROUND_LAUNCH_INTERVAL_SECONDS_TEXT_PREDICATE_PRECEDENCE: Tuple[
@@ -1453,6 +1467,44 @@ def _parse_json_object_text_value(text_value: Any) -> dict[str, Any] | None:
     if isinstance(parsed, Mapping):
         return dict(parsed)
     return None
+
+
+def resolve_workflow_launch_input_contract(
+    workflow_id: str,
+) -> tuple[dict[str, Any] | None, str]:
+    """Resolve launch-time input mappings from workflow text relations."""
+
+    if not isinstance(workflow_id, str) or not workflow_id.strip():
+        return None, WORKFLOW_LAUNCH_INPUT_CONTRACT_SOURCE_NONE
+
+    texts: list[dict[str, Any]] = []
+    try:
+        raw_texts = get_texts_for_concept(workflow_id)
+    except Exception:
+        raw_texts = []
+    if isinstance(raw_texts, list):
+        texts = [item for item in raw_texts if isinstance(item, dict)]
+
+    invalid_sources: list[str] = []
+    for predicate_aliases in WORKFLOW_LAUNCH_INPUT_CONTRACT_TEXT_PREDICATE_PRECEDENCE:
+        for item in texts:
+            predicate = str(item.get("predicate") or "").strip()
+            if predicate not in predicate_aliases:
+                continue
+            raw_payload = _parse_json_object_text_value(item.get("text"))
+            if raw_payload is None:
+                invalid_sources.append(f"text_relation_invalid:{predicate}")
+                continue
+            contract, error = normalise_workflow_launch_input_contract(raw_payload)
+            if contract is not None:
+                return contract, f"text_relation:{predicate}"
+            invalid_sources.append(
+                f"text_relation_invalid:{predicate}:{error or 'invalid_contract'}"
+            )
+
+    if invalid_sources:
+        return None, invalid_sources[0]
+    return None, WORKFLOW_LAUNCH_INPUT_CONTRACT_SOURCE_NONE
 
 
 def _normalise_workflow_publication_lifecycle(
@@ -2826,6 +2878,9 @@ def load_workflow_definition_from_vontology(
     background_launch_policy, background_launch_policy_source = (
         resolve_workflow_background_launch_policy(workflow_id)
     )
+    launch_input_contract, launch_input_contract_source = (
+        resolve_workflow_launch_input_contract(workflow_id)
+    )
     workflow_metadata: Dict[str, Any] = {}
     graph_workflow_metadata = graph.get("workflow_metadata")
     if isinstance(graph_workflow_metadata, Mapping):
@@ -2839,6 +2894,16 @@ def load_workflow_definition_from_vontology(
     ):
         workflow_metadata["background_launch_policy_source"] = (
             background_launch_policy_source
+        )
+    if launch_input_contract is not None:
+        workflow_metadata["launch_input_contract"] = launch_input_contract
+    if (
+        isinstance(launch_input_contract_source, str)
+        and launch_input_contract_source
+        and launch_input_contract_source != WORKFLOW_LAUNCH_INPUT_CONTRACT_SOURCE_NONE
+    ):
+        workflow_metadata["launch_input_contract_source"] = (
+            launch_input_contract_source
         )
     graph_variable_declarations = graph.get("variable_declarations")
     if isinstance(graph_variable_declarations, list) and graph_variable_declarations:

--- a/src/backend/workflows/workflow_launch_input_contracts.py
+++ b/src/backend/workflows/workflow_launch_input_contracts.py
@@ -1,0 +1,366 @@
+"""Reusable launch-time input contracts for workflow execution.
+
+This module lets a workflow concept declare how invocation-context data should
+be mapped into workflow context keys before the initial state runs. The goal is
+to keep selected-workflow handoff behaviour Vontology-defined rather than
+hard-coded in orchestration branches.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any, Dict, List, Mapping, Tuple
+
+WORKFLOW_LAUNCH_INPUT_CONTRACT_SCHEMA_VERSION = "workflow_launch_input_contract.v1"
+
+WORKFLOW_LAUNCH_INPUT_EXTRACTOR_IDENTITY = "identity"
+WORKFLOW_LAUNCH_INPUT_EXTRACTOR_FIRST_QUOTED_TEXT = "first_quoted_text"
+WORKFLOW_LAUNCH_INPUT_EXTRACTOR_WORKFLOW_ID_LIST = "workflow_id_list"
+_ALLOWED_EXTRACTORS: Tuple[str, ...] = (
+    WORKFLOW_LAUNCH_INPUT_EXTRACTOR_IDENTITY,
+    WORKFLOW_LAUNCH_INPUT_EXTRACTOR_FIRST_QUOTED_TEXT,
+    WORKFLOW_LAUNCH_INPUT_EXTRACTOR_WORKFLOW_ID_LIST,
+)
+
+_QUOTED_TEXT_PATTERN = re.compile(
+    r'"([^"]{1,8000})"|\'([^\']{1,8000})\'|“([^”]{1,8000})”|‘([^’]{1,8000})’',
+    re.DOTALL,
+)
+
+
+@dataclass(frozen=True)
+class WorkflowLaunchInputResolution:
+    """Resolved launch-time input mapping outcome."""
+
+    resolved_inputs: Mapping[str, Any]
+    unresolved_required_inputs: tuple[str, ...]
+    unresolved_optional_inputs: tuple[str, ...]
+    diagnostics: Mapping[str, Any]
+
+
+def _normalise_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalise_string_list(value: Any) -> List[str]:
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    if not isinstance(value, list):
+        return []
+    result: List[str] = []
+    seen: set[str] = set()
+    for item in value:
+        text = _normalise_text(item)
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        result.append(text)
+    return result
+
+
+def _coerce_bool(value: Any, *, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    text = _normalise_text(value).lower()
+    if text in {"1", "true", "yes", "on", "y"}:
+        return True
+    if text in {"0", "false", "no", "off", "n"}:
+        return False
+    return default
+
+
+def _lookup_path_value(root: Mapping[str, Any], path: str) -> tuple[bool, Any]:
+    current: Any = root
+    for segment in path.split("."):
+        segment_clean = segment.strip()
+        if not segment_clean:
+            return False, None
+        if not isinstance(current, Mapping) or segment_clean not in current:
+            return False, None
+        current = current.get(segment_clean)
+    return True, current
+
+
+def _resolve_source_expression(
+    expression: str,
+    *,
+    inputs: Mapping[str, Any],
+) -> tuple[bool, Any]:
+    text = _normalise_text(expression)
+    if not text:
+        return False, None
+    if text.startswith("inputs."):
+        return _lookup_path_value(inputs, text.removeprefix("inputs."))
+    if text == "inputs":
+        return True, dict(inputs)
+    return _lookup_path_value(inputs, text)
+
+
+def _extract_first_quoted_text(value: Any) -> tuple[bool, str | None]:
+    if not isinstance(value, str):
+        return False, None
+    for match in _QUOTED_TEXT_PATTERN.finditer(value):
+        for group in match.groups():
+            text = _normalise_text(group)
+            if text:
+                return True, text
+    return False, None
+
+
+def _extract_workflow_id_list(value: Any) -> tuple[bool, list[str] | None]:
+    items = list(value) if isinstance(value, list) else [value]
+    workflow_ids: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        workflow_id = ""
+        if isinstance(item, str):
+            workflow_id = _normalise_text(item)
+        elif isinstance(item, Mapping):
+            for candidate_key in ("workflow_id", "concept_id", "id"):
+                workflow_id = _normalise_text(item.get(candidate_key))
+                if workflow_id:
+                    break
+        if not workflow_id:
+            continue
+        lowered = workflow_id.lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        workflow_ids.append(workflow_id)
+    if not workflow_ids:
+        return False, None
+    return True, workflow_ids
+
+
+def _apply_extractor(
+    *,
+    extractor: str,
+    value: Any,
+) -> tuple[bool, Any, str]:
+    extractor_name = (
+        _normalise_text(extractor) or WORKFLOW_LAUNCH_INPUT_EXTRACTOR_IDENTITY
+    )
+    if extractor_name == WORKFLOW_LAUNCH_INPUT_EXTRACTOR_IDENTITY:
+        if value is None:
+            return False, None, "identity_value_missing"
+        if isinstance(value, str) and not value.strip():
+            return False, None, "identity_value_empty"
+        if isinstance(value, (list, tuple, set, dict)) and len(value) == 0:
+            return False, None, "identity_value_empty"
+        return True, value, "resolved"
+    if extractor_name == WORKFLOW_LAUNCH_INPUT_EXTRACTOR_FIRST_QUOTED_TEXT:
+        found, extracted = _extract_first_quoted_text(value)
+        return found, extracted, "resolved" if found else "quoted_text_not_found"
+    if extractor_name == WORKFLOW_LAUNCH_INPUT_EXTRACTOR_WORKFLOW_ID_LIST:
+        found, extracted = _extract_workflow_id_list(value)
+        return found, extracted, "resolved" if found else "workflow_id_list_empty"
+    return False, None, "extractor_invalid"
+
+
+def normalise_workflow_launch_input_contract(
+    value: Any,
+) -> tuple[Dict[str, Any] | None, str | None]:
+    """Normalise a workflow launch input contract payload."""
+
+    if not isinstance(value, Mapping):
+        return None, "workflow_launch_input_contract_missing_or_not_mapping"
+
+    schema_version = _normalise_text(value.get("schema_version"))
+    if schema_version and schema_version != WORKFLOW_LAUNCH_INPUT_CONTRACT_SCHEMA_VERSION:
+        return None, "workflow_launch_input_contract_schema_unsupported"
+
+    raw_mappings = value.get("input_mappings")
+    if not isinstance(raw_mappings, list):
+        return None, "workflow_launch_input_mappings_missing_or_not_list"
+
+    explicit_required_inputs = set(_normalise_string_list(value.get("required_inputs")))
+    mappings: List[Dict[str, Any]] = []
+    seen_targets: set[str] = set()
+
+    for item in raw_mappings:
+        if not isinstance(item, Mapping):
+            continue
+        target_context_key = _normalise_text(
+            item.get("target_context_key")
+            or item.get("workflow_context_key")
+            or item.get("context_key")
+            or item.get("target_key")
+        )
+        source_expression = _normalise_text(
+            item.get("source_expression")
+            or item.get("source")
+            or item.get("source_context_key")
+            or item.get("source_path")
+        )
+        extractor = (
+            _normalise_text(item.get("extractor"))
+            or WORKFLOW_LAUNCH_INPUT_EXTRACTOR_IDENTITY
+        )
+        if not target_context_key or not source_expression:
+            continue
+        if extractor not in _ALLOWED_EXTRACTORS:
+            return None, "workflow_launch_input_mapping_extractor_invalid"
+        if target_context_key in seen_targets:
+            continue
+        seen_targets.add(target_context_key)
+        required = _coerce_bool(
+            item.get("required"),
+            default=target_context_key in explicit_required_inputs,
+        )
+        mapping_payload: Dict[str, Any] = {
+            "target_context_key": target_context_key,
+            "source_expression": source_expression,
+            "extractor": extractor,
+            "required": required,
+        }
+        description = _normalise_text(item.get("description"))
+        if description:
+            mapping_payload["description"] = description
+        mappings.append(mapping_payload)
+
+    if not mappings:
+        return None, "workflow_launch_input_mappings_empty"
+
+    required_inputs = [
+        mapping["target_context_key"]
+        for mapping in mappings
+        if bool(mapping.get("required"))
+    ]
+    for item in _normalise_string_list(value.get("required_inputs")):
+        if item not in required_inputs:
+            required_inputs.append(item)
+
+    return (
+        {
+            "schema_version": WORKFLOW_LAUNCH_INPUT_CONTRACT_SCHEMA_VERSION,
+            "input_mappings": mappings,
+            "required_inputs": required_inputs,
+        },
+        None,
+    )
+
+
+def resolve_workflow_launch_inputs(
+    *,
+    workflow_id: str,
+    contract: Mapping[str, Any] | None,
+    inputs: Mapping[str, Any],
+    contract_source: str | None = None,
+) -> WorkflowLaunchInputResolution:
+    """Resolve workflow launch inputs from invocation context."""
+
+    normalised_contract, contract_error = normalise_workflow_launch_input_contract(
+        contract
+    )
+    contract_present = isinstance(contract, Mapping)
+    if normalised_contract is None:
+        diagnostics: Dict[str, Any] = {
+            "schema_version": "workflow_launch_input_resolution.v1",
+            "workflow_id": _normalise_text(workflow_id),
+            "status": "no_contract" if not contract_present else "invalid_contract",
+            "contract_source": _normalise_text(contract_source) or None,
+            "required_inputs": [],
+            "resolved_inputs": [],
+            "unresolved_required_inputs": [],
+            "unresolved_optional_inputs": [],
+            "mappings": [],
+        }
+        if contract_error:
+            diagnostics["contract_error"] = contract_error
+        return WorkflowLaunchInputResolution(
+            resolved_inputs={},
+            unresolved_required_inputs=(),
+            unresolved_optional_inputs=(),
+            diagnostics=diagnostics,
+        )
+
+    required_inputs = {
+        item
+        for item in normalised_contract.get("required_inputs", [])
+        if isinstance(item, str) and item.strip()
+    }
+    resolved_inputs: Dict[str, Any] = {}
+    unresolved_required_inputs: list[str] = []
+    unresolved_optional_inputs: list[str] = []
+    mapping_diagnostics: list[Dict[str, Any]] = []
+
+    for mapping in normalised_contract.get("input_mappings", []):
+        if not isinstance(mapping, Mapping):
+            continue
+        target_context_key = _normalise_text(mapping.get("target_context_key"))
+        source_expression = _normalise_text(mapping.get("source_expression"))
+        extractor = (
+            _normalise_text(mapping.get("extractor"))
+            or WORKFLOW_LAUNCH_INPUT_EXTRACTOR_IDENTITY
+        )
+        required = bool(mapping.get("required")) or target_context_key in required_inputs
+        source_found, source_value = _resolve_source_expression(
+            source_expression,
+            inputs=inputs,
+        )
+        mapping_entry: Dict[str, Any] = {
+            "target_context_key": target_context_key,
+            "source_expression": source_expression,
+            "extractor": extractor,
+            "required": required,
+            "source_found": source_found,
+        }
+        if not source_found:
+            mapping_entry["resolved"] = False
+            mapping_entry["resolution_reason"] = "source_missing"
+            if required:
+                unresolved_required_inputs.append(target_context_key)
+            else:
+                unresolved_optional_inputs.append(target_context_key)
+            mapping_diagnostics.append(mapping_entry)
+            continue
+
+        resolved, extracted_value, resolution_reason = _apply_extractor(
+            extractor=extractor,
+            value=source_value,
+        )
+        mapping_entry["resolved"] = resolved
+        mapping_entry["resolution_reason"] = resolution_reason
+        if resolved:
+            resolved_inputs[target_context_key] = extracted_value
+        else:
+            if required:
+                unresolved_required_inputs.append(target_context_key)
+            else:
+                unresolved_optional_inputs.append(target_context_key)
+        mapping_diagnostics.append(mapping_entry)
+
+    diagnostics = {
+        "schema_version": "workflow_launch_input_resolution.v1",
+        "workflow_id": _normalise_text(workflow_id),
+        "status": "failed" if unresolved_required_inputs else "resolved",
+        "contract_source": _normalise_text(contract_source) or None,
+        "required_inputs": sorted(required_inputs),
+        "resolved_inputs": sorted(resolved_inputs.keys()),
+        "unresolved_required_inputs": sorted(dict.fromkeys(unresolved_required_inputs)),
+        "unresolved_optional_inputs": sorted(dict.fromkeys(unresolved_optional_inputs)),
+        "mappings": mapping_diagnostics,
+    }
+    return WorkflowLaunchInputResolution(
+        resolved_inputs=resolved_inputs,
+        unresolved_required_inputs=tuple(
+            sorted(dict.fromkeys(unresolved_required_inputs))
+        ),
+        unresolved_optional_inputs=tuple(
+            sorted(dict.fromkeys(unresolved_optional_inputs))
+        ),
+        diagnostics=diagnostics,
+    )
+
+
+__all__ = [
+    "WORKFLOW_LAUNCH_INPUT_CONTRACT_SCHEMA_VERSION",
+    "WORKFLOW_LAUNCH_INPUT_EXTRACTOR_IDENTITY",
+    "WORKFLOW_LAUNCH_INPUT_EXTRACTOR_FIRST_QUOTED_TEXT",
+    "WORKFLOW_LAUNCH_INPUT_EXTRACTOR_WORKFLOW_ID_LIST",
+    "WorkflowLaunchInputResolution",
+    "normalise_workflow_launch_input_contract",
+    "resolve_workflow_launch_inputs",
+]

--- a/tests/backend/test_orchestrator_durable_instance_telemetry.py
+++ b/tests/backend/test_orchestrator_durable_instance_telemetry.py
@@ -12,6 +12,7 @@ from src.backend.workflows.durable.workflow_instance_submission_service import (
     WorkflowInstanceSubmissionResult,
 )
 from src.backend.workflows import (
+    WorkflowActionInvocation,
     WorkflowDefinition,
     WorkflowStateSpec,
 )
@@ -65,6 +66,39 @@ class _FakeWorkflowInstanceManager:
 
 def _build_orchestrator() -> InternalMCPChatOrchestrator:
     return InternalMCPChatOrchestrator(gateway=cast(Any, _DummyGateway()))
+
+
+def _register_test_workflow(
+    orchestrator: InternalMCPChatOrchestrator,
+    *,
+    workflow_id: str,
+    initial_state: str = "ready",
+    terminal: bool = False,
+    metadata: dict[str, Any] | None = None,
+    actions: tuple[WorkflowActionInvocation, ...] = (),
+) -> WorkflowDefinition:
+    workflow_metadata = dict(metadata or {})
+    definition = WorkflowDefinition(
+        workflow_id=workflow_id,
+        initial_state=initial_state,
+        states={
+            initial_state: WorkflowStateSpec(
+                state_id=initial_state,
+                actions=actions,
+                terminal=terminal,
+                metadata=workflow_metadata,
+            )
+        },
+        metadata=workflow_metadata,
+    )
+    orchestrator._workflow_registry.register_or_replace(
+        WorkflowRegistration(
+            workflow_id=workflow_id,
+            definition=definition,
+            source="test",
+        )
+    )
+    return definition
 
 
 def _patch_submit_verified_instance(monkeypatch) -> None:
@@ -130,6 +164,7 @@ def test_execute_workflow_persists_completed_durable_instance_with_turn_summary(
     monkeypatch,
 ) -> None:
     orchestrator = _build_orchestrator()
+    _register_test_workflow(orchestrator, workflow_id="#V#tool_calling_workflow")
     fake_manager = _FakeWorkflowInstanceManager()
     _patch_submit_verified_instance(monkeypatch)
 
@@ -202,6 +237,20 @@ def test_execute_workflow_persists_completed_durable_instance_with_turn_summary(
             "org_concept_id": "#V#org",
             "conversation_session_id": "chat-1",
             "turn_id": "turn-1",
+            "turn_execution_record": {
+                "workflow_selection": {
+                    "selected_workflow_id": "#V#tool_calling_workflow",
+                    "selector_verdict": "tool_seeking",
+                },
+                "workflow_routing_diagnostics": {
+                    "schema_version": "workflow_routing_diagnostics.v1",
+                    "selected_workflow_id": "#V#tool_calling_workflow",
+                    "dispatch": {
+                        "selected_execution_mode": "tool_pipeline",
+                        "last_successful_boundary": "workflow_terminal",
+                    },
+                },
+            },
             "workflow_routing": {
                 "workflow_id": "#V#tool_calling_workflow",
                 "verdict": "tool_seeking",
@@ -310,6 +359,7 @@ def test_execute_workflow_marks_durable_instance_failed_on_exception(
     monkeypatch,
 ) -> None:
     orchestrator = _build_orchestrator()
+    _register_test_workflow(orchestrator, workflow_id="#V#tool_calling_workflow")
     fake_manager = _FakeWorkflowInstanceManager()
     _patch_submit_verified_instance(monkeypatch)
 
@@ -383,23 +433,12 @@ def test_execute_workflow_materialises_terminal_effect_evidence_on_gateway_path(
     terminal_effect_id = (
         "#V#workflow_effect_terminal_effect_gateway_workflow_done_terminal"
     )
-    definition = WorkflowDefinition(
+    _register_test_workflow(
+        orchestrator,
         workflow_id=workflow_id,
         initial_state="done",
-        states={
-            "done": WorkflowStateSpec(
-                state_id="done",
-                terminal=True,
-                metadata={"effects": [terminal_effect_id]},
-            )
-        },
-    )
-    orchestrator._workflow_registry.register_or_replace(
-        WorkflowRegistration(
-            workflow_id=workflow_id,
-            definition=definition,
-            source="test",
-        )
+        terminal=True,
+        metadata={"effects": [terminal_effect_id]},
     )
 
     result = orchestrator.execute_workflow(
@@ -429,3 +468,183 @@ def test_execute_workflow_materialises_terminal_effect_evidence_on_gateway_path(
     outputs = fake_manager.mark_completed_calls[0].get("outputs")
     assert isinstance(outputs, dict)
     assert outputs.get("completed") is True
+
+
+def test_execute_workflow_applies_launch_input_contract_before_run(
+    monkeypatch,
+) -> None:
+    orchestrator = _build_orchestrator()
+    fake_manager = _FakeWorkflowInstanceManager()
+    _patch_submit_verified_instance(monkeypatch)
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.WorkflowInstanceManager",
+        lambda: fake_manager,
+    )
+
+    workflow_id = "#V#launch_input_contract_workflow"
+    _register_test_workflow(
+        orchestrator,
+        workflow_id=workflow_id,
+        initial_state="prepare",
+        terminal=True,
+        actions=(WorkflowActionInvocation(action_id="tool.prepare"),),
+        metadata={
+            "launch_input_contract": {
+                "schema_version": "workflow_launch_input_contract.v1",
+                "required_inputs": ["invitation_text"],
+                "input_mappings": [
+                    {
+                        "target_context_key": "invitation_text",
+                        "source_expression": "inputs.prompt",
+                        "extractor": "first_quoted_text",
+                        "required": True,
+                    },
+                    {
+                        "target_context_key": "candidate_workflow_ids",
+                        "source_expression": "inputs.workflow_discovery_result.matches",
+                        "extractor": "workflow_id_list",
+                    },
+                ],
+            },
+            "launch_input_contract_source": "test_contract",
+        },
+    )
+
+    captured_data: dict[str, Any] = {}
+
+    def _run(*_args: Any, **kwargs: Any):
+        captured_data.update(dict(kwargs.get("data") or {}))
+        return SimpleNamespace(
+            completed=True,
+            final_state="prepare",
+            error=None,
+            data={"response_text": "Prepared."},
+        )
+
+    monkeypatch.setattr(orchestrator._workflow_executor, "run", _run)
+
+    result = orchestrator.execute_workflow(
+        workflow_id,
+        data={
+            "prompt": (
+                'Run a meeting-invitation test on this invitation text:\n\n'
+                '"Kia ora team, please join us on Tuesday at 2:00pm in Room 4 '
+                'for a project planning meeting about the Q2 roadmap."'
+            ),
+            "workflow_discovery_result": {
+                "matches": [
+                    {"concept_id": "#V#meeting_invitation_testing_workflow"},
+                    {"concept_id": "#V#synthetic_workflow_regression_suite_workflow"},
+                ]
+            },
+            "user_concept_id": "#V#user",
+            "org_concept_id": "#V#org",
+            "conversation_session_id": "chat-launch",
+            "turn_id": "turn-launch",
+        },
+        llm_client=object(),
+        model="test-model",
+        user_namespace="#V#user@org",
+        conversation_session_id="chat-launch",
+        turn_id="turn-launch",
+        episode_source="chat_turn_workflow",
+    )
+
+    assert result is not None
+    assert result.completed is True
+    assert captured_data["invitation_text"] == (
+        "Kia ora team, please join us on Tuesday at 2:00pm in Room 4 for a "
+        "project planning meeting about the Q2 roadmap."
+    )
+    assert captured_data["candidate_workflow_ids"] == [
+        "#V#meeting_invitation_testing_workflow",
+        "#V#synthetic_workflow_regression_suite_workflow",
+    ]
+    launch_resolution = captured_data.get("workflow_launch_input_resolution")
+    assert isinstance(launch_resolution, dict)
+    assert launch_resolution.get("status") == "resolved"
+    assert launch_resolution.get("resolved_inputs") == [
+        "candidate_workflow_ids",
+        "invitation_text",
+    ]
+    assert len(fake_manager.create_for_event_calls) == 1
+    create_inputs = fake_manager.create_for_event_calls[0].get("inputs")
+    assert isinstance(create_inputs, dict)
+    persisted_resolution = create_inputs.get("workflow_launch_input_resolution")
+    assert isinstance(persisted_resolution, dict)
+    assert persisted_resolution.get("status") == "resolved"
+
+
+def test_execute_workflow_fails_closed_when_required_launch_input_unresolved(
+    monkeypatch,
+) -> None:
+    orchestrator = _build_orchestrator()
+    fake_manager = _FakeWorkflowInstanceManager()
+    _patch_submit_verified_instance(monkeypatch)
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.WorkflowInstanceManager",
+        lambda: fake_manager,
+    )
+
+    workflow_id = "#V#launch_input_failure_workflow"
+    _register_test_workflow(
+        orchestrator,
+        workflow_id=workflow_id,
+        initial_state="prepare",
+        terminal=True,
+        actions=(WorkflowActionInvocation(action_id="tool.prepare"),),
+        metadata={
+            "launch_input_contract": {
+                "schema_version": "workflow_launch_input_contract.v1",
+                "required_inputs": ["invitation_text"],
+                "input_mappings": [
+                    {
+                        "target_context_key": "invitation_text",
+                        "source_expression": "inputs.prompt",
+                        "extractor": "first_quoted_text",
+                        "required": True,
+                    }
+                ],
+            },
+            "launch_input_contract_source": "test_contract",
+        },
+    )
+
+    def _unexpected_run(*_args: Any, **_kwargs: Any):
+        raise AssertionError(
+            "workflow executor should not run when launch inputs are unresolved"
+        )
+
+    monkeypatch.setattr(orchestrator._workflow_executor, "run", _unexpected_run)
+
+    result = orchestrator.execute_workflow(
+        workflow_id,
+        data={
+            "prompt": "Run the meeting invitation test without a quoted specimen.",
+            "user_concept_id": "#V#user",
+            "org_concept_id": "#V#org",
+            "conversation_session_id": "chat-fail",
+            "turn_id": "turn-fail",
+        },
+        llm_client=object(),
+        model="test-model",
+        user_namespace="#V#user@org",
+        conversation_session_id="chat-fail",
+        turn_id="turn-fail",
+        episode_source="chat_turn_workflow",
+    )
+
+    assert result is not None
+    assert result.completed is False
+    assert result.final_state == "prepare"
+    assert "workflow_launch_input_resolution_failed" in str(result.error)
+    resolution = result.data.get("workflow_launch_input_resolution")
+    assert isinstance(resolution, dict)
+    assert resolution.get("status") == "failed"
+    assert resolution.get("unresolved_required_inputs") == ["invitation_text"]
+    assert resolution.get("failing_state_id") == "prepare"
+    assert resolution.get("failing_action_id") == "tool.prepare"
+    assert "required launch inputs were unresolved" in str(
+        result.data.get("response_text")
+    )
+    assert fake_manager.create_for_event_calls == []

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -2983,6 +2983,22 @@ def test_non_standard_workflow_routes_via_execute_workflow(monkeypatch):
     """Workflows in the registry but not in the standard set should use execute_workflow."""
 
     orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
+    execute_calls: list[dict[str, Any]] = []
+
+    def _execute_workflow(workflow_id: str, **kwargs: Any):
+        execute_calls.append(
+            {
+                "workflow_id": workflow_id,
+                "data": dict(kwargs.get("data") or {}),
+            }
+        )
+        return SimpleNamespace(
+            completed=True,
+            final_state="completed",
+            data={"response_text": "Todo refresh complete."},
+        )
+
+    monkeypatch.setattr(orchestrator, "execute_workflow", _execute_workflow)
 
     # The selector returns #V#todo_refresh_workflow, which IS in the registry.
     # We pass it via workflow_discovery_result so the selector treats it as a
@@ -3021,6 +3037,12 @@ def test_non_standard_workflow_routes_via_execute_workflow(monkeypatch):
         entry.get("type") for entry in result.aux_llm_calls if isinstance(entry, dict)
     ]
     assert "workflow_selector" in aux_types
+    assert len(execute_calls) == 1
+    assert execute_calls[0]["workflow_id"] == TODO_REFRESH_WORKFLOW_ID
+    handoff_data = execute_calls[0]["data"]
+    assert isinstance(handoff_data.get("workflow_discovery_result"), dict)
+    assert isinstance(handoff_data.get("workflow_routing"), dict)
+    assert handoff_data.get("selected_workflow_id") == TODO_REFRESH_WORKFLOW_ID
 
     # Should have a workflow_execution entry (non-standard workflow dispatch).
     execution_entry = next(

--- a/tests/backend/test_testing_workflow_vontology_service.py
+++ b/tests/backend/test_testing_workflow_vontology_service.py
@@ -65,6 +65,26 @@ def test_bootstrap_materialises_testing_workflow_family(
         definition = load_workflow_definition_from_vontology(workflow_id)
         assert definition is not None
 
+    meeting_definition = load_workflow_definition_from_vontology(
+        MEETING_INVITATION_TESTING_WORKFLOW_ID
+    )
+    assert meeting_definition is not None
+    meeting_launch_contract = meeting_definition.metadata.get("launch_input_contract")
+    assert isinstance(meeting_launch_contract, dict)
+    assert meeting_launch_contract.get("schema_version") == (
+        "workflow_launch_input_contract.v1"
+    )
+    assert meeting_launch_contract.get("required_inputs") == ["invitation_text"]
+    input_mappings = meeting_launch_contract.get("input_mappings")
+    assert isinstance(input_mappings, list)
+    assert any(
+        isinstance(item, dict)
+        and item.get("target_context_key") == "invitation_text"
+        and item.get("source_expression") == "inputs.prompt"
+        and item.get("extractor") == "first_quoted_text"
+        for item in input_mappings
+    )
+
     meeting_concept = concept_service.get_concept_by_concept_id(
         MEETING_INVITATION_TESTING_WORKFLOW_ID
     )

--- a/tests/backend/test_workflow_launch_input_contracts.py
+++ b/tests/backend/test_workflow_launch_input_contracts.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from src.backend.workflows.workflow_launch_input_contracts import (
+    WORKFLOW_LAUNCH_INPUT_CONTRACT_SCHEMA_VERSION,
+    normalise_workflow_launch_input_contract,
+    resolve_workflow_launch_inputs,
+)
+
+
+def test_resolve_workflow_launch_inputs_extracts_declared_values() -> None:
+    resolution = resolve_workflow_launch_inputs(
+        workflow_id="#V#meeting_invitation_testing_workflow",
+        contract={
+            "schema_version": WORKFLOW_LAUNCH_INPUT_CONTRACT_SCHEMA_VERSION,
+            "required_inputs": ["invitation_text"],
+            "input_mappings": [
+                {
+                    "target_context_key": "invitation_text",
+                    "source_expression": "inputs.prompt",
+                    "extractor": "first_quoted_text",
+                    "required": True,
+                },
+                {
+                    "target_context_key": "candidate_workflow_ids",
+                    "source_expression": "inputs.workflow_discovery_result.matches",
+                    "extractor": "workflow_id_list",
+                },
+            ],
+        },
+        inputs={
+            "prompt": (
+                'Run a meeting-invitation test on this invitation text:\n\n'
+                '"Kia ora team, please join us on Tuesday at 2:00pm in Room 4."'
+            ),
+            "workflow_discovery_result": {
+                "matches": [
+                    {"concept_id": "#V#meeting_invitation_testing_workflow"},
+                    {"workflow_id": "#V#synthetic_workflow_regression_suite_workflow"},
+                ]
+            },
+        },
+        contract_source="text_relation:#V#hasWorkflowLaunchInputContractJson",
+    )
+
+    assert dict(resolution.resolved_inputs) == {
+        "invitation_text": "Kia ora team, please join us on Tuesday at 2:00pm in Room 4.",
+        "candidate_workflow_ids": [
+            "#V#meeting_invitation_testing_workflow",
+            "#V#synthetic_workflow_regression_suite_workflow",
+        ],
+    }
+    assert resolution.unresolved_required_inputs == ()
+    assert resolution.diagnostics.get("status") == "resolved"
+
+
+def test_resolve_workflow_launch_inputs_fails_closed_for_missing_required_value() -> None:
+    resolution = resolve_workflow_launch_inputs(
+        workflow_id="#V#meeting_invitation_testing_workflow",
+        contract={
+            "schema_version": WORKFLOW_LAUNCH_INPUT_CONTRACT_SCHEMA_VERSION,
+            "required_inputs": ["invitation_text"],
+            "input_mappings": [
+                {
+                    "target_context_key": "invitation_text",
+                    "source_expression": "inputs.prompt",
+                    "extractor": "first_quoted_text",
+                    "required": True,
+                }
+            ],
+        },
+        inputs={"prompt": "Run the test without a quoted invitation specimen."},
+    )
+
+    assert dict(resolution.resolved_inputs) == {}
+    assert resolution.unresolved_required_inputs == ("invitation_text",)
+    assert resolution.diagnostics.get("status") == "failed"
+    assert resolution.diagnostics.get("unresolved_required_inputs") == [
+        "invitation_text"
+    ]
+
+
+def test_normalise_workflow_launch_input_contract_rejects_invalid_extractor() -> None:
+    contract, error = normalise_workflow_launch_input_contract(
+        {
+            "schema_version": WORKFLOW_LAUNCH_INPUT_CONTRACT_SCHEMA_VERSION,
+            "input_mappings": [
+                {
+                    "target_context_key": "invitation_text",
+                    "source_expression": "inputs.prompt",
+                    "extractor": "unsupported_extractor",
+                }
+            ],
+        }
+    )
+
+    assert contract is None
+    assert error == "workflow_launch_input_mapping_extractor_invalid"


### PR DESCRIPTION
## Summary
- add a generic workflow launch-input contract primitive resolved from Vontology metadata
- apply launch-input resolution before custom workflow execution and fail closed when required inputs cannot be resolved
- materialise the meeting-invitation workflow contract in Vontology-backed testing workflow bootstrap, update docs, and add targeted unit/integration coverage

## Validation
- `pdm run pytest tests/backend/test_workflow_launch_input_contracts.py -q`
- `pdm run pytest tests/backend/test_testing_workflow_vontology_service.py -q`
- `pdm run pytest tests/backend/test_orchestrator_durable_instance_telemetry.py -q`
- `pdm run pytest tests/backend/test_orchestrator_workflow_selector_routing.py -q -k "non_standard_workflow_routes_via_execute_workflow or custom_tool_pipeline_workflow_dispatches_without_id_special_casing"`
- `pdm run pyright src/backend/integrations/internal_mcp/orchestrator.py src/backend/services/testing_workflow_vontology_service.py src/backend/workflows/vontology_loader.py src/backend/workflows/workflow_launch_input_contracts.py tests/backend/test_orchestrator_durable_instance_telemetry.py tests/backend/test_orchestrator_workflow_selector_routing.py tests/backend/test_testing_workflow_vontology_service.py tests/backend/test_workflow_launch_input_contracts.py`