### PR TITLE
JVNAUTOSCI-1559 harden thinking-card progress polling

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -2912,15 +2912,17 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
 
 def _get_tool_progress(scope_key: str, request_id: str) -> dict[str, Any] | None:
     _prune_tool_progress()
+    with _TOOL_PROGRESS_LOCK:
+        value = _TOOL_PROGRESS.get((scope_key, request_id))
+        if isinstance(value, dict):
+            return dict(value)
     try:
         persisted = fetch_tool_progress_state(scope_key=scope_key, request_id=request_id)
     except Exception:
         persisted = None
     if isinstance(persisted, dict):
         return dict(_cache_tool_progress_state(scope_key, request_id, persisted))
-    with _TOOL_PROGRESS_LOCK:
-        value = _TOOL_PROGRESS.get((scope_key, request_id))
-        return dict(value) if isinstance(value, dict) else None
+    return None
 
 
 def _snapshot_tool_progress_for_request(

--- a/src/frontend/web/von_interface/static/js/apiService.js
+++ b/src/frontend/web/von_interface/static/js/apiService.js
@@ -63,6 +63,73 @@ export async function postJson(url, data) {
   return res.json();
 }
 
+export async function fetchWithTimeout(url, options = {}) {
+  const { timeoutMs = 0, signal: parentSignal = null, ...fetchOptions } = options || {};
+
+  if (typeof AbortController !== 'function' || timeoutMs <= 0) {
+    return fetch(url, parentSignal ? { ...fetchOptions, signal: parentSignal } : fetchOptions);
+  }
+
+  const controller = new AbortController();
+  let timeoutId = null;
+  let releaseParentAbort = null;
+  let timedOut = false;
+
+  if (parentSignal?.aborted) {
+    controller.abort();
+  } else if (parentSignal && typeof parentSignal.addEventListener === 'function') {
+    const forwardAbort = () => {
+      try {
+        controller.abort();
+      } catch (_) {
+        // Ignore abort races.
+      }
+    };
+    parentSignal.addEventListener('abort', forwardAbort, { once: true });
+    releaseParentAbort = () => {
+      try {
+        parentSignal.removeEventListener('abort', forwardAbort);
+      } catch (_) {
+        // Ignore detach races.
+      }
+    };
+  }
+
+  timeoutId = setTimeout(() => {
+    timedOut = true;
+    try {
+      controller.abort();
+    } catch (_) {
+      // Ignore abort races.
+    }
+  }, timeoutMs);
+
+  try {
+    return await fetch(url, {
+      ...fetchOptions,
+      signal: controller.signal
+    });
+  } catch (err) {
+    if (timedOut && err && typeof err === 'object') {
+      try {
+        Object.defineProperty(err, 'vonTimeout', {
+          configurable: true,
+          enumerable: false,
+          value: true
+        });
+      } catch (_) {
+        err.vonTimeout = true;
+      }
+    }
+    throw err;
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+    if (typeof releaseParentAbort === 'function') {
+      releaseParentAbort();
+    }
+  }
+}
+
 export async function putJson(url, data, opts = {}) {
   const extraHeaders = opts.headers || {};
   const res = await fetch(url, {

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -1,5 +1,5 @@
 // Chat Tab Module
-import { annotateTurn, getUserContext, getWindowSessionId, postJson, WINDOW_SESSION_HEADER } from './apiService.js';
+import { annotateTurn, fetchWithTimeout, getUserContext, getWindowSessionId, postJson, WINDOW_SESSION_HEADER } from './apiService.js';
 import { initializeConceptAutocomplete } from './components/conceptAutocomplete.js';
 import { initializeMessagePanel, loadUnreadCount } from './components/messagePanel.js';
 import { loadMyOrganisations } from './components/orgSelector.js';
@@ -648,6 +648,7 @@ const THINKING_CARD_TOGGLE_ARIA_LABEL_EXPANDED = 'Collapse thinking details';
 const THINKING_CARD_TOGGLE_ARIA_LABEL_COLLAPSED = 'Expand thinking details';
 const THINKING_ACTIVITY_LOW_LEVEL_EVENT_KINDS = new Set(['llm_call_chunk', 'heartbeat']);
 const THINKING_DIAGNOSTIC_DETAILS_SELECTOR = 'details[data-thinking-diagnostic-key]';
+const THINKING_PROGRESS_POLL_FETCH_TIMEOUT_MS = 2_000;
 const THINKING_DIAGNOSTICS_EXPORT_EVENT_LIMIT = 40;
 const THINKING_DIAGNOSTICS_EXPORT_PHASE_HISTORY_LIMIT = 80;
 const THINKING_TERMINAL_PROGRESS_STATUSES = new Set([
@@ -3627,8 +3628,13 @@ function startToolUseProgressPolling(request) {
         updateThinkingCardMeta(request, request.latestProgress || null);
 
         try {
-            const resp = await fetch(`/von/progress/${encodeURIComponent(requestId)}`,
-                { method: 'GET', signal: abortController.signal, headers: buildChatFetchHeaders() });
+            const resp = await fetchWithTimeout(`/von/progress/${encodeURIComponent(requestId)}`,
+                {
+                    method: 'GET',
+                    signal: poll.abortController?.signal,
+                    headers: buildChatFetchHeaders(),
+                    timeoutMs: THINKING_PROGRESS_POLL_FETCH_TIMEOUT_MS
+                });
             if (!resp) {
                 scheduleNextPoll(Math.min(5000, poll.nextDelayMs * 1.7));
                 poll.nextDelayMs = Math.min(5000, poll.nextDelayMs * 1.7);
@@ -3754,6 +3760,34 @@ function startToolUseProgressPolling(request) {
             scheduleNextPoll(poll.nextDelayMs);
         } catch (err) {
             if (err && err.name === 'AbortError') {
+                if (err.vonTimeout) {
+                    request.latestProgress = buildPendingThinkingProgressFallback(
+                        202,
+                        requestId,
+                        {
+                            ...(request.latestProgress && typeof request.latestProgress === 'object'
+                                ? request.latestProgress
+                                : {}),
+                            status: 'pending',
+                            phase: 'context_build',
+                            stage: 'context_build',
+                            phase_label: 'Retrying live progress',
+                            liveness_state: THINKING_STATUS_WAITING,
+                            pending_reason: 'progress_poll_timeout',
+                            subtask: 'progress visibility',
+                            result_summary: `Live progress polling timed out after ${Math.round(THINKING_PROGRESS_POLL_FETCH_TIMEOUT_MS / 1000)}s; retrying in the background.`
+                        }
+                    );
+                    applyThinkingCardDisplayStateUpdate(request, {
+                        type: 'progress_update',
+                        progress: request.latestProgress
+                    });
+                    setLoadingIndicatorText(formatToolUseProgressText(request.latestProgress, request));
+                    setLoadingIndicatorDetailHtml(renderThinkingCardBodyHTML(request));
+                    updateThinkingCardMeta(request, request.latestProgress);
+                    poll.nextDelayMs = Math.min(5000, poll.nextDelayMs * 1.7);
+                    scheduleNextPoll(poll.nextDelayMs);
+                }
                 return;
             }
 
@@ -18082,21 +18116,15 @@ async function refreshWorkflowStatusSnapshot({ silent = false, preserveRetryAtte
     syncWorkflowStatusSnapshotNotice();
     renderWorkflowStatusBody();
 
-    let timeoutId = null;
-
     try {
-        const controller = new AbortController();
-        timeoutId = setTimeout(() => controller.abort(), WORKFLOW_STATUS_SNAPSHOT_FETCH_TIMEOUT_MS);
-        const resp = await fetch(
+        const resp = await fetchWithTimeout(
             `/api/workflows/instances?${params.toString()}`,
             {
                 method: 'GET',
                 headers: buildChatFetchHeaders(),
-                signal: controller.signal
+                timeoutMs: WORKFLOW_STATUS_SNAPSHOT_FETCH_TIMEOUT_MS
             }
         );
-        clearTimeout(timeoutId);
-        timeoutId = null;
         const data = await resp.json().catch(() => null);
         const payload = (data && typeof data === 'object') ? data : {};
         if (!resp.ok || payload?.degraded === true) {
@@ -18168,10 +18196,6 @@ async function refreshWorkflowStatusSnapshot({ silent = false, preserveRetryAtte
         renderWorkflowStatusBody();
         if (!silent) {
             console.warn('[workflowStatus] Snapshot fetch failed', err);
-        }
-    } finally {
-        if (timeoutId) {
-            clearTimeout(timeoutId);
         }
     }
 }
@@ -18411,16 +18435,15 @@ async function refreshAvailableWorkflowDefinitions({ silent = false } = {}) {
     params.set('limit', '200');
     workflowDefinitionsState.lastRequestQuery = params.toString();
 
-    let timeoutId = null;
     try {
-        const controller = new AbortController();
-        timeoutId = setTimeout(() => controller.abort(), WORKFLOW_DEFINITIONS_FETCH_TIMEOUT_MS);
-        const resp = await fetch(
+        const resp = await fetchWithTimeout(
             `/api/workflows/definitions?${params.toString()}`,
-            { method: 'GET', headers: buildChatFetchHeaders(), signal: controller.signal }
+            {
+                method: 'GET',
+                headers: buildChatFetchHeaders(),
+                timeoutMs: WORKFLOW_DEFINITIONS_FETCH_TIMEOUT_MS
+            }
         );
-        clearTimeout(timeoutId);
-        timeoutId = null;
         const responsePayload = await resp.json().catch(() => null);
         if (!resp.ok) {
             const responseError = typeof responsePayload?.error === 'string'
@@ -18551,9 +18574,6 @@ async function refreshAvailableWorkflowDefinitions({ silent = false } = {}) {
             console.warn('[workflowStatus] Available workflow fetch failed', err);
         }
     } finally {
-        if (timeoutId) {
-            clearTimeout(timeoutId);
-        }
         workflowDefinitionsState.loading = false;
         if (workflowDefinitionsState.visible) {
             renderWorkflowStatusBody();
@@ -20146,9 +20166,6 @@ async function handleSendPrompt(options = {}) {
 
         startThinkingTooltipTicker(request);
 
-        // Start polling immediately while the request is in flight.
-        startToolUseProgressPolling(request);
-
         // Get user context from localStorage to send to backend
         const userContext = getUserContext();
         // Presenter-mode controls whether the backend produces two-channel output
@@ -20156,7 +20173,9 @@ async function handleSendPrompt(options = {}) {
         // is enabled, so clicking Speak later never needs to read raw markdown.
         const presenterMode = true;
 
-        const response = await fetch('/von/generate', {
+        // Start the generate request before polling progress so the first
+        // /von/progress read is less likely to outrun request initialisation.
+        const responsePromise = fetch('/von/generate', {
             method: 'POST',
             headers: buildChatFetchHeaders({
                 'Content-Type': 'application/json',
@@ -20172,6 +20191,12 @@ async function handleSendPrompt(options = {}) {
                 presenter_mode: presenterMode
             })
         });
+        startToolUseProgressPolling(request);
+        // Give an already-available first progress response a chance to land
+        // before an immediate generate response tears down the active card.
+        await Promise.resolve();
+        await Promise.resolve();
+        const response = await responsePromise;
 
         // Defensive: some tests or environments may provide a non-standard fetch
         // mock that doesn't return a Response-like object. Guard before calling

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -50,13 +50,17 @@ import {
 } from '../chatTab';
 
 // Mock dependencies to avoid import errors
-jest.mock('../apiService.js', () => ({
-    annotateTurn: jest.fn(),
-    getUserContext: jest.fn(),
-    getWindowSessionId: jest.fn(() => 'test-window-session'),
-    postJson: jest.fn(),
-    WINDOW_SESSION_HEADER: 'X-Window-Session-ID'
-}));
+jest.mock('../apiService.js', () => {
+    const actual = jest.requireActual('../apiService.js');
+    return {
+        ...actual,
+        annotateTurn: jest.fn(),
+        getUserContext: jest.fn(),
+        getWindowSessionId: jest.fn(() => 'test-window-session'),
+        postJson: jest.fn(),
+        WINDOW_SESSION_HEADER: 'X-Window-Session-ID'
+    };
+});
 jest.mock('../domUtils.js', () => ({
     elements: {},
     getCurrentUserConceptId: jest.fn(),
@@ -555,6 +559,8 @@ describe('workflow monitor definitions refresh contention handling', () => {
     async function flushMicrotasks() {
         await Promise.resolve();
         await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
     }
 
     beforeEach(() => {
@@ -789,6 +795,8 @@ describe('workflow monitor definitions refresh contention handling', () => {
 
 describe('workflow monitor active snapshot degradation handling', () => {
     async function flushMicrotasks() {
+        await Promise.resolve();
+        await Promise.resolve();
         await Promise.resolve();
         await Promise.resolve();
     }
@@ -2477,6 +2485,79 @@ describe('thinking card toggle accessibility', () => {
         document.getElementById('abortButton').click();
         await new Promise((r) => setTimeout(r, 0));
         await expect(sendPromise).resolves.toBeUndefined();
+    });
+
+    test('progress poll timeout falls back to retryable waiting state instead of freezing the card', async () => {
+        jest.useFakeTimers();
+        try {
+            const { getUserContext } = require('../apiService.js');
+            getUserContext.mockReturnValue({
+                user_id: 'user',
+                org_id: 'org',
+                language: 'en-NZ',
+                gmail_profile: null
+            });
+
+            document.getElementById('promptInput').value = 'slow progress prompt';
+
+            let generateSignal = null;
+            global.fetch = jest.fn((url, options = {}) => {
+                if (typeof url === 'string' && url.startsWith('/api/settings/')) {
+                    return Promise.resolve({
+                        ok: true,
+                        json: async () => ({ show_tool_use_during_thinking: true })
+                    });
+                }
+
+                if (typeof url === 'string' && url.startsWith('/von/progress/')) {
+                    return new Promise((resolve, reject) => {
+                        options.signal?.addEventListener('abort', () => {
+                            const err = new Error('progress timeout');
+                            err.name = 'AbortError';
+                            reject(err);
+                        });
+                    });
+                }
+
+                if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                    return Promise.resolve({
+                        ok: true,
+                        json: async () => ({ history_length: 0, authenticated: true })
+                    });
+                }
+
+                if (typeof url === 'string' && url.startsWith('/von/generate')) {
+                    generateSignal = options.signal;
+                    return new Promise((resolve, reject) => {
+                        generateSignal?.addEventListener('abort', () => {
+                            const err = new Error('aborted');
+                            err.name = 'AbortError';
+                            reject(err);
+                        });
+                    });
+                }
+
+                return Promise.resolve({ ok: true, json: async () => ({}) });
+            });
+
+            const sendPromise = sendMessage();
+            await Promise.resolve();
+
+            jest.advanceTimersByTime(2_100);
+            await Promise.resolve();
+            await Promise.resolve();
+
+            const indicatorText = document.querySelector('.loading-indicator-text');
+            expect(indicatorText.textContent).toContain('Retrying live progress');
+            expect(document.getElementById('loadingIndicatorDetail').innerHTML)
+                .toContain('retrying in the background');
+
+            document.getElementById('abortButton').click();
+            await Promise.resolve();
+            await expect(sendPromise).resolves.toBeUndefined();
+        } finally {
+            jest.useRealTimers();
+        }
     });
 
     test('allows unfurl after terminal progress even while request is still active', async () => {

--- a/tests/backend/test_tool_progress_liveness.py
+++ b/tests/backend/test_tool_progress_liveness.py
@@ -125,6 +125,36 @@ def test_progress_endpoint_reads_persisted_state_after_local_cache_miss(
     assert body.get("goal_label") == "https://arxiv.org/abs/2602.20478"
 
 
+def test_get_tool_progress_prefers_live_memory_state_before_persisted_fetch(
+    monkeypatch,
+) -> None:
+    von_routes._set_tool_progress(
+        "scope-live",
+        "req-live",
+        {
+            "status": "thinking",
+            "phase": "tool_execute",
+            "phase_label": "Executing tools",
+            "request_id": "req-live",
+            "subtask": "workflow execution",
+        },
+    )
+
+    def _unexpected_fetch(*, scope_key: str, request_id: str):
+        raise AssertionError(
+            "persisted progress fetch should not run when live memory state exists"
+        )
+
+    monkeypatch.setattr(von_routes, "fetch_tool_progress_state", _unexpected_fetch)
+
+    state = von_routes._get_tool_progress("scope-live", "req-live")
+
+    assert state is not None
+    assert state["request_id"] == "req-live"
+    assert state["phase"] == "tool_execute"
+    assert state["subtask"] == "workflow execution"
+
+
 def test_progress_endpoint_pending_response_includes_explanatory_payload(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- prefer live in-memory tool-progress state before persisted-store reads on the backend progress route
- add a shared bounded `fetchWithTimeout(...)` helper and use it for thinking-card/workflow monitor polling
- degrade timed-out progress polls to an explicit retryable waiting state and give the first poll a microtask head start so fast generate responses do not hide finished-card history

## Validation
- `npx jest src/frontend/web/von_interface/static/js/test/chatTab.test.js --runInBand`
- `pdm run pytest tests/backend/test_tool_progress_liveness.py -q`
- `pdm run pyright src/backend/server/routes/von_routes.py tests/backend/test_tool_progress_liveness.py`