### PR TITLE
Keep queued prompts and session loads scoped

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -132,6 +132,7 @@ let totalHistorySegments = 1;
 let activeChatSessionId = null;
 let activeChatSessionName = null;
 let activeChatSessionOwnerId = null;
+let chatSessionSelectionGeneration = 0;
 let newChatCreationInFlight = null;
 let sessionTabsCache = [];
 let displayedHistorySessionId = null;
@@ -22380,6 +22381,7 @@ function setActiveChatSession(sessionId, sessionName) {
     activeChatSessionOwnerId = null;
 
     if (previousSessionId !== activeChatSessionId) {
+        chatSessionSelectionGeneration += 1;
         synchroniseLlmExecutionContext({ reason: 'conversation_session_changed' });
         if (activeChatSessionId) {
             if (conversationSituationStateBySession.has(activeChatSessionId)) {
@@ -23957,6 +23959,7 @@ async function refreshChatSessionTabs() {
     if (!container) {
         return;
     }
+    const selectionGenerationAtStart = chatSessionSelectionGeneration;
     await _ensureInviteSessionContext();
 
     const hasCachedTabs = Array.isArray(sessionTabsCache) && sessionTabsCache.length > 0;
@@ -24031,6 +24034,17 @@ async function refreshChatSessionTabs() {
                 renderChatSessionTabsPlaceholder('error');
                 setTimeout(() => scheduleChatSessionTabsRefresh(true), 2000);
             }
+            return;
+        }
+
+        // A refresh can begin before an explicit session change and return after it.
+        // Never let that stale response erase a chat that was just selected or created.
+        if (chatSessionSelectionGeneration !== selectionGenerationAtStart) {
+            if (Array.isArray(sessionTabsCache) && sessionTabsCache.length > 0) {
+                renderChatSessionTabs(sessionTabsCache, activeChatSessionId);
+                container.hidden = false;
+            }
+            setTimeout(() => scheduleChatSessionTabsRefresh(true), 0);
             return;
         }
 
@@ -25113,6 +25127,15 @@ async function switchToChatSession(sessionId) {
     });
 
     setActiveChatSession(sid, cachedSession?.session_name);
+    const selectionGeneration = chatSessionSelectionGeneration;
+    const isCurrentSelection = () => (
+        chatSessionSelectionGeneration === selectionGeneration
+        && activeChatSessionId === sid
+    );
+    const finishSupersededSwitch = () => {
+        setChatSessionTabLoading(sid, false);
+        return { ok: false, superseded: true };
+    };
     clearSharedSessionUnread(sid);
     clearLatestUnreadBoundary();
     hideNewSharedMessagesIndicator();
@@ -25135,6 +25158,8 @@ async function switchToChatSession(sessionId) {
     }
 
     scrollableField.innerHTML = '<div class="chat-session-loading">Switching chat…</div>';
+    transcriptTurns.length = 0;
+    clearLlmDebugDataEntries();
     displayedHistorySessionId = null;
     clearHistoryLoadState();
     historySegmentsShown = 0;
@@ -25154,6 +25179,9 @@ async function switchToChatSession(sessionId) {
                 body: JSON.stringify({ session_id: sid, include_history: false })
             });
             data = await response.json().catch(() => ({}));
+            if (!isCurrentSelection()) {
+                return finishSupersededSwitch();
+            }
             setSessionMs = Math.round(performance.now() - setSessionStart);
             console.log('[chatTab] switchToChatSession set_chat_session', {
                 ok: response.ok,
@@ -25172,6 +25200,9 @@ async function switchToChatSession(sessionId) {
                 break;
             }
             await new Promise((resolve) => setTimeout(resolve, 320));
+            if (!isCurrentSelection()) {
+                return finishSupersededSwitch();
+            }
         }
 
         if (!response) {
@@ -25201,6 +25232,11 @@ async function switchToChatSession(sessionId) {
                 forceScrollToBottom: true
             });
             return { ok: false, error: msg };
+        }
+
+        const responseSessionId = normaliseHistorySessionId(data?.session_id);
+        if (responseSessionId !== sid) {
+            throw new Error('Conversation switch response did not match the selected session.');
         }
 
         setActiveChatSession(data?.session_id, data?.session_name);
@@ -25236,6 +25272,9 @@ async function switchToChatSession(sessionId) {
                 showResetNotice: false,
                 forceScrollToBottom: true
             });
+            if (!isCurrentSelection()) {
+                return finishSupersededSwitch();
+            }
             const recentMs = Math.round(performance.now() - recentStart);
             console.log('[chatTab] switchToChatSession recent pair', {
                 loaded,
@@ -25247,7 +25286,7 @@ async function switchToChatSession(sessionId) {
             }
 
             setTimeout(() => {
-                if (activeChatSessionId !== sid) {
+                if (!isCurrentSelection()) {
                     setChatSessionTabLoading(sid, false);
                     return;
                 }
@@ -25259,7 +25298,7 @@ async function switchToChatSession(sessionId) {
                     showResetNotice: false
                 });
                 backfillPromise.finally(() => {
-                    if (activeChatSessionId === sid) {
+                    if (isCurrentSelection()) {
                         setChatSessionTabLoading(sid, false);
                     }
                 });
@@ -25285,6 +25324,9 @@ async function switchToChatSession(sessionId) {
         });
         return { ok: true, data };
     } catch (err) {
+        if (!isCurrentSelection()) {
+            return finishSupersededSwitch();
+        }
         console.error('Error switching chat session:', err);
         setActiveChatSession(previousSessionId, previousSessionName);
         if (sessionTabsCache.length > 0) {
@@ -31768,17 +31810,10 @@ async function sendQueuedChatPromptEntryAtIndex(nextIndex) {
         return;
     }
 
-    const targetSessionId = normaliseHistorySessionId(nextEntry.sessionId);
-    if (targetSessionId && targetSessionId !== activeChatSessionId) {
-        const switchResult = await switchToChatSession(targetSessionId);
-        if (!switchResult?.ok) {
-            nextEntry.syncError = switchResult?.error || 'Could not show this queued task conversation.';
-            renderChatTaskQueuePanel();
-            refreshChatSessionTabActivityIndicators();
-            updateSendButtonForCurrentChatState();
-            return;
-        }
-    }
+    // A queued turn is bound to its originating conversation, but executing it
+    // must not navigate the user away from the conversation they are currently
+    // reading. `handleSendPrompt` accepts the explicit target session and keeps
+    // all live/result rendering scoped to that session.
 
     if (nextEntry.queueId) {
         try {

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -4031,7 +4031,7 @@ describe('thinking activity history normalisation', () => {
             }
         ]);
 
-        expect(entriesHtml).toContain('Prompt (truncated)');
+        expect(entriesHtml).toContain('Prompt (14 chars, truncated)');
         expect(entriesHtml).toContain('Response (truncated)');
     });
 
@@ -7899,6 +7899,156 @@ describe('chat session composer state', () => {
         delete global.fetch;
     });
 
+    test('a late prior switch cannot replace a canonical empty selected session', async () => {
+        jest.useFakeTimers();
+        try {
+            const staleSessionId = 'session-stale-populated';
+            const emptySessionId = 'session-canonical-empty';
+            const ok = (data) => ({
+                ok: true,
+                status: 200,
+                json: async () => data
+            });
+            const carrier = (history, situation = null) => ({
+                history,
+                segments_returned: history.length > 0 ? 1 : 0,
+                total_segments: history.length > 0 ? 1 : 0,
+                has_more_history: false,
+                conversation_situation: situation,
+                conversation_observations: [],
+                conversation_observation_state: {
+                    schema_version: 'conversation_observation_state.v1',
+                    retained_count: 0,
+                    total_count: 0,
+                    omitted_count: 0,
+                    retention_limit: 12
+                }
+            });
+
+            __testOnly_resetHistoryUiState();
+            __testOnly_setActiveChatSession('session-origin', 'Origin');
+            __testOnly_setSessionTabsCache([
+                {
+                    session_id: staleSessionId,
+                    session_name: 'Populated',
+                    message_count: 2,
+                    last_message_at: '2026-08-01T20:00:00Z'
+                },
+                {
+                    session_id: emptySessionId,
+                    session_name: 'Empty',
+                    message_count: 0,
+                    last_message_at: '2026-08-01T20:01:00Z'
+                }
+            ]);
+            __testOnly_setTranscriptTurns([
+                { role: 'user', sender: 'User', message: 'STALE POPULATED TRANSCRIPT' }
+            ]);
+            document.getElementById('scrollableField').innerHTML =
+                '<div class="message-container user-turn">STALE POPULATED TRANSCRIPT</div>';
+
+            let releaseStaleSetSession;
+            const historyUrls = [];
+
+            global.fetch = jest.fn((url, options = {}) => {
+                if (
+                    typeof url === 'string'
+                    && url.startsWith('/von/api/session/set_chat_session')
+                ) {
+                    const body = JSON.parse(options.body || '{}');
+                    const response = ok({
+                        session_id: body.session_id,
+                        session_name: body.session_id === emptySessionId
+                            ? 'Empty'
+                            : 'Populated'
+                    });
+                    if (body.session_id === staleSessionId) {
+                        return new Promise((resolve) => {
+                            releaseStaleSetSession = () => resolve(response);
+                        });
+                    }
+                    return Promise.resolve(response);
+                }
+
+                if (
+                    typeof url === 'string'
+                    && url.startsWith('/von/api/session/chat_session_links')
+                ) {
+                    return Promise.resolve(ok({ session_links: {} }));
+                }
+
+                if (typeof url === 'string' && url.startsWith('/von/history?')) {
+                    historyUrls.push(url);
+                    const sid = new URL(url, 'http://von.test')
+                        .searchParams.get('session_id');
+                    if (sid === staleSessionId) {
+                        return Promise.resolve(ok(carrier([
+                            {
+                                role: 'user',
+                                content: 'STALE POPULATED TRANSCRIPT',
+                                timestamp: '2026-08-01T20:00:00Z'
+                            }
+                        ], {
+                            text: 'Stale populated situation.',
+                            revision: 1,
+                            source: 'adaptive_turn'
+                        })));
+                    }
+                    return Promise.resolve(ok(carrier([])));
+                }
+
+                if (
+                    typeof url === 'string'
+                    && url.startsWith('/von/api/session/context')
+                ) {
+                    return Promise.resolve(ok({
+                        user_id: 'user',
+                        organisation_id: 'org',
+                        namespace: 'user@org'
+                    }));
+                }
+
+                return Promise.resolve(ok({ sessions: [] }));
+            });
+
+            const staleSwitch = switchToChatSession(staleSessionId);
+            expect(typeof releaseStaleSetSession).toBe('function');
+
+            await expect(switchToChatSession(emptySessionId)).resolves.toEqual(
+                expect.objectContaining({ ok: true })
+            );
+
+            let activeCarrier = __testOnly_buildConversationSituationExportPayload();
+            expect(activeCarrier.session_id).toBe(emptySessionId);
+            expect(activeCarrier.availability).toBe('ready');
+            expect(activeCarrier.conversation_situation).toBeNull();
+            expect(__testOnly_getConversationTranscriptTurnsSnapshot()).toEqual([]);
+            expect(document.getElementById('scrollableField').textContent)
+                .not.toContain('STALE POPULATED TRANSCRIPT');
+
+            releaseStaleSetSession();
+            await expect(staleSwitch).resolves.toEqual(
+                expect.objectContaining({ ok: false, superseded: true })
+            );
+
+            activeCarrier = __testOnly_buildConversationSituationExportPayload();
+            expect(activeCarrier.session_id).toBe(emptySessionId);
+            expect(activeCarrier.conversation_situation).toBeNull();
+            expect(__testOnly_getConversationTranscriptTurnsSnapshot()).toEqual([]);
+            expect(document.getElementById('scrollableField').textContent)
+                .not.toContain('STALE POPULATED TRANSCRIPT');
+            expect(
+                document.querySelector('.chat-session-tab.is-active')?.dataset.sessionId
+            ).toBe(emptySessionId);
+            expect(
+                historyUrls.filter((url) => url.includes(`session_id=${staleSessionId}`))
+            ).toHaveLength(0);
+        } finally {
+            jest.clearAllTimers();
+            jest.useRealTimers();
+        }
+    });
+
     test('switching chat sessions keeps the originating request running in the background', async () => {
         const promptInput = document.getElementById('promptInput');
         initializePromptCartoucheOverlay(promptInput);
@@ -8092,6 +8242,8 @@ describe('chat session composer state', () => {
         expect(generateBodies).toHaveLength(2);
         expect(generateBodies[0].conversation_session_id).toBe('session-1');
         expect(generateBodies[1].conversation_session_id).toBe('session-2');
+        expect(document.querySelector('.chat-session-tab.is-active')?.dataset.sessionId)
+            .toBe('session-1');
         expect(document.getElementById('scrollableField').textContent).not.toContain('queued for session 2');
     });
 
@@ -8147,17 +8299,36 @@ describe('chat session composer state', () => {
         const createBodies = [];
         let created = false;
         let resolveCreate;
+        let resolveStaleHistoryRefresh;
+        let historyRequestCount = 0;
         const createResponse = new Promise((resolve) => {
             resolveCreate = resolve;
         });
+        const staleHistoryRefreshResponse = new Promise((resolve) => {
+            resolveStaleHistoryRefresh = resolve;
+        });
         global.fetch = jest.fn((url, options = {}) => {
             if (typeof url === 'string' && url.startsWith('/von/history/sessions')) {
-                const sessions = [{
-                    session_id: created ? 'session-new' : 'session-current',
-                    session_name: created ? 'Chat 2026-04-13 18:30' : 'Current chat',
-                    message_count: created ? 0 : 2,
-                    last_message_at: created ? '2026-04-13T18:30:00Z' : '2026-04-13T05:00:00Z'
-                }];
+                historyRequestCount += 1;
+                if (historyRequestCount === 2) {
+                    return staleHistoryRefreshResponse;
+                }
+                const sessions = [
+                    {
+                        session_id: 'session-current',
+                        session_name: 'Current chat',
+                        message_count: 2,
+                        last_message_at: '2026-04-13T05:00:00Z'
+                    }
+                ];
+                if (created) {
+                    sessions.unshift({
+                        session_id: 'session-new',
+                        session_name: 'Chat 2026-04-13 18:30',
+                        message_count: 0,
+                        last_message_at: '2026-04-13T18:30:00Z'
+                    });
+                }
                 return Promise.resolve({
                     ok: true,
                     json: async () => ({
@@ -8181,6 +8352,11 @@ describe('chat session composer state', () => {
         });
 
         await expect(__testOnly_refreshChatSessionTabs()).resolves.toBeUndefined();
+        const staleRefresh = __testOnly_refreshChatSessionTabs();
+        await Promise.resolve();
+        await Promise.resolve();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(historyRequestCount).toBe(2);
         const promptSpy = jest.spyOn(window, 'prompt').mockImplementation(() => 'should not be used');
         const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
         const newChatButton = document.querySelector('.chat-session-tab-new');
@@ -8201,6 +8377,23 @@ describe('chat session composer state', () => {
                 history: []
             })
         });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        await Promise.resolve();
+
+        resolveStaleHistoryRefresh({
+            ok: true,
+            json: async () => ({
+                authenticated: true,
+                active_session_id: 'session-current',
+                sessions: [{
+                    session_id: 'session-current',
+                    session_name: 'Current chat',
+                    message_count: 2,
+                    last_message_at: '2026-04-13T05:00:00Z'
+                }]
+            })
+        });
+        await expect(staleRefresh).resolves.toBeUndefined();
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(promptInput.value).toBe('Move this draft into a new conversation');

--- a/tests/frontend/chatTaskQueue.test.js
+++ b/tests/frontend/chatTaskQueue.test.js
@@ -382,7 +382,7 @@ describe('chat task queue', () => {
         expect(fetchCalls.some((call) => String(call.url).includes('/queue-2/claim'))).toBe(true);
     }, 15000);
 
-    test('switches to the queued prompt session before starting an off-session selected prompt', async () => {
+    test('starts an off-session selected prompt without switching the visible conversation', async () => {
         const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
         const {
             __testOnly_refreshChatPromptQueueFromServer,
@@ -535,12 +535,13 @@ describe('chat task queue', () => {
             String(call.url) === '/von/api/chat_prompt_queue/queue-off-session/claim'
         ));
         const generateIndex = fetchCalls.findIndex((call) => String(call.url).startsWith('/von/generate'));
-        expect(setSessionIndex).toBeGreaterThanOrEqual(0);
-        expect(claimIndex).toBeGreaterThan(setSessionIndex);
-        expect(generateIndex).toBeGreaterThan(setSessionIndex);
+        expect(setSessionIndex).toBe(-1);
+        expect(claimIndex).toBeGreaterThanOrEqual(0);
+        expect(generateIndex).toBeGreaterThan(claimIndex);
         expect(generateBodies[0].conversation_session_id).toBe('session-2');
-        expect(document.getElementById('scrollableField')?.textContent).toContain('Off-session selected queued');
-        expect(document.getElementById('thinkingCardWrapper')?.getAttribute('aria-hidden')).toBe('false');
+        expect(document.getElementById('scrollableField')?.textContent)
+            .not.toContain('Off-session selected queued');
+        expect(document.getElementById('thinkingCardWrapper')?.getAttribute('aria-hidden')).toBe('true');
 
         expect(resolveGenerate).toBeTruthy();
         resolveGenerate();


### PR DESCRIPTION
## What changed

- execute a queued prompt in its originating conversation without navigating the user away from the conversation they are reading;
- guard session switching and session-list refreshes with a selection generation so stale asynchronous responses cannot repaint a newer or newly created conversation;
- clear transcript/debug state while loading a canonical empty conversation;
- add regression coverage for queued off-session execution and stale switch/refresh races.

## Why

A queued turn already carries its explicit conversation session, so switching the visible UI before dispatch was unnecessary and disruptive. Separately, a slower prior switch or session-list response could arrive after New Chat or a newer selection and overwrite the visible conversation with stale state.

## User impact

Background/queued work stays attached to the correct conversation while the user remains free to read another one. Rapid switching and New Chat no longer risk showing a transcript from an older request.

## Validation

- 272/272 tests passed across the full `chatTab`, abort, queue, session-view-model, and scoped-storage suites
- authenticated AgentTest browser replay on `127.0.0.1:5010`: queued work completed in conversation B while A stayed visible; returning to B showed the queued result; rapid switch to New Chat remained on the new blank conversation with no dialogue
- frontend ESLint: 0 errors, one pre-existing warning outside the diff
- `git diff --check` passed