### PR TITLE
Fix mail workflow visibility and fallback finality

### DIFF
--- a/scripts/migrate_jvnautosci_2591_general_mail_followups.py
+++ b/scripts/migrate_jvnautosci_2591_general_mail_followups.py
@@ -18,6 +18,19 @@ if str(_PROJECT_ROOT) not in sys.path:
 load_dotenv(_PROJECT_ROOT / ".env", override=False)
 
 from src.backend.security.access_control import override_current_actor  # noqa: E402
+from src.backend.security.visibility_predicates import (  # noqa: E402
+    get_specific_to_org_values,
+    get_specific_to_user_values,
+    set_specific_to_org_values,
+    set_specific_to_user_values,
+)
+from src.backend.services import concept_service  # noqa: E402
+from src.backend.services.concept_service import (  # noqa: E402
+    _find_raw_concept_by_exact_concept_id,
+)
+from src.backend.workflows.durable.workflow_instance_submission_service import (  # noqa: E402
+    verify_workflow_runnable,
+)
 from src.backend.workflows.vontology_loader import (  # noqa: E402
     load_workflow_definition_from_vontology,
 )
@@ -26,6 +39,7 @@ from src.backend.workflows.workflow_authoring_service import (  # noqa: E402
 )
 from src.backend.workflows.workflow_concept_authority_service import (  # noqa: E402
     build_seed_canonical_workflow_definitions,
+    workflow_child_visibility_covers_parent,
 )
 from src.backend.workflows.workflow_definition_identity_service import (  # noqa: E402
     build_workflow_definition_identity,
@@ -40,7 +54,23 @@ GENERAL_MAIL_WORKFLOW_ID = "#V#general_mail_review_workflow"
 DETAIL_WORKFLOW_ID = "#V#gmail_message_detail_fetch_workflow"
 WORKFLOW_IDS = (GENERAL_MAIL_WORKFLOW_ID, DETAIL_WORKFLOW_ID)
 DEFAULT_ACTOR_USER_ID = "#V#zhan_von_witbrock"
+DEFAULT_VERIFICATION_ACTOR_USER_ID = "#V#michael_witbrock"
 DEFAULT_ACTOR_ORGANISATION_ID = "#V#university_of_auckland_strong_ai_lab"
+VISIBILITY_REPAIR_CHILD_IDS_BY_WORKFLOW = {
+    GENERAL_MAIL_WORKFLOW_ID: (
+        "#V#workflow_step_general_mail_review_workflow_fetch_mail_profile_status",
+        "#V#workflow_step_general_mail_review_workflow_render_mail_profile_status",
+        "#V#workflow_mapping_mail_review_request_kind_to_mail_review_request_kind",
+        "#V#workflow_mapping_mail_review_include_body_to_mail_review_include_body",
+        "#V#workflow_mapping_mail_profile_status_resource_to_concept_id_parameter",
+        "#V#workflow_mapping_mail_profile_status_runtime_alias_to_mail_review_profile_id",
+    ),
+    DETAIL_WORKFLOW_ID: (
+        "#V#workflow_mapping_gmail_message_detail_fetch_workflow_fetch_message_detail_mail_review_include_body_to_include_body_parameter",
+        "#V#workflow_mapping_gmail_message_detail_fetch_result_body_to_message_detail_body",
+        "#V#workflow_mapping_gmail_message_detail_fetch_result_body_truncated_to_message_detail_body_truncated",
+    ),
+}
 
 
 def _step_with_suffix(steps: list[dict[str, Any]], suffix: str) -> dict[str, Any]:
@@ -247,8 +277,76 @@ def _identity(workflow_id: str, definition: Any) -> dict[str, Any]:
     )
 
 
+def repair_mail_visibility_closure(
+    workflow_id: str,
+    *,
+    apply: bool,
+) -> dict[str, Any]:
+    """Align the nine stale mail children with their parent audiences."""
+
+    workflow_doc = _find_raw_concept_by_exact_concept_id(workflow_id)
+    if not isinstance(workflow_doc, Mapping):
+        raise ValueError(f"workflow_not_found:{workflow_id}")
+    workflow_relationships = (
+        dict(workflow_doc.get("relationships") or {})
+        if isinstance(workflow_doc.get("relationships"), Mapping)
+        else {}
+    )
+    parent_users = get_specific_to_user_values(workflow_relationships)
+    parent_orgs = get_specific_to_org_values(workflow_relationships)
+    repair_required_ids: list[str] = []
+    already_covered_ids: list[str] = []
+    for child_id in VISIBILITY_REPAIR_CHILD_IDS_BY_WORKFLOW[workflow_id]:
+        child_doc = _find_raw_concept_by_exact_concept_id(child_id)
+        if not isinstance(child_doc, Mapping):
+            raise ValueError(f"workflow_child_not_found:{child_id}")
+        if workflow_child_visibility_covers_parent(workflow_doc, child_doc):
+            already_covered_ids.append(child_id)
+            continue
+        repair_required_ids.append(child_id)
+        if not apply:
+            continue
+        child_relationships = (
+            dict(child_doc.get("relationships") or {})
+            if isinstance(child_doc.get("relationships"), Mapping)
+            else {}
+        )
+        updated_relationships = set_specific_to_user_values(
+            child_relationships,
+            parent_users,
+        )
+        updated_relationships = set_specific_to_org_values(
+            updated_relationships,
+            parent_orgs,
+        )
+        concept_service.update_concept(
+            child_id,
+            {"relationships": updated_relationships},
+            defer_side_effects=True,
+        )
+        readback = _find_raw_concept_by_exact_concept_id(child_id)
+        if not workflow_child_visibility_covers_parent(workflow_doc, readback):
+            raise ValueError(
+                f"workflow_child_visibility_repair_readback_failed:{child_id}"
+            )
+    return {
+        "schema_version": "workflow_visibility_closure_repair.v1",
+        "apply": apply,
+        "workflow_id": workflow_id,
+        "parent_user_scope": parent_users,
+        "parent_organisation_scope": parent_orgs,
+        "repair_required_ids": repair_required_ids,
+        "already_covered_ids": already_covered_ids,
+        "closure_verified": bool(apply or not repair_required_ids),
+    }
+
+
 def run_migration(
-    *, apply: bool, actor_user_id: str, actor_organisation_id: str
+    *,
+    apply: bool,
+    actor_user_id: str,
+    actor_organisation_id: str,
+    verification_actor_user_id: str = DEFAULT_VERIFICATION_ACTOR_USER_ID,
 ) -> dict[str, Any]:
     with override_current_actor(
         user_concept_id=actor_user_id,
@@ -272,6 +370,10 @@ def run_migration(
                 desired_definitions[workflow_id]
             )
             candidate_spec, changed = rewrite(current_spec, desired_spec)
+            visibility_repair = repair_mail_visibility_closure(
+                workflow_id,
+                apply=False,
+            )
             base_hash = str(
                 _identity(workflow_id, current_definition).get("definition_hash") or ""
             )
@@ -288,10 +390,20 @@ def run_migration(
                 "contract_valid": bool(validation.get("valid")),
                 "contract_errors": validation.get("errors") or [],
                 "diff_summary": preview_body.get("diff_summary"),
+                "visibility_repair": visibility_repair,
             }
-            if apply and changed:
+            publication_required = bool(
+                changed or visibility_repair.get("repair_required_ids")
+            )
+            if apply and publication_required:
                 if not workflow_report["contract_valid"]:
                     raise ValueError(f"workflow_preview_invalid:{workflow_id}")
+                workflow_report["visibility_repair"] = (
+                    repair_mail_visibility_closure(
+                        workflow_id,
+                        apply=True,
+                    )
+                )
                 apply_result = apply_workflow_authoring_spec(
                     workflow_id,
                     authoring_spec=candidate_spec,
@@ -318,10 +430,49 @@ def run_migration(
                     workflow_id, after
                 ).get("definition_hash")
             reports[workflow_id] = workflow_report
+        actor_verification: dict[str, Any] = {}
+        if apply:
+            with override_current_actor(
+                user_concept_id=verification_actor_user_id,
+                organisation_concept_id=actor_organisation_id,
+            ):
+                for workflow_id in WORKFLOW_IDS:
+                    definition = load_workflow_definition_from_vontology(workflow_id)
+                    if definition is None:
+                        raise ValueError(
+                            f"workflow_not_visible_to_verification_actor:{workflow_id}"
+                        )
+                    verification = verify_workflow_runnable(
+                        workflow_id,
+                        actor_user_id=verification_actor_user_id,
+                        actor_org_id=actor_organisation_id,
+                    ).to_dict()
+                    if not verification.get("runnable_verification_success"):
+                        raise ValueError(
+                            "workflow_not_runnable_for_verification_actor:"
+                            + json.dumps(verification, sort_keys=True, default=str)
+                        )
+                    readback_hash = _identity(workflow_id, definition).get(
+                        "definition_hash"
+                    )
+                    publisher_hash = reports[workflow_id].get(
+                        "readback_definition_hash"
+                    ) or reports[workflow_id].get("base_definition_hash")
+                    if readback_hash != publisher_hash:
+                        raise ValueError(
+                            f"workflow_cross_actor_readback_mismatch:{workflow_id}"
+                        )
+                    actor_verification[workflow_id] = {
+                        "runnable": True,
+                        "state_count": len(definition.states),
+                        "definition_hash": readback_hash,
+                    }
         return {
             "mode": "apply" if apply else "preview",
             "actor_user_id": actor_user_id,
             "actor_organisation_id": actor_organisation_id,
+            "verification_actor_user_id": verification_actor_user_id,
+            "verification_actor_readback": actor_verification,
             "workflows": reports,
         }
 

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -112,6 +112,7 @@ class _PreparedCapabilityCall:
     execution_method_name: str
     arguments: Mapping[str, Any]
     is_effect: bool
+    semantic_effect: bool | None
     minimum_effect_window_seconds: float
     capability_kind: str = "registered_tool"
     represented_workflow_id: str | None = None
@@ -127,6 +128,7 @@ class _ContainedCapabilityResult:
     arguments: Mapping[str, Any]
     capability_name: str
     is_effect: bool
+    semantic_effect: bool | None
     execution_method_name: str
     capability_kind: str = "registered_tool"
     represented_workflow_id: str | None = None
@@ -2829,6 +2831,35 @@ def _effect_status(
     )
 
 
+def _effect_requires_turn_finality(
+    *,
+    capability_kind: str,
+    effect_status: str,
+    changed: bool | None,
+    raw_payload: Any,
+) -> bool:
+    """Keep operational workflow bookkeeping from becoming semantic failure.
+
+    Represented workflows always use effect-grade dispatch because invoking one
+    may create or advance a durable instance. An attempt rejected before any
+    instance was created and reporting known no change, however, has no effect
+    whose finality can invalidate a successfully recovered answer.
+    """
+
+    instance_id = (
+        str(raw_payload.get("instance_id") or "").strip()
+        if isinstance(raw_payload, Mapping)
+        else ""
+    )
+    if capability_kind != "represented_workflow":
+        return True
+    return not (
+        effect_status == "not_started"
+        and changed is False
+        and not instance_id
+    )
+
+
 def _late_effect_observation_state(
     observation: Mapping[str, Any],
 ) -> tuple[str, bool | None]:
@@ -3248,6 +3279,7 @@ def execute_adaptive_turn(
         phase: int,
         effect_status: str,
         changed: bool | None,
+        turn_finality_required: bool = True,
         execution_id: str | None = None,
         late_observation: Mapping[str, Any] | None = None,
         evidence_id: str | None = None,
@@ -3261,6 +3293,7 @@ def execute_adaptive_turn(
                 "phase": phase,
                 "effect_status": effect_status,
                 "changed": changed,
+                "turn_finality_required": turn_finality_required,
                 "execution_id": execution_id,
                 "evidence_id": evidence_id,
             }
@@ -3327,11 +3360,19 @@ def execute_adaptive_turn(
         effect_id: str,
         call_id: str,
         capability_name: str,
+        capability_kind: str,
+        semantic_effect: bool | None,
     ):
         def observe(observation: Mapping[str, Any]) -> None:
             observed = dict(observation)
             effect_status, changed = _late_effect_observation_state(observed)
             payload = observed.get("payload")
+            turn_finality_required = _effect_requires_turn_finality(
+                capability_kind=capability_kind,
+                effect_status=effect_status,
+                changed=changed,
+                raw_payload=payload,
+            )
             evidence_value = (
                 payload
                 if observed.get("outcome") == "late_success"
@@ -3351,6 +3392,8 @@ def execute_adaptive_turn(
                     "capability_name": capability_name,
                     "effect_status": effect_status,
                     "changed": changed,
+                    "semantic_effect": semantic_effect,
+                    "turn_finality_required": turn_finality_required,
                 },
             )
             if not _effect_phase_acknowledged(phase_outcome):
@@ -3368,6 +3411,8 @@ def execute_adaptive_turn(
                     "organisation_concept_id": scope.organisation_concept_id,
                     "effect_id": effect_id,
                     "effect_status": effect_status,
+                    "semantic_effect": semantic_effect,
+                    "turn_finality_required": turn_finality_required,
                     "late_completion": True,
                     "execution_id": observed.get("execution_id"),
                     "output_schema_validation": observed.get(
@@ -3382,6 +3427,7 @@ def execute_adaptive_turn(
                 phase=1,
                 effect_status=effect_status,
                 changed=changed,
+                turn_finality_required=turn_finality_required,
                 execution_id=execution_id,
                 late_observation=observed,
                 evidence_id=envelope.evidence_id,
@@ -3436,6 +3482,7 @@ def execute_adaptive_turn(
             for state in effect_snapshot.values()
             if state.get("effect_status")
             in {"failed", "partial", "indeterminate", "not_started"}
+            and state.get("turn_finality_required") is not False
             and not (
                 state.get("effect_status") == "failed"
                 and state.get("recovery_status") == "succeeded"
@@ -3464,6 +3511,9 @@ def execute_adaptive_turn(
             if isinstance(state, Mapping):
                 invocation["effect_status"] = state.get("effect_status")
                 invocation["changed"] = state.get("changed")
+                invocation["turn_finality_required"] = state.get(
+                    "turn_finality_required"
+                )
                 if state.get("execution_id"):
                     invocation["execution_id"] = state.get("execution_id")
                 if state.get("evidence_id"):
@@ -3482,9 +3532,12 @@ def execute_adaptive_turn(
         relevant_effects = [
             state
             for state in effect_snapshot.values()
-            if (
-                state.get("effect_status")
-                in {"failed", "partial", "indeterminate", "not_started"}
+            if state.get("turn_finality_required") is not False
+            and (
+                (
+                    state.get("effect_status")
+                    in {"failed", "partial", "indeterminate", "not_started"}
+                )
                 or state.get("changed") is True
                 or (
                     state.get("effect_status") == "succeeded"
@@ -4327,6 +4380,11 @@ def execute_adaptive_turn(
                     and definition.ordinary_turn_effect
                 )
             )
+            semantic_effect = (
+                workflow_capability.semantic_effect
+                if is_workflow_capability
+                else bool(is_effect)
+            )
             if not isinstance(arguments, Mapping):
                 raw_capability_results[index] = _ContainedCapabilityResult(
                     raw_payload=_error_payload(
@@ -4337,6 +4395,7 @@ def execute_adaptive_turn(
                     arguments={},
                     capability_name=capability_name,
                     is_effect=is_effect,
+                    semantic_effect=semantic_effect,
                     execution_method_name=execution_method_name,
                     capability_kind=(
                         "represented_workflow"
@@ -4366,6 +4425,7 @@ def execute_adaptive_turn(
                         arguments={},
                         capability_name=capability_name,
                         is_effect=True,
+                        semantic_effect=semantic_effect,
                         execution_method_name=execution_method_name,
                         capability_kind="represented_workflow",
                         represented_workflow_id=str(workflow_capability.workflow_id),
@@ -4384,6 +4444,7 @@ def execute_adaptive_turn(
                         arguments={},
                         capability_name=capability_name,
                         is_effect=True,
+                        semantic_effect=semantic_effect,
                         execution_method_name=execution_method_name,
                         capability_kind="represented_workflow",
                         represented_workflow_id=str(workflow_capability.workflow_id),
@@ -4421,6 +4482,7 @@ def execute_adaptive_turn(
                         arguments={},
                         capability_name=capability_name,
                         is_effect=True,
+                        semantic_effect=semantic_effect,
                         execution_method_name=execution_method_name,
                         capability_kind="represented_workflow",
                         represented_workflow_id=str(workflow_capability.workflow_id),
@@ -4491,6 +4553,7 @@ def execute_adaptive_turn(
                     execution_method_name=execution_method_name,
                     arguments=trusted_arguments,
                     is_effect=is_effect,
+                    semantic_effect=semantic_effect,
                     minimum_effect_window_seconds=minimum_effect_window,
                     capability_kind=(
                         "represented_workflow"
@@ -4530,6 +4593,7 @@ def execute_adaptive_turn(
                     arguments=arguments,
                     capability_name=canonical_name,
                     is_effect=is_effect,
+                    semantic_effect=item.semantic_effect,
                     execution_method_name=execution_method_name,
                     capability_kind=item.capability_kind,
                     represented_workflow_id=item.represented_workflow_id,
@@ -4697,6 +4761,8 @@ def execute_adaptive_turn(
                                 effect_id=effect_identifier,
                                 call_id=call.call_id,
                                 capability_name=canonical_name,
+                                capability_kind=item.capability_kind,
+                                semantic_effect=item.semantic_effect,
                             )
                             if effect_identifier is not None
                             else None
@@ -4922,6 +4988,7 @@ def execute_adaptive_turn(
                 arguments = contained_result.arguments
                 canonical_name = contained_result.capability_name
                 is_effect = contained_result.is_effect
+                semantic_effect = contained_result.semantic_effect
                 execution_method_name = contained_result.execution_method_name
                 effect_identifier = (
                     _effect_id(
@@ -4944,6 +5011,30 @@ def execute_adaptive_turn(
                     _effect_status(
                         raw_payload,
                         transport_result=transport_result,
+                    )
+                    if is_effect
+                    else None
+                )
+                changed = (
+                    (
+                        raw_payload.get("changed")
+                        if isinstance(raw_payload, Mapping)
+                        and isinstance(raw_payload.get("changed"), bool)
+                        else (
+                            False
+                            if effect_status in {"failed", "not_started"}
+                            else None
+                        )
+                    )
+                    if is_effect
+                    else None
+                )
+                turn_finality_required = (
+                    _effect_requires_turn_finality(
+                        capability_kind=contained_result.capability_kind,
+                        effect_status=str(effect_status),
+                        changed=changed,
+                        raw_payload=raw_payload,
                     )
                     if is_effect
                     else None
@@ -4982,6 +5073,8 @@ def execute_adaptive_turn(
                             {
                                 "effect_id": effect_identifier,
                                 "effect_status": effect_status,
+                                "semantic_effect": semantic_effect,
+                                "turn_finality_required": turn_finality_required,
                             }
                             if is_effect
                             else {}
@@ -4994,21 +5087,12 @@ def execute_adaptive_turn(
                 if result_target_ids:
                     envelope_payload["result_target_ids"] = result_target_ids
                 if is_effect:
-                    changed = (
-                        raw_payload.get("changed")
-                        if isinstance(raw_payload, Mapping)
-                        and isinstance(raw_payload.get("changed"), bool)
-                        else (
-                            False
-                            if effect_status in {"failed", "not_started"}
-                            else None
-                        )
-                    )
                     remember_effect_state(
                         effect_identifier,
                         phase=0,
                         effect_status=effect_status,
                         changed=changed,
+                        turn_finality_required=bool(turn_finality_required),
                         execution_id=(
                             str(
                                 getattr(
@@ -5036,6 +5120,8 @@ def execute_adaptive_turn(
                             "effect_id": effect_identifier,
                             "effect_status": effect_status,
                             "changed": changed,
+                            "semantic_effect": semantic_effect,
+                            "turn_finality_required": turn_finality_required,
                         }
                     )
                     if isinstance(raw_payload, Mapping):
@@ -5088,6 +5174,8 @@ def execute_adaptive_turn(
                             "effect_id": effect_identifier,
                             "effect_status": effect_status,
                             "changed": envelope_payload.get("changed"),
+                            "semantic_effect": semantic_effect,
+                            "turn_finality_required": turn_finality_required,
                         }
                     )
                     if isinstance(raw_payload, Mapping):

--- a/src/backend/services/workflow_turn_capability_service.py
+++ b/src/backend/services/workflow_turn_capability_service.py
@@ -799,7 +799,7 @@ def normalise_workflow_effect_receipt(
         effect_status = "indeterminate"
         changed = None
     elif receipt.get("success") is False and instance_id is None:
-        effect_status = "failed"
+        effect_status = "not_started"
         changed = False
     elif status_key in _TERMINAL_SUCCESS_STATUSES and not timed_out:
         effect_status = "succeeded"
@@ -824,6 +824,8 @@ def normalise_workflow_effect_receipt(
             "workflow_id": capability.workflow_id,
             "effect_status": effect_status,
             "changed": changed,
+            "semantic_effect": capability.semantic_effect,
+            "operational_state_effect": True,
             "mutation_outcome": (
                 "completed"
                 if effect_status == "succeeded"

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -6238,6 +6238,130 @@ def test_represented_workflow_is_discovered_and_invoked_as_bound_capability(
     assert result.response_text == "The represented work product was completed."
 
 
+def test_read_only_workflow_not_started_preserves_successful_direct_recovery(
+    monkeypatch,
+) -> None:
+    from src.backend.services.workflow_turn_capability_service import (
+        WorkflowTurnCapability,
+    )
+
+    workflow_capability = WorkflowTurnCapability(
+        name="represented_workflow_mail_review_test",
+        workflow_id="#V#mail_review_test_workflow",
+        display_name="Mail review test workflow",
+        description="Review recent messages through bounded read capabilities.",
+        relevance_score=0.96,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "inputs": {"type": "object", "properties": {}},
+            },
+            "additionalProperties": False,
+        },
+        component_capability_names=("general_read",),
+        declared_component_count=1,
+        declared_step_count=3,
+        semantic_effect=None,
+        semantic_effect_source="insufficient_declared_component_evidence",
+    )
+    monkeypatch.setattr(
+        "src.backend.services.workflow_turn_capability_service."
+        "discover_turn_workflow_capabilities",
+        lambda *_args, **_kwargs: (
+            [workflow_capability],
+            {
+                "schema_version": "workflow_turn_capability_discovery.v1",
+                "status": "completed",
+                "match_count": 1,
+            },
+        ),
+    )
+
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_capabilities",
+                    call_id="discover-mail-workflow",
+                    payload={"query": "summarise recent messages"},
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="invoke-mail-workflow",
+                    payload={
+                        "name": workflow_capability.name,
+                        "arguments": {"inputs": {}},
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="recover-with-direct-read",
+                    payload={
+                        "name": "general_read",
+                        "arguments": {"query": "recent messages"},
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response="The recent messages were summarised successfully."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_workflow_gateway(
+            lambda **_kwargs: {
+                "success": False,
+                "error_code": "workflow_not_runnable",
+                "status": "rejected_preflight",
+            }
+        ),
+        prompt="Summarise my recent messages.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#real_user@real_org",
+        user_concept_id="#V#real_user",
+        org_concept_id="#V#real_org",
+        turn_id="turn-read-only-workflow-direct-recovery",
+        turn_budget_seconds=20,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert result.response_text == (
+        "The recent messages were summarised successfully."
+    )
+    assert result.terminal_status == "completed"
+    assert result.effect_finality_fallback is False
+    workflow_invocation = next(
+        item
+        for item in result.tool_invocations
+        if item.get("tool") == workflow_capability.name
+    )
+    assert workflow_invocation["effect_status"] == "not_started"
+    assert workflow_invocation["changed"] is False
+    assert workflow_invocation["semantic_effect"] is None
+    assert workflow_invocation["turn_finality_required"] is False
+    assert "instance_id" not in workflow_invocation
+    assert workflow_invocation["evidence"]["semantic_effect"] is None
+    assert workflow_invocation["evidence"]["turn_finality_required"] is False
+    direct_invocation = next(
+        item
+        for item in result.tool_invocations
+        if item.get("tool") == "general_read"
+    )
+    assert direct_invocation["status"] == "ok"
+
+
 def test_represented_workflow_retry_reuses_same_turn_idempotency_key(
     monkeypatch,
 ) -> None:

--- a/tests/backend/test_workflow_turn_capability_service.py
+++ b/tests/backend/test_workflow_turn_capability_service.py
@@ -360,7 +360,7 @@ def test_workflow_receipt_distinguishes_completion_partial_failure_and_no_start(
     assert terminal_failure["recovery_affordances"][0]["arguments"] == {
         "instance_id": "instance-3"
     }
-    assert no_start["effect_status"] == "failed"
+    assert no_start["effect_status"] == "not_started"
     assert no_start["changed"] is False
     assert no_start["mutation_outcome"] == "not_started"
     assert indeterminate["effect_status"] == "indeterminate"

--- a/tests/test_migrate_jvnautosci_2591_general_mail_followups.py
+++ b/tests/test_migrate_jvnautosci_2591_general_mail_followups.py
@@ -108,3 +108,83 @@ def test_rewrite_is_idempotent() -> None:
     assert changed is True
     assert changed_again is False
     assert second == first
+
+
+def test_rewrite_repairs_dangling_profile_status_branch() -> None:
+    current = _current_spec()
+    current["steps"] = [
+        step
+        for step in current["steps"]
+        if not step["state_id"].endswith(
+            ("fetch_mail_profile_status", "render_mail_profile_status")
+        )
+    ]
+
+    rewritten, changed = mod.rewrite_general_mail_followups(
+        current,
+        _desired_spec(),
+    )
+
+    assert changed is True
+    state_ids = {step["state_id"] for step in rewritten["steps"]}
+    assert (
+        "#V#workflow_step_general_mail_review_workflow_fetch_mail_profile_status"
+        in state_ids
+    )
+    assert (
+        "#V#workflow_step_general_mail_review_workflow_render_mail_profile_status"
+        in state_ids
+    )
+
+
+def test_visibility_repair_copies_parent_scope_and_preserves_other_relations(
+    monkeypatch,
+) -> None:
+    workflow_id = mod.GENERAL_MAIL_WORKFLOW_ID
+    child_id = "#V#stale_mail_child"
+    docs = {
+        workflow_id: {
+            "concept_id": workflow_id,
+            "relationships": {"#V#is_an_instance_of": ["#V#ai_workflow"]},
+        },
+        child_id: {
+            "concept_id": child_id,
+            "relationships": {
+                "#V#specific_to_user": ["#V#zhan_von_witbrock"],
+                "#V#is_an_instance_of": ["#V#workflow_step"],
+            },
+        },
+    }
+    monkeypatch.setitem(
+        mod.VISIBILITY_REPAIR_CHILD_IDS_BY_WORKFLOW,
+        workflow_id,
+        (child_id,),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_find_raw_concept_by_exact_concept_id",
+        lambda concept_id: copy.deepcopy(docs.get(concept_id)),
+    )
+
+    def update_concept(
+        concept_id: str,
+        update_data: dict,
+        *,
+        defer_side_effects: bool,
+    ) -> None:
+        assert defer_side_effects is True
+        docs[concept_id]["relationships"] = copy.deepcopy(
+            update_data["relationships"]
+        )
+
+    monkeypatch.setattr(mod.concept_service, "update_concept", update_concept)
+
+    preview = mod.repair_mail_visibility_closure(workflow_id, apply=False)
+    applied = mod.repair_mail_visibility_closure(workflow_id, apply=True)
+
+    assert preview["repair_required_ids"] == [child_id]
+    assert applied["closure_verified"] is True
+    assert "#V#specific_to_user" not in docs[child_id]["relationships"]
+    assert docs[child_id]["relationships"]["#V#is_an_instance_of"] == [
+        "#V#workflow_step"
+    ]


### PR DESCRIPTION
## What changed

- repair the nine stale represented-mail workflow children so their visibility covers the parent workflow audience;
- verify both mail workflows through a second organisation member after publication;
- classify a represented-workflow rejection before instance creation as `not_started`, with `changed=false`;
- retain that attempt and its evidence while excluding only this known no-effect case from turn-level effect-finality failure.

## Why

The July mail workflow publication left child concepts narrower than their parent, so an organisation member could discover the workflow but not load or run its complete definition. Recovery through a simpler mail path could then still make the outer turn fail because an operational workflow attempt with no created instance was treated as an unresolved semantic effect.

## User impact

Organisation members covered by the workflow parent visibility can load and run the complete mail workflows after the migration is applied. A rejected pre-instance represented-workflow attempt no longer invalidates an otherwise successful recovered answer, while the failed attempt remains visible in evidence.

## Validation

- 131 targeted tests passed, including the complete adaptive-turn suite and PR #336 evidence compaction/source-diagnostic coverage
- Ruff `E9,F` passed on all changed files
- `git diff --check` passed

The already-applied live mail repair was independently read back earlier; this PR makes that repair reproducible in version control.