### PR TITLE
docs: update codex automation vontology control-flow review notes

### DIFF
--- a/docs/codex-automation/vontology-control-flow-review/confirmed_non_issues.md
+++ b/docs/codex-automation/vontology-control-flow-review/confirmed_non_issues.md
@@ -7,6 +7,9 @@ This avoids duplicate filing. Re-check if code or live evidence changes.
 - Broad tool metadata/write/evidence authority: `JVNAUTOSCI-1985`.
 - Workflow-purity prompt-source/repo-seed drift: `JVNAUTOSCI-2080`.
 - Broad buttonify prose-extraction heuristics: completed `JVNAUTOSCI-1971`.
+- Regex-heavy person/company/meeting file-copy inference: completed
+  `JVNAUTOSCI-1952`; current issue is downstream materialisation contracts,
+  now tracked by `JVNAUTOSCI-2216`.
 
 ## Inspected, Not Filed On 2026-04-30
 
@@ -19,6 +22,18 @@ This avoids duplicate filing. Re-check if code or live evidence changes.
   evidence of durable semantic/display-profile authority.
 - `workflow_override_policy_service.py` and `workflow_continuation_service.py`:
   watch areas; file only if they override represented workflow/routing policy.
+- `workflow_launch_input_contracts.py` arXiv ID extraction: covered by
+  `JVNAUTOSCI-2212` as deterministic launch-input support. File only if the
+  extractor registry grows into phrase-specific or domain launch policy.
+
+## Inspected, Not Filed On 2026-05-01
+
+- `tool_result_hint_actions.py`: generic action support for Vontology-authored
+  signal/follow-up hints. File only if integration-specific hint text or
+  selection policy appears in Python.
+- `workflow_mcp_tool_actions.py`: generic static MCP invocation support with
+  namespace and write guardrails. File only if tool choice or domain process
+  policy is added there rather than represented workflow metadata.
 
 Do not file solely because a file is large or contains domain nouns. File when
 Python owns durable decision policy, evidence choice, prompt/workflow content,

--- a/docs/codex-automation/vontology-control-flow-review/detection_heuristics.md
+++ b/docs/codex-automation/vontology-control-flow-review/detection_heuristics.md
@@ -17,6 +17,14 @@ represented authority before filing Jira work.
 - Prompt text appended to Vontology-rendered prompts in Python.
 - Python-generated Vontology descriptions containing domain labels, capability
   wording, cost, maturity, or success-likelihood claims.
+- After prompt-backed interpretation migrations, inspect the downstream
+  materialisation contract separately: Python candidate schemas,
+  field-to-predicate mappings, note text, and success criteria can remain
+  hidden policy even when extraction/inference is prompt-owned.
+- In generic workflow-authoring surfaces, domain action ids such as
+  `workflow_authoring.resolve_<domain>`, hard-coded type/predicate defaults,
+  domain profile fields, and tests asserting those action ids are strong
+  represented-authority drift signals.
 
 ## 2026-04-30 Examples
 
@@ -25,3 +33,6 @@ represented authority before filing Jira work.
 - Onboarding launch/process policy: `JVNAUTOSCI-2195`.
 - Deterministic workflow-description authoring: `JVNAUTOSCI-2196`.
 - Buttonify prompt suffix: `JVNAUTOSCI-2197`.
+- File-copy entity materialisation contract bindings: `JVNAUTOSCI-2216`.
+- PhD-student workflow-authoring action contracts and handlers:
+  `JVNAUTOSCI-2219`.

--- a/docs/codex-automation/vontology-control-flow-review/jira_index.md
+++ b/docs/codex-automation/vontology-control-flow-review/jira_index.md
@@ -22,6 +22,13 @@ Use this before creating new drift-review tasks.
 - `JVNAUTOSCI-2195` - onboarding route/stub launch policy.
 - `JVNAUTOSCI-2196` - deterministic workflow-description policy.
 - `JVNAUTOSCI-2197` - buttonify prompt quality-gate suffix.
+- `JVNAUTOSCI-2216` - file-copy entity materialisation contracts and
+  field-to-predicate bindings.
+
+## 2026-05-01 Drift Tasks
+
+- `JVNAUTOSCI-2219` - PhD-student workflow-authoring policy, profile fields,
+  domain action ids, and relationship/postcondition handling in Python.
 
 Parent new architectural drift tasks under `JVNAUTOSCI-1116` unless a more
 specific active epic clearly owns the area. Link code-side policy drift to

--- a/docs/codex-automation/vontology-control-flow-review/ownership_boundaries.md
+++ b/docs/codex-automation/vontology-control-flow-review/ownership_boundaries.md
@@ -12,6 +12,11 @@ predicates, and KB assertions should own durable:
 - prompt bodies and model-facing behavioural rules;
 - profile applicability and field semantics;
 - representation contracts and required evidence/tool policy;
+- representation candidate schemas, field-to-predicate bindings, note relation
+  policy, and materialisation success/postcondition criteria;
+- workflow-authoring representation profiles, domain field schemas,
+  type/predicate bindings, candidate-resolution policy, and generated workflow
+  postconditions;
 - recommendation matching, feedback semantics, and delivery wording;
 - domain-specific workflow launch policy;
 - workflow-description semantics such as domain labels, capability wording,
@@ -25,6 +30,10 @@ Python can remain the surface for:
 - prompt/workflow/profile loading with fail-closed diagnostics;
 - telemetry, provenance, persistence plumbing, and gateway/tool invocation;
 - embedding/vector execution primitives;
+- generic materialisation executors that apply represented field bindings and
+  relation specs through canonical Vontology services;
+- generic entity-representation primitives that execute represented profile
+  specs without hard-coded domain action ids or predicate defaults;
 - generic HTTP/request plumbing that passes represented decisions through.
 
 Seed bundles are publication/migration artefacts, not normal runtime authority

--- a/docs/codex-automation/vontology-control-flow-review/run_log.md
+++ b/docs/codex-automation/vontology-control-flow-review/run_log.md
@@ -14,3 +14,32 @@
 
 - Compacted operational memory files at user request. Removed long per-run
   evidence blocks; kept issue keys, duplicate boundaries, and review heuristics.
+
+## 2026-04-30T21:59:17.4992277+12:00
+
+- Created `JVNAUTOSCI-2216` for file-copy entity materialisation contracts:
+  candidate schemas, field-to-predicate bindings, note policy, and success
+  criteria still live in Python after `JVNAUTOSCI-1952` moved inference toward
+  prompt authority.
+- Linked `JVNAUTOSCI-2216` to `JVNAUTOSCI-1913`, `JVNAUTOSCI-1952`,
+  `JVNAUTOSCI-2193`, and `JVNAUTOSCI-2173`; added a visible Jira user-impact
+  comment.
+- Treated the arXiv launch-input extractor as covered by `JVNAUTOSCI-2212`
+  rather than filing a duplicate.
+- No production code was changed.
+
+## 2026-05-01T03:11:18.0583273+12:00
+
+- Created `JVNAUTOSCI-2219` for PhD-student workflow-authoring policy in
+  Python: domain action ids, profile fields, concept/predicate defaults,
+  handlers, template states, and tests now need represented Vontology/VWL
+  ownership.
+- Linked `JVNAUTOSCI-2219` to `JVNAUTOSCI-1913`, `JVNAUTOSCI-1307`,
+  `JVNAUTOSCI-2195`, and `JVNAUTOSCI-2080`; added a visible Jira user-impact
+  comment.
+- Updated `JVNAUTOSCI-2080` with current `check_workflow_purity.py` evidence,
+  including the additional repo-seed path
+  `multilingual_concept_enrichment_vontology_service.py`.
+- Inspected `tool_result_hint_actions.py` and `workflow_mcp_tool_actions.py`;
+  treated them as generic support surfaces, not new drift tasks.
+- No production code was changed.


### PR DESCRIPTION
## Summary
- add the new 2026-05-01 review outcomes to the codex automation control-flow review notes
- record `JVNAUTOSCI-2216` and `JVNAUTOSCI-2219` in the duplicate-avoidance and heuristic guidance docs
- extend the run log with the latest review and Jira follow-up notes

## Validation
- `git diff --check -- docs/codex-automation`
- verified the branch-vs-main compare contains only the five intended markdown files under `docs/codex-automation/`
