### PR TITLE
JVNAUTOSCI-2592: fix KR description output contract

### DIFF
--- a/scripts/generate_spreadsheet_programme_workflow_seed.py
+++ b/scripts/generate_spreadsheet_programme_workflow_seed.py
@@ -1594,7 +1594,7 @@ def build_bundle() -> dict[str, object]:
     return {
         "family_id": "spreadsheet_programme_representation_workflow_seed_bundle",
         "schema_version": "repo_seed_workflow_bundle.v1",
-        "seed_version": "17",
+        "seed_version": "18",
         "source_tag": "JVNAUTOSCI-2592",
         "managed_by": "spreadsheet_programme_workflow_vontology_service",
         "processing_authority_fingerprint": authority_fingerprint,

--- a/src/backend/workflows/repo_seed_bundles/kr_materialisation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/kr_materialisation_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "#V#kr_design_materialisation_workflow_family",
   "managed_by": "kr_materialisation_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "4",
+  "seed_version": "5",
   "source_tag": "JVNAUTOSCI-2271",
   "supported_action_ids": [
     "llm.action",
@@ -718,7 +718,7 @@
               {
                 "concept_id": "#V#workflow_mapping_tool_field_kr_design_concept_materialisation_item_workflow_attach_description_relation_id_to_kr_description_relation_id",
                 "context_key": "kr_description_relation_id",
-                "tool_output_field": "relation_id"
+                "tool_output_field": "kept_relation_id"
               },
               {
                 "concept_id": "#V#workflow_mapping_tool_field_kr_design_concept_materialisation_item_workflow_attach_description_text_value_id_to_kr_description_text_value_id",

--- a/src/backend/workflows/repo_seed_bundles/spreadsheet_programme_representation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/spreadsheet_programme_representation_workflow_seed_bundle.json
@@ -3,14 +3,14 @@
   "managed_by": "spreadsheet_programme_workflow_vontology_service",
   "processing_authority_dependencies": {
     "kr_materialisation_workflow_seed_bundle": {
-      "canonical_payload_sha256": "sha256:d01ea4c91f61802ebd4c8935d5e6d8c817f2f2559db495da965c38add43a0b33",
+      "canonical_payload_sha256": "sha256:89dd92a52fd395f8d3e464db1dded926d229d34318e1be2f898fd5e24b30a9e4",
       "family_id": "#V#kr_design_materialisation_workflow_family",
-      "seed_version": "4"
+      "seed_version": "5"
     }
   },
-  "processing_authority_fingerprint": "sha256:4a23437988d6e745aac1a2515ed8b1231b8b3fb0f63abe078c107d176b74f79f",
+  "processing_authority_fingerprint": "sha256:9f32be33af418e0c6aba292882ce87531d49632cc43d5352398b7f30bb24fff3",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "17",
+  "seed_version": "18",
   "source_tag": "JVNAUTOSCI-2592",
   "support_concepts": [
     {
@@ -306,7 +306,7 @@
               },
               {
                 "key": "processing_authority_fingerprint",
-                "value": "sha256:4a23437988d6e745aac1a2515ed8b1231b8b3fb0f63abe078c107d176b74f79f"
+                "value": "sha256:9f32be33af418e0c6aba292882ce87531d49632cc43d5352398b7f30bb24fff3"
               }
             ],
             "tool_output_mapping_specs": [
@@ -702,7 +702,7 @@
               },
               {
                 "key": "processing_authority_fingerprint",
-                "value": "sha256:4a23437988d6e745aac1a2515ed8b1231b8b3fb0f63abe078c107d176b74f79f"
+                "value": "sha256:9f32be33af418e0c6aba292882ce87531d49632cc43d5352398b7f30bb24fff3"
               }
             ],
             "tool_output_mapping_specs": [
@@ -776,7 +776,7 @@
               },
               {
                 "key": "processing_authority_fingerprint",
-                "value": "sha256:4a23437988d6e745aac1a2515ed8b1231b8b3fb0f63abe078c107d176b74f79f"
+                "value": "sha256:9f32be33af418e0c6aba292882ce87531d49632cc43d5352398b7f30bb24fff3"
               }
             ],
             "tool_output_mapping_specs": [
@@ -1234,7 +1234,7 @@
               },
               {
                 "key": "processing_authority_fingerprint",
-                "value": "sha256:4a23437988d6e745aac1a2515ed8b1231b8b3fb0f63abe078c107d176b74f79f"
+                "value": "sha256:9f32be33af418e0c6aba292882ce87531d49632cc43d5352398b7f30bb24fff3"
               }
             ],
             "tool_output_mapping_specs": [
@@ -1557,7 +1557,7 @@
               },
               {
                 "key": "processing_authority_fingerprint",
-                "value": "sha256:4a23437988d6e745aac1a2515ed8b1231b8b3fb0f63abe078c107d176b74f79f"
+                "value": "sha256:9f32be33af418e0c6aba292882ce87531d49632cc43d5352398b7f30bb24fff3"
               }
             ],
             "tool_output_mapping_specs": [
@@ -1625,7 +1625,7 @@
               },
               {
                 "key": "processing_authority_fingerprint",
-                "value": "sha256:4a23437988d6e745aac1a2515ed8b1231b8b3fb0f63abe078c107d176b74f79f"
+                "value": "sha256:9f32be33af418e0c6aba292882ce87531d49632cc43d5352398b7f30bb24fff3"
               }
             ],
             "tool_output_mapping_specs": [

--- a/tests/backend/test_kr_materialisation_workflow_vontology_service.py
+++ b/tests/backend/test_kr_materialisation_workflow_vontology_service.py
@@ -161,7 +161,7 @@ def test_kr_prompt_seed_assets_hold_operational_prompt_content() -> None:
 
 def test_kr_seed_applies_optional_guard_before_each_write_phase() -> None:
     bundle = json.loads(_SEED_BUNDLE_PATH.read_text(encoding="utf-8"))
-    assert bundle["seed_version"] == "4"
+    assert bundle["seed_version"] == "5"
     workflow = next(
         row
         for row in bundle["workflows"]
@@ -231,6 +231,14 @@ def test_kr_seed_applies_optional_guard_before_each_write_phase() -> None:
         )
         for binding in concept_item_states["create_concept"]["static_input_bindings"]
     )
+    description_outputs = {
+        row["context_key"]: row["tool_output_field"]
+        for row in concept_item_states["attach_description"][
+            "tool_output_mapping_specs"
+        ]
+    }
+    assert description_outputs["kr_description_relation_id"] == "kept_relation_id"
+    assert description_outputs["kr_description_text_value_id"] == "text_value_id"
     concept_iteration_bindings = dict(
         states["materialise_concepts"]["static_input_bindings"]
     )

--- a/tests/backend/test_spreadsheet_programme_workflow_vontology_service.py
+++ b/tests/backend/test_spreadsheet_programme_workflow_vontology_service.py
@@ -343,7 +343,7 @@ def test_processing_authority_fingerprint_tracks_exact_kr_dependency(
     from scripts import generate_spreadsheet_programme_workflow_seed as generator
 
     baseline = generator.build_bundle()
-    assert baseline["seed_version"] == "17"
+    assert baseline["seed_version"] == "18"
     baseline_dependency = baseline["processing_authority_dependencies"][
         "kr_materialisation_workflow_seed_bundle"
     ]
@@ -352,7 +352,7 @@ def test_processing_authority_fingerprint_tracks_exact_kr_dependency(
     )
     assert baseline_dependency["family_id"] == source_payload["family_id"]
     assert baseline_dependency["seed_version"] == source_payload["seed_version"]
-    assert baseline_dependency["seed_version"] == "4"
+    assert baseline_dependency["seed_version"] == "5"
     assert baseline_dependency["canonical_payload_sha256"].startswith("sha256:")
 
     changed_payload = dict(source_payload)


### PR DESCRIPTION
## Live failure

The post-merge one-record replay reached the guarded KR child and stopped after its first reuse item. The singleton description mutation succeeded, but workflow metadata validation failed because the represented step mapped a nonexistent `relation_id` output.

## Fix

- map `upsert_singleton_text_relation.kept_relation_id` to `kr_description_relation_id`
- bump KR seed v4 to v5
- regenerate the dependent spreadsheet bundle as seed v18 with fingerprint `sha256:9f32be33af418e0c6aba292882ce87531d49632cc43d5352398b7f30bb24fff3`
- add a regression assertion for both description output mappings

## Validation

- 19 focused tests pass
- KR bundle validation and seed-version checks pass
- generator output, Ruff, formatting, and diff checks pass
- live failure made zero creates and wrote no record marker; retry remains safe and idempotent