### PR TITLE
Show semantic relation progress in Thinking

### DIFF
--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -44,6 +44,9 @@ from src.backend.services.turn_evidence_store import (
     TrustedTurnScope,
     TurnEvidenceStore,
 )
+from src.backend.services.thinking_semantic_projection_service import (
+    build_semantic_operation_projection,
+)
 
 _CAPABILITY_TOOL_NAME = "turn_capabilities"
 _INVOKE_TOOL_NAME = "turn_invoke_capability"
@@ -4748,6 +4751,27 @@ def execute_adaptive_turn(
                         )
                     return index, contained(denial_payload)
             try:
+                semantic_operation = build_semantic_operation_projection(
+                    operation_id=call.call_id,
+                    capability_name=canonical_name,
+                    execution_method=execution_method_name,
+                    capability_kind=item.capability_kind,
+                    arguments=arguments,
+                    lifecycle_status="running",
+                )
+                _emit(
+                    progress_tracker,
+                    {
+                        "status": "tool_call_start",
+                        "event_kind": "tool_call_start",
+                        "stage": "adaptive_research",
+                        "phase": "adaptive_research",
+                        "tool": canonical_name,
+                        "execution_method": execution_method_name,
+                        "call_id": call.call_id,
+                        "result_summary": semantic_operation["summary"],
+                    },
+                )
                 with override_current_actor(
                     scope.user_concept_id,
                     scope.organisation_concept_id,
@@ -5260,28 +5284,43 @@ def execute_adaptive_turn(
                     }
                 )
                 tool_invocations.append(invocation)
+                semantic_result = {
+                    **dict(envelope_payload),
+                    **(
+                        dict(raw_payload)
+                        if isinstance(raw_payload, Mapping)
+                        else {}
+                    ),
+                    **(
+                        {"result_target_ids": result_target_ids}
+                        if result_target_ids
+                        else {}
+                    ),
+                }
+                semantic_operation = build_semantic_operation_projection(
+                    operation_id=call.call_id,
+                    capability_name=canonical_name,
+                    execution_method=execution_method_name,
+                    capability_kind=contained_result.capability_kind,
+                    arguments=arguments,
+                    lifecycle_status=(
+                        effect_status or ("succeeded" if status == "ok" else "failed")
+                    ),
+                    success=status == "ok",
+                    result=semantic_result,
+                )
                 _emit(
                     progress_tracker,
                     {
                         "status": "tool_completed",
+                        "event_kind": "tool_call_end",
                         "stage": "adaptive_research",
                         "phase": "adaptive_research",
                         "tool": canonical_name,
                         "execution_method": execution_method_name,
                         "call_id": call.call_id,
                         "success": status == "ok",
-                        "result_summary": (
-                            (
-                                f"Effect {effect_identifier} completed with "
-                                f"status {effect_status}; evidence recorded as "
-                                f"{envelope_payload.get('evidence_id')}."
-                            )
-                            if is_effect
-                            else (
-                                f"Read evidence recorded as "
-                                f"{envelope_payload.get('evidence_id')}."
-                            )
-                        ),
+                        "result_summary": semantic_operation["summary"],
                     },
                 )
 

--- a/src/backend/services/thinking_semantic_projection_service.py
+++ b/src/backend/services/thinking_semantic_projection_service.py
@@ -1,0 +1,284 @@
+"""Bounded, human-readable projections of capability activity.
+
+The projection is deliberately a view model, not a second execution record.
+It retains exact identifiers needed for inspection while giving the ordinary
+Thinking surface labels and role-labelled arguments that a person can read.
+No database lookup is performed here: richer naming remains an optional later
+enrichment rather than another source of latency or failure on the answer path.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+SEMANTIC_OPERATION_SCHEMA_VERSION = "thinking_semantic_operation.v1"
+_MAX_TEXT_CHARS = 240
+_MAX_ARGUMENTS = 8
+
+_ARGUMENT_SPECS = (
+    ("subject_concept_id", "subject", "Subject", "concept"),
+    ("source_id", "subject", "Subject", "concept"),
+    ("concept_id", "subject", "Subject", "concept"),
+    ("predicate", "predicate", "Relation", "predicate"),
+    ("predicate_id", "predicate", "Relation", "predicate"),
+    ("predicate_ref", "predicate", "Relation", "predicate"),
+    ("target_concept_id", "object", "Object", "concept"),
+    ("target_id", "object", "Object", "concept"),
+    ("target", "object", "Object", "concept"),
+    ("target_text", "value", "Value", "text"),
+    ("text", "value", "Value", "text"),
+    ("workflow_id", "workflow", "Workflow", "workflow"),
+    ("instance_id", "instance", "Workflow instance", "identifier"),
+    ("name", "name", "Name", "text"),
+)
+
+
+def _clean_text(value: Any, *, limit: int = _MAX_TEXT_CHARS) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = re.sub(r"\s+", " ", value).strip()
+    if not cleaned:
+        return None
+    if len(cleaned) <= limit:
+        return cleaned
+    return f"{cleaned[: max(0, limit - 3)].rstrip()}..."
+
+
+def _display_label(value: str) -> str:
+    cleaned = value.removeprefix("#V#")
+    cleaned = re.sub(r"[_\-]+", " ", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned.title() if cleaned else value
+
+
+def _scalar_value(value: Any) -> str | int | float | bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value
+    return _clean_text(value)
+
+
+def _argument_value(value: Any) -> str | int | float | bool | None:
+    scalar = _scalar_value(value)
+    if scalar is not None:
+        return scalar
+    if isinstance(value, Mapping):
+        for key in ("concept_id", "predicate_id", "id", "value"):
+            scalar = _scalar_value(value.get(key))
+            if scalar is not None:
+                return scalar
+    return None
+
+
+def _argument_projection(arguments: Mapping[str, Any]) -> list[dict[str, Any]]:
+    projected: list[dict[str, Any]] = []
+    seen_roles: set[str] = set()
+    for key, role, label, value_kind in _ARGUMENT_SPECS:
+        if role in seen_roles or key not in arguments:
+            continue
+        value = _argument_value(arguments.get(key))
+        if value is None:
+            continue
+        display = (
+            value
+            if isinstance(value, str) and value_kind == "text"
+            else _display_label(value)
+            if isinstance(value, str)
+            else str(value)
+        )
+        item: dict[str, Any] = {
+            "role": role,
+            "label": label,
+            "source_argument": key,
+            "value_kind": value_kind,
+            "value": value,
+            "display": display,
+        }
+        if isinstance(value, str) and value.startswith("#V#"):
+            item["concept_id"] = value
+        projected.append(item)
+        seen_roles.add(role)
+        if len(projected) >= _MAX_ARGUMENTS:
+            break
+    return projected
+
+
+def _argument_by_role(
+    arguments: list[dict[str, Any]], role: str
+) -> dict[str, Any] | None:
+    return next((item for item in arguments if item.get("role") == role), None)
+
+
+def _relation_projection(
+    arguments: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    subject = _argument_by_role(arguments, "subject")
+    predicate = _argument_by_role(arguments, "predicate")
+    target = _argument_by_role(arguments, "object") or _argument_by_role(
+        arguments, "value"
+    )
+    if subject is None or predicate is None or target is None:
+        return None
+    return {
+        "subject": dict(subject),
+        "predicate": dict(predicate),
+        "object": dict(target),
+    }
+
+
+def _outcome_projection(
+    result: Mapping[str, Any] | None,
+    *,
+    lifecycle_status: str,
+    success: bool | None,
+) -> dict[str, Any] | None:
+    if result is None and lifecycle_status == "running":
+        return None
+    payload = result if isinstance(result, Mapping) else {}
+    outcome: dict[str, Any] = {
+        "status": lifecycle_status,
+        "success": success,
+    }
+    for key in (
+        "effect_status",
+        "changed",
+        "mutation_outcome",
+        "outcome_finality",
+        "error_code",
+        "effect_id",
+        "evidence_id",
+        "workflow_id",
+        "instance_id",
+        "final_status",
+    ):
+        value = _scalar_value(payload.get(key))
+        if value is not None:
+            outcome[key] = value
+    target_ids = payload.get("result_target_ids")
+    if isinstance(target_ids, list):
+        bounded_ids = [
+            item
+            for item in (_clean_text(value) for value in target_ids[:8])
+            if item
+        ]
+        if bounded_ids:
+            outcome["result_target_ids"] = bounded_ids
+    return outcome
+
+
+def _summary(
+    *,
+    capability_label: str,
+    relation: Mapping[str, Any] | None,
+    lifecycle_status: str,
+    success: bool | None,
+    result: Mapping[str, Any] | None,
+) -> str:
+    if isinstance(relation, Mapping):
+        subject = str(relation["subject"].get("display") or "the subject")
+        predicate = str(relation["predicate"].get("display") or "the relation")
+        target = str(relation["object"].get("display") or "the object")
+        target_is_text = relation["object"].get("value_kind") == "text"
+        if target_is_text:
+            target = f"“{target}”"
+        target_role_label = "Value" if target_is_text else "Object"
+        statement = (
+            f"Subject: {subject}; Relation: {predicate}; "
+            f"{target_role_label}: {target}"
+        )
+        if lifecycle_status == "running":
+            return f"{capability_label}: {statement} (in progress)."
+        outcome = result if isinstance(result, Mapping) else {}
+        changed = outcome.get("changed")
+        effect_status = str(outcome.get("effect_status") or "").strip().lower()
+        mutation_outcome = str(
+            outcome.get("mutation_outcome") or ""
+        ).strip().lower()
+        if success is True:
+            if changed is False:
+                return (
+                    f"{capability_label} confirmed no change was needed: "
+                    f"{statement}."
+                )
+            if changed is True:
+                return f"{capability_label} reported a change: {statement}."
+            return f"{capability_label} finished: {statement}."
+        if success is False:
+            if effect_status == "partial":
+                return f"{capability_label} completed only partially: {statement}."
+            if effect_status == "indeterminate" or mutation_outcome == "unknown":
+                return (
+                    f"The outcome of {capability_label} could not be verified: "
+                    f"{statement}."
+                )
+            return f"{capability_label} did not succeed: {statement}."
+        return f"{capability_label}: {statement}."
+    if lifecycle_status == "running":
+        return f"Using {capability_label}."
+    if success is True:
+        return f"Finished {capability_label}."
+    if success is False:
+        return f"{capability_label} did not succeed."
+    return f"Observed {capability_label}."
+
+
+def build_semantic_operation_projection(
+    *,
+    operation_id: str,
+    capability_name: str,
+    execution_method: str,
+    capability_kind: str,
+    arguments: Mapping[str, Any],
+    lifecycle_status: str,
+    success: bool | None = None,
+    result: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build one bounded lifecycle projection without additional retrieval."""
+
+    operation_id_value = _clean_text(operation_id) or "unknown-operation"
+    capability_id = _clean_text(capability_name) or "unknown_capability"
+    execution_method_id = _clean_text(execution_method) or capability_id
+    kind = _clean_text(capability_kind) or "registered_tool"
+    status = _clean_text(lifecycle_status, limit=80) or "unknown"
+    capability_label = _display_label(capability_id)
+    projected_arguments = _argument_projection(arguments)
+    relation = _relation_projection(projected_arguments)
+    projection: dict[str, Any] = {
+        "schema_version": SEMANTIC_OPERATION_SCHEMA_VERSION,
+        "operation_id": operation_id_value,
+        "lifecycle_status": status,
+        "capability": {
+            "id": capability_id,
+            "label": capability_label,
+            "kind": kind,
+            "execution_method": execution_method_id,
+        },
+        "arguments": projected_arguments,
+        "summary": _summary(
+            capability_label=capability_label,
+            relation=relation,
+            lifecycle_status=status,
+            success=success,
+            result=result,
+        ),
+        "visibility": "actor_scope",
+    }
+    if relation is not None:
+        projection["relation"] = relation
+    outcome = _outcome_projection(
+        result,
+        lifecycle_status=status,
+        success=success,
+    )
+    if outcome is not None:
+        projection["outcome"] = outcome
+    return projection
+
+
+__all__ = [
+    "SEMANTIC_OPERATION_SCHEMA_VERSION",
+    "build_semantic_operation_projection",
+]

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -3155,6 +3155,44 @@ describe('thinking activity history normalisation', () => {
         expect(fallbackHtml).toContain('Fetched');
     });
 
+    test('renders a semantic relation summary in Default thinking without raw receipts', () => {
+        const resultSummary = 'Add Relationship confirmed no change was needed: '
+            + 'Subject: Nathan Young Doctoral Candidature Situation; '
+            + 'Relation: Has Doctoral Supervisor; Object: Robert Amor.';
+        const html = __testOnly_renderThinkingCardBodyHTML({
+            promptRaw: 'Re-assert the existing supervision relationship.',
+            thinkingStartedAtMs: Date.now() - 1000,
+            latestProgress: {
+                status: 'tool_completed',
+                stage: 'adaptive_research',
+                result_summary: resultSummary,
+                tool_history: [{
+                    tool: 'add_relationship',
+                    workflowTask: '',
+                    batchSize: null,
+                    phase: 'adaptive_research',
+                    resultSummary,
+                    success: true,
+                    callId: 'call-semantic-relation'
+                }],
+                tool_call_count: 1,
+                tool_success_count: 1,
+                tool_failure_count: 0,
+                tool_pending_count: 0
+            }
+        }, { mode: 'default' });
+
+        expect(html).toContain('Nathan Young Doctoral Candidature Situation');
+        expect(html).toContain('Subject:');
+        expect(html).toContain('Relation:');
+        expect(html).toContain('Object:');
+        expect(html).toContain('Has Doctoral Supervisor');
+        expect(html).toContain('Robert Amor');
+        expect(html).toContain('no change was needed');
+        expect(html).not.toContain('effect_');
+        expect((html.match(/<div class="thinking-card-tool">/g) || [])).toHaveLength(1);
+    });
+
     test('prefers canonical latest progress tool history over stale local tool history', () => {
         const request = {
             toolUseProgressHistory: [{

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -4882,6 +4882,88 @@ def test_effect_batch_preserves_order_and_read_can_observe_prior_effect(
     ) >= 0
 
 
+def test_relation_progress_emits_one_human_start_and_terminal_summary(
+    monkeypatch,
+) -> None:
+    from src.backend.services import adaptive_turn_service
+
+    progress_events: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        adaptive_turn_service,
+        "_effect_subject_authorised",
+        lambda *_args, **_kwargs: True,
+    )
+
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="robert-amor-supervision",
+                    payload={
+                        "name": "add_relationship",
+                        "arguments": {
+                            "source_id": (
+                                "#V#nathan_young_doctoral_candidature_situation"
+                            ),
+                            "predicate": "#V#has_doctoral_supervisor",
+                            "target": "#V#robert_amor",
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response="That supervision relationship was already known."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_effect_gateway(
+            lambda _name, _arguments: {
+                "success": True,
+                "effect_status": "succeeded",
+                "changed": False,
+            }
+        ),
+        prompt="Re-assert the existing Robert Amor supervision relationship.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="semantic-relation-progress",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+        progress_tracker=SimpleNamespace(
+            emit=lambda event: progress_events.append(dict(event)),
+            check_cancellation=lambda: None,
+        ),
+    )
+
+    relation_events = [
+        event
+        for event in progress_events
+        if event.get("call_id") == "robert-amor-supervision"
+    ]
+    assert [event["event_kind"] for event in relation_events] == [
+        "tool_call_start",
+        "tool_call_end",
+    ]
+    assert relation_events[0]["result_summary"] == (
+        "Add Relationship: Subject: Nathan Young Doctoral Candidature Situation; "
+        "Relation: Has Doctoral Supervisor; Object: Robert Amor (in progress)."
+    )
+    assert relation_events[1]["success"] is True
+    assert relation_events[1]["result_summary"] == (
+        "Add Relationship confirmed no change was needed: "
+        "Subject: Nathan Young Doctoral Candidature Situation; "
+        "Relation: Has Doctoral Supervisor; Object: Robert Amor."
+    )
+    assert "semantic_operation" not in relation_events[0]
+    assert result.tool_invocations[0]["changed"] is False
+
+
 def test_effect_evidence_preserves_success_partial_failure_and_unknown_timeout() -> None:
     seen_cases: list[str] = []
     progress_events: list[dict[str, Any]] = []
@@ -4971,6 +5053,7 @@ def test_effect_evidence_preserves_success_partial_failure_and_unknown_timeout()
         and event.get("call_id") == "effect-partial"
     )
     assert partial_progress["success"] is False
+    assert not partial_progress["result_summary"].startswith("Finished ")
 
 
 def test_partial_effect_downgrades_nominal_model_completion() -> None:

--- a/tests/backend/test_thinking_semantic_projection_service.py
+++ b/tests/backend/test_thinking_semantic_projection_service.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from src.backend.services.thinking_semantic_projection_service import (
+    SEMANTIC_OPERATION_SCHEMA_VERSION,
+    build_semantic_operation_projection,
+)
+
+
+def _relation_projection(**overrides):
+    arguments = {
+        "source_id": "#V#nathan_young_doctoral_candidature_situation",
+        "predicate": "#V#has_doctoral_supervisor",
+        "target": "#V#robert_amor",
+    }
+    arguments.update(overrides.pop("arguments", {}))
+    values = {
+        "operation_id": "call-relationship",
+        "capability_name": "add_relationship",
+        "execution_method": "add_relationship",
+        "capability_kind": "registered_tool",
+        "arguments": arguments,
+        "lifecycle_status": "running",
+    }
+    values.update(overrides)
+    return build_semantic_operation_projection(**values)
+
+
+def test_relation_projection_has_role_labelled_arguments_and_readable_start() -> None:
+    projection = _relation_projection()
+
+    assert projection["schema_version"] == SEMANTIC_OPERATION_SCHEMA_VERSION
+    assert [item["role"] for item in projection["arguments"]] == [
+        "subject",
+        "predicate",
+        "object",
+    ]
+    assert projection["relation"]["predicate"]["concept_id"] == (
+        "#V#has_doctoral_supervisor"
+    )
+    assert projection["summary"] == (
+        "Add Relationship: Subject: Nathan Young Doctoral Candidature Situation; "
+        "Relation: Has Doctoral Supervisor; Object: Robert Amor (in progress)."
+    )
+
+
+def test_nested_predicate_reference_and_unchanged_outcome_are_truthful() -> None:
+    projection = _relation_projection(
+        arguments={
+            "predicate": None,
+            "predicate_ref": {"concept_id": "#V#has_doctoral_supervisor"},
+        },
+        lifecycle_status="succeeded",
+        success=True,
+        result={"effect_status": "succeeded", "changed": False},
+    )
+
+    assert projection["relation"]["predicate"]["concept_id"] == (
+        "#V#has_doctoral_supervisor"
+    )
+    assert projection["outcome"]["changed"] is False
+    assert projection["summary"] == (
+        "Add Relationship confirmed no change was needed: "
+        "Subject: Nathan Young Doctoral Candidature Situation; "
+        "Relation: Has Doctoral Supervisor; Object: Robert Amor."
+    )
+
+
+def test_relation_operation_wording_preserves_remove_partial_and_unknown() -> None:
+    removed = _relation_projection(
+        capability_name="remove_relationship",
+        execution_method="remove_relationship",
+        lifecycle_status="succeeded",
+        success=True,
+        result={"effect_status": "succeeded", "changed": True},
+    )
+    partial = _relation_projection(
+        capability_name="preview_remove_relationship",
+        execution_method="preview_remove_relationship",
+        lifecycle_status="partial",
+        success=False,
+        result={"effect_status": "partial", "changed": True},
+    )
+    unknown = _relation_projection(
+        lifecycle_status="indeterminate",
+        success=False,
+        result={
+            "effect_status": "indeterminate",
+            "mutation_outcome": "unknown",
+        },
+    )
+
+    assert removed["summary"].startswith("Remove Relationship reported a change:")
+    assert partial["summary"].startswith(
+        "Preview Remove Relationship completed only partially:"
+    )
+    assert unknown["summary"].startswith(
+        "The outcome of Add Relationship could not be verified:"
+    )
+    assert "Represented" not in " ".join(
+        (removed["summary"], partial["summary"], unknown["summary"])
+    )
+
+
+def test_literal_text_preserves_case_and_punctuation() -> None:
+    projection = build_semantic_operation_projection(
+        operation_id="call-text",
+        capability_name="upsert_text_relation",
+        execution_method="upsert_text_relation",
+        capability_kind="registered_tool",
+        arguments={
+            "concept_id": "#V#robert_amor",
+            "predicate": "#V#has_professional_title",
+            "text": "Professor of Computer Science (emeritus).",
+        },
+        lifecycle_status="succeeded",
+        success=True,
+        result={"effect_status": "succeeded", "changed": False},
+    )
+
+    assert projection["relation"]["object"]["display"] == (
+        "Professor of Computer Science (emeritus)."
+    )
+    assert (
+        "Value: “Professor of Computer Science (emeritus).”"
+        in projection["summary"]
+    )
+    assert "Professor Of Computer Science" not in projection["summary"]
+
+
+def test_projection_bounds_values_and_does_not_invent_a_relation() -> None:
+    projection = build_semantic_operation_projection(
+        operation_id="call-generic",
+        capability_name="create_concepts",
+        execution_method="create_concepts",
+        capability_kind="registered_tool",
+        arguments={
+            "name": "x" * 1_000,
+            "unused_1": "one",
+            "unused_2": "two",
+        },
+        lifecycle_status="succeeded",
+        success=True,
+        result={"effect_status": "succeeded", "changed": True},
+    )
+
+    assert "relation" not in projection
+    assert len(projection["arguments"]) == 1
+    assert len(projection["arguments"][0]["value"]) <= 240
+    assert projection["summary"] == "Finished Create Concepts."

--- a/tests/backend/test_tool_progress_liveness.py
+++ b/tests/backend/test_tool_progress_liveness.py
@@ -953,6 +953,72 @@ def test_tool_summary_survives_a_long_heartbeat_tail(monkeypatch) -> None:
     assert tool_history[0]["resultSummary"] == "One evidence item read."
 
 
+def test_relation_start_and_end_collapse_to_one_human_tool_row(monkeypatch) -> None:
+    clock = _set_clock(monkeypatch, start=5600.0)
+    scope_key = "scope-semantic-relation"
+    request_id = "req-semantic-relation"
+    call_id = "call-semantic-relation"
+    running_summary = (
+        "Add Relationship: Subject: Nathan Young Doctoral Candidature Situation; "
+        "Relation: Has Doctoral Supervisor; Object: Robert Amor (in progress)."
+    )
+    terminal_summary = (
+        "Add Relationship confirmed no change was needed: "
+        "Subject: Nathan Young Doctoral Candidature Situation; "
+        "Relation: Has Doctoral Supervisor; Object: Robert Amor."
+    )
+
+    von_routes._set_tool_progress(
+        scope_key,
+        request_id,
+        {
+            "status": "tool_call_start",
+            "event_kind": "tool_call_start",
+            "phase": "adaptive_research",
+            "tool": "add_relationship",
+            "call_id": call_id,
+            "result_summary": running_summary,
+            "request_id": request_id,
+        },
+    )
+    clock["now"] += 0.1
+    von_routes._set_tool_progress(
+        scope_key,
+        request_id,
+        {
+            "status": "tool_completed",
+            "event_kind": "tool_call_end",
+            "phase": "adaptive_research",
+            "tool": "add_relationship",
+            "call_id": call_id,
+            "success": True,
+            "result_summary": terminal_summary,
+            "request_id": request_id,
+        },
+    )
+
+    snapshot = von_routes._snapshot_tool_progress_for_request(
+        scope_key,
+        request_id,
+    )
+    assert snapshot is not None
+    assert snapshot["result_summary"] == terminal_summary
+    assert snapshot["tool_call_count"] == 1
+    assert snapshot["tool_success_count"] == 1
+    assert snapshot["tool_pending_count"] == 0
+    assert snapshot["tool_history"] == [
+        {
+            "tool": "add_relationship",
+            "workflowTask": "",
+            "batchSize": None,
+            "phase": "adaptive_research",
+            "resultSummary": terminal_summary,
+            "success": True,
+            "callId": call_id,
+        }
+    ]
+
+
 def test_serialisation_exposes_a_bounded_timing_trace(monkeypatch) -> None:
     clock = _set_clock(monkeypatch, start=6000.0)
     von_routes._set_tool_progress(


### PR DESCRIPTION
## Outcome

Make relation-shaped work in the Thinking pane understandable in Default mode. Tool progress now names the capability and renders a bounded semantic operation, for example:

> Add Relationship confirmed no change was needed: Subject: Nathan Young Doctoral Candidature Situation; Relation: Has Doctoral Supervisor; Object: Robert Amor.

The completion wording distinguishes changed, unchanged, partial, failed, and indeterminate outcomes without claiming success from outer turn completion.

## Scope

- Adds a bounded semantic projection service for relation/text-relation capability arguments.
- Adds human `result_summary` values to adaptive-capability start/completion progress.
- Preserves the existing frontend rendering path; no new workflow, datastore, actor-scope, cancellation, or synchronous Situation machinery.
- Generic and batched operations deliberately keep the existing generic fallback.

Relates to JVNAUTOSCI-2619. This is a coherent slice, not closure of the broader Thinking/Situation task.

## Validation

- Backend targeted suite: 146 passed.
- Frontend chatTab suite: 244 passed.
- ESLint on changed frontend test: passed.
- Ruff E9/F and `git diff --check`: passed.
- Authenticated browser replay against commit `212410bd`: Default-mode Thinking displayed the semantic Subject/Relation/Object summary; the idempotent canonical relation call reported no state change; new-chat opened without a blocking dialog.
- Adjacent observation: the fresh conversation still had no recorded shared Situation description. That remains out of this PR because the available prototype adds synchronous Mongo operations on the answer path and does not solve this semantic display case.