### PR TITLE
JVNAUTOSCI-1558 prefer launchable custom workflow candidates

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -67,6 +67,7 @@ from ...workflows.conversation_turn_stage_model import (
     build_conversation_turn_stage_path,
 )
 from ...workflows.engine import WorkflowExecutor, WorkflowResult
+from ...workflows.metadata_validation import validate_state_metadata_pre_action
 from ...workflows.workflow_launch_input_contracts import (
     resolve_workflow_launch_inputs,
 )
@@ -25416,6 +25417,330 @@ class InternalMCPChatOrchestrator:
                 },
             )
 
+        def _build_custom_workflow_dispatch_data(
+            workflow_id_override: str | None = None,
+        ) -> dict[str, Any]:
+            effective_workflow_id = (
+                workflow_id_override.strip()
+                if isinstance(workflow_id_override, str)
+                and workflow_id_override.strip()
+                else selected_workflow_id_text
+            )
+            return {
+                "prompt": prompt,
+                "augmented_context": augmented_context,
+                "workflow_routing": (
+                    asdict(routing_info)
+                    if isinstance(routing_info, WorkflowRoutingInfo)
+                    else None
+                ),
+                "workflow_discovery_result": (
+                    dict(workflow_discovery_result)
+                    if isinstance(workflow_discovery_result, Mapping)
+                    else None
+                ),
+                "selected_workflow_id": effective_workflow_id,
+                "selected_workflow_name": _resolve_selected_workflow_name(
+                    effective_workflow_id
+                ),
+                "workflow_selector_verdict": selector_verdict or None,
+                "workflow_selector_source": (
+                    routing_info.source
+                    if isinstance(routing_info, WorkflowRoutingInfo)
+                    else None
+                ),
+                "user_concept_id": user_concept_id,
+                "org_concept_id": org_concept_id,
+                "gmail_profile": gmail_profile or self._default_gmail_profile,
+                "aux_llm_calls": aux_llm_calls,
+                "policy_state": policy_state,
+                "registry_snapshot": registry_snapshot,
+                "conversation_session_id": conversation_session_id,
+                "turn_id": turn_id,
+                "workflow_episode_source": "chat_turn_workflow",
+                "workflow_episode_stage": "workflow_dispatch",
+            }
+
+        def _probe_custom_workflow_launchability(
+            workflow_id: str | None,
+        ) -> dict[str, Any]:
+            clean_workflow_id = (
+                workflow_id.strip()
+                if isinstance(workflow_id, str) and workflow_id.strip()
+                else None
+            )
+            if not clean_workflow_id:
+                return {
+                    "workflow_id": None,
+                    "launchable": False,
+                    "launch_input_resolution": {"status": "workflow_id_missing"},
+                    "pre_action_validation": {
+                        "applied": False,
+                        "ok": False,
+                        "reason_code": "workflow_id_missing",
+                    },
+                }
+
+            workflow_def = self._workflow_registry.get(clean_workflow_id)
+            if workflow_def is None:
+                return {
+                    "workflow_id": clean_workflow_id,
+                    "launchable": False,
+                    "launch_input_resolution": {"status": "workflow_missing"},
+                    "pre_action_validation": {
+                        "applied": False,
+                        "ok": False,
+                        "reason_code": "workflow_missing",
+                    },
+                }
+
+            probe_data = _build_custom_workflow_dispatch_data(
+                workflow_id_override=clean_workflow_id
+            )
+            workflow_metadata = getattr(workflow_def, "metadata", None)
+            launch_contract = (
+                workflow_metadata.get("launch_input_contract")
+                if isinstance(workflow_metadata, Mapping)
+                else None
+            )
+            launch_contract_source = (
+                workflow_metadata.get("launch_input_contract_source")
+                if isinstance(workflow_metadata, Mapping)
+                else None
+            )
+            launch_resolution = resolve_workflow_launch_inputs(
+                workflow_id=clean_workflow_id,
+                contract=launch_contract if isinstance(launch_contract, Mapping) else None,
+                inputs=probe_data,
+                contract_source=(
+                    str(launch_contract_source).strip()
+                    if isinstance(launch_contract_source, str)
+                    and launch_contract_source.strip()
+                    else None
+                ),
+            )
+            for key, value in launch_resolution.resolved_inputs.items():
+                probe_data.setdefault(key, value)
+
+            initial_state_id = (
+                str(getattr(workflow_def, "initial_state", "") or "").strip() or None
+            )
+            state_spec = None
+            workflow_states = getattr(workflow_def, "states", None)
+            if initial_state_id and isinstance(workflow_states, Mapping):
+                state_spec = workflow_states.get(initial_state_id)
+
+            pre_action_summary: dict[str, Any]
+            pre_action_ok = False
+            if initial_state_id and state_spec is not None:
+                pre_validation = validate_state_metadata_pre_action(
+                    state_id=initial_state_id,
+                    metadata=getattr(state_spec, "metadata", None),
+                    context=probe_data,
+                )
+                pre_action_ok = bool(pre_validation.ok)
+                pre_action_failure = pre_validation.failure
+                pre_action_summary = {
+                    "applied": bool(pre_validation.applied),
+                    "ok": bool(pre_validation.ok),
+                    "reason_code": (
+                        str(pre_action_failure.reason_code)
+                        if pre_action_failure is not None
+                        and isinstance(pre_action_failure.reason_code, str)
+                        and pre_action_failure.reason_code
+                        else None
+                    ),
+                    "symbol": (
+                        str(pre_action_failure.details.get("symbol"))
+                        if pre_action_failure is not None
+                        and isinstance(pre_action_failure.details, Mapping)
+                        and isinstance(pre_action_failure.details.get("symbol"), str)
+                        and str(pre_action_failure.details.get("symbol")).strip()
+                        else None
+                    ),
+                    "message": (
+                        str(pre_action_failure.message)
+                        if pre_action_failure is not None
+                        and isinstance(pre_action_failure.message, str)
+                        and pre_action_failure.message
+                        else None
+                    ),
+                }
+            else:
+                pre_action_summary = {
+                    "applied": False,
+                    "ok": False,
+                    "reason_code": "initial_state_missing",
+                    "symbol": None,
+                    "message": None,
+                }
+
+            resolution_diagnostics = (
+                dict(launch_resolution.diagnostics)
+                if isinstance(launch_resolution.diagnostics, Mapping)
+                else {}
+            )
+            launch_input_summary = {
+                "status": resolution_diagnostics.get("status"),
+                "contract_source": resolution_diagnostics.get("contract_source"),
+                "resolved_inputs": list(
+                    resolution_diagnostics.get("resolved_inputs", [])
+                )
+                if isinstance(resolution_diagnostics.get("resolved_inputs"), list)
+                else [],
+                "unresolved_required_inputs": list(
+                    resolution_diagnostics.get("unresolved_required_inputs", [])
+                )
+                if isinstance(
+                    resolution_diagnostics.get("unresolved_required_inputs"), list
+                )
+                else [],
+            }
+            unresolved_required_inputs = tuple(
+                item
+                for item in launch_resolution.unresolved_required_inputs
+                if isinstance(item, str) and item.strip()
+            )
+            return {
+                "workflow_id": clean_workflow_id,
+                "initial_state_id": initial_state_id,
+                "launchable": not unresolved_required_inputs and pre_action_ok,
+                "launch_input_resolution": launch_input_summary,
+                "pre_action_validation": pre_action_summary,
+            }
+
+        def _maybe_override_selected_custom_workflow_for_launchability() -> None:
+            nonlocal selected_workflow_id
+            nonlocal selected_workflow_id_text
+            nonlocal selector_verdict
+            nonlocal routing_info
+
+            if not selected_workflow_id_text:
+                return
+            if selected_workflow_id_text in {
+                CHAT_ASSISTANT_WORKFLOW_ID,
+                CHAT_NARRATION_WORKFLOW_ID,
+                TOOL_CALLING_WORKFLOW_ID,
+            }:
+                return
+
+            selected_probe = _probe_custom_workflow_launchability(
+                selected_workflow_id_text
+            )
+            if bool(selected_probe.get("launchable")):
+                return
+
+            replacement_probe: dict[str, Any] | None = None
+            for match in discovered_matches:
+                if not isinstance(match, Mapping):
+                    continue
+                candidate_workflow_id = str(match.get("concept_id") or "").strip()
+                if (
+                    not candidate_workflow_id
+                    or candidate_workflow_id == selected_workflow_id_text
+                    or candidate_workflow_id
+                    in {
+                        CHAT_ASSISTANT_WORKFLOW_ID,
+                        CHAT_NARRATION_WORKFLOW_ID,
+                        TOOL_CALLING_WORKFLOW_ID,
+                    }
+                ):
+                    continue
+                candidate_probe = _probe_custom_workflow_launchability(
+                    candidate_workflow_id
+                )
+                if bool(candidate_probe.get("launchable")):
+                    replacement_probe = candidate_probe
+                    break
+
+            if replacement_probe is None:
+                return
+
+            prior_selected_workflow_id = selected_workflow_id_text
+            prior_selector_verdict = selector_verdict or None
+            replacement_workflow_id = str(replacement_probe.get("workflow_id") or "").strip()
+            if not replacement_workflow_id:
+                return
+
+            selected_workflow_id = replacement_workflow_id
+            selected_workflow_id_text = replacement_workflow_id
+            selector_verdict = "launch_contract_override"
+
+            discovered_workflow_ids: tuple[str, ...] = ()
+            prompt_id = None
+            routing_duration_ms = None
+            confidence_score = 0.0
+            if isinstance(routing_info, WorkflowRoutingInfo):
+                discovered_workflow_ids = routing_info.discovered_workflow_ids
+                prompt_id = routing_info.prompt_id
+                routing_duration_ms = routing_info.routing_duration_ms
+                confidence_score = routing_info.confidence_score
+            elif discovered_matches:
+                discovered_workflow_ids = tuple(
+                    str(item.get("concept_id"))
+                    for item in discovered_matches
+                    if isinstance(item, Mapping)
+                    and isinstance(item.get("concept_id"), str)
+                    and str(item.get("concept_id")).strip()
+                )
+
+            reason = "selected_custom_workflow_not_launchable_from_turn_inputs"
+            reasoning = (
+                "Selected custom workflow could not launch from the current turn "
+                "inputs after launch-contract resolution and initial-state metadata "
+                "validation, so the first discovered launchable custom workflow was used."
+            )
+            routing_info = WorkflowRoutingInfo(
+                workflow_id=replacement_workflow_id,
+                verdict="launch_contract_override",
+                prompt_id=prompt_id,
+                discovered_workflow_ids=discovered_workflow_ids,
+                routing_duration_ms=routing_duration_ms,
+                source="selector_override",
+                confidence_score=confidence_score,
+                reasoning=reasoning,
+                selection_rationale=reason,
+            )
+
+            override_payload = {
+                "type": "workflow_selector_override",
+                "reason": reason,
+                "selected_workflow_id": replacement_workflow_id,
+                "prior_selected_workflow_id": prior_selected_workflow_id,
+                "prior_selector_verdict": prior_selector_verdict,
+                "candidate_workflow_ids_considered": [
+                    str(item.get("concept_id"))
+                    for item in discovered_matches
+                    if isinstance(item, Mapping)
+                    and isinstance(item.get("concept_id"), str)
+                    and str(item.get("concept_id")).strip()
+                ],
+                "launch_viability_probe": {
+                    "prior_selected_workflow": selected_probe,
+                    "replacement_workflow": replacement_probe,
+                },
+            }
+            aux_llm_calls.append(override_payload)
+            if trace_enabled and trace is not None:
+                trace.metadata["workflow_selector_override"] = dict(override_payload)
+            _emit_progress_local(
+                {
+                    "status": "thinking",
+                    "stage": "workflow_dispatch",
+                    "phase": "workflow_dispatch",
+                    "phase_label": "Workflow routing overridden",
+                    "workflow_selector_verdict": "launch_contract_override",
+                    "selected_workflow_id": replacement_workflow_id,
+                    "selected_workflow_name": _resolve_selected_workflow_name(
+                        replacement_workflow_id
+                    ),
+                    "workflow_selection_rationale": reason,
+                    **_build_live_workflow_routing_payload(),
+                }
+            )
+
+        _maybe_override_selected_custom_workflow_for_launchability()
+
         selected_workflow_name = _resolve_selected_workflow_name(
             selected_workflow_id_text
         )
@@ -25728,38 +26053,7 @@ class InternalMCPChatOrchestrator:
                 )
                 wf_result = self.execute_workflow(
                     selected_workflow_id_text,
-                    data={
-                        "prompt": prompt,
-                        "augmented_context": augmented_context,
-                        "workflow_routing": (
-                            asdict(routing_info)
-                            if isinstance(routing_info, WorkflowRoutingInfo)
-                            else None
-                        ),
-                        "workflow_discovery_result": (
-                            dict(workflow_discovery_result)
-                            if isinstance(workflow_discovery_result, Mapping)
-                            else None
-                        ),
-                        "selected_workflow_id": selected_workflow_id_text,
-                        "selected_workflow_name": selected_workflow_name,
-                        "workflow_selector_verdict": selector_verdict or None,
-                        "workflow_selector_source": (
-                            routing_info.source
-                            if isinstance(routing_info, WorkflowRoutingInfo)
-                            else None
-                        ),
-                        "user_concept_id": user_concept_id,
-                        "org_concept_id": org_concept_id,
-                        "gmail_profile": gmail_profile or self._default_gmail_profile,
-                        "aux_llm_calls": aux_llm_calls,
-                        "policy_state": policy_state,
-                        "registry_snapshot": registry_snapshot,
-                        "conversation_session_id": conversation_session_id,
-                        "turn_id": turn_id,
-                        "workflow_episode_source": "chat_turn_workflow",
-                        "workflow_episode_stage": "workflow_dispatch",
-                    },
+                    data=_build_custom_workflow_dispatch_data(),
                     llm_client=llm_client,
                     model=model,
                     user_namespace=user_namespace,

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -3190,6 +3190,211 @@ def test_custom_workflow_run_applies_launch_contract_without_workflow_specific_g
     ]
 
 
+def test_custom_workflow_routing_prefers_launchable_discovered_candidate(monkeypatch):
+    import src.backend.services.workflow_selection_policy_service as policy_module
+
+    monkeypatch.setattr(policy_module, "get_live_selection_policy", lambda: None)
+    orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
+    selected_workflow_id = "#V#non_launchable_custom_workflow"
+    launchable_workflow_id = "#V#launchable_custom_workflow"
+    monkeypatch.setenv("VON_WORKFLOW_SELECTOR_ALLOW_POLICY_UNSAFE", "1")
+
+    orchestrator._workflow_registry.register_or_replace(
+        WorkflowRegistration(
+            workflow_id=selected_workflow_id,
+            definition=WorkflowDefinition(
+                workflow_id=selected_workflow_id,
+                initial_state="prepare_spec",
+                states={
+                    "prepare_spec": WorkflowStateSpec(
+                        state_id="prepare_spec",
+                        actions=(
+                            WorkflowActionInvocation(action_id="tool.prepare_spec"),
+                        ),
+                        terminal=True,
+                        metadata={"reads_context_keys": ["target_workflow_ids"]},
+                    )
+                },
+            ),
+            purpose="Non-launchable custom workflow for selector override tests.",
+            source="test",
+        )
+    )
+    orchestrator._workflow_registry.register_or_replace(
+        WorkflowRegistration(
+            workflow_id=launchable_workflow_id,
+            definition=WorkflowDefinition(
+                workflow_id=launchable_workflow_id,
+                initial_state="prepare_spec",
+                states={
+                    "prepare_spec": WorkflowStateSpec(
+                        state_id="prepare_spec",
+                        actions=(
+                            WorkflowActionInvocation(action_id="tool.prepare_spec"),
+                        ),
+                        terminal=True,
+                        metadata={"reads_context_keys": ["invitation_text"]},
+                    )
+                },
+                metadata={
+                    "launch_input_contract": {
+                        "schema_version": "workflow_launch_input_contract.v1",
+                        "required_inputs": ["invitation_text"],
+                        "input_mappings": [
+                            {
+                                "target_context_key": "invitation_text",
+                                "source_expression": "inputs.prompt",
+                                "extractor": "first_quoted_text",
+                                "required": True,
+                            },
+                            {
+                                "target_context_key": "candidate_workflow_ids",
+                                "source_expression": "inputs.workflow_discovery_result.matches",
+                                "extractor": "workflow_id_list",
+                            },
+                        ],
+                    },
+                    "launch_input_contract_source": "test_contract",
+                },
+            ),
+            purpose="Launchable custom workflow for selector override tests.",
+            source="test",
+        )
+    )
+
+    captured_execution: dict[str, Any] = {}
+
+    def _run_workflow(
+        workflow_def: WorkflowDefinition,
+        *,
+        data: Mapping[str, Any],
+        **_kwargs: Any,
+    ):
+        captured_execution["workflow_id"] = workflow_def.workflow_id
+        captured_execution["data"] = dict(data)
+        return SimpleNamespace(
+            completed=True,
+            final_state="prepare_spec",
+            error=None,
+            data={"response_text": "Prepared via launchable workflow."},
+        )
+
+    monkeypatch.setattr(orchestrator._workflow_executor, "run", _run_workflow)
+
+    result = orchestrator.run(
+        prompt=(
+            'Run a meeting-invitation test on this invitation text:\n\n'
+            '"Kia ora team, please join us on Tuesday at 2:00pm in Room 4 '
+            'for a project planning meeting about the Q2 roadmap."'
+        ),
+        context=[],
+        llm_client=_CapturingLLM([selected_workflow_id]),
+        model=None,
+        user_namespace="#V#user@org",
+        workflow_discovery_result={
+            "matches": [
+                {
+                    "concept_id": selected_workflow_id,
+                    "name": "Non-launchable custom workflow",
+                    "is_executable": True,
+                    "executability_reason": "executable_now",
+                },
+                {
+                    "concept_id": launchable_workflow_id,
+                    "name": "Launchable custom workflow",
+                    "is_executable": True,
+                    "executability_reason": "executable_now",
+                },
+            ],
+            "candidates": [
+                {
+                    "concept_id": selected_workflow_id,
+                    "name": "Non-launchable custom workflow",
+                    "is_executable": True,
+                    "executability_reason": "executable_now",
+                },
+                {
+                    "concept_id": launchable_workflow_id,
+                    "name": "Launchable custom workflow",
+                    "is_executable": True,
+                    "executability_reason": "executable_now",
+                },
+            ],
+            "match_count": 2,
+        },
+        conversation_session_id="chat-launch-override",
+        turn_id="turn-launch-override",
+    )
+
+    assert result.response_text == "Prepared via launchable workflow."
+    assert captured_execution["workflow_id"] == launchable_workflow_id
+
+    captured_data = captured_execution["data"]
+    assert captured_data["selected_workflow_id"] == launchable_workflow_id
+    assert captured_data["invitation_text"] == (
+        "Kia ora team, please join us on Tuesday at 2:00pm in Room 4 for a "
+        "project planning meeting about the Q2 roadmap."
+    )
+
+    assert result.workflow_routing is not None
+    assert result.workflow_routing.workflow_id == launchable_workflow_id
+    assert result.workflow_routing.verdict == "launch_contract_override"
+    assert result.workflow_routing.source == "selector_override"
+
+    override_entry = next(
+        (
+            entry
+            for entry in result.aux_llm_calls
+            if isinstance(entry, dict)
+            and entry.get("type") == "workflow_selector_override"
+            and entry.get("reason")
+            == "selected_custom_workflow_not_launchable_from_turn_inputs"
+        ),
+        None,
+    )
+    assert override_entry is not None
+    assert override_entry.get("prior_selected_workflow_id") == selected_workflow_id
+    assert override_entry.get("selected_workflow_id") == launchable_workflow_id
+
+    launch_viability_probe = override_entry.get("launch_viability_probe")
+    assert isinstance(launch_viability_probe, dict)
+
+    prior_probe = launch_viability_probe.get("prior_selected_workflow")
+    assert isinstance(prior_probe, dict)
+    assert prior_probe.get("launchable") is False
+    assert prior_probe.get("launch_input_resolution", {}).get("status") == "no_contract"
+    assert (
+        prior_probe.get("pre_action_validation", {}).get("reason_code")
+        == "metadata_read_context_key_missing"
+    )
+    assert (
+        prior_probe.get("pre_action_validation", {}).get("symbol")
+        == "target_workflow_ids"
+    )
+
+    replacement_probe = launch_viability_probe.get("replacement_workflow")
+    assert isinstance(replacement_probe, dict)
+    assert replacement_probe.get("launchable") is True
+    assert (
+        replacement_probe.get("launch_input_resolution", {}).get("status")
+        == "resolved"
+    )
+
+    dispatch_boundaries = [
+        entry
+        for entry in result.aux_llm_calls
+        if isinstance(entry, dict) and entry.get("type") == "workflow_dispatch_boundary"
+    ]
+    assert [entry.get("boundary") for entry in dispatch_boundaries[-3:]] == [
+        "execution_mode_selected",
+        "workflow_handoff",
+        "workflow_terminal",
+    ]
+    assert dispatch_boundaries[-3].get("selected_workflow_id") == launchable_workflow_id
+    assert dispatch_boundaries[-2].get("selected_workflow_id") == launchable_workflow_id
+    assert dispatch_boundaries[-1].get("selected_workflow_id") == launchable_workflow_id
+
+
 def test_custom_workflow_first_step_failure_projects_terminal_locality(monkeypatch):
     import src.backend.services.workflow_selection_policy_service as policy_module
 


### PR DESCRIPTION
## Summary
- probe selected custom workflows for launchability using launch-input resolution plus initial-state metadata validation
- override selector routing to the first discovered custom workflow that is launchable from the current turn inputs
- add regression coverage for the non-launchable-selected vs launchable-alternative custom workflow path

## Validation
- `python -m py_compile src/backend/integrations/internal_mcp/orchestrator.py tests/backend/test_orchestrator_workflow_selector_routing.py`
- `pdm run pytest tests/backend/test_orchestrator_workflow_selector_routing.py -k "custom_workflow_run_applies_launch_contract_without_workflow_specific_glue or custom_workflow_routing_prefers_launchable_discovered_candidate or custom_workflow_first_step_failure_projects_terminal_locality"`
- `pdm run pytest tests/backend/test_orchestrator_workflow_selector_routing.py -k "custom_workflow or custom_tool_pipeline_workflow_dispatches_without_id_special_casing or custom_workflow_result_preserves_messages_and_invocations"`
- `.\.venv\Scripts\pyright.exe src/backend/integrations/internal_mcp/orchestrator.py tests/backend/test_orchestrator_workflow_selector_routing.py`