### PR TITLE
Repair exact tooling recovery and adaptive deadlines

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -392,13 +392,16 @@ def _get_vontology_tree(**kwargs):
 
 
 def _get_concept_by_concept_id(**kwargs):
-    from ...services.concept_relation_service import build_concept_relations_payload
-    from ...services.concept_service import (
-        enrich_concept_with_text_relations,
-        get_concept_by_concept_id,
-    )
     from ...security.access_control import describe_concept_access
+    from ...services.concept_relation_service import build_concept_relations_payload
+    from ...services.concept_rename_service import resolve_concept_by_alias
+    from ...services.concept_service import (
+        ConceptNotFoundError,
+        enrich_concept_with_text_relations,
+        get_concept_by_concept_id_exact,
+    )
     from ...services.relationship_write_service import detect_vacuous_typing
+    from ...vontology.code_concepts_registry import build_virtual_concept_doc
 
     concept_id = kwargs.get("concept_id")
     if not concept_id:
@@ -426,12 +429,49 @@ def _get_concept_by_concept_id(**kwargs):
                 ],
             )
 
-        concept = get_concept_by_concept_id(concept_id=concept_id)
+        try:
+            concept = get_concept_by_concept_id_exact(concept_id=concept_id)
+        except ConceptNotFoundError:
+            concept = build_virtual_concept_doc(concept_id)
+            if isinstance(concept, dict) and concept.get("concept_id"):
+                concept = {**concept}
+                concept.setdefault("id", f"virtual:{concept_id}")
+                concept.setdefault(
+                    "kind",
+                    concept.get("metadata", {}).get("concept_type", "unknown"),
+                )
+            else:
+                resolved_id = resolve_concept_by_alias(concept_id)
+                if resolved_id and resolved_id != concept_id:
+                    try:
+                        concept = get_concept_by_concept_id_exact(
+                            concept_id=resolved_id
+                        )
+                    except ConceptNotFoundError:
+                        concept = None
+                else:
+                    concept = None
 
-        # Use shared enrichment logic (migrate-on-read + fetch names from text relations)
         if not concept:
-            return concept
+            return make_error_response(
+                "concept_not_found",
+                f"Concept not found: {concept_id}",
+                details={
+                    "concept_id": concept_id,
+                    "status": "not_found",
+                    "lookup_modes": ["exact_concept_id", "exact_code_alias"],
+                },
+                suggestions=[
+                    (
+                        "Use resolve_concept_by_name for a human-readable name "
+                        "or legacy variant"
+                    ),
+                    "Use search_concepts when the exact concept ID is unknown",
+                ],
+                related_concept_ids=[concept_id],
+            )
 
+        # Use shared enrichment logic (migrate-on-read plus text-relation names).
         concept = enrich_concept_with_text_relations(concept)
 
         scoped_assertion_rows: list[dict[str, Any]] = []
@@ -441,7 +481,7 @@ def _get_concept_by_concept_id(**kwargs):
             )
 
             scoped_assertion_rows = list_visible_scoped_assertions(
-                subject_concept_ids=[concept_id],
+                subject_concept_ids=[concept.get("concept_id", concept_id)],
                 limit=101,
             )
         scoped_assertions_truncated = len(scoped_assertion_rows) > 100
@@ -3443,9 +3483,11 @@ def _add_relationship(**kwargs):
         repo = ConceptsRepository
 
         from ...services.relationship_write_service import (
+            CORE_RELATIONSHIP_TEXT_PREDICATES,
             add_relationship,
             is_structural_predicate,
             normalise_structural_predicate,
+            resolve_existing_predicate_value_kind,
             validate_predicate_concept,
         )
         from ...utils.concept_id_utils import canonicalise_vontology_concept_id
@@ -3474,7 +3516,7 @@ def _add_relationship(**kwargs):
         predicate_normalised = (
             predicate_str[3:] if predicate_str.startswith("#V#") else predicate_str
         )
-        well_known_text_predicates = {"hasContent", "hasDescription", "hasName"}
+        well_known_text_predicates = CORE_RELATIONSHIP_TEXT_PREDICATES
         if (
             not predicate_str.startswith("#V#")
             and predicate_normalised not in well_known_text_predicates
@@ -3874,19 +3916,9 @@ def _add_relationship(**kwargs):
                 ),
             }
 
-        # Determine if this is a text predicate (binary_text_predicate instance)
-        is_text_predicate = False
-        if predicate_str.startswith("#V#"):
-            pred_doc = repo.find_one(
-                {"concept_id": predicate_str}, {"relationships.is_an_instance_of": 1}
-            )
-            if pred_doc:
-                instance_of = pred_doc.get("relationships", {}).get(
-                    "is_an_instance_of", []
-                )
-                if isinstance(instance_of, str):
-                    instance_of = [instance_of]
-                is_text_predicate = "#V#binary_text_predicate" in instance_of
+        is_text_predicate = (
+            resolve_existing_predicate_value_kind(predicate_str, repo) == "text"
+        )
 
         # Handle text predicates (target is text value, not concept)
         if is_text_predicate:
@@ -34185,6 +34217,8 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             input_schema=_upsert_scoped_assertion_input_schema(),
             output_schema=_upsert_scoped_assertion_output_schema(),
             category="write",
+            advisory_timeout_sec=20.0,
+            hard_timeout_enabled=False,
             ordinary_turn_trusted_argument_bindings={
                 "acting_user_concept_id": "actor_user_concept_id",
                 "organisation_concept_id": "actor_organisation_concept_id",
@@ -34232,6 +34266,8 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             input_schema=_list_scoped_assertions_input_schema(),
             output_schema=_list_scoped_assertions_output_schema(),
             category="read",
+            advisory_timeout_sec=20.0,
+            hard_timeout_enabled=False,
             ordinary_turn_trusted_argument_bindings={
                 "acting_user_concept_id": "actor_user_concept_id",
                 "organisation_concept_id": "actor_organisation_concept_id",
@@ -34729,10 +34765,8 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             input_schema=_download_paper_input_schema(),
             output_schema=_download_paper_output_schema(),
             category="write",
-            # 140s is just over twice the observed 68.321s late-completion path;
-            # 85s warns before that capability-specific liveness boundary.
-            timeout_sec=140.0,
-            advisory_timeout_sec=85.0,
+            # Seed adaptive windows from the observed 68.321s cold completion.
+            successful_duration_bootstrap_sec=68.321,
             description="Download PDF of an arXiv paper, then store it in the configured blob store (local, OpenStack Swift, or S3-compatible object storage). The external arXiv tool writes into a local cache directory; this tool returns both the local cache file_path and a durable storage.uri and may register a #V#computer_file_copy when authenticated. Use when user asks to download/save/fetch a paper. This tool does not materialise the scholarly-paper concept.",
         ),
         MethodDefinition(
@@ -34909,10 +34943,8 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             input_schema=_import_url_file_copy_input_schema(),
             output_schema=_import_url_file_copy_output_schema(),
             category="write",
-            # 350s is just over twice the observed 173.641s successful path;
-            # 220s warns before that capability-specific liveness boundary.
-            timeout_sec=350.0,
-            advisory_timeout_sec=220.0,
+            # Seed adaptive windows from the observed 173.641s cold completion.
+            successful_duration_bootstrap_sec=173.641,
             description=(
                 "Fetch a remote artefact directly from an http/https URL, persist its bytes "
                 "to the configured blob store, and register a #V#computer_file_copy concept "
@@ -35116,7 +35148,8 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             ordinary_turn_trusted_argument_bindings={
                 "profile_id": "gmail_profile",
             },
-            timeout_sec=10.0,
+            advisory_timeout_sec=10.0,
+            hard_timeout_enabled=False,
             description=(
                 "Return the OAuth scope and token status for a configured Gmail "
                 "profile. Resolves scope from Vontology (authoritative) with the "
@@ -35156,7 +35189,8 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             ordinary_turn_trusted_argument_bindings={
                 "profile": "gmail_profile",
             },
-            timeout_sec=20.0,
+            advisory_timeout_sec=20.0,
+            hard_timeout_enabled=False,
             description=(
                 "List Gmail messages for a profile with optional query and label "
                 "filters. The 'profile' parameter accepts either the configured "
@@ -35187,7 +35221,8 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             ordinary_turn_trusted_argument_bindings={
                 "profile": "gmail_profile",
             },
-            timeout_sec=20.0,
+            advisory_timeout_sec=20.0,
+            hard_timeout_enabled=False,
             description=(
                 "Fetch a Gmail message for a profile using message_id from "
                 "gmail_list_messages. The 'profile' parameter accepts either "
@@ -35234,7 +35269,8 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             ordinary_turn_trusted_argument_bindings={
                 "profile": "gmail_profile",
             },
-            timeout_sec=20.0,
+            advisory_timeout_sec=20.0,
+            hard_timeout_enabled=False,
             description="Fetch a Gmail attachment for a profile (base64 data). Read-only; profile token required.",
         ),
         MethodDefinition(
@@ -35251,7 +35287,8 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             ordinary_turn_trusted_argument_bindings={
                 "profile": "gmail_profile",
             },
-            timeout_sec=15.0,
+            advisory_timeout_sec=15.0,
+            hard_timeout_enabled=False,
             description="List Gmail labels for a profile. Read-only; useful to discover label IDs for queries.",
         ),
         MethodDefinition(
@@ -35979,6 +36016,7 @@ def _build_default_catalogue_diagnostics_and_research_definitions() -> (
             ),
             output_schema=None,
             category="read",
+            hard_timeout_enabled=False,
             ordinary_turn_trusted_argument_bindings={
                 "namespace": "turn_namespace",
             },
@@ -36024,6 +36062,7 @@ def _build_default_catalogue_diagnostics_and_research_definitions() -> (
             ),
             output_schema=None,
             category="read",
+            hard_timeout_enabled=False,
             ordinary_turn_trusted_argument_bindings={
                 "namespace": "turn_namespace",
             },

--- a/src/backend/integrations/internal_mcp/dynamic_tool_loader.py
+++ b/src/backend/integrations/internal_mcp/dynamic_tool_loader.py
@@ -495,7 +495,8 @@ def load_dynamic_method_definitions(
 
         timeout_sec = target_definition.timeout_sec
         timeout_override = attributes.get("dynamic_timeout_sec")
-        if timeout_override not in (None, ""):
+        has_timeout_override = timeout_override not in (None, "")
+        if has_timeout_override:
             if (
                 isinstance(timeout_override, (int, float))
                 and not isinstance(timeout_override, bool)
@@ -561,6 +562,17 @@ def load_dynamic_method_definitions(
             output_schema=target_definition.output_schema,
             category=target_definition.category,
             timeout_sec=timeout_sec,
+            advisory_timeout_sec=target_definition.advisory_timeout_sec,
+            hard_timeout_enabled=(
+                True
+                if has_timeout_override
+                else target_definition.hard_timeout_enabled
+            ),
+            successful_duration_bootstrap_sec=(
+                None
+                if has_timeout_override
+                else target_definition.successful_duration_bootstrap_sec
+            ),
             description=description,
             ordinary_turn_public=target_definition.ordinary_turn_public,
             ordinary_turn_excluded_reason=ordinary_turn_excluded_reason,

--- a/src/backend/integrations/internal_mcp/gateway.py
+++ b/src/backend/integrations/internal_mcp/gateway.py
@@ -3,10 +3,22 @@
 from __future__ import annotations
 
 import logging
+import math
+import time
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Iterable, Iterator, Mapping, MutableMapping, Optional
+from threading import Lock
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    Mapping,
+    MutableMapping,
+    Optional,
+)
 
 from .schemas import (
     Schema,
@@ -24,6 +36,8 @@ from .transport import (
 logger = logging.getLogger(__name__)
 
 _LOG_TAG = "[mcp_gateway]"
+_SUCCESSFUL_DURATION_ADVISORY_MULTIPLIER = 1.25
+_SUCCESSFUL_DURATION_HARD_MULTIPLIER = 2.0
 _ACTOR_CONTEXT_SOURCE: ContextVar[str | None] = ContextVar(
     "internal_mcp_actor_context_source",
     default=None,
@@ -94,6 +108,9 @@ class MethodDefinition:
     # explicitly make elapsed time advisory-only instead of discarding a live
     # handler result at an arbitrary wall-clock boundary.
     hard_timeout_enabled: bool = True
+    # Seed adaptive warning/hard windows with the longest successful duration
+    # already observed before this process. Omit unless that evidence exists.
+    successful_duration_bootstrap_sec: float | None = None
     description: str | None = None
     write_guardrail: Mapping[str, Any] | None = None
     ordinary_turn_public: bool = False
@@ -122,6 +139,9 @@ class MethodDefinition:
     def resolved_timeout(self, transport: InternalMCPTransport) -> float | None:
         if not self.hard_timeout_enabled:
             return None
+        successful_duration = self.resolved_successful_duration_bootstrap()
+        if successful_duration is not None:
+            return successful_duration * _SUCCESSFUL_DURATION_HARD_MULTIPLIER
         if self.timeout_sec is not None:
             return self.timeout_sec
         if self.category == "write":
@@ -134,6 +154,9 @@ class MethodDefinition:
         self,
         transport: InternalMCPTransport,
     ) -> float:
+        successful_duration = self.resolved_successful_duration_bootstrap()
+        if successful_duration is not None:
+            return successful_duration * _SUCCESSFUL_DURATION_ADVISORY_MULTIPLIER
         if self.advisory_timeout_sec is not None:
             value = float(self.advisory_timeout_sec)
             if value <= 0.0:
@@ -149,6 +172,16 @@ class MethodDefinition:
             self.category,
             hard_timeout_sec=float(hard_timeout or fallback_timeout),
         )
+
+    def resolved_successful_duration_bootstrap(self) -> float | None:
+        if self.successful_duration_bootstrap_sec is None:
+            return None
+        value = float(self.successful_duration_bootstrap_sec)
+        if not math.isfinite(value) or value <= 0.0:
+            raise ValueError(
+                "successful_duration_bootstrap_sec must be positive and finite"
+            )
+        return value
 
     def resolved_effect_admission_window(
         self,
@@ -183,6 +216,7 @@ class MethodMetrics:
     last_error: str | None = None
     last_outcome: str | None = None
     last_duration_ms: float | None = None
+    successful_max_duration_ms: float | None = None
 
     def snapshot(self) -> Dict[str, Any]:
         return {
@@ -193,6 +227,7 @@ class MethodMetrics:
             "last_error": self.last_error,
             "last_outcome": self.last_outcome,
             "last_duration_ms": self.last_duration_ms,
+            "successful_max_duration_ms": self.successful_max_duration_ms,
         }
 
 
@@ -258,6 +293,9 @@ class MethodCatalogue:
                 "timeout_sec": definition.timeout_sec,
                 "advisory_timeout_sec": definition.advisory_timeout_sec,
                 "hard_timeout_enabled": definition.hard_timeout_enabled,
+                "successful_duration_bootstrap_sec": (
+                    definition.successful_duration_bootstrap_sec
+                ),
                 "has_output_schema": definition.output_schema is not None,
                 "description": definition.description,
                 "write_guardrail": (
@@ -323,6 +361,7 @@ class InternalMCPGateway:
         self._method_metrics: Dict[str, MethodMetrics] = {
             name: MethodMetrics() for name in catalogue.list_methods()
         }
+        self._adaptive_history_lock = Lock()
 
     @property
     def enabled(self) -> bool:
@@ -341,6 +380,77 @@ class InternalMCPGateway:
     def register_metrics_if_missing(self, method_name: str) -> None:
         if method_name not in self._method_metrics:
             self._method_metrics[method_name] = MethodMetrics()
+
+    def _advisory_timeout_values(
+        self,
+        definition: MethodDefinition,
+        *,
+        hard_boundary_sec: float | None = None,
+    ) -> tuple[float, float, float]:
+        """Return bootstrap, adaptive, and hard-boundary-clamped advisories."""
+
+        bootstrap_sec = definition.resolved_advisory_timeout(self._transport)
+        successful_max_duration_ms = self._successful_max_duration_ms(
+            definition.name
+        )
+        successful_duration_basis_sec = (
+            float(successful_max_duration_ms) / 1000.0
+            if successful_max_duration_ms is not None
+            else None
+        )
+        configured_bootstrap_sec = (
+            definition.resolved_successful_duration_bootstrap()
+        )
+        if configured_bootstrap_sec is not None:
+            successful_duration_basis_sec = max(
+                configured_bootstrap_sec,
+                successful_duration_basis_sec or 0.0,
+            )
+        adaptive_sec = (
+            successful_duration_basis_sec
+            * _SUCCESSFUL_DURATION_ADVISORY_MULTIPLIER
+            if successful_duration_basis_sec is not None
+            else bootstrap_sec
+        )
+        effective_sec = (
+            min(adaptive_sec, max(0.0, float(hard_boundary_sec)))
+            if hard_boundary_sec is not None
+            else adaptive_sec
+        )
+        return bootstrap_sec, adaptive_sec, effective_sec
+
+    def _hard_timeout_values(
+        self,
+        definition: MethodDefinition,
+    ) -> tuple[float | None, float | None]:
+        """Return configured bootstrap and next adaptive hard boundaries."""
+
+        bootstrap_sec = definition.resolved_timeout(self._transport)
+        configured_bootstrap_sec = (
+            definition.resolved_successful_duration_bootstrap()
+        )
+        if bootstrap_sec is None or configured_bootstrap_sec is None:
+            return bootstrap_sec, bootstrap_sec
+        successful_max_duration_ms = self._successful_max_duration_ms(
+            definition.name
+        )
+        successful_duration_basis_sec = max(
+            configured_bootstrap_sec,
+            (
+                float(successful_max_duration_ms) / 1000.0
+                if successful_max_duration_ms is not None
+                else 0.0
+            ),
+        )
+        return (
+            bootstrap_sec,
+            successful_duration_basis_sec
+            * _SUCCESSFUL_DURATION_HARD_MULTIPLIER,
+        )
+
+    def _successful_max_duration_ms(self, method_name: str) -> float | None:
+        with self._adaptive_history_lock:
+            return self._method_metrics[method_name].successful_max_duration_ms
 
     @staticmethod
     def _clean_concept_id(value: Any) -> str | None:
@@ -444,15 +554,32 @@ class InternalMCPGateway:
             self._record_failure(method_name, error_message)
             raise SchemaValidationError(error_message, stage="input_schema")
 
-        timeout = definition.resolved_timeout(self._transport)
-        advisory_timeout = definition.resolved_advisory_timeout(self._transport)
+        _, timeout = self._hard_timeout_values(definition)
+        remaining_hard_boundary_sec = timeout
+        if deadline_monotonic is not None:
+            caller_remaining_sec = max(
+                0.0,
+                float(deadline_monotonic) - time.monotonic(),
+            )
+            remaining_hard_boundary_sec = (
+                min(timeout, caller_remaining_sec)
+                if timeout is not None
+                else caller_remaining_sec
+            )
+        _, _, advisory_timeout = self._advisory_timeout_values(
+            definition,
+            hard_boundary_sec=remaining_hard_boundary_sec,
+        )
         minimum_execution_window = (
             definition.resolved_effect_admission_window(self._transport)
             if require_effect_admission_window
             else None
         )
         observed_late_completion = late_completion_observer
-        if late_completion_observer is not None:
+        observe_adaptive_late_completion = (
+            definition.resolved_successful_duration_bootstrap() is not None
+        )
+        if late_completion_observer is not None or observe_adaptive_late_completion:
 
             def _observe_validated_late_completion(
                 observation: Dict[str, Any],
@@ -504,7 +631,27 @@ class InternalMCPGateway:
                         "output_schema_error": validation_error,
                     }
                 )
-                late_completion_observer(enriched)
+                if (
+                    enriched.get("outcome") == "late_success"
+                    and enriched.get("payload_truncated") is not True
+                    and valid is not False
+                    and not (
+                        isinstance(result_payload, Mapping)
+                        and result_payload.get("success") is False
+                    )
+                ):
+                    try:
+                        completed_duration_ms = float(
+                            enriched.get("queue_duration_ms") or 0.0
+                        ) + float(enriched.get("handler_duration_ms"))
+                    except (TypeError, ValueError):
+                        completed_duration_ms = None
+                    self._record_successful_duration(
+                        method_name,
+                        completed_duration_ms,
+                    )
+                if late_completion_observer is not None:
+                    late_completion_observer(enriched)
 
             observed_late_completion = _observe_validated_late_completion
         try:
@@ -632,16 +779,51 @@ class InternalMCPGateway:
                     self._record_failure(method_name, message)
                     raise SchemaValidationError(message, stage="output_schema")
 
-        self._record_success(method_name, transport_result.duration_ms)
+        self._record_success(
+            method_name,
+            transport_result.duration_ms,
+            include_in_adaptive_history=not (
+                isinstance(result_payload, Mapping)
+                and result_payload.get("success") is False
+            ),
+        )
         return transport_result
 
-    def _record_success(self, method_name: str, duration_ms: float | None) -> None:
+    def _record_success(
+        self,
+        method_name: str,
+        duration_ms: float | None,
+        *,
+        include_in_adaptive_history: bool = True,
+    ) -> None:
         self._total_calls += 1
         metrics = self._method_metrics[method_name]
         metrics.calls += 1
         metrics.last_duration_ms = duration_ms
         metrics.last_error = None
         metrics.last_outcome = "completed"
+        if include_in_adaptive_history and duration_ms is not None:
+            self._record_successful_duration(method_name, duration_ms)
+
+    def _record_successful_duration(
+        self,
+        method_name: str,
+        duration_ms: Any,
+    ) -> None:
+        if duration_ms is None or isinstance(duration_ms, bool):
+            return
+        try:
+            completed_duration_ms = float(duration_ms)
+        except (TypeError, ValueError):
+            return
+        if not math.isfinite(completed_duration_ms) or completed_duration_ms <= 0.0:
+            return
+        with self._adaptive_history_lock:
+            metrics = self._method_metrics[method_name]
+            metrics.successful_max_duration_ms = max(
+                metrics.successful_max_duration_ms or 0.0,
+                completed_duration_ms,
+            )
 
     def _record_failure(
         self,
@@ -665,15 +847,35 @@ class InternalMCPGateway:
             metrics.saturations += 1
 
     def get_diagnostics(self) -> Dict[str, Any]:
+        method_diagnostics: Dict[str, Dict[str, Any]] = {}
+        for name, metrics in self._method_metrics.items():
+            snapshot = metrics.snapshot()
+            definition = self._catalogue.get(name)
+            bootstrap_hard_timeout_sec, hard_timeout_sec = (
+                self._hard_timeout_values(definition)
+            )
+            bootstrap_sec, adaptive_sec, next_sec = (
+                self._advisory_timeout_values(
+                    definition,
+                    hard_boundary_sec=hard_timeout_sec,
+                )
+            )
+            snapshot.update(
+                {
+                    "bootstrap_advisory_timeout_sec": bootstrap_sec,
+                    "adaptive_advisory_timeout_sec": adaptive_sec,
+                    "next_advisory_timeout_sec": next_sec,
+                    "bootstrap_hard_timeout_sec": bootstrap_hard_timeout_sec,
+                    "next_hard_timeout_sec": hard_timeout_sec,
+                }
+            )
+            method_diagnostics[name] = snapshot
         diagnostics = {
             "enabled": self._enabled,
             "registered_methods": self._catalogue.list_methods(),
             "total_calls": self._total_calls,
             "total_failures": self._total_failures,
-            "methods": {
-                name: metrics.snapshot()
-                for name, metrics in self._method_metrics.items()
-            },
+            "methods": method_diagnostics,
         }
         try:
             from .dynamic_tool_loader import get_dynamic_tool_registration_status
@@ -710,11 +912,11 @@ class InternalMCPGateway:
             return None
 
     def get_method_timeout_sec(self, method_name: str) -> float | None:
-        """Return the configured hard window, or ``None`` for advisory-only."""
+        """Return the next hard window, or ``None`` for advisory-only."""
 
         definition = self.get_method_definition(method_name)
         return (
-            definition.resolved_timeout(self._transport)
+            self._hard_timeout_values(definition)[1]
             if definition is not None
             else None
         )

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -2990,8 +2990,8 @@ def _exact_represented_concept_id(value: Any) -> str | None:
 
 def _exact_scoped_relationship_predicate(
     arguments: Mapping[str, Any],
-) -> str | None:
-    """Extract only a concept-valued predicate that needs no semantic resolution."""
+) -> tuple[str, str] | None:
+    """Extract an exact predicate and its canonical represented value kind."""
 
     if arguments.get("predicate_if_missing") is not None:
         return None
@@ -3001,17 +3001,31 @@ def _exact_scoped_relationship_predicate(
     if isinstance(predicate, str) and predicate.strip():
         if predicate_ref is not None:
             return None
-        return _exact_represented_concept_id(predicate)
+        predicate_id = _exact_represented_concept_id(predicate)
+    else:
+        if not isinstance(predicate_ref, Mapping):
+            return None
+        if isinstance(predicate_ref.get("name"), str) and predicate_ref["name"].strip():
+            return None
+        if str(predicate_ref.get("on_missing") or "fail").strip().lower() != "fail":
+            return None
+        predicate_id = _exact_represented_concept_id(
+            predicate_ref.get("concept_id")
+        )
 
-    if not isinstance(predicate_ref, Mapping):
+    if predicate_id is None:
         return None
-    if isinstance(predicate_ref.get("name"), str) and predicate_ref["name"].strip():
+    try:
+        from src.backend.services.relationship_write_service import (
+            resolve_existing_predicate_value_kind,
+        )
+
+        canonical_value_kind = resolve_existing_predicate_value_kind(predicate_id)
+    except Exception:  # noqa: BLE001
         return None
-    if str(predicate_ref.get("on_missing") or "fail").strip().lower() != "fail":
+    if canonical_value_kind not in {"concept", "text"}:
         return None
-    if str(predicate_ref.get("value_kind") or "concept").strip().lower() != "concept":
-        return None
-    return _exact_represented_concept_id(predicate_ref.get("concept_id"))
+    return predicate_id, canonical_value_kind
 
 
 def _effect_subject_authority_denial(
@@ -3044,17 +3058,28 @@ def _effect_subject_authority_denial(
         )
     elif capability_name == "add_relationship":
         source_id = _exact_represented_concept_id(arguments.get("source_id"))
-        target_id = _exact_represented_concept_id(arguments.get("target"))
-        predicate_id = _exact_scoped_relationship_predicate(arguments)
-        if source_id is None or predicate_id is None or target_id is None:
+        raw_target = arguments.get("target")
+        if not isinstance(raw_target, str) or not raw_target.strip():
+            return payload
+        target = raw_target.strip()
+        predicate_resolution = _exact_scoped_relationship_predicate(arguments)
+        if predicate_resolution is None:
+            return payload
+        predicate_id, target_kind = predicate_resolution
+        if target_kind == "concept" and _exact_represented_concept_id(target) is None:
+            return payload
+        if source_id is None or predicate_id is None:
             return payload
         alternative_arguments = {
             "subject_concept_id": source_id,
             "predicate": predicate_id,
-            "target_concept_id": target_id,
         }
+        alternative_arguments[
+            "target_concept_id" if target_kind == "concept" else "target_text"
+        ] = target
         semantic_effect = (
-            "if the subject, predicate, and target are visible, create a "
+            "if the subject and predicate are visible, and any represented "
+            "target is visible, create a "
             "provenance-bearing actor-scoped assertion without publishing "
             "or mutating the canonical relationship"
         )
@@ -3264,6 +3289,8 @@ def execute_adaptive_turn(
     def scoped_assertion_recovery_key(
         capability_name: str,
         arguments: Mapping[str, Any],
+        *,
+        include_language: bool = True,
     ) -> str | None:
         """Identify one exact scoped assertion independently of trusted bindings."""
 
@@ -3296,16 +3323,11 @@ def execute_adaptive_turn(
             "target": (
                 str(target_text).strip() if has_text else target_concept_id
             ),
-            "language": (
-                str(arguments.get("language") or "en-NZ").strip() or "en-NZ"
-                if has_text
-                else None
-            ),
-            "scope_mode": (
-                str(arguments.get("scope_mode") or "user").strip().lower()
-                or "user"
-            ),
         }
+        if has_text and include_language:
+            language = arguments.get("language")
+            if isinstance(language, str) and language.strip():
+                semantic_identity["language"] = language.strip()
         return hashlib.sha256(_json_bytes(semantic_identity)).hexdigest()
 
     def remember_recovery_affordance(
@@ -3348,18 +3370,32 @@ def execute_adaptive_turn(
         nonlocal effect_state_generation
         if effect_status != "succeeded":
             return
-        recovery_key = scoped_assertion_recovery_key(
+        recovery_keys = [
+            scoped_assertion_recovery_key(
+                capability_name,
+                arguments,
+            )
+        ]
+        language_agnostic_key = scoped_assertion_recovery_key(
             capability_name,
             arguments,
+            include_language=False,
         )
-        if recovery_key is None:
+        if language_agnostic_key not in recovery_keys:
+            recovery_keys.append(language_agnostic_key)
+        failed_effect_id = None
+        for recovery_key in recovery_keys:
+            if recovery_key is None:
+                continue
+            pending_effect_ids = recoverable_effect_ids.get(recovery_key)
+            if not pending_effect_ids:
+                continue
+            failed_effect_id = pending_effect_ids.pop(0)
+            if not pending_effect_ids:
+                recoverable_effect_ids.pop(recovery_key, None)
+            break
+        if failed_effect_id is None:
             return
-        pending_effect_ids = recoverable_effect_ids.get(recovery_key)
-        if not pending_effect_ids:
-            return
-        failed_effect_id = pending_effect_ids.pop(0)
-        if not pending_effect_ids:
-            recoverable_effect_ids.pop(recovery_key, None)
         with effect_state_lock:
             failed_state = effect_states.get(failed_effect_id)
             if (

--- a/src/backend/services/concept_external_identity_service.py
+++ b/src/backend/services/concept_external_identity_service.py
@@ -31,10 +31,7 @@ from ..db.repositories.text_value_repository import (
 )
 from ..security.access_control import filter_accessible_concept_ids
 from ..utils.concept_id_utils import canonicalise_vontology_concept_id
-from .concept_search_service import (
-    CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
-    _consume_search_cursor,
-)
+from .concept_search_service import _consume_search_cursor
 from .text_value_service import get_texts_for_concepts, upsert_text_for_concept
 
 _SCHEME_PATTERN = re.compile(r"^[a-z][a-z0-9+.-]{0,63}$")
@@ -290,7 +287,6 @@ def _identity_marker_relation_candidates(
             },
             projection={"_id": 1, "text": 1},
             limit=_MAX_EXTERNAL_IDENTITY_TEXT_VALUES + 1,
-            max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
         )
     )
     text_query_saturated = (
@@ -327,7 +323,6 @@ def _identity_marker_relation_candidates(
             },
             projection={"subject_concept_id": 1},
             limit=_MAX_EXTERNAL_IDENTITY_TEXT_RELATIONS + 1,
-            max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
         )
     )
     relation_query_saturated = (
@@ -381,7 +376,6 @@ def _legacy_text_reference_candidates(
             {"$text": {"$search": identifier.value}},
             projection={"_id": 1, "text": 1},
             limit=_MAX_EXTERNAL_IDENTITY_TEXT_VALUES + 1,
-            max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
         )
     )
     text_query_saturated = (
@@ -421,7 +415,6 @@ def _legacy_text_reference_candidates(
             },
             projection={"subject_concept_id": 1},
             limit=_MAX_EXTERNAL_IDENTITY_TEXT_RELATIONS + 1,
-            max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
         )
     )
     relation_query_saturated = (
@@ -505,7 +498,6 @@ def _confirmed_candidate_ids(
         sorted(visible_ids),
         predicates=_IDENTITY_EVIDENCE_PREDICATES,
         limit_per_concept=_MAX_IDENTITY_EVIDENCE_ROWS_PER_CONCEPT,
-        max_time_ms=CONCEPT_SEARCH_QUERY_MAX_TIME_MS,
     )
     confirmed: set[str] = set()
     for concept_id in visible_ids:

--- a/src/backend/services/relationship_write_service.py
+++ b/src/backend/services/relationship_write_service.py
@@ -74,6 +74,10 @@ SUGGESTED_SUPERTYPES: List[str] = [
     "#V#information_object",
 ]
 
+CORE_RELATIONSHIP_TEXT_PREDICATES: frozenset[str] = frozenset(
+    {"hasContent", "hasDescription", "hasName"}
+)
+
 
 def _emit_relationship_mutation_event(
     *,
@@ -417,6 +421,50 @@ def validate_predicate_concept(
         )
 
     return True, None, None
+
+
+def resolve_existing_predicate_value_kind(
+    predicate: str,
+    repo: Any = None,
+) -> str | None:
+    """Return the canonical object kind for one existing exact predicate."""
+
+    if repo is None:
+        repo = ConceptsRepository
+    predicate_id = str(predicate or "").strip()
+    if not predicate_id.startswith("#V#"):
+        return None
+    if predicate_id[3:] in CORE_RELATIONSHIP_TEXT_PREDICATES:
+        return "text"
+    if is_structural_predicate(predicate_id):
+        return "concept"
+    with bypass_access_control():
+        predicate_doc = repo.find_one(
+            {"concept_id": predicate_id},
+            {"concept_id": 1, "relationships.is_an_instance_of": 1},
+        )
+    if predicate_doc is None and is_code_concept_id(predicate_id):
+        predicate_doc = build_virtual_concept_doc(predicate_id)
+    if not isinstance(predicate_doc, dict) or not is_predicate(predicate_doc):
+        return None
+    relationships = (
+        predicate_doc.get("relationships")
+        if isinstance(predicate_doc, Mapping)
+        else {}
+    )
+    instance_of = (
+        relationships.get("is_an_instance_of")
+        if isinstance(relationships, Mapping)
+        else None
+    )
+    if isinstance(instance_of, str):
+        instance_of = [instance_of]
+    return (
+        "text"
+        if isinstance(instance_of, list)
+        and "#V#binary_text_predicate" in instance_of
+        else "concept"
+    )
 
 
 def add_structural_relationship(

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -2721,6 +2721,7 @@ def test_canonical_relationship_denial_recovers_as_scoped_assertion(
     predicate_arguments: dict[str, Any],
 ) -> None:
     from src.backend.db import mongo_client
+    from src.backend.services import relationship_write_service
 
     class _Collection:
         def find_one(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
@@ -2730,6 +2731,11 @@ def test_canonical_relationship_denial_recovers_as_scoped_assertion(
         mongo_client,
         "get_concepts_collection",
         lambda: _Collection(),
+    )
+    monkeypatch.setattr(
+        relationship_write_service,
+        "resolve_existing_predicate_value_kind",
+        lambda _predicate: "concept",
     )
     invoked: list[tuple[str, dict[str, Any]]] = []
 
@@ -2838,17 +2844,244 @@ def test_canonical_relationship_denial_recovers_as_scoped_assertion(
 
 
 @pytest.mark.parametrize(
+    "predicate_arguments",
+    [
+        {"predicate": "#V#has_email"},
+        {
+            "predicate_ref": {
+                "concept_id": "#V#has_email",
+                "value_kind": "text",
+            }
+        },
+    ],
+)
+def test_canonical_literal_relationship_denial_recovers_in_chosen_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    predicate_arguments: dict[str, Any],
+) -> None:
+    from src.backend.db import mongo_client
+    from src.backend.services import relationship_write_service
+
+    class _Collection:
+        def find_one(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            return {"relationships": {}}
+
+    monkeypatch.setattr(
+        mongo_client,
+        "get_concepts_collection",
+        lambda: _Collection(),
+    )
+    monkeypatch.setattr(
+        relationship_write_service,
+        "resolve_existing_predicate_value_kind",
+        lambda _predicate: "text",
+    )
+    invoked: list[tuple[str, dict[str, Any]]] = []
+
+    def handler(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        invoked.append((name, arguments))
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "assertion_id": "ska_literal_relationship_recovered",
+            "canonical_publication": False,
+        }
+
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="canonical-literal-relationship-denied",
+                    payload={
+                        "name": "add_relationship",
+                        "arguments": {
+                            "source_id": "#V#globally_visible_subject",
+                            **predicate_arguments,
+                            "target": "Actor-relative observation.",
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="scoped-literal-relationship-recovery",
+                    payload={
+                        "name": "upsert_scoped_assertion",
+                        "arguments": {
+                            "subject_concept_id": (
+                                "#V#globally_visible_subject"
+                            ),
+                            "predicate": "#V#has_email",
+                            "target_text": "Actor-relative observation.",
+                            "language": "en-NZ",
+                            "scope_mode": "organisation",
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response="The scoped observation was recorded."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_effect_gateway(handler, include_scoped_assertion=True),
+        prompt="Record this observation without changing shared publication.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="canonical-literal-relationship-denied",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert len(invoked) == 1
+    recovered_name, recovered_arguments = invoked[0]
+    assert recovered_name == "upsert_scoped_assertion"
+    assert recovered_arguments["scope_mode"] == "organisation"
+    assert recovered_arguments["target_text"] == "Actor-relative observation."
+    denial, recovery = result.tool_invocations
+    assert denial["effect_status"] == "failed"
+    assert "target_text" in denial["evidence"]["preview"]
+    assert recovery["effect_status"] == "succeeded"
+    assert denial["recovery_status"] == "succeeded"
+    assert denial["recovered_by_effect_id"] == recovery["effect_id"]
+    assert result.terminal_status == "completed"
+    assert result.response_text == "The scoped observation was recorded."
+
+
+@pytest.mark.parametrize(
+    "recovery_arguments",
+    [
+        {
+            "subject_concept_id": "#V#different_subject",
+            "predicate": "#V#has_email",
+            "target_text": "Actor-relative observation.",
+        },
+        {
+            "subject_concept_id": "#V#globally_visible_subject",
+            "predicate": "hasDescription",
+            "target_text": "Actor-relative observation.",
+        },
+        {
+            "subject_concept_id": "#V#globally_visible_subject",
+            "predicate": "#V#has_email",
+            "target_text": "Different observation.",
+        },
+        {
+            "subject_concept_id": "#V#globally_visible_subject",
+            "predicate": "#V#has_email",
+            "target_concept_id": "#V#actor_relative_observation",
+        },
+    ],
+    ids=["subject", "predicate", "value", "target-kind"],
+)
+def test_canonical_literal_relationship_recovery_requires_same_object(
+    monkeypatch: pytest.MonkeyPatch,
+    recovery_arguments: dict[str, Any],
+) -> None:
+    from src.backend.db import mongo_client
+    from src.backend.services import relationship_write_service
+
+    class _Collection:
+        def find_one(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            return {"relationships": {}}
+
+    monkeypatch.setattr(
+        mongo_client,
+        "get_concepts_collection",
+        lambda: _Collection(),
+    )
+    monkeypatch.setattr(
+        relationship_write_service,
+        "resolve_existing_predicate_value_kind",
+        lambda _predicate: "text",
+    )
+
+    def handler(_name: str, _arguments: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "assertion_id": "ska_unrelated_recovery",
+            "canonical_publication": False,
+        }
+
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="literal-relationship-denied",
+                    payload={
+                        "name": "add_relationship",
+                        "arguments": {
+                            "source_id": "#V#globally_visible_subject",
+                            "predicate": "#V#has_email",
+                            "target": "Actor-relative observation.",
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="unrelated-scoped-assertion",
+                    payload={
+                        "name": "upsert_scoped_assertion",
+                        "arguments": {
+                            **recovery_arguments,
+                            "scope_mode": "organisation",
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response="The scoped assertion was recorded."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_effect_gateway(handler, include_scoped_assertion=True),
+        prompt="Record this observation without changing shared publication.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="literal-relationship-denied",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    denial = result.tool_invocations[0]
+    assert denial["effect_status"] == "failed"
+    assert "recovery_status" not in denial
+    assert "recovered_by_effect_id" not in denial
+    assert result.terminal_status == "effect_failed"
+    assert result.response_text != "The scoped assertion was recorded."
+
+
+@pytest.mark.parametrize(
     "arguments",
     [
         {
             "source_id": "#V#subject",
             "predicate": "hasResearchInterest",
             "target": "#V#topic",
-        },
-        {
-            "source_id": "#V#subject",
-            "predicate": "#V#hasResearchInterest",
-            "target": "Natural-language target",
         },
         {
             "source_id": "#V#subject",
@@ -2865,14 +3098,6 @@ def test_canonical_relationship_denial_recovers_as_scoped_assertion(
             "source_id": "#V#subject",
             "predicate_ref": {
                 "concept_id": "#V#hasResearchInterest",
-                "value_kind": "text",
-            },
-            "target": "#V#topic",
-        },
-        {
-            "source_id": "#V#subject",
-            "predicate_ref": {
-                "concept_id": "#V#hasResearchInterest",
                 "on_missing": "create_typed_predicate",
             },
             "target": "#V#topic",
@@ -2883,11 +3108,32 @@ def test_canonical_relationship_denial_recovers_as_scoped_assertion(
             "predicate_if_missing": {"name": "hasResearchInterest"},
             "target": "#V#topic",
         },
+        {
+            "source_id": "#V#subject",
+            "predicate_ref": {
+                "concept_id": "#V#hasResearchInterest",
+                "value_kind": "concept",
+            },
+            "target": "Natural-language target",
+        },
+        {
+            "source_id": "#V#subject",
+            "predicate": "#V#hasResearchInterest",
+            "target": "#V#malformed target",
+        },
     ],
 )
 def test_non_exact_relationship_denial_has_no_scoped_recovery(
     arguments: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from src.backend.services import relationship_write_service
+
+    monkeypatch.setattr(
+        relationship_write_service,
+        "resolve_existing_predicate_value_kind",
+        lambda _predicate: "concept",
+    )
     denial = _effect_subject_authority_denial(
         capability_name="add_relationship",
         arguments=arguments,
@@ -2896,6 +3142,116 @@ def test_non_exact_relationship_denial_has_no_scoped_recovery(
 
     assert denial["error_code"] == "effect_subject_not_authorised"
     assert "recovery_affordances" not in denial
+
+
+@pytest.mark.parametrize(
+    ("arguments", "canonical_kind", "expected_target_field"),
+    [
+        (
+            {
+                "source_id": "#V#subject",
+                "predicate": "#V#is_an_instance_of",
+                "target": "Professor",
+            },
+            "concept",
+            None,
+        ),
+        (
+            {
+                "source_id": "#V#subject",
+                "predicate_ref": {
+                    "concept_id": "#V#has_email",
+                    "value_kind": "concept",
+                },
+                "target": "#V#student@example.invalid",
+            },
+            "text",
+            "target_text",
+        ),
+        (
+            {
+                "source_id": "#V#subject",
+                "predicate": "#V#hasResearchInterest",
+                "target": "#v#topic",
+            },
+            "concept",
+            None,
+        ),
+    ],
+    ids=["concept-literal", "text-represented-looking-literal", "lowercase-id"],
+)
+def test_relationship_recovery_uses_represented_predicate_kind(
+    monkeypatch: pytest.MonkeyPatch,
+    arguments: dict[str, Any],
+    canonical_kind: str,
+    expected_target_field: str | None,
+) -> None:
+    from src.backend.services import relationship_write_service
+
+    monkeypatch.setattr(
+        relationship_write_service,
+        "resolve_existing_predicate_value_kind",
+        lambda _predicate: canonical_kind,
+    )
+
+    denial = _effect_subject_authority_denial(
+        capability_name="add_relationship",
+        arguments=arguments,
+        scoped_assertion_available=True,
+    )
+
+    affordances = denial.get("recovery_affordances") or []
+    if expected_target_field is None:
+        assert affordances == []
+    else:
+        assert len(affordances) == 1
+        recovery_arguments = affordances[0]["arguments"]
+        assert recovery_arguments[expected_target_field] == arguments["target"]
+        assert "target_concept_id" not in recovery_arguments
+
+
+def test_existing_predicate_value_kind_comes_from_canonical_typing() -> None:
+    from src.backend.services.relationship_write_service import (
+        resolve_existing_predicate_value_kind,
+    )
+
+    class _PredicateRepo:
+        @staticmethod
+        def find_one(query: dict[str, Any], *_args: Any) -> dict[str, Any] | None:
+            concept_id = query.get("concept_id")
+            if concept_id == "#V#has_email":
+                return {
+                    "concept_id": concept_id,
+                    "relationships": {
+                        "is_an_instance_of": ["#V#binary_text_predicate"]
+                    },
+                }
+            if concept_id == "#V#hasResearchInterest":
+                return {
+                    "concept_id": concept_id,
+                    "relationships": {"is_an_instance_of": ["#V#predicate"]},
+                }
+            return None
+
+    assert (
+        resolve_existing_predicate_value_kind("#V#has_email", _PredicateRepo)
+        == "text"
+    )
+    assert (
+        resolve_existing_predicate_value_kind(
+            "#V#hasResearchInterest",
+            _PredicateRepo,
+        )
+        == "concept"
+    )
+    assert (
+        resolve_existing_predicate_value_kind("#V#hasDescription", _PredicateRepo)
+        == "text"
+    )
+    assert (
+        resolve_existing_predicate_value_kind("#V#is_an_instance_of", _PredicateRepo)
+        == "concept"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/backend/test_blocked_thing_parent_type.py
+++ b/tests/backend/test_blocked_thing_parent_type.py
@@ -337,7 +337,7 @@ def test_mcp_fetch_concept_adds_vacuous_warning(monkeypatch):
         return concept
 
     monkeypatch.setattr(
-        "src.backend.services.concept_service.get_concept_by_concept_id",
+        "src.backend.services.concept_service.get_concept_by_concept_id_exact",
         _fake_get_concept,
     )
     monkeypatch.setattr(

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_internal_mcp_catalogue_builds_and_includes_relationship_tools():
     from src.backend.integrations.internal_mcp import build_default_catalogue
 
@@ -86,23 +89,55 @@ def test_default_catalogue_exposes_calibrated_effect_admission_windows():
 
 
 def test_remote_file_import_has_observed_liveness_headroom():
-    from src.backend.integrations.internal_mcp import build_default_catalogue
+    from src.backend.integrations.internal_mcp import (
+        InternalMCPTransport,
+        build_default_catalogue,
+    )
 
     definition = build_default_catalogue().get("import_url_file_copy")
 
-    assert definition.advisory_timeout_sec == 220.0
-    assert definition.timeout_sec == 350.0
+    assert definition.advisory_timeout_sec is None
+    assert definition.timeout_sec is None
     assert definition.hard_timeout_enabled is True
+    assert definition.successful_duration_bootstrap_sec == pytest.approx(173.641)
+    assert definition.resolved_advisory_timeout(
+        InternalMCPTransport()
+    ) == pytest.approx(173.641 * 1.25)
+    assert definition.resolved_timeout(InternalMCPTransport()) == pytest.approx(
+        173.641 * 2.0
+    )
 
 
 def test_paper_download_cold_start_window_covers_observed_blob_rehydration():
-    from src.backend.integrations.internal_mcp import build_default_catalogue
+    from src.backend.integrations.internal_mcp import (
+        InternalMCPTransport,
+        build_default_catalogue,
+    )
 
     definition = build_default_catalogue().get("download_paper")
 
-    assert definition.advisory_timeout_sec == 85.0
-    assert definition.timeout_sec == 140.0
+    assert definition.advisory_timeout_sec is None
+    assert definition.timeout_sec is None
     assert definition.hard_timeout_enabled is True
+    assert definition.successful_duration_bootstrap_sec == pytest.approx(68.321)
+    assert definition.resolved_advisory_timeout(
+        InternalMCPTransport()
+    ) == pytest.approx(68.321 * 1.25)
+    assert definition.resolved_timeout(InternalMCPTransport()) == pytest.approx(
+        68.321 * 2.0
+    )
+
+
+def test_adaptive_deadline_history_is_limited_to_observed_long_running_imports():
+    from src.backend.integrations.internal_mcp import build_default_catalogue
+
+    snapshot = build_default_catalogue().snapshot()
+
+    assert {
+        name
+        for name, definition in snapshot.items()
+        if definition["successful_duration_bootstrap_sec"] is not None
+    } == {"download_paper", "import_url_file_copy"}
 
 
 def test_ordinary_semantic_reads_use_advisory_only_transport_timing():
@@ -121,6 +156,8 @@ def test_ordinary_semantic_reads_use_advisory_only_transport_timing():
         "get_related_concepts",
         "get_text_relations",
         "get_text_relations_summary",
+        "rag_get_item",
+        "rag_list_collections",
         "rag_list_indexed",
         "resolve_concept_by_name",
         "search_concepts",
@@ -131,6 +168,33 @@ def test_ordinary_semantic_reads_use_advisory_only_transport_timing():
         definition = catalogue.get(method_name)
         assert definition.hard_timeout_enabled is False
         assert definition.resolved_timeout(transport) is None
+
+
+def test_frequent_gmail_and_scoped_assertion_paths_use_advisory_only_timing():
+    from src.backend.integrations.internal_mcp import (
+        InternalMCPTransport,
+        build_default_catalogue,
+    )
+
+    catalogue = build_default_catalogue()
+    transport = InternalMCPTransport()
+    expected_advisory_seconds = {
+        "gmail_get_auth_config": 10.0,
+        "gmail_list_messages": 20.0,
+        "gmail_get_message": 20.0,
+        "gmail_get_attachment": 20.0,
+        "gmail_list_labels": 15.0,
+        "upsert_scoped_assertion": 20.0,
+        "list_scoped_assertions": 20.0,
+    }
+
+    for method_name, advisory_seconds in expected_advisory_seconds.items():
+        definition = catalogue.get(method_name)
+        assert definition.timeout_sec is None
+        assert definition.advisory_timeout_sec == advisory_seconds
+        assert definition.hard_timeout_enabled is False
+        assert definition.resolved_timeout(transport) is None
+        assert definition.resolved_advisory_timeout(transport) == advisory_seconds
 
 
 def test_workflow_execute_uses_its_bounded_await_without_an_outer_hard_timeout():

--- a/tests/backend/test_internal_mcp_dynamic_tool_registration.py
+++ b/tests/backend/test_internal_mcp_dynamic_tool_registration.py
@@ -109,6 +109,44 @@ def test_dynamic_loader_supports_fixed_payload_with_gateway_invoke(monkeypatch):
         pass
 
 
+def test_dynamic_proxy_preserves_target_timing_policy(monkeypatch):
+    _set_dynamic_tool_docs(
+        monkeypatch,
+        [
+            {
+                "concept_id": "#V#dynamic_timing_proxy",
+                "attributes": {
+                    "mcp_tool_name": "timing_proxy",
+                    "dynamic_registration_enabled": True,
+                    "dynamic_registration_approved": True,
+                    "dynamic_target_tool_name": "timing_base",
+                },
+            }
+        ],
+    )
+    base_definition = MethodDefinition(
+        name="timing_base",
+        handler=lambda: {"success": True},
+        input_schema=Schema(allow_unknown=False),
+        category="write",
+        successful_duration_bootstrap_sec=12.0,
+    )
+
+    definitions = load_dynamic_method_definitions(
+        base_definitions={"timing_base": base_definition},
+        protected_method_names={"timing_base"},
+    ).definitions
+
+    assert len(definitions) == 1
+    proxy = definitions[0]
+    assert proxy.successful_duration_bootstrap_sec == 12.0
+    assert proxy.hard_timeout_enabled is True
+    assert proxy.resolved_advisory_timeout(
+        InternalMCPTransport()
+    ) == 15.0
+    assert proxy.resolved_timeout(InternalMCPTransport()) == 24.0
+
+
 def test_dynamic_proxy_preserves_unfixed_target_schema_semantics(monkeypatch):
     _set_dynamic_tool_docs(
         monkeypatch,

--- a/tests/backend/test_internal_mcp_fetch_concept_bounded.py
+++ b/tests/backend/test_internal_mcp_fetch_concept_bounded.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from src.backend.integrations.internal_mcp import catalogue
+from src.backend.services import (
+    concept_rename_service,
+    concept_resolution_service,
+    concept_service,
+)
+
+
+def _patch_fetch_enrichment(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "src.backend.security.access_control.describe_concept_access",
+        lambda concept_id: {
+            "concept_id": concept_id,
+            "exists": concept_id == "#V#paper",
+            "accessible": True,
+        },
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "enrich_concept_with_text_relations",
+        lambda concept: concept,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.relationship_write_service.detect_vacuous_typing",
+        lambda _concept: None,
+    )
+
+
+def test_fetch_concept_uses_exact_lookup_without_alias_or_fuzzy_resolution(
+    monkeypatch,
+) -> None:
+    _patch_fetch_enrichment(monkeypatch)
+    exact_calls: list[str] = []
+
+    def _exact(concept_id: str):
+        exact_calls.append(concept_id)
+        return {"concept_id": concept_id, "relationships": {}}
+
+    monkeypatch.setattr(concept_service, "get_concept_by_concept_id_exact", _exact)
+    monkeypatch.setattr(
+        concept_rename_service,
+        "resolve_concept_by_alias",
+        lambda _concept_id: (_ for _ in ()).throw(
+            AssertionError("alias resolution should not run for an exact hit")
+        ),
+    )
+    monkeypatch.setattr(
+        concept_resolution_service,
+        "resolve_concept_by_name",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("fetch_concept must not perform fuzzy name resolution")
+        ),
+    )
+
+    result = catalogue._get_concept_by_concept_id(concept_id="#V#paper")
+
+    assert result["concept_id"] == "#V#paper"
+    assert exact_calls == ["#V#paper"]
+
+
+def test_fetch_concept_resolves_one_exact_code_alias(monkeypatch) -> None:
+    _patch_fetch_enrichment(monkeypatch)
+    exact_calls: list[str] = []
+
+    def _exact(concept_id: str):
+        exact_calls.append(concept_id)
+        if concept_id == "#V#paper":
+            return {"concept_id": concept_id, "relationships": {}}
+        raise concept_service.ConceptNotFoundError(concept_id)
+
+    monkeypatch.setattr(concept_service, "get_concept_by_concept_id_exact", _exact)
+    monkeypatch.setattr(
+        "src.backend.vontology.code_concepts_registry.build_virtual_concept_doc",
+        lambda _concept_id: None,
+    )
+    monkeypatch.setattr(
+        concept_rename_service,
+        "resolve_concept_by_alias",
+        lambda concept_id: "#V#paper" if concept_id == "#V#old_paper" else None,
+    )
+    monkeypatch.setattr(
+        concept_resolution_service,
+        "resolve_concept_by_name",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("fetch_concept must not perform fuzzy name resolution")
+        ),
+    )
+
+    result = catalogue._get_concept_by_concept_id(concept_id="#V#old_paper")
+
+    assert result["concept_id"] == "#V#paper"
+    assert exact_calls == ["#V#old_paper", "#V#paper"]
+
+
+def test_fetch_concept_returns_typed_not_found_without_fuzzy_scan(monkeypatch) -> None:
+    _patch_fetch_enrichment(monkeypatch)
+
+    def _not_found(concept_id: str):
+        raise concept_service.ConceptNotFoundError(concept_id)
+
+    monkeypatch.setattr(
+        concept_service,
+        "get_concept_by_concept_id_exact",
+        _not_found,
+    )
+    monkeypatch.setattr(
+        "src.backend.vontology.code_concepts_registry.build_virtual_concept_doc",
+        lambda _concept_id: None,
+    )
+    monkeypatch.setattr(
+        concept_rename_service,
+        "resolve_concept_by_alias",
+        lambda _concept_id: None,
+    )
+    monkeypatch.setattr(
+        concept_resolution_service,
+        "resolve_concept_by_name",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("fetch_concept must not perform fuzzy name resolution")
+        ),
+    )
+
+    result = catalogue._get_concept_by_concept_id(concept_id="#V#missing")
+
+    assert result["success"] is False
+    assert result["error_code"] == "concept_not_found"
+    assert result["error_details"] == {
+        "concept_id": "#V#missing",
+        "status": "not_found",
+        "lookup_modes": ["exact_concept_id", "exact_code_alias"],
+    }
+
+
+def test_fetch_concept_preserves_exact_virtual_code_concepts(monkeypatch) -> None:
+    _patch_fetch_enrichment(monkeypatch)
+
+    monkeypatch.setattr(
+        concept_service,
+        "get_concept_by_concept_id_exact",
+        lambda concept_id: (_ for _ in ()).throw(
+            concept_service.ConceptNotFoundError(concept_id)
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.vontology.code_concepts_registry.build_virtual_concept_doc",
+        lambda concept_id: {
+            "concept_id": concept_id,
+            "relationships": {},
+            "metadata": {"concept_type": "predicate", "virtual": True},
+        },
+    )
+    monkeypatch.setattr(
+        concept_rename_service,
+        "resolve_concept_by_alias",
+        lambda _concept_id: (_ for _ in ()).throw(
+            AssertionError("an exact virtual concept must precede alias resolution")
+        ),
+    )
+
+    result = catalogue._get_concept_by_concept_id(concept_id="#V#has_student")
+
+    assert result["concept_id"] == "#V#has_student"
+    assert result["id"] == "virtual:#V#has_student"
+    assert result["kind"] == "predicate"

--- a/tests/backend/test_internal_mcp_scoped_assertion_authority.py
+++ b/tests/backend/test_internal_mcp_scoped_assertion_authority.py
@@ -204,7 +204,7 @@ def _install_route_fakes(monkeypatch: pytest.MonkeyPatch):
         lambda _concept_id: {"exists": True, "accessible": True},
     )
     monkeypatch.setattr(
-        "src.backend.services.concept_service.get_concept_by_concept_id",
+        "src.backend.services.concept_service.get_concept_by_concept_id_exact",
         fake_get_concept,
     )
     monkeypatch.setattr(

--- a/tests/backend/test_internal_mcp_transport_deadlines.py
+++ b/tests/backend/test_internal_mcp_transport_deadlines.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
 import sys
 import time
+from contextlib import contextmanager
 from threading import Event, Thread
 
-from pymongo.errors import ExecutionTimeout
 import pytest
+from pymongo.errors import ExecutionTimeout
 
 from src.backend.integrations.internal_mcp import transport as transport_mod
 from src.backend.integrations.internal_mcp.gateway import (
@@ -17,12 +17,13 @@ from src.backend.integrations.internal_mcp.gateway import (
 )
 from src.backend.integrations.internal_mcp.schemas import Schema
 from src.backend.integrations.internal_mcp.transport import (
-    _BoundedHandlerExecutor,
     InternalMCPTransport,
+    TransportResult,
+    _BoundedHandlerExecutor,
     get_internal_mcp_execution_scope,
     internal_mcp_cancellation_requested,
-    record_internal_mcp_effect_receipt,
     raise_if_internal_mcp_cancelled,
+    record_internal_mcp_effect_receipt,
 )
 
 
@@ -36,6 +37,7 @@ def _gateway_for(
     timeout_sec: float | None = None,
     advisory_timeout_sec: float | None = None,
     hard_timeout_enabled: bool = True,
+    successful_duration_bootstrap_sec: float | None = None,
     effect_admission_window_sec: float | None = None,
 ) -> InternalMCPGateway:
     catalogue = MethodCatalogue()
@@ -49,6 +51,9 @@ def _gateway_for(
             timeout_sec=timeout_sec,
             advisory_timeout_sec=advisory_timeout_sec,
             hard_timeout_enabled=hard_timeout_enabled,
+            successful_duration_bootstrap_sec=(
+                successful_duration_bootstrap_sec
+            ),
             effect_admission_window_sec=effect_admission_window_sec,
         )
     )
@@ -102,6 +107,7 @@ def test_handler_before_hard_deadline_remains_success_after_advisory_budget(
     method_metrics = diagnostics["methods"]["synthetic_fast_read"]
     assert method_metrics["last_outcome"] == "completed"
     assert method_metrics["timeouts"] == 0
+    assert method_metrics["next_hard_timeout_sec"] == pytest.approx(0.25)
 
 
 def test_advisory_only_handler_keeps_usable_completion_after_warning() -> None:
@@ -118,13 +124,351 @@ def test_advisory_only_handler_keeps_usable_completion_after_warning() -> None:
         hard_timeout_enabled=False,
     )
 
-    result = gateway.invoke("synthetic_soft_window_write", {})
+    first_result = gateway.invoke("synthetic_soft_window_write", {})
 
-    assert result.outcome == "completed"
-    assert result.timeout_sec is None
-    assert result.configured_hard_timeout_sec is None
-    assert result.advisory_budget_exceeded is True
-    assert result.payload == {"success": True, "changed": True}
+    assert first_result.outcome == "completed"
+    assert first_result.timeout_sec is None
+    assert first_result.configured_hard_timeout_sec is None
+    assert first_result.advisory_timeout_sec == pytest.approx(0.005)
+    assert first_result.advisory_budget_exceeded is True
+    assert first_result.payload == {"success": True, "changed": True}
+
+    first_metrics = gateway.get_diagnostics()["methods"][
+        "synthetic_soft_window_write"
+    ]
+    expected_next_advisory = first_metrics["next_advisory_timeout_sec"]
+    assert first_metrics["successful_max_duration_ms"] == pytest.approx(
+        first_result.duration_ms
+    )
+    assert expected_next_advisory == pytest.approx(
+        first_result.duration_ms * 1.25 / 1000.0
+    )
+
+    second_result = gateway.invoke("synthetic_soft_window_write", {})
+
+    assert second_result.outcome == "completed"
+    assert second_result.timeout_sec is None
+    assert second_result.configured_hard_timeout_sec is None
+    assert second_result.advisory_timeout_sec == pytest.approx(
+        expected_next_advisory
+    )
+    assert second_result.payload == {"success": True, "changed": True}
+
+
+def test_gateway_advisory_bootstrap_adapts_from_successful_max_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = InternalMCPTransport(
+        read_timeout_sec=2.0,
+        read_advisory_timeout_sec=0.01,
+    )
+    scripted_results = iter(
+        (
+            ({"success": True}, 4.0),
+            ({"success": True}, 80.0),
+            ({"success": True}, 10.0),
+            ({"success": False, "error": "synthetic"}, 500.0),
+        )
+    )
+    observed_advisories: list[float] = []
+
+    def _scripted_execute(**kwargs) -> TransportResult:
+        payload, duration_ms = next(scripted_results)
+        advisory_timeout_sec = float(kwargs["advisory_timeout_sec"])
+        observed_advisories.append(advisory_timeout_sec)
+        return TransportResult(
+            payload=payload,
+            duration_ms=duration_ms,
+            advisory_timeout_sec=advisory_timeout_sec,
+        )
+
+    monkeypatch.setattr(transport, "execute", _scripted_execute)
+    gateway = _gateway_for(
+        method_name="synthetic_adaptive_read",
+        handler=lambda: {"success": True},
+        transport=transport,
+        advisory_timeout_sec=0.01,
+        hard_timeout_enabled=False,
+    )
+
+    initial_metrics = gateway.get_diagnostics()["methods"][
+        "synthetic_adaptive_read"
+    ]
+    assert initial_metrics["bootstrap_advisory_timeout_sec"] == pytest.approx(
+        0.01
+    )
+    assert initial_metrics["adaptive_advisory_timeout_sec"] == pytest.approx(
+        0.01
+    )
+    assert initial_metrics["next_advisory_timeout_sec"] == pytest.approx(0.01)
+    assert initial_metrics["successful_max_duration_ms"] is None
+
+    gateway.invoke("synthetic_adaptive_read", {})
+    learned_metrics = gateway.get_diagnostics()["methods"][
+        "synthetic_adaptive_read"
+    ]
+    assert observed_advisories == pytest.approx([0.01])
+    assert learned_metrics["successful_max_duration_ms"] == pytest.approx(4.0)
+    assert learned_metrics["adaptive_advisory_timeout_sec"] == pytest.approx(
+        0.005
+    )
+    assert learned_metrics["next_advisory_timeout_sec"] == pytest.approx(0.005)
+
+    gateway.invoke("synthetic_adaptive_read", {})
+    assert observed_advisories == pytest.approx([0.01, 0.005])
+
+    gateway.invoke("synthetic_adaptive_read", {})
+    assert observed_advisories == pytest.approx([0.01, 0.005, 0.1])
+
+    gateway.invoke("synthetic_adaptive_read", {})
+    final_metrics = gateway.get_diagnostics()["methods"][
+        "synthetic_adaptive_read"
+    ]
+    assert observed_advisories == pytest.approx([0.01, 0.005, 0.1, 0.1])
+    assert final_metrics["successful_max_duration_ms"] == pytest.approx(80.0)
+
+
+def test_gateway_adaptive_advisory_clamps_to_remaining_hard_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = InternalMCPTransport(
+        read_timeout_sec=2.0,
+        read_advisory_timeout_sec=0.1,
+    )
+    observed_advisories: list[float] = []
+
+    def _scripted_execute(**kwargs) -> TransportResult:
+        advisory_timeout_sec = float(kwargs["advisory_timeout_sec"])
+        observed_advisories.append(advisory_timeout_sec)
+        return TransportResult(
+            payload={"success": True},
+            duration_ms=1_000.0 if len(observed_advisories) == 1 else 1.0,
+            advisory_timeout_sec=advisory_timeout_sec,
+        )
+
+    monkeypatch.setattr(transport, "execute", _scripted_execute)
+    gateway = _gateway_for(
+        method_name="synthetic_caller_bounded_read",
+        handler=lambda: {"success": True},
+        transport=transport,
+        advisory_timeout_sec=0.1,
+        hard_timeout_enabled=False,
+    )
+
+    gateway.invoke("synthetic_caller_bounded_read", {})
+    gateway.invoke(
+        "synthetic_caller_bounded_read",
+        {},
+        deadline_monotonic=time.monotonic() + 0.5,
+    )
+
+    assert observed_advisories[0] == pytest.approx(0.1)
+    assert 0.0 < observed_advisories[1] <= 0.5
+    assert observed_advisories[1] < 1.25
+
+
+def test_opted_in_hard_boundary_adapts_to_twice_successful_max_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = InternalMCPTransport(
+        write_timeout_sec=1.0,
+        write_advisory_timeout_sec=0.6,
+    )
+    scripted_results = iter(
+        (
+            ({"success": True}, 100.0),
+            ({"success": True}, 800.0),
+            ({"success": True}, 100.0),
+            ({"success": False, "error": "synthetic"}, 2_000.0),
+        )
+    )
+    observed_windows: list[tuple[float | None, float]] = []
+
+    def _scripted_execute(**kwargs) -> TransportResult:
+        payload, duration_ms = next(scripted_results)
+        observed_windows.append(
+            (kwargs["timeout_sec"], float(kwargs["advisory_timeout_sec"]))
+        )
+        return TransportResult(
+            payload=payload,
+            duration_ms=duration_ms,
+            advisory_timeout_sec=float(kwargs["advisory_timeout_sec"]),
+        )
+
+    monkeypatch.setattr(transport, "execute", _scripted_execute)
+    gateway = _gateway_for(
+        method_name="synthetic_adaptive_hard_write",
+        handler=lambda: {"success": True},
+        transport=transport,
+        category="write",
+        successful_duration_bootstrap_sec=0.5,
+    )
+
+    initial = gateway.get_diagnostics()["methods"][
+        "synthetic_adaptive_hard_write"
+    ]
+    assert initial["bootstrap_hard_timeout_sec"] == pytest.approx(1.0)
+    assert initial["next_hard_timeout_sec"] == pytest.approx(1.0)
+    assert initial["next_advisory_timeout_sec"] == pytest.approx(0.625)
+
+    gateway.invoke("synthetic_adaptive_hard_write", {})
+    learned = gateway.get_diagnostics()["methods"][
+        "synthetic_adaptive_hard_write"
+    ]
+    assert observed_windows == pytest.approx([(1.0, 0.625)])
+    assert learned["successful_max_duration_ms"] == pytest.approx(100.0)
+    assert learned["next_hard_timeout_sec"] == pytest.approx(1.0)
+    assert learned["next_advisory_timeout_sec"] == pytest.approx(0.625)
+    assert gateway.get_method_timeout_sec(
+        "synthetic_adaptive_hard_write"
+    ) == pytest.approx(1.0)
+
+    gateway.invoke("synthetic_adaptive_hard_write", {})
+    gateway.invoke("synthetic_adaptive_hard_write", {})
+    gateway.invoke("synthetic_adaptive_hard_write", {})
+    final = gateway.get_diagnostics()["methods"][
+        "synthetic_adaptive_hard_write"
+    ]
+    assert observed_windows == pytest.approx(
+        [
+            (1.0, 0.625),
+            (1.0, 0.625),
+            (1.6, 1.0),
+            (1.6, 1.0),
+        ]
+    )
+    assert final["successful_max_duration_ms"] == pytest.approx(800.0)
+    assert final["next_hard_timeout_sec"] == pytest.approx(1.6)
+    assert final["next_advisory_timeout_sec"] == pytest.approx(1.0)
+
+    restarted = _gateway_for(
+        method_name="synthetic_restarted_adaptive_hard_write",
+        handler=lambda: {"success": True},
+        transport=transport,
+        category="write",
+        successful_duration_bootstrap_sec=0.5,
+    )
+    restarted_metrics = restarted.get_diagnostics()["methods"][
+        "synthetic_restarted_adaptive_hard_write"
+    ]
+    assert restarted_metrics["next_hard_timeout_sec"] == pytest.approx(1.0)
+    assert restarted_metrics["next_advisory_timeout_sec"] == pytest.approx(0.625)
+
+
+def test_parallel_successes_preserve_longest_adaptive_duration() -> None:
+    gateway = _gateway_for(
+        method_name="synthetic_parallel_adaptive_write",
+        handler=lambda: {"success": True},
+        transport=InternalMCPTransport(),
+        category="write",
+        successful_duration_bootstrap_sec=0.5,
+    )
+    start = Event()
+    durations = [25.0, 800.0, 40.0, 1_200.0, 300.0, 75.0]
+    threads = [
+        Thread(
+            target=lambda value=value: (
+                start.wait(),
+                gateway._record_successful_duration(
+                    "synthetic_parallel_adaptive_write",
+                    value,
+                ),
+            ),
+            daemon=True,
+        )
+        for value in durations
+    ]
+    for thread in threads:
+        thread.start()
+    start.set()
+    for thread in threads:
+        thread.join(timeout=1.0)
+    for ignored_duration in (None, 0.0, -1.0, float("nan"), float("inf"), "bad"):
+        gateway._record_successful_duration(
+            "synthetic_parallel_adaptive_write",
+            ignored_duration,
+        )
+
+    metrics = gateway.get_diagnostics()["methods"][
+        "synthetic_parallel_adaptive_write"
+    ]
+    assert metrics["successful_max_duration_ms"] == pytest.approx(max(durations))
+    assert metrics["next_hard_timeout_sec"] == pytest.approx(2.4)
+    assert metrics["next_advisory_timeout_sec"] == pytest.approx(1.5)
+
+
+def test_adaptive_history_learns_validated_late_success() -> None:
+    transport = InternalMCPTransport(
+        write_timeout_sec=1.0,
+        write_advisory_timeout_sec=0.01,
+    )
+    gateway = _gateway_for(
+        method_name="synthetic_late_adaptive_write",
+        handler=lambda: (time.sleep(0.03), {"success": True})[1],
+        transport=transport,
+        category="write",
+        successful_duration_bootstrap_sec=0.01,
+    )
+
+    result = gateway.invoke("synthetic_late_adaptive_write", {})
+
+    assert result.outcome == "timed_out"
+    deadline = time.monotonic() + 1.0
+    metrics = gateway.get_diagnostics()["methods"][
+        "synthetic_late_adaptive_write"
+    ]
+    while (
+        metrics["successful_max_duration_ms"] is None
+        and time.monotonic() < deadline
+    ):
+        time.sleep(0.005)
+        metrics = gateway.get_diagnostics()["methods"][
+            "synthetic_late_adaptive_write"
+        ]
+    assert metrics["successful_max_duration_ms"] is not None
+    assert metrics["successful_max_duration_ms"] >= 25.0
+    assert metrics["next_hard_timeout_sec"] >= 0.05
+
+
+def test_adaptive_late_success_includes_queue_duration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = InternalMCPTransport()
+
+    def _scripted_execute(**kwargs) -> TransportResult:
+        kwargs["late_completion_observer"](
+            {
+                "outcome": "late_success",
+                "queue_duration_ms": 40.0,
+                "handler_duration_ms": 80.0,
+                "payload": {"success": True},
+                "payload_truncated": False,
+            }
+        )
+        return TransportResult(
+            payload={"success": False, "error_code": "tool_timeout"},
+            duration_ms=100.0,
+            outcome="timed_out",
+        )
+
+    monkeypatch.setattr(transport, "execute", _scripted_execute)
+    gateway = _gateway_for(
+        method_name="synthetic_queued_late_adaptive_write",
+        handler=lambda: {"success": True},
+        transport=transport,
+        category="write",
+        successful_duration_bootstrap_sec=0.05,
+    )
+
+    result = gateway.invoke("synthetic_queued_late_adaptive_write", {})
+    metrics = gateway.get_diagnostics()["methods"][
+        "synthetic_queued_late_adaptive_write"
+    ]
+
+    assert result.outcome == "timed_out"
+    assert metrics["successful_max_duration_ms"] == pytest.approx(120.0)
+    assert metrics["next_hard_timeout_sec"] == pytest.approx(0.24)
+    assert metrics["next_advisory_timeout_sec"] == pytest.approx(0.15)
 
 
 def test_hard_deadline_returns_typed_timeout_and_requests_cooperative_cancel() -> None:


### PR DESCRIPTION
## Outcome

Repairs the general model-led path behind JVNAUTOSCI-2623 without adding Gmail-, student-, email-address-, or arXiv-specific routing.

- `fetch_concept` now performs bounded exact ID, registered virtual-concept, and exact CODE-alias lookup; misses return typed `concept_not_found` instead of falling into broad lexical resolution.
- A denied canonical relationship write exposes a scoped-assertion recovery only when the exact represented predicate establishes the object kind. A successful matching recovery reconciles turn finality; subject, predicate, value, and object-kind mismatches do not.
- Frequently used Gmail and scoped-assertion operations use adaptive advisory timing with no arbitrary outer hard deadline.
- The two observed slow file operations seed adaptive windows from their longest known successful duration: warning at 1.25x, hard boundary at 2x. Longer valid successes grow both; failed, invalid, zero, or non-finite durations do not train them.
- Dynamic tool proxies preserve timing policy.
- Removes the stale RAG identity-service import and query arguments left behind when the legacy fixed Mongo query deadline was removed.

## Evidence

- 140 internal MCP transport, catalogue, fetch, dynamic registration, external identity, predicate, and scoped-authority tests passed.
- 28 neighbouring adaptive-turn authority/recovery tests passed.
- Additional independent focused reviews passed 67 timing tests, 39 canonical relationship tests, and 19 recovery/finality tests.
- Python compilation, Ruff fatal checks, and `git diff --check` passed.
- Fresh authenticated Terra replay completed in 6m23s through the direct model-led path. It used Gmail list/get only, selected exact concept `#V#timothy_pistotti`, reused the existing `#V#has_email` assertion, and created no duplicate or mailbox mutation.

## Boundaries

- Adaptive runtime maxima are process-local; evidence-backed cold-start seeds survive restart for the two retained hard-boundary capabilities.
- The current RAG corpus still reports `not_indexed` with pending work; this change fixes its deterministic stale-import failure, not index population.
- Existing Thinking/situation and top-level telemetry gaps observed in the replay are not changed here.
- One broader adaptive-turn test remains environment-sensitive because its test handler has a fixed one-second release wait while Mongo failover can delay the turn; no production change was made to hide that pre-existing race.