### PR TITLE
Make semantic retrieval evidence recoverable

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -33959,6 +33959,7 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             input_schema=_concept_fetch_input_schema(),
             output_schema=None,
             category="read",
+            hard_timeout_enabled=False,
             description=(
                 "Fetch full details of one concept by exact ID. An authenticated "
                 "actor receives actor_effective scoped enrichment; identity or "
@@ -33972,6 +33973,7 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             input_schema=_find_relations_with_argument_input_schema(),
             output_schema=_find_relations_with_argument_output_schema(),
             category="read",
+            hard_timeout_enabled=False,
             description=(
                 "Find relation assertions where a concept appears in one or more argument "
                 "positions. The anchor entity must be supplied in concept_id; use "
@@ -34086,6 +34088,7 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             input_schema=concept_search_input_schema,
             output_schema=concept_search_output_schema,
             category="read",
+            hard_timeout_enabled=False,
             description="Find concepts. For 'list instances of X': use instance_of='#V#type' param (e.g., instance_of='#V#researcher'). For 'find X': use query param. Other key params: filter_kind=['individual'|'type'], include_hierarchy_path=true (shows paths), match_type='exact'|'substring'|'similarity'.",
         ),
         MethodDefinition(
@@ -34108,6 +34111,7 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             input_schema=_predicate_incidence_input_schema(),
             output_schema=_predicate_incidence_output_schema(),
             category="read",
+            hard_timeout_enabled=False,
             description=(
                 "Discover predicates actually used around a known anchor or type when "
                 "relationship coverage is uncertain. The anchor entity goes in concept_id. "
@@ -34152,6 +34156,7 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             input_schema=concept_search_input_schema,
             output_schema=concept_search_output_schema,
             category="read",
+            hard_timeout_enabled=False,
             description=(
                 "Search Vontology concept names and descriptions, including "
                 "predicates and types. Use as schema discovery when a represented "
@@ -34167,6 +34172,7 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             input_schema=_resolve_concept_by_name_input_schema(),
             output_schema=_resolve_concept_by_name_output_schema(),
             category="read",
+            hard_timeout_enabled=False,
             description=(
                 "Resolve a Vontology concept deterministically from a user-provided surface form. "
                 "Read-only: does not mutate concepts. Returns resolved/ambiguous/not_found with an audit trail. "
@@ -34264,6 +34270,7 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             input_schema=_get_text_relations_input_schema(),
             output_schema=_get_text_relations_output_schema(),
             category="read",
+            hard_timeout_enabled=False,
             description=(
                 "Retrieve labelled text-assertion rows for a concept, optionally "
                 "filtered by predicate/language. The serving authority boundary "
@@ -34295,6 +34302,7 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             input_schema=_get_text_relations_summary_input_schema(),
             output_schema=_get_text_relations_summary_output_schema(),
             category="read",
+            hard_timeout_enabled=False,
             description=(
                 "Return a lightweight, context-labelled text-assertion summary "
                 "grouped by predicate/language (no full text bodies). The serving "
@@ -35285,6 +35293,7 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             output_schema=_search_knowledge_base_output_schema(),
             category="read",
             timeout_sec=30.0,
+            hard_timeout_enabled=False,
             ordinary_turn_trusted_argument_bindings={
                 "namespace": "turn_namespace",
                 "user_concept_id": "actor_user_concept_id",
@@ -35301,6 +35310,7 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             output_schema=_search_concept_descriptions_output_schema(),
             category="read",
             timeout_sec=30.0,
+            hard_timeout_enabled=False,
             ordinary_turn_trusted_argument_bindings={
                 "namespace": "turn_namespace",
                 "user_concept_id": "actor_user_concept_id",
@@ -35320,6 +35330,7 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             output_schema=_get_related_concepts_output_schema(),
             category="read",
             timeout_sec=30.0,
+            hard_timeout_enabled=False,
             ordinary_turn_trusted_argument_bindings={
                 "namespace": "turn_namespace",
                 "user_concept_id": "actor_user_concept_id",
@@ -35993,6 +36004,7 @@ def _build_default_catalogue_diagnostics_and_research_definitions() -> (
             ),
             output_schema=None,
             category="read",
+            hard_timeout_enabled=False,
             ordinary_turn_trusted_argument_bindings={
                 "namespace": "turn_namespace",
             },

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -20961,6 +20961,7 @@ class InternalMCPChatOrchestrator:
 
         selected_hits: list[Mapping[str, Any]] = []
         seen_related_concept_ids: set[str] = set()
+        related_concept_ids: list[str] = []
         related_predicates_by_concept_id: dict[str, list[str]] = {}
         related_directions_by_concept_id: dict[str, list[str]] = {}
         compacted_duplicate_hit_count = 0
@@ -21021,6 +21022,7 @@ class InternalMCPChatOrchestrator:
                     compacted_duplicate_hit_count += 1
                     continue
                 seen_related_concept_ids.add(related_concept_id)
+                related_concept_ids.append(related_concept_id)
             if len(selected_hits) >= max_hits:
                 continue
             selected_hits.append(hit)
@@ -21169,11 +21171,16 @@ class InternalMCPChatOrchestrator:
         compact_payload: dict[str, Any] = {
             "_llm_view": "find_relations_with_argument_results.v1",
             "concept_id": concept_id,
+            "context_view": payload.get("context_view"),
             "total_hits": int(total_hits),
+            "total_hits_is_lower_bound": payload.get("total_hits_is_lower_bound"),
             "shown_hit_count": len(compact_hits),
             "omitted_hit_count": max(0, int(total_hits) - len(compact_hits)),
+            "related_concept_ids": related_concept_ids,
             "predicates": predicate_values[:12],
             "hits": compact_hits,
+            "paging": payload.get("paging"),
+            "continuation": payload.get("continuation"),
             "retrieval_diagnostics": {"note": diagnostics_note},
         }
         omitted_related_concept_count = max(
@@ -21533,37 +21540,43 @@ class InternalMCPChatOrchestrator:
                 )[:6]
             ]
 
-        for row in results[:max_results]:
+        for row_index, row in enumerate(results):
+            include_detail = row_index < max_results
             compact_row: dict[str, Any] = {}
             row_id = row.get("id")
-            if isinstance(row_id, str) and row_id.strip():
+            if include_detail and isinstance(row_id, str) and row_id.strip():
                 compact_row["id"] = row_id.strip()
             score = row.get("score")
-            if isinstance(score, (int, float)):
+            if include_detail and isinstance(score, (int, float)):
                 compact_row["score"] = round(float(score), 3)
             text = row.get("text")
-            if isinstance(text, str) and text.strip():
+            if include_detail and isinstance(text, str) and text.strip():
                 compact_row["text_preview"] = text.strip()[:max_text_chars]
 
             metadata = row.get("metadata")
             metadata_map = metadata if isinstance(metadata, Mapping) else None
-            title = cls._extract_search_knowledge_base_result_title(row, metadata_map)
-            if title:
+            title = (
+                cls._extract_search_knowledge_base_result_title(row, metadata_map)
+                if include_detail
+                else None
+            )
+            if include_detail and title:
                 compact_row["title"] = title[:120]
 
             if isinstance(metadata_map, Mapping):
-                for field_name in (
-                    "item_kind",
-                    "source_system",
-                    "type",
-                    "predicate",
-                    "concept_id",
-                    "subject_concept_id",
-                    "target_concept_id",
-                ):
-                    field_value = metadata_map.get(field_name)
-                    if isinstance(field_value, str) and field_value.strip():
-                        compact_row[field_name] = field_value.strip()
+                if include_detail:
+                    for field_name in (
+                        "item_kind",
+                        "source_system",
+                        "type",
+                        "predicate",
+                        "concept_id",
+                        "subject_concept_id",
+                        "target_concept_id",
+                    ):
+                        field_value = metadata_map.get(field_name)
+                        if isinstance(field_value, str) and field_value.strip():
+                            compact_row[field_name] = field_value.strip()
                 _bump(source_system_counts, metadata_map.get("source_system"))
                 _bump(item_kind_counts, metadata_map.get("item_kind"))
                 _bump(type_counts, metadata_map.get("type"))
@@ -21584,7 +21597,7 @@ class InternalMCPChatOrchestrator:
                 ):
                     concept_ids.append(concept_id.strip())
 
-            if compact_row:
+            if include_detail and compact_row:
                 compact_results.append(compact_row)
 
         total_count = payload.get("count")
@@ -21655,7 +21668,7 @@ class InternalMCPChatOrchestrator:
             "item_kind_counts": item_kind_counts_payload,
             "type_counts": type_counts_payload,
             "predicates": predicates[:12],
-            "concept_ids": concept_ids[:12],
+            "concept_ids": concept_ids,
             "results": compact_results,
             "retrieval_state": retrieval_state,
             "retrieval_diagnostics": {"note": diagnostics_note},

--- a/src/backend/services/concept_search_service.py
+++ b/src/backend/services/concept_search_service.py
@@ -32,7 +32,6 @@ from difflib import SequenceMatcher
 from typing import List, Dict, Any, Optional
 from datetime import datetime, timezone
 from bson import ObjectId
-from pymongo import timeout
 
 from ..db.repositories.concepts_repository import ConceptsRepository
 from ..db.repositories.text_value_repository import (
@@ -66,8 +65,6 @@ DESCRIPTION_TEXT_PREDICATE_PRECEDENCE = (
 )
 TEXT_RELATION_DEFAULT_TEXT_VALUE_LIMIT = 500
 TEXT_RELATION_DEFAULT_RELATION_LIMIT = 1000
-CONCEPT_SEARCH_QUERY_MAX_TIME_MS = 5_000
-CONCEPT_SEARCH_OPERATION_TIMEOUT_SECONDS = 5.0
 TEXT_VALUE_ID_PROJECTION: Dict[str, int] = {"_id": 1}
 
 
@@ -84,16 +81,9 @@ class InvalidSearchParameters(ConceptSearchError):
 
 
 def _consume_search_cursor(cursor) -> list[dict[str, Any]]:
-    """Materialise one bounded Mongo cursor under a total client deadline.
+    """Materialise one cursor without imposing a local wall-clock cutoff."""
 
-    ``maxTimeMS`` bounds server execution but does not include topology
-    selection, connection acquisition, or network reads. PyMongo CSOT covers
-    that complete operation while the existing server deadline remains useful
-    to Atlas for early cancellation.
-    """
-
-    with timeout(CONCEPT_SEARCH_OPERATION_TIMEOUT_SECONDS):
-        return list(cursor)
+    return list(cursor)
 
 
 def _determine_concept_kind(concept_doc: Dict[str, Any]) -> str:
@@ -291,7 +281,6 @@ def _fetch_text_relation_concept_docs(
         query,
         projection=SEARCH_RESULT_PROJECTION,
         limit=max(limit * 2, len(ordered_ids)),
-        max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
     )
     return _consume_search_cursor(cursor)
 
@@ -328,7 +317,6 @@ def _find_text_values_by_fingerprint(
             },
             projection=TEXT_VALUE_ID_PROJECTION,
             limit=limit,
-            max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
         )
     )
 
@@ -370,7 +358,6 @@ def _scan_text_values_for_match(
             {"predicate": {"$in": predicates}},
             projection={"object_text_id": 1},
             limit=limit,
-            max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
         )
     )
 
@@ -393,7 +380,6 @@ def _scan_text_values_for_match(
         TextValuesRepository.find(
             {"_id": {"$in": candidate_ids}},
             limit=limit,
-            max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
         )
     )
 
@@ -469,7 +455,6 @@ def _search_text_relations(
                 text_query,
                 projection=TEXT_VALUE_ID_PROJECTION,
                 limit=text_value_limit,
-                max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
             )
         )
     elif not matching_texts and not exact:
@@ -480,7 +465,6 @@ def _search_text_relations(
                     text_search_query,
                     projection=TEXT_VALUE_ID_PROJECTION,
                     limit=text_value_limit,
-                    max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
                 )
             )
         except Exception as e:
@@ -493,7 +477,6 @@ def _search_text_relations(
                     substring_query,
                     projection=TEXT_VALUE_ID_PROJECTION,
                     limit=text_value_limit,
-                    max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
                 )
             )
 
@@ -527,7 +510,6 @@ def _search_text_relations(
             },
             projection={"subject_concept_id": 1},
             limit=relation_limit,
-            max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
         )
     )
 
@@ -698,7 +680,6 @@ def _semantic_search(
         concepts_cursor = ConceptsRepository.find(
             {"concept_id": {"$in": concept_ids}},
             projection=SEARCH_RESULT_PROJECTION,
-            max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
         )
 
         # Post-filter and build results
@@ -907,7 +888,6 @@ def search_concepts(
                 base_query,
                 projection=SEARCH_RESULT_PROJECTION,
                 limit=limit,
-                max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
             )
 
             for concept_doc in _consume_search_cursor(all_instances_cursor):
@@ -970,7 +950,6 @@ def search_concepts(
                 base_query,
                 projection=SEARCH_RESULT_PROJECTION,
                 limit=1000,  # Broader fetch for similarity scoring
-                max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
             )
 
             candidates = _consume_search_cursor(candidates_cursor)
@@ -1012,7 +991,6 @@ def search_concepts(
                     combined_query,
                     projection=SEARCH_RESULT_PROJECTION,
                     limit=fetch_limit,
-                    max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
                 )
 
                 substring_added = False
@@ -1065,7 +1043,6 @@ def search_concepts(
                     combined_query,
                     projection=SEARCH_RESULT_PROJECTION,
                     limit=limit * 2,
-                    max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
                 )
 
                 for concept_doc in _consume_search_cursor(prefix_cursor):
@@ -1094,7 +1071,6 @@ def search_concepts(
                         combined_query,
                         projection=SEARCH_RESULT_PROJECTION,
                         limit=max(remaining, fetch_limit),
-                        max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
                     )
 
                     for concept_doc in _consume_search_cursor(substring_cursor):
@@ -1118,7 +1094,6 @@ def search_concepts(
                     combined_query,
                     projection=SEARCH_RESULT_PROJECTION,
                     limit=limit * 2,
-                    max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
                 )
 
                 for concept_doc in _consume_search_cursor(substring_cursor):
@@ -1142,7 +1117,6 @@ def search_concepts(
                     combined_query,
                     projection=SEARCH_RESULT_PROJECTION,
                     limit=limit * 2,
-                    max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
                 )
 
                 for concept_doc in _consume_search_cursor(concepts_cursor):
@@ -1231,7 +1205,6 @@ def search_concepts(
                             "predicate": "hasName",
                         },
                         limit=1000,
-                        max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
                     )
                 )
 
@@ -1261,7 +1234,6 @@ def search_concepts(
                                 }
                             },
                             limit=1000,
-                            max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
                         )
                     )
 

--- a/src/backend/services/rag_backends/llamaindex_backend.py
+++ b/src/backend/services/rag_backends/llamaindex_backend.py
@@ -263,6 +263,8 @@ class LlamaIndexRAGService(RAGService):
         self._runtime_configuration: Dict[str, Any] | None = None
         self._runtime_configuration_serialized: str | None = None
         self._runtime_configuration_refreshed_monotonic: float = 0.0
+        self._runtime_embed_model: Any = None
+        self._runtime_llm: Any = None
 
         # Ensure base persistence directory exists
         os.makedirs(self.persistence_dir, exist_ok=True)
@@ -452,32 +454,25 @@ class LlamaIndexRAGService(RAGService):
                 embed_model=embed_model,
                 llm=runtime_llm,
             )
+            self._runtime_embed_model = embed_model
+            self._runtime_llm = runtime_llm
             self._apply_runtime_components(embed_model=embed_model, llm=runtime_llm)
             self._runtime_configuration = runtime_configuration
             self._runtime_configuration_serialized = serialised
             self._runtime_configuration_refreshed_monotonic = now
 
-    def _index_runtime_kwargs(self) -> Dict[str, Any]:
-        self._refresh_runtime_configuration()
+    def _index_runtime_kwargs(self, *, embed_model: Any) -> Dict[str, Any]:
         if self.service_context is not None:
             return {"service_context": self.service_context}
-        return {}
+        return {"embed_model": embed_model}
 
     def _get_runtime_component(self, component_name: str) -> Any:
         self._refresh_runtime_configuration()
-        if self.service_context is not None:
-            component = getattr(self.service_context, component_name, None)
-            if component is not None:
-                return component
-
-        settings_obj = getattr(self, "llamaindex_settings", None)
-        if settings_obj is None:
-            return None
-
-        try:
-            return getattr(settings_obj, component_name, None)
-        except Exception:
-            return None
+        if component_name == "embed_model":
+            return self._runtime_embed_model
+        if component_name == "llm":
+            return self._runtime_llm
+        return None
 
     def get_runtime_embed_model(self) -> Any:
         return self._get_runtime_component("embed_model")
@@ -610,13 +605,54 @@ class LlamaIndexRAGService(RAGService):
             return None
         return payload if isinstance(payload, dict) else None
 
-    def _write_namespace_metadata(self, namespace: str) -> None:
-        runtime_summary = self.get_runtime_configuration_summary()
+    def _capture_embedding_runtime(
+        self,
+        namespace: str,
+    ) -> tuple[dict[str, Any], Any, Dict[str, Any]]:
+        with self._runtime_configuration_lock:
+            self._refresh_runtime_configuration()
+            runtime_summary = dict(self._runtime_configuration or {})
+            embedding_signature = runtime_summary.get("embedding_signature")
+            embed_model = self._runtime_embed_model
+            if isinstance(embedding_signature, Mapping) and embed_model is not None:
+                return (
+                    runtime_summary,
+                    embed_model,
+                    self._index_runtime_kwargs(embed_model=embed_model),
+                )
+
+            embedder_resolution = runtime_summary.get("embedder_resolution")
+            reason = (
+                str(embedder_resolution.get("reason") or "").strip()
+                if isinstance(embedder_resolution, Mapping)
+                else ""
+            )
+            raise RuntimeError(
+                reason
+                or (
+                    "RAG index mutation requires a resolved embedding configuration "
+                    f"for namespace '{namespace}'."
+                )
+            )
+
+    def _write_namespace_metadata(
+        self,
+        namespace: str,
+        *,
+        runtime_summary: Mapping[str, Any] | None = None,
+    ) -> None:
+        if runtime_summary is None:
+            runtime_summary, _, _ = self._capture_embedding_runtime(namespace)
+        embedding_signature = runtime_summary.get("embedding_signature")
+        if not isinstance(embedding_signature, Mapping):
+            raise RuntimeError(
+                "RAG index metadata requires a resolved embedding signature."
+            )
         payload = {
             "schema_version": "rag_index_metadata.v1",
             "namespace": namespace,
             "written_at_utc": datetime.now(timezone.utc).isoformat(),
-            "embedding_signature": runtime_summary.get("embedding_signature"),
+            "embedding_signature": dict(embedding_signature),
             "llm_signature": runtime_summary.get("llm_signature"),
         }
         persist_dir = self._namespace_persist_dir(namespace)
@@ -647,6 +683,39 @@ class LlamaIndexRAGService(RAGService):
                         os.remove(temp_path)
                     except OSError:
                         pass
+
+    def _require_namespace_mutation_compatible(
+        self,
+        namespace: str,
+        *,
+        embedding_signature: Mapping[str, Any],
+    ) -> None:
+        persist_dir = self._namespace_persist_dir(namespace)
+        try:
+            has_persisted_index = os.path.isdir(persist_dir) and bool(
+                os.listdir(persist_dir)
+            )
+        except Exception:
+            has_persisted_index = os.path.isdir(persist_dir)
+        if not has_persisted_index:
+            return
+
+        metadata = self._read_namespace_metadata(namespace)
+        stored_signature = (
+            metadata.get("embedding_signature")
+            if isinstance(metadata, Mapping)
+            else None
+        )
+        if not isinstance(stored_signature, Mapping):
+            raise RuntimeError(
+                "rebuild_required: persisted RAG index metadata has no verified "
+                f"embedding signature for namespace '{namespace}'."
+            )
+        if dict(stored_signature) != dict(embedding_signature):
+            raise RuntimeError(
+                "rebuild_required: persisted RAG index embeddings do not match "
+                f"the configured embedder for namespace '{namespace}'."
+            )
 
     def _get_current_embedding_signature(self) -> dict[str, Any] | None:
         runtime_summary = self.get_runtime_configuration_summary()
@@ -849,11 +918,23 @@ class LlamaIndexRAGService(RAGService):
             state = self._namespace_retrieval_states.get(effective_namespace)
             return dict(state) if isinstance(state, dict) else None
 
-    def _maybe_load_index(self, namespace: str) -> Any:
+    def _maybe_load_index(
+        self,
+        namespace: str,
+        *,
+        runtime_index_kwargs: Mapping[str, Any] | None = None,
+        expected_embedding_signature: Mapping[str, Any] | None = None,
+    ) -> Any:
         with self._get_namespace_lock(namespace):
-            state = self.get_namespace_runtime_state(namespace)
-            if not bool(state.get("compatible", False)):
-                return None
+            if expected_embedding_signature is not None:
+                self._require_namespace_mutation_compatible(
+                    namespace,
+                    embedding_signature=expected_embedding_signature,
+                )
+            else:
+                state = self.get_namespace_runtime_state(namespace)
+                if not bool(state.get("compatible", False)):
+                    return None
 
             if namespace in self._indices:
                 return self._indices[namespace]
@@ -870,9 +951,13 @@ class LlamaIndexRAGService(RAGService):
                 return None
 
             try:
+                if runtime_index_kwargs is None:
+                    _, _, runtime_index_kwargs = self._capture_embedding_runtime(
+                        namespace
+                    )
                 storage_context = StorageContext.from_defaults(persist_dir=persist_dir)
                 index = load_index_from_storage(
-                    storage_context, **self._index_runtime_kwargs()
+                    storage_context, **dict(runtime_index_kwargs)
                 )
             except Exception:
                 return None
@@ -880,22 +965,42 @@ class LlamaIndexRAGService(RAGService):
             self._indices[namespace] = index
             return index
 
-    def _get_or_create_index(self, namespace: str, documents: List[Any]) -> Any:
+    def _get_or_create_index(
+        self,
+        namespace: str,
+        documents: List[Any],
+        *,
+        runtime_summary: Mapping[str, Any],
+        runtime_index_kwargs: Mapping[str, Any],
+    ) -> Any:
         with self._get_namespace_lock(namespace):
-            state = self.get_namespace_runtime_state(namespace)
-            if state.get("status") in {"signature_missing", "embedding_signature_mismatch"}:
-                self.reset_namespace(namespace)
-            index = self._maybe_load_index(namespace)
+            embedding_signature = runtime_summary.get("embedding_signature")
+            if not isinstance(embedding_signature, Mapping):
+                raise RuntimeError(
+                    "RAG index creation requires a resolved embedding signature."
+                )
+            self._require_namespace_mutation_compatible(
+                namespace,
+                embedding_signature=embedding_signature,
+            )
+            index = self._maybe_load_index(
+                namespace,
+                runtime_index_kwargs=runtime_index_kwargs,
+                expected_embedding_signature=embedding_signature,
+            )
             if index is not None:
                 return index
 
             persist_dir = self._namespace_persist_dir(namespace)
             os.makedirs(persist_dir, exist_ok=True)
             index = VectorStoreIndex.from_documents(
-                documents, **self._index_runtime_kwargs()
+                documents, **dict(runtime_index_kwargs)
             )
             index.storage_context.persist(persist_dir=persist_dir)
-            self._write_namespace_metadata(namespace)
+            self._write_namespace_metadata(
+                namespace,
+                runtime_summary=runtime_summary,
+            )
             self._indices[namespace] = index
             return index
 
@@ -912,12 +1017,10 @@ class LlamaIndexRAGService(RAGService):
         For this implementation, we will convert dicts to Documents and insert them.
         """
         effective_namespace = self._resolve_effective_namespace(namespace)
-        if self.get_runtime_embed_model() is None:
-            state = self.get_namespace_runtime_state(effective_namespace)
-            raise RuntimeError(
-                state.get("detail")
-                or "Embeddings unavailable: LlamaIndex embed_model is not configured."
-            )
+        runtime_summary, _, runtime_index_kwargs = self._capture_embedding_runtime(
+            effective_namespace
+        )
+        embedding_signature = runtime_summary["embedding_signature"]
 
         llama_docs: List[Any] = []
         for doc in docs:
@@ -945,51 +1048,68 @@ class LlamaIndexRAGService(RAGService):
         if not llama_docs:
             return (0, 0)
 
-        index = self._maybe_load_index(effective_namespace)
-        if index is None:
-            index = self._get_or_create_index(effective_namespace, llama_docs)
-            return (len(llama_docs), 0)
+        with self._get_namespace_lock(effective_namespace):
+            self._require_namespace_mutation_compatible(
+                effective_namespace,
+                embedding_signature=embedding_signature,
+            )
+            index = self._maybe_load_index(
+                effective_namespace,
+                runtime_index_kwargs=runtime_index_kwargs,
+                expected_embedding_signature=embedding_signature,
+            )
+            if index is None:
+                index = self._get_or_create_index(
+                    effective_namespace,
+                    llama_docs,
+                    runtime_summary=runtime_summary,
+                    runtime_index_kwargs=runtime_index_kwargs,
+                )
+                return (len(llama_docs), 0)
 
-        success = 0
-        failed = 0
+            success = 0
+            failed = 0
 
-        def _persist() -> None:
-            with self._get_namespace_lock(effective_namespace):
+            def _persist() -> None:
                 index.storage_context.persist(
                     persist_dir=self._namespace_persist_dir(effective_namespace)
                 )
-                self._write_namespace_metadata(effective_namespace)
+                self._write_namespace_metadata(
+                    effective_namespace,
+                    runtime_summary=runtime_summary,
+                )
 
-        # Prefer bulk insertion when supported (significantly faster for embedding-backed indices).
-        try:
-            insert_documents = getattr(index, "insert_documents", None)
-            if callable(insert_documents):
-                insert_documents(llama_docs)
-                success = len(llama_docs)
-                _persist()
-                return (success, failed)
-        except Exception:
-            # Fall back to per-document insertion below.
-            pass
-
-        # Fallback: per-document insertion, optionally allowing partial failures.
-        for l_doc in llama_docs:
+            # Prefer bulk insertion when supported (significantly faster for
+            # embedding-backed indices).
             try:
-                index.insert(l_doc)
-                success += 1
+                insert_documents = getattr(index, "insert_documents", None)
+                if callable(insert_documents):
+                    insert_documents(llama_docs)
+                    success = len(llama_docs)
+                    _persist()
+                    return (success, failed)
             except Exception:
-                failed += 1
-                if not allow_partial_failures:
-                    raise
-
-        if success > 0:
-            try:
-                _persist()
-            except Exception:
-                # Persist failures should not mask successful indexing.
+                # Fall back to per-document insertion below.
                 pass
 
-        return (success, failed)
+            # Fallback: per-document insertion, optionally allowing partial failures.
+            for l_doc in llama_docs:
+                try:
+                    index.insert(l_doc)
+                    success += 1
+                except Exception:
+                    failed += 1
+                    if not allow_partial_failures:
+                        raise
+
+            if success > 0:
+                try:
+                    _persist()
+                except Exception:
+                    # Persist failures should not mask successful indexing.
+                    pass
+
+            return (success, failed)
 
     def delete_documents(
         self,

--- a/tests/backend/test_concept_search_service_performance.py
+++ b/tests/backend/test_concept_search_service_performance.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ast
 import inspect
-from contextlib import contextmanager
 from typing import Any
 
 from src.backend.services import concept_search_service as svc
@@ -16,7 +15,7 @@ def _concept(concept_id: str, name: str | None = None) -> dict[str, Any]:
     }
 
 
-def test_all_direct_concept_search_repository_reads_have_deadlines() -> None:
+def test_direct_concept_search_repository_reads_have_no_local_deadlines() -> None:
     tree = ast.parse(inspect.getsource(svc))
     repositories = {
         "ConceptsRepository",
@@ -42,54 +41,41 @@ def test_all_direct_concept_search_repository_reads_have_deadlines() -> None:
     for repository, calls in calls_by_repository.items():
         assert calls, f"expected at least one {repository}.find call"
         for call in calls:
-            deadline = next(
-                (keyword.value for keyword in call.keywords if keyword.arg == "max_time_ms"),
-                None,
+            assert not any(keyword.arg == "max_time_ms" for keyword in call.keywords), (
+                f"{repository}.find at line {call.lineno} imposes a local deadline"
             )
-            assert isinstance(deadline, ast.Name), (
-                f"{repository}.find at line {call.lineno} has no named deadline"
-            )
-            assert deadline.id == "CONCEPT_SEARCH_QUERY_MAX_TIME_MS"
+    assert not hasattr(svc, "timeout")
 
 
-def test_fingerprint_search_consumes_cursor_under_total_client_deadline(
+def test_fingerprint_search_materialises_cursor_without_local_client_deadline(
     monkeypatch,
 ) -> None:
-    deadline_active = False
-    observed_timeouts: list[float] = []
-
-    @contextmanager
-    def fake_timeout(seconds: float):
-        nonlocal deadline_active
-        observed_timeouts.append(seconds)
-        deadline_active = True
-        try:
-            yield
-        finally:
-            deadline_active = False
-
-    class DeadlineAwareCursor:
+    class RecordingCursor:
         def __init__(self):
             self._rows = iter([{"_id": "507f1f77bcf86cd799439011"}])
+            self.consumed = False
 
         def __iter__(self):
             return self
 
         def __next__(self):
-            assert deadline_active is True
-            return next(self._rows)
+            try:
+                return next(self._rows)
+            except StopIteration:
+                self.consumed = True
+                raise
 
-    monkeypatch.setattr(svc, "timeout", fake_timeout)
+    cursor = RecordingCursor()
     monkeypatch.setattr(
         svc.TextValuesRepository,
         "find",
-        lambda *_args, **_kwargs: DeadlineAwareCursor(),
+        lambda *_args, **_kwargs: cursor,
     )
 
     result = svc._find_text_values_by_fingerprint("bounded")
 
     assert result == [{"_id": "507f1f77bcf86cd799439011"}]
-    assert observed_timeouts == [svc.CONCEPT_SEARCH_OPERATION_TIMEOUT_SECONDS]
+    assert cursor.consumed is True
 
 
 def test_modern_text_relation_hits_skip_legacy_regex_scan(monkeypatch) -> None:
@@ -206,12 +192,10 @@ def test_text_relations_substring_uses_bounded_id_only_text_search(
     assert text_queries[1] == {"$text": {"$search": "workflow"}}
     assert text_value_calls[1]["projection"] == {"_id": 1}
     assert text_value_calls[1]["limit"] == 200
-    assert (
-        text_value_calls[1]["max_time_ms"] == svc.CONCEPT_SEARCH_QUERY_MAX_TIME_MS
-    )
+    assert "max_time_ms" not in text_value_calls[1]
     assert relation_calls[0]["projection"] == {"subject_concept_id": 1}
     assert relation_calls[0]["limit"] == 800
-    assert relation_calls[0]["max_time_ms"] == svc.CONCEPT_SEARCH_QUERY_MAX_TIME_MS
+    assert "max_time_ms" not in relation_calls[0]
     assert result["match_types_used"] == ["text_relations"]
 
 
@@ -237,7 +221,6 @@ def test_text_value_fingerprint_search_uses_partial_index_shape(monkeypatch) -> 
             },
             "projection": {"_id": 1},
             "limit": 7,
-            "max_time_ms": svc.CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
         }
     ]
 

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -105,6 +105,34 @@ def test_paper_download_cold_start_window_covers_observed_blob_rehydration():
     assert definition.hard_timeout_enabled is True
 
 
+def test_ordinary_semantic_reads_use_advisory_only_transport_timing():
+    from src.backend.integrations.internal_mcp import (
+        InternalMCPTransport,
+        build_default_catalogue,
+    )
+
+    catalogue = build_default_catalogue()
+    transport = InternalMCPTransport()
+
+    for method_name in (
+        "fetch_concept",
+        "find_relations_with_argument",
+        "get_predicate_incidence",
+        "get_related_concepts",
+        "get_text_relations",
+        "get_text_relations_summary",
+        "rag_list_indexed",
+        "resolve_concept_by_name",
+        "search_concepts",
+        "search_concept_descriptions",
+        "search_knowledge_base",
+        "vontology_concept_search",
+    ):
+        definition = catalogue.get(method_name)
+        assert definition.hard_timeout_enabled is False
+        assert definition.resolved_timeout(transport) is None
+
+
 def test_workflow_execute_uses_its_bounded_await_without_an_outer_hard_timeout():
     from src.backend.integrations.internal_mcp import (
         InternalMCPTransport,

--- a/tests/backend/test_internal_mcp_orchestrator_context_limits.py
+++ b/tests/backend/test_internal_mcp_orchestrator_context_limits.py
@@ -357,6 +357,53 @@ def test_format_tool_result_shapes_search_knowledge_base_payload_for_live_follow
     assert "source systems" in payload["retrieval_diagnostics"]["note"].lower()
 
 
+def test_format_tool_result_preserves_bounded_rag_concept_frontier():
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=cast(Any, _StubGateway()),
+        max_tool_invocations=1,
+        max_tool_result_chars=8_000,
+        max_tool_result_field_chars=2_000,
+        max_context_chars=80_000,
+    )
+    concept_ids = [f"#V#candidate_{index:02d}" for index in range(18)]
+
+    encoded = orchestrator._format_tool_result(
+        "search_knowledge_base",
+        {
+            "query": "current represented candidates",
+            "count": len(concept_ids),
+            "results": [
+                {
+                    "id": f"text_relation:{index}",
+                    "text": f"Candidate {index}",
+                    "score": 1.0 - (index / 100),
+                    "metadata": {
+                        "concept_id": concept_id,
+                        "predicate": "hasDescription",
+                        "type": "text_relation",
+                        "item_kind": "rag_chunk",
+                        "source_system": "rag.llamaindex",
+                    },
+                }
+                for index, concept_id in enumerate(concept_ids)
+            ],
+            "retrieval_state": {
+                "status": "results_available",
+                "candidate_count": len(concept_ids),
+                "candidate_limit_reached": True,
+            },
+        },
+        1.0,
+        "ok",
+    )
+
+    payload = json.loads(encoded)["payload"]
+    assert len(payload["results"]) == 5
+    assert payload["concept_ids"] == concept_ids
+    assert payload["omitted_result_count"] == 13
+    assert payload["retrieval_state"]["candidate_limit_reached"] is True
+
+
 def test_format_tool_result_shapes_jira_search_payload_for_live_follow_up():
     orchestrator = InternalMCPChatOrchestrator(
         gateway=cast(Any, _StubGateway()),
@@ -734,6 +781,68 @@ def test_format_tool_result_projects_unique_related_entities_in_both_directions(
     assert payload["hits"][1]["related_name"] == "Related Two"
     assert payload["hits"][1]["related_type_ids"] == ["#V#requested_type"]
     assert payload["compacted_duplicate_hit_count"] == 1
+
+
+def test_format_tool_result_preserves_relation_frontier_and_completeness_signals():
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=cast(Any, _StubGateway()),
+        max_tool_invocations=1,
+        max_tool_result_chars=8_000,
+        max_tool_result_field_chars=2_000,
+        max_context_chars=80_000,
+    )
+    related_ids = [f"#V#assignment_{index:02d}" for index in range(18)]
+
+    encoded = orchestrator._format_tool_result(
+        "find_relations_with_argument",
+        {
+            "concept_id": "#V#focal_entity",
+            "context_view": "actor_effective",
+            "total_hits": len(related_ids),
+            "total_hits_is_lower_bound": True,
+            "hits": [
+                {
+                    "source_concept_id": related_id,
+                    "predicate_concept_id": "#V#has_role_filler",
+                    "relation_kind": "binary",
+                    "argument_indexes": [2],
+                    "target_value": "#V#focal_entity",
+                    "source_concept_preview": {
+                        "concept_id": related_id,
+                        "name": related_id.removeprefix("#V#"),
+                    },
+                    "target_concept_preview": {
+                        "concept_id": "#V#focal_entity",
+                        "name": "Focal Entity",
+                    },
+                }
+                for related_id in related_ids
+            ],
+            "paging": {
+                "limit": 100,
+                "offset": 0,
+                "returned": len(related_ids),
+                "total_available": len(related_ids),
+                "total_available_is_lower_bound": True,
+                "continuation_supported": False,
+            },
+            "continuation": {
+                "status": "bounded_overlay_incomplete",
+                "can_continue_with_offset": False,
+            },
+        },
+        1.0,
+        "ok",
+    )
+
+    payload = json.loads(encoded)["payload"]
+    assert payload["context_view"] == "actor_effective"
+    assert payload["total_hits_is_lower_bound"] is True
+    assert payload["shown_hit_count"] == 5
+    assert payload["related_concept_ids"] == related_ids
+    assert payload["paging"]["total_available_is_lower_bound"] is True
+    assert payload["paging"]["continuation_supported"] is False
+    assert payload["continuation"]["can_continue_with_offset"] is False
 
 
 def test_turn_scoped_tool_payload_support_applies_workflow_tool_argument_defaults():

--- a/tests/backend/test_rag_namespace_isolation.py
+++ b/tests/backend/test_rag_namespace_isolation.py
@@ -5,6 +5,32 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def resolved_rag_runtime(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "src.backend.services.settings_service.resolve_rag_embedder_setting",
+        lambda: {
+            "status": "resolved",
+            "effective": {
+                "provider": "ollama",
+                "model": "bge-m3",
+                "host": "http://127.0.0.1:11434",
+            },
+            "selection_source": "explicit_setting",
+            "reason": None,
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.settings_service.resolve_rag_llm_setting",
+        lambda: {
+            "status": "disabled",
+            "effective": None,
+            "selection_source": "configured_disabled",
+            "reason": "disabled_by_setting",
+        },
+    )
+
+
 @pytest.fixture()
 def tmp_rag_storage(workspace_tmp_path: Path):
     storage = workspace_tmp_path / "rag_storage"

--- a/tests/backend/test_rag_service.py
+++ b/tests/backend/test_rag_service.py
@@ -149,8 +149,15 @@ def test_get_rag_service_llamaindex(mock_llamaindex):
     assert type(service).__name__ == "LlamaIndexRAGService"
 
 
-def test_upsert_documents(mock_llamaindex):
-    service = get_rag_service("llamaindex")
+def test_upsert_documents(mock_llamaindex, monkeypatch, workspace_tmp_path):
+    _configure_rag_runtime_settings(monkeypatch)
+    from src.backend.services.rag_backends.llamaindex_backend import (
+        LlamaIndexRAGService,
+    )
+
+    service = LlamaIndexRAGService(
+        persistence_dir=str(workspace_tmp_path / "rag_storage")
+    )
     docs = [{"id": "doc1", "text": "content", "metadata": {"meta": "data"}}]
 
     success, failed = service.upsert_documents(docs)
@@ -527,6 +534,163 @@ def test_llamaindex_runtime_configuration_tracks_embedding_signature_and_mismatc
     state = rag.get_namespace_runtime_state("workflow_capabilities")
 
     assert state["compatible"] is False
+    assert state["status"] == "embedding_signature_mismatch"
+    assert state["current_embedding_signature"]["model"] == "nomic-embed-text"
+
+
+def test_llamaindex_upsert_rejects_unresolved_embedder_before_index_mutation(
+    mock_llamaindex,
+    monkeypatch,
+    workspace_tmp_path,
+):
+    monkeypatch.setattr(
+        "src.backend.services.settings_service.resolve_rag_embedder_setting",
+        lambda *args, **kwargs: {
+            "status": "unresolved",
+            "effective": None,
+            "selection_source": "unavailable",
+            "reason": "embedding_provider_unavailable",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.settings_service.resolve_rag_llm_setting",
+        lambda *args, **kwargs: {
+            "status": "disabled",
+            "effective": None,
+            "selection_source": "configured_disabled",
+            "reason": "disabled_by_setting",
+        },
+    )
+
+    from src.backend.services.rag_backends.llamaindex_backend import (
+        LlamaIndexRAGService,
+    )
+
+    rag = LlamaIndexRAGService(
+        persistence_dir=str(workspace_tmp_path / "rag_storage")
+    )
+    # LlamaIndex may expose a truthy MockEmbedding when no real embedder was
+    # resolved. Mutation authority comes from the resolved configuration, not
+    # from that compatibility fallback object.
+    assert rag.llamaindex_settings.embed_model is not None
+
+    with pytest.raises(RuntimeError, match="embedding_provider_unavailable"):
+        rag.upsert_documents(
+            [{"id": "doc1", "text": "content", "metadata": {}}],
+            namespace="#V#user@org",
+        )
+
+    mock_llamaindex["index_cls"].from_documents.assert_not_called()
+    assert not (workspace_tmp_path / "rag_storage" / "namespaces").exists()
+
+
+@pytest.mark.parametrize(
+    "persisted_signature",
+    ["different", "missing"],
+)
+def test_llamaindex_upsert_requires_explicit_rebuild_for_incompatible_signature(
+    mock_llamaindex,
+    monkeypatch,
+    workspace_tmp_path,
+    persisted_signature,
+):
+    _configure_rag_runtime_settings(monkeypatch)
+    from src.backend.services.rag_backends.llamaindex_backend import (
+        LlamaIndexRAGService,
+    )
+
+    rag = LlamaIndexRAGService(
+        persistence_dir=str(workspace_tmp_path / "rag_storage")
+    )
+    rag.upsert_documents(
+        [{"id": "doc1", "text": "first", "metadata": {}}],
+        namespace="#V#user@org",
+    )
+    metadata_path = next(
+        (workspace_tmp_path / "rag_storage").rglob("index_metadata.json")
+    )
+    if persisted_signature == "missing":
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["embedding_signature"] = None
+        metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+    else:
+        monkeypatch.setattr(
+            "src.backend.services.settings_service.resolve_rag_embedder_setting",
+            lambda *args, **kwargs: {
+                "status": "resolved",
+                "effective": {
+                    "provider": "ollama",
+                    "model": "nomic-embed-text",
+                    "host": "http://localhost:11434",
+                },
+                "selection_source": "explicit_setting",
+                "reason": None,
+            },
+        )
+        rag.invalidate_runtime_configuration_cache()
+    metadata_before = metadata_path.read_bytes()
+
+    with pytest.raises(RuntimeError, match="rebuild_required"):
+        rag.upsert_documents(
+            [{"id": "doc2", "text": "second", "metadata": {}}],
+            namespace="#V#user@org",
+        )
+
+    assert metadata_path.read_bytes() == metadata_before
+    assert mock_llamaindex["index_cls"].from_documents.call_count == 1
+    mock_llamaindex["index"].insert_documents.assert_not_called()
+
+
+def test_llamaindex_metadata_uses_embedder_captured_before_index_creation(
+    mock_llamaindex,
+    monkeypatch,
+    workspace_tmp_path,
+):
+    _configure_rag_runtime_settings(monkeypatch)
+    from src.backend.services.rag_backends import llamaindex_backend as backend
+
+    backend.ServiceContext.from_defaults.side_effect = ValueError(
+        "ServiceContext is deprecated. Use llama_index.settings.Settings instead."
+    )
+    rag = backend.LlamaIndexRAGService(
+        persistence_dir=str(workspace_tmp_path / "rag_storage")
+    )
+
+    def _create_index_after_configuration_change(*args, **kwargs):
+        monkeypatch.setattr(
+            "src.backend.services.settings_service.resolve_rag_embedder_setting",
+            lambda *inner_args, **inner_kwargs: {
+                "status": "resolved",
+                "effective": {
+                    "provider": "ollama",
+                    "model": "nomic-embed-text",
+                    "host": "http://localhost:11434",
+                },
+                "selection_source": "explicit_setting",
+                "reason": None,
+            },
+        )
+        rag.invalidate_runtime_configuration_cache()
+        return mock_llamaindex["index"]
+
+    mock_llamaindex["index_cls"].from_documents.side_effect = (
+        _create_index_after_configuration_change
+    )
+
+    rag.upsert_documents(
+        [{"id": "doc1", "text": "content", "metadata": {}}],
+        namespace="#V#user@org",
+    )
+
+    call_kwargs = mock_llamaindex["index_cls"].from_documents.call_args.kwargs
+    assert call_kwargs["embed_model"].model_name == "text-embedding-3-small"
+    metadata_path = next(
+        (workspace_tmp_path / "rag_storage").rglob("index_metadata.json")
+    )
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert metadata["embedding_signature"]["model"] == "text-embedding-3-small"
+
+    state = rag.get_namespace_runtime_state("#V#user@org")
     assert state["status"] == "embedding_signature_mismatch"
     assert state["current_embedding_signature"]["model"] == "nomic-embed-text"
 


### PR DESCRIPTION
## What changed

- preserve the full bounded concept frontier and completeness metadata when detailed relation/RAG previews are compacted
- remove arbitrary hard cut-offs from the ordinary semantic reads exercised by this incident, leaving their existing advisory timing in place
- prevent RAG namespaces from silently loading or mutating under a mismatched embedding runtime, and serialise index mutation/persistence
- remove the 5-second database execution cut-off from canonical concept search while retaining diagnostics
- add focused regression coverage for frontier preservation, advisory-only reads, concept-search latency handling, and RAG runtime isolation

## Root cause

The earlier turn combined incomplete relation discovery, heterogeneous represented supervision shapes, and a compacted tool view that hid candidate identities beyond five previews. The model then failed to recover through schema discovery. Separately, the namespace RAG store had been contaminated by a mock embedding runtime and could silently reopen under an incompatible runtime signature.

## User impact

A fresh authenticated replay of `List all my current students, and if you have it, the email address for each` returned the expected 17 definite current supervisees plus Andrey Borro (under examination), excluded unrelated scoped candidates, and grounded four addresses. Gmail operations were read-only.

Replay: session `a4604a92-fddc-4930-88fe-c98960eb3495`, request `d74af9de-42ba-4030-acf8-b19d39d713c5`.

Known non-blocking limitations: the successful turn took 17m50s and about 4.0M tokens; conversation-situation and direct-path critic telemetry were absent. This PR does not add speculative orchestration for those separate issues.

## Validation

- 79 affected tests passed
- scoped Ruff undefined-name/import checks passed
- `git diff --check` passed
- live RAG query returned usable results from a 6,673-vector namespace with the expected Ollama embedding signature
- live Gmail audit showed 31 `list_messages` and 2 `get_message` operations, with no mutation

Jira: JVNAUTOSCI-2587