### PR TITLE
Update retired-controller tests for situation carriers

### DIFF
--- a/tests/backend/test_von_generate_workflow_instances.py
+++ b/tests/backend/test_von_generate_workflow_instances.py
@@ -119,8 +119,11 @@ def app(monkeypatch: pytest.MonkeyPatch) -> Flask:
     )
     monkeypatch.setattr(
         von_routes.chat_history_service,
-        "get_chat_history",
-        lambda *_args, **_kwargs: [],
+        "get_chat_history_session_state",
+        lambda **kwargs: {
+            "session_id": kwargs["session_id"],
+            "history": [],
+        },
     )
     monkeypatch.setattr(
         von_routes,
@@ -308,14 +311,17 @@ def test_generate_threads_actor_namespace_through_history_reads_and_persistence(
     history_reads: list[dict[str, Any]] = []
     history_writes: list[dict[str, Any]] = []
 
-    def _get_chat_history(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
-        history_reads.append({"args": args, **kwargs})
-        return []
+    def _get_chat_history_session_state(**kwargs: Any) -> dict[str, Any]:
+        history_reads.append(dict(kwargs))
+        return {
+            "session_id": kwargs["session_id"],
+            "history": [],
+        }
 
     monkeypatch.setattr(
         von_routes.chat_history_service,
-        "get_chat_history",
-        _get_chat_history,
+        "get_chat_history_session_state",
+        _get_chat_history_session_state,
     )
     monkeypatch.setattr(
         von_routes,


### PR DESCRIPTION
## What changed

Update the ordinary-generation test fixture to stub the canonical `get_chat_history_session_state` carrier read introduced by the conversation-situation work, rather than the retired message-only `get_chat_history` call.

## Why

The tests that prove ordinary turns do not instantiate the retired universal conversation controller were failing before reaching that assertion because their mock history collection rejected production-only Mongo query comments. A second namespace-propagation test was still observing the obsolete read seam.

This changes test support only; production behaviour is unchanged.

## Validation

- `27 passed` across:
  - `test_von_generate_workflow_instances.py`
  - `test_conversation_turn_workflow_vontology_service.py`
  - `test_workflow_turn_capability_service.py`
- Ruff passed
- `git diff --check` passed