### PR TITLE
JVNAUTOSCI-2512: scope capability-index invalidation to authoritative workflow concepts

### DIFF
--- a/src/backend/services/text_value_service.py
+++ b/src/backend/services/text_value_service.py
@@ -95,10 +95,22 @@ def _invalidate_workflow_routing_projection_for_text_relation_change(
         return
 
     try:
-        from .workflow_capability_service import invalidate_workflow_capability_index
+        from .workflow_capability_service import (
+            invalidate_workflow_capability_index,
+            is_authoritative_workflow_concept_id,
+        )
         from .workflow_discovery_service import (
             invalidate_workflow_discovery_executability_caches,
         )
+
+        # Scope invalidation to concepts the capability index actually tracks.
+        # Background workflows continually rewrite descriptions on unrelated
+        # (non-workflow) concepts; without this guard every such write churns
+        # the routing index and starves live workflow discovery of a ready
+        # index. New workflows are indexed via the registration path, so this
+        # only suppresses no-op invalidations from non-workflow subjects.
+        if not is_authoritative_workflow_concept_id(subject_concept_id):
+            return
 
         invalidate_workflow_capability_index(
             reason=(

--- a/src/backend/services/workflow_capability_service.py
+++ b/src/backend/services/workflow_capability_service.py
@@ -313,6 +313,34 @@ def _authoritative_registry_workflow_ids(registry: Any) -> tuple[str, ...]:
     )
 
 
+def is_authoritative_workflow_concept_id(concept_id: str) -> bool:
+    """Return True when ``concept_id`` is an authoritative workflow concept.
+
+    Used to scope routing-projection invalidation: only writes to concepts the
+    capability index actually tracks should churn it. Description/content writes
+    on unrelated concepts (e.g. task or episode-critique concepts produced by
+    background workflows) must not invalidate the workflow routing index.
+
+    Fails open (returns True) when the registry cannot be resolved, so a lookup
+    failure degrades to the prior always-invalidate behaviour rather than
+    silently skipping a legitimate workflow update.
+    """
+
+    cleaned = str(concept_id or "").strip()
+    if not cleaned:
+        return False
+    try:
+        from ..workflows.durable.registry_factory import (
+            get_shared_workflow_registry_read_only,
+        )
+
+        registry = get_shared_workflow_registry_read_only(defer_parity_work=True)
+        authoritative_ids = set(_authoritative_registry_workflow_ids(registry))
+    except Exception:
+        return True
+    return cleaned in authoritative_ids
+
+
 def _authoritative_registry_fingerprint_rows(
     registry: Any,
 ) -> tuple[dict[str, str], ...]:

--- a/tests/backend/test_workflow_capability_service.py
+++ b/tests/backend/test_workflow_capability_service.py
@@ -1282,6 +1282,10 @@ def test_workflow_routing_text_relation_change_invalidates_projection(
         "src.backend.services.workflow_discovery_service.invalidate_workflow_discovery_executability_caches",
         lambda: discovery_cache_clears.append(True),
     )
+    monkeypatch.setattr(
+        "src.backend.services.workflow_capability_service.is_authoritative_workflow_concept_id",
+        lambda concept_id: concept_id == "#V#workflow_repair_or_create_workflow",
+    )
 
     text_value_service._invalidate_workflow_routing_projection_for_text_relation_change(
         subject_concept_id="#V#workflow_repair_or_create_workflow",
@@ -1295,6 +1299,85 @@ def test_workflow_routing_text_relation_change_invalidates_projection(
     assert len(invalidations) == 1
     assert "workflow_routing_text_relation_changed" in str(invalidations[0])
     assert discovery_cache_clears == [True]
+
+
+def test_workflow_routing_text_relation_change_skips_non_workflow_subject(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A routing-relevant predicate on a non-workflow concept must not churn
+    the capability index. Background workflows continually rewrite descriptions
+    on task/episode concepts; those writes previously invalidated the routing
+    index and starved live workflow discovery of a ready index."""
+
+    from src.backend.services import text_value_service
+
+    invalidations: list[str | None] = []
+    discovery_cache_clears: list[bool] = []
+
+    monkeypatch.setattr(
+        "src.backend.services.workflow_capability_service.invalidate_workflow_capability_index",
+        lambda **kwargs: (
+            invalidations.append(kwargs.get("reason")) or {"success": True}
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.workflow_discovery_service.invalidate_workflow_discovery_executability_caches",
+        lambda: discovery_cache_clears.append(True),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.workflow_capability_service.is_authoritative_workflow_concept_id",
+        lambda concept_id: False,
+    )
+
+    text_value_service._invalidate_workflow_routing_projection_for_text_relation_change(
+        subject_concept_id=(
+            "#V#task_episode_critique_remediation_"
+            "vpaperrecommendationevaluationworkflow_metadatavalidationfailure_c64dffb4"
+        ),
+        predicate="#V#hasDescription",
+    )
+
+    assert invalidations == []
+    assert discovery_cache_clears == []
+
+
+def test_is_authoritative_workflow_concept_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import src.backend.services.workflow_capability_service as capability_service
+
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.registry_factory.get_shared_workflow_registry_read_only",
+        lambda **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        capability_service,
+        "_authoritative_registry_workflow_ids",
+        lambda registry: ("#V#a_workflow", "#V#b_workflow"),
+    )
+
+    assert capability_service.is_authoritative_workflow_concept_id("#V#a_workflow")
+    assert not capability_service.is_authoritative_workflow_concept_id("#V#task_x")
+    assert not capability_service.is_authoritative_workflow_concept_id("")
+    assert not capability_service.is_authoritative_workflow_concept_id(None)  # type: ignore[arg-type]
+
+
+def test_is_authoritative_workflow_concept_id_fails_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import src.backend.services.workflow_capability_service as capability_service
+
+    def _raise(**kwargs: object) -> object:
+        raise RuntimeError("registry unavailable")
+
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.registry_factory.get_shared_workflow_registry_read_only",
+        _raise,
+    )
+
+    # Registry lookup failure must degrade to the prior always-invalidate
+    # behaviour rather than silently skipping a legitimate workflow update.
+    assert capability_service.is_authoritative_workflow_concept_id("#V#task_x")
 
 
 def test_workflow_graph_relationship_change_invalidates_projection(


### PR DESCRIPTION
## Problem (JVNAUTOSCI-2512)
`_invalidate_workflow_routing_projection_for_text_relation_change` (src/backend/services/text_value_service.py) invalidated the **entire** workflow capability index whenever a text relation with a routing-relevant predicate (`hasDescription`/`hasContent`/`hasDefinition`) was written — filtering only on the predicate, with **no check that the subject is an authoritative workflow concept**.

The sibling relationship path (`relationship_write_service.py`) is already correctly narrow (`is_a_type_of`/`is_an_instance_of` + workflow graph aliases). The text-relation path was the leaky one.

Consequence: the background paper-recommendation / episode-evaluation storm (JVNAUTOSCI-2507) continually rewrites task/episode concept descriptions, so the routing index was invalidated every ~2-3s and never reached `ready=true`. Live workflow discovery returned 0 candidates (`match_absence_reason=capability_index_wait_timed_out_build_in_progress`), which is why the represented selector fast path (JVNAUTOSCI-2406/2501) could not fire end-to-end despite the code being correct — blocking JVNAUTOSCI-2511.

## Fix
- New `is_authoritative_workflow_concept_id()` helper in `workflow_capability_service.py` (consults the shared registry's authoritative workflow ids; **fails open** if the registry can't be resolved, preserving the prior always-invalidate behaviour on lookup failure).
- Gate the text-relation invalidation path on it: description/content writes on non-workflow concepts (tasks, episodes) no longer churn the routing index. New workflows still invalidate via the registration path in `registry_factory.py`, so nothing legitimate is lost.

## Tests
`tests/backend/test_workflow_capability_service.py`: updated the existing invalidation test to be deterministic, plus new tests for the non-workflow-subject skip path and the helper (including fail-open). Full file: 54 pass.

## Verified live
With this deployed (server build `d5d4cadde924`), the index stayed ready and the represented fast path fired with `applied=true`:
- request_id `live-kb-prompt-27fac620-34db-4be1-8060-0276a03cf00a`, prompt "Show me the last 5 email messages"
- `selector_source: represented_fast_path`; single covered candidate `#V#general_mail_review_workflow` (contract `[gmail_list_messages]`)
- turn completed successfully; `gmail_list_messages` ran 3× ok. Evidence captured under JVNAUTOSCI-2511 (now Done, along with 2406/2501).

Related: JVNAUTOSCI-2507 (the storm that supplies the write volume) is still open and independently warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)