### PR TITLE
Show build identity beside footer uptime

### DIFF
--- a/src/frontend/web/von_interface/static/js/main.js
+++ b/src/frontend/web/von_interface/static/js/main.js
@@ -650,6 +650,8 @@ function startHealthPolling() {
   const publicIpSpan = document.getElementById('serverPublicIpValue');
   const pidSpan = document.getElementById('serverPidValue');
   const uptimeSpan = document.getElementById('serverUptimeValue');
+  const buildInfo = document.getElementById('serverBuildInfo');
+  const buildSpan = document.getElementById('serverBuildValue');
   const ragSpan = document.getElementById('ragIndexingValue');
   const ragDetailsBtn = document.getElementById('ragIndexingValue');
   const ragModal = document.getElementById('ragStatusModal');
@@ -1165,6 +1167,39 @@ function startHealthPolling() {
       const newLocalIp = data.local_ip || null;
       const newPublicIp = data.public_ip || null;
       const ragPending = (typeof data.rag_pending_count !== 'undefined') ? data.rag_pending_count : null;
+      const versionDetails = (data.version_details && typeof data.version_details === 'object')
+        ? data.version_details
+        : {};
+      const version = (typeof data.version === 'string' && data.version.trim())
+        ? data.version.trim()
+        : '';
+      const shortCommit = (typeof versionDetails.git_short_commit === 'string')
+        ? versionDetails.git_short_commit.trim()
+        : '';
+      const commitTimestamp = (typeof versionDetails.git_commit_timestamp === 'string')
+        ? versionDetails.git_commit_timestamp.trim()
+        : '';
+      const parsedCommitTime = commitTimestamp ? new Date(commitTimestamp) : null;
+      const compactCommitTime = parsedCommitTime && !Number.isNaN(parsedCommitTime.getTime())
+        ? new Intl.DateTimeFormat('en-NZ', {
+          day: '2-digit', month: 'short', year: '2-digit',
+          hour: '2-digit', minute: '2-digit', hour12: false
+        }).format(parsedCommitTime).replace(',', '')
+        : '';
+      const dirtyMarker = versionDetails.git_dirty === true ? '*' : '';
+      const compactBuildId = shortCommit ? `${shortCommit.slice(0, 8)}${dirtyMarker}` : version;
+
+      if (buildInfo && buildSpan) {
+        const buildText = [compactBuildId, compactCommitTime].filter(Boolean).join(' · ');
+        buildSpan.textContent = buildText;
+        buildInfo.hidden = !buildText;
+        buildInfo.title = [
+          version ? `Build ${version}` : null,
+          shortCommit ? `Commit ${shortCommit}` : null,
+          commitTimestamp ? `Commit time ${commitTimestamp}` : null,
+          versionDetails.git_dirty === true ? 'Working tree dirty' : null
+        ].filter(Boolean).join(' | ');
+      }
 
       if (localIpSpan) {
         localIpSpan.textContent = newLocalIp || '?';

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -10848,6 +10848,12 @@ button.prompt-vontology-cartouche {
     color: #991b1b;
 }
 
+@media (max-width: 760px) {
+    .server-build-info {
+        display: none;
+    }
+}
+
 .footer-separator {
     margin: 0 4px;
     opacity: 0.5;

--- a/src/frontend/web/von_interface/templates/von_interface.html
+++ b/src/frontend/web/von_interface/templates/von_interface.html
@@ -163,6 +163,8 @@
     <p id="languageIndicator" class="language-indicator">🌐 en-NZ</p>
     <p id="serverUptimeFooter" class="pid-indicator" title="Process uptime">
       <span class="footer-label">Uptime:</span> <span id="serverUptimeValue" title="Process uptime">-</span>
+      <span id="serverBuildInfo" class="server-build-info" hidden><span class="footer-separator">|</span>
+        <span class="footer-label">Build:</span> <span id="serverBuildValue">-</span></span>
     </p>
     {% if expert_footer_enabled %}
     <p id="serverPidFooter" class="pid-indicator" title="Server PID & RAG">

--- a/tests/frontend/footerBuildInfo.test.js
+++ b/tests/frontend/footerBuildInfo.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+
+const template = fs.readFileSync(
+    path.resolve(__dirname, '../../src/frontend/web/von_interface/templates/von_interface.html'),
+    'utf8'
+);
+const mainSource = fs.readFileSync(
+    path.resolve(__dirname, '../../src/frontend/web/von_interface/static/js/main.js'),
+    'utf8'
+);
+const styles = fs.readFileSync(
+    path.resolve(__dirname, '../../src/frontend/web/von_interface/static/styles.css'),
+    'utf8'
+);
+
+describe('footer build information', () => {
+    test('places compact build information immediately after uptime', () => {
+        const uptimeFooter = template.match(/<p id="serverUptimeFooter"[\s\S]*?<\/p>/)?.[0] || '';
+
+        expect(uptimeFooter.indexOf('id="serverUptimeValue"')).toBeGreaterThanOrEqual(0);
+        expect(uptimeFooter.indexOf('id="serverBuildInfo"'))
+            .toBeGreaterThan(uptimeFooter.indexOf('id="serverUptimeValue"'));
+        expect(mainSource).toContain('versionDetails.git_short_commit');
+        expect(mainSource).toContain('versionDetails.git_commit_timestamp');
+        expect(mainSource).toContain("shortCommit.slice(0, 8)");
+    });
+
+    test('hides build information, but not uptime, below the footer crowding threshold', () => {
+        expect(styles).toMatch(
+            /@media \(max-width:\s*760px\)\s*\{\s*\.server-build-info\s*\{\s*display:\s*none;/
+        );
+        expect(styles).not.toMatch(
+            /@media \(max-width:\s*760px\)[\s\S]*?#serverUptimeFooter\s*\{\s*display:\s*none;/
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- show the compact runtime build ID and commit date/time immediately beside footer uptime
- retain the full canonical build identity and timestamp in the tooltip
- hide only the build fragment at viewport widths of 760px or less
- reuse the existing `/health.version_details` response without adding another request or backend path

## Validation

- `npx jest tests/frontend/footerBuildInfo.test.js --runInBand`
- `npm run lint:frontend:static -- src/frontend/web/von_interface/static/js/main.js tests/frontend/footerBuildInfo.test.js`
- `node --check src/frontend/web/von_interface/static/js/main.js`
- `git diff --check`
- isolated AgentTest `/health` and `/von/` smoke checks

Playwright visual automation was attempted but the local Playwright Chromium binaries were unavailable; the responsive rule is covered by the focused regression.
