### PR TITLE
JVNAUTOSCI-2592: retry bounded KR read-back timeouts

### DIFF
--- a/scripts/generate_spreadsheet_programme_workflow_seed.py
+++ b/scripts/generate_spreadsheet_programme_workflow_seed.py
@@ -1594,7 +1594,7 @@ def build_bundle() -> dict[str, object]:
     return {
         "family_id": "spreadsheet_programme_representation_workflow_seed_bundle",
         "schema_version": "repo_seed_workflow_bundle.v1",
-        "seed_version": "18",
+        "seed_version": "19",
         "source_tag": "JVNAUTOSCI-2592",
         "managed_by": "spreadsheet_programme_workflow_vontology_service",
         "processing_authority_fingerprint": authority_fingerprint,

--- a/src/backend/workflows/repo_seed_bundles/kr_materialisation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/kr_materialisation_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "#V#kr_design_materialisation_workflow_family",
   "managed_by": "kr_materialisation_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "5",
+  "seed_version": "6",
   "source_tag": "JVNAUTOSCI-2271",
   "supported_action_ids": [
     "llm.action",
@@ -744,6 +744,15 @@
             "execution_mode": "deterministic",
             "next_state": "read_back_text_relations",
             "on_failure_state": "summarise_blocker",
+            "retry_policy": {
+              "backoff_policy": "fixed",
+              "delay_ms": 1000,
+              "max_attempts": 2,
+              "retry_on_outcomes": [
+                "failure"
+              ],
+              "schema_version": "workflow_step_retry_policy.v1"
+            },
             "state_id": "read_back_concept",
             "static_input_bindings": [
               [
@@ -793,6 +802,15 @@
             "execution_mode": "deterministic",
             "next_state": "emit_concept_payload",
             "on_failure_state": "summarise_blocker",
+            "retry_policy": {
+              "backoff_policy": "fixed",
+              "delay_ms": 1000,
+              "max_attempts": 2,
+              "retry_on_outcomes": [
+                "failure"
+              ],
+              "schema_version": "workflow_step_retry_policy.v1"
+            },
             "state_id": "read_back_text_relations",
             "static_input_bindings": [
               [

--- a/src/backend/workflows/repo_seed_bundles/spreadsheet_programme_representation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/spreadsheet_programme_representation_workflow_seed_bundle.json
@@ -3,14 +3,14 @@
   "managed_by": "spreadsheet_programme_workflow_vontology_service",
   "processing_authority_dependencies": {
     "kr_materialisation_workflow_seed_bundle": {
-      "canonical_payload_sha256": "sha256:89dd92a52fd395f8d3e464db1dded926d229d34318e1be2f898fd5e24b30a9e4",
+      "canonical_payload_sha256": "sha256:330476eb8e85bc0ea4aeca0c7bf844968495c8c1018f52b5097a96cd68fd8c0a",
       "family_id": "#V#kr_design_materialisation_workflow_family",
-      "seed_version": "5"
+      "seed_version": "6"
     }
   },
-  "processing_authority_fingerprint": "sha256:9f32be33af418e0c6aba292882ce87531d49632cc43d5352398b7f30bb24fff3",
+  "processing_authority_fingerprint": "sha256:7ecf13bbdfa9a9a95f28eefc3634fad91cc5c7498aa0aa84b6763ab965c46267",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "18",
+  "seed_version": "19",
   "source_tag": "JVNAUTOSCI-2592",
   "support_concepts": [
     {
@@ -306,7 +306,7 @@
               },
               {
                 "key": "processing_authority_fingerprint",
-                "value": "sha256:9f32be33af418e0c6aba292882ce87531d49632cc43d5352398b7f30bb24fff3"
+                "value": "sha256:7ecf13bbdfa9a9a95f28eefc3634fad91cc5c7498aa0aa84b6763ab965c46267"
               }
             ],
             "tool_output_mapping_specs": [
@@ -702,7 +702,7 @@
               },
               {
                 "key": "processing_authority_fingerprint",
-                "value": "sha256:9f32be33af418e0c6aba292882ce87531d49632cc43d5352398b7f30bb24fff3"
+                "value": "sha256:7ecf13bbdfa9a9a95f28eefc3634fad91cc5c7498aa0aa84b6763ab965c46267"
               }
             ],
             "tool_output_mapping_specs": [
@@ -776,7 +776,7 @@
               },
               {
                 "key": "processing_authority_fingerprint",
-                "value": "sha256:9f32be33af418e0c6aba292882ce87531d49632cc43d5352398b7f30bb24fff3"
+                "value": "sha256:7ecf13bbdfa9a9a95f28eefc3634fad91cc5c7498aa0aa84b6763ab965c46267"
               }
             ],
             "tool_output_mapping_specs": [
@@ -1234,7 +1234,7 @@
               },
               {
                 "key": "processing_authority_fingerprint",
-                "value": "sha256:9f32be33af418e0c6aba292882ce87531d49632cc43d5352398b7f30bb24fff3"
+                "value": "sha256:7ecf13bbdfa9a9a95f28eefc3634fad91cc5c7498aa0aa84b6763ab965c46267"
               }
             ],
             "tool_output_mapping_specs": [
@@ -1557,7 +1557,7 @@
               },
               {
                 "key": "processing_authority_fingerprint",
-                "value": "sha256:9f32be33af418e0c6aba292882ce87531d49632cc43d5352398b7f30bb24fff3"
+                "value": "sha256:7ecf13bbdfa9a9a95f28eefc3634fad91cc5c7498aa0aa84b6763ab965c46267"
               }
             ],
             "tool_output_mapping_specs": [
@@ -1625,7 +1625,7 @@
               },
               {
                 "key": "processing_authority_fingerprint",
-                "value": "sha256:9f32be33af418e0c6aba292882ce87531d49632cc43d5352398b7f30bb24fff3"
+                "value": "sha256:7ecf13bbdfa9a9a95f28eefc3634fad91cc5c7498aa0aa84b6763ab965c46267"
               }
             ],
             "tool_output_mapping_specs": [

--- a/tests/backend/test_kr_materialisation_workflow_vontology_service.py
+++ b/tests/backend/test_kr_materialisation_workflow_vontology_service.py
@@ -161,7 +161,7 @@ def test_kr_prompt_seed_assets_hold_operational_prompt_content() -> None:
 
 def test_kr_seed_applies_optional_guard_before_each_write_phase() -> None:
     bundle = json.loads(_SEED_BUNDLE_PATH.read_text(encoding="utf-8"))
-    assert bundle["seed_version"] == "5"
+    assert bundle["seed_version"] == "6"
     workflow = next(
         row
         for row in bundle["workflows"]
@@ -239,6 +239,21 @@ def test_kr_seed_applies_optional_guard_before_each_write_phase() -> None:
     }
     assert description_outputs["kr_description_relation_id"] == "kept_relation_id"
     assert description_outputs["kr_description_text_value_id"] == "text_value_id"
+    expected_readback_retry = {
+        "backoff_policy": "fixed",
+        "delay_ms": 1000,
+        "max_attempts": 2,
+        "retry_on_outcomes": ["failure"],
+        "schema_version": "workflow_step_retry_policy.v1",
+    }
+    assert (
+        concept_item_states["read_back_concept"]["retry_policy"]
+        == expected_readback_retry
+    )
+    assert (
+        concept_item_states["read_back_text_relations"]["retry_policy"]
+        == expected_readback_retry
+    )
     concept_iteration_bindings = dict(
         states["materialise_concepts"]["static_input_bindings"]
     )

--- a/tests/backend/test_spreadsheet_programme_workflow_vontology_service.py
+++ b/tests/backend/test_spreadsheet_programme_workflow_vontology_service.py
@@ -343,7 +343,7 @@ def test_processing_authority_fingerprint_tracks_exact_kr_dependency(
     from scripts import generate_spreadsheet_programme_workflow_seed as generator
 
     baseline = generator.build_bundle()
-    assert baseline["seed_version"] == "18"
+    assert baseline["seed_version"] == "19"
     baseline_dependency = baseline["processing_authority_dependencies"][
         "kr_materialisation_workflow_seed_bundle"
     ]
@@ -352,7 +352,7 @@ def test_processing_authority_fingerprint_tracks_exact_kr_dependency(
     )
     assert baseline_dependency["family_id"] == source_payload["family_id"]
     assert baseline_dependency["seed_version"] == source_payload["seed_version"]
-    assert baseline_dependency["seed_version"] == "5"
+    assert baseline_dependency["seed_version"] == "6"
     assert baseline_dependency["canonical_payload_sha256"].startswith("sha256:")
 
     changed_payload = dict(source_payload)


### PR DESCRIPTION
## Live failure

The corrected description mapping completed three reuse items. A fourth item then failed safely when read-only `fetch_concept` exceeded its 20-second hard deadline under Atlas variance. No write had an unknown outcome; fail-fast left six items unattempted.

## Fix

- add one fixed 1-second retry to `read_back_concept` and `read_back_text_relations`
- retry only the represented `failure` outcome
- do not retry create, relationship writes, description writes, or unknown outcomes
- bump KR seed to v6 and regenerate spreadsheet seed v19 with fingerprint `sha256:7ecf13bbdfa9a9a95f28eefc3634fad91cc5c7498aa0aa84b6763ab965c46267`

## Validation

- 15 focused tests pass
- KR workflow contracts and seed-version checks pass
- generator, Ruff, formatting, and diff checks pass