### PR TITLE
JVNAUTOSCI-1557 Align workflow dispatch telemetry

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -25084,6 +25084,12 @@ class InternalMCPChatOrchestrator:
                 return None
             return dict(renderer_render_plan)
 
+        def _clean_boundary_scalar_text(value: Any) -> str | None:
+            if isinstance(value, str):
+                cleaned = value.strip()
+                return cleaned or None
+            return None
+
         def _emit_dispatch_boundary(
             *,
             boundary: str,
@@ -25102,19 +25108,17 @@ class InternalMCPChatOrchestrator:
                 "selected_execution_mode": selected_execution_mode,
             }
 
-            def _clean_scalar_text(value: Any) -> str | None:
-                if isinstance(value, str):
-                    cleaned = value.strip()
-                    return cleaned or None
-                return None
-
-            cleaned_selected_workflow_id = _clean_scalar_text(selected_workflow_id)
+            cleaned_selected_workflow_id = _clean_boundary_scalar_text(
+                selected_workflow_id
+            )
             if cleaned_selected_workflow_id:
                 payload["selected_workflow_id"] = cleaned_selected_workflow_id
-            cleaned_dispatch_workflow_id = _clean_scalar_text(dispatch_workflow_id)
+            cleaned_dispatch_workflow_id = _clean_boundary_scalar_text(
+                dispatch_workflow_id
+            )
             if cleaned_dispatch_workflow_id:
                 payload["dispatch_workflow_id"] = cleaned_dispatch_workflow_id
-            cleaned_final_state = _clean_scalar_text(final_state)
+            cleaned_final_state = _clean_boundary_scalar_text(final_state)
             if cleaned_final_state:
                 payload["final_state"] = cleaned_final_state
             if isinstance(completed, bool):
@@ -25141,20 +25145,130 @@ class InternalMCPChatOrchestrator:
                 progress_phase_label = "Tool dispatch handoff"
             elif boundary == "workflow_terminal":
                 progress_phase_label = "Workflow terminal state"
-            _emit_progress_local(
-                {
-                    "status": "thinking",
-                    "stage": progress_stage,
-                    "phase": progress_stage,
-                    "phase_label": progress_phase_label,
-                    "result_summary": (
-                        f"{boundary}:{status}"
-                        if boundary and status
-                        else boundary or status or "workflow_dispatch_boundary"
-                    ),
-                    **_build_live_workflow_routing_payload(),
-                }
+            progress_payload: dict[str, Any] = {
+                "status": "thinking",
+                "stage": progress_stage,
+                "phase": progress_stage,
+                "phase_label": progress_phase_label,
+                "result_summary": (
+                    f"{boundary}:{status}"
+                    if boundary and status
+                    else boundary or status or "workflow_dispatch_boundary"
+                ),
+                **_build_live_workflow_routing_payload(),
+            }
+            if cleaned_selected_workflow_id:
+                progress_payload["selected_workflow_id"] = cleaned_selected_workflow_id
+                selected_name = _resolve_selected_workflow_name(
+                    cleaned_selected_workflow_id
+                )
+                if selected_name:
+                    progress_payload["selected_workflow_name"] = selected_name
+                progress_payload.setdefault(
+                    "workflow_task",
+                    cleaned_dispatch_workflow_id or cleaned_selected_workflow_id,
+                )
+            if cleaned_dispatch_workflow_id:
+                progress_payload["dispatch_workflow_id"] = cleaned_dispatch_workflow_id
+            selector_verdict_value = _clean_boundary_scalar_text(selector_verdict)
+            if selector_verdict_value:
+                progress_payload["workflow_selector_verdict"] = selector_verdict_value
+            selector_source_value = (
+                _clean_boundary_scalar_text(routing_info.source)
+                if isinstance(routing_info, WorkflowRoutingInfo)
+                else None
             )
+            if selector_source_value:
+                progress_payload["workflow_selector_source"] = selector_source_value
+            selection_rationale_value = (
+                _clean_boundary_scalar_text(workflow_selection_rationale)
+                or (
+                    _clean_boundary_scalar_text(routing_info.selection_rationale)
+                    if isinstance(routing_info, WorkflowRoutingInfo)
+                    else None
+                )
+            )
+            if selection_rationale_value:
+                progress_payload["workflow_selection_rationale"] = (
+                    selection_rationale_value
+                )
+            _emit_progress_local(progress_payload)
+
+        def _clean_text_sequence(value: Any) -> list[str]:
+            if not isinstance(value, Sequence) or isinstance(
+                value, (str, bytes, bytearray)
+            ):
+                return []
+            cleaned_values: list[str] = []
+            seen_values: set[str] = set()
+            for item in value:
+                item_text = _clean_boundary_scalar_text(item)
+                if not item_text:
+                    continue
+                lowered = item_text.lower()
+                if lowered in seen_values:
+                    continue
+                seen_values.add(lowered)
+                cleaned_values.append(item_text)
+            return cleaned_values
+
+        def _build_workflow_terminal_failure_extra(result: Any) -> dict[str, Any]:
+            if bool(getattr(result, "completed", False)):
+                return {}
+
+            extra_payload: dict[str, Any] = {}
+            result_error = _clean_boundary_scalar_text(getattr(result, "error", None))
+            if result_error:
+                extra_payload["error"] = result_error
+                reason_code = result_error.split(":", 1)[0].strip()
+                if reason_code:
+                    extra_payload["reason"] = reason_code
+
+            result_data = getattr(result, "data", None)
+            if isinstance(result_data, Mapping):
+                failure_detail = _clean_boundary_scalar_text(
+                    result_data.get("summary")
+                ) or (
+                    _clean_boundary_scalar_text(result_data.get("response_text"))
+                )
+                if failure_detail:
+                    extra_payload["detail"] = failure_detail
+
+                launch_resolution = result_data.get("workflow_launch_input_resolution")
+                if isinstance(launch_resolution, Mapping):
+                    resolution_status = _clean_boundary_scalar_text(
+                        launch_resolution.get("status")
+                    )
+                    if resolution_status:
+                        extra_payload["workflow_launch_input_resolution_status"] = (
+                            resolution_status
+                        )
+                        if (
+                            resolution_status.lower() in {"failed", "missing"}
+                            and "reason" not in extra_payload
+                        ):
+                            extra_payload["reason"] = (
+                                "workflow_launch_input_resolution_failed"
+                            )
+                    unresolved_required_inputs = _clean_text_sequence(
+                        launch_resolution.get("unresolved_required_inputs")
+                    )
+                    if unresolved_required_inputs:
+                        extra_payload["unresolved_required_inputs"] = (
+                            unresolved_required_inputs
+                        )
+                    failing_state_id = _clean_boundary_scalar_text(
+                        launch_resolution.get("failing_state_id")
+                    )
+                    if failing_state_id:
+                        extra_payload["failing_state_id"] = failing_state_id
+                    failing_action_id = _clean_boundary_scalar_text(
+                        launch_resolution.get("failing_action_id")
+                    )
+                    if failing_action_id:
+                        extra_payload["failing_action_id"] = failing_action_id
+
+            return extra_payload
 
         # ----------------------------------------------------------------
         # JVNAUTOSCI-825: Route turns to the appropriate pathway.
@@ -25710,6 +25824,7 @@ class InternalMCPChatOrchestrator:
                         dispatch_workflow_id=selected_workflow_id_text,
                         final_state=wf_result.final_state,
                         completed=wf_result.completed,
+                        extra=_build_workflow_terminal_failure_extra(wf_result) or None,
                     )
                     result = _refresh_result_runtime_snapshots(result)
                     _persist_trace(status="completed")
@@ -26070,7 +26185,10 @@ class InternalMCPChatOrchestrator:
                 dispatch_workflow_id=tool_dispatch_workflow_id,
                 final_state=tc_result.final_state,
                 completed=tc_result.completed,
-                extra={"prebuilt_result": True},
+                extra={
+                    **_build_workflow_terminal_failure_extra(tc_result),
+                    "prebuilt_result": True,
+                },
             )
             if isinstance(prebuilt_result, OrchestratorResult):
                 result_with_dispatch_telemetry = _refresh_result_runtime_snapshots(
@@ -26178,6 +26296,7 @@ class InternalMCPChatOrchestrator:
             final_state=tc_result.final_state,
             completed=tc_result.completed,
             extra={
+                **_build_workflow_terminal_failure_extra(tc_result),
                 "requires_follow_up": gate_requires_follow_up,
                 "safe_to_claim_completion": gate_safe_to_claim_completion,
             },

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -237,6 +237,14 @@ _NEGATED_MUTATION_PREFIX_PATTERN = re.compile(
 
 _TOOL_CALLING_SELECTOR_VERDICTS = {"tool_seeking", "tool_calling"}
 
+_SELECTOR_PROMPT_FAILURE_VERDICTS = {
+    "selector_exception",
+    "selector_prompt_missing_candidate_list",
+    "selector_prompt_missing_turn_text",
+    "selector_prompt_render_error",
+    "selector_prompt_unavailable",
+}
+
 _TOOL_EXECUTION_FAILURE_REASON_MAP = {
     "worker_unavailable_zero_execution": "Tool execution was blocked while workers were unavailable.",
     "missing_tool_call_parse_error": "Tool call parsing failed before any tool execution occurred.",
@@ -960,6 +968,24 @@ def build_workflow_routing_diagnostics(
         selector_response_capture = _build_text_capture(
             selector_entry.get("raw_response")
         )
+    selector_prompt_failure_reason = _safe_str(
+        _selector_context_value("prompt_failure_reason")
+    )
+    selector_prompt_failure_detail = _safe_str(
+        _selector_context_value("prompt_failure_detail")
+    )
+    selector_outcome_workflow_id = _safe_str(
+        workflow_routing_payload.get("workflow_id")
+    ) or _safe_str(selector_entry.get("workflow_id"))
+    selector_outcome_verdict = _safe_str(workflow_routing_payload.get("verdict")) or _safe_str(
+        selector_entry.get("verdict")
+    )
+    if selector_outcome_workflow_id and (
+        (selector_outcome_verdict or "").strip().lower()
+        not in _SELECTOR_PROMPT_FAILURE_VERDICTS
+    ):
+        selector_prompt_failure_reason = None
+        selector_prompt_failure_detail = None
     raw_policy_candidate_scores = (
         selector_entry.get("policy_candidate_scores")
         if selector_entry.get("policy_candidate_scores") is not None
@@ -1057,6 +1083,14 @@ def build_workflow_routing_diagnostics(
         if dispatch_primary_failure_code
         else None
     )
+    raw_dispatch_terminal_unresolved_required_inputs = execution_summary_payload.get(
+        "dispatch_terminal_unresolved_required_inputs"
+    )
+    dispatch_terminal_unresolved_required_inputs = (
+        list(raw_dispatch_terminal_unresolved_required_inputs)
+        if isinstance(raw_dispatch_terminal_unresolved_required_inputs, list)
+        else []
+    )
     first_dispatch_boundary = (
         _safe_str(dispatch_events[0].get("boundary")) if dispatch_events else None
     )
@@ -1116,12 +1150,8 @@ def build_workflow_routing_diagnostics(
             ),
             "reasoning": _safe_str(selector_entry.get("reasoning"))
             or _safe_str(workflow_routing_payload.get("reasoning")),
-            "prompt_failure_reason": _safe_str(
-                _selector_context_value("prompt_failure_reason")
-            ),
-            "prompt_failure_detail": _safe_str(
-                _selector_context_value("prompt_failure_detail")
-            ),
+            "prompt_failure_reason": selector_prompt_failure_reason,
+            "prompt_failure_detail": selector_prompt_failure_detail,
             "requested_prompt_ids": selector_requested_prompt_ids,
             "prompt_provenance": selector_prompt_provenance,
             "discovered_workflow_ids": _extract_workflow_ids(
@@ -1221,6 +1251,23 @@ def build_workflow_routing_diagnostics(
             ),
             "dispatch_terminal_failure_error_class": _safe_str(
                 execution_summary_payload.get("dispatch_terminal_failure_error_class")
+            ),
+            "dispatch_terminal_failure_detail": _safe_str(
+                execution_summary_payload.get("dispatch_terminal_failure_detail")
+            ),
+            "dispatch_terminal_failing_state_id": _safe_str(
+                execution_summary_payload.get("dispatch_terminal_failing_state_id")
+            ),
+            "dispatch_terminal_failing_action_id": _safe_str(
+                execution_summary_payload.get("dispatch_terminal_failing_action_id")
+            ),
+            "dispatch_terminal_unresolved_required_inputs": (
+                dispatch_terminal_unresolved_required_inputs
+            ),
+            "dispatch_terminal_launch_input_resolution_status": _safe_str(
+                execution_summary_payload.get(
+                    "dispatch_terminal_launch_input_resolution_status"
+                )
             ),
             "tool_route_selected": bool(
                 execution_summary_payload.get("tool_route_selected")
@@ -1543,6 +1590,11 @@ def _summarise_tool_execution_context(
     dispatch_terminal_completed: bool | None = None
     dispatch_terminal_failure_reason = ""
     dispatch_terminal_failure_error_class = ""
+    dispatch_terminal_failure_detail = ""
+    dispatch_terminal_failing_state_id = ""
+    dispatch_terminal_failing_action_id = ""
+    dispatch_terminal_unresolved_required_inputs: list[str] = []
+    dispatch_terminal_launch_input_resolution_status = ""
     for entry in aux_llm_calls or ():
         if not isinstance(entry, Mapping):
             continue
@@ -1592,6 +1644,29 @@ def _summarise_tool_execution_context(
             completed_value = event.get("completed")
             if isinstance(completed_value, bool):
                 dispatch_terminal_completed = completed_value
+            failure_detail_value = _safe_str(event.get("detail")) or _safe_str(
+                event.get("error")
+            )
+            if failure_detail_value:
+                dispatch_terminal_failure_detail = failure_detail_value
+            failing_state_id = _safe_str(event.get("failing_state_id"))
+            if failing_state_id:
+                dispatch_terminal_failing_state_id = failing_state_id
+            failing_action_id = _safe_str(event.get("failing_action_id"))
+            if failing_action_id:
+                dispatch_terminal_failing_action_id = failing_action_id
+            launch_input_resolution_status = _safe_str(
+                event.get("workflow_launch_input_resolution_status")
+            )
+            if launch_input_resolution_status:
+                dispatch_terminal_launch_input_resolution_status = (
+                    launch_input_resolution_status
+                )
+            unresolved_required_inputs = event.get("unresolved_required_inputs")
+            if isinstance(unresolved_required_inputs, list):
+                dispatch_terminal_unresolved_required_inputs = (
+                    _dedupe_string_sequence(unresolved_required_inputs)
+                )
             if status == "failed":
                 dispatch_terminal_failure_reason = (
                     _safe_str(event.get("reason")) or ""
@@ -1717,6 +1792,21 @@ def _summarise_tool_execution_context(
         "dispatch_terminal_failure_reason": dispatch_terminal_failure_reason or None,
         "dispatch_terminal_failure_error_class": (
             dispatch_terminal_failure_error_class or None
+        ),
+        "dispatch_terminal_failure_detail": dispatch_terminal_failure_detail or None,
+        "dispatch_terminal_failing_state_id": (
+            dispatch_terminal_failing_state_id or None
+        ),
+        "dispatch_terminal_failing_action_id": (
+            dispatch_terminal_failing_action_id or None
+        ),
+        "dispatch_terminal_unresolved_required_inputs": (
+            list(dispatch_terminal_unresolved_required_inputs)
+            if dispatch_terminal_unresolved_required_inputs
+            else []
+        ),
+        "dispatch_terminal_launch_input_resolution_status": (
+            dispatch_terminal_launch_input_resolution_status or None
         ),
         "last_successful_boundary": last_successful_boundary or None,
         "planned_count": planned_count,

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -2987,6 +2987,9 @@ def test_workflow_selector_emits_dispatch_progress_events(monkeypatch):
 def test_non_standard_workflow_routes_via_execute_workflow(monkeypatch):
     """Workflows in the registry but not in the standard set should use execute_workflow."""
 
+    import src.backend.services.workflow_selection_policy_service as policy_module
+
+    monkeypatch.setattr(policy_module, "get_live_selection_policy", lambda: None)
     orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
     execute_calls: list[dict[str, Any]] = []
 
@@ -3066,6 +3069,9 @@ def test_non_standard_workflow_routes_via_execute_workflow(monkeypatch):
 def test_custom_workflow_run_applies_launch_contract_without_workflow_specific_glue(
     monkeypatch,
 ):
+    import src.backend.services.workflow_selection_policy_service as policy_module
+
+    monkeypatch.setattr(policy_module, "get_live_selection_policy", lambda: None)
     orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
     selected_workflow_id = "#V#launch_contract_custom_workflow"
     monkeypatch.setenv("VON_WORKFLOW_SELECTOR_ALLOW_POLICY_UNSAFE", "1")
@@ -3182,6 +3188,137 @@ def test_custom_workflow_run_applies_launch_contract_without_workflow_specific_g
         "candidate_workflow_ids",
         "invitation_text",
     ]
+
+
+def test_custom_workflow_first_step_failure_projects_terminal_locality(monkeypatch):
+    import src.backend.services.workflow_selection_policy_service as policy_module
+
+    monkeypatch.setattr(policy_module, "get_live_selection_policy", lambda: None)
+    orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
+    selected_workflow_id = "#V#launch_contract_failure_custom_workflow"
+    monkeypatch.setenv("VON_WORKFLOW_SELECTOR_ALLOW_POLICY_UNSAFE", "1")
+    orchestrator._workflow_registry.register_or_replace(
+        WorkflowRegistration(
+            workflow_id=selected_workflow_id,
+            definition=WorkflowDefinition(
+                workflow_id=selected_workflow_id,
+                initial_state="prepare_spec",
+                states={
+                    "prepare_spec": WorkflowStateSpec(
+                        state_id="prepare_spec",
+                        actions=(
+                            WorkflowActionInvocation(action_id="tool.prepare_spec"),
+                        ),
+                        terminal=True,
+                    )
+                },
+            ),
+            purpose="Custom workflow failure locality projection test.",
+            source="test",
+        )
+    )
+
+    def _execute_workflow(workflow_id: str, **_kwargs: Any):
+        assert workflow_id == selected_workflow_id
+        return SimpleNamespace(
+            completed=False,
+            final_state="prepare_spec",
+            error="workflow_launch_input_resolution_failed:invitation_text",
+            data={
+                "response_text": (
+                    f"Workflow {selected_workflow_id} could not start because "
+                    "required launch inputs were unresolved: invitation_text."
+                ),
+                "workflow_launch_input_resolution": {
+                    "status": "failed",
+                    "unresolved_required_inputs": ["invitation_text"],
+                    "failing_state_id": "prepare_spec",
+                    "failing_action_id": "tool.prepare_spec",
+                },
+            },
+        )
+
+    monkeypatch.setattr(orchestrator, "execute_workflow", _execute_workflow)
+
+    progress_events: list[dict[str, Any]] = []
+    orchestrator.set_progress_callback(lambda info: progress_events.append(dict(info)))
+
+    result = orchestrator.run(
+        prompt=(
+            'Run the meeting invitation testing workflow on this invitation:\n\n'
+            '"Kia ora team, please join us on Tuesday at 2:00pm in Room 4."'
+        ),
+        context=[],
+        llm_client=_CapturingLLM([selected_workflow_id]),
+        model=None,
+        user_namespace="#V#user@org",
+        workflow_discovery_result={
+            "matches": [
+                {
+                    "concept_id": selected_workflow_id,
+                    "name": "Launch contract failure custom workflow",
+                    "is_executable": True,
+                    "executability_reason": "executable_now",
+                }
+            ],
+            "candidates": [
+                {
+                    "concept_id": selected_workflow_id,
+                    "name": "Launch contract failure custom workflow",
+                    "is_executable": True,
+                    "executability_reason": "executable_now",
+                }
+            ],
+            "match_count": 1,
+        },
+            conversation_session_id="chat-launch-failure",
+            turn_id="turn-launch-failure",
+        )
+
+    assert "required launch inputs were unresolved: invitation_text" in result.response_text
+    assert result.workflow_routing is not None
+    assert result.workflow_routing.workflow_id == selected_workflow_id
+
+    dispatch_boundaries = [
+        entry
+        for entry in result.aux_llm_calls
+        if isinstance(entry, dict) and entry.get("type") == "workflow_dispatch_boundary"
+    ]
+    assert [entry.get("boundary") for entry in dispatch_boundaries[-3:]] == [
+        "execution_mode_selected",
+        "workflow_handoff",
+        "workflow_terminal",
+    ]
+    assert dispatch_boundaries[-2].get("status") == "started"
+    terminal_boundary = dispatch_boundaries[-1]
+    assert terminal_boundary.get("status") == "failed"
+    assert terminal_boundary.get("selected_execution_mode") == "custom_workflow"
+    assert terminal_boundary.get("selected_workflow_id") == selected_workflow_id
+    assert terminal_boundary.get("dispatch_workflow_id") == selected_workflow_id
+    assert terminal_boundary.get("final_state") == "prepare_spec"
+    assert terminal_boundary.get("reason") == "workflow_launch_input_resolution_failed"
+    assert terminal_boundary.get("workflow_launch_input_resolution_status") == "failed"
+    assert terminal_boundary.get("unresolved_required_inputs") == ["invitation_text"]
+    assert terminal_boundary.get("failing_state_id") == "prepare_spec"
+    assert terminal_boundary.get("failing_action_id") == "tool.prepare_spec"
+
+    terminal_progress = next(
+        (
+            entry
+            for entry in reversed(progress_events)
+            if entry.get("phase_label") == "Workflow terminal state"
+        ),
+        None,
+    )
+    assert terminal_progress is not None
+    assert terminal_progress.get("selected_workflow_id") == selected_workflow_id
+    assert terminal_progress.get("selected_workflow_name") == (
+        "Launch contract failure custom workflow"
+    )
+    assert terminal_progress.get("workflow_selector_verdict") == "rag_selected"
+    assert terminal_progress.get("workflow_selector_source") == "selector"
+    assert isinstance(terminal_progress.get("workflow_selection_rationale"), str)
+    assert terminal_progress.get("workflow_selection_rationale")
 
 
 def test_custom_tool_pipeline_workflow_dispatches_without_id_special_casing(monkeypatch):

--- a/tests/backend/test_tool_progress_liveness.py
+++ b/tests/backend/test_tool_progress_liveness.py
@@ -1356,6 +1356,173 @@ def test_turn_execution_diagnostics_include_routing_diagnostics_from_selector_an
     )
 
 
+def test_turn_execution_diagnostics_clear_stale_selector_prompt_failure_after_success(
+    monkeypatch,
+) -> None:
+    clock = _set_clock(monkeypatch, start=5610.0)
+
+    selected_workflow_id = "#V#meeting_invitation_testing_workflow"
+    selector_prompt_entry = {
+        "type": "workflow_selector_prompt",
+        "prompt_id": "#V#chat_turn_classifier_prompt",
+        "requested_prompt_ids": ["#V#chat_turn_classifier_prompt"],
+        "prompt": {"text": "Select workflow", "char_count": 15},
+        "candidate_list": {"text": f"- {selected_workflow_id}", "char_count": 39},
+        "prompt_failure_reason": "selector_prompt_missing_candidate_list",
+        "prompt_failure_detail": "Selector template omitted the candidate list.",
+    }
+    selector_success_entry = {
+        "type": "workflow_selector",
+        "workflow_id": selected_workflow_id,
+        "verdict": "rag_selected",
+        "selection_source": "selector",
+        "response": {"text": selected_workflow_id, "char_count": 38},
+        "selection_rationale": "selector_selected_discovered_candidate",
+    }
+
+    von_routes._set_tool_progress(
+        "scope-custom-workflow",
+        "req-custom-workflow",
+        {
+            "status": "thinking",
+            "phase": "workflow_dispatch",
+            "phase_label": "Workflow selected",
+            "request_id": "req-custom-workflow",
+            "selected_workflow_id": selected_workflow_id,
+            "selected_workflow_name": "Meeting invitation testing workflow",
+            "workflow_selector_verdict": "rag_selected",
+            "workflow_selector_source": "selector",
+            "workflow_selection_rationale": "selector_selected_discovered_candidate",
+            "workflow_routing": {
+                "workflow_id": selected_workflow_id,
+                "verdict": "rag_selected",
+                "source": "selector",
+                "selection_rationale": "selector_selected_discovered_candidate",
+            },
+            "workflow_routing_aux": [selector_prompt_entry, selector_success_entry],
+            "counters": {"tools_started": 0, "tools_completed": 0},
+        },
+    )
+    clock["now"] += 0.1
+    von_routes._set_tool_progress(
+        "scope-custom-workflow",
+        "req-custom-workflow",
+        {
+            "status": "thinking",
+            "phase": "workflow_dispatch",
+            "phase_label": "Workflow terminal state",
+            "request_id": "req-custom-workflow",
+            "selected_workflow_id": selected_workflow_id,
+            "selected_workflow_name": "Meeting invitation testing workflow",
+            "workflow_selector_verdict": "rag_selected",
+            "workflow_selector_source": "selector",
+            "workflow_selection_rationale": "selector_selected_discovered_candidate",
+            "result_summary": "workflow_terminal:failed",
+            "workflow_routing": {
+                "workflow_id": selected_workflow_id,
+                "verdict": "rag_selected",
+                "source": "selector",
+                "selection_rationale": "selector_selected_discovered_candidate",
+            },
+            "workflow_routing_aux": [
+                selector_prompt_entry,
+                selector_success_entry,
+                {
+                    "type": "workflow_dispatch_boundary",
+                    "boundary": "execution_mode_selected",
+                    "status": "selected",
+                    "selected_execution_mode": "custom_workflow",
+                    "selected_workflow_id": selected_workflow_id,
+                    "dispatch_workflow_id": selected_workflow_id,
+                },
+                {
+                    "type": "workflow_dispatch_boundary",
+                    "boundary": "workflow_handoff",
+                    "status": "started",
+                    "selected_execution_mode": "custom_workflow",
+                    "selected_workflow_id": selected_workflow_id,
+                    "dispatch_workflow_id": selected_workflow_id,
+                },
+                {
+                    "type": "workflow_dispatch_boundary",
+                    "boundary": "workflow_terminal",
+                    "status": "failed",
+                    "selected_execution_mode": "custom_workflow",
+                    "selected_workflow_id": selected_workflow_id,
+                    "dispatch_workflow_id": selected_workflow_id,
+                    "final_state": "prepare_spec",
+                    "completed": False,
+                    "reason": "workflow_launch_input_resolution_failed",
+                    "detail": (
+                        "Workflow #V#meeting_invitation_testing_workflow could not "
+                        "start because required launch inputs were unresolved: "
+                        "invitation_text."
+                    ),
+                    "workflow_launch_input_resolution_status": "failed",
+                    "unresolved_required_inputs": ["invitation_text"],
+                    "failing_state_id": "prepare_spec",
+                    "failing_action_id": "tool.prepare_spec",
+                },
+            ],
+            "counters": {"tools_started": 0, "tools_completed": 0},
+        },
+    )
+
+    snapshot = von_routes._snapshot_tool_progress_for_request(
+        "scope-custom-workflow",
+        "req-custom-workflow",
+    )
+    assert snapshot is not None
+
+    diagnostics = von_routes._build_turn_execution_diagnostics(
+        request_id="req-custom-workflow",
+        prompt_text="Run the meeting invitation testing workflow",
+        tool_progress_state=snapshot,
+    )
+
+    stage_diagnostics = diagnostics.get("stage_diagnostics")
+    assert isinstance(stage_diagnostics, list)
+    workflow_dispatch = next(
+        (
+            entry
+            for entry in stage_diagnostics
+            if isinstance(entry, dict) and entry.get("stage_id") == "workflow_dispatch"
+        ),
+        None,
+    )
+    assert workflow_dispatch is not None
+    assert workflow_dispatch.get("selected_workflow_id") == selected_workflow_id
+    assert workflow_dispatch.get("selected_workflow_name") == (
+        "Meeting invitation testing workflow"
+    )
+    assert workflow_dispatch.get("workflow_selector_verdict") == "rag_selected"
+    assert workflow_dispatch.get("workflow_selector_source") == "selector"
+    assert workflow_dispatch.get("workflow_selection_rationale") == (
+        "selector_selected_discovered_candidate"
+    )
+
+    routing_diagnostics = diagnostics.get("workflow_routing_diagnostics")
+    assert isinstance(routing_diagnostics, dict)
+    assert routing_diagnostics.get("selected_workflow_id") == selected_workflow_id
+    assert routing_diagnostics.get("selector", {}).get("prompt_failure_reason") is None
+    assert routing_diagnostics.get("selector", {}).get("prompt_failure_detail") is None
+    assert routing_diagnostics.get("dispatch", {}).get("selected_execution_mode") == (
+        "custom_workflow"
+    )
+    assert routing_diagnostics.get("dispatch", {}).get(
+        "dispatch_terminal_failure_reason"
+    ) == "workflow_launch_input_resolution_failed"
+    assert routing_diagnostics.get("dispatch", {}).get(
+        "dispatch_terminal_failing_state_id"
+    ) == "prepare_spec"
+    assert routing_diagnostics.get("dispatch", {}).get(
+        "dispatch_terminal_failing_action_id"
+    ) == "tool.prepare_spec"
+    assert routing_diagnostics.get("dispatch", {}).get(
+        "dispatch_terminal_unresolved_required_inputs"
+    ) == ["invitation_text"]
+
+
 def test_serialised_tool_progress_state_includes_live_workflow_routing_diagnostics() -> None:
     serialised = von_routes._serialise_tool_progress_state(
         {

--- a/tests/backend/test_turn_execution_record_service_execution_summary.py
+++ b/tests/backend/test_turn_execution_record_service_execution_summary.py
@@ -220,6 +220,81 @@ def test_tool_execution_summary_preserves_local_handoff_failure_reason() -> None
     assert summary["last_successful_boundary"] == "workflow_terminal"
 
 
+def test_tool_execution_summary_preserves_custom_workflow_first_step_failure_locality() -> None:
+    summary = _summarise_tool_execution_context(
+        workflow_routing={
+            "workflow_id": "#V#meeting_invitation_testing_workflow",
+            "verdict": "rag_selected",
+        },
+        turn_execution_diagnostics={
+            "latest_progress": {
+                "counters": {"tools_started": 0, "tools_completed": 0},
+                "diagnostic_events": [],
+            }
+        },
+        aux_llm_calls=[
+            {
+                "type": "workflow_dispatch_boundary",
+                "boundary": "execution_mode_selected",
+                "status": "selected",
+                "selected_execution_mode": "custom_workflow",
+                "selected_workflow_id": "#V#meeting_invitation_testing_workflow",
+                "dispatch_workflow_id": "#V#meeting_invitation_testing_workflow",
+            },
+            {
+                "type": "workflow_dispatch_boundary",
+                "boundary": "workflow_handoff",
+                "status": "started",
+                "selected_execution_mode": "custom_workflow",
+                "selected_workflow_id": "#V#meeting_invitation_testing_workflow",
+                "dispatch_workflow_id": "#V#meeting_invitation_testing_workflow",
+            },
+            {
+                "type": "workflow_dispatch_boundary",
+                "boundary": "workflow_terminal",
+                "status": "failed",
+                "selected_execution_mode": "custom_workflow",
+                "selected_workflow_id": "#V#meeting_invitation_testing_workflow",
+                "dispatch_workflow_id": "#V#meeting_invitation_testing_workflow",
+                "final_state": "prepare_spec",
+                "completed": False,
+                "reason": "workflow_launch_input_resolution_failed",
+                "detail": (
+                    "Workflow #V#meeting_invitation_testing_workflow could not start "
+                    "because required launch inputs were unresolved: invitation_text."
+                ),
+                "workflow_launch_input_resolution_status": "failed",
+                "unresolved_required_inputs": ["invitation_text"],
+                "failing_state_id": "prepare_spec",
+                "failing_action_id": "tool.prepare_spec",
+            },
+        ],
+        serialised_invocations=[],
+    )
+
+    assert summary["tool_route_selected"] is False
+    assert summary["selected_execution_mode"] == "custom_workflow"
+    assert summary["dispatch_workflow_id"] == "#V#meeting_invitation_testing_workflow"
+    assert summary["workflow_handoff_started"] is True
+    assert summary["dispatch_terminal_status"] == "failed"
+    assert summary["dispatch_terminal_final_state"] == "prepare_spec"
+    assert summary["dispatch_terminal_failure_reason"] == (
+        "workflow_launch_input_resolution_failed"
+    )
+    assert summary["dispatch_terminal_failure_detail"] == (
+        "Workflow #V#meeting_invitation_testing_workflow could not start "
+        "because required launch inputs were unresolved: invitation_text."
+    )
+    assert summary["dispatch_terminal_launch_input_resolution_status"] == "failed"
+    assert summary["dispatch_terminal_unresolved_required_inputs"] == [
+        "invitation_text"
+    ]
+    assert summary["dispatch_terminal_failing_state_id"] == "prepare_spec"
+    assert summary["dispatch_terminal_failing_action_id"] == "tool.prepare_spec"
+    assert summary["zero_tools_executed"] is True
+    assert summary["failure_codes"] == []
+
+
 def test_build_workflow_routing_diagnostics_preserves_selector_exchange_and_dispatch_events() -> None:
     diagnostics = build_workflow_routing_diagnostics(
         workflow_discovery={


### PR DESCRIPTION
## Summary
- carry authoritative workflow selection fields through dispatch-boundary progress updates
- project failed workflow terminal locality into dispatch telemetry and routing diagnostics
- add regressions for custom-workflow failure locality and stale selector prompt-failure cleanup

## Validation
- `pdm run pytest tests/backend/test_turn_execution_record_service_execution_summary.py -q`
- `pdm run pytest tests/backend/test_tool_progress_liveness.py -q`
- `pdm run pytest tests/backend/test_orchestrator_workflow_selector_routing.py -k "non_standard_workflow_routes_via_execute_workflow or custom_workflow_run_applies_launch_contract_without_workflow_specific_glue or custom_workflow_first_step_failure_projects_terminal_locality or custom_tool_pipeline_workflow_dispatches_without_id_special_casing or custom_workflow_result_preserves_messages_and_invocations" -q`
- `pdm run pytest tests/backend/test_turn_execution_record_projection.py -k "upserts_turn_execution_projection or synthesises_turn_execution_projection_without_record" -q`
- `pdm run pytest tests/backend/test_rag_turn_execution_records_mcp_read_tools.py -k "rag_list_indexed_supports_turn_execution_records or rag_get_item_supports_turn_execution_records" -q`
- `pdm run pyright src/backend/integrations/internal_mcp/orchestrator.py src/backend/services/turn_execution_record_service.py tests/backend/test_orchestrator_workflow_selector_routing.py tests/backend/test_tool_progress_liveness.py tests/backend/test_turn_execution_record_service_execution_summary.py`

## Notes
- `tests/backend/test_turn_execution_record_projection.py -k "synthesis_infers_workflow_selection" -q` timed out in-session and is not claimed here.
- broader selector-routing and durable-instance telemetry suites were split into targeted subsets per the repo pytest timeout policy.