### PR TITLE
Improve Thinking workflow labels and model telemetry

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -12274,6 +12274,7 @@ def _summarise_turn_execution_tool_invocations(
             "mutation_outcome",
             "outcome_finality",
             "capability_kind",
+            "capability_display_name",
             "execution_method",
             "represented_workflow_id",
             "workflow_id",

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -129,6 +129,7 @@ class _PreparedCapabilityCall:
     minimum_effect_window_seconds: float
     capability_kind: str = "registered_tool"
     represented_workflow_id: str | None = None
+    capability_display_name: str | None = None
     binding_diagnostics: Mapping[str, Any] | None = None
 
 
@@ -145,6 +146,7 @@ class _ContainedCapabilityResult:
     execution_method_name: str
     capability_kind: str = "registered_tool"
     represented_workflow_id: str | None = None
+    capability_display_name: str | None = None
     binding_diagnostics: Mapping[str, Any] | None = None
 
 
@@ -4715,6 +4717,11 @@ def execute_adaptive_turn(
                 if is_workflow_capability
                 else bool(is_effect)
             )
+            capability_display_name = (
+                str(workflow_capability.display_name)
+                if is_workflow_capability
+                else None
+            )
             if not isinstance(arguments, Mapping):
                 raw_capability_results[index] = _ContainedCapabilityResult(
                     raw_payload=_error_payload(
@@ -4737,6 +4744,7 @@ def execute_adaptive_turn(
                         if is_workflow_capability
                         else None
                     ),
+                    capability_display_name=capability_display_name,
                 )
                 continue
             binding_diagnostics: Mapping[str, Any] | None = None
@@ -4759,6 +4767,7 @@ def execute_adaptive_turn(
                         execution_method_name=execution_method_name,
                         capability_kind="represented_workflow",
                         represented_workflow_id=str(workflow_capability.workflow_id),
+                        capability_display_name=capability_display_name,
                     )
                     continue
                 if not scope.user_concept_id or not scope.namespace:
@@ -4778,6 +4787,7 @@ def execute_adaptive_turn(
                         execution_method_name=execution_method_name,
                         capability_kind="represented_workflow",
                         represented_workflow_id=str(workflow_capability.workflow_id),
+                        capability_display_name=capability_display_name,
                     )
                     continue
                 from src.backend.services.workflow_turn_capability_service import (
@@ -4828,6 +4838,7 @@ def execute_adaptive_turn(
                         execution_method_name=execution_method_name,
                         capability_kind="represented_workflow",
                         represented_workflow_id=str(workflow_capability.workflow_id),
+                        capability_display_name=capability_display_name,
                     )
                     continue
                 if turn_id:
@@ -4907,6 +4918,7 @@ def execute_adaptive_turn(
                         if is_workflow_capability
                         else None
                     ),
+                    capability_display_name=capability_display_name,
                     binding_diagnostics=binding_diagnostics,
                 )
             )
@@ -4939,6 +4951,7 @@ def execute_adaptive_turn(
                     execution_method_name=execution_method_name,
                     capability_kind=item.capability_kind,
                     represented_workflow_id=item.represented_workflow_id,
+                    capability_display_name=item.capability_display_name,
                     binding_diagnostics=item.binding_diagnostics,
                 )
 
@@ -5097,6 +5110,7 @@ def execute_adaptive_turn(
                     capability_kind=item.capability_kind,
                     arguments=arguments,
                     lifecycle_status="running",
+                    capability_display_name=item.capability_display_name,
                 )
                 _emit(
                     progress_tracker,
@@ -5568,6 +5582,10 @@ def execute_adaptive_turn(
                     invocation["represented_workflow_id"] = (
                         contained_result.represented_workflow_id
                     )
+                if contained_result.capability_display_name:
+                    invocation["capability_display_name"] = (
+                        contained_result.capability_display_name
+                    )
                 if contained_result.binding_diagnostics:
                     invocation["binding_diagnostics"] = dict(
                         contained_result.binding_diagnostics
@@ -5685,6 +5703,9 @@ def execute_adaptive_turn(
                     arguments=arguments,
                     lifecycle_status=(
                         effect_status or ("succeeded" if status == "ok" else "failed")
+                    ),
+                    capability_display_name=(
+                        contained_result.capability_display_name
                     ),
                     success=status == "ok",
                     result=semantic_result,

--- a/src/backend/services/thinking_semantic_projection_service.py
+++ b/src/backend/services/thinking_semantic_projection_service.py
@@ -3,8 +3,9 @@
 The projection is deliberately a view model, not a second execution record.
 It retains exact identifiers needed for inspection while giving the ordinary
 Thinking surface labels and role-labelled arguments that a person can read.
-No database lookup is performed here: richer naming remains an optional later
-enrichment rather than another source of latency or failure on the answer path.
+No database lookup is performed here: trusted display labels already resolved
+by capability discovery may be carried in, with canonical identifiers retained
+as the bounded fallback and inspection identity.
 """
 
 from __future__ import annotations
@@ -177,6 +178,39 @@ def _argument_by_role(
     arguments: list[dict[str, Any]], role: str
 ) -> dict[str, Any] | None:
     return next((item for item in arguments if item.get("role") == role), None)
+
+
+def _capability_display_label(
+    *,
+    capability_id: str,
+    capability_kind: str,
+    projected_arguments: list[dict[str, Any]],
+    display_name: Any = None,
+    workflow_identity: Any = None,
+) -> str:
+    """Choose a bounded human label without replacing stable capability identity."""
+
+    candidate = _clean_text(display_name)
+    generated_from_capability_id = _display_label(capability_id)
+    if candidate and not (
+        capability_kind == "represented_workflow"
+        and candidate == generated_from_capability_id
+    ):
+        return _display_label(candidate) if candidate.startswith("#V#") else candidate
+
+    if capability_kind == "represented_workflow":
+        workflow = _argument_by_role(projected_arguments, "workflow")
+        argument_workflow_identity = _clean_text(
+            workflow.get("value") if isinstance(workflow, Mapping) else None
+        )
+        if argument_workflow_identity:
+            return _display_label(argument_workflow_identity)
+
+        outcome_workflow_identity = _clean_text(workflow_identity)
+        if outcome_workflow_identity:
+            return _display_label(outcome_workflow_identity)
+
+    return generated_from_capability_id
 
 
 def _relation_projection(
@@ -1075,6 +1109,14 @@ def normalise_semantic_operation_projection(value: Any) -> dict[str, Any] | None
         _clean_text(raw_capability.get("execution_method")) or capability_id
     )
     arguments = _normalise_projected_arguments(value.get("arguments"))
+    outcome = _normalise_projected_outcome(value.get("outcome"))
+    capability_label = _capability_display_label(
+        capability_id=capability_id,
+        capability_kind=kind,
+        projected_arguments=arguments,
+        display_name=raw_capability.get("label"),
+        workflow_identity=(outcome or {}).get("workflow_id"),
+    )
     relation = _relation_projection(arguments)
     focus = _normalise_projected_focus(value.get("focus")) if relation is None else None
     observation = (
@@ -1082,7 +1124,6 @@ def normalise_semantic_operation_projection(value: Any) -> dict[str, Any] | None
         if relation is None
         else None
     )
-    outcome = _normalise_projected_outcome(value.get("outcome"))
     verification = _normalise_projected_verification(
         value.get("verification"),
         lifecycle_status=lifecycle_status,
@@ -1095,14 +1136,14 @@ def normalise_semantic_operation_projection(value: Any) -> dict[str, Any] | None
         "lifecycle_status": lifecycle_status,
         "capability": {
             "id": capability_id,
-            "label": _display_label(capability_id),
+            "label": capability_label,
             "kind": kind,
             "execution_method": execution_method,
         },
         "arguments": arguments,
         "summary": _clean_text(
             _summary(
-                capability_label=_display_label(capability_id),
+                capability_label=capability_label,
                 relation=relation,
                 focus=focus,
                 observation=observation,
@@ -1113,7 +1154,7 @@ def normalise_semantic_operation_projection(value: Any) -> dict[str, Any] | None
             ),
             limit=_MAX_SUMMARY_CHARS,
         )
-        or f"Observed {_display_label(capability_id)}.",
+        or f"Observed {capability_label}.",
         "visibility": "conversation_scope",
         "verification": verification,
     }
@@ -1136,6 +1177,7 @@ def build_semantic_operation_projection(
     capability_kind: str,
     arguments: Mapping[str, Any],
     lifecycle_status: str,
+    capability_display_name: str | None = None,
     success: bool | None = None,
     result: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -1146,8 +1188,18 @@ def build_semantic_operation_projection(
     execution_method_id = _clean_text(execution_method) or capability_id
     kind = _clean_text(capability_kind) or "registered_tool"
     status = _clean_text(lifecycle_status, limit=80) or "unknown"
-    capability_label = _display_label(capability_id)
     projected_arguments = _argument_projection(arguments)
+    capability_label = _capability_display_label(
+        capability_id=capability_id,
+        capability_kind=kind,
+        projected_arguments=projected_arguments,
+        display_name=capability_display_name,
+        workflow_identity=(
+            result.get("workflow_id")
+            if isinstance(result, Mapping)
+            else None
+        ),
+    )
     relation = _relation_projection(projected_arguments)
     focus = _focus_projection(arguments) if relation is None else None
     observation = _observation_projection(result) if relation is None else None

--- a/src/backend/services/turn_execution_diagnostics_service.py
+++ b/src/backend/services/turn_execution_diagnostics_service.py
@@ -633,6 +633,7 @@ def _summarise_tool_invocation_history(
             "error_code",
             "execution_id",
             "capability_kind",
+            "capability_display_name",
             "execution_method",
             "represented_workflow_id",
             "workflow_id",

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -5303,6 +5303,7 @@ def _summarise_tool_invocations(
             "effect_id",
             "effect_status",
             "capability_kind",
+            "capability_display_name",
             "execution_method",
             "represented_workflow_id",
             "workflow_id",

--- a/src/backend/workflows/durable/tool_result_hint_actions.py
+++ b/src/backend/workflows/durable/tool_result_hint_actions.py
@@ -139,6 +139,9 @@ def _build_model_policy_generate(
             call_type: str,
             model_name: str | None,
             duration_ms: float | None,
+            requested_model_name: str | None = None,
+            effective_model_name: str | None = None,
+            model_identity_source: str | None = None,
             usage: Mapping[str, Any] | None = None,
             note: str | None = None,
             stage: str | None = None,
@@ -159,6 +162,17 @@ def _build_model_policy_generate(
                 "duration_ms": duration_ms,
                 "stage": stage,
             }
+            if isinstance(requested_model_name, str) and requested_model_name.strip():
+                entry["requested_model"] = requested_model_name.strip()
+            if isinstance(model_name, str) and model_name.strip():
+                entry["selected_model"] = model_name.strip()
+            if isinstance(effective_model_name, str) and effective_model_name.strip():
+                entry["effective_model"] = effective_model_name.strip()
+                if (
+                    isinstance(model_identity_source, str)
+                    and model_identity_source.strip()
+                ):
+                    entry["model_identity_source"] = model_identity_source.strip()
             if usage:
                 entry["usage"] = dict(usage)
             if note:

--- a/src/backend/workflows/llm_step_executor.py
+++ b/src/backend/workflows/llm_step_executor.py
@@ -2970,6 +2970,9 @@ def _run_gateway_llm_step_no_tools(
         call_type: str,
         model_name: str | None,
         duration_ms: float | None,
+        requested_model_name: str | None = None,
+        effective_model_name: str | None = None,
+        model_identity_source: str | None = None,
         usage: Mapping[str, Any] | None = None,
         note: str | None = None,
         stage: str | None = None,
@@ -2990,6 +2993,14 @@ def _run_gateway_llm_step_no_tools(
             "duration_ms": duration_ms,
             "stage": stage,
         }
+        if isinstance(requested_model_name, str) and requested_model_name.strip():
+            entry["requested_model"] = requested_model_name.strip()
+        if isinstance(model_name, str) and model_name.strip():
+            entry["selected_model"] = model_name.strip()
+        if isinstance(effective_model_name, str) and effective_model_name.strip():
+            entry["effective_model"] = effective_model_name.strip()
+            if isinstance(model_identity_source, str) and model_identity_source.strip():
+                entry["model_identity_source"] = model_identity_source.strip()
         if isinstance(call_id, str) and call_id.strip():
             entry["call_id"] = call_id.strip()
         if usage:
@@ -3451,6 +3462,9 @@ def _execute_llm_step_inner(request: WorkflowActionRequest) -> WorkflowActionRes
         call_type: str,
         model_name: str | None,
         duration_ms: float | None,
+        requested_model_name: str | None = None,
+        effective_model_name: str | None = None,
+        model_identity_source: str | None = None,
         usage: Mapping[str, Any] | None = None,
         note: str | None = None,
         stage: str | None = None,
@@ -3471,6 +3485,14 @@ def _execute_llm_step_inner(request: WorkflowActionRequest) -> WorkflowActionRes
             "duration_ms": duration_ms,
             "stage": stage,
         }
+        if isinstance(requested_model_name, str) and requested_model_name.strip():
+            entry["requested_model"] = requested_model_name.strip()
+        if isinstance(model_name, str) and model_name.strip():
+            entry["selected_model"] = model_name.strip()
+        if isinstance(effective_model_name, str) and effective_model_name.strip():
+            entry["effective_model"] = effective_model_name.strip()
+            if isinstance(model_identity_source, str) and model_identity_source.strip():
+                entry["model_identity_source"] = model_identity_source.strip()
         if isinstance(call_id, str) and call_id.strip():
             entry["call_id"] = call_id.strip()
         if usage:

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -3559,6 +3559,80 @@ function getThinkingSemanticOperation(source) {
     return normaliseThinkingSemanticOperation(source.semanticOperation || source.semantic_operation);
 }
 
+function getThinkingCapabilityDescriptor(source) {
+    if (!source || typeof source !== 'object') {
+        return null;
+    }
+    const semanticOperation = getThinkingSemanticOperation(source);
+    const capabilityId = normaliseThinkingActivityString(
+        semanticOperation?.capability?.id || source.tool || source.workflowTask
+    );
+    const workflowArgument = semanticOperation?.arguments?.find(
+        (argument) => argument?.role === 'workflow'
+    );
+    const workflowId = normaliseThinkingActivityString(
+        source.represented_workflow_id
+        || source.representedWorkflowId
+        || source.workflow_id
+        || source.workflowId
+        || semanticOperation?.outcome?.workflowId
+        || workflowArgument?.value
+    );
+    const capabilityKind = normaliseThinkingActivityString(
+        semanticOperation?.capability?.kind || source.capability_kind || source.capabilityKind
+    ) || (workflowId && capabilityId.startsWith('represented_workflow_')
+        ? 'represented_workflow'
+        : '');
+    const suppliedDisplayName = normaliseThinkingActivityString(
+        source.capability_display_name || source.capabilityDisplayName
+    );
+    const projectedLabel = normaliseThinkingActivityString(
+        semanticOperation?.capability?.label
+    );
+    const generatedCapabilityLabel = formatThinkingActivityFallbackLabel(capabilityId);
+    const workflowFallbackLabel = workflowId
+        ? formatWorkflowName(workflowId).replace(/\b\w/g, (character) => (
+            character.toUpperCase()
+        ))
+        : '';
+    const projectedLabelIsOpaque = (
+        capabilityKind === 'represented_workflow'
+        && projectedLabel.toLowerCase() === generatedCapabilityLabel.toLowerCase()
+    );
+    const label = suppliedDisplayName
+        || (projectedLabelIsOpaque ? workflowFallbackLabel : projectedLabel)
+        || workflowFallbackLabel
+        || generatedCapabilityLabel;
+    if (!capabilityId && !label) {
+        return null;
+    }
+    return {
+        capabilityId,
+        capabilityKind,
+        generatedCapabilityLabel,
+        label,
+        opaqueCapabilityLabel: projectedLabelIsOpaque
+            ? projectedLabel
+            : generatedCapabilityLabel,
+        semanticOperation,
+        workflowId
+    };
+}
+
+function replaceOpaqueThinkingCapabilityLabel(summary, descriptor) {
+    const cleanSummary = normaliseThinkingActivityString(summary);
+    if (
+        !cleanSummary
+        || descriptor?.capabilityKind !== 'represented_workflow'
+        || !descriptor.label
+        || !descriptor.opaqueCapabilityLabel
+        || descriptor.label === descriptor.opaqueCapabilityLabel
+    ) {
+        return cleanSummary;
+    }
+    return cleanSummary.split(descriptor.opaqueCapabilityLabel).join(descriptor.label);
+}
+
 function cloneThinkingToolHistoryEntry(entry) {
     const copy = { ...entry };
     const semanticOperation = getThinkingSemanticOperation(entry);
@@ -6384,8 +6458,14 @@ function deriveThinkingExecutionInterpretation(request = null) {
         selected_workflow_name: normaliseThinkingActivityString(latestProgress?.selected_workflow_name)
     }, workflowDiscovery);
     const toolHistory = getCanonicalThinkingToolHistory(request);
+    const representedWorkflowCapability = toolHistory
+        .map((entry) => getThinkingCapabilityDescriptor(entry))
+        .find((descriptor) => descriptor?.capabilityKind === 'represented_workflow') || null;
     const uniqueToolNames = [...new Set(toolHistory
-        .map((entry) => normaliseThinkingActivityString(entry?.tool || entry?.workflowTask))
+        .map((entry) => {
+            const descriptor = getThinkingCapabilityDescriptor(entry);
+            return normaliseThinkingActivityString(descriptor?.label);
+        })
         .filter(Boolean))];
     const stage = normaliseThinkingActivityString(latestProgress?.stage || latestProgress?.phase);
     const stageLabel = normaliseThinkingActivityString(latestProgress?.stage_label || latestProgress?.phase_label)
@@ -6399,6 +6479,10 @@ function deriveThinkingExecutionInterpretation(request = null) {
         executionFamily = 'selected_workflow';
         progressKind = 'workflow_execution';
         identitySummary = `Selected workflow: ${selectedWorkflow.label}`;
+    } else if (representedWorkflowCapability) {
+        executionFamily = 'selected_workflow';
+        progressKind = 'workflow_execution';
+        identitySummary = `Workflow: ${representedWorkflowCapability.label}`;
     } else if (uniqueToolNames.length > 0 || isToolCentricStage) {
         executionFamily = 'tool_orchestration';
         progressKind = 'tool_execution';
@@ -7052,14 +7136,27 @@ function buildDerivedThinkingCardEvidenceSummary({
     }
 
     const toolHistory = getCanonicalThinkingToolHistory(request);
-    const toolNames = [...new Set(toolHistory
-        .map((entry) => normaliseThinkingActivityString(entry.tool || entry.workflowTask))
-        .filter(Boolean))];
+    const observedCapabilities = toolHistory
+        .map((entry) => {
+            const descriptor = getThinkingCapabilityDescriptor(entry);
+            return {
+                label: normaliseThinkingActivityString(descriptor?.label),
+                kind: normaliseThinkingActivityString(descriptor?.capabilityKind)
+            };
+        })
+        .filter((entry) => entry.label);
+    const toolNames = [...new Set(observedCapabilities.map((entry) => entry.label))];
     if (toolNames.length > 0) {
         const preview = toolNames.slice(0, 3).join(', ');
+        const onlyRepresentedWorkflows = observedCapabilities.every(
+            (entry) => entry.kind === 'represented_workflow'
+        );
+        const observationLabel = onlyRepresentedWorkflows
+            ? 'Workflow observed'
+            : 'Tools observed';
         bits.push(toolNames.length > 3
-            ? `Tools observed: ${preview} +${toolNames.length - 3} more`
-            : `Tools observed: ${preview}`);
+            ? `${observationLabel}: ${preview} +${toolNames.length - 3} more`
+            : `${observationLabel}: ${preview}`);
     }
 
     return bits.join(' · ');
@@ -8284,9 +8381,22 @@ function renderToolHistoryHTML(request, mode = THINKING_CARD_MODE_DEFAULT) {
             continue;
         }
         const batchSize = entry && Number.isFinite(entry.batchSize) ? Number(entry.batchSize) : null;
-        const resultSummary = entry && typeof entry.resultSummary === 'string' ? entry.resultSummary : '';
-        const semanticOperation = getThinkingSemanticOperation(entry);
-        const semanticSummary = normaliseThinkingActivityString(semanticOperation?.summary);
+        const capabilityDescriptor = getThinkingCapabilityDescriptor(entry);
+        const semanticOperation = capabilityDescriptor?.semanticOperation || null;
+        const resultSummary = replaceOpaqueThinkingCapabilityLabel(
+            entry && typeof entry.resultSummary === 'string' ? entry.resultSummary : '',
+            capabilityDescriptor
+        );
+        const semanticSummary = replaceOpaqueThinkingCapabilityLabel(
+            semanticOperation?.summary,
+            capabilityDescriptor
+        );
+        const semanticCapabilityLabel = normaliseThinkingActivityString(
+            capabilityDescriptor?.label
+        );
+        const isRepresentedWorkflow = (
+            capabilityDescriptor?.capabilityKind === 'represented_workflow'
+        );
         const success = entry.success;
 
         // Status icon and class
@@ -8297,9 +8407,15 @@ function renderToolHistoryHTML(request, mode = THINKING_CARD_MODE_DEFAULT) {
             statusClass = 'failure';
         }
 
-        const technicalToolLabel = tool
-            ? `Tool call: ${tool}`
-            : (workflowTask ? `Workflow task: ${workflowTask}` : '');
+        const technicalToolLabel = (
+            renderMode !== THINKING_CARD_MODE_DEBUG
+            && isRepresentedWorkflow
+            && semanticCapabilityLabel
+        )
+            ? `Workflow: ${semanticCapabilityLabel}`
+            : (tool
+                ? `Tool call: ${tool}`
+                : (workflowTask ? `Workflow task: ${workflowTask}` : ''));
         const toolLabel = renderMode === THINKING_CARD_MODE_DEFAULT && semanticSummary
             ? semanticSummary
             : technicalToolLabel;
@@ -10560,13 +10676,33 @@ function buildToolHistoryDiagnosticsHTML(entry, mode = THINKING_CARD_MODE_EXPERT
     const renderMode = normaliseThinkingCardMode(mode);
     const tool = normaliseThinkingActivityString(entry.tool);
     const workflowTask = normaliseThinkingActivityString(entry.workflowTask);
-    const semanticOperation = getThinkingSemanticOperation(entry);
+    const capabilityDescriptor = getThinkingCapabilityDescriptor(entry);
+    const semanticOperation = capabilityDescriptor?.semanticOperation || null;
+    const isRepresentedWorkflow = (
+        capabilityDescriptor?.capabilityKind === 'represented_workflow'
+    );
+    const capabilityLabel = normaliseThinkingActivityString(
+        capabilityDescriptor?.label
+    );
     const facts = [
-        { label: 'Tool', value: tool },
+        {
+            label: isRepresentedWorkflow && renderMode !== THINKING_CARD_MODE_DEBUG
+                ? 'Workflow capability'
+                : 'Tool',
+            value: isRepresentedWorkflow && renderMode !== THINKING_CARD_MODE_DEBUG
+                ? capabilityLabel
+                : tool
+        },
         { label: 'Workflow task', value: workflowTask },
         { label: 'Phase', value: entry.phase ? formatThinkingActivityFallbackLabel(entry.phase) : '' },
         { label: 'Batch size', value: entry.batchSize },
-        { label: 'Result', value: semanticOperation?.summary || entry.resultSummary },
+        {
+            label: 'Result',
+            value: replaceOpaqueThinkingCapabilityLabel(
+                semanticOperation?.summary || entry.resultSummary,
+                capabilityDescriptor
+            )
+        },
         {
             label: 'Outcome',
             value: typeof entry.success === 'boolean'
@@ -10574,6 +10710,17 @@ function buildToolHistoryDiagnosticsHTML(entry, mode = THINKING_CARD_MODE_EXPERT
                 : 'Pending'
         }
     ];
+    const hasWorkflowArgument = semanticOperation?.arguments?.some(
+        (argument) => argument?.role === 'workflow'
+    );
+    if (
+        isRepresentedWorkflow
+        && renderMode !== THINKING_CARD_MODE_DEFAULT
+        && capabilityDescriptor?.workflowId
+        && !hasWorkflowArgument
+    ) {
+        facts.push({ label: 'Workflow ID', value: capabilityDescriptor.workflowId });
+    }
 
     if (semanticOperation) {
         const focusSourceArgument = normaliseThinkingActivityString(

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -3449,6 +3449,127 @@ describe('thinking activity history normalisation', () => {
         expect(expertHtml).toContain('hasName');
     });
 
+    test('shows represented workflow names by default and keeps both machine identities inspectable', () => {
+        const semanticOperation = {
+            schema_version: 'thinking_semantic_operation.v1',
+            operation_id: 'operation-arxiv-workflow',
+            lifecycle_status: 'succeeded',
+            capability: {
+                id: 'represented_workflow_0348c4f884fc88757dcf',
+                label: 'Arxiv Paper Representation Workflow',
+                kind: 'represented_workflow',
+                execution_method: 'workflow_execute'
+            },
+            arguments: [{
+                role: 'workflow',
+                label: 'Workflow',
+                source_argument: 'workflow_id',
+                value_kind: 'workflow',
+                value: '#V#arxiv_paper_representation_workflow',
+                display: 'Arxiv Paper Representation Workflow',
+                concept_id: '#V#arxiv_paper_representation_workflow'
+            }],
+            summary: 'Finished Arxiv Paper Representation Workflow.',
+            visibility: 'conversation_scope',
+            verification: {
+                status: 'receipt_only',
+                canonical_read_back_present: false,
+                source: 'effect_receipt'
+            },
+            outcome: { status: 'succeeded', success: true }
+        };
+        const createRequest = (mode) => ({
+            thinkingCardMode: mode,
+            latestProgress: {
+                status: 'completed',
+                stage: 'adaptive_research',
+                tool_history: [{
+                    tool: semanticOperation.capability.id,
+                    callId: 'call-arxiv-workflow',
+                    success: true,
+                    resultSummary: semanticOperation.summary,
+                    semanticOperation
+                }]
+            }
+        });
+
+        const defaultHtml = __testOnly_renderThinkingCardBodyHTML(createRequest('default'));
+        expect(defaultHtml).toContain('Finished Arxiv Paper Representation Workflow');
+        expect(defaultHtml).not.toContain('represented_workflow_0348c4f884fc88757dcf');
+        expect(defaultHtml).not.toContain('#V#arxiv_paper_representation_workflow');
+
+        const expertHtml = __testOnly_renderThinkingCardBodyHTML(createRequest('expert'));
+        expect(expertHtml).toContain('Arxiv Paper Representation Workflow');
+        expect(expertHtml).toContain('Workflow: Arxiv Paper Representation Workflow');
+        expect(expertHtml).toContain('Workflow ID');
+        expect(expertHtml).toContain('#V#arxiv_paper_representation_workflow');
+        expect(expertHtml).not.toContain('Tool call: represented_workflow_0348c4f884fc88757dcf');
+
+        const debugHtml = __testOnly_renderThinkingCardBodyHTML(createRequest('debug'));
+        expect(debugHtml).toContain('Tool call: represented_workflow_0348c4f884fc88757dcf');
+        expect(debugHtml).toContain('Capability ID');
+        expect(debugHtml).toContain('represented_workflow_0348c4f884fc88757dcf');
+        expect(debugHtml).toContain('workflow_execute');
+    });
+
+    test('recovers a represented workflow name from legacy completed history', () => {
+        const capabilityId = 'represented_workflow_0348c4f884ec88757dcf';
+        const opaqueLabel = 'Represented Workflow 0348C4F884Ec88757Dcf';
+        const semanticOperation = {
+            schema_version: 'thinking_semantic_operation.v1',
+            operation_id: 'operation-legacy-arxiv-workflow',
+            lifecycle_status: 'failed',
+            capability: {
+                id: capabilityId,
+                label: opaqueLabel,
+                kind: 'represented_workflow',
+                execution_method: 'workflow_execute'
+            },
+            arguments: [],
+            summary: `${opaqueLabel} did not succeed.`,
+            visibility: 'conversation_scope',
+            outcome: {
+                status: 'failed',
+                success: false,
+                workflow_id: '#V#arxiv_paper_representation_workflow'
+            },
+            verification: {
+                status: 'receipt_only',
+                canonical_read_back_present: false,
+                source: 'effect_receipt'
+            }
+        };
+        const createRequest = (mode) => ({
+            thinkingCardMode: mode,
+            latestProgress: {
+                status: 'completed',
+                stage: 'adaptive_research',
+                tool_history: [{
+                    tool: capabilityId,
+                    capability_kind: 'represented_workflow',
+                    represented_workflow_id: '#V#arxiv_paper_representation_workflow',
+                    success: false,
+                    resultSummary: semanticOperation.summary,
+                    semanticOperation
+                }]
+            }
+        });
+
+        const defaultHtml = __testOnly_renderThinkingCardBodyHTML(createRequest('default'));
+        expect(defaultHtml).toContain('Arxiv Paper Representation Workflow did not succeed');
+        expect(defaultHtml).not.toContain(opaqueLabel);
+        expect(defaultHtml).not.toContain(capabilityId);
+
+        const expertHtml = __testOnly_renderThinkingCardBodyHTML(createRequest('expert'));
+        expect(expertHtml).toContain('Workflow: Arxiv Paper Representation Workflow');
+        expect(expertHtml).toContain('#V#arxiv_paper_representation_workflow');
+        expect(expertHtml).not.toContain(`Tool call: ${capabilityId}`);
+
+        const debugHtml = __testOnly_renderThinkingCardBodyHTML(createRequest('debug'));
+        expect(debugHtml).toContain(`Tool call: ${capabilityId}`);
+        expect(debugHtml).toContain('Arxiv Paper Representation Workflow did not succeed');
+    });
+
     test('adds bounded semantic IDs and verification in Expert, then execution details only in Debug', () => {
         const semanticOperation = {
             schema_version: 'thinking_semantic_operation.v1',
@@ -6182,7 +6303,7 @@ describe('thinking activity history normalisation', () => {
         const text = container.textContent || '';
 
         expect(text).toContain('Execution path');
-        expect(text).toContain('General tool use: fetch_concept, task_get');
+        expect(text).toContain('General tool use: Fetch concept, Task get');
         expect(text).toContain('Progress meaning');
         expect(text).toContain('Running tool pipeline for this turn.');
     });

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -6647,6 +6647,7 @@ def test_represented_workflow_is_discovered_and_invoked_as_bound_capability(
     )
 
     seen_arguments: dict[str, Any] = {}
+    progress_events: list[dict[str, Any]] = []
     workflow_capability = WorkflowTurnCapability(
         name="represented_workflow_turn_test",
         workflow_id="#V#represented_test_workflow",
@@ -6754,6 +6755,10 @@ def test_represented_workflow_is_discovered_and_invoked_as_bound_capability(
         turn_id="turn-represented-workflow",
         turn_budget_seconds=20,
         final_synthesis_reserve_seconds=2,
+        progress_tracker=SimpleNamespace(
+            emit=lambda event: progress_events.append(dict(event)),
+            check_cancellation=lambda: None,
+        ),
     )
 
     catalogue_result = client.calls[1]["tool_results"][0].output
@@ -6789,6 +6794,7 @@ def test_represented_workflow_is_discovered_and_invoked_as_bound_capability(
     assert invocation["tool"] == workflow_capability.name
     assert invocation["execution_method"] == "workflow_execute"
     assert invocation["capability_kind"] == "represented_workflow"
+    assert invocation["capability_display_name"] == "Represented test workflow"
     assert invocation["represented_workflow_id"] == (
         "#V#represented_test_workflow"
     )
@@ -6805,6 +6811,34 @@ def test_represented_workflow_is_discovered_and_invoked_as_bound_capability(
     assert selection_trace["capability_name"] == workflow_capability.name
     assert selection_trace["selection_policy"]["representedness_priority"] is False
     assert selection_trace["plan_profile"]["shape"] == ("represented_workflow")
+    workflow_events = [
+        event
+        for event in progress_events
+        if event.get("call_id") == "invoke-workflow"
+    ]
+    assert [event["event_kind"] for event in workflow_events] == [
+        "tool_call_start",
+        "tool_call_end",
+    ]
+    assert [event["subtask"] for event in workflow_events] == [
+        "Represented test workflow",
+        "Represented test workflow",
+    ]
+    assert workflow_events[0]["result_summary"] == (
+        "Using Represented test workflow."
+    )
+    assert workflow_events[1]["result_summary"] == (
+        "Finished Represented test workflow."
+    )
+    for event in workflow_events:
+        semantic_operation = event["semantic_operation"]
+        assert semantic_operation["capability"]["id"] == workflow_capability.name
+        assert semantic_operation["capability"]["label"] == (
+            "Represented test workflow"
+        )
+        assert semantic_operation["arguments"][0]["value"] == (
+            "#V#represented_test_workflow"
+        )
     assert result.response_text == "The represented work product was completed."
 
 

--- a/tests/backend/test_llm_step_executor.py
+++ b/tests/backend/test_llm_step_executor.py
@@ -1396,20 +1396,23 @@ def test_execute_llm_step_passes_context_lineage_to_gateway_llm(
     assert captured["check_cancellation"] is None
 
 
-def test_execute_llm_step_preserves_gateway_llm_call_id(monkeypatch) -> None:
+def test_execute_llm_step_preserves_gateway_llm_call_metadata(monkeypatch) -> None:
     class _StubOrchestrator:
         def _run_llm_with_fallbacks(self, **kwargs):
             record_llm_call = kwargs.get("record_llm_call")
             assert callable(record_llm_call)
             record_llm_call(
                 call_type="llm_call",
-                model_name="test-model",
+                model_name="selected-model",
+                requested_model_name="requested-model",
+                effective_model_name="provider-model",
+                model_identity_source="provider_response",
                 duration_ms=12.0,
                 stage="selector",
                 provider="openai",
                 call_id="llm-test:attempt:1",
             )
-            return ('{"ok": true}', "test-model", None)
+            return ('{"ok": true}', "selected-model", None)
 
     monkeypatch.setattr(
         "src.backend.workflows.llm_step_executor._build_gateway_runtime",
@@ -1422,7 +1425,7 @@ def test_execute_llm_step_preserves_gateway_llm_call_id(monkeypatch) -> None:
         environment=WorkflowEnvironment(
             llm_client=MagicMock(),
             gateway=object(),
-            model="test-model",
+            model="requested-model",
         ),
         data={},
         prompt_contract={"prompt_text": "Return JSON only."},
@@ -1433,10 +1436,18 @@ def test_execute_llm_step_preserves_gateway_llm_call_id(monkeypatch) -> None:
     result = execute_llm_step(request)
 
     assert result.status == "success"
-    assert result.outputs["llm_calls"][0]["call_id"] == "llm-test:attempt:1"
+    llm_call = result.outputs["llm_calls"][0]
+    assert llm_call["call_id"] == "llm-test:attempt:1"
+    assert llm_call["requested_model"] == "requested-model"
+    assert llm_call["selected_model"] == "selected-model"
+    assert llm_call["effective_model"] == "provider-model"
+    assert llm_call["model_identity_source"] == "provider_response"
     assert (
         result.outputs["llm_step_envelope"]["llm_calls"][0]["call_id"]
         == "llm-test:attempt:1"
+    )
+    assert (
+        result.outputs["llm_step_envelope"]["llm_calls"] == result.outputs["llm_calls"]
     )
 
 
@@ -1737,7 +1748,7 @@ def test_execute_llm_step_tool_mode_marks_user_model_preference(
 
         def _select_model_for_stage(self, **kwargs):
             captured["prefer_default_model"] = kwargs.get("prefer_default_model")
-            return kwargs.get("default_model")
+            return "selected-model"
 
         def _action_tool_calling_plan(self, request):
             captured["shared_prefer_default_model"] = request.data.get(
@@ -1745,6 +1756,15 @@ def test_execute_llm_step_tool_mode_marks_user_model_preference(
             )
             captured["workflow_step_output_contract"] = request.data.get(
                 "workflow_step_output_contract"
+            )
+            request.data["record_llm_call"](
+                call_type="llm.generate_with_tools",
+                model_name="selected-model",
+                requested_model_name="requested-model",
+                effective_model_name="provider-model",
+                model_identity_source="provider_response",
+                duration_ms=12.0,
+                stage="tool_call",
             )
             request.data["model_for_stage"]("tool_call")
             return type(
@@ -1774,10 +1794,10 @@ def test_execute_llm_step_tool_mode_marks_user_model_preference(
         environment=WorkflowEnvironment(
             llm_client=MagicMock(),
             gateway=_StubGateway(),
-            model="gemma4:26b",
+            model="requested-model",
         ),
         data={
-            "requested_model": "gemma4:26b",
+            "requested_model": "requested-model",
             "requested_client_type": "ollama",
         },
         prompt_contract={"prompt_text": "Return JSON only."},
@@ -1790,6 +1810,14 @@ def test_execute_llm_step_tool_mode_marks_user_model_preference(
     assert result.status == "success"
     assert captured["shared_prefer_default_model"] is True
     assert captured["prefer_default_model"] is True
+    llm_call = result.outputs["llm_calls"][0]
+    assert llm_call["requested_model"] == "requested-model"
+    assert llm_call["selected_model"] == "selected-model"
+    assert llm_call["effective_model"] == "provider-model"
+    assert llm_call["model_identity_source"] == "provider_response"
+    assert (
+        result.outputs["llm_step_envelope"]["llm_calls"] == result.outputs["llm_calls"]
+    )
     assert captured["workflow_step_output_contract"] == {
         "schema_version": "workflow_step_output_contract.v1",
         "output_format": "json_value",

--- a/tests/backend/test_rag_turn_execution_records_mcp_read_tools.py
+++ b/tests/backend/test_rag_turn_execution_records_mcp_read_tools.py
@@ -1823,6 +1823,7 @@ def test_turn_execution_get_prefers_identity_bearing_top_level_invocations(
                     "effect_id": "effect-durable-identities",
                     "effect_status": "partial",
                     "error_code": "tool_timeout_after_durable_submission",
+                    "capability_display_name": "Paper Representation Workflow",
                     "workflow_id": "#V#paper_workflow",
                     "evidence": {
                         "instance_id": "instance-durable-identities",
@@ -1866,6 +1867,7 @@ def test_turn_execution_get_prefers_identity_bearing_top_level_invocations(
             "effect_status": "partial",
             "error_code": "tool_timeout_after_durable_submission",
             "capability_kind": "represented_workflow",
+            "capability_display_name": "Paper Representation Workflow",
             "execution_method": "workflow_execute",
             "represented_workflow_id": "#V#paper_workflow",
             "workflow_id": "#V#paper_workflow",
@@ -1906,6 +1908,9 @@ def test_turn_execution_get_diagnostics_hydrates_empty_progress_tool_history(
                                 "effect_status": "partial",
                                 "error_code": (
                                     "tool_timeout_after_durable_submission"
+                                ),
+                                "capability_display_name": (
+                                    "Paper Representation Workflow"
                                 ),
                                 "execution_id": "mcp-workflow",
                                 "workflow_id": "#V#paper_workflow",
@@ -1968,6 +1973,9 @@ def test_turn_execution_get_diagnostics_hydrates_empty_progress_tool_history(
         "tool_timeout_after_durable_submission"
     )
     assert workflow_call["execution_id"] == "mcp-workflow"
+    assert workflow_call["capability_display_name"] == (
+        "Paper Representation Workflow"
+    )
     assert workflow_call["workflow_id"] == "#V#paper_workflow"
     assert workflow_call["instance_id"] == "instance-workflow"
     assert "effective_arguments" not in workflow_call

--- a/tests/backend/test_thinking_semantic_projection_service.py
+++ b/tests/backend/test_thinking_semantic_projection_service.py
@@ -45,6 +45,65 @@ def test_relation_projection_has_role_labelled_arguments_and_readable_start() ->
     )
 
 
+def test_represented_workflow_uses_human_label_without_losing_identities() -> None:
+    projection = build_semantic_operation_projection(
+        operation_id="call-arxiv-workflow",
+        capability_name="represented_workflow_0348c4f884fc88757dcf",
+        execution_method="workflow_execute",
+        capability_kind="represented_workflow",
+        capability_display_name="Arxiv Paper Representation Workflow",
+        arguments={"workflow_id": "#V#arxiv_paper_representation_workflow"},
+        lifecycle_status="running",
+    )
+
+    assert projection["capability"] == {
+        "id": "represented_workflow_0348c4f884fc88757dcf",
+        "label": "Arxiv Paper Representation Workflow",
+        "kind": "represented_workflow",
+        "execution_method": "workflow_execute",
+    }
+    assert projection["arguments"][0]["value"] == (
+        "#V#arxiv_paper_representation_workflow"
+    )
+    assert projection["summary"] == "Using Arxiv Paper Representation Workflow."
+    assert normalise_semantic_operation_projection(projection) == projection
+
+
+def test_legacy_workflow_projection_falls_back_to_canonical_workflow_id() -> None:
+    projection = build_semantic_operation_projection(
+        operation_id="call-arxiv-workflow",
+        capability_name="represented_workflow_0348c4f884fc88757dcf",
+        execution_method="workflow_execute",
+        capability_kind="represented_workflow",
+        arguments={"workflow_id": "#V#arxiv_paper_representation_workflow"},
+        lifecycle_status="running",
+    )
+    projection["capability"]["label"] = (
+        "Represented Workflow 0348C4F884Fc88757Dcf"
+    )
+    projection["summary"] = "Using Represented Workflow 0348C4F884Fc88757Dcf."
+    projection["arguments"] = []
+    projection["outcome"] = {
+        "status": "failed",
+        "success": False,
+        "workflow_id": "#V#arxiv_paper_representation_workflow",
+    }
+    projection["lifecycle_status"] = "failed"
+
+    normalised = normalise_semantic_operation_projection(projection)
+
+    assert normalised is not None
+    assert normalised["capability"]["id"] == (
+        "represented_workflow_0348c4f884fc88757dcf"
+    )
+    assert normalised["capability"]["label"] == (
+        "Arxiv Paper Representation Workflow"
+    )
+    assert normalised["summary"] == (
+        "Arxiv Paper Representation Workflow did not succeed."
+    )
+
+
 def test_nested_predicate_reference_and_receipt_only_unchanged_are_truthful() -> None:
     projection = _relation_projection(
         arguments={

--- a/tests/backend/test_tool_result_hint_actions.py
+++ b/tests/backend/test_tool_result_hint_actions.py
@@ -186,6 +186,7 @@ def test_action_uses_workflow_model_policy_fallback_with_gateway(
             kwargs["record_llm_call"](
                 call_type="llm.generate",
                 model_name="gpt-4.1-mini",
+                requested_model_name="gpt-4.1-mini",
                 duration_ms=10,
                 note="llm.generate failed; trying fallback",
                 stage=kwargs["stage"],
@@ -196,6 +197,7 @@ def test_action_uses_workflow_model_policy_fallback_with_gateway(
             kwargs["record_llm_call"](
                 call_type="llm.generate",
                 model_name="granite3.3:2b",
+                requested_model_name="gpt-4.1-mini",
                 duration_ms=5,
                 note="Fallback chain generate()",
                 stage=kwargs["stage"],
@@ -266,6 +268,8 @@ def test_action_uses_workflow_model_policy_fallback_with_gateway(
     assert result.outputs["selected_model"] == "granite3.3:2b"
     assert result.outputs["selected_model_candidate"]["provider"] == "ollama"
     assert result.outputs["llm_calls"][0]["provider"] == "openai"
+    assert result.outputs["llm_calls"][0]["requested_model"] == "gpt-4.1-mini"
+    assert result.outputs["llm_calls"][0]["selected_model"] == "gpt-4.1-mini"
     stage_summary = result.outputs["aux_llm_calls"][0]
     assert stage_summary["fallback_attempt_count"] == 2
     assert stage_summary["fallback_attempts"][0]["failure_kind"] == "quota_exhausted"

--- a/tests/backend/test_turn_execution_record_service_execution_summary.py
+++ b/tests/backend/test_turn_execution_record_service_execution_summary.py
@@ -288,6 +288,7 @@ def test_partial_represented_workflow_preserves_durable_identity_in_projection()
                 "tool": "represented_workflow_turn_test",
                 "status": "error",
                 "capability_kind": "represented_workflow",
+                "capability_display_name": "Represented Test Workflow",
                 "execution_method": "workflow_execute",
                 "represented_workflow_id": "#V#represented_test_workflow",
                 "workflow_id": "#V#represented_test_workflow",
@@ -306,6 +307,7 @@ def test_partial_represented_workflow_preserves_durable_identity_in_projection()
     serialised = record["execution"]["tool_invocations"][0]
     assert serialised["status"] == "partial"
     assert serialised["capability_kind"] == "represented_workflow"
+    assert serialised["capability_display_name"] == "Represented Test Workflow"
     assert serialised["execution_method"] == "workflow_execute"
     assert serialised["represented_workflow_id"] == (
         "#V#represented_test_workflow"


### PR DESCRIPTION
## Summary

- carry a trusted, human-readable display label for represented workflow capabilities while retaining the per-turn capability ID and canonical workflow identity
- render the human workflow name in Default and Expert Thinking modes, with raw invocation IDs reserved for Debug
- recover useful workflow names for legacy stored Thinking cards without workflow-specific mappings or a new database lookup
- preserve requested, selected, and provider-observed model identities in durable workflow LLM-call telemetry

## Why

Represented workflows were surfaced as `Represented Workflow <hash>`, so ordinary users could not tell what Von was doing. Separately, nested workflow recorders accepted only the selected model name and dropped the requested/effective identity fields already produced by the gateway.

## User impact

Default Thinking now explains the named workflow in human terms. Expert retains semantic and canonical identity, while Debug adds the raw invocation identifier. Workflow telemetry can now distinguish the model the user requested, the model routing selected, and the model the provider reported.

## Validation

- 194 affected backend tests passed
- 255 Thinking frontend tests passed
- frontend static lint passed
- `git diff --check` passed
- authenticated live browser replay of stored request `727deaec-f483-47ce-a752-f2746b9b38b7`: Default displayed “Arxiv Paper Representation Workflow” without the generated or raw hash; Expert retained the human workflow name; Debug exposed the raw invocation ID alongside it

The historic represented-workflow invocation used for display validation had failed; the browser replay validates display and legacy recovery, not that historic workflow effect.

Jira: JVNAUTOSCI-2619