### PR TITLE
Repair downstream turn progress and recovery

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -5175,13 +5175,17 @@ def delete_file_copy(file_copy_concept_id: str):
     return jsonify(result), 500
 
 
-def _prune_tool_progress() -> None:
+def _prune_tool_progress(
+    *,
+    preserve_key: tuple[str, str] | None = None,
+) -> None:
     cutoff = time.time() - _TOOL_PROGRESS_TTL_SEC
     with _TOOL_PROGRESS_LOCK:
         stale_keys = [
             key
             for key, value in _TOOL_PROGRESS.items()
-            if isinstance(value, dict)
+            if key != preserve_key
+            and isinstance(value, dict)
             and isinstance(value.get("updated_at_epoch"), (int, float))
             and float(value["updated_at_epoch"]) < cutoff
         ]
@@ -5199,7 +5203,7 @@ def _cache_tool_progress_state(
 
 
 def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) -> None:
-    _prune_tool_progress()
+    _prune_tool_progress(preserve_key=(scope_key, request_id))
     now_epoch = time.time()
     now_utc = _now_utc_iso()
     merged: dict[str, Any]
@@ -5781,7 +5785,7 @@ def _set_tool_progress(scope_key: str, request_id: str, update: dict[str, Any]) 
 
 
 def _get_tool_progress(scope_key: str, request_id: str) -> dict[str, Any] | None:
-    _prune_tool_progress()
+    _prune_tool_progress(preserve_key=(scope_key, request_id))
     with _TOOL_PROGRESS_LOCK:
         value = _TOOL_PROGRESS.get((scope_key, request_id))
         if isinstance(value, dict):
@@ -5800,7 +5804,7 @@ def _get_tool_progress(scope_key: str, request_id: str) -> dict[str, Any] | None
 def _get_live_memory_tool_progress(
     scope_key: str, request_id: str
 ) -> dict[str, Any] | None:
-    _prune_tool_progress()
+    _prune_tool_progress(preserve_key=(scope_key, request_id))
     with _TOOL_PROGRESS_LOCK:
         value = _TOOL_PROGRESS.get((scope_key, request_id))
         if isinstance(value, dict):

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -1640,6 +1640,12 @@ def _scope_message(
         "- An effect receipt reports the bounded handler outcome; use returned "
         "identifiers and delegated reads to inspect canonical state before "
         "claiming that a representation persisted.\n"
+        "- A pending or partial represented-workflow receipt with a durable "
+        "instance identifier means submission is complete for this turn. Prefer "
+        "one immediate non-waiting inspection, then return the useful result, "
+        "current state, and exact handle. Do not spend repeated long observation "
+        "intervals unless the user needs synchronous completion or recent "
+        "progress justifies one bounded wait.\n"
         "- Preserve the requested outcome and effect cardinality through "
         "capability choice, retries, and fallback. Discovery and evidence reads "
         "may inspect the smallest bounded candidate set needed to identify the "
@@ -3306,6 +3312,44 @@ def _usage_add(
             totals[str(key)] = totals.get(str(key), 0.0) + float(value)
 
 
+def _can_preserve_pending_durable_response(
+    text: str,
+    effects: Sequence[Mapping[str, Any]],
+) -> bool:
+    """Return whether a useful, honest pending-workflow answer can be shown."""
+
+    cleaned = text.strip()
+    if not cleaned or not effects:
+        return False
+    lowered = cleaned.lower()
+    if not any(
+        marker in lowered
+        for marker in (
+            "pending",
+            "queued",
+            "running",
+            "paused",
+            "partial",
+            "not yet",
+            "not complete",
+            "not finished",
+            "still processing",
+            "in progress",
+        )
+    ):
+        return False
+
+    for effect in effects:
+        if effect.get("capability_kind") != "represented_workflow":
+            return False
+        if effect.get("effect_status") != "partial":
+            return False
+        instance_id = str(effect.get("instance_id") or "").strip()
+        if not instance_id or instance_id not in cleaned:
+            return False
+    return True
+
+
 def execute_adaptive_turn(
     *,
     gateway: InternalMCPGateway | None,
@@ -3924,6 +3968,7 @@ def execute_adaptive_turn(
                     "The model returned a conversation-situation update but no "
                     "user-visible answer."
                 )
+        model_answer_completed = status == "completed"
         with effect_state_lock:
             effect_snapshot = {
                 effect_id: dict(state) for effect_id, state in effect_states.items()
@@ -4000,7 +4045,30 @@ def execute_adaptive_turn(
                 )
             )
         ]
-        effect_finality_fallback = status != "completed" and bool(relevant_effects)
+        preserve_pending_durable_response = (
+            model_answer_completed
+            and status == "effect_partially_completed"
+            and _can_preserve_pending_durable_response(text, relevant_effects)
+        )
+        effect_finality_fallback = (
+            status != "completed"
+            and bool(relevant_effects)
+            and not preserve_pending_durable_response
+        )
+        if preserve_pending_durable_response:
+            aux_calls.append(
+                {
+                    "type": "adaptive_turn_pending_effect_response_preserved",
+                    "schema_version": (
+                        "adaptive_turn_pending_effect_response_preserved.v1"
+                    ),
+                    "terminal_status": status,
+                    "effect_count": len(relevant_effects),
+                    "instance_ids": [
+                        state.get("instance_id") for state in relevant_effects
+                    ],
+                }
+            )
         if effect_finality_fallback:
             status_counts = {
                 effect_status: sum(

--- a/src/backend/services/debug_payload_store.py
+++ b/src/backend/services/debug_payload_store.py
@@ -437,27 +437,53 @@ def hydrate_debug_payload_blob_refs(
 
     hydrated_count = 0
     error_count = 0
+    active_blob_keys: set[str] = set()
 
     def _walk(value: Any) -> Any:
         nonlocal hydrated_count, error_count
 
         if _is_blob_ref_payload(value):
-            result = resolve_debug_payload_blob_ref(value)
-            if result.payload is None:
+            blob_ref = value.get("blob_ref")
+            blob_key = (
+                str(blob_ref.get("key") or "").strip()
+                if isinstance(blob_ref, Mapping)
+                else ""
+            )
+            if blob_key and blob_key in active_blob_keys:
                 error_count += 1
                 if not fail_soft:
-                    raise ValueError(result.error or result.status)
+                    raise ValueError("Cyclic debug payload blob reference")
                 replacement = dict(value)
                 replacement["hydration_error"] = {
                     "schema_version": "debug_payload_blob_hydration_error.v1",
-                    "status": result.status,
-                    "error": result.error,
-                    "error_class": result.error_class,
+                    "status": "cyclic_ref",
+                    "error": "Cyclic debug payload blob reference",
+                    "error_class": "ValueError",
                     "created_at_utc": _utcnow_iso(),
                 }
                 return replacement
-            hydrated_count += 1
-            return result.payload
+            if blob_key:
+                active_blob_keys.add(blob_key)
+            try:
+                result = resolve_debug_payload_blob_ref(value)
+                if result.payload is None:
+                    error_count += 1
+                    if not fail_soft:
+                        raise ValueError(result.error or result.status)
+                    replacement = dict(value)
+                    replacement["hydration_error"] = {
+                        "schema_version": "debug_payload_blob_hydration_error.v1",
+                        "status": result.status,
+                        "error": result.error,
+                        "error_class": result.error_class,
+                        "created_at_utc": _utcnow_iso(),
+                    }
+                    return replacement
+                hydrated_count += 1
+                return _walk(result.payload)
+            finally:
+                if blob_key:
+                    active_blob_keys.discard(blob_key)
 
         if isinstance(value, Mapping):
             return {str(key): _walk(item) for key, item in value.items()}

--- a/src/backend/services/workflow_turn_capability_service.py
+++ b/src/backend/services/workflow_turn_capability_service.py
@@ -865,11 +865,6 @@ def normalise_workflow_effect_receipt(
         recovery_affordances = list(receipt.get("recovery_affordances") or [])
         if instance_id is not None:
             workflow_execution = receipt.get("workflow_execution")
-            prior_wait_seconds = (
-                workflow_execution.get("timeout_seconds")
-                if isinstance(workflow_execution, Mapping)
-                else None
-            )
             prior_poll_interval = (
                 workflow_execution.get("poll_interval_seconds")
                 if isinstance(workflow_execution, Mapping)
@@ -877,18 +872,10 @@ def normalise_workflow_effect_receipt(
             )
             wait_arguments: dict[str, Any] = {"instance_id": instance_id}
             if effect_status == "partial":
-                wait_arguments["await_terminal"] = True
-                if isinstance(prior_wait_seconds, (int, float)) and not isinstance(
-                    prior_wait_seconds,
-                    bool,
-                ) and math.isfinite(float(prior_wait_seconds)):
-                    wait_arguments["timeout_seconds"] = max(
-                        0.1,
-                        min(
-                            float(prior_wait_seconds),
-                            WORKFLOW_OBSERVATION_MAX_SECONDS,
-                        ),
-                    )
+                # The durable handle is already established. Inspecting once is
+                # the least burdensome recovery; another long wait remains an
+                # adaptive choice only when the user's outcome requires it.
+                wait_arguments["await_terminal"] = False
                 if isinstance(prior_poll_interval, (int, float)) and not isinstance(
                     prior_poll_interval,
                     bool,
@@ -900,7 +887,7 @@ def normalise_workflow_effect_receipt(
             recovery_affordances.append(
                 {
                     "action_type": (
-                        "await_or_inspect_workflow_instance"
+                        "inspect_pending_workflow_instance"
                         if effect_status == "partial"
                         else "inspect_workflow_instance"
                     ),
@@ -908,8 +895,8 @@ def normalise_workflow_effect_receipt(
                     "arguments": wait_arguments,
                     "semantic_effect": (
                         (
-                            "observe the already-submitted instance until it is "
-                            "terminal or the chosen wait elapses"
+                            "inspect the already-submitted instance without "
+                            "spending another observation interval waiting"
                             if effect_status == "partial"
                             else "inspect the terminal workflow instance"
                         )

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -7319,6 +7319,143 @@ def test_workflow_instance_readback_reconciles_only_exact_terminal_effect(
         assert result.response_text == "The durable work product was verified."
 
 
+def test_pending_durable_response_with_exact_handle_is_preserved(monkeypatch) -> None:
+    from src.backend.services.workflow_turn_capability_service import (
+        WorkflowTurnCapability,
+    )
+
+    workflow_capability = WorkflowTurnCapability(
+        name="represented_workflow_pending_test",
+        workflow_id="#V#represented_pending_workflow",
+        display_name="Represented pending workflow",
+        description="Produce a durable work product that may continue in background.",
+        relevance_score=0.95,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "inputs": {"type": "object", "additionalProperties": True},
+                "timeout_seconds": {"type": "number"},
+            },
+            "additionalProperties": False,
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.workflow_turn_capability_service."
+        "discover_turn_workflow_capabilities",
+        lambda *_args, **_kwargs: (
+            [workflow_capability],
+            {
+                "schema_version": "workflow_turn_capability_discovery.v1",
+                "status": "completed",
+                "match_count": 1,
+            },
+        ),
+    )
+    instance_id = "workflow-instance-pending-1"
+    instance_reads: list[dict[str, Any]] = []
+
+    def _execute_workflow(**_kwargs: Any) -> dict[str, Any]:
+        return {
+            "success": True,
+            "instance_id": instance_id,
+            "workflow_id": workflow_capability.workflow_id,
+            "created_new": True,
+            "final_status": "running",
+            "timed_out": True,
+            "workflow_execution": {
+                "timeout_seconds": 90.0,
+                "poll_interval_seconds": 0.5,
+            },
+        }
+
+    def _read_instance(**kwargs: Any) -> dict[str, Any]:
+        instance_reads.append(dict(kwargs))
+        return {
+            "success": True,
+            "instance_id": instance_id,
+            "workflow_id": workflow_capability.workflow_id,
+            "status": "running",
+            "timed_out": False,
+        }
+
+    final_text = (
+        "The durable work is still running. Its exact workflow instance is "
+        f"{instance_id}."
+    )
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_capabilities",
+                    call_id="discover-pending-workflow",
+                    payload={"query": "produce the durable work product"},
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="invoke-pending-workflow",
+                    payload={
+                        "name": workflow_capability.name,
+                        "arguments": {"timeout_seconds": 90.0},
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="inspect-pending-workflow",
+                    payload={
+                        "name": "workflow_get_instance",
+                        "arguments": {
+                            "instance_id": instance_id,
+                            "await_terminal": False,
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response=final_text),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_workflow_gateway(
+            _execute_workflow,
+            hard_timeout_enabled=False,
+            instance_handler=_read_instance,
+        ),
+        prompt="Produce the durable work product.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#real_user@real_org",
+        user_concept_id="#V#real_user",
+        org_concept_id="#V#real_org",
+        turn_id="turn-represented-workflow-pending",
+        turn_budget_seconds=20,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert instance_reads == [
+        {"instance_id": instance_id, "await_terminal": False}
+    ]
+    assert result.terminal_status == "effect_partially_completed"
+    assert result.effect_finality_fallback is False
+    assert result.response_text == final_text
+    assert any(
+        call.get("schema_version")
+        == "adaptive_turn_pending_effect_response_preserved.v1"
+        for call in result.aux_llm_calls
+    )
+
+
 def test_workflow_instance_readback_does_not_reconcile_unrelated_effect() -> None:
     instance_id = "shared-looking-instance-id"
     workflow_id = "#V#shared-looking-workflow-id"

--- a/tests/backend/test_debug_payload_blob_offload.py
+++ b/tests/backend/test_debug_payload_blob_offload.py
@@ -151,6 +151,53 @@ def test_hydrate_debug_payload_blob_refs_restores_nested_payload(monkeypatch) ->
     assert hydrated.payload == payload
 
 
+def test_hydration_recurses_through_nested_offload_layers(monkeypatch) -> None:
+    store = _FakeBlobStore()
+    monkeypatch.setenv("VON_BLOB_SPILLWAY_ENABLED", "0")
+    monkeypatch.setattr(
+        "src.backend.services.blob_store.get_blob_store_from_env",
+        lambda: store,
+    )
+
+    inner_payload = {"stage_diagnostics": [{"detail": "x" * 2000}]}
+    compacted_inner = compact_debug_payload_for_storage(
+        inner_payload,
+        root_kind="turn_execution_diagnostics",
+        namespace="#V#michael@org",
+        request_id="req-nested-inner",
+        threshold_bytes=512,
+    )
+    payload = {
+        "turn_execution_diagnostics": {
+            "nested": compacted_inner.payload,
+            "padding": "y" * 2000,
+        }
+    }
+    compacted_outer = compact_debug_payload_for_storage(
+        payload,
+        root_kind="chat_history.llm_debug_data",
+        namespace="#V#michael@org",
+        request_id="req-nested-outer",
+        threshold_bytes=512,
+    )
+
+    hydrated = hydrate_debug_payload_blob_refs(
+        compacted_outer.payload,
+        fail_soft=False,
+    )
+
+    assert compacted_inner.offloaded_count == 1
+    assert compacted_outer.offloaded_count == 1
+    assert hydrated.hydrated_count == 2
+    assert hydrated.error_count == 0
+    assert hydrated.payload == {
+        "turn_execution_diagnostics": {
+            "nested": inner_payload,
+            "padding": "y" * 2000,
+        }
+    }
+
+
 def test_resolve_debug_payload_blob_ref_reports_typed_cache_states(
     monkeypatch,
     tmp_path,

--- a/tests/backend/test_tool_progress_liveness.py
+++ b/tests/backend/test_tool_progress_liveness.py
@@ -116,6 +116,44 @@ def test_heartbeat_updates_sequence_and_keeps_current_activity(monkeypatch) -> N
     )
 
 
+def test_long_quiet_live_request_keeps_original_clock_and_history(monkeypatch) -> None:
+    clock = _set_clock(monkeypatch)
+    scope_key = "scope-long-live-request"
+    request_id = "req-long-live-request"
+
+    von_routes._set_tool_progress(
+        scope_key,
+        request_id,
+        {
+            "status": "thinking",
+            "phase": "workflow_execute",
+            "request_id": request_id,
+        },
+    )
+    initial = von_routes._get_tool_progress(scope_key, request_id)
+    assert initial is not None
+
+    clock["now"] += float(von_routes._TOOL_PROGRESS_TTL_SEC) + 1.0
+    polled = von_routes._get_live_memory_tool_progress(scope_key, request_id)
+    assert polled is not None
+    assert polled["request_started_epoch"] == initial["request_started_epoch"]
+    von_routes._set_tool_progress(
+        scope_key,
+        request_id,
+        {
+            "status": "heartbeat",
+            "phase": "workflow_execute",
+            "request_id": request_id,
+        },
+    )
+
+    current = von_routes._get_tool_progress(scope_key, request_id)
+    assert current is not None
+    assert current["request_started_epoch"] == initial["request_started_epoch"]
+    assert current["sequence_no"] == 2
+    assert len(current["_phase_history"]) == 1
+
+
 def test_observational_progress_does_not_synthesise_a_workflow_stage_path(
     monkeypatch,
 ) -> None:

--- a/tests/backend/test_von_generate_workflow_instances.py
+++ b/tests/backend/test_von_generate_workflow_instances.py
@@ -457,6 +457,37 @@ def test_effect_finality_fallback_is_presented_literally_without_model_backfill(
     )
 
 
+def test_pending_effect_answer_reaches_presenter_channels(app: Flask) -> None:
+    instance_id = "workflow-instance-pending-route-1"
+    adaptive_state = app.config["_ADAPTIVE_TURN_STATE"]
+    adaptive_state["response_text"] = (
+        "<spoken>The work is still running.</spoken>\n"
+        "<screen>The work is still running. Exact workflow instance: "
+        f"{instance_id}.</screen>"
+    )
+    adaptive_state["terminal_status"] = "effect_partially_completed"
+    adaptive_state["effect_finality_fallback"] = False
+
+    response = app.test_client().post(
+        "/von/generate",
+        json={"prompt": "Present the result.", "presenter_mode": True},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["response"] == (
+        f"The work is still running. Exact workflow instance: {instance_id}."
+    )
+    assert payload["response_channels"] == {
+        "spoken": "The work is still running.",
+        "screen": (
+            f"The work is still running. Exact workflow instance: {instance_id}."
+        ),
+        "format": "tagged_blocks_v1",
+    }
+
+
 def test_presenter_channel_parser_ignores_tags_inside_fenced_blocks() -> None:
     from src.backend.server.routes.von_routes import _extract_presenter_channels
 

--- a/tests/backend/test_workflow_turn_capability_service.py
+++ b/tests/backend/test_workflow_turn_capability_service.py
@@ -409,12 +409,11 @@ def test_workflow_receipt_distinguishes_completion_partial_failure_and_no_start(
     assert partial["effect_status"] == "partial"
     assert partial["recovery_affordances"][0]["arguments"] == {
         "instance_id": "instance-2",
-        "await_terminal": True,
-        "timeout_seconds": 90.0,
+        "await_terminal": False,
         "poll_interval_seconds": 0.5,
     }
     assert partial["recovery_affordances"][0]["action_type"] == (
-        "await_or_inspect_workflow_instance"
+        "inspect_pending_workflow_instance"
     )
     assert terminal_failure["effect_status"] == "failed"
     assert terminal_failure["changed"] is True
@@ -436,5 +435,8 @@ def test_workflow_receipt_distinguishes_completion_partial_failure_and_no_start(
     assert durable_timeout["mutation_outcome"] == "partial"
     assert durable_timeout["recovery_affordances"][0]["arguments"] == {
         "instance_id": "instance-4",
-        "await_terminal": True,
+        "await_terminal": False,
     }
+    assert durable_timeout["recovery_affordances"][0]["action_type"] == (
+        "inspect_pending_workflow_instance"
+    )


### PR DESCRIPTION
## What changed

- keep the current live-progress entry observable after a long quiet interval without resetting its original request clock or phase history
- recursively hydrate nested diagnostic blob references, with cycle protection
- expose pending durable workflow recovery as a non-waiting inspection instead of prescribing another long wait
- preserve an honest model-authored partial-workflow answer when it names every exact durable instance handle

## Why

Recent real-path replay work exposed downstream reliability defects after durable workflow submission: active progress could expire, nested diagnostics could remain compacted, recovery guidance could consume another long observation interval, and the useful pending answer could be replaced by a generic finality fallback.

The repair is generic support code. It adds no Gmail-, arXiv-, user-, workflow-ID-, or prompt-specific route.

## Impact

Long-running authorised work remains observable and can return an honest pending result with a precise recovery handle. Diagnostic readers receive the full nested payload, while effect finality and canonical read-back requirements remain intact.

## Validation

- 197 affected backend tests passed
- fatal Ruff checks passed
- changed Python modules compiled
- `git diff --check` passed
- the current server is healthy while running this dirty candidate