### PR TITLE
Clarify delivery decision discipline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,13 @@
+> **Merge impact — complete before implementation detail:** If this PR merged
+> now, what concrete user or operational outcome would become true?
+>
+> Replace this line with one ordinary sentence: `Merge decision: ready — ...`
+> or `Merge decision: not ready — ...`. Review it as prose; do not automate it
+> as a merge gate.
+>
+> A remaining observation blocks merge only when evidence shows that it defeats
+> a minimum ship criterion or satisfies a stated stop-ship condition.
+
 ## User outcome
 
 What user or operational job improves, and why is the change needed?
@@ -17,8 +27,15 @@ and recoverable approach is inadequate. Scope the control to that failure mode.
 What was actually run or inspected, and what scope does that evidence support?
 Include the nearest faithful user path when the claim is user-visible.
 
-## Decision boundary
+## Ship boundary
 
-State any human gate, unmerged experiment, activation step, unresolved
-uncertainty, or follow-up needed. Do not mark inapplicable subsystems or tests
-merely to complete a template.
+- **Minimum ship criteria:** Smallest outcome and evidence sufficient to merge.
+- **Stop-ship conditions:** Concrete material conditions that would defeat
+  those criteria.
+- **Non-blocking observations:** Known limitations, measurements, or questions
+  that do not defeat the criteria.
+- **Non-goals:** Nearby work deliberately outside this PR.
+
+Classify any human gate, experiment, activation step, unresolved uncertainty,
+or follow-up under its actual effect on this boundary. Do not invent entries or
+mark inapplicable subsystems merely to complete the template.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 - **Lifecycle:** Active
 - **Authority:** Governing instructions for work in this repository, subordinate
   to current explicit user direction and higher-level safety rules
-- **Last reviewed:** 29 July 2026
+- **Last reviewed:** 1 August 2026
 - **Review trigger:** A material change to Von's product focus, authority model,
   security posture, or acceptance doctrine
 
@@ -161,12 +161,21 @@ never be forced onto newer evidence.
     unavailable, or authority is missing. Preserve an unanswered material
     question in the shared situation and continue independent useful work; do
     not turn elicitation into performative confirmation.
-12. **Evidence proportional to the claim.** Do not demand release-grade proof
-    for a mechanical change, and do not claim end-to-end success from a unit
-    test. Match validation cost to risk and asserted scope.
-13. **Measure architectural value.** When a represented layer or extra stage is
-    material, compare it with the best fair simpler baseline and include
-    latency, cost, human burden, failure recovery, and maintenance impact.
+12. **Evidence and stopping rule proportional to the claim.** Choose the
+    bounded claim and lowest adequate validation tier before testing. For a
+    bounded, observable, and recoverable change, proceed when the evidence
+    supports a likely net improvement over the fair baseline and no
+    demonstrated material regression remains on the affected path. Do not
+    require perfect stochastic behaviour or repair of unrelated, pre-existing,
+    or merely possible defects. Bound the claim and report material
+    limitations. Stop gathering evidence when another check is unlikely to
+    change the delivery or rollback decision.
+13. **Measure architectural value.** When claiming that a represented layer or
+    extra stage adds material value, compare it with the best fair simpler
+    baseline using existing evidence or the smallest bounded measurement that
+    distinguishes the claim. Include latency, cost, human burden, failure
+    recovery, and maintenance impact where material; a layer change does not by
+    itself require a live multi-arm campaign.
 14. **Prefer subtraction.** Remove obsolete stages, fallbacks, prompts, tools,
     tests, and documentation when evidence shows they add cost without value.
 15. **Preserve contextual degrees of freedom.** When work changes durable
@@ -223,14 +232,33 @@ job and work product; task authority and any material effect; the simplest fair
 baseline and chosen authority surface; recovery or escalation where genuinely
 material; and evidence proportionate to the claim. Omit irrelevant fields.
 
-This is a short planning aid, not a production schema or an invitation to add
-an orchestration layer. Materialise it only when runtime discovery, execution,
-governance, or repeated evaluation actually consumes it.
+Before substantial implementation, state the current delivery decision and the
+minimum evidence that would change it in the existing working note, Jira task,
+pull request, or user update. Whenever a material new observation would prompt
+another patch, a broader validation campaign, or a delay, state explicitly
+whether:
+
+- `Merge decision changes — ...`
+- `Merge decision does not change — ...`
+
+For work without a merge, use the equivalent release or handoff decision. Name
+the candidate-caused material risk or invalidated claim when the decision
+changes. If it does not change, the observation must not expand the current
+work merely because it was discovered; a small already-in-scope cleanup may
+proceed, but it does not become a new acceptance gate. This classification is
+for material decision points, not every diagnostic fact.
+
+The capability-slice summary is a short planning aid, not an invitation to add
+an orchestration layer. Do not create a separate schema, required artefact, CI
+check, or runtime gate for the decision classification. Materialise other
+capability-slice fields only when runtime discovery, execution, governance, or
+repeated evaluation genuinely consumes them.
 
 ## 6. Validation tiers
 
 Choose the lowest tier that supports the claim. Higher-risk aspects of a change
-may use a higher tier without raising every aspect.
+may use a higher tier without raising every aspect. Discovery of an unrelated
+defect or desirable optimisation does not raise the tier or widen the claim.
 
 ### Tier 0: mechanical or documentation
 
@@ -281,6 +309,21 @@ administrative and scientific tasks should dominate ordinary acceptance
 evidence. Weight mistakes by credible residual consequence; do not give every
 hypothetical danger the same veto.
 
+At a merge decision, freeze the smallest coherent candidate once proportionate
+evidence shows a consequence-weighted improvement over the fair pre-change
+baseline and there is no evidence or clear causal demonstration of a new
+materially unacceptable regression. When merge is within current task
+authority, merge it and state the remaining uncertainty. Do not demand zero
+failures: isolated recoverable stochastic variation or merely imaginable
+further improvement is not evidence for another patch. Further implementation
+or validation must address an observed failure or clear causal mechanism that
+matters to the user job, or resolve a named uncertainty whose possible outcomes
+would change the merge decision; otherwise stop changing the candidate. The
+explicit statement is required at material decision points in substantial
+work, but it remains human judgement in an existing working surface, not a
+score threshold, automated release gate, new persistent schema, runtime
+mechanism, or grant of merge authority.
+
 ## 7. Security and mutations
 
 - Never print or commit secrets and never clobber `.env`.
@@ -319,15 +362,13 @@ hypothetical danger the same veto.
   macOS and Linux, except when deliberately invoking or testing another shell.
 - Search before adding helpers, tools, concepts, predicates, workflows, or
   parallel pathways.
-- Treat Atlas efficiency as a standing engineering priority. Take every
-  practical opportunity exposed by telemetry, profiling, explains, tests, or
-  real-path replays to remove wasteful query shapes, scans, index choices,
-  retries, timeouts, topology churn, and avoidable reads. Complete safe,
-  task-relevant improvements while the evidence is fresh, add proportional
-  regression coverage and observability, and create follow-up work only when
-  the improvement cannot safely be completed in the current task. Do not
-  normalise Atlas inefficiency as incidental slowness: it is a material
-  reliability and development-cost defect.
+- Treat Atlas inefficiency on the affected path as a material reliability and
+  development-cost defect. Fix it in the current task only when it is within
+  the stated user outcome and implementation scope and is required for
+  acceptance or is one small bounded change. Otherwise preserve the evidence
+  and record a limitation; create follow-up work only when a concrete
+  consequence justifies its priority. Telemetry exposing adjacent inefficiency
+  does not widen the task.
 - Preserve user-authored text unless change is requested.
 - Preserve unrelated worktree changes. Do not use `git stash` or destructive
   checkout/reset operations as a routine baseline technique; use a clean
@@ -336,6 +377,23 @@ hypothetical danger the same veto.
   path as a product defect rather than an obligation to block unrelated safe
   progress indefinitely.
 
+When creating or substantially rewriting a Jira task, make the release decision
+legible using only the parts material to that task:
+
+- the intended user outcome and simplest fair baseline;
+- the minimum ship criteria: the smallest evidence that would support delivery;
+- concrete stop-ship conditions tied to a plausible user, authority, security,
+  recovery, or operability consequence;
+- non-blocking measurements, known limitations, and evaluation questions; and
+- explicit non-goals where nearby work could otherwise inherit scope.
+
+Do not make every desirable metric, task class, model, telemetry surface, or
+future research question a conjunctive acceptance criterion. Each release gate
+must say what material consequence makes it blocking. Latency percentiles,
+broad prompt families, multi-model comparisons, effect controls, and full
+telemetry reconciliation are release gates only when the task's actual claim
+requires them.
+
 For substantial Jira implementation work:
 
 1. Re-read the live issue, comments, links, current code, and current validation
@@ -343,8 +401,14 @@ For substantial Jira implementation work:
 2. Use a task branch and keep Jira status aligned with reality.
 3. Name the user outcome, authority surfaces, support-code scope, and validation
    tier in the task notes.
-4. Recover relevant existing branch/PR work before reimplementing.
-5. At the current decision boundary, leave the branch, Jira issue, and any live
+4. State why the merge is not ready and the minimum evidence that would make it
+   ready, or record the equivalent current decision if work is already
+   underway.
+5. Recover relevant existing branch/PR work before reimplementing.
+6. Before another patch, wider campaign, or delay prompted by a material new
+   observation, state explicitly whether it changes the merge decision and act
+   accordingly.
+7. At the current decision boundary, leave the branch, Jira issue, and any live
    state consistent with reality. Commit, publish, merge, release, comment, or
    transition only when current task authority permits it and the action helps
    the work. A provisional branch, experiment, or human-gated Jira programme

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,15 +287,21 @@ def create_concept(name: str, parent_id: str, description: str = "") -> dict:
 - **Feature requests:** Propose new features with clear use cases
 - **Questions:** Ask questions about the codebase or development process
 
-### Issue Template
+### Bug-report template
 
-When creating an issue, include:
+For a bug report, include:
 - **Description:** Clear summary of the issue or request
 - **Steps to reproduce:** For bugs, provide detailed steps
 - **Expected behavior:** What should happen
 - **Actual behavior:** What actually happens
 - **Environment:** OS, Python version, browser (if applicable)
 - **Screenshots:** Visual evidence if relevant
+
+For a substantial implementation or Jira task, use the decision-ready task
+boundary in [`AGENTS.md`](AGENTS.md#8-task-and-repository-discipline): minimum
+ship criteria, concrete stop-ship conditions, non-blocking observations, and
+explicit non-goals. Do not turn every desirable measurement into an acceptance
+gate.
 
 ---
 

--- a/docs/design_index.md
+++ b/docs/design_index.md
@@ -6,7 +6,7 @@
   override current user direction, `AGENTS.md`, live represented authority, or
   live evidence
 - **Owner:** Von maintainers
-- **Last reviewed:** 29 July 2026
+- **Last reviewed:** 1 August 2026
 - **Review trigger:** Any change to `AGENTS.md` reading routes, canonical
   document selection, or document supersession
 - **Scope:** Tracked design, engineering, operational, review, and generated
@@ -90,6 +90,7 @@ live.
 | Minimal imposition, elicitation, or write policy | [minimal-imposition principle](engineering/minimal_imposition_design_principle.md) |
 | Frontend or browser acceptance | [Frontend browser validation](engineering/frontend_browser_user_view_validation.md), at the validation tier justified by the claim |
 | Live user-visible behaviour or telemetry diagnosis | Applicable sections of the [real-path replay and telemetry loop](engineering/real_path_server_replay_and_telemetry_loop.md), using the risk tier in `AGENTS.md` |
+| Substantial Jira task definition or pull-request merge boundary | The decision discipline in [`AGENTS.md`](../AGENTS.md#5-capability-slice-planning), the practical [Jira guidance](engineering/operational_engineering_guide.md#53-jira) and [merge-decision procedure](engineering/operational_engineering_guide.md#62-make-new-evidence-change-a-decision), and the [pull-request template](../.github/PULL_REQUEST_TEMPLATE.md) |
 | Practical repository operation | [operational engineering guide](engineering/operational_engineering_guide.md), [authority-alignment scan](engineering/maintaining_global_design_constraints_and_authority_alignment_with_coding_agents.md) |
 
 ## 5. Current governing and routed guidance

--- a/docs/engineering/agent_evaluation_and_research_uptake.md
+++ b/docs/engineering/agent_evaluation_and_research_uptake.md
@@ -3,7 +3,7 @@
 - **Kind:** Evaluation and research-uptake guide
 - **Lifecycle:** Active
 - **Authority:** Normative only for the evaluation or research claim being made
-- **Last reviewed:** 25 July 2026
+- **Last reviewed:** 1 August 2026
 
 ## 1. When to read this
 
@@ -73,13 +73,15 @@ paralysed agent even when the prose asks for useful autonomy.
 
 ## 6. Literature note requirement
 
-For research-sensitive tasks, write a short note that records:
+When a design or acceptance claim relies materially on literature, write a
+short note containing only what is needed to interpret that claim:
 
 - what recent work was checked
 - which claim from that work actually matters to Von
 - what changed in the design because of it
 - what was rejected and why
-- what follow-up measurement remains open
+- any measurement gap that materially limits the current conclusion; do not
+  invent follow-up work
 
 ## 7. Research uptake rules
 

--- a/docs/engineering/operational_engineering_guide.md
+++ b/docs/engineering/operational_engineering_guide.md
@@ -5,8 +5,8 @@
 - **Authority:** Canonical for recurring local engineering procedures; subordinate
   to `AGENTS.md` and the scoped design guides
 - **Created:** 2026-04-04
-- **Last substantive content update:** 2026-07-18
-- **Last reviewed:** 2026-07-25
+- **Last substantive content update:** 2026-08-01
+- **Last reviewed:** 2026-08-01
 - **Freshness boundary:** Revalidate host-, credential-, launcher-, and
   connector-specific facts before relying on them
 
@@ -182,6 +182,9 @@ Do not claim completion from a local file alone.
 For substantial Jira-backed implementation:
 
 - re-read the live issue and follow its actual decision authority;
+- distinguish minimum ship criteria from stop-ship conditions, non-blocking
+  measurements or limitations, and explicit non-goals as required by
+  `AGENTS.md`;
 - use a task branch when the work is substantial;
 - keep comments, assignee, links, and status aligned with reality where doing
   so helps coordination;
@@ -198,6 +201,14 @@ When creating an issue, assign it to the authenticated user by default unless
 directed otherwise or Jira rejects the assignment. Do not open speculative
 refactor issues based on line count alone; record a concrete capability,
 coherence, authority, reliability, or testability problem.
+
+For a substantial task, write acceptance criteria as the minimum evidence that
+would support the intended delivery decision. Put desirable optimisation,
+research questions, additional model arms, broader task families, and
+non-critical telemetry in a visibly non-blocking section unless the task names
+the material consequence that makes one of them a release gate. Do not turn a
+high-quality task description into a conjunctive programme of every useful
+measurement.
 
 ### 5.4 Git and GitHub
 
@@ -229,15 +240,44 @@ Treat telemetry as evidence about a run, not as the user-facing product.
 Use the validation tiers in `AGENTS.md`:
 
 - Tier 0: static/doc/format validation.
-- Tier 1: targeted automated tests and nearest faithful path.
-- Tier 2: exact user-visible replay with relevant telemetry.
-- Tier 3: broader evaluation, release, migration, or safety evidence.
+- Tier 1: bounded behaviour; targeted tests and the exact or nearest faithful
+  path when user-visible, with enough telemetry to identify the affected path.
+- Tier 2: materially consequential or cross-boundary capability; Tier 1 plus
+  canonical effect read-back and the highest material residual risk.
+- Tier 3: security, authority release, certification, or an explicit
+  comparative research claim.
 
-Escalate when evidence reveals greater risk. Do not start with a browser,
-full-server replay, prompt family, or release campaign unless the claim requires
-it.
+Escalate only when evidence reveals a candidate-caused material risk that could
+change the delivery decision. Do not start with a browser, full-server replay,
+prompt family, or release campaign unless the claim requires it.
 
-### 6.2 Start narrow, then test the real boundary
+### 6.2 Make new evidence change a decision
+
+Before the first implementation change on substantial work, record the current
+merge, release, or handoff decision and the minimum evidence that would make it
+ready. Then, before adding a patch, model arm, prompt family, telemetry surface,
+or delay because of a material new observation, write one plain-language
+sentence in the existing working record stating whether:
+
+- `Merge decision changes — ...`; or
+- `Merge decision does not change — ...`.
+
+These are human-readable examples, not machine fields. Do not introduce a
+separate form, schema, CI check, or runtime gate for them.
+
+Use the equivalent delivery term when there is no merge. A changed decision
+must identify a candidate-caused material regression, an invalidated claim, or
+evidence that the current result cannot be trusted. A decision that does not
+change may justify a note or a later prioritised task, but not expansion of the
+current release boundary. A small cleanup already inside the stated scope may
+still be completed without becoming another ship criterion.
+
+Gather more evidence only while a plausible result could change delivery,
+rollback, or the scope of the claim. Stop when the selected tier supports the
+claim and another check would merely search for unrelated defects or improve
+confidence without changing the decision.
+
+### 6.3 Start narrow, then test the real boundary
 
 Run the smallest relevant test first, then expand to the nearest integration
 boundary. A unit test can establish a local invariant; it cannot establish a
@@ -264,21 +304,21 @@ For a live behaviour claim, follow
 browser-specific claim, also follow
 `docs/engineering/frontend_browser_user_view_validation.md`.
 
-### 6.3 Frontend validation
+### 6.4 Frontend validation
 
 For changed JavaScript, run the repository's static/lint gate and the targeted
 frontend tests. Use browser validation when DOM state, rendering, interaction,
 authentication, live progress, or the authenticated user view is part of the
 claim. A screenshot alone is not evidence that an interaction worked.
 
-### 6.4 Timeouts and optional live services
+### 6.5 Timeouts and optional live services
 
 Bound calls to providers, browsers, MCP servers, and live external services.
 Separate deterministic tests from opt-in live acceptance. A timeout or
 unavailable external dependency should produce a clear limitation, not an
 indefinite wait or a false pass.
 
-### 6.5 Acceptance record
+### 6.6 Acceptance record
 
 Record only the evidence needed to support the claim:
 
@@ -286,7 +326,10 @@ Record only the evidence needed to support the claim:
 - pass/fail/typed-blocker result;
 - relevant identifiers or artefact digest;
 - material limitations;
-- user-visible answer and telemetry reconciliation for Tier 2/3 behaviour work.
+- the current merge or equivalent delivery decision, including only material
+  observations that changed it; and
+- the user-visible answer, canonical effect read-back, or path evidence only
+  when the acceptance claim depends on it.
 
 Do not claim broader coverage than was run.
 

--- a/docs/engineering/real_path_server_replay_and_telemetry_loop.md
+++ b/docs/engineering/real_path_server_replay_and_telemetry_loop.md
@@ -5,8 +5,8 @@
 - **Authority:** Canonical replay/telemetry protocol routed by `AGENTS.md`; use
   only the sections and validation depth justified by the claim
 - **Created:** 2026-04-17
-- **Last substantive content update:** 2026-07-25
-- **Last reviewed:** 2026-07-25
+- **Last substantive content update:** 2026-08-01
+- **Last reviewed:** 2026-08-01
 - **Evidence boundary:** Each acceptance claim still requires its own dated
   exact-path evidence
 
@@ -33,8 +33,9 @@ claim needs them.
 
 ## 2. When to Use It
 
-Use the full process for Tier 2 or Tier 3 claims under `AGENTS.md`, and use the
-applicable subset for Tier 1. Typical triggers are:
+Use only the applicable parts for Tier 1 and Tier 2 claims under `AGENTS.md`.
+Use the full process only for Tier 3 or when the specific claim independently
+needs it. Typical triggers are:
 
 - the bug is user-visible or answer-visible;
 - the route, orchestrator, workflow, selector, or response path may be at
@@ -62,12 +63,16 @@ these. Durable semantic policy should not hide in case-specific Python rescue
 logic, but replay evidence must not prescribe a workflow merely to count as
 architecturally valid.
 
-That means every replay should answer two questions:
+An acceptance replay should answer two questions:
 
 1. Did the user-visible behaviour improve?
-2. Does the persisted telemetry show the right reason why it improved?
+2. Is there enough path evidence to attribute that improvement and rule out
+   false success or a point solution?
 
-If those disagree, the task is not done.
+Complete persisted attribution is required when telemetry or provenance is part
+of the claim or is needed to trust the outcome. Otherwise, record a telemetry
+gap separately unless it materially undermines acceptance; missing unrelated
+diagnostics do not automatically make the task unfinished.
 
 ### 3.1 Architecture-neutral sentinel cases
 
@@ -88,10 +93,11 @@ for the claimed capability, not whether it follows the current architecture.
 
 ## 4. Expectation-First Preflight
 
-Before a Tier 2/3 replay, or a Tier 1 case whose answer quality is subjective,
-form a concise expectation for what a reasonable answer would need to achieve.
-Record it in task notes or report it to the user when that helps collaboration;
-do not interrupt the user with a ceremonial preflight for every replay.
+When answer quality is subjective or the acceptance claim needs a stable
+comparison rubric, form a concise expectation for what a reasonable answer
+would need to achieve. Record it in task notes or report it to the user when
+that helps collaboration; do not interrupt the user with a ceremonial preflight
+for every replay.
 
 Do this before seeing the new live answer, not afterwards.
 
@@ -150,29 +156,21 @@ drift and makes the acceptance standard falsifiable.
 
 ## 5. Query-Set Design
 
-When the change claims to repair a general capability class, do not validate
-only the triggering prompt. Use a small prompt family that tests the intended
-generality. A narrowly scoped mechanical defect may need only the exact case
-plus its targeted regression.
+When the change claims to repair a general capability class, use the smallest
+prompt family that distinguishes that claim. Normally this is the exact case
+plus one materially different neighbouring case. Add a named-entity,
+non-user-relative, language, or sampled variant only when it tests a stated
+dimension that could change the delivery decision. A narrowly scoped mechanical
+defect may need only the exact case plus its targeted regression.
 
-Include:
-
-1. The exact triggering prompt.
-2. An explicit named-entity variant.
-3. A nearby relation-query variant that does not use the same noun family.
-4. A non-user-relative variant that should exercise the same retrieval and
-   routing basis.
-5. When useful, one sampled prompt from the maintained live prompt bank that
-   stresses the same or an adjacent capability class.
-
-Example family for entity-relative represented-fact lookup:
+Possible variants for entity-relative represented-fact lookup include:
 
 - `What papers of mine do you know about?`
 - `What papers are associated with Michael Witbrock?`
 - `What students of mine do you know about?`
 - `Which workflows mention episode evaluation?`
 
-The point is not these exact prompts. The point is to test the general
+These are a menu, not a mandatory family. The point is to test the general
 capability class:
 
 - entity-relative KB lookup
@@ -202,10 +200,8 @@ Minimal local command shape:
 pdm run python scripts/run_live_kb_tool_prompt_sampler.py `
   --prompt-text "List my last six email messages." `
   --replay-case-id "mail-listing-failure" `
-  --model "gemma4:26b" `
-  --compare-model "gpt-5.4-mini" `
   --base-prompt-id "#V#mail_answer_prompt" `
-  --prompt-variant-id "#V#gemma_mail_answer_prompt_v2" `
+  --prompt-variant-id "#V#mail_answer_prompt_variant_v2" `
   --workflow-id "#V#general_mail_review_workflow" `
   --workflow-stage-id "turn_answer" `
   --experiment-run-id "#V#experiment_run_mail_prompt_variants"
@@ -228,6 +224,10 @@ diagnostic planning evidence only: it does not run Von workflows, execute tools,
 select represented prompt variants, or prove the user-visible turn is fixed.
 
 ### 5.2 Random Prompt Sampling
+
+Random sampling is optional. Use it only when distributional robustness or
+prompt-bank behaviour is part of the current claim; it does not follow merely
+because the exact case passed.
 
 Von already has a maintained live prompt bank and replay harness for this:
 
@@ -266,8 +266,8 @@ Practical rules:
 3. Record the sampled prompt id, category, bank version, and any random seed so
    the run is reproducible.
 4. Before running a sampled prompt used as acceptance evidence, record the
-   expectation-first preflight when Tier 2/3 or subjective judgement warrants
-   it.
+   expectation-first preflight when subjective judgement or the comparison
+   claim warrants it.
 5. The sampler does not issue a semantic verdict. Its collection status says
    whether the run evidence was captured, not whether the answer was good.
    Compare the real answer and, where relevant, effects, model, timing, and
@@ -277,13 +277,10 @@ Practical rules:
    own task/message state, record whether actual task/message tool use happened.
    A generic "I can help with that" answer is not a pass for a create/update
    prompt.
-7. When the capability spans multiple classes, work up the complexity over
-   time:
-   - start with `direct_context_or_background`;
-   - then move to `vontology_grounded`;
-   - then move to `tool_augmented`.
-   A failure in an easier class should usually be addressed before you put much
-   interpretive weight on a harder-class failure above it.
+7. When an explicit hypothesis spans multiple classes, select the smallest
+   class that can falsify it first. Do not automatically run every complexity
+   class. A failure in an easier selected class should usually be addressed
+   before you put much interpretive weight on a harder-class failure above it.
 
 Useful cases:
 
@@ -324,8 +321,8 @@ Before the first replay:
    or another canonical authenticated route rather than faking user context.
 5. If you are using a sampled prompt, record the prompt id, category, prompt
    bank version, and seed or selection method in your notes.
-6. Record the relevant run-environment features for the replay, not just the
-   prompt text. At minimum, capture:
+6. Record only the run-environment identities material to the claim, choosing
+   as needed from:
    - base URL or server surface used;
    - authenticated user and organisation context;
    - the server-resolved active model/provider for that authenticated context,
@@ -371,13 +368,17 @@ Use the nearest faithful affected surface:
    affected surface or higher-fidelity execution is unsafe/unavailable, with
    the limitation recorded explicitly.
 
-For user-visible answer defects, browser replay is best because it exercises:
+When a user-visible defect depends on browser state, authentication, rendering,
+or live progress, browser replay exercises:
 
 - the actual request shape
 - real auth/session state
 - response rendering
 - narration/screen transforms
 - any live thinking-card or progress telemetry
+
+For a backend answer claim without a browser-only dependency, real
+`/von/generate` may be the nearest faithful path.
 
 For scripted real-route replay against `/von/generate`, prefer the existing live
 sampler harness when it fits the task:
@@ -411,10 +412,13 @@ nearest faithful path.
 
 ## 8. One Replay Cycle
 
-For each replayed prompt:
+Apply only the steps material to the selected validation tier and claim. For a
+Tier 1 backend behaviour claim, a normal pass records the answer, a stable run
+locator, and enough evidence to identify the affected path. The remaining
+steps are a diagnostic menu:
 
-1. Form and record the expectation-first preflight when required by the selected
-   validation tier or subjective answer rubric.
+1. Form and record the expectation-first preflight when subjective answer
+   quality or the comparison claim needs it.
 2. Send the prompt on the real server path.
 3. Record the user-visible answer exactly.
 4. Capture the telemetry locator or the key identifiers:
@@ -423,7 +427,7 @@ For each replayed prompt:
    - `history_location`
    - `chat_session_id`
    - namespace context
-5. Record the relevant environment features for this run:
+5. Record only the environment features material to this run, choosing from:
    - base URL;
    - authenticated user/org;
    - server-resolved active model/provider for that authenticated context, when
@@ -433,10 +437,7 @@ For each replayed prompt:
    - browser-visible model/provider, if a browser pass is part of the run;
    - local branch/commit for the checkout you ran from;
    - server-reported version/branch/commit when the server exposes them.
-   For the current replay programme, the default scripted requested model
-   should normally be Ollama `gemma4:26b`, and the browser pass should be
-   switched to the same visible model where practical before you judge parity.
-6. Fetch the persisted evidence:
+6. Fetch only the persisted evidence needed for the claim, choosing from:
    - `turn_execution_get_diagnostics`
    - `chat_history_get_debug_entry`
    - `conversation_telemetry_get_locator`
@@ -471,18 +472,25 @@ For each replayed prompt:
      would have seen live;
    - failures where the card might reveal useful reasoning/transparency gaps
      even though the final answer was poor.
-12. Read the turn in stage order rather than jumping straight to the answer.
+12. Read the turn in stage order when causal diagnosis requires it rather than
+    fetching every stage by default.
 13. Classify the failure boundary.
 14. Apply the smallest durable fix at the right authority surface.
 15. Replay the same prompt again.
-15. Replay nearby prompt variants when the claimed fix is general rather than
+16. Replay a nearby prompt variant when the claimed fix is general rather than
    mechanical or case-bounded.
-16. If the validation tier or hypothesis warrants it, replay one sampled prompt
+17. If the validation tier or hypothesis warrants it, replay one sampled prompt
    from the live prompt bank.
 
 Do not over-generalise from one improved replay. Conversely, do not require a
 prompt family for a purely mechanical defect whose regression and exact path
 already establish the bounded claim.
+
+Before another fix, wider prompt family, model arm, or release delay prompted by
+a material observation, record whether the merge or equivalent delivery
+decision changes and why, using the rule in `AGENTS.md`. Stop the campaign when
+the selected evidence supports the claim and another replay is unlikely to
+change delivery or rollback.
 
 ## 9. What to Inspect in Telemetry
 
@@ -728,31 +736,29 @@ case-specific production branches, and closure from a synthetic harness alone.
 After each fix, apply the items required by the chosen validation tier:
 
 1. Replay the exact triggering prompt.
-2. Replay the nearby prompt family when generality is claimed.
-3. Replay one sampled live-bank prompt when sampling is part of the hypothesis
-   or Tier 2/3 campaign.
+2. Replay one materially different neighbour when generality is claimed, and
+   add further variants only when each distinguishes a stated dimension.
+3. Replay one sampled live-bank prompt only when sampling is part of the
+   hypothesis or acceptance claim.
 4. Follow a scripted pass with a browser replay when the affected claim includes
    a browser-only surface.
-5. For interesting failures, consider the same browser follow-up when the live
-   card may reveal user-facing transparency gaps.
-6. Re-check the telemetry for the new run.
+5. Use a browser follow-up for a failure only when browser-visible behaviour is
+   part of the claim or could distinguish the current causal hypotheses.
+6. Inspect enough path evidence for the new run to support the claim and rule
+   out false success.
 7. Confirm that the actual reason and path for success changed as intended.
 8. Confirm that the live answer cleared the recorded bar, or exceeded it on its
    own grounded merits, rather than merely improving relative to a bad
    baseline.
-9. For a Tier 2/3 Jira-backed acceptance campaign, prepare a closure record
-   proportionate to the claim:
+9. For a Jira-backed acceptance campaign, record only the closure evidence
+   material to the claim:
    - the exact replayed prompt text;
-   - the exact user-visible answer, or a faithful quoted excerpt if the full
-     answer is too long to quote comfortably in the task;
-   - the key telemetry identifiers for the accepted run;
-   - a short synopsis of what the live Thinking card showed, or would have
-     shown if the browser pass exposed it;
-   - a short note on why that Thinking-card content would or would not have
-     helped a user understand the answering process.
-   If no browser Thinking card or equivalent user-facing progress surface was
-   available, say so explicitly rather than silently omitting that part of the
-   record.
+   - the user-visible answer or a faithful excerpt when answer quality is in
+     the claim;
+   - a stable run or effect identifier when needed to support or reproduce the
+     claim;
+   - material limitations; and
+   - browser or Thinking-card evidence only when that surface is in the claim.
 
 Good signs:
 
@@ -781,12 +787,12 @@ Do not call the behaviour fixed until all applicable items for the selected
 validation tier hold:
 
 1. The exact real-path replay is correct.
-2. A neighbouring prompt family behaves coherently when the change claims a
-   general capability repair.
+2. The smallest selected neighbouring case or cases behave coherently when the
+   change claims a general capability repair.
 3. Where random sampling is part of the acceptance campaign, the sampled replay
    also behaves coherently for its capability class.
-4. The answer clears the expectation-first bar for the prompt, or exceeds it on
-   its own grounded merits.
+4. Where semantic judgement required an expectation-first bar, the answer
+   clears it or exceeds it on its own grounded merits.
 5. Any "no results" or "nothing represented" claim survives post-check against
    the relevant authority surfaces.
 6. The answer is grounded in the relevant evidence and observed effects, with
@@ -797,8 +803,9 @@ validation tier hold:
 8. Where a live Thinking card was part of the affected claim, it also meets a
    user-facing usefulness standard consistent with
    `thinking_card_live_llm_visibility_design.md`.
-9. The persisted telemetry shows the actual successful reason and path,
-   whether direct function/tool, model-led composition, or workflow.
+9. Enough path evidence establishes the actual successful reason, whether
+   direct function/tool, model-led composition, or workflow; complete persisted
+   attribution is required only when the claim depends on it.
 10. Targeted regression tests cover the structural failure, not just the final
    string output.
 
@@ -862,10 +869,8 @@ execution trace visibly ineligible. The workflow may still complete for its
 ordinary user-facing purpose: these checks govern the strong provenance claim,
 not represented recovery or general execution.
 
-For user-visible issues, record both:
-
-- the user-visible acceptance evidence
-- the corresponding telemetry evidence
+For user-visible claims, record the user-visible acceptance evidence and enough
+corresponding path evidence to support the claim and exclude false success.
 
 If a Jira-backed campaign is actually being closed under current decision
 authority, record only the evidence material to its claim: for example the
@@ -875,14 +880,12 @@ the task has a tier or Jira key.
 
 ## 14. Practical Reminder
 
-When a task has gone through several rounds of disappointment, increase the
-burden of proof:
-
-- prefer the exact server path over helper surfaces
-- prefer multiple nearby prompts over one prompt
-- prefer explicit recorded expectations over retrospective generosity
-- prefer telemetry-backed diagnosis over intuition
-- prefer "still not fixed" over premature closure
-
-That is slower than a narrow patch, but it is much faster than reopening the
-same behaviour repeatedly.
+When a task has gone through several disappointing rounds, increase
+discrimination rather than breadth. Choose the smallest next observation that
+can distinguish the suspected causes, state what result would change the merge
+or rollback decision, and stop when the selected tier supports the bounded
+claim. Prefer the exact path and causal evidence over intuition, but do not add
+prompt variants, telemetry surfaces, or another compensating layer merely
+because earlier attempts failed. Repeated disappointment warrants better
+diagnosis, not an unbounded campaign or a presumption that the task remains
+unfixed.


### PR DESCRIPTION
> **Merge impact:** Engineering tasks gain an explicit stopping discipline: a material new observation must be classified by whether it changes the delivery decision.
>
> Merge decision: ready — the docs-only change is internally consistent, its local links resolve, and bounded review found no remaining gate or authority contradiction.

## User outcome

Von engineering work can ship a likely net improvement once proportionate evidence supports the bounded claim, instead of turning every stochastic miss, adjacent defect, or useful measurement into another blocking patch.

## Root cause

The existing guidance made several validation practices cumulative and allowed Jira acceptance criteria to become a conjunctive research programme. It did not require a new observation to justify how its possible outcomes would alter merge, rollback, or claim scope.

## Material changes

- Make delivery-decision classification compulsory at material decision points in substantial work.
- Keep it as human judgement in an existing working surface; explicitly forbid a separate schema, required artefact, CI check, runtime gate, or new authority mechanism.
- Define Jira tasks by minimum ship criteria, concrete stop-ship conditions, non-blocking observations, and non-goals.
- Put the merge decision first and visibly in the pull-request template.
- Prune replay guidance that defaulted to broad prompt families, exhaustive telemetry, browser follow-ups, sampling, or a programme-specific Ollama model.
- Clarify that stronger or cheaper model comparisons are selected by the causal hypothesis, not made universal.

## Evidence

- `git diff --check`
- Verified every newly linked local file and heading.
- Searched the affected guidance for stale model defaults and contradictory mandatory telemetry or replay language.
- Ran a bounded adversarial tabletop review covering: likely improvement plus an isolated stochastic miss; a repeatable candidate-caused silent-loss regression; and readiness without merge authority.
- Rechecked the only blocker found: the text now distinguishes a required human statement from a new machine-enforced artefact.

This is Tier 0 documentation validation. No runtime or model campaign was run because neither could change the documentation merge decision.

## Ship boundary

- **Minimum ship criteria:** The constitution states the stopping rule; Jira and PR guidance expose it at task definition and merge; replay guidance no longer silently expands validation.
- **Stop-ship conditions:** A contradiction that creates a numeric, CI, runtime, or authority gate; broken routing links; or tabletop guidance that merges a demonstrated material regression.
- **Non-blocking observations:** Future experience may suggest better prose or examples. Those do not defeat this change.
- **Non-goals:** Runtime enforcement, Jira custom fields, Jira workflow changes, model-routing rules, a benchmark campaign, or resolution of unrelated repository defects.
