### PR TITLE
Allow slower launcher health initialisation

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -39,7 +39,7 @@ FOLLOW=0
 LOG_RETENTION=20
 ADMIN_TOKEN=""
 SKIP_HEALTH=0
-HEALTH_TIMEOUT_SEC=60
+HEALTH_TIMEOUT_SEC=180
 HEALTH_GRACE_SEC=45
 BACKUP_DRY_RUN=0
 BACKUP_TAG="manual"
@@ -3511,7 +3511,7 @@ Von Launcher Help
         -LogRetention <n>
         -AdminToken <token>
         -SkipHealth
-        -HealthTimeoutSec <n>
+        -HealthTimeoutSec <n>  Initial health wait in seconds (default 180)
         -HealthGraceSec <n>
         -ReadyLogPatterns <p>
         -DisableLogReady

--- a/tests/test_run_sh_start_behaviour.py
+++ b/tests/test_run_sh_start_behaviour.py
@@ -40,6 +40,19 @@ def shlex_quote(value: str) -> str:
     return "'" + value.replace("'", "'\"'\"'") + "'"
 
 
+def test_run_sh_default_health_timeout_covers_slow_startup() -> None:
+    payload = _run_bash_probe(
+        r"""
+python3 - <<PY
+import json
+print(json.dumps({"health_timeout_seconds": int("$HEALTH_TIMEOUT_SEC")}))
+PY
+"""
+    )
+
+    assert payload == {"health_timeout_seconds": 180}
+
+
 def _prepare_backup_launcher(
     tmp_path: Path,
     *,


### PR DESCRIPTION
## What changed

- Increase the POSIX launcher's initial health wait from 60 to 180 seconds.
- Show the 180-second default in launcher help.
- Add a regression test for the default.

## Why

A measured healthy startup took 66.1 seconds, so the old 60-second default could report failure while Von was still initialising. The longer default retains the explicit `-HealthTimeoutSec` override and the existing health-grace behaviour.

## Validation

- `29 passed` in `tests/test_run_sh_start_behaviour.py`
- `bash -n run.sh`
- `git diff --check origin/main...HEAD`
- launcher help read-back shows the 180-second default

`uv.lock` is unrelated generated local residue and is not included.