### PR TITLE
Require explicit premium model eligibility and surface turn cost

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -11,6 +11,7 @@ import re
 import threading
 import time
 import requests
+from contextvars import copy_context
 from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 from typing import (
@@ -15222,8 +15223,9 @@ class InternalMCPChatOrchestrator:
             finally:
                 done.set()
 
+        worker_context = copy_context()
         threading.Thread(
-            target=_worker,
+            target=lambda: worker_context.run(_worker),
             daemon=True,
             name=f"von-llm-{stage_name}",
         ).start()
@@ -15473,8 +15475,10 @@ class InternalMCPChatOrchestrator:
             # JVNAUTOSCI-2373: model-resolution telemetry shared across all
             # attempts. ``model_source`` records why this candidate was tried
             # (active_llm, enabled_settings, policy primary/fallback, ...);
-            # ``requested_model`` and ``effective_model`` distinguish what the
-            # caller asked for from what the fallback chain actually used;
+            # ``requested_model`` and ``selected_model`` distinguish what the
+            # caller asked for from what the fallback chain chose.  An
+            # ``effective_model`` is added only when a provider response
+            # reports one.
             # ``model_switch_reason`` explains divergence (dead-candidate
             # skip, previous-attempt failure class).
             attempt_meta: dict[str, Any] = {
@@ -15482,7 +15486,9 @@ class InternalMCPChatOrchestrator:
                 "fallback_candidate_count": total_candidates,
                 "model_source": candidate.source,
                 "requested_model": default_model,
-                "effective_model": model_name,
+                "selected_model": model_name,
+                "effective_model": None,
+                "model_identity_source": None,
                 # JVNAUTOSCI-2517: carry the stable exchange/attempt identity on
                 # every per-attempt live lifecycle event (sent/received/
                 # completed/cancelled/failed) so the Thinking card groups them.
@@ -15576,6 +15582,7 @@ class InternalMCPChatOrchestrator:
                 record_llm_call(
                     call_type="llm.generate",
                     model_name=model_name,
+                    requested_model_name=default_model,
                     duration_ms=duration_ms,
                     usage=None,
                     note="candidate reachability probe failed; trying fallback",
@@ -15741,6 +15748,7 @@ class InternalMCPChatOrchestrator:
                     record_llm_call(
                         call_type="llm.generate",
                         model_name=model_name,
+                        requested_model_name=default_model,
                         duration_ms=duration_ms,
                         usage=None,
                         note="llm.generate response failed validation; trying fallback",
@@ -15835,6 +15843,7 @@ class InternalMCPChatOrchestrator:
                 record_llm_call(
                     call_type="llm.generate",
                     model_name=model_name,
+                    requested_model_name=default_model,
                     duration_ms=duration_ms,
                     usage=None,
                     note=("Fallback chain generate()" if errors else "llm.generate"),
@@ -15910,7 +15919,9 @@ class InternalMCPChatOrchestrator:
                         "skipped_candidates": list(skipped_candidates),
                         "skipped_candidate_count": len(skipped_candidates),
                         "requested_model": default_model,
-                        "effective_model": model_name,
+                        "selected_model": model_name,
+                        "effective_model": None,
+                        "model_identity_source": None,
                         "model_source": candidate.source,
                         **_stage_extra,
                         **selection_metadata,
@@ -15945,6 +15956,7 @@ class InternalMCPChatOrchestrator:
                 record_llm_call(
                     call_type="llm.generate",
                     model_name=model_name,
+                    requested_model_name=default_model,
                     duration_ms=duration_ms,
                     usage=None,
                     note="llm.generate cancelled",
@@ -16064,6 +16076,7 @@ class InternalMCPChatOrchestrator:
                 record_llm_call(
                     call_type="llm.generate",
                     model_name=model_name,
+                    requested_model_name=default_model,
                     duration_ms=duration_ms,
                     usage=None,
                     note="llm.generate failed; trying fallback",
@@ -16772,7 +16785,9 @@ class InternalMCPChatOrchestrator:
                 "fallback_candidate_count": total_candidates,
                 "model_source": candidate.source,
                 "requested_model": default_model,
-                "effective_model": model_name,
+                "selected_model": model_name,
+                "effective_model": None,
+                "model_identity_source": None,
                 # JVNAUTOSCI-2517: carry the stable exchange/attempt identity on
                 # every per-attempt live lifecycle event (sent/received/
                 # completed/cancelled/failed) so the Thinking card groups them.
@@ -17066,6 +17081,7 @@ class InternalMCPChatOrchestrator:
                 record_llm_call(
                     call_type="llm.generate_with_tools",
                     model_name=model_name,
+                    requested_model_name=default_model,
                     duration_ms=duration_ms,
                     usage=None,
                     note="candidate reachability probe failed; trying fallback",
@@ -17141,6 +17157,15 @@ class InternalMCPChatOrchestrator:
                     timeout_override_sec=timeout_override_sec,
                 )
                 duration_ms = (time.perf_counter() - llm_start) * 1000.0
+                provider_response_model = (
+                    llm_response.model.strip()
+                    if isinstance(getattr(llm_response, "model", None), str)
+                    and llm_response.model.strip()
+                    else None
+                )
+                if provider_response_model:
+                    attempt_meta["effective_model"] = provider_response_model
+                    attempt_meta["model_identity_source"] = "provider_response"
                 response_transport = getattr(
                     llm_response,
                     "transport_metadata",
@@ -17245,14 +17270,14 @@ class InternalMCPChatOrchestrator:
                         failure_kind=validation_failure_kind,
                     )
                     failure_extra["validation"] = dict(response_validation_failure)
-                    resolved_model_name = (
-                        llm_response.model
-                        if isinstance(getattr(llm_response, "model", None), str)
-                        else model_name
-                    )
                     record_llm_call(
                         call_type="llm.generate_with_tools",
-                        model_name=resolved_model_name,
+                        model_name=model_name,
+                        requested_model_name=default_model,
+                        effective_model_name=provider_response_model,
+                        model_identity_source=(
+                            "provider_response" if provider_response_model else None
+                        ),
                         duration_ms=duration_ms,
                         usage=(
                             llm_response.usage
@@ -17279,7 +17304,7 @@ class InternalMCPChatOrchestrator:
                             prompt=prompt,
                             context=context,
                             response=response_text,
-                            model_name=resolved_model_name,
+                            model_name=provider_response_model or model_name,
                             provider=provider,
                             prepared_at_utc=request_prepared_at_utc,
                             sent_at_utc=request_sent_at_utc,
@@ -17368,10 +17393,11 @@ class InternalMCPChatOrchestrator:
                     )
                 record_llm_call(
                     call_type="llm.generate_with_tools",
-                    model_name=(
-                        llm_response.model
-                        if isinstance(getattr(llm_response, "model", None), str)
-                        else model_name
+                    model_name=model_name,
+                    requested_model_name=default_model,
+                    effective_model_name=provider_response_model,
+                    model_identity_source=(
+                        "provider_response" if provider_response_model else None
                     ),
                     duration_ms=duration_ms,
                     usage=(
@@ -17480,7 +17506,11 @@ class InternalMCPChatOrchestrator:
                         "skipped_candidates": list(skipped_candidates),
                         "skipped_candidate_count": len(skipped_candidates),
                         "requested_model": default_model,
-                        "effective_model": model_name,
+                        "selected_model": model_name,
+                        "effective_model": provider_response_model,
+                        "model_identity_source": (
+                            "provider_response" if provider_response_model else None
+                        ),
                         "model_source": candidate.source,
                         **_stage_extra,
                         **selection_metadata,
@@ -17535,6 +17565,7 @@ class InternalMCPChatOrchestrator:
                 record_llm_call(
                     call_type="llm.generate_with_tools",
                     model_name=model_name,
+                    requested_model_name=default_model,
                     duration_ms=duration_ms,
                     usage=None,
                     note="structured tool transport failed; compatible fallback candidates only",
@@ -17654,6 +17685,7 @@ class InternalMCPChatOrchestrator:
                 record_llm_call(
                     call_type="llm.generate_with_tools",
                     model_name=model_name,
+                    requested_model_name=default_model,
                     duration_ms=duration_ms,
                     usage=None,
                     note="llm.generate_with_tools failed; trying fallback",

--- a/src/backend/languagemodels/llm_interface.py
+++ b/src/backend/languagemodels/llm_interface.py
@@ -25,7 +25,11 @@ import openai
 import requests
 
 from ..services.llm_api_key_resolution import get_gemini_api_key
-from ..services.settings_service import get_openai_env_var, resolve_llm_setting
+from ..services.settings_service import (
+    get_openai_env_var,
+    resolve_enabled_llm_settings,
+    resolve_llm_setting,
+)
 from ..services.model_parameter_service import (
     openai_responses_kwargs_from_model_parameters,
 )
@@ -712,6 +716,124 @@ def _resolve_effective_llm_actor_scope(
     return resolved_user, resolved_org
 
 
+class ModelExecutionEligibilityError(PermissionError):
+    """Raised before an external model call that lacks scoped eligibility."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        provider: str,
+        model: str,
+        failure_kind: str = "model_not_enabled",
+    ) -> None:
+        super().__init__(message)
+        self.provider = provider
+        self.model = model
+        self.failure_kind = failure_kind
+
+
+def _normalise_model_execution_key(
+    provider: Any,
+    model: Any,
+) -> tuple[str, str]:
+    provider_key = str(provider or "").strip().lower()
+    model_key = str(model or "").strip()
+    provider_prefix = f"{provider_key}:"
+    if provider_key and model_key.lower().startswith(provider_prefix):
+        model_key = model_key.split(":", 1)[1].strip()
+    if provider_key == "openai":
+        model_key = resolve_openai_model_name(model_key) or model_key
+    return provider_key, model_key
+
+
+def assert_model_execution_allowed(
+    *,
+    provider: Any,
+    model: Any,
+    user_concept_id: Optional[str] = None,
+    org_concept_id: Optional[str] = None,
+) -> Mapping[str, Any]:
+    """Require an exact scoped allow-list match for external model execution.
+
+    The existing actor-scoped ``enabled_llms`` setting is the sole authority.
+    Local Ollama calls do not consume this external-model authority. Every
+    other provider must be selected explicitly, including providers added in
+    future, so extending the client factory cannot silently bypass the gate.
+    """
+
+    provider_key, model_key = _normalise_model_execution_key(provider, model)
+    if provider_key == "ollama":
+        return {
+            "allowed": True,
+            "provider": provider_key,
+            "model": model_key,
+            "scope": "local_provider",
+        }
+
+    provider_label = {
+        "openai": "OpenAI",
+        "gemini": "Gemini",
+    }.get(provider_key, provider_key or "External")
+    if not model_key:
+        raise ModelExecutionEligibilityError(
+            f"No concrete {provider_label} model was selected, so the external "
+            "model request was not sent.",
+            provider=provider_key,
+            model=model_key,
+        )
+
+    resolved_user, resolved_org = _resolve_effective_llm_actor_scope(
+        user_concept_id,
+        org_concept_id,
+    )
+    if not resolved_user and not resolved_org:
+        raise ModelExecutionEligibilityError(
+            f"{provider_label} model '{model_key}' cannot be used because no "
+            "authenticated user or organisation model scope is active.",
+            provider=provider_key,
+            model=model_key,
+            failure_kind="model_scope_required",
+        )
+
+    try:
+        enabled_entries = resolve_enabled_llm_settings(
+            user_concept_id=resolved_user,
+            org_concept_id=resolved_org,
+        )
+    except Exception as exc:
+        raise ModelExecutionEligibilityError(
+            f"{provider_label} model '{model_key}' cannot be used because its "
+            "scoped model eligibility could not be verified.",
+            provider=provider_key,
+            model=model_key,
+            failure_kind="model_eligibility_unavailable",
+        ) from exc
+
+    for entry in enabled_entries:
+        if not isinstance(entry, Mapping):
+            continue
+        entry_provider, entry_model = _normalise_model_execution_key(
+            entry.get("provider"),
+            entry.get("model"),
+        )
+        if entry_provider == provider_key and entry_model == model_key:
+            return {
+                "allowed": True,
+                "provider": provider_key,
+                "model": model_key,
+                "scope": entry.get("scope"),
+            }
+
+    raise ModelExecutionEligibilityError(
+        f"{provider_label} model '{model_key}' is not enabled for the current "
+        "user or organisation. Add that exact provider and model to the scoped "
+        "model pool in Settings before using it.",
+        provider=provider_key,
+        model=model_key,
+    )
+
+
 def initialize_clients(force: bool = False):
     """
     Initialize LLM clients based on settings.
@@ -857,6 +979,10 @@ class LLMInterface(ABC):
 
         # Default implementation delegates to structured_tool_calling module
         config = self._get_structured_client_config(model)
+        assert_model_execution_allowed(
+            provider=config.provider,
+            model=config.model,
+        )
         client = get_structured_client(config)
         structured_options = dict(provider_options)
         if llm_params:
@@ -1870,6 +1996,10 @@ class OpenAIClient(LLMInterface):
         target_model = (
             resolve_openai_model_name(model or self.DEFAULT_MODEL) or self.DEFAULT_MODEL
         )
+        assert_model_execution_allowed(
+            provider="openai",
+            model=target_model,
+        )
 
         logger.info(f"Generating response using OpenAI model: {target_model}")
         if _should_log_llm_io():
@@ -2182,6 +2312,10 @@ class GeminiClient(LLMInterface):
         """Generate a response using the Gemini API. Raises RuntimeError on failure."""
         assert genai is not None
         target_model_name = model or self.default_model
+        assert_model_execution_allowed(
+            provider="gemini",
+            model=target_model_name,
+        )
         logger.info(f"Generating response using Gemini model: {target_model_name}")
         if _should_log_llm_io():
             logger.debug(

--- a/src/backend/languagemodels/structured_tool_calling/providers/openai_client.py
+++ b/src/backend/languagemodels/structured_tool_calling/providers/openai_client.py
@@ -1358,6 +1358,9 @@ class OpenAIClient(LLMClient):
                         }
                     )
         transport_metadata = decision.to_telemetry()
+        service_tier = _value(response, "service_tier")
+        if isinstance(service_tier, str) and service_tier.strip():
+            transport_metadata["effective_service_tier"] = service_tier.strip().lower()
         accepted_tool_call_ids = [call.call_id for call in tool_calls]
         provider_tool_call_ids = [
             str(item.get("id"))
@@ -1504,6 +1507,9 @@ class OpenAIClient(LLMClient):
         raw_response_id = _value(response, "id")
         accepted_tool_call_ids = [call.call_id for call in tool_calls]
         transport_metadata = decision.to_telemetry()
+        service_tier = _value(response, "service_tier")
+        if isinstance(service_tier, str) and service_tier.strip():
+            transport_metadata["effective_service_tier"] = service_tier.strip().lower()
         transport_metadata["response_id"] = sanitise_transport_telemetry_value(
             raw_response_id,
             key="provider_response_id",
@@ -1729,14 +1735,23 @@ class OpenAIClient(LLMClient):
         if responses:
             prompt = _value(usage, "input_tokens")
             completion = _value(usage, "output_tokens")
+            input_details = _value(usage, "input_tokens_details")
         else:
             prompt = _value(usage, "prompt_tokens")
             completion = _value(usage, "completion_tokens")
-        return {
+            input_details = _value(usage, "prompt_tokens_details")
+        usage_payload = {
             "prompt_tokens": prompt,
             "completion_tokens": completion,
             "total_tokens": _value(usage, "total_tokens"),
         }
+        cached_input_tokens = _value(input_details, "cached_tokens")
+        if cached_input_tokens is not None:
+            usage_payload["cached_input_tokens"] = cached_input_tokens
+        cache_write_input_tokens = _value(input_details, "cache_write_tokens")
+        if cache_write_input_tokens is not None:
+            usage_payload["cache_write_input_tokens"] = cache_write_input_tokens
+        return usage_payload
 
     @staticmethod
     def _attach_parameter_telemetry(

--- a/src/backend/server/routes/generate_route_support.py
+++ b/src/backend/server/routes/generate_route_support.py
@@ -5,6 +5,7 @@ import time
 from contextlib import AbstractContextManager, nullcontext
 from typing import Any, Callable, Mapping, Sequence, cast
 
+from src.backend.languagemodels.llm_interface import ModelExecutionEligibilityError
 from src.backend.services.debug_payload_store import (
     compact_debug_payload_for_storage,
     default_tool_message_threshold_bytes,
@@ -233,11 +234,33 @@ def _invoke_presenter_screen_backfill_prompt(
     emit_stage_progress(
         {"status": "llm_call_start", "stage": "screen_backfill", "model": model_name}
     )
-    synthesis_response = llm_client.generate(
-        prompt=represented_screen_prompt,
-        context=screen_context_messages,
-        model=model_name,
-    )
+    try:
+        synthesis_response = llm_client.generate(
+            prompt=represented_screen_prompt,
+            context=screen_context_messages,
+            model=model_name,
+        )
+    except Exception as exc:
+        screen_duration_ms = (time.perf_counter() - llm_start) * 1000.0
+        eligibility_denied = isinstance(exc, ModelExecutionEligibilityError)
+        record_stage_llm_call(
+            call_type="llm.generate",
+            model_name=model_name,
+            duration_ms=screen_duration_ms,
+            usage=None,
+            note="Screen backfill represented prompt invocation.",
+            stage="screen_backfill",
+            workflow_stage_id=SCREEN_BACKFILL_STAGE_CONCEPT_ID,
+            provider=(
+                exc.provider if eligibility_denied else infer_provider(model_name)
+            ),
+            status="failed",
+            success=False,
+            error_class=type(exc).__name__,
+            failure_kind=(exc.failure_kind if eligibility_denied else None),
+            provider_request_sent=False if eligibility_denied else None,
+        )
+        raise
     screen_duration_ms = (time.perf_counter() - llm_start) * 1000.0
     emit_stage_progress(
         {
@@ -246,16 +269,6 @@ def _invoke_presenter_screen_backfill_prompt(
             "model": model_name,
             "chunks": 1,
             "duration_ms": int(screen_duration_ms),
-        }
-    )
-    emit_stage_progress(
-        {
-            "status": "llm_call_end",
-            "stage": "screen_backfill",
-            "model": model_name,
-            "duration_ms": int(screen_duration_ms),
-            "success": True,
-            "error": None,
         }
     )
     prompt_ids = _normalise_prompt_concept_ids(
@@ -283,6 +296,9 @@ def _invoke_presenter_screen_backfill_prompt(
             "char_count": len(str(synthesis_response)),
             "is_truncated": False,
         },
+        status="completed",
+        success=True,
+        provider_request_sent=True,
     )
     return synthesis_response, model_name
 
@@ -496,6 +512,7 @@ def _build_generate_error_debug_info(
     error_workflow_discovery: Mapping[str, Any] | None,
     error_workflow_routing: Mapping[str, Any] | None,
     auxiliary_llm_calls: Sequence[Mapping[str, Any]] | None,
+    llm_interaction: Mapping[str, Any] | None,
     error_elapsed_ms: float | None,
     session_id: str | None,
     namespace: str | None,
@@ -545,6 +562,9 @@ def _build_generate_error_debug_info(
         if auxiliary_llm_calls is not None
         else None
     )
+    normalised_llm_interaction = (
+        dict(llm_interaction) if isinstance(llm_interaction, Mapping) else None
+    )
 
     error_debug_info = {
         "interaction_timestamp_utc": interaction_timestamp_utc,
@@ -561,6 +581,7 @@ def _build_generate_error_debug_info(
         "user_prompt": user_prompt_debug,
         "tool_invocations": [],
         "response_transformations": normalised_response_transformations,
+        "llm_interaction": normalised_llm_interaction,
         "turn_execution_diagnostics": build_turn_execution_diagnostics_fn(
             request_id=request_id,
             prompt_text=prompt_text,

--- a/src/backend/server/routes/settings_routes.py
+++ b/src/backend/server/routes/settings_routes.py
@@ -89,12 +89,18 @@ from ...services.model_parameter_service import (
     normalise_model_parameters_for_storage,
     openai_responses_kwargs_from_model_parameters,
 )
+from ...services.llm_model_cost_history_service import (
+    get_actor_historical_model_cost_summary,
+)
+from ...services.model_registry_service import get_model_registry_snapshot
 from ...services.rag_service import peek_rag_service
 from ...integrations.google.gmail_service import list_profile_ids_from_env
 from ...services.concept_service import list_concepts, get_concept_by_id
 from ...services.concept_service import ConceptNotFoundError
 from ...languagemodels.llm_interface import (
+    ModelExecutionEligibilityError,
     OpenAIClient,
+    assert_model_execution_allowed,
     get_ollama_auto_pull_state_snapshot,
     resolve_openai_responses_max_output_tokens,
 )
@@ -856,6 +862,57 @@ def get_llm_info():
     except Exception as e:
         current_app.logger.error(f"Error retrieving LLM info: {e}", exc_info=True)
         return jsonify({"error": "Failed to retrieve LLM info."}), 500
+
+
+@settings_bp.route("/llm/cost_summary", methods=["GET"])
+def get_llm_cost_summary():
+    """Return a bounded persisted cost summary for the current actor/model."""
+
+    user_id = get_effective_user_concept_id()
+    effective = get_effective_context(
+        request.headers.get("X-Von-Window-Session"),
+        dict(session),
+        user_id,
+    )
+    namespace = str(effective.get("namespace") or "").strip()
+    provider = str(request.args.get("provider") or "").strip().lower()
+    model = str(request.args.get("model") or "").strip()
+    if not user_id or not namespace:
+        return _jsonify_no_store(
+            {"error": "An authenticated actor and namespace are required."}, 401
+        )
+    if not provider or not model:
+        return _jsonify_no_store(
+            {"error": "provider and model are required."}, 400
+        )
+    try:
+        limit = int(request.args.get("limit") or 200)
+        window_days = int(request.args.get("window_days") or 30)
+    except (TypeError, ValueError):
+        return _jsonify_no_store(
+            {"error": "limit and window_days must be integers."}, 400
+        )
+    try:
+        model_registry = get_model_registry_snapshot()
+    except Exception:
+        model_registry = None
+    try:
+        payload = get_actor_historical_model_cost_summary(
+            user_id=user_id,
+            namespace=namespace,
+            provider=provider,
+            model=model,
+            model_registry=model_registry,
+            limit=limit,
+            window_days=window_days,
+        )
+    except Exception:
+        current_app.logger.exception("Could not read persisted LLM cost history")
+        return _jsonify_no_store(
+            {"error": "Persisted LLM cost history is currently unavailable."},
+            503,
+        )
+    return _jsonify_no_store(payload, 200)
 
 
 def _get_entity_with_fallback(
@@ -3428,6 +3485,22 @@ def test_openai_model():
         from ...languagemodels.llm_interface import resolve_openai_model_name
 
         resolved_model = resolve_openai_model_name(requested_model) or requested_model
+        try:
+            assert_model_execution_allowed(
+                provider="openai",
+                model=resolved_model,
+            )
+        except ModelExecutionEligibilityError as exc:
+            return _jsonify_no_store(
+                {
+                    "success": False,
+                    "usable": False,
+                    "model": exc.model or resolved_model,
+                    "failure_kind": exc.failure_kind,
+                    "reason": str(exc),
+                },
+                403,
+            )
         model_parameters = normalise_model_parameters_for_storage(
             payload.get(MODEL_PARAMETERS_KEY) or payload.get("modelParameters"),
             provider="openai",

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -38,6 +38,7 @@ from ...workflows.durable.turn_execution_runtime_support import (
     coerce_user_visible_response_text,
 )
 from ...languagemodels.llm_interface import (
+    ModelExecutionEligibilityError,
     _extract_ollama_model_id,
     _extract_openai_model_id,
     _looks_like_browser_object_model_reference,
@@ -80,6 +81,11 @@ from ...services.model_parameter_service import (
     MODEL_PARAMETERS_KEY,
     normalise_model_parameters_for_storage,
 )
+from ...services.llm_usage_cost_service import (
+    LLM_USAGE_COST_SUMMARY_SCHEMA_VERSION,
+    build_llm_usage_cost_summary,
+)
+from ...services.model_registry_service import get_model_registry_snapshot
 from ...services.feature_flags import (
     get_display_elements_screen_fence_compat_enabled,
 )
@@ -7384,6 +7390,23 @@ def _finalise_llm_debug_info(
             else []
         )
     )
+    supplied_llm_usage_cost_summary = llm_debug_info.get("llm_usage_cost_summary")
+    if (
+        isinstance(supplied_llm_usage_cost_summary, Mapping)
+        and supplied_llm_usage_cost_summary.get("schema_version")
+        == LLM_USAGE_COST_SUMMARY_SCHEMA_VERSION
+    ):
+        llm_usage_cost_summary = dict(supplied_llm_usage_cost_summary)
+    else:
+        try:
+            model_registry = get_model_registry_snapshot()
+        except Exception:
+            model_registry = None
+        llm_usage_cost_summary = build_llm_usage_cost_summary(
+            llm_calls_payload,
+            model_registry=model_registry,
+        )
+    llm_debug_info["llm_usage_cost_summary"] = llm_usage_cost_summary
     evidence_index: list[dict[str, Any]] = []
     for entry in reversed(aux_llm_calls_payload):
         if not isinstance(entry, Mapping):
@@ -7430,6 +7453,7 @@ def _finalise_llm_debug_info(
             ),
         },
         "llm_calls": [dict(item) for item in llm_calls_payload if isinstance(item, Mapping)],
+        "llm_usage_cost_summary": llm_usage_cost_summary,
         "tool_invocations": [
             dict(item)
             for item in turn_record_tool_invocations_payload
@@ -11220,6 +11244,11 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             )
 
         # ---------------------------------------------------------
+        try:
+            turn_model_registry_snapshot = get_model_registry_snapshot()
+        except Exception:
+            turn_model_registry_snapshot = None
+
         llm_interaction: dict = {
             "requested_model": model_name,
             "requested_model_parameters": requested_model_parameters or None,
@@ -11229,6 +11258,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             "usage": None,
             "calls": [],
         }
+        stage_llm_call_sequence = 0
         render_plan_debug: dict[str, Any] | None = None
 
         def _infer_provider(model_id: str | None) -> str | None:
@@ -11270,14 +11300,50 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             error: str | None = None,
             error_class: str | None = None,
             failure_kind: str | None = None,
+            provider_request_sent: bool | None = None,
+            requested_model_name: str | None = None,
+            effective_model_name: str | None = None,
+            model_identity_source: str | None = None,
         ) -> None:
+            nonlocal stage_llm_call_sequence
+            stage_llm_call_sequence += 1
+            call_id = f"{request_id}:support-llm:{stage_llm_call_sequence}"
+            resolved_provider = provider or _infer_provider(model_name)
+            call_succeeded = (
+                success
+                if isinstance(success, bool)
+                else not any(
+                    isinstance(value, str) and value.strip()
+                    for value in (error, error_class, failure_kind)
+                )
+            )
+            resolved_status = (
+                status.strip()
+                if isinstance(status, str) and status.strip()
+                else ("completed" if call_succeeded else "failed")
+            )
+            resolved_request_sent = (
+                provider_request_sent
+                if isinstance(provider_request_sent, bool)
+                else (True if call_succeeded else None)
+            )
             payload = {
+                "call_id": call_id,
                 "type": call_type,
                 "model": model_name,
-                "provider": provider or _infer_provider(model_name),
+                "provider": resolved_provider,
+                "requested_model": requested_model_name or model_name,
+                "selected_model": model_name,
+                "effective_model": effective_model_name,
+                "model_identity_source": (
+                    model_identity_source if effective_model_name else None
+                ),
+                "provider_request_sent": resolved_request_sent,
                 "duration_ms": duration_ms,
                 "usage": usage,
                 "workflow": "von_generate",
+                "status": resolved_status,
+                "success": call_succeeded,
             }
             if stage:
                 payload["stage"] = stage
@@ -11293,10 +11359,6 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                 payload["prompt"] = prompt
             if response is not None:
                 payload["response"] = response
-            if isinstance(status, str) and status.strip():
-                payload["status"] = status.strip()
-            if isinstance(success, bool):
-                payload["success"] = success
             if isinstance(error, str) and error.strip():
                 payload["error"] = error.strip()
             if isinstance(error_class, str) and error_class.strip():
@@ -11305,6 +11367,23 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                 payload["failure_kind"] = failure_kind.strip()
             _stamp_llm_call_timestamps(payload, duration_ms=duration_ms)
             llm_interaction["calls"].append(payload)
+            llm_usage_cost_summary = build_llm_usage_cost_summary(
+                llm_interaction["calls"],
+                model_registry=turn_model_registry_snapshot,
+            )
+            _emit_stage_progress(
+                {
+                    "status": "llm_call_end",
+                    "event_kind": "llm_call_end",
+                    "stage": stage or "support",
+                    "call_id": call_id,
+                    "model": model_name,
+                    "provider": resolved_provider,
+                    "success": call_succeeded,
+                    "duration_ms": duration_ms,
+                    "llm_usage_cost_summary": llm_usage_cost_summary,
+                }
+            )
 
         def _emit_stage_progress(info: Mapping[str, Any] | None) -> None:
             if not show_tool_use_progress:
@@ -11360,6 +11439,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             conversation_situation=conversation_situation_text,
             conversation_observations=conversation_observations,
             conversation_observation_state=conversation_observation_state,
+            model_registry_snapshot=turn_model_registry_snapshot,
         )
         llm_interaction["duration_ms"] = (
             time.perf_counter() - adaptive_turn_started
@@ -12026,6 +12106,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
         spoken_backfill_model_id = None
         spoken_backfill_error_class = None
         spoken_backfill_applied = False
+        narration_llm_started: float | None = None
 
         # If presenter mode was requested but the model didn't produce a usable
         # <spoken> channel, generate it in a second pass for reliability.
@@ -12150,6 +12231,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                     f"{screen_text}\n"
                 )
 
+                narration_llm_started = time.perf_counter()
                 narration_response = _llm_generate_spoken_backfill(
                     llm_client,
                     narration_system,
@@ -12157,6 +12239,21 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                     model_name,
                     requested_model_parameters or None,
                 )
+                _record_stage_llm_call(
+                    call_type="llm.generate",
+                    model_name=model_name,
+                    duration_ms=(
+                        time.perf_counter() - narration_llm_started
+                    )
+                    * 1000.0,
+                    usage=None,
+                    note="Presenter narration synthesis.",
+                    stage="narration",
+                    status="completed",
+                    success=True,
+                    provider_request_sent=True,
+                )
+                narration_llm_started = None
                 spoken_backfill_source = "llm_synthesis"
                 spoken_backfill_model_id = model_name
 
@@ -12210,6 +12307,31 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             except Exception as exc:
                 # Defensive: never fail the request just because narration generation failed.
                 spoken_backfill_error_class = type(exc).__name__
+                if narration_llm_started is not None:
+                    eligibility_denied = isinstance(
+                        exc, ModelExecutionEligibilityError
+                    )
+                    _record_stage_llm_call(
+                        call_type="llm.generate",
+                        model_name=model_name,
+                        duration_ms=(
+                            time.perf_counter() - narration_llm_started
+                        )
+                        * 1000.0,
+                        usage=None,
+                        note="Presenter narration synthesis.",
+                        stage="narration",
+                        provider=(exc.provider if eligibility_denied else None),
+                        status="failed",
+                        success=False,
+                        error_class=spoken_backfill_error_class,
+                        failure_kind=(
+                            exc.failure_kind if eligibility_denied else None
+                        ),
+                        provider_request_sent=(
+                            False if eligibility_denied else None
+                        ),
+                    )
                 presenter_channels = presenter_channels
 
         spoken_backfill_latency_ms = (
@@ -12525,6 +12647,32 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                         )
                     except Exception as exc:
                         buttonify_error_class = type(exc).__name__
+                        eligibility_denied = isinstance(
+                            exc, ModelExecutionEligibilityError
+                        )
+                        _record_stage_llm_call(
+                            call_type="llm.generate",
+                            model_name=buttonify_model_used,
+                            duration_ms=(time.perf_counter() - llm_start) * 1000.0,
+                            usage=None,
+                            note=(
+                                "Buttonify quick-reply extraction "
+                                "(workflow unavailable)."
+                            ),
+                            stage="buttonify",
+                            provider=(
+                                exc.provider if eligibility_denied else None
+                            ),
+                            status="failed",
+                            success=False,
+                            error_class=buttonify_error_class,
+                            failure_kind=(
+                                exc.failure_kind if eligibility_denied else None
+                            ),
+                            provider_request_sent=(
+                                False if eligibility_denied else None
+                            ),
+                        )
                         if _contains_openai_quota_error(exc):
                             buttonify_suppression_reason = "quota_exhausted"
                         buttonify_response = None
@@ -12765,6 +12913,10 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             _serialise_tool_invocations_for_turn_execution_record(tool_invocations)
         )
         search_evidence = build_search_tool_evidence(tool_invocations)
+        turn_llm_usage_cost_summary = build_llm_usage_cost_summary(
+            llm_interaction["calls"],
+            model_registry=turn_model_registry_snapshot,
+        )
 
         llm_debug_info = {
             "interaction_timestamp_utc": interaction_timestamp_utc,
@@ -12821,6 +12973,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             "response_transformations": response_transformations,
             "display_elements": display_elements_contract,
             "turn_execution_diagnostics": turn_execution_diagnostics,
+            "llm_usage_cost_summary": turn_llm_usage_cost_summary,
         }
         llm_debug_info["turn_output_health"] = build_turn_output_health(llm_debug_info)
         if isinstance(render_plan_debug, dict):
@@ -13103,6 +13256,12 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                 auxiliary_llm_calls
                 if "auxiliary_llm_calls" in locals()
                 and isinstance(auxiliary_llm_calls, list)
+                else None
+            ),
+            llm_interaction=(
+                llm_interaction
+                if "llm_interaction" in locals()
+                and isinstance(llm_interaction, Mapping)
                 else None
             ),
             error_elapsed_ms=error_elapsed_ms,

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -30,6 +30,7 @@ from src.backend.integrations.internal_mcp.schemas import (
 from src.backend.integrations.internal_mcp.tool_argument_resolution import (
     is_unresolved_tool_argument_placeholder,
 )
+from src.backend.languagemodels.llm_interface import ModelExecutionEligibilityError
 from src.backend.languagemodels.structured_tool_calling.types import (
     LLMContinuation,
     LLMResponse,
@@ -41,6 +42,9 @@ from src.backend.languagemodels.structured_tool_calling.types import (
     ToolResult,
 )
 from src.backend.security.access_control import override_current_actor
+from src.backend.services.llm_usage_cost_service import (
+    build_llm_usage_cost_summary,
+)
 from src.backend.services.thinking_semantic_projection_service import (
     build_semantic_operation_projection,
 )
@@ -3145,6 +3149,7 @@ def execute_adaptive_turn(
     conversation_situation: str | None = None,
     conversation_observations: Sequence[Mapping[str, Any]] | None = None,
     conversation_observation_state: Mapping[str, Any] | None = None,
+    model_registry_snapshot: Any = None,
     turn_budget_seconds: float | None = None,
     final_synthesis_reserve_seconds: float | None = None,
     final_answer_reserve_seconds: float | None = None,
@@ -3267,6 +3272,53 @@ def execute_adaptive_turn(
         }
     ]
     usage_totals: dict[str, float] = {}
+    model_call_sequence = 0
+    client_config = getattr(llm_client, "config", None)
+    configured_provider = str(getattr(client_config, "provider", "") or "").strip()
+    if not configured_provider:
+        client_name = type(llm_client).__name__.lower()
+        configured_provider = next(
+            (
+                provider_name
+                for provider_name in ("openai", "gemini", "ollama")
+                if provider_name in client_name
+            ),
+            "",
+        )
+
+    def current_llm_usage_cost_summary() -> dict[str, Any]:
+        return build_llm_usage_cost_summary(
+            llm_calls,
+            model_registry=model_registry_snapshot,
+        )
+
+    def emit_model_call_end(call: Mapping[str, Any]) -> None:
+        _emit(
+            progress_tracker,
+            {
+                "status": "llm_call_end",
+                "event_kind": "llm_call_end",
+                "stage": call.get("stage") or "adaptive_research",
+                "phase": call.get("stage") or "adaptive_research",
+                "call_id": call.get("call_id"),
+                "model": call.get("selected_model") or call.get("model"),
+                "provider": call.get("provider"),
+                "requested_model": call.get("requested_model"),
+                "selected_model": call.get("selected_model"),
+                "effective_model": call.get("effective_model"),
+                "model_identity_source": call.get("model_identity_source"),
+                "provider_request_sent": call.get("provider_request_sent"),
+                "usage": call.get("usage"),
+                "success": call.get("success"),
+                "duration_ms": call.get("duration_ms"),
+                "llm_usage_cost_summary": current_llm_usage_cost_summary(),
+                "result_summary": (
+                    "The model call completed; usage and cost evidence were updated."
+                    if call.get("success") is True
+                    else "The model call ended without a successful response."
+                ),
+            },
+        )
     seen_request_digests: set[str] = set()
     model_liveness_recovery_used = False
     last_partial_text = ""
@@ -4032,6 +4084,8 @@ def execute_adaptive_turn(
         )
 
     while True:
+        model_call_sequence += 1
+        model_call_id = f"{turn_id or 'adaptive-turn'}:llm:{model_call_sequence}"
         _check_cancellation(progress_tracker)
         now = clock()
         note_crossed_elapsed_time_advisories(now)
@@ -4045,10 +4099,18 @@ def execute_adaptive_turn(
         _emit(
             progress_tracker,
             {
-                "status": "thinking",
+                "status": "llm_call_start",
+                "event_kind": "llm_call_start",
                 "stage": stage,
                 "phase": stage,
                 "mode": mode,
+                "call_id": model_call_id,
+                "model": model,
+                "provider": configured_provider or None,
+                "requested_model": model,
+                "selected_model": model,
+                "effective_model": None,
+                "model_identity_source": None,
                 "phase_label": (
                     "Generating response" if final_synthesis else "Researching"
                 ),
@@ -4191,12 +4253,22 @@ def execute_adaptive_turn(
         # classes. Keep those failures inside the honest turn result.
         except Exception as exc:  # noqa: BLE001
             call_failed_at = clock()
+            provider_request_sent = (
+                False if isinstance(exc, ModelExecutionEligibilityError) else None
+            )
             llm_calls.append(
                 {
+                    "call_id": model_call_id,
                     "type": "adaptive_turn_model_call",
                     "stage": stage,
                     "mode": mode,
                     "model": model,
+                    "provider": configured_provider or None,
+                    "requested_model": model,
+                    "selected_model": model,
+                    "effective_model": None,
+                    "model_identity_source": None,
+                    "provider_request_sent": provider_request_sent,
                     "request_timeout_seconds": effective_params[
                         "request_timeout_seconds"
                     ],
@@ -4210,6 +4282,10 @@ def execute_adaptive_turn(
                     "error_class": type(exc).__name__,
                 }
             )
+            emit_model_call_end(llm_calls[-1])
+            if isinstance(exc, ModelExecutionEligibilityError):
+                terminal_status = exc.failure_kind
+                return finish(str(exc), status=terminal_status)
             if final_synthesis and not answer_only:
                 enter_answer_only("evidence_call_failed")
                 continue
@@ -4293,12 +4369,26 @@ def execute_adaptive_turn(
             (response_received_at - request_started) * 1000.0,
         )
         _usage_add(usage_totals, response.usage)
+        provider_response_model = (
+            response.model.strip()
+            if isinstance(response.model, str) and response.model.strip()
+            else None
+        )
         llm_calls.append(
             {
+                "call_id": model_call_id,
                 "type": "adaptive_turn_model_call",
                 "stage": stage,
                 "mode": mode,
-                "model": response.model or model,
+                "model": provider_response_model or model,
+                "provider": configured_provider or None,
+                "requested_model": model,
+                "selected_model": model,
+                "effective_model": provider_response_model,
+                "model_identity_source": (
+                    "provider_response" if provider_response_model else None
+                ),
+                "provider_request_sent": True,
                 "request_timeout_seconds": effective_params["request_timeout_seconds"],
                 "duration_ms": call_duration_ms,
                 "usage": dict(response.usage) if response.usage else None,
@@ -4309,6 +4399,7 @@ def execute_adaptive_turn(
                 "tool_call_count": len(response.tool_calls),
             }
         )
+        emit_model_call_end(llm_calls[-1])
         if response.text_response.strip():
             last_partial_text = response.text_response.strip()
             last_partial_effect_generation = request_effect_generation

--- a/src/backend/services/file_copy_interpretation_service.py
+++ b/src/backend/services/file_copy_interpretation_service.py
@@ -990,6 +990,32 @@ def _resolve_active_provider_and_model(
     return provider, model
 
 
+def _external_image_model_execution_denial(
+    *,
+    provider: str,
+    model: str,
+) -> dict[str, Any] | None:
+    """Return the image-service error shape when scoped eligibility is absent."""
+
+    from ..languagemodels.llm_interface import (
+        ModelExecutionEligibilityError,
+        assert_model_execution_allowed,
+    )
+
+    try:
+        assert_model_execution_allowed(provider=provider, model=model)
+    except ModelExecutionEligibilityError as exc:
+        return {
+            "description": None,
+            "method": f"{provider}_vision_not_enabled",
+            "error": str(exc),
+            "failure_kind": exc.failure_kind,
+            "provider": provider,
+            "model": exc.model or model,
+        }
+    return None
+
+
 def _describe_image_with_openai(
     *,
     data_bytes: bytes,
@@ -1030,6 +1056,12 @@ def _describe_image_with_openai(
         }
 
     target_model = model or DEFAULT_OPENAI_MODEL
+    eligibility_denial = _external_image_model_execution_denial(
+        provider="openai",
+        model=target_model,
+    )
+    if eligibility_denial is not None:
+        return eligibility_denial
     mime = _normalise_optional_text(content_type) or "image/png"
     image_b64 = base64.b64encode(bytes(data_bytes)).decode("ascii")
     data_url = f"data:{mime};base64,{image_b64}"
@@ -1109,6 +1141,12 @@ def _describe_image_with_gemini(
         }
 
     target_model = model or "gemini-2.0-flash"
+    eligibility_denial = _external_image_model_execution_denial(
+        provider="gemini",
+        model=target_model,
+    )
+    if eligibility_denial is not None:
+        return eligibility_denial
     mime = _normalise_optional_text(content_type) or "image/png"
     try:
         genai.configure(api_key=api_key)  # type: ignore[attr-defined]

--- a/src/backend/services/llm_model_cost_history_service.py
+++ b/src/backend/services/llm_model_cost_history_service.py
@@ -1,0 +1,416 @@
+"""Bounded actor-scoped historical model-cost projection."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from .llm_usage_cost_service import (
+    LLM_USAGE_COST_SUMMARY_SCHEMA_VERSION,
+    build_llm_usage_cost_summary,
+    exact_model_identity_matches,
+)
+from .turn_execution_record_service import get_turn_execution_records_collection
+
+LLM_MODEL_TURN_COST_SUMMARY_SCHEMA_VERSION = "llm_model_turn_cost_summary.v1"
+
+
+def _calls_from_one_canonical_source(record: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    calls = record.get("llm_calls")
+    if isinstance(calls, Sequence) and not isinstance(calls, (str, bytes)):
+        return [call for call in calls if isinstance(call, Mapping)]
+    execution = record.get("execution")
+    calls = execution.get("llm_calls") if isinstance(execution, Mapping) else None
+    if isinstance(calls, Sequence) and not isinstance(calls, (str, bytes)):
+        return [call for call in calls if isinstance(call, Mapping)]
+    return []
+
+
+def _matching_calls(
+    calls: Sequence[Mapping[str, Any]], *, provider: str, model: str
+) -> list[Mapping[str, Any]]:
+    return [
+        call
+        for call in calls
+        if call.get("provider_request_sent") is not False
+        if call.get("model_identity_source") == "provider_response"
+        if exact_model_identity_matches(
+            provider=provider,
+            model=model,
+            candidate_provider=call.get("provider"),
+            candidate_model=call.get("effective_model"),
+        )
+    ]
+
+
+def _calls_from_content_free_summary(
+    record: Mapping[str, Any], *, provider: str, model: str
+) -> tuple[bool, bool, list[Mapping[str, Any]] | None]:
+    """Project safely repriceable calls from a persisted bounded summary.
+
+    Returns whether the record has the current summary schema, whether that
+    summary attributes the turn to the target, and either the complete
+    content-free call groups needed to price that turn or ``None`` when the
+    retained evidence is incomplete.
+    """
+
+    summary = record.get("llm_usage_cost_summary")
+    if not isinstance(summary, Mapping) or (
+        summary.get("schema_version") != LLM_USAGE_COST_SUMMARY_SCHEMA_VERSION
+    ):
+        return False, False, None
+
+    identities_value = summary.get("model_identities")
+    identities = (
+        [row for row in identities_value if isinstance(row, Mapping)]
+        if isinstance(identities_value, Sequence)
+        and not isinstance(identities_value, (str, bytes))
+        else []
+    )
+    billable_identities = [
+        row for row in identities if row.get("provider_request_sent") is not False
+    ]
+    matching_identities = [
+        row
+        for row in billable_identities
+        if row.get("model_identity_source") == "provider_response"
+        if exact_model_identity_matches(
+            provider=provider,
+            model=model,
+            candidate_provider=row.get("provider"),
+            candidate_model=row.get("effective_model"),
+        )
+    ]
+    if not matching_identities:
+        return True, False, None
+
+    groups_value = summary.get("pricing_usage_groups")
+    if isinstance(groups_value, Sequence) and not isinstance(
+        groups_value, (str, bytes)
+    ):
+        omitted_groups = summary.get("pricing_usage_group_omitted_count")
+        if (
+            not isinstance(omitted_groups, int)
+            or isinstance(omitted_groups, bool)
+            or omitted_groups != 0
+        ):
+            return True, True, None
+        valid_groups = [
+            row
+            for row in groups_value
+            if isinstance(row, Mapping)
+            and row.get("provider_request_sent") is not False
+            and row.get("model_identity_source") == "provider_response"
+        ]
+        covered_call_count = summary.get(
+            "pricing_usage_group_covered_call_count"
+        )
+        grouped_call_count = sum(
+            row.get("call_count")
+            for row in valid_groups
+            if isinstance(row.get("call_count"), int)
+            and not isinstance(row.get("call_count"), bool)
+            and row.get("call_count") > 0
+        )
+        if (
+            not isinstance(covered_call_count, int)
+            or isinstance(covered_call_count, bool)
+            or covered_call_count != summary.get("billable_call_count")
+            or grouped_call_count != covered_call_count
+            or len(valid_groups) != len(groups_value)
+        ):
+            return True, True, None
+        matching_groups = [
+            row
+            for row in valid_groups
+            if exact_model_identity_matches(
+                provider=provider,
+                model=model,
+                candidate_provider=row.get("provider"),
+                candidate_model=row.get("effective_model"),
+            )
+        ]
+        if not matching_groups:
+            return True, True, None
+        projected_calls: list[Mapping[str, Any]] = []
+        for group in valid_groups:
+            usage = group.get("usage")
+            if not isinstance(usage, Mapping):
+                return True, True, None
+            projected_calls.append(
+                {
+                    "provider": group.get("provider"),
+                    "effective_model": group.get("effective_model"),
+                    "model_identity_source": "provider_response",
+                    "provider_request_sent": True,
+                    "usage": usage,
+                    "transport": {
+                        "effective_service_tier": group.get(
+                            "effective_service_tier"
+                        ),
+                        "effective_connection_id": group.get("connection_id"),
+                        "pricing_context_input_tokens": group.get(
+                            "pricing_context_input_tokens"
+                        ),
+                    },
+                }
+            )
+        return True, True, projected_calls
+
+    # A pre-group v1 summary can be re-priced only when it represents exactly
+    # one provider-observed call. Aggregating multiple calls loses the
+    # per-request input size required for context-band pricing.
+    omitted_identities = summary.get("model_identity_omitted_count")
+    if (
+        summary.get("unique_call_count") != 1
+        or not isinstance(omitted_identities, int)
+        or isinstance(omitted_identities, bool)
+        or omitted_identities != 0
+        or len(matching_identities) != len(billable_identities)
+    ):
+        return True, True, None
+    usage = summary.get("usage")
+    if not isinstance(usage, Mapping):
+        return True, True, None
+    identity = matching_identities[0]
+    return True, True, [
+        {
+            "provider": provider,
+            "effective_model": model,
+            "model_identity_source": "provider_response",
+            "provider_request_sent": True,
+            "usage": usage,
+            "transport": {
+                "effective_service_tier": identity.get(
+                    "effective_service_tier"
+                ),
+                "effective_connection_id": identity.get("connection_id"),
+                "pricing_context_input_tokens": usage.get("input_tokens"),
+            },
+        }
+    ]
+
+
+def _decimal(value: Any) -> Decimal | None:
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    return result if result.is_finite() and result >= 0 else None
+
+
+def build_historical_model_cost_summary(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    provider: str,
+    model: str,
+    model_registry: Any = None,
+    limit: int = 200,
+    window_days: int = 30,
+) -> dict[str, Any]:
+    attributed = priced = partial = unavailable = 0
+    priced_amounts: list[Decimal] = []
+    currency: str | None = None
+    timestamps: list[str] = []
+    pricing_rows: list[Mapping[str, Any]] = []
+
+    for record in records[:limit]:
+        has_summary, summary_attributed, summary_calls = (
+            _calls_from_content_free_summary(record, provider=provider, model=model)
+        )
+        if has_summary:
+            if not summary_attributed:
+                continue
+            matching = summary_calls
+        else:
+            canonical_calls = _calls_from_one_canonical_source(record)
+            matching = _matching_calls(
+                canonical_calls, provider=provider, model=model
+            )
+            if not matching:
+                continue
+        attributed += 1
+        timestamp = str(record.get("created_at_utc") or "").strip()
+        if timestamp:
+            timestamps.append(timestamp)
+
+        if matching is None:
+            unavailable += 1
+            continue
+
+        # Usage and exact effective identity are durable observations. Rebuild
+        # their estimate under the current one-version pricing basis so calls
+        # recorded before pricing existed are not permanently stranded and a
+        # sample cannot silently mix price versions.
+        turn_summary = build_llm_usage_cost_summary(
+            matching,
+            model_registry=model_registry,
+        )
+        turn_cost = turn_summary.get("estimated_cost")
+        turn_cost = turn_cost if isinstance(turn_cost, Mapping) else {}
+        turn_currency = str(turn_cost.get("currency") or "").strip().upper()
+        turn_amount = _decimal(turn_cost.get("amount"))
+        if (
+            turn_cost.get("status") == "estimated"
+            and turn_currency
+            and turn_amount is not None
+        ):
+            if currency is None:
+                currency = turn_currency
+            if currency == turn_currency:
+                priced += 1
+                priced_amounts.append(turn_amount)
+                if isinstance(turn_cost.get("pricing"), Mapping):
+                    pricing_rows.append(turn_cost["pricing"])
+                continue
+        if (
+            turn_cost.get("status") == "partial"
+            and turn_currency
+            and _decimal(turn_cost.get("known_amount")) is not None
+        ):
+            partial += 1
+        else:
+            unavailable += 1
+
+    average = (
+        sum(priced_amounts, Decimal(0)) / Decimal(len(priced_amounts))
+        if priced_amounts
+        else None
+    )
+    if attributed == 0:
+        status = "insufficient_coverage"
+    elif priced == attributed:
+        status = "available"
+    elif priced or partial:
+        status = "partial"
+    else:
+        status = "unavailable"
+    pricing_identities = {
+        (
+            row.get("source"),
+            row.get("version"),
+            row.get("effective_at_utc"),
+        )
+        for row in pricing_rows
+    }
+    pricing = None
+    if len(pricing_identities) == 1:
+        source, version, effective_at_utc = next(iter(pricing_identities))
+        pricing = {
+            "source": source,
+            "version": version,
+            "effective_at_utc": effective_at_utc,
+        }
+    return {
+        "schema_version": LLM_MODEL_TURN_COST_SUMMARY_SCHEMA_VERSION,
+        "status": status,
+        "model_identity": {"provider": provider.lower(), "model": model},
+        "average_attributed_cost_per_turn": {
+            "amount": (
+                float(average)
+                if status == "available" and average is not None
+                else None
+            ),
+            "currency": currency if status == "available" else None,
+        },
+        "sample_window": {
+            "attributed_turn_count": attributed,
+            "started_at_utc": min(timestamps) if timestamps else None,
+            "ended_at_utc": max(timestamps) if timestamps else None,
+            "limit": limit,
+            "window_days": window_days,
+        },
+        "coverage": {
+            "priced_turn_count": priced,
+            "partial_turn_count": partial,
+            "unavailable_turn_count": unavailable,
+            "attributed_turn_count": attributed,
+        },
+        "pricing": pricing,
+    }
+
+
+def get_actor_historical_model_cost_summary(
+    *,
+    user_id: str,
+    namespace: str,
+    provider: str,
+    model: str,
+    model_registry: Any = None,
+    limit: int = 200,
+    window_days: int = 30,
+) -> dict[str, Any]:
+    safe_limit = max(1, min(int(limit), 500))
+    safe_days = max(1, min(int(window_days), 365))
+    collection = get_turn_execution_records_collection()
+    records: list[Mapping[str, Any]] = []
+    if collection is not None:
+        since = (datetime.now(UTC) - timedelta(days=safe_days)).isoformat()
+        provider_key = provider.strip().lower()
+        model_key = model.strip()
+
+        def _matching_call() -> dict[str, Any]:
+            return {
+                "provider": provider_key,
+                "effective_model": model_key,
+                "model_identity_source": "provider_response",
+                "provider_request_sent": {"$ne": False},
+            }
+
+        current_summary = {
+            "llm_usage_cost_summary.schema_version": (
+                LLM_USAGE_COST_SUMMARY_SCHEMA_VERSION
+            ),
+            "llm_usage_cost_summary.model_identities": {
+                "$elemMatch": {
+                    **_matching_call(),
+                }
+            },
+        }
+        legacy_summary = {
+            "llm_usage_cost_summary.schema_version": {
+                "$ne": LLM_USAGE_COST_SUMMARY_SCHEMA_VERSION
+            }
+        }
+
+        cursor = collection.find(
+            {
+                "user_id": user_id,
+                "namespace": namespace,
+                "created_at_utc": {"$gte": since},
+                "$or": [
+                    current_summary,
+                    {
+                        **legacy_summary,
+                        "llm_calls": {"$elemMatch": _matching_call()},
+                    },
+                    {
+                        **legacy_summary,
+                        "llm_calls": {"$exists": False},
+                        "execution.llm_calls": {"$elemMatch": _matching_call()},
+                    },
+                ],
+            },
+            {
+                "_id": 0,
+                "created_at_utc": 1,
+                "llm_usage_cost_summary": 1,
+                "llm_calls": 1,
+                "execution.llm_calls": 1,
+            },
+        )
+        try:
+            cursor = cursor.sort("created_at_utc", -1).limit(safe_limit)
+        except AttributeError:
+            pass
+        records = [record for record in cursor if isinstance(record, Mapping)]
+    return build_historical_model_cost_summary(
+        records,
+        provider=provider,
+        model=model,
+        model_registry=model_registry,
+        limit=safe_limit,
+        window_days=safe_days,
+    )

--- a/src/backend/services/llm_usage_cost_service.py
+++ b/src/backend/services/llm_usage_cost_service.py
@@ -1,0 +1,809 @@
+"""Pure token-usage normalisation and estimated-cost projection.
+
+The caller supplies already-recorded LLM calls and, optionally, a model
+registry snapshot.  This module performs no I/O.  Missing usage, exact model
+identity, or pricing remains unavailable rather than becoming a misleading
+zero.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from decimal import Decimal, DecimalException, InvalidOperation
+from typing import Any
+
+LLM_USAGE_COST_SUMMARY_SCHEMA_VERSION = "llm_usage_cost_summary.v1"
+LLM_MODEL_PRICING_SCHEMA_VERSION = "llm_model_pricing.v1"
+_TOKEN_FIELDS = (
+    "input_tokens",
+    "cached_input_tokens",
+    "cache_write_input_tokens",
+    "output_tokens",
+    "total_tokens",
+)
+
+
+def _text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _count(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    number = float(value)
+    if not math.isfinite(number) or number < 0 or not number.is_integer():
+        return None
+    return int(number)
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    return result if result.is_finite() and result >= 0 else None
+
+
+def _amount(value: Decimal | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        amount = float(value)
+    except (OverflowError, ValueError):
+        return None
+    return amount if math.isfinite(amount) else None
+
+
+def normalise_llm_usage(
+    value: Any,
+    *,
+    provider_request_sent: bool | None = None,
+) -> dict[str, Any]:
+    """Normalise existing OpenAI-style and provider-neutral token fields."""
+
+    if provider_request_sent is False:
+        return {
+            "status": "not_applicable",
+            "input_tokens": None,
+            "cached_input_tokens": None,
+            "cache_write_input_tokens": None,
+            "output_tokens": None,
+            "total_tokens": None,
+        }
+    usage = value if isinstance(value, Mapping) else {}
+    input_tokens = _count(usage.get("input_tokens"))
+    if input_tokens is None:
+        input_tokens = _count(usage.get("prompt_tokens"))
+    output_tokens = _count(usage.get("output_tokens"))
+    if output_tokens is None:
+        output_tokens = _count(usage.get("completion_tokens"))
+    input_details = usage.get("input_tokens_details")
+    if not isinstance(input_details, Mapping):
+        input_details = usage.get("prompt_tokens_details")
+    cached_input_tokens = _count(usage.get("cached_input_tokens"))
+    if cached_input_tokens is None and isinstance(input_details, Mapping):
+        cached_input_tokens = _count(input_details.get("cached_tokens"))
+    cache_write_input_tokens = _count(usage.get("cache_write_input_tokens"))
+    if cache_write_input_tokens is None and isinstance(input_details, Mapping):
+        cache_write_input_tokens = _count(input_details.get("cache_write_tokens"))
+    total_tokens = _count(usage.get("total_tokens"))
+    if total_tokens is None and input_tokens is not None and output_tokens is not None:
+        total_tokens = input_tokens + output_tokens
+
+    if input_tokens is not None and output_tokens is not None:
+        status = "reported"
+    elif any(value is not None for value in (input_tokens, output_tokens, total_tokens)):
+        status = "partial"
+    else:
+        status = "unavailable"
+    return {
+        "status": status,
+        "input_tokens": input_tokens,
+        "cached_input_tokens": cached_input_tokens,
+        "cache_write_input_tokens": cache_write_input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+    }
+
+
+def _provider(value: Any) -> str | None:
+    cleaned = _text(value)
+    return cleaned.lower() if cleaned else None
+
+
+def _model(value: Any, *, provider: str | None) -> str | None:
+    cleaned = _text(value)
+    if not cleaned:
+        return None
+    lowered = cleaned.lower()
+    prefix = f"{provider}:" if provider else None
+    return lowered[len(prefix) :] if prefix and lowered.startswith(prefix) else lowered
+
+
+def exact_model_identity_matches(
+    *,
+    provider: Any,
+    model: Any,
+    candidate_provider: Any,
+    candidate_model: Any,
+) -> bool:
+    """Match an exact provider/model pair without family-prefix expansion."""
+
+    provider_key = _provider(provider)
+    candidate_provider_key = _provider(candidate_provider)
+    if not provider_key or provider_key != candidate_provider_key:
+        return False
+    return bool(
+        _model(model, provider=provider_key)
+        and _model(model, provider=provider_key)
+        == _model(candidate_model, provider=provider_key)
+    )
+
+
+def _registry_entries(value: Any) -> list[Mapping[str, Any]]:
+    models = value.get("models") if isinstance(value, Mapping) else value
+    if not isinstance(models, Sequence) or isinstance(models, (str, bytes)):
+        return []
+    return [entry for entry in models if isinstance(entry, Mapping)]
+
+
+def _exact_pricing(
+    *,
+    provider: str | None,
+    effective_model: str | None,
+    model_registry: Any,
+) -> Mapping[str, Any] | None:
+    if not provider or not effective_model:
+        return None
+    for entry in _registry_entries(model_registry):
+        pricing = entry.get("pricing")
+        if not isinstance(pricing, Mapping):
+            continue
+        if exact_model_identity_matches(
+            provider=provider,
+            model=effective_model,
+            candidate_provider=entry.get("provider"),
+            candidate_model=pricing.get("model_id") or entry.get("model_id"),
+        ):
+            return pricing
+    return None
+
+
+def _pricing_metadata(
+    pricing: Mapping[str, Any], *, effective_model: str
+) -> dict[str, Any]:
+    return {
+        "schema_version": _text(pricing.get("schema_version")),
+        "version": _text(pricing.get("version")),
+        "source": _text(pricing.get("source")),
+        "effective_at_utc": _text(pricing.get("effective_at_utc")),
+        "model_id": _text(pricing.get("model_id")) or effective_model,
+        "unit_tokens": _count(pricing.get("unit_tokens")),
+    }
+
+
+def _estimate_call_cost(
+    *,
+    usage: Mapping[str, Any],
+    provider_request_sent: bool | None,
+    provider: str | None,
+    effective_model: str | None,
+    pricing: Mapping[str, Any] | None,
+    effective_service_tier: str | None,
+    connection_id: str | None,
+    pricing_context_input_tokens: int | None,
+) -> dict[str, Any]:
+    if provider_request_sent is False:
+        return {
+            "status": "not_applicable",
+            "amount": None,
+            "known_amount": None,
+            "currency": None,
+            "reason": "provider_request_not_sent",
+            "pricing": None,
+        }
+    if provider == "ollama":
+        return {
+            "status": "not_applicable",
+            "amount": None,
+            "known_amount": None,
+            "currency": None,
+            "reason": "local_provider_financial_cost_not_applicable",
+            "pricing": None,
+        }
+    if not effective_model:
+        reason = "effective_model_unavailable"
+    elif not isinstance(pricing, Mapping):
+        reason = "exact_model_pricing_unavailable"
+    else:
+        reason = None
+    if reason:
+        return {
+            "status": "unavailable",
+            "amount": None,
+            "known_amount": None,
+            "currency": None,
+            "reason": reason,
+            "pricing": None,
+        }
+
+    assert isinstance(pricing, Mapping) and effective_model is not None
+    metadata = _pricing_metadata(pricing, effective_model=effective_model)
+    currency = _text(pricing.get("currency"))
+    currency = currency.upper() if currency else None
+    unit_tokens = _count(pricing.get("unit_tokens"))
+    applicability = pricing.get("applicability")
+    if isinstance(applicability, Mapping):
+        allowed_tiers = applicability.get("effective_service_tiers")
+        allowed_tiers = (
+            {
+                str(item).strip().lower()
+                for item in allowed_tiers
+                if isinstance(item, str) and item.strip()
+            }
+            if isinstance(allowed_tiers, Sequence)
+            and not isinstance(allowed_tiers, (str, bytes))
+            else set()
+        )
+        if allowed_tiers and effective_service_tier not in allowed_tiers:
+            return {
+                "status": "unavailable",
+                "amount": None,
+                "known_amount": None,
+                "currency": currency,
+                "reason": "effective_service_tier_unpriced",
+                "pricing": metadata,
+            }
+        allowed_connections = applicability.get("connection_ids")
+        allowed_connections = (
+            {
+                str(item).strip()
+                for item in allowed_connections
+                if isinstance(item, str) and item.strip()
+            }
+            if isinstance(allowed_connections, Sequence)
+            and not isinstance(allowed_connections, (str, bytes))
+            else set()
+        )
+        if allowed_connections and connection_id not in allowed_connections:
+            return {
+                "status": "unavailable",
+                "amount": None,
+                "known_amount": None,
+                "currency": currency,
+                "reason": "provider_connection_unpriced",
+                "pricing": metadata,
+            }
+    rates = pricing.get("rates")
+    input_tokens = _count(usage.get("input_tokens"))
+    output_tokens = _count(usage.get("output_tokens"))
+    context_band = "standard"
+    long_context = pricing.get("long_context")
+    if isinstance(long_context, Mapping):
+        threshold = _count(long_context.get("threshold_input_tokens"))
+        if threshold is None:
+            return {
+                "status": "unavailable",
+                "amount": None,
+                "known_amount": None,
+                "currency": currency,
+                "reason": "pricing_metadata_incomplete",
+                "pricing": metadata,
+            }
+        context_input_tokens = (
+            pricing_context_input_tokens
+            if pricing_context_input_tokens is not None
+            else input_tokens
+        )
+        if context_input_tokens is None:
+            return {
+                "status": "unavailable",
+                "amount": None,
+                "known_amount": None,
+                "currency": currency,
+                "reason": "input_tokens_required_for_context_band",
+                "pricing": metadata,
+            }
+        metadata["context_threshold_input_tokens"] = threshold
+        if context_input_tokens > threshold:
+            rates = long_context.get("rates")
+            context_band = "long"
+        else:
+            context_band = "short"
+    metadata["context_band"] = context_band
+    if effective_service_tier:
+        metadata["effective_service_tier"] = effective_service_tier
+    input_rate = _decimal(rates.get("input_tokens")) if isinstance(rates, Mapping) else None
+    output_rate = _decimal(rates.get("output_tokens")) if isinstance(rates, Mapping) else None
+    pricing_complete = bool(
+        pricing.get("schema_version") == LLM_MODEL_PRICING_SCHEMA_VERSION
+        and metadata.get("version")
+        and metadata.get("source")
+        and metadata.get("effective_at_utc")
+        and currency
+        and unit_tokens
+    )
+    if not pricing_complete:
+        return {
+            "status": "unavailable",
+            "amount": None,
+            "known_amount": None,
+            "currency": currency,
+            "reason": "pricing_metadata_incomplete",
+            "pricing": metadata,
+        }
+
+    subtotal = Decimal(0)
+    priced_components = 0
+    missing_components: list[str] = []
+    detailed_input_pricing = bool(
+        isinstance(rates, Mapping)
+        and (
+            "cached_input_tokens" in rates
+            or "cache_write_input_tokens" in rates
+        )
+    )
+    if detailed_input_pricing:
+        cached_input_tokens = _count(usage.get("cached_input_tokens"))
+        cache_write_input_tokens = _count(usage.get("cache_write_input_tokens"))
+        if (
+            input_tokens is not None
+            and cached_input_tokens is not None
+            and cache_write_input_tokens is not None
+            and cached_input_tokens + cache_write_input_tokens > input_tokens
+        ):
+            return {
+                "status": "unavailable",
+                "amount": None,
+                "known_amount": None,
+                "currency": currency,
+                "reason": "usage_breakdown_invalid",
+                "pricing": metadata,
+            }
+        ordinary_input_tokens = (
+            input_tokens - cached_input_tokens - cache_write_input_tokens
+            if input_tokens is not None
+            and cached_input_tokens is not None
+            and cache_write_input_tokens is not None
+            else None
+        )
+        cost_components = (
+            ("input_tokens", ordinary_input_tokens, input_rate),
+            (
+                "cached_input_tokens",
+                cached_input_tokens,
+                _decimal(rates.get("cached_input_tokens")),
+            ),
+            (
+                "cache_write_input_tokens",
+                cache_write_input_tokens,
+                _decimal(rates.get("cache_write_input_tokens")),
+            ),
+            ("output_tokens", output_tokens, output_rate),
+        )
+    else:
+        cost_components = (
+            ("input_tokens", input_tokens, input_rate),
+            ("output_tokens", output_tokens, output_rate),
+        )
+    try:
+        for field, count, rate in cost_components:
+            if count is None:
+                missing_components.append(field)
+            elif rate is None and count > 0:
+                missing_components.append(f"{field}_rate")
+            elif rate is not None:
+                subtotal += Decimal(count) * rate
+                priced_components += 1
+        known_amount = subtotal / Decimal(unit_tokens) if priced_components else None
+    except DecimalException:
+        return {
+            "status": "unavailable",
+            "amount": None,
+            "known_amount": None,
+            "currency": currency,
+            "reason": "estimated_cost_not_representable",
+            "pricing": metadata,
+        }
+    if not missing_components and usage.get("status") == "reported":
+        status = "estimated"
+        amount = known_amount
+        reason = None
+    elif known_amount is not None:
+        status = "partial"
+        amount = None
+        reason = "usage_or_rate_coverage_partial"
+    else:
+        status = "unavailable"
+        amount = None
+        known_amount = None
+        reason = "usage_or_rate_coverage_unavailable"
+    rendered_amount = _amount(amount)
+    rendered_known_amount = _amount(known_amount)
+    if status == "estimated" and rendered_amount is None:
+        status = "unavailable"
+        reason = "estimated_cost_not_representable"
+    elif status == "partial" and rendered_known_amount is None:
+        status = "unavailable"
+        reason = "known_cost_not_representable"
+    if status == "unavailable":
+        rendered_amount = None
+        rendered_known_amount = None
+    return {
+        "status": status,
+        "amount": rendered_amount,
+        "known_amount": rendered_known_amount,
+        "currency": currency,
+        "reason": reason,
+        "pricing": metadata,
+    }
+
+
+def _merge_duplicate(previous: Mapping[str, Any], later: Mapping[str, Any]) -> dict:
+    merged = dict(previous)
+    for key, value in later.items():
+        if value not in (None, "", [], {}):
+            merged[str(key)] = value
+    if isinstance(previous.get("usage"), Mapping) and isinstance(
+        later.get("usage"), Mapping
+    ):
+        merged["usage"] = {**previous["usage"], **later["usage"]}
+    return merged
+
+
+def _deduplicate(value: Any) -> tuple[list[Mapping[str, Any]], int, int]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return [], 0, 0
+    raw = [call for call in value if isinstance(call, Mapping)]
+    result: list[Mapping[str, Any]] = []
+    indexes: dict[str, int] = {}
+    duplicates = 0
+    for call in raw:
+        call_id = _text(call.get("call_id"))
+        if not call_id:
+            result.append(call)
+        elif call_id not in indexes:
+            indexes[call_id] = len(result)
+            result.append(call)
+        else:
+            index = indexes[call_id]
+            result[index] = _merge_duplicate(result[index], call)
+            duplicates += 1
+    return result, len(raw), duplicates
+
+
+def _normalise_call(
+    call: Mapping[str, Any], *, source_index: int, model_registry: Any
+) -> dict[str, Any]:
+    provider_request_sent = (
+        call.get("provider_request_sent")
+        if isinstance(call.get("provider_request_sent"), bool)
+        else None
+    )
+    provider = _provider(call.get("provider"))
+    effective_model = _text(call.get("effective_model"))
+    identity_source = _text(call.get("model_identity_source"))
+    pricing_effective_model = (
+        effective_model if identity_source == "provider_response" else None
+    )
+    usage_value = call.get("usage")
+    usage = normalise_llm_usage(
+        usage_value if isinstance(usage_value, Mapping) else call,
+        provider_request_sent=provider_request_sent,
+    )
+    transport = call.get("transport")
+    transport = transport if isinstance(transport, Mapping) else {}
+    effective_service_tier = _text(
+        call.get("effective_service_tier")
+        or transport.get("effective_service_tier")
+    )
+    effective_service_tier = (
+        effective_service_tier.lower() if effective_service_tier else None
+    )
+    connection_id = _text(
+        call.get("connection_id")
+        or transport.get("effective_connection_id")
+        or transport.get("connection_id")
+    )
+    pricing_context_input_tokens = _count(
+        transport.get("pricing_context_input_tokens")
+    )
+    cost = _estimate_call_cost(
+        usage=usage,
+        provider_request_sent=provider_request_sent,
+        provider=provider,
+        effective_model=pricing_effective_model,
+        pricing=_exact_pricing(
+            provider=provider,
+            effective_model=pricing_effective_model,
+            model_registry=model_registry,
+        ),
+        effective_service_tier=effective_service_tier,
+        connection_id=connection_id,
+        pricing_context_input_tokens=pricing_context_input_tokens,
+    )
+    return {
+        "call_id": _text(call.get("call_id")),
+        "source_index": source_index,
+        "type": _text(call.get("type") or call.get("call_type")),
+        "stage": _text(call.get("stage")),
+        "status": _text(call.get("status")),
+        "success": call.get("success") if isinstance(call.get("success"), bool) else None,
+        "provider_request_sent": provider_request_sent,
+        "provider": provider,
+        "requested_model": _text(call.get("requested_model")),
+        "selected_model": _text(call.get("selected_model")),
+        "effective_model": effective_model,
+        "model_identity_source": identity_source,
+        "effective_service_tier": effective_service_tier,
+        "connection_id": connection_id,
+        "usage": usage,
+        "estimated_cost": cost,
+    }
+
+
+def _usage_summary(calls: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    billable = [call for call in calls if call.get("provider_request_sent") is not False]
+    statuses = [call["usage"]["status"] for call in billable]
+    if not billable:
+        status = "not_applicable"
+    elif all(value == "reported" for value in statuses):
+        status = "reported"
+    elif any(value in {"reported", "partial"} for value in statuses):
+        status = "partial"
+    else:
+        status = "unavailable"
+    result: dict[str, Any] = {
+        "status": status,
+        "reported_call_count": statuses.count("reported"),
+        "partial_call_count": statuses.count("partial"),
+        "unavailable_call_count": statuses.count("unavailable"),
+    }
+    for field in _TOKEN_FIELDS:
+        values = [
+            _count(call["usage"].get(field))
+            for call in billable
+            if call["usage"].get("status") != "not_applicable"
+        ]
+        known = [value for value in values if value is not None]
+        known_total = sum(known) if known else None
+        result[f"known_{field}"] = known_total
+        result[field] = known_total if values and len(known) == len(values) else None
+    return result
+
+
+def _cost_summary(calls: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    billable = [
+        call
+        for call in calls
+        if call["estimated_cost"].get("status") != "not_applicable"
+    ]
+    costs = [call["estimated_cost"] for call in billable]
+    currencies = {
+        cost["currency"]
+        for cost in costs
+        if cost.get("known_amount") is not None and cost.get("currency")
+    }
+    currency = next(iter(currencies)) if len(currencies) == 1 else None
+    known_values = [
+        _decimal(cost.get("known_amount"))
+        for cost in costs
+        if currency and cost.get("currency") == currency
+    ]
+    known_values = [value for value in known_values if value is not None]
+    known_amount = sum(known_values, Decimal(0)) if known_values else None
+    priced = sum(cost.get("status") == "estimated" for cost in costs)
+    partial = sum(cost.get("status") == "partial" for cost in costs)
+    unavailable = sum(cost.get("status") == "unavailable" for cost in costs)
+    if not billable:
+        status = "not_applicable"
+        known_amount = None
+    elif priced == len(billable) and currency:
+        status = "estimated"
+    elif known_amount is not None and currency:
+        status = "partial"
+    else:
+        status = "unavailable"
+        known_amount = None
+    versions = sorted(
+        {
+            cost["pricing"]["version"]
+            for cost in costs
+            if isinstance(cost.get("pricing"), Mapping)
+            and cost["pricing"].get("version")
+        }
+    )
+    pricing_identities = {
+        (
+            cost["pricing"].get("source"),
+            cost["pricing"].get("version"),
+            cost["pricing"].get("effective_at_utc"),
+        )
+        for cost in costs
+        if isinstance(cost.get("pricing"), Mapping)
+    }
+    pricing = None
+    if len(pricing_identities) == 1:
+        source, version, effective_at_utc = next(iter(pricing_identities))
+        pricing = {
+            "source": source,
+            "version": version,
+            "effective_at_utc": effective_at_utc,
+        }
+    return {
+        "status": status,
+        "amount": _amount(known_amount) if status == "estimated" else None,
+        "known_amount": _amount(known_amount),
+        "currency": currency,
+        "priced_call_count": priced,
+        "partial_call_count": partial,
+        "unpriced_call_count": unavailable,
+        "pricing_versions": versions,
+        "pricing": pricing,
+        "unavailable_reasons": sorted(
+            {
+                str(cost.get("reason"))
+                for cost in costs
+                if cost.get("status") == "unavailable" and cost.get("reason")
+            }
+        )[:20],
+    }
+
+
+def _model_identity_summary(
+    calls: Sequence[Mapping[str, Any]], *, limit: int = 20
+) -> tuple[list[dict[str, Any]], int]:
+    rows: list[dict[str, Any]] = []
+    indexes: dict[tuple[Any, ...], int] = {}
+    seen: set[tuple[Any, ...]] = set()
+    for call in calls:
+        identity = {
+            "provider": call.get("provider"),
+            "requested_model": call.get("requested_model"),
+            "selected_model": call.get("selected_model"),
+            "effective_model": call.get("effective_model"),
+            "model_identity_source": call.get("model_identity_source"),
+            "provider_request_sent": call.get("provider_request_sent"),
+            "effective_service_tier": call.get("effective_service_tier"),
+            "connection_id": call.get("connection_id"),
+        }
+        key = tuple(identity.values())
+        seen.add(key)
+        if key in indexes:
+            rows[indexes[key]]["call_count"] += 1
+            continue
+        if len(rows) >= limit:
+            continue
+        indexes[key] = len(rows)
+        rows.append({**identity, "call_count": 1})
+    return rows, max(0, len(seen) - len(rows))
+
+
+def _pricing_usage_group_summary(
+    calls: Sequence[Mapping[str, Any]], *, limit: int = 50
+) -> tuple[list[dict[str, Any]], int, int, int]:
+    """Retain bounded content-free usage groups for honest re-pricing.
+
+    Calls are grouped only when their exact per-call usage is identical. The
+    aggregate token counts therefore remain linear while
+    ``pricing_context_input_tokens`` preserves the per-request input size used
+    to select a context price band.
+    """
+
+    rows: list[dict[str, Any]] = []
+    indexes: dict[tuple[Any, ...], int] = {}
+    seen: set[tuple[Any, ...]] = set()
+    covered_call_count = 0
+    unattributed_call_count = 0
+    for call in calls:
+        if call.get("provider_request_sent") is False or call.get("provider") == "ollama":
+            continue
+        if (
+            not call.get("provider")
+            or not call.get("effective_model")
+            or call.get("model_identity_source") != "provider_response"
+        ):
+            unattributed_call_count += 1
+            continue
+        usage = call.get("usage")
+        if not isinstance(usage, Mapping):
+            continue
+        identity = (
+            call.get("provider"),
+            call.get("effective_model"),
+            call.get("model_identity_source"),
+            call.get("provider_request_sent"),
+            call.get("effective_service_tier"),
+            call.get("connection_id"),
+        )
+        usage_key = tuple(usage.get(field) for field in ("status", *_TOKEN_FIELDS))
+        key = (*identity, *usage_key)
+        seen.add(key)
+        if key in indexes:
+            row = rows[indexes[key]]
+            row["call_count"] += 1
+            covered_call_count += 1
+            aggregate_usage = row["usage"]
+            for field in _TOKEN_FIELDS:
+                prior = _count(aggregate_usage.get(field))
+                current = _count(usage.get(field))
+                aggregate_usage[field] = (
+                    prior + current
+                    if prior is not None and current is not None
+                    else None
+                )
+            continue
+        if len(rows) >= limit:
+            continue
+        indexes[key] = len(rows)
+        rows.append(
+            {
+                "provider": call.get("provider"),
+                "effective_model": call.get("effective_model"),
+                "model_identity_source": call.get("model_identity_source"),
+                "provider_request_sent": call.get("provider_request_sent"),
+                "effective_service_tier": call.get("effective_service_tier"),
+                "connection_id": call.get("connection_id"),
+                "pricing_context_input_tokens": _count(
+                    usage.get("input_tokens")
+                ),
+                "usage": {str(key): value for key, value in usage.items()},
+                "call_count": 1,
+            }
+        )
+        covered_call_count += 1
+    return (
+        rows,
+        max(0, len(seen) - len(rows)),
+        covered_call_count,
+        unattributed_call_count,
+    )
+
+
+def build_llm_usage_cost_summary(
+    llm_calls: Any,
+    *,
+    model_registry: Any = None,
+) -> dict[str, Any]:
+    """Build one content-free summary from one canonical call sequence."""
+
+    unique, raw_count, duplicate_count = _deduplicate(llm_calls)
+    calls = [
+        _normalise_call(call, source_index=index, model_registry=model_registry)
+        for index, call in enumerate(unique)
+    ]
+    model_identities, omitted_identity_count = _model_identity_summary(calls)
+    (
+        pricing_usage_groups,
+        omitted_usage_group_count,
+        covered_usage_call_count,
+        unattributed_usage_call_count,
+    ) = (
+        _pricing_usage_group_summary(calls)
+    )
+    return {
+        "schema_version": LLM_USAGE_COST_SUMMARY_SCHEMA_VERSION,
+        "call_count": raw_count,
+        "unique_call_count": len(calls),
+        "duplicate_call_count": duplicate_count,
+        "billable_call_count": sum(
+            call["estimated_cost"].get("status") != "not_applicable"
+            for call in calls
+        ),
+        "usage": _usage_summary(calls),
+        "estimated_cost": _cost_summary(calls),
+        "model_identities": model_identities,
+        "model_identity_omitted_count": omitted_identity_count,
+        "pricing_usage_groups": pricing_usage_groups,
+        "pricing_usage_group_omitted_count": omitted_usage_group_count,
+        "pricing_usage_group_covered_call_count": covered_usage_call_count,
+        "pricing_usage_group_unattributed_call_count": (
+            unattributed_usage_call_count
+        ),
+    }

--- a/src/backend/services/model_registry_service.py
+++ b/src/backend/services/model_registry_service.py
@@ -28,6 +28,7 @@ PRED_HAS_MODEL_API_PROFILE = "#V#has_model_api_profile"
 PRED_HAS_MODEL_PARAMETER_CONSTRAINT = "#V#has_model_parameter_constraint"
 PRED_CONSTRAINS_MODEL_PARAMETER = "#V#constrains_model_parameter"
 PRED_HAS_MODEL_ID = "#V#has_model_id"
+PRED_HAS_MODEL_PRICING_JSON = "#V#has_model_pricing_json"
 PRED_HAS_API_SURFACE = "#V#has_api_surface"
 PRED_HAS_STRUCTURED_TOOL_CALLING = "#V#has_structured_tool_calling_support"
 PRED_HAS_TOOL_CONTINUATION_MODE = "#V#has_tool_continuation_mode"
@@ -790,7 +791,14 @@ def _resolve_model_entry_from_graph(
             }
         )
 
-    return {
+    pricing = _parse_registry_json(
+        _get_first_text(
+            registry_entry_id,
+            predicate=PRED_HAS_MODEL_PRICING_JSON,
+        )
+        or ""
+    )
+    entry = {
         "model_id": model_id,
         "model_aliases": model_aliases,
         "provider": provider,
@@ -799,6 +807,9 @@ def _resolve_model_entry_from_graph(
         "registry_entry_id": registry_entry_id,
         "api_profiles": api_profiles,
     }
+    if pricing is not None:
+        entry["pricing"] = dict(pricing)
+    return entry
 
 
 def _load_registry_from_vontology_graph(

--- a/src/backend/services/turn_execution_diagnostics_service.py
+++ b/src/backend/services/turn_execution_diagnostics_service.py
@@ -1954,10 +1954,14 @@ def _normalise_llm_exchange_entry(
     )
     stage = _safe_str(entry.get("stage")) or _safe_str(entry.get("phase"))
     workflow_stage_id = _safe_str(entry.get("workflow_stage_id"))
+    requested_model = _safe_str(entry.get("requested_model"))
+    selected_model = _safe_str(entry.get("selected_model"))
+    effective_model = _safe_str(entry.get("effective_model"))
     model = (
-        _safe_str(entry.get("model"))
+        effective_model
+        or _safe_str(entry.get("model"))
         or _safe_str(entry.get("model_name"))
-        or _safe_str(entry.get("selected_model"))
+        or selected_model
     )
     provider = _safe_str(entry.get("provider")) or _safe_str(
         entry.get("selected_provider")
@@ -1969,6 +1973,7 @@ def _normalise_llm_exchange_entry(
     error = _safe_str(entry.get("error"))
     error_class = _safe_str(entry.get("error_class"))
     failure_kind = _safe_str(entry.get("failure_kind"))
+    usage = _safe_mapping(entry.get("usage"))
 
     exchange_blob_ref = entry.get("exchange_blob_ref")
     exchange_blob_ref_payload = (
@@ -2003,11 +2008,23 @@ def _normalise_llm_exchange_entry(
         "schema_version": "turn_llm_exchange_entry.v1",
         "source": source,
         "source_index": source_index,
+        "call_id": _safe_str(entry.get("call_id")),
+        "llm_exchange_id": _safe_str(entry.get("llm_exchange_id")),
         "call_type": call_type,
         "stage": stage,
         "workflow_stage_id": workflow_stage_id,
         "model": model,
         "provider": provider,
+        "requested_model": requested_model,
+        "selected_model": selected_model,
+        "effective_model": effective_model,
+        "model_identity_source": _safe_str(entry.get("model_identity_source")),
+        "provider_request_sent": (
+            entry.get("provider_request_sent")
+            if isinstance(entry.get("provider_request_sent"), bool)
+            else None
+        ),
+        "usage": usage,
         "duration_ms": duration_ms,
         "status": status,
         "success": success,
@@ -2331,22 +2348,43 @@ def _collect_llm_exchange_entries(
         )
 
     deduped: list[dict[str, Any]] = []
-    seen_keys: set[tuple[Any, ...]] = set()
+    seen_keys: dict[tuple[Any, ...], int] = {}
     for row in rows:
         prompt = row.get("prompt")
         response = row.get("response")
+        call_id = _safe_str(row.get("call_id"))
         key = (
-            row.get("call_type"),
-            row.get("stage"),
-            row.get("workflow_stage_id"),
-            row.get("model"),
-            row.get("at_utc"),
-            (prompt.get("text") if isinstance(prompt, Mapping) else None),
-            (response.get("text") if isinstance(response, Mapping) else None),
+            ("call_id", call_id)
+            if call_id
+            else (
+                "legacy",
+                row.get("call_type"),
+                row.get("stage"),
+                row.get("workflow_stage_id"),
+                row.get("model"),
+                row.get("at_utc"),
+                (prompt.get("text") if isinstance(prompt, Mapping) else None),
+                (response.get("text") if isinstance(response, Mapping) else None),
+            )
         )
-        if key in seen_keys:
+        existing_index = seen_keys.get(key)
+        if existing_index is not None:
+            if call_id:
+                existing = deduped[existing_index]
+                for field in (
+                    "llm_exchange_id",
+                    "requested_model",
+                    "selected_model",
+                    "effective_model",
+                    "model_identity_source",
+                    "provider_request_sent",
+                    "usage",
+                ):
+                    value = row.get(field)
+                    if value is not None:
+                        existing[field] = value
             continue
-        seen_keys.add(key)
+        seen_keys[key] = len(deduped)
         deduped.append(row)
 
     def _sort_key(row: Mapping[str, Any]) -> tuple[int, str, int]:

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -2794,11 +2794,22 @@ def _normalise_llm_call_entry(value: Any) -> dict[str, Any] | None:
     exchange_blob_ref = value.get("exchange_blob_ref")
     candidate = value.get("candidate")
     payload: dict[str, Any] = {
+        "call_id": _safe_str(value.get("call_id")),
+        "llm_exchange_id": _safe_str(value.get("llm_exchange_id")),
         "call_type": _safe_str(value.get("type")) or _safe_str(value.get("call_type")),
         "stage": _safe_str(value.get("stage")),
         "workflow_stage_id": _safe_str(value.get("workflow_stage_id")),
         "model": _safe_str(value.get("model")) or _safe_str(value.get("model_name")),
         "provider": _safe_str(value.get("provider")),
+        "requested_model": _safe_str(value.get("requested_model")),
+        "selected_model": _safe_str(value.get("selected_model")),
+        "effective_model": _safe_str(value.get("effective_model")),
+        "model_identity_source": _safe_str(value.get("model_identity_source")),
+        "provider_request_sent": (
+            value.get("provider_request_sent")
+            if isinstance(value.get("provider_request_sent"), bool)
+            else None
+        ),
         "duration_ms": _safe_non_negative_int(value.get("duration_ms")),
         "note": _safe_str(value.get("note")),
         "exchange_blob_ref": (
@@ -11125,6 +11136,26 @@ def persist_failed_turn_execution_record(
         value = debug.get(key)
         return list(value) if isinstance(value, list) else None
 
+    def _debug_llm_calls() -> list[Any] | None:
+        direct = _debug_list("llm_calls")
+        if direct is not None:
+            return direct
+        llm_interaction = _debug_mapping("llm_interaction")
+        interaction_calls = (
+            llm_interaction.get("calls")
+            if isinstance(llm_interaction, Mapping)
+            else None
+        )
+        if isinstance(interaction_calls, list):
+            return list(interaction_calls)
+        embedded_record = _debug_mapping("turn_execution_record")
+        embedded_calls = (
+            embedded_record.get("llm_calls")
+            if isinstance(embedded_record, Mapping)
+            else None
+        )
+        return list(embedded_calls) if isinstance(embedded_calls, list) else None
+
     critic_verdict = _debug_mapping("critic_verdict")
     receipt_authority: dict[str, Any] | None = None
     if not isinstance(critic_verdict, Mapping):
@@ -11163,7 +11194,7 @@ def persist_failed_turn_execution_record(
             ),
             turn_execution_diagnostics=_debug_mapping("turn_execution_diagnostics"),
             aux_llm_calls=_debug_list("aux_llm_calls"),
-            llm_calls=_debug_list("llm_calls"),
+            llm_calls=_debug_llm_calls(),
             selected_workflow_trace=_debug_mapping("selected_workflow_trace"),
             turn_expected_outcome_contract=_debug_mapping(
                 "turn_expected_outcome_contract"
@@ -11189,6 +11220,19 @@ def persist_failed_turn_execution_record(
             "schema_version": TURN_EXECUTION_RECORD_SCHEMA_VERSION,
             "request_id": clean_request_id,
         }
+
+    llm_usage_cost_summary = _debug_mapping("llm_usage_cost_summary")
+    if llm_usage_cost_summary is None:
+        embedded_record = _debug_mapping("turn_execution_record")
+        embedded_summary = (
+            embedded_record.get("llm_usage_cost_summary")
+            if isinstance(embedded_record, Mapping)
+            else None
+        )
+        if isinstance(embedded_summary, Mapping):
+            llm_usage_cost_summary = embedded_summary
+    if isinstance(llm_usage_cost_summary, Mapping):
+        record["llm_usage_cost_summary"] = dict(llm_usage_cost_summary)
 
     record["execution_terminal_status"] = clean_terminal_status
     if isinstance(receipt_authority, Mapping):

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -4193,6 +4193,10 @@ function buildRetainedThinkingCardRequestFromDebugData(turnId, debugData) {
         latestProgress: null,
         turnExecutionDiagnostics: diagnostics,
         turn_execution_diagnostics: diagnostics,
+        llmUsageCostSummary: (
+            debugData.llm_usage_cost_summary
+            && typeof debugData.llm_usage_cost_summary === 'object'
+        ) ? { ...debugData.llm_usage_cost_summary } : null,
         criticOutput: criticOutput ? cloneThinkingCriticObject(criticOutput) : null,
         thinkingCriticPanelOpen: false,
         thinkingCardMode: loadStoredThinkingCardMode(),
@@ -11699,21 +11703,22 @@ function renderThinkingCardBodyHTML(request, options = {}) {
     const mode = getThinkingCardMode(request, options);
     const progressViewModel = buildThinkingCardProgressViewModel(request);
     const synopsisHtml = renderThinkingCardProgressSynopsisHTML(progressViewModel, mode, request);
+    const llmUsageCostHtml = renderThinkingLlmUsageCostSummaryHTML(request);
     const criticHtml = renderThinkingCriticPanelHTML(request);
     const workflowStageHtml = renderThinkingWorkflowStageHistoryHTML(request, mode);
     const llmCallLogHtml = renderThinkingLlmCallLogSectionHTML(request, mode);
     const timingHtml = renderThinkingTimingBreakdownHTML(request, mode);
     if (mode === THINKING_CARD_MODE_DEFAULT && synopsisHtml) {
-        return synopsisHtml + criticHtml + workflowStageHtml + timingHtml + renderToolHistoryHTML(request, mode) + llmCallLogHtml;
+        return synopsisHtml + llmUsageCostHtml + criticHtml + workflowStageHtml + timingHtml + renderToolHistoryHTML(request, mode) + llmCallLogHtml;
     }
 
     if (workflowStageHtml) {
-        return synopsisHtml + criticHtml + workflowStageHtml + timingHtml + renderToolHistoryHTML(request, mode) + llmCallLogHtml;
+        return synopsisHtml + llmUsageCostHtml + criticHtml + workflowStageHtml + timingHtml + renderToolHistoryHTML(request, mode) + llmCallLogHtml;
     }
 
     const activityHistoryHtml = renderThinkingActivityHistoryHTML(request, mode);
     if (activityHistoryHtml) {
-        return synopsisHtml + criticHtml + activityHistoryHtml + timingHtml + llmCallLogHtml;
+        return synopsisHtml + llmUsageCostHtml + criticHtml + activityHistoryHtml + timingHtml + llmCallLogHtml;
     }
 
     const toolHistoryHtml = renderToolHistoryHTML(request, mode);
@@ -11722,7 +11727,129 @@ function renderThinkingCardBodyHTML(request, options = {}) {
         : '';
     const fallbackProgressHtml = renderThinkingLatestProgressSummaryHTML(request);
 
-    return synopsisHtml + criticHtml + timingHtml + toolHistoryHtml + workflowHtml + fallbackProgressHtml + llmCallLogHtml;
+    return synopsisHtml + llmUsageCostHtml + criticHtml + timingHtml + toolHistoryHtml + workflowHtml + fallbackProgressHtml + llmCallLogHtml;
+}
+
+function resolveThinkingLlmUsageCostSummary(request) {
+    const candidates = [
+        request?.llmUsageCostSummary,
+        request?.latestProgress?.llm_usage_cost_summary
+    ];
+    return candidates.find((candidate) => candidate && typeof candidate === 'object') || null;
+}
+
+function thinkingUsageNumber(value) {
+    return Number.isFinite(value) && Number(value) >= 0 ? Number(value) : null;
+}
+
+function formatThinkingTokenCount(value, label) {
+    const count = thinkingUsageNumber(value);
+    return count === null ? '' : `${count.toLocaleString('en-NZ')} ${label}`;
+}
+
+function formatThinkingEstimatedCost(cost) {
+    if (!cost || typeof cost !== 'object') {
+        return 'cost estimate unavailable';
+    }
+    const status = normaliseThinkingActivityString(cost.status).toLowerCase();
+    const currency = normaliseThinkingActivityString(cost.currency).toUpperCase();
+    const amount = status === 'estimated'
+        ? thinkingUsageNumber(cost.amount)
+        : thinkingUsageNumber(cost.known_amount);
+    if (amount !== null && currency) {
+        let renderedAmount = `${currency} ${amount.toFixed(6)}`;
+        if (amount > 0 && amount < 0.0001) {
+            renderedAmount = `${currency === 'USD' ? 'US$' : `${currency} `}${amount.toPrecision(3)}`;
+        } else {
+            try {
+                renderedAmount = new Intl.NumberFormat('en-NZ', {
+                    style: 'currency',
+                    currency,
+                    minimumFractionDigits: amount > 0 && amount < 0.01 ? 4 : 2,
+                    maximumFractionDigits: 6
+                }).format(amount);
+            } catch (_) {
+                // Keep the explicit currency fallback for an unrecognised code.
+            }
+        }
+        return status === 'partial'
+            ? `known cost subtotal ${renderedAmount} (partial)`
+            : `estimated ${renderedAmount}`;
+    }
+    if (status === 'not_applicable') {
+        return 'no billable model request';
+    }
+    return status === 'partial'
+        ? 'cost estimate partial; no priced subtotal available'
+        : 'cost estimate unavailable';
+}
+
+function effectiveThinkingModelIdentity(call) {
+    if (!call || typeof call !== 'object') {
+        return '';
+    }
+    const model = normaliseThinkingActivityString(
+        call.effective_model || call.model || call.selected_model || call.requested_model
+    );
+    const provider = normaliseThinkingActivityString(call.provider);
+    return model ? (provider ? `${provider}/${model}` : model) : '';
+}
+
+function providerObservedThinkingModelIdentity(call) {
+    if (normaliseThinkingActivityString(call?.model_identity_source) !== 'provider_response') {
+        return '';
+    }
+    const model = normaliseThinkingActivityString(call?.effective_model);
+    const provider = normaliseThinkingActivityString(call?.provider);
+    return model ? (provider ? `${provider}/${model}` : model) : '';
+}
+
+function renderThinkingLlmUsageCostSummaryHTML(request) {
+    const summary = resolveThinkingLlmUsageCostSummary(request);
+    if (!summary) {
+        const liveEntries = collectThinkingLiveLlmCallLogEntries(request);
+        const liveModels = Array.from(new Set(
+            liveEntries.map((entry) => effectiveThinkingModelIdentity(entry)).filter(Boolean)
+        ));
+        if (liveModels.length === 0) {
+            return '';
+        }
+        return `<section class="thinking-card-diagnostic-section thinking-card-llm-usage-cost">
+            <div class="thinking-card-diagnostic-section-title">Model usage</div>
+            <div class="thinking-card-diagnostic-text">${escapeHtml(liveModels.join(', '))} · in progress · token usage pending</div>
+        </section>`;
+    }
+
+    const identitiesSource = Array.isArray(summary.model_identities)
+        ? summary.model_identities
+        : [];
+    const calls = identitiesSource.filter(
+        (call) => call && typeof call === 'object'
+    );
+    const identities = Array.from(new Set(
+        calls.map((call) => providerObservedThinkingModelIdentity(call)).filter(Boolean)
+    ));
+    const usage = summary.usage && typeof summary.usage === 'object' ? summary.usage : {};
+    const inputTokens = thinkingUsageNumber(usage.input_tokens) ?? thinkingUsageNumber(usage.known_input_tokens);
+    const outputTokens = thinkingUsageNumber(usage.output_tokens) ?? thinkingUsageNumber(usage.known_output_tokens);
+    const totalTokens = thinkingUsageNumber(usage.total_tokens) ?? thinkingUsageNumber(usage.known_total_tokens);
+    const usageStatus = normaliseThinkingActivityString(usage.status).toLowerCase();
+    const callCount = thinkingUsageNumber(summary.unique_call_count) ?? thinkingUsageNumber(summary.call_count);
+    const bits = [
+        identities.length > 0 ? identities.join(', ') : 'effective model identity unavailable',
+        formatThinkingTokenCount(inputTokens, 'input'),
+        formatThinkingTokenCount(outputTokens, 'output'),
+        (inputTokens === null && outputTokens === null) ? formatThinkingTokenCount(totalTokens, 'tokens') : '',
+        formatThinkingEstimatedCost(summary.estimated_cost),
+        callCount !== null ? `${callCount.toLocaleString('en-NZ')} model call${callCount === 1 ? '' : 's'}` : '',
+        usageStatus === 'partial' ? 'token coverage partial' : '',
+        usageStatus === 'unavailable' ? 'token usage unavailable' : ''
+    ].filter(Boolean);
+
+    return `<section class="thinking-card-diagnostic-section thinking-card-llm-usage-cost">
+        <div class="thinking-card-diagnostic-section-title">Model usage</div>
+        <div class="thinking-card-diagnostic-text">${escapeHtml(bits.join(' · '))}</div>
+    </section>`;
 }
 
 function resolveThinkingRequestIdForLlmCallLog(request) {
@@ -11944,6 +12071,13 @@ function mergeThinkingLiveLlmCallEvent(existing, entry, index) {
     const sequenceNo = Number.isFinite(entry?.sequence_no)
         ? Number(entry.sequence_no)
         : (Number.isFinite(existing?.sequence_no) ? Number(existing.sequence_no) : index + 1);
+    const incomingIdentitySource = normaliseThinkingActivityString(entry?.model_identity_source);
+    const existingIdentitySource = normaliseThinkingActivityString(existing?.model_identity_source);
+    const effectiveModel = incomingIdentitySource === 'provider_response'
+        ? normaliseThinkingActivityString(entry?.effective_model)
+        : (existingIdentitySource === 'provider_response'
+            ? normaliseThinkingActivityString(existing?.effective_model)
+            : '');
 
     return {
         call_id: explicitCallId || existing?.call_id || '',
@@ -11959,6 +12093,14 @@ function mergeThinkingLiveLlmCallEvent(existing, entry, index) {
             || normaliseThinkingActivityString(entry?.selected_model)
             || existing?.model
             || 'unknown model',
+        requested_model: normaliseThinkingActivityString(entry?.requested_model)
+            || existing?.requested_model
+            || '',
+        selected_model: normaliseThinkingActivityString(entry?.selected_model)
+            || existing?.selected_model
+            || '',
+        effective_model: effectiveModel,
+        model_identity_source: incomingIdentitySource || existingIdentitySource || '',
         provider: normaliseThinkingActivityString(entry?.provider)
             || normaliseThinkingActivityString(entry?.selected_provider)
             || existing?.provider
@@ -11986,6 +12128,9 @@ function mergeThinkingLiveLlmCallEvent(existing, entry, index) {
                 is_truncated: responseCapture?.preview_truncated === true
             }
             : (existing?.response || null),
+        usage: entry?.usage && typeof entry.usage === 'object'
+            ? { ...entry.usage }
+            : (existing?.usage || null),
         unavailable_reason: responseText
             ? ''
             : (state.toLowerCase() === 'sent'
@@ -12028,7 +12173,8 @@ function cloneThinkingLlmCallLogEntry(entry) {
     return {
         ...entry,
         prompt: entry.prompt && typeof entry.prompt === 'object' ? { ...entry.prompt } : entry.prompt,
-        response: entry.response && typeof entry.response === 'object' ? { ...entry.response } : entry.response
+        response: entry.response && typeof entry.response === 'object' ? { ...entry.response } : entry.response,
+        usage: entry.usage && typeof entry.usage === 'object' ? { ...entry.usage } : entry.usage
     };
 }
 
@@ -12166,6 +12312,34 @@ function classifyThinkingLlmCallLogEntry(entry) {
     return '';
 }
 
+function thinkingLlmCallUsageCostBits(entry) {
+    const usage = entry?.usage && typeof entry.usage === 'object' ? entry.usage : {};
+    const inputTokens = thinkingUsageNumber(usage.input_tokens) ?? thinkingUsageNumber(usage.known_input_tokens);
+    const outputTokens = thinkingUsageNumber(usage.output_tokens) ?? thinkingUsageNumber(usage.known_output_tokens);
+    const totalTokens = thinkingUsageNumber(usage.total_tokens) ?? thinkingUsageNumber(usage.known_total_tokens);
+    return [
+        formatThinkingTokenCount(inputTokens, 'input'),
+        formatThinkingTokenCount(outputTokens, 'output'),
+        (inputTokens === null && outputTokens === null) ? formatThinkingTokenCount(totalTokens, 'tokens') : ''
+    ].filter(Boolean);
+}
+
+function renderThinkingLlmModelLineageHTML(entry) {
+    const requested = normaliseThinkingActivityString(entry?.requested_model);
+    const selected = normaliseThinkingActivityString(entry?.selected_model);
+    const effective = normaliseThinkingActivityString(entry?.model_identity_source) === 'provider_response'
+        ? normaliseThinkingActivityString(entry?.effective_model)
+        : '';
+    const lineageBits = [
+        requested ? `requested ${requested}` : '',
+        selected && selected !== requested ? `selected ${selected}` : '',
+        effective && effective !== selected && effective !== requested ? `effective ${effective}` : ''
+    ].filter(Boolean);
+    return lineageBits.length > 1
+        ? `<div class="thinking-card-diagnostic-text">Model lineage: ${escapeHtml(lineageBits.join(' · '))}</div>`
+        : '';
+}
+
 function renderThinkingLlmCallLogEntriesHTML(entries, options = {}) {
     if (!Array.isArray(entries) || entries.length === 0) {
         return '<div class="thinking-card-diagnostic-text">No LLM exchanges were recorded for this turn.</div>';
@@ -12198,6 +12372,7 @@ function renderThinkingLlmCallLogEntriesHTML(entries, options = {}) {
             || normaliseThinkingActivityString(entry?.completed_at_utc)
             || normaliseThinkingActivityString(entry?.started_at_utc);
         const timestampLabel = formatThinkingLlmCallTimestamp(atUtc);
+        const usageCostBits = thinkingLlmCallUsageCostBits(entry);
 
         const headerBits = [
             seq !== null ? `#${seq}` : '',
@@ -12207,6 +12382,7 @@ function renderThinkingLlmCallLogEntriesHTML(entries, options = {}) {
             formatThinkingActivityFallbackLabel(callType),
             liveState,
             provider ? `${model} (${provider})` : model,
+            ...usageCostBits,
             promptSizeCue,
             durationMs !== null ? `${durationMs}ms` : ''
         ].filter(Boolean);
@@ -12238,6 +12414,7 @@ function renderThinkingLlmCallLogEntriesHTML(entries, options = {}) {
         return `<details class="thinking-card-diagnostic" data-thinking-diagnostic-key="${escapeHtml(diagnosticKey)}" data-thinking-llm-call-log-key="${escapeHtml(diagnosticKey)}" data-thinking-llm-call-at-utc="${escapeHtml(atUtc || '')}" data-thinking-llm-call-model="${escapeHtml(model)}">
             <summary>${escapeHtml(headerBits.join(' · '))}</summary>
             <div class="thinking-card-diagnostic-content">
+                ${renderThinkingLlmModelLineageHTML(entry)}
                 ${promptBlock}
                 ${responseBlock}
                 ${availability}
@@ -32501,6 +32678,10 @@ async function handleSendPrompt(options = {}) {
                 displayElements
             });
             enriched.foreground_delivery_source = source;
+            request.llmUsageCostSummary = (
+                enriched.llm_usage_cost_summary
+                && typeof enriched.llm_usage_cost_summary === 'object'
+            ) ? { ...enriched.llm_usage_cost_summary } : null;
             syncThinkingCriticOutputFromSource(request, enriched);
             setLlmDebugDataEntry(assistantTurnId, enriched, request.executionContextBinding);
             if (isRequestVisible()) {
@@ -32570,6 +32751,10 @@ async function handleSendPrompt(options = {}) {
         // Store LLM debug data if available even on error
         const errorTurnId = `e-${Date.now()}`;
         if (data?.llm_debug) {
+            request.llmUsageCostSummary = (
+                data.llm_debug.llm_usage_cost_summary
+                && typeof data.llm_debug.llm_usage_cost_summary === 'object'
+            ) ? { ...data.llm_debug.llm_usage_cost_summary } : null;
             syncThinkingCriticOutputFromSource(request, data.llm_debug);
             setLlmDebugDataEntry(errorTurnId, data.llm_debug, request.executionContextBinding);
             if (isRequestVisible()) {

--- a/src/frontend/web/von_interface/static/js/settingsPage.js
+++ b/src/frontend/web/von_interface/static/js/settingsPage.js
@@ -112,6 +112,8 @@ const INTERNAL_MCP_MAX_TOOL_INVOCATIONS_MAX = 500;
 const INTERNAL_MCP_TOOL_BATCH_CAP_DEFAULT = 10;
 const INTERNAL_MCP_TOOL_BATCH_CAP_MIN = 1;
 const INTERNAL_MCP_TOOL_BATCH_CAP_MAX = 20;
+const OPENAI_MODEL_COST_SUMMARY_SCHEMA_VERSION = 'llm_model_turn_cost_summary.v1';
+const OPENAI_MODEL_COST_SUMMARY_ENDPOINT = '/api/settings/llm/cost_summary';
 
 let runtimeIntervalId = null;
 let runtimeAbortController = null;
@@ -126,6 +128,7 @@ let currentEffectiveLlm = null;
 let currentEffectiveEnabledLlms = [];
 let latestOpenAiModelProbe = null;
 let latestOpenAiModelParameterCapability = null;
+let openAiModelCostSummaryGeneration = 0;
 let latestOllamaModelProbe = null;
 let latestSettingsAuthStatus = null;
 let latestCapabilityIndexStatus = null;
@@ -1128,6 +1131,7 @@ function updateOpenAiModelStatusMessage() {
   const selectEl = document.getElementById('openaiModelSelect');
   if (!statusEl) return;
 
+  const allowed = updateSelectedOpenAiEligibilityControls();
   const premiumEnabled = !!toggleEl?.checked;
   const selectedModel = String(selectEl?.value || getStoredOpenAiSelectedModel() || '').trim();
   const selectedModelParameters = readOpenAiModelParametersFromUi()
@@ -1141,6 +1145,15 @@ function updateOpenAiModelStatusMessage() {
         ? 'Select a premium model, then test it before relying on it.'
         : 'Premium use is disabled on this machine. Ollama remains the active provider here.',
       null,
+    );
+    return;
+  }
+
+  if (!allowed) {
+    setInlineStatusMessage(
+      statusEl,
+      `Testing and browser use remain unavailable until ${selectedModel} is allowed for this scope and saved.`,
+      'error',
     );
     return;
   }
@@ -1253,6 +1266,17 @@ async function testSelectedOpenAiModel() {
     latestOpenAiModelProbe = null;
     updateOpenAiModelStatusMessage();
     return { usable: false, model: null, reason: 'No premium model selected.' };
+  }
+
+  if (!isPersistedEffectiveModelAllowed(selectedOpenAiPoolEntry())) {
+    latestOpenAiModelProbe = null;
+    updateOpenAiModelStatusMessage();
+    return {
+      usable: false,
+      model: selectedModel,
+      reason: 'The exact premium model is not allowed for the selected scope.',
+      failure_kind: 'premium_model_not_allowed',
+    };
   }
 
   setStoredOpenAiSelectedModel(selectedModel);
@@ -1549,6 +1573,7 @@ function invalidateScopedModelState(message = 'Loading model settings for the cu
   scopedModelStateReady = false;
   currentResolvedLlm = null;
   stagedScopedPrimaryLlm = null;
+  invalidateSelectedOpenAiCostSummary();
   currentEnabledLlmAlternatives = [];
   explicitlyRemovedWorkflowPoolKeys = new Set();
   updateScopedModelSaveAvailability();
@@ -1647,6 +1672,7 @@ async function reloadScopedModelSettings({
       'Model settings loaded for the current user and organisation.',
       null,
     );
+    void refreshSelectedOpenAiCostSummary();
     return { applied: true, stale: false, generation: loadGeneration, settings };
   } catch (error) {
     if (
@@ -1676,6 +1702,152 @@ function selectedOpenAiPoolEntry() {
     model,
     ...(modelParameters ? { model_parameters: modelParameters } : {}),
   });
+}
+
+function isPersistedEffectiveModelAllowed(entry) {
+  const canonical = buildCanonicalLlmEntry(entry);
+  return Boolean(
+    scopedModelStateReady
+    && canonical
+    && currentEffectiveEnabledLlms.some((candidate) => sameLlmSlot(candidate, canonical)),
+  );
+}
+
+function formatHistoricalCostAmount(amount, currency) {
+  if (amount === null || typeof amount === 'undefined' || typeof amount === 'boolean' || amount === '') return '';
+  const numericAmount = Number(amount);
+  const currencyCode = String(currency || '').trim().toUpperCase();
+  if (!Number.isFinite(numericAmount) || numericAmount < 0 || !currencyCode) return '';
+  const renderedAmount = numericAmount > 0 && numericAmount < 0.0001
+    ? numericAmount.toPrecision(3)
+    : numericAmount.toFixed(numericAmount > 0 && numericAmount < 0.01 ? 4 : 2);
+  return `${currencyCode === 'USD' ? 'US$' : `${currencyCode} `}${renderedAmount}`;
+}
+
+function renderSelectedOpenAiCostSummary(summary = null) {
+  const element = document.getElementById('openaiModelCostSummary');
+  if (!element) return;
+  const selected = selectedOpenAiPoolEntry();
+  const identityMatches = Boolean(
+    selected
+    && String(summary?.schema_version || '') === OPENAI_MODEL_COST_SUMMARY_SCHEMA_VERSION
+    && String(summary?.model_identity?.provider || '').toLowerCase() === 'openai'
+    && String(summary?.model_identity?.model || '') === selected.model
+  );
+  if (!selected) {
+    element.textContent = 'Select an OpenAI model to view historical cost.';
+    return;
+  }
+  if (summary?.status === 'loading') {
+    element.textContent = `Loading historical cost for ${selected.model}...`;
+    return;
+  }
+  const unavailableMessage = {
+    partial: 'Historical cost coverage is partial; average unavailable.',
+    insufficient_coverage: 'Insufficient historical coverage for an average cost.',
+  }[summary?.status];
+  if (identityMatches && unavailableMessage) {
+    element.textContent = unavailableMessage;
+    return;
+  }
+  if (identityMatches && summary.status === 'available') {
+    const average = summary.average_attributed_cost_per_turn;
+    const amount = formatHistoricalCostAmount(average?.amount, average?.currency);
+    const turns = Number(summary.sample_window?.attributed_turn_count);
+    const priced = Number(summary.coverage?.priced_turn_count);
+    const attributed = Number(summary.coverage?.attributed_turn_count);
+    const started = String(summary.sample_window?.started_at_utc || '').slice(0, 10);
+    const ended = String(summary.sample_window?.ended_at_utc || '').slice(0, 10);
+    const pricing = summary.pricing || {};
+    const source = String(pricing.source || '').trim();
+    const version = String(pricing.version || '').trim();
+    const effective = String(pricing.effective_at_utc || '').slice(0, 10);
+    if (
+      amount && Number.isInteger(turns) && turns > 0
+      && priced === turns && attributed === turns
+      && started && ended && source && version && effective
+    ) {
+      element.textContent = `Historical average: ${amount} per turn · ${priced}/${attributed} priced · ${started}–${ended} · pricing ${source} ${version} effective ${effective} · estimate from retained provider-reported usage, not provider billing.`;
+      return;
+    }
+  }
+  element.textContent = 'Historical cost estimate unavailable.';
+}
+
+function invalidateSelectedOpenAiCostSummary() {
+  openAiModelCostSummaryGeneration += 1;
+  renderSelectedOpenAiCostSummary(null);
+}
+
+async function refreshSelectedOpenAiCostSummary() {
+  const selected = selectedOpenAiPoolEntry();
+  if (!scopedModelStateReady || !selected) {
+    invalidateSelectedOpenAiCostSummary();
+    return false;
+  }
+
+  const model = selected.model;
+  const modelScope = selectedModelPoolTargetScope;
+  const generation = ++openAiModelCostSummaryGeneration;
+  renderSelectedOpenAiCostSummary({
+    schema_version: OPENAI_MODEL_COST_SUMMARY_SCHEMA_VERSION,
+    status: 'loading',
+    model_identity: { provider: 'openai', model },
+  });
+
+  const params = new URLSearchParams({
+    provider: 'openai', model,
+  });
+  const url = `${OPENAI_MODEL_COST_SUMMARY_ENDPOINT}?${params.toString()}`;
+
+  let summary = null;
+  try {
+    const response = await fetch(url, {
+      cache: 'no-store',
+      headers: buildSettingsFetchHeaders(),
+    });
+    if (response.ok) summary = await response.json();
+  } catch (_) { /* unavailable */ }
+  if (
+    generation !== openAiModelCostSummaryGeneration
+    || selectedModelPoolTargetScope !== modelScope
+    || selectedOpenAiPoolEntry()?.model !== model
+  ) return false;
+  renderSelectedOpenAiCostSummary(summary);
+  return true;
+}
+
+function updateSelectedOpenAiEligibilityControls() {
+  const statusEl = document.getElementById('openaiModelEligibilityStatus');
+  const toggleEl = document.getElementById('enableOpenAiPremiumToggle');
+  const testButton = document.getElementById('testOpenAiModelButton');
+  const selected = selectedOpenAiPoolEntry();
+  const allowed = isPersistedEffectiveModelAllowed(selected);
+  for (const control of [toggleEl, testButton]) {
+    if (!control) continue;
+    control.disabled = !allowed;
+    control.setAttribute('aria-disabled', String(!allowed));
+  }
+  if (!allowed && toggleEl?.checked) {
+    toggleEl.checked = false;
+    setLocalPremiumModelUseEnabled(false);
+    notifyLocalModelPreferenceChanged();
+  }
+  if (statusEl) {
+    const message = !scopedModelStateReady
+      ? 'Loading persisted allowed models for this scope.'
+      : !selected
+        ? 'Select an OpenAI model to check whether it is allowed for this scope.'
+        : allowed
+          ? `Allowed: ${formatLlmEntry(selected)} is persisted for the current effective actor scope.`
+          : `Not allowed: allow ${formatLlmEntry(selected)} for this scope and save before testing it or using it for browser chat.`;
+    setInlineStatusMessage(
+      statusEl,
+      message,
+      scopedModelStateReady && selected ? (allowed ? 'success' : 'error') : null,
+    );
+  }
+  return allowed;
 }
 
 function selectedOllamaPoolEntry() {
@@ -1784,7 +1956,7 @@ function renderModelPoolTargetScopeNote() {
   }
   if (!currentResolvedLlm && effectiveModelScope() === 'organisation') {
     const inheritedPoolSize = currentEffectiveEnabledLlms.length;
-    note.textContent = `The current user inherits the organisation configuration (${inheritedPoolSize} enabled model${inheritedPoolSize === 1 ? '' : 's'}). Saving creates an explicit user override from the selected primary and explicitly added alternatives; the organisation pool is not copied.`;
+    note.textContent = `The current user inherits the organisation configuration (${inheritedPoolSize} allowed model${inheritedPoolSize === 1 ? '' : 's'}). Saving creates an explicit user override from the selected primary and explicitly added alternatives; the organisation allowed models are not copied.`;
     return;
   }
   note.textContent = 'Saving changes only the current user primary and pool.';
@@ -1814,12 +1986,14 @@ function updatePoolActionButton(buttonId, entry) {
   const existing = currentEnabledLlmAlternatives.find((candidate) => sameLlmSlot(candidate, entry));
   if (existing && sameLlmEntry(existing, entry)) {
     button.disabled = true;
-    button.textContent = 'Already in workflow pool';
+    button.textContent = isPersistedEffectiveModelAllowed(entry)
+      ? 'Already allowed for this scope'
+      : 'Pending allowed-model save';
     return;
   }
 
   button.disabled = false;
-  button.textContent = existing ? 'Update workflow pool entry' : 'Add to workflow pool';
+  button.textContent = existing ? 'Update allowed model entry' : 'Allow for this scope';
 }
 
 function renderWorkflowModelPool() {
@@ -1836,6 +2010,7 @@ function renderWorkflowModelPool() {
       updatePoolActionButton('addOpenAiToWorkflowPoolButton', selectedOpenAiPoolEntry());
       updatePoolActionButton('addOllamaToWorkflowPoolButton', selectedOllamaPoolEntry());
       updateScopedPrimaryActionButtons();
+      updateSelectedOpenAiEligibilityControls();
       updateScopedModelSaveAvailability();
       return;
     }
@@ -1848,7 +2023,7 @@ function renderWorkflowModelPool() {
       const role = document.createElement('span');
       role.className = 'settings-model-pool-entry-role';
       role.textContent = persistedPrimary && sameLlmEntry(persistedPrimary, displayPrimary)
-        ? 'Primary · always enabled'
+        ? 'Primary · always allowed'
         : 'Pending primary · explicit save required';
       label.appendChild(role);
       primaryRow.appendChild(label);
@@ -1864,13 +2039,13 @@ function renderWorkflowModelPool() {
       label.textContent = formatLlmEntry(entry);
       const role = document.createElement('span');
       role.className = 'settings-model-pool-entry-role';
-      role.textContent = 'Enabled alternative';
+      role.textContent = 'Allowed alternative';
       label.appendChild(role);
       const removeButton = document.createElement('button');
       removeButton.type = 'button';
       removeButton.className = 'btn-secondary';
       removeButton.textContent = 'Remove';
-      removeButton.setAttribute('aria-label', `Remove ${formatLlmEntry(entry)} from workflow pool`);
+      removeButton.setAttribute('aria-label', `Remove ${formatLlmEntry(entry)} from scoped allowed models`);
       const key = modelEntryKey(entry);
       removeButton.addEventListener('click', () => {
         explicitlyRemovedWorkflowPoolKeys.add(key);
@@ -1879,7 +2054,7 @@ function renderWorkflowModelPool() {
         );
         setInlineStatusMessage(
           document.getElementById('modelPoolStatusMessage'),
-          'Workflow pool change pending. Save the scoped primary and workflow pool to apply it.',
+          'Allowed-model change pending. Save the scoped primary and allowed models to apply it.',
           null,
         );
         renderModelScopeOverview();
@@ -1891,7 +2066,7 @@ function renderWorkflowModelPool() {
     if (!displayPrimary && alternatives.length === 0) {
       const empty = document.createElement('div');
       empty.className = 'settings-model-pool-empty';
-      empty.textContent = 'No scoped primary or enabled alternatives are configured.';
+      empty.textContent = 'No scoped primary or allowed alternatives are configured.';
       listEl.appendChild(empty);
     }
   }
@@ -1899,6 +2074,7 @@ function renderWorkflowModelPool() {
   updatePoolActionButton('addOpenAiToWorkflowPoolButton', selectedOpenAiPoolEntry());
   updatePoolActionButton('addOllamaToWorkflowPoolButton', selectedOllamaPoolEntry());
   updateScopedPrimaryActionButtons();
+  updateSelectedOpenAiEligibilityControls();
 }
 
 function renderModelScopeOverview() {
@@ -1939,7 +2115,7 @@ function addOrUpdateWorkflowPoolEntry(entry) {
   ];
   setInlineStatusMessage(
     document.getElementById('modelPoolStatusMessage'),
-    'Workflow pool change pending. Save the scoped primary and workflow pool to apply it.',
+    'Allowed-model change pending. Save the scoped primary and allowed models to apply it.',
     null,
   );
   renderModelScopeOverview();
@@ -2000,7 +2176,7 @@ function restoreScopedPrimary() {
   stagedScopedPrimaryLlm = baselineScopedPrimaryEntry();
   setInlineStatusMessage(
     document.getElementById('modelPoolStatusMessage'),
-    'Pending primary change cleared. Pool edits will retain the selected target primary.',
+    'Pending primary change cleared. Allowed-model edits will retain the selected target primary.',
     null,
   );
   renderModelScopeOverview();
@@ -2022,7 +2198,7 @@ async function persistModelScopeSettings() {
   updateScopedModelSaveAvailability();
   setInlineStatusMessage(
     document.getElementById('modelPoolStatusMessage'),
-    'Saving scoped primary and workflow pool...',
+    'Saving scoped primary and allowed models...',
     null,
   );
   try {
@@ -2030,13 +2206,14 @@ async function persistModelScopeSettings() {
     if (!saved) throw new Error('Model scope save did not complete.');
     setInlineStatusMessage(
       document.getElementById('modelPoolStatusMessage'),
-      'Scoped primary and workflow pool saved for the current scope.',
+      'Scoped primary and allowed models saved for the current scope.',
       'success',
     );
+    void refreshSelectedOpenAiCostSummary();
   } catch (error) {
     setInlineStatusMessage(
       document.getElementById('modelPoolStatusMessage'),
-      error?.message || 'Failed to save scoped primary and workflow pool.',
+      error?.message || 'Failed to save scoped primary and allowed models.',
       'error',
     );
   } finally {
@@ -3717,6 +3894,10 @@ export function __testOnly_getScopedModelState() {
   };
 }
 
+export function __testOnly_refreshSelectedOpenAiCostSummary() {
+  return refreshSelectedOpenAiCostSummary();
+}
+
 export function __testOnly_saveAllSettings(options = {}) {
   return saveAllSettings(options);
 }
@@ -4069,6 +4250,7 @@ function failClosedActorTransition(error, snapshot) {
   actorSessionReady = false;
   scopedModelStateReady = false;
   currentResolvedLlm = null;
+  invalidateSelectedOpenAiCostSummary();
   currentEnabledLlmAlternatives = [];
   explicitlyRemovedWorkflowPoolKeys = new Set();
   syncModelPoolTargetScopeControls();
@@ -4346,12 +4528,14 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('openaiModelSelect')?.addEventListener('change', async () => {
     const selectedModel = document.getElementById('openaiModelSelect')?.value || '';
     setStoredOpenAiSelectedModel(selectedModel);
+    invalidateSelectedOpenAiCostSummary();
     await refreshOpenAiReasoningEffortControls();
     latestOpenAiModelProbe = null;
     updateOpenAiModelStatusMessage();
     refreshActiveSettingsConcernGuidance();
     notifyLocalModelPreferenceChanged();
     renderModelScopeOverview();
+    void refreshSelectedOpenAiCostSummary();
   });
   document.getElementById('openaiReasoningEffortSelect')?.addEventListener('change', async () => {
     setStoredOpenAiModelParameters(readOpenAiModelParametersFromUi());
@@ -4373,6 +4557,16 @@ document.addEventListener('DOMContentLoaded', async () => {
       setLocalPremiumModelUseEnabled(false);
       updateOpenAiModelStatusMessage();
       updateOllamaModelStatusMessage();
+      refreshActiveSettingsConcernGuidance();
+      notifyLocalModelPreferenceChanged();
+      renderModelScopeOverview();
+      return;
+    }
+
+    if (!isPersistedEffectiveModelAllowed(selectedOpenAiPoolEntry())) {
+      premiumToggle.checked = false;
+      setLocalPremiumModelUseEnabled(false);
+      updateOpenAiModelStatusMessage();
       refreshActiveSettingsConcernGuidance();
       notifyLocalModelPreferenceChanged();
       renderModelScopeOverview();
@@ -5373,8 +5567,15 @@ async function saveAllSettings({ includeChatModels = false, includeRuntimeModels
       currentResolvedLlm = payload.resolved_llm;
       stagedScopedPrimaryLlm = buildCanonicalLlmEntry(payload.resolved_llm);
       if (Array.isArray(payload?.enabled_llms)) {
-        currentEnabledLlmAlternatives = normaliseEnabledLlmEntries(payload.enabled_llms)
+        const persistedTargetEnabledLlms = normaliseEnabledLlmEntries(payload.enabled_llms);
+        currentEnabledLlmAlternatives = [...persistedTargetEnabledLlms]
           .filter((entry) => !currentResolvedLlm || !sameLlmSlot(entry, currentResolvedLlm));
+        if (
+          selectedModelPoolTargetScope === 'user'
+          || effectiveModelScope(currentEffectiveLlm) === 'organisation'
+        ) {
+          currentEffectiveEnabledLlms = [...persistedTargetEnabledLlms];
+        }
       }
       explicitlyRemovedWorkflowPoolKeys = new Set();
       scopedModelStateReady = true;
@@ -5580,6 +5781,7 @@ async function verifyOpenAiApiKey(savedModel = null) {
       await refreshOpenAiReasoningEffortControls();
       latestOpenAiModelProbe = null;
       updateOpenAiModelStatusMessage();
+      void refreshSelectedOpenAiCostSummary();
     } else {
       throw new Error(response.error || 'Failed to verify API key.');
     }
@@ -5596,6 +5798,7 @@ async function verifyOpenAiApiKey(savedModel = null) {
       modelsContainer.classList.remove('hidden');
       latestOpenAiModelProbe = null;
       updateOpenAiModelStatusMessage();
+      void refreshSelectedOpenAiCostSummary();
     } catch (_) {
       setInlineStatusMessage(statusMessage, `Error: ${error.message}`, 'error');
       modelsContainer.style.display = 'none';

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -4023,6 +4023,90 @@ describe('thinking activity history normalisation', () => {
         expect(html).toContain('data-thinking-action="llm-call-log-toggle"');
     });
 
+    test('shows cumulative model tokens and estimated cost in the default Thinking view', () => {
+        const request = {
+            clientRequestId: 'req-llm-usage-cost',
+            thinkingCardMode: 'default',
+            latestProgress: {
+                request_id: 'req-llm-usage-cost',
+                status: 'completed',
+                stage: 'completed'
+            },
+            llmUsageCostSummary: {
+                schema_version: 'llm_usage_cost_summary.v1',
+                call_count: 1,
+                unique_call_count: 1,
+                usage: {
+                    status: 'reported',
+                    input_tokens: 12340,
+                    output_tokens: 820,
+                    total_tokens: 13160
+                },
+                estimated_cost: {
+                    status: 'estimated',
+                    amount: 0.123456,
+                    known_amount: 0.123456,
+                    currency: 'USD'
+                },
+                model_identities: [
+                    {
+                        provider: 'openai',
+                        requested_model: 'gpt-requested',
+                        selected_model: 'gpt-selected',
+                        effective_model: 'gpt-effective',
+                        model_identity_source: 'provider_response',
+                        call_count: 1
+                    }
+                ]
+            }
+        };
+
+        const html = __testOnly_renderThinkingCardBodyHTML(request);
+        expect(html).toContain('Model usage');
+        expect(html).toContain('openai/gpt-effective');
+        expect(html).toContain('12,340 input');
+        expect(html).toContain('820 output');
+        expect(html).toMatch(/estimated .*0\.123456/);
+        expect(html).toContain('1 model call');
+    });
+
+    test('reports missing pricing and token coverage as unavailable rather than zero', () => {
+        const request = {
+            clientRequestId: 'req-llm-usage-unavailable',
+            thinkingCardMode: 'default',
+            latestProgress: {
+                request_id: 'req-llm-usage-unavailable',
+                status: 'completed',
+                stage: 'completed'
+            },
+            llmUsageCostSummary: {
+                schema_version: 'llm_usage_cost_summary.v1',
+                call_count: 1,
+                unique_call_count: 1,
+                usage: { status: 'unavailable' },
+                estimated_cost: {
+                    status: 'unavailable',
+                    amount: null,
+                    known_amount: null,
+                    currency: null
+                },
+                model_identities: [
+                    {
+                        provider: 'openai',
+                        effective_model: 'gpt-unpriced',
+                        model_identity_source: 'provider_response',
+                        call_count: 1
+                    }
+                ]
+            }
+        };
+
+        const html = __testOnly_renderThinkingCardBodyHTML(request);
+        expect(html).toContain('cost estimate unavailable');
+        expect(html).toContain('token usage unavailable');
+        expect(html).not.toContain('$0');
+    });
+
     test('completed turns clarify that archived LLM exchange details are not loaded yet', () => {
         const request = {
             clientRequestId: 'req-llm-log-completed-not-loaded',
@@ -4065,6 +4149,9 @@ describe('thinking activity history normalisation', () => {
                         status: 'llm_call_start',
                         stage: 'workflow_dispatch',
                         model: 'gpt-5.4-mini',
+                        requested_model: 'gpt-requested',
+                        selected_model: 'gpt-5.4-mini',
+                        effective_model: 'gpt-5.4-mini',
                         provider: 'openai',
                         fallback_attempt_no: 1,
                         llm_request_state: 'sent',
@@ -4088,6 +4175,8 @@ describe('thinking activity history normalisation', () => {
         expect(html).toContain('LIVE-PROMPT-SENT-IMMEDIATELY');
         expect(html).toContain('Sent');
         expect(html).toContain('response pending');
+        expect(html).toContain('Model lineage: requested gpt-requested · selected gpt-5.4-mini');
+        expect(html).not.toContain('effective gpt-5.4-mini');
         expect(html).not.toContain('Full LLM call log not loaded yet.');
     });
 
@@ -4269,6 +4358,54 @@ describe('thinking activity history normalisation', () => {
         expect(entriesHtml).toContain('data-thinking-llm-call-model="gpt-5.4-mini"');
         // Timestamp is rendered in the summary header (seconds precision present).
         expect(entriesHtml).toMatch(/\d{2}:\d{2}:\d{2}\.\d{3}/);
+    });
+
+    test('renders archived per-call usage and requested-to-effective lineage', () => {
+        const entriesHtml = __testOnly_renderThinkingLlmCallLogEntriesHTML([
+            {
+                call_id: 'call-with-cost-1',
+                sequence_no: 1,
+                stage: 'plain_response',
+                call_type: 'adaptive_turn_model_call',
+                provider: 'openai',
+                model: 'gpt-effective',
+                requested_model: 'gpt-requested',
+                selected_model: 'gpt-selected',
+                effective_model: 'gpt-effective',
+                model_identity_source: 'provider_response',
+                usage: {
+                    status: 'reported',
+                    input_tokens: 1000,
+                    output_tokens: 250,
+                    total_tokens: 1250
+                },
+                prompt: { text: 'Prompt', is_truncated: false },
+                response: { text: 'Response', is_truncated: false }
+            }
+        ]);
+
+        expect(entriesHtml).toContain('1,000 input');
+        expect(entriesHtml).toContain('250 output');
+        expect(entriesHtml).toContain('Model lineage: requested gpt-requested · selected gpt-selected · effective gpt-effective');
+    });
+
+    test('does not present a selected model as provider-effective without provider evidence', () => {
+        const entriesHtml = __testOnly_renderThinkingLlmCallLogEntriesHTML([
+            {
+                stage: 'workflow_dispatch',
+                call_type: 'live_llm_call',
+                model: 'gpt-selected',
+                requested_model: 'gpt-requested',
+                selected_model: 'gpt-selected',
+                effective_model: 'gpt-selected',
+                model_identity_source: '',
+                prompt: { text: 'Prompt', is_truncated: false },
+                response: { text: 'Response', is_truncated: false }
+            }
+        ]);
+
+        expect(entriesHtml).toContain('Model lineage: requested gpt-requested · selected gpt-selected');
+        expect(entriesHtml).not.toContain('effective gpt-selected');
     });
 
     test('marks a truncated LLM exchange so the exact-text expectation is visible (JVNAUTOSCI-2385)', () => {

--- a/src/frontend/web/von_interface/templates/settings_tab.html
+++ b/src/frontend/web/von_interface/templates/settings_tab.html
@@ -244,8 +244,8 @@
                 <h2 id="modelScopeOverviewHeading">Model Selection Scopes</h2>
                 <p class="settings-note">
                     Chat selection, workflow routing, and shared server services are separate scopes. Von's
-                    represented model-selection workflow may choose any model in the enabled pool; Settings
-                    controls eligibility, not routing policy.
+                    represented model-selection workflow may choose only from the scoped allowed models;
+                    Settings controls eligibility, not routing policy.
                 </p>
                 <dl class="settings-model-scope-summary">
                     <div>
@@ -266,7 +266,7 @@
                     </div>
                 </dl>
                 <div class="settings-model-pool-panel">
-                    <h3>Workflow-enabled model pool</h3>
+                    <h3>Scoped allowed models</h3>
                     <div class="inline-form inline-form-tight mb-1">
                         <label for="modelPoolTargetScopeSelect">Save target</label>
                         <select id="modelPoolTargetScopeSelect" disabled>
@@ -286,17 +286,17 @@
                         </button>
                     </div>
                     <p class="settings-note">
-                        Pool-only edits retain the selected target primary. Replacing it with this browser's chat
+                        Allowed-model edits retain the selected target primary. Replacing it with this browser's chat
                         model requires the explicit action above.
                     </p>
                     <p class="settings-note">
-                        The scoped primary is always enabled. Add or remove alternatives explicitly; configuring
-                        or testing a model does not add it to this pool.
+                        The scoped primary is always allowed. Add or remove alternatives explicitly; configuring
+                        or testing a model does not allow it.
                     </p>
                     <div id="workflowModelPoolList" class="settings-model-pool-list"></div>
                     <div class="inline-form inline-form-tight mt-2">
                         <button id="saveModelPoolButton" class="btn-azure" type="button" disabled>
-                            Save scoped primary &amp; workflow pool
+                            Save scoped primary &amp; allowed models
                         </button>
                     </div>
                     <div id="modelPoolStatusMessage" class="status-message" role="status"></div>
@@ -310,11 +310,11 @@
             <div class="inline-form inline-form-tight mt-2">
                 <input type="checkbox" id="enableOpenAiPremiumToggle" />
                 <label for="enableOpenAiPremiumToggle"
-                    title="When enabled, this browser requests the selected OpenAI model for chat. When disabled, it requests the selected Ollama model.">Use
-                    selected OpenAI model for chat in this browser</label>
+                    title="When enabled, this browser requests the selected OpenAI model for chat, provided the exact model is allowed for the selected scope. When disabled, it requests the selected Ollama model.">Use
+                    selected allowed OpenAI model for chat in this browser</label>
             </div>
-            <small class="settings-note">Turn this off to use the selected Ollama model for browser chat. Editing or
-                testing a model does not add it to workflow routing.</small>
+            <small class="settings-note">First allow the exact OpenAI model for this scope and save. Turn this off
+                to use the selected Ollama model for browser chat. Editing or testing a model does not allow it.</small>
             <div id="openaiModelsContainer" class="hidden">
                 <label for="openaiModelSelect">Select OpenAI Model:</label>
                 <select id="openaiModelSelect" name="openai_model">
@@ -325,11 +325,19 @@
                     <select id="openaiReasoningEffortSelect" name="openai_reasoning_effort"></select>
                 </div>
                 <div class="inline-form inline-form-tight mt-2">
-                    <button id="testOpenAiModelButton" class="btn-secondary" type="button">Test this model</button>
-                    <button id="addOpenAiToWorkflowPoolButton" class="btn-secondary" type="button">Add to workflow pool</button>
+                    <button id="testOpenAiModelButton" class="btn-secondary" type="button" disabled>Test this model</button>
+                    <button id="addOpenAiToWorkflowPoolButton" class="btn-secondary" type="button">Allow for this scope</button>
                 </div>
-                <small class="settings-note">A test is a live probe only; it does not change the browser chat
-                    choice, scoped primary, or workflow pool.</small>
+                <small class="settings-note">A test is a live paid-provider probe and is available only after the
+                    exact model is allowed and saved. It does not change the browser choice or scoped primary.</small>
+                <div id="openaiModelEligibilityStatus" class="status-message" role="status">
+                    Select an OpenAI model to check whether it is allowed for this scope.
+                </div>
+                <div id="openaiModelCostSummary"
+                    class="settings-note"
+                    role="status">
+                    Historical cost estimate unavailable until persisted usage and pricing evidence is provided.
+                </div>
                 <div id="openaiModelStatusMessage" class="status-message" role="alert">
                     <!-- Status messages for the selected premium model will appear here -->
                 </div>
@@ -412,10 +420,10 @@
             </div>
             <div class="inline-form inline-form-tight mt-2">
                 <button id="testOllamaModelButton" class="btn-secondary" type="button">Test this model</button>
-                <button id="addOllamaToWorkflowPoolButton" class="btn-secondary" type="button">Add to workflow pool</button>
+                <button id="addOllamaToWorkflowPoolButton" class="btn-secondary" type="button">Allow for this scope</button>
             </div>
             <small class="settings-note">A test is a live probe only; it does not change the browser chat choice,
-                scoped primary, or workflow pool.</small>
+                scoped primary, or scoped allowed models.</small>
             <div id="ollamaModelStatusMessage" class="status-message" role="alert">
                 <!-- Status messages for the selected Ollama model will appear here -->
             </div>

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -18,6 +18,7 @@ from src.backend.integrations.internal_mcp.transport import (
     InternalMCPTransport,
     internal_mcp_cancellation_requested,
 )
+from src.backend.languagemodels.llm_interface import ModelExecutionEligibilityError
 from src.backend.languagemodels.structured_tool_calling.types import (
     LLMContinuation,
     LLMResponse,
@@ -744,6 +745,40 @@ def test_plain_answer_gets_trusted_scope_and_generic_read_doorway() -> None:
         "offset",
         "limit",
     }
+
+
+def test_model_eligibility_denial_is_returned_in_ordinary_language() -> None:
+    denial = ModelExecutionEligibilityError(
+        "OpenAI model 'gpt-5.6-terra' is not enabled for the current user or "
+        "organisation.",
+        provider="openai",
+        model="gpt-5.6-terra",
+    )
+    client = _SequenceClient(denial)
+
+    result = execute_adaptive_turn(
+        gateway=_gateway(lambda **_kwargs: {"success": True}),
+        prompt="Help with this.",
+        context=[],
+        llm_client=client,
+        model="gpt-5.6-terra",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="model-not-enabled",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert result.terminal_status == "model_not_enabled"
+    assert result.response_text == str(denial)
+    assert len(client.calls) == 1
+    assert result.llm_calls[0]["call_id"] == "model-not-enabled:llm:1"
+    assert result.llm_calls[0]["requested_model"] == "gpt-5.6-terra"
+    assert result.llm_calls[0]["selected_model"] == "gpt-5.6-terra"
+    assert result.llm_calls[0]["effective_model"] is None
+    assert result.llm_calls[0]["model_identity_source"] is None
+    assert result.llm_calls[0]["provider_request_sent"] is False
 
 
 def test_terminal_answer_can_update_a_revisable_conversation_situation() -> None:
@@ -7415,3 +7450,103 @@ def test_unchanged_terminally_failed_effect_is_not_dispatched_twice(
     )
     assert result.tool_invocations[1]["effect_status"] == "not_started"
     assert result.tool_invocations[1]["changed"] is False
+
+
+def test_model_call_progress_reports_cumulative_usage_cost_and_exact_identity() -> None:
+    progress_events: list[dict[str, Any]] = []
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_list_evidence",
+                    call_id="list-evidence",
+                    payload={},
+                )
+            ],
+            model="gpt-test-effective",
+            usage={"prompt_tokens": 100, "completion_tokens": 10},
+            transport_metadata={
+                "effective_service_tier": "default",
+                "effective_connection_id": "#V#openai_provider",
+            },
+        ),
+        LLMResponse(
+            text_response="Done.",
+            model="gpt-test-effective",
+            usage={"prompt_tokens": 50, "completion_tokens": 5},
+            transport_metadata={
+                "effective_service_tier": "default",
+                "effective_connection_id": "#V#openai_provider",
+            },
+        ),
+    )
+    client.config = SimpleNamespace(provider="openai")
+    registry = {
+        "models": [
+            {
+                "provider": "openai",
+                "model_id": "gpt-test-effective",
+                "pricing": {
+                    "schema_version": "llm_model_pricing.v1",
+                    "version": "test-v1",
+                    "source": "test",
+                    "effective_at_utc": "2026-08-05T00:00:00Z",
+                    "model_id": "gpt-test-effective",
+                    "currency": "USD",
+                    "unit_tokens": 1_000,
+                    "rates": {
+                        "input_tokens": 1.0,
+                        "output_tokens": 2.0,
+                    },
+                },
+            }
+        ]
+    }
+
+    execute_adaptive_turn(
+        gateway=None,
+        prompt="Use evidence if useful, then answer.",
+        context=[],
+        llm_client=client,
+        model="gpt-test-requested",
+        progress_tracker=SimpleNamespace(
+            emit=lambda event: progress_events.append(dict(event))
+        ),
+        turn_id="usage-cost-progress",
+        model_registry_snapshot=registry,
+    )
+
+    model_end_events = [
+        event
+        for event in progress_events
+        if event.get("event_kind") == "llm_call_end"
+        and str(event.get("call_id") or "").startswith("usage-cost-progress:llm:")
+    ]
+    assert [event["call_id"] for event in model_end_events] == [
+        "usage-cost-progress:llm:1",
+        "usage-cost-progress:llm:2",
+    ]
+    assert model_end_events[0]["requested_model"] == "gpt-test-requested"
+    assert model_end_events[0]["selected_model"] == "gpt-test-requested"
+    assert model_end_events[0]["effective_model"] == "gpt-test-effective"
+    assert model_end_events[0]["model_identity_source"] == "provider_response"
+    first_summary = model_end_events[0]["llm_usage_cost_summary"]
+    second_summary = model_end_events[1]["llm_usage_cost_summary"]
+    assert first_summary["usage"]["total_tokens"] == 110
+    assert first_summary["estimated_cost"]["amount"] == 0.12
+    assert second_summary["usage"]["total_tokens"] == 165
+    assert second_summary["estimated_cost"]["amount"] == 0.18
+    assert second_summary["model_identities"] == [
+        {
+            "provider": "openai",
+            "requested_model": "gpt-test-requested",
+            "selected_model": "gpt-test-requested",
+            "effective_model": "gpt-test-effective",
+            "model_identity_source": "provider_response",
+            "provider_request_sent": True,
+            "effective_service_tier": "default",
+            "connection_id": "#V#openai_provider",
+            "call_count": 2,
+        }
+    ]

--- a/tests/backend/test_llm_api_key_resolution.py
+++ b/tests/backend/test_llm_api_key_resolution.py
@@ -40,6 +40,7 @@ def test_gemini_client_accepts_legacy_google_api_key(monkeypatch):
 
 
 def test_describe_image_with_gemini_accepts_legacy_google_api_key(monkeypatch):
+    from src.backend.languagemodels import llm_interface
     from src.backend.services import file_copy_interpretation_service as service
 
     google_mod = types.ModuleType("google")
@@ -68,6 +69,11 @@ def test_describe_image_with_gemini_accepts_legacy_google_api_key(monkeypatch):
     )
 
     monkeypatch.setitem(sys.modules, "google", google_mod)
+    monkeypatch.setattr(
+        llm_interface,
+        "assert_model_execution_allowed",
+        lambda **_kwargs: {"allowed": True},
+    )
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
     monkeypatch.setenv("GOOGLE_API_KEY", "legacy-key")
 
@@ -85,6 +91,7 @@ def test_describe_image_with_gemini_accepts_legacy_google_api_key(monkeypatch):
 
 
 def test_describe_image_with_openai_uses_central_default_model(monkeypatch):
+    from src.backend.languagemodels import llm_interface
     from src.backend.services import file_copy_interpretation_service as service
 
     openai_mod = types.ModuleType("openai")
@@ -112,6 +119,11 @@ def test_describe_image_with_openai_uses_central_default_model(monkeypatch):
     setattr(openai_mod, "OpenAI", _Client)
 
     monkeypatch.setitem(sys.modules, "openai", openai_mod)
+    monkeypatch.setattr(
+        llm_interface,
+        "assert_model_execution_allowed",
+        lambda **_kwargs: {"allowed": True},
+    )
     monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
 
     result = service._describe_image_with_openai(
@@ -125,3 +137,41 @@ def test_describe_image_with_openai_uses_central_default_model(monkeypatch):
     assert captured["model"] == "gpt-5.5"
     assert result["method"] == "openai_vision"
     assert result["model"] == "gpt-5.5"
+
+
+def test_describe_image_with_openai_denies_actorless_execution_before_provider(
+    monkeypatch,
+):
+    from src.backend.languagemodels import llm_interface
+    from src.backend.services import file_copy_interpretation_service as service
+
+    openai_mod = types.ModuleType("openai")
+    constructed = False
+
+    class _Client:
+        def __init__(self, *, api_key):
+            del api_key
+            nonlocal constructed
+            constructed = True
+
+    setattr(openai_mod, "OpenAI", _Client)
+    monkeypatch.setitem(sys.modules, "openai", openai_mod)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+    monkeypatch.setattr(
+        llm_interface,
+        "_resolve_effective_llm_actor_scope",
+        lambda *_args, **_kwargs: (None, None),
+    )
+
+    result = service._describe_image_with_openai(
+        data_bytes=b"png-data",
+        content_type="image/png",
+        model="gpt-5.6-terra",
+        prompt="Describe the image.",
+    )
+
+    assert result["description"] is None
+    assert result["method"] == "openai_vision_not_enabled"
+    assert result["failure_kind"] == "model_scope_required"
+    assert "no authenticated user or organisation model scope" in result["error"]
+    assert constructed is False

--- a/tests/backend/test_llm_openai_temperature_guards.py
+++ b/tests/backend/test_llm_openai_temperature_guards.py
@@ -9,6 +9,21 @@ import pytest
 import src.backend.services  # noqa: F401
 
 
+@pytest.fixture(autouse=True)
+def _allow_external_model_for_parameter_transport_tests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """These tests isolate OpenAI parameter transport, not eligibility policy."""
+
+    from src.backend.languagemodels import llm_interface
+
+    monkeypatch.setattr(
+        llm_interface,
+        "assert_model_execution_allowed",
+        lambda **_kwargs: {"allowed": True},
+    )
+
+
 def _install_openai_temperature_registry(monkeypatch) -> None:
     import src.backend.services.model_registry_service as registry_module
 

--- a/tests/backend/test_llm_usage_cost_service.py
+++ b/tests/backend/test_llm_usage_cost_service.py
@@ -1,0 +1,525 @@
+from __future__ import annotations
+
+from src.backend.services.llm_usage_cost_service import (
+    build_llm_usage_cost_summary,
+    normalise_llm_usage,
+)
+
+
+def _registry(*, model_id: str = "gpt-5-test") -> dict:
+    return {
+        "source": "test_registry",
+        "models": [
+            {
+                "provider": "openai",
+                "model_id": model_id,
+                "pricing": {
+                    "schema_version": "llm_model_pricing.v1",
+                    "version": "test-2026-08-05",
+                    "source": "test_fixture",
+                    "effective_at_utc": "2026-08-05T00:00:00Z",
+                    "model_id": model_id,
+                    "currency": "USD",
+                    "unit_tokens": 1_000_000,
+                    "rates": {
+                        "input_tokens": 2.0,
+                        "output_tokens": 8.0,
+                    },
+                },
+            }
+        ],
+    }
+
+
+def test_normalise_usage_accepts_existing_token_field_names() -> None:
+    usage = normalise_llm_usage(
+        {
+            "prompt_tokens": 100,
+            "completion_tokens": 40,
+        }
+    )
+
+    assert usage == {
+        "status": "reported",
+        "input_tokens": 100,
+        "cached_input_tokens": None,
+        "cache_write_input_tokens": None,
+        "output_tokens": 40,
+        "total_tokens": 140,
+    }
+
+
+def _detailed_registry(*, model_id: str = "gpt-5.6-terra") -> dict:
+    return {
+        "models": [
+            {
+                "provider": "openai",
+                "model_id": model_id,
+                "pricing": {
+                    "schema_version": "llm_model_pricing.v1",
+                    "version": "openai-standard-2026-08-05",
+                    "source": "https://developers.openai.com/api/docs/pricing",
+                    "effective_at_utc": "2026-08-05T00:00:00Z",
+                    "model_id": model_id,
+                    "currency": "USD",
+                    "unit_tokens": 1_000_000,
+                    "applicability": {
+                        "effective_service_tiers": ["default"],
+                        "connection_ids": ["#V#openai_provider"],
+                    },
+                    "rates": {
+                        "input_tokens": 2.0,
+                        "cached_input_tokens": 0.2,
+                        "cache_write_input_tokens": 2.5,
+                        "output_tokens": 12.0,
+                    },
+                    "long_context": {
+                        "threshold_input_tokens": 272_000,
+                        "rates": {
+                            "input_tokens": 4.0,
+                            "cached_input_tokens": 0.4,
+                            "cache_write_input_tokens": 5.0,
+                            "output_tokens": 18.0,
+                        },
+                    },
+                },
+            }
+        ]
+    }
+
+
+def _priced_terra_call(*, usage: dict, tier: str = "default") -> dict:
+    return {
+        "call_id": "terra-call",
+        "provider": "openai",
+        "effective_model": "gpt-5.6-terra",
+        "model_identity_source": "provider_response",
+        "usage": usage,
+        "transport": {
+            "effective_service_tier": tier,
+            "effective_connection_id": "#V#openai_provider",
+        },
+    }
+
+
+def test_detailed_openai_price_uses_cache_breakdown_and_context_band() -> None:
+    short = build_llm_usage_cost_summary(
+        [
+            _priced_terra_call(
+                usage={
+                    "prompt_tokens": 1_000,
+                    "cached_input_tokens": 200,
+                    "cache_write_input_tokens": 100,
+                    "completion_tokens": 100,
+                }
+            )
+        ],
+        model_registry=_detailed_registry(),
+    )
+    assert short["estimated_cost"]["status"] == "estimated"
+    assert short["estimated_cost"]["amount"] == 0.00289
+
+    long = build_llm_usage_cost_summary(
+        [
+            _priced_terra_call(
+                usage={
+                    "prompt_tokens": 300_000,
+                    "cached_input_tokens": 100_000,
+                    "cache_write_input_tokens": 50_000,
+                    "completion_tokens": 1_000,
+                }
+            )
+        ],
+        model_registry=_detailed_registry(),
+    )
+    assert long["estimated_cost"]["status"] == "estimated"
+    assert long["estimated_cost"]["amount"] == 0.908
+
+
+def test_detailed_price_is_partial_without_cache_breakdown() -> None:
+    summary = build_llm_usage_cost_summary(
+        [
+            _priced_terra_call(
+                usage={"prompt_tokens": 1_000, "completion_tokens": 100}
+            )
+        ],
+        model_registry=_detailed_registry(),
+    )
+
+    assert summary["estimated_cost"]["status"] == "partial"
+    assert summary["estimated_cost"]["amount"] is None
+    assert summary["estimated_cost"]["known_amount"] == 0.0012
+
+
+def test_detailed_price_requires_effective_tier_and_direct_connection() -> None:
+    missing_tier = _priced_terra_call(
+        usage={
+            "prompt_tokens": 1_000,
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
+            "completion_tokens": 100,
+        },
+        tier="",
+    )
+    unknown_connection = _priced_terra_call(usage=dict(missing_tier["usage"]))
+    unknown_connection["transport"]["effective_connection_id"] = "compatible:opaque"
+
+    for call in (missing_tier, unknown_connection):
+        summary = build_llm_usage_cost_summary(
+            [call],
+            model_registry=_detailed_registry(),
+        )
+        assert summary["estimated_cost"]["status"] == "unavailable"
+        assert summary["estimated_cost"]["amount"] is None
+
+
+def test_cost_uses_effective_model_and_exact_registry_match() -> None:
+    summary = build_llm_usage_cost_summary(
+        [
+            {
+                "call_id": "call-1",
+                "provider": "openai",
+                "requested_model": "gpt-5-requested",
+                "selected_model": "gpt-5-selected",
+                "effective_model": "gpt-5-test",
+                "model_identity_source": "provider_response",
+                "usage": {"prompt_tokens": 100, "completion_tokens": 40},
+            }
+        ],
+        model_registry=_registry(),
+    )
+
+    assert summary["estimated_cost"]["status"] == "estimated"
+    assert summary["estimated_cost"]["amount"] == 0.00052
+    assert summary["model_identities"] == [
+        {
+            "provider": "openai",
+            "requested_model": "gpt-5-requested",
+            "selected_model": "gpt-5-selected",
+            "effective_model": "gpt-5-test",
+            "model_identity_source": "provider_response",
+            "provider_request_sent": None,
+            "effective_service_tier": None,
+            "connection_id": None,
+            "call_count": 1,
+        }
+    ]
+
+    family_only = build_llm_usage_cost_summary(
+        [
+            {
+                "call_id": "call-2",
+                "provider": "openai",
+                "effective_model": "gpt-5-test-2026-08-05",
+                "model_identity_source": "provider_response",
+                "usage": {"prompt_tokens": 100, "completion_tokens": 40},
+            }
+        ],
+        model_registry=_registry(),
+    )
+    assert family_only["estimated_cost"]["status"] == "unavailable"
+    assert family_only["estimated_cost"]["amount"] is None
+    assert family_only["model_identities"][0]["effective_model"] == (
+        "gpt-5-test-2026-08-05"
+    )
+
+
+def test_stable_call_id_is_counted_once_and_richer_record_wins() -> None:
+    summary = build_llm_usage_cost_summary(
+        [
+            {
+                "call_id": "same-attempt",
+                "provider": "openai",
+                "effective_model": "gpt-5-test",
+                "model_identity_source": "provider_response",
+                "status": "timeout_observed",
+                "usage": None,
+            },
+            {
+                "call_id": "same-attempt",
+                "provider": "openai",
+                "effective_model": "gpt-5-test",
+                "model_identity_source": "provider_response",
+                "status": "completed",
+                "usage": {"prompt_tokens": 1_000, "completion_tokens": 500},
+            },
+        ],
+        model_registry=_registry(),
+    )
+
+    assert summary["call_count"] == 2
+    assert summary["unique_call_count"] == 1
+    assert summary["duplicate_call_count"] == 1
+    assert summary["usage"]["total_tokens"] == 1_500
+    assert summary["estimated_cost"]["amount"] == 0.006
+    assert summary["model_identities"][0]["call_count"] == 1
+
+
+def test_calls_without_stable_ids_remain_distinct() -> None:
+    call = {
+        "provider": "openai",
+        "effective_model": "gpt-5-test",
+        "model_identity_source": "provider_response",
+        "usage": {"prompt_tokens": 100, "completion_tokens": 50},
+    }
+    summary = build_llm_usage_cost_summary(
+        [dict(call), dict(call)], model_registry=_registry()
+    )
+
+    assert summary["unique_call_count"] == 2
+    assert summary["duplicate_call_count"] == 0
+    assert summary["usage"]["total_tokens"] == 300
+
+
+def test_missing_usage_or_pricing_is_unavailable_not_zero() -> None:
+    missing_usage = build_llm_usage_cost_summary(
+        [
+            {
+                "call_id": "call-1",
+                "provider": "openai",
+                "effective_model": "gpt-5-test",
+                "model_identity_source": "provider_response",
+                "usage": None,
+            }
+        ],
+        model_registry=_registry(),
+    )
+    assert missing_usage["usage"]["status"] == "unavailable"
+    assert missing_usage["usage"]["total_tokens"] is None
+    assert missing_usage["estimated_cost"]["status"] == "unavailable"
+    assert missing_usage["estimated_cost"]["amount"] is None
+    assert missing_usage["estimated_cost"]["known_amount"] is None
+
+    missing_pricing = build_llm_usage_cost_summary(
+        [
+            {
+                "call_id": "call-2",
+                "provider": "openai",
+                "effective_model": "gpt-5-test",
+                "model_identity_source": "provider_response",
+                "usage": {"prompt_tokens": 100, "completion_tokens": 40},
+            }
+        ]
+    )
+    assert missing_pricing["usage"]["status"] == "reported"
+    assert missing_pricing["estimated_cost"]["status"] == "unavailable"
+    assert missing_pricing["estimated_cost"]["amount"] is None
+
+
+def test_missing_effective_model_is_not_priced_from_legacy_model_field() -> None:
+    summary = build_llm_usage_cost_summary(
+        [
+            {
+                "call_id": "legacy-identity",
+                "provider": "openai",
+                "model": "gpt-5-test",
+                "usage": {"prompt_tokens": 100, "completion_tokens": 40},
+            }
+        ],
+        model_registry=_registry(),
+    )
+
+    assert summary["model_identities"][0]["effective_model"] is None
+    assert summary["estimated_cost"]["status"] == "unavailable"
+    assert summary["estimated_cost"]["amount"] is None
+    assert "effective_model_unavailable" in summary["estimated_cost"][
+        "unavailable_reasons"
+    ]
+
+
+def test_selected_request_identity_is_not_priced_as_provider_effective() -> None:
+    summary = build_llm_usage_cost_summary(
+        [
+            {
+                "call_id": "selected-only",
+                "provider": "openai",
+                "selected_model": "gpt-5-test",
+                "effective_model": "gpt-5-test",
+                "model_identity_source": "selected_request",
+                "usage": {"prompt_tokens": 100, "completion_tokens": 40},
+            }
+        ],
+        model_registry=_registry(),
+    )
+
+    assert summary["estimated_cost"]["status"] == "unavailable"
+    assert summary["estimated_cost"]["amount"] is None
+    assert summary["pricing_usage_groups"] == []
+    assert summary["pricing_usage_group_unattributed_call_count"] == 1
+
+
+def test_historical_repricing_preserves_per_call_context_bands() -> None:
+    from src.backend.services.llm_model_cost_history_service import (
+        build_historical_model_cost_summary,
+    )
+
+    first = _priced_terra_call(
+        usage={
+            "prompt_tokens": 150_000,
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
+            "completion_tokens": 0,
+        }
+    )
+    second = {**first, "call_id": "terra-call-2"}
+    summary = build_llm_usage_cost_summary(
+        [first, second], model_registry=_detailed_registry()
+    )
+    assert summary["estimated_cost"]["amount"] == 0.6
+    assert summary["pricing_usage_groups"][0][
+        "pricing_context_input_tokens"
+    ] == 150_000
+    assert summary["pricing_usage_groups"][0]["usage"]["input_tokens"] == 300_000
+
+    historical = build_historical_model_cost_summary(
+        [
+            {
+                "created_at_utc": "2026-08-05T10:00:00Z",
+                "llm_usage_cost_summary": summary,
+            }
+        ],
+        provider="openai",
+        model="gpt-5.6-terra",
+        model_registry=_detailed_registry(),
+    )
+
+    assert historical["status"] == "available"
+    assert historical["average_attributed_cost_per_turn"] == {
+        "amount": 0.6,
+        "currency": "USD",
+    }
+
+
+def test_unattributed_paid_call_prevents_full_turn_cost_estimate() -> None:
+    from src.backend.services.llm_model_cost_history_service import (
+        build_historical_model_cost_summary,
+    )
+
+    summary = build_llm_usage_cost_summary(
+        [
+            {
+                "call_id": "main",
+                "provider": "openai",
+                "effective_model": "gpt-5-test",
+                "model_identity_source": "provider_response",
+                "provider_request_sent": True,
+                "usage": {"prompt_tokens": 100, "completion_tokens": 40},
+            },
+            {
+                "call_id": "support",
+                "provider": "openai",
+                "selected_model": "gpt-5-test",
+                "provider_request_sent": True,
+                "usage": None,
+            },
+        ],
+        model_registry=_registry(),
+    )
+    assert summary["billable_call_count"] == 2
+    assert summary["pricing_usage_group_covered_call_count"] == 1
+    assert summary["pricing_usage_group_unattributed_call_count"] == 1
+
+    historical = build_historical_model_cost_summary(
+        [
+            {
+                "created_at_utc": "2026-08-05T10:00:00Z",
+                "llm_usage_cost_summary": summary,
+            }
+        ],
+        provider="openai",
+        model="gpt-5-test",
+        model_registry=_registry(),
+    )
+    assert historical["status"] == "unavailable"
+    assert historical["average_attributed_cost_per_turn"]["amount"] is None
+
+
+def test_partial_cost_exposes_only_a_labelled_known_subtotal() -> None:
+    summary = build_llm_usage_cost_summary(
+        [
+            {
+                "call_id": "priced",
+                "provider": "openai",
+                "effective_model": "gpt-5-test",
+                "model_identity_source": "provider_response",
+                "usage": {"prompt_tokens": 100, "completion_tokens": 40},
+            },
+            {
+                "call_id": "unknown",
+                "provider": "openai",
+                "effective_model": "gpt-5-unpriced",
+                "model_identity_source": "provider_response",
+                "usage": {"prompt_tokens": 100, "completion_tokens": 40},
+            },
+        ],
+        model_registry=_registry(),
+    )
+
+    assert summary["estimated_cost"]["status"] == "partial"
+    assert summary["estimated_cost"]["amount"] is None
+    assert summary["estimated_cost"]["known_amount"] == 0.00052
+    assert summary["estimated_cost"]["priced_call_count"] == 1
+    assert summary["estimated_cost"]["unpriced_call_count"] == 1
+
+
+def test_unsent_provider_request_is_not_billable() -> None:
+    summary = build_llm_usage_cost_summary(
+        [
+            {
+                "call_id": "reachability-skip",
+                "provider": "openai",
+                "effective_model": "gpt-5-test",
+                "model_identity_source": "provider_response",
+                "provider_request_sent": False,
+                "usage": None,
+            }
+        ],
+        model_registry=_registry(),
+    )
+
+    assert summary["billable_call_count"] == 0
+    assert summary["usage"]["status"] == "not_applicable"
+    assert summary["estimated_cost"]["status"] == "not_applicable"
+    assert summary["estimated_cost"]["amount"] is None
+
+
+def test_local_ollama_usage_is_reported_but_financial_cost_is_not_applicable() -> None:
+    summary = build_llm_usage_cost_summary(
+        [
+            {
+                "call_id": "local-call",
+                "provider": "ollama",
+                "effective_model": "gemma4:31b",
+                "usage": {"prompt_tokens": 100, "completion_tokens": 20},
+            }
+        ]
+    )
+
+    assert summary["usage"]["status"] == "reported"
+    assert summary["usage"]["total_tokens"] == 120
+    assert summary["billable_call_count"] == 0
+    assert summary["estimated_cost"]["status"] == "not_applicable"
+    assert summary["estimated_cost"]["amount"] is None
+
+
+def test_unrepresentably_large_price_is_unavailable_instead_of_raising() -> None:
+    registry = _registry()
+    registry["models"][0]["pricing"]["rates"]["input_tokens"] = "1e999999"
+
+    summary = build_llm_usage_cost_summary(
+        [
+            {
+                "call_id": "huge-price",
+                "provider": "openai",
+                "effective_model": "gpt-5-test",
+                "model_identity_source": "provider_response",
+                "usage": {"prompt_tokens": 100, "completion_tokens": 40},
+            }
+        ],
+        model_registry=registry,
+    )
+
+    assert summary["estimated_cost"]["status"] == "unavailable"
+    assert summary["estimated_cost"]["amount"] is None
+    assert summary["estimated_cost"]["known_amount"] is None
+    assert "calls" not in summary

--- a/tests/backend/test_model_execution_eligibility.py
+++ b/tests/backend/test_model_execution_eligibility.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.backend.languagemodels import llm_interface
+
+
+def test_local_ollama_execution_does_not_require_scoped_eligibility(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        llm_interface,
+        "resolve_enabled_llm_settings",
+        lambda **_kwargs: pytest.fail("local execution must not read the premium pool"),
+    )
+
+    decision = llm_interface.assert_model_execution_allowed(
+        provider="ollama",
+        model="gemma4:31b",
+    )
+
+    assert decision["allowed"] is True
+    assert decision["scope"] == "local_provider"
+
+
+def test_unlisted_future_external_provider_does_not_bypass_eligibility(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        llm_interface,
+        "resolve_enabled_llm_settings",
+        lambda **_kwargs: [],
+    )
+
+    with pytest.raises(llm_interface.ModelExecutionEligibilityError):
+        llm_interface.assert_model_execution_allowed(
+            provider="anthropic",
+            model="claude-example",
+            user_concept_id="#V#current_user",
+        )
+
+
+def test_external_execution_requires_an_exact_enabled_provider_and_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        llm_interface,
+        "resolve_enabled_llm_settings",
+        lambda **_kwargs: [
+            {
+                "provider": "openai",
+                "model": "gpt-5.6-terra",
+                "scope": "user",
+            }
+        ],
+    )
+
+    decision = llm_interface.assert_model_execution_allowed(
+        provider="openai",
+        model="openai:gpt-5.6-terra",
+        user_concept_id="#V#current_user",
+    )
+
+    assert decision == {
+        "allowed": True,
+        "provider": "openai",
+        "model": "gpt-5.6-terra",
+        "scope": "user",
+    }
+
+    with pytest.raises(llm_interface.ModelExecutionEligibilityError) as exc_info:
+        llm_interface.assert_model_execution_allowed(
+            provider="openai",
+            model="gpt-5.6-terra-preview",
+            user_concept_id="#V#current_user",
+        )
+
+    assert exc_info.value.failure_kind == "model_not_enabled"
+    assert "exact provider and model" in str(exc_info.value)
+
+
+def test_external_execution_does_not_accept_a_provider_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        llm_interface,
+        "resolve_enabled_llm_settings",
+        lambda **_kwargs: [
+            {
+                "provider": "gemini",
+                "model": "gpt-5.6-terra",
+                "scope": "organisation",
+            }
+        ],
+    )
+
+    with pytest.raises(llm_interface.ModelExecutionEligibilityError):
+        llm_interface.assert_model_execution_allowed(
+            provider="openai",
+            model="gpt-5.6-terra",
+            org_concept_id="#V#current_org",
+        )
+
+
+def test_actorless_external_execution_fails_closed_before_pool_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        llm_interface,
+        "resolve_enabled_llm_settings",
+        lambda **_kwargs: pytest.fail("actorless execution must fail first"),
+    )
+
+    with pytest.raises(llm_interface.ModelExecutionEligibilityError) as exc_info:
+        llm_interface.assert_model_execution_allowed(
+            provider="openai",
+            model="gpt-5.6-terra",
+        )
+
+    assert exc_info.value.failure_kind == "model_scope_required"
+    assert "no authenticated user or organisation model scope" in str(
+        exc_info.value
+    )
+
+
+def test_structured_generation_checks_eligibility_before_client_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constructed = False
+
+    def _unexpected_client(_config: Any) -> Any:
+        nonlocal constructed
+        constructed = True
+        raise AssertionError("structured provider client must not be constructed")
+
+    monkeypatch.setattr(llm_interface, "get_structured_client", _unexpected_client)
+
+    class _ExternalClient(llm_interface.LLMInterface):
+        def generate(self, *args: Any, **kwargs: Any) -> str:
+            raise AssertionError("legacy generation is not part of this test")
+
+        def get_embedding(self, text: str) -> list[float]:
+            raise AssertionError("embedding is not part of this test")
+
+        def list_models(self) -> list[str]:
+            raise AssertionError("model listing is not part of this test")
+
+        def _get_structured_client_config(
+            self, model: str | None
+        ) -> llm_interface.LLMClientConfig:
+            return llm_interface.LLMClientConfig(
+                provider="openai",
+                model=model or "gpt-5.6-terra",
+            )
+
+    with pytest.raises(llm_interface.ModelExecutionEligibilityError):
+        _ExternalClient().generate_with_tools(
+            prompt="hello",
+            available_tools=[],
+            model="gpt-5.6-terra",
+        )
+
+    assert constructed is False
+
+
+def test_legacy_provider_generation_checks_eligibility_before_provider_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider_calls = 0
+
+    class _UnexpectedResponses:
+        @staticmethod
+        def create(**_kwargs: Any) -> Any:
+            nonlocal provider_calls
+            provider_calls += 1
+            raise AssertionError("provider must not be called")
+
+    openai_client = llm_interface.OpenAIClient.__new__(llm_interface.OpenAIClient)
+    openai_client.client = type(
+        "Client",
+        (),
+        {
+            "responses": _UnexpectedResponses(),
+            "chat": type(
+                "Chat",
+                (),
+                {"completions": _UnexpectedResponses()},
+            )(),
+        },
+    )()
+
+    with pytest.raises(llm_interface.ModelExecutionEligibilityError):
+        openai_client.generate("hello", model="gpt-5.6-terra")
+
+    monkeypatch.setattr(llm_interface, "genai", object())
+    gemini_client = llm_interface.GeminiClient.__new__(llm_interface.GeminiClient)
+    gemini_client.default_model = "gemini-2.0-flash"
+    gemini_client.client = object()
+
+    with pytest.raises(llm_interface.ModelExecutionEligibilityError):
+        gemini_client.generate("hello")
+
+    assert provider_calls == 0

--- a/tests/backend/test_model_registry_service.py
+++ b/tests/backend/test_model_registry_service.py
@@ -49,6 +49,17 @@ def test_get_model_registry_snapshot_prefers_graph_and_exposes_constraints(
         ],
         ("#V#openai_gpt5_mini_registry_entry", mod.PRED_HAS_MODEL_ID): ["gpt-5-mini"],
         (
+            "#V#openai_gpt5_mini_registry_entry",
+            mod.PRED_HAS_MODEL_PRICING_JSON,
+        ): [
+            '{"schema_version":"llm_model_pricing.v1",'
+            '"version":"test-v1","source":"test",'
+            '"effective_at_utc":"2026-08-05T00:00:00Z",'
+            '"model_id":"gpt-5-mini","currency":"USD",'
+            '"unit_tokens":1000000,"rates":{'
+            '"input_tokens":1.0,"output_tokens":4.0}}'
+        ],
+        (
             "#V#openai_gpt5_mini_chat_completions_profile",
             mod.PRED_HAS_API_SURFACE,
         ): ["chat_completions"],
@@ -102,6 +113,8 @@ def test_get_model_registry_snapshot_prefers_graph_and_exposes_constraints(
     assert model_entry["concept_id"] == "#V#openai_gpt_5_mini"
     assert model_entry["registry_entry_id"] == "#V#openai_gpt5_mini_registry_entry"
     assert "gpt-5-mini" in model_entry["model_aliases"]
+    assert model_entry["pricing"]["schema_version"] == "llm_model_pricing.v1"
+    assert model_entry["pricing"]["rates"]["output_tokens"] == 4.0
 
     profile = model_entry["api_profiles"][0]
     assert profile["api_surface"] == "chat_completions"

--- a/tests/backend/test_openai_structured_tool_transport.py
+++ b/tests/backend/test_openai_structured_tool_transport.py
@@ -188,6 +188,45 @@ def _install_fake_openai(
     return captured
 
 
+def test_openai_response_preserves_usage_breakdown_and_effective_service_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = "usage-breakdown-model"
+    response = _text_response(model=model)
+    response["service_tier"] = "default"
+    response["usage"]["input_tokens_details"] = {
+        "cached_tokens": 2,
+        "cache_write_tokens": 1,
+    }
+    _install_profiles(monkeypatch, _registry_profiles(_responses_profile()))
+    _install_fake_openai(monkeypatch, responses=[response])
+    client = OpenAIClient(
+        LLMClientConfig(
+            model=model,
+            provider="openai",
+            api_key="test-key",
+            temperature=None,
+        )
+    )
+
+    result = asyncio.run(
+        client.generate_with_tools(prompt="Test", available_tools=[_tool()])
+    )
+
+    assert result.usage == {
+        "prompt_tokens": 4,
+        "completion_tokens": 2,
+        "total_tokens": 6,
+        "cached_input_tokens": 2,
+        "cache_write_input_tokens": 1,
+    }
+    assert result.transport_metadata["effective_service_tier"] == "default"
+    assert (
+        result.transport_metadata["effective_connection_id"]
+        == "#V#openai_provider"
+    )
+
+
 def test_sync_calls_close_each_async_client_before_its_loop_closes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/backend/test_orchestrator_model_fallback_execution.py
+++ b/tests/backend/test_orchestrator_model_fallback_execution.py
@@ -486,10 +486,17 @@ def test_run_llm_with_fallbacks_passes_candidate_model_parameters(
     end_event = next(
         event for event in progress_events if event.get("status") == "llm_call_end"
     )
+    assert end_event["requested_model"] == "gpt-5.5"
+    assert end_event["selected_model"] == "gpt-5.5"
+    assert end_event["effective_model"] is None
+    assert end_event["model_identity_source"] is None
     assert end_event["effective_model_parameters"] == {"reasoning_effort": "low"}
     stage_summary = next(
         entry for entry in aux_log if entry.get("type") == "workflow_model_policy_stage"
     )
+    assert stage_summary["selected_model"] == "gpt-5.5"
+    assert stage_summary["effective_model"] is None
+    assert stage_summary["model_identity_source"] is None
     assert stage_summary["effective_model_parameters"] == {"reasoning_effort": "low"}
 
 
@@ -508,6 +515,7 @@ def test_run_llm_with_tools_fallbacks_passes_default_model_parameters(
     client = _StructuredToolClient(
         LLMResponse(
             text_response="",
+            model="gpt-5.6-luna-provider-response",
             tool_calls=[
                 ToolCall(
                     tool_name="fetch_concept",
@@ -597,10 +605,17 @@ def test_run_llm_with_tools_fallbacks_passes_default_model_parameters(
     end_event = next(
         event for event in progress_events if event.get("status") == "llm_call_end"
     )
+    assert end_event["requested_model"] == "gpt-5.6-luna"
+    assert end_event["selected_model"] == "gpt-5.6-luna"
+    assert end_event["effective_model"] == "gpt-5.6-luna-provider-response"
+    assert end_event["model_identity_source"] == "provider_response"
     assert end_event["effective_model_parameters"] == requested_parameters
     stage_summary = next(
         entry for entry in aux_log if entry.get("type") == "workflow_model_policy_stage"
     )
+    assert stage_summary["selected_model"] == "gpt-5.6-luna"
+    assert stage_summary["effective_model"] == "gpt-5.6-luna-provider-response"
+    assert stage_summary["model_identity_source"] == "provider_response"
     assert stage_summary["requested_model_parameters"] == requested_parameters
     assert stage_summary["effective_model_parameters"] == requested_parameters
 
@@ -2426,6 +2441,28 @@ def test_invoke_with_llm_heartbeat_uses_backfill_timeout_for_summariser(
     assert progress_events[-1]["status"] == "heartbeat"
     assert progress_events[-1]["stage"] == "summariser"
     assert progress_events[-1]["liveness_reason"] == "llm_call_pending"
+
+
+def test_invoke_with_llm_heartbeat_preserves_actor_context() -> None:
+    from src.backend.security.access_control import (
+        get_effective_organisation_concept_id,
+        get_effective_user_concept_id,
+        override_current_actor,
+    )
+
+    orchestrator = object.__new__(InternalMCPChatOrchestrator)
+    with override_current_actor("#V#current_user", "#V#current_org"):
+        result = orchestrator._invoke_with_llm_heartbeat(
+            call=lambda: (
+                get_effective_user_concept_id(),
+                get_effective_organisation_concept_id(),
+            ),
+            stage_name="plain_response",
+            model_name="gpt-test",
+            emit_progress=lambda _payload: None,
+        )
+
+    assert result == ("#V#current_user", "#V#current_org")
 
 
 def test_invoke_with_llm_heartbeat_prefers_explicit_timeout_override(

--- a/tests/backend/test_settings_llm_cost_summary.py
+++ b/tests/backend/test_settings_llm_cost_summary.py
@@ -1,0 +1,547 @@
+from __future__ import annotations
+
+from flask import Flask
+
+
+def test_settings_cost_summary_is_bound_to_ambient_actor_scope(monkeypatch) -> None:
+    from src.backend.server.routes import settings_routes
+
+    captured: dict = {}
+
+    def fake_summary(**kwargs):
+        captured.update(kwargs)
+        return {
+            "schema_version": "llm_model_turn_cost_summary.v1",
+            "status": "insufficient_coverage",
+            "model_identity": {"provider": "openai", "model": "gpt-test"},
+            "average_attributed_cost_per_turn": {
+                "amount": None,
+                "currency": None,
+            },
+            "sample_window": {"attributed_turn_count": 0},
+            "coverage": {
+                "priced_turn_count": 0,
+                "partial_turn_count": 0,
+                "unavailable_turn_count": 0,
+                "attributed_turn_count": 0,
+            },
+            "pricing": None,
+        }
+
+    monkeypatch.setattr(
+        settings_routes, "get_effective_user_concept_id", lambda: "#V#person"
+    )
+    monkeypatch.setattr(
+        settings_routes,
+        "get_effective_context",
+        lambda *_args, **_kwargs: {"namespace": "#V#person@org"},
+    )
+    monkeypatch.setattr(settings_routes, "get_model_registry_snapshot", dict)
+    monkeypatch.setattr(
+        settings_routes, "get_actor_historical_model_cost_summary", fake_summary
+    )
+
+    app = Flask(__name__)
+    app.secret_key = "test"
+    app.register_blueprint(settings_routes.settings_bp, url_prefix="/api/settings")
+    response = app.test_client().get(
+        "/api/settings/llm/cost_summary",
+        query_string={"provider": "openai", "model": "gpt-test"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "insufficient_coverage"
+    assert captured["user_id"] == "#V#person"
+    assert captured["namespace"] == "#V#person@org"
+    assert captured["provider"] == "openai"
+    assert captured["model"] == "gpt-test"
+    assert captured["limit"] == 200
+    assert captured["window_days"] == 30
+
+
+def test_historical_summary_reprices_stored_usage_once_without_duplicate_sources() -> None:
+    from src.backend.services.llm_model_cost_history_service import (
+        build_historical_model_cost_summary,
+    )
+
+    stored_call = {
+        "call_id": "call-1",
+        "provider": "openai",
+        "effective_model": "gpt-test",
+        "model_identity_source": "provider_response",
+        "usage": {"prompt_tokens": 100, "completion_tokens": 50},
+        "estimated_cost": {
+            "status": "estimated",
+            "amount": 0.25,
+            "known_amount": 0.25,
+            "currency": "USD",
+            "pricing": {
+                "source": "test",
+                "version": "v1",
+                "effective_at_utc": "2026-08-05T00:00:00Z",
+            },
+        },
+    }
+    result = build_historical_model_cost_summary(
+        [
+            {
+                "created_at_utc": "2026-08-05T10:00:00Z",
+                "llm_usage_cost_summary": {"status": "legacy-projection"},
+                "llm_calls": [stored_call],
+                "execution": {"llm_calls": [stored_call]},
+            }
+        ],
+        provider="openai",
+        model="gpt-test",
+        model_registry={
+            "models": [
+                {
+                    "provider": "openai",
+                    "model_id": "gpt-test",
+                    "pricing": {
+                        "schema_version": "llm_model_pricing.v1",
+                        "version": "current-v2",
+                        "source": "current-test-pricing",
+                        "effective_at_utc": "2026-08-05T00:00:00Z",
+                        "model_id": "gpt-test",
+                        "currency": "USD",
+                        "unit_tokens": 1_000,
+                        "rates": {
+                            "input_tokens": 1.0,
+                            "output_tokens": 2.0,
+                        },
+                    },
+                }
+            ]
+        },
+    )
+
+    assert result["coverage"]["attributed_turn_count"] == 1
+    assert result["coverage"]["priced_turn_count"] == 1
+    assert result["average_attributed_cost_per_turn"] == {
+        "amount": 0.2,
+        "currency": "USD",
+    }
+    assert result["pricing"] == {
+        "source": "current-test-pricing",
+        "version": "current-v2",
+        "effective_at_utc": "2026-08-05T00:00:00Z",
+    }
+
+
+def test_historical_summary_classifies_known_subtotal_as_partial() -> None:
+    from src.backend.services.llm_model_cost_history_service import (
+        build_historical_model_cost_summary,
+    )
+
+    result = build_historical_model_cost_summary(
+        [
+            {
+                "created_at_utc": "2026-08-05T10:00:00Z",
+                "llm_usage_cost_summary": {
+                    "status": "legacy-projection"
+                },
+                "llm_calls": [
+                    {
+                        "call_id": "partial-call",
+                        "provider": "openai",
+                        "effective_model": "gpt-test",
+                        "model_identity_source": "provider_response",
+                        "usage": {"prompt_tokens": 100},
+                    }
+                ],
+            }
+        ],
+        provider="openai",
+        model="gpt-test",
+        model_registry={
+            "models": [
+                {
+                    "provider": "openai",
+                    "model_id": "gpt-test",
+                    "pricing": {
+                        "schema_version": "llm_model_pricing.v1",
+                        "version": "v2",
+                        "source": "test",
+                        "effective_at_utc": "2026-08-05T00:00:00Z",
+                        "model_id": "gpt-test",
+                        "currency": "USD",
+                        "unit_tokens": 1_000,
+                        "rates": {
+                            "input_tokens": 1.0,
+                            "output_tokens": 2.0,
+                        },
+                    },
+                }
+            ]
+        },
+    )
+
+    assert result["status"] == "partial"
+    assert result["coverage"]["partial_turn_count"] == 1
+    assert result["coverage"]["unavailable_turn_count"] == 0
+    assert result["average_attributed_cost_per_turn"]["amount"] is None
+
+
+def test_partial_coverage_does_not_publish_a_misleading_average() -> None:
+    from src.backend.services.llm_model_cost_history_service import (
+        build_historical_model_cost_summary,
+    )
+
+    def record(call_id: str, usage: dict | None) -> dict:
+        return {
+            "created_at_utc": f"2026-08-0{call_id[-1]}T10:00:00Z",
+            "llm_usage_cost_summary": {
+                "status": "legacy-projection"
+            },
+            "llm_calls": [
+                {
+                    "call_id": call_id,
+                    "provider": "openai",
+                    "effective_model": "gpt-test",
+                    "model_identity_source": "provider_response",
+                    "usage": usage,
+                }
+            ],
+        }
+
+    result = build_historical_model_cost_summary(
+        [
+            record("call-1", {"prompt_tokens": 100, "completion_tokens": 50}),
+            record("call-2", None),
+        ],
+        provider="openai",
+        model="gpt-test",
+        model_registry={
+            "models": [
+                {
+                    "provider": "openai",
+                    "model_id": "gpt-test",
+                    "pricing": {
+                        "schema_version": "llm_model_pricing.v1",
+                        "version": "v2",
+                        "source": "test",
+                        "effective_at_utc": "2026-08-05T00:00:00Z",
+                        "model_id": "gpt-test",
+                        "currency": "USD",
+                        "unit_tokens": 1_000,
+                        "rates": {
+                            "input_tokens": 1.0,
+                            "output_tokens": 2.0,
+                        },
+                    },
+                }
+            ]
+        },
+    )
+
+    assert result["status"] == "partial"
+    assert result["coverage"]["priced_turn_count"] == 1
+    assert result["coverage"]["unavailable_turn_count"] == 1
+    assert result["average_attributed_cost_per_turn"] == {
+        "amount": None,
+        "currency": None,
+    }
+
+
+def test_historical_summary_excludes_unsent_provider_denials() -> None:
+    from src.backend.services.llm_model_cost_history_service import (
+        build_historical_model_cost_summary,
+    )
+
+    result = build_historical_model_cost_summary(
+        [
+            {
+                "created_at_utc": "2026-08-05T10:00:00Z",
+                "llm_calls": [
+                    {
+                        "call_id": "denied",
+                        "provider": "openai",
+                        "effective_model": "gpt-test",
+                        "model_identity_source": "provider_response",
+                        "provider_request_sent": False,
+                    }
+                ],
+            },
+            {
+                "created_at_utc": "2026-08-05T11:00:00Z",
+                "llm_calls": [
+                    {
+                        "call_id": "paid",
+                        "provider": "openai",
+                        "effective_model": "gpt-test",
+                        "model_identity_source": "provider_response",
+                        "provider_request_sent": True,
+                        "usage": {"prompt_tokens": 100, "completion_tokens": 50},
+                    }
+                ],
+            },
+        ],
+        provider="openai",
+        model="gpt-test",
+        model_registry={
+            "models": [
+                {
+                    "provider": "openai",
+                    "model_id": "gpt-test",
+                    "pricing": {
+                        "schema_version": "llm_model_pricing.v1",
+                        "version": "v2",
+                        "source": "test",
+                        "effective_at_utc": "2026-08-05T00:00:00Z",
+                        "model_id": "gpt-test",
+                        "currency": "USD",
+                        "unit_tokens": 1_000,
+                        "rates": {"input_tokens": 1.0, "output_tokens": 2.0},
+                    },
+                }
+            ]
+        },
+    )
+
+    assert result["status"] == "available"
+    assert result["coverage"]["attributed_turn_count"] == 1
+    assert result["coverage"]["priced_turn_count"] == 1
+    assert result["average_attributed_cost_per_turn"] == {
+        "amount": 0.2,
+        "currency": "USD",
+    }
+
+
+def test_content_free_summary_remains_repriceable_without_raw_calls() -> None:
+    from src.backend.services.llm_model_cost_history_service import (
+        build_historical_model_cost_summary,
+    )
+
+    result = build_historical_model_cost_summary(
+        [
+            {
+                "created_at_utc": "2026-08-05T10:00:00Z",
+                "llm_usage_cost_summary": {
+                    "schema_version": "llm_usage_cost_summary.v1",
+                    "usage": {
+                        "status": "reported",
+                        "input_tokens": 100,
+                        "cached_input_tokens": 0,
+                        "cache_write_input_tokens": 0,
+                        "output_tokens": 50,
+                        "total_tokens": 150,
+                    },
+                    "model_identities": [
+                        {
+                            "provider": "openai",
+                            "effective_model": "gpt-test",
+                            "model_identity_source": "provider_response",
+                            "provider_request_sent": True,
+                            "effective_service_tier": "default",
+                            "connection_id": "#V#openai_provider",
+                            "call_count": 2,
+                        }
+                    ],
+                    "model_identity_omitted_count": 0,
+                    "billable_call_count": 2,
+                    "pricing_usage_groups": [
+                        {
+                            "provider": "openai",
+                            "effective_model": "gpt-test",
+                            "model_identity_source": "provider_response",
+                            "provider_request_sent": True,
+                            "effective_service_tier": "default",
+                            "connection_id": "#V#openai_provider",
+                            "pricing_context_input_tokens": 50,
+                            "usage": {
+                                "status": "reported",
+                                "input_tokens": 100,
+                                "cached_input_tokens": 0,
+                                "cache_write_input_tokens": 0,
+                                "output_tokens": 50,
+                                "total_tokens": 150,
+                            },
+                            "call_count": 2,
+                        }
+                    ],
+                    "pricing_usage_group_omitted_count": 0,
+                    "pricing_usage_group_covered_call_count": 2,
+                    "pricing_usage_group_unattributed_call_count": 0,
+                },
+            }
+        ],
+        provider="openai",
+        model="gpt-test",
+        model_registry={
+            "models": [
+                {
+                    "provider": "openai",
+                    "model_id": "gpt-test",
+                    "pricing": {
+                        "schema_version": "llm_model_pricing.v1",
+                        "version": "v2",
+                        "source": "test",
+                        "effective_at_utc": "2026-08-05T00:00:00Z",
+                        "model_id": "gpt-test",
+                        "currency": "USD",
+                        "unit_tokens": 1_000,
+                        "applicability": {
+                            "effective_service_tiers": ["default"],
+                            "connection_ids": ["#V#openai_provider"],
+                        },
+                        "rates": {
+                            "input_tokens": 1.0,
+                            "cached_input_tokens": 0.1,
+                            "cache_write_input_tokens": 1.25,
+                            "output_tokens": 2.0,
+                        },
+                    },
+                }
+            ]
+        },
+    )
+
+    assert result["status"] == "available"
+    assert result["coverage"]["attributed_turn_count"] == 1
+    assert result["average_attributed_cost_per_turn"] == {
+        "amount": 0.2,
+        "currency": "USD",
+    }
+
+
+def test_mixed_content_free_summary_is_attributed_but_not_mispriced() -> None:
+    from src.backend.services.llm_model_cost_history_service import (
+        build_historical_model_cost_summary,
+    )
+
+    result = build_historical_model_cost_summary(
+        [
+            {
+                "created_at_utc": "2026-08-05T10:00:00Z",
+                "llm_usage_cost_summary": {
+                    "schema_version": "llm_usage_cost_summary.v1",
+                    "usage": {
+                        "status": "reported",
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                        "total_tokens": 150,
+                    },
+                    "model_identities": [
+                        {
+                            "provider": "openai",
+                            "effective_model": "gpt-test",
+                            "model_identity_source": "provider_response",
+                            "provider_request_sent": True,
+                        },
+                        {
+                            "provider": "openai",
+                            "effective_model": "gpt-other",
+                            "model_identity_source": "provider_response",
+                            "provider_request_sent": True,
+                        },
+                    ],
+                    "model_identity_omitted_count": 0,
+                    "billable_call_count": 2,
+                    "pricing_usage_groups": [
+                        {
+                            "provider": "openai",
+                            "effective_model": "gpt-test",
+                            "model_identity_source": "provider_response",
+                            "provider_request_sent": True,
+                            "pricing_context_input_tokens": 100,
+                            "usage": {
+                                "status": "reported",
+                                "input_tokens": 100,
+                                "output_tokens": 50,
+                                "total_tokens": 150,
+                            },
+                            "call_count": 1,
+                        },
+                        {
+                            "provider": "openai",
+                            "effective_model": "gpt-other",
+                            "model_identity_source": "provider_response",
+                            "provider_request_sent": True,
+                            "pricing_context_input_tokens": 100,
+                            "usage": {
+                                "status": "reported",
+                                "input_tokens": 100,
+                                "output_tokens": 50,
+                                "total_tokens": 150,
+                            },
+                            "call_count": 1,
+                        },
+                    ],
+                    "pricing_usage_group_omitted_count": 0,
+                    "pricing_usage_group_covered_call_count": 2,
+                    "pricing_usage_group_unattributed_call_count": 0,
+                },
+            }
+        ],
+        provider="openai",
+        model="gpt-test",
+        model_registry={},
+    )
+
+    assert result["status"] == "unavailable"
+    assert result["coverage"] == {
+        "priced_turn_count": 0,
+        "partial_turn_count": 0,
+        "unavailable_turn_count": 1,
+        "attributed_turn_count": 1,
+    }
+    assert result["average_attributed_cost_per_turn"]["amount"] is None
+
+
+def test_actor_history_query_is_bounded_by_actor_namespace_time_and_limit(
+    monkeypatch,
+) -> None:
+    from src.backend.services import llm_model_cost_history_service as service
+
+    captured: dict = {}
+
+    class Cursor(list):
+        def sort(self, key, direction):
+            captured["sort"] = (key, direction)
+            return self
+
+        def limit(self, value):
+            captured["limit"] = value
+            return self
+
+    class Collection:
+        def find(self, query, projection):
+            captured["query"] = query
+            captured["projection"] = projection
+            return Cursor()
+
+    monkeypatch.setattr(
+        service, "get_turn_execution_records_collection", lambda: Collection()
+    )
+
+    result = service.get_actor_historical_model_cost_summary(
+        user_id="#V#person",
+        namespace="#V#person@org",
+        provider="openai",
+        model="gpt-test",
+        limit=10_000,
+        window_days=10_000,
+    )
+
+    assert captured["query"]["user_id"] == "#V#person"
+    assert captured["query"]["namespace"] == "#V#person@org"
+    assert "$gte" in captured["query"]["created_at_utc"]
+    summary_branch = captured["query"]["$or"][0]
+    assert summary_branch["llm_usage_cost_summary.schema_version"] == (
+        "llm_usage_cost_summary.v1"
+    )
+    canonical_match = summary_branch[
+        "llm_usage_cost_summary.model_identities"
+    ]["$elemMatch"]
+    assert canonical_match["provider"] == "openai"
+    assert canonical_match["effective_model"] == "gpt-test"
+    assert canonical_match["model_identity_source"] == "provider_response"
+    assert canonical_match["provider_request_sent"] == {"$ne": False}
+    legacy_match = captured["query"]["$or"][1]["llm_calls"]["$elemMatch"]
+    assert legacy_match == canonical_match
+    assert captured["projection"]["llm_usage_cost_summary"] == 1
+    assert captured["sort"] == ("created_at_utc", -1)
+    assert captured["limit"] == 500
+    assert result["sample_window"]["limit"] == 500
+    assert result["sample_window"]["window_days"] == 365

--- a/tests/backend/test_settings_openai_model_probe.py
+++ b/tests/backend/test_settings_openai_model_probe.py
@@ -2,9 +2,25 @@ from __future__ import annotations
 
 import types
 
+import pytest
 from flask import Flask
 
 from src.backend.server.routes.settings_routes import settings_bp
+
+
+@pytest.fixture(autouse=True)
+def _allow_external_model_for_probe_transport_tests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """These tests isolate probe transport; policy denial has its own case."""
+
+    import src.backend.server.routes.settings_routes as settings_routes
+
+    monkeypatch.setattr(
+        settings_routes,
+        "assert_model_execution_allowed",
+        lambda **_kwargs: {"allowed": True},
+    )
 
 
 def _make_app() -> Flask:
@@ -116,6 +132,46 @@ def test_openai_model_probe_passes_reasoning_effort_to_responses(
     assert payload["fallback_used"] is False
     assert captured_responses_kwargs["reasoning"] == {"effort": "low"}
     assert captured_responses_kwargs["max_output_tokens"] == 4096
+
+
+def test_openai_model_probe_rejects_non_enabled_model_before_client_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import src.backend.server.routes.settings_routes as settings_routes
+
+    constructed = False
+
+    class _UnexpectedOpenAIClient:
+        def __init__(self, **_kwargs):
+            nonlocal constructed
+            constructed = True
+
+    def _deny(**_kwargs):
+        raise settings_routes.ModelExecutionEligibilityError(
+            "OpenAI model 'gpt-5.6-terra' is not enabled for the current user "
+            "or organisation.",
+            provider="openai",
+            model="gpt-5.6-terra",
+        )
+
+    monkeypatch.setattr(settings_routes, "OpenAIClient", _UnexpectedOpenAIClient)
+    monkeypatch.setattr(settings_routes, "assert_model_execution_allowed", _deny)
+    monkeypatch.setattr(settings_routes, "get_openai_env_var", lambda: "OPENAI_API_KEY")
+
+    response = _make_app().test_client().post(
+        "/api/settings/openai/test_model",
+        json={
+            "api_key_env_var": "OPENAI_API_KEY",
+            "model": "gpt-5.6-terra",
+        },
+    )
+
+    assert response.status_code == 403
+    payload = response.get_json()
+    assert payload["usable"] is False
+    assert payload["failure_kind"] == "model_not_enabled"
+    assert "not enabled" in payload["reason"]
+    assert constructed is False
 
 
 def test_ollama_model_probe_uses_selected_host_and_model(monkeypatch) -> None:

--- a/tests/backend/test_subworkflow_budget_diagnosability.py
+++ b/tests/backend/test_subworkflow_budget_diagnosability.py
@@ -149,6 +149,30 @@ def test_persist_failed_turn_execution_record_stamps_terminal_envelope():
             prompt_text="Show me the last 5 email messages",
             llm_debug_info={
                 "aux_llm_calls": [{"type": "workflow_continuation_decision"}],
+                "llm_interaction": {
+                    "calls": [
+                        {
+                            "call_id": "req-2502-test:llm:1",
+                            "type": "adaptive_turn_model_call",
+                            "provider": "openai",
+                            "effective_model": "gpt-test",
+                            "provider_request_sent": True,
+                            "usage": {
+                                "prompt_tokens": 100,
+                                "completion_tokens": 20,
+                            },
+                        }
+                    ]
+                },
+                "llm_usage_cost_summary": {
+                    "schema_version": "llm_usage_cost_summary.v1",
+                    "call_count": 1,
+                    "unique_call_count": 1,
+                    "estimated_cost": {
+                        "status": "unavailable",
+                        "amount": None,
+                    },
+                },
                 "tool_invocations": [
                     {
                         "tool": "represented_workflow_test",
@@ -196,6 +220,14 @@ def test_persist_failed_turn_execution_record_stamps_terminal_envelope():
     assert record["workflow_selection"]["selected_workflow_id"] == (
         "#V#paper_workflow"
     )
+    assert record["execution"]["llm_calls"][0]["call_id"] == (
+        "req-2502-test:llm:1"
+    )
+    assert record["execution"]["llm_calls"][0]["usage"] == {
+        "prompt_tokens": 100,
+        "completion_tokens": 20,
+    }
+    assert record["llm_usage_cost_summary"]["call_count"] == 1
 
 
 def test_persist_failed_turn_execution_record_requires_request_id():

--- a/tests/backend/test_thinking_llm_call_timestamps_and_precedence.py
+++ b/tests/backend/test_thinking_llm_call_timestamps_and_precedence.py
@@ -171,6 +171,40 @@ def test_normalise_llm_exchange_entry_accepts_preview_and_selected_model_aliases
     assert payload["at_utc"] == "2026-06-02T16:45:54.356959Z"
 
 
+def test_normalise_llm_exchange_entry_preserves_usage_and_model_lineage():
+    from src.backend.services.turn_execution_diagnostics_service import (
+        _normalise_llm_exchange_entry,
+    )
+
+    payload = _normalise_llm_exchange_entry(
+        {
+            "call_id": "call-2624",
+            "type": "adaptive_turn_model_call",
+            "provider": "openai",
+            "requested_model": "requested-model",
+            "selected_model": "selected-model",
+            "effective_model": "effective-model",
+            "model_identity_source": "provider_response",
+            "provider_request_sent": True,
+            "usage": {
+                "status": "reported",
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+            },
+        },
+        source="unit",
+        source_index=0,
+    )
+
+    assert payload["call_id"] == "call-2624"
+    assert payload["model"] == "effective-model"
+    assert payload["requested_model"] == "requested-model"
+    assert payload["selected_model"] == "selected-model"
+    assert payload["effective_model"] == "effective-model"
+    assert payload["usage"]["total_tokens"] == 120
+
+
 def test_collect_llm_exchange_entries_salvages_embedded_stage_summaries():
     from src.backend.services.turn_execution_diagnostics_service import (
         _collect_llm_exchange_entries,
@@ -264,27 +298,18 @@ def test_collect_llm_exchange_entries_filters_skipped_pseudo_calls():
     assert entries[0]["prompt"]["text"] == "PROMPT"
 
 
-def test_finalise_llm_debug_info_passes_primary_llm_calls_to_record_builder(monkeypatch):
+def test_finalise_llm_debug_info_persists_primary_calls_and_cost_summary(monkeypatch):
     from src.backend.server.routes import von_routes
 
-    captured: dict = {}
-
-    def fake_build_turn_execution_record(**kwargs):
-        captured.update(kwargs)
-        return {
-            "request_id": kwargs.get("request_id"),
-            "workflow_routing_diagnostics": {},
-        }
-
-    monkeypatch.setattr(
-        von_routes,
-        "build_turn_execution_record",
-        fake_build_turn_execution_record,
-    )
+    monkeypatch.setattr(von_routes, "get_model_registry_snapshot", lambda: {})
 
     llm_call = {
+        "call_id": "req-2385:llm:1",
         "type": "llm.generate",
         "stage": "screen_backfill",
+        "provider": "openai",
+        "effective_model": "gpt-test",
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5},
         "prompt": {"text": "PROMPT"},
         "response": {"text": "RESPONSE"},
     }
@@ -305,7 +330,10 @@ def test_finalise_llm_debug_info_passes_primary_llm_calls_to_record_builder(monk
     )
 
     assert result["turn_execution_record"]["request_id"] == "req-2385"
-    assert captured["llm_calls"] == [llm_call]
+    assert result["turn_execution_record"]["llm_calls"] == [llm_call]
+    summary = result["turn_execution_record"]["llm_usage_cost_summary"]
+    assert summary["usage"]["total_tokens"] == 15
+    assert summary["estimated_cost"]["status"] == "unavailable"
 
 
 def test_build_turn_execution_record_persists_primary_and_aux_llm_logs():

--- a/tests/backend/test_von_generate_workflow_instances.py
+++ b/tests/backend/test_von_generate_workflow_instances.py
@@ -93,6 +93,11 @@ def app(monkeypatch: pytest.MonkeyPatch) -> Flask:
     monkeypatch.setattr(von_routes, "get_llm_client", lambda **_kwargs: object())
     monkeypatch.setattr(
         von_routes,
+        "get_model_registry_snapshot",
+        lambda: {"source": "test", "models": []},
+    )
+    monkeypatch.setattr(
+        von_routes,
         "_resolve_generate_requested_model",
         lambda *_args, **_kwargs: ("test-model", None, {}),
     )
@@ -185,6 +190,10 @@ def test_ordinary_generate_uses_adaptive_turn_without_master_workflow_or_gate(
     adaptive_calls = app.config["_ADAPTIVE_TURN_CALLS"]
     assert len(adaptive_calls) == 1
     assert adaptive_calls[0]["prompt"] == "Answer this ordinary scientific question."
+    assert adaptive_calls[0]["model_registry_snapshot"] == {
+        "source": "test",
+        "models": [],
+    }
 
     llm_debug = payload["llm_debug"]
     assert llm_debug["llm_interaction"]["ordinary_turn_engine"] == (
@@ -519,6 +528,63 @@ def test_presenter_mode_generates_spoken_backfill_for_screen_only_answer(
     assert payload["llm_debug"]["spoken_backfill_second_pass_reason"] == (
         "missing_spoken"
     )
+    narration_call = next(
+        call
+        for call in payload["llm_debug"]["llm_interaction"]["calls"]
+        if call.get("stage") == "narration"
+    )
+    assert narration_call["call_id"].endswith(":support-llm:1")
+    assert narration_call["selected_model"] == "test-model"
+    assert narration_call["effective_model"] is None
+    assert narration_call["model_identity_source"] is None
+    assert narration_call["provider_request_sent"] is True
+    assert narration_call["status"] == "completed"
+    assert payload["llm_debug"]["llm_usage_cost_summary"]["call_count"] == 2
+
+
+def test_narration_eligibility_denial_is_recorded_without_failing_turn(
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.languagemodels.llm_interface import (
+        ModelExecutionEligibilityError,
+    )
+    from src.backend.server.routes import von_routes
+
+    app.config["_ADAPTIVE_TURN_STATE"]["response_text"] = (
+        "<screen>A grounded visual summary.</screen>"
+    )
+
+    def _denied_spoken_backfill(*_args: Any, **_kwargs: Any) -> str:
+        raise ModelExecutionEligibilityError(
+            "This model is not enabled for the active scope.",
+            provider="openai",
+            model="test-model",
+        )
+
+    monkeypatch.setattr(
+        von_routes,
+        "_llm_generate_spoken_backfill",
+        _denied_spoken_backfill,
+    )
+
+    response = app.test_client().post(
+        "/von/generate",
+        json={"prompt": "Present the result.", "presenter_mode": True},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    narration_call = next(
+        call
+        for call in payload["llm_debug"]["llm_interaction"]["calls"]
+        if call.get("stage") == "narration"
+    )
+    assert narration_call["provider"] == "openai"
+    assert narration_call["provider_request_sent"] is False
+    assert narration_call["status"] == "failed"
+    assert narration_call["failure_kind"] == "model_not_enabled"
+    assert narration_call["error_class"] == "ModelExecutionEligibilityError"
 
 
 def test_presenter_mode_uses_represented_prompt_to_backfill_missing_screen(

--- a/tests/backend/test_von_turn_execution_debug_info.py
+++ b/tests/backend/test_von_turn_execution_debug_info.py
@@ -11,6 +11,31 @@ def test_finalise_llm_debug_info_records_observations_without_rebuilding_a_gate(
         "get_runtime_code_version_info",
         lambda: {"version": "test-version"},
     )
+    monkeypatch.setattr(
+        von_routes,
+        "get_model_registry_snapshot",
+        lambda: {
+            "models": [
+                {
+                    "provider": "openai",
+                    "model_id": "gpt-test",
+                    "pricing": {
+                        "schema_version": "llm_model_pricing.v1",
+                        "version": "test-v1",
+                        "source": "test",
+                        "effective_at_utc": "2026-08-05T00:00:00Z",
+                        "model_id": "gpt-test",
+                        "currency": "USD",
+                        "unit_tokens": 1_000,
+                        "rates": {
+                            "input_tokens": 1.0,
+                            "output_tokens": 2.0,
+                        },
+                    },
+                }
+            ]
+        },
+    )
     evidence = {
         "evidence_id": "evidence_opaque",
         "tool_name": "general_read",
@@ -29,8 +54,18 @@ def test_finalise_llm_debug_info_records_observations_without_rebuilding_a_gate(
                 "ordinary_turn_terminal_status": "completed",
                 "calls": [
                     {
+                        "call_id": "req-adaptive-observation:llm:1",
                         "type": "adaptive_turn_model_call",
                         "status": "completed",
+                        "provider": "openai",
+                        "requested_model": "gpt-test",
+                            "selected_model": "gpt-test",
+                            "effective_model": "gpt-test",
+                            "model_identity_source": "provider_response",
+                        "usage": {
+                            "prompt_tokens": 100,
+                            "completion_tokens": 20,
+                        },
                     }
                 ],
             },
@@ -81,9 +116,160 @@ def test_finalise_llm_debug_info_records_observations_without_rebuilding_a_gate(
     assert record["terminal_status"] == "completed"
     assert record["response"]["present"] is True
     assert record["evidence_index"] == [evidence]
+    summary = result["llm_usage_cost_summary"]
+    assert summary["usage"]["total_tokens"] == 120
+    assert summary["estimated_cost"]["status"] == "estimated"
+    assert summary["estimated_cost"]["amount"] == 0.14
+    assert record["llm_usage_cost_summary"] == summary
     assert "completion_gate" not in record
     assert "required_effects" not in record
     assert "required_tool_obligation_ledger" not in record
+
+
+def test_generate_error_debug_preserves_paid_calls_before_route_failure(
+    monkeypatch,
+) -> None:
+    from src.backend.server.routes import von_routes
+    from src.backend.server.routes.generate_route_support import (
+        _build_generate_error_debug_info,
+    )
+
+    monkeypatch.setattr(
+        von_routes,
+        "get_runtime_code_version_info",
+        lambda: {"version": "test-version"},
+    )
+    monkeypatch.setattr(
+        von_routes,
+        "get_model_registry_snapshot",
+        lambda: {
+            "models": [
+                {
+                    "provider": "openai",
+                    "model_id": "gpt-test",
+                    "pricing": {
+                        "schema_version": "llm_model_pricing.v1",
+                        "version": "test-v1",
+                        "source": "test",
+                        "effective_at_utc": "2026-08-05T00:00:00Z",
+                        "model_id": "gpt-test",
+                        "currency": "USD",
+                        "unit_tokens": 1_000,
+                        "rates": {
+                            "input_tokens": 1.0,
+                            "output_tokens": 2.0,
+                        },
+                    },
+                }
+            ]
+        },
+    )
+
+    result = _build_generate_error_debug_info(
+        interaction_timestamp_utc="2026-08-05T10:00:00Z",
+        request_id="request-paid-then-failed",
+        model_name="gpt-test",
+        prompt_text="Do useful work.",
+        error_text="route finalisation failed",
+        enhanced_context=[],
+        user_prompt_debug=None,
+        response_transformations=None,
+        error_tool_progress_snapshot=None,
+        error_workflow_discovery=None,
+        error_workflow_routing=None,
+        auxiliary_llm_calls=[],
+        llm_interaction={
+            "ordinary_turn_terminal_status": "model_error",
+            "calls": [
+                {
+                    "call_id": "request-paid-then-failed:llm:1",
+                        "provider": "openai",
+                        "effective_model": "gpt-test",
+                        "model_identity_source": "provider_response",
+                        "provider_request_sent": True,
+                    "usage": {"prompt_tokens": 100, "completion_tokens": 20},
+                }
+            ],
+        },
+        error_elapsed_ms=100.0,
+        session_id="session-test",
+        namespace="#V#person@org",
+        history_user_id="#V#person",
+        org_concept_id="#V#org",
+        calculate_context_stats_fn=lambda _context: {},
+        build_response_transformation_telemetry_payload_fn=lambda **_kwargs: {},
+        build_turn_execution_diagnostics_fn=lambda **_kwargs: {},
+        finalise_llm_debug_info_fn=von_routes._finalise_llm_debug_info,
+    )
+
+    assert result["llm_usage_cost_summary"]["usage"]["total_tokens"] == 120
+    assert result["llm_usage_cost_summary"]["estimated_cost"]["amount"] == 0.14
+    assert (
+        result["turn_execution_record"]["llm_usage_cost_summary"]
+        == result["llm_usage_cost_summary"]
+    )
+
+
+def test_finalise_reuses_turn_pricing_snapshot_summary(monkeypatch) -> None:
+    from src.backend.server.routes import von_routes
+
+    monkeypatch.setattr(
+        von_routes,
+        "get_runtime_code_version_info",
+        lambda: {"version": "test-version"},
+    )
+
+    def fail_if_registry_is_read_again():
+        raise AssertionError("turn finalisation must reuse the supplied summary")
+
+    monkeypatch.setattr(
+        von_routes,
+        "get_model_registry_snapshot",
+        fail_if_registry_is_read_again,
+    )
+    supplied_summary = {
+        "schema_version": "llm_usage_cost_summary.v1",
+        "call_count": 1,
+        "unique_call_count": 1,
+        "duplicate_call_count": 0,
+        "billable_call_count": 1,
+        "usage": {"status": "reported", "total_tokens": 120},
+        "estimated_cost": {
+            "status": "estimated",
+            "amount": 0.14,
+            "known_amount": 0.14,
+            "currency": "USD",
+        },
+        "model_identities": [],
+        "model_identity_omitted_count": 0,
+    }
+
+    result = von_routes._finalise_llm_debug_info(
+        llm_debug_info={
+            "request_id": "reuse-summary",
+            "interaction_timestamp_utc": "2026-08-05T10:00:00Z",
+            "response": "Done.",
+            "llm_interaction": {
+                "ordinary_turn_terminal_status": "completed",
+                "calls": [],
+            },
+            "llm_usage_cost_summary": supplied_summary,
+            "tool_invocations": [],
+            "turn_execution_record_tool_invocations": [],
+            "search_evidence": [],
+            "turn_execution_diagnostics": {},
+            "aux_llm_calls": [],
+        },
+        prompt_text="Do the task.",
+        response_text="Done.",
+        session_id="session-reuse-summary",
+        namespace="#V#person@org",
+        user_id="#V#person",
+        org_id="#V#org",
+    )
+
+    assert result["llm_usage_cost_summary"] == supplied_summary
+    assert result["turn_execution_record"]["llm_usage_cost_summary"] == supplied_summary
 
 
 def test_finalise_llm_debug_info_preserves_bounded_evidence_envelope(

--- a/tests/frontend/settingsModelPoolControls.test.js
+++ b/tests/frontend/settingsModelPoolControls.test.js
@@ -12,6 +12,7 @@ import {
     __testOnly_applySettingsActorRole,
     __testOnly_invalidateActorScopedCapabilityStatus,
     __testOnly_queueActorContextTransition,
+    __testOnly_refreshSelectedOpenAiCostSummary,
     __testOnly_reloadScopedModelSettings,
     __testOnly_renderModelScopeOverview,
     __testOnly_restoreScopedPrimary,
@@ -61,7 +62,11 @@ describe('settings model scope and workflow pool controls', () => {
             <button id="restoreScopedPrimaryButton"></button>
             <select id="openaiModelSelect"><option value="gpt-5.6-luna" selected>gpt-5.6-luna</option></select>
             <select id="openaiReasoningEffortSelect"><option value="low" selected>low</option></select>
+            <input id="enableOpenAiPremiumToggle" type="checkbox" />
+            <button id="testOpenAiModelButton"></button>
             <button id="addOpenAiToWorkflowPoolButton"></button>
+            <div id="openaiModelEligibilityStatus"></div>
+            <div id="openaiModelCostSummary"></div>
             <select id="globalModelSelect">
                 <option value="http://127.0.0.1:11434:gemma4:latest"
                     data-host-url="http://127.0.0.1:11434"
@@ -98,12 +103,161 @@ describe('settings model scope and workflow pool controls', () => {
 
         const rows = Array.from(document.querySelectorAll('.settings-model-pool-entry'));
         expect(rows).toHaveLength(3);
-        expect(rows[0].textContent).toContain('Primary · always enabled');
+        expect(rows[0].textContent).toContain('Primary · always allowed');
         expect(rows[0].querySelector('button')).toBeNull();
         expect(rows[1].textContent).toContain('gpt-5.6-luna');
         expect(rows[2].textContent).toContain('gemini-2.5-pro');
         expect(document.getElementById('browserChatModelSummary').textContent).toContain('gemma4:latest');
         expect(document.getElementById('sharedServerDefaultModelSummary').textContent).toContain('qwen3:8b');
+    });
+
+    test('uses the persisted effective allow list, not staged edits', () => {
+        const eligibility = document.getElementById('openaiModelEligibilityStatus');
+        const testButton = document.getElementById('testOpenAiModelButton');
+        __testOnly_setModelScopeState({
+            targetScope: 'user',
+            resolvedLlm: null,
+            enabledLlms: [],
+            effectiveLlm: {
+                provider: 'ollama',
+                model: 'organisation-primary',
+                scope: 'organisation',
+            },
+            effectiveEnabledLlms: [
+                { provider: 'ollama', model: 'organisation-primary' },
+                { provider: 'openai', model: 'gpt-5.6-luna' },
+            ],
+        });
+        __testOnly_renderModelScopeOverview();
+        expect(testButton.disabled).toBe(false);
+        expect(document.getElementById('enableOpenAiPremiumToggle').disabled).toBe(false);
+
+        __testOnly_setModelScopeState({
+            resolvedLlm: { provider: 'ollama', model: 'gemma4:latest', scope: 'user' },
+            enabledLlms: [
+                { provider: 'ollama', model: 'gemma4:latest' },
+                { provider: 'openai', model: 'gpt-5.6-terra' },
+            ],
+        });
+        __testOnly_renderModelScopeOverview();
+        expect(testButton.disabled).toBe(true);
+        expect(__testOnly_addOrUpdateWorkflowPoolEntry({
+            provider: 'openai', model: 'gpt-5.6-luna',
+            model_parameters: { reasoning_effort: 'low' },
+        })).toBe(true);
+        expect(document.getElementById('addOpenAiToWorkflowPoolButton').textContent)
+            .toBe('Pending allowed-model save');
+    });
+
+    test('fetches and renders bounded actor-scoped cost evidence without inventing zero', async () => {
+        __testOnly_setModelScopeState({
+            targetScope: 'user',
+            resolvedLlm: { provider: 'ollama', model: 'gemma4:latest', scope: 'user' },
+            enabledLlms: [{ provider: 'ollama', model: 'gemma4:latest' }],
+        });
+        const projection = (status, amount = null) => ({
+            schema_version: 'llm_model_turn_cost_summary.v1',
+            status,
+            model_identity: { provider: 'openai', model: 'gpt-5.6-luna' },
+            average_attributed_cost_per_turn: { amount, currency: 'USD' },
+            sample_window: {
+                attributed_turn_count: 5,
+                started_at_utc: '2026-08-01T00:00:00Z',
+                ended_at_utc: '2026-08-05T00:00:00Z',
+                limit: 100,
+            },
+            coverage: { priced_turn_count: 5, attributed_turn_count: 5 },
+            pricing: {
+                source: 'provider', version: '2026-08', effective_at_utc: '2026-08-01T00:00:00Z',
+            },
+        });
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => projection('available', 0.05),
+        });
+
+        await __testOnly_refreshSelectedOpenAiCostSummary();
+
+        const [url, options] = global.fetch.mock.calls[0];
+        const parsed = new URL(url, 'http://von.test');
+        expect(parsed.pathname).toBe('/api/settings/llm/cost_summary');
+        expect(Object.fromEntries(parsed.searchParams.entries())).toEqual({
+            provider: 'openai',
+            model: 'gpt-5.6-luna',
+        });
+        expect(options.cache).toBe('no-store');
+        expect(options.headers['X-Von-Window-Session']).toBeTruthy();
+        const cost = document.getElementById('openaiModelCostSummary');
+        expect(cost.textContent).toContain('US$0.05 per turn');
+        expect(cost.textContent).toContain('5/5 priced · 2026-08-01–2026-08-05');
+        expect(cost.textContent).toContain('pricing provider 2026-08 effective 2026-08-01');
+        expect(cost.textContent).toContain('not provider billing');
+
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => projection('available', 0.000012),
+        });
+        await __testOnly_refreshSelectedOpenAiCostSummary();
+        expect(cost.textContent).toContain('US$0.0000120 per turn');
+        expect(cost.textContent).not.toContain('US$0.0000 per turn');
+
+        for (const [status, expected] of [
+            ['partial', 'coverage is partial'],
+            ['unavailable', 'estimate unavailable'],
+            ['insufficient_coverage', 'Insufficient historical coverage'],
+            ['available', 'estimate unavailable'],
+        ]) {
+            global.fetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => projection(status),
+            });
+            await __testOnly_refreshSelectedOpenAiCostSummary();
+            expect(cost.textContent).toContain(expected);
+            expect(cost.textContent).not.toContain('US$0.00');
+        }
+
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ ...projection('available', 0.05), pricing: null }),
+        });
+        await __testOnly_refreshSelectedOpenAiCostSummary();
+        expect(cost.textContent).toContain('estimate unavailable');
+    });
+
+    test('does not let an older model response replace the latest selection', async () => {
+        __testOnly_setModelScopeState({
+            resolvedLlm: { provider: 'ollama', model: 'gemma4:latest', scope: 'user' },
+            enabledLlms: [{ provider: 'ollama', model: 'gemma4:latest' }],
+        });
+        let resolveOlder;
+        global.fetch.mockImplementationOnce(() => new Promise((resolve) => { resolveOlder = resolve; }));
+        const older = __testOnly_refreshSelectedOpenAiCostSummary();
+
+        document.getElementById('openaiModelSelect').innerHTML = '<option value="gpt-5.6-terra" selected>gpt-5.6-terra</option>';
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                schema_version: 'llm_model_turn_cost_summary.v1',
+                status: 'partial',
+                model_identity: { provider: 'openai', model: 'gpt-5.6-terra' },
+            }),
+        });
+        await __testOnly_refreshSelectedOpenAiCostSummary();
+        resolveOlder({
+            ok: true,
+            json: async () => ({
+                schema_version: 'llm_model_turn_cost_summary.v1',
+                status: 'available',
+                model_identity: { provider: 'openai', model: 'gpt-5.6-luna' },
+                average_attributed_cost_per_turn: { amount: 99, currency: 'USD' },
+                sample_window: { attributed_turn_count: 100 },
+            }),
+        });
+        await older;
+
+        const cost = document.getElementById('openaiModelCostSummary');
+        expect(cost.textContent).toContain('coverage is partial');
+        expect(cost.textContent).not.toContain('US$99.00');
     });
 
     test('adds, updates, and removes alternatives only through explicit pool actions', () => {
@@ -241,7 +395,7 @@ describe('settings model scope and workflow pool controls', () => {
         expect(document.getElementById('scopedPrimaryModelSummary').textContent)
             .toContain('inherited; saving creates a user override');
         expect(document.getElementById('modelPoolTargetScopeNote').textContent)
-            .toContain('organisation pool is not copied');
+            .toContain('organisation allowed models are not copied');
         expect(document.getElementById('workflowModelPoolList').textContent)
             .not.toContain('organisation-alternative');
         expect(__testOnly_buildPersistedLlmSelections()).toEqual([
@@ -619,7 +773,8 @@ describe('settings model scope and workflow pool controls', () => {
         expect(settingsTemplate.match(/Inherit server default/g)).toHaveLength(2);
         expect(settingsTemplate).not.toContain('Inherit chat default');
         expect(settingsTemplate).toContain('Effective shared RAG LLM: —');
-        expect(settingsTemplate).toContain('Save scoped primary &amp; workflow pool');
+        expect(settingsTemplate).toContain('Save scoped primary &amp; allowed models');
+        expect(settingsTemplate).toContain('Scoped allowed models');
         expect(settingsTemplate).toContain('Blank fields retain the saved');
         expect(settingsTemplate).not.toContain('uses the current browser chat selection as the server default');
         expect(settingsPageSource).toContain("'Effective shared RAG LLM'");

--- a/tests/frontend/settingsOpenAiModelChange.test.js
+++ b/tests/frontend/settingsOpenAiModelChange.test.js
@@ -48,6 +48,8 @@ describe('settingsPage OpenAI model change handling', () => {
                 <select id="openaiReasoningEffortSelect"></select>
             </div>
             <button id="testOpenAiModelButton" type="button">Test this model</button>
+            <div id="openaiModelEligibilityStatus"></div>
+            <div id="openaiModelCostSummary"></div>
             <div id="openaiModelStatusMessage"></div>
             <div id="browserChatModelSummary"></div>
             <div id="scopedPrimaryModelSummary"></div>
@@ -219,8 +221,10 @@ describe('settingsPage OpenAI model change handling', () => {
         expect(document.getElementById('browserChatModelSummary').textContent).toContain('gemma4:latest');
         expect(document.getElementById('workflowModelPoolList').textContent).toContain('low effort');
         expect(document.getElementById('addOpenAiToWorkflowPoolButton').textContent).toBe(
-            'Update workflow pool entry'
+            'Update allowed model entry'
         );
+        expect(document.getElementById('openaiModelEligibilityStatus').textContent).toContain('Allowed:');
+        expect(document.getElementById('testOpenAiModelButton').disabled).toBe(false);
         expect(testPayloads).toEqual([]);
         expect(savePayloads).toEqual([]);
 


### PR DESCRIPTION
## Outcome

Implements JVNAUTOSCI-2624 so external generative models can run only when the exact provider/model is in the existing actor- and organisation-scoped allowed-model pool. Persisted, content-free provider usage and effective-model evidence now supports honest per-turn cost estimates in Thinking and bounded recent-cost summaries in Settings.

## Smallest coherent design

- Reuse `enabled_llms` as the single scoped execution authority; enforce it at the shared generation boundary and the few raw vision/live-probe call sites.
- Keep requested, selected, and provider-reported effective model identities distinct.
- Persist stable call IDs, provider-reported token usage, completeness, and pricing provenance; deduplicate retries and retain multi-call turns.
- Estimate only from exact represented provider/model pricing. Unknown identity, unsupported usage, or incomplete evidence remains partial or unavailable rather than being guessed.
- Show effective model, token use, call count, cost status, and lineage in Thinking; show a bounded actor-scoped recent summary in Settings.

Embeddings are intentionally outside chat-model eligibility: they are fixed non-generative infrastructure, while the RAG runtime LLM already passes through the gated generation boundary. Adding embeddings to `enabled_llms` would expand this task and break the existing retrieval contract.

## Represented pricing evidence

- Predicate `#V#has_model_pricing_json`: `40543e7b-e706-40db-8df4-b58608456a6e`
- Terra registry relation: `6a732a105c780564a2070522`
- Luna registry relation: `6a732a265c780564a2070523`
- Source: official OpenAI API pricing, version `openai-standard-observed-2026-08-05`

## Validation

- Backend affected-path suite: 231 passed
- Adaptive-turn suite: 132 passed
- Orchestrator and stale-response coverage: 53 passed
- Frontend: 272 passed; static lint clean
- Targeted cost, eligibility, history, identity-lineage, retry-deduplication, and multi-call checks passed
- `ruff`, `py_compile`, and diff checks passed
- Automated tests invoked no provider models

The existing repository-level Sol prohibition remains unchanged; this change neither invokes nor restores Sol.