### PR TITLE
JVNAUTOSCI-1653 Fix retryable empty-state loading failures

### DIFF
--- a/src/backend/server/routes/settings_routes.py
+++ b/src/backend/server/routes/settings_routes.py
@@ -1599,6 +1599,22 @@ def verify_ollama_host():
 def get_available_people():
     """API endpoint to retrieve all available person entities for selection."""
     try:
+        if ConceptsRepository.collection() is None:
+            current_app.logger.warning(
+                "People selector unavailable: concepts collection could not be reached."
+            )
+            response = _jsonify_no_store(
+                {
+                    "error": "People are temporarily unavailable. Please retry shortly.",
+                    "retryable": True,
+                    "reason": "concepts_collection_unavailable",
+                    "retry_after_seconds": 5,
+                },
+                503,
+            )
+            response.headers["Retry-After"] = "5"
+            return response
+
         # Get all Von user entities by using the specific Von user concept ID
         concepts, total_count = list_concepts(
             concept_id="#V#von_user",  # Use the specific Von user concept ID
@@ -1633,7 +1649,13 @@ def get_available_people():
             )
 
         return (
-            jsonify({"people": people_options, "total_count": len(people_options)}),
+            jsonify(
+                {
+                    "people": people_options,
+                    "total_count": len(people_options),
+                    "available": True,
+                }
+            ),
             200,
         )
 
@@ -1651,6 +1673,22 @@ def get_available_people():
 def get_available_organisations():
     """API endpoint to retrieve all available organisation entities for selection."""
     try:
+        if ConceptsRepository.collection() is None:
+            current_app.logger.warning(
+                "Organisation selector unavailable: concepts collection could not be reached."
+            )
+            response = _jsonify_no_store(
+                {
+                    "error": "Organisations are temporarily unavailable. Please retry shortly.",
+                    "retryable": True,
+                    "reason": "concepts_collection_unavailable",
+                    "retry_after_seconds": 5,
+                },
+                503,
+            )
+            response.headers["Retry-After"] = "5"
+            return response
+
         # Get all Von user organisation entities using the specific concept
         concepts, total_count = list_concepts(
             concept_id="#V#von_user_organisation",  # Use the specific Von user organisation concept ID
@@ -1695,6 +1733,7 @@ def get_available_organisations():
                 {
                     "organisations": organisation_options,
                     "total_count": len(organisation_options),
+                    "available": True,
                 }
             ),
             200,

--- a/src/frontend/web/von_interface/static/js/apiService.js
+++ b/src/frontend/web/von_interface/static/js/apiService.js
@@ -18,7 +18,11 @@ function getWindowSessionId() {
   let sessionId = sessionStorage.getItem(WINDOW_SESSION_KEY);
   if (!sessionId) {
     // Generate a new UUID-like session ID
-    sessionId = 'ws_' + crypto.randomUUID().replace(/-/g, '');
+    const randomId =
+      (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function')
+        ? crypto.randomUUID().replace(/-/g, '')
+        : `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
+    sessionId = 'ws_' + randomId;
     sessionStorage.setItem(WINDOW_SESSION_KEY, sessionId);
     console.debug('[windowSession] Generated new window session:', sessionId);
   }
@@ -51,6 +55,49 @@ export async function getJson(url) {
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json();
+}
+
+export async function getJsonDetailed(url, options = {}) {
+  const {
+    headers: extraHeaders = {},
+    method = 'GET',
+    ...fetchOptions
+  } = options || {};
+
+  const res = await fetch(url, {
+    method,
+    headers: buildHeaders(extraHeaders),
+    ...fetchOptions
+  });
+
+  let data = null;
+  try {
+    data = await res.json();
+  } catch (_) {
+    data = null;
+  }
+
+  if (!res.ok) {
+    const err = new Error(
+      (data && (data.error || data.message)) || `HTTP ${res.status}`
+    );
+    err.status = res.status;
+    err.payload = data;
+
+    const retryAfterHeader = res.headers.get('Retry-After');
+    const parsedRetryAfter = Number.parseInt(retryAfterHeader || '', 10);
+    if (Number.isFinite(parsedRetryAfter)) {
+      err.retryAfterSeconds = parsedRetryAfter;
+    }
+
+    throw err;
+  }
+
+  return {
+    data,
+    status: res.status,
+    headers: res.headers
+  };
 }
 
 export async function postJson(url, data) {

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -1,5 +1,5 @@
 // Chat Tab Module
-import { annotateTurn, fetchWithTimeout, getUserContext, getWindowSessionId, postJson, WINDOW_SESSION_HEADER } from './apiService.js';
+import { annotateTurn, fetchWithTimeout, getJsonDetailed, getUserContext, getWindowSessionId, postJson, WINDOW_SESSION_HEADER } from './apiService.js';
 import { initializeConceptAutocomplete } from './components/conceptAutocomplete.js';
 import { initializeMessagePanel, loadUnreadCount } from './components/messagePanel.js';
 import { loadMyOrganisations } from './components/orgSelector.js';
@@ -23,6 +23,11 @@ import {
     resetCopyJsonButtonPreCopyState
 } from './utils/copyJsonButtonState.js';
 import { saveJsonTextViaDialog } from './utils/fileSave.js';
+import {
+    armRetryableLoadState,
+    clearRetryableLoadState,
+    describeRetryableLoadFailure
+} from './utils/retryableLoadState.js';
 import {
     CHAT_HISTORY_RECENT_LIMIT_STORAGE_KEY,
     CHAT_HISTORY_RECENT_WINDOW_DAYS_STORAGE_KEY,
@@ -13470,6 +13475,8 @@ function _buildChatSessionMetadataSuggestions({ inputEl, suggestionsEl, onPick, 
         state.activeIndex = -1;
         suggestionsEl.classList.remove('open');
         suggestionsEl.innerHTML = '';
+        clearRetryableLoadState(suggestionsEl);
+        suggestionsEl.title = '';
     };
 
     const setActive = (idx) => {
@@ -13486,6 +13493,8 @@ function _buildChatSessionMetadataSuggestions({ inputEl, suggestionsEl, onPick, 
     const render = (items) => {
         suggestionsEl.innerHTML = '';
         if (!items.length) {
+            clearRetryableLoadState(suggestionsEl);
+            suggestionsEl.title = '';
             suggestionsEl.classList.remove('open');
             return;
         }
@@ -13517,6 +13526,49 @@ function _buildChatSessionMetadataSuggestions({ inputEl, suggestionsEl, onPick, 
         });
 
         suggestionsEl.classList.add('open');
+        clearRetryableLoadState(suggestionsEl);
+        suggestionsEl.title = '';
+    };
+
+    const renderFailure = (query, error) => {
+        const failure = describeRetryableLoadFailure(
+            error,
+            'Concept suggestions are temporarily unavailable.'
+        );
+
+        state.items = [];
+        state.activeIndex = -1;
+        suggestionsEl.innerHTML = '';
+        suggestionsEl.classList.add('open');
+        suggestionsEl.title = failure.message;
+
+        const row = document.createElement('div');
+        row.className = 'chat-session-metadata-suggestion chat-session-metadata-suggestion-error';
+        row.textContent = failure.retryable
+            ? `${failure.message} Click to retry.`
+            : failure.message;
+
+        if (failure.retryable) {
+            row.tabIndex = 0;
+            row.addEventListener('click', () => {
+                void performSearch(query);
+            });
+            row.addEventListener('keydown', (event) => {
+                const key = String(event?.key || '');
+                if (key === 'Enter' || key === ' ' || key === 'Spacebar') {
+                    event.preventDefault();
+                    void performSearch(query);
+                }
+            });
+
+            armRetryableLoadState(suggestionsEl, () => performSearch(query), {
+                backgroundDelayMs: Math.max(0, failure.retryAfterSeconds) * 1000
+            });
+        } else {
+            clearRetryableLoadState(suggestionsEl);
+        }
+
+        suggestionsEl.appendChild(row);
     };
 
     const performSearch = async (query) => {
@@ -13534,19 +13586,14 @@ function _buildChatSessionMetadataSuggestions({ inputEl, suggestionsEl, onPick, 
 
         const url = `/vontology/api/vontology/search?q=${encodeURIComponent(q)}&limit=12&fallback_substring=true${includeIndividuals ? '&include_individuals=true' : ''}`;
         try {
-            const resp = await fetch(url, { signal: ac.signal });
-            if (!resp.ok) {
-                clearSuggestions();
-                return;
-            }
-            const data = await resp.json();
+            const { data } = await getJsonDetailed(url, { signal: ac.signal });
             const items = Array.isArray(data?.results) ? data.results : [];
             state.items = items;
             state.activeIndex = -1;
             render(items);
         } catch (err) {
             if (err?.name === 'AbortError') return;
-            clearSuggestions();
+            renderFailure(q, err);
         }
     };
 
@@ -13562,7 +13609,7 @@ function _buildChatSessionMetadataSuggestions({ inputEl, suggestionsEl, onPick, 
 
     inputEl.addEventListener('input', () => debouncedSearch());
     inputEl.addEventListener('focus', () => {
-        if (state.items.length) {
+        if (state.items.length || suggestionsEl.childElementCount) {
             suggestionsEl.classList.add('open');
         }
     });

--- a/src/frontend/web/von_interface/static/js/components/conceptAutocomplete.js
+++ b/src/frontend/web/von_interface/static/js/components/conceptAutocomplete.js
@@ -13,7 +13,13 @@
  * - Graceful fallback if search unavailable
  */
 
+import { getJsonDetailed } from '../apiService.js';
 import { makeNonTriggerVontologyId } from './promptCartoucheOverlay.js';
+import {
+    armRetryableLoadState,
+    clearRetryableLoadState,
+    describeRetryableLoadFailure
+} from '../utils/retryableLoadState.js';
 
 const TRIGGER_PATTERN = /#[Vv]#/;
 const DEBOUNCE_MS = 200;
@@ -38,6 +44,8 @@ function getOrCreateState(textarea) {
             triggerEndPos: null,
             searchTimeout: null,
             dropdownPointerDown: false,
+            searchController: null,
+            failureVisible: false,
         });
     }
     return textareaStates.get(textarea);
@@ -89,15 +97,24 @@ export function closeAutocomplete() {
     const dropdown = document.querySelector('.concept-autocomplete-dropdown');
     if (dropdown) {
         dropdown.style.display = 'none';
+        clearRetryableLoadState(dropdown);
+        dropdown.title = '';
     }
     if (activeTextarea) {
         const state = getOrCreateState(activeTextarea);
         state.isOpen = false;
         state.selectedIndex = -1;
         state.results = [];
+        state.failureVisible = false;
         state.triggerPos = null;
         state.triggerEndPos = null;
+        try {
+            state.searchController?.abort?.();
+        } catch (_) {
+            // Ignore best-effort shutdown failures.
+        }
     }
+    activeTextarea = null;
 }
 
 // Export for testing
@@ -109,6 +126,80 @@ export function buildConceptSearchUrl(query) {
     if (INCLUDE_INDIVIDUALS) params.set('include_individuals', 'true');
     if (FALLBACK_SUBSTRING) params.set('fallback_substring', 'true');
     return `${SEARCH_API}?${params.toString()}`;
+}
+
+function getDropdown() {
+    let dropdown = document.querySelector('.concept-autocomplete-dropdown');
+    if (!dropdown) {
+        dropdown = createDropdown();
+        document.body.appendChild(dropdown);
+    }
+    return dropdown;
+}
+
+function showDropdown(dropdown) {
+    if (!dropdown) {
+        return;
+    }
+    if (activeTextarea) {
+        const rect = activeTextarea.getBoundingClientRect();
+        dropdown.style.top = `${rect.bottom + window.scrollY}px`;
+        dropdown.style.left = `${rect.left + window.scrollX}px`;
+        dropdown.style.width = `${Math.max(rect.width, 250)}px`;
+    }
+    dropdown.style.display = 'block';
+}
+
+function renderFailureDropdown(query, originTextarea, error) {
+    const dropdown = getDropdown();
+    const state = originTextarea ? getOrCreateState(originTextarea) : null;
+    const failure = describeRetryableLoadFailure(
+        error,
+        'Concept search is temporarily unavailable.'
+    );
+
+    dropdown.innerHTML = '';
+    dropdown.title = failure.message;
+
+    const item = document.createElement('div');
+    item.className = 'concept-autocomplete-item concept-autocomplete-item-error';
+    item.style.padding = '8px 12px';
+    item.style.cursor = failure.retryable ? 'pointer' : 'default';
+    item.style.fontSize = '14px';
+    item.style.color = '#6b7280';
+    item.textContent = failure.retryable
+        ? `${failure.message} Click to retry.`
+        : failure.message;
+
+    if (failure.retryable) {
+        item.tabIndex = 0;
+        item.addEventListener('click', () => {
+            searchConcepts(query, originTextarea);
+        });
+        item.addEventListener('keydown', (event) => {
+            const key = String(event?.key || '');
+            if (key === 'Enter' || key === ' ' || key === 'Spacebar') {
+                event.preventDefault();
+                searchConcepts(query, originTextarea);
+            }
+        });
+
+        armRetryableLoadState(dropdown, () => searchConcepts(query, originTextarea), {
+            backgroundDelayMs: Math.max(0, failure.retryAfterSeconds) * 1000
+        });
+    } else {
+        clearRetryableLoadState(dropdown);
+    }
+
+    dropdown.appendChild(item);
+    showDropdown(dropdown);
+
+    if (state) {
+        state.results = [];
+        state.selectedIndex = -1;
+        state.failureVisible = true;
+        state.isOpen = true;
+    }
 }
 
 /**
@@ -123,7 +214,18 @@ async function searchConcepts(query, originTextarea) {
             return;
         }
 
-        const response = await fetch(buildConceptSearchUrl(query));
+        const state = getOrCreateState(originTextarea);
+        try {
+            state.searchController?.abort?.();
+        } catch (_) {
+            // Ignore stale controller shutdown failures.
+        }
+        const controller = new AbortController();
+        state.searchController = controller;
+
+        const { data } = await getJsonDetailed(buildConceptSearchUrl(query), {
+            signal: controller.signal
+        });
 
         // Race condition guard: if the active textarea changed while we were fetching, abort
         if (activeTextarea !== originTextarea) {
@@ -131,14 +233,7 @@ async function searchConcepts(query, originTextarea) {
             return;
         }
 
-        if (!response.ok) {
-            console.warn('Concept search failed:', response.status);
-            closeAutocomplete();
-            return;
-        }
-
-        const data = await response.json();
-        const results = Array.isArray(data.results) ? data.results : [];
+        const results = Array.isArray(data?.results) ? data.results : [];
 
         // Race condition guard again after parsing
         if (activeTextarea !== originTextarea) {
@@ -147,11 +242,16 @@ async function searchConcepts(query, originTextarea) {
         }
 
         // Update state for this textarea
-        const state = getOrCreateState(originTextarea);
         state.results = results;
         state.selectedIndex = -1;
+        state.failureVisible = false;
 
         if (results.length === 0) {
+            const dropdown = document.querySelector('.concept-autocomplete-dropdown');
+            if (dropdown) {
+                clearRetryableLoadState(dropdown);
+                dropdown.title = '';
+            }
             closeAutocomplete();
             return;
         }
@@ -159,8 +259,14 @@ async function searchConcepts(query, originTextarea) {
         // Render dropdown
         renderDropdown(results);
     } catch (err) {
+        if (err?.name === 'AbortError') {
+            return;
+        }
+        if (activeTextarea !== originTextarea) {
+            return;
+        }
         console.error('Concept search error:', err);
-        closeAutocomplete();
+        renderFailureDropdown(query, originTextarea, err);
     }
 }
 
@@ -232,14 +338,12 @@ function getStoredTriggerRange(text, state) {
  * Render the autocomplete dropdown
  */
 function renderDropdown(results) {
-    let dropdown = document.querySelector('.concept-autocomplete-dropdown');
-    if (!dropdown) {
-        dropdown = createDropdown();
-        document.body.appendChild(dropdown);
-    }
+    const dropdown = getDropdown();
 
     // Clear previous items
     dropdown.innerHTML = '';
+    clearRetryableLoadState(dropdown);
+    dropdown.title = '';
 
     // Get state for active textarea
     const state = activeTextarea ? getOrCreateState(activeTextarea) : null;
@@ -316,16 +420,11 @@ function renderDropdown(results) {
         dropdown.appendChild(item);
     });
 
-    // Position dropdown below the textarea
-    if (activeTextarea) {
-        const rect = activeTextarea.getBoundingClientRect();
-        dropdown.style.top = `${rect.bottom + window.scrollY}px`;
-        dropdown.style.left = `${rect.left + window.scrollX}px`;
-        dropdown.style.width = `${Math.max(rect.width, 250)}px`;
+    showDropdown(dropdown);
+    if (state) {
+        state.isOpen = true;
+        state.failureVisible = false;
     }
-
-    dropdown.style.display = 'block';
-    if (state) state.isOpen = true;
 }
 
 /**
@@ -514,6 +613,13 @@ export function initializeConceptAutocomplete(textareaElement) {
     // Set as active on focus to handle tab switches
     textareaElement.addEventListener('focus', () => {
         activeTextarea = textareaElement;
+        const state = getOrCreateState(textareaElement);
+        if (state.failureVisible) {
+            const dropdown = document.querySelector('.concept-autocomplete-dropdown');
+            if (dropdown && dropdown.childElementCount) {
+                showDropdown(dropdown);
+            }
+        }
     });
 
     // Close on blur
@@ -551,5 +657,10 @@ export function cleanupConceptAutocomplete() {
     if (activeTextarea) {
         const state = getOrCreateState(activeTextarea);
         clearTimeout(state.searchTimeout);
+        try {
+            state.searchController?.abort?.();
+        } catch (_) {
+            // Ignore best-effort shutdown failures.
+        }
     }
 }

--- a/src/frontend/web/von_interface/static/js/components/orgSelector.js
+++ b/src/frontend/web/von_interface/static/js/components/orgSelector.js
@@ -9,7 +9,12 @@
  * windows without interference.
  */
 
-import { getJson, getUserContext, postJson } from '../apiService.js';
+import { getJsonDetailed, getUserContext, postJson } from '../apiService.js';
+import {
+    armRetryableLoadState,
+    clearRetryableLoadState,
+    describeRetryableLoadFailure,
+} from '../utils/retryableLoadState.js';
 
 // JVNAUTOSCI-1011: Switch to sessionStorage for window-scoped org context
 const SS_ORG_CONTEXT = 'von_org_context';
@@ -31,36 +36,58 @@ export function normaliseOrganisationDisplayName(label) {
  * Load user's available organisations from backend
  */
 export async function loadMyOrganisations() {
-    try {
-        const ctx = getUserContext();
-        const userConceptId = ctx?.user_id;
-        const url = userConceptId
-            ? `/von/api/organisations/my_organisations?user_concept_id=${encodeURIComponent(userConceptId)}`
-            : '/von/api/organisations/my_organisations';
+    const ctx = getUserContext();
+    const userConceptId = ctx?.user_id;
+    const url = userConceptId
+        ? `/von/api/organisations/my_organisations?user_concept_id=${encodeURIComponent(userConceptId)}`
+        : '/von/api/organisations/my_organisations';
 
-        const response = await getJson(url);
-        return response.organisations || [];
-    } catch (err) {
-        console.error('Error loading organisations:', err);
-        return [];
-    }
+    const { data } = await getJsonDetailed(url);
+    return data?.organisations || [];
 }
 
 /**
  * Get current session context (user, org, role, namespace)
  */
 export async function getSessionContext() {
-    try {
-        return await getJson('/von/api/session/context');
-    } catch (err) {
-        console.error('Error getting session context:', err);
-        return {
-            authenticated: false,
-            user_id: null,
-            organisation_id: null,
-            role: null,
-            namespace: null
-        };
+    const { data } = await getJsonDetailed('/von/api/session/context');
+    return data;
+}
+
+function renderRetryableOrgSelectorFailure(container, containerId, error) {
+    if (!container) return;
+
+    const failure = describeRetryableLoadFailure(
+        error,
+        'Organisations are temporarily unavailable.'
+    );
+
+    container.innerHTML = '';
+
+    const message = document.createElement('span');
+    message.className = 'org-error';
+    message.textContent = failure.retryable
+        ? `${failure.message} Click to retry.`
+        : failure.message;
+    container.appendChild(message);
+    container.title = failure.message;
+
+    if (failure.retryable) {
+        const retryButton = document.createElement('button');
+        retryButton.type = 'button';
+        retryButton.className = 'org-retry-button';
+        retryButton.textContent = 'Retry';
+        retryButton.style.marginLeft = '8px';
+        retryButton.addEventListener('click', () => {
+            renderOrgSelector(containerId);
+        });
+        container.appendChild(retryButton);
+
+        armRetryableLoadState(container, () => renderOrgSelector(containerId), {
+            backgroundDelayMs: Math.max(0, failure.retryAfterSeconds) * 1000
+        });
+    } else {
+        clearRetryableLoadState(container);
     }
 }
 
@@ -134,6 +161,9 @@ export async function renderOrgSelector(containerId) {
             container.innerHTML = '<span class="org-info">No organisations</span>';
             return;
         }
+
+        clearRetryableLoadState(container);
+        container.title = '';
 
         // Build dropdown HTML
         let html = '<div class="org-selector-wrapper">';
@@ -252,7 +282,7 @@ export async function renderOrgSelector(containerId) {
 
     } catch (err) {
         console.error('Error rendering org selector:', err);
-        container.innerHTML = '<span class="org-error">Error loading organisations</span>';
+        renderRetryableOrgSelectorFailure(container, containerId, err);
     }
 }
 

--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -4,6 +4,7 @@
 // Removed imported populateContentSection to avoid duplicate with local implementation below
 
 import { initializeAnnotationTab } from './annotationTab.js';
+import { getJsonDetailed } from './apiService.js';
 import { fetchConceptListWithSuffix, fetchSubtypesWithSuffix, initializeNamesForm, loadConceptAttributes, loadConceptNames, selectConceptWithSuffix } from './conceptTab.js';
 import { getCurrentUserConceptId } from './domUtils.js';
 import { isAnnotationEnabled } from './featureFlags.js';
@@ -16,6 +17,11 @@ import { createVontologyCartouche, normalisePotentialConceptId } from './utils/t
 import { copyJsonTextWithButtonFeedback, resetCopyJsonButtonPreCopyState } from './utils/copyJsonButtonState.js';
 import { mountJsonInspector } from './utils/jsonInspector.js';
 import { showToast } from './utils/toast.js';
+import {
+    armRetryableLoadState,
+    clearRetryableLoadState,
+    describeRetryableLoadFailure
+} from './utils/retryableLoadState.js';
 import {
     buildNamespaceScopedStorageKey,
     getSessionScopedNamespace,
@@ -6016,7 +6022,12 @@ async function initializeRelationshipsUI(conceptId, suffix, kind) {
             };
 
             const clearResults = () => {
-                state.items = []; state.activeIndex = -1; results.classList.remove('open'); results.innerHTML = '';
+                state.items = [];
+                state.activeIndex = -1;
+                results.classList.remove('open');
+                results.innerHTML = '';
+                clearRetryableLoadState(results);
+                results.title = '';
             };
 
             const clearPredicateResults = () => {
@@ -6024,6 +6035,8 @@ async function initializeRelationshipsUI(conceptId, suffix, kind) {
                 predicateState.activeIndex = -1;
                 predicateResults.classList.remove('open');
                 predicateResults.innerHTML = '';
+                clearRetryableLoadState(predicateResults);
+                predicateResults.title = '';
             };
 
             const setActive = (idx) => {
@@ -6042,7 +6055,12 @@ async function initializeRelationshipsUI(conceptId, suffix, kind) {
 
             const render = (items) => {
                 results.innerHTML = '';
-                if (!items.length) { results.classList.remove('open'); return; }
+                if (!items.length) {
+                    clearRetryableLoadState(results);
+                    results.title = '';
+                    results.classList.remove('open');
+                    return;
+                }
                 const list = document.createElement('div');
                 list.setAttribute('role', 'listbox');
                 items.forEach((it, idx) => {
@@ -6064,12 +6082,19 @@ async function initializeRelationshipsUI(conceptId, suffix, kind) {
                     list.appendChild(row);
                 });
                 results.appendChild(list);
+                clearRetryableLoadState(results);
+                results.title = '';
                 if (items.length) results.classList.add('open');
             };
 
             const renderPredicate = (items) => {
                 predicateResults.innerHTML = '';
-                if (!items.length) { predicateResults.classList.remove('open'); return; }
+                if (!items.length) {
+                    clearRetryableLoadState(predicateResults);
+                    predicateResults.title = '';
+                    predicateResults.classList.remove('open');
+                    return;
+                }
                 const list = document.createElement('div');
                 list.setAttribute('role', 'listbox');
                 items.forEach((it, idx) => {
@@ -6095,7 +6120,48 @@ async function initializeRelationshipsUI(conceptId, suffix, kind) {
                     list.appendChild(row);
                 });
                 predicateResults.appendChild(list);
+                clearRetryableLoadState(predicateResults);
+                predicateResults.title = '';
                 if (items.length) predicateResults.classList.add('open');
+            };
+
+            const renderSearchFailure = (container, messageClassName, query, error, retryAction) => {
+                const failure = describeRetryableLoadFailure(
+                    error,
+                    'Concept suggestions are temporarily unavailable.'
+                );
+
+                container.innerHTML = '';
+                container.classList.add('open');
+                container.title = failure.message;
+
+                const row = document.createElement('div');
+                row.className = messageClassName;
+                row.textContent = failure.retryable
+                    ? `${failure.message} Click to retry.`
+                    : failure.message;
+
+                if (failure.retryable) {
+                    row.tabIndex = 0;
+                    row.addEventListener('click', () => {
+                        void retryAction(query);
+                    });
+                    row.addEventListener('keydown', (event) => {
+                        const key = String(event?.key || '');
+                        if (key === 'Enter' || key === ' ' || key === 'Spacebar') {
+                            event.preventDefault();
+                            void retryAction(query);
+                        }
+                    });
+
+                    armRetryableLoadState(container, () => retryAction(query), {
+                        backgroundDelayMs: Math.max(0, failure.retryAfterSeconds) * 1000
+                    });
+                } else {
+                    clearRetryableLoadState(container);
+                }
+
+                container.appendChild(row);
             };
 
             const performSearch = async (q) => {
@@ -6119,9 +6185,7 @@ async function initializeRelationshipsUI(conceptId, suffix, kind) {
                 })();
                 const url = `/vontology/api/vontology/search?q=${encodeURIComponent(q)}&limit=12&fallback_substring=true${includeIndividuals ? '&include_individuals=true' : ''}`;
                 try {
-                    const resp = await fetch(url, { signal: ac.signal });
-                    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-                    const data = await resp.json();
+                    const { data } = await getJsonDetailed(url, { signal: ac.signal });
                     let items = Array.isArray(data?.results) ? data.results : [];
                     // Reorder to prefer exact match and shorter names
                     const qc = q ? q.toLowerCase() : '';
@@ -6143,7 +6207,16 @@ async function initializeRelationshipsUI(conceptId, suffix, kind) {
                     state.items = items;
                     render(state.items);
                 } catch (e) {
-                    if (e?.name === 'AbortError') return; clearResults();
+                    if (e?.name === 'AbortError') return;
+                    state.items = [];
+                    state.activeIndex = -1;
+                    renderSearchFailure(
+                        results,
+                        'vontology-search-item vontology-search-item-error',
+                        q,
+                        e,
+                        performSearch
+                    );
                 }
             };
 
@@ -6152,9 +6225,7 @@ async function initializeRelationshipsUI(conceptId, suffix, kind) {
                 const ac = new AbortController(); predicateState.ac = ac;
                 const url = `/vontology/api/vontology/search?q=${encodeURIComponent(q)}&limit=12&fallback_substring=true&filter_kind=predicate&include_predicate_metadata=true`;
                 try {
-                    const resp = await fetch(url, { signal: ac.signal });
-                    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-                    const data = await resp.json();
+                    const { data } = await getJsonDetailed(url, { signal: ac.signal });
                     let items = Array.isArray(data?.results) ? data.results : [];
                     items = items.filter((item) => item && item.kind === 'predicate');
                     const qc = q ? q.toLowerCase() : '';
@@ -6176,7 +6247,16 @@ async function initializeRelationshipsUI(conceptId, suffix, kind) {
                     predicateState.items = items;
                     renderPredicate(predicateState.items);
                 } catch (e) {
-                    if (e?.name === 'AbortError') return; clearPredicateResults();
+                    if (e?.name === 'AbortError') return;
+                    predicateState.items = [];
+                    predicateState.activeIndex = -1;
+                    renderSearchFailure(
+                        predicateResults,
+                        'vontology-search-item vontology-search-item-error',
+                        q,
+                        e,
+                        performPredicateSearch
+                    );
                 }
             };
 
@@ -6208,12 +6288,12 @@ async function initializeRelationshipsUI(conceptId, suffix, kind) {
             });
             targetInput.addEventListener('focus', () => {
                 // Only show results if not a text predicate and we have results
-                if (!isCurrentSelectionTextPredicate() && state.items.length) {
+                if (!isCurrentSelectionTextPredicate() && (state.items.length || results.childElementCount)) {
                     results.classList.add('open');
                 }
             });
             predicateInput.addEventListener('focus', () => {
-                if (isOtherPredicateSelected() && predicateState.items.length) {
+                if (isOtherPredicateSelected() && (predicateState.items.length || predicateResults.childElementCount)) {
                     predicateResults.classList.add('open');
                 }
             });

--- a/src/frontend/web/von_interface/static/js/predicateExtentDisplay.js
+++ b/src/frontend/web/von_interface/static/js/predicateExtentDisplay.js
@@ -6,12 +6,18 @@
  */
 
 import { fetchPredicateExtent } from './predicateUtils.js';
+import { getJsonDetailed } from './apiService.js';
 import { selectBestNameForContext, selectShortestNameForContext } from './utils/nameSelection.js';
 import {
     createVontologyCartouche,
     getCartoucheAppearanceSettings,
     normalisePotentialConceptId
 } from './utils/textDecorator.js';
+import {
+    armRetryableLoadState,
+    clearRetryableLoadState,
+    describeRetryableLoadFailure
+} from './utils/retryableLoadState.js';
 
 const CONCEPT_SEARCH_API = '/vontology/api/vontology/search';
 const CONCEPT_SEARCH_LIMIT = 8;
@@ -192,9 +198,7 @@ export function createPredicateExtentDisplay(conceptId, container) {
 
     async function searchConcepts(query) {
         if (!query || query.trim().length < 1) return [];
-        const resp = await fetch(buildConceptSearchUrl(query));
-        if (!resp.ok) return [];
-        const data = await resp.json();
+        const { data } = await getJsonDetailed(buildConceptSearchUrl(query));
         return Array.isArray(data?.results) ? data.results : [];
     }
 
@@ -206,6 +210,8 @@ export function createPredicateExtentDisplay(conceptId, container) {
         const closeResults = () => {
             resultsEl.innerHTML = '';
             resultsEl.classList.remove('open');
+            clearRetryableLoadState(resultsEl);
+            resultsEl.title = '';
             active = false;
         };
 
@@ -217,6 +223,8 @@ export function createPredicateExtentDisplay(conceptId, container) {
             }
             resultsEl.classList.add('open');
             active = true;
+            clearRetryableLoadState(resultsEl);
+            resultsEl.title = '';
             items.forEach((item) => {
                 const row = document.createElement('div');
                 row.className = 'predicate-extent-search-item';
@@ -242,14 +250,69 @@ export function createPredicateExtentDisplay(conceptId, container) {
             });
         };
 
+        const renderFailure = (query, error) => {
+            const failure = describeRetryableLoadFailure(
+                error,
+                'Concept search is temporarily unavailable.'
+            );
+
+            resultsEl.innerHTML = '';
+            resultsEl.classList.add('open');
+            resultsEl.title = failure.message;
+            active = true;
+
+            const row = document.createElement('div');
+            row.className = 'predicate-extent-search-item';
+            row.style.color = '#6b7280';
+            row.textContent = failure.retryable
+                ? `${failure.message} Click to retry.`
+                : failure.message;
+
+            if (failure.retryable) {
+                row.tabIndex = 0;
+                row.addEventListener('click', () => {
+                    inputEl.focus();
+                    inputEl.dispatchEvent(new Event('input'));
+                });
+                row.addEventListener('keydown', (event) => {
+                    const key = String(event?.key || '');
+                    if (key === 'Enter' || key === ' ' || key === 'Spacebar') {
+                        event.preventDefault();
+                        inputEl.focus();
+                        inputEl.dispatchEvent(new Event('input'));
+                    }
+                });
+
+                armRetryableLoadState(resultsEl, () => searchConcepts(query).then(renderResults).catch((retryErr) => {
+                    console.error('Error retrying predicate extent concept search:', retryErr);
+                    renderFailure(query, retryErr);
+                }), {
+                    backgroundDelayMs: Math.max(0, failure.retryAfterSeconds) * 1000
+                });
+            } else {
+                clearRetryableLoadState(resultsEl);
+            }
+
+            resultsEl.appendChild(row);
+        };
+
         inputEl.addEventListener('input', () => {
             const query = inputEl.value || '';
             if (debounceId) {
                 clearTimeout(debounceId);
             }
             debounceId = setTimeout(async () => {
-                const results = await searchConcepts(query);
-                renderResults(results);
+                if (!query.trim()) {
+                    closeResults();
+                    return;
+                }
+                try {
+                    const results = await searchConcepts(query);
+                    renderResults(results);
+                } catch (error) {
+                    console.error('Error searching predicate extent concepts:', error);
+                    renderFailure(query, error);
+                }
             }, CONCEPT_SEARCH_DEBOUNCE_MS);
         });
 

--- a/src/frontend/web/von_interface/static/js/settings.js
+++ b/src/frontend/web/von_interface/static/js/settings.js
@@ -1,32 +1,24 @@
-import { getJson, postJson } from './apiService.js';
+import { getJsonDetailed, postJson } from './apiService.js';
+import {
+  armRetryableLoadState,
+  clearRetryableLoadState,
+  describeRetryableLoadFailure
+} from './utils/retryableLoadState.js';
 
 // Settings management functions
 export async function loadAvailableModels() {
-  try {
-    return await getJson('/api/settings/models/ollama');
-  } catch (err) {
-    console.error('Error loading Ollama models:', err);
-    return [];
-  }
+  const { data } = await getJsonDetailed('/api/settings/models/ollama');
+  return data;
 }
 
 export async function loadOllamaModelsFromAllHosts() {
-  try {
-    const response = await getJson('/api/settings/ollama/models');
-    return response.models || [];
-  } catch (err) {
-    console.error('Error loading Ollama models from all hosts:', err);
-    return [];
-  }
+  const { data } = await getJsonDetailed('/api/settings/ollama/models');
+  return data?.models || [];
 }
 
 export async function loadOllamaHosts() {
-  try {
-    return await getJson('/api/settings/ollama/hosts');
-  } catch (err) {
-    console.error('Error loading Ollama hosts:', err);
-    return { hosts: [], active_host: null };
-  }
+  const { data } = await getJsonDetailed('/api/settings/ollama/hosts');
+  return data;
 }
 
 export async function saveOllamaHosts(hosts, activeHost = null) {
@@ -53,12 +45,8 @@ export async function verifyOllamaHost(hostUrl) {
 }
 
 export async function loadAvailableOpenAIModels() {
-  try {
-    return await getJson('/api/settings/models/openai');
-  } catch (err) {
-    console.error('Error loading OpenAI models:', err);
-    return [];
-  }
+  const { data } = await getJsonDetailed('/api/settings/models/openai');
+  return data;
 }
 
 function renderOpenAiModelSelect(select, models = [], selectedModel = null) {
@@ -97,21 +85,13 @@ export function renderOpenAIModelOptions(selectElementId, models = [], selectedM
 }
 
 export async function loadAvailablePeople() {
-  try {
-    return await getJson('/api/settings/people');
-  } catch (err) {
-    console.error('Error loading people:', err);
-    return { people: [], total_count: 0 };
-  }
+  const { data } = await getJsonDetailed('/api/settings/people');
+  return data;
 }
 
 export async function loadAvailableOrganisations() {
-  try {
-    return await getJson('/api/settings/organisations');
-  } catch (err) {
-    console.error('Error loading organisations:', err);
-    return { organisations: [], total_count: 0 };
-  }
+  const { data } = await getJsonDetailed('/api/settings/organisations');
+  return data;
 }
 
 // Settings UI management functions
@@ -132,6 +112,90 @@ export function showStatusMessage(elementId, message, isError = false) {
   setTimeout(() => {
     element.style.display = 'none';
   }, 5000);
+}
+
+function setSelectSingleOption(select, text) {
+  if (!select) return;
+
+  select.innerHTML = '';
+  const option = document.createElement('option');
+  option.value = '';
+  option.textContent = text;
+  select.appendChild(option);
+}
+
+function clearSelectRetryState(select) {
+  clearRetryableLoadState(select);
+  if (select) {
+    select.title = '';
+  }
+}
+
+function renderRetryableSelectFailure(select, {
+  error,
+  fallbackMessage,
+  retryAction
+}) {
+  const failure = describeRetryableLoadFailure(error, fallbackMessage);
+  const optionText = failure.retryable
+    ? `${failure.message} Click to retry.`
+    : failure.message;
+
+  setSelectSingleOption(select, optionText);
+  select.title = failure.message;
+
+  if (failure.retryable) {
+    armRetryableLoadState(select, retryAction, {
+      backgroundDelayMs: Math.max(0, failure.retryAfterSeconds) * 1000
+    });
+  } else {
+    clearRetryableLoadState(select);
+  }
+}
+
+function renderRetryablePanelFailure(container, {
+  error,
+  fallbackMessage,
+  retryAction,
+  buttonLabel
+}) {
+  if (!container) return;
+
+  const failure = describeRetryableLoadFailure(error, fallbackMessage);
+  container.innerHTML = '';
+  container.title = failure.message;
+
+  const message = document.createElement('p');
+  message.style.color = '#666';
+  message.style.fontStyle = 'italic';
+  message.textContent = failure.retryable
+    ? `${failure.message} Auto-retrying shortly.`
+    : failure.message;
+  container.appendChild(message);
+
+  if (failure.retryable) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = buttonLabel;
+    button.style.padding = '4px 8px';
+    button.style.fontSize = '0.85em';
+    button.style.marginTop = '6px';
+    button.style.background = '#6c757d';
+    button.style.color = 'white';
+    button.style.border = 'none';
+    button.style.borderRadius = '3px';
+    button.style.cursor = 'pointer';
+    button.addEventListener('click', () => {
+      retryAction({ source: 'button' });
+    });
+    container.appendChild(button);
+
+    armRetryableLoadState(container, retryAction, {
+      backgroundDelayMs: Math.max(0, failure.retryAfterSeconds) * 1000
+    });
+  } else {
+    clearRetryableLoadState(container);
+  }
 }
 
 export async function populateModelDropdown(selectElementId, selectedModel = null) {
@@ -171,9 +235,14 @@ export async function populateModelDropdown(selectElementId, selectedModel = nul
         }
       }
     }
+    clearSelectRetryState(select);
   } catch (err) {
     console.error('Error populating Ollama model dropdown:', err);
-    select.innerHTML = '<option value="">Error loading Ollama models</option>';
+    renderRetryableSelectFailure(select, {
+      error: err,
+      fallbackMessage: 'Ollama models are temporarily unavailable.',
+      retryAction: () => populateModelDropdown(selectElementId, selectedModel)
+    });
   }
 }
 
@@ -184,9 +253,14 @@ export async function populateOpenAIModelDropdown(selectElementId, selectedModel
   try {
     const models = await loadAvailableOpenAIModels();
     renderOpenAiModelSelect(select, models, selectedModel);
+    clearSelectRetryState(select);
   } catch (err) {
     console.error('Error populating OpenAI model dropdown:', err);
-    select.innerHTML = '<option value="">Error loading OpenAI models</option>';
+    renderRetryableSelectFailure(select, {
+      error: err,
+      fallbackMessage: 'OpenAI models are temporarily unavailable.',
+      retryAction: () => populateOpenAIModelDropdown(selectElementId, selectedModel)
+    });
   }
 }
 
@@ -232,9 +306,14 @@ export async function populatePeopleDropdown(selectElementId, selectedPersonId =
         }
       }
     }
+    clearSelectRetryState(select);
   } catch (err) {
     console.error('Error populating people dropdown:', err);
-    select.innerHTML = '<option value="">Error loading people</option>';
+    renderRetryableSelectFailure(select, {
+      error: err,
+      fallbackMessage: 'People are temporarily unavailable.',
+      retryAction: () => populatePeopleDropdown(selectElementId, selectedPersonId)
+    });
   }
 }
 
@@ -279,9 +358,14 @@ export async function populateOrganisationsDropdown(selectElementId, selectedOrg
         }
       }
     }
+    clearSelectRetryState(select);
   } catch (err) {
     console.error('Error populating organisations dropdown:', err);
-    select.innerHTML = '<option value="">Error loading organisations</option>';
+    renderRetryableSelectFailure(select, {
+      error: err,
+      fallbackMessage: 'Organisations are temporarily unavailable.',
+      retryAction: () => populateOrganisationsDropdown(selectElementId, selectedOrgId)
+    });
   }
 }
 
@@ -289,6 +373,8 @@ export async function populateOrganisationsDropdown(selectElementId, selectedOrg
 export function renderOllamaHostsList(hosts, activeHost) {
   const hostsList = document.getElementById('ollamaHostsList');
   if (!hostsList) return;
+  clearRetryableLoadState(hostsList);
+  hostsList.title = '';
   
   if (!hosts || hosts.length === 0) {
     hostsList.innerHTML = '<p style="color: #666; font-style: italic;">No Ollama hosts configured</p>';
@@ -320,14 +406,25 @@ export function renderOllamaHostsList(hosts, activeHost) {
 }
 
 export async function loadAndRenderOllamaHosts() {
+  const hostsList = document.getElementById('ollamaHostsList');
   try {
     const data = await loadOllamaHosts();
     renderOllamaHostsList(data.hosts, data.active_host);
     return data;
   } catch (err) {
     console.error('Error loading Ollama hosts:', err);
-    showStatusMessage('settingsStatusMessage', 'Error loading Ollama hosts', true);
-    return { hosts: [], active_host: null };
+    renderRetryablePanelFailure(hostsList, {
+      error: err,
+      fallbackMessage: 'Ollama hosts are temporarily unavailable.',
+      retryAction: () => loadAndRenderOllamaHosts(),
+      buttonLabel: 'Retry host load'
+    });
+    showStatusMessage(
+      'settingsStatusMessage',
+      describeRetryableLoadFailure(err, 'Ollama hosts are temporarily unavailable.').message,
+      true
+    );
+    return null;
   }
 }
 

--- a/src/frontend/web/von_interface/static/js/test/orgSelectorRetryableState.test.js
+++ b/src/frontend/web/von_interface/static/js/test/orgSelectorRetryableState.test.js
@@ -1,0 +1,89 @@
+jest.mock('../apiService.js', () => ({
+    getJsonDetailed: jest.fn(),
+    getUserContext: jest.fn(),
+    postJson: jest.fn(),
+}));
+
+import { renderOrgSelector } from '../components/orgSelector.js';
+import { getJsonDetailed, getUserContext } from '../apiService.js';
+
+function flushMicrotasks() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('org selector retryable load state', () => {
+    let consoleErrorSpy;
+
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        jest.clearAllMocks();
+        getUserContext.mockReturnValue({ user_id: '#V#michael_witbrock' });
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    test('renders retryable failure state and recovers on retry click', async () => {
+        document.body.innerHTML = '<div id="orgSelectorContainer"></div>';
+
+        getJsonDetailed.mockImplementation((url) => {
+            if (url.includes('/von/api/organisations/my_organisations')) {
+                return Promise.reject({
+                    message: 'HTTP 503',
+                    status: 503,
+                    payload: {
+                        error: 'Organisations are temporarily unavailable.',
+                        retryable: true,
+                        retry_after_seconds: 0,
+                    },
+                });
+            }
+            return Promise.resolve({
+                data: {
+                    authenticated: true,
+                    organisation_id: null,
+                    role: null,
+                    namespace: '#V#michael_witbrock',
+                },
+            });
+        });
+
+        await renderOrgSelector('orgSelectorContainer');
+
+        const container = document.getElementById('orgSelectorContainer');
+        expect(container.textContent).toContain('Click to retry');
+
+        getJsonDetailed.mockImplementation((url) => {
+            if (url.includes('/von/api/organisations/my_organisations')) {
+                return Promise.resolve({
+                    data: {
+                        organisations: [
+                            {
+                                concept_id: '#V#university_of_auckland_strong_ai_lab',
+                                name: 'University Of Auckland Strong Ai Lab',
+                                role: 'admin',
+                            },
+                        ],
+                    },
+                });
+            }
+            return Promise.resolve({
+                data: {
+                    authenticated: true,
+                    organisation_id: '#V#university_of_auckland_strong_ai_lab',
+                    role: 'admin',
+                    namespace: '#V#michael_witbrock@university_of_auckland_strong_ai_lab',
+                },
+            });
+        });
+
+        container.querySelector('button').click();
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        expect(container.querySelector('#orgSelect')).not.toBeNull();
+        expect(container.textContent).toContain('University Of Auckland Strong Ai Lab');
+    });
+});

--- a/src/frontend/web/von_interface/static/js/test/settingsRetryableLoads.test.js
+++ b/src/frontend/web/von_interface/static/js/test/settingsRetryableLoads.test.js
@@ -1,0 +1,110 @@
+jest.mock('../apiService.js', () => ({
+    getJsonDetailed: jest.fn(),
+    postJson: jest.fn(),
+}));
+
+import {
+    loadAndRenderOllamaHosts,
+    populateOpenAIModelDropdown,
+    populatePeopleDropdown,
+} from '../settings.js';
+import { getJsonDetailed } from '../apiService.js';
+
+function flushMicrotasks() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('settings retryable load states', () => {
+    let consoleErrorSpy;
+
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        jest.clearAllMocks();
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    test('people dropdown shows retryable error state and reloads on focus', async () => {
+        document.body.innerHTML = '<select id="currentUserSelect"></select>';
+
+        getJsonDetailed
+            .mockRejectedValueOnce({
+                message: 'HTTP 503',
+                status: 503,
+                payload: {
+                    error: 'People are temporarily unavailable. Please retry shortly.',
+                    retryable: true,
+                    retry_after_seconds: 0,
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    people: [
+                        {
+                            id: '682de9200a04490dc7afee09',
+                            concept_id: '#V#michael_witbrock',
+                            name: 'Michael Witbrock',
+                            system_tags: [],
+                        },
+                    ],
+                    total_count: 1,
+                },
+            });
+
+        await populatePeopleDropdown('currentUserSelect');
+
+        const select = document.getElementById('currentUserSelect');
+        expect(select.options[0].textContent).toContain('Click to retry');
+
+        select.dispatchEvent(new Event('focus'));
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        expect(getJsonDetailed).toHaveBeenCalledTimes(2);
+        expect(select.options[1].textContent).toBe('Michael Witbrock');
+    });
+
+    test('openai model dropdown distinguishes load failure from a true empty list', async () => {
+        document.body.innerHTML = '<select id="openaiModelSelect"></select>';
+
+        getJsonDetailed.mockRejectedValueOnce({
+            message: 'HTTP 503',
+            status: 503,
+            payload: {
+                error: 'OpenAI models are temporarily unavailable.',
+                retryable: true,
+                retry_after_seconds: 0,
+            },
+        });
+
+        await populateOpenAIModelDropdown('openaiModelSelect');
+
+        const select = document.getElementById('openaiModelSelect');
+        expect(select.options[0].textContent).toContain('temporarily unavailable');
+        expect(select.options[0].textContent).not.toContain('No OpenAI models available');
+    });
+
+    test('ollama hosts panel shows retry guidance instead of pretending nothing is configured', async () => {
+        document.body.innerHTML = '<div id="ollamaHostsList"></div>';
+
+        getJsonDetailed.mockRejectedValueOnce({
+            message: 'HTTP 503',
+            status: 503,
+            payload: {
+                error: 'Ollama hosts are temporarily unavailable.',
+                retryable: true,
+                retry_after_seconds: 0,
+            },
+        });
+
+        await loadAndRenderOllamaHosts();
+
+        const hostsList = document.getElementById('ollamaHostsList');
+        expect(hostsList.textContent).toContain('temporarily unavailable');
+        expect(hostsList.textContent).not.toContain('No Ollama hosts configured');
+        expect(hostsList.querySelector('button')?.textContent).toBe('Retry host load');
+    });
+});

--- a/src/frontend/web/von_interface/static/js/utils/retryableLoadState.js
+++ b/src/frontend/web/von_interface/static/js/utils/retryableLoadState.js
@@ -1,0 +1,157 @@
+const RETRY_STATE_KEY = '__vonRetryableLoadState';
+const RETRY_HANDLER_KEY = '__vonRetryableLoadHandlersAttached';
+
+function getRetryState(target) {
+  if (!target || typeof target !== 'object') {
+    return null;
+  }
+  return target[RETRY_STATE_KEY] || null;
+}
+
+function invokeRetry(target, source) {
+  const state = getRetryState(target);
+  if (!state || !state.enabled || state.inFlight || typeof state.retry !== 'function') {
+    return;
+  }
+
+  state.inFlight = true;
+  Promise.resolve()
+    .then(() => state.retry({ source }))
+    .catch(() => {})
+    .finally(() => {
+      const latestState = getRetryState(target);
+      if (latestState) {
+        latestState.inFlight = false;
+      }
+    });
+}
+
+function ensureRetryHandlers(target) {
+  if (!target || target[RETRY_HANDLER_KEY]) {
+    return;
+  }
+
+  const pointerHandler = () => invokeRetry(target, 'interaction');
+  const focusHandler = () => invokeRetry(target, 'interaction');
+  const keyHandler = (event) => {
+    const key = String(event?.key || '');
+    if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'ArrowDown') {
+      invokeRetry(target, 'interaction');
+    }
+  };
+
+  target.addEventListener?.('pointerdown', pointerHandler);
+  target.addEventListener?.('focus', focusHandler);
+  target.addEventListener?.('keydown', keyHandler);
+
+  target[RETRY_HANDLER_KEY] = {
+    pointerHandler,
+    focusHandler,
+    keyHandler
+  };
+}
+
+export function clearRetryableLoadState(target) {
+  const state = getRetryState(target);
+  if (state?.timerId) {
+    window.clearTimeout(state.timerId);
+  }
+
+  if (target && typeof target === 'object') {
+    target[RETRY_STATE_KEY] = null;
+    if (target.dataset) {
+      delete target.dataset.retryableLoad;
+    }
+  }
+}
+
+export function armRetryableLoadState(target, retry, options = {}) {
+  if (!target || typeof retry !== 'function') {
+    return;
+  }
+
+  ensureRetryHandlers(target);
+
+  const existing = getRetryState(target);
+  if (existing?.timerId) {
+    window.clearTimeout(existing.timerId);
+  }
+
+  const nextState = {
+    enabled: true,
+    inFlight: false,
+    retry,
+    backgroundAttempts:
+      existing && typeof existing.backgroundAttempts === 'number'
+        ? existing.backgroundAttempts
+        : 0,
+    backgroundDelayMs:
+      Number.isFinite(options.backgroundDelayMs) ? Number(options.backgroundDelayMs) : 5000,
+    maxBackgroundAttempts:
+      Number.isFinite(options.maxBackgroundAttempts)
+        ? Number(options.maxBackgroundAttempts)
+        : 2,
+    timerId: null
+  };
+
+  target[RETRY_STATE_KEY] = nextState;
+  if (target.dataset) {
+    target.dataset.retryableLoad = 'true';
+  }
+
+  const shouldScheduleBackgroundRetry =
+    nextState.backgroundDelayMs > 0 &&
+    nextState.backgroundAttempts < nextState.maxBackgroundAttempts &&
+    !(typeof document !== 'undefined' && document.hidden === true);
+
+  if (shouldScheduleBackgroundRetry) {
+    nextState.timerId = window.setTimeout(() => {
+      const latestState = getRetryState(target);
+      if (!latestState || !latestState.enabled) {
+        return;
+      }
+      latestState.timerId = null;
+      latestState.backgroundAttempts += 1;
+      invokeRetry(target, 'background');
+    }, nextState.backgroundDelayMs);
+  }
+}
+
+export function describeRetryableLoadFailure(error, fallbackMessage) {
+  const payload =
+    error && typeof error === 'object' && error.payload && typeof error.payload === 'object'
+      ? error.payload
+      : null;
+  const status = Number.isFinite(error?.status) ? Number(error.status) : null;
+
+  let message = '';
+  if (payload && typeof payload.error === 'string' && payload.error.trim()) {
+    message = payload.error.trim();
+  } else if (error && typeof error.message === 'string' && error.message.trim()) {
+    message = error.message.trim();
+  }
+
+  if (!message || /^HTTP \d+$/.test(message)) {
+    message = fallbackMessage;
+  }
+
+  const retryable =
+    payload?.retryable === false
+      ? false
+      : Boolean(payload?.retryable) || status === null || status >= 500;
+
+  let retryAfterSeconds = null;
+  if (payload && Number.isFinite(payload.retry_after_seconds)) {
+    retryAfterSeconds = Number(payload.retry_after_seconds);
+  } else if (Number.isFinite(error?.retryAfterSeconds)) {
+    retryAfterSeconds = Number(error.retryAfterSeconds);
+  }
+
+  return {
+    message,
+    retryable,
+    retryAfterSeconds: retryAfterSeconds ?? 5,
+    status,
+    reason: payload?.reason || null
+  };
+}

--- a/tests/backend/test_settings_selector_routes.py
+++ b/tests/backend/test_settings_selector_routes.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from flask import Flask
+
+from src.backend.server.routes.settings_routes import settings_bp
+
+
+def _make_settings_app() -> Flask:
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.config["TESTING"] = True
+    app.register_blueprint(settings_bp, url_prefix="/api/settings")
+    return app
+
+
+def test_people_selector_returns_retryable_503_when_concepts_collection_unavailable(
+    monkeypatch,
+):
+    import src.backend.server.routes.settings_routes as settings_routes
+
+    app = _make_settings_app()
+    monkeypatch.setattr(
+        settings_routes.ConceptsRepository,
+        "collection",
+        staticmethod(lambda: None),
+    )
+
+    with app.test_client() as client:
+        response = client.get("/api/settings/people")
+
+    payload = response.get_json() or {}
+    assert response.status_code == 503
+    assert payload["retryable"] is True
+    assert payload["reason"] == "concepts_collection_unavailable"
+    assert payload["retry_after_seconds"] == 5
+    assert response.headers["Retry-After"] == "5"
+
+
+def test_organisation_selector_returns_retryable_503_when_concepts_collection_unavailable(
+    monkeypatch,
+):
+    import src.backend.server.routes.settings_routes as settings_routes
+
+    app = _make_settings_app()
+    monkeypatch.setattr(
+        settings_routes.ConceptsRepository,
+        "collection",
+        staticmethod(lambda: None),
+    )
+
+    with app.test_client() as client:
+        response = client.get("/api/settings/organisations")
+
+    payload = response.get_json() or {}
+    assert response.status_code == 503
+    assert payload["retryable"] is True
+    assert payload["reason"] == "concepts_collection_unavailable"
+    assert payload["retry_after_seconds"] == 5
+    assert response.headers["Retry-After"] == "5"

--- a/tests/frontend/conceptAutocomplete.test.js
+++ b/tests/frontend/conceptAutocomplete.test.js
@@ -10,6 +10,7 @@ const { closeAutocomplete, initializeConceptAutocomplete } = conceptAutocomplete
 describe('conceptAutocomplete', () => {
     let textarea;
     let container;
+    const originalFetch = global.fetch;
 
     beforeEach(() => {
         // Create a mock container and textarea
@@ -26,6 +27,7 @@ describe('conceptAutocomplete', () => {
 
     afterEach(() => {
         closeAutocomplete();
+        global.fetch = originalFetch;
         document.body.removeChild(container);
     });
 
@@ -203,6 +205,57 @@ describe('conceptAutocomplete', () => {
             const ZWSP = '\u200B';
             expect(textarea.value).toBe(`Plan #V${ZWSP}#person and more`);
             done();
+        }, 300);
+    });
+
+    test('autocomplete shows a retryable error instead of silently hiding backend failures', (done) => {
+        initializeConceptAutocomplete(textarea);
+
+        global.fetch = jest
+            .fn()
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 503,
+                json: () =>
+                    Promise.resolve({
+                        error: 'Concept search is temporarily unavailable.',
+                        retryable: true,
+                        retry_after_seconds: 0,
+                    }),
+                headers: {
+                    get: (name) => (name === 'Retry-After' ? '0' : null),
+                },
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: () =>
+                    Promise.resolve({
+                        results: [{ id: '#V#person', name: 'Person', kind: 'type' }],
+                    }),
+                headers: {
+                    get: () => null,
+                },
+            });
+
+        textarea.value = '#V#pe';
+        textarea.selectionStart = textarea.value.length;
+        textarea.selectionEnd = textarea.value.length;
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+
+        setTimeout(() => {
+            const dropdown = document.querySelector('.concept-autocomplete-dropdown');
+            const failureItem = dropdown?.querySelector('.concept-autocomplete-item-error');
+            expect(failureItem).toBeTruthy();
+            expect(failureItem.textContent).toContain('Click to retry');
+
+            failureItem.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+            setTimeout(() => {
+                const successItem = dropdown?.querySelector('.concept-autocomplete-item[data-concept-id="#V#person"]');
+                expect(successItem).toBeTruthy();
+                done();
+            }, 50);
         }, 300);
     });
 });


### PR DESCRIPTION
## Summary
- return retryable `503` responses for settings people/organisation selectors when concepts storage is unavailable
- distinguish retryable backend failure from true emptiness in settings/org selectors and related search suggestion widgets
- add shared retryable UI state helpers plus regression coverage for settings routes and concept autocomplete

## Validation
- `pdm run pytest tests/backend/test_settings_selector_routes.py -q`
- `npx pyright src/backend/server/routes/settings_routes.py tests/backend/test_settings_selector_routes.py`
- `npx jest tests/frontend/conceptAutocomplete.test.js src/frontend/web/von_interface/static/js/test/settingsRetryableLoads.test.js src/frontend/web/von_interface/static/js/test/orgSelectorRetryableState.test.js --runInBand`
- `npx jest tests/frontend/chatSessionMetadataLabelLinks.test.js --runInBand`
- `npx jest tests/frontend/dynamicTabsIdCollision.test.js --runInBand`