### PR TITLE
Expose semantic tool receipts in Thinking

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -109,6 +109,9 @@ from ...services.turn_execution_diagnostic_event_service import (
     derive_tool_observations_from_diagnostic_events,
     update_tool_observation_summary,
 )
+from ...services.thinking_semantic_projection_service import (
+    normalise_semantic_operation_projection,
+)
 from ...services.tool_observation_ledger_service import build_tool_observation_ledger
 from ...services.tool_evidence_projection_service import (
     project_nested_workflow_progress_evidence,
@@ -1166,6 +1169,15 @@ def _serialise_tool_progress_state(
     payload = dict(state)
     payload.update(_derive_progress_liveness(payload, now_epoch=now_epoch))
 
+    semantic_operation = normalise_semantic_operation_projection(
+        payload.get("semantic_operation") or payload.get("semanticOperation")
+    )
+    payload.pop("semanticOperation", None)
+    if semantic_operation is not None:
+        payload["semantic_operation"] = semantic_operation
+    else:
+        payload.pop("semantic_operation", None)
+
     payload.pop("updated_at_epoch", None)
     payload.pop("request_started_epoch", None)
     payload.pop("last_activity_epoch", None)
@@ -1173,9 +1185,21 @@ def _serialise_tool_progress_state(
 
     events = payload.get("diagnostic_events")
     if isinstance(events, list):
-        payload["diagnostic_events"] = list(
-            events[-_TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT:]
-        )
+        normalised_events: list[dict[str, Any]] = []
+        for raw_event in events[-_TURN_EXECUTION_DIAGNOSTICS_EVENT_LIMIT:]:
+            if not isinstance(raw_event, Mapping):
+                continue
+            event = dict(raw_event)
+            event_semantic_operation = normalise_semantic_operation_projection(
+                event.get("semantic_operation") or event.get("semanticOperation")
+            )
+            event.pop("semanticOperation", None)
+            if event_semantic_operation is not None:
+                event["semantic_operation"] = event_semantic_operation
+            else:
+                event.pop("semantic_operation", None)
+            normalised_events.append(event)
+        payload["diagnostic_events"] = normalised_events
 
     workflow_stage_path = _extract_workflow_stage_path_from_progress(payload)
     if workflow_stage_path is not None:
@@ -3794,6 +3818,7 @@ def _build_turn_execution_diagnostics(
         "tool",
         "batch_size",
         "result_summary",
+        "semantic_operation",
         "success",
         "error",
         "error_class",
@@ -3842,6 +3867,7 @@ def _build_turn_execution_diagnostics(
                 "call_id",
                 "batch_size",
                 "result_summary",
+                "semantic_operation",
                 "duration_ms",
                 "model",
                 "success",
@@ -5180,6 +5206,17 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
                 return
 
         safe_update = dict(update or {})
+        incoming_semantic_operation: dict[str, Any] | None = None
+        if "semantic_operation" in safe_update or "semanticOperation" in safe_update:
+            incoming_semantic_operation = normalise_semantic_operation_projection(
+                safe_update.get("semantic_operation")
+                or safe_update.get("semanticOperation")
+            )
+            safe_update.pop("semanticOperation", None)
+            if incoming_semantic_operation is not None:
+                safe_update["semantic_operation"] = incoming_semantic_operation
+            else:
+                safe_update.pop("semantic_operation", None)
         status = _progress_str(safe_update.get("status")) or _progress_str(
             existing.get("status")
         )
@@ -5423,6 +5460,8 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
             "liveness_reason": liveness.get("liveness_reason"),
             "stall_detected": liveness.get("stall_detected"),
         }
+        if incoming_semantic_operation is not None:
+            event_entry["semantic_operation"] = incoming_semantic_operation
         progress_facts = _normalise_progress_facts(safe_update.get("progress_facts"))
         if "progress_facts" in safe_update:
             if progress_facts:

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -39,13 +39,13 @@ from src.backend.languagemodels.structured_tool_calling.types import (
     ToolResult,
 )
 from src.backend.security.access_control import override_current_actor
+from src.backend.services.thinking_semantic_projection_service import (
+    build_semantic_operation_projection,
+)
 from src.backend.services.turn_evidence_store import (
     EVIDENCE_SLICE_SCHEMA_VERSION,
     TrustedTurnScope,
     TurnEvidenceStore,
-)
-from src.backend.services.thinking_semantic_projection_service import (
-    build_semantic_operation_projection,
 )
 
 _CAPABILITY_TOOL_NAME = "turn_capabilities"
@@ -4770,6 +4770,7 @@ def execute_adaptive_turn(
                         "execution_method": execution_method_name,
                         "call_id": call.call_id,
                         "result_summary": semantic_operation["summary"],
+                        "semantic_operation": semantic_operation,
                     },
                 )
                 with override_current_actor(
@@ -5321,6 +5322,7 @@ def execute_adaptive_turn(
                         "call_id": call.call_id,
                         "success": status == "ok",
                         "result_summary": semantic_operation["summary"],
+                        "semantic_operation": semantic_operation,
                     },
                 )
 

--- a/src/backend/services/thinking_semantic_projection_service.py
+++ b/src/backend/services/thinking_semantic_projection_service.py
@@ -15,8 +15,18 @@ from typing import Any
 
 SEMANTIC_OPERATION_SCHEMA_VERSION = "thinking_semantic_operation.v1"
 _MAX_TEXT_CHARS = 240
+_MAX_SUMMARY_CHARS = 1_024
 _MAX_ARGUMENTS = 8
 
+_ARGUMENT_LABELS = {
+    "subject": "Subject",
+    "predicate": "Relation",
+    "object": "Object",
+    "value": "Value",
+    "workflow": "Workflow",
+    "instance": "Workflow instance",
+    "name": "Name",
+}
 _ARGUMENT_SPECS = (
     ("subject_concept_id", "subject", "Subject", "concept"),
     ("source_id", "subject", "Subject", "concept"),
@@ -33,6 +43,17 @@ _ARGUMENT_SPECS = (
     ("instance_id", "instance", "Workflow instance", "identifier"),
     ("name", "name", "Name", "text"),
 )
+_ARGUMENT_KIND_BY_ROLE = {
+    role: value_kind for _key, role, _label, value_kind in _ARGUMENT_SPECS
+}
+_ARGUMENT_SOURCE_KEYS_BY_ROLE = {
+    role: frozenset(
+        key
+        for key, source_role, _label, _value_kind in _ARGUMENT_SPECS
+        if source_role == role
+    )
+    for _key, role, _label, _value_kind in _ARGUMENT_SPECS
+}
 
 
 def _clean_text(value: Any, *, limit: int = _MAX_TEXT_CHARS) -> str | None:
@@ -85,9 +106,7 @@ def _argument_projection(arguments: Mapping[str, Any]) -> list[dict[str, Any]]:
         display = (
             value
             if isinstance(value, str) and value_kind == "text"
-            else _display_label(value)
-            if isinstance(value, str)
-            else str(value)
+            else _display_label(value) if isinstance(value, str) else str(value)
         )
         item: dict[str, Any] = {
             "role": role,
@@ -148,8 +167,6 @@ def _outcome_projection(
         "mutation_outcome",
         "outcome_finality",
         "error_code",
-        "effect_id",
-        "evidence_id",
         "workflow_id",
         "instance_id",
         "final_status",
@@ -160,13 +177,164 @@ def _outcome_projection(
     target_ids = payload.get("result_target_ids")
     if isinstance(target_ids, list):
         bounded_ids = [
-            item
-            for item in (_clean_text(value) for value in target_ids[:8])
-            if item
+            item for item in (_clean_text(value) for value in target_ids[:8]) if item
         ]
         if bounded_ids:
             outcome["result_target_ids"] = bounded_ids
     return outcome
+
+
+def _read_back_value(value: Any) -> str | int | float | bool | None:
+    scalar = _scalar_value(value)
+    if scalar is not None:
+        return scalar
+    if isinstance(value, Mapping):
+        for key in ("concept_id", "predicate_id", "id", "value", "text"):
+            scalar = _scalar_value(value.get(key))
+            if scalar is not None:
+                return scalar
+    return None
+
+
+def _read_back_relation_assessment(
+    read_back: Mapping[str, Any],
+    relation: Mapping[str, Any] | None,
+) -> tuple[bool, bool]:
+    """Return whether a relation proof exists and whether it matches the view."""
+
+    relation_keys = frozenset(
+        {
+            "subject_concept_id",
+            "source_id",
+            "concept_id",
+            "subject",
+            "predicate",
+            "predicate_id",
+            "predicate_ref",
+            "target_concept_id",
+            "target_id",
+            "target",
+            "object_concept_id",
+            "object",
+            "target_text",
+            "text",
+            "object_text",
+        }
+    )
+    if not relation_keys.intersection(read_back):
+        return False, True
+    if not isinstance(relation, Mapping):
+        return True, True
+
+    def first_value(*keys: str) -> str | int | float | bool | None:
+        for key in keys:
+            if key not in read_back:
+                continue
+            value = _read_back_value(read_back.get(key))
+            if value is not None:
+                return value
+        return None
+
+    actual_subject = first_value(
+        "subject_concept_id",
+        "source_id",
+        "concept_id",
+        "subject",
+    )
+    actual_predicate = first_value("predicate", "predicate_id", "predicate_ref")
+    actual_object = first_value(
+        "target_concept_id",
+        "target_id",
+        "target",
+        "object_concept_id",
+        "object",
+        "target_text",
+        "text",
+        "object_text",
+    )
+    expected_subject = _read_back_value(relation.get("subject"))
+    expected_predicate = _read_back_value(relation.get("predicate"))
+    expected_object = _read_back_value(relation.get("object"))
+    matches = (
+        actual_subject is not None
+        and actual_predicate is not None
+        and actual_object is not None
+        and actual_subject == expected_subject
+        and actual_predicate == expected_predicate
+        and actual_object == expected_object
+    )
+    return True, matches
+
+
+def _verification_projection(
+    result: Mapping[str, Any] | None,
+    *,
+    lifecycle_status: str,
+    relation: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Describe the evidence boundary without performing another read.
+
+    A tool result is an effect receipt, not canonical verification.  Only an
+    explicit, successful ``canonical_read_back`` evidence upgrades the
+    projection to ``verified``.  A non-empty object alone is insufficient and a
+    relation-shaped read-back must match the relation being displayed.  The
+    read-back body is deliberately not copied into live progress: the Thinking
+    view needs the evidence class, not an unbounded or potentially sensitive
+    second result payload.
+    """
+
+    payload = result if isinstance(result, Mapping) else {}
+    raw_read_back = payload.get("canonical_read_back")
+    read_back_present = isinstance(raw_read_back, Mapping)
+    successful_receipt = (
+        payload.get("success") is True
+        and str(payload.get("effect_status") or "").strip().lower() == "succeeded"
+        and not _clean_text(payload.get("error"))
+        and not _clean_text(payload.get("error_code"))
+    )
+    read_back_reports_failure = bool(
+        isinstance(raw_read_back, Mapping)
+        and (
+            raw_read_back.get("success") is False
+            or _clean_text(raw_read_back.get("error"))
+            or _clean_text(raw_read_back.get("error_code"))
+        )
+    )
+    has_relation_proof = False
+    relation_matches = True
+    explicit_read_back_success = False
+    if isinstance(raw_read_back, Mapping):
+        has_relation_proof, relation_matches = _read_back_relation_assessment(
+            raw_read_back,
+            relation,
+        )
+        explicit_read_back_success = (
+            bool(has_relation_proof and relation_matches)
+            if isinstance(relation, Mapping)
+            else raw_read_back.get("success") is True
+        )
+    read_back_verified = bool(
+        read_back_present
+        and raw_read_back
+        and successful_receipt
+        and explicit_read_back_success
+        and not read_back_reports_failure
+        and relation_matches
+    )
+    if read_back_verified:
+        status = "verified"
+        source = "canonical_read_back"
+    elif result is not None or lifecycle_status != "running":
+        status = "receipt_only"
+        source = "effect_receipt"
+    else:
+        status = "unknown"
+        source = "none"
+    return {
+        "status": status,
+        "canonical_read_back_present": read_back_present,
+        "source": source,
+    }
 
 
 def _summary(
@@ -176,6 +344,7 @@ def _summary(
     lifecycle_status: str,
     success: bool | None,
     result: Mapping[str, Any] | None,
+    verification: Mapping[str, Any],
 ) -> str:
     if isinstance(relation, Mapping):
         subject = str(relation["subject"].get("display") or "the subject")
@@ -194,16 +363,25 @@ def _summary(
         outcome = result if isinstance(result, Mapping) else {}
         changed = outcome.get("changed")
         effect_status = str(outcome.get("effect_status") or "").strip().lower()
-        mutation_outcome = str(
-            outcome.get("mutation_outcome") or ""
-        ).strip().lower()
+        mutation_outcome = str(outcome.get("mutation_outcome") or "").strip().lower()
+        read_back_verified = verification.get("status") == "verified"
         if success is True:
             if changed is False:
+                if read_back_verified:
+                    return (
+                        f"{capability_label} verified that no change was needed: "
+                        f"{statement}."
+                    )
                 return (
-                    f"{capability_label} confirmed no change was needed: "
+                    f"{capability_label} reported that no change was needed: "
                     f"{statement}."
                 )
             if changed is True:
+                if read_back_verified:
+                    return (
+                        f"{capability_label} verified the reported change: "
+                        f"{statement}."
+                    )
                 return f"{capability_label} reported a change: {statement}."
             return f"{capability_label} finished: {statement}."
         if success is False:
@@ -223,6 +401,218 @@ def _summary(
     if success is False:
         return f"{capability_label} did not succeed."
     return f"Observed {capability_label}."
+
+
+def _normalise_projected_arguments(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    projected: list[dict[str, Any]] = []
+    seen_roles: set[str] = set()
+    for raw_item in value[:_MAX_ARGUMENTS]:
+        if not isinstance(raw_item, Mapping):
+            continue
+        role = _clean_text(raw_item.get("role"), limit=40)
+        value_kind = _clean_text(raw_item.get("value_kind"), limit=40)
+        if (
+            role not in _ARGUMENT_LABELS
+            or role in seen_roles
+            or value_kind != _ARGUMENT_KIND_BY_ROLE.get(role)
+        ):
+            continue
+        argument_value = _scalar_value(raw_item.get("value"))
+        if argument_value is None:
+            continue
+        source_argument = _clean_text(
+            raw_item.get("source_argument"),
+            limit=80,
+        )
+        if source_argument not in _ARGUMENT_SOURCE_KEYS_BY_ROLE[role]:
+            source_argument = "unknown"
+        display = (
+            argument_value
+            if isinstance(argument_value, str) and value_kind == "text"
+            else (
+                _display_label(argument_value)
+                if isinstance(argument_value, str)
+                else str(argument_value)
+            )
+        )
+        item: dict[str, Any] = {
+            "role": role,
+            "label": _ARGUMENT_LABELS[role],
+            "source_argument": source_argument or "unknown",
+            "value_kind": value_kind,
+            "value": argument_value,
+            "display": display,
+        }
+        if isinstance(argument_value, str) and argument_value.startswith("#V#"):
+            item["concept_id"] = argument_value
+        projected.append(item)
+        seen_roles.add(role)
+    return projected
+
+
+def _normalise_projected_outcome(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    status = _clean_text(value.get("status"), limit=80)
+    success = value.get("success")
+    outcome: dict[str, Any] = {
+        "status": status or "unknown",
+        "success": success if isinstance(success, bool) else None,
+    }
+    for key in (
+        "effect_status",
+        "changed",
+        "mutation_outcome",
+        "outcome_finality",
+        "error_code",
+        "workflow_id",
+        "instance_id",
+        "final_status",
+    ):
+        item = _scalar_value(value.get(key))
+        if item is not None:
+            outcome[key] = item
+    target_ids = value.get("result_target_ids")
+    if isinstance(target_ids, list):
+        bounded_ids = [
+            item
+            for item in (_clean_text(raw) for raw in target_ids[:_MAX_ARGUMENTS])
+            if item
+        ]
+        if bounded_ids:
+            outcome["result_target_ids"] = bounded_ids
+    return outcome
+
+
+def _normalise_projected_verification(
+    value: Any,
+    *,
+    lifecycle_status: str,
+    has_outcome: bool,
+) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        status = _clean_text(value.get("status"), limit=40)
+        source = _clean_text(value.get("source"), limit=40)
+        present = value.get("canonical_read_back_present") is True
+        has_terminal_evidence = has_outcome or lifecycle_status != "running"
+        if (
+            has_terminal_evidence
+            and status == "verified"
+            and present
+            and source == "canonical_read_back"
+        ):
+            return {
+                "status": "verified",
+                "canonical_read_back_present": True,
+                "source": "canonical_read_back",
+            }
+        if (
+            has_terminal_evidence
+            and status == "receipt_only"
+            and source == "effect_receipt"
+        ):
+            return {
+                "status": "receipt_only",
+                "canonical_read_back_present": present,
+                "source": "effect_receipt",
+            }
+        if (
+            not has_terminal_evidence
+            and status == "unknown"
+            and source == "none"
+            and not present
+        ):
+            return {
+                "status": "unknown",
+                "canonical_read_back_present": False,
+                "source": "none",
+            }
+    if has_outcome or lifecycle_status != "running":
+        return {
+            "status": "receipt_only",
+            "canonical_read_back_present": False,
+            "source": "effect_receipt",
+        }
+    return {
+        "status": "unknown",
+        "canonical_read_back_present": False,
+        "source": "none",
+    }
+
+
+def normalise_semantic_operation_projection(value: Any) -> dict[str, Any] | None:
+    """Return a strictly bounded v1 projection safe for live/reloaded display.
+
+    Stored progress is treated as untrusted display data.  This function keeps
+    only the v1 allowlist, bounds every collection and string, reconstructs the
+    relation from role-labelled arguments, and accepts only the explicit
+    conversation-participant visibility contract.
+    """
+
+    if not isinstance(value, Mapping):
+        return None
+    if value.get("schema_version") != SEMANTIC_OPERATION_SCHEMA_VERSION:
+        return None
+    if value.get("visibility") != "conversation_scope":
+        return None
+    operation_id = _clean_text(value.get("operation_id"))
+    lifecycle_status = _clean_text(value.get("lifecycle_status"), limit=80)
+    raw_capability = value.get("capability")
+    if (
+        not operation_id
+        or not lifecycle_status
+        or not isinstance(raw_capability, Mapping)
+    ):
+        return None
+    capability_id = _clean_text(raw_capability.get("id"))
+    if not capability_id:
+        return None
+    kind = _clean_text(raw_capability.get("kind")) or "registered_tool"
+    execution_method = (
+        _clean_text(raw_capability.get("execution_method")) or capability_id
+    )
+    arguments = _normalise_projected_arguments(value.get("arguments"))
+    relation = _relation_projection(arguments)
+    outcome = _normalise_projected_outcome(value.get("outcome"))
+    verification = _normalise_projected_verification(
+        value.get("verification"),
+        lifecycle_status=lifecycle_status,
+        has_outcome=outcome is not None,
+    )
+    success = outcome.get("success") if outcome is not None else None
+    projection: dict[str, Any] = {
+        "schema_version": SEMANTIC_OPERATION_SCHEMA_VERSION,
+        "operation_id": operation_id,
+        "lifecycle_status": lifecycle_status,
+        "capability": {
+            "id": capability_id,
+            "label": _display_label(capability_id),
+            "kind": kind,
+            "execution_method": execution_method,
+        },
+        "arguments": arguments,
+        "summary": _clean_text(
+            _summary(
+                capability_label=_display_label(capability_id),
+                relation=relation,
+                lifecycle_status=lifecycle_status,
+                success=success if isinstance(success, bool) else None,
+                result=outcome,
+                verification=verification,
+            ),
+            limit=_MAX_SUMMARY_CHARS,
+        )
+        or f"Observed {_display_label(capability_id)}.",
+        "visibility": "conversation_scope",
+        "verification": verification,
+    }
+    if relation is not None:
+        projection["relation"] = relation
+    if outcome is not None:
+        projection["outcome"] = outcome
+    return projection
 
 
 def build_semantic_operation_projection(
@@ -246,6 +636,19 @@ def build_semantic_operation_projection(
     capability_label = _display_label(capability_id)
     projected_arguments = _argument_projection(arguments)
     relation = _relation_projection(projected_arguments)
+    verification = _verification_projection(
+        result,
+        lifecycle_status=status,
+        relation=relation,
+    )
+    summary = _summary(
+        capability_label=capability_label,
+        relation=relation,
+        lifecycle_status=status,
+        success=success,
+        result=result,
+        verification=verification,
+    )
     projection: dict[str, Any] = {
         "schema_version": SEMANTIC_OPERATION_SCHEMA_VERSION,
         "operation_id": operation_id_value,
@@ -257,14 +660,10 @@ def build_semantic_operation_projection(
             "execution_method": execution_method_id,
         },
         "arguments": projected_arguments,
-        "summary": _summary(
-            capability_label=capability_label,
-            relation=relation,
-            lifecycle_status=status,
-            success=success,
-            result=result,
-        ),
-        "visibility": "actor_scope",
+        "summary": _clean_text(summary, limit=_MAX_SUMMARY_CHARS)
+        or f"Observed {capability_label}.",
+        "visibility": "conversation_scope",
+        "verification": verification,
     }
     if relation is not None:
         projection["relation"] = relation
@@ -281,4 +680,5 @@ def build_semantic_operation_projection(
 __all__ = [
     "SEMANTIC_OPERATION_SCHEMA_VERSION",
     "build_semantic_operation_projection",
+    "normalise_semantic_operation_projection",
 ]

--- a/src/backend/services/turn_execution_diagnostic_event_service.py
+++ b/src/backend/services/turn_execution_diagnostic_event_service.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from src.backend.services.thinking_semantic_projection_service import (
+    normalise_semantic_operation_projection,
+)
 
 _TOOL_START_STATUSES = frozenset({"tool_call_start"})
 _TOOL_SUCCESS_STATUSES = frozenset({"tool_invoked"})
@@ -61,8 +66,13 @@ def _normalise_tool_history_entry(entry: Mapping[str, Any]) -> dict[str, Any] | 
     )
     call_id = _safe_str(entry.get("callId")) or _safe_str(entry.get("call_id"))
     success = entry.get("success")
+    semantic_operation = normalise_semantic_operation_projection(
+        entry.get("semanticOperation")
+        if "semanticOperation" in entry
+        else entry.get("semantic_operation")
+    )
 
-    return {
+    normalised: dict[str, Any] = {
         "tool": tool_name,
         "workflowTask": workflow_task or "",
         "batchSize": _normalise_batch_size(
@@ -73,6 +83,9 @@ def _normalise_tool_history_entry(entry: Mapping[str, Any]) -> dict[str, Any] | 
         "success": success if isinstance(success, bool) else None,
         "callId": call_id,
     }
+    if semantic_operation is not None:
+        normalised["semanticOperation"] = semantic_operation
+    return normalised
 
 
 def _finalise_tool_observation_summary(
@@ -251,7 +264,9 @@ def update_tool_observation_summary(
 
     status = (_safe_str(event.get("status")) or "").lower()
     event_kind = (_safe_str(event.get("event_kind")) or "").lower()
-    is_tool_start = status in _TOOL_START_STATUSES or event_kind in _TOOL_START_EVENT_KINDS
+    is_tool_start = (
+        status in _TOOL_START_STATUSES or event_kind in _TOOL_START_EVENT_KINDS
+    )
     is_tool_terminal = (
         status in _TOOL_SUCCESS_STATUSES
         or status in _TOOL_FAILURE_STATUSES
@@ -279,6 +294,11 @@ def update_tool_observation_summary(
     phase = _safe_str(event.get("phase")) or _safe_str(event.get("stage")) or ""
     result_summary = _safe_str(event.get("result_summary")) or ""
     workflow_task = _safe_str(event.get("workflow_task")) or ""
+    semantic_operation = normalise_semantic_operation_projection(
+        event.get("semantic_operation")
+        if "semantic_operation" in event
+        else event.get("semanticOperation")
+    )
     key = call_id or f"{tool_name.lower()}::{batch_size!r}"
 
     history_index: int | None = None
@@ -312,6 +332,8 @@ def update_tool_observation_summary(
         history_entry["resultSummary"] = result_summary
     if call_id and not history_entry.get("callId"):
         history_entry["callId"] = call_id
+    if semantic_operation is not None:
+        history_entry["semanticOperation"] = semantic_operation
 
     if status in _TOOL_SUCCESS_STATUSES:
         history_entry["success"] = True

--- a/src/backend/services/turn_execution_live_progress_service.py
+++ b/src/backend/services/turn_execution_live_progress_service.py
@@ -6,10 +6,13 @@ import json
 from collections.abc import Mapping
 from typing import Any
 
-from .namespace_service import derive_actor_context_from_namespace
 from ..workflows.terminal_outcome_receipts import (
     build_terminal_outcome_receipt_projection,
     terminal_outcome_receipt_projection_from_record,
+)
+from .namespace_service import derive_actor_context_from_namespace
+from .thinking_semantic_projection_service import (
+    normalise_semantic_operation_projection,
 )
 
 _DEFAULT_SECTION_LIMIT = 20
@@ -22,11 +25,13 @@ _LIVE_PROGRESS_DETAIL_SECTIONS = frozenset(
         "diagnostic_events",
         "llm_request",
         "progress_events",
+        "semantic_operation",
         "selected_workflow_execution",
         "stage_diagnostics",
         "terminal_outcome_receipt_projection",
         "thinking_interpretability",
         "timing_spans",
+        "tool_history",
         "turn_timing_trace",
         "workflow_routing_diagnostics",
         "workflow_stage_path",
@@ -226,6 +231,10 @@ def _build_bounded_live_progress_payload(
         else:
             timing_summary = None
 
+    semantic_operation = normalise_semantic_operation_projection(
+        payload.get("semantic_operation") or payload.get("semanticOperation")
+    )
+
     return {
         "schema_version": "turn_live_progress_snapshot.v1",
         "success": True,
@@ -242,6 +251,7 @@ def _build_bounded_live_progress_payload(
         "liveness_state": compact_summary.get("liveness_state"),
         "liveness_reason": compact_summary.get("liveness_reason"),
         "stall_detected": compact_summary.get("stall_detected"),
+        "semantic_operation": semantic_operation,
         "progress_events": _tail_list(
             payload.get("progress_events"),
             _DEFAULT_RECENT_EVENT_LIMIT,

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -1566,6 +1566,26 @@ const THINKING_CARD_MODE_CLASS_NAMES = new Set([
 const THINKING_CARD_PROGRESS_VIEW_MODEL_SCHEMA = 'thinking_card_progress_view_model.v1';
 const THINKING_CARD_PROGRESS_VIEW_MODEL_SOURCE_EXPLICIT = 'explicit_turn_state';
 const THINKING_CARD_PROGRESS_VIEW_MODEL_SOURCE_DERIVED = 'derived_from_live_telemetry';
+const THINKING_SEMANTIC_OPERATION_SCHEMA_VERSION = 'thinking_semantic_operation.v1';
+const THINKING_SEMANTIC_OPERATION_MAX_ARGUMENTS = 8;
+const THINKING_SEMANTIC_OPERATION_MAX_TEXT_CHARS = 240;
+const THINKING_SEMANTIC_OPERATION_MAX_SUMMARY_CHARS = 1024;
+const THINKING_SEMANTIC_ARGUMENT_LABELS = new Map([
+    ['subject', 'Subject'],
+    ['predicate', 'Relation'],
+    ['object', 'Object'],
+    ['value', 'Value'],
+    ['workflow', 'Workflow'],
+    ['instance', 'Workflow instance'],
+    ['name', 'Name']
+]);
+const THINKING_SEMANTIC_ARGUMENT_VALUE_KINDS = new Set([
+    'concept',
+    'predicate',
+    'text',
+    'workflow',
+    'identifier'
+]);
 const THINKING_ACTIVITY_LOW_LEVEL_EVENT_KINDS = new Set(['llm_call_chunk', 'heartbeat']);
 const THINKING_DIAGNOSTIC_DETAILS_SELECTOR = 'details[data-thinking-diagnostic-key]';
 const THINKING_LLM_CALL_LOG_DETAILS_SELECTOR = 'details[data-thinking-llm-call-log-key]';
@@ -3192,13 +3212,206 @@ function toggleThinkingCardExpanded(request = getThinkingCardDisplayRequest(), c
     applyThinkingCardDisplayStateUpdate(request, { type: 'manual_toggle' }, cardRoot);
 }
 
+function normaliseThinkingSemanticText(value, maxChars = THINKING_SEMANTIC_OPERATION_MAX_TEXT_CHARS) {
+    return truncateThinkingCardSummary(value, Math.max(1, Number(maxChars) || THINKING_SEMANTIC_OPERATION_MAX_TEXT_CHARS));
+}
+
+function normaliseThinkingSemanticScalar(value, maxChars = THINKING_SEMANTIC_OPERATION_MAX_TEXT_CHARS) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (Number.isFinite(value)) {
+        return Number(value);
+    }
+    const text = normaliseThinkingSemanticText(value, maxChars);
+    return text || null;
+}
+
+function normaliseThinkingSemanticArgument(rawArgument) {
+    if (!rawArgument || typeof rawArgument !== 'object') {
+        return null;
+    }
+    const role = normaliseThinkingSemanticText(rawArgument.role, 40).toLowerCase();
+    const label = THINKING_SEMANTIC_ARGUMENT_LABELS.get(role);
+    if (!label) {
+        return null;
+    }
+    const value = normaliseThinkingSemanticScalar(rawArgument.value);
+    if (value === null) {
+        return null;
+    }
+    const valueKind = normaliseThinkingSemanticText(rawArgument.value_kind || rawArgument.valueKind, 40).toLowerCase();
+    if (!THINKING_SEMANTIC_ARGUMENT_VALUE_KINDS.has(valueKind)) {
+        return null;
+    }
+    const display = normaliseThinkingSemanticText(rawArgument.display) || String(value);
+    const conceptId = normaliseThinkingSemanticText(rawArgument.concept_id || rawArgument.conceptId);
+    return {
+        role,
+        label,
+        sourceArgument: normaliseThinkingSemanticText(
+            rawArgument.source_argument || rawArgument.sourceArgument,
+            80
+        ),
+        valueKind,
+        value,
+        display,
+        conceptId
+    };
+}
+
+function normaliseThinkingSemanticOutcome(rawOutcome) {
+    if (!rawOutcome || typeof rawOutcome !== 'object') {
+        return null;
+    }
+    const outcome = {};
+    const textFields = [
+        ['status', 'status'],
+        ['effectStatus', 'effect_status'],
+        ['mutationOutcome', 'mutation_outcome'],
+        ['outcomeFinality', 'outcome_finality'],
+        ['errorCode', 'error_code'],
+        ['workflowId', 'workflow_id'],
+        ['instanceId', 'instance_id'],
+        ['finalStatus', 'final_status']
+    ];
+    for (const [targetKey, sourceKey] of textFields) {
+        const value = normaliseThinkingSemanticText(rawOutcome[sourceKey] ?? rawOutcome[targetKey]);
+        if (value) {
+            outcome[targetKey] = value;
+        }
+    }
+    if (typeof rawOutcome.success === 'boolean') {
+        outcome.success = rawOutcome.success;
+    }
+    if (typeof rawOutcome.changed === 'boolean') {
+        outcome.changed = rawOutcome.changed;
+    }
+    const targetIds = Array.isArray(rawOutcome.result_target_ids)
+        ? rawOutcome.result_target_ids
+        : rawOutcome.resultTargetIds;
+    if (Array.isArray(targetIds)) {
+        outcome.resultTargetIds = targetIds
+            .slice(0, THINKING_SEMANTIC_OPERATION_MAX_ARGUMENTS)
+            .map((value) => normaliseThinkingSemanticText(value))
+            .filter(Boolean);
+    }
+    return Object.keys(outcome).length > 0 ? outcome : null;
+}
+
+function normaliseThinkingSemanticVerification(rawVerification) {
+    if (!rawVerification || typeof rawVerification !== 'object') {
+        return null;
+    }
+    const status = normaliseThinkingSemanticText(rawVerification.status, 40).toLowerCase();
+    const source = normaliseThinkingSemanticText(rawVerification.source, 40);
+    const readBackPresent = rawVerification.canonical_read_back_present
+        ?? rawVerification.canonicalReadBackPresent;
+    if (typeof readBackPresent !== 'boolean') {
+        return null;
+    }
+    const isValid = (
+        status === 'verified'
+        && readBackPresent
+        && source === 'canonical_read_back'
+    ) || (
+        status === 'receipt_only'
+        && source === 'effect_receipt'
+    ) || (
+        status === 'unknown'
+        && !readBackPresent
+        && source === 'none'
+    );
+    return isValid
+        ? { status, source, canonicalReadBackPresent: readBackPresent }
+        : null;
+}
+
+function normaliseThinkingSemanticOperation(rawOperation) {
+    if (!rawOperation || typeof rawOperation !== 'object') {
+        return null;
+    }
+    const schemaVersion = normaliseThinkingSemanticText(rawOperation.schema_version || rawOperation.schemaVersion, 80);
+    const visibility = normaliseThinkingSemanticText(rawOperation.visibility, 40).toLowerCase();
+    if (schemaVersion !== THINKING_SEMANTIC_OPERATION_SCHEMA_VERSION || visibility !== 'conversation_scope') {
+        return null;
+    }
+    const rawCapability = rawOperation.capability && typeof rawOperation.capability === 'object'
+        ? rawOperation.capability
+        : {};
+    const capabilityId = normaliseThinkingSemanticText(rawCapability.id);
+    const operationId = normaliseThinkingSemanticText(rawOperation.operation_id || rawOperation.operationId);
+    const lifecycleStatus = normaliseThinkingSemanticText(
+        rawOperation.lifecycle_status || rawOperation.lifecycleStatus,
+        80
+    );
+    if (!operationId || !lifecycleStatus || !capabilityId) {
+        return null;
+    }
+    const capability = {
+        id: capabilityId,
+        label: normaliseThinkingSemanticText(rawCapability.label) || formatThinkingActivityFallbackLabel(capabilityId),
+        kind: normaliseThinkingSemanticText(rawCapability.kind, 80),
+        executionMethod: normaliseThinkingSemanticText(
+            rawCapability.execution_method || rawCapability.executionMethod
+        )
+    };
+    const seenRoles = new Set();
+    const argumentsList = [];
+    if (Array.isArray(rawOperation.arguments)) {
+        for (const rawArgument of rawOperation.arguments.slice(0, THINKING_SEMANTIC_OPERATION_MAX_ARGUMENTS)) {
+            const argument = normaliseThinkingSemanticArgument(rawArgument);
+            if (!argument || seenRoles.has(argument.role)) {
+                continue;
+            }
+            seenRoles.add(argument.role);
+            argumentsList.push(argument);
+        }
+    }
+    const operation = {
+        schemaVersion,
+        operationId,
+        lifecycleStatus,
+        capability,
+        arguments: argumentsList,
+        summary: normaliseThinkingSemanticText(rawOperation.summary, THINKING_SEMANTIC_OPERATION_MAX_SUMMARY_CHARS),
+        visibility,
+        outcome: normaliseThinkingSemanticOutcome(rawOperation.outcome),
+        verification: normaliseThinkingSemanticVerification(
+            rawOperation.verification || rawOperation.outcome?.verification
+        )
+    };
+    if (!operation.summary && argumentsList.length === 0) {
+        return null;
+    }
+    return operation;
+}
+
+function getThinkingSemanticOperation(source) {
+    if (!source || typeof source !== 'object') {
+        return null;
+    }
+    return normaliseThinkingSemanticOperation(source.semanticOperation || source.semantic_operation);
+}
+
+function cloneThinkingToolHistoryEntry(entry) {
+    const copy = { ...entry };
+    const semanticOperation = getThinkingSemanticOperation(entry);
+    delete copy.semantic_operation;
+    delete copy.semanticOperation;
+    if (semanticOperation) {
+        copy.semanticOperation = semanticOperation;
+    }
+    return copy;
+}
+
 function cloneThinkingToolHistory(history) {
     if (!Array.isArray(history)) {
         return [];
     }
     return history
         .filter((entry) => entry && typeof entry === 'object')
-        .map((entry) => ({ ...entry }));
+        .map((entry) => cloneThinkingToolHistoryEntry(entry));
 }
 
 function cloneThinkingStructuredHistory(history) {
@@ -3573,7 +3786,7 @@ function applyThinkingProgressUpdate(request, nextProgress) {
         return false;
     }
 
-    request.latestProgress = nextProgress;
+    request.latestProgress = cloneThinkingLatestProgress(nextProgress) || nextProgress;
     const workflowSelection = buildThinkingWorkflowSelectionSnapshot(nextProgress);
     if (workflowSelection) {
         request.workflowSelection = workflowSelection;
@@ -6810,10 +7023,12 @@ function buildThinkingCardProgressViewModel(request) {
     const routeSummary = routingNarrative.text
         || (selectedWorkflow?.label ? `Selected route: ${selectedWorkflow.label}` : '')
         || firstThinkingCardText(latestProgress?.route_summary, latestProgress?.workflow_summary);
+    const latestSemanticOperation = getThinkingSemanticOperation(latestProgress);
     const currentActivity = firstThinkingCardText(
         latestProgress?.current_activity,
         latestProgress?.activity_summary,
         latestProgress?.result_summary,
+        latestSemanticOperation?.summary,
         latestProgress?.subtask,
         latestProgress?.workflow_task,
         presentation?.stageText ? presentation.stageText.replace(/\.{3}$/, '') : ''
@@ -7155,6 +7370,15 @@ function cloneThinkingLatestProgress(progress) {
         return null;
     }
     const copy = { ...progress };
+    const semanticOperation = getThinkingSemanticOperation(progress);
+    delete copy.semantic_operation;
+    delete copy.semanticOperation;
+    if (semanticOperation) {
+        copy.semanticOperation = semanticOperation;
+    }
+    if (Array.isArray(progress.tool_history)) {
+        copy.tool_history = cloneThinkingToolHistory(progress.tool_history);
+    }
     const timingSummary = cloneThinkingTimingSummary(progress.timing_summary);
     if (timingSummary) {
         copy.timing_summary = timingSummary;
@@ -7360,6 +7584,7 @@ function recordToolUseHistory(request, progress) {
     const phaseLabel = typeof progress.phase_label === 'string' ? progress.phase_label.trim() : '';
     const status = typeof progress.status === 'string' ? progress.status.trim() : '';
     const resultSummary = typeof progress.result_summary === 'string' ? progress.result_summary.trim() : '';
+    const semanticOperation = getThinkingSemanticOperation(progress);
 
     // Track phase transitions in addition to tool use.
     if (!Array.isArray(request.toolUseProgressHistory)) {
@@ -7417,11 +7642,22 @@ function recordToolUseHistory(request, progress) {
             if (isSuccess || isFail) {
                 last.success = isSuccess;
             }
+            if (semanticOperation) {
+                last.semanticOperation = semanticOperation;
+            }
         }
         return;
     }
 
-    history.push({ tool, workflowTask, batchSize, phase, resultSummary, success: isSuccess ? true : (isFail ? false : null) });
+    history.push({
+        tool,
+        workflowTask,
+        batchSize,
+        phase,
+        resultSummary,
+        success: isSuccess ? true : (isFail ? false : null),
+        ...(semanticOperation ? { semanticOperation } : {})
+    });
 }
 
 function normaliseThinkingActivityString(value) {
@@ -7801,6 +8037,56 @@ function formatThinkingDuration(elapsedMs) {
     return `${totalSeconds}s`;
 }
 
+function describeThinkingSemanticVerification(operation) {
+    if (!operation || typeof operation !== 'object') {
+        return '';
+    }
+    const verification = operation.verification && typeof operation.verification === 'object'
+        ? operation.verification
+        : null;
+    const status = normaliseThinkingActivityString(verification?.status).toLowerCase();
+    if (
+        status === 'verified'
+        && verification?.canonicalReadBackPresent === true
+        && verification?.source === 'canonical_read_back'
+    ) {
+        return 'Canonical read-back verified';
+    }
+    if (verification?.canonicalReadBackPresent === true) {
+        return 'Canonical read-back recorded; verification not confirmed';
+    }
+    if (status === 'receipt_only' && verification?.canonicalReadBackPresent === false) {
+        return 'Tool receipt only; canonical read-back not recorded';
+    }
+    if (status === 'receipt_only') {
+        return 'Tool receipt only; canonical read-back did not verify the outcome';
+    }
+    const lifecycleStatus = normaliseThinkingActivityString(operation.lifecycleStatus).toLowerCase();
+    if (lifecycleStatus === 'running' || lifecycleStatus === 'pending') {
+        return 'Canonical read-back pending';
+    }
+    if (operation.outcome) {
+        return 'Tool receipt only; canonical read-back not recorded';
+    }
+    return 'Canonical read-back status unavailable';
+}
+
+function getThinkingSemanticArgumentCanonicalId(argument) {
+    if (!argument || typeof argument !== 'object') {
+        return '';
+    }
+    const explicitId = normaliseThinkingActivityString(argument.conceptId);
+    if (explicitId) {
+        return explicitId;
+    }
+    if (normaliseThinkingActivityString(argument.valueKind).toLowerCase() === 'text') {
+        return '';
+    }
+    return typeof argument.value === 'string'
+        ? normaliseThinkingActivityString(argument.value)
+        : '';
+}
+
 /**
  * Render the tool history as structured HTML for the thinking card body.
  * No longer shows phase history (phases are in the header).
@@ -7826,6 +8112,8 @@ function renderToolHistoryHTML(request, mode = THINKING_CARD_MODE_DEFAULT) {
         }
         const batchSize = entry && Number.isFinite(entry.batchSize) ? Number(entry.batchSize) : null;
         const resultSummary = entry && typeof entry.resultSummary === 'string' ? entry.resultSummary : '';
+        const semanticOperation = getThinkingSemanticOperation(entry);
+        const semanticSummary = normaliseThinkingActivityString(semanticOperation?.summary);
         const success = entry.success;
 
         // Status icon and class
@@ -7841,13 +8129,13 @@ function renderToolHistoryHTML(request, mode = THINKING_CARD_MODE_DEFAULT) {
             : (workflowTask ? `Workflow task: ${workflowTask}` : '');
         items.push(renderThinkingDiagnosticRowHTML({
             label: toolLabel,
-            detail: resultSummary,
+            detail: semanticSummary || resultSummary,
             detailHtml: '',
             state: statusClass,
             diagnosticKey: buildThinkingDiagnosticKey('tool', tool || workflowTask, batchSize || ''),
             diagnosticHtml: renderMode === THINKING_CARD_MODE_DEFAULT
                 ? ''
-                : buildToolHistoryDiagnosticsHTML(entry)
+                : buildToolHistoryDiagnosticsHTML(entry, renderMode)
         }, 'thinking-card-tool'));
     }
 
@@ -10085,19 +10373,21 @@ function buildThinkingActivityDiagnosticsHTML(entry) {
     return renderThinkingDiagnosticPanelHTML({ facts });
 }
 
-function buildToolHistoryDiagnosticsHTML(entry) {
+function buildToolHistoryDiagnosticsHTML(entry, mode = THINKING_CARD_MODE_EXPERT) {
     if (!entry || typeof entry !== 'object') {
         return '';
     }
 
+    const renderMode = normaliseThinkingCardMode(mode);
     const tool = normaliseThinkingActivityString(entry.tool);
     const workflowTask = normaliseThinkingActivityString(entry.workflowTask);
+    const semanticOperation = getThinkingSemanticOperation(entry);
     const facts = [
         { label: 'Tool', value: tool },
         { label: 'Workflow task', value: workflowTask },
         { label: 'Phase', value: entry.phase ? formatThinkingActivityFallbackLabel(entry.phase) : '' },
         { label: 'Batch size', value: entry.batchSize },
-        { label: 'Result', value: entry.resultSummary },
+        { label: 'Result', value: semanticOperation?.summary || entry.resultSummary },
         {
             label: 'Outcome',
             value: typeof entry.success === 'boolean'
@@ -10105,6 +10395,52 @@ function buildToolHistoryDiagnosticsHTML(entry) {
                 : 'Pending'
         }
     ];
+
+    if (semanticOperation) {
+        for (const argument of semanticOperation.arguments) {
+            const label = normaliseThinkingActivityString(argument.label);
+            const display = normaliseThinkingActivityString(argument.display)
+                || formatThinkingDiagnosticFactValue(argument.value);
+            if (!label || !display) {
+                continue;
+            }
+            facts.push({ label, value: display });
+            const canonicalId = getThinkingSemanticArgumentCanonicalId(argument);
+            if (canonicalId) {
+                facts.push({ label: `${label} ID`, value: canonicalId });
+            }
+            if (renderMode === THINKING_CARD_MODE_DEBUG && argument.sourceArgument) {
+                facts.push({ label: `${label} source argument`, value: argument.sourceArgument });
+            }
+        }
+        facts.push({
+            label: 'Verification',
+            value: describeThinkingSemanticVerification(semanticOperation)
+        });
+        if (semanticOperation.outcome && typeof semanticOperation.outcome.changed === 'boolean') {
+            facts.push({
+                label: 'Reported change',
+                value: semanticOperation.outcome.changed ? 'Yes' : 'No'
+            });
+        }
+    }
+
+    if (renderMode === THINKING_CARD_MODE_DEBUG) {
+        const outcome = semanticOperation?.outcome || null;
+        facts.push(
+            { label: 'Tool call ID', value: entry.callId || entry.call_id },
+            { label: 'Semantic operation ID', value: semanticOperation?.operationId },
+            { label: 'Semantic schema', value: semanticOperation?.schemaVersion },
+            { label: 'Lifecycle', value: semanticOperation?.lifecycleStatus },
+            { label: 'Capability ID', value: semanticOperation?.capability?.id },
+            { label: 'Capability kind', value: semanticOperation?.capability?.kind },
+            { label: 'Execution method', value: semanticOperation?.capability?.executionMethod },
+            { label: 'Effect status', value: outcome?.effectStatus },
+            { label: 'Outcome finality', value: outcome?.outcomeFinality },
+            { label: 'Verification source', value: semanticOperation?.verification?.source },
+            { label: 'Visibility', value: semanticOperation?.visibility }
+        );
+    }
 
     return renderThinkingDiagnosticPanelHTML({ facts });
 }
@@ -30521,7 +30857,7 @@ function buildThinkingDiagnosticsPayload(request) {
         progress_view_model: progressViewModel,
         elapsed_ms: elapsedMs,
         prompt_preview: typeof request.promptRaw === 'string' ? request.promptRaw.slice(0, 1000) : null,
-        latest_progress: latestProgress,
+        latest_progress: cloneThinkingLatestProgress(latestProgress),
         activity_history: Array.isArray(request.activityHistory)
             ? request.activityHistory.slice(-THINKING_DIAGNOSTICS_EXPORT_EVENT_LIMIT)
             : [],

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -3193,6 +3193,221 @@ describe('thinking activity history normalisation', () => {
         expect((html.match(/<div class="thinking-card-tool">/g) || [])).toHaveLength(1);
     });
 
+    test('adds bounded semantic IDs and verification in Expert, then execution details only in Debug', () => {
+        const semanticOperation = {
+            schema_version: 'thinking_semantic_operation.v1',
+            operation_id: 'operation-semantic-relation',
+            lifecycle_status: 'completed',
+            capability: {
+                id: 'add_relationship',
+                label: 'Add Relationship',
+                kind: 'registered_tool',
+                execution_method: 'vontology.add_relationship'
+            },
+            arguments: [
+                {
+                    role: 'subject',
+                    label: 'Subject',
+                    source_argument: 'subject_concept_id',
+                    value_kind: 'concept',
+                    value: '#V#nathan_young_doctoral_candidature_situation',
+                    display: 'Nathan Young Doctoral Candidature Situation',
+                    concept_id: '#V#nathan_young_doctoral_candidature_situation'
+                },
+                {
+                    role: 'predicate',
+                    label: 'Relation',
+                    source_argument: 'predicate',
+                    value_kind: 'predicate',
+                    value: '#V#has_doctoral_supervisor',
+                    display: 'Has Doctoral Supervisor',
+                    concept_id: '#V#has_doctoral_supervisor'
+                },
+                {
+                    role: 'object',
+                    label: 'Object',
+                    source_argument: 'target_concept_id',
+                    value_kind: 'concept',
+                    value: '#V#robert_amor',
+                    display: 'Robert Amor',
+                    concept_id: '#V#robert_amor'
+                }
+            ],
+            summary: 'Add Relationship reported that no change was needed: '
+                + 'Subject: Nathan Young Doctoral Candidature Situation; '
+                + 'Relation: Has Doctoral Supervisor; Object: Robert Amor.',
+            visibility: 'conversation_scope',
+            verification: {
+                status: 'receipt_only',
+                canonical_read_back_present: false,
+                source: 'effect_receipt'
+            },
+            outcome: {
+                status: 'completed',
+                success: true,
+                changed: false,
+                effect_status: 'completed',
+                effect_id: 'effect-semantic-relation',
+                evidence_id: 'evidence-semantic-relation',
+                outcome_finality: 'effect_receipt'
+            }
+        };
+        const createRequest = (mode) => ({
+            thinkingCardMode: mode,
+            promptRaw: 'Re-assert the existing supervision relationship.',
+            latestProgress: {
+                status: 'completed',
+                stage: 'adaptive_research',
+                semantic_operation: semanticOperation,
+                tool_history: [{
+                    tool: 'add_relationship',
+                    phase: 'adaptive_research',
+                    resultSummary: semanticOperation.summary,
+                    success: true,
+                    callId: 'call-semantic-relation',
+                    semanticOperation
+                }]
+            }
+        });
+
+        const defaultHtml = __testOnly_renderThinkingCardBodyHTML(createRequest('default'));
+        expect(defaultHtml).toContain('Add Relationship reported that no change was needed');
+        expect(defaultHtml).not.toContain('Subject ID');
+        expect(defaultHtml).not.toContain('#V#nathan_young_doctoral_candidature_situation');
+        expect(defaultHtml).not.toContain('effect-semantic-relation');
+
+        const expertHtml = __testOnly_renderThinkingCardBodyHTML(createRequest('expert'));
+        expect(expertHtml).toContain('Add Relationship reported that no change was needed');
+        expect(expertHtml).toContain('Subject ID');
+        expect(expertHtml).toContain('#V#nathan_young_doctoral_candidature_situation');
+        expect(expertHtml).toContain('Relation ID');
+        expect(expertHtml).toContain('#V#has_doctoral_supervisor');
+        expect(expertHtml).toContain('Object ID');
+        expect(expertHtml).toContain('#V#robert_amor');
+        expect(expertHtml).toContain('Tool receipt only; canonical read-back not recorded');
+        expect(expertHtml).toContain('Reported change');
+        expect(expertHtml).not.toContain('effect-semantic-relation');
+        expect(expertHtml).not.toContain('vontology.add_relationship');
+
+        const debugHtml = __testOnly_renderThinkingCardBodyHTML(createRequest('debug'));
+        expect(debugHtml).toContain('Add Relationship reported that no change was needed');
+        expect(debugHtml).toContain('Tool call ID');
+        expect(debugHtml).toContain('call-semantic-relation');
+        expect(debugHtml).toContain('Semantic operation ID');
+        expect(debugHtml).toContain('operation-semantic-relation');
+        expect(debugHtml).toContain('Semantic schema');
+        expect(debugHtml).toContain('thinking_semantic_operation.v1');
+        expect(debugHtml).not.toContain('effect-semantic-relation');
+        expect(debugHtml).not.toContain('evidence-semantic-relation');
+        expect(debugHtml).toContain('Lifecycle');
+        expect(debugHtml).toContain('Execution method');
+        expect(debugHtml).toContain('vontology.add_relationship');
+        expect(debugHtml).toContain('Visibility');
+        expect(debugHtml).toContain('conversation_scope');
+    });
+
+    test('keeps a completed semantic receipt in history without replacing later current activity', () => {
+        const semanticOperation = {
+            schema_version: 'thinking_semantic_operation.v1',
+            operation_id: 'operation-completed-relation',
+            lifecycle_status: 'completed',
+            capability: {
+                id: 'add_relationship',
+                label: 'Add Relationship'
+            },
+            arguments: [],
+            summary: 'Add Relationship reported the doctoral supervisor relation.',
+            visibility: 'conversation_scope'
+        };
+        const request = {
+            promptRaw: 'Represent the supervision information.',
+            latestProgress: {
+                status: 'heartbeat',
+                stage: 'final_synthesis',
+                result_summary: 'Synthesising from accumulated evidence.',
+                semantic_operation: semanticOperation,
+                tool_history: [{
+                    tool: 'add_relationship',
+                    phase: 'adaptive_research',
+                    resultSummary: semanticOperation.summary,
+                    success: true,
+                    semanticOperation
+                }]
+            }
+        };
+
+        const viewModel = __testOnly_buildThinkingCardProgressViewModel(request);
+        expect(viewModel.current_activity).toBe('Synthesising from accumulated evidence.');
+
+        const html = __testOnly_renderThinkingCardBodyHTML(request);
+        expect(html).toContain('Synthesising from accumulated evidence.');
+        expect(html).toContain('Add Relationship reported the doctoral supervisor relation.');
+    });
+
+    test('escapes and bounds semantic receipt values, and ignores unsupported structures', () => {
+        const longId = `#V#${'x'.repeat(600)}`;
+        const semanticOperation = {
+            schema_version: 'thinking_semantic_operation.v1',
+            operation_id: 'operation-unsafe-display',
+            lifecycle_status: 'completed',
+            capability: {
+                id: 'add_relationship',
+                label: '<img src=x onerror=alert(1)>',
+                kind: 'registered_tool',
+                execution_method: 'add_relationship'
+            },
+            arguments: [{
+                role: 'subject',
+                source_argument: 'subject_concept_id',
+                value_kind: 'concept',
+                value: longId,
+                display: '<script>alert(1)</script>',
+                concept_id: longId
+            }],
+            summary: '<img src=x onerror=alert(1)> worked',
+            visibility: 'conversation_scope',
+            verification: {
+                status: 'verified',
+                canonical_read_back_present: true,
+                source: 'canonical_read_back'
+            },
+            outcome: { status: 'completed', success: true }
+        };
+        const html = __testOnly_renderThinkingCardBodyHTML({
+            thinkingCardMode: 'expert',
+            latestProgress: {
+                tool_history: [{
+                    tool: 'add_relationship',
+                    success: true,
+                    semantic_operation: semanticOperation
+                }]
+            }
+        });
+
+        expect(html).not.toContain('<img src=x');
+        expect(html).not.toContain('<script>alert(1)</script>');
+        expect(html).toContain('&lt;img src=x onerror=alert(1)&gt; worked');
+        expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+        expect(html).not.toContain(longId);
+        expect(html).toContain('Canonical read-back verified');
+
+        const fallbackHtml = __testOnly_renderThinkingCardBodyHTML({
+            thinkingCardMode: 'expert',
+            toolUseProgressHistory: [{
+                tool: 'fetch_concept',
+                resultSummary: 'Fetched the concept.',
+                success: true,
+                semanticOperation: {
+                    ...semanticOperation,
+                    schema_version: 'thinking_semantic_operation.v2'
+                }
+            }]
+        });
+        expect(fallbackHtml).toContain('Fetched the concept.');
+        expect(fallbackHtml).not.toContain('Canonical read-back verified');
+        expect(fallbackHtml).not.toContain('Subject ID');
+    });
+
     test('prefers canonical latest progress tool history over stale local tool history', () => {
         const request = {
             toolUseProgressHistory: [{

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -4956,11 +4956,22 @@ def test_relation_progress_emits_one_human_start_and_terminal_summary(
     )
     assert relation_events[1]["success"] is True
     assert relation_events[1]["result_summary"] == (
-        "Add Relationship confirmed no change was needed: "
+        "Add Relationship reported that no change was needed: "
         "Subject: Nathan Young Doctoral Candidature Situation; "
         "Relation: Has Doctoral Supervisor; Object: Robert Amor."
     )
-    assert "semantic_operation" not in relation_events[0]
+    assert relation_events[0]["semantic_operation"]["lifecycle_status"] == "running"
+    assert relation_events[0]["semantic_operation"]["verification"] == {
+        "status": "unknown",
+        "canonical_read_back_present": False,
+        "source": "none",
+    }
+    assert relation_events[1]["semantic_operation"]["outcome"]["changed"] is False
+    assert relation_events[1]["semantic_operation"]["verification"] == {
+        "status": "receipt_only",
+        "canonical_read_back_present": False,
+        "source": "effect_receipt",
+    }
     assert result.tool_invocations[0]["changed"] is False
 
 

--- a/tests/backend/test_thinking_semantic_projection_service.py
+++ b/tests/backend/test_thinking_semantic_projection_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from src.backend.services.thinking_semantic_projection_service import (
     SEMANTIC_OPERATION_SCHEMA_VERSION,
     build_semantic_operation_projection,
+    normalise_semantic_operation_projection,
 )
 
 
@@ -29,6 +30,7 @@ def test_relation_projection_has_role_labelled_arguments_and_readable_start() ->
     projection = _relation_projection()
 
     assert projection["schema_version"] == SEMANTIC_OPERATION_SCHEMA_VERSION
+    assert projection["visibility"] == "conversation_scope"
     assert [item["role"] for item in projection["arguments"]] == [
         "subject",
         "predicate",
@@ -43,7 +45,7 @@ def test_relation_projection_has_role_labelled_arguments_and_readable_start() ->
     )
 
 
-def test_nested_predicate_reference_and_unchanged_outcome_are_truthful() -> None:
+def test_nested_predicate_reference_and_receipt_only_unchanged_are_truthful() -> None:
     projection = _relation_projection(
         arguments={
             "predicate": None,
@@ -58,11 +60,164 @@ def test_nested_predicate_reference_and_unchanged_outcome_are_truthful() -> None
         "#V#has_doctoral_supervisor"
     )
     assert projection["outcome"]["changed"] is False
+    assert projection["verification"] == {
+        "status": "receipt_only",
+        "canonical_read_back_present": False,
+        "source": "effect_receipt",
+    }
     assert projection["summary"] == (
-        "Add Relationship confirmed no change was needed: "
+        "Add Relationship reported that no change was needed: "
         "Subject: Nathan Young Doctoral Candidature Situation; "
         "Relation: Has Doctoral Supervisor; Object: Robert Amor."
     )
+
+
+def test_explicit_successful_matching_canonical_read_back_is_labelled_verified() -> None:
+    projection = _relation_projection(
+        lifecycle_status="succeeded",
+        success=True,
+        result={
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": False,
+            "canonical_read_back": {
+                "source_id": "#V#nathan_young_doctoral_candidature_situation",
+                "predicate": "#V#has_doctoral_supervisor",
+                "target": "#V#robert_amor",
+            },
+            "effect_id": "actor-private-effect",
+            "evidence_id": "actor-private-evidence",
+        },
+    )
+
+    assert projection["verification"] == {
+        "status": "verified",
+        "canonical_read_back_present": True,
+        "source": "canonical_read_back",
+    }
+    assert projection["summary"].startswith(
+        "Add Relationship verified that no change was needed:"
+    )
+    assert "effect_id" not in projection["outcome"]
+    assert "evidence_id" not in projection["outcome"]
+
+
+def test_real_scoped_assertion_read_back_shape_can_verify_matching_relation() -> None:
+    projection = build_semantic_operation_projection(
+        operation_id="call-scoped-assertion",
+        capability_name="upsert_scoped_assertion",
+        execution_method="upsert_scoped_assertion",
+        capability_kind="registered_tool",
+        arguments={
+            "subject_concept_id": "#V#candidate_situation",
+            "predicate": "#V#has_doctoral_supervisor",
+            "target_concept_id": "#V#robert_amor",
+        },
+        lifecycle_status="succeeded",
+        success=True,
+        result={
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": False,
+            "canonical_read_back": {
+                "schema_version": "scoped_knowledge_assertion.v1",
+                "assertion_id": "ska_1234567890abcdef",
+                "subject_concept_id": "#V#candidate_situation",
+                "predicate": "#V#has_doctoral_supervisor",
+                "object_kind": "concept",
+                "object_concept_id": "#V#robert_amor",
+                "status": "asserted",
+            },
+        },
+    )
+
+    assert projection["verification"]["status"] == "verified"
+    assert projection["summary"].startswith(
+        "Upsert Scoped Assertion verified that no change was needed:"
+    )
+
+
+def test_failed_canonical_read_back_object_remains_receipt_only() -> None:
+    projection = _relation_projection(
+        lifecycle_status="succeeded",
+        success=True,
+        result={
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "canonical_read_back": {
+                "success": False,
+                "error": "read-back unavailable",
+            },
+        },
+    )
+
+    assert projection["verification"] == {
+        "status": "receipt_only",
+        "canonical_read_back_present": True,
+        "source": "effect_receipt",
+    }
+    assert "verified" not in projection["summary"]
+
+
+def test_arbitrary_nonempty_canonical_read_back_remains_receipt_only() -> None:
+    projection = _relation_projection(
+        lifecycle_status="succeeded",
+        success=True,
+        result={
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "canonical_read_back": {
+                "success": True,
+                "detail": "a payload existed but did not prove the relation",
+            },
+        },
+    )
+
+    assert projection["verification"]["status"] == "receipt_only"
+    assert "verified" not in projection["summary"]
+
+
+def test_mismatched_relation_read_back_remains_receipt_only() -> None:
+    projection = _relation_projection(
+        lifecycle_status="succeeded",
+        success=True,
+        result={
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "canonical_read_back": {
+                "subject_concept_id": (
+                    "#V#nathan_young_doctoral_candidature_situation"
+                ),
+                "predicate": "#V#has_doctoral_supervisor",
+                "object_concept_id": "#V#someone_else",
+            },
+        },
+    )
+
+    assert projection["verification"]["status"] == "receipt_only"
+    assert "verified" not in projection["summary"]
+
+
+def test_empty_canonical_read_back_is_present_but_not_claimed_verified() -> None:
+    projection = _relation_projection(
+        lifecycle_status="succeeded",
+        success=True,
+        result={
+            "effect_status": "succeeded",
+            "changed": False,
+            "canonical_read_back": {},
+        },
+    )
+
+    assert projection["verification"] == {
+        "status": "receipt_only",
+        "canonical_read_back_present": True,
+        "source": "effect_receipt",
+    }
+    assert "verified" not in projection["summary"]
 
 
 def test_relation_operation_wording_preserves_remove_partial_and_unknown() -> None:
@@ -120,10 +275,7 @@ def test_literal_text_preserves_case_and_punctuation() -> None:
     assert projection["relation"]["object"]["display"] == (
         "Professor of Computer Science (emeritus)."
     )
-    assert (
-        "Value: “Professor of Computer Science (emeritus).”"
-        in projection["summary"]
-    )
+    assert "Value: “Professor of Computer Science (emeritus).”" in projection["summary"]
     assert "Professor Of Computer Science" not in projection["summary"]
 
 
@@ -147,3 +299,67 @@ def test_projection_bounds_values_and_does_not_invent_a_relation() -> None:
     assert len(projection["arguments"]) == 1
     assert len(projection["arguments"][0]["value"]) <= 240
     assert projection["summary"] == "Finished Create Concepts."
+
+
+def test_strict_normaliser_reconstructs_bounded_allowlisted_projection() -> None:
+    projection = _relation_projection(
+        lifecycle_status="succeeded",
+        success=True,
+        result={"effect_status": "succeeded", "changed": True},
+    )
+    projection["summary"] = "<script>untrusted()</script>" + ("x" * 5_000)
+    projection["unexpected"] = {"unbounded": "x" * 10_000}
+    projection["arguments"][0]["value"] = "#V#" + ("x" * 1_000)
+    projection["arguments"][0]["display"] = "x" * 1_000
+    projection["outcome"]["effect_id"] = "actor-private-effect"
+    projection["outcome"]["evidence_id"] = "actor-private-evidence"
+    projection["verification"] = {
+        "status": "verified",
+        "canonical_read_back_present": False,
+        "source": "none",
+    }
+
+    normalised = normalise_semantic_operation_projection(projection)
+
+    assert normalised is not None
+    assert "unexpected" not in normalised
+    assert "<script>" not in normalised["summary"]
+    assert len(normalised["arguments"][0]["value"]) <= 240
+    assert len(normalised["arguments"][0]["display"]) <= 240
+    assert len(normalised["summary"]) <= 1_024
+    assert "effect_id" not in normalised["outcome"]
+    assert "evidence_id" not in normalised["outcome"]
+    assert normalised["verification"] == {
+        "status": "receipt_only",
+        "canonical_read_back_present": False,
+        "source": "effect_receipt",
+    }
+
+
+def test_strict_normaliser_rejects_unknown_schema_or_visibility_contract() -> None:
+    projection = _relation_projection()
+    forged_running_verification = normalise_semantic_operation_projection(
+        {
+            **projection,
+            "verification": {
+                "status": "verified",
+                "canonical_read_back_present": True,
+                "source": "canonical_read_back",
+            },
+        }
+    )
+
+    assert forged_running_verification is not None
+    assert forged_running_verification["verification"]["status"] == "unknown"
+    assert (
+        normalise_semantic_operation_projection(
+            {**projection, "schema_version": "thinking_semantic_operation.v2"}
+        )
+        is None
+    )
+    assert (
+        normalise_semantic_operation_projection(
+            {**projection, "visibility": "organisation_scope"}
+        )
+        is None
+    )

--- a/tests/backend/test_tool_progress_liveness.py
+++ b/tests/backend/test_tool_progress_liveness.py
@@ -7,6 +7,9 @@ from types import SimpleNamespace
 from flask import Flask
 
 from src.backend.server.routes import von_routes
+from src.backend.services.thinking_semantic_projection_service import (
+    build_semantic_operation_projection,
+)
 from src.backend.services.tool_progress_store_service import (
     clear_tool_progress_documents_for_tests,
     flush_queued_tool_progress_states,
@@ -36,6 +39,28 @@ def _progress_app() -> Flask:
     app.secret_key = "test-secret"
     app.register_blueprint(von_routes.von_bp, url_prefix="/von")
     return app
+
+
+def _relation_semantic_operation(
+    *,
+    lifecycle_status: str,
+    success: bool | None = None,
+    result: dict | None = None,
+) -> dict:
+    return build_semantic_operation_projection(
+        operation_id="call-semantic-relation",
+        capability_name="add_relationship",
+        execution_method="add_relationship",
+        capability_kind="registered_tool",
+        arguments={
+            "source_id": "#V#nathan_young_doctoral_candidature_situation",
+            "predicate": "#V#has_doctoral_supervisor",
+            "target": "#V#robert_amor",
+        },
+        lifecycle_status=lifecycle_status,
+        success=success,
+        result=result,
+    )
 
 
 def setup_function() -> None:
@@ -238,6 +263,7 @@ def test_progress_endpoint_reads_persisted_state_after_local_cache_miss(
     )
 
     scope_key = "user:#V#test_user"
+    semantic_operation = _relation_semantic_operation(lifecycle_status="running")
     von_routes._set_tool_progress(
         scope_key,
         "req-persisted",
@@ -247,6 +273,7 @@ def test_progress_endpoint_reads_persisted_state_after_local_cache_miss(
             "phase_label": "Reading evidence",
             "request_id": "req-persisted",
             "goal_label": "Summarise the represented evidence",
+            "semantic_operation": semantic_operation,
         },
     )
     flush_queued_tool_progress_states(force=True)
@@ -261,6 +288,8 @@ def test_progress_endpoint_reads_persisted_state_after_local_cache_miss(
     assert body.get("stage") == "evidence_read"
     assert body.get("phase_label") == "Reading evidence"
     assert body.get("goal_label") == "Summarise the represented evidence"
+    assert body.get("semantic_operation") == semantic_operation
+    assert body["diagnostic_events"][-1]["semantic_operation"] == semantic_operation
 
 
 def test_get_tool_progress_prefers_live_memory_before_persisted_fetch(
@@ -963,9 +992,15 @@ def test_relation_start_and_end_collapse_to_one_human_tool_row(monkeypatch) -> N
         "Relation: Has Doctoral Supervisor; Object: Robert Amor (in progress)."
     )
     terminal_summary = (
-        "Add Relationship confirmed no change was needed: "
+        "Add Relationship reported that no change was needed: "
         "Subject: Nathan Young Doctoral Candidature Situation; "
         "Relation: Has Doctoral Supervisor; Object: Robert Amor."
+    )
+    running_operation = _relation_semantic_operation(lifecycle_status="running")
+    terminal_operation = _relation_semantic_operation(
+        lifecycle_status="succeeded",
+        success=True,
+        result={"effect_status": "succeeded", "changed": False},
     )
 
     von_routes._set_tool_progress(
@@ -978,6 +1013,7 @@ def test_relation_start_and_end_collapse_to_one_human_tool_row(monkeypatch) -> N
             "tool": "add_relationship",
             "call_id": call_id,
             "result_summary": running_summary,
+            "semantic_operation": running_operation,
             "request_id": request_id,
         },
     )
@@ -993,6 +1029,7 @@ def test_relation_start_and_end_collapse_to_one_human_tool_row(monkeypatch) -> N
             "call_id": call_id,
             "success": True,
             "result_summary": terminal_summary,
+            "semantic_operation": terminal_operation,
             "request_id": request_id,
         },
     )
@@ -1006,6 +1043,13 @@ def test_relation_start_and_end_collapse_to_one_human_tool_row(monkeypatch) -> N
     assert snapshot["tool_call_count"] == 1
     assert snapshot["tool_success_count"] == 1
     assert snapshot["tool_pending_count"] == 0
+    assert snapshot["semantic_operation"] == terminal_operation
+    semantic_events = [
+        event["semantic_operation"]
+        for event in snapshot["diagnostic_events"]
+        if "semantic_operation" in event
+    ]
+    assert semantic_events == [running_operation, terminal_operation]
     assert snapshot["tool_history"] == [
         {
             "tool": "add_relationship",
@@ -1015,8 +1059,20 @@ def test_relation_start_and_end_collapse_to_one_human_tool_row(monkeypatch) -> N
             "resultSummary": terminal_summary,
             "success": True,
             "callId": call_id,
+            "semanticOperation": terminal_operation,
         }
     ]
+
+    diagnostics = von_routes._build_turn_execution_diagnostics(
+        request_id=request_id,
+        prompt_text="Reassert the represented supervision relation.",
+        tool_progress_state=snapshot,
+    )
+    assert diagnostics["latest_progress"]["semantic_operation"] == terminal_operation
+    assert diagnostics["latest_progress"]["diagnostic_events"][-1][
+        "semantic_operation"
+    ] == terminal_operation
+    assert diagnostics["tool_history"][0]["semanticOperation"] == terminal_operation
 
 
 def test_serialisation_exposes_a_bounded_timing_trace(monkeypatch) -> None:

--- a/tests/backend/test_turn_execution_diagnostic_event_service.py
+++ b/tests/backend/test_turn_execution_diagnostic_event_service.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from src.backend.services.thinking_semantic_projection_service import (
+    build_semantic_operation_projection,
+)
+from src.backend.services.turn_execution_diagnostic_event_service import (
+    update_tool_observation_summary,
+)
+
+
+def _semantic_operation(
+    *,
+    lifecycle_status: str,
+    success: bool | None = None,
+    result: dict | None = None,
+) -> dict:
+    return build_semantic_operation_projection(
+        operation_id="call-relationship",
+        capability_name="add_relationship",
+        execution_method="add_relationship",
+        capability_kind="registered_tool",
+        arguments={
+            "source_id": "#V#candidate_situation",
+            "predicate": "#V#has_doctoral_supervisor",
+            "target": "#V#robert_amor",
+        },
+        lifecycle_status=lifecycle_status,
+        success=success,
+        result=result,
+    )
+
+
+def test_tool_history_preserves_terminal_semantic_operation_across_reload() -> None:
+    running = _semantic_operation(lifecycle_status="running")
+    terminal = _semantic_operation(
+        lifecycle_status="succeeded",
+        success=True,
+        result={"effect_status": "succeeded", "changed": False},
+    )
+
+    summary = update_tool_observation_summary(
+        None,
+        {
+            "status": "tool_call_start",
+            "event_kind": "tool_call_start",
+            "phase": "adaptive_research",
+            "tool": "add_relationship",
+            "call_id": "call-relationship",
+            "result_summary": running["summary"],
+            "semantic_operation": running,
+        },
+    )
+    summary = update_tool_observation_summary(
+        summary,
+        {
+            "status": "tool_completed",
+            "event_kind": "tool_call_end",
+            "phase": "adaptive_research",
+            "tool": "add_relationship",
+            "call_id": "call-relationship",
+            "success": True,
+            "result_summary": terminal["summary"],
+            "semantic_operation": terminal,
+        },
+    )
+    reloaded = update_tool_observation_summary(summary, None)
+
+    assert reloaded["tool_call_count"] == 1
+    assert reloaded["tool_success_count"] == 1
+    assert reloaded["tool_pending_count"] == 0
+    assert len(reloaded["tool_history"]) == 1
+    operation = reloaded["tool_history"][0]["semanticOperation"]
+    assert operation["lifecycle_status"] == "succeeded"
+    assert operation["outcome"]["changed"] is False
+    assert operation["verification"]["status"] == "receipt_only"
+
+
+def test_tool_history_drops_semantic_operation_with_wrong_visibility() -> None:
+    operation = {
+        **_semantic_operation(lifecycle_status="running"),
+        "visibility": "organisation_scope",
+    }
+
+    summary = update_tool_observation_summary(
+        None,
+        {
+            "status": "tool_call_start",
+            "event_kind": "tool_call_start",
+            "tool": "add_relationship",
+            "call_id": "call-relationship",
+            "semantic_operation": operation,
+        },
+    )
+
+    assert "semanticOperation" not in summary["tool_history"][0]

--- a/tests/backend/test_turn_execution_live_progress_mcp_bounds.py
+++ b/tests/backend/test_turn_execution_live_progress_mcp_bounds.py
@@ -12,6 +12,66 @@ from mcp.client.session import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
 
 
+def _semantic_operation() -> dict[str, Any]:
+    return {
+        "schema_version": "thinking_semantic_operation.v1",
+        "operation_id": "call-supervisor-edge",
+        "lifecycle_status": "succeeded",
+        "capability": {
+            "id": "add_relationship",
+            "label": "Add Relationship",
+            "kind": "registered_tool",
+            "execution_method": "add_relationship",
+        },
+        "arguments": [
+            {
+                "role": "subject",
+                "label": "Subject",
+                "source_argument": "source_id",
+                "value_kind": "concept",
+                "value": "#V#candidate_situation",
+                "display": "Candidate Situation",
+                "concept_id": "#V#candidate_situation",
+            },
+            {
+                "role": "predicate",
+                "label": "Relation",
+                "source_argument": "predicate",
+                "value_kind": "predicate",
+                "value": "#V#has_doctoral_supervisor",
+                "display": "Has Doctoral Supervisor",
+                "concept_id": "#V#has_doctoral_supervisor",
+            },
+            {
+                "role": "object",
+                "label": "Object",
+                "source_argument": "target",
+                "value_kind": "concept",
+                "value": "#V#robert_amor",
+                "display": "Robert Amor",
+                "concept_id": "#V#robert_amor",
+            },
+        ],
+        "summary": (
+            "Add Relationship reported that no change was needed: Subject: "
+            "Candidate Situation; Relation: Has Doctoral Supervisor; Object: "
+            "Robert Amor."
+        ),
+        "visibility": "conversation_scope",
+        "verification": {
+            "status": "receipt_only",
+            "canonical_read_back_present": False,
+            "source": "effect_receipt",
+        },
+        "outcome": {
+            "status": "succeeded",
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": False,
+        },
+    }
+
+
 def _large_serialised_progress_payload() -> dict[str, Any]:
     return {
         "request_id": "req-large-live-progress",
@@ -25,6 +85,13 @@ def _large_serialised_progress_payload() -> dict[str, Any]:
         "stall_detected": False,
         "activity_idle_ms": 250,
         "stage_idle_ms": 125,
+        "semantic_operation": _semantic_operation(),
+        "tool_history": [
+            {
+                "tool": "add_relationship",
+                "resultSummary": "The relation tool reported no change.",
+            }
+        ],
         "diagnostic_summary": {"event_count": 500},
         "counters": {
             "tokens_streamed": 42,
@@ -165,6 +232,9 @@ def test_live_progress_default_projection_is_bounded(monkeypatch) -> None:
     assert result["success"] is True
     assert result["projection"] == "bounded_snapshot"
     assert result["status"] == "workflow_step_complete"
+    assert result["semantic_operation"]["operation_id"] == "call-supervisor-edge"
+    assert result["semantic_operation"]["verification"]["status"] == "receipt_only"
+    assert result["semantic_operation"]["visibility"] == "conversation_scope"
     assert "diagnostic_events" not in result
     assert "stage_diagnostics" not in result
     assert "llm_request" not in result
@@ -174,6 +244,7 @@ def test_live_progress_default_projection_is_bounded(monkeypatch) -> None:
     assert result["timing_summary"]["slowest_spans"][0]["duration_ms"] == 42000
     assert result["section_counts"]["diagnostic_events"] == 30
     assert result["section_counts"]["timing_spans"] == 12
+    assert result["section_counts"]["tool_history"] == 1
     assert result["detail_access"]["arguments"]["section"] == "<one of available_sections>"
     assert len(json.dumps(result, indent=2, default=str)) < 20_000
 


### PR DESCRIPTION
## What

- carries a bounded `thinking_semantic_operation.v1` receipt from adaptive tool execution through live progress, diagnostics, persistence and archived reload
- renders a human semantic story in Default, canonical arguments and verification boundaries in Expert, and execution mechanics in Debug
- keeps terminal tool receipts in history while allowing later live phases to remain the current activity
- labels tool outcomes as reported unless explicit successful canonical read-back proves the exact represented relation

## Why

Thinking previously collapsed useful subject–predicate–object arguments and effect evidence into tool names or opaque identifiers. This is the smallest reusable vertical slice from JVNAUTOSCI-2619; it does not add a bespoke spreadsheet workflow, extra model/tool/database calls, or broad Situation persistence.

## Validation

- 184 affected backend tests passed
- 247 `chatTab` tests passed
- changed-file ESLint and `git diff --check` passed
- authenticated browser replay exercised an existing doctoral-supervisor relation: Default showed the semantic no-change report; Expert showed canonical IDs plus receipt-only status; Debug added bounded mechanics without effect/evidence IDs
- full browser reload recovered the same receipt from archived progress while current activity remained current
- independent backend/archive and frontend reviews found no stop-ship issue

JVNAUTOSCI-2619 remains broader than this slice: durable shared Situation continuity and truthful Stop/Skip affordances remain non-goals here.