### PR TITLE
Start Thinking cards at content height

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -2263,17 +2263,18 @@ function clampThinkingCardBodyHeightPx(value) {
     );
 }
 
+function getThinkingCardInitialBodyHeightPx(detailEl = null) {
+    const contentHeight = (detailEl instanceof HTMLElement && Number.isFinite(detailEl.scrollHeight))
+        ? detailEl.scrollHeight
+        : THINKING_CARD_BODY_DEFAULT_HEIGHT_PX;
+    return clampThinkingCardBodyHeightPx(
+        Math.max(contentHeight, THINKING_CARD_BODY_DEFAULT_HEIGHT_PX)
+    );
+}
+
 function ensureThinkingCardBodyHeightPx(request, detailEl = null) {
     if (!request || typeof request !== 'object') {
-        const contentHeight = (detailEl instanceof HTMLElement && Number.isFinite(detailEl.scrollHeight))
-            ? detailEl.scrollHeight
-            : THINKING_CARD_BODY_DEFAULT_HEIGHT_PX;
-        return clampThinkingCardBodyHeightPx(
-            Math.min(
-                Math.max(contentHeight, THINKING_CARD_BODY_MIN_HEIGHT_PX),
-                THINKING_CARD_BODY_DEFAULT_HEIGHT_PX
-            )
-        );
+        return getThinkingCardInitialBodyHeightPx(detailEl);
     }
 
     const existingHeight = Number(request.thinkingCardBodyHeightPx);
@@ -2282,15 +2283,7 @@ function ensureThinkingCardBodyHeightPx(request, detailEl = null) {
         return request.thinkingCardBodyHeightPx;
     }
 
-    const contentHeight = (detailEl instanceof HTMLElement && Number.isFinite(detailEl.scrollHeight))
-        ? detailEl.scrollHeight
-        : THINKING_CARD_BODY_DEFAULT_HEIGHT_PX;
-    request.thinkingCardBodyHeightPx = clampThinkingCardBodyHeightPx(
-        Math.min(
-            Math.max(contentHeight, THINKING_CARD_BODY_MIN_HEIGHT_PX),
-            THINKING_CARD_BODY_DEFAULT_HEIGHT_PX
-        )
-    );
+    request.thinkingCardBodyHeightPx = getThinkingCardInitialBodyHeightPx(detailEl);
     return request.thinkingCardBodyHeightPx;
 }
 

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -8346,12 +8346,12 @@ describe('thinking card toggle accessibility', () => {
         const retained = getRetainedThinkingCardElements();
         retained.toggleButton.click();
 
-        expect(retained.detail.style.height).toBe('120px');
-        expect(retained.sizeDecreaseButton.disabled).toBe(true);
+        expect(retained.detail.style.height).toBe('220px');
+        expect(retained.sizeDecreaseButton.disabled).toBe(false);
         expect(retained.sizeIncreaseButton.disabled).toBe(false);
 
         retained.sizeIncreaseButton.click();
-        expect(retained.detail.style.height).toBe('200px');
+        expect(retained.detail.style.height).toBe('300px');
         expect(retained.sizeDecreaseButton.disabled).toBe(false);
 
         retained.sizeIncreaseButton.click();
@@ -8430,6 +8430,22 @@ describe('active thinking card manual resize persistence', () => {
             }]
         };
     }
+
+    test('starts tall enough for the initial thinking-card content', () => {
+        const request = createActiveThinkingRequest();
+        __testOnly_setThinkingCardRequests(request, null);
+
+        const detail = document.getElementById('loadingIndicatorDetail');
+        Object.defineProperty(detail, 'scrollHeight', {
+            configurable: true,
+            value: 360
+        });
+
+        __testOnly_refreshThinkingCardProgressUi(request);
+
+        expect(request.thinkingCardBodyHeightPx).toBe(360);
+        expect(detail.style.height).toBe('360px');
+    });
 
     test('keeps a manually dragged active thinking-card height across live refreshes', () => {
         const request = createActiveThinkingRequest();


### PR DESCRIPTION
## What changed

- Size a new Thinking card to its rendered initial content, bounded by the existing 220–520 px limits.
- Preserve existing vertical drag-resizing, size controls, and remembered manual heights.
- Add regression coverage for content-fitting initial height and update the retained-card starting-height expectations.

## Why

The initial-height calculation capped every new card at 220 px even when its first rendered content was taller, forcing immediate scrolling or manual resizing.

## User impact

Thinking cards now open tall enough for their initial content when it fits within the existing maximum, while remaining resizable.

## Validation

- `npm test -- --runInBand --silent --runTestsByPath src/frontend/web/von_interface/static/js/test/chatTab.test.js` — 258 passed
- `npm run lint:frontend:static -- src/frontend/web/von_interface/static/js/chatTab.js`
- `git diff --check`
- Local and server-served `chatTab.js` hashes matched
