### PR TITLE
JVNAUTOSCI-2600: revise A3 mechanical authority and persistence

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -862,7 +862,10 @@ def _normalise_create_concepts_scope_mode(raw_value: Any) -> str | None:
 
 
 def _create_concepts(**kwargs):
-    from .transport import raise_if_internal_mcp_cancelled
+    from .transport import (
+        InternalMCPHandlerCancelled,
+        raise_if_internal_mcp_cancelled,
+    )
 
     # A handler may sit in the bounded executor queue until after its caller's
     # deadline. Never begin a write-side preflight in that state.
@@ -871,6 +874,7 @@ def _create_concepts(**kwargs):
     from ...vontology.utils_vontology import create_vontology_concept
     from ...vontology.code_concepts_registry import PREDICATE_TYPE_ID
     from ...services.create_concepts_duplicate_guard_service import (
+        build_canonical_identity_conflict_create_concepts_result,
         build_duplicate_prevented_create_concepts_result,
         find_existing_concept_for_create_concepts,
     )
@@ -1107,14 +1111,16 @@ def _create_concepts(**kwargs):
         )
     }
     if (
-        parent_resolution.resolved_parent_kind in {"individual", "instance"}
+        parent_resolution.resolved_parent_kind is not None
+        and parent_resolution.resolved_parent_kind != "type"
         and requested_non_predicate_kinds
     ):
         return make_error_response(
             "parent_is_not_a_type",
             (
-                f"Parent concept '{validated_parent_id}' is an individual, not "
-                "a semantic type. No concepts were created."
+                f"Parent concept '{validated_parent_id}' is "
+                f"{parent_resolution.resolved_parent_kind!r}, not a semantic "
+                "type. No concepts were created."
             ),
             details={
                 "original_parent_id": parent_id,
@@ -1138,11 +1144,25 @@ def _create_concepts(**kwargs):
         )
 
     results = []
+    cancelled_after_partial_error: str | None = None
+
+    def _cancelled_after_completed_items() -> bool:
+        nonlocal cancelled_after_partial_error
+        try:
+            raise_if_internal_mcp_cancelled()
+        except InternalMCPHandlerCancelled as exc:
+            if not results:
+                raise
+            cancelled_after_partial_error = str(exc)
+            return True
+        return False
+
     with defer_relationship_extent_index_sync():
         for concept_data in concepts:
             # This is both the batch boundary and the safe cancellation point after
             # the preceding concept's complete logical write bundle.
-            raise_if_internal_mcp_cancelled()
+            if _cancelled_after_completed_items():
+                break
             if not isinstance(concept_data, dict):
                 results.append(
                     {"error": "Concept must be an object", "data": concept_data}
@@ -1185,24 +1205,38 @@ def _create_concepts(**kwargs):
                 ),
             )
             if duplicate_match is not None:
-                result = build_duplicate_prevented_create_concepts_result(
-                    requested_name=str(name),
-                    requested_kind=kind,
-                    existing_concept_id=duplicate_match.existing_concept_id,
-                    guard_scope=duplicate_match.guard_scope,
-                    match_source=duplicate_match.match_source,
-                )
+                if duplicate_match.identity_conflict:
+                    result = build_canonical_identity_conflict_create_concepts_result(
+                        requested_name=str(name),
+                        requested_kind=kind,
+                        existing_concept_id=duplicate_match.existing_concept_id,
+                        guard_scope=duplicate_match.guard_scope,
+                        existing_kind=duplicate_match.existing_kind,
+                        existing_parent_ids=duplicate_match.existing_parent_ids,
+                        requested_parent_id=duplicate_match.requested_parent_id,
+                        mismatch_reasons=duplicate_match.mismatch_reasons,
+                    )
+                else:
+                    result = build_duplicate_prevented_create_concepts_result(
+                        requested_name=str(name),
+                        requested_kind=kind,
+                        existing_concept_id=duplicate_match.existing_concept_id,
+                        guard_scope=duplicate_match.guard_scope,
+                        match_source=duplicate_match.match_source,
+                    )
                 result["concept_id"] = duplicate_match.existing_concept_id
                 results.append(result)
                 continue
 
             # Duplicate preflights are read-only and may consume the entire
             # transport budget. Never start an insert after cancellation.
-            raise_if_internal_mcp_cancelled()
+            if _cancelled_after_completed_items():
+                break
             result = create_vontology_concept(
                 parent_id=parent_id_for_concept,
                 new_concept_name=name,
                 create_as_instance=create_as_instance,
+                allow_duplicate_instance_suffix=allow_duplicate_instances,
                 description=concept_data.get("description"),
                 notes=concept_data.get("notes"),
                 created_by_concept_id=actor_user_id,
@@ -1259,7 +1293,7 @@ def _create_concepts(**kwargs):
         for failure in (r.get("concept") or {}).get("partial_failures", [])
         if isinstance(failure, dict)
     ]
-    failed = len(concepts) - successful - already_exists
+    failed = len(results) - successful - already_exists
     if partial_failures or (failed > 0 and (successful > 0 or already_exists > 0)):
         effect_status = "partial"
     elif failed > 0:
@@ -1289,7 +1323,7 @@ def _create_concepts(**kwargs):
         }
     )
 
-    return {
+    response = {
         "success": failed == 0 and not partial_failures,
         "effect_status": effect_status,
         "changed": successful > 0,
@@ -1316,6 +1350,24 @@ def _create_concepts(**kwargs):
             "namespace": namespace,
         },
     }
+    if cancelled_after_partial_error is not None:
+        response.update(
+            {
+                "success": False,
+                "effect_status": "partial",
+                "error_code": "handler_cancelled_after_partial_completion",
+                "error": (
+                    "Concept creation was cancelled after one or more batch items "
+                    "had completed. Completed item receipts are preserved and no "
+                    "later item was started."
+                ),
+                "cancellation_requested": True,
+                "cancellation_error": cancelled_after_partial_error,
+                "completed_before_cancellation": len(results),
+                "unattempted_count": len(concepts) - len(results),
+            }
+        )
+    return response
 
 
 def _extract_annotations(**kwargs):
@@ -10183,6 +10235,131 @@ def _summarise_late_effect_observations(
             }
         summary.append(entry)
     return summary, len(raw_observations)
+
+
+def _summarise_effect_observation_journal(
+    raw_journal: Any,
+    *,
+    max_items: int = 32,
+) -> tuple[list[dict[str, Any]], int]:
+    """Return a bounded mechanical lifecycle projection for ordinary effects."""
+
+    if not isinstance(raw_journal, Mapping):
+        return [], 0
+    items = [
+        (str(effect_id), value)
+        for effect_id, value in raw_journal.items()
+        if isinstance(effect_id, str) and isinstance(value, Mapping)
+    ]
+    summary: list[dict[str, Any]] = []
+    for effect_id, raw_entry in items[-max_items:]:
+        identity = (
+            raw_entry.get("identity")
+            if isinstance(raw_entry.get("identity"), Mapping)
+            else {}
+        )
+        entry: dict[str, Any] = {
+            "schema_version": identity.get("schema_version"),
+            "effect_id": effect_id,
+        }
+        for field_name in ("call_id", "capability_name", "created_at_utc"):
+            if field_name in identity:
+                entry[field_name] = identity.get(field_name)
+
+        available_phases: list[str] = []
+        for phase_name in (
+            "dispatch_intent",
+            "turn_terminal",
+            "late_terminal",
+        ):
+            raw_phase = raw_entry.get(phase_name)
+            if not isinstance(raw_phase, Mapping):
+                continue
+            available_phases.append(phase_name)
+            phase_projection = {
+                key: raw_phase.get(key)
+                for key in (
+                    "phase",
+                    "recorded_at_utc",
+                    "dispatch_state",
+                    "execution_id",
+                    "outcome",
+                    "effect_status",
+                    "changed",
+                    "output_schema_validation",
+                    "output_schema_valid",
+                    "payload_truncated",
+                    "error_type",
+                    "error",
+                )
+                if key in raw_phase
+            }
+            transport = raw_phase.get("transport")
+            if isinstance(transport, Mapping):
+                phase_projection["transport"] = {
+                    key: transport.get(key)
+                    for key in (
+                        "execution_id",
+                        "outcome",
+                        "timeout_sec",
+                        "configured_hard_timeout_sec",
+                        "minimum_execution_window_sec",
+                        "timeout_phase",
+                        "late_result_policy",
+                    )
+                    if key in transport
+                }
+            receipt = raw_phase.get("receipt")
+            if not isinstance(receipt, Mapping):
+                payload = raw_phase.get("payload")
+                receipt = payload if isinstance(payload, Mapping) else None
+            if isinstance(receipt, Mapping):
+                phase_projection["receipt"] = {
+                    key: receipt.get(key)
+                    for key in (
+                        "success",
+                        "status",
+                        "effect_status",
+                        "changed",
+                        "error",
+                        "error_code",
+                        "mutation_outcome",
+                        "partial_failures",
+                    )
+                    if key in receipt
+                }
+            entry[phase_name] = phase_projection
+        entry["available_phases"] = available_phases
+        entry["latest_phase"] = (
+            available_phases[-1] if available_phases else None
+        )
+        late_terminal = raw_entry.get("late_terminal")
+        turn_terminal = raw_entry.get("turn_terminal")
+        outcome_resolved = False
+        if isinstance(late_terminal, Mapping):
+            late_payload = late_terminal.get("payload")
+            outcome_resolved = bool(
+                late_terminal.get("outcome") == "late_success"
+                and late_terminal.get("effect_status")
+                not in {None, "indeterminate", "unknown"}
+                and isinstance(late_payload, Mapping)
+                and late_payload.get("mutation_outcome") != "unknown"
+            )
+        elif isinstance(turn_terminal, Mapping):
+            transport = turn_terminal.get("transport")
+            receipt = turn_terminal.get("receipt")
+            outcome_resolved = bool(
+                isinstance(transport, Mapping)
+                and transport.get("outcome")
+                not in {None, "timed_out"}
+                and turn_terminal.get("effect_status")
+                not in {None, "indeterminate", "unknown"}
+                and isinstance(receipt, Mapping)
+                and receipt.get("mutation_outcome") != "unknown"
+            )
+        entry["outcome_resolved"] = outcome_resolved
+        summary.append(entry)
+    return summary, len(items)
 
 
 def _extract_turn_execution_tool_invocation_summary(
@@ -21779,6 +21956,12 @@ def _rag_get_item(**kwargs):
         ) = _summarise_late_effect_observations(
             doc.get("late_effect_observations")
         )
+        (
+            effect_observation_journal,
+            effect_observation_journal_count,
+        ) = _summarise_effect_observation_journal(
+            doc.get("effect_observation_journal")
+        )
 
         payload = {
             "collection": collection,
@@ -21825,6 +22008,14 @@ def _rag_get_item(**kwargs):
             "late_effect_observations": late_effect_observations,
             "late_effect_observations_truncated": (
                 late_effect_observation_count > len(late_effect_observations)
+            ),
+            "effect_observation_journal_count": (
+                effect_observation_journal_count
+            ),
+            "effect_observation_journal": effect_observation_journal,
+            "effect_observation_journal_truncated": (
+                effect_observation_journal_count
+                > len(effect_observation_journal)
             ),
             "required_effects": required_effects,
             "postcondition_checks": postcondition_checks,
@@ -30958,6 +31149,7 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             },
             ordinary_turn_fixed_arguments={"provenance": None},
             ordinary_turn_effect=True,
+            effect_admission_window_sec=8.0,
             ordinary_turn_mutation_subject_argument="concept_id",
             description="Add or update ANY text relation (hasContent, hasDescription, hasNote, custom predicates, etc.). Use for attaching text content to concepts with flexible predicate types. More general than add_names which is specialized for hasName relations only.",
         ),
@@ -31032,6 +31224,7 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             output_schema=_add_relationship_output_schema(),
             category="write",
             ordinary_turn_effect=True,
+            effect_admission_window_sec=5.0,
             ordinary_turn_mutation_subject_argument="source_id",
             description="Add a relationship between two concepts or from a concept to a text value. Use to add instance_of/typeOf relationships (e.g., add '#V#professor' as instance_of for a person), custom predicates (e.g., '#V#hasAffiliation' → 'Auckland University'), or any binary relationship. Supports both concept-to-concept relations (target is concept ID) and text predicates (target is text value). Common predicates: 'instance_of'/'instanceOf' (maps to is_an_instance_of), 'typeOf' (maps to is_a_type_of), or custom predicates like '#V#hasAffiliation', '#V#founderOf', '#V#hasResearchInterest'. Examples: source_id='#V#nikola_k._kasabov', predicate='instance_of', target='#V#professor' OR source_id='#V#nikola_k._kasabov', predicate='#V#hasAffiliation', target='Auckland University of Technology'.",
         ),

--- a/src/backend/integrations/internal_mcp/gateway.py
+++ b/src/backend/integrations/internal_mcp/gateway.py
@@ -103,6 +103,11 @@ class MethodDefinition:
     # This is an access/effect ceiling, not a request classifier or preferred
     # solution route.
     ordinary_turn_effect: bool = False
+    # Minimum caller window required before an ordinary effect may start.  The
+    # hard timeout remains an upper bound; this separate mechanical threshold
+    # prevents a generic maximum from starving normally fast later effects.
+    # Omission retains the conservative full-hard-window requirement.
+    effect_admission_window_sec: float | None = None
     # Existing concepts may be changed only when this authoritative forward
     # subject is scoped to the trusted actor or organisation. Creation effects
     # leave this unset because their scope is fixed server-side.
@@ -116,6 +121,29 @@ class MethodDefinition:
         if self.category == "read":
             return transport.read_timeout_sec
         return transport.read_timeout_sec
+
+    def resolved_effect_admission_window(
+        self,
+        transport: InternalMCPTransport,
+    ) -> float:
+        hard_timeout = float(
+            self.resolved_timeout(transport) or transport.write_timeout_sec
+        )
+        raw_window = self.effect_admission_window_sec
+        if raw_window is None:
+            return hard_timeout
+        if self.category != "write":
+            raise ValueError(
+                "effect_admission_window_sec is valid only for write methods"
+            )
+        window = float(raw_window)
+        if window <= 0.0:
+            raise ValueError("effect_admission_window_sec must be positive")
+        if window > hard_timeout:
+            raise ValueError(
+                "effect_admission_window_sec cannot exceed the hard timeout"
+            )
+        return window
 
 
 @dataclass
@@ -228,6 +256,9 @@ class MethodCatalogue:
                     else None
                 ),
                 "ordinary_turn_effect": definition.ordinary_turn_effect,
+                "effect_admission_window_sec": (
+                    definition.effect_admission_window_sec
+                ),
                 "ordinary_turn_mutation_subject_argument": (
                     definition.ordinary_turn_mutation_subject_argument
                 ),
@@ -343,7 +374,7 @@ class InternalMCPGateway:
         payload: Optional[MutableMapping[str, Any]] = None,
         *,
         deadline_monotonic: float | None = None,
-        require_configured_timeout: bool = False,
+        require_effect_admission_window: bool = False,
         late_completion_observer: LateCompletionObserver | None = None,
     ) -> TransportResult:
         if not self._enabled:
@@ -384,6 +415,11 @@ class InternalMCPGateway:
             raise SchemaValidationError(error_message, stage="input_schema")
 
         timeout = definition.resolved_timeout(self._transport)
+        minimum_execution_window = (
+            definition.resolved_effect_admission_window(self._transport)
+            if require_effect_admission_window
+            else None
+        )
         advisory_timeout = self._transport.advisory_timeout_sec(
             definition.category,
             hard_timeout_sec=float(timeout or self._transport.read_timeout_sec),
@@ -521,7 +557,7 @@ class InternalMCPGateway:
                         category=definition.category,
                         advisory_timeout_sec=advisory_timeout,
                         deadline_monotonic=deadline_monotonic,
-                        require_configured_timeout=require_configured_timeout,
+                        minimum_execution_window_sec=minimum_execution_window,
                         log_tag=self._log_tag,
                         late_completion_observer=observed_late_completion,
                     )

--- a/src/backend/integrations/internal_mcp/transport.py
+++ b/src/backend/integrations/internal_mcp/transport.py
@@ -46,6 +46,11 @@ _DEFAULT_WRITE_ADVISORY_TIMEOUT_SEC = 20.0
 _DEFAULT_WRITE_HARD_TIMEOUT_SEC = 20.0
 _DEFAULT_HANDLER_WORKER_COUNT = 8
 _DEFAULT_HANDLER_QUEUE_CAPACITY = 32
+# A task admitted with a minimum equal to its hard timeout necessarily loses a
+# few microseconds between the submission and worker locks.  This is the only
+# scheduling tolerance applied at handler start; materially queued work must
+# still retain its configured minimum.
+_EFFECT_ADMISSION_START_TOLERANCE_SEC = 0.005
 _LATE_COMPLETION_HISTORY_LIMIT = 50
 _LATE_COMPLETION_MAX_PAYLOAD_CHARS = 32_000
 _LATE_COMPLETION_MAX_RECEIPT_FIELD_CHARS = 4_000
@@ -197,6 +202,8 @@ class TransportResult:
     transport_overhead_ms: float | None = None
     timeout_phase: str | None = None
     late_result_policy: str = "discard_from_turn"
+    configured_hard_timeout_sec: float | None = None
+    minimum_execution_window_sec: float | None = None
 
     @property
     def timed_out(self) -> bool:
@@ -219,6 +226,8 @@ class TransportResult:
             "transport_overhead_ms": self.transport_overhead_ms,
             "timeout_phase": self.timeout_phase,
             "late_result_policy": self.late_result_policy,
+            "configured_hard_timeout_sec": self.configured_hard_timeout_sec,
+            "minimum_execution_window_sec": self.minimum_execution_window_sec,
         }
 
 
@@ -236,6 +245,7 @@ class _HandlerTask:
     submitted_at: float
     on_late_completion: Callable[["_HandlerTask"], None]
     category: str = "read"
+    minimum_execution_window_sec: float | None = None
     late_completion_observer: LateCompletionObserver | None = None
     cancellation_event: threading.Event = field(default_factory=threading.Event)
     done_event: threading.Event = field(default_factory=threading.Event)
@@ -247,6 +257,8 @@ class _HandlerTask:
     exception: BaseException | None = None
     terminal_returned: bool = False
     cancelled_before_start: bool = False
+    admission_denied_before_start: bool = False
+    admission_remaining_window_sec: float | None = None
     late_completion_recorded: bool = False
 
     def _invoke(self) -> Any:
@@ -270,6 +282,25 @@ class _HandlerTask:
                 self.completed_monotonic = time.monotonic()
                 self.done_event.set()
                 return
+            admission_checked_monotonic = time.monotonic()
+            if self.minimum_execution_window_sec is not None:
+                remaining_window_sec = max(
+                    0.0,
+                    self.deadline_monotonic - admission_checked_monotonic,
+                )
+                self.admission_remaining_window_sec = remaining_window_sec
+                if (
+                    remaining_window_sec
+                    + _EFFECT_ADMISSION_START_TOLERANCE_SEC
+                    < self.minimum_execution_window_sec
+                ):
+                    self.admission_denied_before_start = True
+                    # No handler starts, so no late receipt can exist.
+                    self.late_completion_observer = None
+                    self.completed_at = time.perf_counter()
+                    self.completed_monotonic = admission_checked_monotonic
+                    self.done_event.set()
+                    return
             self.started_at = time.perf_counter()
 
         try:
@@ -287,7 +318,11 @@ class _HandlerTask:
             self.exception = exception
             self.completed_at = completed_at
             self.completed_monotonic = completed_monotonic
-            was_late = self.terminal_returned
+            was_late = bool(
+                self.terminal_returned
+                or completed_monotonic > self.deadline_monotonic
+            )
+            # Wake the caller before any potentially blocking durable observer.
             self.done_event.set()
 
         if was_late:
@@ -666,6 +701,55 @@ class InternalMCPTransport:
             payload["mutation_outcome"] = "not_started"
         return payload
 
+    @staticmethod
+    def _admission_denied_payload(
+        *,
+        method_name: str,
+        execution_id: str,
+        category: str,
+        configured_hard_timeout_sec: float,
+        minimum_window_sec: float,
+        effective_window_sec: float,
+        remaining_window_sec: float,
+        timeout_phase: str,
+        queue_duration_ms: float,
+    ) -> Dict[str, Any]:
+        is_write = str(category or "").strip().lower() == "write"
+        payload: Dict[str, Any] = {
+            "success": False,
+            "status": "not_started",
+            "error": (
+                f"{method_name!r} was not started because the caller's "
+                "remaining window is shorter than its minimum admission "
+                "window."
+            ),
+            "error_code": (
+                "insufficient_effect_window"
+                if is_write
+                else "insufficient_execution_window"
+            ),
+            "error_type": "admission_denied",
+            "retryable": True,
+            "execution_id": execution_id,
+            "configured_hard_timeout_seconds": configured_hard_timeout_sec,
+            "minimum_admission_window_seconds": minimum_window_sec,
+            "effective_execution_window_seconds": effective_window_sec,
+            "remaining_execution_window_seconds": remaining_window_sec,
+            "timeout_phase": timeout_phase,
+            "queue_duration_ms": queue_duration_ms,
+            "outcome_finality": "terminal_for_turn",
+            "recovery_affordances": [
+                {
+                    "action_type": (
+                        "return_bounded_failure_or_retry_in_new_turn"
+                    )
+                }
+            ],
+        }
+        if is_write:
+            payload["mutation_outcome"] = "not_started"
+        return payload
+
     def execute(
         self,
         *,
@@ -676,7 +760,7 @@ class InternalMCPTransport:
         category: str = "read",
         advisory_timeout_sec: float | None = None,
         deadline_monotonic: float | None = None,
-        require_configured_timeout: bool = False,
+        minimum_execution_window_sec: float | None = None,
         log_tag: str = "[mcp_gateway]",
         late_completion_observer: LateCompletionObserver | None = None,
     ) -> TransportResult:
@@ -701,6 +785,16 @@ class InternalMCPTransport:
                 else self._read_timeout_sec
             )
         )
+        minimum_window_sec: float | None = None
+        if minimum_execution_window_sec is not None:
+            minimum_window_sec = float(minimum_execution_window_sec)
+            if minimum_window_sec <= 0.0:
+                raise ValueError("minimum_execution_window_sec must be positive")
+            if minimum_window_sec > configured_hard_timeout_sec:
+                raise ValueError(
+                    "minimum_execution_window_sec cannot exceed the configured "
+                    "hard timeout"
+                )
         submitted_at = time.perf_counter()
         submitted_monotonic = time.monotonic()
         hard_timeout_sec = configured_hard_timeout_sec
@@ -731,43 +825,20 @@ class InternalMCPTransport:
         )
 
         if (
-            require_configured_timeout
-            and deadline_monotonic is not None
-            and hard_timeout_sec < configured_hard_timeout_sec
+            minimum_window_sec is not None
+            and hard_timeout_sec < minimum_window_sec
         ):
-            is_write = str(category or "").strip().lower() == "write"
-            payload: Dict[str, Any] = {
-                "success": False,
-                "status": "not_started",
-                "error": (
-                    f"{method_name!r} was not started because the caller's "
-                    "remaining window is shorter than its configured hard "
-                    "execution window."
-                ),
-                "error_code": (
-                    "insufficient_effect_window"
-                    if is_write
-                    else "insufficient_execution_window"
-                ),
-                "error_type": "admission_denied",
-                "retryable": True,
-                "execution_id": execution_id,
-                "configured_execution_window_seconds": (
-                    configured_hard_timeout_sec
-                ),
-                "remaining_execution_window_seconds": hard_timeout_sec,
-                "timeout_phase": "pre_dispatch",
-                "outcome_finality": "terminal_for_turn",
-                "recovery_affordances": [
-                    {
-                        "action_type": (
-                            "return_bounded_failure_or_retry_in_new_turn"
-                        )
-                    }
-                ],
-            }
-            if is_write:
-                payload["mutation_outcome"] = "not_started"
+            payload = self._admission_denied_payload(
+                method_name=method_name,
+                execution_id=execution_id,
+                category=category,
+                configured_hard_timeout_sec=configured_hard_timeout_sec,
+                minimum_window_sec=minimum_window_sec,
+                effective_window_sec=hard_timeout_sec,
+                remaining_window_sec=hard_timeout_sec,
+                timeout_phase="pre_dispatch",
+                queue_duration_ms=0.0,
+            )
             return TransportResult(
                 payload=payload,
                 duration_ms=max(0.0, (time.perf_counter() - submitted_at) * 1000.0),
@@ -780,6 +851,8 @@ class InternalMCPTransport:
                 handler_elapsed_ms=None,
                 transport_overhead_ms=0.0,
                 timeout_phase="pre_dispatch",
+                configured_hard_timeout_sec=configured_hard_timeout_sec,
+                minimum_execution_window_sec=minimum_window_sec,
             )
 
         if hard_timeout_sec <= 0.0:
@@ -808,6 +881,8 @@ class InternalMCPTransport:
                 handler_elapsed_ms=None,
                 transport_overhead_ms=0.0,
                 timeout_phase="pre_dispatch",
+                configured_hard_timeout_sec=configured_hard_timeout_sec,
+                minimum_execution_window_sec=minimum_window_sec,
             )
 
         task = _HandlerTask(
@@ -820,6 +895,7 @@ class InternalMCPTransport:
             submitted_at=submitted_at,
             on_late_completion=self._record_late_completion,
             category=category,
+            minimum_execution_window_sec=minimum_window_sec,
             late_completion_observer=(
                 late_completion_observer if observe_late_write else None
             ),
@@ -856,11 +932,12 @@ class InternalMCPTransport:
                 handler_elapsed_ms=None,
                 transport_overhead_ms=0.0,
                 timeout_phase="queue",
+                configured_hard_timeout_sec=configured_hard_timeout_sec,
+                minimum_execution_window_sec=minimum_window_sec,
             )
 
         completed = task.done_event.wait(timeout=hard_timeout_sec)
         terminal_at = time.perf_counter()
-        record_already_completed_late = False
         with task.lock:
             completed_within_deadline = bool(
                 (completed or task.done_event.is_set())
@@ -878,22 +955,66 @@ class InternalMCPTransport:
                     # lock so no future worker path can imply otherwise.
                     task.late_completion_observer = None
                 task_completed = False
-                record_already_completed_late = bool(
-                    task.done_event.is_set()
-                    and task.completed_monotonic is not None
-                    and task.completed_monotonic > handler_deadline_monotonic
-                )
             result = task.result
             exception = task.exception
             started_at = task.started_at
-        if record_already_completed_late:
-            self._record_late_completion(task)
+            admission_denied_before_start = (
+                task.admission_denied_before_start
+            )
+            admission_remaining_window_sec = (
+                task.admission_remaining_window_sec
+            )
 
         queue_ms, handler_ms, handler_elapsed_ms = self._timing_snapshot(
             task,
             terminal_at=terminal_at,
         )
         duration_ms = max(0.0, (terminal_at - submitted_at) * 1000.0)
+
+        if task_completed and admission_denied_before_start:
+            remaining_window_sec = max(
+                0.0,
+                float(admission_remaining_window_sec or 0.0),
+            )
+            admission_payload = self._admission_denied_payload(
+                method_name=method_name,
+                execution_id=execution_id,
+                category=category,
+                configured_hard_timeout_sec=configured_hard_timeout_sec,
+                minimum_window_sec=float(minimum_window_sec or 0.0),
+                effective_window_sec=hard_timeout_sec,
+                remaining_window_sec=remaining_window_sec,
+                timeout_phase="queue",
+                queue_duration_ms=queue_ms,
+            )
+            advisory_exceeded = duration_ms > advisory_sec * 1000.0
+            logger.info(
+                "%s denied queued admission for %s after %.2fms "
+                "(remaining=%.3fs, minimum=%.3fs, execution_id=%s)",
+                log_tag,
+                method_name,
+                duration_ms,
+                remaining_window_sec,
+                minimum_window_sec,
+                execution_id,
+            )
+            return TransportResult(
+                payload=admission_payload,
+                duration_ms=duration_ms,
+                execution_id=execution_id,
+                outcome="not_started",
+                timeout_sec=hard_timeout_sec,
+                advisory_timeout_sec=advisory_sec,
+                advisory_budget_exceeded=advisory_exceeded,
+                queue_duration_ms=queue_ms,
+                handler_duration_ms=None,
+                handler_elapsed_ms=None,
+                transport_overhead_ms=max(0.0, duration_ms - queue_ms),
+                timeout_phase="queue",
+                late_result_policy="discard_from_turn",
+                configured_hard_timeout_sec=configured_hard_timeout_sec,
+                minimum_execution_window_sec=minimum_window_sec,
+            )
 
         if not task_completed:
             with self._diagnostics_lock:
@@ -944,6 +1065,8 @@ class InternalMCPTransport:
                 transport_overhead_ms=transport_overhead_ms,
                 timeout_phase=timeout_phase,
                 late_result_policy=late_result_policy,
+                configured_hard_timeout_sec=configured_hard_timeout_sec,
+                minimum_execution_window_sec=minimum_window_sec,
             )
 
         if exception is not None:
@@ -975,6 +1098,8 @@ class InternalMCPTransport:
             handler_duration_ms=handler_ms,
             handler_elapsed_ms=handler_ms,
             transport_overhead_ms=transport_overhead_ms,
+            configured_hard_timeout_sec=configured_hard_timeout_sec,
+            minimum_execution_window_sec=minimum_window_sec,
         )
 
     def get_diagnostics(self) -> Dict[str, Any]:

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -957,7 +957,7 @@ class _RestrictedGateway:
         *,
         deadline_monotonic: float | None = None,
         late_completion_observer: Any | None = None,
-        require_configured_timeout: bool = False,
+        require_effect_admission_window: bool = False,
     ):
         if not self._allow_writes:
             meta = self._gateway.describe_methods().get(method_name) or {}
@@ -972,7 +972,7 @@ class _RestrictedGateway:
             payload,
             deadline_monotonic=deadline_monotonic,
             late_completion_observer=late_completion_observer,
-            require_configured_timeout=require_configured_timeout,
+            require_effect_admission_window=require_effect_admission_window,
         )
 
 

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -2787,10 +2787,28 @@ def _build_health_runtime_authority_projection(app: Flask) -> dict[str, object]:
                 "scheduler_running": None,
             }
 
+    try:
+        from ..services.model_registry_service import (
+            get_model_registry_snapshot_status,
+        )
+
+        model_registry = dict(get_model_registry_snapshot_status())
+    except Exception:
+        model_registry = {
+            "schema_version": "model_registry_snapshot_status.v1",
+            "ready": False,
+            "source": None,
+            "cache_state": "unavailable",
+            "age_seconds": None,
+            "refresh_in_progress": False,
+            "last_refresh_succeeded": None,
+        }
+
     return {
         "schema_version": "health_runtime_authority_projection.v1",
         "mongo": mongo,
         "durable_workflows": durable,
+        "model_registry": model_registry,
     }
 
 

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -1784,6 +1784,35 @@ def execute_adaptive_turn(
             effect_states[effect_id] = state
             effect_state_generation += 1
 
+    def persist_effect_observation_phase(
+        *,
+        effect_id: str,
+        phase: str,
+        observation: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        if not turn_id:
+            return {
+                "updated": False,
+                "duplicate": False,
+                "reason": "missing_request_id",
+            }
+        from src.backend.services.turn_execution_record_service import (
+            record_effect_observation_phase,
+        )
+
+        return record_effect_observation_phase(
+            request_id=turn_id,
+            effect_id=effect_id,
+            phase=phase,
+            observation=observation,
+            user_id=scope.user_concept_id,
+            namespace=scope.namespace,
+            org_id=scope.organisation_concept_id,
+        )
+
+    def _effect_phase_acknowledged(outcome: Mapping[str, Any]) -> bool:
+        return bool(outcome.get("updated") or outcome.get("duplicate"))
+
     def late_effect_observer(
         *,
         effect_id: str,
@@ -1804,6 +1833,22 @@ def execute_adaptive_turn(
                     "mutation_outcome": "unknown",
                 }
             )
+            phase_outcome = persist_effect_observation_phase(
+                effect_id=effect_id,
+                phase="late_terminal",
+                observation={
+                    **observed,
+                    "call_id": call_id,
+                    "capability_name": capability_name,
+                    "effect_status": effect_status,
+                    "changed": changed,
+                },
+            )
+            if not _effect_phase_acknowledged(phase_outcome):
+                raise RuntimeError(
+                    "late_effect_observation_not_persisted:"
+                    f"{phase_outcome.get('reason') or 'not_acknowledged'}"
+                )
             envelope = evidence_store.record(
                 capability_name,
                 call_id,
@@ -1831,27 +1876,6 @@ def execute_adaptive_turn(
                 execution_id=execution_id,
                 late_observation=observed,
                 evidence_id=envelope.evidence_id,
-            )
-            if not turn_id or not execution_id:
-                return
-            from src.backend.services.turn_execution_record_service import (
-                submit_late_effect_observation,
-            )
-
-            submit_late_effect_observation(
-                request_id=turn_id,
-                effect_id=effect_id,
-                execution_id=execution_id,
-                observation={
-                    **observed,
-                    "call_id": call_id,
-                    "capability_name": capability_name,
-                    "effect_status": effect_status,
-                    "changed": changed,
-                },
-                user_id=scope.user_concept_id,
-                namespace=scope.namespace,
-                org_id=scope.organisation_concept_id,
             )
 
         return observe
@@ -2706,39 +2730,43 @@ def execute_adaptive_turn(
                         canonical_name,
                         is_effect,
                     )
-            if is_effect:
-                configured_effect_window = gateway.get_method_timeout_sec(
-                    canonical_name
+            effect_identifier = (
+                _effect_id(
+                    turn_id=turn_id,
+                    call_id=call.call_id,
+                    capability_name=canonical_name,
                 )
-                remaining_research_window = max(
-                    0.0,
-                    research_deadline - clock(),
+                if is_effect
+                else None
+            )
+            if effect_identifier is not None:
+                dispatch_outcome = persist_effect_observation_phase(
+                    effect_id=effect_identifier,
+                    phase="dispatch_intent",
+                    observation={
+                        "call_id": call.call_id,
+                        "capability_name": canonical_name,
+                        "dispatch_state": "intent_recorded",
+                    },
                 )
-                if (
-                    configured_effect_window is not None
-                    and configured_effect_window > remaining_research_window
-                ):
+                if not _effect_phase_acknowledged(dispatch_outcome):
                     return index, (
                         {
                             **_error_payload(
-                                "insufficient_effect_window",
+                                "effect_observation_unavailable",
                                 (
-                                    f"{canonical_name!r} was not started because "
-                                    "the remaining research window is shorter "
-                                    "than its configured hard execution window."
+                                    "The effect was not started because its "
+                                    "durable observation intent could not be "
+                                    "recorded."
                                 ),
                                 retryable=True,
                             ),
                             "status": "not_started",
                             "mutation_outcome": "not_started",
                             "outcome_finality": "terminal_for_turn",
-                            "configured_effect_window_seconds": round(
-                                configured_effect_window,
-                                6,
-                            ),
-                            "remaining_research_window_seconds": round(
-                                remaining_research_window,
-                                6,
+                            "persistence_reason": (
+                                dispatch_outcome.get("reason")
+                                or "not_acknowledged"
                             ),
                             "recovery_affordances": [
                                 {
@@ -2754,15 +2782,6 @@ def execute_adaptive_turn(
                         is_effect,
                     )
             try:
-                effect_identifier = (
-                    _effect_id(
-                        turn_id=turn_id,
-                        call_id=call.call_id,
-                        capability_name=canonical_name,
-                    )
-                    if is_effect
-                    else None
-                )
                 with override_current_actor(
                     scope.user_concept_id,
                     scope.organisation_concept_id,
@@ -2780,7 +2799,7 @@ def execute_adaptive_turn(
                             if effect_identifier is not None
                             else None
                         ),
-                        require_configured_timeout=is_effect,
+                        require_effect_admission_window=is_effect,
                     )
                 raw_payload = transport_result.payload
             except SchemaValidationError as exc:
@@ -2814,6 +2833,62 @@ def execute_adaptive_turn(
                 if is_effect:
                     raw_payload["mutation_outcome"] = "unknown"
                 transport_result = None
+            if effect_identifier is not None:
+                transport_metadata_fn = getattr(
+                    transport_result,
+                    "telemetry_metadata",
+                    None,
+                )
+                transport_metadata = (
+                    transport_metadata_fn()
+                    if callable(transport_metadata_fn)
+                    else {}
+                )
+                terminal_effect_status = _effect_status(
+                    raw_payload,
+                    transport_result=transport_result,
+                )
+                changed = (
+                    raw_payload.get("changed")
+                    if isinstance(raw_payload, Mapping)
+                    and isinstance(raw_payload.get("changed"), bool)
+                    else (
+                        False
+                        if terminal_effect_status == "failed"
+                        else None
+                    )
+                )
+                terminal_outcome = persist_effect_observation_phase(
+                    effect_id=effect_identifier,
+                    phase="turn_terminal",
+                    observation={
+                        "call_id": call.call_id,
+                        "capability_name": canonical_name,
+                        "effect_status": terminal_effect_status,
+                        "changed": changed,
+                        "transport": transport_metadata,
+                        "receipt": (
+                            dict(raw_payload)
+                            if isinstance(raw_payload, Mapping)
+                            else {"value": raw_payload}
+                        ),
+                    },
+                )
+                if not _effect_phase_acknowledged(terminal_outcome):
+                    aux_calls.append(
+                        {
+                            "type": "effect_observation_persistence_failure",
+                            "schema_version": (
+                                "effect_observation_persistence_failure.v1"
+                            ),
+                            "effect_id": effect_identifier,
+                            "phase": "turn_terminal",
+                            "reason": (
+                                terminal_outcome.get("reason")
+                                or "not_acknowledged"
+                            ),
+                        }
+                    )
             return index, (
                 raw_payload,
                 transport_result,

--- a/src/backend/services/concept_resolution_service.py
+++ b/src/backend/services/concept_resolution_service.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, Sequence, Tuple
 from bson import ObjectId
 
 from .concept_search_service import _search_text_relations
-from .text_value_service import get_texts_for_concept
+from .text_value_service import get_texts_for_concept, get_texts_for_concepts
 from ..db.repositories.concepts_repository import ConceptsRepository
 from ..db.repositories.text_value_repository import (
     TextRelationsRepository,
@@ -146,7 +146,12 @@ def resolve_concept_by_name(
     # Stage 1: exact name match via text relations.
     for query_text, variant in query_variants:
         hits = _accessible_candidate_ids(
-            _search_text_relations(query_text, exact=True)
+            _search_text_relations(
+                query_text,
+                exact=True,
+                result_limit=max_results,
+                allow_fallback_scan=False,
+            )
         )
         if hits:
             audit.append(
@@ -163,7 +168,11 @@ def resolve_concept_by_name(
     # Stage 2+: broaden if nothing found.
     if not candidate_ids:
         hits = _accessible_candidate_ids(
-            _search_text_relations(raw, prefix=True)
+            _search_text_relations(
+                raw,
+                prefix=True,
+                result_limit=max_results,
+            )
         )
         audit.append(
             {
@@ -176,7 +185,9 @@ def resolve_concept_by_name(
         candidate_ids.update(hits)
 
     if not candidate_ids:
-        hits = _accessible_candidate_ids(_search_text_relations(raw))
+        hits = _accessible_candidate_ids(
+            _search_text_relations(raw, result_limit=max_results)
+        )
         audit.append(
             {
                 "stage": "candidate_generation",
@@ -387,13 +398,26 @@ def resolve_concept_by_name(
     }
 
     matches: list[_CandidateMatch] = []
+    ordered_candidate_ids = sorted(candidate_ids)
+    name_query_metadata: dict[str, Any] = {}
+    names_by_concept_id = get_texts_for_concepts(
+        ordered_candidate_ids,
+        predicate="hasName",
+        limit_per_concept=200,
+        query_metadata=name_query_metadata,
+    )
+    if name_query_metadata.get("relation_query_truncated") is True:
+        names_by_concept_id = {
+            concept_id: get_texts_for_concept(
+                concept_id,
+                predicate="hasName",
+                limit=200,
+            )
+            for concept_id in ordered_candidate_ids
+        }
 
-    for concept_id in sorted(candidate_ids):
-        names = get_texts_for_concept(
-            concept_id,
-            predicate="hasName",
-            limit=200,
-        )
+    for concept_id in ordered_candidate_ids:
+        names = names_by_concept_id.get(concept_id, [])
 
         best: Optional[_CandidateMatch] = None
         for name_doc in names:

--- a/src/backend/services/concept_search_service.py
+++ b/src/backend/services/concept_search_service.py
@@ -421,6 +421,7 @@ def _search_text_relations(
     prefix: bool = False,
     include_description: bool = False,
     result_limit: Optional[int] = None,
+    allow_fallback_scan: bool = True,
 ) -> set[str]:
     """Search modern text_relations schema for matching concept IDs.
 
@@ -434,6 +435,9 @@ def _search_text_relations(
         prefix: If True, match query at start of text (prefix match)
         include_description: If True, search hasDescription predicate too
         result_limit: Caller result window used to bound intermediate candidates
+        allow_fallback_scan: If False, return after indexed text lookup misses
+            instead of scanning predicate-linked text values. Staged callers can
+            use this when their next broader stage subsumes the exact match.
 
     Returns:
         Set of concept_ids that have matching text relations
@@ -493,7 +497,7 @@ def _search_text_relations(
                 )
             )
 
-    if not matching_texts:
+    if not matching_texts and allow_fallback_scan:
         matching_texts = _scan_text_values_for_match(
             normalized_query,
             predicates,

--- a/src/backend/services/create_concepts_duplicate_guard_service.py
+++ b/src/backend/services/create_concepts_duplicate_guard_service.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from ..db.repositories.concepts_repository import ConceptsRepository
 from ..utils.concept_id_utils import canonicalise_vontology_concept_id
+from .relationship_write_service import compute_kind_from_relationships
 from ..workflows.workflow_concept_authority_service import (
     WORKFLOW_INSTANCE_TYPE_ID_CANDIDATES,
     resolve_available_workflow_type_ids,
@@ -34,6 +35,15 @@ _SAFE_CREATE_DUPLICATE_RESOLUTION_STAGES = {
     "diacritic_insensitive",
     "token_exact",
 }
+_DUPLICATE_GUARD_PROJECTION = {
+    "concept_id": 1,
+    "kind": 1,
+    "computed_kind": 1,
+    "relationships.is_a_type_of": 1,
+    "relationships.#V#is_a_type_of": 1,
+    "relationships.is_an_instance_of": 1,
+    "relationships.#V#is_an_instance_of": 1,
+}
 
 
 @dataclass(frozen=True)
@@ -41,6 +51,12 @@ class CreateConceptDuplicateGuardMatch:
     existing_concept_id: str
     match_source: str
     guard_scope: str
+    identity_conflict: bool = False
+    existing_kind: str | None = None
+    requested_kind: str | None = None
+    existing_parent_ids: tuple[str, ...] = ()
+    requested_parent_id: str | None = None
+    mismatch_reasons: tuple[str, ...] = ()
 
 
 def _normalise_kind(kind: str | None) -> str:
@@ -74,28 +90,89 @@ def _extract_str_list(value: Any) -> list[str]:
     return []
 
 
+def _normalised_relationships(doc: dict[str, Any]) -> dict[str, Any]:
+    relationships = doc.get("relationships")
+    if not isinstance(relationships, dict):
+        return {}
+
+    normalised = dict(relationships)
+    for canonical_key, compatibility_key in (
+        ("is_a_type_of", "#V#is_a_type_of"),
+        ("is_an_instance_of", "#V#is_an_instance_of"),
+    ):
+        if canonical_key not in normalised:
+            compatibility_value = normalised.get(compatibility_key)
+            if compatibility_value:
+                normalised[canonical_key] = compatibility_value
+    return normalised
+
+
 def _infer_kind(doc: dict[str, Any]) -> str | None:
-    computed = doc.get("computed_kind")
-    if isinstance(computed, str):
+    relationships = _normalised_relationships(doc)
+    if any(
+        relationships.get(key)
+        for key in ("is_a_type_of", "is_an_instance_of")
+    ):
+        inferred = compute_kind_from_relationships(relationships)
+        return "instance" if inferred == "individual" else inferred
+
+    for field_name in ("computed_kind", "kind"):
+        computed = doc.get(field_name)
+        if not isinstance(computed, str):
+            continue
         raw = computed.strip().lower()
         if raw == "individual":
             return "instance"
         if raw in {"type", "instance", "predicate"}:
             return raw
-
-    relationships = doc.get("relationships")
-    if not isinstance(relationships, dict):
-        return None
-
-    is_type_of = _extract_str_list(relationships.get("is_a_type_of"))
-    is_instance_of = _extract_str_list(relationships.get("is_an_instance_of"))
-    if is_type_of:
-        return "type"
-    if "#V#predicate" in is_instance_of:
-        return "predicate"
-    if is_instance_of:
-        return "instance"
     return None
+
+
+def _existing_parent_ids(doc: dict[str, Any], requested_kind: str) -> tuple[str, ...]:
+    relationships = _normalised_relationships(doc)
+    relationship_key = (
+        "is_a_type_of" if requested_kind == "type" else "is_an_instance_of"
+    )
+    parent_ids: list[str] = []
+    seen: set[str] = set()
+    for raw_parent_id in _extract_str_list(relationships.get(relationship_key)):
+        canonical_parent_id = (
+            canonicalise_vontology_concept_id(raw_parent_id) or raw_parent_id
+        )
+        if canonical_parent_id in seen:
+            continue
+        parent_ids.append(canonical_parent_id)
+        seen.add(canonical_parent_id)
+    return tuple(parent_ids)
+
+
+def _identity_mismatch_details(
+    *,
+    doc: dict[str, Any],
+    scope: str,
+    parent_id_for_concept: str | None,
+) -> tuple[str | None, str, tuple[str, ...], str | None, tuple[str, ...]]:
+    requested_kind = "instance" if scope == "workflow_instance" else scope
+    existing_kind = _infer_kind(doc)
+    existing_parent_ids = _existing_parent_ids(doc, requested_kind)
+    requested_parent_id = canonicalise_vontology_concept_id(parent_id_for_concept)
+
+    mismatch_reasons: list[str] = []
+    if existing_kind != requested_kind:
+        mismatch_reasons.append("kind_mismatch")
+    if (
+        scope in {"instance", "workflow_instance"}
+        and requested_parent_id
+        and requested_parent_id not in set(existing_parent_ids)
+    ):
+        mismatch_reasons.append("parent_mismatch")
+    return (
+        existing_kind,
+        requested_kind,
+        existing_parent_ids,
+        requested_parent_id,
+        tuple(mismatch_reasons),
+    )
 
 
 def _guard_scope_for_request(
@@ -126,36 +203,33 @@ def _matches_guard_scope(
     scope: str,
     parent_id_for_concept: str | None,
 ) -> bool:
-    inferred_kind = _infer_kind(doc)
-    relationships = doc.get("relationships")
-    if isinstance(relationships, dict):
-        instance_of = set(_extract_str_list(relationships.get("is_an_instance_of")))
-    else:
-        instance_of = set()
-
-    if scope == "type":
-        return inferred_kind == "type"
-    if scope == "predicate":
-        return inferred_kind == "predicate" or "#V#predicate" in instance_of
-    if scope == "instance":
-        if inferred_kind != "instance":
-            return False
-        canonical_parent = canonicalise_vontology_concept_id(parent_id_for_concept)
-        if canonical_parent:
-            return canonical_parent in instance_of
-        return True
+    (
+        existing_kind,
+        _requested_kind,
+        existing_parent_ids,
+        requested_parent_id,
+        mismatch_reasons,
+    ) = _identity_mismatch_details(
+        doc=doc,
+        scope=scope,
+        parent_id_for_concept=parent_id_for_concept,
+    )
     if scope == "workflow_instance":
-        canonical_parent = canonicalise_vontology_concept_id(parent_id_for_concept)
-        if canonical_parent and canonical_parent in instance_of:
+        if existing_kind != "instance":
+            return False
+        if requested_parent_id and requested_parent_id in set(existing_parent_ids):
             return True
-        return bool(instance_of.intersection(_workflow_type_ids()))
-    return False
+        return bool(set(existing_parent_ids).intersection(_workflow_type_ids()))
+    return not mismatch_reasons
 
 
 def _find_concept(concept_id: str) -> dict[str, Any] | None:
     if not isinstance(concept_id, str) or not concept_id.strip():
         return None
-    doc = ConceptsRepository.find_one({"concept_id": concept_id.strip()})
+    doc = ConceptsRepository.find_one(
+        {"concept_id": concept_id.strip()},
+        _DUPLICATE_GUARD_PROJECTION,
+    )
     return doc if isinstance(doc, dict) else None
 
 
@@ -186,15 +260,28 @@ def find_existing_concept_for_create_concepts(
     canonical_requested_id = canonicalise_vontology_concept_id(concept_name)
     if canonical_requested_id:
         doc = _find_concept(canonical_requested_id)
-        if isinstance(doc, dict) and _matches_guard_scope(
-            doc=doc,
-            scope=scope,
-            parent_id_for_concept=parent_id_for_concept,
-        ):
+        if isinstance(doc, dict):
+            (
+                existing_kind,
+                requested_kind,
+                existing_parent_ids,
+                requested_parent_id,
+                mismatch_reasons,
+            ) = _identity_mismatch_details(
+                doc=doc,
+                scope=scope,
+                parent_id_for_concept=parent_id_for_concept,
+            )
             return CreateConceptDuplicateGuardMatch(
                 existing_concept_id=canonical_requested_id,
                 match_source="canonical_concept_id",
                 guard_scope=scope,
+                identity_conflict=bool(mismatch_reasons),
+                existing_kind=existing_kind,
+                requested_kind=requested_kind,
+                existing_parent_ids=existing_parent_ids,
+                requested_parent_id=requested_parent_id,
+                mismatch_reasons=mismatch_reasons,
             )
 
     if duplicate_resolution_mode == "canonical_id_only":
@@ -284,5 +371,46 @@ def build_duplicate_prevented_create_concepts_result(
         "suggestion": (
             "Use fetch_concept_content or fetch_concept on existing_concept_id before "
             "attempting create_concepts again."
+        ),
+    }
+
+
+def build_canonical_identity_conflict_create_concepts_result(
+    *,
+    requested_name: str,
+    requested_kind: str,
+    existing_concept_id: str,
+    guard_scope: str,
+    existing_kind: str | None,
+    existing_parent_ids: tuple[str, ...],
+    requested_parent_id: str | None,
+    mismatch_reasons: tuple[str, ...],
+) -> dict[str, Any]:
+    mismatch_summary = ", ".join(mismatch_reasons) or "incompatible identity"
+    return {
+        "success": False,
+        "effect_status": "failed",
+        "changed": False,
+        "message": (
+            f"Canonical concept identity '{existing_concept_id}' is already occupied "
+            f"by an incompatible concept ({mismatch_summary}). No concept was created."
+        ),
+        "concept": None,
+        "error_code": "canonical_identity_conflict",
+        "existing_concept_id": existing_concept_id,
+        "canonical_concept_id": existing_concept_id,
+        "input_name": requested_name,
+        "requested_name": requested_name,
+        "requested_kind": requested_kind,
+        "existing_kind": existing_kind,
+        "requested_parent_id": requested_parent_id,
+        "existing_parent_ids": list(existing_parent_ids),
+        "identity_mismatch_reasons": list(mismatch_reasons),
+        "duplicate_prevented": True,
+        "duplicate_guard_scope": guard_scope,
+        "duplicate_match_source": "canonical_concept_id",
+        "suggestion": (
+            "Use a different canonical name, or inspect the existing concept and "
+            "explicitly update its typing if that existing identity is the intended one."
         ),
     }

--- a/src/backend/services/create_concepts_parent_resolution_service.py
+++ b/src/backend/services/create_concepts_parent_resolution_service.py
@@ -14,7 +14,9 @@ from dataclasses import dataclass
 from typing import Any, Iterable, Mapping, Tuple
 
 from ..db.repositories.concepts_repository import ConceptsRepository
+from ..security.access_control import bypass_access_control
 from ..utils.concept_id_utils import canonicalise_vontology_concept_id
+from .relationship_write_service import compute_kind_from_relationships
 from ..workflows.workflow_concept_authority_service import (
     WORKFLOW_INSTANCE_TYPE_ID_CANDIDATES,
     resolve_available_workflow_type_ids,
@@ -22,6 +24,16 @@ from ..workflows.workflow_concept_authority_service import (
 
 
 _WORKFLOW_DEFINITION_SLUGS = frozenset({"workflowdefinition", "workflowdef"})
+_PARENT_VISIBILITY_PROJECTION = {"concept_id": 1}
+_PARENT_KIND_PROJECTION = {
+    "concept_id": 1,
+    "kind": 1,
+    "computed_kind": 1,
+    "relationships.is_a_type_of": 1,
+    "relationships.#V#is_a_type_of": 1,
+    "relationships.is_an_instance_of": 1,
+    "relationships.#V#is_an_instance_of": 1,
+}
 
 
 @dataclass(frozen=True)
@@ -50,19 +62,67 @@ class ParentResolutionResult:
         }
 
 
-def _find_concept(concept_id: str) -> Mapping[str, Any] | None:
-    concept = ConceptsRepository.find_one({"concept_id": concept_id})
-    return concept if isinstance(concept, Mapping) else None
+@dataclass(frozen=True)
+class _VisibleParentClassification:
+    concept_id: str
+    structural_kind: str | None
+
+
+def _find_concept(concept_id: str) -> _VisibleParentClassification | None:
+    visible_concept = ConceptsRepository.find_one(
+        {"concept_id": concept_id},
+        _PARENT_VISIBILITY_PROJECTION,
+    )
+    if not isinstance(visible_concept, Mapping):
+        return None
+
+    # Relationship sanitisation correctly removes targets the actor cannot
+    # inspect, but those removals must not change the parent's own structural
+    # classification. After actor visibility of the parent is established,
+    # derive only the scalar kind under bypass and do not return the raw edges.
+    with bypass_access_control():
+        structural_projection = ConceptsRepository.find_one(
+            {"concept_id": concept_id},
+            _PARENT_KIND_PROJECTION,
+        )
+    if not isinstance(structural_projection, Mapping):
+        return None
+    return _VisibleParentClassification(
+        concept_id=concept_id,
+        structural_kind=_concept_kind(structural_projection),
+    )
 
 
 def _concept_kind(concept: Mapping[str, Any] | None) -> str | None:
     if not isinstance(concept, Mapping):
         return None
-    raw_kind = concept.get("kind")
-    if not isinstance(raw_kind, str):
-        return None
-    kind = raw_kind.strip().lower()
-    return kind or None
+
+    relationships = concept.get("relationships")
+    if isinstance(relationships, Mapping):
+        normalised_relationships = dict(relationships)
+        for canonical_key, compatibility_key in (
+            ("is_a_type_of", "#V#is_a_type_of"),
+            ("is_an_instance_of", "#V#is_an_instance_of"),
+        ):
+            if canonical_key not in normalised_relationships:
+                compatibility_value = normalised_relationships.get(compatibility_key)
+                if compatibility_value:
+                    normalised_relationships[canonical_key] = compatibility_value
+
+        if any(
+            normalised_relationships.get(key)
+            for key in ("is_a_type_of", "is_an_instance_of")
+        ):
+            return compute_kind_from_relationships(normalised_relationships)
+
+    for field_name in ("computed_kind", "kind"):
+        raw_kind = concept.get(field_name)
+        if not isinstance(raw_kind, str):
+            continue
+        kind = raw_kind.strip().lower()
+        if kind in {"type", "predicate", "individual", "instance"}:
+            return kind
+    return None
 
 
 def _canonicalise_candidates(candidates: Iterable[str]) -> tuple[str, ...]:
@@ -113,7 +173,7 @@ def resolve_parent_for_create_concepts(parent_id: str) -> ParentResolutionResult
             fallback_used=False,
             fallback_candidates_checked=(),
             fallback_selected_parent_id=None,
-            resolved_parent_kind=_concept_kind(canonical_concept),
+            resolved_parent_kind=canonical_concept.structural_kind,
         )
 
     fallback_candidates = _fallback_candidates_for_parent(canonical_parent)
@@ -131,7 +191,7 @@ def resolve_parent_for_create_concepts(parent_id: str) -> ParentResolutionResult
                 fallback_used=True,
                 fallback_candidates_checked=tuple(checked),
                 fallback_selected_parent_id=candidate,
-                resolved_parent_kind=_concept_kind(candidate_concept),
+                resolved_parent_kind=candidate_concept.structural_kind,
             )
 
     return ParentResolutionResult(

--- a/src/backend/services/model_registry_service.py
+++ b/src/backend/services/model_registry_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import hashlib
 import json
 import logging
 import os
@@ -11,6 +12,7 @@ import tempfile
 import threading
 import time
 from typing import Any, Mapping, Optional, Sequence
+from urllib.parse import parse_qsl, unquote, urlsplit
 
 from .settings_service import resolve_enabled_llm_settings, resolve_llm_setting
 
@@ -50,7 +52,9 @@ PARAMETER_ACTION_FIXED_VALUE = "fixed_value"
 
 _MODEL_REGISTRY_SNAPSHOT_CACHE: dict[str, dict[str, Any]] = {}
 _MODEL_REGISTRY_SNAPSHOT_CACHE_LOCK = threading.Lock()
-_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_SCHEMA_VERSION = "model_registry_snapshot_cache.v1"
+_MODEL_REGISTRY_SNAPSHOT_REFRESH_INFLIGHT: set[str] = set()
+_MODEL_REGISTRY_SNAPSHOT_REFRESH_STATE: dict[str, dict[str, Any]] = {}
+_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_SCHEMA_VERSION = "model_registry_snapshot_cache.v2"
 _MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_SOURCES = frozenset(
     {"vontology_graph", "vontology_json"}
 )
@@ -83,9 +87,8 @@ def _registry_snapshot_cache_ttl_seconds() -> float:
 
 
 def _registry_snapshot_disk_cache_enabled() -> bool:
-    if (
-        os.getenv("PYTEST_CURRENT_TEST")
-        and not os.getenv("VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_PATH")
+    if os.getenv("PYTEST_CURRENT_TEST") and not os.getenv(
+        "VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_PATH"
     ):
         # Tests that intentionally exercise the disk cache provide an isolated
         # path.  All other pytest processes must not overwrite the live
@@ -100,6 +103,15 @@ def _registry_snapshot_disk_cache_enabled() -> bool:
 def _registry_snapshot_disk_cache_ttl_seconds() -> float:
     return _env_float_seconds(
         "VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_TTL_SECONDS",
+        default=3600.0,
+    )
+
+
+def _registry_snapshot_max_stale_seconds() -> float:
+    # The one-hour default matches one extra default refresh interval. Operators
+    # may configure the refresh and stale-grace intervals independently.
+    return _env_float_seconds(
+        "VON_MODEL_REGISTRY_SNAPSHOT_MAX_STALE_SECONDS",
         default=3600.0,
     )
 
@@ -119,21 +131,135 @@ def _registry_snapshot_cache_key(preferred_language: str | None) -> str:
     )
 
 
+def _registry_snapshot_refresh_token(
+    *, cache_key: str, authority_fingerprint: str
+) -> str:
+    return f"{cache_key}:{authority_fingerprint}"
+
+
 def _utc_iso_from_timestamp(timestamp: float) -> str:
     return datetime.fromtimestamp(timestamp, timezone.utc).isoformat()
+
+
+def _mongo_principal_fingerprint(uri: Any) -> str | None:
+    """Return a non-reversible identity for Mongo role-scoped authority."""
+
+    if not isinstance(uri, str) or not uri.strip():
+        return None
+    try:
+        parsed = urlsplit(uri.strip())
+        username = unquote(parsed.username or "").strip()
+        query_options = {
+            str(key).strip().lower(): str(value).strip()
+            for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        }
+        authority_identity = {
+            "username": username,
+            "auth_source": query_options.get("authsource", ""),
+            "auth_mechanism": query_options.get("authmechanism", ""),
+        }
+        if not any(authority_identity.values()):
+            return None
+        encoded = json.dumps(
+            authority_identity,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+    except Exception:
+        return None
+
+
+def _model_registry_authority_fingerprint() -> str:
+    """Identify the represented authority without persisting connection secrets."""
+
+    namespace = str(os.getenv("VON_DEFAULT_NAMESPACE") or "").strip()
+    try:
+        from ..db.mongo_client import (
+            get_configured_database_name,
+            get_effective_mongo_uri,
+            is_using_fallback_uri,
+        )
+        from ..db.mongo_uri_redaction import build_safe_mongo_connection_location
+
+        effective_mongo_uri = get_effective_mongo_uri()
+        authority = {
+            "database_name": get_configured_database_name(),
+            "mongo_location": build_safe_mongo_connection_location(
+                effective_mongo_uri,
+                using_fallback=is_using_fallback_uri(),
+            ),
+            "mongo_principal_fingerprint": _mongo_principal_fingerprint(
+                effective_mongo_uri
+            ),
+            "namespace": namespace,
+        }
+    except Exception:
+        # The fallback remains secret-free and separates configured databases.
+        # A later successful refresh recomputes the fingerprint from the
+        # effective, sanitised connection location before it persists.
+        authority = {
+            "database_name": str(os.getenv("VON_DB_NAME") or "von_db").strip(),
+            "mongo_location": {"available": False},
+            "namespace": namespace,
+        }
+    encoded = json.dumps(
+        authority,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _represented_registry_snapshot(snapshot: Any) -> bool:
+    if (
+        not isinstance(snapshot, Mapping)
+        or snapshot.get("source") not in _MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_SOURCES
+    ):
+        return False
+    models = snapshot.get("models")
+    if not isinstance(models, Sequence) or isinstance(models, str) or not models:
+        return False
+    for model in models:
+        if not isinstance(model, Mapping):
+            return False
+        if not any(
+            isinstance(model.get(field), str) and str(model.get(field)).strip()
+            for field in ("model_id", "concept_id", "registry_entry_id")
+        ):
+            return False
+    return True
+
+
+def _registry_snapshot_refresh_seconds() -> float:
+    if _registry_snapshot_disk_cache_enabled():
+        disk_ttl_seconds = _registry_snapshot_disk_cache_ttl_seconds()
+        if disk_ttl_seconds > 0:
+            return disk_ttl_seconds
+    return _registry_snapshot_cache_ttl_seconds()
 
 
 def _store_registry_snapshot_in_memory(
     *,
     cache_key: str,
     snapshot: Mapping[str, Any],
-    expires_at: float,
+    authority_fingerprint: str,
+    created_at: float,
+    refresh_after: float,
+    stale_until: float,
 ) -> None:
-    if expires_at <= time.time():
+    if stale_until <= time.time() or not _represented_registry_snapshot(snapshot):
         return
     with _MODEL_REGISTRY_SNAPSHOT_CACHE_LOCK:
         _MODEL_REGISTRY_SNAPSHOT_CACHE[cache_key] = {
-            "expires_at": expires_at,
+            "authority_fingerprint": authority_fingerprint,
+            "created_at": created_at,
+            "refresh_after": refresh_after,
+            "stale_until": stale_until,
             "snapshot": snapshot,
         }
 
@@ -141,8 +267,9 @@ def _store_registry_snapshot_in_memory(
 def _load_registry_snapshot_from_disk(
     *,
     cache_key: str,
+    authority_fingerprint: str,
     now: float,
-) -> tuple[Mapping[str, Any], float] | None:
+) -> Mapping[str, Any] | None:
     if not _registry_snapshot_disk_cache_enabled():
         return None
     try:
@@ -167,18 +294,41 @@ def _load_registry_snapshot_from_disk(
             return None
         if not isinstance(entry, Mapping):
             return None
-        expires_at = entry.get("expires_at")
-        if not isinstance(expires_at, (int, float)) or expires_at <= now:
+        if entry.get("authority_fingerprint") != authority_fingerprint:
+            return None
+        created_at = entry.get("created_at")
+        refresh_after = entry.get("refresh_after")
+        stale_until = entry.get("stale_until")
+        if not all(
+            isinstance(value, (int, float))
+            for value in (created_at, refresh_after, stale_until)
+        ):
+            return None
+        configured_stale_until = (
+            float(refresh_after) + _registry_snapshot_max_stale_seconds()
+        )
+        effective_stale_until = min(float(stale_until), configured_stale_until)
+        if not (
+            float(created_at) <= float(refresh_after) <= float(stale_until)
+            and effective_stale_until > now
+        ):
             return None
         source = entry.get("source")
         if source not in _MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_SOURCES:
             return None
         snapshot = entry.get("snapshot")
-        if not isinstance(snapshot, Mapping):
+        if (
+            not _represented_registry_snapshot(snapshot)
+            or snapshot.get("source") != source
+        ):
             return None
-        if snapshot.get("source") != source:
-            return None
-        return snapshot, float(expires_at)
+        return {
+            "authority_fingerprint": authority_fingerprint,
+            "created_at": float(created_at),
+            "refresh_after": float(refresh_after),
+            "stale_until": effective_stale_until,
+            "snapshot": snapshot,
+        }
     except Exception as exc:
         logger.debug("Could not load model registry snapshot disk cache: %s", exc)
         return None
@@ -189,26 +339,33 @@ def _persist_registry_snapshot_to_disk(
     cache_key: str,
     preferred_language: str | None,
     snapshot: Mapping[str, Any],
+    authority_fingerprint: str,
+    created_at: float,
+    refresh_after: float,
+    stale_until: float,
     hydrate_duration_ms: int | None,
 ) -> None:
     if not _registry_snapshot_disk_cache_enabled():
         return
+    if _registry_snapshot_disk_cache_ttl_seconds() <= 0:
+        return
     source = snapshot.get("source")
     if source not in _MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_SOURCES:
         return
-    disk_ttl_seconds = _registry_snapshot_disk_cache_ttl_seconds()
-    if disk_ttl_seconds <= 0:
+    if stale_until <= created_at:
         return
 
-    created_at = time.time()
     entry = {
         "cache_key": cache_key,
         "preferred_language": preferred_language or "",
+        "authority_fingerprint": authority_fingerprint,
         "source": source,
         "created_at": created_at,
         "created_at_utc": _utc_iso_from_timestamp(created_at),
-        "expires_at": created_at + disk_ttl_seconds,
-        "expires_at_utc": _utc_iso_from_timestamp(created_at + disk_ttl_seconds),
+        "refresh_after": refresh_after,
+        "refresh_after_utc": _utc_iso_from_timestamp(refresh_after),
+        "stale_until": stale_until,
+        "stale_until_utc": _utc_iso_from_timestamp(stale_until),
         "metadata": {
             "hydrate_duration_ms": hydrate_duration_ms,
         },
@@ -282,6 +439,8 @@ def _persist_registry_snapshot_to_disk(
 def clear_model_registry_snapshot_caches(*, remove_disk: bool = False) -> None:
     with _MODEL_REGISTRY_SNAPSHOT_CACHE_LOCK:
         _MODEL_REGISTRY_SNAPSHOT_CACHE.clear()
+        _MODEL_REGISTRY_SNAPSHOT_REFRESH_INFLIGHT.clear()
+        _MODEL_REGISTRY_SNAPSHOT_REFRESH_STATE.clear()
     if not remove_disk:
         return
     try:
@@ -768,83 +927,339 @@ def _build_registry_from_settings() -> Mapping[str, Any]:
     }
 
 
+def _usable_registry_memory_entry(
+    *,
+    cache_key: str,
+    authority_fingerprint: str,
+    now: float,
+) -> Mapping[str, Any] | None:
+    with _MODEL_REGISTRY_SNAPSHOT_CACHE_LOCK:
+        cached = _MODEL_REGISTRY_SNAPSHOT_CACHE.get(cache_key)
+        if not isinstance(cached, Mapping):
+            return None
+        if cached.get("authority_fingerprint") != authority_fingerprint:
+            return None
+        refresh_after = cached.get("refresh_after")
+        stale_until = cached.get("stale_until")
+        snapshot = cached.get("snapshot")
+        if (
+            not isinstance(refresh_after, (int, float))
+            or not isinstance(stale_until, (int, float))
+            or not _represented_registry_snapshot(snapshot)
+        ):
+            _MODEL_REGISTRY_SNAPSHOT_CACHE.pop(cache_key, None)
+            return None
+        effective_stale_until = min(
+            float(stale_until),
+            float(refresh_after) + _registry_snapshot_max_stale_seconds(),
+        )
+        if effective_stale_until <= now:
+            _MODEL_REGISTRY_SNAPSHOT_CACHE.pop(cache_key, None)
+            return None
+        return {
+            **dict(cached),
+            "stale_until": effective_stale_until,
+        }
+
+
+def _hydrate_represented_registry_snapshot(
+    *, preferred_language: str | None = None
+) -> tuple[Mapping[str, Any] | None, int]:
+    started_at = time.time()
+    try:
+        registry = _load_registry_from_vontology_graph(
+            preferred_language=preferred_language
+        )
+    except Exception as exc:
+        logger.warning("Model registry graph hydration failed: %s", exc)
+        registry = None
+    if registry is not None:
+        return (
+            {
+                "source": "vontology_graph",
+                **registry,
+            },
+            int((time.time() - started_at) * 1000),
+        )
+
+    try:
+        registry = _load_registry_from_vontology_json(
+            preferred_language=preferred_language
+        )
+    except Exception as exc:
+        logger.warning("Model registry JSON hydration failed: %s", exc)
+        registry = None
+    if registry is not None:
+        return (
+            {
+                "source": "vontology_json",
+                **registry,
+            },
+            int((time.time() - started_at) * 1000),
+        )
+    return None, int((time.time() - started_at) * 1000)
+
+
+def _commit_represented_registry_snapshot(
+    *,
+    cache_key: str,
+    preferred_language: str | None,
+    snapshot: Mapping[str, Any],
+    authority_fingerprint: str,
+    hydrate_duration_ms: int | None,
+) -> bool:
+    if not _represented_registry_snapshot(snapshot):
+        return False
+    if _model_registry_authority_fingerprint() != authority_fingerprint:
+        return False
+    created_at = time.time()
+    refresh_after = created_at + _registry_snapshot_refresh_seconds()
+    stale_until = refresh_after + _registry_snapshot_max_stale_seconds()
+    _store_registry_snapshot_in_memory(
+        cache_key=cache_key,
+        snapshot=snapshot,
+        authority_fingerprint=authority_fingerprint,
+        created_at=created_at,
+        refresh_after=refresh_after,
+        stale_until=stale_until,
+    )
+    _persist_registry_snapshot_to_disk(
+        cache_key=cache_key,
+        preferred_language=preferred_language,
+        snapshot=snapshot,
+        authority_fingerprint=authority_fingerprint,
+        created_at=created_at,
+        refresh_after=refresh_after,
+        stale_until=stale_until,
+        hydrate_duration_ms=hydrate_duration_ms,
+    )
+    refresh_token = _registry_snapshot_refresh_token(
+        cache_key=cache_key,
+        authority_fingerprint=authority_fingerprint,
+    )
+    with _MODEL_REGISTRY_SNAPSHOT_CACHE_LOCK:
+        _MODEL_REGISTRY_SNAPSHOT_REFRESH_STATE[refresh_token] = {
+            "last_refresh_succeeded": True,
+            "last_refresh_completed_at": created_at,
+        }
+    return True
+
+
+def _refresh_represented_registry_snapshot(
+    *,
+    cache_key: str,
+    preferred_language: str | None,
+    authority_fingerprint: str,
+) -> None:
+    refresh_token = _registry_snapshot_refresh_token(
+        cache_key=cache_key,
+        authority_fingerprint=authority_fingerprint,
+    )
+    try:
+        snapshot, hydrate_duration_ms = _hydrate_represented_registry_snapshot(
+            preferred_language=preferred_language
+        )
+        if snapshot is None:
+            with _MODEL_REGISTRY_SNAPSHOT_CACHE_LOCK:
+                _MODEL_REGISTRY_SNAPSHOT_REFRESH_STATE[refresh_token] = {
+                    "last_refresh_succeeded": False,
+                    "last_refresh_completed_at": time.time(),
+                    "failure_reason": "represented_registry_unavailable",
+                }
+            return
+        committed = _commit_represented_registry_snapshot(
+            cache_key=cache_key,
+            preferred_language=preferred_language,
+            snapshot=snapshot,
+            authority_fingerprint=authority_fingerprint,
+            hydrate_duration_ms=hydrate_duration_ms,
+        )
+        if not committed:
+            with _MODEL_REGISTRY_SNAPSHOT_CACHE_LOCK:
+                _MODEL_REGISTRY_SNAPSHOT_REFRESH_STATE[refresh_token] = {
+                    "last_refresh_succeeded": False,
+                    "last_refresh_completed_at": time.time(),
+                    "failure_reason": "authority_changed_during_refresh",
+                }
+    except Exception:
+        logger.exception("Model registry background refresh failed")
+        with _MODEL_REGISTRY_SNAPSHOT_CACHE_LOCK:
+            _MODEL_REGISTRY_SNAPSHOT_REFRESH_STATE[refresh_token] = {
+                "last_refresh_succeeded": False,
+                "last_refresh_completed_at": time.time(),
+                "failure_reason": "refresh_exception",
+            }
+    finally:
+        with _MODEL_REGISTRY_SNAPSHOT_CACHE_LOCK:
+            _MODEL_REGISTRY_SNAPSHOT_REFRESH_INFLIGHT.discard(refresh_token)
+
+
+def _start_registry_snapshot_background_refresh(
+    *,
+    cache_key: str,
+    preferred_language: str | None,
+    authority_fingerprint: str,
+) -> bool:
+    refresh_token = _registry_snapshot_refresh_token(
+        cache_key=cache_key,
+        authority_fingerprint=authority_fingerprint,
+    )
+    with _MODEL_REGISTRY_SNAPSHOT_CACHE_LOCK:
+        if refresh_token in _MODEL_REGISTRY_SNAPSHOT_REFRESH_INFLIGHT:
+            return False
+        _MODEL_REGISTRY_SNAPSHOT_REFRESH_INFLIGHT.add(refresh_token)
+    try:
+        threading.Thread(
+            target=_refresh_represented_registry_snapshot,
+            kwargs={
+                "cache_key": cache_key,
+                "preferred_language": preferred_language,
+                "authority_fingerprint": authority_fingerprint,
+            },
+            name="model-registry-refresh",
+            daemon=True,
+        ).start()
+        return True
+    except Exception:
+        with _MODEL_REGISTRY_SNAPSHOT_CACHE_LOCK:
+            _MODEL_REGISTRY_SNAPSHOT_REFRESH_INFLIGHT.discard(refresh_token)
+        logger.exception("Could not start model registry background refresh")
+        return False
+
+
 def get_model_registry_snapshot(
     *, preferred_language: str | None = None
 ) -> Mapping[str, Any]:
-    cache_ttl_seconds = _registry_snapshot_cache_ttl_seconds()
     cache_key = _registry_snapshot_cache_key(preferred_language)
-    now = time.time()
-    if cache_ttl_seconds > 0:
-        with _MODEL_REGISTRY_SNAPSHOT_CACHE_LOCK:
-            cached = _MODEL_REGISTRY_SNAPSHOT_CACHE.get(cache_key)
-            if isinstance(cached, Mapping):
-                expires_at = cached.get("expires_at")
-                snapshot = cached.get("snapshot")
-                if (
-                    isinstance(expires_at, (int, float))
-                    and expires_at > now
-                    and isinstance(snapshot, Mapping)
-                ):
-                    return snapshot
+    for attempt in range(2):
+        authority_fingerprint = _model_registry_authority_fingerprint()
+        now = time.time()
+        cached = _usable_registry_memory_entry(
+            cache_key=cache_key,
+            authority_fingerprint=authority_fingerprint,
+            now=now,
+        )
+        if cached is not None:
+            refresh_after = cached.get("refresh_after")
+            if isinstance(refresh_after, (int, float)) and refresh_after <= now:
+                _start_registry_snapshot_background_refresh(
+                    cache_key=cache_key,
+                    preferred_language=preferred_language,
+                    authority_fingerprint=authority_fingerprint,
+                )
+            return cached["snapshot"]
 
-    disk_cache_hit = _load_registry_snapshot_from_disk(cache_key=cache_key, now=now)
-    if disk_cache_hit is not None:
-        disk_snapshot, disk_expires_at = disk_cache_hit
-        if cache_ttl_seconds > 0:
+        cached = _load_registry_snapshot_from_disk(
+            cache_key=cache_key,
+            authority_fingerprint=authority_fingerprint,
+            now=now,
+        )
+        if cached is not None:
             _store_registry_snapshot_in_memory(
                 cache_key=cache_key,
-                snapshot=disk_snapshot,
-                expires_at=min(time.time() + cache_ttl_seconds, disk_expires_at),
+                snapshot=cached["snapshot"],
+                authority_fingerprint=authority_fingerprint,
+                created_at=float(cached["created_at"]),
+                refresh_after=float(cached["refresh_after"]),
+                stale_until=float(cached["stale_until"]),
             )
-        return disk_snapshot
+            refresh_after = cached.get("refresh_after")
+            if isinstance(refresh_after, (int, float)) and refresh_after <= now:
+                _start_registry_snapshot_background_refresh(
+                    cache_key=cache_key,
+                    preferred_language=preferred_language,
+                    authority_fingerprint=authority_fingerprint,
+                )
+            return cached["snapshot"]
 
-    graph_started_at = time.time()
-    registry = _load_registry_from_vontology_graph(
-        preferred_language=preferred_language
-    )
-    graph_duration_ms = int((time.time() - graph_started_at) * 1000)
-    if registry is not None:
-        snapshot = {
-            "source": "vontology_graph",
-            **registry,
-        }
-        if cache_ttl_seconds > 0:
-            _store_registry_snapshot_in_memory(
-                cache_key=cache_key,
-                snapshot=snapshot,
-                expires_at=time.time() + cache_ttl_seconds,
-            )
-        _persist_registry_snapshot_to_disk(
+        snapshot, hydrate_duration_ms = _hydrate_represented_registry_snapshot(
+            preferred_language=preferred_language
+        )
+        if snapshot is None:
+            break
+        committed = _commit_represented_registry_snapshot(
             cache_key=cache_key,
             preferred_language=preferred_language,
             snapshot=snapshot,
-            hydrate_duration_ms=graph_duration_ms,
+            authority_fingerprint=authority_fingerprint,
+            hydrate_duration_ms=hydrate_duration_ms,
         )
-        return snapshot
+        if committed:
+            return snapshot
+        if attempt == 0:
+            continue
+        break
 
-    json_started_at = time.time()
-    registry = _load_registry_from_vontology_json(preferred_language=preferred_language)
-    json_duration_ms = int((time.time() - json_started_at) * 1000)
-    if registry is not None:
-        snapshot = {
-            "source": "vontology_json",
-            **registry,
-        }
-        if cache_ttl_seconds > 0:
-            _store_registry_snapshot_in_memory(
-                cache_key=cache_key,
-                snapshot=snapshot,
-                expires_at=time.time() + cache_ttl_seconds,
-            )
-        _persist_registry_snapshot_to_disk(
-            cache_key=cache_key,
-            preferred_language=preferred_language,
-            snapshot=snapshot,
-            hydrate_duration_ms=json_duration_ms,
-        )
-        return snapshot
-
+    # Settings remain an availability fallback, never a durable or stale
+    # representation of model API-profile authority. In particular, a
+    # represented snapshot rejected after both bounded authority-stable
+    # hydration attempts is not returned to the caller.
     return _build_registry_from_settings()
+
+
+def get_model_registry_snapshot_status(
+    *, preferred_language: str | None = None
+) -> Mapping[str, Any]:
+    """Return a secret-free, non-hydrating registry readiness projection."""
+
+    cache_key = _registry_snapshot_cache_key(preferred_language)
+    authority_fingerprint = _model_registry_authority_fingerprint()
+    now = time.time()
+    cached = _usable_registry_memory_entry(
+        cache_key=cache_key,
+        authority_fingerprint=authority_fingerprint,
+        now=now,
+    )
+    refresh_token = _registry_snapshot_refresh_token(
+        cache_key=cache_key,
+        authority_fingerprint=authority_fingerprint,
+    )
+    with _MODEL_REGISTRY_SNAPSHOT_CACHE_LOCK:
+        refresh_in_progress = refresh_token in _MODEL_REGISTRY_SNAPSHOT_REFRESH_INFLIGHT
+        refresh_state = dict(
+            _MODEL_REGISTRY_SNAPSHOT_REFRESH_STATE.get(refresh_token) or {}
+        )
+    if cached is None:
+        return {
+            "schema_version": "model_registry_snapshot_status.v1",
+            "ready": False,
+            "source": None,
+            "cache_state": "unavailable",
+            "age_seconds": None,
+            "refresh_in_progress": refresh_in_progress,
+            "last_refresh_succeeded": refresh_state.get("last_refresh_succeeded"),
+        }
+
+    created_at = float(cached["created_at"])
+    refresh_after = float(cached["refresh_after"])
+    stale = refresh_after <= now
+    return {
+        "schema_version": "model_registry_snapshot_status.v1",
+        "ready": True,
+        "source": cached["snapshot"].get("source"),
+        "cache_state": (
+            "stale_refreshing"
+            if stale and refresh_in_progress
+            else ("stale" if stale else "fresh")
+        ),
+        "age_seconds": round(max(0.0, now - created_at), 3),
+        "refresh_in_progress": refresh_in_progress,
+        "last_refresh_succeeded": refresh_state.get("last_refresh_succeeded", True),
+    }
+
+
+def preload_model_registry_snapshot(
+    *, preferred_language: str | None = None
+) -> Mapping[str, Any]:
+    """Load represented profile authority before the HTTP server accepts calls."""
+
+    started_at = time.time()
+    get_model_registry_snapshot(preferred_language=preferred_language)
+    status = get_model_registry_snapshot_status(preferred_language=preferred_language)
+    return {
+        **status,
+        "preload_duration_ms": int((time.time() - started_at) * 1000),
+    }
 
 
 def _entry_matches_model(
@@ -990,8 +1405,7 @@ def _iter_parameter_constraints_for_entry(
         if not isinstance(profile, Mapping):
             continue
         if requested_profile_id is not None and (
-            str(profile.get("profile_concept_id") or "").strip()
-            != requested_profile_id
+            str(profile.get("profile_concept_id") or "").strip() != requested_profile_id
         ):
             continue
         constraints = profile.get("parameter_constraints")

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -13,7 +13,6 @@ import logging
 import re
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from typing import Any, Mapping, Sequence, cast
 
@@ -82,6 +81,7 @@ logger = logging.getLogger(__name__)
 TURN_EXECUTION_RECORD_SCHEMA_VERSION = "turn_execution_record.v1"
 TURN_EXECUTION_CORRECTNESS_SCHEMA_VERSION = "turn_execution_correctness.v1"
 LATE_EFFECT_OBSERVATION_SCHEMA_VERSION = "late_effect_observation.v1"
+EFFECT_OBSERVATION_JOURNAL_SCHEMA_VERSION = "effect_observation_journal.v1"
 WORKFLOW_ROUTING_DIAGNOSTICS_SCHEMA_VERSION = "workflow_routing_diagnostics.v1"
 FINAL_ANSWER_SYNTHESIS_TELEMETRY_SCHEMA_VERSION = "final_answer_synthesis_telemetry.v1"
 TOOL_EVIDENCE_PROJECTION_REACHABILITY_SCHEMA_VERSION = (
@@ -123,15 +123,10 @@ _FINAL_ANSWER_PUBLIC_PROJECTION_MAX_ENTRIES = 16
 _FINAL_ANSWER_PUBLIC_PROJECTION_MAX_FIELD_ENTRIES = 32
 _FINAL_ANSWER_PUBLIC_PROJECTION_MAX_IDENTIFIERS = 32
 _LATE_EFFECT_OBSERVATION_MAX_ID_CHARS = 512
-_LATE_EFFECT_APPEND_WORKERS = 2
-_LATE_EFFECT_APPEND_MAX_PENDING = 32
-_LATE_EFFECT_APPEND_EXECUTOR = ThreadPoolExecutor(
-    max_workers=_LATE_EFFECT_APPEND_WORKERS,
-    thread_name_prefix="late-effect-observation",
+_EFFECT_OBSERVATION_PHASES = frozenset(
+    {"dispatch_intent", "turn_terminal", "late_terminal"}
 )
-_LATE_EFFECT_APPEND_SLOTS = threading.BoundedSemaphore(
-    _LATE_EFFECT_APPEND_WORKERS + _LATE_EFFECT_APPEND_MAX_PENDING
-)
+_SAFE_EFFECT_JOURNAL_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 _FINAL_ANSWER_PROJECTION_SECRET_KEY_PARTS = (
     "access_token",
     "api_key",
@@ -10471,10 +10466,11 @@ def upsert_turn_execution_record_projection(
 
     now = _now_utc()
     payload = ensure_turn_execution_record_execution_correctness(record)
-    # Late observations arrive independently after the ordinary projection was
-    # assembled.  They are append-only and must not be replaced by a later
-    # whole-turn snapshot containing no, or stale, late-observation state.
+    # Effect observations arrive independently around the ordinary projection.
+    # They must not be replaced by a later whole-turn snapshot containing no,
+    # or stale, observation state.
     payload.pop("late_effect_observations", None)
+    payload.pop("effect_observation_journal", None)
     payload["request_id"] = request_id
     if _safe_str(user_id):
         payload["user_id"] = _safe_str(user_id)
@@ -10561,6 +10557,284 @@ def upsert_turn_execution_record_projection(
             "updated": False,
             "reason": "mongo_error",
             "request_id": request_id,
+        }
+
+
+def record_effect_observation_phase(
+    *,
+    request_id: Any,
+    effect_id: Any,
+    phase: Any,
+    observation: Mapping[str, Any],
+    user_id: Any = None,
+    session_id: Any = None,
+    namespace: Any = None,
+    org_id: Any = None,
+) -> dict[str, Any]:
+    """Persist one immutable mechanical phase for an ordinary effect.
+
+    The journal is embedded in the actor-scoped turn record and keyed by the
+    server-generated effect ID.  Each phase is written at most once.  Recovery
+    and read-back may inspect these receipts, but this service never invokes,
+    retries, requeues, or otherwise executes the underlying effect.
+    """
+
+    clean_request_id = _safe_str(request_id)
+    clean_effect_id = _safe_str(effect_id)
+    clean_phase = _safe_str(phase)
+    if not clean_request_id:
+        return {"updated": False, "reason": "missing_request_id"}
+    if (
+        not clean_effect_id
+        or len(clean_effect_id) > _LATE_EFFECT_OBSERVATION_MAX_ID_CHARS
+        or not _SAFE_EFFECT_JOURNAL_KEY_RE.fullmatch(clean_effect_id)
+    ):
+        return {
+            "updated": False,
+            "reason": "invalid_effect_id",
+            "request_id": clean_request_id,
+        }
+    if clean_phase not in _EFFECT_OBSERVATION_PHASES:
+        return {
+            "updated": False,
+            "reason": "invalid_phase",
+            "request_id": clean_request_id,
+            "effect_id": clean_effect_id,
+        }
+    if not isinstance(observation, Mapping):
+        return {
+            "updated": False,
+            "reason": "invalid_observation",
+            "request_id": clean_request_id,
+            "effect_id": clean_effect_id,
+        }
+
+    actor_scope: dict[str, str] = {}
+    for field_name, raw_value in (
+        ("namespace", namespace),
+        ("user_id", user_id),
+        ("org_id", org_id),
+    ):
+        clean_value = _safe_str(raw_value)
+        if clean_value:
+            actor_scope[field_name] = clean_value
+    if not actor_scope:
+        return {
+            "updated": False,
+            "reason": "missing_actor_scope",
+            "request_id": clean_request_id,
+            "effect_id": clean_effect_id,
+        }
+
+    coll = get_turn_execution_records_collection()
+    if coll is None:
+        return {
+            "updated": False,
+            "reason": "collection_unavailable",
+            "request_id": clean_request_id,
+            "effect_id": clean_effect_id,
+        }
+
+    bounded = _compact_final_answer_projection_payload(
+        dict(observation),
+        max_depth=4,
+        max_items=32,
+        max_string_chars=2_000,
+    )
+    if not isinstance(bounded, Mapping):
+        bounded = {"value": bounded}
+    now = _now_utc()
+    recorded_at_utc = _iso_utc(now)
+    phase_entry = dict(bounded)
+    phase_entry.update(
+        {
+            "schema_version": EFFECT_OBSERVATION_JOURNAL_SCHEMA_VERSION,
+            "phase": clean_phase,
+            "effect_id": clean_effect_id,
+            "recorded_at_utc": recorded_at_utc,
+        }
+    )
+
+    journal_root = f"effect_observation_journal.{clean_effect_id}"
+    phase_path = f"{journal_root}.{clean_phase}"
+    identity_path = f"{journal_root}.identity"
+    record_scope_query = {"request_id": clean_request_id, **actor_scope}
+    phase_absent_query = {
+        **record_scope_query,
+        phase_path: {"$exists": False},
+    }
+    identity_entry = {
+        "schema_version": EFFECT_OBSERVATION_JOURNAL_SCHEMA_VERSION,
+        "effect_id": clean_effect_id,
+        "created_at_utc": recorded_at_utc,
+    }
+    for field_name in ("call_id", "capability_name"):
+        clean_value = _safe_str(observation.get(field_name))
+        if clean_value:
+            identity_entry[field_name] = clean_value
+    phase_set: dict[str, Any] = {phase_path: phase_entry}
+    # Dispatch intent is durably acknowledged before the handler can start, so
+    # it is the authoritative creation point for stable effect identity.  Later
+    # terminal receipts must never replace its creation time or call identity.
+    if clean_phase == "dispatch_intent":
+        phase_set[identity_path] = identity_entry
+    phase_update = {
+        "$set": phase_set,
+        "$max": {
+            "updated_at_utc": recorded_at_utc,
+            "effect_observation_updated_at_utc": recorded_at_utc,
+        },
+    }
+    insert_payload: dict[str, Any] = {
+        "request_id": clean_request_id,
+        "schema_version": TURN_EXECUTION_RECORD_SCHEMA_VERSION,
+        "created_at_utc": recorded_at_utc,
+        "updated_at_utc": recorded_at_utc,
+        "inserted_at": now,
+    }
+    for field_name, raw_value in (
+        ("user_id", user_id),
+        ("session_id", session_id),
+        ("namespace", namespace),
+        ("org_id", org_id),
+    ):
+        clean_value = _safe_str(raw_value)
+        if clean_value:
+            insert_payload[field_name] = clean_value
+
+    try:
+        result = _turn_execution_update_one(
+            coll,
+            phase_absent_query,
+            phase_update,
+            operation="record_effect_observation_phase.update_one",
+            detail=f"{clean_effect_id}:{clean_phase}",
+            upsert=False,
+        )
+        updated = bool(getattr(result, "modified_count", 0) > 0)
+        matched = bool(getattr(result, "matched_count", 0) > 0)
+        inserted = False
+        if not matched:
+            existing = _turn_execution_find_one(
+                coll,
+                record_scope_query,
+                projection={
+                    "_id": 0,
+                    phase_path: 1,
+                },
+                operation="record_effect_observation_phase.find_existing",
+                detail=f"{clean_effect_id}:{clean_phase}",
+            )
+            if isinstance(existing, Mapping):
+                journal = existing.get("effect_observation_journal")
+                effect_entry = (
+                    journal.get(clean_effect_id)
+                    if isinstance(journal, Mapping)
+                    else None
+                )
+                if (
+                    isinstance(effect_entry, Mapping)
+                    and isinstance(effect_entry.get(clean_phase), Mapping)
+                ):
+                    return {
+                        "updated": False,
+                        "duplicate": True,
+                        "matched": True,
+                        "inserted": False,
+                        "request_id": clean_request_id,
+                        "effect_id": clean_effect_id,
+                        "phase": clean_phase,
+                    }
+            if existing is None:
+                request_id_collision = _turn_execution_find_one(
+                    coll,
+                    {"request_id": clean_request_id},
+                    projection={
+                        "_id": 0,
+                        "namespace": 1,
+                        "user_id": 1,
+                        "org_id": 1,
+                    },
+                    operation=(
+                        "record_effect_observation_phase.find_scope_collision"
+                    ),
+                    detail=f"{clean_effect_id}:{clean_phase}",
+                )
+                if request_id_collision is not None:
+                    return {
+                        "updated": False,
+                        "duplicate": False,
+                        "reason": "actor_scope_mismatch",
+                        "request_id": clean_request_id,
+                        "effect_id": clean_effect_id,
+                        "phase": clean_phase,
+                    }
+                ensured = _turn_execution_update_one(
+                    coll,
+                    record_scope_query,
+                    {"$setOnInsert": insert_payload},
+                    operation="record_effect_observation_phase.ensure_record",
+                    detail=f"{clean_effect_id}:{clean_phase}",
+                    upsert=True,
+                )
+                inserted = getattr(ensured, "upserted_id", None) is not None
+
+            result = _turn_execution_update_one(
+                coll,
+                phase_absent_query,
+                phase_update,
+                operation="record_effect_observation_phase.retry_update_one",
+                detail=f"{clean_effect_id}:{clean_phase}",
+                upsert=False,
+            )
+            updated = bool(getattr(result, "modified_count", 0) > 0)
+            matched = bool(getattr(result, "matched_count", 0) > 0)
+
+        if not updated and not matched:
+            return {
+                "updated": False,
+                "duplicate": False,
+                "inserted": inserted,
+                "matched": False,
+                "reason": "phase_write_not_acknowledged",
+                "request_id": clean_request_id,
+                "effect_id": clean_effect_id,
+                "phase": clean_phase,
+            }
+        return {
+            "updated": updated,
+            "duplicate": not updated and matched,
+            "inserted": inserted,
+            "matched": matched,
+            "request_id": clean_request_id,
+            "effect_id": clean_effect_id,
+            "phase": clean_phase,
+        }
+    except DuplicateKeyError:
+        return {
+            "updated": False,
+            "duplicate": False,
+            "reason": "actor_scope_mismatch",
+            "request_id": clean_request_id,
+            "effect_id": clean_effect_id,
+            "phase": clean_phase,
+        }
+    except PyMongoError as exc:
+        logger.warning(
+            "Failed to persist effect observation phase request_id=%s "
+            "effect_id=%s phase=%s: %s",
+            clean_request_id,
+            clean_effect_id,
+            clean_phase,
+            exc,
+        )
+        return {
+            "updated": False,
+            "duplicate": False,
+            "reason": "mongo_error",
+            "request_id": clean_request_id,
+            "effect_id": clean_effect_id,
+            "phase": clean_phase,
         }
 
 
@@ -10867,49 +11141,32 @@ def append_late_effect_observation(
 
 
 def submit_late_effect_observation(**kwargs: Any) -> bool:
-    """Queue a durable append without occupying an MCP handler worker."""
+    """Synchronously persist a late receipt; never rerun its underlying effect.
 
-    if not _LATE_EFFECT_APPEND_SLOTS.acquire(blocking=False):
-        logger.warning(
-            "Late-effect observation queue is full; request_id=%s effect_id=%s",
-            _safe_str(kwargs.get("request_id")),
-            _safe_str(kwargs.get("effect_id")),
-        )
-        return False
-
-    def _append() -> None:
-        try:
-            outcome = append_late_effect_observation(**kwargs)
-            if not outcome.get("updated") and not outcome.get("duplicate"):
-                logger.warning(
-                    "Late-effect observation was not persisted; request_id=%s "
-                    "effect_id=%s reason=%s",
-                    _safe_str(kwargs.get("request_id")),
-                    _safe_str(kwargs.get("effect_id")),
-                    _safe_str(outcome.get("reason")) or "append_not_acknowledged",
-                )
-        except Exception:
-            logger.exception(
-                "Late-effect observation append failed; request_id=%s "
-                "effect_id=%s",
-                _safe_str(kwargs.get("request_id")),
-                _safe_str(kwargs.get("effect_id")),
-            )
-        finally:
-            _LATE_EFFECT_APPEND_SLOTS.release()
+    Retained as a compatibility wrapper for callers outside the adaptive path.
+    Unlike the former volatile executor queue, ``True`` means Mongo
+    acknowledged either the append or an idempotent duplicate.
+    """
 
     try:
-        _LATE_EFFECT_APPEND_EXECUTOR.submit(_append)
-    except RuntimeError:
-        _LATE_EFFECT_APPEND_SLOTS.release()
-        logger.warning(
-            "Late-effect observation executor is unavailable; request_id=%s "
-            "effect_id=%s",
+        outcome = append_late_effect_observation(**kwargs)
+    except Exception:
+        logger.exception(
+            "Late-effect observation append failed; request_id=%s effect_id=%s",
             _safe_str(kwargs.get("request_id")),
             _safe_str(kwargs.get("effect_id")),
         )
         return False
-    return True
+    acknowledged = bool(outcome.get("updated") or outcome.get("duplicate"))
+    if not acknowledged:
+        logger.warning(
+            "Late-effect observation was not persisted; request_id=%s "
+            "effect_id=%s reason=%s",
+            _safe_str(kwargs.get("request_id")),
+            _safe_str(kwargs.get("effect_id")),
+            _safe_str(outcome.get("reason")) or "append_not_acknowledged",
+        )
+    return acknowledged
 
 
 def get_latest_turn_execution_record_projection(

--- a/src/backend/vontology/utils_vontology.py
+++ b/src/backend/vontology/utils_vontology.py
@@ -3739,6 +3739,7 @@ def create_vontology_concept(
     organisation_concept_id: Optional[str] = None,
     event_namespace: Optional[str] = None,
     visibility_scope_mode: Optional[str] = None,
+    allow_duplicate_instance_suffix: bool = True,
 ) -> Dict[str, Any]:
     """
     Creates a new concept in the Vontology.
@@ -3748,6 +3749,10 @@ def create_vontology_concept(
         new_concept_name: The name for the new concept (will be used to generate concept_id)
         create_as_instance: If True, creates an instance of the parent type.
                            If False, creates a subtype of the parent.
+        allow_duplicate_instance_suffix: If True, legacy low-level callers may
+            allocate ``_2``, ``_3``, and later IDs for duplicate instance names.
+            Higher-level creation surfaces should opt out unless duplicate
+            instances were explicitly requested.
         notes: Optional notes for the new concept
         description: Optional description for the new concept
         instance_of_type: Optional concept_id to create an is_an_instance_of relationship.
@@ -3768,7 +3773,10 @@ def create_vontology_concept(
     """
     try:
         # Local import to avoid circular dependency at module import time
-        from ..services.concept_service import create_concept  # type: ignore
+        from ..services.concept_service import (  # type: ignore
+            InvalidConceptDataError,
+            create_concept,
+        )
         from ..utils.concept_id_utils import canonicalise_vontology_concept_id
 
         # Validate concept name constraints upfront
@@ -3795,17 +3803,22 @@ def create_vontology_concept(
 
         candidate_concept_id = canonical_id
         if create_as_instance:
-            # Preflight existence check and append incremental suffix until free
-            counter = 2
-            while ConceptsRepository.find_one({"concept_id": candidate_concept_id}):
-                candidate_concept_id = f"#V#{base_slug}_{counter}"
-                counter += 1
-                if counter > 50:  # safety stop to avoid pathological loops
-                    return {
-                        "success": False,
-                        "message": "Unable to allocate unique concept_id after 49 retries.",
-                        "concept": None,
-                    }
+            if allow_duplicate_instance_suffix:
+                # Preflight existence check and append incremental suffix until free
+                counter = 2
+                while ConceptsRepository.find_one(
+                    {"concept_id": candidate_concept_id}
+                ):
+                    candidate_concept_id = f"#V#{base_slug}_{counter}"
+                    counter += 1
+                    if counter > 50:  # safety stop to avoid pathological loops
+                        return {
+                            "success": False,
+                            "message": (
+                                "Unable to allocate unique concept_id after 49 retries."
+                            ),
+                            "concept": None,
+                        }
         else:
             # For type creation, fail fast if the concept_id already exists
             if ConceptsRepository.find_one({"concept_id": candidate_concept_id}):
@@ -3821,19 +3834,40 @@ def create_vontology_concept(
 
         parent_concept_ids = [parent_id] if parent_id else []
 
-        created_concept = create_concept(
-            name=new_concept_name,
-            concept_id=candidate_concept_id,
-            parent_concept_ids=parent_concept_ids,
-            create_as_instance=create_as_instance,
-            description=description,
-            notes=notes,
-            instance_of_type=instance_of_type,
-            created_by_concept_id=created_by_concept_id,
-            organisation_concept_id=organisation_concept_id,
-            event_namespace=event_namespace,
-            visibility_scope_mode=visibility_scope_mode,
-        )
+        try:
+            created_concept = create_concept(
+                name=new_concept_name,
+                concept_id=candidate_concept_id,
+                parent_concept_ids=parent_concept_ids,
+                create_as_instance=create_as_instance,
+                description=description,
+                notes=notes,
+                instance_of_type=instance_of_type,
+                created_by_concept_id=created_by_concept_id,
+                organisation_concept_id=organisation_concept_id,
+                event_namespace=event_namespace,
+                visibility_scope_mode=visibility_scope_mode,
+            )
+        except InvalidConceptDataError as exc:
+            if "duplicate key" not in str(exc).lower():
+                raise
+            return {
+                "success": False,
+                "changed": False,
+                "message": (
+                    f"Concept identity '{candidate_concept_id}' became occupied "
+                    "before creation completed. No suffixed concept was created."
+                ),
+                "concept": None,
+                "error_code": "already_exists",
+                "existing_concept_id": candidate_concept_id,
+                "canonical_concept_id": candidate_concept_id,
+                "input_name": new_concept_name,
+                "suggestion": (
+                    "Fetch the existing concept before deciding whether to reuse "
+                    "or update it."
+                ),
+            }
 
         if created_concept:
             return {

--- a/src/workflows/von/main.py
+++ b/src/workflows/von/main.py
@@ -158,6 +158,7 @@ _apply_dotenv_overrides(
         "VON_MODEL_REGISTRY_SNAPSHOT_CACHE_TTL_SECONDS",
         "VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_ENABLED",
         "VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_TTL_SECONDS",
+        "VON_MODEL_REGISTRY_SNAPSHOT_MAX_STALE_SECONDS",
         "VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_PATH",
         "VON_DEFAULT_NAMESPACE",
         "VON_DETERMINISTIC_INTROSPECTION",
@@ -345,6 +346,27 @@ def main():
     except Exception as e:  # pragma: no cover - startup failure path
         logger.error("Failed to initialize LLM client: %s", e, exc_info=True)
         sys.exit(1)  # Exit if client fails to initialize
+
+    # Resolve represented model/API-profile authority before the HTTP server
+    # can accept a caller-owned provider deadline. A cold worktree may spend
+    # time hydrating here; a bounded last-known represented snapshot returns
+    # immediately and refreshes outside the first user call.
+    try:
+        from src.backend.services.model_registry_service import (
+            preload_model_registry_snapshot,
+        )
+
+        registry_preload = preload_model_registry_snapshot()
+        logger.info(
+            "Model registry startup preload ready=%s source=%s "
+            "cache_state=%s duration_ms=%s.",
+            registry_preload.get("ready"),
+            registry_preload.get("source"),
+            registry_preload.get("cache_state"),
+            registry_preload.get("preload_duration_ms"),
+        )
+    except Exception as exc:
+        logger.warning("Model registry startup preload failed: %s", exc)
 
     # Create the Flask app, injecting the client's methods
     app = create_flask_app(

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -43,6 +43,23 @@ from src.backend.services.adaptive_turn_service import (
 from src.backend.services.turn_evidence_store import TrustedTurnScope
 
 
+@pytest.fixture(autouse=True)
+def _acknowledge_effect_observation_journal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.services import turn_execution_record_service
+
+    monkeypatch.setattr(
+        turn_execution_record_service,
+        "record_effect_observation_phase",
+        lambda **kwargs: {
+            "updated": True,
+            "duplicate": False,
+            "phase": kwargs.get("phase"),
+        },
+    )
+
+
 class _SequenceClient:
     def __init__(self, *responses: Any) -> None:
         self.responses = list(responses)
@@ -208,6 +225,7 @@ def _effect_gateway(
     *,
     write_timeout_sec: float = 1.0,
     effect_output_schema: Schema | None = None,
+    effect_admission_window_sec: float | None = None,
 ) -> InternalMCPGateway:
     catalogue = MethodCatalogue()
     catalogue.register(
@@ -231,6 +249,7 @@ def _effect_gateway(
                 output_schema=effect_output_schema,
                 category="write",
                 ordinary_turn_effect=True,
+                effect_admission_window_sec=effect_admission_window_sec,
                 ordinary_turn_mutation_subject_argument=subject_argument,
                 ordinary_turn_trusted_argument_bindings=(
                     {
@@ -1031,15 +1050,16 @@ def test_late_effect_completion_is_persisted_without_rewriting_terminal_result(
             "created_ids": ["#V#late_real_concept"],
         }
 
-    def append_observation(**kwargs: Any) -> dict[str, Any]:
+    def persist_phase(**kwargs: Any) -> dict[str, Any]:
         persisted.append(dict(kwargs))
-        observation_persisted.set()
+        if kwargs.get("phase") == "late_terminal":
+            observation_persisted.set()
         return {"updated": True}
 
     monkeypatch.setattr(
         turn_execution_record_service,
-        "append_late_effect_observation",
-        append_observation,
+        "record_effect_observation_phase",
+        persist_phase,
     )
     client = _SequenceClient(
         LLMResponse(
@@ -1080,8 +1100,11 @@ def test_late_effect_completion_is_persisted_without_rewriting_terminal_result(
 
     release_handler.set()
     assert observation_persisted.wait(timeout=1.0)
-    assert len(persisted) == 1
-    durable = persisted[0]
+    late_phases = [
+        item for item in persisted if item.get("phase") == "late_terminal"
+    ]
+    assert len(late_phases) == 1
+    durable = late_phases[0]
     assert durable["request_id"] == "late-effect-request"
     assert durable["effect_id"] == result.tool_invocations[0]["effect_id"]
     assert durable["observation"]["effect_status"] == "succeeded"
@@ -1090,9 +1113,7 @@ def test_late_effect_completion_is_persisted_without_rewriting_terminal_result(
     assert result.tool_invocations[0]["effect_status"] == "indeterminate"
 
 
-def test_effect_is_not_started_without_its_configured_execution_window() -> None:
-    started = time.monotonic()
-    clock = _ManualClock(started)
+def test_effect_is_not_started_without_its_minimum_admission_window() -> None:
     invoked: list[str] = []
 
     def handler(name: str, _arguments: dict[str, Any]) -> dict[str, Any]:
@@ -1103,39 +1124,32 @@ def test_effect_is_not_started_without_its_configured_execution_window() -> None
             "changed": True,
         }
 
-    client = _TimedSequenceClient(
-        clock,
-        (
-            started + 7.5,
-            LLMResponse(
-                text_response="",
-                tool_calls=[
-                    ToolCall(
-                        tool_name="turn_invoke_capability",
-                        call_id="effect-with-clipped-window",
-                        payload={
-                            "name": "create_concepts",
-                            "arguments": {
-                                "concepts": [{"name": "Must not start late"}]
-                            },
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="effect-with-clipped-window",
+                    payload={
+                        "name": "create_concepts",
+                        "arguments": {
+                            "concepts": [{"name": "Must not start late"}]
                         },
-                    )
-                ],
-            ),
-        ),
-        (
-            started + 7.6,
-            LLMResponse(
-                text_response=(
-                    "The write was not started because its full bounded window "
-                    "was no longer available."
+                    },
                 )
-            ),
+            ],
+        ),
+        LLMResponse(
+            text_response=(
+                "The write was not started because its full bounded window "
+                "was no longer available."
+            )
         ),
     )
 
     result = execute_adaptive_turn(
-        gateway=_effect_gateway(handler, write_timeout_sec=1.0),
+        gateway=_effect_gateway(handler, write_timeout_sec=0.2),
         prompt="Represent this concept.",
         context=[],
         llm_client=client,
@@ -1144,9 +1158,8 @@ def test_effect_is_not_started_without_its_configured_execution_window() -> None
         user_concept_id="#V#person",
         org_concept_id="#V#org",
         turn_id="effect-window-admission",
-        turn_budget_seconds=10,
-        final_synthesis_reserve_seconds=2,
-        clock=clock,
+        turn_budget_seconds=0.2,
+        final_synthesis_reserve_seconds=0.15,
     )
 
     assert invoked == []
@@ -1157,6 +1170,135 @@ def test_effect_is_not_started_without_its_configured_execution_window() -> None
         result.tool_invocations[0]["evidence"]["preview"]
     )
     assert "not_started" in result.tool_invocations[0]["evidence"]["preview"]
+
+
+def test_per_method_minimum_admits_sequential_effects_below_hard_cap() -> None:
+    invoked: list[str] = []
+
+    def handler(name: str, _arguments: dict[str, Any]) -> dict[str, Any]:
+        invoked.append(name)
+        time.sleep(0.015)
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+        }
+
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="first-late-window-effect",
+                    payload={
+                        "name": "upsert_text_relation",
+                        "arguments": {"concept_id": "#V#person"},
+                    },
+                ),
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="second-late-window-effect",
+                    payload={
+                        "name": "add_relationship",
+                        "arguments": {"source_id": "#V#person"},
+                    },
+                ),
+            ],
+        ),
+        LLMResponse(text_response="Both bounded effects completed."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_effect_gateway(
+            handler,
+            write_timeout_sec=0.2,
+            effect_admission_window_sec=0.01,
+        ),
+        prompt="Apply both bounded effects.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="sequential-effect-admission",
+        turn_budget_seconds=0.2,
+        final_synthesis_reserve_seconds=0.12,
+    )
+
+    assert invoked == ["upsert_text_relation", "add_relationship"]
+    assert [item["effect_status"] for item in result.tool_invocations] == [
+        "succeeded",
+        "succeeded",
+    ]
+
+
+def test_effect_is_not_dispatched_when_durable_intent_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.services import turn_execution_record_service
+
+    invoked: list[str] = []
+
+    def handler(name: str, _arguments: dict[str, Any]) -> dict[str, Any]:
+        invoked.append(name)
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+        }
+
+    monkeypatch.setattr(
+        turn_execution_record_service,
+        "record_effect_observation_phase",
+        lambda **_kwargs: {
+            "updated": False,
+            "duplicate": False,
+            "reason": "collection_unavailable",
+        },
+    )
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="effect-without-durable-intent",
+                    payload={
+                        "name": "create_concepts",
+                        "arguments": {
+                            "concepts": [{"name": "Must not be dispatched"}]
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response=(
+                "The effect was not started because its durable intent could "
+                "not be recorded."
+            )
+        ),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_effect_gateway(handler),
+        prompt="Represent this concept.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="effect-intent-persistence-failure",
+    )
+
+    assert invoked == []
+    assert result.tool_invocations[0]["effect_status"] == "failed"
+    preview = result.tool_invocations[0]["evidence"]["preview"]
+    assert "effect_observation_unavailable" in preview
+    assert "not_started" in preview
 
 
 @pytest.mark.parametrize(

--- a/tests/backend/test_concept_search_service_performance.py
+++ b/tests/backend/test_concept_search_service_performance.py
@@ -240,3 +240,52 @@ def test_text_value_fingerprint_search_uses_partial_index_shape(monkeypatch) -> 
             "max_time_ms": svc.CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
         }
     ]
+
+
+def test_exact_lookup_can_defer_scan_to_subsuming_prefix_stage(monkeypatch) -> None:
+    text_value_id = "507f1f77bcf86cd799439011"
+    concept_id = "#V#legacy_exact_name"
+    text_value_calls: list[dict[str, Any]] = []
+    relation_calls: list[dict[str, Any]] = []
+
+    def fake_text_values_find(query, *args, **kwargs):
+        text_value_calls.append({"query": query, **kwargs})
+        if query.get("text"):
+            return [{"_id": text_value_id}]
+        return []
+
+    def fake_text_relations_find(query, *args, **kwargs):
+        relation_calls.append({"query": query, **kwargs})
+        return [{"subject_concept_id": concept_id}]
+
+    monkeypatch.setattr(svc.TextValuesRepository, "find", fake_text_values_find)
+    monkeypatch.setattr(svc.TextRelationsRepository, "find", fake_text_relations_find)
+
+    exact_hits = svc._search_text_relations(
+        "Legacy exact name",
+        exact=True,
+        result_limit=5,
+        allow_fallback_scan=False,
+    )
+    prefix_hits = svc._search_text_relations(
+        "Legacy exact name",
+        prefix=True,
+        result_limit=5,
+    )
+
+    assert exact_hits == set()
+    assert prefix_hits == {concept_id}
+    assert len(text_value_calls) == 3
+    assert text_value_calls[0]["query"].get("fingerprint")
+    assert text_value_calls[1]["query"].get("fingerprint")
+    assert text_value_calls[2]["query"] == {
+        "text": {
+            "$regex": r"^Legacy\\s+exact\\s+name",
+            "$options": "i",
+        }
+    }
+    assert all(call["limit"] == 200 for call in text_value_calls)
+    assert len(relation_calls) == 1
+    assert relation_calls[0]["query"]["object_text_id"] == {
+        "$in": [text_value_id, text_value_id]
+    }

--- a/tests/backend/test_create_vontology_concept_suffix_policy.py
+++ b/tests/backend/test_create_vontology_concept_suffix_policy.py
@@ -1,0 +1,40 @@
+"""Focused low-level identity allocation tests for concept creation."""
+
+from __future__ import annotations
+
+from src.backend.services import concept_service
+from src.backend.services.concept_service import InvalidConceptDataError
+from src.backend.vontology.utils_vontology import create_vontology_concept
+
+
+def test_no_suffix_mode_uses_unique_insert_and_returns_race_receipt(monkeypatch):
+    repository_reads: list[dict[str, object]] = []
+    attempted_ids: list[str] = []
+
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.ConceptsRepository.find_one",
+        lambda query: repository_reads.append(dict(query)),
+    )
+
+    def _duplicate_insert(**kwargs):
+        attempted_ids.append(str(kwargs["concept_id"]))
+        raise InvalidConceptDataError(
+            "concept creation failed due to duplicate key: simulated race"
+        )
+
+    monkeypatch.setattr(concept_service, "create_concept", _duplicate_insert)
+
+    result = create_vontology_concept(
+        parent_id="#V#abstract_object",
+        new_concept_name="Race occupied identity",
+        create_as_instance=True,
+        allow_duplicate_instance_suffix=False,
+    )
+
+    assert attempted_ids == ["#V#race_occupied_identity"]
+    assert repository_reads == []
+    assert result["success"] is False
+    assert result["changed"] is False
+    assert result["error_code"] == "already_exists"
+    assert result["existing_concept_id"] == "#V#race_occupied_identity"
+    assert result["canonical_concept_id"] == "#V#race_occupied_identity"

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -64,6 +64,20 @@ def test_internal_mcp_catalogue_builds_and_includes_relationship_tools():
     assert "testing_cleanup_arxiv_paper_ingestion_artifacts" in methods
 
 
+def test_default_catalogue_exposes_calibrated_effect_admission_windows():
+    from src.backend.integrations.internal_mcp import build_default_catalogue
+
+    catalogue = build_default_catalogue()
+    snapshot = catalogue.snapshot()
+
+    assert catalogue.get("create_concepts").effect_admission_window_sec is None
+    assert catalogue.get("upsert_text_relation").effect_admission_window_sec == 8.0
+    assert catalogue.get("add_relationship").effect_admission_window_sec == 5.0
+    assert snapshot["create_concepts"]["effect_admission_window_sec"] is None
+    assert snapshot["upsert_text_relation"]["effect_admission_window_sec"] == 8.0
+    assert snapshot["add_relationship"]["effect_admission_window_sec"] == 5.0
+
+
 def test_ordinary_turn_read_projection_follows_capability_authority_metadata():
     from src.backend.integrations.internal_mcp import (
         InternalMCPGateway,

--- a/tests/backend/test_internal_mcp_transport_deadlines.py
+++ b/tests/backend/test_internal_mcp_transport_deadlines.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import time
 from threading import Event, Thread
 
@@ -27,6 +28,7 @@ def _gateway_for(
     category: str = "read",
     output_schema: Schema | None = None,
     timeout_sec: float | None = None,
+    effect_admission_window_sec: float | None = None,
 ) -> InternalMCPGateway:
     catalogue = MethodCatalogue()
     catalogue.register(
@@ -37,6 +39,7 @@ def _gateway_for(
             output_schema=output_schema,
             category=category,
             timeout_sec=timeout_sec,
+            effect_admission_window_sec=effect_admission_window_sec,
         )
     )
     return InternalMCPGateway(
@@ -189,7 +192,7 @@ def test_caller_deadline_shortens_the_registered_method_timeout() -> None:
     assert cancellation_seen.wait(timeout=1.0)
 
 
-def test_required_configured_write_window_is_denied_atomically_before_dispatch() -> None:
+def test_required_effect_window_is_denied_atomically_before_dispatch() -> None:
     handler_called = Event()
     executor = _BoundedHandlerExecutor(worker_count=1, queue_capacity=1)
     transport = InternalMCPTransport(
@@ -209,17 +212,219 @@ def test_required_configured_write_window_is_denied_atomically_before_dispatch()
         "synthetic_full_window_write",
         {},
         deadline_monotonic=time.monotonic() + 0.19,
-        require_configured_timeout=True,
+        require_effect_admission_window=True,
     )
 
     assert result.outcome == "not_started"
     assert result.timeout_phase == "pre_dispatch"
     assert result.payload["error_code"] == "insufficient_effect_window"
     assert result.payload["mutation_outcome"] == "not_started"
-    assert result.payload["configured_execution_window_seconds"] == 0.2
+    assert result.payload["configured_hard_timeout_seconds"] == 0.2
+    assert result.payload["minimum_admission_window_seconds"] == 0.2
+    assert 0.0 < result.payload["effective_execution_window_seconds"] < 0.2
     assert 0.0 < result.payload["remaining_execution_window_seconds"] < 0.2
+    assert result.configured_hard_timeout_sec == 0.2
+    assert result.minimum_execution_window_sec == 0.2
     assert handler_called.is_set() is False
     assert executor.diagnostics()["submitted_count"] == 0
+
+
+def test_default_full_window_effect_starts_on_idle_executor() -> None:
+    handler_called = Event()
+    executor = _BoundedHandlerExecutor(worker_count=1, queue_capacity=1)
+    transport = InternalMCPTransport(
+        write_timeout_sec=0.2,
+        write_advisory_timeout_sec=0.01,
+        handler_executor=executor,
+    )
+
+    def _handler() -> dict[str, bool]:
+        handler_called.set()
+        return {"success": True, "changed": True}
+
+    gateway = _gateway_for(
+        method_name="synthetic_default_full_window_effect",
+        handler=_handler,
+        transport=transport,
+        category="write",
+        timeout_sec=0.2,
+    )
+
+    result = gateway.invoke(
+        "synthetic_default_full_window_effect",
+        {},
+        require_effect_admission_window=True,
+    )
+
+    assert result.outcome == "completed"
+    assert result.payload == {"success": True, "changed": True}
+    assert result.minimum_execution_window_sec == 0.2
+    assert handler_called.is_set() is True
+
+
+def test_method_minimum_admits_effect_below_its_hard_timeout() -> None:
+    handler_called = Event()
+    transport = InternalMCPTransport(
+        write_timeout_sec=0.5,
+        write_advisory_timeout_sec=0.01,
+    )
+
+    def _handler() -> dict[str, bool]:
+        handler_called.set()
+        return {"success": True, "changed": True}
+
+    gateway = _gateway_for(
+        method_name="synthetic_short_effect",
+        handler=_handler,
+        transport=transport,
+        category="write",
+        timeout_sec=0.2,
+        effect_admission_window_sec=0.02,
+    )
+
+    result = gateway.invoke(
+        "synthetic_short_effect",
+        {},
+        deadline_monotonic=time.monotonic() + 0.08,
+        require_effect_admission_window=True,
+    )
+
+    assert handler_called.is_set() is True
+    assert result.outcome == "completed"
+    assert result.payload == {"success": True, "changed": True}
+    assert result.timeout_sec is not None
+    assert 0.02 < result.timeout_sec < 0.2
+    assert result.configured_hard_timeout_sec == 0.2
+    assert result.minimum_execution_window_sec == 0.02
+    assert result.telemetry_metadata()["minimum_execution_window_sec"] == 0.02
+
+
+def test_method_minimum_denies_effect_below_its_admission_window() -> None:
+    handler_called = Event()
+    executor = _BoundedHandlerExecutor(worker_count=1, queue_capacity=1)
+    transport = InternalMCPTransport(
+        write_timeout_sec=0.5,
+        write_advisory_timeout_sec=0.01,
+        handler_executor=executor,
+    )
+    gateway = _gateway_for(
+        method_name="synthetic_short_effect",
+        handler=lambda: handler_called.set(),
+        transport=transport,
+        category="write",
+        timeout_sec=0.2,
+        effect_admission_window_sec=0.05,
+    )
+
+    result = gateway.invoke(
+        "synthetic_short_effect",
+        {},
+        deadline_monotonic=time.monotonic() + 0.02,
+        require_effect_admission_window=True,
+    )
+
+    assert result.outcome == "not_started"
+    assert result.payload["minimum_admission_window_seconds"] == 0.05
+    assert result.payload["configured_hard_timeout_seconds"] == 0.2
+    assert handler_called.is_set() is False
+    assert executor.diagnostics()["submitted_count"] == 0
+
+
+def test_queued_effect_rechecks_minimum_before_handler_start() -> None:
+    blocker_started = Event()
+    release_blocker = Event()
+    effect_handler_called = Event()
+    observations: list[dict] = []
+    executor = _BoundedHandlerExecutor(worker_count=1, queue_capacity=1)
+    transport = InternalMCPTransport(
+        read_timeout_sec=0.5,
+        write_timeout_sec=0.5,
+        read_advisory_timeout_sec=0.1,
+        write_advisory_timeout_sec=0.01,
+        handler_executor=executor,
+    )
+
+    def _blocker() -> dict[str, bool]:
+        blocker_started.set()
+        assert release_blocker.wait(timeout=1.0)
+        return {"success": True}
+
+    blocker_gateway = _gateway_for(
+        method_name="synthetic_admission_blocker",
+        handler=_blocker,
+        transport=transport,
+    )
+    blocker_results = []
+    blocker_thread = Thread(
+        target=lambda: blocker_results.append(
+            blocker_gateway.invoke("synthetic_admission_blocker", {})
+        )
+    )
+    blocker_thread.start()
+    assert blocker_started.wait(timeout=1.0)
+
+    def _effect_handler() -> dict[str, bool]:
+        effect_handler_called.set()
+        return {"success": True, "changed": True}
+
+    effect_gateway = _gateway_for(
+        method_name="synthetic_queued_minimum_effect",
+        handler=_effect_handler,
+        transport=transport,
+        category="write",
+        timeout_sec=0.3,
+        effect_admission_window_sec=0.2,
+    )
+    effect_results = []
+    effect_thread = Thread(
+        target=lambda: effect_results.append(
+            effect_gateway.invoke(
+                "synthetic_queued_minimum_effect",
+                {},
+                require_effect_admission_window=True,
+                late_completion_observer=observations.append,
+            )
+        )
+    )
+    effect_thread.start()
+
+    queue_deadline = time.monotonic() + 1.0
+    while (
+        executor.diagnostics()["queue_depth"] < 1
+        and time.monotonic() < queue_deadline
+    ):
+        time.sleep(0.002)
+    assert executor.diagnostics()["queue_depth"] == 1
+
+    # Consume enough of the admitted 0.3s window that less than the method's
+    # 0.2s minimum remains, while leaving time for a typed queue-phase denial.
+    time.sleep(0.13)
+    release_blocker.set()
+    blocker_thread.join(timeout=1.0)
+    effect_thread.join(timeout=1.0)
+
+    assert blocker_thread.is_alive() is False
+    assert effect_thread.is_alive() is False
+    assert blocker_results and blocker_results[0].outcome == "completed"
+    assert len(effect_results) == 1
+    result = effect_results[0]
+    assert result.outcome == "not_started"
+    assert result.timeout_phase == "queue"
+    assert result.payload["status"] == "not_started"
+    assert result.payload["error_code"] == "insufficient_effect_window"
+    assert result.payload["mutation_outcome"] == "not_started"
+    assert result.payload["timeout_phase"] == "queue"
+    assert result.payload["minimum_admission_window_seconds"] == 0.2
+    assert (
+        0.0
+        <= result.payload["remaining_execution_window_seconds"]
+        < 0.2
+    )
+    assert result.queue_duration_ms is not None
+    assert result.queue_duration_ms >= 100.0
+    assert effect_handler_called.is_set() is False
+    assert observations == []
+    assert transport.get_diagnostics()["late_completion_count"] == 0
 
 
 def test_result_completed_after_absolute_deadline_is_discarded() -> None:
@@ -232,6 +437,7 @@ def test_result_completed_after_absolute_deadline_is_discarded() -> None:
                 task.completed_at = time.perf_counter()
                 task.completed_monotonic = task.deadline_monotonic + 0.001
                 task.done_event.set()
+            task.on_late_completion(task)
             return True
 
         @staticmethod
@@ -258,6 +464,69 @@ def test_result_completed_after_absolute_deadline_is_discarded() -> None:
     diagnostics = transport.get_diagnostics()
     assert diagnostics["late_completion_count"] == 1
     assert diagnostics["late_completions"][0]["payload_discarded"] is True
+
+
+def test_late_observer_does_not_extend_caller_deadline() -> None:
+    observer_started = Event()
+    release_observer = Event()
+    observer_finished = Event()
+    observations: list[dict] = []
+    executor = _BoundedHandlerExecutor(worker_count=1, queue_capacity=1)
+    transport = InternalMCPTransport(
+        write_timeout_sec=0.04,
+        write_advisory_timeout_sec=0.01,
+        handler_executor=executor,
+    )
+
+    def _handler() -> dict[str, bool]:
+        scope = get_internal_mcp_execution_scope()
+        assert scope is not None
+        # Holding the GIL across the deadline makes the completion/deadline race
+        # deterministic: the worker records completion before the caller can
+        # mark terminal_returned.
+        while time.monotonic() <= scope.deadline_monotonic + 0.005:
+            pass
+        return {"success": True, "changed": True}
+
+    def _blocking_observer(observation: dict) -> None:
+        observer_started.set()
+        release_observer.wait(timeout=2.0)
+        observations.append(observation)
+        observer_finished.set()
+
+    gateway = _gateway_for(
+        method_name="synthetic_deadline_race_write",
+        handler=_handler,
+        transport=transport,
+        category="write",
+    )
+    original_switch_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1.0)
+    started_at = time.perf_counter()
+    try:
+        result = gateway.invoke(
+            "synthetic_deadline_race_write",
+            {},
+            late_completion_observer=_blocking_observer,
+        )
+        elapsed = time.perf_counter() - started_at
+
+        assert result.outcome == "timed_out"
+        assert result.timeout_phase == "handler"
+        assert elapsed < 0.2
+        assert observer_started.wait(timeout=1.0)
+        assert observer_finished.is_set() is False
+        assert observations == []
+    finally:
+        release_observer.set()
+        sys.setswitchinterval(original_switch_interval)
+
+    assert observer_finished.wait(timeout=1.0)
+    assert len(observations) == 1
+    assert observations[0]["outcome"] == "late_success"
+    diagnostics = transport.get_diagnostics()
+    assert diagnostics["late_completion_count"] == 1
+    assert diagnostics["late_completions"][0]["observer_notified"] is True
 
 
 def test_expired_caller_deadline_returns_timeout_without_dispatch() -> None:

--- a/tests/backend/test_mcp_create_concepts_duplicate_resolution_mode.py
+++ b/tests/backend/test_mcp_create_concepts_duplicate_resolution_mode.py
@@ -190,6 +190,230 @@ def test_canonical_id_only_still_reuses_exact_existing_identity(
     assert create_calls == []
 
 
+def test_canonical_id_only_reports_wrong_kind_as_canonical_identity_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_common_preflights(monkeypatch)
+    create_calls: list[dict[str, Any]] = []
+    semantic_calls: list[str] = []
+    existing = {
+        "concept_id": "#V#occupied_identity",
+        "relationships": {
+            "is_a_type_of": [_PARENT_ID],
+            "is_an_instance_of": [_PARENT_ID],
+        },
+    }
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        lambda query, _projection=None: (
+            existing if query.get("concept_id") == existing["concept_id"] else None
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_resolution_service.resolve_concept_by_name",
+        lambda **kwargs: semantic_calls.append(str(kwargs.get("name")))
+        or _not_found_resolution(),
+    )
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        lambda **kwargs: create_calls.append(kwargs),
+    )
+
+    result = _create_concepts(
+        parent_id=_PARENT_ID,
+        concepts=[{"name": "occupied identity", "kind": "instance"}],
+        duplicate_resolution_mode="canonical_id_only",
+    )
+
+    item = result["results"][0]
+    assert result["effect_status"] == "failed"
+    assert result["successful"] == 0
+    assert result["already_existed"] == 0
+    assert result["failed"] == 1
+    assert item["error_code"] == "canonical_identity_conflict"
+    assert item["existing_concept_id"] == existing["concept_id"]
+    assert item["existing_kind"] == "type"
+    assert item["requested_kind"] == "instance"
+    assert item["identity_mismatch_reasons"] == ["kind_mismatch"]
+    assert item["changed"] is False
+    assert semantic_calls == []
+    assert create_calls == []
+
+
+def test_canonical_id_only_reports_wrong_instance_parent_as_identity_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_common_preflights(monkeypatch)
+    create_calls: list[dict[str, Any]] = []
+    existing = {
+        "concept_id": "#V#occupied_instance",
+        "relationships": {
+            "is_a_type_of": [],
+            "is_an_instance_of": ["#V#other_parent"],
+        },
+    }
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        lambda query, _projection=None: (
+            existing if query.get("concept_id") == existing["concept_id"] else None
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        lambda **kwargs: create_calls.append(kwargs),
+    )
+
+    result = _create_concepts(
+        parent_id=_PARENT_ID,
+        concepts=[{"name": "occupied instance", "kind": "instance"}],
+        duplicate_resolution_mode="canonical_id_only",
+    )
+
+    item = result["results"][0]
+    assert item["error_code"] == "canonical_identity_conflict"
+    assert item["existing_kind"] == "instance"
+    assert item["requested_parent_id"] == _PARENT_ID
+    assert item["existing_parent_ids"] == ["#V#other_parent"]
+    assert item["identity_mismatch_reasons"] == ["parent_mismatch"]
+    assert create_calls == []
+
+
+def test_type_identity_remains_singleton_across_requested_parents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_common_preflights(monkeypatch)
+    existing = {
+        "concept_id": "#V#singleton_type",
+        "relationships": {
+            "is_a_type_of": ["#V#other_parent"],
+            "is_an_instance_of": [],
+        },
+    }
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        lambda query, _projection=None: (
+            existing if query.get("concept_id") == existing["concept_id"] else None
+        ),
+    )
+
+    result = _create_concepts(
+        parent_id=_PARENT_ID,
+        concepts=[{"name": "singleton type", "kind": "type"}],
+        duplicate_resolution_mode="canonical_id_only",
+    )
+
+    item = result["results"][0]
+    assert item["error_code"] == "already_exists"
+    assert item["existing_concept_id"] == existing["concept_id"]
+    assert item.get("identity_mismatch_reasons") is None
+
+
+def test_secondary_name_match_reuses_recognised_workflow_instance_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_common_preflights(monkeypatch)
+    requested_parent = "#V#durable_workflow"
+    existing_parent = "#V#ai_workflow"
+    existing_concept_id = "#V#existing_named_workflow"
+    create_calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(
+        "src.backend.services.create_concepts_parent_resolution_service."
+        "resolve_parent_for_create_concepts",
+        lambda parent_id: ParentResolutionResult(
+            requested_parent_id=parent_id,
+            canonical_parent_id=requested_parent,
+            resolved_parent_id=requested_parent,
+            fallback_used=False,
+            fallback_candidates_checked=(),
+            fallback_selected_parent_id=None,
+            resolved_parent_kind="type",
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.create_concepts_duplicate_guard_service."
+        "_workflow_type_ids",
+        lambda: {requested_parent, existing_parent},
+    )
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        lambda query, _projection=None: (
+            {
+                "concept_id": existing_concept_id,
+                "relationships": {
+                    "is_a_type_of": [],
+                    "is_an_instance_of": [existing_parent],
+                },
+            }
+            if query.get("concept_id") == existing_concept_id
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_resolution_service.resolve_concept_by_name",
+        lambda **_kwargs: {
+            "success": True,
+            "status": "resolved",
+            "resolved_concept_id": existing_concept_id,
+            "match": {"stage": "exact", "score": 400},
+            "candidates": [],
+            "audit": [],
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        lambda **kwargs: create_calls.append(kwargs),
+    )
+
+    result = _create_concepts(
+        parent_id=requested_parent,
+        concepts=[{"name": "Existing named workflow alias", "kind": "instance"}],
+    )
+
+    item = result["results"][0]
+    assert result["already_existed"] == 1
+    assert item["error_code"] == "already_exists"
+    assert item["existing_concept_id"] == existing_concept_id
+    assert item["duplicate_guard_scope"] == "workflow_instance"
+    assert item["duplicate_match_source"] == "name_resolution"
+    assert create_calls == []
+
+
+def test_create_concepts_disables_suffixing_unless_explicitly_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_common_preflights(monkeypatch)
+    suffix_flags: list[bool] = []
+    monkeypatch.setattr(
+        "src.backend.services.create_concepts_duplicate_guard_service."
+        "find_existing_concept_for_create_concepts",
+        lambda **_kwargs: None,
+    )
+
+    def _create(**kwargs: Any) -> dict[str, Any]:
+        suffix_flags.append(bool(kwargs["allow_duplicate_instance_suffix"]))
+        return _created_payload(**kwargs)
+
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        _create,
+    )
+
+    default_result = _create_concepts(
+        parent_id=_PARENT_ID,
+        concepts=[{"name": "default singleton", "kind": "instance"}],
+    )
+    explicit_result = _create_concepts(
+        parent_id=_PARENT_ID,
+        concepts=[{"name": "explicit homonym", "kind": "instance"}],
+        allow_duplicate_instances=True,
+    )
+
+    assert default_result["successful"] == 1
+    assert explicit_result["successful"] == 1
+    assert suffix_flags == [False, True]
+
+
 def test_duplicate_resolution_mode_schema_and_handler_reject_unknown_value() -> None:
     schema = _concepts_create_input_schema()
     assert schema.enum_values["duplicate_resolution_mode"] == [
@@ -310,13 +534,22 @@ def test_cancellation_between_batch_items_prevents_later_creates(
         _create,
     )
 
-    with pytest.raises(InternalMCPHandlerCancelled):
-        _create_concepts(
-            parent_id=_PARENT_ID,
-            concepts=[
-                {"name": "first complete identity", "kind": "type"},
-                {"name": "later blocked identity", "kind": "type"},
-            ],
-        )
+    result = _create_concepts(
+        parent_id=_PARENT_ID,
+        concepts=[
+            {"name": "first complete identity", "kind": "type"},
+            {"name": "later blocked identity", "kind": "type"},
+        ],
+    )
 
     assert created_names == ["first complete identity"]
+    assert result["success"] is False
+    assert result["effect_status"] == "partial"
+    assert result["changed"] is True
+    assert result["error_code"] == "handler_cancelled_after_partial_completion"
+    assert result["cancellation_requested"] is True
+    assert result["completed_before_cancellation"] == 1
+    assert result["unattempted_count"] == 1
+    assert result["successful"] == 1
+    assert result["failed"] == 0
+    assert result["created_concept_ids"] == ["#V#first_complete_identity"]

--- a/tests/backend/test_mcp_create_concepts_parent_recovery.py
+++ b/tests/backend/test_mcp_create_concepts_parent_recovery.py
@@ -13,6 +13,7 @@ from src.backend.integrations.internal_mcp.catalogue import (
 from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
 from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
 from src.backend.mcp_server import mcp_stdio_server
+from src.backend.security.access_control import is_bypass_enabled
 
 
 def _patch_create_concept_success(monkeypatch):
@@ -40,7 +41,7 @@ def test_create_concepts_recovers_workflow_definition_parent(monkeypatch):
         lambda: ("#V#durable_workflow",),
     )
 
-    def _fake_find_one(query):
+    def _fake_find_one(query, _projection=None):
         concept_id = query.get("concept_id")
         if concept_id == "#V#durable_workflow":
             return {"concept_id": concept_id}
@@ -73,7 +74,7 @@ def test_create_concepts_parent_not_found_includes_recovery_details(monkeypatch)
     )
     monkeypatch.setattr(
         "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
-        lambda _query: None,
+        lambda _query, _projection=None: None,
     )
 
     result = _create_concepts(
@@ -97,7 +98,7 @@ def test_create_concepts_rejects_individual_as_semantic_parent(monkeypatch):
     created: list[dict[str, Any]] = []
     monkeypatch.setattr(
         "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
-        lambda query: (
+        lambda query, _projection=None: (
             {
                 "concept_id": "#V#example_research_lab",
                 "kind": "individual",
@@ -127,6 +128,137 @@ def test_create_concepts_rejects_individual_as_semantic_parent(monkeypatch):
     assert created == []
 
 
+def test_create_concepts_derives_parent_kind_beyond_sanitised_relationships(
+    monkeypatch,
+):
+    created: list[dict[str, Any]] = []
+    reads: list[tuple[bool, dict[str, int] | None]] = []
+    hidden_type_id = "#V#hidden_research_organisation"
+
+    def _find_one(query, projection=None):
+        bypassed = is_bypass_enabled()
+        reads.append((bypassed, projection))
+        if query.get("concept_id") != "#V#example_research_lab":
+            return None
+        if not bypassed:
+            # The parent itself is visible, but normal relationship sanitisation
+            # removes the actor-invisible type target.
+            return {
+                "concept_id": "#V#example_research_lab",
+                "relationships": {
+                    "is_a_type_of": [],
+                    "is_an_instance_of": [],
+                },
+            }
+        return {
+            "concept_id": "#V#example_research_lab",
+            "relationships": {
+                "is_a_type_of": [],
+                "is_an_instance_of": [hidden_type_id],
+            },
+        }
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _find_one,
+    )
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        lambda **kwargs: created.append(dict(kwargs)) or {"success": True},
+    )
+
+    result = _create_concepts(
+        parent_id="#V#example_research_lab",
+        concepts=[{"name": "Synthetic scenario", "kind": "instance"}],
+    )
+
+    assert result.get("error_code") == "parent_is_not_a_type"
+    assert (result.get("error_details") or {}).get("resolved_parent_kind") == (
+        "individual"
+    )
+    assert created == []
+    assert hidden_type_id not in json.dumps(result)
+    assert reads == [
+        (False, {"concept_id": 1}),
+        (
+            True,
+            {
+                "concept_id": 1,
+                "kind": 1,
+                "computed_kind": 1,
+                "relationships.is_a_type_of": 1,
+                "relationships.#V#is_a_type_of": 1,
+                "relationships.is_an_instance_of": 1,
+                "relationships.#V#is_an_instance_of": 1,
+            },
+        ),
+    ]
+
+
+def test_create_concepts_rejects_invisible_parent_without_bypassed_discovery(
+    monkeypatch,
+):
+    reads: list[bool] = []
+    hidden_type_id = "#V#hidden_parent_type"
+
+    def _find_one(_query, _projection=None):
+        bypassed = is_bypass_enabled()
+        reads.append(bypassed)
+        if bypassed:
+            return {
+                "concept_id": "#V#invisible_parent",
+                "relationships": {"is_an_instance_of": [hidden_type_id]},
+            }
+        return None
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _find_one,
+    )
+
+    result = _create_concepts(
+        parent_id="#V#invisible_parent",
+        concepts=[{"name": "Disallowed child", "kind": "instance"}],
+    )
+
+    assert result.get("error_code") == "parent_not_found"
+    assert reads == [False]
+    assert hidden_type_id not in json.dumps(result)
+
+
+def test_create_concepts_rejects_relationship_derived_predicate_parent(monkeypatch):
+    created: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        lambda query, _projection=None: (
+            {
+                "concept_id": "#V#example_relation",
+                "relationships": {
+                    "is_a_type_of": ["#V#binary_relation"],
+                    "is_an_instance_of": ["#V#predicate"],
+                },
+            }
+            if query.get("concept_id") == "#V#example_relation"
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        lambda **kwargs: created.append(dict(kwargs)) or {"success": True},
+    )
+
+    result = _create_concepts(
+        parent_id="#V#example_relation",
+        concepts=[{"name": "Invalid child type", "kind": "type"}],
+    )
+
+    assert result.get("error_code") == "parent_is_not_a_type"
+    assert (result.get("error_details") or {}).get("resolved_parent_kind") == (
+        "predicate"
+    )
+    assert created == []
+
+
 def test_create_concepts_recovery_works_through_gateway(monkeypatch):
     _patch_create_concept_success(monkeypatch)
     monkeypatch.setattr(
@@ -134,7 +266,7 @@ def test_create_concepts_recovery_works_through_gateway(monkeypatch):
         lambda: ("#V#durable_workflow",),
     )
 
-    def _fake_find_one(query):
+    def _fake_find_one(query, _projection=None):
         return {"concept_id": "#V#durable_workflow"} if query.get("concept_id") == "#V#durable_workflow" else None
 
     monkeypatch.setattr(
@@ -171,7 +303,7 @@ def test_stdio_create_concepts_recovery_uses_same_parent_logic(monkeypatch):
     )
     monkeypatch.setattr(
         "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
-        lambda query: (
+        lambda query, _projection=None: (
             {"concept_id": "#V#durable_workflow"}
             if query.get("concept_id") == "#V#durable_workflow"
             else None

--- a/tests/backend/test_model_registry_policy_resolution.py
+++ b/tests/backend/test_model_registry_policy_resolution.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import ast
 import json
+from pathlib import Path
+import threading
 import time
 from typing import Any, Mapping, cast
 from unittest.mock import patch
@@ -116,10 +119,24 @@ def _write_registry_disk_cache(
     path,
     *,
     cache_key="en-nz",
-    expires_at=None,
+    refresh_after=None,
+    stale_until=None,
     source="vontology_graph",
+    authority_fingerprint=None,
+    schema_version="model_registry_snapshot_cache.v2",
+    created_at=None,
 ):
+    import src.backend.services.model_registry_service as registry_service
+
     now = time.time()
+    created_at = created_at if created_at is not None else now
+    authority_fingerprint = (
+        authority_fingerprint
+        if authority_fingerprint is not None
+        else registry_service._model_registry_authority_fingerprint()
+    )
+    refresh_after = refresh_after if refresh_after is not None else now + 60
+    stale_until = stale_until if stale_until is not None else now + 3600
     snapshot = {
         "source": source,
         "registry_concept_id": "#V#default_model_registry",
@@ -133,17 +150,17 @@ def _write_registry_disk_cache(
     path.write_text(
         json.dumps(
             {
-                "schema_version": "model_registry_snapshot_cache.v1",
+                "schema_version": schema_version,
                 "updated_at": now,
                 "entries": {
                     cache_key: {
                         "cache_key": cache_key,
                         "preferred_language": "en-NZ",
+                        "authority_fingerprint": authority_fingerprint,
                         "source": source,
-                        "created_at": now,
-                        "expires_at": (
-                            expires_at if expires_at is not None else now + 60
-                        ),
+                        "created_at": created_at,
+                        "refresh_after": refresh_after,
+                        "stale_until": stale_until,
                         "metadata": {
                             "hydrate_duration_ms": 1234,
                         },
@@ -202,15 +219,258 @@ def test_model_registry_snapshot_uses_valid_disk_cache(tmp_path, monkeypatch):
     snapshot = registry_service.get_model_registry_snapshot(preferred_language="en-NZ")
 
     assert snapshot == expected_snapshot
-    assert registry_service._MODEL_REGISTRY_SNAPSHOT_CACHE["en-nz"]["snapshot"] is snapshot
+    assert (
+        registry_service._MODEL_REGISTRY_SNAPSHOT_CACHE["en-nz"]["snapshot"] is snapshot
+    )
     registry_service.clear_model_registry_snapshot_caches()
 
 
-def test_model_registry_snapshot_ignores_stale_disk_cache(tmp_path, monkeypatch):
+def test_model_registry_snapshot_rejects_different_authority_fingerprint(
+    tmp_path, monkeypatch
+):
     import src.backend.services.model_registry_service as registry_service
 
     cache_path = tmp_path / "registry_snapshot.json"
-    _write_registry_disk_cache(cache_path, expires_at=time.time() - 1)
+    _write_registry_disk_cache(
+        cache_path,
+        authority_fingerprint="different-authority",
+    )
+    registry_service.clear_model_registry_snapshot_caches()
+    calls = {"graph": 0}
+
+    def _load_graph(**_kwargs):
+        calls["graph"] += 1
+        return {
+            "registry_concept_id": "#V#default_model_registry",
+            "models": [{"model_id": "openai:gpt-5.5-nano", "provider": "openai"}],
+        }
+
+    monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_ENABLED", "1")
+    monkeypatch.setenv(
+        "VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_PATH",
+        str(cache_path),
+    )
+    monkeypatch.setattr(
+        registry_service,
+        "_load_registry_from_vontology_graph",
+        _load_graph,
+    )
+    monkeypatch.setattr(
+        registry_service,
+        "_load_registry_from_vontology_json",
+        lambda **_kwargs: None,
+    )
+
+    snapshot = registry_service.get_model_registry_snapshot(preferred_language="en-NZ")
+
+    assert calls["graph"] == 1
+    assert snapshot["models"][0]["model_id"] == "openai:gpt-5.5-nano"
+    persisted = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert persisted["entries"]["en-nz"]["authority_fingerprint"] != (
+        "different-authority"
+    )
+    registry_service.clear_model_registry_snapshot_caches()
+
+
+def test_model_registry_authority_fingerprint_separates_mongo_principals(
+    monkeypatch,
+):
+    import src.backend.db.mongo_client as mongo_client
+    import src.backend.services.model_registry_service as registry_service
+
+    uri = {
+        "value": (
+            "mongodb+srv://reader-one:password-a@example.mongodb.net/"
+            "?authSource=admin"
+        )
+    }
+    monkeypatch.setattr(
+        mongo_client,
+        "get_effective_mongo_uri",
+        lambda: uri["value"],
+    )
+    monkeypatch.setattr(
+        mongo_client,
+        "get_configured_database_name",
+        lambda: "von_db",
+    )
+    monkeypatch.setattr(
+        mongo_client,
+        "is_using_fallback_uri",
+        lambda: False,
+    )
+
+    first = registry_service._model_registry_authority_fingerprint()
+    uri["value"] = (
+        "mongodb+srv://reader-two:password-b@example.mongodb.net/"
+        "?authSource=admin"
+    )
+    second = registry_service._model_registry_authority_fingerprint()
+    uri["value"] = (
+        "mongodb+srv://reader-two:rotated-secret@example.mongodb.net/"
+        "?authSource=admin"
+    )
+    rotated_password = registry_service._model_registry_authority_fingerprint()
+
+    assert first != second
+    assert second == rotated_password
+    assert "reader-one" not in first
+    assert "reader-two" not in second
+
+
+def test_only_structurally_valid_represented_snapshots_qualify():
+    import src.backend.services.model_registry_service as registry_service
+
+    assert (
+        registry_service._represented_registry_snapshot(
+            {"source": "vontology_graph", "models": []}
+        )
+        is False
+    )
+    assert (
+        registry_service._represented_registry_snapshot(
+            {"source": "vontology_graph", "models": ["gpt-5.6-terra"]}
+        )
+        is False
+    )
+    assert (
+        registry_service._represented_registry_snapshot(
+            {"source": "vontology_graph", "models": [{"provider": "openai"}]}
+        )
+        is False
+    )
+    assert (
+        registry_service._represented_registry_snapshot(
+            {
+                "source": "vontology_graph",
+                "models": [
+                    {
+                        "model_id": "gpt-5.6-terra",
+                        "provider": "openai",
+                    }
+                ],
+            }
+        )
+        is True
+    )
+
+
+def test_disk_cache_rejects_source_only_snapshot(tmp_path, monkeypatch):
+    import src.backend.services.model_registry_service as registry_service
+
+    cache_path = tmp_path / "registry_snapshot.json"
+    _write_registry_disk_cache(cache_path)
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    payload["entries"]["en-nz"]["snapshot"]["models"] = []
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_ENABLED", "1")
+    monkeypatch.setenv(
+        "VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_PATH",
+        str(cache_path),
+    )
+
+    cached = registry_service._load_registry_snapshot_from_disk(
+        cache_key="en-nz",
+        authority_fingerprint=(
+            registry_service._model_registry_authority_fingerprint()
+        ),
+        now=time.time(),
+    )
+
+    assert cached is None
+
+
+def test_stale_represented_snapshot_returns_while_one_refresh_runs(
+    tmp_path, monkeypatch
+):
+    import src.backend.services.model_registry_service as registry_service
+
+    cache_path = tmp_path / "registry_snapshot.json"
+    expected_snapshot = _write_registry_disk_cache(
+        cache_path,
+        created_at=time.time() - 60,
+        refresh_after=time.time() - 1,
+        stale_until=time.time() + 300,
+    )
+    registry_service.clear_model_registry_snapshot_caches()
+    refresh_started = threading.Event()
+    release_refresh = threading.Event()
+    calls = {"graph": 0}
+
+    def _load_graph(**_kwargs):
+        calls["graph"] += 1
+        refresh_started.set()
+        assert release_refresh.wait(3.0)
+        return {
+            "registry_concept_id": "#V#default_model_registry",
+            "models": [{"model_id": "openai:gpt-5.6-terra", "provider": "openai"}],
+        }
+
+    monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_ENABLED", "1")
+    monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_TTL_SECONDS", "120")
+    monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_MAX_STALE_SECONDS", "300")
+    monkeypatch.setenv(
+        "VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_PATH",
+        str(cache_path),
+    )
+    monkeypatch.setattr(
+        registry_service,
+        "_load_registry_from_vontology_graph",
+        _load_graph,
+    )
+    monkeypatch.setattr(
+        registry_service,
+        "_load_registry_from_vontology_json",
+        lambda **_kwargs: None,
+    )
+
+    started_at = time.perf_counter()
+    first = registry_service.get_model_registry_snapshot(preferred_language="en-NZ")
+    second = registry_service.get_model_registry_snapshot(preferred_language="en-NZ")
+    elapsed = time.perf_counter() - started_at
+
+    try:
+        assert first == expected_snapshot
+        assert second == expected_snapshot
+        assert elapsed < 0.5
+        assert refresh_started.wait(1.0)
+        assert calls["graph"] == 1
+        status = registry_service.get_model_registry_snapshot_status(
+            preferred_language="en-NZ"
+        )
+        assert status["ready"] is True
+        assert status["cache_state"] == "stale_refreshing"
+        assert status["refresh_in_progress"] is True
+    finally:
+        release_refresh.set()
+
+    deadline = time.time() + 3.0
+    while (
+        time.time() < deadline
+        and registry_service.get_model_registry_snapshot_status(
+            preferred_language="en-NZ"
+        )["refresh_in_progress"]
+    ):
+        time.sleep(0.01)
+
+    refreshed = registry_service.get_model_registry_snapshot(preferred_language="en-NZ")
+    assert refreshed["models"][0]["model_id"] == "openai:gpt-5.6-terra"
+    assert calls["graph"] == 1
+    registry_service.clear_model_registry_snapshot_caches()
+
+
+def test_model_registry_snapshot_enforces_current_hard_stale_limit(
+    tmp_path, monkeypatch
+):
+    import src.backend.services.model_registry_service as registry_service
+
+    cache_path = tmp_path / "registry_snapshot.json"
+    _write_registry_disk_cache(
+        cache_path,
+        created_at=time.time() - 7200,
+        refresh_after=time.time() - 3700,
+        stale_until=time.time() + 86400,
+    )
     registry_service.clear_model_registry_snapshot_caches()
     calls = {"graph": 0}
 
@@ -229,12 +489,17 @@ def test_model_registry_snapshot_ignores_stale_disk_cache(tmp_path, monkeypatch)
     monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_CACHE_TTL_SECONDS", "60")
     monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_ENABLED", "1")
     monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_TTL_SECONDS", "120")
+    monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_MAX_STALE_SECONDS", "3600")
     monkeypatch.setenv(
         "VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_PATH",
         str(cache_path),
     )
-    monkeypatch.setattr(registry_service, "_load_registry_from_vontology_graph", _load_graph)
-    monkeypatch.setattr(registry_service, "_load_registry_from_vontology_json", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        registry_service, "_load_registry_from_vontology_graph", _load_graph
+    )
+    monkeypatch.setattr(
+        registry_service, "_load_registry_from_vontology_json", lambda **_kwargs: None
+    )
 
     snapshot = registry_service.get_model_registry_snapshot(preferred_language="en-NZ")
     persisted = json.loads(cache_path.read_text(encoding="utf-8"))
@@ -269,8 +534,12 @@ def test_model_registry_snapshot_ignores_wrong_key_disk_cache(tmp_path, monkeypa
         "VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_PATH",
         str(cache_path),
     )
-    monkeypatch.setattr(registry_service, "_load_registry_from_vontology_graph", _load_graph)
-    monkeypatch.setattr(registry_service, "_load_registry_from_vontology_json", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        registry_service, "_load_registry_from_vontology_graph", _load_graph
+    )
+    monkeypatch.setattr(
+        registry_service, "_load_registry_from_vontology_json", lambda **_kwargs: None
+    )
 
     snapshot = registry_service.get_model_registry_snapshot(preferred_language="en-NZ")
 
@@ -300,13 +569,61 @@ def test_model_registry_snapshot_ignores_invalid_disk_cache(tmp_path, monkeypatc
         "VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_PATH",
         str(cache_path),
     )
-    monkeypatch.setattr(registry_service, "_load_registry_from_vontology_graph", _load_graph)
-    monkeypatch.setattr(registry_service, "_load_registry_from_vontology_json", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        registry_service, "_load_registry_from_vontology_graph", _load_graph
+    )
+    monkeypatch.setattr(
+        registry_service, "_load_registry_from_vontology_json", lambda **_kwargs: None
+    )
 
     snapshot = registry_service.get_model_registry_snapshot(preferred_language="en-NZ")
 
     assert calls["graph"] == 1
     assert snapshot["models"][0]["model_id"] == "openai:gpt-5.5-nano"
+    registry_service.clear_model_registry_snapshot_caches()
+
+
+def test_model_registry_snapshot_rejects_v1_projection_cache(tmp_path, monkeypatch):
+    import src.backend.services.model_registry_service as registry_service
+
+    cache_path = tmp_path / "registry_snapshot.json"
+    _write_registry_disk_cache(
+        cache_path,
+        schema_version="model_registry_snapshot_cache.v1",
+    )
+    registry_service.clear_model_registry_snapshot_caches()
+    calls = {"graph": 0}
+
+    def _load_graph(**_kwargs):
+        calls["graph"] += 1
+        return {
+            "registry_concept_id": "#V#default_model_registry",
+            "models": [{"model_id": "openai:gpt-5.6-terra", "provider": "openai"}],
+        }
+
+    monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_ENABLED", "1")
+    monkeypatch.setenv(
+        "VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_PATH",
+        str(cache_path),
+    )
+    monkeypatch.setattr(
+        registry_service,
+        "_load_registry_from_vontology_graph",
+        _load_graph,
+    )
+    monkeypatch.setattr(
+        registry_service,
+        "_load_registry_from_vontology_json",
+        lambda **_kwargs: None,
+    )
+
+    snapshot = registry_service.get_model_registry_snapshot(preferred_language="en-NZ")
+
+    assert calls["graph"] == 1
+    assert snapshot["models"][0]["model_id"] == "openai:gpt-5.6-terra"
+    assert json.loads(cache_path.read_text(encoding="utf-8"))["schema_version"] == (
+        "model_registry_snapshot_cache.v2"
+    )
     registry_service.clear_model_registry_snapshot_caches()
 
 
@@ -330,17 +647,34 @@ def test_model_registry_settings_fallback_is_not_disk_cached(tmp_path, monkeypat
         "VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_PATH",
         str(cache_path),
     )
-    monkeypatch.setattr(registry_service, "_load_registry_from_vontology_graph", lambda **_kwargs: None)
-    monkeypatch.setattr(registry_service, "_load_registry_from_vontology_json", lambda **_kwargs: None)
-    monkeypatch.setattr(registry_service, "_build_registry_from_settings", _build_settings)
+    monkeypatch.setattr(
+        registry_service, "_load_registry_from_vontology_graph", lambda **_kwargs: None
+    )
+    monkeypatch.setattr(
+        registry_service, "_load_registry_from_vontology_json", lambda **_kwargs: None
+    )
+    monkeypatch.setattr(
+        registry_service, "_build_registry_from_settings", _build_settings
+    )
 
     first = registry_service.get_model_registry_snapshot(preferred_language="en-NZ")
     second = registry_service.get_model_registry_snapshot(preferred_language="en-NZ")
+    preload_report = registry_service.preload_model_registry_snapshot(
+        preferred_language="en-NZ"
+    )
 
     assert first["source"] == "settings"
     assert second["source"] == "settings"
-    assert calls["settings"] == 2
+    assert calls["settings"] == 3
     assert not cache_path.exists()
+    assert preload_report["ready"] is False
+    assert preload_report["source"] is None
+    status = registry_service.get_model_registry_snapshot_status(
+        preferred_language="en-NZ"
+    )
+    assert status["ready"] is False
+    assert status["source"] is None
+    assert status["cache_state"] == "unavailable"
     registry_service.clear_model_registry_snapshot_caches()
 
 
@@ -366,21 +700,26 @@ def test_model_registry_disk_cache_write_is_atomic_enough_for_readers(
             "models": [{"model_id": "openai:gpt-5.4-nano", "provider": "openai"}],
         },
     )
-    monkeypatch.setattr(registry_service, "_load_registry_from_vontology_json", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        registry_service, "_load_registry_from_vontology_json", lambda **_kwargs: None
+    )
 
     registry_service.get_model_registry_snapshot(preferred_language="en-NZ")
 
     persisted = json.loads(cache_path.read_text(encoding="utf-8"))
-    assert persisted["schema_version"] == "model_registry_snapshot_cache.v1"
+    assert persisted["schema_version"] == "model_registry_snapshot_cache.v2"
     assert persisted["entries"]["en-nz"]["cache_key"] == "en-nz"
+    assert persisted["entries"]["en-nz"]["authority_fingerprint"]
+    assert (
+        persisted["entries"]["en-nz"]["refresh_after"]
+        <= (persisted["entries"]["en-nz"]["stale_until"])
+    )
     assert persisted["entries"]["en-nz"]["snapshot"]["source"] == "vontology_graph"
     assert list(tmp_path.glob(".*.tmp")) == []
     registry_service.clear_model_registry_snapshot_caches()
 
 
-def test_model_registry_disk_cache_keeps_multiple_language_keys(
-    tmp_path, monkeypatch
-):
+def test_model_registry_disk_cache_keeps_multiple_language_keys(tmp_path, monkeypatch):
     import src.backend.services.model_registry_service as registry_service
 
     cache_path = tmp_path / "registry_snapshot.json"
@@ -418,6 +757,231 @@ def test_model_registry_disk_cache_keeps_multiple_language_keys(
         "openai:gpt-5.5-nano"
     )
     registry_service.clear_model_registry_snapshot_caches()
+
+
+def test_zero_disk_ttl_retains_the_independent_memory_refresh_interval(
+    tmp_path,
+    monkeypatch,
+):
+    import src.backend.services.model_registry_service as registry_service
+
+    cache_path = tmp_path / "registry_snapshot.json"
+    registry_service.clear_model_registry_snapshot_caches()
+    calls = {"graph": 0}
+    background_refreshes: list[dict[str, object]] = []
+
+    def _load_graph(**_kwargs):
+        calls["graph"] += 1
+        return {
+            "registry_concept_id": "#V#default_model_registry",
+            "models": [{"model_id": "openai:gpt-5.6-terra", "provider": "openai"}],
+        }
+
+    monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_CACHE_TTL_SECONDS", "60")
+    monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_ENABLED", "1")
+    monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_TTL_SECONDS", "0")
+    monkeypatch.setenv(
+        "VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_PATH",
+        str(cache_path),
+    )
+    monkeypatch.setattr(
+        registry_service,
+        "_load_registry_from_vontology_graph",
+        _load_graph,
+    )
+    monkeypatch.setattr(
+        registry_service,
+        "_load_registry_from_vontology_json",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        registry_service,
+        "_start_registry_snapshot_background_refresh",
+        lambda **kwargs: background_refreshes.append(dict(kwargs)) or True,
+    )
+
+    first = registry_service.get_model_registry_snapshot()
+    second = registry_service.get_model_registry_snapshot()
+
+    assert first["source"] == "vontology_graph"
+    assert second["source"] == "vontology_graph"
+    assert calls["graph"] == 1
+    assert background_refreshes == []
+    assert cache_path.exists() is False
+    registry_service.clear_model_registry_snapshot_caches()
+
+
+def test_model_registry_preload_hydrates_before_returning(monkeypatch):
+    import src.backend.services.model_registry_service as registry_service
+
+    registry_service.clear_model_registry_snapshot_caches()
+    calls = {"graph": 0}
+
+    def _load_graph(**_kwargs):
+        calls["graph"] += 1
+        return {
+            "registry_concept_id": "#V#default_model_registry",
+            "models": [{"model_id": "openai:gpt-5.6-terra", "provider": "openai"}],
+        }
+
+    monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_ENABLED", "0")
+    monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_CACHE_TTL_SECONDS", "60")
+    monkeypatch.setattr(
+        registry_service,
+        "_load_registry_from_vontology_graph",
+        _load_graph,
+    )
+    monkeypatch.setattr(
+        registry_service,
+        "_load_registry_from_vontology_json",
+        lambda **_kwargs: None,
+    )
+
+    report = registry_service.preload_model_registry_snapshot()
+
+    assert calls["graph"] == 1
+    assert report["ready"] is True
+    assert report["source"] == "vontology_graph"
+    assert report["cache_state"] == "fresh"
+    assert report["preload_duration_ms"] >= 0
+    registry_service.clear_model_registry_snapshot_caches()
+
+
+def test_model_registry_getter_retries_after_runtime_authority_change(monkeypatch):
+    import src.backend.services.model_registry_service as registry_service
+
+    registry_service.clear_model_registry_snapshot_caches()
+    authority = {"fingerprint": "authority-before-hydration"}
+    calls = {"graph": 0}
+
+    def _load_graph(**_kwargs):
+        calls["graph"] += 1
+        authority["fingerprint"] = "authority-after-hydration"
+        return {
+            "registry_concept_id": "#V#default_model_registry",
+            "models": [{"model_id": "openai:gpt-5.6-terra", "provider": "openai"}],
+        }
+
+    monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_ENABLED", "0")
+    monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_CACHE_TTL_SECONDS", "60")
+    monkeypatch.setattr(
+        registry_service,
+        "_model_registry_authority_fingerprint",
+        lambda: authority["fingerprint"],
+    )
+    monkeypatch.setattr(
+        registry_service,
+        "_load_registry_from_vontology_graph",
+        _load_graph,
+    )
+    monkeypatch.setattr(
+        registry_service,
+        "_load_registry_from_vontology_json",
+        lambda **_kwargs: None,
+    )
+
+    snapshot = registry_service.get_model_registry_snapshot()
+
+    assert calls["graph"] == 2
+    assert snapshot["source"] == "vontology_graph"
+    assert snapshot["models"][0]["model_id"] == "openai:gpt-5.6-terra"
+    assert (
+        registry_service._MODEL_REGISTRY_SNAPSHOT_CACHE[""]["authority_fingerprint"]
+        == "authority-after-hydration"
+    )
+    registry_service.clear_model_registry_snapshot_caches()
+
+
+def test_model_registry_getter_falls_back_after_two_authority_changes(monkeypatch):
+    import src.backend.services.model_registry_service as registry_service
+
+    registry_service.clear_model_registry_snapshot_caches()
+    authority = {"version": 0}
+    calls = {"graph": 0, "settings": 0}
+
+    def _load_graph(**_kwargs):
+        calls["graph"] += 1
+        authority["version"] += 1
+        return {
+            "registry_concept_id": "#V#default_model_registry",
+            "models": [
+                {
+                    "model_id": f"openai:wrong-authority-{calls['graph']}",
+                    "provider": "openai",
+                }
+            ],
+        }
+
+    def _load_settings():
+        calls["settings"] += 1
+        return {
+            "source": "settings",
+            "models": [{"model_id": "openai:safe-fallback", "provider": "openai"}],
+        }
+
+    monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_DISK_CACHE_ENABLED", "0")
+    monkeypatch.setenv("VON_MODEL_REGISTRY_SNAPSHOT_CACHE_TTL_SECONDS", "60")
+    monkeypatch.setattr(
+        registry_service,
+        "_model_registry_authority_fingerprint",
+        lambda: f"authority-{authority['version']}",
+    )
+    monkeypatch.setattr(
+        registry_service,
+        "_load_registry_from_vontology_graph",
+        _load_graph,
+    )
+    monkeypatch.setattr(
+        registry_service,
+        "_load_registry_from_vontology_json",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        registry_service,
+        "_build_registry_from_settings",
+        _load_settings,
+    )
+
+    snapshot = registry_service.get_model_registry_snapshot()
+
+    assert calls == {"graph": 2, "settings": 1}
+    assert snapshot["source"] == "settings"
+    assert snapshot["models"][0]["model_id"] == "openai:safe-fallback"
+    assert registry_service._MODEL_REGISTRY_SNAPSHOT_CACHE == {}
+    registry_service.clear_model_registry_snapshot_caches()
+
+
+def test_clearing_registry_caches_resets_inflight_refresh_state():
+    import src.backend.services.model_registry_service as registry_service
+
+    registry_service._MODEL_REGISTRY_SNAPSHOT_REFRESH_INFLIGHT.add("en-nz:authority")
+
+    registry_service.clear_model_registry_snapshot_caches()
+
+    assert registry_service._MODEL_REGISTRY_SNAPSHOT_REFRESH_INFLIGHT == set()
+
+
+def test_server_main_preloads_registry_before_creating_flask_app() -> None:
+    source_path = (
+        Path(__file__).resolve().parents[2] / "src" / "workflows" / "von" / "main.py"
+    )
+    module = ast.parse(source_path.read_text(encoding="utf-8"))
+    main_function = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.FunctionDef) and node.name == "main"
+    )
+    calls = [
+        node
+        for node in ast.walk(main_function)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    ]
+    preload_call = next(
+        node for node in calls if node.func.id == "preload_model_registry_snapshot"
+    )
+    create_app_call = next(node for node in calls if node.func.id == "create_flask_app")
+
+    assert preload_call.lineno < create_app_call.lineno
 
 
 def test_policy_candidate_prefers_active_llm_primary_before_enabled_models():
@@ -536,8 +1100,8 @@ def test_model_stage_suitability_evidence_blocks_single_case_certification():
     assert decision["schema_version"] == "model_stage_certification_decision.v1"
     assert decision["promotion_authorised"] is False
     assert "insufficient_distinct_replay_cases" in decision["promotion_blockers"]
-    assert "evidence_entry_promotion_blockers_present" in (
-        decision["promotion_blockers"]
+    assert (
+        "evidence_entry_promotion_blockers_present" in (decision["promotion_blockers"])
     )
 
 

--- a/tests/backend/test_rag_turn_execution_records_mcp_read_tools.py
+++ b/tests/backend/test_rag_turn_execution_records_mcp_read_tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 from typing import Any
 
@@ -1061,6 +1062,81 @@ def test_rag_get_item_supports_turn_execution_records(monkeypatch):
                 },
             }
         ],
+        "effect_observation_journal": {
+            "effect_2": {
+                "identity": {
+                    "schema_version": "effect_observation_journal.v1",
+                    "effect_id": "effect_2",
+                    "call_id": "call-effect-2",
+                    "capability_name": "add_relationship",
+                    "created_at_utc": "2026-02-19T01:00:00Z",
+                },
+                "dispatch_intent": {
+                    "phase": "dispatch_intent",
+                    "dispatch_state": "intent_recorded",
+                    "recorded_at_utc": "2026-02-19T01:00:00Z",
+                },
+                "turn_terminal": {
+                    "phase": "turn_terminal",
+                    "effect_status": "indeterminate",
+                    "changed": None,
+                    "recorded_at_utc": "2026-02-19T01:00:01Z",
+                    "transport": {
+                        "execution_id": "mcp_late_9",
+                        "outcome": "timed_out",
+                    },
+                    "receipt": {"mutation_outcome": "unknown"},
+                },
+                "late_terminal": {
+                    "phase": "late_terminal",
+                    "outcome": "late_success",
+                    "effect_status": "succeeded",
+                    "changed": True,
+                    "recorded_at_utc": "2026-02-19T01:00:02Z",
+                    "payload": {
+                        "success": True,
+                        "effect_status": "succeeded",
+                        "changed": True,
+                        "private_detail": "not projected",
+                    },
+                },
+            },
+            "effect_unresolved": {
+                "identity": {
+                    "schema_version": "effect_observation_journal.v1",
+                    "effect_id": "effect_unresolved",
+                },
+                "turn_terminal": {
+                    "phase": "turn_terminal",
+                    "effect_status": "indeterminate",
+                    "receipt": {"mutation_outcome": "unknown"},
+                },
+            },
+            "effect_missing_late_payload": {
+                "identity": {
+                    "schema_version": "effect_observation_journal.v1",
+                    "effect_id": "effect_missing_late_payload",
+                },
+                "late_terminal": {
+                    "phase": "late_terminal",
+                    "outcome": "late_success",
+                    "effect_status": "succeeded",
+                    "changed": True,
+                },
+            },
+            "effect_missing_turn_receipt": {
+                "identity": {
+                    "schema_version": "effect_observation_journal.v1",
+                    "effect_id": "effect_missing_turn_receipt",
+                },
+                "turn_terminal": {
+                    "phase": "turn_terminal",
+                    "effect_status": "succeeded",
+                    "changed": True,
+                    "transport": {"outcome": "completed"},
+                },
+            },
+        },
     }
 
     coll = _TurnExecutionCollection([doc])
@@ -1115,6 +1191,29 @@ def test_rag_get_item_supports_turn_execution_records(monkeypatch):
             },
         }
     ]
+    assert result["effect_observation_journal_count"] == 4
+    assert result["effect_observation_journal_truncated"] is False
+    journal_by_id = {
+        item["effect_id"]: item
+        for item in result["effect_observation_journal"]
+    }
+    assert journal_by_id["effect_2"]["latest_phase"] == "late_terminal"
+    assert journal_by_id["effect_2"]["outcome_resolved"] is True
+    assert journal_by_id["effect_2"]["late_terminal"]["receipt"] == {
+        "success": True,
+        "effect_status": "succeeded",
+        "changed": True,
+    }
+    assert "private_detail" not in json.dumps(journal_by_id["effect_2"])
+    assert journal_by_id["effect_unresolved"]["outcome_resolved"] is False
+    assert (
+        journal_by_id["effect_missing_late_payload"]["outcome_resolved"]
+        is False
+    )
+    assert (
+        journal_by_id["effect_missing_turn_receipt"]["outcome_resolved"]
+        is False
+    )
 
 
 def test_rag_get_item_does_not_expose_late_effects_across_namespaces(
@@ -1135,6 +1234,13 @@ def test_rag_get_item_does_not_expose_late_effects_across_namespaces(
                         "outcome": "late_success",
                     }
                 ],
+                "effect_observation_journal": {
+                    "private-effect": {
+                        "dispatch_intent": {
+                            "phase": "dispatch_intent",
+                        }
+                    }
+                },
             }
         ]
     )
@@ -1152,6 +1258,7 @@ def test_rag_get_item_does_not_expose_late_effects_across_namespaces(
     assert result["success"] is False
     assert result["error_code"] == "not_found"
     assert "late_effect_observations" not in result
+    assert "effect_observation_journal" not in result
 
 
 def test_rag_list_indexed_supports_episode_critique_improvement_suggestion_summary(

--- a/tests/backend/test_resolve_concept_by_name.py
+++ b/tests/backend/test_resolve_concept_by_name.py
@@ -108,6 +108,229 @@ def test_resolve_concept_by_name_returns_ambiguous_on_tie():
     assert {c["concept_id"] for c in result["candidates"]} == {concept_a, concept_b}
 
 
+def test_resolve_concept_by_name_hydrates_candidate_names_in_one_batch(
+    monkeypatch,
+) -> None:
+    candidate_ids = ["#V#batch_candidate_a", "#V#batch_candidate_b"]
+    batch_calls: list[tuple[list[str], str | None, int]] = []
+
+    monkeypatch.setattr(
+        concept_resolution_service,
+        "_search_text_relations",
+        lambda *_args, **_kwargs: set(candidate_ids),
+    )
+    monkeypatch.setattr(
+        concept_resolution_service,
+        "filter_accessible_concept_ids",
+        lambda ids: set(ids),
+    )
+    monkeypatch.setattr(
+        concept_resolution_service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: [
+            {"concept_id": concept_id, "relationships": {}}
+            for concept_id in candidate_ids
+        ],
+    )
+
+    def _get_texts_for_concepts(
+        concept_ids,
+        *,
+        predicate=None,
+        limit_per_concept=50,
+        **_kwargs,
+    ):
+        ordered_ids = list(concept_ids)
+        batch_calls.append((ordered_ids, predicate, limit_per_concept))
+        return {
+            concept_id: [
+                {
+                    "text": "Shared batch candidate",
+                    "lang": "en-NZ",
+                    "predicate": "hasName",
+                    "context": {"name_type": "NL"},
+                }
+            ]
+            for concept_id in ordered_ids
+        }
+
+    monkeypatch.setattr(
+        concept_resolution_service,
+        "get_texts_for_concepts",
+        _get_texts_for_concepts,
+    )
+
+    result = resolve_concept_by_name(
+        name="Shared batch candidate",
+        match_code_strings=False,
+    )
+
+    assert result["status"] == "ambiguous"
+    assert {
+        candidate["concept_id"] for candidate in result["candidates"]
+    } == set(candidate_ids)
+    assert batch_calls == [(sorted(candidate_ids), "hasName", 200)]
+
+
+def test_resolve_concept_by_name_falls_back_when_batch_hydration_is_truncated(
+    monkeypatch,
+) -> None:
+    candidate_ids = ["#V#name_heavy_candidate", "#V#starved_candidate"]
+    query = "Shared complete candidate"
+    batch_calls: list[list[str]] = []
+    single_calls: list[tuple[str, str | None, int]] = []
+
+    monkeypatch.setattr(
+        concept_resolution_service,
+        "_search_text_relations",
+        lambda *_args, **_kwargs: set(candidate_ids),
+    )
+    monkeypatch.setattr(
+        concept_resolution_service,
+        "filter_accessible_concept_ids",
+        lambda ids: set(ids),
+    )
+    monkeypatch.setattr(
+        concept_resolution_service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: [
+            {"concept_id": concept_id, "relationships": {}}
+            for concept_id in candidate_ids
+        ],
+    )
+
+    def _truncated_batch(concept_ids, *, query_metadata, **_kwargs):
+        ordered_ids = list(concept_ids)
+        batch_calls.append(ordered_ids)
+        query_metadata["relation_query_truncated"] = True
+        return {
+            ordered_ids[0]: [
+                {
+                    "text": query,
+                    "lang": "en-NZ",
+                    "predicate": "hasName",
+                    "context": {"name_type": "NL"},
+                }
+            ]
+        }
+
+    def _complete_single(concept_id, *, predicate=None, limit=50, **_kwargs):
+        single_calls.append((concept_id, predicate, limit))
+        return [
+            {
+                "text": query,
+                "lang": "en-NZ",
+                "predicate": "hasName",
+                "context": {"name_type": "NL"},
+            }
+        ]
+
+    monkeypatch.setattr(
+        concept_resolution_service,
+        "get_texts_for_concepts",
+        _truncated_batch,
+    )
+    monkeypatch.setattr(
+        concept_resolution_service,
+        "get_texts_for_concept",
+        _complete_single,
+    )
+
+    result = resolve_concept_by_name(
+        name=query,
+        match_code_strings=False,
+    )
+
+    assert result["status"] == "ambiguous"
+    assert {
+        candidate["concept_id"] for candidate in result["candidates"]
+    } == set(candidate_ids)
+    assert batch_calls == [sorted(candidate_ids)]
+    assert single_calls == [
+        (concept_id, "hasName", 200) for concept_id in sorted(candidate_ids)
+    ]
+
+
+def test_resolve_concept_by_name_bounds_each_stage_and_filters_before_fallback(
+    monkeypatch,
+) -> None:
+    private_concept_id = "#V#private_bounded_candidate"
+    public_concept_id = "#V#public_bounded_candidate"
+    query = "Bounded accessible match"
+    search_calls: list[tuple[str, dict[str, object]]] = []
+    access_calls: list[set[str]] = []
+
+    def _search(query_text, **kwargs):
+        search_calls.append((query_text, dict(kwargs)))
+        if kwargs.get("exact") or kwargs.get("prefix"):
+            return {private_concept_id}
+        return {public_concept_id}
+
+    def _filter_accessible(candidate_ids):
+        candidate_set = set(candidate_ids)
+        access_calls.append(candidate_set)
+        return candidate_set.intersection({public_concept_id})
+
+    monkeypatch.setattr(
+        concept_resolution_service,
+        "_search_text_relations",
+        _search,
+    )
+    monkeypatch.setattr(
+        concept_resolution_service,
+        "filter_accessible_concept_ids",
+        _filter_accessible,
+    )
+    monkeypatch.setattr(
+        concept_resolution_service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: [
+            {"concept_id": public_concept_id, "relationships": {}}
+        ],
+    )
+    monkeypatch.setattr(
+        concept_resolution_service,
+        "get_texts_for_concepts",
+        lambda concept_ids, **_kwargs: {
+            concept_id: [
+                {
+                    "text": query,
+                    "lang": "en-NZ",
+                    "predicate": "hasName",
+                    "context": {"name_type": "NL"},
+                }
+            ]
+            for concept_id in concept_ids
+        },
+    )
+
+    result = resolve_concept_by_name(
+        name=query,
+        match_code_strings=False,
+        max_results=7,
+    )
+
+    assert result["status"] == "resolved"
+    assert result["resolved_concept_id"] == public_concept_id
+    assert search_calls == [
+        (
+            query,
+            {
+                "exact": True,
+                "result_limit": 7,
+                "allow_fallback_scan": False,
+            },
+        ),
+        (query, {"prefix": True, "result_limit": 7}),
+        (query, {"result_limit": 7}),
+    ]
+    assert access_calls == [
+        {private_concept_id},
+        {private_concept_id},
+        {public_concept_id},
+    ]
+
+
 def test_resolve_concept_by_name_honours_instance_of_filter():
     if TextValuesRepository.db() is None:
         pytest.skip("MongoDB not configured for this test run")
@@ -235,15 +458,18 @@ def test_resolve_concept_by_name_audit_counts_only_actor_accessible_candidates(
     )
     monkeypatch.setattr(
         concept_resolution_service,
-        "get_texts_for_concept",
-        lambda *_args, **_kwargs: [
-            {
-                "text": private_name,
-                "lang": "en-NZ",
-                "predicate": "hasName",
-                "context": {"name_type": "NL"},
-            }
-        ],
+        "get_texts_for_concepts",
+        lambda concept_ids, **_kwargs: {
+            concept_id: [
+                {
+                    "text": private_name,
+                    "lang": "en-NZ",
+                    "predicate": "hasName",
+                    "context": {"name_type": "NL"},
+                }
+            ]
+            for concept_id in concept_ids
+        },
     )
     monkeypatch.setattr(
         concept_resolution_service.TextRelationsRepository,

--- a/tests/backend/test_turn_execution_record_service_execution_summary.py
+++ b/tests/backend/test_turn_execution_record_service_execution_summary.py
@@ -13,6 +13,7 @@ from src.backend.services.turn_execution_record_service import (
     build_workflow_routing_diagnostics,
     get_turn_execution_record_projection,
     project_final_answer_tool_evidence,
+    record_effect_observation_phase,
     upsert_turn_execution_record_projection,
     _normalise_projection_field_entries,
     _summarise_tool_execution_context,
@@ -344,6 +345,163 @@ def test_late_effect_observation_is_bounded_idempotent_and_survives_full_upsert(
         == "succeeded"
     )
     assert readback["late_effect_observations"][0]["payload"]["changed"] is True
+
+
+def test_effect_observation_journal_is_actor_scoped_idempotent_and_survives_upsert(
+    monkeypatch,
+) -> None:
+    import mongomock
+    import src.backend.services.turn_execution_record_service as record_service
+
+    collection = mongomock.MongoClient().von_test.turn_execution_records
+    collection.create_index("request_id", unique=True)
+    monkeypatch.setattr(
+        record_service,
+        "get_turn_execution_records_collection",
+        lambda: collection,
+    )
+    monkeypatch.setattr(
+        record_service,
+        "_turn_execution_mongo_comment",
+        lambda *_args, **_kwargs: None,
+    )
+    scope = {
+        "user_id": "#V#user",
+        "namespace": "#V#user@org",
+        "org_id": "#V#org",
+    }
+
+    dispatch = record_effect_observation_phase(
+        request_id="req-effect-journal",
+        effect_id="effect_abc123",
+        phase="dispatch_intent",
+        observation={
+            "call_id": "call-1",
+            "capability_name": "upsert_text_relation",
+            "dispatch_state": "intent_recorded",
+        },
+        **scope,
+    )
+    assert dispatch["updated"] is True
+    identity = collection.find_one(
+        {"request_id": "req-effect-journal"}
+    )["effect_observation_journal"]["effect_abc123"]["identity"]
+
+    terminal = record_effect_observation_phase(
+        request_id="req-effect-journal",
+        effect_id="effect_abc123",
+        phase="turn_terminal",
+        observation={
+            "call_id": "must-not-replace-call-identity",
+            "capability_name": "must_not_replace_capability",
+            "effect_status": "indeterminate",
+            "changed": None,
+            "transport": {"outcome": "timed_out"},
+            "receipt": {"mutation_outcome": "unknown"},
+        },
+        **scope,
+    )
+    late = record_effect_observation_phase(
+        request_id="req-effect-journal",
+        effect_id="effect_abc123",
+        phase="late_terminal",
+        observation={
+            "call_id": "call-1",
+            "capability_name": "upsert_text_relation",
+            "outcome": "late_success",
+            "effect_status": "succeeded",
+            "changed": True,
+            "payload": {"success": True, "changed": True},
+        },
+        **scope,
+    )
+    duplicate_late = record_effect_observation_phase(
+        request_id="req-effect-journal",
+        effect_id="effect_abc123",
+        phase="late_terminal",
+        observation={
+            "outcome": "late_success",
+            "effect_status": "failed",
+            "changed": False,
+        },
+        **scope,
+    )
+
+    assert terminal["updated"] is True
+    assert late["updated"] is True
+    assert duplicate_late["updated"] is False
+    assert duplicate_late["duplicate"] is True
+    stored = collection.find_one({"request_id": "req-effect-journal"})
+    journal = stored["effect_observation_journal"]["effect_abc123"]
+    assert journal["identity"] == identity
+    assert journal["identity"]["call_id"] == "call-1"
+    assert journal["identity"]["capability_name"] == "upsert_text_relation"
+    assert journal["late_terminal"]["effect_status"] == "succeeded"
+
+    full_record = build_turn_execution_record(
+        request_id="req-effect-journal",
+        session_id="session-effect-journal",
+        namespace="#V#user@org",
+        user_id="#V#user",
+        org_id="#V#org",
+        prompt_text="Apply the bounded effect.",
+        response_text="The turn returned an indeterminate receipt.",
+        interaction_timestamp_utc="2026-07-27T10:00:01Z",
+    )
+    full_record["effect_observation_journal"] = {}
+    upsert = upsert_turn_execution_record_projection(
+        record=full_record,
+        session_id="session-effect-journal",
+        **scope,
+    )
+    assert upsert["updated"] is True
+    preserved = collection.find_one({"request_id": "req-effect-journal"})
+    assert (
+        preserved["effect_observation_journal"]["effect_abc123"]
+        == journal
+    )
+
+
+def test_effect_observation_journal_refuses_cross_actor_request_collision(
+    monkeypatch,
+) -> None:
+    import mongomock
+    import src.backend.services.turn_execution_record_service as record_service
+
+    collection = mongomock.MongoClient().von_test.turn_execution_records
+    collection.insert_one(
+        {
+            "request_id": "shared-effect-request",
+            "namespace": "#V#actor_a@org",
+            "user_id": "#V#actor_a",
+            "org_id": "#V#org",
+        }
+    )
+    monkeypatch.setattr(
+        record_service,
+        "get_turn_execution_records_collection",
+        lambda: collection,
+    )
+    monkeypatch.setattr(
+        record_service,
+        "_turn_execution_mongo_comment",
+        lambda *_args, **_kwargs: None,
+    )
+
+    outcome = record_effect_observation_phase(
+        request_id="shared-effect-request",
+        effect_id="effect_actor_b",
+        phase="dispatch_intent",
+        observation={"dispatch_state": "intent_recorded"},
+        namespace="#V#actor_b@org",
+        user_id="#V#actor_b",
+        org_id="#V#org",
+    )
+
+    assert outcome["updated"] is False
+    assert outcome["reason"] == "actor_scope_mismatch"
+    stored = collection.find_one({"request_id": "shared-effect-request"})
+    assert "effect_observation_journal" not in stored
 
 
 def test_late_effect_observation_refuses_cross_actor_request_id_collision(

--- a/tests/backend/test_utils_flask_health_agent_test_marker.py
+++ b/tests/backend/test_utils_flask_health_agent_test_marker.py
@@ -183,6 +183,7 @@ def test_diagnostics_use_live_durable_workflow_status_by_default(
 
 def test_health_runtime_authority_uses_count_free_durable_status(monkeypatch) -> None:
     import src.backend.server.utils_flask as utils_flask
+    import src.backend.services.model_registry_service as model_registry_service
     import src.backend.workflows.durable.startup as durable_startup
 
     monkeypatch.delenv("VON_AGENT_TEST_INSTANCE", raising=False)
@@ -198,6 +199,19 @@ def test_health_runtime_authority_uses_count_free_durable_status(monkeypatch) ->
         }
 
     monkeypatch.setattr(durable_startup, "get_system_status", _status)
+    monkeypatch.setattr(
+        model_registry_service,
+        "get_model_registry_snapshot_status",
+        lambda: {
+            "schema_version": "model_registry_snapshot_status.v1",
+            "ready": True,
+            "source": "vontology_graph",
+            "cache_state": "stale_refreshing",
+            "age_seconds": 3612.5,
+            "refresh_in_progress": True,
+            "last_refresh_succeeded": True,
+        },
+    )
     app = Flask(__name__)
     app.config["DURABLE_WORKFLOW_STARTUP_STATUS"] = {"state": "ready"}
 
@@ -210,5 +224,14 @@ def test_health_runtime_authority_uses_count_free_durable_status(monkeypatch) ->
         "database_connected": True,
         "worker_running": True,
         "scheduler_running": True,
+    }
+    assert payload["model_registry"] == {
+        "schema_version": "model_registry_snapshot_status.v1",
+        "ready": True,
+        "source": "vontology_graph",
+        "cache_state": "stale_refreshing",
+        "age_seconds": 3612.5,
+        "refresh_in_progress": True,
+        "last_refresh_succeeded": True,
     }
     assert "worker_id" not in json.dumps(payload)

--- a/tests/backend/test_von_chat_run_timeout.py
+++ b/tests/backend/test_von_chat_run_timeout.py
@@ -112,7 +112,7 @@ def test_restricted_gateway_forwards_adaptive_read_transport_options() -> None:
             *,
             deadline_monotonic=None,
             late_completion_observer=None,
-            require_configured_timeout=False,
+            require_effect_admission_window=False,
         ):
             captured.update(
                 {
@@ -120,7 +120,9 @@ def test_restricted_gateway_forwards_adaptive_read_transport_options() -> None:
                     "payload": payload,
                     "deadline_monotonic": deadline_monotonic,
                     "late_completion_observer": late_completion_observer,
-                    "require_configured_timeout": require_configured_timeout,
+                    "require_effect_admission_window": (
+                        require_effect_admission_window
+                    ),
                 }
             )
             return "result"
@@ -133,7 +135,7 @@ def test_restricted_gateway_forwards_adaptive_read_transport_options() -> None:
         {"query": "bounded"},
         deadline_monotonic=123.5,
         late_completion_observer=None,
-        require_configured_timeout=False,
+        require_effect_admission_window=False,
     )
 
     assert result == "result"
@@ -142,7 +144,7 @@ def test_restricted_gateway_forwards_adaptive_read_transport_options() -> None:
         "payload": {"query": "bounded"},
         "deadline_monotonic": 123.5,
         "late_completion_observer": None,
-        "require_configured_timeout": False,
+        "require_effect_admission_window": False,
     }
 
 


### PR DESCRIPTION
## Summary

This stacked A3r6 revision hardens the mechanical support surface exposed by A3r5:

- recovers cold model-profile startup from a versioned, principal-scoped, authority-fingerprinted registry snapshot while retaining Vontology graph authority;
- makes effect admission queue-aware and records durable actor-scoped dispatch, turn-terminal, and late-terminal observations;
- returns at caller deadlines while observing timed-out effects out of band;
- rejects hidden/incompatible creation parents, reports canonical identity conflicts, removes implicit numeric suffix creation, and preserves partial batch receipts;
- bounds concept resolution, removes a redundant exact scan, and makes candidate hydration truncation-safe;
- exposes registry readiness and the durable effect journal through existing health/read surfaces.

No task-specific semantic workflow or Python policy is added.

## Why

A3r5 improved provider selection but still left three mechanical failure classes: cold profile lookup could block startup, timed-out mutations could finish without durable outcome visibility, and create/resolver behaviour could choose wrong parents or create suffix duplicates. This revision makes those paths bounded and diagnosable.

## Validation

- Final uncontended transport/create/resolver/registry/health regression: **70 passed in 73.87s**.
- Model-registry/health group: **32 passed**.
- Transport/adaptive/catalogue group: **107 passed**.
- Create/resolver/performance group: **36 passed in 68.10s**.
- Journal/read-back group: **85 passed, 11 inherited failures**; the same 11 reproduce on the exact A3r5 base with `workflow_global_admin_authority_required`.
- Ruff, Python compilation, and `git diff --check`: passed.
- Cold start to bind was about 71s; warm restart was 10.07s; first post-cold Terra Responses dispatch returned `READY` in about 2.045s.

## Disclosed-case result

**REVISE — this is not a candidate freeze.** Each disclosed case was run once with `gpt-5.6-terra`; all three failed semantic acceptance despite improved mechanical evidence:

1. Bayesian paper: typed parent conflict, no suffix, but two late partial batches and no complete representation.
2. Coral paper: late successful paper write, but a duplicate bibliographic identity was created and both cross-paper writes were correctly left `not_started` for insufficient window.
3. Counterfactual scenario: no new duplicate, but no A3r6 write occurred and required scenario-scoped relations remain absent; the response overclaimed cumulative prose state.

The runs also exposed invalid root evidence reads and a completion projection that can report `safe_to_claim_completion=true` despite a durable `not_started` attempted effect.

## Boundary and remaining work

This PR is deliberately stacked on the A3r5 provider-seams branch and remains draft. It does not authorise merge, freeze, holdout, shadow, cutover, release, or A4.

Next revision targets are external-ID-aware bibliographic identity, effect-window reservation/sequencing, valid canonical evidence reads, completion-gate accounting for attempted effects, and structural scenario scoping with read-back.