### PR TITLE
Repair Gmail arXiv replay reliability

### DIFF
--- a/src/backend/integrations/google/gmail_service.py
+++ b/src/backend/integrations/google/gmail_service.py
@@ -9,17 +9,23 @@ the default posture; mutations require explicit opt-in flags and OAuth scopes.
 from __future__ import annotations
 
 import base64
+import http.client
 import json
-import os
 import logging
+import os
+import socket
 from dataclasses import dataclass, field
 from email.message import EmailMessage
 from email.utils import formataddr, getaddresses
 from typing import Any, Dict, Iterable, List, Mapping, Optional
 
+import google_auth_httplib2
+import httplib2
+from googleapiclient.discovery import build
+from googleapiclient.http import DEFAULT_HTTP_TIMEOUT_SEC
+
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
-from googleapiclient.discovery import build
 
 try:  # Optional dependency: agent Gmail OAuth token store.
     from ...services.agent_gmail_token_store import (
@@ -59,6 +65,100 @@ MESSAGE_LIST_VISIBILITY_VALUES: set[str] = {
 }
 
 PROFILES_ENV_VAR = "VON_GMAIL_PROFILES"
+
+
+def _create_connection_prefer_ipv4(
+    address,
+    timeout=None,
+    source_address=None,
+    *,
+    all_errors: bool = False,
+):
+    """Create a connection with IPv4-first, IPv6-fallback address ordering.
+
+    Python's standard HTTP transports try ``getaddrinfo`` results serially.
+    On dual-stack hosts with a non-functional IPv6 route, an IPv6-first DNS
+    answer can therefore consume the entire socket timeout before a reachable
+    IPv4 address is attempted. Keep this policy local to Google API transport;
+    do not mutate process-wide resolver or socket defaults.
+    """
+
+    host, port = address
+    address_info = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)
+    address_info.sort(key=lambda row: 0 if row[0] == socket.AF_INET else 1)
+    exceptions: list[OSError] = []
+
+    for family, socktype, proto, _canonname, sockaddr in address_info:
+        sock = None
+        try:
+            sock = socket.socket(family, socktype, proto)
+            if timeout is not None:
+                sock.settimeout(timeout)
+            if source_address:
+                sock.bind(source_address)
+            sock.connect(sockaddr)
+            exceptions.clear()
+            return sock
+        except OSError as exc:
+            if not all_errors:
+                exceptions.clear()
+            exceptions.append(exc)
+            if sock is not None:
+                sock.close()
+
+    if exceptions:
+        try:
+            if not all_errors:
+                raise exceptions[0]
+            raise ExceptionGroup("create_connection failed", exceptions)
+        finally:
+            exceptions.clear()
+    raise OSError("getaddrinfo returned no addresses")
+
+
+class _GoogleApiHTTPSConnection(httplib2.HTTPSConnectionWithTimeout):
+    """HTTPS connection with bounded, local dual-stack fallback semantics."""
+
+    def connect(self):
+        proxy_info = self.proxy_info
+        if proxy_info and proxy_info.isgood() and proxy_info.applies_to(self.host):
+            return super().connect()
+
+        original_create_connection = self._create_connection
+        self._create_connection = _create_connection_prefer_ipv4
+        try:
+            return http.client.HTTPSConnection.connect(self)
+        finally:
+            self._create_connection = original_create_connection
+
+
+class _GoogleApiHttp(httplib2.Http):
+    """Google API HTTP transport using the local dual-stack connection."""
+
+    def request(
+        self,
+        uri,
+        method="GET",
+        body=None,
+        headers=None,
+        redirections=httplib2.DEFAULT_MAX_REDIRECTS,
+        connection_type=None,
+    ):
+        if connection_type is None and str(uri).lower().startswith("https://"):
+            connection_type = _GoogleApiHTTPSConnection
+        return super().request(
+            uri,
+            method=method,
+            body=body,
+            headers=headers,
+            redirections=redirections,
+            connection_type=connection_type,
+        )
+
+
+def _build_authorized_google_http(creds: Credentials):
+    http_transport = _GoogleApiHttp(timeout=DEFAULT_HTTP_TIMEOUT_SEC)
+    return google_auth_httplib2.AuthorizedHttp(creds, http=http_transport)
 
 
 @dataclass
@@ -431,7 +531,12 @@ def get_profile(
 def get_service(profile_id: str, profiles: Optional[Dict[str, GmailProfile]] = None):
     profile = get_profile(profile_id, profiles)
     creds = profile.ensure_credentials()
-    return build("gmail", "v1", credentials=creds, cache_discovery=False)
+    return build(
+        "gmail",
+        "v1",
+        http=_build_authorized_google_http(creds),
+        cache_discovery=False,
+    )
 
 
 def _compose_query(profile: GmailProfile, query: Optional[str]) -> Optional[str]:

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -25879,6 +25879,108 @@ def _gmail_label_conflict_error(exc: Exception) -> bool:
     )
 
 
+def _gmail_api_error_response(
+    operation: str,
+    exc: Exception,
+    *,
+    suggestions: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Return a typed Gmail failure without conflating OAuth and transport.
+
+    The model needs to know whether retrying the request can help or whether the
+    user must repair the OAuth grant.  Preserve the original exception type and
+    HTTP status for diagnostics while exposing stable recovery-oriented codes.
+    """
+
+    exception_type = type(exc).__name__
+    error_text = str(exc)
+    error_lower = error_text.lower()
+    status_code = _gmail_exception_status_code(exc)
+    details: dict[str, Any] = {
+        "exception_type": exception_type,
+        "failure_kind": "api",
+        "reauthorisation_required": False,
+    }
+    if status_code is not None:
+        details["http_status"] = status_code
+
+    invalid_grant = (
+        "invalid_grant" in error_lower
+        or "expired or revoked" in error_lower
+        or "token has been expired" in error_lower
+    )
+    if invalid_grant:
+        details.update(
+            failure_kind="authorisation",
+            reauthorisation_required=True,
+        )
+        return make_error_response(
+            "invalid_grant",
+            f"Gmail {operation} failed because the OAuth grant is expired or revoked.",
+            details=details,
+            suggestions=[
+                "Re-authorise this Gmail profile, then retry the operation",
+            ],
+        )
+
+    insufficient_scope = any(
+        marker in error_lower
+        for marker in (
+            "insufficient_scope",
+            "insufficient scopes",
+            "insufficientpermissions",
+            "insufficient authentication scopes",
+        )
+    )
+    if insufficient_scope:
+        details.update(
+            failure_kind="authorisation",
+            reauthorisation_required=True,
+        )
+        return make_error_response(
+            "insufficient_scopes",
+            f"Gmail {operation} failed because the OAuth grant lacks a required scope.",
+            details=details,
+            suggestions=[
+                "Inspect the profile with gmail_get_auth_config",
+                "Update the represented scopes and re-authorise the Gmail profile",
+            ],
+        )
+
+    if status_code == 401:
+        details.update(
+            failure_kind="authorisation",
+            reauthorisation_required=True,
+        )
+        return make_error_response(
+            "gmail_authorisation_failed",
+            f"Gmail {operation} was rejected by Google as unauthorised.",
+            details=details,
+            suggestions=[
+                "Inspect the profile with gmail_get_auth_config and re-authorise it if required",
+            ],
+        )
+
+    if isinstance(exc, TimeoutError) or "timeout" in exception_type.lower():
+        details["failure_kind"] = "transport_timeout"
+        return make_error_response(
+            "gmail_transport_timeout",
+            f"Gmail {operation} timed out before Google returned a response.",
+            details=details,
+            suggestions=[
+                "Retry the bounded Gmail operation",
+                "Check network and Gmail API reachability if the timeout recurs",
+            ],
+        )
+
+    return make_error_response(
+        "gmail_api_error",
+        f"Gmail {operation} failed: {error_text}",
+        details=details,
+        suggestions=list(suggestions or ["Check Gmail API connectivity and credentials"]),
+    )
+
+
 def _gmail_list_profiles(**kwargs):  # noqa: ARG001 (namespace ignored)
     from ...integrations.google import gmail_service as gs
 
@@ -26035,11 +26137,9 @@ def _gmail_list_messages(**kwargs):
             notes=notes or None,
         )
     except Exception as exc:  # noqa: BLE001
-        return make_error_response(
-            "gmail_api_error",
-            f"Gmail list failed: {exc}",
-            details={"exception_type": type(exc).__name__},
-            suggestions=["Check Gmail API connectivity and credentials"],
+        return _gmail_api_error_response(
+            "message listing",
+            exc,
         )
 
 
@@ -26086,11 +26186,9 @@ def _gmail_get_message(**kwargs):
                 normalised["body_truncated"] = body_truncated
         return normalised
     except Exception as exc:  # noqa: BLE001
-        return make_error_response(
-            "gmail_api_error",
-            f"Gmail get message failed: {exc}",
-            details={"exception_type": type(exc).__name__},
-            suggestions=["Check Gmail API connectivity and credentials"],
+        return _gmail_api_error_response(
+            "message read",
+            exc,
         )
 
 
@@ -26160,10 +26258,9 @@ def _gmail_send_message(**kwargs):
             },
         )
     except Exception as exc:  # noqa: BLE001
-        return make_error_response(
-            "gmail_api_error",
-            f"Gmail send failed: {exc}",
-            details={"exception_type": type(exc).__name__},
+        return _gmail_api_error_response(
+            "message send",
+            exc,
             suggestions=[
                 "Check Gmail API connectivity, credentials, profile ID, and send-capable OAuth scope",
             ],
@@ -26459,10 +26556,9 @@ def _gmail_get_attachment(**kwargs):
             payload["text_extraction"] = extraction_method.strip()
         return payload
     except Exception as exc:  # noqa: BLE001
-        return make_error_response(
-            "gmail_api_error",
-            f"Gmail attachment inspection failed: {exc}",
-            details={"exception_type": type(exc).__name__},
+        return _gmail_api_error_response(
+            "attachment inspection",
+            exc,
             suggestions=[
                 "Check Gmail API connectivity, credentials, attachment metadata, and blob storage"
             ],
@@ -26493,11 +26589,9 @@ def _gmail_list_labels(**kwargs):
             },
         )
     except Exception as exc:  # noqa: BLE001
-        return make_error_response(
-            "gmail_api_error",
-            f"Gmail list labels failed: {exc}",
-            details={"exception_type": type(exc).__name__},
-            suggestions=["Check Gmail API connectivity and credentials"],
+        return _gmail_api_error_response(
+            "label listing",
+            exc,
         )
 
 
@@ -26583,10 +26677,9 @@ def _gmail_create_label(**kwargs):
                     "Use gmail_list_labels to fetch the existing label ID before applying it to messages",
                 ],
             )
-        return make_error_response(
-            "gmail_api_error",
-            f"Gmail create label failed: {exc}",
-            details={"exception_type": type(exc).__name__},
+        return _gmail_api_error_response(
+            "label creation",
+            exc,
             suggestions=[
                 "Check Gmail API connectivity, credentials, profile ID, and gmail.modify OAuth scope",
             ],
@@ -26629,11 +26722,9 @@ def _gmail_modify_labels(**kwargs):
             },
         )
     except Exception as exc:  # noqa: BLE001
-        return make_error_response(
-            "gmail_api_error",
-            f"Gmail modify labels failed: {exc}",
-            details={"exception_type": type(exc).__name__},
-            suggestions=["Check Gmail API connectivity and credentials"],
+        return _gmail_api_error_response(
+            "label modification",
+            exc,
         )
 
 

--- a/src/backend/server/routes/settings_routes.py
+++ b/src/backend/server/routes/settings_routes.py
@@ -701,9 +701,7 @@ def get_db_location_info():
             # Try to discover outward-facing IP (best-effort, short timeout). Avoid blocking failures.
             try:
                 import urllib.request
-                import socket
 
-                socket.setdefaulttimeout(1.5)
                 with urllib.request.urlopen(
                     "https://api.ipify.org?format=text", timeout=1.5
                 ) as resp:

--- a/src/backend/server/routes/workflows_routes.py
+++ b/src/backend/server/routes/workflows_routes.py
@@ -604,7 +604,10 @@ def _build_workflow_definitions_payload(
         )
         attempts = usage.get("attempts")
         completions = usage.get("completions")
+        failures = usage.get("failures")
+        in_progress = usage.get("in_progress")
         completion_rate = usage.get("completion_rate")
+        terminal_success_rate = usage.get("terminal_success_rate")
 
         if not bool(listing_entry.get("definition_loaded")):
             is_executable = False
@@ -632,9 +635,20 @@ def _build_workflow_definitions_payload(
                 "completions": (
                     int(completions) if isinstance(completions, (int, float)) else 0
                 ),
+                "failures": (
+                    int(failures) if isinstance(failures, (int, float)) else 0
+                ),
+                "in_progress": (
+                    int(in_progress) if isinstance(in_progress, (int, float)) else 0
+                ),
                 "completion_rate": (
                     float(completion_rate)
                     if isinstance(completion_rate, (int, float))
+                    else None
+                ),
+                "terminal_success_rate": (
+                    float(terminal_success_rate)
+                    if isinstance(terminal_success_rate, (int, float))
                     else None
                 ),
                 "last_episode_at": (

--- a/src/backend/services/workflow_episode_service.py
+++ b/src/backend/services/workflow_episode_service.py
@@ -28,6 +28,7 @@ from ..db.repositories.concepts_repository import ConceptsRepository
 logger = logging.getLogger(__name__)
 
 WORKFLOW_USE_EPISODES_COLLECTION = "workflow_use_episodes"
+WORKFLOW_USE_AGGREGATE_SCHEMA_VERSION = "workflow_use_aggregate.v2"
 
 _indexes_ensured = False
 
@@ -175,6 +176,39 @@ def _iso_or_none(value: Any) -> str | None:
         cleaned = value.strip()
         return cleaned or None
     return None
+
+
+def _usage_count_fields(
+    *,
+    attempts: int,
+    completions: int,
+    failures: int,
+) -> dict[str, Any]:
+    """Return internally consistent execution-health counts.
+
+    ``completions`` remains the compatibility name for terminal workflow
+    successes.  A terminal non-success is counted separately from an episode
+    that is still open, so an interrupted or long-running execution is not
+    prematurely labelled a failure.
+    """
+
+    safe_completions = max(0, int(completions))
+    safe_failures = max(0, int(failures))
+    safe_attempts = max(0, int(attempts), safe_completions + safe_failures)
+    terminal_count = safe_completions + safe_failures
+    return {
+        "schema_version": WORKFLOW_USE_AGGREGATE_SCHEMA_VERSION,
+        "attempts": safe_attempts,
+        "completions": safe_completions,
+        "failures": safe_failures,
+        "in_progress": max(0, safe_attempts - terminal_count),
+        "completion_rate": (
+            safe_completions / safe_attempts if safe_attempts > 0 else None
+        ),
+        "terminal_success_rate": (
+            safe_completions / terminal_count if terminal_count > 0 else None
+        ),
+    }
 
 
 def build_workflow_episode_stable_key(
@@ -342,9 +376,7 @@ def _compute_episode_aggregate(workflow_id: str) -> dict[str, Any]:
     if coll is None:
         return {
             "workflow_id": workflow_id,
-            "attempts": 0,
-            "completions": 0,
-            "completion_rate": None,
+            **_usage_count_fields(attempts=0, completions=0, failures=0),
             "last_episode_at": None,
             "updated_at": _utcnow().isoformat(),
         }
@@ -358,6 +390,9 @@ def _compute_episode_aggregate(workflow_id: str) -> dict[str, Any]:
                 "completions": {
                     "$sum": {"$cond": [{"$eq": ["$completed", True]}, 1, 0]}
                 },
+                "failures": {
+                    "$sum": {"$cond": [{"$eq": ["$status", "terminated"]}, 1, 0]}
+                },
                 "last_episode_at": {"$max": "$attempt_started_at"},
             }
         },
@@ -366,21 +401,21 @@ def _compute_episode_aggregate(workflow_id: str) -> dict[str, Any]:
     if not grouped:
         return {
             "workflow_id": workflow_id,
-            "attempts": 0,
-            "completions": 0,
-            "completion_rate": None,
+            **_usage_count_fields(attempts=0, completions=0, failures=0),
             "last_episode_at": None,
             "updated_at": _utcnow().isoformat(),
         }
 
     attempts = int(grouped[0].get("attempts", 0))
     completions = int(grouped[0].get("completions", 0))
-    completion_rate = (completions / attempts) if attempts > 0 else None
+    failures = int(grouped[0].get("failures", 0))
     return {
         "workflow_id": workflow_id,
-        "attempts": attempts,
-        "completions": completions,
-        "completion_rate": completion_rate,
+        **_usage_count_fields(
+            attempts=attempts,
+            completions=completions,
+            failures=failures,
+        ),
         "last_episode_at": _iso_or_none(grouped[0].get("last_episode_at")),
         "updated_at": _utcnow().isoformat(),
     }
@@ -409,9 +444,7 @@ def _max_iso_datetime(left: Any, right: Any) -> str | None:
 def _existing_workflow_use_aggregate(workflow_id: str) -> dict[str, Any]:
     return {
         "workflow_id": workflow_id,
-        "attempts": 0,
-        "completions": 0,
-        "completion_rate": None,
+        **_usage_count_fields(attempts=0, completions=0, failures=0),
         "last_episode_at": None,
         "updated_at": _utcnow().isoformat(),
         "concept_found": False,
@@ -423,6 +456,7 @@ def _apply_workflow_concept_aggregate_delta(
     *,
     attempts_delta: int = 0,
     completions_delta: int = 0,
+    failures_delta: int = 0,
     last_episode_at: Any = None,
 ) -> dict[str, Any]:
     """Persist an idempotent aggregate delta without scanning the episode log."""
@@ -437,26 +471,67 @@ def _apply_workflow_concept_aggregate_delta(
 
     aggregate["concept_found"] = True
     usage = (concept_doc.get("concept_data") or {}).get("workflow_use_aggregates") or {}
+    if usage and usage.get("schema_version") != WORKFLOW_USE_AGGREGATE_SCHEMA_VERSION:
+        recomputed = _compute_episode_aggregate(workflow_id)
+        recomputed["concept_found"] = True
+        persisted_recomputed = {
+            key: recomputed.get(key)
+            for key in (
+                "schema_version",
+                "attempts",
+                "completions",
+                "failures",
+                "in_progress",
+                "completion_rate",
+                "terminal_success_rate",
+                "last_episode_at",
+                "updated_at",
+            )
+        }
+        try:
+            ConceptsRepository.update_one(
+                {"concept_id": workflow_id},
+                {
+                    "$set": {
+                        "concept_data.workflow_use_aggregates": persisted_recomputed
+                    }
+                },
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                "[workflow_episode] Failed to migrate concept aggregate for %s: %s",
+                workflow_id,
+                exc,
+            )
+        return recomputed
+
     attempts = max(0, _coerce_int(usage.get("attempts")) + int(attempts_delta or 0))
     completions = max(
         0, _coerce_int(usage.get("completions")) + int(completions_delta or 0)
     )
-    attempts = max(attempts, completions)
-    completion_rate = (completions / attempts) if attempts > 0 else None
+    failures = max(0, _coerce_int(usage.get("failures")) + int(failures_delta or 0))
+    counts = _usage_count_fields(
+        attempts=attempts,
+        completions=completions,
+        failures=failures,
+    )
     last_episode_iso = _max_iso_datetime(usage.get("last_episode_at"), last_episode_at)
     updated_at = _utcnow().isoformat()
 
     aggregate.update(
         {
-            "attempts": attempts,
-            "completions": completions,
-            "completion_rate": completion_rate,
+            **counts,
             "last_episode_at": last_episode_iso,
             "updated_at": updated_at,
         }
     )
 
-    if not attempts_delta and not completions_delta and last_episode_at is None:
+    if (
+        not attempts_delta
+        and not completions_delta
+        and not failures_delta
+        and last_episode_at is None
+    ):
         return aggregate
 
     try:
@@ -464,9 +539,23 @@ def _apply_workflow_concept_aggregate_delta(
             {"concept_id": workflow_id},
             {
                 "$set": {
-                    "concept_data.workflow_use_aggregates.attempts": attempts,
-                    "concept_data.workflow_use_aggregates.completions": completions,
-                    "concept_data.workflow_use_aggregates.completion_rate": completion_rate,
+                    "concept_data.workflow_use_aggregates.schema_version": counts[
+                        "schema_version"
+                    ],
+                    "concept_data.workflow_use_aggregates.attempts": counts["attempts"],
+                    "concept_data.workflow_use_aggregates.completions": counts[
+                        "completions"
+                    ],
+                    "concept_data.workflow_use_aggregates.failures": counts["failures"],
+                    "concept_data.workflow_use_aggregates.in_progress": counts[
+                        "in_progress"
+                    ],
+                    "concept_data.workflow_use_aggregates.completion_rate": counts[
+                        "completion_rate"
+                    ],
+                    "concept_data.workflow_use_aggregates.terminal_success_rate": counts[
+                        "terminal_success_rate"
+                    ],
                     "concept_data.workflow_use_aggregates.last_episode_at": last_episode_iso,
                     "concept_data.workflow_use_aggregates.updated_at": updated_at,
                 }
@@ -488,9 +577,7 @@ def sync_workflow_concept_aggregates(workflow_id: str) -> dict[str, Any]:
     if not cleaned_workflow_id:
         return {
             "workflow_id": workflow_id,
-            "attempts": 0,
-            "completions": 0,
-            "completion_rate": None,
+            **_usage_count_fields(attempts=0, completions=0, failures=0),
             "last_episode_at": None,
             "updated_at": _utcnow().isoformat(),
             "concept_found": False,
@@ -511,14 +598,26 @@ def sync_workflow_concept_aggregates(workflow_id: str) -> dict[str, Any]:
             {"concept_id": cleaned_workflow_id},
             {
                 "$set": {
+                    "concept_data.workflow_use_aggregates.schema_version": aggregate[
+                        "schema_version"
+                    ],
                     "concept_data.workflow_use_aggregates.attempts": aggregate[
                         "attempts"
                     ],
                     "concept_data.workflow_use_aggregates.completions": aggregate[
                         "completions"
                     ],
+                    "concept_data.workflow_use_aggregates.failures": aggregate[
+                        "failures"
+                    ],
+                    "concept_data.workflow_use_aggregates.in_progress": aggregate[
+                        "in_progress"
+                    ],
                     "concept_data.workflow_use_aggregates.completion_rate": aggregate[
                         "completion_rate"
+                    ],
+                    "concept_data.workflow_use_aggregates.terminal_success_rate": aggregate[
+                        "terminal_success_rate"
                     ],
                     "concept_data.workflow_use_aggregates.last_episode_at": aggregate[
                         "last_episode_at"
@@ -694,6 +793,10 @@ def finalise_workflow_use_episode(
         else False
     )
     completions_delta = int(bool(completed)) - int(previous_completed)
+    previous_failed = bool(
+        isinstance(previous_doc, Mapping) and previous_doc.get("status") == "terminated"
+    )
+    failures_delta = int(not completed) - int(previous_failed)
     last_episode_at = (
         previous_doc.get("attempt_started_at")
         if isinstance(previous_doc, Mapping)
@@ -705,6 +808,7 @@ def finalise_workflow_use_episode(
             cleaned_workflow_id,
             attempts_delta=attempts_delta,
             completions_delta=completions_delta,
+            failures_delta=failures_delta,
             last_episode_at=last_episode_at,
         )
     return {
@@ -846,7 +950,7 @@ def get_workflow_usage_aggregates_for_workflows(
     turn_id: str | None = None,
     strict_namespace_scope: bool = False,
 ) -> dict[str, dict[str, Any]]:
-    """Return attempts/completions aggregates keyed by workflow_id.
+    """Return use, terminal-success, failure and open aggregates by workflow.
 
     When an actor/session filter is supplied, derive the result from episode
     rows under that exact scope. Process-global concept aggregates are useful
@@ -863,9 +967,7 @@ def get_workflow_usage_aggregates_for_workflows(
     unique_ids = sorted(set(ids))
     aggregate_map: dict[str, dict[str, Any]] = {
         workflow_id: {
-            "attempts": 0,
-            "completions": 0,
-            "completion_rate": None,
+            **_usage_count_fields(attempts=0, completions=0, failures=0),
             "last_episode_at": None,
             "updated_at": None,
         }
@@ -895,6 +997,9 @@ def get_workflow_usage_aggregates_for_workflows(
                     "completions": {
                         "$sum": {"$cond": [{"$eq": ["$completed", True]}, 1, 0]}
                     },
+                    "failures": {
+                        "$sum": {"$cond": [{"$eq": ["$status", "terminated"]}, 1, 0]}
+                    },
                     "last_episode_at": {"$max": "$attempt_started_at"},
                 }
             },
@@ -905,11 +1010,12 @@ def get_workflow_usage_aggregates_for_workflows(
                 continue
             attempts = int(row.get("attempts", 0))
             completions = int(row.get("completions", 0))
+            failures = int(row.get("failures", 0))
             aggregate_map[workflow_id] = {
-                "attempts": attempts,
-                "completions": completions,
-                "completion_rate": (
-                    completions / attempts if attempts > 0 else None
+                **_usage_count_fields(
+                    attempts=attempts,
+                    completions=completions,
+                    failures=failures,
                 ),
                 "last_episode_at": _iso_or_none(row.get("last_episode_at")),
                 "updated_at": None,
@@ -936,23 +1042,28 @@ def get_workflow_usage_aggregates_for_workflows(
             if isinstance(usage_raw, Mapping):
                 usage = usage_raw
 
-        if not usage:
+        if (
+            not usage
+            or usage.get("schema_version") != WORKFLOW_USE_AGGREGATE_SCHEMA_VERSION
+        ):
             continue
 
         attempts = usage.get("attempts")
         completions = usage.get("completions")
-        completion_rate = usage.get("completion_rate")
+        failures = usage.get("failures")
+        if not all(
+            isinstance(value, (int, float))
+            for value in (attempts, completions, failures)
+        ):
+            continue
+        counts = _usage_count_fields(
+            attempts=int(attempts),
+            completions=int(completions),
+            failures=int(failures),
+        )
         concept_aggregate_ids.add(concept_id)
         aggregate_map[concept_id] = {
-            "attempts": int(attempts) if isinstance(attempts, (int, float)) else 0,
-            "completions": (
-                int(completions) if isinstance(completions, (int, float)) else 0
-            ),
-            "completion_rate": (
-                float(completion_rate)
-                if isinstance(completion_rate, (int, float))
-                else None
-            ),
+            **counts,
             "last_episode_at": _iso_or_none(usage.get("last_episode_at")),
             "updated_at": _iso_or_none(usage.get("updated_at")),
         }
@@ -974,6 +1085,9 @@ def get_workflow_usage_aggregates_for_workflows(
                     "completions": {
                         "$sum": {"$cond": [{"$eq": ["$completed", True]}, 1, 0]}
                     },
+                    "failures": {
+                        "$sum": {"$cond": [{"$eq": ["$status", "terminated"]}, 1, 0]}
+                    },
                     "last_episode_at": {"$max": "$attempt_started_at"},
                 }
             },
@@ -985,11 +1099,13 @@ def get_workflow_usage_aggregates_for_workflows(
                 continue
             attempts = int(row.get("attempts", 0))
             completions = int(row.get("completions", 0))
-            completion_rate = (completions / attempts) if attempts > 0 else None
+            failures = int(row.get("failures", 0))
             aggregate_map[workflow_id] = {
-                "attempts": attempts,
-                "completions": completions,
-                "completion_rate": completion_rate,
+                **_usage_count_fields(
+                    attempts=attempts,
+                    completions=completions,
+                    failures=failures,
+                ),
                 "last_episode_at": _iso_or_none(row.get("last_episode_at")),
                 "updated_at": aggregate_map[workflow_id].get("updated_at"),
             }

--- a/src/backend/workflows/repo_seed_bundles/canonical_workflow_publication_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/canonical_workflow_publication_seed_bundle.json
@@ -1,7 +1,7 @@
 {
   "family_id": "canonical_workflow_publication_seed_bundle",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "47",
+  "seed_version": "48",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#tool_calling_workflow": {
       "42": [
@@ -3186,7 +3186,7 @@
       "text_relations": [
         {
           "predicate": "#V#hasWorkflowRoutingProfileJson",
-          "text": "{\"schema_version\":\"workflow_routing_profile.v1\",\"role\":\"execution\",\"authoring_intent_required\":false,\"explicit_workflow_context_required\":false,\"prefer_existing_capability\":true,\"ordinary_mail_review\":true,\"excludes_auth_or_token_refresh\":true,\"excludes_authoring_or_ingestion_without_explicit_intent\":true}",
+          "text": "{\"schema_version\":\"workflow_routing_profile.v1\",\"role\":\"execution\",\"authoring_intent_required\":false,\"explicit_workflow_context_required\":false,\"prefer_existing_capability\":false,\"routing_eligible\":false,\"ordinary_mail_review\":false,\"retained_for_explicit_durable_review_only\":true,\"excludes_auth_or_token_refresh\":true,\"excludes_authoring_or_ingestion_without_explicit_intent\":true}",
           "lang": "en-NZ"
         },
         {

--- a/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
@@ -2,9 +2,10 @@
   "family_id": "email_source_representation_convergence_workflow_seed_bundle",
   "managed_by": "email_source_representation_convergence_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "4",
+  "seed_version": "10",
   "source_tag": "JVNAUTOSCI-2335",
   "supported_action_ids": [
+    "arxiv.inspect_existing_state",
     "extract_signals_from_tool_result",
     "resolve_tool_output_followup_hint",
     "workflow_control.context_set",
@@ -31,7 +32,7 @@
         },
         {
           "predicate": "#V#hasWorkflowRoutingProfileJson",
-          "text": "{\"authoring_intent_required\": false, \"execution_mode\": \"tool_pipeline\", \"explicit_workflow_context_required\": false, \"prefer_existing_capability\": true, \"role\": \"execution\", \"schema_version\": \"workflow_routing_profile.v1\"}",
+          "text": "{\"authoring_intent_required\": false, \"execution_mode\": \"tool_pipeline\", \"explicit_workflow_context_required\": true, \"prefer_existing_capability\": false, \"role\": \"execution\", \"routing_eligible\": true, \"schema_version\": \"workflow_routing_profile.v1\"}",
           "lang": "en-NZ"
         },
         {
@@ -188,6 +189,17 @@
             "execution_mode": "deterministic",
             "next_state": "decide_messages",
             "on_failure_state": "failed",
+            "retry_policy": {
+              "backoff_policy": "fixed",
+              "initial_delay_ms": 1000,
+              "max_attempts": 2,
+              "max_delay_ms": 5000,
+              "retry_on_outcomes": [
+                "failure",
+                "unknown"
+              ],
+              "schema_version": "workflow_step_retry_policy.v1"
+            },
             "state_id": "list_messages",
             "static_input_bindings": [
               [
@@ -391,16 +403,21 @@
     {
       "workflow_id": "#V#email_arxiv_ingestion_from_message_workflow",
       "display_name": "Email Arxiv Ingestion From Message Workflow",
-      "description": "Processes one Gmail message: check for durable represented source-processing evidence, extract resource links when needed, ingest each arXiv reference through represented subworkflows, then record a Vontology source-processing marker only after successful arXiv ingestion.",
+      "description": "Processes one exact Gmail message selected by the caller: check for durable represented source-processing evidence, extract resource links when needed, ingest each arXiv reference through represented subworkflows, then record and canonically read back a Vontology source-processing marker only after successful arXiv ingestion. Use this after read-only discovery has selected the source message; it does not select mailbox messages or mutate Gmail.",
       "text_relations": [
         {
+          "predicate": "#V#hasWorkflowDiscoveryExemplarsJson",
+          "text": "{\"examples\": [\"Represent the arXiv paper linked from this exact Gmail message and verify its represented processing marker.\", \"Process this selected Gmail message through the durable arXiv representation path without changing Gmail labels.\"], \"keywords\": [\"exact gmail message arxiv representation\", \"selected email arxiv paper ingestion\", \"represent paper from this message\", \"gmail message processing marker\"], \"required_query_cues\": [\"gmail\", \"email\", \"mail\", \"message\"], \"routing_notes\": [\"Use only after read-only discovery or explicit user context identifies one exact Gmail source message.\", \"Pass include_body explicitly on every gmail_get_message discovery read. When a Gmail search result matched the paper query but its subject or snippet does not expose the arXiv reference, use include_body=true and inspect the bounded message body before rejecting it or moving to an older message.\", \"The caller must supply the exact Gmail profile and current_message object; this workflow does not choose a message or scan a mailbox.\", \"Prefer this durable unit over a paper-only representation workflow when the user outcome also requires source-message processing evidence.\", \"Do not mutate Gmail labels; completion is an idempotent represented marker followed by canonical marker read-back.\"], \"schema_version\": \"workflow_discovery_exemplars.v1\"}",
+          "lang": "en-NZ"
+        },
+        {
           "predicate": "#V#hasWorkflowLifecycleJson",
-          "text": "{\"phase\": \"published\", \"postconditions_verified\": false, \"published\": true, \"rollout_state\": \"support_subworkflow\", \"routing_eligible\": false, \"schema_version\": \"workflow_publication_lifecycle.v1\", \"validation_passed\": true}",
+          "text": "{\"phase\": \"published\", \"postconditions_verified\": true, \"published\": true, \"rollout_state\": \"published\", \"routing_eligible\": true, \"schema_version\": \"workflow_publication_lifecycle.v1\", \"validation_passed\": true}",
           "lang": "en-NZ"
         },
         {
           "predicate": "#V#hasWorkflowRoutingProfileJson",
-          "text": "{\"authoring_intent_required\": false, \"explicit_workflow_context_required\": false, \"prefer_existing_capability\": false, \"role\": \"execution\", \"routing_eligible\": false, \"schema_version\": \"workflow_routing_profile.v1\"}",
+          "text": "{\"authoring_intent_required\": false, \"execution_mode\": \"tool_pipeline\", \"explicit_workflow_context_required\": false, \"prefer_existing_capability\": true, \"role\": \"execution\", \"routing_eligible\": true, \"schema_version\": \"workflow_routing_profile.v1\"}",
           "lang": "en-NZ"
         }
       ],
@@ -579,6 +596,17 @@
             "invoked_workflow_id": "#V#email_resource_link_extraction",
             "next_state": "decide_arxiv_resources",
             "on_failure_state": "failed",
+            "retry_policy": {
+              "backoff_policy": "fixed",
+              "initial_delay_ms": 1000,
+              "max_attempts": 2,
+              "max_delay_ms": 5000,
+              "retry_on_outcomes": [
+                "failure",
+                "unknown"
+              ],
+              "schema_version": "workflow_step_retry_policy.v1"
+            },
             "state_id": "extract_email_resources",
             "static_input_bindings": [
               [
@@ -752,7 +780,19 @@
               "reason_code": "source_processing_marker_additive_vontology_write",
               "schema_version": "workflow_step_mutation_authority.v1"
             },
-            "next_state": "done",
+            "next_state": "verify_done_marker",
+            "on_failure_state": "failed_unmarked",
+            "retry_policy": {
+              "backoff_policy": "fixed",
+              "initial_delay_ms": 1000,
+              "max_attempts": 2,
+              "max_delay_ms": 5000,
+              "retry_on_outcomes": [
+                "failure",
+                "unknown"
+              ],
+              "schema_version": "workflow_step_retry_policy.v1"
+            },
             "state_id": "mark_done",
             "static_input_bindings": [
               [
@@ -819,6 +859,82 @@
             ]
           },
           {
+            "action_id": "workflow_mcp.invoke_tool",
+            "conditional_transitions": [
+              {
+                "condition_spec": {
+                  "expected": true,
+                  "key": "source_processing_marker_exists",
+                  "kind": "context_flag"
+                },
+                "reason": "source_processing_marker_canonically_verified",
+                "to_state": "done"
+              }
+            ],
+            "execution_mode": "deterministic",
+            "next_state": "failed_unmarked",
+            "on_failure_state": "failed_unmarked",
+            "state_id": "verify_done_marker",
+            "static_input_bindings": [
+              [
+                "tool_arguments",
+                {
+                  "source_item_id": {
+                    "$context_key": "message_id"
+                  },
+                  "source_profile": {
+                    "$context_key": "gmail_profile"
+                  },
+                  "source_system": "gmail"
+                }
+              ],
+              [
+                "tool_name",
+                "get_source_processing_marker"
+              ]
+            ],
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_verify_done_marker_result_source_processing_marker_exists_to_source_processing_marker_exists",
+                "context_key": "source_processing_marker_exists",
+                "tool_output_field": "result.source_processing_marker_exists"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_verify_done_marker_result_message_processing_marker_to_message_processing_marker",
+                "context_key": "message_processing_marker",
+                "tool_output_field": "result.message_processing_marker"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_verify_done_marker_result_processed_message_id_to_processed_message_id",
+                "context_key": "processed_message_id",
+                "tool_output_field": "result.processed_message_id"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_verify_done_marker_result_paper_concept_id_to_paper_concept_id",
+                "context_key": "paper_concept_id",
+                "tool_output_field": "result.paper_concept_id"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_verify_done_marker_result_file_copy_concept_id_to_file_copy_concept_id",
+                "context_key": "file_copy_concept_id",
+                "tool_output_field": "result.file_copy_concept_id"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_verify_done_marker_result_arxiv_id_to_arxiv_id",
+                "context_key": "arxiv_id",
+                "tool_output_field": "result.arxiv_id"
+              }
+            ],
+            "writes_context_keys": [
+              "source_processing_marker_exists",
+              "message_processing_marker",
+              "processed_message_id",
+              "paper_concept_id",
+              "file_copy_concept_id",
+              "arxiv_id"
+            ]
+          },
+          {
             "state_id": "done"
           },
           {
@@ -870,6 +986,7 @@
                 "tool_arguments",
                 {
                   "format": "full",
+                  "include_body": true,
                   "message_id": {
                     "$context_key": "message_id"
                   },
@@ -953,7 +1070,7 @@
     {
       "workflow_id": "#V#arxiv_resource_ingestion_from_email_reference_workflow",
       "display_name": "Arxiv Resource Ingestion From Email Reference Workflow",
-      "description": "Ingests one arXiv resource reference discovered from email by delegating paper representation to #V#arxiv_paper_representation_workflow. The email-source convergence path succeeds once the paper representation concept is available; heavier paper reading and claim extraction belong in separate enrichment workflows.",
+      "description": "Converges one arXiv resource reference discovered from email. It first reads the canonical stable arXiv paper identity and reuses an existing represented paper when present; otherwise it delegates to #V#arxiv_paper_representation_workflow. The email-source convergence path succeeds once the paper representation concept is available; heavier paper reading and claim extraction belong in separate enrichment workflows.",
       "text_relations": [
         {
           "predicate": "#V#hasWorkflowLifecycleJson",
@@ -988,7 +1105,7 @@
           {
             "action_id": "workflow_control.context_set",
             "execution_mode": "deterministic",
-            "next_state": "represent_arxiv_paper",
+            "next_state": "inspect_existing_paper",
             "on_failure_state": "failed",
             "state_id": "normalise_reference",
             "static_input_bindings": [
@@ -1020,6 +1137,70 @@
                   }
                 ]
               ]
+            ]
+          },
+          {
+            "action_id": "arxiv.inspect_existing_state",
+            "conditional_transitions": [
+              {
+                "condition_spec": {
+                  "conditions": [
+                    {
+                      "expected": true,
+                      "key": "paper_concept_id",
+                      "kind": "context_exists"
+                    },
+                    {
+                      "expected": false,
+                      "key": "paper_concept_id",
+                      "kind": "context_is_null"
+                    }
+                  ],
+                  "kind": "all"
+                },
+                "reason": "paper_already_represented",
+                "to_state": "done"
+              },
+              {
+                "condition_spec": {
+                  "kind": "always"
+                },
+                "reason": "paper_not_yet_represented",
+                "to_state": "represent_arxiv_paper"
+              }
+            ],
+            "context_input_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_arxiv_resource_ingestion_from_email_reference_workflow_inspect_existing_paper_arxiv_id_to_arxiv_id_parameter",
+                "context_key": "arxiv_id",
+                "required": true,
+                "tool_param": "arxiv_id"
+              }
+            ],
+            "execution_mode": "deterministic",
+            "on_failure_state": "failed",
+            "state_id": "inspect_existing_paper",
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_arxiv_resource_ingestion_from_email_reference_workflow_inspect_existing_paper_arxiv_id_to_arxiv_id",
+                "context_key": "arxiv_id",
+                "tool_output_field": "arxiv_id"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_arxiv_resource_ingestion_from_email_reference_workflow_inspect_existing_paper_paper_concept_id_to_paper_concept_id",
+                "context_key": "paper_concept_id",
+                "tool_output_field": "paper_concept_id"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_arxiv_resource_ingestion_from_email_reference_workflow_inspect_existing_paper_file_copy_concept_id_to_file_copy_concept_id",
+                "context_key": "file_copy_concept_id",
+                "tool_output_field": "file_copy_concept_id"
+              }
+            ],
+            "writes_context_keys": [
+              "arxiv_id",
+              "paper_concept_id",
+              "file_copy_concept_id"
             ]
           },
           {

--- a/src/backend/workflows/workflow_studio_service.py
+++ b/src/backend/workflows/workflow_studio_service.py
@@ -399,7 +399,10 @@ def build_workflow_catalogue_payload(
         )
         attempts = usage.get("attempts")
         completions = usage.get("completions")
+        failures = usage.get("failures")
+        in_progress = usage.get("in_progress")
         completion_rate = usage.get("completion_rate")
+        terminal_success_rate = usage.get("terminal_success_rate")
 
         if not bool(listing_entry.get("definition_loaded")):
             is_executable = False
@@ -426,9 +429,18 @@ def build_workflow_catalogue_payload(
             "completions": (
                 int(completions) if isinstance(completions, (int, float)) else 0
             ),
+            "failures": int(failures) if isinstance(failures, (int, float)) else 0,
+            "in_progress": (
+                int(in_progress) if isinstance(in_progress, (int, float)) else 0
+            ),
             "completion_rate": (
                 float(completion_rate)
                 if isinstance(completion_rate, (int, float))
+                else None
+            ),
+            "terminal_success_rate": (
+                float(terminal_success_rate)
+                if isinstance(terminal_success_rate, (int, float))
                 else None
             ),
             "last_episode_at": (
@@ -1622,9 +1634,16 @@ def build_workflow_studio_detail_payload(
             **listing_entry,
             "attempts": int(usage.get("attempts") or 0),
             "completions": int(usage.get("completions") or 0),
+            "failures": int(usage.get("failures") or 0),
+            "in_progress": int(usage.get("in_progress") or 0),
             "completion_rate": (
                 float(completion_rate)
                 if isinstance(completion_rate, (int, float))
+                else None
+            ),
+            "terminal_success_rate": (
+                float(usage.get("terminal_success_rate"))
+                if isinstance(usage.get("terminal_success_rate"), (int, float))
                 else None
             ),
             "last_episode_at": usage.get("last_episode_at"),

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -28702,8 +28702,17 @@ function _buildWorkflowDefinitionExportPayload({
             completions: Number.isFinite(Number(definitionSummary?.completions))
                 ? Number(definitionSummary.completions)
                 : 0,
+            failures: Number.isFinite(Number(definitionSummary?.failures))
+                ? Number(definitionSummary.failures)
+                : 0,
+            in_progress: Number.isFinite(Number(definitionSummary?.in_progress))
+                ? Number(definitionSummary.in_progress)
+                : 0,
             completion_rate: Number.isFinite(Number(definitionSummary?.completion_rate))
                 ? Number(definitionSummary.completion_rate)
+                : null,
+            terminal_success_rate: Number.isFinite(Number(definitionSummary?.terminal_success_rate))
+                ? Number(definitionSummary.terminal_success_rate)
                 : null,
             last_episode_at: definitionSummary?.last_episode_at || null,
             episodes_count: Number.isFinite(Number(definitionSummary?.episodes_count))
@@ -29742,9 +29751,11 @@ function renderWorkflowDefinitionsList(items) {
         const executableSummary = formatWorkflowExecutabilitySummary(item);
         const attempts = Number.isFinite(Number(item?.attempts)) ? Number(item.attempts) : 0;
         const completions = Number.isFinite(Number(item?.completions)) ? Number(item.completions) : 0;
-        const completionRateRaw = Number(item?.completion_rate);
-        const completionRate = Number.isFinite(completionRateRaw)
-            ? `${Math.round(Math.max(0, Math.min(1, completionRateRaw)) * 100)}%`
+        const failures = Number.isFinite(Number(item?.failures)) ? Number(item.failures) : 0;
+        const inProgress = Number.isFinite(Number(item?.in_progress)) ? Number(item.in_progress) : 0;
+        const terminalSuccessRateRaw = Number(item?.terminal_success_rate);
+        const terminalSuccessRate = Number.isFinite(terminalSuccessRateRaw)
+            ? `${Math.round(Math.max(0, Math.min(1, terminalSuccessRateRaw)) * 100)}%`
             : '—';
         const episodesCountRaw = Number(item?.episodes_count);
         const episodesCount = Number.isFinite(episodesCountRaw) && episodesCountRaw >= 0
@@ -29758,7 +29769,7 @@ function renderWorkflowDefinitionsList(items) {
                 episodesSummary = `Episodes: ${episodesCount}`;
             }
         }
-        const usageMeta = `Attempts: ${attempts} · Completions: ${completions} · ${episodesSummary} · Completion: ${completionRate}`;
+        const usageMeta = `Uses: ${attempts} · Succeeded: ${completions} · Failed: ${failures} · Open: ${inProgress} · ${episodesSummary} · Terminal success: ${terminalSuccessRate}`;
         const executionMeta = executableSummary
             ? `<div class="workflow-status-definition-meta">Status detail: ${escapeHtml(executableSummary)}</div>`
             : '';

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -639,11 +639,20 @@ describe('workflow monitor concept links', () => {
                 is_executable: false,
                 executability_reason: 'workflow_step_partially_vacuous',
                 attempts: 12,
+                completions: 6,
+                failures: 4,
+                in_progress: 2,
+                terminal_success_rate: 0.6,
                 episodes_count: 8
             }
         ]);
 
         expect(document.body.textContent).toContain('Episodes: 8 scoped (12 total)');
+        expect(document.body.textContent).toContain('Uses: 12');
+        expect(document.body.textContent).toContain('Succeeded: 6');
+        expect(document.body.textContent).toContain('Failed: 4');
+        expect(document.body.textContent).toContain('Open: 2');
+        expect(document.body.textContent).toContain('Terminal success: 60%');
     });
 });
 

--- a/tests/backend/test_email_source_representation_convergence_bootstrap.py
+++ b/tests/backend/test_email_source_representation_convergence_bootstrap.py
@@ -1,8 +1,22 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 
+import pytest
+
+from src.backend.workflows.action_registry import (
+    ActionRegistry,
+    ActionSpec,
+    WorkflowActionRequest,
+    WorkflowActionResult,
+    WorkflowEnvironment,
+)
+from src.backend.workflows.durable.control_flow_actions import (
+    register_control_flow_actions,
+)
 from src.backend.workflows.durable.models import WorkflowSchedule
+from src.backend.workflows.engine import WorkflowExecutor
 from src.backend.workflows.workflow_launch_input_contracts import (
     resolve_workflow_launch_inputs,
 )
@@ -96,11 +110,152 @@ def test_email_source_seed_keeps_claim_enrichment_out_of_source_completion() -> 
 
     assert state_ids == {
         "normalise_reference",
+        "inspect_existing_paper",
         "represent_arxiv_paper",
         "done",
         "failed",
     }
     assert all("claim" not in json.dumps(step).lower() for step in steps)
+
+
+def _arxiv_resource_definition():
+    from src.backend.services import (
+        email_source_representation_convergence_workflow_vontology_service as mod,
+    )
+    from src.backend.workflows.workflow_concept_authority_service import (
+        build_repo_seed_workflow_definitions,
+    )
+
+    return build_repo_seed_workflow_definitions(
+        bundle_paths=[mod._REPO_SEED_ASSET_PATH],
+        target_workflow_ids=[
+            mod.ARXIV_RESOURCE_INGESTION_FROM_EMAIL_REFERENCE_WORKFLOW_ID
+        ],
+    )[mod.ARXIV_RESOURCE_INGESTION_FROM_EMAIL_REFERENCE_WORKFLOW_ID]
+
+
+def test_arxiv_resource_workflow_reuses_existing_representation() -> None:
+    definition = _arxiv_resource_definition()
+    registry = ActionRegistry()
+    register_control_flow_actions(registry)
+    calls: list[str] = []
+
+    def inspect(request: WorkflowActionRequest) -> WorkflowActionResult:
+        calls.append("inspect")
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "arxiv_id": request.inputs["arxiv_id"],
+                "paper_concept_id": "#V#paper_on_arxiv_2607_10563_existing",
+                "file_copy_concept_id": "#V#arxiv_pdf_existing",
+            },
+        )
+
+    def represent(_request: WorkflowActionRequest) -> WorkflowActionResult:
+        raise AssertionError("existing paper was represented again")
+
+    registry.register(
+        ActionSpec(action_id="arxiv.inspect_existing_state", handler=inspect)
+    )
+    registry.register(
+        ActionSpec(action_id="workflow_invoke_subworkflow", handler=represent)
+    )
+    result = WorkflowExecutor(registry=registry, max_transitions=8).run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={
+            "current_resource_reference": {
+                "identifier": "2607.10563",
+                "url": "https://arxiv.org/abs/2607.10563",
+            }
+        },
+    )
+
+    assert result.completed is True
+    assert result.final_state == "done"
+    assert calls == ["inspect"]
+    assert result.data["paper_concept_id"] == (
+        "#V#paper_on_arxiv_2607_10563_existing"
+    )
+
+
+def test_arxiv_resource_workflow_represents_only_when_not_already_present() -> None:
+    definition = _arxiv_resource_definition()
+    registry = ActionRegistry()
+    register_control_flow_actions(registry)
+    calls: list[str] = []
+
+    def inspect(request: WorkflowActionRequest) -> WorkflowActionResult:
+        calls.append("inspect")
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "arxiv_id": request.inputs["arxiv_id"],
+                "paper_concept_id": None,
+                "file_copy_concept_id": None,
+            },
+        )
+
+    def represent(request: WorkflowActionRequest) -> WorkflowActionResult:
+        calls.append("represent")
+        assert request.inputs["arxiv_id"] == "2607.22925"
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "result": {
+                    "paper_concept_id": "#V#paper_on_arxiv_2607_22925_new",
+                    "file_copy_concept_id": "#V#arxiv_pdf_new",
+                    "article_readback": {
+                        "concept_id": "#V#paper_on_arxiv_2607_22925_new"
+                    },
+                }
+            },
+        )
+
+    registry.register(
+        ActionSpec(action_id="arxiv.inspect_existing_state", handler=inspect)
+    )
+    registry.register(
+        ActionSpec(action_id="workflow_invoke_subworkflow", handler=represent)
+    )
+    result = WorkflowExecutor(registry=registry, max_transitions=8).run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={
+            "current_resource_reference": {
+                "identifier": "2607.22925",
+                "url": "https://arxiv.org/abs/2607.22925",
+            }
+        },
+    )
+
+    assert result.completed is True
+    assert result.final_state == "done"
+    assert calls == ["inspect", "represent"]
+    assert result.data["paper_concept_id"] == "#V#paper_on_arxiv_2607_22925_new"
+
+
+def test_email_resource_extraction_fetches_body_needed_to_find_cited_resources() -> None:
+    from src.backend.services import (
+        email_source_representation_convergence_workflow_vontology_service as mod,
+    )
+
+    payload = json.loads(mod._REPO_SEED_ASSET_PATH.read_text(encoding="utf-8"))
+    workflow = next(
+        item
+        for item in payload.get("workflows") or []
+        if item.get("workflow_id") == mod.EMAIL_RESOURCE_LINK_EXTRACTION_WORKFLOW_ID
+    )
+    fetch_payload = next(
+        step
+        for step in workflow["publication_spec"]["steps"]
+        if step["state_id"] == "fetch_payload"
+    )
+    bindings = dict(fetch_payload["static_input_bindings"])
+
+    assert bindings["tool_name"] == "gmail_get_message"
+    assert bindings["tool_arguments"]["format"] == "full"
+    assert bindings["tool_arguments"]["include_body"] is True
 
 
 def test_email_source_seed_excludes_mail_profile_status_questions() -> None:
@@ -186,6 +341,338 @@ def test_email_source_seed_uses_represented_markers_instead_of_gmail_writes() ->
         "record_source_processing_marker",
     ]
     assert "message_processing_marker" in mark_done["writes_context_keys"]
+    assert mark_done["next_state"] == "verify_done_marker"
+    assert mark_done["on_failure_state"] == "failed_unmarked"
+
+    verify_done_marker = steps["verify_done_marker"]
+    assert verify_done_marker["static_input_bindings"][1] == [
+        "tool_name",
+        "get_source_processing_marker",
+    ]
+    assert verify_done_marker["on_failure_state"] == "failed_unmarked"
+    assert verify_done_marker["next_state"] == "failed_unmarked"
+    assert verify_done_marker["conditional_transitions"] == [
+        {
+            "condition_spec": {
+                "expected": True,
+                "key": "source_processing_marker_exists",
+                "kind": "context_flag",
+            },
+            "reason": "source_processing_marker_canonically_verified",
+            "to_state": "done",
+        }
+    ]
+
+
+def test_email_source_seed_routes_exact_message_unit_and_explicit_batch() -> None:
+    from src.backend.services import (
+        email_source_representation_convergence_workflow_vontology_service as mod,
+    )
+
+    payload = json.loads(mod._REPO_SEED_ASSET_PATH.read_text(encoding="utf-8"))
+    workflows = {
+        item["workflow_id"]: item
+        for item in payload.get("workflows") or []
+        if isinstance(item, dict)
+    }
+    parent = workflows[mod.ZHAN_GMAIL_ARXIV_INGESTION_WORKFLOW_ID]
+    child = workflows[mod.EMAIL_ARXIV_INGESTION_FROM_MESSAGE_WORKFLOW_ID]
+
+    def relations(workflow: dict) -> dict[str, dict]:
+        return {
+            item["predicate"]: json.loads(item["text"])
+            for item in workflow.get("text_relations") or []
+            if isinstance(item, dict) and isinstance(item.get("text"), str)
+        }
+
+    parent_relations = relations(parent)
+    child_relations = relations(child)
+    parent_lifecycle = parent_relations["#V#hasWorkflowLifecycleJson"]
+    parent_routing = parent_relations["#V#hasWorkflowRoutingProfileJson"]
+    child_lifecycle = child_relations["#V#hasWorkflowLifecycleJson"]
+    child_routing = child_relations["#V#hasWorkflowRoutingProfileJson"]
+    child_discovery = child_relations["#V#hasWorkflowDiscoveryExemplarsJson"]
+
+    assert parent_lifecycle["routing_eligible"] is True
+    assert parent_routing["routing_eligible"] is True
+    assert parent_routing["explicit_workflow_context_required"] is True
+    assert parent_routing["prefer_existing_capability"] is False
+
+    assert child_lifecycle["routing_eligible"] is True
+    assert child_lifecycle["postconditions_verified"] is True
+    assert child_routing["routing_eligible"] is True
+    assert child_routing["prefer_existing_capability"] is True
+    assert any("exact Gmail" in example for example in child_discovery["examples"])
+    assert any(
+        "does not choose a message" in note
+        for note in child_discovery["routing_notes"]
+    )
+    assert any(
+        "include_body=true" in note and "older message" in note
+        for note in child_discovery["routing_notes"]
+    )
+
+
+def test_email_message_launch_contract_accepts_exact_selected_message() -> None:
+    from src.backend.services import (
+        email_source_representation_convergence_workflow_vontology_service as mod,
+    )
+
+    payload = json.loads(mod._REPO_SEED_ASSET_PATH.read_text(encoding="utf-8"))
+    workflow = next(
+        item
+        for item in payload.get("workflows") or []
+        if item.get("workflow_id")
+        == mod.EMAIL_ARXIV_INGESTION_FROM_MESSAGE_WORKFLOW_ID
+    )
+
+    current_message = {
+        "id": "gmail-message-1",
+        "message_id": "gmail-message-1",
+        "subject": "A paper https://arxiv.org/abs/2606.12345",
+    }
+    resolution = resolve_workflow_launch_inputs(
+        workflow_id=mod.EMAIL_ARXIV_INGESTION_FROM_MESSAGE_WORKFLOW_ID,
+        contract=workflow["launch_input_contract"],
+        inputs={
+            "gmail_profile": "#V#gmail_profile_vonwitbrock_gmail",
+            "current_message": current_message,
+        },
+        contract_source="repo_seed_test",
+    )
+
+    assert resolution.diagnostics["status"] == "resolved"
+    assert resolution.resolved_inputs == {
+        "gmail_profile": "#V#gmail_profile_vonwitbrock_gmail",
+        "current_message": current_message,
+    }
+
+
+def _exact_message_definition(*state_ids: str, initial_state: str):
+    from src.backend.services import (
+        email_source_representation_convergence_workflow_vontology_service as mod,
+    )
+    from src.backend.workflows.workflow_concept_authority_service import (
+        build_repo_seed_workflow_definitions,
+    )
+
+    definition = build_repo_seed_workflow_definitions(
+        bundle_paths=[mod._REPO_SEED_ASSET_PATH],
+        target_workflow_ids=[mod.EMAIL_ARXIV_INGESTION_FROM_MESSAGE_WORKFLOW_ID],
+    )[mod.EMAIL_ARXIV_INGESTION_FROM_MESSAGE_WORKFLOW_ID]
+    return replace(
+        definition,
+        initial_state=initial_state,
+        states={state_id: definition.states[state_id] for state_id in state_ids},
+        termination_states=(),
+    )
+
+
+def _run_exact_message_slice(definition, handler):
+    registry = ActionRegistry()
+    registry.register(ActionSpec(action_id="workflow_mcp.invoke_tool", handler=handler))
+    return WorkflowExecutor(registry=registry, max_transitions=8).run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={
+            "message_id": "gmail-message-1",
+            "gmail_profile": "#V#gmail_profile_vonwitbrock_gmail",
+            "arxiv_iteration_results": [
+                {"paper_concept_id": "#V#paper_2606_12345", "arxiv_id": "2606.12345"}
+            ],
+        },
+    )
+
+
+def test_exact_message_workflow_records_then_reads_back_marker_before_success() -> None:
+    calls: list[str] = []
+
+    def handler(request: WorkflowActionRequest) -> WorkflowActionResult:
+        tool_name = str(request.inputs.get("tool_name") or "")
+        calls.append(tool_name)
+        if tool_name == "record_source_processing_marker":
+            return WorkflowActionResult(
+                status="success",
+                outputs={
+                    "result": {
+                        "message_processing_marker": "#V#marker_1",
+                        "processed_message_id": "gmail-message-1",
+                        "paper_concept_id": "#V#paper_2606_12345",
+                        "file_copy_concept_id": "#V#file_2606_12345",
+                        "arxiv_id": "2606.12345",
+                    }
+                },
+            )
+        assert tool_name == "get_source_processing_marker"
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "result": {
+                    "source_processing_marker_exists": True,
+                    "message_processing_marker": "#V#marker_1",
+                    "processed_message_id": "gmail-message-1",
+                    "paper_concept_id": "#V#paper_2606_12345",
+                    "file_copy_concept_id": "#V#file_2606_12345",
+                    "arxiv_id": "2606.12345",
+                }
+            },
+        )
+
+    definition = _exact_message_definition(
+        "mark_done",
+        "verify_done_marker",
+        "done",
+        "failed_unmarked",
+        initial_state="mark_done",
+    )
+    result = _run_exact_message_slice(definition, handler)
+
+    assert result.completed is True
+    assert result.final_state == "done"
+    assert calls == [
+        "record_source_processing_marker",
+        "get_source_processing_marker",
+    ]
+    assert result.data["source_processing_marker_exists"] is True
+    assert result.data["message_processing_marker"] == "#V#marker_1"
+
+
+@pytest.mark.parametrize("failure_mode", ["write_failed", "readback_missing"])
+def test_exact_message_workflow_never_claims_success_without_verified_marker(
+    failure_mode: str,
+) -> None:
+    calls: list[str] = []
+
+    def handler(request: WorkflowActionRequest) -> WorkflowActionResult:
+        tool_name = str(request.inputs.get("tool_name") or "")
+        calls.append(tool_name)
+        if tool_name == "record_source_processing_marker":
+            if failure_mode == "write_failed":
+                return WorkflowActionResult(status="failure", error="write failed")
+            return WorkflowActionResult(
+                status="success",
+                outputs={
+                    "result": {
+                        "message_processing_marker": "#V#marker_1",
+                        "processed_message_id": "gmail-message-1",
+                        "paper_concept_id": "#V#paper_2606_12345",
+                        "file_copy_concept_id": "#V#file_2606_12345",
+                        "arxiv_id": "2606.12345",
+                    }
+                },
+            )
+        assert tool_name == "get_source_processing_marker"
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "result": {
+                    "source_processing_marker_exists": False,
+                    "message_processing_marker": None,
+                    "processed_message_id": None,
+                    "paper_concept_id": None,
+                    "file_copy_concept_id": None,
+                    "arxiv_id": None,
+                }
+            },
+        )
+
+    definition = _exact_message_definition(
+        "mark_done",
+        "verify_done_marker",
+        "done",
+        "failed_unmarked",
+        initial_state="mark_done",
+    )
+    result = _run_exact_message_slice(definition, handler)
+
+    assert result.completed is True
+    assert result.final_state == "failed_unmarked"
+    assert calls == (
+        ["record_source_processing_marker", "record_source_processing_marker"]
+        if failure_mode == "write_failed"
+        else ["record_source_processing_marker", "get_source_processing_marker"]
+    )
+
+
+def test_exact_message_workflow_reuses_existing_marker_without_representing_again() -> None:
+    calls: list[str] = []
+
+    def handler(request: WorkflowActionRequest) -> WorkflowActionResult:
+        tool_name = str(request.inputs.get("tool_name") or "")
+        calls.append(tool_name)
+        assert tool_name == "get_source_processing_marker"
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "result": {
+                    "source_processing_marker_exists": True,
+                    "message_processing_marker": "#V#marker_existing",
+                    "processed_message_id": "gmail-message-1",
+                    "paper_concept_id": "#V#paper_2606_12345",
+                    "file_copy_concept_id": "#V#file_2606_12345",
+                    "arxiv_id": "2606.12345",
+                }
+            },
+        )
+
+    definition = _exact_message_definition(
+        "check_processed_marker",
+        "done_already_processed",
+        "failed",
+        initial_state="check_processed_marker",
+    )
+    result = _run_exact_message_slice(definition, handler)
+
+    assert result.completed is True
+    assert result.final_state == "done_already_processed"
+    assert calls == ["get_source_processing_marker"]
+
+
+def test_exact_message_workflow_does_not_mark_after_arxiv_ingestion_failure() -> None:
+    from src.backend.workflows.action_registry import ActionRegistry
+
+    calls: list[str] = []
+
+    def failed_ingestion(_request: WorkflowActionRequest) -> WorkflowActionResult:
+        calls.append("workflow_control.for_each")
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "for_each_error_count": 1,
+                "for_each_item_count": 1,
+                "for_each_partial_success": False,
+                "for_each_success_count": 0,
+                "iteration_results": [{"status": "failed"}],
+            },
+        )
+
+    def marker_must_not_run(_request: WorkflowActionRequest) -> WorkflowActionResult:
+        raise AssertionError("marker action ran after failed arXiv ingestion")
+
+    definition = _exact_message_definition(
+        "ingest_arxiv_resources",
+        "mark_done",
+        "verify_done_marker",
+        "done",
+        "failed_unmarked",
+        initial_state="ingest_arxiv_resources",
+    )
+    registry = ActionRegistry()
+    registry.register(
+        ActionSpec(action_id="workflow_control.for_each", handler=failed_ingestion)
+    )
+    registry.register(
+        ActionSpec(action_id="workflow_mcp.invoke_tool", handler=marker_must_not_run)
+    )
+    result = WorkflowExecutor(registry=registry, max_transitions=8).run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={"arxiv_resource_references": [{"identifier": "2606.12345"}]},
+    )
+
+    assert result.completed is True
+    assert result.final_state == "failed_unmarked"
+    assert calls == ["workflow_control.for_each"]
 
 
 def test_zhan_seed_launch_contract_can_narrow_from_prior_arxiv_evidence() -> None:

--- a/tests/backend/test_gmail_service.py
+++ b/tests/backend/test_gmail_service.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import socket
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -7,6 +8,82 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.backend.integrations.google import gmail_service as gs
+
+
+class _FakeSocket:
+    def __init__(self, family, attempts, failures):
+        self.family = family
+        self.attempts = attempts
+        self.failures = failures
+        self.closed = False
+
+    def settimeout(self, _timeout):
+        return None
+
+    def bind(self, _source_address):
+        return None
+
+    def connect(self, sockaddr):
+        self.attempts.append((self.family, sockaddr))
+        failure = self.failures.get(self.family)
+        if failure is not None:
+            raise failure
+
+    def close(self):
+        self.closed = True
+
+
+def test_google_connection_prefers_ipv4_over_ipv6(monkeypatch):
+    attempts = []
+    failures = {}
+    monkeypatch.setattr(
+        gs.socket,
+        "getaddrinfo",
+        lambda *_args: [
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("2001:db8::1", 443, 0, 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.0.2.1", 443)),
+        ],
+    )
+    monkeypatch.setattr(
+        gs.socket,
+        "socket",
+        lambda family, *_args: _FakeSocket(family, attempts, failures),
+    )
+
+    sock = gs._create_connection_prefer_ipv4(  # noqa: SLF001
+        ("gmail.googleapis.com", 443), 1.0
+    )
+
+    assert sock.family == socket.AF_INET
+    assert attempts == [(socket.AF_INET, ("192.0.2.1", 443))]
+
+
+def test_google_connection_retains_ipv6_fallback(monkeypatch):
+    attempts = []
+    failures = {socket.AF_INET: TimeoutError("IPv4 unavailable")}
+    monkeypatch.setattr(
+        gs.socket,
+        "getaddrinfo",
+        lambda *_args: [
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("2001:db8::1", 443, 0, 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.0.2.1", 443)),
+        ],
+    )
+    monkeypatch.setattr(
+        gs.socket,
+        "socket",
+        lambda family, *_args: _FakeSocket(family, attempts, failures),
+    )
+
+    sock = gs._create_connection_prefer_ipv4(  # noqa: SLF001
+        ("gmail.googleapis.com", 443), 1.0
+    )
+
+    assert sock.family == socket.AF_INET6
+    assert attempts == [
+        (socket.AF_INET, ("192.0.2.1", 443)),
+        (socket.AF_INET6, ("2001:db8::1", 443, 0, 0)),
+    ]
 
 
 def test_load_profiles_from_env_json_list(monkeypatch):

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -1,6 +1,12 @@
 import pytest
 
 
+class _GmailHttpError(Exception):
+    def __init__(self, message: str, status: int):
+        super().__init__(message)
+        self.resp = type("Response", (), {"status": status})()
+
+
 def test_internal_mcp_catalogue_builds_and_includes_relationship_tools():
     from src.backend.integrations.internal_mcp import build_default_catalogue
 
@@ -761,6 +767,73 @@ def test_internal_mcp_gmail_get_message_includes_body_only_when_requested(
     assert "body" not in metadata_payload
     assert body_payload["body"] == "Explicitly requested message body"
     assert body_payload["body_truncated"] is False
+
+
+def test_gmail_list_messages_surfaces_invalid_grant_as_reauthorisation(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as catalogue_module
+
+    def fake_list_messages(**_kwargs):
+        raise RuntimeError("invalid_grant: Token has been expired or revoked")
+
+    monkeypatch.setattr(
+        "src.backend.integrations.google.gmail_service.list_messages",
+        fake_list_messages,
+    )
+
+    payload = catalogue_module._gmail_list_messages(profile="zhan-gmail")
+
+    assert payload["success"] is False
+    assert payload["error_code"] == "invalid_grant"
+    assert payload["error_details"] == {
+        "exception_type": "RuntimeError",
+        "failure_kind": "authorisation",
+        "reauthorisation_required": True,
+    }
+
+
+def test_gmail_get_message_keeps_transport_timeout_distinct_from_auth(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as catalogue_module
+
+    def fake_get_message(**_kwargs):
+        raise TimeoutError("connection attempt timed out")
+
+    monkeypatch.setattr(
+        "src.backend.integrations.google.gmail_service.get_message",
+        fake_get_message,
+    )
+
+    payload = catalogue_module._gmail_get_message(
+        profile="zhan-gmail",
+        message_id="msg-timeout",
+    )
+
+    assert payload["success"] is False
+    assert payload["error_code"] == "gmail_transport_timeout"
+    assert payload["error_details"]["failure_kind"] == "transport_timeout"
+    assert payload["error_details"]["reauthorisation_required"] is False
+
+
+def test_gmail_get_message_surfaces_insufficient_oauth_scope(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as catalogue_module
+
+    def fake_get_message(**_kwargs):
+        raise _GmailHttpError("insufficientPermissions", 403)
+
+    monkeypatch.setattr(
+        "src.backend.integrations.google.gmail_service.get_message",
+        fake_get_message,
+    )
+
+    payload = catalogue_module._gmail_get_message(
+        profile="zhan-gmail",
+        message_id="msg-scope",
+    )
+
+    assert payload["success"] is False
+    assert payload["error_code"] == "insufficient_scopes"
+    assert payload["error_details"]["http_status"] == 403
+    assert payload["error_details"]["failure_kind"] == "authorisation"
+    assert payload["error_details"]["reauthorisation_required"] is True
 
 
 def test_gmail_list_messages_zero_results_exposes_empty_messages(monkeypatch):

--- a/tests/backend/test_mongo_uri_redaction.py
+++ b/tests/backend/test_mongo_uri_redaction.py
@@ -216,3 +216,58 @@ def test_db_info_snapshots_route_after_ping_recovery(monkeypatch) -> None:
     assert payload["classification"] == "atlas"
     assert payload["connection_location"]["upstream_sanitized_uri"] == SAFE_URI
     _assert_no_secret_fragments(payload)
+
+
+def test_db_info_public_ip_probe_does_not_change_global_socket_timeout(
+    monkeypatch,
+) -> None:
+    app = Flask(__name__)
+    socket_timeout_calls: list[float | None] = []
+    urlopen_timeouts: list[float | None] = []
+
+    class _FakeIpResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self) -> bytes:
+            return b"203.0.113.42"
+
+    def _urlopen(_url: str, *, timeout: float | None = None):
+        urlopen_timeouts.append(timeout)
+        return _FakeIpResponse()
+
+    monkeypatch.setattr(settings_routes, "_read_cached_db_info", lambda **_kwargs: None)
+    monkeypatch.setattr(settings_routes, "_write_cached_db_info", lambda _payload: None)
+    monkeypatch.setattr(settings_routes, "get_db", lambda: _FakeDb())
+    monkeypatch.setattr(
+        settings_routes, "get_effective_mongo_uri", lambda: FAKE_SECRET_URI
+    )
+    monkeypatch.setattr(settings_routes, "is_using_fallback_uri", lambda: True)
+    monkeypatch.setattr(
+        settings_routes,
+        "get_mongo_fallback_policy_state",
+        lambda: {"active_fallback_kind": "local"},
+    )
+    monkeypatch.setattr(settings_routes, "MONGO_URI", FAKE_SECRET_URI)
+    monkeypatch.setattr(settings_routes, "DATABASE_NAME", "test_database")
+
+    import socket
+    import urllib.request
+
+    monkeypatch.setattr(
+        socket,
+        "setdefaulttimeout",
+        lambda value: socket_timeout_calls.append(value),
+    )
+    monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+
+    with app.test_request_context("/api/settings/db/info?nocache=1"):
+        response, status = settings_routes.get_db_location_info()
+
+    assert status == 200
+    assert response.get_json()["server_public_ip"] == "203.0.113.42"
+    assert urlopen_timeouts == [1.5]
+    assert socket_timeout_calls == []

--- a/tests/backend/test_repo_seed_bundle_invariants.py
+++ b/tests/backend/test_repo_seed_bundle_invariants.py
@@ -203,6 +203,26 @@ def test_referenced_prompt_seed_files_exist_for_canonical_bundle() -> None:
     )
 
 
+def test_legacy_general_mail_review_is_not_an_ordinary_routing_candidate() -> None:
+    payload = json.loads(CANONICAL_BUNDLE_PATH.read_text(encoding="utf-8"))
+    workflow = next(
+        item
+        for item in payload.get("workflows", [])
+        if item.get("workflow_id") == "#V#general_mail_review_workflow"
+    )
+    routing_relation = next(
+        item
+        for item in workflow.get("text_relations", [])
+        if item.get("predicate") == "#V#hasWorkflowRoutingProfileJson"
+    )
+    routing_profile = json.loads(routing_relation["text"])
+
+    assert routing_profile["routing_eligible"] is False
+    assert routing_profile["ordinary_mail_review"] is False
+    assert routing_profile["prefer_existing_capability"] is False
+    assert routing_profile["retained_for_explicit_durable_review_only"] is True
+
+
 def test_explicit_workflow_experience_prelude_callers_keep_their_seed_definition() -> (
     None
 ):

--- a/tests/backend/test_workflow_episode_service.py
+++ b/tests/backend/test_workflow_episode_service.py
@@ -86,6 +86,8 @@ def test_workflow_episode_idempotent_start_for_stable_key():
     aggregate = get_workflow_usage_aggregates_for_workflows([workflow_id])[workflow_id]
     assert aggregate["attempts"] == 1
     assert aggregate["completions"] == 0
+    assert aggregate["failures"] == 0
+    assert aggregate["in_progress"] == 1
 
 
 def test_workflow_episode_aggregates_sync_to_workflow_concept():
@@ -144,7 +146,10 @@ def test_workflow_episode_aggregates_sync_to_workflow_concept():
     aggregate = get_workflow_usage_aggregates_for_workflows([workflow_id])[workflow_id]
     assert aggregate["attempts"] == 2
     assert aggregate["completions"] == 1
+    assert aggregate["failures"] == 1
+    assert aggregate["in_progress"] == 0
     assert aggregate["completion_rate"] == pytest.approx(0.5)
+    assert aggregate["terminal_success_rate"] == pytest.approx(0.5)
 
     concept_doc = ConceptsRepository.find_one(
         {"concept_id": workflow_id},
@@ -154,6 +159,8 @@ def test_workflow_episode_aggregates_sync_to_workflow_concept():
     usage = (concept_doc.get("concept_data") or {}).get("workflow_use_aggregates") or {}
     assert usage.get("attempts") == 2
     assert usage.get("completions") == 1
+    assert usage.get("failures") == 1
+    assert usage.get("in_progress") == 0
     assert usage.get("completion_rate") == pytest.approx(0.5)
 
 
@@ -195,7 +202,75 @@ def test_workflow_episode_hot_path_updates_aggregates_without_log_scan(
     aggregate = get_workflow_usage_aggregates_for_workflows([workflow_id])[workflow_id]
     assert aggregate["attempts"] == 1
     assert aggregate["completions"] == 1
+    assert aggregate["failures"] == 0
+    assert aggregate["in_progress"] == 0
     assert aggregate["completion_rate"] == pytest.approx(1.0)
+
+
+def test_workflow_episode_migrates_legacy_aggregate_from_episode_log():
+    workflow_id = "#V#workflow_episode_legacy_aggregate"
+    _ensure_workflow_concept(workflow_id)
+
+    for index, completed in enumerate((True, False)):
+        stable_key = build_workflow_episode_stable_key(
+            workflow_id=workflow_id,
+            source="chat_turn_workflow",
+            turn_id=f"turn-legacy-{index}",
+        )
+        start_workflow_use_episode(
+            workflow_id=workflow_id,
+            source="chat_turn_workflow",
+            stable_key=stable_key,
+            sync_aggregates=False,
+        )
+        finalise_workflow_use_episode(
+            workflow_id=workflow_id,
+            stable_key=stable_key,
+            completed=completed,
+            terminal_stage="completed" if completed else "failed",
+            sync_aggregates=False,
+        )
+
+    ConceptsRepository.update_one(
+        {"concept_id": workflow_id},
+        {
+            "$set": {
+                "concept_data.workflow_use_aggregates": {
+                    "attempts": 2,
+                    "completions": 1,
+                    "completion_rate": 0.5,
+                }
+            }
+        },
+    )
+
+    open_stable_key = build_workflow_episode_stable_key(
+        workflow_id=workflow_id,
+        source="chat_turn_workflow",
+        turn_id="turn-legacy-open",
+    )
+    started = start_workflow_use_episode(
+        workflow_id=workflow_id,
+        source="chat_turn_workflow",
+        stable_key=open_stable_key,
+    )
+
+    assert started is not None
+    aggregate = started["aggregate"]
+    assert aggregate["schema_version"] == "workflow_use_aggregate.v2"
+    assert aggregate["attempts"] == 3
+    assert aggregate["completions"] == 1
+    assert aggregate["failures"] == 1
+    assert aggregate["in_progress"] == 1
+    assert aggregate["terminal_success_rate"] == pytest.approx(0.5)
+
+    concept_doc = ConceptsRepository.find_one({"concept_id": workflow_id}) or {}
+    persisted = (concept_doc.get("concept_data") or {}).get(
+        "workflow_use_aggregates"
+    ) or {}
+    assert persisted["schema_version"] == "workflow_use_aggregate.v2"
+    assert persisted["failures"] == 1
+    assert persisted["in_progress"] == 1
 
 
 def test_workflow_episode_duplicate_finalise_does_not_double_count_completion():
@@ -235,6 +310,44 @@ def test_workflow_episode_duplicate_finalise_does_not_double_count_completion():
     aggregate = get_workflow_usage_aggregates_for_workflows([workflow_id])[workflow_id]
     assert aggregate["attempts"] == 1
     assert aggregate["completions"] == 1
+    assert aggregate["failures"] == 0
+
+
+def test_workflow_episode_terminal_outcome_can_be_reconciled_idempotently():
+    workflow_id = "#V#workflow_episode_reconciled_terminal"
+    _ensure_workflow_concept(workflow_id)
+    stable_key = build_workflow_episode_stable_key(
+        workflow_id=workflow_id,
+        source="chat_turn_workflow",
+        turn_id="turn-reconciled-terminal",
+        session_id="session-reconciled-terminal",
+        stage="tool_calling",
+    )
+
+    start_workflow_use_episode(
+        workflow_id=workflow_id,
+        source="chat_turn_workflow",
+        stable_key=stable_key,
+    )
+    finalise_workflow_use_episode(
+        workflow_id=workflow_id,
+        stable_key=stable_key,
+        completed=False,
+        terminal_stage="failed",
+    )
+    finalise_workflow_use_episode(
+        workflow_id=workflow_id,
+        stable_key=stable_key,
+        completed=True,
+        terminal_stage="completed",
+    )
+
+    aggregate = get_workflow_usage_aggregates_for_workflows([workflow_id])[workflow_id]
+    assert aggregate["attempts"] == 1
+    assert aggregate["completions"] == 1
+    assert aggregate["failures"] == 0
+    assert aggregate["in_progress"] == 0
+    assert aggregate["terminal_success_rate"] == 1.0
 
 
 def test_workflow_episode_can_skip_concept_aggregate_sync():
@@ -495,9 +608,13 @@ def test_usage_aggregates_skip_episode_log_fallback_when_concept_aggregates_exis
                 "concept_id": workflow_ids[0],
                 "concept_data": {
                     "workflow_use_aggregates": {
+                        "schema_version": "workflow_use_aggregate.v2",
                         "attempts": 3,
                         "completions": 2,
+                        "failures": 1,
+                        "in_progress": 0,
                         "completion_rate": 2 / 3,
+                        "terminal_success_rate": 2 / 3,
                         "last_episode_at": datetime(
                             2026, 3, 5, 12, 0, tzinfo=timezone.utc
                         ),
@@ -509,9 +626,13 @@ def test_usage_aggregates_skip_episode_log_fallback_when_concept_aggregates_exis
                 "concept_id": workflow_ids[1],
                 "concept_data": {
                     "workflow_use_aggregates": {
+                        "schema_version": "workflow_use_aggregate.v2",
                         "attempts": 1,
                         "completions": 1,
+                        "failures": 0,
+                        "in_progress": 0,
                         "completion_rate": 1.0,
+                        "terminal_success_rate": 1.0,
                     }
                 },
             },
@@ -559,9 +680,13 @@ def test_usage_aggregates_fallback_queries_only_missing_concept_aggregates(
                 "concept_id": populated_id,
                 "concept_data": {
                     "workflow_use_aggregates": {
+                        "schema_version": "workflow_use_aggregate.v2",
                         "attempts": 8,
                         "completions": 8,
+                        "failures": 0,
+                        "in_progress": 0,
                         "completion_rate": 1.0,
+                        "terminal_success_rate": 1.0,
                     }
                 },
             }


### PR DESCRIPTION
## What changed

- de-route the obsolete broad mail-review workflow and make the Gmail/arXiv path converge through canonical paper-state inspection
- skip messages with verified processing markers, reuse represented papers, and represent only genuinely missing papers
- record and read back source-processing markers without mutating Gmail labels
- keep Google API connection fallback local to Gmail, preferring reachable IPv4 while retaining IPv6 fallback
- prevent the database-info probe from changing the process-wide socket timeout
- expose typed Gmail OAuth, scope, and transport failures to Von
- add focused workflow, Gmail transport, diagnostic, and error-classification coverage

## Why

The replay was being derailed by a legacy workflow and later stalled before Gmail could return a response because the HTTP transport exhausted its timeout on unusable IPv6 addresses. The generic Gmail error envelope also made OAuth and transport failures too easy to conflate.

## Validation

- live MJW Personal Chrome replay: durable instance `76e46041-5949-446f-8c6d-0d5a2ae08237` completed 25/25 message iterations with zero errors
- newest 20 messages skipped via existing markers; next five processed backwards and canonically read back
- no Gmail label mutation capability invoked
- 44 workflow/Gmail/settings focused tests passed
- 23 internal Gmail catalogue tests passed
- targeted Ruff checks and `git diff --check` passed

Atlas/start-up latency is deliberately out of scope.