### PR TITLE
JVNAUTOSCI-2600 revise external identity and effect finality

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -874,15 +874,27 @@ def _create_concepts(**kwargs):
     from ...vontology.utils_vontology import create_vontology_concept
     from ...vontology.code_concepts_registry import PREDICATE_TYPE_ID
     from ...services.create_concepts_duplicate_guard_service import (
+        CreateConceptDuplicateGuardBlock,
         build_canonical_identity_conflict_create_concepts_result,
+        build_duplicate_guard_block_create_concepts_result,
         build_duplicate_prevented_create_concepts_result,
         find_existing_concept_for_create_concepts,
+    )
+    from ...services.concept_external_identity_service import (
+        ExternalIdentityInputError,
+        canonical_concept_id_for_external_identifiers,
+        normalise_create_external_identifiers,
+        persist_external_identity_names,
     )
     from ...services.create_concepts_parent_resolution_service import (
         resolve_parent_for_create_concepts,
     )
     from ...services.relationship_extent_index_service import (
         defer_relationship_extent_index_sync,
+    )
+    from ...security.access_control import (
+        override_current_organisation,
+        override_current_user,
     )
 
     parent_id: str | None = kwargs.get("parent_id")
@@ -1157,7 +1169,11 @@ def _create_concepts(**kwargs):
             return True
         return False
 
-    with defer_relationship_extent_index_sync():
+    with (
+        override_current_user(actor_user_id),
+        override_current_organisation(actor_org_id),
+        defer_relationship_extent_index_sync(),
+    ):
         for concept_data in concepts:
             # This is both the batch boundary and the safe cancellation point after
             # the preceding concept's complete logical write bundle.
@@ -1192,6 +1208,66 @@ def _create_concepts(**kwargs):
                 create_as_instance = kind == "instance"
                 parent_id_for_concept = validated_parent_id
 
+            try:
+                external_identifiers = normalise_create_external_identifiers(
+                    external_identifiers=concept_data.get("external_identifiers"),
+                    concept_name=str(name),
+                    kind=kind,
+                )
+            except ExternalIdentityInputError as exc:
+                results.append(
+                    {
+                        "success": False,
+                        "effect_status": "failed",
+                        "changed": False,
+                        "error_code": exc.error_code,
+                        "message": str(exc),
+                        "error_details": dict(exc.details),
+                        "concept": None,
+                        "input_name": str(name),
+                        "requested_name": str(name),
+                        "requested_kind": kind,
+                    }
+                )
+                continue
+
+            canonical_concept_id_override = None
+            if external_identifiers:
+                canonical_concept_id_override = (
+                    canonical_concept_id_for_external_identifiers(
+                        external_identifiers,
+                        kind=kind,
+                        parent_id=parent_id_for_concept,
+                        scope_mode=scope_mode,
+                        actor_user_id=actor_user_id,
+                        actor_org_id=actor_org_id,
+                    )
+                )
+                if canonical_concept_id_override is None:
+                    results.append(
+                        {
+                            "success": False,
+                            "effect_status": "failed",
+                            "changed": False,
+                            "error_code": "external_identity_parent_incompatible",
+                            "message": (
+                                "The external identity identifies an arXiv paper, "
+                                "but the requested kind or parent is not a supported "
+                                "scholarly-paper identity scope. No concept was created."
+                            ),
+                            "concept": None,
+                            "input_name": str(name),
+                            "requested_name": str(name),
+                            "requested_kind": kind,
+                            "requested_parent_id": parent_id_for_concept,
+                            "external_identifiers": [
+                                identifier.to_dict()
+                                for identifier in external_identifiers
+                            ],
+                        }
+                    )
+                    continue
+
             duplicate_match = find_existing_concept_for_create_concepts(
                 concept_name=str(name),
                 kind=kind,
@@ -1203,9 +1279,29 @@ def _create_concepts(**kwargs):
                     if canonical_id_only
                     else None
                 ),
+                external_identifiers=external_identifiers,
+                external_identity_concept_ids=(
+                    (canonical_concept_id_override,)
+                    if canonical_concept_id_override
+                    else ()
+                ),
             )
             if duplicate_match is not None:
+                if isinstance(
+                    duplicate_match,
+                    CreateConceptDuplicateGuardBlock,
+                ):
+                    result = build_duplicate_guard_block_create_concepts_result(
+                        requested_name=str(name),
+                        requested_kind=kind,
+                        block=duplicate_match,
+                    )
+                    results.append(result)
+                    continue
                 if duplicate_match.identity_conflict:
+                    is_external_identity = duplicate_match.match_source.startswith(
+                        "external_identifier:"
+                    )
                     result = build_canonical_identity_conflict_create_concepts_result(
                         requested_name=str(name),
                         requested_kind=kind,
@@ -1215,6 +1311,12 @@ def _create_concepts(**kwargs):
                         existing_parent_ids=duplicate_match.existing_parent_ids,
                         requested_parent_id=duplicate_match.requested_parent_id,
                         mismatch_reasons=duplicate_match.mismatch_reasons,
+                        error_code=(
+                            "external_identity_conflict"
+                            if is_external_identity
+                            else "canonical_identity_conflict"
+                        ),
+                        match_source=duplicate_match.match_source,
                     )
                 else:
                     result = build_duplicate_prevented_create_concepts_result(
@@ -1243,7 +1345,33 @@ def _create_concepts(**kwargs):
                 organisation_concept_id=actor_org_id,
                 event_namespace=namespace,
                 visibility_scope_mode=scope_mode,
+                canonical_concept_id_override=canonical_concept_id_override,
             )
+            if (
+                external_identifiers
+                and canonical_concept_id_override
+                and result.get("error_code") == "already_exists"
+            ):
+                # The external-identity preflight did not verify this record.
+                # A unique-key collision may be a concurrent legitimate create,
+                # an actor-invisible record, or an unrelated record occupying the
+                # predicted ID. None is safe to report as successful reuse until
+                # a later actor-scoped lookup verifies the persisted identity.
+                result = {
+                    "success": False,
+                    "effect_status": "failed",
+                    "changed": False,
+                    "error_code": "external_identity_collision_unverified",
+                    "message": (
+                        "The actor-scoped external identity became occupied before "
+                        "creation completed, but its identity was not verified. "
+                        "No existing concept was exposed or reused."
+                    ),
+                    "concept": None,
+                    "canonical_concept_id": canonical_concept_id_override,
+                    "input_name": name,
+                    "retryable": True,
+                }
             # Enrich result with the requested name for traceability and surface
             # the canonical created concept_id at a stable top-level key so UI
             # summaries can reliably name what was created.
@@ -1266,6 +1394,34 @@ def _create_concepts(**kwargs):
                     concept_id_value = existing_id
             if isinstance(concept_id_value, str) and concept_id_value.strip():
                 result["concept_id"] = concept_id_value.strip()
+                if result.get("success") and external_identifiers:
+                    identity_persistence = persist_external_identity_names(
+                        concept_id=concept_id_value.strip(),
+                        identifiers=external_identifiers,
+                    )
+                    result["external_identity"] = {
+                        "identifiers": [
+                            identifier.to_dict() for identifier in external_identifiers
+                        ],
+                        "canonical_concept_id_override": (
+                            canonical_concept_id_override
+                        ),
+                        "persistence": identity_persistence,
+                    }
+                    identity_failures = identity_persistence.get("failures")
+                    if (
+                        isinstance(identity_failures, list)
+                        and identity_failures
+                        and isinstance(result.get("concept"), dict)
+                    ):
+                        concept_partial_failures = result["concept"].setdefault(
+                            "partial_failures",
+                            [],
+                        )
+                        if isinstance(concept_partial_failures, list):
+                            concept_partial_failures.extend(identity_failures)
+                        result["effect_status"] = "partial"
+                        result["changed"] = True
             results.append(result)
 
     # Count different outcome types for summary
@@ -7268,7 +7424,14 @@ def _concepts_create_input_schema() -> Schema:
         allow_unknown=True,
         description=(
             "create_concepts input: parent_id (str, semantic type concept_id; not an owner, organisation, user, or container individual), "
-            "concepts (list of {name, kind?, description?, notes?}). "
+            "concepts (list of {name, kind?, description?, notes?, external_identifiers?}). "
+            "external_identifiers is a list of identity objects such as "
+            "{scheme:'arxiv', value:'2506.03346v1', role:'identity'}; arXiv "
+            "URLs and versioned IDs are normalised to the base identifier. "
+            "A leading 'arXiv:ID — title' instance name is supported only as a "
+            "legacy compatibility form. Identified arXiv entities must use a "
+            "supported scholarly-paper parent. Arbitrary description citations "
+            "are not identities. "
             "kind: 'instance' for individuals, 'type' for subtypes (default), 'predicate' for relationships. "
             "By default, deterministic pre-create lookup blocks duplicate instances/types/predicates; "
             "set allow_duplicate_instances=true to opt into legacy instance suffixing. "

--- a/src/backend/integrations/internal_mcp/gateway.py
+++ b/src/backend/integrations/internal_mcp/gateway.py
@@ -691,6 +691,17 @@ class InternalMCPGateway:
             else None
         )
 
+    def get_method_effect_admission_window_sec(
+        self,
+        method_name: str,
+    ) -> float | None:
+        """Return the resolved minimum window for one delegated effect."""
+
+        definition = self.get_method_definition(method_name)
+        if definition is None or not definition.ordinary_turn_effect:
+            return None
+        return definition.resolved_effect_admission_window(self._transport)
+
     def extend_catalogue(self, definitions: Iterable[MethodDefinition]) -> None:
         for definition in definitions:
             self._catalogue.register(definition)

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -57,10 +57,10 @@ _LOCAL_TOOL_NAMES = {
 }
 _DEFAULT_TURN_BUDGET_SECONDS = 180.0
 _DEFAULT_FINAL_RESERVE_SECONDS = 30.0
-# The answer checkpoint is an experimental allocation seam, disabled unless a
-# candidate environment or caller supplies a value. It is not Von's theory of
-# how much thought a task deserves.
-_DEFAULT_FINAL_ANSWER_RESERVE_SECONDS = 0.0
+# The answer checkpoint keeps a small live-path reserve while remaining an
+# explicit allocation seam. A caller-supplied zero intentionally disables it
+# for experiments that need the full evidence-capable synthesis interval.
+_DEFAULT_FINAL_ANSWER_RESERVE_SECONDS = 5.0
 _DEFAULT_OUTER_TOOL_WORKERS = 8
 _MODEL_EVIDENCE_INDEX_MAX_BYTES = 24_000
 _MODEL_TOOL_RESULT_BATCH_MAX_BYTES = 24_000
@@ -133,12 +133,16 @@ def _compact_evidence_envelope(
     for key in (
         "schema_version",
         "evidence_id",
+        "effect_status",
+        "changed",
+        "error_code",
+        "mutation_outcome",
+        "outcome_finality",
         "tool_name",
         "call_id",
         "status",
         "trust_boundary",
         "success",
-        "error_code",
         "sha256",
         "source_sha256",
         "size_bytes",
@@ -251,12 +255,18 @@ def _capability_schema_reference(
             "description",
             "query_match",
             "server_bound_arguments",
+            "semantic_effect",
+            "minimum_effect_window_seconds",
             "surface_family",
             "evidence_surface_family",
             "external_surface",
         )
         if include_metadata
-        else ("name",)
+        else (
+            "name",
+            "semantic_effect",
+            "minimum_effect_window_seconds",
+        )
     )
     compact = {
         key: capability.get(key)
@@ -299,6 +309,8 @@ def _capability_schema_focused_projection(
             "name",
             "input_schema",
             "server_bound_arguments",
+            "semantic_effect",
+            "minimum_effect_window_seconds",
         )
         if key in capability
     }
@@ -509,6 +521,11 @@ def _bounded_model_tool_output(value: Any, *, max_bytes: int) -> Any:
             "success",
             "error_code",
             "evidence_id",
+            "status",
+            "effect_status",
+            "changed",
+            "mutation_outcome",
+            "outcome_finality",
             "total",
             "offset",
             "next_offset",
@@ -522,6 +539,27 @@ def _bounded_model_tool_output(value: Any, *, max_bytes: int) -> Any:
     return summary
 
 
+def _model_tool_output_receipt(value: Any) -> dict[str, Any]:
+    """Retain exact effect finality when a result batch must be compacted."""
+
+    if not isinstance(value, Mapping):
+        return {}
+    return {
+        key: value.get(key)
+        for key in (
+            "evidence_id",
+            "status",
+            "effect_status",
+            "changed",
+            "error_code",
+            "mutation_outcome",
+            "outcome_finality",
+            "success",
+        )
+        if key in value
+    }
+
+
 def _bound_tool_results_for_model(
     results: Sequence[ToolResult],
     *,
@@ -531,58 +569,71 @@ def _bound_tool_results_for_model(
 
     if not results:
         return []
+    receipt_outputs = [
+        _model_tool_output_receipt(result.output) for result in results
+    ]
     serialisable_shells = [
         {
             "call_id": result.call_id,
             "tool_name": result.tool_name,
             "status": result.status,
-            "output": {},
+            "output": receipt_outputs[index],
         }
-        for result in results
+        for index, result in enumerate(results)
     ]
     shell_bytes = len(_json_bytes(serialisable_shells))
     if shell_bytes > max_bytes:
         return None
     output_budget = max(0, max_bytes - shell_bytes)
     per_result_budget = max(1, output_budget // len(results))
-    bounded = [
-        ToolResult(
-            call_id=result.call_id,
-            tool_name=result.tool_name,
-            status=result.status,
-            output=_bounded_model_tool_output(
-                result.output,
-                max_bytes=per_result_budget,
-            ),
+    bounded: list[ToolResult] = []
+    for index, result in enumerate(results):
+        bounded_output = _bounded_model_tool_output(
+            result.output,
+            max_bytes=per_result_budget,
         )
-        for result in results
-    ]
-    if len(
-        _json_bytes(
-            [
-                {
-                    "call_id": result.call_id,
-                    "tool_name": result.tool_name,
-                    "status": result.status,
-                    "output": result.output,
-                }
-                for result in bounded
-            ]
+        if isinstance(bounded_output, Mapping):
+            bounded_output = {
+                **dict(bounded_output),
+                **receipt_outputs[index],
+            }
+        bounded.append(
+            ToolResult(
+                call_id=result.call_id,
+                tool_name=result.tool_name,
+                status=result.status,
+                output=bounded_output,
+            )
         )
-    ) <= max_bytes:
+    if (
+        len(
+            _json_bytes(
+                [
+                    {
+                        "call_id": result.call_id,
+                        "tool_name": result.tool_name,
+                        "status": result.status,
+                        "output": result.output,
+                    }
+                    for result in bounded
+                ]
+            )
+        )
+        <= max_bytes
+    ):
         return bounded
 
-    # Correlation shells fit but useful per-call payloads do not. Empty
-    # correlated results remain within the same exact byte budget; all evidence
-    # handles are still discoverable through the pageable turn index.
+    # Correlation shells and exact finality receipts fit even when richer
+    # previews do not. Full evidence remains discoverable through the pageable
+    # turn index.
     return [
         ToolResult(
             call_id=result.call_id,
             tool_name=result.tool_name,
             status=result.status,
-            output={},
+            output=receipt_outputs[index],
         )
-        for result in results
+        for index, result in enumerate(results)
     ]
 
 
@@ -1014,13 +1065,21 @@ def _tool_definitions() -> list[ToolDefinition]:
                 "Read a selected bounded slice of a prior tool result by its "
                 "turn-scoped evidence handle. Select with a JSON pointer, a text "
                 "query, an offset, or any combination. Repeated calls may inspect "
-                "different portions; the raw result is not discarded."
+                "different portions; the raw result is not discarded. Omit "
+                "json_pointer, use the RFC root pointer (an empty string), or use "
+                "'/' as this model-facing tool's root alias to read the whole result."
             ),
             input_schema={
                 "type": "object",
                 "properties": {
                     "evidence_id": {"type": "string"},
-                    "json_pointer": {"type": "string"},
+                    "json_pointer": {
+                        "type": "string",
+                        "description": (
+                            "RFC 6901 JSON pointer. Omit it, use an empty string, "
+                            "or use '/' as this tool's root alias for the whole result."
+                        ),
+                    },
                     "query": {"type": "string"},
                     "offset": {"type": "integer", "minimum": 0},
                     "max_chars": {
@@ -1059,6 +1118,7 @@ def _scope_message(
     delegated_count: int,
     final_synthesis: bool,
     answer_only: bool = False,
+    remaining_effect_capable_seconds: float = 0.0,
 ) -> str:
     actor = scope.user_concept_id or "unauthenticated"
     organisation = scope.organisation_concept_id or "none"
@@ -1072,6 +1132,8 @@ def _scope_message(
         "capabilities.\n"
         "- Effect boundary: only explicitly marked bounded effects are available; "
         "all other writes are unavailable.\n"
+        "- Remaining effect-capable window before the protected final-answer "
+        f"reserve: {max(0.0, remaining_effect_capable_seconds):.3f} seconds.\n"
         f"- {_CAPABILITY_TOOL_NAME} exposes the complete delegated catalogue "
         "without interpreting the user's intent.\n"
         f"- {_INVOKE_TOOL_NAME} invokes any named delegated capability.\n"
@@ -1301,6 +1363,11 @@ def _capability_catalogue(
         }
         if definition.ordinary_turn_effect:
             capability["semantic_effect"] = True
+            minimum_effect_window = gateway.get_method_effect_admission_window_sec(name)
+            if minimum_effect_window is not None:
+                capability["minimum_effect_window_seconds"] = float(
+                    minimum_effect_window
+                )
         if surface_metadata is not None:
             capability.update(
                 {
@@ -1554,6 +1621,83 @@ def _effect_id(*, turn_id: str | None, call_id: str, capability_name: str) -> st
     return f"effect_{hashlib.sha256(material).hexdigest()[:24]}"
 
 
+def _effect_result_target_ids(raw_payload: Any) -> list[str]:
+    """Extract bounded concrete mutation targets from a handler receipt."""
+
+    scalar_fields = {
+        "canonical_concept_id",
+        "computer_file_copy_concept_id",
+        "concept_id",
+        "created_concept_id",
+        "existing_concept_id",
+        "file_copy_concept_id",
+        "object_id",
+        "paper_concept_id",
+        "relation_id",
+        "source_concept_id",
+        "source_id",
+        "subject_id",
+        "target_concept_id",
+        "target_id",
+    }
+    sequence_fields = {
+        "concept_ids",
+        "created_concept_ids",
+        "relation_ids",
+        "source_ids",
+        "target_ids",
+    }
+    traversal_fields = {
+        "concept",
+        "created",
+        "data",
+        "hits",
+        "items",
+        "relationship",
+        "relationships",
+        "result",
+        "results",
+    }
+    collected: list[str] = []
+    seen: set[str] = set()
+
+    def append_value(value: Any) -> None:
+        if not isinstance(value, str):
+            return
+        cleaned = value.strip()
+        lowered = cleaned.lower()
+        if not cleaned or lowered in seen:
+            return
+        seen.add(lowered)
+        collected.append(cleaned)
+
+    def walk(value: Any, *, depth: int) -> None:
+        if depth > 5 or len(collected) >= 50:
+            return
+        if isinstance(value, Mapping):
+            for raw_key, item in list(value.items())[:100]:
+                key = str(raw_key).strip().lower()
+                if key in scalar_fields:
+                    append_value(item)
+                elif key in sequence_fields and isinstance(item, Sequence) and not isinstance(
+                    item,
+                    (str, bytes, bytearray),
+                ):
+                    for nested in list(item)[:50]:
+                        append_value(nested)
+                if key in traversal_fields:
+                    walk(item, depth=depth + 1)
+        elif isinstance(value, Sequence) and not isinstance(
+            value,
+            (str, bytes, bytearray),
+        ):
+            for item in list(value)[:100]:
+                walk(item, depth=depth + 1)
+
+    walk(raw_payload, depth=0)
+    return collected
+
+
 def _effect_status(
     raw_payload: Any,
     *,
@@ -1561,12 +1705,24 @@ def _effect_status(
 ) -> str:
     if isinstance(raw_payload, Mapping):
         if (
+            str(raw_payload.get("status") or "").strip().lower() == "not_started"
+            or str(raw_payload.get("mutation_outcome") or "").strip().lower()
+            == "not_started"
+        ):
+            return "not_started"
+        if (
             raw_payload.get("mutation_outcome") == "unknown"
             or raw_payload.get("error_code") == "tool_timeout_outcome_unknown"
         ):
             return "indeterminate"
         explicit = str(raw_payload.get("effect_status") or "").strip().lower()
-        if explicit in {"succeeded", "partial", "failed", "indeterminate"}:
+        if explicit in {
+            "succeeded",
+            "partial",
+            "failed",
+            "indeterminate",
+            "not_started",
+        }:
             return explicit
     if isinstance(raw_payload, Mapping) and raw_payload.get("success") is False:
         return "failed"
@@ -1590,7 +1746,7 @@ def _late_effect_observation_state(
         payload.get("changed")
         if isinstance(payload, Mapping)
         and isinstance(payload.get("changed"), bool)
-        else (False if effect_status == "failed" else None)
+        else (False if effect_status in {"failed", "not_started"} else None)
     )
     return effect_status, changed
 
@@ -1728,7 +1884,27 @@ def execute_adaptive_turn(
     extra_messages: list[dict[str, Any]] = []
     tool_invocations: list[dict[str, Any]] = []
     llm_calls: list[dict[str, Any]] = []
-    aux_calls: list[dict[str, Any]] = []
+    aux_calls: list[dict[str, Any]] = [
+        {
+            "type": "adaptive_turn_budget_allocation",
+            "schema_version": "adaptive_turn_budget_allocation.v1",
+            "turn_budget_seconds": turn_budget,
+            "final_synthesis_reserve_seconds": final_reserve,
+            "requested_final_answer_reserve_seconds": (
+                requested_final_answer_reserve
+            ),
+            "effective_final_answer_reserve_seconds": final_answer_reserve,
+            "final_answer_reserve_source": (
+                "caller"
+                if final_answer_reserve_seconds is not None
+                else "environment_or_default"
+            ),
+            "explicit_zero_override": bool(
+                final_answer_reserve_seconds is not None
+                and requested_final_answer_reserve == 0.0
+            ),
+        }
+    ]
     usage_totals: dict[str, float] = {}
     seen_request_digests: set[str] = set()
     last_partial_text = ""
@@ -1916,6 +2092,25 @@ def execute_adaptive_turn(
                 effect_id: dict(state)
                 for effect_id, state in effect_states.items()
             }
+        incomplete_effects = [
+            state
+            for state in effect_snapshot.values()
+            if state.get("effect_status")
+            in {"failed", "partial", "indeterminate", "not_started"}
+        ]
+        if status == "completed" and incomplete_effects:
+            incomplete_statuses = {
+                str(state.get("effect_status") or "")
+                for state in incomplete_effects
+            }
+            if "indeterminate" in incomplete_statuses:
+                status = "effect_outcome_indeterminate"
+            elif "partial" in incomplete_statuses:
+                status = "effect_partially_completed"
+            elif "failed" in incomplete_statuses:
+                status = "effect_failed"
+            else:
+                status = "effect_not_started"
         reconciled_invocations: list[dict[str, Any]] = []
         for raw_invocation in tool_invocations:
             invocation = dict(raw_invocation)
@@ -1942,7 +2137,8 @@ def execute_adaptive_turn(
             state
             for state in effect_snapshot.values()
             if (
-                state.get("effect_status") in {"partial", "indeterminate"}
+                state.get("effect_status")
+                in {"failed", "partial", "indeterminate", "not_started"}
                 or state.get("changed") is True
                 or (
                     state.get("effect_status") == "succeeded"
@@ -1963,6 +2159,7 @@ def execute_adaptive_turn(
                     "partial",
                     "failed",
                     "indeterminate",
+                    "not_started",
                 )
             }
             count_text = ", ".join(
@@ -1976,13 +2173,41 @@ def execute_adaptive_turn(
                     f"{'s' if len(relevant_effects) != 1 else ''} "
                     "with unresolved status"
                 )
-            text = (
-                "That turn did not finish cleanly. Its effect receipts currently "
-                f"report {count_text}. A handler receipt is not canonical "
-                "read-back, so I will not claim that nothing changed. Inspect "
-                "the represented state before retrying any effect whose outcome "
-                "is unknown."
-            )
+            unknown_change_effects = [
+                state
+                for state in relevant_effects
+                if state.get("effect_status") in {"partial", "indeterminate"}
+                or state.get("changed") is True
+                or (
+                    state.get("effect_status") == "succeeded"
+                    and state.get("changed") is None
+                )
+            ]
+            if unknown_change_effects:
+                text = (
+                    "That turn did not finish cleanly. Its effect receipts currently "
+                    f"report {count_text}. A handler receipt is not canonical "
+                    "read-back, so I will not claim that nothing changed. Inspect "
+                    "the represented state before retrying any effect whose outcome "
+                    "is unknown."
+                )
+            elif status_counts["not_started"]:
+                text = (
+                    "That turn did not finish cleanly. Its effect receipts currently "
+                    f"report {count_text}. The not-started effect"
+                    f"{'s were' if status_counts['not_started'] != 1 else ' was'} "
+                    "not dispatched and "
+                    f"{'report' if status_counts['not_started'] != 1 else 'reports'} "
+                    "no change; "
+                    f"{'they can' if status_counts['not_started'] != 1 else 'it can'} "
+                    "be retried in a new turn."
+                )
+            else:
+                text = (
+                    "That turn did not finish cleanly. Its effect receipts currently "
+                    f"report {count_text} and report no change. Inspect the failure "
+                    "receipt before retrying."
+                )
             aux_calls.append(
                 {
                     "type": "adaptive_turn_effect_finality_fallback",
@@ -2196,6 +2421,11 @@ def execute_adaptive_turn(
                     delegated_count=len(delegated_names),
                     final_synthesis=final_synthesis,
                     answer_only=answer_only,
+                    remaining_effect_capable_seconds=(
+                        0.0
+                        if final_synthesis or answer_only
+                        else max(0.0, final_answer_deadline - request_started)
+                    ),
                 ),
                 llm_params=effective_params,
                 **(
@@ -2483,7 +2713,7 @@ def execute_adaptive_turn(
             tuple[Any, Any, dict[str, Any], str, bool],
         ] = {}
         actual_capabilities: list[
-            tuple[int, ToolCall, str, dict[str, Any], bool]
+            tuple[int, ToolCall, str, dict[str, Any], bool, float]
         ] = []
 
         for index, call in enumerate(calls):
@@ -2576,13 +2806,24 @@ def execute_adaptive_turn(
                 continue
             if call.tool_name == _EVIDENCE_TOOL_NAME:
                 try:
+                    requested_json_pointer = (
+                        str(call.payload.get("json_pointer"))
+                        if call.payload.get("json_pointer") is not None
+                        else None
+                    )
+                    # RFC 6901 assigns the empty string to the document root and
+                    # "/" to a member whose key is empty. Models nevertheless
+                    # routinely use "/" for "the whole result". Keep the evidence
+                    # store's RFC semantics exact and provide that ergonomic alias
+                    # only at this model-facing adaptive boundary.
+                    evidence_json_pointer = (
+                        None
+                        if requested_json_pointer == "/"
+                        else requested_json_pointer
+                    )
                     output = evidence_store.read(
                         str(call.payload.get("evidence_id") or ""),
-                        json_pointer=(
-                            str(call.payload.get("json_pointer"))
-                            if call.payload.get("json_pointer") is not None
-                            else None
-                        ),
+                        json_pointer=evidence_json_pointer,
                         query=(
                             str(call.payload.get("query"))
                             if call.payload.get("query") is not None
@@ -2677,6 +2918,19 @@ def execute_adaptive_turn(
                 model_payload=arguments,
                 trusted_argument_values=trusted_values,
             )
+            minimum_effect_window = 0.0
+            if is_effect:
+                resolved_effect_window = gateway.get_method_effect_admission_window_sec(
+                    canonical_name
+                )
+                if resolved_effect_window is None:
+                    resolved_effect_window = gateway.get_method_timeout_sec(
+                        canonical_name
+                    )
+                minimum_effect_window = max(
+                    0.0,
+                    float(resolved_effect_window or 0.0),
+                )
             actual_capabilities.append(
                 (
                     index,
@@ -2684,16 +2938,27 @@ def execute_adaptive_turn(
                     canonical_name,
                     trusted_arguments,
                     is_effect,
+                    minimum_effect_window,
                 )
             )
 
         def invoke_and_contain(
-            item: tuple[int, ToolCall, str, dict[str, Any], bool],
+            item: tuple[int, ToolCall, str, dict[str, Any], bool, float],
+            *,
+            deadline_monotonic: float,
+            effect_window_denial: Mapping[str, Any] | None = None,
         ) -> tuple[
             int,
             tuple[Any, Any, dict[str, Any], str, bool],
         ]:
-            index, call, canonical_name, arguments, is_effect = item
+            (
+                index,
+                call,
+                canonical_name,
+                arguments,
+                is_effect,
+                _minimum_effect_window,
+            ) = item
             assert gateway is not None
             definition = gateway.get_method_definition(canonical_name)
             subject_argument = (
@@ -2781,6 +3046,45 @@ def execute_adaptive_turn(
                         canonical_name,
                         is_effect,
                     )
+                if isinstance(effect_window_denial, Mapping):
+                    denial_payload = dict(effect_window_denial)
+                    terminal_effect_status = _effect_status(
+                        denial_payload,
+                        transport_result=None,
+                    )
+                    terminal_outcome = persist_effect_observation_phase(
+                        effect_id=effect_identifier,
+                        phase="turn_terminal",
+                        observation={
+                            "call_id": call.call_id,
+                            "capability_name": canonical_name,
+                            "effect_status": terminal_effect_status,
+                            "changed": False,
+                            "transport": {},
+                            "receipt": dict(denial_payload),
+                        },
+                    )
+                    if not _effect_phase_acknowledged(terminal_outcome):
+                        aux_calls.append(
+                            {
+                                "type": "effect_observation_persistence_failure",
+                                "schema_version": (
+                                    "effect_observation_persistence_failure.v1"
+                                ),
+                                "effect_id": effect_identifier,
+                                "phase": "turn_terminal",
+                                "reason": (
+                                    terminal_outcome.get("reason") or "not_acknowledged"
+                                ),
+                            }
+                        )
+                    return index, (
+                        denial_payload,
+                        None,
+                        arguments,
+                        canonical_name,
+                        is_effect,
+                    )
             try:
                 with override_current_actor(
                     scope.user_concept_id,
@@ -2789,7 +3093,7 @@ def execute_adaptive_turn(
                     transport_result = gateway.invoke(
                         canonical_name,
                         arguments,
-                        deadline_monotonic=research_deadline,
+                        deadline_monotonic=deadline_monotonic,
                         late_completion_observer=(
                             late_effect_observer(
                                 effect_id=effect_identifier,
@@ -2854,7 +3158,7 @@ def execute_adaptive_turn(
                     and isinstance(raw_payload.get("changed"), bool)
                     else (
                         False
-                        if terminal_effect_status == "failed"
+                        if terminal_effect_status in {"failed", "not_started"}
                         else None
                     )
                 )
@@ -2899,11 +3203,68 @@ def execute_adaptive_turn(
 
         if actual_capabilities and any(item[4] for item in actual_capabilities):
             # Preserve model-call order whenever the batch contains an effect.
-            # This leaves the model free to mix reads and writes while ensuring
-            # that later calls can observe earlier committed state.
+            # Each effect receives an independent admission decision in model
+            # order. One invalid or oversized call therefore cannot deny an
+            # otherwise admissible sibling. A dispatched indeterminate effect
+            # stops later effects until canonical state can be inspected; reads
+            # remain available for that inspection.
+            prior_indeterminate_effect_id: str | None = None
             for item in actual_capabilities:
-                result_index, contained = invoke_and_contain(item)
+                (
+                    _item_index,
+                    _call,
+                    canonical_name,
+                    _arguments,
+                    is_effect,
+                    _minimum_effect_window,
+                ) = item
+                effect_window_denial = None
+                if is_effect and prior_indeterminate_effect_id is not None:
+                    effect_window_denial = {
+                        **_error_payload(
+                            "prior_effect_outcome_indeterminate",
+                            (
+                                "This effect was not started because an earlier "
+                                "effect in the same ordered batch has an "
+                                "indeterminate outcome. Inspect canonical state "
+                                "before attempting another effect."
+                            ),
+                            retryable=True,
+                        ),
+                        "status": "not_started",
+                        "mutation_outcome": "not_started",
+                        "outcome_finality": "terminal_for_turn",
+                        "prior_effect_id": prior_indeterminate_effect_id,
+                        "capability_name": canonical_name,
+                        "recovery_affordances": [
+                            {
+                                "action_type": (
+                                    "inspect_canonical_state_before_retry"
+                                )
+                            }
+                        ],
+                    }
+                result_index, contained = invoke_and_contain(
+                    item,
+                    deadline_monotonic=final_answer_deadline,
+                    effect_window_denial=effect_window_denial,
+                )
                 raw_capability_results[result_index] = contained
+                raw_payload, transport_result, *_rest = contained
+                if (
+                    is_effect
+                    and effect_window_denial is None
+                    and _effect_status(
+                        raw_payload,
+                        transport_result=transport_result,
+                    )
+                    == "indeterminate"
+                ):
+                    prior_indeterminate_effect_id = _effect_id(
+                        turn_id=turn_id,
+                        call_id=_call.call_id,
+                        capability_name=canonical_name,
+                    )
         elif actual_capabilities:
             max_workers = min(
                 len(actual_capabilities),
@@ -2923,6 +3284,7 @@ def execute_adaptive_turn(
                         context_snapshot.run,
                         invoke_and_contain,
                         item,
+                        deadline_monotonic=research_deadline,
                     )
                     futures.append(future)
                 for future in futures:
@@ -2970,11 +3332,7 @@ def execute_adaptive_turn(
                     else None
                 )
                 status = (
-                    (
-                        "ok"
-                        if effect_status in {"succeeded", "partial"}
-                        else "error"
-                    )
+                    ("ok" if effect_status == "succeeded" else "error")
                     if is_effect
                     else (
                         "error"
@@ -3004,12 +3362,19 @@ def execute_adaptive_turn(
                     status=effect_status or status,
                 )
                 envelope_payload = envelope.to_mapping()
+                result_target_ids = _effect_result_target_ids(raw_payload)
+                if result_target_ids:
+                    envelope_payload["result_target_ids"] = result_target_ids
                 if is_effect:
                     changed = (
                         raw_payload.get("changed")
                         if isinstance(raw_payload, Mapping)
                         and isinstance(raw_payload.get("changed"), bool)
-                        else (False if effect_status == "failed" else None)
+                        else (
+                            False
+                            if effect_status in {"failed", "not_started"}
+                            else None
+                        )
                     )
                     remember_effect_state(
                         effect_identifier,
@@ -3035,6 +3400,15 @@ def execute_adaptive_turn(
                             "changed": changed,
                         }
                     )
+                    if isinstance(raw_payload, Mapping):
+                        for receipt_key in (
+                            "mutation_outcome",
+                            "outcome_finality",
+                            "error_code",
+                        ):
+                            receipt_value = raw_payload.get(receipt_key)
+                            if isinstance(receipt_value, (str, int, float, bool)):
+                                envelope_payload[receipt_key] = receipt_value
                 batch_results[index] = ToolResult(
                     call_id=call.call_id,
                     tool_name=call.tool_name,
@@ -3049,6 +3423,11 @@ def execute_adaptive_turn(
                     "effective_arguments": arguments,
                     "evidence": envelope_payload,
                     "status": status,
+                    **(
+                        {"result_target_ids": result_target_ids}
+                        if result_target_ids
+                        else {}
+                    ),
                 }
                 if is_effect:
                     invocation.update(
@@ -3058,6 +3437,15 @@ def execute_adaptive_turn(
                             "changed": envelope_payload.get("changed"),
                         }
                     )
+                    if isinstance(raw_payload, Mapping):
+                        for receipt_key in (
+                            "mutation_outcome",
+                            "outcome_finality",
+                            "error_code",
+                        ):
+                            receipt_value = raw_payload.get(receipt_key)
+                            if isinstance(receipt_value, (str, int, float, bool)):
+                                invocation[receipt_key] = receipt_value
                 if transport_metadata:
                     invocation["transport"] = transport_metadata
                 tool_invocations.append(invocation)

--- a/src/backend/services/concept_external_identity_service.py
+++ b/src/backend/services/concept_external_identity_service.py
@@ -1,0 +1,584 @@
+"""Bounded external-identity support for concept creation.
+
+The create-concepts path normally derives a concept ID from the requested
+display name.  That is not sufficient for entities such as scholarly papers,
+whose title can vary while an external identifier remains stable.  This module
+provides mechanical identifier normalisation, actor-scoped candidate lookup,
+and identity-name persistence without making merge or reconciliation choices.
+
+Only arXiv identity is supported initially.  Adding another scheme requires an
+explicit normaliser and exact-verification rule; arbitrary description text is
+never treated as an entity identity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import re
+from typing import Any, Mapping, Sequence
+
+from ..db.repositories.concepts_repository import ConceptsRepository
+from ..db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
+from ..security.access_control import filter_accessible_concept_ids
+from .concept_search_service import (
+    CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
+    _consume_search_cursor,
+)
+from .text_value_service import get_texts_for_concepts, upsert_text_for_concept
+
+_ARXIV_ID_BODY = r"(?:\d{4}\.\d{4,5}|[a-z][a-z0-9.\-]+/\d{7})"
+_ARXIV_FULL_PATTERN = re.compile(
+    rf"(?i)^(?:arxiv\s*:?\s*)?({_ARXIV_ID_BODY})(?:v\d+)?$"
+)
+_ARXIV_URL_PATTERN = re.compile(
+    rf"(?i)^https?://(?:www\.)?arxiv\.org/(?:abs|pdf)/"
+    rf"({_ARXIV_ID_BODY})(?:v\d+)?(?:\.pdf)?/?(?:[?#].*)?$"
+)
+_LEADING_ARXIV_LABEL_PATTERN = re.compile(
+    rf"(?i)^\s*arxiv\s*:?\s*({_ARXIV_ID_BODY})(?:v\d+)?" r"(?=\s*(?:$|[-–—:|]))"
+)
+_SUPPORTED_SCHEMES = frozenset({"arxiv"})
+_ARXIV_PAPER_PARENT_IDS = frozenset(
+    {
+        "#V#academic_paper",
+        "#V#paper",
+        "#V#paper_on_arxiv",
+        "#V#publication",
+        "#V#research_paper",
+        "#V#scholarly_article",
+        "#V#scholarly_work",
+        "#V#scientific_paper",
+    }
+)
+_ARXIV_PAPER_HIERARCHY_ROOT_IDS = frozenset(
+    {
+        "#V#academic_paper",
+        "#V#paper",
+        "#V#paper_on_arxiv",
+        "#V#research_paper",
+        "#V#scholarly_article",
+        "#V#scientific_paper",
+    }
+)
+_MAX_EXTERNAL_IDENTITY_CANDIDATES = 50
+_MAX_EXTERNAL_IDENTITY_TEXT_VALUES = 200
+_MAX_EXTERNAL_IDENTITY_TEXT_RELATIONS = 2_000
+_MAX_IDENTITY_NAMES_PER_CONCEPT = 50
+_MAX_PAPER_PARENT_ANCESTOR_DEPTH = 6
+
+
+class ExternalIdentityInputError(ValueError):
+    """Typed invalid external-identity input."""
+
+    def __init__(
+        self,
+        error_code: str,
+        message: str,
+        *,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+        self.details = dict(details or {})
+
+
+@dataclass(frozen=True)
+class ExternalIdentifier:
+    scheme: str
+    value: str
+    source: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "scheme": self.scheme,
+            "value": self.value,
+            "source": self.source,
+        }
+
+
+@dataclass(frozen=True)
+class ExternalIdentityResolution:
+    status: str
+    identifier: ExternalIdentifier
+    candidate_concept_ids: tuple[str, ...] = ()
+
+
+def normalise_arxiv_id(value: Any) -> str | None:
+    """Return a lower-case, version-free arXiv identifier."""
+
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+
+    url_match = _ARXIV_URL_PATTERN.fullmatch(cleaned)
+    if url_match:
+        return url_match.group(1).lower()
+
+    full_match = _ARXIV_FULL_PATTERN.fullmatch(cleaned)
+    if full_match:
+        return full_match.group(1).lower()
+    return None
+
+
+def _leading_arxiv_identifier(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    match = _LEADING_ARXIV_LABEL_PATTERN.search(value)
+    return match.group(1).lower() if match else None
+
+
+def _verified_arxiv_ids_from_name(value: Any) -> set[str]:
+    """Extract only an exact ID/URL or a leading labelled paper identity."""
+
+    if not isinstance(value, str):
+        return set()
+    exact = normalise_arxiv_id(value)
+    if exact:
+        return {exact}
+    leading = _leading_arxiv_identifier(value)
+    return {leading} if leading else set()
+
+
+def _arxiv_identity_relation_candidates(arxiv_id: str) -> set[str]:
+    """Return bounded hasName candidates from one indexed fingerprint lookup."""
+
+    normalised_id = arxiv_id.casefold()
+    url_prefixes = tuple(
+        f"{scheme}://{host}arxiv.org/{path}/{normalised_id}"
+        for scheme in ("http", "https")
+        for host in ("", "www.")
+        for path in ("abs", "pdf")
+    )
+    labelled_prefixes = (
+        f"arxiv{normalised_id}",
+        f"arxiv:{normalised_id}",
+        f"arxiv: {normalised_id}",
+        f"arxiv {normalised_id}",
+        f"arxiv :{normalised_id}",
+        f"arxiv : {normalised_id}",
+    )
+    # A prefix range keeps this one lookup on the fingerprint index while
+    # surfacing version, .pdf, slash, query, and fragment suffixes. The ranges
+    # deliberately admit longer near-prefixes; exact identity verification
+    # below rejects those before any candidate can be reused.
+    fingerprint_prefixes = (
+        normalised_id,
+        *url_prefixes,
+        *labelled_prefixes,
+    )
+    matching_texts = _consume_search_cursor(
+        TextValuesRepository.find(
+            {
+                "$or": [
+                    {
+                        "fingerprint": {
+                            "$type": "string",
+                            "$gte": prefix,
+                            "$lt": f"{prefix}\uffff",
+                        }
+                    }
+                    for prefix in fingerprint_prefixes
+                ]
+            },
+            projection={"_id": 1},
+            limit=_MAX_EXTERNAL_IDENTITY_TEXT_VALUES,
+            max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
+        )
+    )
+    text_value_ids: list[Any] = []
+    for row in matching_texts:
+        raw_id = row.get("_id") if isinstance(row, Mapping) else None
+        if raw_id is None:
+            continue
+        text_value_ids.extend((raw_id, str(raw_id)))
+    if not text_value_ids:
+        return set()
+
+    relations = _consume_search_cursor(
+        TextRelationsRepository.find(
+            {
+                "object_text_id": {"$in": text_value_ids},
+                "predicate": "hasName",
+            },
+            projection={"subject_concept_id": 1},
+            limit=_MAX_EXTERNAL_IDENTITY_TEXT_RELATIONS,
+            max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
+        )
+    )
+    return {
+        str(row.get("subject_concept_id")).strip()
+        for row in relations
+        if isinstance(row, Mapping)
+        and isinstance(row.get("subject_concept_id"), str)
+        and str(row.get("subject_concept_id")).strip()
+    }
+
+
+def _normalise_explicit_identifier(raw: Any) -> ExternalIdentifier:
+    if isinstance(raw, ExternalIdentifier):
+        return raw
+    if not isinstance(raw, Mapping):
+        raise ExternalIdentityInputError(
+            "invalid_external_identifier",
+            "Each external identifier must be an object.",
+            details={"value_type": type(raw).__name__},
+        )
+
+    scheme = str(raw.get("scheme") or raw.get("type") or "").strip().lower()
+    if not scheme:
+        raise ExternalIdentityInputError(
+            "invalid_external_identifier",
+            "External identifier scheme is required.",
+        )
+    if scheme not in _SUPPORTED_SCHEMES:
+        raise ExternalIdentityInputError(
+            "unsupported_external_identifier_scheme",
+            f"External identifier scheme '{scheme}' is not supported.",
+            details={"scheme": scheme, "supported_schemes": sorted(_SUPPORTED_SCHEMES)},
+        )
+
+    role = str(raw.get("role") or "identity").strip().lower()
+    if role != "identity":
+        raise ExternalIdentityInputError(
+            "invalid_external_identifier_role",
+            "create_concepts external identifiers must have role='identity'.",
+            details={"role": role},
+        )
+
+    value = normalise_arxiv_id(raw.get("value") or raw.get("identifier"))
+    if not value:
+        raise ExternalIdentityInputError(
+            "invalid_external_identifier",
+            "The supplied arXiv identifier is invalid.",
+            details={"scheme": scheme},
+        )
+    return ExternalIdentifier(scheme=scheme, value=value, source="explicit")
+
+
+def normalise_create_external_identifiers(
+    *,
+    external_identifiers: Any,
+    concept_name: str,
+    kind: str | None,
+) -> tuple[ExternalIdentifier, ...]:
+    """Normalise explicit identity input plus a conservative legacy name form."""
+
+    explicit_items: list[Any] = []
+    explicit_supplied = external_identifiers is not None
+    if isinstance(external_identifiers, Mapping) or isinstance(
+        external_identifiers, ExternalIdentifier
+    ):
+        explicit_items = [external_identifiers]
+    elif isinstance(external_identifiers, Sequence) and not isinstance(
+        external_identifiers, (str, bytes, bytearray)
+    ):
+        explicit_items = list(external_identifiers)
+    elif explicit_supplied:
+        raise ExternalIdentityInputError(
+            "invalid_external_identifiers",
+            "external_identifiers must be an object or list of objects.",
+        )
+
+    identifiers: list[ExternalIdentifier] = [
+        _normalise_explicit_identifier(item) for item in explicit_items
+    ]
+
+    normalised_kind = str(kind or "type").strip().lower()
+    if normalised_kind == "individual":
+        normalised_kind = "instance"
+    leading_arxiv_id = (
+        _leading_arxiv_identifier(concept_name)
+        if normalised_kind == "instance"
+        else None
+    )
+    explicit_arxiv_ids = {item.value for item in identifiers if item.scheme == "arxiv"}
+    if (
+        leading_arxiv_id
+        and explicit_arxiv_ids
+        and leading_arxiv_id not in explicit_arxiv_ids
+    ):
+        raise ExternalIdentityInputError(
+            "external_identifier_name_mismatch",
+            "The leading arXiv label does not match external_identifiers.",
+            details={
+                "leading_arxiv_id": leading_arxiv_id,
+                "explicit_arxiv_ids": sorted(explicit_arxiv_ids),
+            },
+        )
+    if leading_arxiv_id and not explicit_arxiv_ids:
+        identifiers.append(
+            ExternalIdentifier(
+                scheme="arxiv",
+                value=leading_arxiv_id,
+                source="leading_arxiv_label",
+            )
+        )
+
+    deduplicated: list[ExternalIdentifier] = []
+    seen: set[tuple[str, str]] = set()
+    for identifier in identifiers:
+        key = (identifier.scheme, identifier.value)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduplicated.append(identifier)
+
+    if len(deduplicated) > 1:
+        raise ExternalIdentityInputError(
+            "conflicting_external_identifiers",
+            "A create_concepts item must identify at most one external entity.",
+            details={
+                "external_identifiers": [item.to_dict() for item in deduplicated],
+            },
+        )
+    return tuple(deduplicated)
+
+
+def is_supported_arxiv_paper_parent(parent_id: str | None) -> bool:
+    """Return whether a visible type is in the bounded scholarly-paper family."""
+
+    from ..utils.concept_id_utils import canonicalise_vontology_concept_id
+
+    canonical_parent_id = canonicalise_vontology_concept_id(parent_id)
+    if canonical_parent_id in _ARXIV_PAPER_PARENT_IDS:
+        return True
+    if not canonical_parent_id:
+        return False
+
+    try:
+        from .context_bundle_service import _collect_type_ancestors
+
+        ancestors = _collect_type_ancestors(
+            canonical_parent_id,
+            max_depth=_MAX_PAPER_PARENT_ANCESTOR_DEPTH,
+        )
+    except Exception:
+        return False
+    ancestor_ids = {
+        str(row.get("concept_id")).strip()
+        for row in ancestors
+        if isinstance(row, Mapping)
+        and isinstance(row.get("concept_id"), str)
+        and str(row.get("concept_id")).strip()
+    }
+    return bool(ancestor_ids.intersection(_ARXIV_PAPER_HIERARCHY_ROOT_IDS))
+
+
+def arxiv_paper_parent_scopes_compatible(
+    *,
+    existing_parent_ids: Sequence[str],
+    requested_parent_id: str | None,
+) -> bool:
+    """Treat supported scholarly-paper parent variants as one identity scope."""
+
+    if not is_supported_arxiv_paper_parent(requested_parent_id):
+        return False
+    return any(
+        is_supported_arxiv_paper_parent(parent_id) for parent_id in existing_parent_ids
+    )
+
+
+def _scope_stable_arxiv_concept_id(
+    *,
+    arxiv_id: str,
+    scope_mode: str | None,
+    actor_user_id: str | None,
+    actor_org_id: str | None,
+) -> str:
+    from ..utils.concept_id_utils import canonicalise_vontology_concept_id
+    from .arxiv_paper_link_service import predict_arxiv_paper_concept_id
+
+    global_id = predict_arxiv_paper_concept_id(arxiv_id=arxiv_id)
+    normalised_scope_mode = str(scope_mode or "").strip().lower()
+    canonical_user_id = canonicalise_vontology_concept_id(actor_user_id)
+    canonical_org_id = canonicalise_vontology_concept_id(actor_org_id)
+    if normalised_scope_mode == "global_general" or not (
+        canonical_user_id or canonical_org_id
+    ):
+        return global_id
+
+    if canonical_org_id:
+        visibility_scope = f"organisation:{canonical_org_id}"
+    else:
+        visibility_scope = f"user:{canonical_user_id}"
+    scope_digest = hashlib.sha256(
+        visibility_scope.casefold().encode("utf-8")
+    ).hexdigest()[:10]
+    return f"{global_id}_scope_{scope_digest}"
+
+
+def resolve_external_identity_candidates(
+    identifier: ExternalIdentifier,
+    *,
+    canonical_concept_id_candidates: Sequence[str] = (),
+) -> ExternalIdentityResolution:
+    """Resolve every actor-visible concept carrying an exact external identity."""
+
+    if identifier.scheme != "arxiv":
+        return ExternalIdentityResolution(status="not_found", identifier=identifier)
+
+    from .arxiv_paper_link_service import predict_arxiv_paper_concept_id
+
+    predicted_id = predict_arxiv_paper_concept_id(arxiv_id=identifier.value)
+    trusted_predicted_ids = {predicted_id}
+    scoped_id_pattern = re.compile(rf"^{re.escape(predicted_id)}_scope_[0-9a-f]{{10}}$")
+    for candidate_id in canonical_concept_id_candidates:
+        candidate_clean = candidate_id.strip() if isinstance(candidate_id, str) else ""
+        if candidate_clean and scoped_id_pattern.fullmatch(candidate_clean):
+            trusted_predicted_ids.add(candidate_clean)
+
+    raw_candidate_ids: set[str] = set(trusted_predicted_ids)
+    raw_candidate_ids.update(_arxiv_identity_relation_candidates(identifier.value))
+
+    if not raw_candidate_ids:
+        return ExternalIdentityResolution(status="not_found", identifier=identifier)
+
+    existing_ids = {
+        str(doc.get("concept_id")).strip()
+        for doc in ConceptsRepository.find(
+            {"concept_id": {"$in": sorted(raw_candidate_ids)}},
+            projection={"concept_id": 1},
+            limit=_MAX_EXTERNAL_IDENTITY_CANDIDATES,
+        )
+        if isinstance(doc, Mapping)
+        and isinstance(doc.get("concept_id"), str)
+        and str(doc.get("concept_id")).strip()
+    }
+    visible_ids = filter_accessible_concept_ids(existing_ids)
+    if not visible_ids:
+        return ExternalIdentityResolution(status="not_found", identifier=identifier)
+
+    names_by_concept = get_texts_for_concepts(
+        sorted(visible_ids),
+        predicate="hasName",
+        limit_per_concept=_MAX_IDENTITY_NAMES_PER_CONCEPT,
+    )
+    verified_ids: set[str] = set()
+    for concept_id in visible_ids:
+        if concept_id in trusted_predicted_ids:
+            verified_ids.add(concept_id)
+            continue
+        for row in names_by_concept.get(concept_id, []):
+            if identifier.value in _verified_arxiv_ids_from_name(row.get("text")):
+                verified_ids.add(concept_id)
+                break
+
+    ordered_ids = tuple(sorted(verified_ids))
+    if not ordered_ids:
+        status = "not_found"
+    elif len(ordered_ids) == 1:
+        status = "resolved"
+    else:
+        status = "ambiguous"
+    return ExternalIdentityResolution(
+        status=status,
+        identifier=identifier,
+        candidate_concept_ids=ordered_ids,
+    )
+
+
+def canonical_concept_id_for_external_identifiers(
+    identifiers: Sequence[ExternalIdentifier],
+    *,
+    kind: str,
+    parent_id: str | None,
+    scope_mode: str | None = None,
+    actor_user_id: str | None = None,
+    actor_org_id: str | None = None,
+) -> str | None:
+    """Return an atomic stable ID for a newly identified scholarly paper."""
+
+    if len(identifiers) != 1:
+        return None
+    identifier = identifiers[0]
+    normalised_kind = str(kind or "").strip().lower()
+    if normalised_kind == "individual":
+        normalised_kind = "instance"
+    if normalised_kind != "instance" or identifier.scheme != "arxiv":
+        return None
+
+    if not is_supported_arxiv_paper_parent(parent_id):
+        return None
+    return _scope_stable_arxiv_concept_id(
+        arxiv_id=identifier.value,
+        scope_mode=scope_mode,
+        actor_user_id=actor_user_id,
+        actor_org_id=actor_org_id,
+    )
+
+
+def persist_external_identity_names(
+    *,
+    concept_id: str,
+    identifiers: Sequence[ExternalIdentifier],
+) -> dict[str, Any]:
+    """Persist exact searchable identity names, retaining per-write failures."""
+
+    writes: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    for identifier in identifiers:
+        if identifier.scheme != "arxiv":
+            continue
+        for text in (
+            identifier.value,
+            f"https://arxiv.org/abs/{identifier.value}",
+        ):
+            try:
+                result = upsert_text_for_concept(
+                    subject_concept_id=concept_id,
+                    predicate="hasName",
+                    text=text,
+                    lang="en-NZ",
+                    provenance={
+                        "source": "create_concepts_external_identity",
+                        "external_identifier_scheme": identifier.scheme,
+                    },
+                    context={
+                        "name_type": "CODE",
+                        "source": "create_concepts_external_identity",
+                    },
+                )
+                writes.append(
+                    {
+                        "scheme": identifier.scheme,
+                        "value": text,
+                        "relation_id": result.get("relation_id"),
+                        "relation_created": bool(result.get("relation_created")),
+                        "context_updated": bool(result.get("context_updated")),
+                    }
+                )
+            except Exception as exc:
+                failures.append(
+                    {
+                        "stage": "external_identity_persistence",
+                        "scheme": identifier.scheme,
+                        "value": text,
+                        "error": str(exc),
+                        "exception_type": type(exc).__name__,
+                    }
+                )
+    return {
+        "success": not failures,
+        "writes": writes,
+        "failures": failures,
+    }
+
+
+__all__ = [
+    "ExternalIdentifier",
+    "ExternalIdentityInputError",
+    "ExternalIdentityResolution",
+    "arxiv_paper_parent_scopes_compatible",
+    "canonical_concept_id_for_external_identifiers",
+    "is_supported_arxiv_paper_parent",
+    "normalise_arxiv_id",
+    "normalise_create_external_identifiers",
+    "persist_external_identity_names",
+    "resolve_external_identity_candidates",
+]

--- a/src/backend/services/create_concepts_duplicate_guard_service.py
+++ b/src/backend/services/create_concepts_duplicate_guard_service.py
@@ -13,12 +13,14 @@ Policy:
 - Callers with deterministic stable identities can select
   ``duplicate_resolution_mode="canonical_id_only"`` to retain exact identity
   reuse while skipping semantic name resolution after an exact miss.
+- Explicit external identifiers, and conservative leading arXiv labels on
+  instances, are checked before title-derived canonical or semantic reuse.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Sequence
 
 from ..db.repositories.concepts_repository import ConceptsRepository
 from ..utils.concept_id_utils import canonicalise_vontology_concept_id
@@ -57,6 +59,18 @@ class CreateConceptDuplicateGuardMatch:
     existing_parent_ids: tuple[str, ...] = ()
     requested_parent_id: str | None = None
     mismatch_reasons: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class CreateConceptDuplicateGuardBlock:
+    error_code: str
+    message: str
+    match_source: str
+    guard_scope: str
+    candidate_concept_ids: tuple[str, ...] = ()
+    external_identifier_scheme: str | None = None
+    external_identifier_value: str | None = None
+    retryable: bool = False
 
 
 def _normalise_kind(kind: str | None) -> str:
@@ -175,6 +189,38 @@ def _identity_mismatch_details(
     )
 
 
+def _external_identity_mismatch_details(
+    *,
+    doc: dict[str, Any],
+    scope: str,
+    parent_id_for_concept: str | None,
+) -> tuple[str | None, str, tuple[str, ...], str | None, tuple[str, ...]]:
+    from .concept_external_identity_service import (
+        arxiv_paper_parent_scopes_compatible,
+    )
+
+    requested_kind = "instance" if scope == "workflow_instance" else scope
+    existing_kind = _infer_kind(doc)
+    existing_parent_ids = _existing_parent_ids(doc, requested_kind)
+    requested_parent_id = canonicalise_vontology_concept_id(parent_id_for_concept)
+
+    mismatch_reasons: list[str] = []
+    if existing_kind != requested_kind:
+        mismatch_reasons.append("kind_mismatch")
+    if requested_kind == "instance" and not arxiv_paper_parent_scopes_compatible(
+        existing_parent_ids=existing_parent_ids,
+        requested_parent_id=requested_parent_id,
+    ):
+        mismatch_reasons.append("parent_mismatch")
+    return (
+        existing_kind,
+        requested_kind,
+        existing_parent_ids,
+        requested_parent_id,
+        tuple(mismatch_reasons),
+    )
+
+
 def _guard_scope_for_request(
     kind: str,
     parent_id_for_concept: str | None,
@@ -241,21 +287,133 @@ def find_existing_concept_for_create_concepts(
     preferred_language: str | None = None,
     allow_duplicate_instances: bool = False,
     duplicate_resolution_mode: str | None = None,
-) -> CreateConceptDuplicateGuardMatch | None:
+    external_identifiers: Any = None,
+    external_identity_concept_ids: Sequence[str] = (),
+) -> CreateConceptDuplicateGuardMatch | CreateConceptDuplicateGuardBlock | None:
     """Return an existing concept match when duplicate creation should be blocked.
 
     ``canonical_id_only`` retains the normal exact match and scope checks, but
     deliberately returns after an exact miss instead of searching text values.
     """
 
+    from .concept_external_identity_service import (
+        normalise_create_external_identifiers,
+        resolve_external_identity_candidates,
+    )
+
     normalised_kind = _normalise_kind(kind)
+    normalised_external_identifiers = normalise_create_external_identifiers(
+        external_identifiers=external_identifiers,
+        concept_name=concept_name,
+        kind=normalised_kind,
+    )
     scope = _guard_scope_for_request(
         normalised_kind,
         parent_id_for_concept,
-        allow_duplicate_instances=allow_duplicate_instances,
+        # True homonyms may share a name, but an asserted external identity
+        # remains singleton even when duplicate instance names were requested.
+        allow_duplicate_instances=(
+            allow_duplicate_instances and not normalised_external_identifiers
+        ),
     )
     if scope is None:
         return None
+
+    if normalised_external_identifiers:
+        external_identifier = normalised_external_identifiers[0]
+        match_source = f"external_identifier:{external_identifier.scheme}"
+        try:
+            external_resolution = resolve_external_identity_candidates(
+                external_identifier,
+                canonical_concept_id_candidates=external_identity_concept_ids,
+            )
+        except Exception:
+            return CreateConceptDuplicateGuardBlock(
+                error_code="external_identity_resolution_failed",
+                message=(
+                    "External identity lookup failed before concept creation. "
+                    "No concept was created."
+                ),
+                match_source=match_source,
+                guard_scope=scope,
+                external_identifier_scheme=external_identifier.scheme,
+                external_identifier_value=external_identifier.value,
+                retryable=True,
+            )
+
+        if external_resolution.status == "not_found":
+            # An asserted external identity is authoritative. A title or
+            # title-derived concept ID must not substitute for an identity miss.
+            return None
+
+        if external_resolution.status == "ambiguous":
+            return CreateConceptDuplicateGuardBlock(
+                error_code="ambiguous_external_identity",
+                message=(
+                    "More than one visible concept carries the requested external "
+                    "identity. No concept was selected or created."
+                ),
+                match_source=match_source,
+                guard_scope=scope,
+                candidate_concept_ids=external_resolution.candidate_concept_ids,
+                external_identifier_scheme=external_identifier.scheme,
+                external_identifier_value=external_identifier.value,
+            )
+
+        if (
+            external_resolution.status == "resolved"
+            and len(external_resolution.candidate_concept_ids) == 1
+        ):
+            existing_concept_id = external_resolution.candidate_concept_ids[0]
+            doc = _find_concept(existing_concept_id)
+            if not isinstance(doc, dict):
+                return CreateConceptDuplicateGuardBlock(
+                    error_code="external_identity_resolution_failed",
+                    message=(
+                        "The externally identified concept changed during "
+                        "creation preflight. No concept was created."
+                    ),
+                    match_source=match_source,
+                    guard_scope=scope,
+                    external_identifier_scheme=external_identifier.scheme,
+                    external_identifier_value=external_identifier.value,
+                    retryable=True,
+                )
+            (
+                existing_kind,
+                requested_kind,
+                existing_parent_ids,
+                requested_parent_id,
+                mismatch_reasons,
+            ) = _external_identity_mismatch_details(
+                doc=doc,
+                scope=scope,
+                parent_id_for_concept=parent_id_for_concept,
+            )
+            return CreateConceptDuplicateGuardMatch(
+                existing_concept_id=existing_concept_id,
+                match_source=match_source,
+                guard_scope=scope,
+                identity_conflict=bool(mismatch_reasons),
+                existing_kind=existing_kind,
+                requested_kind=requested_kind,
+                existing_parent_ids=existing_parent_ids,
+                requested_parent_id=requested_parent_id,
+                mismatch_reasons=mismatch_reasons,
+            )
+
+        return CreateConceptDuplicateGuardBlock(
+            error_code="external_identity_resolution_failed",
+            message=(
+                "External identity lookup returned an invalid resolution state. "
+                "No concept was created."
+            ),
+            match_source=match_source,
+            guard_scope=scope,
+            external_identifier_scheme=external_identifier.scheme,
+            external_identifier_value=external_identifier.value,
+            retryable=True,
+        )
 
     canonical_requested_id = canonicalise_vontology_concept_id(concept_name)
     if canonical_requested_id:
@@ -385,18 +543,25 @@ def build_canonical_identity_conflict_create_concepts_result(
     existing_parent_ids: tuple[str, ...],
     requested_parent_id: str | None,
     mismatch_reasons: tuple[str, ...],
+    error_code: str = "canonical_identity_conflict",
+    match_source: str = "canonical_concept_id",
 ) -> dict[str, Any]:
     mismatch_summary = ", ".join(mismatch_reasons) or "incompatible identity"
+    identity_label = (
+        "External concept identity"
+        if match_source.startswith("external_identifier:")
+        else "Canonical concept identity"
+    )
     return {
         "success": False,
         "effect_status": "failed",
         "changed": False,
         "message": (
-            f"Canonical concept identity '{existing_concept_id}' is already occupied "
+            f"{identity_label} '{existing_concept_id}' is already occupied "
             f"by an incompatible concept ({mismatch_summary}). No concept was created."
         ),
         "concept": None,
-        "error_code": "canonical_identity_conflict",
+        "error_code": error_code,
         "existing_concept_id": existing_concept_id,
         "canonical_concept_id": existing_concept_id,
         "input_name": requested_name,
@@ -408,9 +573,43 @@ def build_canonical_identity_conflict_create_concepts_result(
         "identity_mismatch_reasons": list(mismatch_reasons),
         "duplicate_prevented": True,
         "duplicate_guard_scope": guard_scope,
-        "duplicate_match_source": "canonical_concept_id",
+        "duplicate_match_source": match_source,
         "suggestion": (
-            "Use a different canonical name, or inspect the existing concept and "
-            "explicitly update its typing if that existing identity is the intended one."
+            "Inspect the existing concept and explicitly reconcile its typing "
+            "before deciding whether to reuse or update it."
+        ),
+    }
+
+
+def build_duplicate_guard_block_create_concepts_result(
+    *,
+    requested_name: str,
+    requested_kind: str,
+    block: CreateConceptDuplicateGuardBlock,
+) -> dict[str, Any]:
+    return {
+        "success": False,
+        "effect_status": "failed",
+        "changed": False,
+        "message": block.message,
+        "concept": None,
+        "error_code": block.error_code,
+        "input_name": requested_name,
+        "requested_name": requested_name,
+        "requested_kind": requested_kind,
+        "duplicate_prevented": True,
+        "duplicate_guard_scope": block.guard_scope,
+        "duplicate_match_source": block.match_source,
+        "candidate_concept_ids": list(block.candidate_concept_ids),
+        "external_identifier": {
+            "scheme": block.external_identifier_scheme,
+            "value": block.external_identifier_value,
+        },
+        "retryable": block.retryable,
+        "suggestion": (
+            "Inspect the candidate concepts and explicitly reconcile their "
+            "identity evidence before retrying."
+            if block.candidate_concept_ids
+            else "Retry after the external identity lookup is available."
         ),
     }

--- a/src/backend/services/display_elements_service.py
+++ b/src/backend/services/display_elements_service.py
@@ -95,6 +95,7 @@ _RELATION_EXTENT_ARG1_TOKENS = frozenset({"arg1", "subject", "left", "source"})
 _RELATION_EXTENT_PREDICATE_TOKENS = frozenset({"predicate", "relation"})
 _RELATION_EXTENT_ARG2_TOKENS = frozenset({"arg2", "object", "right", "target"})
 _TABLE_COLUMN_VISIBILITY_DEFAULT_MODES = frozenset({"compact", "full"})
+_TABLE_PRESENTATION_MODES = frozenset({"augment", "inline_primary"})
 
 
 def _normalise_text(value: object) -> str | None:
@@ -482,7 +483,12 @@ def extract_markdown_tables(text: str | None) -> list[dict[str, Any]]:
         return []
 
     # Avoid treating pipe-delimited content inside code fences as table rows.
-    sanitised = _FENCED_CODE_BLOCK_PATTERN.sub("", text)
+    # Preserve newline positions so source spans continue to identify the
+    # untouched screen text even when an earlier code fence is removed.
+    sanitised = _FENCED_CODE_BLOCK_PATTERN.sub(
+        lambda match: "\n" * match.group(0).count("\n"),
+        text,
+    )
     lines = sanitised.splitlines()
     tables: list[dict[str, Any]] = []
 
@@ -2007,6 +2013,172 @@ _DISPLAY_ELEMENT_PAYLOAD_VALIDATORS: dict[str, Callable[..., None]] = {
 }
 
 
+def _validate_display_element_presentation(
+    *,
+    element: Mapping[str, Any],
+    element_type: object,
+    label: str,
+    errors: list[str],
+) -> None:
+    presentation = element.get("presentation")
+    if presentation is None:
+        return
+    if element_type != "table":
+        errors.append(f"{label}.presentation is currently supported only for table elements")
+        return
+    if not isinstance(presentation, Mapping):
+        errors.append(f"{label}.presentation must be a mapping when provided")
+        return
+
+    mode = presentation.get("mode")
+    if not isinstance(mode, str) or mode.strip() not in _TABLE_PRESENTATION_MODES:
+        errors.append(
+            f"{label}.presentation.mode must be one of {sorted(_TABLE_PRESENTATION_MODES)}"
+        )
+        return
+
+    if mode.strip() != "inline_primary":
+        return
+
+    source_element_id = presentation.get("source_element_id")
+    if not isinstance(source_element_id, str) or not source_element_id.strip():
+        errors.append(
+            f"{label}.presentation.source_element_id must be a non-empty string for inline_primary"
+        )
+
+    source_span = presentation.get("source_span")
+    if not isinstance(source_span, Mapping):
+        errors.append(
+            f"{label}.presentation.source_span must be a mapping for inline_primary"
+        )
+        return
+
+    start_line = source_span.get("start_line")
+    end_line = source_span.get("end_line")
+    if (
+        isinstance(start_line, bool)
+        or not isinstance(start_line, int)
+        or start_line < 1
+    ):
+        errors.append(
+            f"{label}.presentation.source_span.start_line must be a positive integer"
+        )
+    if (
+        isinstance(end_line, bool)
+        or not isinstance(end_line, int)
+        or end_line < 1
+    ):
+        errors.append(
+            f"{label}.presentation.source_span.end_line must be a positive integer"
+        )
+    if (
+        isinstance(start_line, int)
+        and not isinstance(start_line, bool)
+        and isinstance(end_line, int)
+        and not isinstance(end_line, bool)
+        and end_line < start_line
+    ):
+        errors.append(
+            f"{label}.presentation.source_span.end_line must not precede start_line"
+        )
+
+
+def _validate_inline_primary_table_relationships(
+    *,
+    elements: Sequence[object],
+    errors: list[str],
+) -> None:
+    elements_by_id: dict[str, list[tuple[int, Mapping[str, Any]]]] = {}
+    for index, element in enumerate(elements):
+        if not isinstance(element, Mapping):
+            continue
+        element_id = element.get("element_id")
+        if not isinstance(element_id, str) or not element_id.strip():
+            continue
+        elements_by_id.setdefault(element_id.strip(), []).append((index, element))
+
+    for index, element in enumerate(elements):
+        if not isinstance(element, Mapping) or element.get("element_type") != "table":
+            continue
+        presentation = element.get("presentation")
+        if (
+            not isinstance(presentation, Mapping)
+            or presentation.get("mode") != "inline_primary"
+        ):
+            continue
+
+        label = f"elements[{index}].presentation"
+        source_element_id = presentation.get("source_element_id")
+        if not isinstance(source_element_id, str) or not source_element_id.strip():
+            continue
+
+        source_matches = elements_by_id.get(source_element_id.strip(), [])
+        if len(source_matches) != 1:
+            errors.append(
+                f"{label}.source_element_id must identify exactly one element in the contract"
+            )
+            continue
+
+        _, source_element = source_matches[0]
+        if (
+            source_element.get("element_type") != "text_block"
+            or source_element.get("channel") != "screen"
+        ):
+            errors.append(
+                f"{label}.source_element_id must reference a screen text_block element"
+            )
+            continue
+
+        source_payload = source_element.get("payload")
+        source_text = (
+            source_payload.get("text")
+            if isinstance(source_payload, Mapping)
+            else None
+        )
+        if not isinstance(source_text, str) or not source_text.strip():
+            errors.append(
+                f"{label}.source_element_id must reference a non-empty text payload"
+            )
+            continue
+
+        source_span = presentation.get("source_span")
+        if not isinstance(source_span, Mapping):
+            continue
+        start_line = source_span.get("start_line")
+        end_line = source_span.get("end_line")
+        if (
+            isinstance(start_line, bool)
+            or not isinstance(start_line, int)
+            or start_line < 1
+            or isinstance(end_line, bool)
+            or not isinstance(end_line, int)
+            or end_line < start_line
+        ):
+            continue
+
+        source_line_count = len(source_text.splitlines())
+        if end_line > source_line_count:
+            errors.append(
+                f"{label}.source_span must fall within the referenced text payload"
+            )
+            continue
+
+        markdown_table_spans = {
+            (
+                candidate_span.get("start_line"),
+                candidate_span.get("end_line"),
+            )
+            for table_payload in extract_markdown_tables(source_text)
+            if isinstance(table_payload, Mapping)
+            for candidate_span in [table_payload.get("source_span")]
+            if isinstance(candidate_span, Mapping)
+        }
+        if (start_line, end_line) not in markdown_table_spans:
+            errors.append(
+                f"{label}.source_span must identify a Markdown table in the referenced text"
+            )
+
+
 def validate_turn_display_elements(
     contract: Mapping[str, Any] | None,
 ) -> tuple[bool, list[str]]:
@@ -2059,6 +2231,13 @@ def validate_turn_display_elements(
         if not isinstance(provenance, Mapping):
             errors.append(f"{label}.provenance must be a mapping")
 
+        _validate_display_element_presentation(
+            element=element,
+            element_type=element_type,
+            label=label,
+            errors=errors,
+        )
+
         if element_type in OPTIONAL_PAYLOAD_TITLE_ELEMENT_TYPES:
             _validate_optional_payload_title(
                 payload=payload,
@@ -2074,6 +2253,11 @@ def validate_turn_display_elements(
                 errors=errors,
             )
             continue
+
+    _validate_inline_primary_table_relationships(
+        elements=elements,
+        errors=errors,
+    )
 
     return len(errors) == 0, errors
 
@@ -2137,6 +2321,9 @@ def _normalise_supplied_screen_tables(
         provenance = metadata.get("provenance")
         if not isinstance(provenance, Mapping):
             provenance = {}
+        presentation = metadata.get("presentation")
+        if not isinstance(presentation, Mapping):
+            presentation = {"mode": "augment"}
         canonical_payload = _with_default_table_column_visibility(
             _with_optional_payload_title(payload, metadata=metadata)
         )
@@ -2156,6 +2343,7 @@ def _normalise_supplied_screen_tables(
                         "payload": dict(canonical_payload),
                         "constraints": dict(constraints),
                         "provenance": dict(provenance),
+                        "presentation": dict(presentation),
                     }
                 ],
                 "reason_codes": [],
@@ -2173,6 +2361,7 @@ def _normalise_supplied_screen_tables(
                 "payload": dict(canonical_payload),
                 "constraints": dict(constraints),
                 "provenance": dict(provenance),
+                "presentation": dict(presentation),
             }
         )
 
@@ -3261,6 +3450,11 @@ def _build_structured_screen_specs(
                 "payload": spec.get("payload") or {},
                 "constraints": spec.get("constraints") or dict(default_constraints),
                 "provenance": provenance,
+                "presentation": (
+                    dict(spec["presentation"])
+                    if isinstance(spec.get("presentation"), Mapping)
+                    else None
+                ),
             }
         )
     return structured_specs
@@ -3298,18 +3492,20 @@ def _emit_structured_screen_elements(
             next_default_order += 1
 
         element_id = _next_unique_element_id(str(spec["element_id"]), used_ids)
-        elements.append(
-            {
-                "element_id": element_id,
-                "element_type": element_type,
-                "channel": "screen",
-                "order": int(order),
-                "intent": str(spec["intent"]),
-                "payload": dict(spec["payload"]),
-                "constraints": dict(spec["constraints"]),
-                "provenance": dict(spec["provenance"]),
-            }
-        )
+        element = {
+            "element_id": element_id,
+            "element_type": element_type,
+            "channel": "screen",
+            "order": int(order),
+            "intent": str(spec["intent"]),
+            "payload": dict(spec["payload"]),
+            "constraints": dict(spec["constraints"]),
+            "provenance": dict(spec["provenance"]),
+        }
+        presentation = spec.get("presentation")
+        if isinstance(presentation, Mapping):
+            element["presentation"] = dict(presentation)
+        elements.append(element)
 
 
 def build_turn_display_elements(
@@ -3549,6 +3745,7 @@ def build_turn_display_elements(
 
     markdown_tables = extract_markdown_tables(effective_screen)
     for index, table_payload in enumerate(markdown_tables, start=1):
+        source_span = table_payload.get("source_span")
         table_specs.append(
             {
                 "element_id": f"screen_table_{index}",
@@ -3564,6 +3761,15 @@ def build_turn_display_elements(
                     "source": "screen_markdown_table",
                     "table_index": index,
                     "required_by_user_prompt": False,
+                },
+                "presentation": {
+                    "mode": "inline_primary",
+                    "source_element_id": "screen_text",
+                    "source_span": (
+                        dict(source_span)
+                        if isinstance(source_span, Mapping)
+                        else {}
+                    ),
                 },
             }
         )

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -5122,19 +5122,80 @@ def _classify_tool_invocation_status(
         if isinstance(raw_success, bool):
             payload_success = raw_success
 
-    if blocked:
-        return "blocked"
     invocation_status = (_safe_str(invocation.get("status")) or "").lower()
-    error_code = (_safe_str(invocation.get("error_code")) or "").lower()
+    effect_status = (
+        _safe_str(invocation.get("effect_status"))
+        or (
+            _safe_str(payload_value.get("effect_status"))
+            if isinstance(payload_value, Mapping)
+            else None
+        )
+        or ""
+    ).lower()
+    mutation_outcome = (
+        _safe_str(invocation.get("mutation_outcome"))
+        or (
+            _safe_str(payload_value.get("mutation_outcome"))
+            if isinstance(payload_value, Mapping)
+            else None
+        )
+        or ""
+    ).lower()
+    transport_value = invocation.get("transport")
+    transport_outcome = (
+        (_safe_str(transport_value.get("outcome")) or "").lower()
+        if isinstance(transport_value, Mapping)
+        else ""
+    )
+    error_code = (
+        _safe_str(invocation.get("error_code"))
+        or (
+            _safe_str(payload_value.get("error_code"))
+            if isinstance(payload_value, Mapping)
+            else None
+        )
+        or ""
+    ).lower()
+
+    if blocked or invocation_status == "blocked":
+        return "blocked"
     if (
         invocation_status in {"timeout", "timed_out"}
         or payload_status in {"timeout", "timed_out"}
         or error_code in {"tool_timeout", "tool_timeout_outcome_unknown"}
+        or transport_outcome in {"timeout", "timed_out"}
     ):
         return "timeout"
     if (
+        invocation_status == "not_started"
+        or payload_status == "not_started"
+        or mutation_outcome == "not_started"
+        or transport_outcome == "not_started"
+    ):
+        return "not_started"
+    if (
+        invocation_status == "indeterminate"
+        or payload_status == "indeterminate"
+        or effect_status == "indeterminate"
+        or mutation_outcome == "unknown"
+        or transport_outcome == "unknown"
+    ):
+        return "indeterminate"
+    if (
+        invocation_status == "partial"
+        or payload_status == "partial"
+        or effect_status == "partial"
+        or mutation_outcome == "partial"
+        or transport_outcome == "partial"
+    ):
+        return "partial"
+    if (
         error_value
+        or invocation_status in {"error", "failed", "failure"}
         or payload_status in {"error", "failed", "failure"}
+        or effect_status in {"error", "failed", "failure"}
+        or mutation_outcome in {"error", "failed", "failure"}
+        or transport_outcome in {"error", "failed", "failure", "cancelled"}
         or payload_success is False
     ):
         return "error"
@@ -5176,6 +5237,11 @@ def _summarise_tool_invocations(
             invocation=invocation, payload=payload_value
         )
         error_value = _safe_str(invocation.get("error"))
+        payload_error_code = (
+            _safe_str(payload_value.get("error_code"))
+            if isinstance(payload_value, Mapping)
+            else None
+        )
 
         result_summary = _safe_str(invocation.get("result_summary"))
         if not result_summary and isinstance(payload_value, Mapping):
@@ -5190,10 +5256,18 @@ def _summarise_tool_invocations(
             "started_at_utc": _safe_str(invocation.get("started_at_utc")),
             "completed_at_utc": _safe_str(invocation.get("completed_at_utc")),
             "error": error_value,
-            "error_code": _safe_str(invocation.get("error_code")),
+            "error_code": (
+                _safe_str(invocation.get("error_code")) or payload_error_code
+            ),
             "result_summary": result_summary,
             "payload_fingerprint": _hash_payload(payload_value),
         }
+        for receipt_key in ("mutation_outcome", "outcome_finality"):
+            receipt_value = _safe_str(invocation.get(receipt_key))
+            if not receipt_value and isinstance(payload_value, Mapping):
+                receipt_value = _safe_str(payload_value.get(receipt_key))
+            if receipt_value:
+                serialised_invocation[receipt_key] = receipt_value
         for timing_key in (
             "duration_ms",
             "queue_duration_ms",
@@ -5243,8 +5317,31 @@ def _summarise_tool_invocations(
                 )
                 if key in transport_metadata
             }
+            if (
+                "mutation_outcome" not in serialised_invocation
+                and (_safe_str(transport_metadata.get("outcome")) or "").lower()
+                == "not_started"
+            ):
+                serialised_invocation["mutation_outcome"] = "not_started"
         if target_ids:
             serialised_invocation["target_ids"] = target_ids
+        predicate_ids = _extract_tool_invocation_predicate_ids(invocation)
+        if predicate_ids:
+            serialised_invocation["predicate_ids"] = predicate_ids
+        argument_relation_tuples = _extract_tool_invocation_relation_tuples(
+            invocation,
+            include_results=False,
+        )
+        if argument_relation_tuples:
+            serialised_invocation["argument_relation_tuples"] = (
+                argument_relation_tuples
+            )
+        result_relation_tuples = _extract_tool_invocation_relation_tuples(
+            invocation,
+            include_arguments=False,
+        )
+        if result_relation_tuples:
+            serialised_invocation["result_relation_tuples"] = result_relation_tuples
         serialised.append(serialised_invocation)
 
         lowered = tool_name.lower()
@@ -7578,7 +7675,7 @@ def _extract_tool_invocation_target_ids(invocation: Mapping[str, Any]) -> list[s
         raw_arguments = invocation.get("arguments")
         arguments = raw_arguments if isinstance(raw_arguments, Mapping) else None
 
-    return _normalise_representation_target_tokens(
+    raw_targets: list[Any] = [
         payload.get("concept_id") if isinstance(payload, Mapping) else None,
         payload.get("instance_of") if isinstance(payload, Mapping) else None,
         payload.get("file_copy_concept_id") if isinstance(payload, Mapping) else None,
@@ -7605,7 +7702,296 @@ def _extract_tool_invocation_target_ids(invocation: Mapping[str, Any]) -> list[s
         arguments.get("url") if isinstance(arguments, Mapping) else None,
         arguments.get("source_url") if isinstance(arguments, Mapping) else None,
         arguments.get("arxiv_id") if isinstance(arguments, Mapping) else None,
+    ]
+    for source in (payload, arguments):
+        if not isinstance(source, Mapping):
+            continue
+        for key in (
+            "canonical_concept_id",
+            "created_concept_id",
+            "existing_concept_id",
+            "object_id",
+            "paper_concept_id",
+            "relation_id",
+            "source",
+            "source_concept_id",
+            "source_id",
+            "subject",
+            "subject_id",
+            "target",
+            "target_concept_id",
+            "target_id",
+        ):
+            raw_targets.append(source.get(key))
+        for key in (
+            "concept_ids",
+            "created_concept_ids",
+            "relation_ids",
+            "source_ids",
+            "target_ids",
+        ):
+            value = source.get(key)
+            if isinstance(value, Sequence) and not isinstance(
+                value,
+                (str, bytes, bytearray),
+            ):
+                raw_targets.extend(list(value)[:100])
+
+    for invocation_key in ("result_target_ids", "target_ids"):
+        result_target_ids = invocation.get(invocation_key)
+        if isinstance(result_target_ids, Sequence) and not isinstance(
+            result_target_ids,
+            (str, bytes, bytearray),
+        ):
+            raw_targets.extend(list(result_target_ids)[:100])
+
+    def collect_nested(value: Any, *, depth: int = 0) -> None:
+        if depth > 5 or len(raw_targets) >= 500:
+            return
+        if isinstance(value, Mapping):
+            for raw_key, item in list(value.items())[:100]:
+                key = str(raw_key).strip().lower()
+                if key in {
+                    "canonical_concept_id",
+                    "computer_file_copy_concept_id",
+                    "concept_id",
+                    "created_concept_id",
+                    "existing_concept_id",
+                    "file_copy_concept_id",
+                    "object_id",
+                    "paper_concept_id",
+                    "relation_id",
+                    "source_concept_id",
+                    "source_id",
+                    "subject_id",
+                    "target_concept_id",
+                    "target_id",
+                }:
+                    raw_targets.append(item)
+                elif key in {
+                    "concept_ids",
+                    "created_concept_ids",
+                    "relation_ids",
+                    "source_ids",
+                    "target_ids",
+                } and isinstance(item, Sequence) and not isinstance(
+                    item,
+                    (str, bytes, bytearray),
+                ):
+                    raw_targets.extend(list(item)[:100])
+                if key in {
+                    "arguments",
+                    "concept",
+                    "created",
+                    "data",
+                    "hits",
+                    "items",
+                    "relationship",
+                    "relationships",
+                    "result",
+                    "results",
+                }:
+                    collect_nested(item, depth=depth + 1)
+        elif isinstance(value, Sequence) and not isinstance(
+            value,
+            (str, bytes, bytearray),
+        ):
+            for item in list(value)[:100]:
+                collect_nested(item, depth=depth + 1)
+
+    collect_nested(payload)
+    return _normalise_representation_target_tokens(*raw_targets)
+
+
+def _extract_tool_invocation_predicate_ids(
+    invocation: Mapping[str, Any],
+) -> list[str]:
+    raw_predicate_ids = invocation.get("predicate_ids")
+    values: list[Any] = (
+        list(raw_predicate_ids)
+        if isinstance(raw_predicate_ids, Sequence)
+        and not isinstance(raw_predicate_ids, (str, bytes, bytearray))
+        else []
     )
+    sources = (
+        invocation.get("effective_arguments"),
+        invocation.get("arguments"),
+        invocation.get("effective_payload"),
+        invocation.get("payload"),
+    )
+    for source in sources:
+        if not isinstance(source, Mapping):
+            continue
+        for key in ("predicate", "predicate_concept_id", "predicate_id"):
+            values.append(source.get(key))
+
+    def collect_nested(value: Any, *, depth: int = 0) -> None:
+        if depth > 5 or len(values) >= 500:
+            return
+        if isinstance(value, Mapping):
+            for raw_key, item in list(value.items())[:100]:
+                key = str(raw_key).strip().lower()
+                if key in {"predicate", "predicate_concept_id", "predicate_id"}:
+                    values.append(item)
+                if key in {
+                    "arguments",
+                    "data",
+                    "hits",
+                    "items",
+                    "relationship",
+                    "relationships",
+                    "result",
+                    "results",
+                }:
+                    collect_nested(item, depth=depth + 1)
+        elif isinstance(value, Sequence) and not isinstance(
+            value,
+            (str, bytes, bytearray),
+        ):
+            for item in list(value)[:100]:
+                collect_nested(item, depth=depth + 1)
+
+    for source in sources:
+        collect_nested(source)
+    return _dedupe_string_sequence(values)
+
+
+def _relation_identifier(
+    row: Mapping[str, Any],
+    keys: Sequence[str],
+) -> str | None:
+    for key in keys:
+        value = row.get(key)
+        identifier = _safe_str(value)
+        if identifier:
+            return identifier
+        if not isinstance(value, Mapping):
+            continue
+        for nested_key in (
+            "canonical_concept_id",
+            "concept_id",
+            "id",
+            "predicate_concept_id",
+        ):
+            identifier = _safe_str(value.get(nested_key))
+            if identifier:
+                return identifier
+    return None
+
+
+def _relation_tuple_from_mapping(
+    row: Mapping[str, Any],
+) -> dict[str, str] | None:
+    source_id = _relation_identifier(
+        row,
+        (
+            "source_concept_id",
+            "source_id",
+            "source",
+            "subject_concept_id",
+            "subject_id",
+            "subject",
+        ),
+    )
+    predicate_id = _relation_identifier(
+        row,
+        ("predicate_concept_id", "predicate_id", "predicate"),
+    )
+    target_id = _relation_identifier(
+        row,
+        (
+            "target_concept_id",
+            "target_id",
+            "target",
+            "object_concept_id",
+            "object_id",
+            "object",
+        ),
+    )
+    if not source_id or not predicate_id or not target_id:
+        return None
+    return {
+        "source_id": source_id,
+        "predicate_id": predicate_id,
+        "target_id": target_id,
+    }
+
+
+def _relation_tuple_key(relation: Mapping[str, Any]) -> tuple[str, str, str] | None:
+    normalised = _relation_tuple_from_mapping(relation)
+    if normalised is None:
+        return None
+    return (
+        normalised["source_id"].lower(),
+        normalised["predicate_id"].lower(),
+        normalised["target_id"].lower(),
+    )
+
+
+def _extract_tool_invocation_relation_tuples(
+    invocation: Mapping[str, Any],
+    *,
+    include_arguments: bool = True,
+    include_results: bool = True,
+) -> list[dict[str, str]]:
+    """Retain source-predicate-target membership from individual mappings."""
+
+    relations: list[dict[str, str]] = []
+    seen: set[tuple[str, str, str]] = set()
+    visited_mappings = 0
+
+    def collect(value: Any, *, depth: int = 0) -> None:
+        nonlocal visited_mappings
+        if depth > 6 or visited_mappings >= 500:
+            return
+        if isinstance(value, Mapping):
+            visited_mappings += 1
+            relation = _relation_tuple_from_mapping(value)
+            if relation is not None:
+                key = _relation_tuple_key(relation)
+                if key is not None and key not in seen:
+                    seen.add(key)
+                    relations.append(relation)
+            for item in list(value.values())[:100]:
+                if isinstance(item, Mapping) or (
+                    isinstance(item, Sequence)
+                    and not isinstance(item, (str, bytes, bytearray))
+                ):
+                    collect(item, depth=depth + 1)
+        elif isinstance(value, Sequence) and not isinstance(
+            value,
+            (str, bytes, bytearray),
+        ):
+            for item in list(value)[:100]:
+                collect(item, depth=depth + 1)
+
+    sources: list[Any] = []
+    raw_payload = invocation.get("payload")
+    payload_arguments = (
+        raw_payload.get("arguments") if isinstance(raw_payload, Mapping) else None
+    )
+    if include_arguments:
+        sources.extend(
+            (
+                invocation.get("effective_arguments"),
+                invocation.get("arguments"),
+                payload_arguments,
+            )
+        )
+    if include_results:
+        sources.extend(
+            (
+                invocation.get("effective_payload"),
+                invocation.get("result"),
+                invocation.get("output"),
+            )
+        )
+        if not isinstance(payload_arguments, Mapping):
+            sources.append(raw_payload)
+
+    for source in sources:
+        collect(source)
+    return relations
 
 
 def _normalise_representation_target_tokens(*raw_values: Any) -> list[str]:
@@ -8281,44 +8667,69 @@ def _extract_mutation_metadata_from_invocation(
     payload = _extract_tool_invocation_payload(invocation)
     status = _classify_tool_invocation_status(invocation=invocation, payload=payload)
     targets = _extract_tool_invocation_target_ids(invocation)
+    transport = invocation.get("transport")
 
-    predicates: list[str] = []
-    for source in (
-        invocation.get("effective_arguments"),
-        invocation.get("arguments"),
-        payload,
+    def _receipt_text(field_name: str) -> str | None:
+        value = _safe_str(invocation.get(field_name))
+        if value:
+            return value
+        if isinstance(payload, Mapping):
+            value = _safe_str(payload.get(field_name))
+            if value:
+                return value
+        return None
+
+    mutation_outcome = _receipt_text("mutation_outcome")
+    if (
+        not mutation_outcome
+        and isinstance(transport, Mapping)
+        and (_safe_str(transport.get("outcome")) or "").lower() == "not_started"
     ):
-        if not isinstance(source, Mapping):
-            continue
-        for key in ("predicate_concept_id", "predicate"):
-            val = _safe_str(source.get(key))
-            if val and val not in predicates:
-                predicates.append(val)
+        mutation_outcome = "not_started"
+
+    predicates = _extract_tool_invocation_predicate_ids(invocation)
+    relation_tuples = _extract_tool_invocation_relation_tuples(
+        invocation,
+        include_results=False,
+    )
+    if not relation_tuples:
+        relation_tuples = _extract_tool_invocation_relation_tuples(
+            invocation,
+            include_arguments=False,
+        )
 
     return {
         "tool_name": tool_name,
         "status": status,
         "targets": targets,
         "predicates": predicates,
+        "relation_tuples": relation_tuples,
         "payload": payload if isinstance(payload, Mapping) else None,
+        "effect_id": _safe_str(invocation.get("effect_id")),
+        "effect_status": _receipt_text("effect_status"),
+        "mutation_outcome": mutation_outcome,
+        "outcome_finality": _receipt_text("outcome_finality"),
+        "error_code": _receipt_text("error_code"),
     }
 
 
 def _build_tool_authored_mutation_effects(
     *,
     tool_invocations: Sequence[Mapping[str, Any]] | None,
+    include_legacy_without_effect_id: bool = True,
 ) -> list[dict[str, Any]]:
     """Build mutation effects from tool-authored invocation metadata.
 
-    Groups write tool invocations by tool name, collecting targets and
-    predicates from each invocation's arguments/payload.  Each group
-    yields one effect with ``intent_origin: "tool_authored"``.
+    Durable adaptive effects are projected independently by their stable
+    ``effect_id`` so one successful invocation cannot mask another attempted
+    effect that was not started, partial, or indeterminate. Legacy invocations
+    without an effect identifier retain the existing per-tool grouping.
     """
     if not tool_invocations:
         return []
 
     groups: dict[str, dict[str, Any]] = {}
-    tool_order: list[str] = []
+    group_order: list[str] = []
 
     for invocation in tool_invocations:
         if not isinstance(invocation, Mapping):
@@ -8327,31 +8738,91 @@ def _build_tool_authored_mutation_effects(
         if metadata is None:
             continue
 
-        canonical_key = _tool_requirement_key(metadata["tool_name"])
-        if canonical_key not in groups:
-            groups[canonical_key] = {
+        canonical_tool_key = _tool_requirement_key(metadata["tool_name"])
+        stable_effect_id = _safe_str(metadata.get("effect_id"))
+        if not stable_effect_id and not include_legacy_without_effect_id:
+            continue
+        group_key = (
+            f"effect:{stable_effect_id}"
+            if stable_effect_id
+            else f"tool:{canonical_tool_key}"
+        )
+        if group_key not in groups:
+            groups[group_key] = {
                 "tool_name": metadata["tool_name"],
+                "effect_id": stable_effect_id,
                 "targets": [],
                 "predicates": [],
+                "relation_tuples": [],
                 "any_success": False,
                 "any_failure": False,
                 "any_blocked": False,
+                "any_not_started": False,
+                "any_partial": False,
+                "any_indeterminate": False,
                 "payloads": [],
+                "effect_statuses": [],
+                "mutation_outcomes": [],
+                "outcome_finalities": [],
+                "error_codes": [],
             }
-            tool_order.append(canonical_key)
+            group_order.append(group_key)
 
-        group = groups[canonical_key]
+        group = groups[group_key]
         for t in metadata["targets"]:
             if t not in group["targets"]:
                 group["targets"].append(t)
         for p in metadata["predicates"]:
             if p not in group["predicates"]:
                 group["predicates"].append(p)
+        existing_relation_keys = {
+            _relation_tuple_key(relation)
+            for relation in group["relation_tuples"]
+            if isinstance(relation, Mapping)
+        }
+        for relation in metadata["relation_tuples"]:
+            relation_key = _relation_tuple_key(relation)
+            if relation_key is not None and relation_key not in existing_relation_keys:
+                group["relation_tuples"].append(dict(relation))
+                existing_relation_keys.add(relation_key)
         payload = metadata.get("payload")
         if isinstance(payload, Mapping):
             group["payloads"].append(payload)
 
-        if metadata["status"] == "ok":
+        for field_name, group_field in (
+            ("effect_status", "effect_statuses"),
+            ("mutation_outcome", "mutation_outcomes"),
+            ("outcome_finality", "outcome_finalities"),
+            ("error_code", "error_codes"),
+        ):
+            field_value = _safe_str(metadata.get(field_name))
+            if field_value and field_value not in group[group_field]:
+                group[group_field].append(field_value)
+
+        normalised_effect_status = (
+            _safe_str(metadata.get("effect_status")) or ""
+        ).lower()
+        normalised_mutation_outcome = (
+            _safe_str(metadata.get("mutation_outcome")) or ""
+        ).lower()
+        if (
+            metadata["status"] == "not_started"
+            or normalised_mutation_outcome == "not_started"
+        ):
+            group["any_not_started"] = True
+        elif (
+            metadata["status"] == "indeterminate"
+            or normalised_effect_status == "indeterminate"
+            or normalised_mutation_outcome == "unknown"
+        ):
+            group["any_indeterminate"] = True
+        elif (
+            metadata["status"] == "partial"
+            or normalised_effect_status == "partial"
+            or normalised_mutation_outcome == "partial"
+        ):
+            group["any_partial"] = True
+        elif metadata["status"] == "ok":
             group["any_success"] = True
         elif metadata["status"] == "blocked":
             group["any_blocked"] = True
@@ -8359,13 +8830,30 @@ def _build_tool_authored_mutation_effects(
             group["any_failure"] = True
 
     effects: list[dict[str, Any]] = []
-    for index, lowered in enumerate(tool_order):
-        group = groups[lowered]
+    for index, group_key in enumerate(group_order):
+        group = groups[group_key]
         tool_name = group["tool_name"]
         targets = group["targets"][:5]
         predicates = group["predicates"][:5]
+        relation_tuples = group["relation_tuples"][:5]
+        independently_observed = bool(group["effect_id"])
 
-        if group["any_success"]:
+        if independently_observed and group["any_not_started"]:
+            effect_status = "not_executed"
+            status_reason = f"{tool_name} invocation was not started."
+        elif independently_observed and group["any_indeterminate"]:
+            effect_status = "not_satisfied"
+            status_reason = f"{tool_name} invocation outcome is indeterminate."
+        elif independently_observed and group["any_partial"]:
+            effect_status = "not_satisfied"
+            status_reason = f"{tool_name} invocation completed only partially."
+        elif independently_observed and group["any_blocked"]:
+            effect_status = "not_satisfied"
+            status_reason = f"{tool_name} invocation was blocked."
+        elif independently_observed and group["any_failure"]:
+            effect_status = "not_satisfied"
+            status_reason = f"{tool_name} invocation failed."
+        elif group["any_success"]:
             effect_status = "satisfied"
             status_reason = f"Successful {tool_name} invocation observed."
         elif group["any_blocked"]:
@@ -8378,15 +8866,21 @@ def _build_tool_authored_mutation_effects(
             effect_status = "not_executed"
             status_reason = f"No {tool_name} invocation completed."
 
-        failure_codes: list[str] = []
-        if effect_status == "not_satisfied":
-            failure_codes = [f"kb_mutation_{tool_name.lower()}_failed"]
+        failure_codes: list[str] = _dedupe_string_sequence(group["error_codes"])
+        if effect_status in {"not_satisfied", "not_executed"} and not failure_codes:
+            failure_codes = [
+                (
+                    f"kb_mutation_{tool_name.lower()}_not_started"
+                    if effect_status == "not_executed"
+                    else f"kb_mutation_{tool_name.lower()}_failed"
+                )
+            ]
 
         target_detail = f" targeting {', '.join(targets[:2])}" if targets else ""
         predicate_detail = f" ({', '.join(predicates[:2])})" if predicates else ""
 
         effect: dict[str, Any] = {
-            "effect_id": f"mutation_{index + 1}",
+            "effect_id": group["effect_id"] or f"mutation_{index + 1}",
             "intent_origin": "tool_authored",
             "effect_type": "kb_mutation",
             "description": (
@@ -8401,13 +8895,32 @@ def _build_tool_authored_mutation_effects(
             "status_reason": status_reason,
             "failure_codes": failure_codes,
         }
+        if relation_tuples:
+            effect["required_relation_tuples"] = relation_tuples
+        if independently_observed and (
+            group["any_partial"] or group["any_indeterminate"]
+        ):
+            effect["repeat_eligible"] = False
+        for source_field, effect_field in (
+            ("effect_statuses", "observed_effect_status"),
+            ("mutation_outcomes", "mutation_outcome"),
+            ("outcome_finalities", "outcome_finality"),
+        ):
+            observed_values = group[source_field]
+            if len(observed_values) == 1:
+                effect[effect_field] = observed_values[0]
+            elif observed_values:
+                effect[f"{effect_field}s"] = list(observed_values)
         if failure_codes:
             effect["failure_code"] = failure_codes[0]
 
         if tool_name.lower() == "materialise_scholarly_representation_for_file_copy":
             effect.update(
                 {
-                    "effect_id": f"effect_paper_representation_tool_{index + 1}",
+                    "effect_id": (
+                        group["effect_id"]
+                        or f"effect_paper_representation_tool_{index + 1}"
+                    ),
                     "effect_type": "scholarly_representation",
                     "representation_domain_id": "paper",
                     "description": (
@@ -8446,11 +8959,181 @@ def _build_tool_authored_mutation_effects(
     return effects
 
 
+def _effect_postcondition_readback(
+    *,
+    effect: Mapping[str, Any],
+    tool_invocations: Sequence[Mapping[str, Any]] | None,
+) -> dict[str, Any]:
+    """Correlate successful verification reads to one effect's exact targets."""
+
+    required_targets = _dedupe_string_sequence(effect.get("targets") or [])
+    required_predicates = _dedupe_string_sequence(
+        effect.get("required_predicates") or []
+    )
+    required_relation_tuples: list[dict[str, str]] = []
+    required_relation_keys: set[tuple[str, str, str]] = set()
+    raw_required_relations = effect.get("required_relation_tuples")
+    if isinstance(raw_required_relations, Sequence) and not isinstance(
+        raw_required_relations,
+        (str, bytes, bytearray),
+    ):
+        for raw_relation in raw_required_relations:
+            if not isinstance(raw_relation, Mapping):
+                continue
+            relation = _relation_tuple_from_mapping(raw_relation)
+            relation_key = (
+                _relation_tuple_key(relation) if relation is not None else None
+            )
+            if relation is None or relation_key is None:
+                continue
+            if relation_key not in required_relation_keys:
+                required_relation_keys.add(relation_key)
+                required_relation_tuples.append(relation)
+    if required_relation_tuples:
+        required_targets = _dedupe_string_sequence(
+            [
+                *required_targets,
+                *(
+                    endpoint
+                    for relation in required_relation_tuples
+                    for endpoint in (
+                        relation["source_id"],
+                        relation["target_id"],
+                    )
+                ),
+            ]
+        )
+        required_predicates = _dedupe_string_sequence(
+            [
+                *required_predicates,
+                *(
+                    relation["predicate_id"]
+                    for relation in required_relation_tuples
+                ),
+            ]
+        )
+    target_lookup = {value.lower() for value in required_targets}
+    predicate_lookup = {value.lower() for value in required_predicates}
+    observations: list[dict[str, Any]] = []
+
+    for invocation in tool_invocations or ():
+        if not isinstance(invocation, Mapping):
+            continue
+        tool_name = _safe_str(invocation.get("tool")) or _safe_str(
+            invocation.get("method")
+        )
+        if not tool_name or not _is_verification_read_tool(tool_name):
+            continue
+        payload = _extract_tool_invocation_payload(invocation)
+        if _classify_tool_invocation_status(
+            invocation=invocation,
+            payload=payload,
+        ) != "ok":
+            continue
+        targets = _extract_tool_invocation_target_ids(invocation)
+        predicates = _extract_tool_invocation_predicate_ids(invocation)
+        relation_tuples = _extract_tool_invocation_relation_tuples(
+            invocation,
+            include_arguments=False,
+        )
+        observations.append(
+            {
+                "tool": tool_name,
+                "targets": targets,
+                "predicates": predicates,
+                "relation_tuples": relation_tuples,
+                "relation_tuple_keys": {
+                    key
+                    for relation in relation_tuples
+                    if (key := _relation_tuple_key(relation)) is not None
+                },
+                "target_lookup": {value.lower() for value in targets},
+                "predicate_lookup": {value.lower() for value in predicates},
+            }
+        )
+
+    observed_targets = _dedupe_string_sequence(
+        target
+        for observation in observations
+        for target in observation["targets"]
+    )
+    observed_predicates = _dedupe_string_sequence(
+        predicate
+        for observation in observations
+        for predicate in observation["predicates"]
+    )
+    observed_relation_tuples: list[dict[str, str]] = []
+    observed_relation_keys: set[tuple[str, str, str]] = set()
+    for observation in observations:
+        for relation in observation["relation_tuples"]:
+            relation_key = _relation_tuple_key(relation)
+            if relation_key is None or relation_key in observed_relation_keys:
+                continue
+            observed_relation_keys.add(relation_key)
+            observed_relation_tuples.append(dict(relation))
+    correlated_tools: list[str] = []
+    correlated = False
+    if target_lookup:
+        if required_relation_keys:
+            matched_relation_keys: set[tuple[str, str, str]] = set()
+            for observation in observations:
+                matches = required_relation_keys.intersection(
+                    observation["relation_tuple_keys"]
+                )
+                if not matches:
+                    continue
+                matched_relation_keys.update(matches)
+                correlated_tools.append(observation["tool"])
+            correlated = required_relation_keys.issubset(matched_relation_keys)
+            if not correlated:
+                correlated_tools = []
+        elif predicate_lookup:
+            matched_predicates: set[str] = set()
+            candidate_tools: list[str] = []
+            for observation in observations:
+                matched_observation = False
+                for source_id, predicate_id, target_id in observation[
+                    "relation_tuple_keys"
+                ]:
+                    if predicate_id not in predicate_lookup:
+                        continue
+                    if not target_lookup.issubset({source_id, target_id}):
+                        continue
+                    matched_predicates.add(predicate_id)
+                    matched_observation = True
+                if matched_observation:
+                    candidate_tools.append(observation["tool"])
+            correlated = predicate_lookup.issubset(matched_predicates)
+            if correlated:
+                correlated_tools = candidate_tools
+        else:
+            aggregate_targets = {value.lower() for value in observed_targets}
+            correlated = target_lookup.issubset(aggregate_targets)
+            if correlated:
+                correlated_tools = _dedupe_string_sequence(
+                    observation["tool"]
+                    for observation in observations
+                    if target_lookup.intersection(observation["target_lookup"])
+                )
+
+    return {
+        "correlated": correlated,
+        "correlated_tools": correlated_tools,
+        "required_targets": required_targets,
+        "required_predicates": required_predicates,
+        "required_relation_tuples": required_relation_tuples,
+        "observed_targets": observed_targets,
+        "observed_predicates": observed_predicates,
+        "observed_relation_tuples": observed_relation_tuples,
+    }
+
+
 def _build_postcondition_checks(
     *,
     required_effects: Sequence[Mapping[str, Any]],
     successful_write_tools: Sequence[str],
     successful_verification_tools: Sequence[str],
+    tool_invocations: Sequence[Mapping[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     checks: list[dict[str, Any]] = []
     for effect in required_effects:
@@ -8460,6 +9143,10 @@ def _build_postcondition_checks(
         postcondition_strategy = (
             _safe_str(effect.get("postcondition_strategy")) or ""
         ).lower()
+        readback = _effect_postcondition_readback(
+            effect=effect,
+            tool_invocations=tool_invocations,
+        )
         if effect_type == "tool_execution":
             if effect_status == "satisfied":
                 check_status = "verified"
@@ -8516,6 +9203,25 @@ def _build_postcondition_checks(
                 check_status = "inconclusive"
                 evidence = f"{representation_label} verification is inconclusive."
                 verification_mode = "execution_inconclusive"
+        elif _is_evidence_effect_type(effect_type):
+            if effect_status == "satisfied":
+                check_status = "verified"
+                evidence = (
+                    _safe_str(effect.get("status_reason"))
+                    or "Required evidence retrieval was observed."
+                )
+                verification_mode = "evidence_execution_observed"
+            elif effect_status in {"not_satisfied", "not_executed"}:
+                check_status = "not_verified"
+                evidence = (
+                    _safe_str(effect.get("status_reason"))
+                    or "Required evidence retrieval was not observed."
+                )
+                verification_mode = "evidence_execution_missing"
+            else:
+                check_status = "inconclusive"
+                evidence = "Evidence retrieval verification is inconclusive."
+                verification_mode = "evidence_execution_inconclusive"
         else:
             if postcondition_strategy == "execution_observed":
                 if effect_status == "satisfied":
@@ -8537,20 +9243,35 @@ def _build_postcondition_checks(
                     evidence = "Execution-observed verification is inconclusive."
                     verification_mode = "execution_inconclusive"
             elif effect_status == "satisfied" and successful_write_tools:
-                if successful_verification_tools:
-                    check_status = "verified"
-                    evidence = (
-                        "Observed postcondition verification read/check tool(s): "
-                        + ", ".join(successful_verification_tools[:3])
-                    )
-                    verification_mode = "state_requery_observed"
-                else:
+                if not successful_verification_tools:
                     check_status = "inconclusive"
                     evidence = (
                         "Write tool invocation succeeded but explicit state "
                         "re-query/check tool invocation was not observed."
                     )
                     verification_mode = "state_requery_missing"
+                elif not readback["required_targets"]:
+                    check_status = "inconclusive"
+                    evidence = (
+                        "A verification read was observed, but the write receipt "
+                        "did not expose a concrete target for correlation."
+                    )
+                    verification_mode = "state_requery_target_unavailable"
+                elif readback["correlated"]:
+                    check_status = "verified"
+                    evidence = (
+                        "Observed target-correlated postcondition read/check "
+                        "tool(s): "
+                        + ", ".join(readback["correlated_tools"][:3])
+                    )
+                    verification_mode = "state_requery_correlated"
+                else:
+                    check_status = "inconclusive"
+                    evidence = (
+                        "Verification reads were observed, but none correlated "
+                        "with this effect's concrete targets and predicates."
+                    )
+                    verification_mode = "state_requery_target_mismatch"
             elif effect_status in {"not_satisfied", "not_executed"}:
                 check_status = "not_verified"
                 evidence = "Required mutation effect is unresolved."
@@ -8574,9 +9295,14 @@ def _build_postcondition_checks(
                             "scholarly_representation_observed"
                             if _is_representation_effect_type(effect_type)
                             else (
-                                "effect_execution_observed"
-                                if postcondition_strategy == "execution_observed"
-                                else "predicate_exists"
+                                "evidence_retrieval_observed"
+                                if _is_evidence_effect_type(effect_type)
+                                else (
+                                    "effect_execution_observed"
+                                    if postcondition_strategy
+                                    == "execution_observed"
+                                    else "predicate_exists"
+                                )
                             )
                         )
                     )
@@ -8587,6 +9313,23 @@ def _build_postcondition_checks(
                     "successful_write_tools": list(successful_write_tools),
                     "successful_verification_tools": list(
                         successful_verification_tools
+                    ),
+                    "correlated_verification_tools": list(
+                        readback["correlated_tools"]
+                    ),
+                    "required_targets": list(readback["required_targets"]),
+                    "required_predicates": list(readback["required_predicates"]),
+                    "required_relation_tuples": list(
+                        readback["required_relation_tuples"]
+                    ),
+                    "observed_verification_targets": list(
+                        readback["observed_targets"]
+                    ),
+                    "observed_verification_predicates": list(
+                        readback["observed_predicates"]
+                    ),
+                    "observed_verification_relation_tuples": list(
+                        readback["observed_relation_tuples"]
                     ),
                     "effect_status": effect_status,
                     "effect_type": effect_type,
@@ -8824,7 +9567,16 @@ def _derive_completion_gate(
             blocking_failure_codes = ["postcondition_inconclusive"]
 
     execution_signal_blocker = None
-    repeat_eligible = True
+    repeat_ineligible_effect_ids = sorted(
+        {
+            _safe_str(effect.get("effect_id")) or "effect_1"
+            for effect in required_effects
+            if (_safe_str(effect.get("status")) or "")
+            in {"not_satisfied", "not_executed"}
+            and effect.get("repeat_eligible") is False
+        }
+    )
+    repeat_eligible = not repeat_ineligible_effect_ids
     if decision == "completed":
         execution_signal_blocker = _derive_execution_signal_completion_blocker(
             execution_summary=execution_summary
@@ -8900,6 +9652,7 @@ def _derive_completion_gate(
             if isinstance(execution_signal_blocker, Mapping)
             else None
         ),
+        "repeat_ineligible_effect_ids": repeat_ineligible_effect_ids,
         "repeat_eligible": repeat_eligible,
         "completion_outcome": (
             "success"
@@ -9410,13 +10163,16 @@ def build_turn_execution_record(
         validation_failure_context=tool_call_validation_failure_context,
     )
 
-    mutation_effects: list[dict[str, Any]] = []
-    if not representation_effects and not workflow_required_effects:
-        # Mutation effects must remain tool-authored or workflow-authored.
-        # Do not fall back to generic observed-tool mutation contracts.
-        mutation_effects = _build_tool_authored_mutation_effects(
-            tool_invocations=tool_invocations,
-        )
+    # Stable durable receipts remain independently visible even when a
+    # represented/workflow contract also describes the intended outcome. Only
+    # legacy invocations without an effect ID are suppressed in that case, so
+    # generic observed-tool inference does not duplicate the authored contract.
+    mutation_effects = _build_tool_authored_mutation_effects(
+        tool_invocations=tool_invocations,
+        include_legacy_without_effect_id=(
+            not representation_effects and not workflow_required_effects
+        ),
+    )
     required_effects.extend(mutation_effects)
 
     required_tool_effect = required_tool_obligation_effect(
@@ -9541,6 +10297,7 @@ def build_turn_execution_record(
         required_effects=required_effects,
         successful_write_tools=effective_successful_write_tools,
         successful_verification_tools=successful_verification_tools,
+        tool_invocations=tool_invocations,
     )
     critic_summary = _summarise_check_counts(postcondition_checks)
 

--- a/src/backend/vontology/utils_vontology.py
+++ b/src/backend/vontology/utils_vontology.py
@@ -3740,6 +3740,7 @@ def create_vontology_concept(
     event_namespace: Optional[str] = None,
     visibility_scope_mode: Optional[str] = None,
     allow_duplicate_instance_suffix: bool = True,
+    canonical_concept_id_override: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Creates a new concept in the Vontology.
@@ -3753,6 +3754,10 @@ def create_vontology_concept(
             allocate ``_2``, ``_3``, and later IDs for duplicate instance names.
             Higher-level creation surfaces should opt out unless duplicate
             instances were explicitly requested.
+        canonical_concept_id_override: Optional already-normalised concept ID
+            selected by an authoritative mechanical identity rule. When set,
+            instance suffix allocation is disabled so the concept ID uniqueness
+            constraint provides atomic race handling.
         notes: Optional notes for the new concept
         description: Optional description for the new concept
         instance_of_type: Optional concept_id to create an is_an_instance_of relationship.
@@ -3784,14 +3789,27 @@ def create_vontology_concept(
         if not is_valid:
             return {"success": False, "message": error_msg, "concept": None}
 
-        # Generate a canonical concept_id from the provided name (slug-like input).
-        # This prevents punctuation variants (e.g. hyphen vs underscore) creating distinct concepts.
-        canonical_id = canonicalise_vontology_concept_id(new_concept_name)
+        # Generate a canonical concept_id from the provided name unless an
+        # authoritative mechanical identity rule supplied a stable override.
+        canonical_id = canonicalise_vontology_concept_id(
+            canonical_concept_id_override or new_concept_name
+        )
         if not canonical_id:
             return {
                 "success": False,
                 "message": "New concept name is empty after normalisation.",
                 "concept": None,
+            }
+
+        if (
+            canonical_concept_id_override is not None
+            and canonical_id != canonical_concept_id_override.strip()
+        ):
+            return {
+                "success": False,
+                "message": "canonical_concept_id_override is not canonical.",
+                "concept": None,
+                "error_code": "invalid_canonical_concept_id_override",
             }
 
         base_slug = canonical_id[3:]
@@ -3803,12 +3821,13 @@ def create_vontology_concept(
 
         candidate_concept_id = canonical_id
         if create_as_instance:
-            if allow_duplicate_instance_suffix:
+            if (
+                allow_duplicate_instance_suffix
+                and canonical_concept_id_override is None
+            ):
                 # Preflight existence check and append incremental suffix until free
                 counter = 2
-                while ConceptsRepository.find_one(
-                    {"concept_id": candidate_concept_id}
-                ):
+                while ConceptsRepository.find_one({"concept_id": candidate_concept_id}):
                     candidate_concept_id = f"#V#{base_slug}_{counter}"
                     counter += 1
                     if counter > 50:  # safety stop to avoid pathological loops

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -12207,6 +12207,7 @@ const RELATION_TRUTH_STATE_MAX_ASSERTIONS_PER_GROUP = 200;
 const RELATION_TRUTH_STATE_FALLBACK_MAX_LINES = 300;
 const RELATION_TRUTH_STATE_FALLBACK_MAX_ASSERTIONS = 120;
 const JIRA_ISSUE_KEY_PATTERN = /^[A-Z][A-Z0-9]+-\d+$/;
+const TABLE_PRESENTATION_MODES = new Set(['augment', 'inline_primary']);
 
 // Keep heading resolution centralised so new display element families stay consistent.
 function normaliseOptionalDisplayElementTitle(value) {
@@ -12224,6 +12225,71 @@ function resolveDisplayElementSectionTitle(explicitTitle, fallbackLabel, index, 
     const safeIndex = Number.isInteger(index) && index >= 0 ? index : 0;
     const multipleElements = Number.isInteger(totalElements) && totalElements > 1;
     return multipleElements ? `${fallbackLabel} ${safeIndex + 1}` : fallbackLabel;
+}
+
+function normaliseTableSourceSpan(value) {
+    if (!value || typeof value !== 'object') {
+        return null;
+    }
+    const startLine = Number(value.start_line);
+    const endLine = Number(value.end_line);
+    if (
+        !Number.isInteger(startLine)
+        || !Number.isInteger(endLine)
+        || startLine < 1
+        || endLine < startLine
+    ) {
+        return null;
+    }
+    return {
+        start_line: startLine,
+        end_line: endLine
+    };
+}
+
+function normaliseTablePresentation(element, payload) {
+    const presentation = (
+        element?.presentation
+        && typeof element.presentation === 'object'
+    ) ? element.presentation : null;
+    const provenance = (
+        element?.provenance
+        && typeof element.provenance === 'object'
+    ) ? element.provenance : null;
+    const provenanceSource = typeof provenance?.source === 'string'
+        ? provenance.source.trim()
+        : '';
+    const explicitMode = typeof presentation?.mode === 'string'
+        ? presentation.mode.trim()
+        : '';
+    const mode = TABLE_PRESENTATION_MODES.has(explicitMode)
+        ? explicitMode
+        : (
+            provenanceSource === 'screen_markdown_table'
+                ? 'inline_primary'
+                : 'augment'
+        );
+    const sourceSpan = normaliseTableSourceSpan(
+        presentation?.source_span ?? payload?.source_span
+    );
+    const sourceElementId = typeof presentation?.source_element_id === 'string'
+        ? presentation.source_element_id.trim()
+        : '';
+
+    if (mode === 'inline_primary' && !sourceSpan) {
+        return {
+            mode: 'augment',
+            source_element_id: null,
+            source_span: null
+        };
+    }
+    return {
+        mode,
+        source_element_id: sourceElementId || (
+            mode === 'inline_primary' ? 'screen_text' : null
+        ),
+        source_span: sourceSpan
+    };
 }
 
 function normaliseTableSortMetadata(value, columns) {
@@ -12518,6 +12584,7 @@ function normaliseTableDisplayElement(element) {
     const sort = normaliseTableSortMetadata(payload.sort, columns);
     const pagination = normaliseTablePaginationMetadata(payload.pagination, rows.length);
     const columnVisibility = normaliseTableColumnVisibilityMetadata(payload.column_visibility, columns);
+    const presentation = normaliseTablePresentation(element, payload);
 
     return {
         element_id: typeof element.element_id === 'string' ? element.element_id : null,
@@ -12526,7 +12593,8 @@ function normaliseTableDisplayElement(element) {
         rows,
         sort,
         pagination,
-        column_visibility: columnVisibility
+        column_visibility: columnVisibility,
+        presentation
     };
 }
 
@@ -12545,6 +12613,98 @@ function resolveTableDisplayElements(debugData) {
         tables.push(tableElement);
     }
     return tables;
+}
+
+function partitionTableDisplayElementsByPresentation(container, debugData, tableElements) {
+    const inlinePrimaryCandidates = tableElements.filter(
+        (tableElement) => tableElement?.presentation?.mode === 'inline_primary'
+    );
+    if (!inlinePrimaryCandidates.length) {
+        return {
+            inlinePrimaryTableElements: [],
+            appendedTableElements: tableElements
+        };
+    }
+
+    const contract = normaliseDisplayElementsContract(debugData?.display_elements);
+    const contractElements = Array.isArray(contract?.elements) ? contract.elements : [];
+    const sourceElementsById = new Map();
+    contractElements.forEach((element) => {
+        const elementId = typeof element?.element_id === 'string'
+            ? element.element_id.trim()
+            : '';
+        if (!elementId) {
+            return;
+        }
+        const existing = sourceElementsById.get(elementId) || [];
+        existing.push(element);
+        sourceElementsById.set(elementId, existing);
+    });
+
+    const originalText = typeof container?.dataset?.originalText === 'string'
+        ? container.dataset.originalText
+        : null;
+    const claimedSourceSpans = new Set();
+    const relationshipsAreValid = originalText !== null && inlinePrimaryCandidates.every(
+        (tableElement) => {
+            const sourceElementId = tableElement?.presentation?.source_element_id;
+            const sourceMatches = sourceElementsById.get(sourceElementId) || [];
+            if (sourceMatches.length !== 1) {
+                return false;
+            }
+            const sourceElement = sourceMatches[0];
+            const sourcePayload = (
+                sourceElement?.payload
+                && typeof sourceElement.payload === 'object'
+            ) ? sourceElement.payload : null;
+            const sourceText = typeof sourcePayload?.text === 'string'
+                ? sourcePayload.text
+                : null;
+            if (
+                sourceElement?.element_type !== 'text_block'
+                || sourceElement?.channel !== 'screen'
+                || sourceText !== originalText
+            ) {
+                return false;
+            }
+
+            const sourceSpan = tableElement?.presentation?.source_span;
+            const sourceLineCount = sourceText.split(/\r?\n/).length;
+            if (!sourceSpan || sourceSpan.end_line > sourceLineCount) {
+                return false;
+            }
+            const sourceSpanKey = [
+                sourceElementId,
+                sourceSpan.start_line,
+                sourceSpan.end_line
+            ].join(':');
+            if (claimedSourceSpans.has(sourceSpanKey)) {
+                return false;
+            }
+            claimedSourceSpans.add(sourceSpanKey);
+            return true;
+        }
+    );
+
+    const renderedPrimaryTableCount = container.querySelectorAll('table').length;
+    const primaryPresentationIsComplete = (
+        relationshipsAreValid
+        && renderedPrimaryTableCount === inlinePrimaryCandidates.length
+    );
+    if (!primaryPresentationIsComplete) {
+        return {
+            inlinePrimaryTableElements: [],
+            appendedTableElements: tableElements
+        };
+    }
+
+    const inlinePrimaryIds = new Set(inlinePrimaryCandidates);
+    return {
+        inlinePrimaryTableElements: inlinePrimaryCandidates,
+        appendedTableElements: tableElements.filter(
+            (tableElement) => !inlinePrimaryIds.has(tableElement)
+        )
+    };
 }
 
 function normaliseWorkflowTaskLink(rawLink) {
@@ -15675,7 +15835,15 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
         return;
     }
 
-    const tableElements = resolveTableDisplayElements(debugData);
+    const resolvedTableElements = resolveTableDisplayElements(debugData);
+    const {
+        inlinePrimaryTableElements,
+        appendedTableElements: tableElements
+    } = partitionTableDisplayElementsByPresentation(
+        container,
+        debugData,
+        resolvedTableElements
+    );
     const workflowElements = resolveWorkflowDisplayElements(debugData);
     const taskViewElements = resolveTaskViewDisplayElements(debugData);
     const kanbanElements = resolveKanbanDisplayElements(debugData);
@@ -15703,6 +15871,9 @@ function renderTableDisplayElementsIntoContainer(container, debugData) {
     try {
         container.dataset.relationTruthStateSource = relationTruthStateSource;
         container.dataset.relationTripleParseCount = String(relationTripleParseCount);
+        container.dataset.inlinePrimaryTableCount = String(
+            inlinePrimaryTableElements.length
+        );
     } catch (_) {
         // Ignore dataset assignment failures.
     }
@@ -17901,13 +18072,15 @@ function formatBytesForUi(sizeBytes) {
 let uploadUiState = {
     button: null,
     statusEl: null,
-    inFlight: 0,
-    lastStatusTimeoutId: null,
+    statusRegion: null,
+    pendingAttachmentEl: null,
     defaultButtonLabel: null
 };
 
 const PENDING_FILE_COPY_SESSION_FALLBACK_KEY = '__pending_chat_session__';
 const pendingFileCopyConceptIdsBySession = new Map();
+const pendingFileCopyDisplayNamesBySession = new Map();
+const uploadStatesBySession = new Map();
 
 function normaliseTrustedUploadedFileCopyConceptId(value) {
     if (typeof value !== 'string') return null;
@@ -17925,23 +18098,103 @@ function getPendingFileCopySessionKey(sessionId = activeChatSessionId) {
     return normaliseHistorySessionId(sessionId) || PENDING_FILE_COPY_SESSION_FALLBACK_KEY;
 }
 
-function rememberPendingUploadedFileCopyConceptId(conceptId, sessionId = activeChatSessionId) {
-    const normalisedConceptId = normaliseTrustedUploadedFileCopyConceptId(conceptId);
-    if (!normalisedConceptId) return;
-    pendingFileCopyConceptIdsBySession.set(
-        getPendingFileCopySessionKey(sessionId),
-        normalisedConceptId
+function normalisePendingAttachmentDisplayName(value) {
+    if (typeof value !== 'string') return null;
+    const displayName = value.trim();
+    if (!displayName) return null;
+    return displayName.slice(0, 240);
+}
+
+function resolveUploadUiElement(stateKey, elementId) {
+    const existing = uploadUiState[stateKey];
+    if (existing && existing.isConnected !== false) {
+        return existing;
+    }
+    const resolved = document.getElementById(elementId);
+    uploadUiState[stateKey] = resolved || null;
+    return uploadUiState[stateKey];
+}
+
+function refreshAttachmentStatusRegionVisibility() {
+    const region = resolveUploadUiElement('statusRegion', 'chatAttachmentStatus');
+    if (!region) return;
+    const statusEl = resolveUploadUiElement('statusEl', 'uploadFileStatus');
+    const pendingEl = resolveUploadUiElement(
+        'pendingAttachmentEl',
+        'pendingAttachmentStatus'
+    );
+    const hasUploadStatus = !!String(statusEl?.textContent || '').trim();
+    const hasPendingAttachment = !!(
+        pendingEl
+        && !pendingEl.classList.contains('hidden')
+        && String(pendingEl.textContent || '').trim()
+    );
+    region.classList.toggle(
+        'hidden',
+        !hasUploadStatus && !hasPendingAttachment
     );
 }
 
-function takePendingUploadedFileCopyConceptId(sessionId) {
+function renderPendingAttachmentState() {
+    const el = resolveUploadUiElement(
+        'pendingAttachmentEl',
+        'pendingAttachmentStatus'
+    );
+    if (!el) return;
+
+    const sessionKey = getPendingFileCopySessionKey(activeChatSessionId);
+    const conceptId = pendingFileCopyConceptIdsBySession.get(sessionKey) || null;
+    const displayName = pendingFileCopyDisplayNamesBySession.get(sessionKey) || null;
+    if (!conceptId) {
+        el.textContent = '';
+        el.removeAttribute('title');
+        el.classList.add('hidden');
+        refreshAttachmentStatusRegionVisibility();
+        return;
+    }
+
+    el.textContent = displayName
+        ? `Attachment ready: ${displayName}`
+        : 'Attachment ready for the next prompt';
+    el.title = 'This attachment will be sent with the next accepted prompt.';
+    el.classList.remove('hidden');
+    refreshAttachmentStatusRegionVisibility();
+}
+
+function rememberPendingUploadedFileCopyConceptId(
+    conceptId,
+    sessionId = activeChatSessionId,
+    displayName = null
+) {
+    const normalisedConceptId = normaliseTrustedUploadedFileCopyConceptId(conceptId);
+    if (!normalisedConceptId) return;
+    const targetKey = getPendingFileCopySessionKey(sessionId);
+    pendingFileCopyConceptIdsBySession.set(targetKey, normalisedConceptId);
+    const normalisedDisplayName = normalisePendingAttachmentDisplayName(displayName);
+    if (normalisedDisplayName) {
+        pendingFileCopyDisplayNamesBySession.set(targetKey, normalisedDisplayName);
+    } else {
+        pendingFileCopyDisplayNamesBySession.delete(targetKey);
+    }
+    renderPendingAttachmentState();
+}
+
+function takePendingUploadedFileCopyBinding(sessionId) {
     const targetKey = getPendingFileCopySessionKey(sessionId);
     const targetConceptId = pendingFileCopyConceptIdsBySession.get(targetKey) || null;
-    if (targetConceptId) {
-        pendingFileCopyConceptIdsBySession.delete(targetKey);
-        return targetConceptId;
-    }
-    return null;
+    if (!targetConceptId) return null;
+    const displayName = pendingFileCopyDisplayNamesBySession.get(targetKey) || null;
+    pendingFileCopyConceptIdsBySession.delete(targetKey);
+    pendingFileCopyDisplayNamesBySession.delete(targetKey);
+    renderPendingAttachmentState();
+    return {
+        conceptId: targetConceptId,
+        displayName
+    };
+}
+
+function takePendingUploadedFileCopyConceptId(sessionId) {
+    return takePendingUploadedFileCopyBinding(sessionId)?.conceptId || null;
 }
 
 function restorePendingUploadedFileCopyConceptId(
@@ -17959,6 +18212,11 @@ function restorePendingUploadedFileCopyConceptId(
         return false;
     }
     pendingFileCopyConceptIdsBySession.set(targetKey, normalisedConceptId);
+    const displayName = normalisePendingAttachmentDisplayName(options.displayName);
+    if (displayName) {
+        pendingFileCopyDisplayNamesBySession.set(targetKey, displayName);
+    }
+    renderPendingAttachmentState();
     return true;
 }
 
@@ -17974,19 +18232,15 @@ function releaseRequestFileCopyBinding(request) {
     }
     request.attachmentBindingReleased = restorePendingUploadedFileCopyConceptId(
         request.pendingFileCopyConceptId,
-        request.sessionId
+        request.sessionId,
+        { displayName: request.pendingFileCopyDisplayName }
     );
     return request.attachmentBindingReleased;
 }
 
-function setUploadStatus(message, type = 'info') {
-    const el = uploadUiState.statusEl;
+function renderUploadStatus(message, type = 'info') {
+    const el = resolveUploadUiElement('statusEl', 'uploadFileStatus');
     if (!el) return;
-
-    if (uploadUiState.lastStatusTimeoutId) {
-        clearTimeout(uploadUiState.lastStatusTimeoutId);
-        uploadUiState.lastStatusTimeoutId = null;
-    }
 
     el.textContent = message || '';
     el.classList.remove('is-uploading', 'is-success', 'is-error');
@@ -17997,21 +18251,56 @@ function setUploadStatus(message, type = 'info') {
     } else if (type === 'error') {
         el.classList.add('is-error');
     }
+    refreshAttachmentStatusRegionVisibility();
 }
 
-function clearUploadStatusAfterDelay(delayMs = 5000) {
-    if (!uploadUiState.statusEl) return;
-    if (uploadUiState.lastStatusTimeoutId) {
-        clearTimeout(uploadUiState.lastStatusTimeoutId);
+function renderActiveUploadUi() {
+    const activeSessionKey = getPendingFileCopySessionKey(activeChatSessionId);
+    const activeUploadState = uploadStatesBySession.get(activeSessionKey) || null;
+    renderUploadStatus(
+        activeUploadState?.message || '',
+        activeUploadState?.tone || 'info'
+    );
+    setUploadButtonBusy(activeUploadState?.inFlight === true);
+}
+
+function setUploadStatusForState(uploadState, message, tone = 'info') {
+    if (!uploadState) return;
+    if (uploadState.clearTimerId) {
+        clearTimeout(uploadState.clearTimerId);
+        uploadState.clearTimerId = null;
     }
-    uploadUiState.lastStatusTimeoutId = window.setTimeout(() => {
-        setUploadStatus('');
-        uploadUiState.lastStatusTimeoutId = null;
+    uploadState.message = message || '';
+    uploadState.tone = tone;
+    if (
+        uploadStatesBySession.get(uploadState.sessionKey) === uploadState
+        && uploadState.sessionKey === getPendingFileCopySessionKey(activeChatSessionId)
+    ) {
+        renderActiveUploadUi();
+    }
+}
+
+function clearUploadStatusAfterDelay(uploadState, delayMs = 5000) {
+    if (!uploadState) return;
+    if (uploadState.clearTimerId) {
+        clearTimeout(uploadState.clearTimerId);
+    }
+    uploadState.clearTimerId = window.setTimeout(() => {
+        uploadState.clearTimerId = null;
+        if (uploadStatesBySession.get(uploadState.sessionKey) !== uploadState) {
+            return;
+        }
+        if (uploadState.inFlight) {
+            setUploadStatusForState(uploadState, '', 'info');
+            return;
+        }
+        uploadStatesBySession.delete(uploadState.sessionKey);
+        renderActiveUploadUi();
     }, delayMs);
 }
 
 function setUploadButtonBusy(isBusy) {
-    const btn = uploadUiState.button;
+    const btn = resolveUploadUiElement('button', 'uploadFileButton');
     if (!btn) return;
 
     if (!uploadUiState.defaultButtonLabel) {
@@ -18025,6 +18314,37 @@ function setUploadButtonBusy(isBusy) {
         btn.disabled = false;
         btn.textContent = uploadUiState.defaultButtonLabel;
     }
+}
+
+function rekeyUploadStateForSession(uploadState, sessionId) {
+    if (!uploadState) return;
+    const nextSessionId = normaliseHistorySessionId(sessionId);
+    const nextSessionKey = getPendingFileCopySessionKey(nextSessionId);
+    if (uploadState.sessionKey !== nextSessionKey) {
+        if (uploadStatesBySession.get(uploadState.sessionKey) === uploadState) {
+            uploadStatesBySession.delete(uploadState.sessionKey);
+        }
+        uploadState.sessionKey = nextSessionKey;
+        uploadStatesBySession.set(nextSessionKey, uploadState);
+    }
+    uploadState.targetSessionId = nextSessionId;
+    renderActiveUploadUi();
+}
+
+function appendUploadMessageForSession(sessionId, ...appendMessageArgs) {
+    const targetSessionId = normaliseHistorySessionId(sessionId);
+    if (
+        targetSessionId
+        && targetSessionId === normaliseHistorySessionId(activeChatSessionId)
+    ) {
+        appendMessage(...appendMessageArgs);
+        return true;
+    }
+    if (targetSessionId) {
+        invalidateSessionHistoryCache(targetSessionId);
+        refreshChatSessionTabActivityIndicators();
+    }
+    return false;
 }
 
 function isFileDragEvent(event) {
@@ -18204,7 +18524,11 @@ function buildUploadFailureDiagnosticPayload(file, error, context = {}) {
         upload_context: {
             index: Number.isFinite(context.index) ? Number(context.index) : null,
             total: Number.isFinite(context.total) ? Number(context.total) : null,
-            active_chat_session_id: activeChatSessionId || null
+            active_chat_session_id: (
+                normaliseHistorySessionId(context.targetSessionId)
+                || normaliseHistorySessionId(activeChatSessionId)
+                || null
+            )
         },
         error: {
             message: String(error?.message || error || 'Upload failed'),
@@ -18228,10 +18552,10 @@ function buildTurnDiagnosticDebugPayload(errorMessage, diagnosticPayload) {
     };
 }
 
-async function uploadFilesToVon(files) {
-    const list = Array.from(files || []).filter(Boolean);
-    if (!list.length) return;
-    let uploadTargetSessionId = normaliseHistorySessionId(activeChatSessionId);
+async function performUploadFilesToVon(list, uploadState) {
+    let uploadTargetSessionId = normaliseHistorySessionId(
+        uploadState?.targetSessionId
+    );
     if (!uploadTargetSessionId) {
         try {
             const ensuredTarget = await ensurePromptTargetChatSession();
@@ -18240,20 +18564,24 @@ async function uploadFilesToVon(files) {
             );
         } catch (error) {
             console.error('[chatTab] Unable to prepare an upload conversation:', error);
-            setUploadStatus('Unable to prepare a conversation for this upload.', 'error');
-            clearUploadStatusAfterDelay();
+            setUploadStatusForState(
+                uploadState,
+                'Unable to prepare a conversation for this upload.',
+                'error'
+            );
+            clearUploadStatusAfterDelay(uploadState);
             return;
         }
         if (!uploadTargetSessionId) {
-            setUploadStatus('Unable to prepare a conversation for this upload.', 'error');
-            clearUploadStatusAfterDelay();
+            setUploadStatusForState(
+                uploadState,
+                'Unable to prepare a conversation for this upload.',
+                'error'
+            );
+            clearUploadStatusAfterDelay(uploadState);
             return;
         }
-    }
-
-    uploadUiState.inFlight += 1;
-    if (uploadUiState.inFlight === 1) {
-        setUploadButtonBusy(true);
+        rekeyUploadStateForSession(uploadState, uploadTargetSessionId);
     }
 
     const total = list.length;
@@ -18264,9 +18592,16 @@ async function uploadFilesToVon(files) {
     for (const file of list) {
         index += 1;
         const sizeLabel = formatBytesForUi(file.size);
-        appendMessage('User', `Uploading file: ${file.name}${sizeLabel ? ` (${sizeLabel})` : ''}`);
-
-        setUploadStatus(`Uploading ${index}/${total}: ${file.name}`, 'uploading');
+        appendUploadMessageForSession(
+            uploadTargetSessionId,
+            'User',
+            `Uploading file: ${file.name}${sizeLabel ? ` (${sizeLabel})` : ''}`
+        );
+        setUploadStatusForState(
+            uploadState,
+            `Uploading ${index}/${total}: ${file.name}`,
+            'uploading'
+        );
 
         try {
             const result = await uploadSingleFileToVon(file);
@@ -18286,7 +18621,8 @@ async function uploadFilesToVon(files) {
             if (historyRecorded) details.push('Recorded in Conversation history.');
             if (downloadUrl) details.push(`[Download attachment](${downloadUrl})`);
 
-            appendMessage(
+            appendUploadMessageForSession(
+                uploadTargetSessionId,
                 'Von',
                 `File uploaded and registered as ${conceptId || '(unknown)'}${details.length ? `\n${details.join('\n')}` : ''}`
             );
@@ -18296,23 +18632,25 @@ async function uploadFilesToVon(files) {
             if (conceptId) {
                 rememberPendingUploadedFileCopyConceptId(
                     conceptId,
-                    uploadTargetSessionId
+                    uploadTargetSessionId,
+                    file.name
                 );
-                insertTextIntoChatPrompt('Attached file uploaded.');
             }
         } catch (error) {
             console.error('[chatTab] file upload error', error);
             const errorMessage = `File upload failed: ${String(error?.message || error)}`;
             const diagnosticsPayload = buildUploadFailureDiagnosticPayload(file, error, {
                 index,
-                total
+                total,
+                targetSessionId: uploadTargetSessionId
             });
             const errorTurnId = `e-upload-${Date.now()}-${index}`;
             setLlmDebugDataEntry(
                 errorTurnId,
                 buildTurnDiagnosticDebugPayload(errorMessage, diagnosticsPayload)
             );
-            appendMessage(
+            appendUploadMessageForSession(
+                uploadTargetSessionId,
                 'Error',
                 errorMessage,
                 errorTurnId,
@@ -18324,18 +18662,94 @@ async function uploadFilesToVon(files) {
                 { diagnosticsPayload }
             );
             failureCount += 1;
-            setUploadStatus(`Upload failed: ${file.name}`, 'error');
+            setUploadStatusForState(
+                uploadState,
+                `Upload failed: ${file.name}`,
+                'error'
+            );
         }
     }
 
     const summary = `Upload complete: ${successCount} succeeded${failureCount ? `, ${failureCount} failed` : ''}.`;
-    setUploadStatus(summary, failureCount ? 'error' : 'success');
-    clearUploadStatusAfterDelay();
+    setUploadStatusForState(
+        uploadState,
+        summary,
+        failureCount ? 'error' : 'success'
+    );
+    clearUploadStatusAfterDelay(uploadState);
+}
 
-    uploadUiState.inFlight = Math.max(0, uploadUiState.inFlight - 1);
-    if (uploadUiState.inFlight === 0) {
-        setUploadButtonBusy(false);
+function buildUploadSelectionFingerprint(list) {
+    return list.map((file) => [
+        String(file?.name || ''),
+        Number.isFinite(file?.size) ? Number(file.size) : '',
+        Number.isFinite(file?.lastModified) ? Number(file.lastModified) : '',
+        String(file?.type || '')
+    ].join('|')).join('\n');
+}
+
+function uploadFilesToVon(files) {
+    const list = Array.from(files || []).filter(Boolean);
+    if (!list.length) return Promise.resolve();
+
+    const targetSessionId = normaliseHistorySessionId(activeChatSessionId);
+    const sessionKey = getPendingFileCopySessionKey(targetSessionId);
+    const selectionFingerprint = buildUploadSelectionFingerprint(list);
+    const existingState = uploadStatesBySession.get(sessionKey) || null;
+    if (existingState?.inFlight && existingState.promise) {
+        const repeatedSelection = (
+            existingState.selectionFingerprint === selectionFingerprint
+        );
+        setUploadStatusForState(
+            existingState,
+            repeatedSelection
+                ? 'Upload already in progress; repeated action ignored.'
+                : 'Another upload is already in progress; this additional selection was not uploaded.',
+            'uploading'
+        );
+        return existingState.promise;
     }
+
+    const preparingLabel = list.length === 1
+        ? `Preparing upload: ${String(list[0]?.name || 'file')}`
+        : `Preparing ${list.length} uploads…`;
+
+    if (existingState?.clearTimerId) {
+        clearTimeout(existingState.clearTimerId);
+    }
+    const uploadState = {
+        sessionKey,
+        targetSessionId,
+        selectionFingerprint,
+        message: preparingLabel,
+        tone: 'uploading',
+        inFlight: true,
+        promise: null,
+        clearTimerId: null
+    };
+    const uploadPromise = Promise.resolve()
+        .then(() => performUploadFilesToVon(list, uploadState))
+        .catch((error) => {
+            console.error('[chatTab] unexpected file upload error', error);
+            setUploadStatusForState(
+                uploadState,
+                `Upload failed: ${String(error?.message || error)}`,
+                'error'
+            );
+            clearUploadStatusAfterDelay(uploadState);
+        });
+    uploadState.promise = uploadPromise;
+    uploadStatesBySession.set(sessionKey, uploadState);
+    renderActiveUploadUi();
+
+    const settleUploadState = () => {
+        uploadState.inFlight = false;
+        if (uploadStatesBySession.get(uploadState.sessionKey) === uploadState) {
+            renderActiveUploadUi();
+        }
+    };
+    void uploadPromise.then(settleUploadState, settleUploadState);
+    return uploadPromise;
 }
 
 function convertJustSayInstructionsToButtons(root) {
@@ -21235,6 +21649,8 @@ function setActiveChatSession(sessionId, sessionName) {
     }
 
     refreshConversationInfoCopyButtonState();
+    renderPendingAttachmentState();
+    renderActiveUploadUi();
 }
 
 function getChatSessionTabsContainer() {
@@ -28592,6 +29008,8 @@ export function initializeChatTab() {
     const uploadFileButton = document.getElementById('uploadFileButton');
     const uploadFileInput = document.getElementById('uploadFileInput');
     const uploadFileStatus = document.getElementById('uploadFileStatus');
+    const chatAttachmentStatus = document.getElementById('chatAttachmentStatus');
+    const pendingAttachmentStatus = document.getElementById('pendingAttachmentStatus');
     const chatTab = document.getElementById('chatTab');
     const inviteButton = document.getElementById('inviteConversationBtn');
     const inviteCloseButton = document.getElementById('closeInviteConversation');
@@ -28636,6 +29054,10 @@ export function initializeChatTab() {
 
     uploadUiState.button = uploadFileButton || null;
     uploadUiState.statusEl = uploadFileStatus || null;
+    uploadUiState.statusRegion = chatAttachmentStatus || null;
+    uploadUiState.pendingAttachmentEl = pendingAttachmentStatus || null;
+    renderPendingAttachmentState();
+    renderActiveUploadUi();
 
     if (uploadFileButton && uploadFileInput) {
         uploadFileButton.addEventListener('click', () => {
@@ -29509,6 +29931,9 @@ function retryActiveChatRequest() {
     const fileCopyConceptId = normaliseTrustedUploadedFileCopyConceptId(
         request.pendingFileCopyConceptId
     );
+    const fileCopyDisplayName = normalisePendingAttachmentDisplayName(
+        request.pendingFileCopyDisplayName
+    );
     request.attachmentBindingTransferred = !!fileCopyConceptId;
     abortActiveChatRequest();
     if (!prompt.trim()) {
@@ -29520,7 +29945,8 @@ function retryActiveChatRequest() {
             promptOverride: prompt,
             sessionId: request.sessionId || null,
             sessionName: request.sessionName || null,
-            fileCopyConceptId
+            fileCopyConceptId,
+            fileCopyDisplayName
         });
     }, 0);
 }
@@ -30668,11 +31094,15 @@ async function handleSendPrompt(options = {}) {
     const explicitFileCopyConceptId = normaliseTrustedUploadedFileCopyConceptId(
         options?.fileCopyConceptId
     );
-    const pendingFileCopyConceptId = explicitFileCopyConceptId || (
-        fromQueue
-            ? null
-            : takePendingUploadedFileCopyConceptId(targetSessionId)
-    );
+    const pendingFileCopyBinding = (!explicitFileCopyConceptId && !fromQueue)
+        ? takePendingUploadedFileCopyBinding(targetSessionId)
+        : null;
+    const pendingFileCopyConceptId = explicitFileCopyConceptId
+        || pendingFileCopyBinding?.conceptId
+        || null;
+    const pendingFileCopyDisplayName = explicitFileCopyConceptId
+        ? normalisePendingAttachmentDisplayName(options?.fileCopyDisplayName)
+        : (pendingFileCopyBinding?.displayName || null);
     const request = {
         abortController: new AbortController(),
         sessionId: targetSessionId,
@@ -30683,6 +31113,7 @@ async function handleSendPrompt(options = {}) {
         selectionStart,
         selectionEnd,
         pendingFileCopyConceptId,
+        pendingFileCopyDisplayName,
         attachmentBindingAccepted: false,
         attachmentBindingTransferred: false,
         attachmentBindingReleased: false,
@@ -33867,6 +34298,15 @@ export function __testOnly_resetChatRequestState() {
     liveChatRequestsBySession.clear();
     finishedThinkingCardsBySession.clear();
     pendingFileCopyConceptIdsBySession.clear();
+    pendingFileCopyDisplayNamesBySession.clear();
+    for (const uploadState of uploadStatesBySession.values()) {
+        if (uploadState?.clearTimerId) {
+            clearTimeout(uploadState.clearTimerId);
+        }
+    }
+    uploadStatesBySession.clear();
+    renderActiveUploadUi();
+    renderPendingAttachmentState();
     queuedChatPrompts = [];
     if (queuedChatPromptDrainTimer !== null) {
         clearTimeout(queuedChatPromptDrainTimer);
@@ -34006,7 +34446,7 @@ export function __testOnly_setTranscriptTurns(turns = []) {
 export function __testOnly_extractImageFilesFromClipboardEvent(event) {
     return extractImageFilesFromClipboardEvent(event);
 }
-export async function __testOnly_uploadFilesToVon(files) {
+export function __testOnly_uploadFilesToVon(files) {
     return uploadFilesToVon(files);
 }
 export { formatChatTimestamp, showLlmDebugPopup, switchToChatSession, updateHistoryLength };

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -9323,8 +9323,19 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     }
 }
 
+.chat-attachment-status {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    min-height: 1.6rem;
+}
+
+.chat-attachment-status.hidden {
+    display: none;
+}
+
 .upload-file-status {
-    margin-left: 10px;
     font-size: 0.85rem;
     color: #475569;
     min-height: 1.1em;
@@ -9343,6 +9354,24 @@ body[data-active-tab="settingsTab"] .tab-content-area {
 .upload-file-status.is-error {
     color: #b91c1c;
     font-weight: 600;
+}
+
+.pending-attachment-status {
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    padding: 3px 9px;
+    border: 1px solid #93c5fd;
+    border-radius: 999px;
+    background: #eff6ff;
+    color: #1d4ed8;
+    font-size: 0.82rem;
+    font-weight: 600;
+    overflow-wrap: anywhere;
+}
+
+.pending-attachment-status.hidden {
+    display: none;
 }
 
 /* Legacy loading-indicator-sep removed - replaced by thinking-card design */

--- a/src/frontend/web/von_interface/templates/chat_tab.html
+++ b/src/frontend/web/von_interface/templates/chat_tab.html
@@ -141,6 +141,11 @@
       <!-- Textarea for user prompt -->
       <textarea id="promptInput" rows="1" class="prompt-input" placeholder="Talk with Von here..."></textarea>
 
+      <div id="chatAttachmentStatus" class="chat-attachment-status hidden">
+        <span id="uploadFileStatus" class="upload-file-status" aria-live="polite"></span>
+        <span id="pendingAttachmentStatus" class="pending-attachment-status hidden" aria-live="polite"></span>
+      </div>
+
       <div class="chat-composer-actions">
         <div class="chat-composer-primary-actions">
           <button id="sendButton" class="btn btn-primary">Send Prompt</button>
@@ -158,7 +163,6 @@
 
             <button id="uploadFileButton" class="btn btn-secondary" type="button"
               title="Upload a file, drag and drop onto the conversation, or paste an image">Upload File</button>
-            <span id="uploadFileStatus" class="upload-file-status" aria-live="polite"></span>
             <input id="uploadFileInput" class="visually-hidden" type="file" aria-label="Upload file" />
 
             {% if expert_tabs_enabled %}

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import time
 from threading import Event
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -465,6 +466,82 @@ class _HydrationDeadlineClient:
         )
 
 
+class _RootAliasHydrationClient:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.hydrated_slice: dict[str, Any] | None = None
+
+    @staticmethod
+    def _latest_tool_output(kwargs: dict[str, Any]) -> dict[str, Any]:
+        tool_results = kwargs.get("tool_results")
+        assert isinstance(tool_results, list)
+        assert len(tool_results) == 1
+        assert isinstance(tool_results[0], ToolResult)
+        assert isinstance(tool_results[0].output, dict)
+        return dict(tool_results[0].output)
+
+    def generate_with_tools(
+        self,
+        prompt: str,
+        available_tools: list[Any],
+        **kwargs: Any,
+    ) -> LLMResponse:
+        call_number = len(self.calls)
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "available_tools": list(available_tools),
+                **kwargs,
+            }
+        )
+        if call_number == 0:
+            return LLMResponse(
+                text_response="",
+                tool_calls=[
+                    ToolCall(
+                        tool_name="turn_invoke_capability",
+                        call_id="root-alias-source",
+                        payload={
+                            "name": "general_read",
+                            "arguments": {"query": "canonical record"},
+                        },
+                    )
+                ],
+                continuation=LLMContinuation(
+                    provider="test",
+                    api_surface="responses",
+                    model="test-model",
+                    response_id="root-source-response",
+                ),
+            )
+        if call_number == 1:
+            envelope = self._latest_tool_output(kwargs)
+            return LLMResponse(
+                text_response="",
+                tool_calls=[
+                    ToolCall(
+                        tool_name="turn_read_evidence",
+                        call_id="root-alias-hydration",
+                        payload={
+                            "evidence_id": envelope["evidence_id"],
+                            "json_pointer": "/",
+                            "max_chars": 4_000,
+                        },
+                    )
+                ],
+                continuation=LLMContinuation(
+                    provider="test",
+                    api_surface="responses",
+                    model="test-model",
+                    response_id="root-hydration-response",
+                ),
+            )
+        if call_number == 2:
+            self.hydrated_slice = self._latest_tool_output(kwargs)
+            return LLMResponse(text_response="The canonical identifier was retained.")
+        raise AssertionError("unexpected model call")
+
+
 def test_plain_answer_gets_trusted_scope_and_generic_read_doorway() -> None:
     client = _SequenceClient(LLMResponse(text_response="A useful answer."))
     gateway = _gateway(lambda **_kwargs: {"success": True})
@@ -509,6 +586,48 @@ def test_plain_answer_gets_trusted_scope_and_generic_read_doorway() -> None:
         "offset",
         "limit",
     }
+
+
+def test_model_slash_evidence_pointer_hydrates_the_whole_result() -> None:
+    client = _RootAliasHydrationClient()
+
+    result = execute_adaptive_turn(
+        gateway=_gateway(
+            lambda **_kwargs: {
+                "": "RFC slash would select this empty-key member.",
+                "canonical_concept_id": "#V#stable_readback_id",
+                "success": True,
+            }
+        ),
+        prompt="Read the canonical record.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="root-alias-hydration",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert result.response_text == "The canonical identifier was retained."
+    assert client.hydrated_slice is not None
+    assert client.hydrated_slice["success"] is True
+    assert client.hydrated_slice["selector"]["json_pointer"] is None
+    assert (
+        json.loads(client.hydrated_slice["content"])["canonical_concept_id"]
+        == "#V#stable_readback_id"
+    )
+    read_tool = next(
+        tool
+        for tool in client.calls[0]["available_tools"]
+        if tool.name == "turn_read_evidence"
+    )
+    assert "root alias" in read_tool.description
+    assert "root alias" in (
+        read_tool.input_schema["properties"]["json_pointer"]["description"]
+    )
 
 
 def test_ordinary_delegation_is_actor_capability_not_every_read_method() -> None:
@@ -602,6 +721,93 @@ def test_effect_delegation_is_authenticated_and_exactly_metadata_marked() -> Non
         "add_relationship",
     }
     assert "other_write" not in delegated
+
+
+def test_effect_catalogue_and_scope_project_resolved_remaining_windows() -> None:
+    gateway = _effect_gateway(
+        lambda _name, _arguments: {"success": True},
+        write_timeout_sec=0.5,
+        effect_admission_window_sec=0.125,
+    )
+    trusted = {
+        "turn_namespace": "#V#person@org",
+        "actor_user_concept_id": "#V#person",
+    }
+    delegated = ordinary_turn_capability_delegation(
+        gateway,
+        user_concept_id="#V#person",
+        trusted_argument_values=trusted,
+    )
+
+    catalogue_entry = _capability_catalogue(
+        gateway,
+        delegated,
+        {"names": ["create_concepts"]},
+    )["capabilities"][0]
+
+    assert gateway.get_method_effect_admission_window_sec(
+        "create_concepts"
+    ) == pytest.approx(0.125)
+    assert gateway.get_method_effect_admission_window_sec("general_read") is None
+    assert catalogue_entry["semantic_effect"] is True
+    assert catalogue_entry["minimum_effect_window_seconds"] == pytest.approx(0.125)
+
+    clock = _ManualClock(100.0)
+    client = _SequenceClient(LLMResponse(text_response="A useful answer."))
+    execute_adaptive_turn(
+        gateway=gateway,
+        prompt="Help with this.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="effect-window-scope",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=4,
+        final_answer_reserve_seconds=2,
+        clock=clock,
+    )
+
+    assert (
+        "Remaining effect-capable window before the protected final-answer "
+        "reserve: 8.000 seconds." in client.calls[0]["system_message"]
+    )
+
+
+def test_default_final_answer_reserve_is_nonzero_and_clamped() -> None:
+    gateway = _effect_gateway(lambda _name, _arguments: {"success": True})
+    clock = _ManualClock(100.0)
+    client = _SequenceClient(LLMResponse(text_response="A useful answer."))
+
+    result = execute_adaptive_turn(
+        gateway=gateway,
+        prompt="Help with this.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="default-answer-reserve",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=4,
+        clock=clock,
+    )
+
+    assert (
+        "Remaining effect-capable window before the protected final-answer "
+        "reserve: 6.000 seconds." in client.calls[0]["system_message"]
+    )
+    allocation = next(
+        item
+        for item in result.aux_llm_calls
+        if item.get("type") == "adaptive_turn_budget_allocation"
+    )
+    assert allocation["effective_final_answer_reserve_seconds"] == 4.0
+    assert allocation["final_answer_reserve_source"] == "environment_or_default"
+    assert allocation["explicit_zero_override"] is False
 
 
 def test_create_effect_scope_is_hidden_and_server_overrides_spoofed_values() -> None:
@@ -1160,16 +1366,398 @@ def test_effect_is_not_started_without_its_minimum_admission_window() -> None:
         turn_id="effect-window-admission",
         turn_budget_seconds=0.2,
         final_synthesis_reserve_seconds=0.15,
+        final_answer_reserve_seconds=0.15,
     )
 
     assert invoked == []
-    assert result.response_text.startswith("The write was not started")
-    assert result.tool_invocations[0]["effect_status"] == "failed"
+    assert result.terminal_status == "effect_not_started"
+    assert result.effect_finality_fallback is True
+    assert "1 not_started" in result.response_text
+    assert "was not dispatched and reports no change" in result.response_text
+    assert "it can be retried in a new turn" in result.response_text
+    assert "will not claim that nothing changed" not in result.response_text
+    assert "The write was not started" not in result.response_text
+    assert result.tool_invocations[0]["effect_status"] == "not_started"
     assert result.tool_invocations[0]["changed"] is False
     assert "insufficient_effect_window" in (
         result.tool_invocations[0]["evidence"]["preview"]
     )
     assert "not_started" in result.tool_invocations[0]["evidence"]["preview"]
+
+
+def test_research_effect_uses_window_through_protected_answer_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _ManualClock()
+    observed_deadlines: list[float] = []
+    gateway = _effect_gateway(
+        lambda _name, _arguments: {"success": True},
+        write_timeout_sec=3.0,
+        effect_admission_window_sec=3.0,
+    )
+
+    def invoke(
+        method_name: str,
+        _arguments: dict[str, Any],
+        *,
+        deadline_monotonic: float,
+        **_kwargs: Any,
+    ) -> SimpleNamespace:
+        observed_deadlines.append(deadline_monotonic)
+        return SimpleNamespace(
+            payload={
+                "success": True,
+                "effect_status": "succeeded",
+                "changed": True,
+                "mutation_outcome": "completed",
+                "outcome_finality": "terminal_for_turn",
+                "private_detail": "x" * 10_000,
+            },
+            execution_id=f"execution-{method_name}",
+            timed_out=False,
+            telemetry_metadata=lambda: {
+                "schema_version": "internal_mcp_transport.v1",
+                "outcome": "completed",
+            },
+        )
+
+    monkeypatch.setattr(gateway, "invoke", invoke)
+    client = _TimedSequenceClient(
+        clock,
+        (
+            3.5,
+            LLMResponse(
+                text_response="",
+                tool_calls=[
+                    ToolCall(
+                        tool_name="turn_invoke_capability",
+                        call_id="protected-window-effect",
+                        payload={
+                            "name": "create_concepts",
+                            "arguments": {"concepts": [{"name": "Protected"}]},
+                        },
+                    )
+                ],
+            ),
+        ),
+        (3.6, LLMResponse(text_response="The effect completed.")),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=gateway,
+        prompt="Represent this.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="protected-effect-window",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=6,
+        final_answer_reserve_seconds=2,
+        clock=clock,
+    )
+
+    assert result.response_text == "The effect completed."
+    assert observed_deadlines == [pytest.approx(8.0)]
+    invocation = result.tool_invocations[0]
+    assert invocation["effect_status"] == "succeeded"
+    assert invocation["mutation_outcome"] == "completed"
+    assert invocation["outcome_finality"] == "terminal_for_turn"
+    assert "effective_payload" not in invocation
+    assert "private_detail" not in invocation
+    assert "x" * 10_000 not in json.dumps(invocation)
+
+
+def test_mixed_effect_batch_preserves_order_with_independent_admission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _ManualClock()
+    observed: list[tuple[str, float]] = []
+    gateway = _effect_gateway(
+        lambda _name, _arguments: {"success": True},
+        write_timeout_sec=0.05,
+        effect_admission_window_sec=0.05,
+    )
+
+    def invoke(
+        method_name: str,
+        _arguments: dict[str, Any],
+        *,
+        deadline_monotonic: float,
+        **_kwargs: Any,
+    ) -> SimpleNamespace:
+        observed.append((method_name, deadline_monotonic))
+        is_effect = method_name != "general_read"
+        return SimpleNamespace(
+            payload={
+                "success": True,
+                **(
+                    {"effect_status": "succeeded", "changed": True}
+                    if is_effect
+                    else {"observed": True}
+                ),
+            },
+            execution_id=f"execution-{len(observed)}",
+            timed_out=False,
+            telemetry_metadata=lambda: {
+                "schema_version": "internal_mcp_transport.v1",
+                "outcome": "completed",
+            },
+        )
+
+    monkeypatch.setattr(gateway, "invoke", invoke)
+    calls = [
+        ToolCall(
+            tool_name="turn_invoke_capability",
+            call_id=f"mixed-{index}",
+            payload={"name": name, "arguments": arguments},
+        )
+        for index, (name, arguments) in enumerate(
+            (
+                ("general_read", {"query": "before"}),
+                ("create_concepts", {"concepts": [{"name": "One"}]}),
+                ("general_read", {"query": "between"}),
+                ("add_relationship", {"source_id": "#V#person"}),
+                ("general_read", {"query": "after"}),
+            )
+        )
+    ]
+    client = _TimedSequenceClient(
+        clock,
+        (0.1, LLMResponse(text_response="", tool_calls=calls)),
+        (0.15, LLMResponse(text_response="The ordered batch completed.")),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=gateway,
+        prompt="Apply and verify both effects.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="mixed-suffix-reservation",
+        turn_budget_seconds=1.0,
+        final_synthesis_reserve_seconds=0.8,
+        final_answer_reserve_seconds=0.2,
+        clock=clock,
+    )
+
+    assert result.response_text == "The ordered batch completed."
+    assert [item[0] for item in observed] == [
+        "general_read",
+        "create_concepts",
+        "general_read",
+        "add_relationship",
+        "general_read",
+    ]
+    assert [item[1] for item in observed] == pytest.approx([0.8] * 5)
+
+
+def test_invalid_effect_does_not_reserve_window_or_block_valid_sibling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _ManualClock()
+    invoked: list[str] = []
+    gateway = _effect_gateway(
+        lambda _name, _arguments: {"success": True},
+        write_timeout_sec=0.11,
+        effect_admission_window_sec=0.11,
+    )
+
+    def invoke(method_name: str, *_args: Any, **_kwargs: Any) -> SimpleNamespace:
+        invoked.append(method_name)
+        return SimpleNamespace(
+            payload={
+                "success": True,
+                "effect_status": "succeeded",
+                "changed": True,
+            },
+            execution_id=f"execution-{method_name}",
+            timed_out=False,
+            telemetry_metadata=lambda: {
+                "schema_version": "internal_mcp_transport.v1",
+                "outcome": "completed",
+            },
+        )
+
+    monkeypatch.setattr(gateway, "invoke", invoke)
+    client = _TimedSequenceClient(
+        clock,
+        (
+            0.1,
+            LLMResponse(
+                text_response="",
+                tool_calls=[
+                    ToolCall(
+                        tool_name="turn_invoke_capability",
+                        call_id="invalid-relationship",
+                        payload={
+                            "name": "add_relationship",
+                            "arguments": {
+                                "source_id": "#V#person",
+                                "predicate": "#V#specific_to_user",
+                                "target": "#V#other_actor",
+                            },
+                        },
+                    ),
+                    ToolCall(
+                        tool_name="turn_invoke_capability",
+                        call_id="valid-create",
+                        payload={
+                            "name": "create_concepts",
+                            "arguments": {"concepts": [{"name": "One"}]},
+                        },
+                    ),
+                ],
+            ),
+        ),
+        (0.15, LLMResponse(text_response="The valid effect completed.")),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=gateway,
+        prompt="Apply both effects.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="independent-effect-admission",
+        turn_budget_seconds=1.0,
+        final_synthesis_reserve_seconds=0.8,
+        final_answer_reserve_seconds=0.7,
+        clock=clock,
+    )
+
+    assert result.terminal_status == "effect_failed"
+    assert result.effect_finality_fallback is True
+    assert "1 failed" in result.response_text
+    assert "The valid effect completed." not in result.response_text
+    assert invoked == ["create_concepts"]
+    assert len(result.tool_invocations) == 2
+    assert len({item["effect_id"] for item in result.tool_invocations}) == 2
+    assert result.tool_invocations[0]["status"] == "error"
+    assert result.tool_invocations[0]["effect_status"] == "failed"
+    assert result.tool_invocations[0]["changed"] is False
+    assert "visibility_effect_not_delegated" in (
+        result.tool_invocations[0]["evidence"]["preview"]
+    )
+    assert result.tool_invocations[1]["status"] == "ok"
+    assert result.tool_invocations[1]["effect_status"] == "succeeded"
+
+
+def test_indeterminate_effect_stops_later_effect_but_allows_readback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    invoked: list[str] = []
+    gateway = _effect_gateway(
+        lambda _name, _arguments: {"success": True},
+        write_timeout_sec=0.2,
+        effect_admission_window_sec=0.05,
+    )
+
+    def invoke(method_name: str, *_args: Any, **_kwargs: Any) -> SimpleNamespace:
+        invoked.append(method_name)
+        if method_name == "create_concepts":
+            return SimpleNamespace(
+                payload={
+                    "success": False,
+                    "error_code": "tool_timeout_outcome_unknown",
+                    "mutation_outcome": "unknown",
+                    "outcome_finality": "terminal_for_turn",
+                },
+                execution_id="execution-indeterminate",
+                timed_out=True,
+                telemetry_metadata=lambda: {
+                    "schema_version": "internal_mcp_transport.v1",
+                    "outcome": "timed_out",
+                    "timeout_phase": "handler",
+                },
+            )
+        assert method_name == "general_read"
+        return SimpleNamespace(
+            payload={"success": True, "concept_id": "#V#created_if_present"},
+            execution_id="execution-readback",
+            timed_out=False,
+            telemetry_metadata=lambda: {
+                "schema_version": "internal_mcp_transport.v1",
+                "outcome": "completed",
+            },
+        )
+
+    monkeypatch.setattr(gateway, "invoke", invoke)
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="indeterminate-create",
+                    payload={
+                        "name": "create_concepts",
+                        "arguments": {"concepts": [{"name": "Uncertain"}]},
+                    },
+                ),
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="read-after-indeterminate",
+                    payload={
+                        "name": "general_read",
+                        "arguments": {"concept_id": "#V#created_if_present"},
+                    },
+                ),
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="blocked-later-effect",
+                    payload={
+                        "name": "upsert_text_relation",
+                        "arguments": {
+                            "concept_id": "#V#person",
+                            "predicate": "#V#has_note",
+                            "text": "must not run",
+                        },
+                    },
+                ),
+            ],
+        ),
+        LLMResponse(text_response="The first effect needs canonical inspection."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=gateway,
+        prompt="Create, inspect, then update.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="stop-after-indeterminate-effect",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+        final_answer_reserve_seconds=1,
+    )
+
+    assert invoked == ["create_concepts", "general_read"]
+    assert result.terminal_status == "effect_outcome_indeterminate"
+    assert result.effect_finality_fallback is True
+    assert "indeterminate" in result.response_text
+    assert "The first effect needs canonical inspection." not in result.response_text
+    assert result.tool_invocations[0]["effect_status"] == "indeterminate"
+    assert result.tool_invocations[1]["result_target_ids"] == [
+        "#V#created_if_present"
+    ]
+    blocked = result.tool_invocations[2]
+    assert blocked["status"] == "error"
+    assert blocked["effect_status"] == "not_started"
+    assert blocked["changed"] is False
+    assert blocked["mutation_outcome"] == "not_started"
+    assert blocked["error_code"] == "prior_effect_outcome_indeterminate"
 
 
 def test_per_method_minimum_admits_sequential_effects_below_hard_cap() -> None:
@@ -1295,7 +1883,11 @@ def test_effect_is_not_dispatched_when_durable_intent_is_unavailable(
     )
 
     assert invoked == []
-    assert result.tool_invocations[0]["effect_status"] == "failed"
+    assert result.terminal_status == "effect_not_started"
+    assert "1 not_started" in result.response_text
+    assert "was not dispatched and reports no change" in result.response_text
+    assert result.tool_invocations[0]["effect_status"] == "not_started"
+    assert result.tool_invocations[0]["changed"] is False
     preview = result.tool_invocations[0]["evidence"]["preview"]
     assert "effect_observation_unavailable" in preview
     assert "not_started" in preview
@@ -2252,6 +2844,35 @@ def test_tool_result_correlation_shell_overflow_has_no_oversized_fallback() -> N
     assert _bound_tool_results_for_model(results) is None
 
 
+def test_bounded_effect_result_preserves_exact_partial_receipt() -> None:
+    result = ToolResult(
+        call_id="partial-effect",
+        tool_name="turn_invoke_capability",
+        status="error",
+        output={
+            "evidence_id": "ev-partial",
+            "status": "partial",
+            "effect_status": "partial",
+            "changed": True,
+            "error_code": "derived_identity_write_failed",
+            "mutation_outcome": "partial",
+            "outcome_finality": "terminal_for_turn",
+            "preview": "x" * 20_000,
+        },
+    )
+
+    bounded = _bound_tool_results_for_model([result], max_bytes=450)
+
+    assert bounded is not None
+    assert bounded[0].status == "error"
+    assert bounded[0].output["evidence_id"] == "ev-partial"
+    assert bounded[0].output["effect_status"] == "partial"
+    assert bounded[0].output["changed"] is True
+    assert bounded[0].output["error_code"] == "derived_identity_write_failed"
+    assert bounded[0].output["mutation_outcome"] == "partial"
+    assert bounded[0].output["outcome_finality"] == "terminal_for_turn"
+
+
 def test_model_can_invoke_any_delegated_read_without_a_prompt_classifier() -> None:
     raw_tail = "z" * 50_000
     seen_actor: dict[str, Any] = {}
@@ -2413,6 +3034,7 @@ def test_effect_batch_preserves_order_and_read_can_observe_prior_effect(
 
 def test_effect_evidence_preserves_success_partial_failure_and_unknown_timeout() -> None:
     seen_cases: list[str] = []
+    progress_events: list[dict[str, Any]] = []
 
     def handler(_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         case = str(arguments["case"])
@@ -2463,14 +3085,27 @@ def test_effect_evidence_preserves_success_partial_failure_and_unknown_timeout()
         turn_id="effect-statuses",
         turn_budget_seconds=10,
         final_synthesis_reserve_seconds=2,
+        progress_tracker=SimpleNamespace(
+            emit=lambda event: progress_events.append(dict(event)),
+            check_cancellation=lambda: None,
+        ),
     )
 
     assert seen_cases == ["succeeded", "partial", "failed", "timeout"]
+    assert result.terminal_status == "effect_outcome_indeterminate"
+    assert result.effect_finality_fallback is True
+    assert "The bounded effects were reported truthfully." not in result.response_text
     assert [item["effect_status"] for item in result.tool_invocations] == [
         "succeeded",
         "partial",
         "failed",
         "indeterminate",
+    ]
+    assert [item["status"] for item in result.tool_invocations] == [
+        "ok",
+        "error",
+        "error",
+        "error",
     ]
     assert len({item["effect_id"] for item in result.tool_invocations}) == 4
     assert result.tool_invocations[0]["changed"] is True
@@ -2479,6 +3114,58 @@ def test_effect_evidence_preserves_success_partial_failure_and_unknown_timeout()
     assert result.tool_invocations[2]["changed"] is False
     assert result.tool_invocations[3]["changed"] is None
     assert all(item.get("evidence", {}).get("evidence_id") for item in result.tool_invocations)
+    partial_progress = next(
+        event
+        for event in progress_events
+        if event.get("status") == "tool_completed"
+        and event.get("call_id") == "effect-partial"
+    )
+    assert partial_progress["success"] is False
+
+
+def test_partial_effect_downgrades_nominal_model_completion() -> None:
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="partial-effect",
+                    payload={
+                        "name": "create_concepts",
+                        "arguments": {"concepts": [{"name": "Only partly created"}]},
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response="Everything was created."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_effect_gateway(
+            lambda _name, _arguments: {
+                "success": False,
+                "effect_status": "partial",
+                "changed": True,
+                "error_code": "derived_relation_failed",
+            }
+        ),
+        prompt="Create the represented concept.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="partial-effect-terminal-status",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert result.terminal_status == "effect_partially_completed"
+    assert result.effect_finality_fallback is True
+    assert "1 partial" in result.response_text
+    assert "Everything was created." not in result.response_text
 
 
 def test_identity_shaped_targets_are_not_globally_rewritten() -> None:
@@ -2749,6 +3436,7 @@ def test_research_deadline_failure_preserves_final_synthesis_reserve() -> None:
         turn_id="turn-research-deadline",
         turn_budget_seconds=10,
         final_synthesis_reserve_seconds=2,
+        final_answer_reserve_seconds=0,
         clock=clock,
     )
 
@@ -2759,6 +3447,13 @@ def test_research_deadline_failure_preserves_final_synthesis_reserve() -> None:
     assert {
         tool.name for tool in client.calls[1]["available_tools"]
     } == {"turn_list_evidence", "turn_read_evidence"}
+    allocation = next(
+        item
+        for item in result.aux_llm_calls
+        if item.get("type") == "adaptive_turn_budget_allocation"
+    )
+    assert allocation["final_answer_reserve_source"] == "caller"
+    assert allocation["explicit_zero_override"] is True
     assert result.llm_calls[1]["mode"] == "evidence_capable"
     recovery = next(
         item
@@ -3171,6 +3866,7 @@ def test_final_synthesis_receives_bounded_evidence_after_native_continuation() -
         turn_id="turn-final-evidence",
         turn_budget_seconds=10,
         final_synthesis_reserve_seconds=2,
+        final_answer_reserve_seconds=0,
         clock=clock,
     )
 
@@ -3250,6 +3946,7 @@ def test_final_reset_carries_exact_hydrated_evidence_for_provider_styles(
         turn_id=f"turn-hydration-{'native' if native_continuation else 'stateless'}",
         turn_budget_seconds=10,
         final_synthesis_reserve_seconds=2,
+        final_answer_reserve_seconds=0,
         clock=clock,
     )
 

--- a/tests/backend/test_concept_external_identity_service.py
+++ b/tests/backend/test_concept_external_identity_service.py
@@ -1,0 +1,477 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.backend.services import concept_external_identity_service as service
+from src.backend.services.concept_external_identity_service import (
+    ExternalIdentifier,
+    ExternalIdentityInputError,
+)
+
+
+def test_normalises_explicit_arxiv_url_and_version_to_base_id() -> None:
+    identifiers = service.normalise_create_external_identifiers(
+        external_identifiers=[
+            {
+                "scheme": "arxiv",
+                "value": "https://arxiv.org/pdf/2506.03346v3.pdf",
+                "role": "identity",
+            }
+        ],
+        concept_name="A title without identifier text",
+        kind="instance",
+    )
+
+    assert identifiers == (
+        ExternalIdentifier(
+            scheme="arxiv",
+            value="2506.03346",
+            source="explicit",
+        ),
+    )
+
+
+def test_leading_arxiv_label_is_accepted_but_incidental_number_is_not() -> None:
+    leading = service.normalise_create_external_identifiers(
+        external_identifiers=None,
+        concept_name="arXiv:2506.03346v2 — A test of five storage effects",
+        kind="instance",
+    )
+    incidental = service.normalise_create_external_identifiers(
+        external_identifiers=None,
+        concept_name="Dataset notes mentioning 2506.03346",
+        kind="instance",
+    )
+    labelled_incidental = service.normalise_create_external_identifiers(
+        external_identifiers=None,
+        concept_name="Commentary on arXiv:2506.03346",
+        kind="instance",
+    )
+
+    assert leading == (
+        ExternalIdentifier(
+            scheme="arxiv",
+            value="2506.03346",
+            source="leading_arxiv_label",
+        ),
+    )
+    assert incidental == ()
+    assert labelled_incidental == ()
+
+
+def test_explicit_identity_and_leading_label_must_agree() -> None:
+    with pytest.raises(ExternalIdentityInputError) as exc_info:
+        service.normalise_create_external_identifiers(
+            external_identifiers=[{"scheme": "arxiv", "value": "2506.03346"}],
+            concept_name="arXiv:2408.02603 — Different paper",
+            kind="instance",
+        )
+
+    assert exc_info.value.error_code == "external_identifier_name_mismatch"
+
+
+def test_resolver_filters_inaccessible_and_non_exact_legacy_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identifier = ExternalIdentifier(
+        scheme="arxiv",
+        value="2506.03346",
+        source="explicit",
+    )
+    visible_id = "#V#legacy_visible"
+    hidden_id = "#V#legacy_hidden"
+    incidental_id = "#V#incidental_number"
+    labelled_incidental_id = "#V#labelled_incidental"
+
+    monkeypatch.setattr(
+        service,
+        "_arxiv_identity_relation_candidates",
+        lambda *_args, **_kwargs: {
+            visible_id,
+            hidden_id,
+            incidental_id,
+            labelled_incidental_id,
+        },
+    )
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find_one",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: [
+            {"concept_id": visible_id},
+            {"concept_id": hidden_id},
+            {"concept_id": incidental_id},
+            {"concept_id": labelled_incidental_id},
+        ],
+    )
+    monkeypatch.setattr(
+        service,
+        "filter_accessible_concept_ids",
+        lambda candidate_ids: set(candidate_ids) - {hidden_id},
+    )
+    monkeypatch.setattr(
+        service,
+        "get_texts_for_concepts",
+        lambda *_args, **_kwargs: {
+            visible_id: [
+                {
+                    "text": (
+                        "arXiv 2506.03346 — Negligible effects of "
+                        "environmental fluctuations"
+                    )
+                }
+            ],
+            incidental_id: [{"text": "Dataset notes mentioning 2506.03346"}],
+            labelled_incidental_id: [{"text": "Commentary on arXiv:2506.03346"}],
+        },
+    )
+
+    resolution = service.resolve_external_identity_candidates(identifier)
+
+    assert resolution.status == "resolved"
+    assert resolution.candidate_concept_ids == (visible_id,)
+
+
+def test_resolver_returns_all_visible_exact_candidates_as_ambiguous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identifier = ExternalIdentifier(
+        scheme="arxiv",
+        value="2506.03346",
+        source="leading_arxiv_label",
+    )
+    candidate_ids = {"#V#paper_b", "#V#paper_a"}
+
+    monkeypatch.setattr(
+        service,
+        "_arxiv_identity_relation_candidates",
+        lambda *_args, **_kwargs: set(candidate_ids),
+    )
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find_one",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: [
+            {"concept_id": concept_id} for concept_id in candidate_ids
+        ],
+    )
+    monkeypatch.setattr(
+        service,
+        "filter_accessible_concept_ids",
+        lambda values: set(values),
+    )
+    monkeypatch.setattr(
+        service,
+        "get_texts_for_concepts",
+        lambda *_args, **_kwargs: {
+            concept_id: [{"text": "arXiv:2506.03346 — Paper"}]
+            for concept_id in candidate_ids
+        },
+    )
+
+    resolution = service.resolve_external_identity_candidates(identifier)
+
+    assert resolution.status == "ambiguous"
+    assert resolution.candidate_concept_ids == (
+        "#V#paper_a",
+        "#V#paper_b",
+    )
+
+
+def test_resolver_uses_one_bounded_identity_candidate_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def _search(arxiv_id: str) -> set[str]:
+        calls.append(arxiv_id)
+        return set()
+
+    monkeypatch.setattr(service, "_arxiv_identity_relation_candidates", _search)
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: [],
+    )
+
+    resolution = service.resolve_external_identity_candidates(
+        ExternalIdentifier(
+            scheme="arxiv",
+            value="2506.03346",
+            source="explicit",
+        )
+    )
+
+    assert resolution.status == "not_found"
+    assert calls == ["2506.03346"]
+
+
+def test_identity_lookup_uses_bounded_fingerprint_and_relation_indexes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    text_queries: list[dict[str, Any]] = []
+    relation_queries: list[dict[str, Any]] = []
+
+    def _find_text(query: dict[str, Any], **kwargs: Any) -> list[dict[str, Any]]:
+        text_queries.append({"query": query, **kwargs})
+        return [{"_id": "text-1"}]
+
+    def _find_relation(
+        query: dict[str, Any],
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        relation_queries.append({"query": query, **kwargs})
+        return [{"subject_concept_id": "#V#legacy_paper"}]
+
+    monkeypatch.setattr(service.TextValuesRepository, "find", _find_text)
+    monkeypatch.setattr(service.TextRelationsRepository, "find", _find_relation)
+
+    candidates = service._arxiv_identity_relation_candidates("2506.03346")
+
+    assert candidates == {"#V#legacy_paper"}
+    fingerprint_ranges = text_queries[0]["query"]["$or"]
+    range_bounds = [
+        (
+            item["fingerprint"]["$gte"],
+            item["fingerprint"]["$lt"],
+        )
+        for item in fingerprint_ranges
+    ]
+    assert {lower for lower, _upper in range_bounds} == {
+        "2506.03346",
+        "http://arxiv.org/abs/2506.03346",
+        "http://arxiv.org/pdf/2506.03346",
+        "http://www.arxiv.org/abs/2506.03346",
+        "http://www.arxiv.org/pdf/2506.03346",
+        "https://arxiv.org/abs/2506.03346",
+        "https://arxiv.org/pdf/2506.03346",
+        "https://www.arxiv.org/abs/2506.03346",
+        "https://www.arxiv.org/pdf/2506.03346",
+        "arxiv2506.03346",
+        "arxiv:2506.03346",
+        "arxiv: 2506.03346",
+        "arxiv 2506.03346",
+        "arxiv :2506.03346",
+        "arxiv : 2506.03346",
+    }
+    assert all(
+        item["fingerprint"]["$type"] == "string"
+        and item["fingerprint"]["$lt"].endswith("\uffff")
+        for item in fingerprint_ranges
+    )
+    accepted_exact_forms = (
+        "2506.03346",
+        "2506.03346v12",
+        "arXiv2506.03346v2",
+        "arXiv : 2506.03346v3",
+        "http://arxiv.org/abs/2506.03346v4",
+        "https://arxiv.org/pdf/2506.03346.pdf",
+        "http://www.arxiv.org/pdf/2506.03346v5.pdf?download=1",
+        "https://www.arxiv.org/abs/2506.03346v6/#section",
+    )
+
+    def _is_indexed_candidate(value: str) -> bool:
+        fingerprint = f"{value.casefold()}||en-nz"
+        return any(lower <= fingerprint < upper for lower, upper in range_bounds)
+
+    assert all(
+        service.normalise_arxiv_id(value) == "2506.03346"
+        for value in accepted_exact_forms
+    )
+    assert all(_is_indexed_candidate(value) for value in accepted_exact_forms)
+    assert all(
+        service._verified_arxiv_ids_from_name(value) == {"2506.03346"}
+        for value in accepted_exact_forms
+    )
+    assert text_queries[0]["limit"] == 200
+    assert relation_queries[0]["query"]["predicate"] == "hasName"
+    assert relation_queries[0]["limit"] == 2_000
+
+
+def test_identity_post_verification_rejects_indexed_false_prefixes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    false_prefix_names = {
+        "#V#extra_digit": "2506.033460",
+        "#V#version_suffix": "2506.03346v2extra",
+        "#V#url_extra_digit": "https://arxiv.org/abs/2506.033460",
+        "#V#url_pdf_suffix": ("https://www.arxiv.org/pdf/2506.03346v2.pdfx?download=1"),
+        "#V#label_extra_digit": "arXiv:2506.033460 — Different paper",
+    }
+    candidate_ids = set(false_prefix_names)
+
+    monkeypatch.setattr(
+        service,
+        "_arxiv_identity_relation_candidates",
+        lambda *_args, **_kwargs: set(candidate_ids),
+    )
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: [
+            {"concept_id": concept_id} for concept_id in candidate_ids
+        ],
+    )
+    monkeypatch.setattr(
+        service,
+        "filter_accessible_concept_ids",
+        lambda values: set(values),
+    )
+    monkeypatch.setattr(
+        service,
+        "get_texts_for_concepts",
+        lambda *_args, **_kwargs: {
+            concept_id: [{"text": text}]
+            for concept_id, text in false_prefix_names.items()
+        },
+    )
+
+    resolution = service.resolve_external_identity_candidates(
+        ExternalIdentifier(
+            scheme="arxiv",
+            value="2506.03346",
+            source="explicit",
+        )
+    )
+
+    assert all(
+        service._verified_arxiv_ids_from_name(value) == set()
+        for value in false_prefix_names.values()
+    )
+    assert resolution.status == "not_found"
+    assert resolution.candidate_concept_ids == ()
+
+
+def test_scholarly_parent_scope_accepts_known_and_bounded_descendant_types(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.services import context_bundle_service
+
+    monkeypatch.setattr(
+        context_bundle_service,
+        "_collect_type_ancestors",
+        lambda concept_id, **_kwargs: (
+            [{"concept_id": "#V#scholarly_article", "depth": 1}]
+            if concept_id == "#V#specialised_paper"
+            else []
+        ),
+    )
+
+    assert service.is_supported_arxiv_paper_parent("#V#scientific_paper") is True
+    assert service.is_supported_arxiv_paper_parent("#V#specialised_paper") is True
+    assert service.is_supported_arxiv_paper_parent("#V#research_note") is False
+
+
+def test_actor_scope_stable_ids_share_by_org_and_isolate_other_scopes() -> None:
+    identifier = ExternalIdentifier(
+        scheme="arxiv",
+        value="2506.03346",
+        source="explicit",
+    )
+
+    global_id = service.canonical_concept_id_for_external_identifiers(
+        [identifier],
+        kind="instance",
+        parent_id="#V#scientific_paper",
+        scope_mode="global_general",
+        actor_user_id="#V#user_a",
+        actor_org_id="#V#org_a",
+    )
+    org_a_user_a = service.canonical_concept_id_for_external_identifiers(
+        [identifier],
+        kind="instance",
+        parent_id="#V#scientific_paper",
+        actor_user_id="#V#user_a",
+        actor_org_id="#V#org_a",
+    )
+    org_a_user_b = service.canonical_concept_id_for_external_identifiers(
+        [identifier],
+        kind="instance",
+        parent_id="#V#scientific_paper",
+        actor_user_id="#V#user_b",
+        actor_org_id="#V#org_a",
+    )
+    org_a_general = service.canonical_concept_id_for_external_identifiers(
+        [identifier],
+        kind="instance",
+        parent_id="#V#scientific_paper",
+        scope_mode="organisation_general",
+        actor_user_id="#V#user_b",
+        actor_org_id="#V#org_a",
+    )
+    org_b = service.canonical_concept_id_for_external_identifiers(
+        [identifier],
+        kind="instance",
+        parent_id="#V#scientific_paper",
+        actor_user_id="#V#user_a",
+        actor_org_id="#V#org_b",
+    )
+    user_only = service.canonical_concept_id_for_external_identifiers(
+        [identifier],
+        kind="instance",
+        parent_id="#V#scientific_paper",
+        actor_user_id="#V#user_a",
+    )
+
+    assert global_id is not None
+    assert "_scope_" not in global_id
+    assert org_a_user_a == org_a_user_b == org_a_general
+    assert org_a_user_a != global_id
+    assert org_b != org_a_user_a
+    assert user_only not in {global_id, org_a_user_a, org_b}
+
+
+def test_persist_external_identity_names_retains_per_write_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def _upsert(**kwargs: Any) -> dict[str, Any]:
+        text = str(kwargs["text"])
+        calls.append(text)
+        if text.startswith("https://"):
+            raise RuntimeError("identity URL write failed")
+        return {
+            "relation_id": "rel-arxiv-id",
+            "relation_created": True,
+            "context_updated": False,
+        }
+
+    monkeypatch.setattr(service, "upsert_text_for_concept", _upsert)
+
+    result = service.persist_external_identity_names(
+        concept_id="#V#paper",
+        identifiers=[
+            ExternalIdentifier(
+                scheme="arxiv",
+                value="2506.03346",
+                source="explicit",
+            )
+        ],
+    )
+
+    assert calls == [
+        "2506.03346",
+        "https://arxiv.org/abs/2506.03346",
+    ]
+    assert result["success"] is False
+    assert result["writes"][0]["relation_id"] == "rel-arxiv-id"
+    assert result["failures"] == [
+        {
+            "stage": "external_identity_persistence",
+            "scheme": "arxiv",
+            "value": "https://arxiv.org/abs/2506.03346",
+            "error": "identity URL write failed",
+            "exception_type": "RuntimeError",
+        }
+    ]

--- a/tests/backend/test_create_vontology_concept_suffix_policy.py
+++ b/tests/backend/test_create_vontology_concept_suffix_policy.py
@@ -38,3 +38,34 @@ def test_no_suffix_mode_uses_unique_insert_and_returns_race_receipt(monkeypatch)
     assert result["error_code"] == "already_exists"
     assert result["existing_concept_id"] == "#V#race_occupied_identity"
     assert result["canonical_concept_id"] == "#V#race_occupied_identity"
+
+
+def test_canonical_override_disables_suffixing_and_preserves_atomic_identity(
+    monkeypatch,
+):
+    repository_reads: list[dict[str, object]] = []
+    attempted_ids: list[str] = []
+
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.ConceptsRepository.find_one",
+        lambda query: repository_reads.append(dict(query)),
+    )
+
+    def _create(**kwargs):
+        attempted_ids.append(str(kwargs["concept_id"]))
+        return {"concept_id": kwargs["concept_id"]}
+
+    monkeypatch.setattr(concept_service, "create_concept", _create)
+
+    result = create_vontology_concept(
+        parent_id="#V#scholarly_article",
+        new_concept_name="A title that may change",
+        create_as_instance=True,
+        allow_duplicate_instance_suffix=True,
+        canonical_concept_id_override="#V#paper_on_arxiv_2506_03346_1234abcd",
+    )
+
+    assert attempted_ids == ["#V#paper_on_arxiv_2506_03346_1234abcd"]
+    assert repository_reads == []
+    assert result["success"] is True
+    assert result["canonical_concept_id"] == "#V#paper_on_arxiv_2506_03346_1234abcd"

--- a/tests/backend/test_display_elements_service.py
+++ b/tests/backend/test_display_elements_service.py
@@ -137,6 +137,29 @@ def test_extract_markdown_tables_parses_rows_and_typed_cells() -> None:
     assert second_row_types == ["text", "boolean", "date", "number"]
 
 
+def test_extract_markdown_tables_preserves_source_lines_after_code_fences() -> None:
+    tables = extract_markdown_tables(
+        (
+            "Before\n"
+            "```text\n"
+            "| not | a table |\n"
+            "| --- | --- |\n"
+            "```\n"
+            "Between\n"
+            "| Task | Status |\n"
+            "| --- | --- |\n"
+            "| Alpha | done |\n"
+            "After\n"
+        )
+    )
+
+    assert len(tables) == 1
+    assert tables[0]["source_span"] == {
+        "start_line": 7,
+        "end_line": 9,
+    }
+
+
 def test_build_turn_display_elements_includes_table_elements_for_markdown_tables() -> None:
     contract = build_turn_display_elements(
         response_text=(
@@ -166,6 +189,15 @@ def test_build_turn_display_elements_includes_table_elements_for_markdown_tables
     table_element = table_elements[0]
     assert table_element["payload"]["columns"][0]["label"] == "Task"
     assert table_element["payload"]["rows"][0]["cells"][1]["value_raw"] == "done"
+    assert table_element["presentation"] == {
+        "mode": "inline_primary",
+        "source_element_id": "screen_text",
+        "source_span": {
+            "start_line": 1,
+            "end_line": 4,
+        },
+    }
+    assert table_element["provenance"]["source"] == "screen_markdown_table"
     assert "screen_markdown_tables_detected" in contract["reason_codes"]
     assert contract["validation"]["valid"] is True
 
@@ -210,6 +242,8 @@ def test_build_turn_display_elements_includes_supplied_table_elements() -> None:
         table_element["payload"]["rows"][0]["provenance"]["source_concept_id"]
         == "#V#task_alpha"
     )
+    assert table_element["presentation"] == {"mode": "augment"}
+    assert table_element["provenance"]["source"] == "screen_structured_table"
     assert "screen_structured_tables_supplied" in contract["reason_codes"]
     assert contract["validation"]["valid"] is True
 
@@ -1326,6 +1360,121 @@ def test_validate_turn_display_elements_rejects_invalid_table_shape() -> None:
 
     assert valid is False
     assert any("must reference a declared column" in message for message in errors)
+
+
+def _table_presentation_validation_contract(
+    *,
+    source_element_id: str = "screen_text",
+    source_element_type: str = "text_block",
+    source_channel: str = "screen",
+    source_text: str = "| Task | Status |\n| --- | --- |\n| Alpha | done |",
+    source_span: dict[str, int] | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": "turn_display_elements_v1",
+        "elements": [
+            {
+                "element_id": "screen_text",
+                "element_type": source_element_type,
+                "channel": source_channel,
+                "order": 10,
+                "intent": "primary_response",
+                "payload": {"text": source_text},
+                "provenance": {"source": "response_text"},
+            },
+            {
+                "element_id": "screen_table_1",
+                "element_type": "table",
+                "channel": "screen",
+                "order": 16,
+                "intent": "structured_tabular_view",
+                "payload": {
+                    "columns": [
+                        {
+                            "column_id": "task",
+                            "label": "Task",
+                            "data_type": "text",
+                        }
+                    ],
+                    "rows": [
+                        {
+                            "row_id": "row_1",
+                            "cells": [
+                                {
+                                    "column_id": "task",
+                                    "value_raw": "Alpha",
+                                    "value_display": "Alpha",
+                                    "value_type": "text",
+                                }
+                            ],
+                        }
+                    ],
+                },
+                "presentation": {
+                    "mode": "inline_primary",
+                    "source_element_id": source_element_id,
+                    "source_span": source_span or {
+                        "start_line": 1,
+                        "end_line": 3,
+                    },
+                },
+                "provenance": {"source": "screen_markdown_table"},
+            },
+        ],
+        "reason_codes": [],
+    }
+
+
+def test_validate_turn_display_elements_rejects_reversed_table_presentation_span() -> None:
+    valid, errors = validate_turn_display_elements(
+        _table_presentation_validation_contract(
+            source_span={"start_line": 4, "end_line": 2},
+        )
+    )
+
+    assert valid is False
+    assert any("must not precede start_line" in message for message in errors)
+
+
+def test_validate_turn_display_elements_rejects_missing_table_presentation_source() -> None:
+    valid, errors = validate_turn_display_elements(
+        _table_presentation_validation_contract(source_element_id="missing_text")
+    )
+
+    assert valid is False
+    assert any("must identify exactly one element" in message for message in errors)
+
+
+def test_validate_turn_display_elements_rejects_wrong_table_presentation_source_type() -> None:
+    valid, errors = validate_turn_display_elements(
+        _table_presentation_validation_contract(source_element_type="json_block")
+    )
+
+    assert valid is False
+    assert any("must reference a screen text_block" in message for message in errors)
+
+
+def test_validate_turn_display_elements_rejects_table_presentation_span_outside_source() -> None:
+    valid, errors = validate_turn_display_elements(
+        _table_presentation_validation_contract(
+            source_span={"start_line": 1, "end_line": 4},
+        )
+    )
+
+    assert valid is False
+    assert any("must fall within the referenced text" in message for message in errors)
+
+
+def test_validate_turn_display_elements_rejects_span_without_markdown_table() -> None:
+    valid, errors = validate_turn_display_elements(
+        _table_presentation_validation_contract(
+            source_text="Before\nNot a table\nAfter",
+            source_span={"start_line": 1, "end_line": 3},
+        )
+    )
+
+    assert valid is False
+    assert any("must identify a Markdown table" in message for message in errors)
 
 
 def test_validate_turn_display_elements_rejects_invalid_workflow_links() -> None:

--- a/tests/backend/test_mcp_create_concepts_duplicate_resolution_mode.py
+++ b/tests/backend/test_mcp_create_concepts_duplicate_resolution_mode.py
@@ -17,10 +17,13 @@ from src.backend.integrations.internal_mcp.transport import (
 from src.backend.services.create_concepts_parent_resolution_service import (
     ParentResolutionResult,
 )
+from src.backend.services.concept_external_identity_service import (
+    ExternalIdentityResolution,
+)
 from src.backend.utils.concept_id_utils import canonicalise_vontology_concept_id
 
-
 _PARENT_ID = "#V#abstract_object"
+_PAPER_PARENT_ID = "#V#scholarly_article"
 
 
 def _patch_common_preflights(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -40,6 +43,31 @@ def _patch_common_preflights(monkeypatch: pytest.MonkeyPatch) -> None:
         "src.backend.services.workflow_event_integration_service."
         "resolve_event_actor_context",
         lambda **_kwargs: (None, None),
+    )
+
+
+def _patch_paper_preflights(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    actor_user_id: str | None = None,
+    actor_org_id: str | None = None,
+) -> None:
+    monkeypatch.setattr(
+        "src.backend.services.create_concepts_parent_resolution_service."
+        "resolve_parent_for_create_concepts",
+        lambda parent_id: ParentResolutionResult(
+            requested_parent_id=parent_id,
+            canonical_parent_id=_PAPER_PARENT_ID,
+            resolved_parent_id=_PAPER_PARENT_ID,
+            fallback_used=False,
+            fallback_candidates_checked=(),
+            fallback_selected_parent_id=None,
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.workflow_event_integration_service."
+        "resolve_event_actor_context",
+        lambda **_kwargs: (actor_user_id, actor_org_id),
     )
 
 
@@ -553,3 +581,527 @@ def test_cancellation_between_batch_items_prevents_later_creates(
     assert result["successful"] == 1
     assert result["failed"] == 0
     assert result["created_concept_ids"] == ["#V#first_complete_identity"]
+
+
+def test_canonical_id_only_reuses_external_identity_before_title_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_paper_preflights(monkeypatch)
+    existing_id = "#V#legacy_title_derived_paper"
+    create_calls: list[dict[str, Any]] = []
+
+    def _find_one(
+        query: dict[str, Any],
+        _projection: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        if query.get("concept_id") == existing_id:
+            return {
+                "concept_id": existing_id,
+                "relationships": {
+                    "is_an_instance_of": ["#V#paper_on_arxiv"],
+                    "is_a_type_of": [],
+                },
+            }
+        return None
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _find_one,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_external_identity_service."
+        "resolve_external_identity_candidates",
+        lambda identifier, **_kwargs: ExternalIdentityResolution(
+            status="resolved",
+            identifier=identifier,
+            candidate_concept_ids=(existing_id,),
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        lambda **kwargs: create_calls.append(kwargs),
+    )
+
+    result = _create_concepts(
+        parent_id=_PAPER_PARENT_ID,
+        concepts=[
+            {
+                "name": "arXiv:2506.03346 — Short title",
+                "kind": "instance",
+            }
+        ],
+        duplicate_resolution_mode="canonical_id_only",
+    )
+
+    item = result["results"][0]
+    assert result["successful"] == 0
+    assert result["already_existed"] == 1
+    assert item["existing_concept_id"] == existing_id
+    assert item["duplicate_match_source"] == "external_identifier:arxiv"
+    assert create_calls == []
+
+
+def test_multiple_external_identity_candidates_fail_closed_without_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_paper_preflights(monkeypatch)
+    create_calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_external_identity_service."
+        "resolve_external_identity_candidates",
+        lambda identifier, **_kwargs: ExternalIdentityResolution(
+            status="ambiguous",
+            identifier=identifier,
+            candidate_concept_ids=("#V#paper_a", "#V#paper_b"),
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        lambda **kwargs: create_calls.append(kwargs),
+    )
+
+    result = _create_concepts(
+        parent_id=_PAPER_PARENT_ID,
+        concepts=[
+            {
+                "name": "Coral biodiversity paper",
+                "kind": "instance",
+                "external_identifiers": [{"scheme": "arxiv", "value": "2506.03346v1"}],
+            }
+        ],
+        duplicate_resolution_mode="canonical_id_only",
+    )
+
+    item = result["results"][0]
+    assert result["effect_status"] == "failed"
+    assert item["error_code"] == "ambiguous_external_identity"
+    assert item["candidate_concept_ids"] == ["#V#paper_a", "#V#paper_b"]
+    assert item["changed"] is False
+    assert create_calls == []
+
+
+def test_new_identified_paper_uses_stable_id_and_persists_identity_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_create: dict[str, Any] = {}
+    persistence_calls: list[dict[str, Any]] = []
+
+    _patch_paper_preflights(
+        monkeypatch,
+        actor_user_id="#V#test_user",
+    )
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_external_identity_service."
+        "resolve_external_identity_candidates",
+        lambda identifier, **_kwargs: ExternalIdentityResolution(
+            status="not_found",
+            identifier=identifier,
+        ),
+    )
+
+    def _create(**kwargs: Any) -> dict[str, Any]:
+        captured_create.update(kwargs)
+        concept_id = str(kwargs["canonical_concept_id_override"])
+        return {
+            "success": True,
+            "concept": {"concept_id": concept_id},
+            "canonical_concept_id": concept_id,
+        }
+
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        _create,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_external_identity_service."
+        "persist_external_identity_names",
+        lambda **kwargs: persistence_calls.append(kwargs)
+        or {"success": True, "writes": [{"relation_id": "rel-1"}], "failures": []},
+    )
+
+    result = _create_concepts(
+        parent_id=_PAPER_PARENT_ID,
+        concepts=[
+            {
+                "name": "Negligible effects of environmental fluctuations",
+                "kind": "instance",
+                "external_identifiers": [
+                    {
+                        "scheme": "arxiv",
+                        "value": "https://arxiv.org/abs/2506.03346v2",
+                    }
+                ],
+            }
+        ],
+        duplicate_resolution_mode="canonical_id_only",
+    )
+
+    stable_id = captured_create["canonical_concept_id_override"]
+    assert isinstance(stable_id, str)
+    assert stable_id.startswith("#V#paper_on_arxiv_2506_03346_")
+    assert captured_create["allow_duplicate_instance_suffix"] is False
+    assert result["success"] is True
+    assert result["created_concept_ids"] == [stable_id]
+    assert persistence_calls[0]["concept_id"] == stable_id
+    assert persistence_calls[0]["identifiers"][0].value == "2506.03346"
+
+
+def test_external_identity_miss_bypasses_title_derived_duplicate_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_paper_preflights(monkeypatch)
+    repository_reads: list[dict[str, Any]] = []
+    create_calls: list[dict[str, Any]] = []
+
+    def _find_one(
+        query: dict[str, Any],
+        _projection: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        repository_reads.append(query)
+        if query.get("concept_id") == "#V#a_paper":
+            return {
+                "concept_id": "#V#a_paper",
+                "relationships": {
+                    "is_an_instance_of": [_PAPER_PARENT_ID],
+                },
+            }
+        return None
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _find_one,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_external_identity_service."
+        "resolve_external_identity_candidates",
+        lambda identifier, **_kwargs: ExternalIdentityResolution(
+            status="not_found",
+            identifier=identifier,
+        ),
+    )
+
+    def _create(**kwargs: Any) -> dict[str, Any]:
+        create_calls.append(kwargs)
+        concept_id = str(kwargs["canonical_concept_id_override"])
+        return {
+            "success": True,
+            "concept": {"concept_id": concept_id},
+            "canonical_concept_id": concept_id,
+        }
+
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        _create,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_external_identity_service."
+        "persist_external_identity_names",
+        lambda **_kwargs: {"success": True, "writes": [], "failures": []},
+    )
+
+    result = _create_concepts(
+        parent_id=_PAPER_PARENT_ID,
+        concepts=[
+            {
+                "name": "A paper",
+                "kind": "instance",
+                "external_identifiers": [{"scheme": "arxiv", "value": "2506.03346"}],
+            }
+        ],
+    )
+
+    assert result["success"] is True
+    assert len(create_calls) == 1
+    assert "#V#a_paper" not in {query.get("concept_id") for query in repository_reads}
+
+
+def test_direct_stdio_namespace_binds_actor_during_external_identity_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed_actors: list[tuple[str | None, str | None]] = []
+    captured_create: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        "src.backend.services.create_concepts_parent_resolution_service."
+        "resolve_parent_for_create_concepts",
+        lambda parent_id: ParentResolutionResult(
+            requested_parent_id=parent_id,
+            canonical_parent_id=_PAPER_PARENT_ID,
+            resolved_parent_id=_PAPER_PARENT_ID,
+            fallback_used=False,
+            fallback_candidates_checked=(),
+            fallback_selected_parent_id=None,
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def _resolve(identifier, **_kwargs):
+        from src.backend.security.access_control import (
+            get_effective_organisation_concept_id,
+            get_effective_user_concept_id,
+        )
+
+        observed_actors.append(
+            (
+                get_effective_user_concept_id(),
+                get_effective_organisation_concept_id(),
+            )
+        )
+        return ExternalIdentityResolution(
+            status="not_found",
+            identifier=identifier,
+        )
+
+    monkeypatch.setattr(
+        "src.backend.services.concept_external_identity_service."
+        "resolve_external_identity_candidates",
+        _resolve,
+    )
+
+    def _create(**kwargs: Any) -> dict[str, Any]:
+        captured_create.update(kwargs)
+        concept_id = str(kwargs["canonical_concept_id_override"])
+        return {
+            "success": True,
+            "concept": {"concept_id": concept_id},
+            "canonical_concept_id": concept_id,
+        }
+
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        _create,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_external_identity_service."
+        "persist_external_identity_names",
+        lambda **_kwargs: {"success": True, "writes": [], "failures": []},
+    )
+
+    result = _create_concepts(
+        parent_id=_PAPER_PARENT_ID,
+        namespace="#V#user_a@org_a",
+        concepts=[
+            {
+                "name": "A directly-created paper",
+                "kind": "instance",
+                "external_identifiers": [{"scheme": "arxiv", "value": "2506.03346"}],
+            }
+        ],
+    )
+
+    assert result["success"] is True
+    assert observed_actors == [("#V#user_a", "#V#org_a")]
+    assert "_scope_" in captured_create["canonical_concept_id_override"]
+
+
+def test_hidden_atomic_collision_is_not_reported_as_existing_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_paper_preflights(
+        monkeypatch,
+        actor_user_id="#V#user_a",
+        actor_org_id="#V#org_a",
+    )
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_external_identity_service."
+        "resolve_external_identity_candidates",
+        lambda identifier, **_kwargs: ExternalIdentityResolution(
+            status="not_found",
+            identifier=identifier,
+        ),
+    )
+
+    def _collision(**kwargs: Any) -> dict[str, Any]:
+        concept_id = str(kwargs["canonical_concept_id_override"])
+        return {
+            "success": False,
+            "changed": False,
+            "error_code": "already_exists",
+            "existing_concept_id": concept_id,
+            "canonical_concept_id": concept_id,
+            "concept": None,
+        }
+
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        _collision,
+    )
+
+    result = _create_concepts(
+        parent_id=_PAPER_PARENT_ID,
+        concepts=[
+            {
+                "name": "A hidden-collision paper",
+                "kind": "instance",
+                "external_identifiers": [{"scheme": "arxiv", "value": "2506.03346"}],
+            }
+        ],
+    )
+
+    item = result["results"][0]
+    assert result["success"] is False
+    assert result["effect_status"] == "failed"
+    assert result["changed"] is False
+    assert result["already_existed"] == 0
+    assert item["error_code"] == "external_identity_collision_unverified"
+    assert item.get("existing_concept_id") is None
+
+
+def test_new_external_identity_with_non_paper_parent_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_common_preflights(monkeypatch)
+    create_calls: list[dict[str, Any]] = []
+    resolver_calls: list[str] = []
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_external_identity_service."
+        "resolve_external_identity_candidates",
+        lambda identifier, **_kwargs: resolver_calls.append(identifier.value),
+    )
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        lambda **kwargs: create_calls.append(kwargs),
+    )
+
+    result = _create_concepts(
+        parent_id=_PARENT_ID,
+        concepts=[
+            {
+                "name": "arXiv:2506.03346 — Paper under a non-paper parent",
+                "kind": "instance",
+            }
+        ],
+    )
+
+    assert result["effect_status"] == "failed"
+    assert result["changed"] is False
+    assert result["results"][0]["error_code"] == (
+        "external_identity_parent_incompatible"
+    )
+    assert resolver_calls == []
+    assert create_calls == []
+
+
+def test_new_external_identity_with_non_instance_kind_fails_before_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_paper_preflights(monkeypatch)
+    resolver_calls: list[str] = []
+    create_calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(
+        "src.backend.services.concept_external_identity_service."
+        "resolve_external_identity_candidates",
+        lambda identifier, **_kwargs: resolver_calls.append(identifier.value),
+    )
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        lambda **kwargs: create_calls.append(kwargs),
+    )
+
+    result = _create_concepts(
+        parent_id=_PAPER_PARENT_ID,
+        concepts=[
+            {
+                "name": "A paper identity asserted for a type",
+                "kind": "type",
+                "external_identifiers": [{"scheme": "arxiv", "value": "2506.03346"}],
+            }
+        ],
+    )
+
+    assert result["effect_status"] == "failed"
+    assert result["results"][0]["error_code"] == (
+        "external_identity_parent_incompatible"
+    )
+    assert resolver_calls == []
+    assert create_calls == []
+
+
+def test_identity_persistence_failure_makes_create_result_partial(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_paper_preflights(
+        monkeypatch,
+        actor_user_id="#V#test_user",
+    )
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_external_identity_service."
+        "resolve_external_identity_candidates",
+        lambda identifier, **_kwargs: ExternalIdentityResolution(
+            status="not_found",
+            identifier=identifier,
+        ),
+    )
+
+    def _create(**kwargs: Any) -> dict[str, Any]:
+        concept_id = str(kwargs["canonical_concept_id_override"])
+        return {
+            "success": True,
+            "concept": {"concept_id": concept_id},
+            "canonical_concept_id": concept_id,
+        }
+
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        _create,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_external_identity_service."
+        "persist_external_identity_names",
+        lambda **_kwargs: {
+            "success": False,
+            "writes": [{"relation_id": "rel-base-id"}],
+            "failures": [
+                {
+                    "stage": "external_identity_persistence",
+                    "value": "https://arxiv.org/abs/2506.03346",
+                    "error": "write failed",
+                }
+            ],
+        },
+    )
+
+    result = _create_concepts(
+        parent_id=_PAPER_PARENT_ID,
+        concepts=[
+            {
+                "name": "A paper",
+                "kind": "instance",
+                "external_identifiers": [{"scheme": "arxiv", "value": "2506.03346"}],
+            }
+        ],
+    )
+
+    assert result["effect_status"] == "partial"
+    assert result["success"] is False
+    assert result["changed"] is True
+    assert result["successful"] == 1
+    assert result["partial_failure_count"] == 1
+    assert result["partial_failures"][0]["stage"] == "external_identity_persistence"

--- a/tests/backend/test_turn_evidence_store.py
+++ b/tests/backend/test_turn_evidence_store.py
@@ -126,6 +126,42 @@ def test_read_supports_bounded_pointer_slices_and_escaped_tokens() -> None:
     assert escaped["has_more"] is False
 
 
+def test_store_keeps_rfc_slash_and_empty_string_pointer_semantics() -> None:
+    scope = _scope()
+    store = TurnEvidenceStore(scope, "turn-rfc-root")
+    envelope = store.record(
+        "generic_lookup",
+        "call-rfc-root",
+        {
+            "": "empty-key-member",
+            "canonical_concept_id": "#V#stable_readback_id",
+        },
+    )
+
+    slash_member = store.read(
+        envelope.evidence_id,
+        json_pointer="/",
+        max_chars=100,
+        trusted_scope=scope,
+        turn_id="turn-rfc-root",
+    )
+    document_root = store.read(
+        envelope.evidence_id,
+        json_pointer="",
+        max_chars=1_000,
+        trusted_scope=scope,
+        turn_id="turn-rfc-root",
+    )
+
+    assert slash_member["success"] is True
+    assert slash_member["content"] == "empty-key-member"
+    assert document_root["success"] is True
+    assert (
+        json.loads(document_root["content"])["canonical_concept_id"]
+        == "#V#stable_readback_id"
+    )
+
+
 def test_read_hides_handle_existence_across_actor_and_turn_boundaries() -> None:
     owner_scope = _scope()
     store = TurnEvidenceStore(owner_scope, "turn-owner")

--- a/tests/backend/test_turn_execution_record_service_execution_summary.py
+++ b/tests/backend/test_turn_execution_record_service_execution_summary.py
@@ -1,6 +1,8 @@
 import json
 from types import SimpleNamespace
 
+import pytest
+
 from src.backend.services.turn_decision_attribution_service import (
     DECISION_KINDS,
     TURN_DECISION_ATTRIBUTION_SCHEMA_VERSION,
@@ -15,6 +17,7 @@ from src.backend.services.turn_execution_record_service import (
     project_final_answer_tool_evidence,
     record_effect_observation_phase,
     upsert_turn_execution_record_projection,
+    _classify_tool_invocation_status,
     _normalise_projection_field_entries,
     _summarise_tool_execution_context,
 )
@@ -34,6 +37,497 @@ _KR_REQUIRED_TOOLS = [
     "fetch_concept",
     "get_text_relations_summary",
 ]
+
+
+def _build_effect_projection_record(
+    request_id: str,
+    tool_invocations: list[dict],
+    **overrides,
+):
+    return build_turn_execution_record(
+        request_id=request_id,
+        session_id=f"session-{request_id}",
+        namespace="#V#user@org",
+        user_id="#V#user",
+        org_id="#V#org",
+        prompt_text="Continue this bounded turn.",
+        response_text="The bounded turn completed.",
+        interaction_timestamp_utc="2026-07-27T00:00:00Z",
+        tool_invocations=tool_invocations,
+        **overrides,
+    )
+
+
+def test_explicit_error_with_argument_payload_is_not_classified_as_success() -> None:
+    assert (
+        _classify_tool_invocation_status(
+            invocation={
+                "tool": "create_concepts",
+                "status": "error",
+                "payload": {
+                    "name": "create_concepts",
+                    "arguments": {"concepts": [{"name": "Unstarted"}]},
+                },
+            }
+        )
+        == "error"
+    )
+
+
+def test_not_started_durable_effect_blocks_completion_with_exact_receipt() -> None:
+    invocation = {
+        "tool": "create_concepts",
+        "status": "error",
+        "payload": {
+            "name": "create_concepts",
+            "arguments": {"concepts": [{"name": "Unstarted"}]},
+        },
+        "effective_arguments": {"concepts": [{"name": "Unstarted"}]},
+        "effect_id": "effect_not_started_1",
+        "effect_status": "failed",
+        "changed": False,
+        "mutation_outcome": "not_started",
+        "outcome_finality": "terminal_for_turn",
+        "error_code": "insufficient_effect_window",
+        "transport": {
+            "schema_version": "internal_mcp_transport.v1",
+            "outcome": "not_started",
+            "timeout_phase": "pre_dispatch",
+        },
+        "evidence": {"preview": "private bounded receipt detail"},
+    }
+
+    record = _build_effect_projection_record(
+        "req-not-started-effect",
+        [invocation],
+    )
+
+    serialised = record["execution"]["tool_invocations"][0]
+    assert serialised["status"] == "not_started"
+    assert serialised["mutation_outcome"] == "not_started"
+    assert serialised["outcome_finality"] == "terminal_for_turn"
+    assert serialised["error_code"] == "insufficient_effect_window"
+    assert "effective_payload" not in serialised
+    assert "evidence" not in serialised
+    effect = next(
+        item
+        for item in record["required_effects"]
+        if item["effect_id"] == "effect_not_started_1"
+    )
+    assert effect["status"] == "not_executed"
+    assert effect["failure_codes"] == ["insufficient_effect_window"]
+    assert record["execution"]["summary"]["successful_invocation_count"] == 0
+    assert record["completion_gate"]["decision"] == "escalation_required"
+    assert record["completion_gate"]["safe_to_claim_completion"] is False
+    assert record["execution_correctness"]["failure_mode"] == "mutation_not_executed"
+
+
+def test_distinct_same_tool_effect_failure_is_not_masked_by_success() -> None:
+    record = _build_effect_projection_record(
+        "req-distinct-effects",
+        [
+            {
+                "tool": "create_concepts",
+                "status": "ok",
+                "payload": {
+                    "name": "create_concepts",
+                    "arguments": {"concepts": [{"name": "Created"}]},
+                },
+                "effect_id": "effect_created",
+                "effect_status": "succeeded",
+                "changed": True,
+            },
+            {
+                "tool": "create_concepts",
+                "status": "error",
+                "payload": {
+                    "name": "create_concepts",
+                    "arguments": {"concepts": [{"name": "Unstarted"}]},
+                },
+                "effect_id": "effect_unstarted",
+                "effect_status": "failed",
+                "changed": False,
+                "mutation_outcome": "not_started",
+                "outcome_finality": "terminal_for_turn",
+                "error_code": "insufficient_effect_batch_window",
+                "transport": {"outcome": "not_started"},
+            },
+        ],
+    )
+
+    effects = {
+        item["effect_id"]: item["status"]
+        for item in record["required_effects"]
+        if item["effect_id"] in {"effect_created", "effect_unstarted"}
+    }
+    assert effects == {
+        "effect_created": "satisfied",
+        "effect_unstarted": "not_executed",
+    }
+    assert record["completion_gate"]["safe_to_claim_completion"] is False
+
+
+@pytest.mark.parametrize(
+    ("invocation_status", "effect_status", "mutation_outcome"),
+    [
+        ("ok", "partial", "partial"),
+        ("error", "indeterminate", "unknown"),
+    ],
+)
+def test_partial_and_indeterminate_effects_remain_unsafe(
+    invocation_status: str,
+    effect_status: str,
+    mutation_outcome: str,
+) -> None:
+    effect_id = f"effect_{effect_status}"
+    record = _build_effect_projection_record(
+        f"req-{effect_status}-effect",
+        [
+            {
+                "tool": "create_concepts",
+                "status": invocation_status,
+                "payload": {
+                    "name": "create_concepts",
+                    "arguments": {"concepts": [{"name": "Incomplete"}]},
+                },
+                "effect_id": effect_id,
+                "effect_status": effect_status,
+                "changed": True if effect_status == "partial" else None,
+                "mutation_outcome": mutation_outcome,
+                "outcome_finality": "terminal_for_turn",
+            }
+        ],
+    )
+
+    serialised = record["execution"]["tool_invocations"][0]
+    assert serialised["status"] == effect_status
+    projected_effect = next(
+        item for item in record["required_effects"] if item["effect_id"] == effect_id
+    )
+    assert projected_effect["status"] == "not_satisfied"
+    assert record["completion_gate"]["safe_to_claim_completion"] is False
+    assert record["completion_gate"]["repeat_eligible"] is False
+    assert effect_id in record["completion_gate"]["evidence_payload"][
+        "repeat_ineligible_effect_ids"
+    ]
+
+
+def test_successful_effect_with_canonical_readback_remains_completable() -> None:
+    record = _build_effect_projection_record(
+        "req-successful-effect-readback",
+        [
+            {
+                "tool": "create_concepts",
+                "status": "ok",
+                "payload": {
+                    "name": "create_concepts",
+                    "arguments": {"concepts": [{"name": "Created"}]},
+                },
+                "effect_id": "effect_created_and_read",
+                "effect_status": "succeeded",
+                "changed": True,
+                "result_target_ids": ["#V#created"],
+            },
+            {
+                "tool": "fetch_concept",
+                "status": "ok",
+                "effective_arguments": {"concept_id": "#V#created"},
+                "effective_payload": {
+                    "success": True,
+                    "concept_id": "#V#created",
+                },
+            },
+        ],
+    )
+
+    effect = next(
+        item
+        for item in record["required_effects"]
+        if item["effect_id"] == "effect_created_and_read"
+    )
+    assert effect["status"] == "satisfied"
+    assert record["postcondition_checks"][0]["status"] == "verified"
+    assert (
+        record["postcondition_checks"][0]["verification_mode"]
+        == "state_requery_correlated"
+    )
+    assert record["completion_gate"]["safe_to_claim_completion"] is True
+
+
+def test_unrelated_verification_read_does_not_verify_effect() -> None:
+    record = _build_effect_projection_record(
+        "req-unrelated-readback",
+        [
+            {
+                "tool": "create_concepts",
+                "status": "ok",
+                "effect_id": "effect_created",
+                "effect_status": "succeeded",
+                "changed": True,
+                "result_target_ids": ["#V#created"],
+            },
+            {
+                "tool": "fetch_concept",
+                "status": "ok",
+                "effective_arguments": {"concept_id": "#V#unrelated"},
+                "effective_payload": {
+                    "success": True,
+                    "concept_id": "#V#unrelated",
+                },
+            },
+        ],
+    )
+
+    check = next(
+        item
+        for item in record["postcondition_checks"]
+        if item["effect_id"] == "effect_created"
+    )
+    assert check["status"] == "inconclusive"
+    assert check["verification_mode"] == "state_requery_target_mismatch"
+    assert check["observed"]["required_targets"] == ["#V#created"]
+    assert check["observed"]["observed_verification_targets"] == ["#V#unrelated"]
+    assert record["completion_gate"]["safe_to_claim_completion"] is False
+
+
+def test_relationship_readback_correlates_source_target_and_predicate() -> None:
+    record = _build_effect_projection_record(
+        "req-relationship-readback",
+        [
+            {
+                "tool": "add_relationship",
+                "status": "ok",
+                "effect_id": "effect_relationship",
+                "effect_status": "succeeded",
+                "changed": True,
+                "effective_arguments": {
+                    "source_id": "#V#source",
+                    "target_id": "#V#target",
+                    "predicate": "#V#related_to",
+                },
+            },
+            {
+                "tool": "find_relations_with_argument",
+                "status": "ok",
+                "effective_arguments": {
+                    "source_id": "#V#source",
+                    "target_id": "#V#target",
+                    "predicate": "#V#related_to",
+                },
+                "effective_payload": {
+                    "success": True,
+                    "hits": [
+                        {
+                            "source_concept_id": "#V#source",
+                            "target_concept_id": "#V#target",
+                            "predicate_concept_id": "#V#related_to",
+                        }
+                    ],
+                },
+            },
+        ],
+    )
+
+    effect = next(
+        item
+        for item in record["required_effects"]
+        if item["effect_id"] == "effect_relationship"
+    )
+    assert effect["targets"] == ["#V#source", "#V#target"]
+    assert effect["required_predicates"] == ["#V#related_to"]
+    assert effect["required_relation_tuples"] == [
+        {
+            "source_id": "#V#source",
+            "predicate_id": "#V#related_to",
+            "target_id": "#V#target",
+        }
+    ]
+    check = next(
+        item
+        for item in record["postcondition_checks"]
+        if item["effect_id"] == "effect_relationship"
+    )
+    assert check["status"] == "verified"
+    assert check["verification_mode"] == "state_requery_correlated"
+    assert record["completion_gate"]["safe_to_claim_completion"] is True
+
+
+def test_relationship_readback_does_not_join_fields_across_distinct_rows() -> None:
+    record = _build_effect_projection_record(
+        "req-relationship-split-readback",
+        [
+            {
+                "tool": "add_relationship",
+                "status": "ok",
+                "effect_id": "effect_relationship_split",
+                "effect_status": "succeeded",
+                "changed": True,
+                "effective_arguments": {
+                    "source_id": "#V#source",
+                    "target_id": "#V#target",
+                    "predicate": "#V#related_to",
+                },
+            },
+            {
+                "tool": "find_relations_with_argument",
+                "status": "ok",
+                "effective_arguments": {
+                    "source_id": "#V#source",
+                    "target_id": "#V#target",
+                    "predicate": "#V#related_to",
+                },
+                "effective_payload": {
+                    "success": True,
+                    "hits": [
+                        {
+                            "source_concept_id": "#V#source",
+                            "target_concept_id": "#V#other_target",
+                            "predicate_concept_id": "#V#related_to",
+                        },
+                        {
+                            "source_concept_id": "#V#source",
+                            "target_concept_id": "#V#target",
+                            "predicate_concept_id": "#V#other_predicate",
+                        },
+                    ],
+                },
+            },
+        ],
+    )
+
+    check = next(
+        item
+        for item in record["postcondition_checks"]
+        if item["effect_id"] == "effect_relationship_split"
+    )
+    assert check["status"] == "inconclusive"
+    assert check["verification_mode"] == "state_requery_target_mismatch"
+    assert check["observed"]["observed_verification_relation_tuples"] == [
+        {
+            "source_id": "#V#source",
+            "predicate_id": "#V#related_to",
+            "target_id": "#V#other_target",
+        },
+        {
+            "source_id": "#V#source",
+            "predicate_id": "#V#other_predicate",
+            "target_id": "#V#target",
+        },
+    ]
+    assert record["completion_gate"]["safe_to_claim_completion"] is False
+
+
+def test_relationship_readback_accepts_exact_tuple_among_distractor_rows() -> None:
+    record = _build_effect_projection_record(
+        "req-relationship-exact-readback",
+        [
+            {
+                "tool": "add_relationship",
+                "status": "ok",
+                "effect_id": "effect_relationship_exact",
+                "effect_status": "succeeded",
+                "changed": True,
+                "effective_arguments": {
+                    "source_id": "#V#source",
+                    "target_id": "#V#target",
+                    "predicate": "#V#related_to",
+                },
+            },
+            {
+                "tool": "find_relations_with_argument",
+                "status": "ok",
+                "effective_payload": {
+                    "success": True,
+                    "hits": [
+                        {
+                            "source_concept_id": "#V#source",
+                            "target_concept_id": "#V#other_target",
+                            "predicate_concept_id": "#V#related_to",
+                        },
+                        {
+                            "source_concept_id": "#V#source",
+                            "target_concept_id": "#V#target",
+                            "predicate_concept_id": "#V#related_to",
+                        },
+                    ],
+                },
+            },
+        ],
+    )
+
+    check = next(
+        item
+        for item in record["postcondition_checks"]
+        if item["effect_id"] == "effect_relationship_exact"
+    )
+    assert check["status"] == "verified"
+    assert check["verification_mode"] == "state_requery_correlated"
+    assert check["observed"]["correlated_verification_tools"] == [
+        "find_relations_with_argument"
+    ]
+    assert record["completion_gate"]["safe_to_claim_completion"] is True
+
+
+def test_stable_effect_receipts_remain_visible_with_workflow_contract() -> None:
+    record = _build_effect_projection_record(
+        "req-workflow-and-stable-effects",
+        [
+            {
+                "tool": "create_concepts",
+                "status": "ok",
+                "effect_id": "effect_created",
+                "effect_status": "succeeded",
+                "changed": True,
+                "result_target_ids": ["#V#created"],
+            },
+            {
+                "tool": "create_concepts",
+                "status": "error",
+                "effect_id": "effect_unstarted",
+                "effect_status": "failed",
+                "changed": False,
+                "mutation_outcome": "not_started",
+                "outcome_finality": "terminal_for_turn",
+                "error_code": "insufficient_effect_window",
+                "transport": {"outcome": "not_started"},
+            },
+            {
+                "tool": "fetch_concept",
+                "status": "ok",
+                "effective_arguments": {"concept_id": "#V#created"},
+                "effective_payload": {
+                    "success": True,
+                    "concept_id": "#V#created",
+                },
+            },
+        ],
+        selected_workflow_trace={
+            "workflow_required_effects_contract": {
+                "schema_version": "workflow_required_effects_contract.v1",
+                "contract_id": "bounded-readback",
+                "required_effects": [
+                    {
+                        "effect_id": "workflow_readback",
+                        "effect_type": "tool_execution",
+                        "required_tools": ["fetch_concept"],
+                    }
+                ],
+            }
+        },
+    )
+
+    effects = {
+        item["effect_id"]: item["status"]
+        for item in record["required_effects"]
+        if item["effect_id"]
+        in {"workflow_readback", "effect_created", "effect_unstarted"}
+    }
+    assert effects == {
+        "workflow_readback": "satisfied",
+        "effect_created": "satisfied",
+        "effect_unstarted": "not_executed",
+    }
+    assert record["completion_gate"]["safe_to_claim_completion"] is False
 
 
 def test_timeout_transport_metadata_survives_durable_turn_record_readback(

--- a/tests/frontend/chatAttachmentWorkflowInput.test.js
+++ b/tests/frontend/chatAttachmentWorkflowInput.test.js
@@ -45,6 +45,11 @@ describe('chat attachment workflow input binding', () => {
             </div>
             <button id="sendButton"></button>
             <textarea id="promptInput"></textarea>
+            <div id="chatAttachmentStatus" class="chat-attachment-status hidden">
+                <span id="uploadFileStatus" class="upload-file-status"></span>
+                <span id="pendingAttachmentStatus" class="pending-attachment-status hidden"></span>
+            </div>
+            <button id="uploadFileButton">Upload File</button>
             <input type="checkbox" id="annotationToggle" />
         `;
 
@@ -130,13 +135,20 @@ describe('chat attachment workflow input binding', () => {
                 type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
             }
         );
+        const promptInput = document.getElementById('promptInput');
+        promptInput.value = 'Represent the PhD students and supervision information.';
         await __testOnly_uploadFilesToVon([uploadedFile]);
 
-        const promptInput = document.getElementById('promptInput');
-        expect(promptInput.value).toContain('Attached file uploaded.');
+        expect(promptInput.value).toBe(
+            'Represent the PhD students and supervision information.'
+        );
         expect(promptInput.value).not.toContain('supervision.xlsx');
         expect(promptInput.value).not.toContain(fileCopyConceptId);
-        promptInput.value += '\nRepresent the PhD students and supervision information.';
+        const pendingAttachmentStatus = document.getElementById(
+            'pendingAttachmentStatus'
+        );
+        expect(pendingAttachmentStatus.classList.contains('hidden')).toBe(false);
+        expect(pendingAttachmentStatus.textContent).toContain('supervision.xlsx');
 
         await sendMessage();
 
@@ -146,12 +158,262 @@ describe('chat attachment workflow input binding', () => {
         });
         expect(generateBodies[0].prompt).not.toContain(fileCopyConceptId);
         expect(generateBodies[0].prompt).not.toContain('supervision.xlsx');
+        expect(pendingAttachmentStatus.classList.contains('hidden')).toBe(true);
 
         promptInput.value = 'A separate follow-up without an attachment.';
         await sendMessage();
 
         expect(generateBodies).toHaveLength(2);
         expect(generateBodies[1]).not.toHaveProperty('workflow_inputs');
+    }, 15000);
+
+    test('a slow upload exposes progress and coalesces repeated attachment actions', async () => {
+        const { __testOnly_uploadFilesToVon } = require(chatTabModulePath);
+        const fileCopyConceptId = '#V#uploaded_file_copy_slow_guard_test';
+        let resolveUpload;
+        let uploadFetchCount = 0;
+        const uploadResponse = new Promise((resolve) => {
+            resolveUpload = resolve;
+        });
+
+        global.fetch = jest.fn((url, options = {}) => {
+            if (url === '/von/api/files/upload') {
+                uploadFetchCount += 1;
+                return uploadResponse;
+            }
+            if (typeof url === 'string' && url.startsWith('/von/api/render_markdown')) {
+                const body = JSON.parse(options.body || '{}');
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ html: String(body.text || '') })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ history_length: 0, authenticated: true })
+                });
+            }
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        const uploadedFile = new File(
+            ['candidate,supervisor\nExample,Professor Example\n'],
+            'slow-supervision.xlsx',
+            {
+                type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                lastModified: 1785167279463
+            }
+        );
+        const promptInput = document.getElementById('promptInput');
+        promptInput.value = 'Keep this draft exactly as written.';
+
+        const firstUpload = __testOnly_uploadFilesToVon([uploadedFile]);
+        await Promise.resolve();
+        const repeatedUpload = __testOnly_uploadFilesToVon([uploadedFile]);
+
+        expect(repeatedUpload).toBe(firstUpload);
+        expect(uploadFetchCount).toBe(1);
+        expect(promptInput.value).toBe('Keep this draft exactly as written.');
+        expect(document.getElementById('chatAttachmentStatus').classList.contains('hidden')).toBe(false);
+        expect(document.getElementById('uploadFileStatus').textContent).toContain(
+            'already in progress'
+        );
+        expect(document.getElementById('uploadFileButton').disabled).toBe(true);
+
+        resolveUpload({
+            ok: true,
+            json: async () => ({
+                success: true,
+                uploaded: {
+                    concept_id: fileCopyConceptId,
+                    type_concept_id: '#V#computer_file_copy'
+                },
+                storage: {
+                    backend: 'test',
+                    key: 'uploads/test/slow-supervision.xlsx'
+                },
+                chat_history_recorded: true
+            })
+        });
+        await Promise.all([firstUpload, repeatedUpload]);
+        await Promise.resolve();
+
+        expect(uploadFetchCount).toBe(1);
+        expect(promptInput.value).toBe('Keep this draft exactly as written.');
+        expect(document.getElementById('uploadFileButton').disabled).toBe(false);
+        expect(document.getElementById('pendingAttachmentStatus').textContent).toContain(
+            'slow-supervision.xlsx'
+        );
+        const confirmationCount = (
+            document.getElementById('scrollableField').textContent.match(
+                /File uploaded and registered as/g
+            ) || []
+        ).length;
+        expect(confirmationCount).toBe(1);
+    }, 15000);
+
+    test('uploads independently in two conversations without discarding either file', async () => {
+        const {
+            __testOnly_setActiveChatSession,
+            __testOnly_uploadFilesToVon
+        } = require(chatTabModulePath);
+        const deferredUploads = new Map();
+        const uploadFileNames = [];
+
+        global.fetch = jest.fn((url, options = {}) => {
+            if (url === '/von/api/files/upload') {
+                const fileName = options.body.get('file').name;
+                uploadFileNames.push(fileName);
+                return new Promise((resolve) => {
+                    deferredUploads.set(fileName, resolve);
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/api/render_markdown')) {
+                const body = JSON.parse(options.body || '{}');
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ html: String(body.text || '') })
+                });
+            }
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        const fileA = new File(['A'], 'conversation-a.xlsx', {
+            type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        });
+        const fileB = new File(['B'], 'conversation-b.xlsx', {
+            type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        });
+
+        const uploadA = __testOnly_uploadFilesToVon([fileA]);
+        await Promise.resolve();
+        __testOnly_setActiveChatSession('conversation-b', 'Conversation B');
+        expect(document.getElementById('uploadFileButton').disabled).toBe(false);
+
+        const uploadB = __testOnly_uploadFilesToVon([fileB]);
+        await Promise.resolve();
+
+        expect(uploadB).not.toBe(uploadA);
+        expect(uploadFileNames).toEqual([
+            'conversation-a.xlsx',
+            'conversation-b.xlsx'
+        ]);
+
+        deferredUploads.get('conversation-b.xlsx')({
+            ok: true,
+            json: async () => ({
+                success: true,
+                uploaded: {
+                    concept_id: '#V#uploaded_file_copy_conversation_b',
+                    type_concept_id: '#V#computer_file_copy'
+                },
+                storage: {
+                    backend: 'test',
+                    key: 'uploads/test/conversation-b.xlsx'
+                },
+                chat_history_recorded: true
+            })
+        });
+        await uploadB;
+        expect(document.getElementById('pendingAttachmentStatus').textContent).toContain(
+            'conversation-b.xlsx'
+        );
+
+        deferredUploads.get('conversation-a.xlsx')({
+            ok: true,
+            json: async () => ({
+                success: true,
+                uploaded: {
+                    concept_id: '#V#uploaded_file_copy_conversation_a',
+                    type_concept_id: '#V#computer_file_copy'
+                },
+                storage: {
+                    backend: 'test',
+                    key: 'uploads/test/conversation-a.xlsx'
+                },
+                chat_history_recorded: true
+            })
+        });
+        await uploadA;
+
+        expect(document.getElementById('pendingAttachmentStatus').textContent).toContain(
+            'conversation-b.xlsx'
+        );
+        __testOnly_setActiveChatSession('attachment-session', 'Attachment test');
+        expect(document.getElementById('pendingAttachmentStatus').textContent).toContain(
+            'conversation-a.xlsx'
+        );
+    }, 15000);
+
+    test('does not leak upload progress or completion into another conversation', async () => {
+        const {
+            __testOnly_setActiveChatSession,
+            __testOnly_uploadFilesToVon
+        } = require(chatTabModulePath);
+        let resolveUpload;
+        const uploadResponse = new Promise((resolve) => {
+            resolveUpload = resolve;
+        });
+
+        global.fetch = jest.fn((url, options = {}) => {
+            if (url === '/von/api/files/upload') {
+                return uploadResponse;
+            }
+            if (typeof url === 'string' && url.startsWith('/von/api/render_markdown')) {
+                const body = JSON.parse(options.body || '{}');
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ html: String(body.text || '') })
+                });
+            }
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        const uploadedFile = new File(['A'], 'stay-in-a.xlsx', {
+            type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        });
+        const upload = __testOnly_uploadFilesToVon([uploadedFile]);
+        await Promise.resolve();
+        expect(document.getElementById('uploadFileStatus').textContent).toContain(
+            'stay-in-a.xlsx'
+        );
+
+        __testOnly_setActiveChatSession('conversation-b', 'Conversation B');
+        document.getElementById('scrollableField').textContent = '';
+        expect(document.getElementById('uploadFileStatus').textContent).toBe('');
+        expect(document.getElementById('uploadFileButton').disabled).toBe(false);
+
+        resolveUpload({
+            ok: true,
+            json: async () => ({
+                success: true,
+                uploaded: {
+                    concept_id: '#V#uploaded_file_copy_stay_in_a',
+                    type_concept_id: '#V#computer_file_copy'
+                },
+                storage: {
+                    backend: 'test',
+                    key: 'uploads/test/stay-in-a.xlsx'
+                },
+                chat_history_recorded: true
+            })
+        });
+        await upload;
+
+        expect(document.getElementById('uploadFileStatus').textContent).toBe('');
+        expect(document.getElementById('pendingAttachmentStatus').classList.contains('hidden')).toBe(true);
+        expect(document.getElementById('scrollableField').textContent).not.toContain(
+            'File uploaded and registered as'
+        );
+
+        __testOnly_setActiveChatSession('attachment-session', 'Attachment test');
+        expect(document.getElementById('uploadFileStatus').textContent).toContain(
+            'Upload complete'
+        );
+        expect(document.getElementById('pendingAttachmentStatus').textContent).toContain(
+            'stay-in-a.xlsx'
+        );
     }, 15000);
 
     test('a rejected generate request retains the attachment for retry', async () => {
@@ -220,11 +482,17 @@ describe('chat attachment workflow input binding', () => {
         await __testOnly_uploadFilesToVon([uploadedFile]);
 
         const promptInput = document.getElementById('promptInput');
-        promptInput.value += '\nRepresent this spreadsheet.';
+        const pendingAttachmentStatus = document.getElementById(
+            'pendingAttachmentStatus'
+        );
+        promptInput.value = 'Represent this spreadsheet.';
         await sendMessage();
+        expect(pendingAttachmentStatus.classList.contains('hidden')).toBe(false);
+        expect(pendingAttachmentStatus.textContent).toContain('retry.xlsx');
 
         promptInput.value = 'Retry the spreadsheet representation.';
         await sendMessage();
+        expect(pendingAttachmentStatus.classList.contains('hidden')).toBe(true);
 
         expect(generateBodies).toHaveLength(2);
         expect(generateBodies[0].workflow_inputs).toEqual({
@@ -295,11 +563,18 @@ describe('chat attachment workflow input binding', () => {
         await __testOnly_uploadFilesToVon([uploadedFile]);
 
         const promptInput = document.getElementById('promptInput');
+        const pendingAttachmentStatus = document.getElementById(
+            'pendingAttachmentStatus'
+        );
+        expect(pendingAttachmentStatus.textContent).toContain('session.xlsx');
         __testOnly_setActiveChatSession('unrelated-session', 'Unrelated');
+        expect(pendingAttachmentStatus.classList.contains('hidden')).toBe(true);
         promptInput.value = 'An unrelated question.';
         await sendMessage();
 
         __testOnly_setActiveChatSession('attachment-session', 'Attachment test');
+        expect(pendingAttachmentStatus.classList.contains('hidden')).toBe(false);
+        expect(pendingAttachmentStatus.textContent).toContain('session.xlsx');
         promptInput.value = 'Represent the uploaded spreadsheet.';
         await sendMessage();
 

--- a/tests/frontend/chatDisplayElementOwnership.test.js
+++ b/tests/frontend/chatDisplayElementOwnership.test.js
@@ -1,0 +1,320 @@
+/** @jest-environment jsdom */
+
+const chatTabModulePath = '../../src/frontend/web/von_interface/static/js/chatTab.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    annotateTurn: jest.fn(),
+    getUserContext: jest.fn(),
+    getWindowSessionId: jest.fn(() => 'window-display-ownership-test')
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
+    elements: {},
+    renderSpanSuggestions: jest.fn(),
+    getCurrentUserConceptId: jest.fn(() => null)
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/utils/textDecorator.js', () => ({
+    applyCartoucheAppearance: jest.fn(),
+    cartouchifyElementText: jest.fn(),
+    cartouchifyVontologyTokensInElement: jest.fn(),
+    createVontologyAliasCartouche: jest.fn(),
+    createVontologyCartouche: jest.fn(),
+    findPotentialConceptAliasMatches: jest.fn(() => []),
+    getCartoucheAppearanceSettings: jest.fn(() => ({})),
+    linkifyVontologyTokensInElement: jest.fn(),
+    normalisePotentialConceptAlias: jest.fn((value) => value),
+    normalisePotentialConceptId: jest.fn((value) => value),
+    replaceTextNodeWithVontologyAliasCartouches: jest.fn(() => [])
+}));
+
+const {
+    __testOnly_renderDisplayElementsIntoContainer
+} = require(chatTabModulePath);
+
+function buildTablePayload(label, value) {
+    return {
+        columns: [
+            { column_id: 'name', label: 'Name', data_type: 'text' },
+            { column_id: 'status', label: 'Status', data_type: 'text' }
+        ],
+        rows: [
+            {
+                row_id: `row_${label}`,
+                cells: [
+                    {
+                        column_id: 'name',
+                        value_raw: label,
+                        value_display: label,
+                        value_type: 'text'
+                    },
+                    {
+                        column_id: 'status',
+                        value_raw: value,
+                        value_display: value,
+                        value_type: 'text'
+                    }
+                ]
+            }
+        ]
+    };
+}
+
+describe('chat display-element renderer ownership', () => {
+    test('keeps inline-derived tables primary while rendering explicit structured tables', () => {
+        const container = document.createElement('div');
+        container.dataset.renderMode = 'rendered';
+        container.dataset.originalText = [
+            'Before the tables.',
+            '| Name | Status |',
+            '| --- | --- |',
+            '| Alpha | **Yes** |',
+            '',
+            '| Name | Status |',
+            '| --- | --- |',
+            '| Beta | `pending` |',
+            'After the tables.'
+        ].join('\n');
+        container.innerHTML = [
+            '<p>Before the tables.</p>',
+            '<table class="inline-primary-table"><tbody><tr><td>Alpha</td><td><strong>Yes</strong></td></tr></tbody></table>',
+            '<table class="inline-primary-table"><tbody><tr><td>Beta</td><td><code>pending</code></td></tr></tbody></table>',
+            '<p>After the tables.</p>'
+        ].join('');
+
+        __testOnly_renderDisplayElementsIntoContainer(container, {
+            display_elements: {
+                schema_version: 'turn_display_elements_v1',
+                elements: [
+                    {
+                        element_id: 'screen_text',
+                        element_type: 'text_block',
+                        channel: 'screen',
+                        order: 10,
+                        intent: 'primary_response',
+                        payload: { text: container.dataset.originalText },
+                        provenance: { source: 'response_text' }
+                    },
+                    {
+                        element_id: 'screen_table_1',
+                        element_type: 'table',
+                        channel: 'screen',
+                        order: 16,
+                        intent: 'structured_tabular_view',
+                        payload: {
+                            ...buildTablePayload('Alpha', '**Yes**'),
+                            source_span: { start_line: 2, end_line: 4 }
+                        },
+                        presentation: {
+                            mode: 'inline_primary',
+                            source_element_id: 'screen_text',
+                            source_span: { start_line: 2, end_line: 4 }
+                        },
+                        provenance: {
+                            source: 'screen_markdown_table',
+                            table_index: 1
+                        }
+                    },
+                    {
+                        element_id: 'screen_table_2',
+                        element_type: 'table',
+                        channel: 'screen',
+                        order: 17,
+                        intent: 'structured_tabular_view',
+                        payload: {
+                            ...buildTablePayload('Beta', '`pending`'),
+                            source_span: { start_line: 6, end_line: 8 }
+                        },
+                        provenance: {
+                            source: 'screen_markdown_table',
+                            table_index: 2
+                        }
+                    },
+                    {
+                        element_id: 'screen_structured_table_1',
+                        element_type: 'table',
+                        channel: 'screen',
+                        order: 18,
+                        intent: 'structured_tabular_view',
+                        payload: {
+                            ...buildTablePayload('Alpha', 'Yes with provenance'),
+                            title: 'Explicit comparison'
+                        },
+                        presentation: { mode: 'augment' },
+                        provenance: {
+                            source: 'screen_structured_table',
+                            table_index: 1
+                        }
+                    }
+                ]
+            }
+        });
+
+        expect(container.dataset.inlinePrimaryTableCount).toBe('2');
+        expect(container.querySelectorAll('.inline-primary-table')).toHaveLength(2);
+        expect(container.querySelectorAll('.chat-display-elements-table')).toHaveLength(1);
+        expect(
+            container.querySelector('.chat-display-elements-table-title').textContent
+        ).toBe('Explicit comparison');
+        expect(container.textContent).toContain('Before the tables.');
+        expect(container.textContent).toContain('After the tables.');
+        expect(container.textContent).toContain('Yes with provenance');
+        expect(container.textContent).not.toContain('**Yes**');
+        expect(container.textContent).not.toContain('`pending`');
+    });
+
+    test('raw view remains faithful and never appends display cards', () => {
+        const originalText = [
+            'Before.',
+            '| Name | Status |',
+            '| --- | --- |',
+            '| Alpha | **Yes** |',
+            'After.'
+        ].join('\n');
+        const container = document.createElement('div');
+        container.dataset.renderMode = 'text';
+        container.dataset.originalText = originalText;
+        container.textContent = originalText;
+
+        __testOnly_renderDisplayElementsIntoContainer(container, {
+            display_elements: {
+                schema_version: 'turn_display_elements_v1',
+                elements: [
+                    {
+                        element_id: 'screen_table_1',
+                        element_type: 'table',
+                        channel: 'screen',
+                        order: 16,
+                        intent: 'structured_tabular_view',
+                        payload: {
+                            ...buildTablePayload('Alpha', '**Yes**'),
+                            source_span: { start_line: 2, end_line: 4 }
+                        },
+                        presentation: {
+                            mode: 'inline_primary',
+                            source_element_id: 'screen_text',
+                            source_span: { start_line: 2, end_line: 4 }
+                        },
+                        provenance: { source: 'screen_markdown_table' }
+                    }
+                ]
+            }
+        });
+
+        expect(container.textContent).toBe(originalText);
+        expect(container.querySelector('.chat-display-elements')).toBeNull();
+    });
+
+    test('keeps structured fallback when the declared inline source is missing', () => {
+        const originalText = [
+            '| Name | Status |',
+            '| --- | --- |',
+            '| Alpha | Yes |'
+        ].join('\n');
+        const container = document.createElement('div');
+        container.dataset.renderMode = 'rendered';
+        container.dataset.originalText = originalText;
+        container.innerHTML = '<table><tbody><tr><td>Alpha</td><td>Yes</td></tr></tbody></table>';
+
+        __testOnly_renderDisplayElementsIntoContainer(container, {
+            display_elements: {
+                schema_version: 'turn_display_elements_v1',
+                elements: [
+                    {
+                        element_id: 'screen_table_1',
+                        element_type: 'table',
+                        channel: 'screen',
+                        order: 16,
+                        intent: 'structured_tabular_view',
+                        payload: {
+                            ...buildTablePayload('Alpha', 'Yes'),
+                            source_span: { start_line: 1, end_line: 3 }
+                        },
+                        presentation: {
+                            mode: 'inline_primary',
+                            source_element_id: 'missing_text',
+                            source_span: { start_line: 1, end_line: 3 }
+                        },
+                        provenance: { source: 'screen_markdown_table' }
+                    }
+                ]
+            }
+        });
+
+        expect(container.dataset.inlinePrimaryTableCount).toBe('0');
+        expect(container.querySelectorAll('table')).toHaveLength(2);
+        expect(container.querySelector('.chat-display-elements-table')).not.toBeNull();
+    });
+
+    test('keeps all structured fallbacks when inline table rendering is incomplete', () => {
+        const originalText = [
+            '| Name | Status |',
+            '| --- | --- |',
+            '| Alpha | Yes |',
+            '',
+            '| Name | Status |',
+            '| --- | --- |',
+            '| Beta | pending |'
+        ].join('\n');
+        const container = document.createElement('div');
+        container.dataset.renderMode = 'rendered';
+        container.dataset.originalText = originalText;
+        container.innerHTML = '<table><tbody><tr><td>Alpha</td><td>Yes</td></tr></tbody></table>';
+
+        __testOnly_renderDisplayElementsIntoContainer(container, {
+            display_elements: {
+                schema_version: 'turn_display_elements_v1',
+                elements: [
+                    {
+                        element_id: 'screen_text',
+                        element_type: 'text_block',
+                        channel: 'screen',
+                        order: 10,
+                        intent: 'primary_response',
+                        payload: { text: originalText },
+                        provenance: { source: 'response_text' }
+                    },
+                    {
+                        element_id: 'screen_table_1',
+                        element_type: 'table',
+                        channel: 'screen',
+                        order: 16,
+                        intent: 'structured_tabular_view',
+                        payload: {
+                            ...buildTablePayload('Alpha', 'Yes'),
+                            source_span: { start_line: 1, end_line: 3 }
+                        },
+                        presentation: {
+                            mode: 'inline_primary',
+                            source_element_id: 'screen_text',
+                            source_span: { start_line: 1, end_line: 3 }
+                        },
+                        provenance: { source: 'screen_markdown_table' }
+                    },
+                    {
+                        element_id: 'screen_table_2',
+                        element_type: 'table',
+                        channel: 'screen',
+                        order: 17,
+                        intent: 'structured_tabular_view',
+                        payload: {
+                            ...buildTablePayload('Beta', 'pending'),
+                            source_span: { start_line: 5, end_line: 7 }
+                        },
+                        presentation: {
+                            mode: 'inline_primary',
+                            source_element_id: 'screen_text',
+                            source_span: { start_line: 5, end_line: 7 }
+                        },
+                        provenance: { source: 'screen_markdown_table' }
+                    }
+                ]
+            }
+        });
+
+        expect(container.dataset.inlinePrimaryTableCount).toBe('0');
+        expect(container.querySelectorAll('.chat-display-elements-table')).toHaveLength(2);
+        expect(container.textContent).toContain('Alpha');
+        expect(container.textContent).toContain('Beta');
+    });
+});

--- a/tests/frontend/chatTabMarkdownRender.test.js
+++ b/tests/frontend/chatTabMarkdownRender.test.js
@@ -767,6 +767,63 @@ describe('chat markdown rendering (assistant)', () => {
             '</tbody>',
             '</table>'
         ].join('');
+        const displayElements = {
+            schema_version: 'turn_display_elements_v1',
+            elements: [
+                {
+                    element_id: 'screen_text',
+                    element_type: 'text_block',
+                    channel: 'screen',
+                    order: 10,
+                    intent: 'primary_response',
+                    payload: { text: assistantResponse },
+                    provenance: { source: 'response_text' }
+                },
+                {
+                    element_id: 'screen_table_1',
+                    element_type: 'table',
+                    channel: 'screen',
+                    order: 16,
+                    intent: 'structured_tabular_view',
+                    payload: {
+                        columns: [
+                            { column_id: 'name', label: 'Name', data_type: 'text' },
+                            { column_id: 'degree', label: 'Degree', data_type: 'text' },
+                            { column_id: 'role', label: 'Role', data_type: 'text' }
+                        ],
+                        rows: [
+                            {
+                                row_id: 'row_1',
+                                cells: [
+                                    { column_id: 'name', value_raw: 'Alice', value_display: 'Alice', value_type: 'text' },
+                                    { column_id: 'degree', value_raw: 'PhD', value_display: 'PhD', value_type: 'text' },
+                                    { column_id: 'role', value_raw: 'Student', value_display: 'Student', value_type: 'text' }
+                                ]
+                            },
+                            {
+                                row_id: 'row_2',
+                                cells: [
+                                    { column_id: 'name', value_raw: 'Bob', value_display: 'Bob', value_type: 'text' },
+                                    { column_id: 'degree', value_raw: 'MSc', value_display: 'MSc', value_type: 'text' },
+                                    { column_id: 'role', value_raw: 'Tutor', value_display: 'Tutor', value_type: 'text' }
+                                ]
+                            }
+                        ]
+                    },
+                    presentation: {
+                        mode: 'inline_primary',
+                        source_element_id: 'screen_text',
+                        source_span: { start_line: 1, end_line: 4 }
+                    },
+                    provenance: {
+                        source: 'screen_markdown_table',
+                        table_index: 1
+                    }
+                }
+            ],
+            reason_codes: ['screen_markdown_tables_detected'],
+            validation: { valid: true, errors: [] }
+        };
 
         global.fetch = jest.fn((url) => {
             const common = mockCommonChatSessionResponse(url);
@@ -791,7 +848,11 @@ describe('chat markdown rendering (assistant)', () => {
                     ok: true,
                     json: async () => ({
                         response: assistantResponse,
-                        llm_debug: { model: 'gpt-5.4-mini-2026-03-17' }
+                        display_elements: displayElements,
+                        llm_debug: {
+                            model: 'gpt-5.4-mini-2026-03-17',
+                            display_elements: displayElements
+                        }
                     })
                 });
             }
@@ -806,6 +867,9 @@ describe('chat markdown rendering (assistant)', () => {
         const assistantMarkdown = scrollableField.querySelector('.chat-markdown.markdown-rendered');
         expect(assistantMarkdown).not.toBeNull();
         expect(assistantMarkdown.querySelector('table')).not.toBeNull();
+        expect(assistantMarkdown.querySelectorAll('table')).toHaveLength(1);
+        expect(assistantMarkdown.querySelector('.chat-display-elements-table')).toBeNull();
+        expect(assistantMarkdown.dataset.inlinePrimaryTableCount).toBe('1');
         expect(assistantMarkdown.textContent).toContain('Alice');
 
         const assistantContainer = assistantMarkdown.closest('.message-container');
@@ -829,6 +893,8 @@ describe('chat markdown rendering (assistant)', () => {
         expect(assistantMarkdown.dataset.renderMode).toBe('rendered');
         expect(assistantMarkdown.classList.contains('chat-markdown')).toBe(true);
         expect(assistantMarkdown.querySelector('table')).not.toBeNull();
+        expect(assistantMarkdown.querySelectorAll('table')).toHaveLength(1);
+        expect(assistantMarkdown.querySelector('.chat-display-elements-table')).toBeNull();
         expect(renderBadge.textContent).toContain('View: Rendered');
         expect(toggleButton.textContent).toBe('Text');
     });


### PR DESCRIPTION
## Summary

This stacked draft carries the next JVNAUTOSCI-2600 A3 revision on top of `codex/JVNAUTOSCI-2600-a3r6-mechanical-revise`. It also retains the already-reviewed JVNAUTOSCI-2605/2606 chat UI hardening commit in the stack.

### What changed

- add actor-scoped arXiv external identity normalisation, indexed candidate lookup, atomic stable-ID creation, ambiguity blocking, and identity-name persistence
- give ordered durable effects independent admission decisions and reserve a final-answer window
- preserve failed, partial, indeterminate, and not-started receipts through turn finality
- report pre-dispatch not-started effects accurately as unchanged and retryable
- support model-facing root evidence reads without changing RFC JSON Pointer storage semantics
- require exact source-predicate-target tuples for relationship postcondition verification

### Why

A3r6 showed that title-derived identity could duplicate one paper, effect time could be exhausted before writes, root evidence could be discarded, and completion projection could miss attempted effects. This revision addresses those mechanical failures without moving paper- or scenario-specific semantic policy into Python.

## Validation

- identity/catalogue/suffix: 60 passed
- adaptive/effect/transport/evidence: 203 passed
- parent recovery: 8 passed
- route-facing generate: 16 passed
- total focused/regression: **287 passed**
- Ruff, Python compilation, and `git diff --check`: passed
- exact clean agent-test server on port 5014 reported commit `fcee7225a472260411557e04efd0ff47dd1ffb3b`

## Disclosed live evidence

Verdict: **REVISE**. All three original Terra prompts were run once with no retry.

- Case 1 honestly failed but created a new Bayesian-paper title variant after external-identity attempts rejected `#V#scholarly_paper`.
- Case 2 made useful source-qualified updates and created no third coral paper, but its new relationship was not completed.
- Case 3 attempted nine structural edges; all failed because their predicates did not yet exist, and canonical read-back confirmed no graph change.
- The two existing coral records and all other evidence-bearing duplicates were preserved.

This is a reviewable mechanical revision, not a frozen candidate. No merge, holdout, shadow, cutover, release, duplicate reconciliation, or A4 advancement is proposed.