### PR TITLE
JVNAUTOSCI-1561 Add mutation authority guardrails

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -415,6 +415,7 @@ Per-state metadata keys currently used:
 - `invokes_workflow`
 - `retry_policy`
 - `approval_gate`
+- `mutation_authority`
 - `idempotency_policy`
 - `checkpoint_policy`
 - `loop_scope_id`
@@ -428,6 +429,7 @@ Canonical workflow-step runtime policy payloads are stored as singleton text rel
 
 - `#V#hasWorkflowStepRetryPolicyJson`
 - `#V#hasWorkflowStepApprovalGateJson`
+- `#V#hasWorkflowStepMutationAuthorityJson`
 - `#V#hasWorkflowStepIdempotencyPolicyJson`
 - `#V#hasWorkflowStepCheckpointPolicyJson`
 
@@ -441,6 +443,7 @@ Current schema versions:
 
 - `workflow_step_retry_policy.v1`
 - `workflow_step_approval_gate.v1`
+- `workflow_step_mutation_authority.v1`
 - `workflow_step_idempotency_policy.v1`
 - `workflow_step_checkpoint_policy.v1`
 - `workflow_plan_state_policy.v1`
@@ -453,6 +456,10 @@ Normative semantics:
 - retry and idempotency policies currently apply only to single-action states;
 - approval gates MUST fail closed when the required approval context key is absent or falsey;
 - destructive or otherwise high-risk approval-gated states SHOULD provide an explicit `on_approval_required` route to a blocked terminal or escalation state;
+- mutation-authority policies cap the strongest mutation class a step may exercise, using `maximum_level` from `workflow_step_mutation_authority.v1`;
+- effective mutation authority is the intersection of user grant, workflow-step cap, global runtime policy, and environment hard stops, and MUST fail closed when any input is invalid;
+- mutation guardrail decisions use stable outcomes `allowed|blocked|approval_required|deferred`;
+- every mutation guardrail evaluation and every tool-surface guardrail hit MUST emit explicit `mutation_guardrail` telemetry with workflow/step IDs when available, risk class, required/effective authority, decision basis, and block source;
 - checkpoint policies update the shared runtime plan-state artefact rather than introducing workflow-specific Python persistence logic;
 - plan-state items support `pending|in_progress|blocked|done` statuses, bounded checkpoint history, periodic summary snapshots, resumable cursor snapshots, and resume telemetry;
 - completion gates MUST fail closed before terminal success when required plan items or required context keys are not satisfied;

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -82,12 +82,14 @@ from ...workflows.workflow_gap_workflow_contracts import (
 )
 
 from src.backend.workflows.write_tool_policy import (
+    build_mutation_guardrail_events,
     classify_write_tool_risk,
     compute_allowed_write_tools,
     prompt_has_low_risk_additive_write_evidence,
     prompt_grants_high_impact_kb_write_approval,
     prompt_explicitly_denies_write,
     REASON_DEFAULT_ALLOW_ADDITIVE_LOW_RISK,
+    required_mutation_authority_level_for_risk,
     tool_requires_confirmation,
     write_policy_reason_is_session_memory_eligible,
 )
@@ -334,11 +336,17 @@ class _ResolvedWritePolicyDecision:
     allowed_tools: frozenset[str]
     reason: str
     decision_basis: str
+    outcome: str
     user_denial_detected: bool
     risk_classes: Mapping[str, str]
+    tool_outcomes: Mapping[str, str]
     blocked_reasons: Mapping[str, str]
+    authority_block_sources: Mapping[str, str]
     confirmation_required_tools: frozenset[str]
     confirmation_prompts: Mapping[str, str]
+    effective_mutation_authority: str
+    authority_sources: Mapping[str, str]
+    guardrail_events: tuple[Mapping[str, Any], ...]
 
 
 class ProgressTracker:
@@ -1525,7 +1533,14 @@ class InternalMCPChatOrchestrator:
             method_catalogue = gateway.describe_methods()
             schema = self._tool_schema_for_name(tool_name, method_catalogue)
         except Exception:
+            method_catalogue = {}
             schema = None
+
+        tool_category = ""
+        if isinstance(method_catalogue, Mapping):
+            tool_meta = method_catalogue.get(tool_name)
+            if isinstance(tool_meta, Mapping):
+                tool_category = str(tool_meta.get("category") or "").strip().lower()
 
         self._apply_payload_defaults(
             tool_name,
@@ -1537,6 +1552,68 @@ class InternalMCPChatOrchestrator:
             turn_id=request.data.get("turn_id"),
         )
 
+        if tool_category == "write":
+            resolved_write_policy = self._resolve_allowed_write_tools(
+                prompt=(
+                    str(request.data.get("prompt") or "").strip()
+                    if isinstance(request.data, Mapping)
+                    else ""
+                ),
+                requested_write_tools=[tool_name],
+                recent_user_prompts=(
+                    [
+                        str(item).strip()
+                        for item in (request.data.get("recent_user_prompts") or [])
+                        if isinstance(item, str) and str(item).strip()
+                    ]
+                    if isinstance(request.data, Mapping)
+                    else []
+                ),
+                llm_client=env.llm_client,
+                model=env.model,
+                user_namespace=env.user_namespace,
+                auxiliary_system_prompt=env.auxiliary_system_prompt,
+                trace=request.trace,
+                conversation_session_id=request.data.get("conversation_session_id"),
+                turn_id=request.data.get("turn_id"),
+                aux_llm_calls=request.data.get("aux_llm_calls"),
+                caller_workflow_id=request.workflow_id,
+                caller_workflow_step_id=request.workflow_state_id,
+                caller_workflow_step_metadata=request.workflow_state_metadata,
+                guardrail_surface="workflow_action_fallback",
+                guardrail_stage="workflow_action",
+            )
+            self._record_mutation_guardrail_events(
+                events=resolved_write_policy.guardrail_events,
+                context=(
+                    request.data
+                    if isinstance(request.data, MutableMapping)
+                    else None
+                ),
+                aux_llm_calls=request.data.get("aux_llm_calls"),
+            )
+            if tool_name not in resolved_write_policy.allowed_tools:
+                message = self._build_blocked_write_message(
+                    tool_name=tool_name,
+                    reason=resolved_write_policy.blocked_reasons.get(tool_name),
+                    payload=payload,
+                )
+                return WorkflowActionResult(
+                    status="failed",
+                    error=message,
+                    outputs={
+                        "mutation_guardrail_blocked": True,
+                        "write_policy_reason": resolved_write_policy.reason,
+                        "write_policy_decision_basis": (
+                            resolved_write_policy.decision_basis
+                        ),
+                        "write_policy_outcome": resolved_write_policy.outcome,
+                        "write_policy_blocked_reason": (
+                            resolved_write_policy.blocked_reasons.get(tool_name)
+                        ),
+                    },
+                )
+
         try:
             result = gateway.invoke(tool_name, payload)
             try:
@@ -1547,6 +1624,37 @@ class InternalMCPChatOrchestrator:
                 record_generic_fallback_mcp_invocation(success=True)
             except Exception:
                 pass
+            if tool_category == "write" and isinstance(result.payload, Mapping):
+                tool_surface_guardrail_event = self._build_tool_surface_guardrail_event(
+                    tool_name=tool_name,
+                    payload=cast(Mapping[str, Any], result.payload),
+                    stage="workflow_action",
+                    workflow_id=request.workflow_id,
+                    workflow_step_id=request.workflow_state_id,
+                    action_id=request.action_id,
+                    conversation_session_id=request.data.get("conversation_session_id"),
+                    turn_id=request.data.get("turn_id"),
+                    effective_mutation_authority=(
+                        resolved_write_policy.effective_mutation_authority
+                        if "resolved_write_policy" in locals()
+                        else None
+                    ),
+                    authority_sources=(
+                        resolved_write_policy.authority_sources
+                        if "resolved_write_policy" in locals()
+                        else {}
+                    ),
+                )
+                if isinstance(tool_surface_guardrail_event, Mapping):
+                    self._record_mutation_guardrail_events(
+                        events=(tool_surface_guardrail_event,),
+                        context=(
+                            request.data
+                            if isinstance(request.data, MutableMapping)
+                            else None
+                        ),
+                        aux_llm_calls=request.data.get("aux_llm_calls"),
+                    )
             return workflow_action_result_from_mcp_payload(
                 tool_name=tool_name,
                 payload=result.payload,
@@ -1808,46 +1916,19 @@ class InternalMCPChatOrchestrator:
             requested_tools = []
         if not isinstance(recent_user_prompts, list):
             recent_user_prompts = []
-
-        # Admin override: allow all requested write tools.
-        try:
-            from src.backend.services.settings_service import (
-                get_disable_write_tool_conservatism,
-            )
-
-            if get_disable_write_tool_conservatism():
-                if not prompt_explicitly_denies_write(prompt):
-                    allowed = sorted({str(tool) for tool in requested_tools if tool})
-                    risk_classes = {
-                        tool_name: classify_write_tool_risk(tool_name)
-                        for tool_name in allowed
-                    }
-                    try:
-                        from ...workflows.workflow_baseline_telemetry import (
-                            record_write_policy_decision,
-                        )
-
-                        record_write_policy_decision(
-                            stage="write_policy.decide",
-                            allowed_tools_count=len(allowed),
-                        )
-                    except Exception:
-                        pass
-                    return WorkflowActionResult(
-                        outputs={
-                            "allowed_write_tools": allowed,
-                            "write_policy_reason": "write_conservatism_disabled_by_admin_setting",
-                            "write_policy_decision_basis": "write_conservatism_disabled_by_admin_setting",
-                            "write_policy_user_denial_detected": False,
-                            "write_policy_risk_classes": risk_classes,
-                            "write_policy_blocked_reasons": {},
-                            "write_policy_requires_confirmation": [],
-                            "approval_required": False,
-                        }
-                    )
-        except Exception:
-            # Defensive: do not fail policy evaluation if Settings storage is unavailable.
-            pass
+        caller_workflow_id = request.data.get("caller_workflow_id")
+        caller_workflow_step_id = request.data.get("caller_workflow_step_id")
+        caller_workflow_step_metadata = request.data.get(
+            "caller_workflow_step_metadata"
+        )
+        guardrail_surface = str(
+            request.data.get("write_policy_guardrail_surface") or "write_policy"
+        ).strip() or "write_policy"
+        guardrail_stage = str(
+            request.data.get("write_policy_guardrail_stage") or "write_policy.decide"
+        ).strip() or "write_policy.decide"
+        conversation_session_id = request.data.get("conversation_session_id")
+        turn_id = request.data.get("turn_id")
 
         decision = compute_allowed_write_tools(
             prompt=prompt,
@@ -1855,6 +1936,15 @@ class InternalMCPChatOrchestrator:
             recent_user_prompts=[
                 str(item) for item in recent_user_prompts if isinstance(item, str)
             ],
+            user_mutation_authority=self._resolve_user_mutation_authority_level(
+                user_namespace=request.environment.user_namespace
+            ),
+            workflow_mutation_authority=(
+                caller_workflow_step_metadata.get("mutation_authority")
+                if isinstance(caller_workflow_step_metadata, Mapping)
+                else None
+            ),
+            global_mutation_authority=self._resolve_global_mutation_authority_level(),
         )
         try:
             from ...workflows.workflow_baseline_telemetry import (
@@ -1868,25 +1958,73 @@ class InternalMCPChatOrchestrator:
         except Exception:
             pass
 
+        mutation_guardrail_events = build_mutation_guardrail_events(
+            policy_decision=decision,
+            guardrail_surface=guardrail_surface,
+            stage=guardrail_stage,
+            workflow_id=(
+                str(caller_workflow_id).strip()
+                if isinstance(caller_workflow_id, str) and caller_workflow_id.strip()
+                else None
+            ),
+            workflow_step_id=(
+                str(caller_workflow_step_id).strip()
+                if isinstance(caller_workflow_step_id, str)
+                and caller_workflow_step_id.strip()
+                else None
+            ),
+            action_id=(
+                str(request.action_id).strip()
+                if isinstance(request.action_id, str) and request.action_id.strip()
+                else None
+            ),
+            conversation_session_id=(
+                str(conversation_session_id).strip()
+                if isinstance(conversation_session_id, str)
+                and conversation_session_id.strip()
+                else None
+            ),
+            turn_id=(
+                str(turn_id).strip()
+                if isinstance(turn_id, str) and turn_id.strip()
+                else None
+            ),
+        )
+
         return WorkflowActionResult(
             outputs={
                 "allowed_write_tools": sorted(decision.allowed_tools),
                 "write_policy_reason": decision.reason,
                 "write_policy_decision_basis": decision.decision_basis,
+                "write_policy_outcome": decision.outcome,
                 "write_policy_user_denial_detected": decision.user_denial_detected,
+                "write_policy_effective_mutation_authority": (
+                    decision.effective_mutation_authority
+                ),
+                "write_policy_authority_sources": dict(decision.authority_sources),
                 "write_policy_risk_classes": {
                     item.tool_name: item.risk_class for item in decision.tool_decisions
+                },
+                "write_policy_tool_outcomes": {
+                    item.tool_name: item.outcome for item in decision.tool_decisions
                 },
                 "write_policy_blocked_reasons": {
                     item.tool_name: item.blocked_reason
                     for item in decision.tool_decisions
                     if isinstance(item.blocked_reason, str) and item.blocked_reason
                 },
+                "write_policy_authority_block_sources": {
+                    item.tool_name: item.authority_block_source
+                    for item in decision.tool_decisions
+                    if isinstance(item.authority_block_source, str)
+                    and item.authority_block_source
+                },
                 "write_policy_requires_confirmation": [
                     item.tool_name
                     for item in decision.tool_decisions
                     if item.requires_confirmation
                 ],
+                "mutation_guardrail_events": list(mutation_guardrail_events),
                 "approval_required": any(
                     item.requires_confirmation and not item.allowed
                     for item in decision.tool_decisions
@@ -4486,17 +4624,36 @@ class InternalMCPChatOrchestrator:
         write_policy_decision_basis = data.get(
             "write_policy_decision_basis", write_policy_reason
         )
+        write_policy_outcome = str(data.get("write_policy_outcome") or "").strip()
         write_policy_user_denial_detected = bool(
             data.get("write_policy_user_denial_detected")
+        )
+        write_policy_effective_mutation_authority = str(
+            data.get("write_policy_effective_mutation_authority") or ""
+        ).strip()
+        write_policy_authority_sources = (
+            dict(data.get("write_policy_authority_sources"))
+            if isinstance(data.get("write_policy_authority_sources"), Mapping)
+            else {}
         )
         write_policy_risk_classes = (
             dict(data.get("write_policy_risk_classes"))
             if isinstance(data.get("write_policy_risk_classes"), Mapping)
             else {}
         )
+        write_policy_tool_outcomes = (
+            dict(data.get("write_policy_tool_outcomes"))
+            if isinstance(data.get("write_policy_tool_outcomes"), Mapping)
+            else {}
+        )
         write_policy_blocked_reasons = (
             dict(data.get("write_policy_blocked_reasons"))
             if isinstance(data.get("write_policy_blocked_reasons"), Mapping)
+            else {}
+        )
+        write_policy_authority_block_sources = (
+            dict(data.get("write_policy_authority_block_sources"))
+            if isinstance(data.get("write_policy_authority_block_sources"), Mapping)
             else {}
         )
         write_policy_requires_confirmation = {
@@ -4589,7 +4746,7 @@ class InternalMCPChatOrchestrator:
                     conversation_session_id=conversation_session_id,
                     turn_id=turn_id if isinstance(turn_id, str) else None,
                 )
-            if tool_category == "write" and tool_name not in allowed_write_tools:
+            if tool_category == "write":
                 resolved_write_policy = self._resolve_allowed_write_tools(
                     prompt=prompt,
                     requested_write_tools=[tool_name],
@@ -4602,16 +4759,39 @@ class InternalMCPChatOrchestrator:
                     conversation_session_id=conversation_session_id,
                     turn_id=data.get("turn_id"),
                     aux_llm_calls=data.get("aux_llm_calls"),
+                    caller_workflow_id=request.workflow_id,
+                    caller_workflow_step_id=request.workflow_state_id,
+                    caller_workflow_step_metadata=request.workflow_state_metadata,
+                    guardrail_surface="execution",
+                    guardrail_stage="tool_execute",
+                )
+                self._record_mutation_guardrail_events(
+                    events=resolved_write_policy.guardrail_events,
+                    context=data,
+                    aux_llm_calls=aux_llm_calls,
                 )
                 allowed_write_tools = set(resolved_write_policy.allowed_tools)
                 write_policy_reason = resolved_write_policy.reason
                 write_policy_decision_basis = resolved_write_policy.decision_basis
+                write_policy_outcome = resolved_write_policy.outcome
                 write_policy_user_denial_detected = (
                     resolved_write_policy.user_denial_detected
                 )
+                write_policy_effective_mutation_authority = str(
+                    resolved_write_policy.effective_mutation_authority or ""
+                ).strip()
+                write_policy_authority_sources = dict(
+                    resolved_write_policy.authority_sources
+                )
                 write_policy_risk_classes = dict(resolved_write_policy.risk_classes)
+                write_policy_tool_outcomes = dict(
+                    resolved_write_policy.tool_outcomes
+                )
                 write_policy_blocked_reasons = dict(
                     resolved_write_policy.blocked_reasons
+                )
+                write_policy_authority_block_sources = dict(
+                    resolved_write_policy.authority_block_sources
                 )
                 write_policy_requires_confirmation = set(
                     resolved_write_policy.confirmation_required_tools
@@ -4621,6 +4801,9 @@ class InternalMCPChatOrchestrator:
                 write_policy_risk_classes.get(tool_name)
                 or classify_write_tool_risk(tool_name)
             )
+            tool_write_outcome = str(
+                write_policy_tool_outcomes.get(tool_name) or write_policy_outcome or ""
+            ).strip()
             tool_blocked_reason = str(
                 write_policy_blocked_reasons.get(tool_name) or write_policy_reason or ""
             ).strip()
@@ -4646,7 +4829,19 @@ class InternalMCPChatOrchestrator:
                     "error": message,
                     "blocked": True,
                     "write_policy_risk_class": tool_write_risk_class,
+                    "write_policy_outcome": tool_write_outcome or None,
                     "write_policy_decision_basis": write_policy_decision_basis,
+                    "write_policy_effective_mutation_authority": (
+                        write_policy_effective_mutation_authority or None
+                    ),
+                    "write_policy_authority_sources": (
+                        dict(write_policy_authority_sources)
+                        if write_policy_authority_sources
+                        else {}
+                    ),
+                    "write_policy_authority_block_source": (
+                        write_policy_authority_block_sources.get(tool_name)
+                    ),
                     "write_policy_requires_confirmation": tool_requires_confirmation,
                     "write_policy_blocked_reason": tool_blocked_reason or None,
                     "write_policy_user_denial_detected": write_policy_user_denial_detected,
@@ -4772,8 +4967,19 @@ class InternalMCPChatOrchestrator:
                     invocation_record["knowledge_interaction"] = write_interaction_metadata
                 if tool_category == "write":
                     invocation_record["write_policy_risk_class"] = tool_write_risk_class
+                    invocation_record["write_policy_outcome"] = (
+                        tool_write_outcome or None
+                    )
                     invocation_record["write_policy_decision_basis"] = (
                         write_policy_decision_basis
+                    )
+                    invocation_record["write_policy_effective_mutation_authority"] = (
+                        write_policy_effective_mutation_authority or None
+                    )
+                    invocation_record["write_policy_authority_sources"] = (
+                        dict(write_policy_authority_sources)
+                        if write_policy_authority_sources
+                        else {}
                     )
                 if call_id:
                     invocation_record["call_id"] = call_id
@@ -4782,6 +4988,33 @@ class InternalMCPChatOrchestrator:
                     invocation_record["error"] = logical_error
                     if logical_error_code:
                         invocation_record["error_code"] = logical_error_code
+                        if tool_category == "write" and isinstance(result.payload, Mapping):
+                            tool_surface_guardrail_event = (
+                                self._build_tool_surface_guardrail_event(
+                                    tool_name=tool_name,
+                                    payload=cast(Mapping[str, Any], result.payload),
+                                    stage="tool_execute",
+                                    workflow_id=request.workflow_id,
+                                    workflow_step_id=request.workflow_state_id,
+                                    action_id=request.action_id,
+                                    conversation_session_id=conversation_session_id,
+                                    turn_id=(
+                                        str(turn_id).strip()
+                                        if isinstance(turn_id, str) and turn_id.strip()
+                                        else None
+                                    ),
+                                    effective_mutation_authority=(
+                                        write_policy_effective_mutation_authority
+                                    ),
+                                    authority_sources=write_policy_authority_sources,
+                                )
+                            )
+                            if isinstance(tool_surface_guardrail_event, Mapping):
+                                self._record_mutation_guardrail_events(
+                                    events=(tool_surface_guardrail_event,),
+                                    context=data,
+                                    aux_llm_calls=aux_llm_calls,
+                                )
                 else:
                     invocation_record["status"] = "ok"
                 if result_summary:
@@ -11891,6 +12124,121 @@ class InternalMCPChatOrchestrator:
             metadata["guard_reason"] = guard_reason
         return metadata
 
+    def _resolve_user_mutation_authority_level(
+        self,
+        *,
+        user_namespace: str | None,
+    ) -> str | None:
+        actor_concept_id = self._derive_actor_concept_id_from_namespace(user_namespace)
+        if not actor_concept_id:
+            return None
+        try:
+            from src.backend.services.settings_service import (
+                get_user_mutation_authority_level,
+            )
+
+            return get_user_mutation_authority_level(actor_concept_id)
+        except Exception:
+            return None
+
+    def _resolve_global_mutation_authority_level(self) -> str | None:
+        try:
+            from src.backend.services.settings_service import (
+                get_global_mutation_authority_level,
+            )
+
+            return get_global_mutation_authority_level()
+        except Exception:
+            return None
+
+    def _record_mutation_guardrail_events(
+        self,
+        *,
+        events: Sequence[Mapping[str, Any]] | None,
+        context: MutableMapping[str, Any] | None = None,
+        aux_llm_calls: list[Mapping[str, Any]] | None = None,
+    ) -> None:
+        if not isinstance(events, Sequence):
+            return
+        context_events = None
+        if isinstance(context, MutableMapping):
+            existing = context.get("mutation_guardrail_events")
+            if isinstance(existing, list):
+                context_events = existing
+            else:
+                context_events = []
+                context["mutation_guardrail_events"] = context_events
+        for event in events:
+            if not isinstance(event, Mapping):
+                continue
+            event_payload = {
+                str(key): value for key, value in event.items() if isinstance(key, str)
+            }
+            if isinstance(context_events, list):
+                context_events.append(dict(event_payload))
+            if isinstance(aux_llm_calls, list):
+                aux_llm_calls.append(dict(event_payload))
+            try:
+                from ...workflows.workflow_baseline_telemetry import (
+                    record_mutation_guardrail_event,
+                )
+
+                record_mutation_guardrail_event(event_payload)
+            except Exception:
+                pass
+
+    def _build_tool_surface_guardrail_event(
+        self,
+        *,
+        tool_name: str,
+        payload: Mapping[str, Any],
+        stage: str,
+        workflow_id: str | None,
+        workflow_step_id: str | None,
+        action_id: str | None,
+        conversation_session_id: str | None,
+        turn_id: str | None,
+        effective_mutation_authority: str | None,
+        authority_sources: Mapping[str, str] | None,
+    ) -> Mapping[str, Any] | None:
+        error_code = str(payload.get("error_code") or "").strip()
+        if not error_code:
+            return None
+        risk_class = classify_write_tool_risk(tool_name)
+        event: dict[str, Any] = {
+            "type": "mutation_guardrail",
+            "guardrail_surface": "tool_surface",
+            "stage": stage,
+            "tool_name": tool_name,
+            "risk_class": risk_class,
+            "required_mutation_authority": required_mutation_authority_level_for_risk(
+                risk_class
+            ),
+            "effective_mutation_authority": str(
+                effective_mutation_authority or ""
+            ).strip(),
+            "authority_sources": dict(authority_sources or {}),
+            "decision": (
+                "approval_required"
+                if error_code == "approval_required"
+                else "blocked"
+            ),
+            "decision_basis": f"tool_surface:{error_code}",
+            "blocked_reason": error_code,
+            "tool_surface_error_code": error_code,
+        }
+        if workflow_id:
+            event["workflow_id"] = workflow_id
+        if workflow_step_id:
+            event["workflow_step_id"] = workflow_step_id
+        if action_id:
+            event["action_id"] = action_id
+        if conversation_session_id:
+            event["conversation_session_id"] = conversation_session_id
+        if turn_id:
+            event["turn_id"] = turn_id
+        return event
+
     def _tool_call_repair_enabled(self) -> bool:
         return os.getenv("VON_TOOL_CALL_REPAIR_ENABLE", "1").lower() in {
             "1",
@@ -17406,6 +17754,11 @@ class InternalMCPChatOrchestrator:
         conversation_session_id: str | None = None,
         turn_id: str | None = None,
         aux_llm_calls: list[Mapping[str, Any]] | None = None,
+        caller_workflow_id: str | None = None,
+        caller_workflow_step_id: str | None = None,
+        caller_workflow_step_metadata: Mapping[str, Any] | None = None,
+        guardrail_surface: str = "write_policy",
+        guardrail_stage: str = "write_policy.decide",
     ) -> _ResolvedWritePolicyDecision:
         workflow_result = self.execute_workflow(
             WRITE_TOOL_POLICY_WORKFLOW_ID,
@@ -17416,6 +17769,15 @@ class InternalMCPChatOrchestrator:
                 "conversation_session_id": conversation_session_id,
                 "turn_id": turn_id,
                 "aux_llm_calls": aux_llm_calls or [],
+                "caller_workflow_id": caller_workflow_id,
+                "caller_workflow_step_id": caller_workflow_step_id,
+                "caller_workflow_step_metadata": (
+                    dict(caller_workflow_step_metadata)
+                    if isinstance(caller_workflow_step_metadata, Mapping)
+                    else None
+                ),
+                "write_policy_guardrail_surface": guardrail_surface,
+                "write_policy_guardrail_stage": guardrail_stage,
                 "workflow_episode_source": "chat_turn_workflow",
                 "workflow_episode_stage": "write_policy",
             },
@@ -17438,27 +17800,43 @@ class InternalMCPChatOrchestrator:
                 allowed_tools=frozenset(),
                 reason="workflow_unavailable",
                 decision_basis="workflow_unavailable",
+                outcome="blocked",
                 user_denial_detected=False,
+                tool_outcomes={},
                 risk_classes={
                     str(tool_name): classify_write_tool_risk(str(tool_name))
                     for tool_name in requested_write_tools
                     if isinstance(tool_name, str) and str(tool_name).strip()
                 },
                 blocked_reasons=blocked_reasons,
+                authority_block_sources={},
                 confirmation_required_tools=frozenset(),
                 confirmation_prompts={},
+                effective_mutation_authority="",
+                authority_sources={},
+                guardrail_events=(),
             )
         allowed = workflow_result.data.get("allowed_write_tools")
         reason = workflow_result.data.get("write_policy_reason")
         decision_basis = workflow_result.data.get("write_policy_decision_basis")
+        outcome = workflow_result.data.get("write_policy_outcome")
         user_denial_detected = workflow_result.data.get(
             "write_policy_user_denial_detected"
         )
+        effective_mutation_authority = workflow_result.data.get(
+            "write_policy_effective_mutation_authority"
+        )
+        authority_sources = workflow_result.data.get("write_policy_authority_sources")
         risk_classes = workflow_result.data.get("write_policy_risk_classes")
+        tool_outcomes = workflow_result.data.get("write_policy_tool_outcomes")
         blocked_reasons = workflow_result.data.get("write_policy_blocked_reasons")
+        authority_block_sources = workflow_result.data.get(
+            "write_policy_authority_block_sources"
+        )
         confirmation_required = workflow_result.data.get(
             "write_policy_requires_confirmation"
         )
+        guardrail_events_raw = workflow_result.data.get("mutation_guardrail_events")
         allowed_set: set[str] = set()
         if isinstance(allowed, list):
             allowed_set = {
@@ -17480,7 +17858,11 @@ class InternalMCPChatOrchestrator:
             allowed_tools=frozenset(allowed_set),
             reason=str(reason or ""),
             decision_basis=str(decision_basis or reason or ""),
+            outcome=str(outcome or ""),
             user_denial_detected=bool(user_denial_detected),
+            tool_outcomes=(
+                dict(tool_outcomes) if isinstance(tool_outcomes, Mapping) else {}
+            ),
             risk_classes=(
                 dict(risk_classes)
                 if isinstance(risk_classes, Mapping)
@@ -17495,8 +17877,24 @@ class InternalMCPChatOrchestrator:
                 if isinstance(blocked_reasons, Mapping)
                 else {}
             ),
+            authority_block_sources=(
+                dict(authority_block_sources)
+                if isinstance(authority_block_sources, Mapping)
+                else {}
+            ),
             confirmation_required_tools=confirmation_required_tools,
             confirmation_prompts=confirmation_prompts,
+            effective_mutation_authority=str(effective_mutation_authority or ""),
+            authority_sources=(
+                dict(authority_sources)
+                if isinstance(authority_sources, Mapping)
+                else {}
+            ),
+            guardrail_events=tuple(
+                item
+                for item in (guardrail_events_raw or [])
+                if isinstance(item, Mapping)
+            ),
         )
 
     def execute_workflow(
@@ -20855,15 +21253,29 @@ class InternalMCPChatOrchestrator:
                 prompt=prompt,
                 requested_tools=write_tool_candidates_for_routing,
                 recent_user_prompts=recent_user_prompts_for_write or None,
+                user_mutation_authority=self._resolve_user_mutation_authority_level(
+                    user_namespace=user_namespace
+                ),
+                global_mutation_authority=self._resolve_global_mutation_authority_level(),
             )
             write_routing_policy_reason = str(
                 write_routing_policy_decision.reason or ""
             ).strip()
+            self._record_mutation_guardrail_events(
+                events=build_mutation_guardrail_events(
+                    policy_decision=write_routing_policy_decision,
+                    guardrail_surface="routing",
+                    stage="routing",
+                    conversation_session_id=conversation_session_id,
+                    turn_id=turn_id,
+                ),
+                aux_llm_calls=aux_llm_calls,
+            )
             low_risk_additive_routing_evidence = (
                 prompt_has_low_risk_additive_write_evidence(prompt)
                 or bool(
                     isinstance(write_intent_rehydrate_telemetry, Mapping)
-                    and write_intent_rehydrate_telemetry.get("reused")
+                        and write_intent_rehydrate_telemetry.get("reused")
                 )
             )
             routing_gate_allowed = any(
@@ -26322,6 +26734,7 @@ class InternalMCPChatOrchestrator:
             },
         )
         tool_pipeline_handoff_started = False
+        tc_data: dict[str, Any] = {}
         try:
             tc_env = WorkflowEnvironment(
                 llm_client=llm_client,
@@ -26351,7 +26764,7 @@ class InternalMCPChatOrchestrator:
             routing_info_payload = (
                 asdict(routing_info) if routing_info is not None else None
             )
-            tc_data: dict[str, Any] = {
+            tc_data = {
                 # Inputs.
                 "prompt": prompt,
                 "prompt_for_requirements": effective_prompt_for_routing,
@@ -26454,6 +26867,12 @@ class InternalMCPChatOrchestrator:
                 if tool_pipeline_handoff_started
                 else "tool_pipeline_setup_exception"
             )
+            partial_tool_messages = _coerce_message_sequence(
+                tc_data.get("tool_messages") if isinstance(tc_data, Mapping) else ()
+            )
+            partial_tool_invocations = _coerce_message_sequence(
+                tc_data.get("invocations") if isinstance(tc_data, Mapping) else ()
+            )
             if not tool_pipeline_handoff_started:
                 _emit_dispatch_boundary(
                     boundary="workflow_handoff",
@@ -26493,8 +26912,8 @@ class InternalMCPChatOrchestrator:
                     "before tool execution could begin. Please try again or report "
                     "this issue."
                 ),
-                extra_messages=(),
-                tool_invocations=(),
+                extra_messages=partial_tool_messages,
+                tool_invocations=partial_tool_invocations,
                 aux_llm_calls=tuple(aux_llm_calls),
                 llm_calls=tuple(llm_calls),
                 llm_usage=_aggregate_usage_total(),
@@ -26502,6 +26921,7 @@ class InternalMCPChatOrchestrator:
                 workflow_routing=routing_info,
                 render_plan=_result_render_plan(),
             )
+            result = _refresh_result_runtime_snapshots(result)
             _finalise_selection_experience_record(
                 result=result,
                 outcome="failed",

--- a/src/backend/server/routes/settings_routes.py
+++ b/src/backend/server/routes/settings_routes.py
@@ -42,8 +42,11 @@ from ...services.settings_service import (
     set_internal_mcp_tool_batch_cap,
     get_disable_write_tool_conservatism,
     set_disable_write_tool_conservatism,
+    get_global_mutation_authority_level,
     get_require_human_review_for_high_impact_kb_writes,
+    get_user_mutation_authority_level,
     set_require_human_review_for_high_impact_kb_writes,
+    set_user_mutation_authority_level,
     get_buttonify_model_enabled,
     set_buttonify_model_enabled,
     set_auto_proceed_minimal_imposition_enabled,
@@ -67,6 +70,13 @@ from ...db.mongo_client import (
     get_effective_mongo_uri,
     is_using_fallback_uri,
     assert_destructive_db_operation_allowed,
+)
+from ...workflows.write_tool_policy import (
+    MUTATION_AUTHORITY_LEVEL_ADDITIVE_VONTOLOGY,
+    MUTATION_AUTHORITY_LEVEL_DESTRUCTIVE_VONTOLOGY_WITH_CONFIRMATION,
+    MUTATION_AUTHORITY_LEVEL_EXTERNAL_SYSTEM_GUARDED,
+    MUTATION_AUTHORITY_LEVEL_MUTATIVE_VONTOLOGY_NON_DESTRUCTIVE,
+    MUTATION_AUTHORITY_LEVEL_READ_ONLY,
 )
 import re
 
@@ -682,6 +692,25 @@ def get_all_settings():
             user_concept_id=user_concept_id,
             org_concept_id=org_concept_id,
         )
+        settings["available_mutation_authority_levels"] = [
+            MUTATION_AUTHORITY_LEVEL_READ_ONLY,
+            MUTATION_AUTHORITY_LEVEL_ADDITIVE_VONTOLOGY,
+            MUTATION_AUTHORITY_LEVEL_MUTATIVE_VONTOLOGY_NON_DESTRUCTIVE,
+            MUTATION_AUTHORITY_LEVEL_DESTRUCTIVE_VONTOLOGY_WITH_CONFIRMATION,
+            MUTATION_AUTHORITY_LEVEL_EXTERNAL_SYSTEM_GUARDED,
+        ]
+        settings["global_mutation_authority_level"] = (
+            get_global_mutation_authority_level()
+        )
+        if user_concept_id:
+            settings["resolved_mutation_authority"] = {
+                "scope": "user",
+                "concept_id": user_concept_id,
+                "level": (
+                    get_user_mutation_authority_level(user_concept_id)
+                    or MUTATION_AUTHORITY_LEVEL_EXTERNAL_SYSTEM_GUARDED
+                ),
+            }
         return jsonify(settings), 200
     except Exception as e:
         current_app.logger.error(f"Error retrieving all settings: {e}", exc_info=True)
@@ -703,6 +732,7 @@ def save_all_settings():
     try:
         resolved_llm = None
         resolved_enabled_llms = None
+        resolved_mutation_authority = None
         llm_scope = None
         llm_scope_concept_id = None
         if "disable_write_tool_conservatism" in data:
@@ -846,12 +876,51 @@ def save_all_settings():
                     ),
                     500,
                 )
-            resolved_enabled_llms = resolve_enabled_llm_settings(
-                user_concept_id=llm_scope_concept_id if llm_scope == "user" else None,
-                org_concept_id=(
-                    llm_scope_concept_id if llm_scope == "organisation" else None
-                ),
-            )
+
+        if "mutation_authority" in data and data["mutation_authority"]:
+            authority_data = data["mutation_authority"]
+            if not isinstance(authority_data, dict):
+                return (
+                    jsonify(
+                        {
+                            "status": "error",
+                            "message": "mutation_authority must be an object payload.",
+                        }
+                    ),
+                    400,
+                )
+            scope = authority_data.get("scope")
+            concept_id = authority_data.get("concept_id")
+            level = authority_data.get("level")
+            if scope != "user" or not concept_id or not level:
+                return (
+                    jsonify(
+                        {
+                            "status": "error",
+                            "message": (
+                                "Saving mutation_authority requires user scope, "
+                                "concept_id, and level."
+                            ),
+                        }
+                    ),
+                    400,
+                )
+            ok = set_user_mutation_authority_level(str(concept_id), str(level))
+            if not ok:
+                return (
+                    jsonify(
+                        {
+                            "status": "error",
+                            "message": "Failed to save mutation_authority setting.",
+                        }
+                    ),
+                    500,
+                )
+            resolved_mutation_authority = {
+                "scope": "user",
+                "concept_id": str(concept_id),
+                "level": get_user_mutation_authority_level(str(concept_id)),
+            }
 
         if "openai_api_key_env_var" in data and data["openai_api_key_env_var"]:
             env_var = data["openai_api_key_env_var"]
@@ -933,6 +1002,7 @@ def save_all_settings():
                     "message": "Settings updated successfully.",
                     "resolved_llm": resolved_llm,
                     "enabled_llms": resolved_enabled_llms,
+                    "resolved_mutation_authority": resolved_mutation_authority,
                 }
             ),
             200,

--- a/src/backend/services/settings_service.py
+++ b/src/backend/services/settings_service.py
@@ -62,12 +62,16 @@ DISABLE_WRITE_TOOL_CONSERVATISM_SETTING_NAME = "disable_write_tool_conservatism"
 REQUIRE_HUMAN_REVIEW_FOR_HIGH_IMPACT_KB_WRITES_SETTING_NAME = (
     "require_human_review_for_high_impact_kb_writes"
 )
+MUTATION_AUTHORITY_LEVEL_SETTING_NAME = "mutation_authority_level"
 
 # Prefixes for contextual (scoped) LLM settings (Phase 2 scaffold)
 _ACTIVE_LLM_USER_PREFIX = f"{ACTIVE_LLM_SETTING_NAME}:user:"
 _ACTIVE_LLM_ORG_PREFIX = f"{ACTIVE_LLM_SETTING_NAME}:org:"
 _ENABLED_LLMS_USER_PREFIX = f"{ENABLED_LLMS_SETTING_NAME}:user:"
 _ENABLED_LLMS_ORG_PREFIX = f"{ENABLED_LLMS_SETTING_NAME}:org:"
+_MUTATION_AUTHORITY_LEVEL_USER_PREFIX = (
+    f"{MUTATION_AUTHORITY_LEVEL_SETTING_NAME}:user:"
+)
 
 
 def _normalise_llm_setting_entry(raw: Any) -> dict[str, str] | None:
@@ -405,6 +409,10 @@ def _build_user_llm_setting_name(user_concept_id: str) -> str:
     return f"{_ACTIVE_LLM_USER_PREFIX}{user_concept_id}"
 
 
+def _build_user_mutation_authority_setting_name(user_concept_id: str) -> str:
+    return f"{_MUTATION_AUTHORITY_LEVEL_USER_PREFIX}{user_concept_id}"
+
+
 def _build_org_llm_setting_name(org_concept_id: str) -> str:
     return f"{_ACTIVE_LLM_ORG_PREFIX}{org_concept_id}"
 
@@ -493,6 +501,36 @@ def get_user_llm_setting(user_concept_id: str):
         logger.warning("User LLM setting malformed (not dict); ignoring")
         return None
     return raw
+
+
+def set_user_mutation_authority_level(user_concept_id: str, level: str) -> bool:
+    if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+        logger.error(
+            "set_user_mutation_authority_level requires a non-empty user_concept_id"
+        )
+        return False
+    from ..workflows.write_tool_policy import (
+        normalise_mutation_authority_level,
+    )
+
+    normalised = normalise_mutation_authority_level(level)
+    return update_setting(
+        _build_user_mutation_authority_setting_name(user_concept_id),
+        normalised,
+    )
+
+
+def get_user_mutation_authority_level(user_concept_id: str) -> str | None:
+    if not isinstance(user_concept_id, str) or not user_concept_id.strip():
+        return None
+    raw = get_setting(_build_user_mutation_authority_setting_name(user_concept_id))
+    if raw is None:
+        return None
+    from ..workflows.write_tool_policy import (
+        normalise_mutation_authority_level,
+    )
+
+    return normalise_mutation_authority_level(raw)
 
 
 def set_org_llm_setting(org_concept_id: str, provider: str, model_name: str) -> bool:
@@ -1154,6 +1192,19 @@ def get_disable_write_tool_conservatism() -> bool:
 
 def set_disable_write_tool_conservatism(disabled: bool) -> bool:
     return update_setting(DISABLE_WRITE_TOOL_CONSERVATISM_SETTING_NAME, bool(disabled))
+
+
+def get_global_mutation_authority_level() -> str:
+    from ..workflows.write_tool_policy import (
+        MUTATION_AUTHORITY_LEVEL_EXTERNAL_SYSTEM_GUARDED,
+    )
+
+    # The legacy admin flag no longer acts as a coarse "full access" or
+    # "reduced access" ceiling. Mutation authority is now modelled primarily
+    # through user grants, workflow step contracts, and tool-surface guardrails.
+    # Keep the global source explicit and stable until a dedicated global
+    # authority setting is introduced.
+    return MUTATION_AUTHORITY_LEVEL_EXTERNAL_SYSTEM_GUARDED
 
 
 def get_require_human_review_for_high_impact_kb_writes() -> bool:

--- a/src/backend/vontology/code_concepts_registry.py
+++ b/src/backend/vontology/code_concepts_registry.py
@@ -101,6 +101,8 @@ _WORKFLOW_PREDICATE_IDS = [
     "#V#has_workflow_step_idempotency_policy_json",
     "#V#hasWorkflowStepCheckpointPolicyJson",
     "#V#has_workflow_step_checkpoint_policy_json",
+    "#V#hasWorkflowStepMutationAuthorityJson",
+    "#V#has_workflow_step_mutation_authority_json",
     "#V#hasWorkflowPlanStatePolicyJson",
     "#V#has_workflow_plan_state_policy_json",
     "#V#hasWorkflowCompletionGateJson",

--- a/src/backend/workflows/action_registry.py
+++ b/src/backend/workflows/action_registry.py
@@ -73,6 +73,9 @@ class WorkflowActionRequest:
     prompt_contract: Mapping[str, Any] | None = None
     llm_policy: Mapping[str, Any] | None = None
     validation_policy: Mapping[str, Any] | None = None
+    workflow_id: str | None = None
+    workflow_state_id: str | None = None
+    workflow_state_metadata: Mapping[str, Any] | None = None
 
 
 @dataclass
@@ -278,6 +281,9 @@ class ActionRegistry:
         context: Dict[str, Any],
         env: WorkflowEnvironment,
         trace: Any | None = None,
+        workflow_id: str | None = None,
+        workflow_state_id: str | None = None,
+        workflow_state_metadata: Mapping[str, Any] | None = None,
     ) -> WorkflowActionResult:
         action_target_id = str(action_id or "").strip()
         spec = self.resolve_action_spec(action_target_id)
@@ -311,6 +317,13 @@ class ActionRegistry:
                 trace=trace,
                 action_target_id=action_target_id or None,
                 contract_concept_id=contract_concept_id,
+                workflow_id=workflow_id,
+                workflow_state_id=workflow_state_id,
+                workflow_state_metadata=(
+                    dict(workflow_state_metadata)
+                    if isinstance(workflow_state_metadata, Mapping)
+                    else None
+                ),
             )
             raw_result = handler(request)
             if isinstance(raw_result, WorkflowActionResult):

--- a/src/backend/workflows/durable/durable_executor.py
+++ b/src/backend/workflows/durable/durable_executor.py
@@ -403,6 +403,9 @@ class DurableWorkflowExecutor:
                 )
                 result = execute_workflow_step_invocation(
                     registry=self._registry,
+                    workflow_id=definition.workflow_id,
+                    workflow_state_id=current_state,
+                    workflow_state_metadata=state_spec.metadata,
                     action=action,
                     resolved_inputs=resolved_inputs,
                     context=context,

--- a/src/backend/workflows/engine.py
+++ b/src/backend/workflows/engine.py
@@ -446,6 +446,9 @@ def _apply_action_result_context(
 def execute_workflow_step_invocation(
     *,
     registry: ActionRegistry,
+    workflow_id: str,
+    workflow_state_id: str,
+    workflow_state_metadata: Mapping[str, Any] | None,
     action: WorkflowActionInvocation,
     resolved_inputs: MutableMapping[str, Any],
     context: Dict[str, Any],
@@ -480,6 +483,13 @@ def execute_workflow_step_invocation(
                 if isinstance(action.validation_policy, Mapping)
                 else None
             ),
+            workflow_id=workflow_id,
+            workflow_state_id=workflow_state_id,
+            workflow_state_metadata=(
+                dict(workflow_state_metadata)
+                if isinstance(workflow_state_metadata, Mapping)
+                else None
+            ),
         )
         return execute_llm_step(request)
 
@@ -489,6 +499,9 @@ def execute_workflow_step_invocation(
         context=context,
         env=env,
         trace=trace,
+        workflow_id=workflow_id,
+        workflow_state_id=workflow_state_id,
+        workflow_state_metadata=workflow_state_metadata,
     )
 
 
@@ -1545,6 +1558,9 @@ class WorkflowExecutor:
                             )
                     else:
                         if approval_gate is not None:
+                            prior_approval_state = str(
+                                context.get("approval_state") or ""
+                            ).strip()
                             found, approval_value = resolve_context_path(
                                 context=context,
                                 path=str(
@@ -1556,8 +1572,15 @@ class WorkflowExecutor:
                                 is bool(approval_gate.get("expected", True))
                             )
                             approval_event = {
+                                "type": "mutation_guardrail",
                                 "status": "approval_gate_checked",
+                                "guardrail_surface": "workflow_approval_gate",
+                                "decision": (
+                                    "allowed" if approved else "approval_required"
+                                ),
+                                "stage": current_state,
                                 "workflow_id": definition.workflow_id,
+                                "workflow_step_id": current_state,
                                 "state_id": current_state,
                                 "action_id": action_target_id,
                                 "approval_context_key": approval_gate.get(
@@ -1568,6 +1591,15 @@ class WorkflowExecutor:
                                 if approved
                                 else "blocked",
                                 "approval_required": not approved,
+                                "approval_transition": (
+                                    "entered_approval_required"
+                                    if (not approved and prior_approval_state != "blocked")
+                                    else (
+                                        "exited_approval_required"
+                                        if (approved and prior_approval_state == "blocked")
+                                        else "approval_state_unchanged"
+                                    )
+                                ),
                             }
                             _append_context_event(
                                 context=context,
@@ -1579,6 +1611,14 @@ class WorkflowExecutor:
                                 context=context,
                                 event=approval_event,
                             )
+                            try:
+                                from .workflow_baseline_telemetry import (
+                                    record_mutation_guardrail_event,
+                                )
+
+                                record_mutation_guardrail_event(approval_event)
+                            except Exception:
+                                pass
                             if trace is not None:
                                 trace.record_state_transition(
                                     current_state,
@@ -1595,6 +1635,9 @@ class WorkflowExecutor:
 
                         result = execute_workflow_step_invocation(
                             registry=self._registry,
+                            workflow_id=definition.workflow_id,
+                            workflow_state_id=current_state,
+                            workflow_state_metadata=state_spec.metadata,
                             action=action,
                             resolved_inputs=resolved_inputs,
                             context=context,

--- a/src/backend/workflows/vontology_loader.py
+++ b/src/backend/workflows/vontology_loader.py
@@ -30,6 +30,9 @@ from .workflow_launch_input_contracts import (
     normalise_workflow_launch_input_contract,
 )
 from .workflow_action_contracts import resolve_workflow_action_target
+from .write_tool_policy import (
+    normalise_workflow_step_mutation_authority_spec,
+)
 from .engine import (
     WorkflowDefinition,
     WorkflowStateSpec,
@@ -260,6 +263,16 @@ WORKFLOW_STEP_CHECKPOINT_POLICY_TEXT_PREDICATE_PRECEDENCE: Tuple[
         "hasWorkflowStepCheckpointPolicyJson",
         "#V#has_workflow_step_checkpoint_policy_json",
         "has_workflow_step_checkpoint_policy_json",
+    ),
+)
+WORKFLOW_STEP_MUTATION_AUTHORITY_TEXT_PREDICATE_PRECEDENCE: Tuple[
+    Tuple[str, ...], ...
+] = (
+    (
+        "#V#hasWorkflowStepMutationAuthorityJson",
+        "hasWorkflowStepMutationAuthorityJson",
+        "#V#has_workflow_step_mutation_authority_json",
+        "has_workflow_step_mutation_authority_json",
     ),
 )
 WORKFLOW_BACKGROUND_LAUNCH_POLICY_TEXT_PREDICATE_PRECEDENCE: Tuple[
@@ -1690,6 +1703,19 @@ def resolve_workflow_step_runtime_policies(
             f"{step_id}:{checkpoint_source}"
         )
 
+    mutation_authority, mutation_authority_source = _resolve_policy_from_text_relations(
+        concept_id=step_id,
+        predicate_precedence=WORKFLOW_STEP_MUTATION_AUTHORITY_TEXT_PREDICATE_PRECEDENCE,
+        normaliser=normalise_workflow_step_mutation_authority_spec,
+    )
+    if mutation_authority is not None:
+        policies["mutation_authority"] = mutation_authority
+    elif isinstance(mutation_authority_source, str) and mutation_authority_source:
+        warnings.append(
+            "workflow_step_mutation_authority_invalid:"
+            f"{step_id}:{mutation_authority_source}"
+        )
+
     return policies, warnings
 
 
@@ -2338,6 +2364,7 @@ def load_workflow_definition_from_vontology(
         "workflow_step_approval_gate_invalid:",
         "workflow_step_idempotency_policy_invalid:",
         "workflow_step_checkpoint_policy_invalid:",
+        "workflow_step_mutation_authority_invalid:",
         "workflow_plan_state_policy_invalid:",
         "workflow_completion_gate_invalid:",
     )
@@ -2774,6 +2801,7 @@ def load_workflow_definition_from_vontology(
         approval_gate = step.get("approval_gate")
         idempotency_policy = step.get("idempotency_policy")
         checkpoint_policy = step.get("checkpoint_policy")
+        mutation_authority = step.get("mutation_authority")
         prompt_contract = step.get("prompt_contract")
         if preconditions:
             step_metadata["preconditions"] = preconditions
@@ -2795,6 +2823,8 @@ def load_workflow_definition_from_vontology(
             step_metadata["idempotency_policy"] = idempotency_policy
         if checkpoint_policy:
             step_metadata["checkpoint_policy"] = checkpoint_policy
+        if mutation_authority:
+            step_metadata["mutation_authority"] = mutation_authority
         if prompt_contract:
             step_metadata["prompt_contract"] = prompt_contract
         action_execution_modes = [

--- a/src/backend/workflows/workflow_baseline_telemetry.py
+++ b/src/backend/workflows/workflow_baseline_telemetry.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import copy
 from threading import Lock
-from typing import Any, Dict
+from typing import Any, Dict, Mapping
 
 _lock = Lock()
 _state: Dict[str, Any] = {
@@ -24,6 +24,12 @@ _state: Dict[str, Any] = {
     "write_policy_allow_total": 0,
     "write_policy_deny_total": 0,
     "write_policy_stage_counts": {},
+    "mutation_guardrail_events_total": 0,
+    "mutation_guardrail_decision_counts": {},
+    "mutation_guardrail_surface_counts": {},
+    "mutation_guardrail_risk_counts": {},
+    "mutation_guardrail_stage_counts": {},
+    "recent_mutation_guardrail_events": [],
 }
 
 
@@ -37,6 +43,15 @@ def _get_stage_bucket(stage: str) -> Dict[str, int]:
         bucket = {"allow": 0, "deny": 0}
         stage_counts[stage] = bucket
     return bucket
+
+
+def _increment_bucket(name: str, key: str) -> None:
+    bucket = _state.get(name)
+    if not isinstance(bucket, dict):
+        bucket = {}
+        _state[name] = bucket
+    cleaned = key.strip() if isinstance(key, str) and key.strip() else "unknown"
+    bucket[cleaned] = int(bucket.get(cleaned, 0)) + 1
 
 
 def record_workflow_discovery_observation(
@@ -86,6 +101,38 @@ def record_write_policy_decision(
             bucket["allow"] = int(bucket.get("allow", 0)) + 1
         else:
             bucket["deny"] = int(bucket.get("deny", 0)) + 1
+
+
+def record_mutation_guardrail_event(event: Mapping[str, Any]) -> None:
+    """Record one structured mutation-guardrail encounter."""
+
+    if not isinstance(event, Mapping):
+        return
+
+    decision = str(event.get("decision") or "").strip() or "unknown"
+    surface = str(event.get("guardrail_surface") or "").strip() or "unknown"
+    risk_class = str(event.get("risk_class") or "").strip() or "unknown"
+    stage = str(event.get("stage") or "").strip() or "unknown"
+    event_copy = {
+        str(key): value
+        for key, value in event.items()
+        if isinstance(key, str)
+    }
+
+    with _lock:
+        _state["mutation_guardrail_events_total"] += 1
+        _increment_bucket("mutation_guardrail_decision_counts", decision)
+        _increment_bucket("mutation_guardrail_surface_counts", surface)
+        _increment_bucket("mutation_guardrail_risk_counts", risk_class)
+        _increment_bucket("mutation_guardrail_stage_counts", stage)
+
+        recent = _state.get("recent_mutation_guardrail_events")
+        if not isinstance(recent, list):
+            recent = []
+            _state["recent_mutation_guardrail_events"] = recent
+        recent.append(event_copy)
+        if len(recent) > 100:
+            del recent[:-100]
 
 
 def get_workflow_baseline_telemetry_snapshot() -> Dict[str, Any]:

--- a/src/backend/workflows/workflow_concept_authority_service.py
+++ b/src/backend/workflows/workflow_concept_authority_service.py
@@ -19,7 +19,10 @@ from ..db.repositories.concepts_repository import ConceptsRepository
 from ..services import concept_service
 from ..services.concept_service import ConceptNotFoundError
 from ..services.effort_unit_ontology_service import ensure_effort_unit_ontology
-from ..services.text_value_service import upsert_text_for_concept
+from ..services.text_value_service import (
+    upsert_singleton_text_relation,
+    upsert_text_for_concept,
+)
 from .definitions import (
     CHAT_ASSISTANT_WORKFLOW_ID,
     CHAT_BUTTONIFY_WORKFLOW_ID,
@@ -121,6 +124,9 @@ from .subworkflow_contracts import (
     normalise_subworkflow_contract,
 )
 from .workflow_registry import WorkflowRegistry
+from .write_tool_policy import (
+    WORKFLOW_STEP_MUTATION_AUTHORITY_SCHEMA_VERSION,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -273,6 +279,7 @@ class _CanonicalStepPublicationSpec:
     execution_mode: str | None = None
     llm_policy: Mapping[str, Any] | None = None
     validation_policy: Mapping[str, Any] | None = None
+    mutation_authority: Mapping[str, Any] | None = None
     invoked_workflow_id: str | None = None
     static_input_bindings: tuple[tuple[str, str], ...] = ()
     context_input_mappings: tuple[str, ...] = ()
@@ -311,6 +318,7 @@ class _RuntimeStepPublicationDetails:
     execution_mode: str | None = None
     llm_policy: Mapping[str, Any] | None = None
     validation_policy: Mapping[str, Any] | None = None
+    mutation_authority: Mapping[str, Any] | None = None
     invoked_workflow_id: str | None = None
     static_input_bindings: tuple[tuple[str, str], ...] = ()
     context_input_mapping_specs: tuple[_CanonicalContextInputMappingSpec, ...] = ()
@@ -664,6 +672,10 @@ _CANONICAL_WORKFLOW_PUBLICATION_SPECS: Dict[str, _CanonicalWorkflowPublicationSp
                     "tool_mode": "allowed",
                     "policy_stage": "tool_call",
                     "prompt_text_context_key": "prompt",
+                },
+                mutation_authority={
+                    "schema_version": WORKFLOW_STEP_MUTATION_AUTHORITY_SCHEMA_VERSION,
+                    "maximum_level": "external_system_guarded",
                 },
                 conditional_transitions=(
                     _CanonicalConditionalTransitionPublicationSpec(
@@ -2050,11 +2062,15 @@ def _build_definition_from_publication_spec(
         is_terminal = not transitions
         if is_terminal:
             termination_states.append(step.state_id)
+        state_metadata: dict[str, Any] = {}
+        if isinstance(step.mutation_authority, Mapping):
+            state_metadata["mutation_authority"] = dict(step.mutation_authority)
         states[step.state_id] = WorkflowStateSpec(
             state_id=step.state_id,
             actions=actions,
             transitions=tuple(transitions),
             terminal=is_terminal,
+            metadata=state_metadata,
         )
     return WorkflowDefinition(
         workflow_id=workflow_id,
@@ -2232,6 +2248,7 @@ def _extract_runtime_step_publication_details(
     execution_mode: str | None = None
     llm_policy: Mapping[str, Any] | None = None
     validation_policy: Mapping[str, Any] | None = None
+    mutation_authority: Mapping[str, Any] | None = None
 
     for action in actions:
         execution_mode = str(getattr(action, "execution_mode", "") or "").strip() or execution_mode
@@ -2286,6 +2303,9 @@ def _extract_runtime_step_publication_details(
     tool_output_mapping_specs: list[_CanonicalToolOutputMappingSpec] = []
     writes_context_keys: list[str] = []
     if isinstance(metadata, Mapping):
+        raw_mutation_authority = metadata.get("mutation_authority")
+        if isinstance(raw_mutation_authority, Mapping):
+            mutation_authority = dict(raw_mutation_authority)
         raw_tool_output_mappings = metadata.get("tool_output_context_mappings")
         if isinstance(raw_tool_output_mappings, list):
             for item in raw_tool_output_mappings:
@@ -2324,6 +2344,11 @@ def _extract_runtime_step_publication_details(
         validation_policy=(
             dict(validation_policy)
             if isinstance(validation_policy, Mapping)
+            else None
+        ),
+        mutation_authority=(
+            dict(mutation_authority)
+            if isinstance(mutation_authority, Mapping)
             else None
         ),
         invoked_workflow_id=invoked_workflow_id or None,
@@ -2980,6 +3005,15 @@ def publish_canonical_chat_workflow_graphs(
                     else None
                 )
             )
+            mutation_authority = (
+                dict(step.mutation_authority)
+                if isinstance(step.mutation_authority, Mapping)
+                else (
+                    dict(runtime_details.mutation_authority)
+                    if isinstance(runtime_details.mutation_authority, Mapping)
+                    else None
+                )
+            )
             static_input_bindings = (
                 step.static_input_bindings
                 if step.static_input_bindings
@@ -3234,6 +3268,22 @@ def publish_canonical_chat_workflow_graphs(
                     resolve_to_state=lambda state_id: step_id_by_state[state_id],
                 ),
             }
+
+            if isinstance(mutation_authority, Mapping):
+                try:
+                    upsert_singleton_text_relation(
+                        subject_concept_id=step_concept_id,
+                        predicate="#V#hasWorkflowStepMutationAuthorityJson",
+                        text=json.dumps(mutation_authority, sort_keys=True),
+                        lang="en-NZ",
+                    )
+                except Exception as exc:  # pragma: no cover - defensive
+                    errors_by_workflow_id[workflow_id] = (
+                        "step_mutation_authority_upsert_failed:"
+                        f"{step_concept_id}:{exc}"
+                    )
+                    step_update_failed = True
+                    break
 
             try:
                 concept_service.update_concept(

--- a/src/backend/workflows/workflow_definition_identity_service.py
+++ b/src/backend/workflows/workflow_definition_identity_service.py
@@ -29,6 +29,9 @@ from .execution_contracts import (
     WORKFLOW_CONTROL_JOIN_ACTION_IDS,
     WORKFLOW_FOR_EACH_ALLOWED_SUCCESS_POLICIES,
 )
+from .write_tool_policy import (
+    normalise_workflow_step_mutation_authority_spec,
+)
 
 WORKFLOW_DEFINITION_IDENTITY_SCHEMA_VERSION = "workflow_definition_identity.v1"
 WORKFLOW_DEFINITION_IDENTITY_VERSION = 1
@@ -52,6 +55,7 @@ _STATE_METADATA_CONTRACT_KEYS: tuple[str, ...] = (
     "approval_gate",
     "idempotency_policy",
     "checkpoint_policy",
+    "mutation_authority",
     "prompt_contract",
 )
 
@@ -844,6 +848,19 @@ def validate_workflow_definition_contract(
                     "reason_code": str(exc),
                 }
             )
+        if metadata.get("mutation_authority") is not None:
+            if (
+                normalise_workflow_step_mutation_authority_spec(
+                    metadata.get("mutation_authority")
+                )
+                is None
+            ):
+                runtime_policy_issues.append(
+                    {
+                        "state_id": state_id,
+                        "reason_code": "mutation_authority_invalid",
+                    }
+                )
         requested_prompt_concept_ids = _normalise_symbol_list(
             prompt_contract.get("requested_prompt_concept_ids")
         )

--- a/src/backend/workflows/write_tool_policy.py
+++ b/src/backend/workflows/write_tool_policy.py
@@ -14,7 +14,32 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import re
-from typing import Sequence
+from typing import Any, Mapping, Sequence
+
+
+MUTATION_AUTHORITY_LEVEL_READ_ONLY = "read_only"
+MUTATION_AUTHORITY_LEVEL_ADDITIVE_VONTOLOGY = "additive_vontology"
+MUTATION_AUTHORITY_LEVEL_MUTATIVE_VONTOLOGY_NON_DESTRUCTIVE = (
+    "mutative_vontology_non_destructive"
+)
+MUTATION_AUTHORITY_LEVEL_DESTRUCTIVE_VONTOLOGY_WITH_CONFIRMATION = (
+    "destructive_vontology_with_confirmation"
+)
+MUTATION_AUTHORITY_LEVEL_EXTERNAL_SYSTEM_GUARDED = "external_system_guarded"
+
+WORKFLOW_STEP_MUTATION_AUTHORITY_SCHEMA_VERSION = (
+    "workflow_step_mutation_authority.v1"
+)
+
+MUTATION_GUARDRAIL_DECISION_ALLOWED = "allowed"
+MUTATION_GUARDRAIL_DECISION_BLOCKED = "blocked"
+MUTATION_GUARDRAIL_DECISION_APPROVAL_REQUIRED = "approval_required"
+MUTATION_GUARDRAIL_DECISION_DEFERRED = "deferred"
+
+REASON_NO_REQUESTED_WRITE_TOOLS = "no_requested_write_tools"
+REASON_MUTATION_AUTHORITY_DEFAULT = "mutation_authority_default"
+REASON_INSUFFICIENT_MUTATION_AUTHORITY = "insufficient_mutation_authority"
+REASON_WORKFLOW_MUTATION_AUTHORITY_INVALID = "workflow_mutation_authority_invalid"
 
 WRITE_RISK_ADDITIVE_LOW_RISK = "additive_low_risk"
 WRITE_RISK_MUTATIVE_NON_DESTRUCTIVE = "mutative_non_destructive"
@@ -40,6 +65,17 @@ REASON_EXTERNAL_WRITE_REQUIRES_EXPLICIT_REQUEST = (
     "external_write_requires_explicit_request"
 )
 REASON_EXPLICIT_WRITE_DENIAL_DETECTED = "explicit_write_denial_detected"
+
+_MUTATION_AUTHORITY_LEVEL_ORDER: tuple[str, ...] = (
+    MUTATION_AUTHORITY_LEVEL_READ_ONLY,
+    MUTATION_AUTHORITY_LEVEL_ADDITIVE_VONTOLOGY,
+    MUTATION_AUTHORITY_LEVEL_MUTATIVE_VONTOLOGY_NON_DESTRUCTIVE,
+    MUTATION_AUTHORITY_LEVEL_DESTRUCTIVE_VONTOLOGY_WITH_CONFIRMATION,
+    MUTATION_AUTHORITY_LEVEL_EXTERNAL_SYSTEM_GUARDED,
+)
+_MUTATION_AUTHORITY_LEVEL_RANKS: dict[str, int] = {
+    level: index for index, level in enumerate(_MUTATION_AUTHORITY_LEVEL_ORDER)
+}
 
 _EXTERNAL_WRITE_PREFIXES: tuple[str, ...] = (
     "jira_",
@@ -165,10 +201,16 @@ _ARXIV_ID_OR_URL_PATTERN = re.compile(
 class WriteToolDecision:
     tool_name: str
     risk_class: str
+    required_mutation_authority: str
+    effective_mutation_authority: str
+    authority_sources: Mapping[str, str]
     allowed: bool
+    outcome: str
     decision_basis: str
     requires_confirmation: bool = False
     blocked_reason: str | None = None
+    authority_block_source: str | None = None
+    continuation_context_used: bool = False
 
 
 @dataclass(frozen=True)
@@ -176,6 +218,9 @@ class WriteToolPolicyDecision:
     allowed_tools: frozenset[str]
     reason: str
     decision_basis: str
+    outcome: str
+    effective_mutation_authority: str
+    authority_sources: Mapping[str, str]
     user_denial_detected: bool
     tool_decisions: tuple[WriteToolDecision, ...]
 
@@ -187,6 +232,88 @@ class WriteToolPolicyDecision:
             if decision.tool_name.lower() == lowered:
                 return decision
         return None
+
+
+def normalise_mutation_authority_level(
+    value: Any,
+    *,
+    default: str = MUTATION_AUTHORITY_LEVEL_EXTERNAL_SYSTEM_GUARDED,
+) -> str:
+    cleaned = str(value or "").strip().lower()
+    if cleaned in _MUTATION_AUTHORITY_LEVEL_RANKS:
+        return cleaned
+    return default
+
+
+def mutation_authority_level_rank(level: Any) -> int:
+    return int(
+        _MUTATION_AUTHORITY_LEVEL_RANKS.get(
+            normalise_mutation_authority_level(level),
+            _MUTATION_AUTHORITY_LEVEL_RANKS[
+                MUTATION_AUTHORITY_LEVEL_EXTERNAL_SYSTEM_GUARDED
+            ],
+        )
+    )
+
+
+def intersect_mutation_authority_levels(
+    *levels: Any,
+    default: str = MUTATION_AUTHORITY_LEVEL_EXTERNAL_SYSTEM_GUARDED,
+) -> str:
+    resolved = [normalise_mutation_authority_level(item, default=default) for item in levels]
+    if not resolved:
+        return normalise_mutation_authority_level(default)
+    return min(resolved, key=mutation_authority_level_rank)
+
+
+def required_mutation_authority_level_for_risk(risk_class: str) -> str:
+    if risk_class == WRITE_RISK_ADDITIVE_LOW_RISK:
+        return MUTATION_AUTHORITY_LEVEL_ADDITIVE_VONTOLOGY
+    if risk_class == WRITE_RISK_MUTATIVE_NON_DESTRUCTIVE:
+        return MUTATION_AUTHORITY_LEVEL_MUTATIVE_VONTOLOGY_NON_DESTRUCTIVE
+    if risk_class == WRITE_RISK_DESTRUCTIVE:
+        return MUTATION_AUTHORITY_LEVEL_DESTRUCTIVE_VONTOLOGY_WITH_CONFIRMATION
+    return MUTATION_AUTHORITY_LEVEL_EXTERNAL_SYSTEM_GUARDED
+
+
+def normalise_workflow_step_mutation_authority_spec(
+    value: Any,
+) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        maximum_level = normalise_mutation_authority_level(value, default="")
+        if maximum_level:
+            return {
+                "schema_version": WORKFLOW_STEP_MUTATION_AUTHORITY_SCHEMA_VERSION,
+                "maximum_level": maximum_level,
+            }
+        return None
+    if not isinstance(value, Mapping):
+        return None
+
+    schema_version = str(value.get("schema_version") or "").strip()
+    if schema_version and schema_version != WORKFLOW_STEP_MUTATION_AUTHORITY_SCHEMA_VERSION:
+        return None
+
+    maximum_level_raw = (
+        value.get("maximum_level")
+        or value.get("max_level")
+        or value.get("level")
+        or value.get("mutation_authority_level")
+    )
+    maximum_level = normalise_mutation_authority_level(maximum_level_raw, default="")
+    if not maximum_level:
+        return None
+
+    normalised = {
+        "schema_version": WORKFLOW_STEP_MUTATION_AUTHORITY_SCHEMA_VERSION,
+        "maximum_level": maximum_level,
+    }
+    reason_code = str(value.get("reason_code") or "").strip()
+    if reason_code:
+        normalised["reason_code"] = reason_code
+    return normalised
 
 
 def classify_write_tool_risk(tool_name: str) -> str:
@@ -249,16 +376,52 @@ def compute_allowed_write_tools(
     prompt: str,
     requested_tools: list[str],
     recent_user_prompts: list[str] | None = None,
+    user_mutation_authority: str | None = None,
+    workflow_mutation_authority: Mapping[str, Any] | str | None = None,
+    global_mutation_authority: str | None = None,
+    environment_mutation_authority: str | None = None,
 ) -> WriteToolPolicyDecision:
     """Compute which write tools are allowed for this user prompt."""
 
     requested = _normalise_tool_names(requested_tools)
     recent_prompts = _clean_prompt_list(recent_user_prompts)
+    workflow_mutation_authority_spec = normalise_workflow_step_mutation_authority_spec(
+        workflow_mutation_authority
+    )
+    workflow_authority_invalid = (
+        workflow_mutation_authority is not None
+        and workflow_mutation_authority_spec is None
+    )
+    authority_sources = {
+        "user": normalise_mutation_authority_level(user_mutation_authority),
+        "workflow": (
+            str(workflow_mutation_authority_spec.get("maximum_level") or "").strip()
+            if isinstance(workflow_mutation_authority_spec, Mapping)
+            else (
+                MUTATION_AUTHORITY_LEVEL_READ_ONLY
+                if workflow_authority_invalid
+                else MUTATION_AUTHORITY_LEVEL_EXTERNAL_SYSTEM_GUARDED
+            )
+        ),
+        "global": normalise_mutation_authority_level(global_mutation_authority),
+        "environment": normalise_mutation_authority_level(
+            environment_mutation_authority
+        ),
+    }
+    effective_mutation_authority = intersect_mutation_authority_levels(
+        authority_sources["user"],
+        authority_sources["workflow"],
+        authority_sources["global"],
+        authority_sources["environment"],
+    )
     if not requested:
         return WriteToolPolicyDecision(
             allowed_tools=frozenset(),
-            reason="no_requested_write_tools",
-            decision_basis="no_requested_write_tools",
+            reason=REASON_NO_REQUESTED_WRITE_TOOLS,
+            decision_basis=REASON_NO_REQUESTED_WRITE_TOOLS,
+            outcome=MUTATION_GUARDRAIL_DECISION_ALLOWED,
+            effective_mutation_authority=effective_mutation_authority,
+            authority_sources=authority_sources,
             user_denial_detected=False,
             tool_decisions=(),
         )
@@ -268,7 +431,13 @@ def compute_allowed_write_tools(
             WriteToolDecision(
                 tool_name=tool_name,
                 risk_class=classify_write_tool_risk(tool_name),
+                required_mutation_authority=required_mutation_authority_level_for_risk(
+                    classify_write_tool_risk(tool_name)
+                ),
+                effective_mutation_authority=effective_mutation_authority,
+                authority_sources=authority_sources,
                 allowed=False,
+                outcome=MUTATION_GUARDRAIL_DECISION_BLOCKED,
                 decision_basis=REASON_EXPLICIT_WRITE_DENIAL_DETECTED,
                 requires_confirmation=False,
                 blocked_reason=REASON_EXPLICIT_WRITE_DENIAL_DETECTED,
@@ -279,6 +448,9 @@ def compute_allowed_write_tools(
             allowed_tools=frozenset(),
             reason=REASON_EXPLICIT_WRITE_DENIAL_DETECTED,
             decision_basis=REASON_EXPLICIT_WRITE_DENIAL_DETECTED,
+            outcome=MUTATION_GUARDRAIL_DECISION_BLOCKED,
+            effective_mutation_authority=effective_mutation_authority,
+            authority_sources=authority_sources,
             user_denial_detected=True,
             tool_decisions=tool_decisions,
         )
@@ -292,23 +464,86 @@ def compute_allowed_write_tools(
             tool_name=tool_name,
             prompt=prompt,
             recent_user_prompts=recent_prompts,
+            effective_mutation_authority=effective_mutation_authority,
+            authority_sources=authority_sources,
+            workflow_authority_invalid=workflow_authority_invalid,
         )
         decisions.append(decision)
         if decision.allowed:
             allowed_tools.add(tool_name)
-        if not overall_reason or not decision.allowed:
+        if (
+            not overall_reason
+            or decision.outcome != MUTATION_GUARDRAIL_DECISION_ALLOWED
+        ):
             overall_reason = decision.blocked_reason or decision.decision_basis
 
     if not overall_reason and decisions:
         overall_reason = decisions[0].decision_basis
 
+    overall_decision = min(
+        decisions,
+        key=lambda item: {
+            MUTATION_GUARDRAIL_DECISION_BLOCKED: 0,
+            MUTATION_GUARDRAIL_DECISION_APPROVAL_REQUIRED: 1,
+            MUTATION_GUARDRAIL_DECISION_DEFERRED: 2,
+            MUTATION_GUARDRAIL_DECISION_ALLOWED: 3,
+        }.get(item.outcome, 99),
+    )
+
     return WriteToolPolicyDecision(
         allowed_tools=frozenset(allowed_tools),
-        reason=overall_reason or "write_policy_evaluated",
-        decision_basis=overall_reason or "write_policy_evaluated",
+        reason=overall_reason or REASON_MUTATION_AUTHORITY_DEFAULT,
+        decision_basis=overall_reason or REASON_MUTATION_AUTHORITY_DEFAULT,
+        outcome=overall_decision.outcome,
+        effective_mutation_authority=effective_mutation_authority,
+        authority_sources=authority_sources,
         user_denial_detected=False,
         tool_decisions=tuple(decisions),
     )
+
+
+def build_mutation_guardrail_events(
+    *,
+    policy_decision: WriteToolPolicyDecision,
+    guardrail_surface: str,
+    stage: str | None,
+    workflow_id: str | None = None,
+    workflow_step_id: str | None = None,
+    action_id: str | None = None,
+    conversation_session_id: str | None = None,
+    turn_id: str | None = None,
+) -> tuple[dict[str, Any], ...]:
+    events: list[dict[str, Any]] = []
+    for decision in policy_decision.tool_decisions:
+        event: dict[str, Any] = {
+            "type": "mutation_guardrail",
+            "guardrail_surface": str(guardrail_surface or "").strip() or "unknown",
+            "stage": str(stage or "").strip() or None,
+            "tool_name": decision.tool_name,
+            "risk_class": decision.risk_class,
+            "required_mutation_authority": decision.required_mutation_authority,
+            "effective_mutation_authority": decision.effective_mutation_authority,
+            "authority_sources": dict(decision.authority_sources),
+            "decision": decision.outcome,
+            "decision_basis": decision.decision_basis,
+            "blocked_reason": decision.blocked_reason,
+            "authority_block_source": decision.authority_block_source,
+            "requires_confirmation": decision.requires_confirmation,
+            "continuation_context_used": decision.continuation_context_used,
+            "user_denial_detected": policy_decision.user_denial_detected,
+        }
+        if workflow_id:
+            event["workflow_id"] = workflow_id
+        if workflow_step_id:
+            event["workflow_step_id"] = workflow_step_id
+        if action_id:
+            event["action_id"] = action_id
+        if conversation_session_id:
+            event["conversation_session_id"] = conversation_session_id
+        if turn_id:
+            event["turn_id"] = turn_id
+        events.append(event)
+    return tuple(events)
 
 
 def write_policy_reason_is_session_memory_eligible(reason: str | None) -> bool:
@@ -462,14 +697,50 @@ def _decide_single_tool(
     tool_name: str,
     prompt: str,
     recent_user_prompts: Sequence[str],
+    effective_mutation_authority: str,
+    authority_sources: Mapping[str, str],
+    workflow_authority_invalid: bool,
 ) -> WriteToolDecision:
     risk_class = classify_write_tool_risk(tool_name)
+    required_mutation_authority = required_mutation_authority_level_for_risk(risk_class)
+    authority_block_source = _resolve_authority_block_source(
+        required_mutation_authority=required_mutation_authority,
+        authority_sources=authority_sources,
+    )
+    if workflow_authority_invalid:
+        authority_block_source = "workflow"
+
+    if (
+        mutation_authority_level_rank(effective_mutation_authority)
+        < mutation_authority_level_rank(required_mutation_authority)
+    ):
+        blocked_reason = (
+            REASON_WORKFLOW_MUTATION_AUTHORITY_INVALID
+            if workflow_authority_invalid
+            else REASON_INSUFFICIENT_MUTATION_AUTHORITY
+        )
+        return WriteToolDecision(
+            tool_name=tool_name,
+            risk_class=risk_class,
+            required_mutation_authority=required_mutation_authority,
+            effective_mutation_authority=effective_mutation_authority,
+            authority_sources=authority_sources,
+            allowed=False,
+            outcome=MUTATION_GUARDRAIL_DECISION_BLOCKED,
+            decision_basis=blocked_reason,
+            blocked_reason=blocked_reason,
+            authority_block_source=authority_block_source,
+        )
 
     if risk_class == WRITE_RISK_ADDITIVE_LOW_RISK:
         return WriteToolDecision(
             tool_name=tool_name,
             risk_class=risk_class,
+            required_mutation_authority=required_mutation_authority,
+            effective_mutation_authority=effective_mutation_authority,
+            authority_sources=authority_sources,
             allowed=True,
+            outcome=MUTATION_GUARDRAIL_DECISION_ALLOWED,
             decision_basis=REASON_DEFAULT_ALLOW_ADDITIVE_LOW_RISK,
         )
 
@@ -488,13 +759,22 @@ def _decide_single_tool(
             return WriteToolDecision(
                 tool_name=tool_name,
                 risk_class=risk_class,
+                required_mutation_authority=required_mutation_authority,
+                effective_mutation_authority=effective_mutation_authority,
+                authority_sources=authority_sources,
                 allowed=True,
+                outcome=MUTATION_GUARDRAIL_DECISION_ALLOWED,
                 decision_basis=reason,
+                continuation_context_used=recent and not explicit,
             )
         return WriteToolDecision(
             tool_name=tool_name,
             risk_class=risk_class,
+            required_mutation_authority=required_mutation_authority,
+            effective_mutation_authority=effective_mutation_authority,
+            authority_sources=authority_sources,
             allowed=False,
+            outcome=MUTATION_GUARDRAIL_DECISION_DEFERRED,
             decision_basis=REASON_MUTATIVE_NON_DESTRUCTIVE_REQUEST_REQUIRED,
             blocked_reason=REASON_MUTATIVE_NON_DESTRUCTIVE_REQUEST_REQUIRED,
         )
@@ -520,14 +800,23 @@ def _decide_single_tool(
             return WriteToolDecision(
                 tool_name=tool_name,
                 risk_class=risk_class,
+                required_mutation_authority=required_mutation_authority,
+                effective_mutation_authority=effective_mutation_authority,
+                authority_sources=authority_sources,
                 allowed=True,
+                outcome=MUTATION_GUARDRAIL_DECISION_ALLOWED,
                 decision_basis=reason,
                 requires_confirmation=True,
+                continuation_context_used=recent_confirmation,
             )
         return WriteToolDecision(
             tool_name=tool_name,
             risk_class=risk_class,
+            required_mutation_authority=required_mutation_authority,
+            effective_mutation_authority=effective_mutation_authority,
+            authority_sources=authority_sources,
             allowed=False,
+            outcome=MUTATION_GUARDRAIL_DECISION_APPROVAL_REQUIRED,
             decision_basis=REASON_DESTRUCTIVE_CONFIRMATION_REQUIRED,
             requires_confirmation=True,
             blocked_reason=REASON_DESTRUCTIVE_CONFIRMATION_REQUIRED,
@@ -550,17 +839,39 @@ def _decide_single_tool(
         return WriteToolDecision(
             tool_name=tool_name,
             risk_class=risk_class,
+            required_mutation_authority=required_mutation_authority,
+            effective_mutation_authority=effective_mutation_authority,
+            authority_sources=authority_sources,
             allowed=True,
+            outcome=MUTATION_GUARDRAIL_DECISION_ALLOWED,
             decision_basis=reason,
+            continuation_context_used=recent_external and not explicit_external,
         )
 
     return WriteToolDecision(
         tool_name=tool_name,
         risk_class=risk_class,
+        required_mutation_authority=required_mutation_authority,
+        effective_mutation_authority=effective_mutation_authority,
+        authority_sources=authority_sources,
         allowed=False,
+        outcome=MUTATION_GUARDRAIL_DECISION_DEFERRED,
         decision_basis=REASON_EXTERNAL_WRITE_REQUIRES_EXPLICIT_REQUEST,
         blocked_reason=REASON_EXTERNAL_WRITE_REQUIRES_EXPLICIT_REQUEST,
     )
+
+
+def _resolve_authority_block_source(
+    *,
+    required_mutation_authority: str,
+    authority_sources: Mapping[str, str],
+) -> str | None:
+    required_rank = mutation_authority_level_rank(required_mutation_authority)
+    for source_name in ("workflow", "user", "global", "environment"):
+        level = authority_sources.get(source_name)
+        if mutation_authority_level_rank(level) < required_rank:
+            return source_name
+    return None
 
 
 def _prompt_requests_non_destructive_mutation(prompt: str) -> bool:

--- a/tests/backend/test_admin_disable_write_conservatism_setting.py
+++ b/tests/backend/test_admin_disable_write_conservatism_setting.py
@@ -1,33 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 
 import pytest
 from flask import Flask
 
-from src.backend.integrations.internal_mcp.orchestrator import (
-    InternalMCPChatOrchestrator,
-)
 from src.backend.server.routes.settings_routes import settings_bp
 from src.backend.services import settings_service
-
-
-class _StubGateway:
-    enabled = True
-
-    def describe_methods(self):
-        return {}
-
-    def invoke(self, tool_name, payload=None):
-        raise RuntimeError("not used")
-
-
-class _StubRequest:
-    def __init__(self, data: dict[str, Any]):
-        self.data = data
-        self.trace = None
-        self.environment = None
-
 
 @pytest.mark.parametrize(
     "raw, expected",
@@ -50,31 +29,23 @@ def test_get_disable_write_tool_conservatism_coerces(
     assert settings_service.get_disable_write_tool_conservatism() is expected
 
 
-def test_orchestrator_write_policy_bypasses_when_setting_enabled(monkeypatch):
+def test_get_global_mutation_authority_level_reflects_legacy_admin_setting(
+    monkeypatch,
+):
     monkeypatch.setattr(
         settings_service, "get_disable_write_tool_conservatism", lambda: True
     )
-
-    orchestrator = InternalMCPChatOrchestrator(
-        gateway=cast(Any, _StubGateway()),
-        max_tool_invocations=30,
-        tool_batch_cap=10,
-    )
-
-    result = orchestrator._action_write_policy_decide(
-        _StubRequest(
-            {
-                "prompt": "please do something",
-                "requested_write_tools": ["download_paper", "upsert_concept"],
-                "recent_user_prompts": [],
-            }
-        )
-    )
-
-    assert result.outputs["allowed_write_tools"] == ["download_paper", "upsert_concept"]
     assert (
-        result.outputs["write_policy_reason"]
-        == "write_conservatism_disabled_by_admin_setting"
+        settings_service.get_global_mutation_authority_level()
+        == "external_system_guarded"
+    )
+
+    monkeypatch.setattr(
+        settings_service, "get_disable_write_tool_conservatism", lambda: False
+    )
+    assert (
+        settings_service.get_global_mutation_authority_level()
+        == "external_system_guarded"
     )
 
 
@@ -281,6 +252,63 @@ def test_settings_endpoint_returns_resolved_llm_after_scoped_save(monkeypatch):
         "provider": "openai",
         "model": "gpt-5-mini",
     }
+
+
+def test_settings_endpoint_saves_user_mutation_authority(monkeypatch):
+    app = _make_settings_app()
+
+    captured: dict[str, Any] = {}
+
+    def _setter(concept_id: str, level: str) -> bool:
+        captured["concept_id"] = concept_id
+        captured["level"] = level
+        return True
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.settings_routes.set_user_mutation_authority_level",
+        _setter,
+    )
+
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/settings/",
+            json={
+                "mutation_authority": {
+                    "scope": "user",
+                    "concept_id": "#V#michael_witbrock",
+                    "level": "mutative_vontology_non_destructive",
+                }
+            },
+        )
+
+    assert resp.status_code == 200
+    assert captured == {
+        "concept_id": "#V#michael_witbrock",
+        "level": "mutative_vontology_non_destructive",
+    }
+
+
+def test_settings_endpoint_returns_resolved_mutation_authority(monkeypatch):
+    app = _make_settings_app()
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.settings_routes.get_global_mutation_authority_level",
+        lambda: "external_system_guarded",
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.settings_routes.get_user_mutation_authority_level",
+        lambda _concept_id: "additive_vontology",
+    )
+
+    with app.test_client() as client:
+        resp = client.get("/api/settings/?user_concept_id=%23V%23michael_witbrock")
+
+    assert resp.status_code == 200
+    payload = resp.get_json() or {}
+    resolved = payload.get("resolved_mutation_authority") or {}
+    assert resolved.get("scope") == "user"
+    assert resolved.get("concept_id") == "#V#michael_witbrock"
+    assert resolved.get("level") == "additive_vontology"
 
 
 @pytest.mark.parametrize(

--- a/tests/backend/test_code_concepts_registry.py
+++ b/tests/backend/test_code_concepts_registry.py
@@ -44,6 +44,8 @@ def test_workflow_runtime_policy_predicates_are_registered():
     assert "#V#has_workflow_step_idempotency_policy_json" in ids
     assert "#V#hasWorkflowStepCheckpointPolicyJson" in ids
     assert "#V#has_workflow_step_checkpoint_policy_json" in ids
+    assert "#V#hasWorkflowStepMutationAuthorityJson" in ids
+    assert "#V#has_workflow_step_mutation_authority_json" in ids
     assert "#V#hasWorkflowPlanStatePolicyJson" in ids
     assert "#V#has_workflow_plan_state_policy_json" in ids
     assert "#V#hasWorkflowCompletionGateJson" in ids

--- a/tests/backend/test_mcp_action_handler.py
+++ b/tests/backend/test_mcp_action_handler.py
@@ -130,6 +130,34 @@ class TestFallbackHandler:
         assert req.data is ctx
         assert req.environment is env
 
+    def test_fallback_receives_workflow_context(self):
+        captured: list[WorkflowActionRequest] = []
+
+        def capture(request: WorkflowActionRequest) -> WorkflowActionResult:
+            captured.append(request)
+            return WorkflowActionResult()
+
+        registry = ActionRegistry()
+        registry.set_fallback_handler(capture)
+
+        registry.execute(
+            "tool_x",
+            inputs={"a": 1},
+            context={},
+            env=WorkflowEnvironment(llm_client=None),
+            workflow_id="#V#workflow",
+            workflow_state_id="write_step",
+            workflow_state_metadata={"mutation_authority": {"maximum_level": "read_only"}},
+        )
+
+        assert len(captured) == 1
+        req = captured[0]
+        assert req.workflow_id == "#V#workflow"
+        assert req.workflow_state_id == "write_step"
+        assert req.workflow_state_metadata == {
+            "mutation_authority": {"maximum_level": "read_only"}
+        }
+
 
 class TestActionOutcomeEnvelope:
     """WS2 safety envelope: action outcomes should always stamp context flags."""
@@ -301,6 +329,80 @@ class TestMCPToolInvoke:
         gw.invoke.assert_called_once()
         call_args = gw.invoke.call_args
         assert call_args[0][0] == "search_concepts"
+
+    def test_write_tools_in_fallback_path_are_blocked_by_guardrail(self):
+        from src.backend.integrations.internal_mcp.orchestrator import (
+            _ResolvedWritePolicyDecision,
+        )
+
+        orch, gw = _build_mock_orchestrator(
+            describe_methods_result={"delete_concept": {"category": "write"}}
+        )
+        orch._resolve_allowed_write_tools = MagicMock(
+            return_value=_ResolvedWritePolicyDecision(
+                allowed_tools=frozenset(),
+                reason="destructive_confirmation_required",
+                decision_basis="destructive_confirmation_required",
+                outcome="approval_required",
+                user_denial_detected=False,
+                risk_classes={"delete_concept": "destructive"},
+                tool_outcomes={"delete_concept": "approval_required"},
+                blocked_reasons={
+                    "delete_concept": "destructive_confirmation_required"
+                },
+                authority_block_sources={},
+                confirmation_required_tools=frozenset({"delete_concept"}),
+                confirmation_prompts={},
+                effective_mutation_authority=(
+                    "destructive_vontology_with_confirmation"
+                ),
+                authority_sources={
+                    "user": "external_system_guarded",
+                    "workflow": "external_system_guarded",
+                    "global": "external_system_guarded",
+                    "environment": "external_system_guarded",
+                },
+                guardrail_events=(
+                    {
+                        "type": "mutation_guardrail",
+                        "guardrail_surface": "workflow_action_fallback",
+                        "stage": "workflow_action",
+                        "tool_name": "delete_concept",
+                        "decision": "approval_required",
+                    },
+                ),
+            )
+        )
+
+        context: dict[str, Any] = {
+            "prompt": "Tell me about this concept.",
+            "recent_user_prompts": [],
+            "aux_llm_calls": [],
+        }
+        request = WorkflowActionRequest(
+            action_id="delete_concept",
+            inputs={"concept_id": "#V#example"},
+            environment=WorkflowEnvironment(
+                llm_client=None,
+                user_namespace="#V#test_user",
+            ),
+            data=context,
+            workflow_id="#V#custom_workflow",
+            workflow_state_id="write_step",
+            workflow_state_metadata={
+                "mutation_authority": {
+                    "schema_version": "workflow_step_mutation_authority.v1",
+                    "maximum_level": "destructive_vontology_with_confirmation",
+                }
+            },
+        )
+
+        result = orch._action_mcp_tool_invoke(request)
+
+        assert not result.ok
+        gw.invoke.assert_not_called()
+        assert result.outputs["mutation_guardrail_blocked"] is True
+        assert context["mutation_guardrail_events"][0]["tool_name"] == "delete_concept"
 
     def test_inputs_passed_as_payload(self):
         orch, gw = _build_mock_orchestrator()

--- a/tests/backend/test_vontology_loader.py
+++ b/tests/backend/test_vontology_loader.py
@@ -459,6 +459,13 @@ class TestWorkflowStepRuntimePolicyResolution:
                         '"summary_context_keys":["dispatch.summary"]}'
                     ),
                 },
+                {
+                    "predicate": "#V#hasWorkflowStepMutationAuthorityJson",
+                    "text": (
+                        '{"schema_version":"workflow_step_mutation_authority.v1",'
+                        '"maximum_level":"mutative_vontology_non_destructive"}'
+                    ),
+                },
             ],
         ):
             policies, warnings = resolve_workflow_step_runtime_policies("#V#step")
@@ -473,6 +480,9 @@ class TestWorkflowStepRuntimePolicyResolution:
         assert policies["checkpoint_policy"]["summary_context_keys"] == [
             "dispatch.summary"
         ]
+        assert policies["mutation_authority"]["maximum_level"] == (
+            "mutative_vontology_non_destructive"
+        )
 
 
 class TestWorkflowLongHorizonPolicyResolution:

--- a/tests/backend/test_workflow_baseline_telemetry.py
+++ b/tests/backend/test_workflow_baseline_telemetry.py
@@ -1,6 +1,7 @@
 from src.backend.workflows.workflow_baseline_telemetry import (
     get_workflow_baseline_telemetry_snapshot,
     record_generic_fallback_mcp_invocation,
+    record_mutation_guardrail_event,
     record_workflow_discovery_observation,
     record_write_policy_decision,
 )
@@ -47,3 +48,30 @@ def test_fallback_and_write_policy_counters_increment():
 
     stage_counts = after.get("write_policy_stage_counts", {})
     assert "write_policy.decide" in stage_counts
+
+
+def test_mutation_guardrail_event_updates_counters_and_recent_history():
+    before = get_workflow_baseline_telemetry_snapshot()
+    before_total = int(before.get("mutation_guardrail_events_total", 0))
+
+    record_mutation_guardrail_event(
+        {
+            "type": "mutation_guardrail",
+            "guardrail_surface": "execution",
+            "stage": "tool_execute",
+            "tool_name": "delete_concept",
+            "risk_class": "destructive",
+            "decision": "approval_required",
+        }
+    )
+
+    after = get_workflow_baseline_telemetry_snapshot()
+    assert int(after.get("mutation_guardrail_events_total", 0)) == before_total + 1
+    assert after.get("mutation_guardrail_decision_counts", {}).get(
+        "approval_required", 0
+    ) >= 1
+    assert after.get("mutation_guardrail_surface_counts", {}).get("execution", 0) >= 1
+    assert after.get("mutation_guardrail_risk_counts", {}).get("destructive", 0) >= 1
+    recent = after.get("recent_mutation_guardrail_events", [])
+    assert isinstance(recent, list)
+    assert recent

--- a/tests/backend/test_workflow_concept_authority_service.py
+++ b/tests/backend/test_workflow_concept_authority_service.py
@@ -469,6 +469,7 @@ def _comparable_state_metadata(state: Any) -> dict[str, Any]:
         "writes_context_keys",
         "tool_output_context_mappings",
         "subworkflow_contract",
+        "mutation_authority",
     ):
         value = metadata.get(key)
         if value:

--- a/tests/backend/test_workflow_definition_identity_service.py
+++ b/tests/backend/test_workflow_definition_identity_service.py
@@ -526,6 +526,37 @@ def test_validate_contract_reports_invalid_checkpoint_policy() -> None:
     )
 
 
+def test_validate_contract_reports_invalid_mutation_authority() -> None:
+    definition = WorkflowDefinition(
+        workflow_id="#V#mutation_authority_invalid_workflow",
+        initial_state="write",
+        states={
+            "write": WorkflowStateSpec(
+                state_id="write",
+                actions=(WorkflowActionInvocation(action_id="write.action"),),
+                terminal=True,
+                metadata={
+                    "mutation_authority": {
+                        "schema_version": "workflow_step_mutation_authority.v1",
+                        "maximum_level": "unguarded_everything",
+                    }
+                },
+            ),
+        },
+        termination_states=("write",),
+    )
+
+    validation = validate_workflow_definition_contract(definition=definition)
+
+    assert validation["valid"] is False
+    assert "workflow_runtime_policy_invalid" in (validation.get("errors") or [])
+    assert any(
+        issue.get("state_id") == "write"
+        and issue.get("reason_code") == "mutation_authority_invalid"
+        for issue in validation.get("runtime_policy_issues", [])
+    )
+
+
 def test_validate_contract_accepts_context_only_completion_gate() -> None:
     definition = WorkflowDefinition(
         workflow_id="#V#completion_gate_context_only_workflow",

--- a/tests/backend/test_workflow_runtime_policies.py
+++ b/tests/backend/test_workflow_runtime_policies.py
@@ -81,6 +81,12 @@ def test_approval_gate_routes_to_blocked_state_without_running_action() -> None:
     assert calls["count"] == 0
     assert result.data.get("approval_required") is True
     assert result.data.get("approval_state") == "blocked"
+    approval_events = result.data.get("workflow_approval_gate_events")
+    assert isinstance(approval_events, list)
+    assert approval_events
+    assert approval_events[0]["type"] == "mutation_guardrail"
+    assert approval_events[0]["guardrail_surface"] == "workflow_approval_gate"
+    assert approval_events[0]["decision"] == "approval_required"
 
 
 def test_retry_policy_retries_until_success(monkeypatch) -> None:

--- a/tests/backend/test_write_tool_policy.py
+++ b/tests/backend/test_write_tool_policy.py
@@ -148,6 +148,84 @@ def test_external_write_requires_explicit_request():
     assert decision.reason == REASON_EXTERNAL_WRITE_REQUIRES_EXPLICIT_REQUEST
 
 
+def test_global_mutation_authority_caps_external_write():
+    from src.backend.workflows.write_tool_policy import (
+        MUTATION_AUTHORITY_LEVEL_MUTATIVE_VONTOLOGY_NON_DESTRUCTIVE,
+        REASON_INSUFFICIENT_MUTATION_AUTHORITY,
+        compute_allowed_write_tools,
+    )
+
+    decision = compute_allowed_write_tools(
+        prompt="Update the Jira issue status now.",
+        requested_tools=["jira_update_issue"],
+        recent_user_prompts=[],
+        global_mutation_authority=(
+            MUTATION_AUTHORITY_LEVEL_MUTATIVE_VONTOLOGY_NON_DESTRUCTIVE
+        ),
+    )
+
+    assert "jira_update_issue" not in decision.allowed_tools
+    assert decision.reason == REASON_INSUFFICIENT_MUTATION_AUTHORITY
+    tool_decision = decision.decision_for_tool("jira_update_issue")
+    assert tool_decision is not None
+    assert tool_decision.authority_block_source == "global"
+
+
+def test_workflow_mutation_authority_can_cap_mutations_to_additive_only():
+    from src.backend.workflows.write_tool_policy import (
+        REASON_INSUFFICIENT_MUTATION_AUTHORITY,
+        compute_allowed_write_tools,
+    )
+
+    decision = compute_allowed_write_tools(
+        prompt="Update the Vontology concept description now.",
+        requested_tools=["update_concept"],
+        recent_user_prompts=[],
+        workflow_mutation_authority={
+            "schema_version": "workflow_step_mutation_authority.v1",
+            "maximum_level": "additive_vontology",
+        },
+    )
+
+    assert "update_concept" not in decision.allowed_tools
+    assert decision.reason == REASON_INSUFFICIENT_MUTATION_AUTHORITY
+    tool_decision = decision.decision_for_tool("update_concept")
+    assert tool_decision is not None
+    assert tool_decision.authority_block_source == "workflow"
+
+
+def test_build_mutation_guardrail_events_includes_authority_context():
+    from src.backend.workflows.write_tool_policy import (
+        build_mutation_guardrail_events,
+        compute_allowed_write_tools,
+    )
+
+    decision = compute_allowed_write_tools(
+        prompt="Delete concept #V#paper_on_arxiv_2510_06248.",
+        requested_tools=["delete_concept"],
+        recent_user_prompts=[],
+    )
+
+    events = build_mutation_guardrail_events(
+        policy_decision=decision,
+        guardrail_surface="execution",
+        stage="tool_execute",
+        workflow_id="#V#tool_calling_workflow",
+        workflow_step_id="respond",
+        action_id="write_policy.decide",
+        conversation_session_id="sess-1",
+        turn_id="turn-1",
+    )
+
+    assert len(events) == 1
+    event = events[0]
+    assert event["guardrail_surface"] == "execution"
+    assert event["decision"] == "approval_required"
+    assert event["workflow_id"] == "#V#tool_calling_workflow"
+    assert event["workflow_step_id"] == "respond"
+    assert event["conversation_session_id"] == "sess-1"
+
+
 def test_prompt_has_low_risk_additive_write_evidence_for_arxiv_url():
     from src.backend.workflows.write_tool_policy import (
         prompt_has_low_risk_additive_write_evidence,


### PR DESCRIPTION
## Summary
- add general mutation-authority evaluation to shared write-policy handling and expose per-user mutation authority settings
- load, validate, publish, and document workflow-step mutation-authority metadata and record guardrail events in baseline telemetry
- enforce the same authority-aware guardrails in orchestrator tool execution and generic MCP fallback paths, preserving blocked-write telemetry even when later pipeline steps fail

## Validation
- `pdm run pyright $(git diff --name-only -- '*.py')`
- `pdm run pytest tests/backend/test_write_tool_policy.py -q`
- `pdm run pytest tests/backend/test_workflow_baseline_telemetry.py -q`
- `pdm run pytest tests/backend/test_code_concepts_registry.py -q`
- `pdm run pytest tests/backend/test_vontology_loader.py -q`
- `pdm run pytest tests/backend/test_workflow_definition_identity_service.py -q`
- `pdm run pytest tests/backend/test_workflow_runtime_policies.py -q`
- `pdm run pytest tests/backend/test_admin_disable_write_conservatism_setting.py -q`
- `pdm run pytest tests/backend/test_mcp_action_handler.py -q`
- `pdm run pytest tests/backend/test_workflow_concept_authority_service.py::test_bootstrap_publishes_canonical_chat_graphs_with_loader_runtime_parity -q`
- `pdm run pytest tests/backend/test_orchestrator_tool_pipeline_handoff_failure.py -q`
- `pdm run pytest tests/backend/test_orchestrator_write_guardrail.py::test_write_guard_blocks_download_paper_when_user_explicitly_denies_write -q`

## Notes
- materialised `#V#hasWorkflowStepMutationAuthorityJson` on `#V#workflow_step_tool_calling_workflow_respond` in Vontology
- a heavier real-gateway orchestrator e2e test remains slow/flaky in this interactive environment because of unrelated startup parity work, so the merge decision is based on the harnessed orchestrator regressions plus direct gateway-fallback coverage