### PR TITLE
JVNAUTOSCI-1560 prefer launchable custom workflows for mutative turns

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -25350,23 +25350,6 @@ class InternalMCPChatOrchestrator:
                 trace.metadata["workflow_selector_override"] = dict(override_payload)
 
         if (
-            selected_prefers_direct_response
-            and mutative_intent_requires_tool_routing
-            and not selected_uses_tool_pipeline_contract
-        ):
-            _force_tool_pipeline_routing(
-                reason="mutative_intent_requires_tool_pipeline",
-                excluded_selector_verdicts=[selector_verdict or "direct_response"],
-                extra_payload={
-                    "write_policy_reason": write_routing_policy_reason,
-                    "write_tool_candidate_count": len(
-                        write_tool_candidates_for_routing
-                    ),
-                    "write_tool_candidates": write_tool_candidates_for_routing[:12],
-                },
-            )
-
-        if (
             routing_prompt_requirements.has_missing_requirements
             and not selected_uses_tool_pipeline_contract
         ):
@@ -25609,62 +25592,80 @@ class InternalMCPChatOrchestrator:
                 "pre_action_validation": pre_action_summary,
             }
 
-        def _maybe_override_selected_custom_workflow_for_launchability() -> None:
-            nonlocal selected_workflow_id
-            nonlocal selected_workflow_id_text
-            nonlocal selector_verdict
-            nonlocal routing_info
-
-            if not selected_workflow_id_text:
-                return
-            if selected_workflow_id_text in {
-                CHAT_ASSISTANT_WORKFLOW_ID,
-                CHAT_NARRATION_WORKFLOW_ID,
-                TOOL_CALLING_WORKFLOW_ID,
-            }:
-                return
-
-            selected_probe = _probe_custom_workflow_launchability(
-                selected_workflow_id_text
-            )
-            if bool(selected_probe.get("launchable")):
-                return
-
-            replacement_probe: dict[str, Any] | None = None
+        def _find_first_launchable_discovered_custom_workflow(
+            *,
+            exclude_workflow_ids: Sequence[str] = (),
+        ) -> dict[str, Any] | None:
+            excluded = {
+                str(workflow_id).strip().lower()
+                for workflow_id in exclude_workflow_ids
+                if isinstance(workflow_id, str) and str(workflow_id).strip()
+            }
+            builtin_workflow_ids = {
+                CHAT_ASSISTANT_WORKFLOW_ID.lower(),
+                CHAT_NARRATION_WORKFLOW_ID.lower(),
+                TOOL_CALLING_WORKFLOW_ID.lower(),
+            }
             for match in discovered_matches:
                 if not isinstance(match, Mapping):
                     continue
                 candidate_workflow_id = str(match.get("concept_id") or "").strip()
+                if not candidate_workflow_id:
+                    continue
+                lowered_candidate_workflow_id = candidate_workflow_id.lower()
                 if (
-                    not candidate_workflow_id
-                    or candidate_workflow_id == selected_workflow_id_text
-                    or candidate_workflow_id
-                    in {
-                        CHAT_ASSISTANT_WORKFLOW_ID,
-                        CHAT_NARRATION_WORKFLOW_ID,
-                        TOOL_CALLING_WORKFLOW_ID,
-                    }
+                    lowered_candidate_workflow_id in builtin_workflow_ids
+                    or lowered_candidate_workflow_id in excluded
                 ):
                     continue
                 candidate_probe = _probe_custom_workflow_launchability(
                     candidate_workflow_id
                 )
                 if bool(candidate_probe.get("launchable")):
-                    replacement_probe = candidate_probe
-                    break
+                    return candidate_probe
+            return None
 
-            if replacement_probe is None:
-                return
+        def _promote_selected_workflow_to_custom_dispatch(
+            *,
+            replacement_probe: Mapping[str, Any] | None,
+            reason: str,
+            verdict: str,
+            reasoning: str,
+            prior_selected_workflow_id: str | None = None,
+            prior_selector_verdict: str | None = None,
+            extra_payload: Mapping[str, Any] | None = None,
+        ) -> bool:
+            nonlocal selected_workflow_id
+            nonlocal selected_workflow_id_text
+            nonlocal selector_verdict
+            nonlocal selector_requests_narration
+            nonlocal selector_requests_custom_workflow
+            nonlocal selected_uses_narration_contract
+            nonlocal selected_prefers_direct_response
+            nonlocal routing_info
+            nonlocal selected_uses_tool_pipeline_contract
 
-            prior_selected_workflow_id = selected_workflow_id_text
-            prior_selector_verdict = selector_verdict or None
-            replacement_workflow_id = str(replacement_probe.get("workflow_id") or "").strip()
+            replacement_workflow_id = (
+                str(replacement_probe.get("workflow_id") or "").strip()
+                if isinstance(replacement_probe, Mapping)
+                else ""
+            )
             if not replacement_workflow_id:
-                return
+                return False
+
+            if prior_selected_workflow_id is None:
+                prior_selected_workflow_id = selected_workflow_id_text
+            if prior_selector_verdict is None:
+                prior_selector_verdict = selector_verdict or None
 
             selected_workflow_id = replacement_workflow_id
             selected_workflow_id_text = replacement_workflow_id
-            selector_verdict = "launch_contract_override"
+            selector_verdict = verdict
+            selector_requests_narration = False
+            selector_requests_custom_workflow = True
+            selected_uses_narration_contract = False
+            selected_prefers_direct_response = False
+            selected_uses_tool_pipeline_contract = False
 
             discovered_workflow_ids: tuple[str, ...] = ()
             prompt_id = None
@@ -25684,15 +25685,9 @@ class InternalMCPChatOrchestrator:
                     and str(item.get("concept_id")).strip()
                 )
 
-            reason = "selected_custom_workflow_not_launchable_from_turn_inputs"
-            reasoning = (
-                "Selected custom workflow could not launch from the current turn "
-                "inputs after launch-contract resolution and initial-state metadata "
-                "validation, so the first discovered launchable custom workflow was used."
-            )
             routing_info = WorkflowRoutingInfo(
                 workflow_id=replacement_workflow_id,
-                verdict="launch_contract_override",
+                verdict=verdict,
                 prompt_id=prompt_id,
                 discovered_workflow_ids=discovered_workflow_ids,
                 routing_duration_ms=routing_duration_ms,
@@ -25715,11 +25710,9 @@ class InternalMCPChatOrchestrator:
                     and isinstance(item.get("concept_id"), str)
                     and str(item.get("concept_id")).strip()
                 ],
-                "launch_viability_probe": {
-                    "prior_selected_workflow": selected_probe,
-                    "replacement_workflow": replacement_probe,
-                },
             }
+            if extra_payload:
+                override_payload.update(dict(extra_payload))
             aux_llm_calls.append(override_payload)
             if trace_enabled and trace is not None:
                 trace.metadata["workflow_selector_override"] = dict(override_payload)
@@ -25729,7 +25722,7 @@ class InternalMCPChatOrchestrator:
                     "stage": "workflow_dispatch",
                     "phase": "workflow_dispatch",
                     "phase_label": "Workflow routing overridden",
-                    "workflow_selector_verdict": "launch_contract_override",
+                    "workflow_selector_verdict": verdict,
                     "selected_workflow_id": replacement_workflow_id,
                     "selected_workflow_name": _resolve_selected_workflow_name(
                         replacement_workflow_id
@@ -25737,6 +25730,102 @@ class InternalMCPChatOrchestrator:
                     "workflow_selection_rationale": reason,
                     **_build_live_workflow_routing_payload(),
                 }
+            )
+            return True
+
+        if (
+            selected_prefers_direct_response
+            and mutative_intent_requires_tool_routing
+            and not selected_uses_tool_pipeline_contract
+        ):
+            replacement_probe = _find_first_launchable_discovered_custom_workflow()
+            promoted_to_custom_workflow = False
+            if replacement_probe is not None:
+                promoted_to_custom_workflow = (
+                    _promote_selected_workflow_to_custom_dispatch(
+                        replacement_probe=replacement_probe,
+                        reason="mutative_intent_prefers_launchable_custom_workflow",
+                        verdict="custom_workflow_override",
+                        reasoning=(
+                            "Mutative/tool-using turn selected a direct-response "
+                            "pathway, but a discovered custom workflow was "
+                            "launchable from the current turn inputs, so the "
+                            "launchable custom workflow was used instead of the "
+                            "generic tool pipeline."
+                        ),
+                        extra_payload={
+                            "write_policy_reason": write_routing_policy_reason,
+                            "write_tool_candidate_count": len(
+                                write_tool_candidates_for_routing
+                            ),
+                            "write_tool_candidates": write_tool_candidates_for_routing[
+                                :12
+                            ],
+                            "launch_viability_probe": {
+                                "replacement_workflow": dict(replacement_probe),
+                            },
+                        },
+                    )
+                )
+            if not promoted_to_custom_workflow:
+                _force_tool_pipeline_routing(
+                    reason="mutative_intent_requires_tool_pipeline",
+                    excluded_selector_verdicts=[selector_verdict or "direct_response"],
+                    extra_payload={
+                        "write_policy_reason": write_routing_policy_reason,
+                        "write_tool_candidate_count": len(
+                            write_tool_candidates_for_routing
+                        ),
+                        "write_tool_candidates": write_tool_candidates_for_routing[
+                            :12
+                        ],
+                    },
+                )
+
+        def _maybe_override_selected_custom_workflow_for_launchability() -> None:
+            if not selected_workflow_id_text:
+                return
+            if selected_workflow_id_text in {
+                CHAT_ASSISTANT_WORKFLOW_ID,
+                CHAT_NARRATION_WORKFLOW_ID,
+                TOOL_CALLING_WORKFLOW_ID,
+            }:
+                return
+
+            selected_probe = _probe_custom_workflow_launchability(
+                selected_workflow_id_text
+            )
+            if bool(selected_probe.get("launchable")):
+                return
+
+            replacement_probe = _find_first_launchable_discovered_custom_workflow(
+                exclude_workflow_ids=(selected_workflow_id_text,)
+            )
+            if replacement_probe is None:
+                return
+
+            prior_selected_workflow_id = selected_workflow_id_text
+            prior_selector_verdict = selector_verdict or None
+
+            reason = "selected_custom_workflow_not_launchable_from_turn_inputs"
+            reasoning = (
+                "Selected custom workflow could not launch from the current turn "
+                "inputs after launch-contract resolution and initial-state metadata "
+                "validation, so the first discovered launchable custom workflow was used."
+            )
+            _promote_selected_workflow_to_custom_dispatch(
+                replacement_probe=replacement_probe,
+                reason=reason,
+                verdict="launch_contract_override",
+                reasoning=reasoning,
+                prior_selected_workflow_id=prior_selected_workflow_id,
+                prior_selector_verdict=prior_selector_verdict,
+                extra_payload={
+                    "launch_viability_probe": {
+                        "prior_selected_workflow": dict(selected_probe),
+                        "replacement_workflow": dict(replacement_probe),
+                    },
+                },
             )
 
         _maybe_override_selected_custom_workflow_for_launchability()

--- a/tests/backend/test_orchestrator_workflow_selector_routing.py
+++ b/tests/backend/test_orchestrator_workflow_selector_routing.py
@@ -3973,6 +3973,132 @@ def test_plain_response_overridden_to_tool_pipeline_for_mutative_intent(monkeypa
     assert "workflow_selector_override" in aux_types
 
 
+def test_mutative_intent_prefers_launchable_discovered_custom_workflow(monkeypatch):
+    """Launchable discovered custom workflows should outrank generic tool fallback."""
+
+    orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)
+    selected_workflow_id = "#V#launchable_mutative_custom_workflow"
+
+    orchestrator._workflow_registry.register_or_replace(
+        WorkflowRegistration(
+            workflow_id=selected_workflow_id,
+            definition=WorkflowDefinition(
+                workflow_id=selected_workflow_id,
+                initial_state="complete",
+                states={
+                    "complete": WorkflowStateSpec(
+                        state_id="complete",
+                        actions=(
+                            WorkflowActionInvocation(action_id="tool.prepare_custom"),
+                        ),
+                        terminal=True,
+                    )
+                },
+            ),
+            purpose="Launchable custom workflow for mutative routing tests.",
+            source="test",
+        )
+    )
+
+    monkeypatch.setattr(
+        orchestrator._gateway,
+        "describe_methods",
+        lambda: {"add_relationship": {"category": "write"}},
+    )
+
+    captured_execution: dict[str, Any] = {}
+
+    def _run_workflow(
+        workflow_def: WorkflowDefinition,
+        *,
+        data: Mapping[str, Any],
+        **_kwargs: Any,
+    ):
+        captured_execution["workflow_id"] = workflow_def.workflow_id
+        captured_execution["data"] = dict(data)
+        return SimpleNamespace(
+            completed=True,
+            final_state="complete",
+            error=None,
+            data={"response_text": "Executed via specialised workflow."},
+        )
+
+    monkeypatch.setattr(orchestrator._workflow_executor, "run", _run_workflow)
+
+    result = orchestrator.run(
+        prompt="Create a concept link in Vontology.",
+        context=[],
+        llm_client=_CapturingLLM([CHAT_ASSISTANT_WORKFLOW_ID]),
+        model=None,
+        user_namespace="#V#user",
+        workflow_discovery_result={
+            "matches": [
+                {
+                    "concept_id": selected_workflow_id,
+                    "name": "Launchable mutative custom workflow",
+                    "is_executable": True,
+                    "executability_reason": "executable_now",
+                }
+            ],
+            "candidates": [
+                {
+                    "concept_id": selected_workflow_id,
+                    "name": "Launchable mutative custom workflow",
+                    "is_executable": True,
+                    "executability_reason": "executable_now",
+                }
+            ],
+            "match_count": 1,
+        },
+        conversation_session_id="session-mutative-custom",
+        turn_id="turn-mutative-custom",
+    )
+
+    assert result.response_text.startswith("Executed via specialised workflow.")
+    assert captured_execution["workflow_id"] == selected_workflow_id
+    assert captured_execution["data"]["selected_workflow_id"] == selected_workflow_id
+
+    assert result.workflow_routing is not None
+    assert result.workflow_routing.workflow_id == selected_workflow_id
+    assert result.workflow_routing.verdict == "custom_workflow_override"
+    assert result.workflow_routing.source == "selector_override"
+
+    override_entry = next(
+        (
+            entry
+            for entry in result.aux_llm_calls
+            if isinstance(entry, dict)
+            and entry.get("type") == "workflow_selector_override"
+            and entry.get("reason")
+            == "mutative_intent_prefers_launchable_custom_workflow"
+        ),
+        None,
+    )
+    assert override_entry is not None
+    assert override_entry.get("prior_selected_workflow_id") == CHAT_ASSISTANT_WORKFLOW_ID
+    assert override_entry.get("selected_workflow_id") == selected_workflow_id
+    assert override_entry.get("write_policy_reason") == "default_allow_additive_low_risk"
+
+    launch_probe = override_entry.get("launch_viability_probe", {}).get(
+        "replacement_workflow"
+    )
+    assert isinstance(launch_probe, dict)
+    assert launch_probe.get("launchable") is True
+
+    dispatch_boundaries = [
+        entry
+        for entry in result.aux_llm_calls
+        if isinstance(entry, dict) and entry.get("type") == "workflow_dispatch_boundary"
+    ]
+    assert [entry.get("boundary") for entry in dispatch_boundaries[-3:]] == [
+        "execution_mode_selected",
+        "workflow_handoff",
+        "workflow_terminal",
+    ]
+    assert dispatch_boundaries[-3].get("selected_execution_mode") == "custom_workflow"
+    assert dispatch_boundaries[-3].get("selected_workflow_id") == selected_workflow_id
+
+
 def test_plain_response_overridden_when_prompt_requires_tool_verification(monkeypatch):
     """Prompt-required tool checks must not be bypassed by plain-response routing."""
     orchestrator = _build_orchestrator(monkeypatch, selector_enabled=True)


### PR DESCRIPTION
## Summary
- prefer a launchable discovered custom workflow before falling back to the generic tool pipeline on mutative/tool-using turns
- refactor custom-workflow promotion so launchability override and mutative override share the same generic promotion path
- add regression coverage for the new routing behaviour

## Validation
- `pdm run pyright src/backend/integrations/internal_mcp/orchestrator.py tests/backend/test_orchestrator_workflow_selector_routing.py`
- `pdm run pytest tests/backend/test_orchestrator_workflow_selector_routing.py::test_mutative_intent_prefers_launchable_discovered_custom_workflow tests/backend/test_orchestrator_workflow_selector_routing.py::test_plain_response_overridden_to_tool_pipeline_for_mutative_intent tests/backend/test_orchestrator_workflow_selector_routing.py::test_custom_workflow_routing_prefers_launchable_discovered_candidate -q`
- `pdm run pytest tests/backend/test_turn_execution_record_service_execution_summary.py -k "meeting_invitation_testing_workflow or custom_workflow" -q`
- `pdm run pytest tests/backend/test_tool_progress_liveness.py::test_turn_execution_diagnostics_clear_stale_selector_prompt_failure_after_success -q`
- `pdm run pytest tests/backend/test_workflow_launch_input_contracts.py -q`

## Notes
- durable-instance telemetry tests in `tests/backend/test_orchestrator_durable_instance_telemetry.py` timed out in this interactive environment even when split to single-test invocations