### PR TITLE
Make scheduled paper ingestion reliable and observable

### DIFF
--- a/scripts/repair_jvnautosci_2272_zhan_gmail_arxiv_ingestion_workflow.py
+++ b/scripts/repair_jvnautosci_2272_zhan_gmail_arxiv_ingestion_workflow.py
@@ -1,10 +1,8 @@
-"""Repair JVNAUTOSCI-2272 Zhan Gmail arXiv ingestion workflow authority.
+"""Legacy JVNAUTOSCI-2272 repair entry point.
 
-This is a Vontology-authoring maintenance script. It keeps request-path policy
-out of Python and materialises the repair as VWL/Vontology state: partial batch
-semantics, represented retry metadata, valid launch contracts, and represented
-source-processing markers used to avoid repeating completed work without
-mutating Gmail.
+The old marker-only rewrite helpers remain for historical unit coverage, but the
+executable entry point delegates to the current canonical repo-seed publisher.
+It must not overwrite the newer verified Gmail label/archive convergence policy.
 """
 
 from __future__ import annotations
@@ -541,77 +539,37 @@ def _load_gmail_completion_hint() -> dict[str, Any]:
 
 
 def publish_jvnautosci_2272_repair(*, dry_run: bool = False) -> dict[str, Any]:
-    parent_spec, parent_changes = rewrite_zhan_parent_workflow_spec(
-        _load_authoring_spec(ZHAN_GMAIL_ARXIV_WORKFLOW_ID)
-    )
-    child_spec, child_changes = rewrite_email_message_workflow_spec(
-        _load_authoring_spec(EMAIL_ARXIV_MESSAGE_WORKFLOW_ID)
-    )
-    parent_definition = build_workflow_definition_from_authoring_spec(parent_spec)
-    child_definition = build_workflow_definition_from_authoring_spec(child_spec)
-
-    zhan_contract = _validate_launch_contract(build_zhan_launch_input_contract())
-    child_contract = _validate_launch_contract(
-        build_email_message_launch_input_contract()
-    )
-    hint_payload, hint_changed = rewrite_gmail_completion_hint_payload(
-        _load_gmail_completion_hint()
+    from src.backend.services import (
+        email_source_representation_convergence_workflow_vontology_service as service,
     )
 
-    result: dict[str, Any] = {
-        "success": True,
-        "dry_run": dry_run,
-        "parent_changes": parent_changes,
-        "child_changes": child_changes,
-        "gmail_completion_hint_changed": hint_changed,
-        "launch_contracts": {
-            ZHAN_GMAIL_ARXIV_WORKFLOW_ID: zhan_contract,
-            EMAIL_ARXIV_MESSAGE_WORKFLOW_ID: child_contract,
-        },
-    }
     if dry_run:
-        return result
+        payload = json.loads(service._REPO_SEED_ASSET_PATH.read_text(encoding="utf-8"))
+        return {
+            "success": True,
+            "dry_run": True,
+            "deprecated_entry_point": True,
+            "delegates_to": (
+                "bootstrap_canonical_email_source_representation_convergence_workflows"
+            ),
+            "seed_version": payload.get("seed_version"),
+            "workflow_ids": [
+                item.get("workflow_id")
+                for item in payload.get("workflows") or []
+                if isinstance(item, Mapping)
+            ],
+        }
 
-    result["parent_publication"] = _publish_definition(parent_definition)
-    result["child_publication"] = _publish_definition(child_definition)
-    result["zhan_launch_input_contract"] = (
-        workflow_concept_authority_service.upsert_workflow_json_policy_text(
-            workflow_id=ZHAN_GMAIL_ARXIV_WORKFLOW_ID,
-            predicate=workflow_concept_authority_service.WORKFLOW_LAUNCH_INPUT_CONTRACT_TEXT_PREDICATE,
-            payload=zhan_contract,
-            context={"source": "jvnautosci_2272_repair"},
-        )
+    result = service.bootstrap_canonical_email_source_representation_convergence_workflows(
+        force_republish=True
     )
-    result["child_launch_input_contract"] = (
-        workflow_concept_authority_service.upsert_workflow_json_policy_text(
-            workflow_id=EMAIL_ARXIV_MESSAGE_WORKFLOW_ID,
-            predicate=workflow_concept_authority_service.WORKFLOW_LAUNCH_INPUT_CONTRACT_TEXT_PREDICATE,
-            payload=child_contract,
-            context={"source": "jvnautosci_2272_repair"},
-        )
-    )
-    result["gmail_completion_hint"] = upsert_singleton_text_relation(
-        subject_concept_id=GMAIL_GET_MESSAGE_TOOL_CONCEPT_ID,
-        predicate=GMAIL_OUTPUT_FOLLOWUP_HINT_PREDICATE,
-        text=json.dumps(hint_payload, ensure_ascii=True, sort_keys=True),
-        lang="en-NZ",
-        context={"source": "jvnautosci_2272_repair"},
-        garbage_collect=True,
-    )
-    result["resolved_launch_contract_sources"] = {
-        workflow_id: resolve_workflow_launch_input_contract(workflow_id)[1]
-        for workflow_id in (
-            ZHAN_GMAIL_ARXIV_WORKFLOW_ID,
-            EMAIL_ARXIV_MESSAGE_WORKFLOW_ID,
-        )
+    return {
+        **dict(result),
+        "deprecated_entry_point": True,
+        "delegates_to": (
+            "bootstrap_canonical_email_source_representation_convergence_workflows"
+        ),
     }
-    try:
-        from src.backend.workflows.durable import registry_factory
-
-        registry_factory._resolve_subworkflow_definition.cache_clear()
-    except Exception:
-        pass
-    return result
 
 
 def main() -> None:

--- a/src/backend/integrations/google/gmail_service.py
+++ b/src/backend/integrations/google/gmail_service.py
@@ -711,6 +711,8 @@ def find_attachment_part_metadata(
 
 def list_labels(
     profile_id: str,
+    exact_name: str | None = None,
+    require_exact_match: bool = False,
     profiles: Optional[Dict[str, GmailProfile]] = None,
     audit_context: Optional[Mapping[str, object]] = None,
 ) -> Dict:
@@ -723,7 +725,45 @@ def list_labels(
     service = get_service(profile_id, profiles)
 
     request = service.users().labels().list(userId=profile.user_id)
-    return request.execute() or {}
+    result = request.execute() or {}
+    if exact_name is None:
+        return result
+    if not isinstance(exact_name, str) or not exact_name.strip():
+        raise ValueError("exact_name must be a non-empty string when provided")
+
+    label_name = exact_name.strip()
+    raw_labels = result.get("labels")
+    labels = raw_labels if isinstance(raw_labels, list) else []
+    matches = [
+        dict(label)
+        for label in labels
+        if isinstance(label, Mapping) and label.get("name") == label_name
+    ]
+    if require_exact_match and len(matches) != 1:
+        raise ValueError(
+            "Gmail label exact-name resolution requires exactly one match: "
+            f"{label_name!r} matched {len(matches)} labels"
+        )
+
+    payload = dict(result)
+    matched_label = matches[0] if len(matches) == 1 else None
+    payload.update(
+        {
+            "profile": profile.profile_id,
+            "exact_name": label_name,
+            "exact_match_count": len(matches),
+            "matched_label": matched_label,
+            "label_id": (
+                matched_label.get("id") if isinstance(matched_label, Mapping) else None
+            ),
+            "label_name": (
+                matched_label.get("name")
+                if isinstance(matched_label, Mapping)
+                else None
+            ),
+        }
+    )
+    return payload
 
 
 def _normalise_optional_visibility(
@@ -956,6 +996,7 @@ def modify_labels(
     add_labels: Optional[List[str]] = None,
     remove_labels: Optional[List[str]] = None,
     allow_mutation: bool = False,
+    verify_after: bool = False,
     profiles: Optional[Dict[str, GmailProfile]] = None,
     audit_context: Optional[Mapping[str, object]] = None,
 ) -> Dict:
@@ -983,6 +1024,16 @@ def modify_labels(
         raise PermissionError("Profile scopes do not include gmail.modify")
 
     service = get_service(profile_id, profiles)
+    requested_add = list(dict.fromkeys(add_labels or []))
+    requested_remove = list(dict.fromkeys(remove_labels or []))
+    if any(
+        not isinstance(label_id, str) or not label_id.strip()
+        for label_id in [*requested_add, *requested_remove]
+    ):
+        raise ValueError("Gmail label IDs must be non-empty strings")
+    if set(requested_add).intersection(requested_remove):
+        raise ValueError("The same Gmail label cannot be both added and removed")
+
     request = (
         service.users()
         .messages()
@@ -990,9 +1041,57 @@ def modify_labels(
             userId=profile.user_id,
             id=message_id,
             body={
-                "addLabelIds": add_labels or [],
-                "removeLabelIds": remove_labels or [],
+                "addLabelIds": requested_add,
+                "removeLabelIds": requested_remove,
             },
         )
     )
-    return request.execute() or {}
+    modify_error: Exception | None = None
+    modify_result: Dict[str, object] = {}
+    try:
+        raw_result = request.execute() or {}
+        modify_result = dict(raw_result) if isinstance(raw_result, Mapping) else {}
+    except Exception as exc:  # noqa: BLE001
+        if not verify_after:
+            raise
+        modify_error = exc
+
+    if not verify_after:
+        return modify_result
+
+    try:
+        readback = (
+            service.users()
+            .messages()
+            .get(userId=profile.user_id, id=message_id, format="minimal")
+            .execute()
+            or {}
+        )
+    except Exception:
+        if modify_error is not None:
+            raise modify_error
+        raise
+
+    readback_label_ids = [
+        label_id
+        for label_id in (readback.get("labelIds") or [])
+        if isinstance(label_id, str) and label_id.strip()
+    ]
+    readback_set = set(readback_label_ids)
+    state_verified = set(requested_add).issubset(readback_set) and not set(
+        requested_remove
+    ).intersection(readback_set)
+    if not state_verified and modify_error is not None:
+        raise modify_error
+
+    return {
+        "success": state_verified,
+        "profile": profile.profile_id,
+        "message_id": message_id,
+        "requested_add_label_ids": requested_add,
+        "requested_remove_label_ids": requested_remove,
+        "modify_result": modify_result,
+        "readback_label_ids": readback_label_ids,
+        "gmail_label_state_verified": state_verified,
+        "modify_reconciled_after_error": modify_error is not None and state_verified,
+    }

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -9903,6 +9903,7 @@ def _source_processing_marker_input_schema(*, read_only: bool = False) -> Schema
         "organisation_concept_id": (str, type(None)),
         "source_fingerprint": (str, type(None)),
         "processing_authority_fingerprint": (str, type(None)),
+        "require_represented_artifacts": bool,
     }
     if read_only:
         # Historical markers predate profile-scoped identity. Keep their exact
@@ -9988,12 +9989,15 @@ def _source_processing_marker_output_schema() -> Schema:
             "stored_processing_authority_fingerprint": (str, type(None)),
             "expected_processing_authority_fingerprint": (str, type(None)),
             "processing_authority_matches": (bool, type(None)),
+            "represented_artifacts_required": (bool, type(None)),
             "represented_artifacts_exist": (bool, type(None)),
         },
         allow_unknown=True,
         description=(
             "source processing marker output: compact represented evidence that a "
-            "source item has or has not been processed."
+            "source item has or has not been processed. When "
+            "require_represented_artifacts=true, currentness also requires at "
+            "least one represented artefact whose concept still exists."
         ),
     )
 
@@ -26582,6 +26586,8 @@ def _gmail_list_labels(**kwargs):
     try:
         return gs.list_labels(
             profile_id=profile,
+            exact_name=kwargs.get("exact_name"),
+            require_exact_match=kwargs.get("require_exact_match") is True,
             audit_context={
                 "namespace": kwargs.get("namespace"),
                 "source": "internal_mcp_gateway",
@@ -26715,6 +26721,7 @@ def _gmail_modify_labels(**kwargs):
             add_labels=kwargs.get("add_labels"),
             remove_labels=kwargs.get("remove_labels"),
             allow_mutation=allow_mutation,
+            verify_after=kwargs.get("verify_after") is True,
             audit_context={
                 "namespace": kwargs.get("namespace"),
                 "source": "internal_mcp_gateway",
@@ -35873,9 +35880,17 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
     )
     gmail_list_labels_input_schema = Schema(
         required={"profile": str},
-        optional={},
+        optional={
+            "exact_name": str,
+            "require_exact_match": bool,
+        },
         allow_unknown=False,
-        description="List Gmail labels for a profile (read-only).",
+        description=(
+            "List Gmail labels for a profile (read-only). exact_name performs "
+            "case-sensitive exact-name resolution and returns label_id plus "
+            "exact_match_count. require_exact_match=true fails unless exactly one "
+            "label matches."
+        ),
     )
     gmail_create_label_input_schema = Schema(
         required={"profile": str, "name": str, "allow_mutation": bool},
@@ -35912,9 +35927,15 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
         optional={
             "add_labels": list,
             "remove_labels": list,
+            "verify_after": bool,
         },
         allow_unknown=False,
-        description="Add/remove labels on a Gmail message. Requires allow_mutation=true and gmail.modify scope.",
+        description=(
+            "Atomically add/remove labels on a Gmail message. Requires "
+            "allow_mutation=true and gmail.modify scope. verify_after=true performs "
+            "an independent minimal message read-back and reconciles an "
+            "indeterminate modify response when the requested label state holds."
+        ),
     )
     definitions: List[MethodDefinition] = [
         MethodDefinition(
@@ -36469,7 +36490,10 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             },
             advisory_timeout_sec=15.0,
             hard_timeout_enabled=False,
-            description="List Gmail labels for a profile. Read-only; useful to discover label IDs for queries.",
+            description=(
+                "List Gmail labels for a profile. Read-only; exact_name can resolve "
+                "one case-sensitive label name to its mailbox-specific ID."
+            ),
         ),
         MethodDefinition(
             name="gmail_create_label",
@@ -36501,7 +36525,12 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             ),
             category="write",
             timeout_sec=20.0,
-            description="Add/remove labels on a Gmail message. Requires allow_mutation=true and profile with gmail.modify scope.",
+            description=(
+                "Atomically add/remove labels on a Gmail message. Requires "
+                "allow_mutation=true and profile with gmail.modify scope. Use "
+                "verify_after=true for independent canonical state read-back and "
+                "lost-response reconciliation."
+            ),
         ),
         MethodDefinition(
             name="search_knowledge_base",

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -3146,6 +3146,8 @@ async def _handle_gmail_list_labels(arguments: dict[str, Any]) -> list[TextConte
     try:
         result = gmail_service.list_labels(
             profile_id=profile,
+            exact_name=arguments.get("exact_name"),
+            require_exact_match=arguments.get("require_exact_match") is True,
             audit_context=_gmail_audit_context("gmail_list_labels"),
         )
         return [_json_text(result)]
@@ -3239,6 +3241,7 @@ async def _handle_gmail_modify_labels(arguments: dict[str, Any]) -> list[TextCon
             add_labels=arguments.get("add_labels"),
             remove_labels=arguments.get("remove_labels"),
             allow_mutation=allow_mutation,
+            verify_after=arguments.get("verify_after") is True,
             audit_context=_gmail_audit_context("gmail_modify_labels"),
         )
         return [_json_text(result)]

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -2782,19 +2782,25 @@
         },
         {
             "name": "gmail_list_labels",
-            "description": "List Gmail labels for a profile. Read-only; useful to discover label IDs for queries.",
+            "description": "List Gmail labels for a profile. Read-only; exact_name can resolve one case-sensitive label name to its mailbox-specific ID.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "profile": {
                         "type": "string"
+                    },
+                    "exact_name": {
+                        "type": "string"
+                    },
+                    "require_exact_match": {
+                        "type": "boolean"
                     }
                 },
                 "required": [
                     "profile"
                 ],
                 "additionalProperties": false,
-                "description": "List Gmail labels for a profile (read-only)."
+                "description": "List Gmail labels for a profile (read-only). exact_name performs case-sensitive exact-name resolution and returns label_id plus exact_match_count. require_exact_match=true fails unless exactly one label matches."
             }
         },
         {
@@ -2864,7 +2870,7 @@
         },
         {
             "name": "gmail_modify_labels",
-            "description": "Add/remove labels on a Gmail message. Requires allow_mutation=true and profile with gmail.modify scope.",
+            "description": "Atomically add/remove labels on a Gmail message. Requires allow_mutation=true and profile with gmail.modify scope. Use verify_after=true for independent canonical state read-back and lost-response reconciliation.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -2884,6 +2890,9 @@
                     "remove_labels": {
                         "type": "array",
                         "items": {}
+                    },
+                    "verify_after": {
+                        "type": "boolean"
                     }
                 },
                 "required": [
@@ -2892,7 +2901,7 @@
                     "allow_mutation"
                 ],
                 "additionalProperties": false,
-                "description": "Add/remove labels on a Gmail message. Requires allow_mutation=true and gmail.modify scope."
+                "description": "Atomically add/remove labels on a Gmail message. Requires allow_mutation=true and gmail.modify scope. verify_after=true performs an independent minimal message read-back and reconciles an indeterminate modify response when the requested label state holds."
             }
         },
         {

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -430,7 +430,11 @@ def _get_durable_definition_loader():
     return loader
 
 
-def _start_durable_workflow_system(app_logger) -> dict | None:
+def _start_durable_workflow_system(
+    app_logger,
+    *,
+    queue_ready_callback: Callable[[dict[str, Any]], None] | None = None,
+) -> dict | None:
     """Start the durable workflow worker and scheduler.
 
     Returns the system components dict or None if disabled/failed.
@@ -600,6 +604,14 @@ def _start_durable_workflow_system(app_logger) -> dict | None:
             "recovered_orphaned_instances": recovered,
             "released_ineligible_worker_claims": released_ineligible_claims,
         }
+        if queue_ready_callback is not None:
+            try:
+                queue_ready_callback(dict(result))
+            except Exception as callback_exc:
+                app_logger.warning(
+                    "[durable_workflows] Queue-ready callback failed: %s",
+                    callback_exc,
+                )
 
         entity_workflow_bootstrap_report = _run_workflow_family_bootstrap(
             label="entity workflow",
@@ -2599,17 +2611,58 @@ def _configure_durable_workflow_startup(app: Flask) -> None:
     ).strip().lower() in {"1", "true", "yes", "on"}
 
     def _bootstrap_durable_workflow_system() -> None:
+        core_components: dict[str, Any] | None = None
+        shutdown_registered = False
+        bootstrap_started_at = _dt.datetime.now(_dt.timezone.utc).isoformat()
         _set_durable_workflow_startup_status_snapshot(
             app,
             {
                 "state": "initialising",
                 "ready": False,
-                "started_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+                "started_at": bootstrap_started_at,
             },
         )
         startup_perf = time.perf_counter()
+
+        def _mark_queue_ready(components: dict[str, Any]) -> None:
+            nonlocal core_components
+            nonlocal shutdown_registered
+            core_components = dict(components)
+            duration_ms = int((time.perf_counter() - startup_perf) * 1000)
+            _set_durable_workflow_components_snapshot(app, core_components)
+            _set_durable_workflow_startup_status_snapshot(
+                app,
+                {
+                    "state": "ready",
+                    "ready": True,
+                    "started_at": bootstrap_started_at,
+                    "duration_ms": duration_ms,
+                    "startup_phase": "canonical_maintenance",
+                    "maintenance_in_progress": True,
+                    "workflow_bootstrap_summary": (
+                        _build_durable_workflow_bootstrap_summary(core_components)
+                    ),
+                },
+            )
+            if not shutdown_registered:
+                import atexit
+
+                atexit.register(_stop_durable_workflow_system)
+                shutdown_registered = True
+            try:
+                app.logger.info(
+                    "[durable_workflows] Core ready in %dms; "
+                    "canonical startup maintenance continues in background.",
+                    duration_ms,
+                )
+            except Exception:
+                pass
+
         try:
-            components = _start_durable_workflow_system(app.logger)
+            components = _start_durable_workflow_system(
+                app.logger,
+                queue_ready_callback=_mark_queue_ready,
+            )
             duration_ms = int((time.perf_counter() - startup_perf) * 1000)
             if components is not None:
                 _set_durable_workflow_components_snapshot(app, components)
@@ -2618,8 +2671,10 @@ def _configure_durable_workflow_startup(app: Flask) -> None:
                     {
                         "state": "ready",
                         "ready": True,
-                        "started_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+                        "started_at": bootstrap_started_at,
                         "duration_ms": duration_ms,
+                        "startup_phase": "complete",
+                        "maintenance_in_progress": False,
                         "workflow_bootstrap_summary": _build_durable_workflow_bootstrap_summary(
                             components
                         ),
@@ -2634,29 +2689,69 @@ def _configure_durable_workflow_startup(app: Flask) -> None:
                 except Exception:
                     pass
 
-                import atexit
+                if not shutdown_registered:
+                    import atexit
 
-                atexit.register(_stop_durable_workflow_system)
+                    atexit.register(_stop_durable_workflow_system)
+                    shutdown_registered = True
+            else:
+                if core_components is None:
+                    _set_durable_workflow_startup_status_snapshot(
+                        app,
+                        {
+                            "state": "not_started",
+                            "ready": False,
+                            "started_at": bootstrap_started_at,
+                            "duration_ms": duration_ms,
+                        },
+                    )
+                else:
+                    _set_durable_workflow_startup_status_snapshot(
+                        app,
+                        {
+                            "state": "ready",
+                            "ready": True,
+                            "started_at": bootstrap_started_at,
+                            "duration_ms": duration_ms,
+                            "startup_phase": "canonical_maintenance_failed",
+                            "maintenance_in_progress": False,
+                            "maintenance_error": "startup_maintenance_failed",
+                            "workflow_bootstrap_summary": (
+                                _build_durable_workflow_bootstrap_summary(
+                                    core_components
+                                )
+                            ),
+                        },
+                    )
+        except Exception as exc:  # pragma: no cover
+            if core_components is None:
+                _set_durable_workflow_startup_status_snapshot(
+                    app,
+                    {
+                        "state": "failed",
+                        "ready": False,
+                        "started_at": bootstrap_started_at,
+                        "error": str(exc),
+                    },
+                )
             else:
                 _set_durable_workflow_startup_status_snapshot(
                     app,
                     {
-                        "state": "not_started",
-                        "ready": False,
-                        "started_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
-                        "duration_ms": duration_ms,
+                        "state": "ready",
+                        "ready": True,
+                        "started_at": bootstrap_started_at,
+                        "duration_ms": int(
+                            (time.perf_counter() - startup_perf) * 1000
+                        ),
+                        "startup_phase": "canonical_maintenance_failed",
+                        "maintenance_in_progress": False,
+                        "maintenance_error": str(exc),
+                        "workflow_bootstrap_summary": (
+                            _build_durable_workflow_bootstrap_summary(core_components)
+                        ),
                     },
                 )
-        except Exception as exc:  # pragma: no cover
-            _set_durable_workflow_startup_status_snapshot(
-                app,
-                {
-                    "state": "failed",
-                    "ready": False,
-                    "started_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
-                    "error": str(exc),
-                },
-            )
             try:
                 app.logger.warning(
                     "[startup] Durable workflow system startup failed: %s", exc

--- a/src/backend/services/email_source_representation_convergence_schedule_bootstrap_service.py
+++ b/src/backend/services/email_source_representation_convergence_schedule_bootstrap_service.py
@@ -15,8 +15,9 @@ from ..workflows.durable.models import ScheduleType, WorkflowSchedule
 from ..workflows.durable.startup import get_instance_manager
 
 EMAIL_ARXIV_REPRESENTATION_CONVERGENCE_SCHEDULE_MANAGED_KEY = (
-    "email_arxiv_representation_convergence_v1"
+    "email_arxiv_representation_convergence_v2"
 )
+_LEGACY_MANAGED_KEYS = frozenset({"email_arxiv_representation_convergence_v1"})
 
 _bootstrap_lock = threading.Lock()
 _bootstrap_completed = False
@@ -83,11 +84,11 @@ def _desired_schedule_config() -> dict[str, Any]:
     )
     gmail_profile = _clean_env(
         "VON_EMAIL_ARXIV_CONVERGENCE_GMAIL_PROFILE",
-        "#V#gmail_profile_zhan_gmail",
+        "#V#gmail_profile_vonwitbrock_gmail",
     )
     base_gmail_query = _clean_env(
         "VON_EMAIL_ARXIV_CONVERGENCE_BASE_QUERY",
-        "arxiv.org newer_than:365d",
+        "arxiv.org",
     )
     return {
         **identity,
@@ -99,8 +100,10 @@ def _desired_schedule_config() -> dict[str, Any]:
             ),
             "trigger_source": "email_arxiv_representation_convergence_schedule",
             "prompt": (
-                "Look for recent email messages about arxiv papers and represent "
-                "them if they are not already represented."
+                "Process the newest Inbox messages containing arXiv paper "
+                "references that do not have VON/PAPER/REPRESENTED. Represent "
+                "each paper, verify current processing evidence, then apply the "
+                "represented label and remove INBOX."
             ),
             "gmail_profile": gmail_profile,
             "base_gmail_query": base_gmail_query,
@@ -119,11 +122,14 @@ def _is_managed_schedule(schedule: WorkflowSchedule, desired: dict[str, Any]) ->
         schedule.default_inputs if isinstance(schedule.default_inputs, dict) else {}
     )
     marker = str(inputs.get("managed_schedule_key") or "").strip()
-    if marker == EMAIL_ARXIV_REPRESENTATION_CONVERGENCE_SCHEDULE_MANAGED_KEY:
+    known_keys = {
+        EMAIL_ARXIV_REPRESENTATION_CONVERGENCE_SCHEDULE_MANAGED_KEY,
+        *_LEGACY_MANAGED_KEYS,
+    }
+    if marker in known_keys:
         return True
-    return EMAIL_ARXIV_REPRESENTATION_CONVERGENCE_SCHEDULE_MANAGED_KEY in str(
-        schedule.description or ""
-    )
+    description = str(schedule.description or "")
+    return any(key in description for key in known_keys)
 
 
 def _matches_desired(schedule: WorkflowSchedule, desired: dict[str, Any]) -> bool:
@@ -138,15 +144,22 @@ def _matches_desired(schedule: WorkflowSchedule, desired: dict[str, Any]) -> boo
         and str(schedule.org_id or "") == str(desired["org_id"])
         and str(schedule.namespace or "") == str(desired["namespace"])
         and inputs == desired["default_inputs"]
+        and schedule.next_run_at is not None
     )
 
 
-def ensure_email_arxiv_representation_convergence_schedule() -> dict[str, Any]:
+def ensure_email_arxiv_representation_convergence_schedule(
+    *,
+    activate: bool | None = None,
+) -> dict[str, Any]:
     """Ensure a managed interval schedule exists for recurring arXiv email runs."""
 
     global _bootstrap_completed
 
-    if not _env_flag("VON_EMAIL_ARXIV_CONVERGENCE_SCHEDULE_ENABLE", default=True):
+    if (
+        not _env_flag("VON_EMAIL_ARXIV_CONVERGENCE_SCHEDULE_ENABLE", default=True)
+        and activate is not True
+    ):
         _bootstrap_completed = True
         return {
             "success": True,
@@ -158,7 +171,7 @@ def ensure_email_arxiv_representation_convergence_schedule() -> dict[str, Any]:
         }
 
     with _bootstrap_lock:
-        if _bootstrap_completed:
+        if _bootstrap_completed and activate is None:
             return {
                 "success": True,
                 "ensured": True,
@@ -169,6 +182,14 @@ def ensure_email_arxiv_representation_convergence_schedule() -> dict[str, Any]:
             }
 
         desired = _desired_schedule_config()
+        should_activate = (
+            bool(activate)
+            if activate is not None
+            else _env_flag(
+                "VON_EMAIL_ARXIV_CONVERGENCE_SCHEDULE_AUTO_ACTIVATE",
+                default=False,
+            )
+        )
         manager = get_instance_manager()
         schedules = manager.list_schedules(limit=500)
         managed = [item for item in schedules if _is_managed_schedule(item, desired)]
@@ -182,7 +203,7 @@ def ensure_email_arxiv_representation_convergence_schedule() -> dict[str, Any]:
         if matching:
             primary = sorted(matching, key=lambda item: item.schedule_id)[0]
             active_schedule_id = primary.schedule_id
-            if not primary.enabled and manager.set_schedule_enabled(
+            if should_activate and not primary.enabled and manager.set_schedule_enabled(
                 primary.schedule_id, True
             ):
                 updated_count += 1
@@ -218,6 +239,7 @@ def ensure_email_arxiv_representation_convergence_schedule() -> dict[str, Any]:
                 ),
                 start_at=datetime.now(timezone.utc),
             )
+            schedule.enabled = should_activate
             active_schedule_id = manager.create_schedule(schedule)
             created_count += 1
 
@@ -237,6 +259,19 @@ def ensure_email_arxiv_representation_convergence_schedule() -> dict[str, Any]:
             "namespace": str(desired["namespace"]),
             "gmail_profile": desired["default_inputs"]["gmail_profile"],
             "gmail_max_results": int(desired["default_inputs"]["gmail_max_results"]),
+            "schedule_enabled": bool(
+                should_activate
+                or (
+                    matching
+                    and bool(
+                        next(
+                            item.enabled
+                            for item in matching
+                            if item.schedule_id == active_schedule_id
+                        )
+                    )
+                )
+            ),
         }
 
 

--- a/src/backend/services/source_processing_marker_service.py
+++ b/src/backend/services/source_processing_marker_service.py
@@ -319,6 +319,7 @@ def _marker_response_from_payload(
     text_relation_result: Mapping[str, Any] | None = None,
     expected_source_fingerprint: str | None = None,
     expected_processing_authority_fingerprint: str | None = None,
+    require_represented_artifacts: bool = False,
 ) -> dict[str, Any]:
     payload = dict(evidence_payload or {})
     represented_ids = _ordered_unique(
@@ -343,11 +344,14 @@ def _marker_response_from_payload(
         and stored_source_fingerprint == expected_fingerprint
     )
     source_system = _clean_text(payload.get("source_system")).lower()
-    represented_outputs_required = source_system in {
-        "spreadsheet_dataset",
-        "spreadsheet_record",
-    }
-    represented_ids_exist = True
+    represented_outputs_required = bool(require_represented_artifacts) or (
+        source_system
+        in {
+            "spreadsheet_dataset",
+            "spreadsheet_record",
+        }
+    )
+    represented_ids_exist = not represented_outputs_required or bool(represented_ids)
     if represented_outputs_required and represented_ids:
         represented_ids_exist = set(represented_ids).issubset(
             _find_existing_concept_ids(represented_ids)
@@ -397,6 +401,7 @@ def _marker_response_from_payload(
             expected_authority_fingerprint or None
         ),
         "processing_authority_matches": processing_authority_matches,
+        "represented_artifacts_required": represented_outputs_required,
         "represented_artifacts_exist": represented_ids_exist,
         "source_processing_current": source_processing_current,
         # Keep the output contract stable when the marker has not been written
@@ -440,6 +445,7 @@ def get_source_processing_marker(
     source_profile: str | None = None,
     source_fingerprint: str | None = None,
     processing_authority_fingerprint: str | None = None,
+    require_represented_artifacts: bool = False,
     **_: Any,
 ) -> dict[str, Any]:
     source_system_clean = _clean_text(source_system)
@@ -466,6 +472,7 @@ def get_source_processing_marker(
         expected_processing_authority_fingerprint=(
             processing_authority_fingerprint
         ),
+        require_represented_artifacts=require_represented_artifacts,
     )
 
 
@@ -487,6 +494,7 @@ def record_source_processing_marker(
     organisation_concept_id: str | None = None,
     source_fingerprint: str | None = None,
     processing_authority_fingerprint: str | None = None,
+    require_represented_artifacts: bool = False,
     processing_evidence: Mapping[str, Any] | None = None,
     **_: Any,
 ) -> dict[str, Any]:
@@ -632,6 +640,7 @@ def record_source_processing_marker(
         expected_processing_authority_fingerprint=(
             processing_authority_fingerprint
         ),
+        require_represented_artifacts=require_represented_artifacts,
     )
 
 

--- a/src/backend/services/tool_metadata_service.py
+++ b/src/backend/services/tool_metadata_service.py
@@ -589,6 +589,10 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
         "salience": "medium",
         "category": "gmail",
         "display_template": "{count} labels",
+        "planner_hint": (
+            "Use exact_name with require_exact_match=true when a workflow needs "
+            "one existing mailbox-specific label ID before mutation."
+        ),
     },
     "gmail_create_label": {
         "salience": "medium",
@@ -605,6 +609,11 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
         "salience": "medium",
         "category": "gmail",
         "display_template": "Labels modified",
+        "planner_hint": (
+            "Use one message-level call for atomic add/remove. Set verify_after=true "
+            "when the outcome requires independent canonical label read-back and "
+            "lost-response reconciliation."
+        ),
     },
     "upsert_text_relation": {
         "salience": "medium",

--- a/src/backend/services/workflow_capability_service.py
+++ b/src/backend/services/workflow_capability_service.py
@@ -2911,8 +2911,12 @@ def run_workflow_capability_index_startup_check(
     started_at = time.perf_counter()
     checked_at_utc = _utc_now_iso()
 
+    # Startup readiness must stay bounded even when an invalidated, older
+    # generation still owns the rebuild lock. Start or join the background
+    # build and wait only for the declared startup interval; routed request
+    # paths can continue to use their existing explicit blocking policy.
     ensure_workflow_capability_index_populated(
-        block=True,
+        block=False,
         max_wait_seconds=effective_timeout,
         workflow_registry=workflow_registry,
     )

--- a/src/backend/workflows/durable/durable_executor.py
+++ b/src/backend/workflows/durable/durable_executor.py
@@ -15,28 +15,24 @@ from ...db.transient_errors import run_with_transient_mongo_retry
 from ...services.relationship_extent_index_service import (
     defer_relationship_extent_index_sync,
 )
-from ..engine import (
-    WorkflowDefinition,
-    materialise_terminal_effect_context,
-    WorkflowExecutor,
-)
-from ..metadata_validation import (
-    format_metadata_validation_error,
-)
 from ..action_registry import (
     ActionRegistry,
     WorkflowEnvironment,
     WorkflowExecutionScope,
 )
-from ..trace_model import WorkflowExecutionTrace
+from ..engine import (
+    WorkflowDefinition,
+    WorkflowExecutor,
+    materialise_terminal_effect_context,
+)
 from ..execution_contracts import (
     LAST_WORKFLOW_CHECKPOINT_PAUSE_EVENT_KEY,
-    WORKFLOW_CONTROL_SIGNAL_RETURN,
     WORKFLOW_CHECKPOINT_PAUSE_EVENTS_KEY,
     WORKFLOW_CHECKPOINT_PAUSE_RECEIPT_KEY,
     WORKFLOW_CHECKPOINT_PAUSE_REQUEST_KEY,
     WORKFLOW_CHECKPOINT_PAUSE_REQUEST_SCHEMA_VERSION,
     WORKFLOW_CHECKPOINT_RESUME_RECEIPT_KEY,
+    WORKFLOW_CONTROL_SIGNAL_RETURN,
     WORKFLOW_RETURN_PAYLOAD_KEY,
     build_workflow_result_envelope,
     clear_control_signal_context,
@@ -44,18 +40,17 @@ from ..execution_contracts import (
     set_workflow_result_envelope,
     workflow_final_state_is_failure_like,
 )
+from ..metadata_validation import (
+    format_metadata_validation_error,
+)
 from ..plan_state_runtime import (
     apply_workflow_step_checkpoint,
     compute_plan_state_progress,
     evaluate_workflow_completion_gate,
     mark_workflow_plan_state_resume,
 )
+from ..trace_model import WorkflowExecutionTrace
 from ..trace_store import insert_workflow_execution_trace
-from .checkpoint_context_projection import (
-    CHECKPOINT_CONTEXT_PROJECTION_KEY,
-    CHECKPOINT_CONTEXT_PROJECTION_SCHEMA_VERSION,
-    project_workflow_context_for_checkpoint,
-)
 from .authority_snapshot_attestation import (
     DURABLE_EXECUTED_WORKFLOW_DEFINITION_IDENTITY_KEY,
     PROMPT_CONTEXT_DIAGNOSTICS_KEY,
@@ -65,7 +60,17 @@ from .authority_snapshot_attestation import (
     validate_authority_checkpoint_attestation,
     worker_claim_supports_exact_authority_snapshot,
 )
+from .checkpoint_context_projection import (
+    CHECKPOINT_CONTEXT_PROJECTION_KEY,
+    CHECKPOINT_CONTEXT_PROJECTION_SCHEMA_VERSION,
+    project_workflow_context_for_checkpoint,
+)
 from .instance_manager import WorkflowInstanceManager
+from .llm_cost_tracking import (
+    LLM_USAGE_COST_SUMMARY_KEY,
+    build_durable_llm_usage_cost_summary,
+    project_llm_calls_for_cost,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -556,6 +561,16 @@ class DurableWorkflowExecutor(WorkflowExecutor):
             context = dict(instance.inputs)
             current_state = definition.initial_state
             step_index = 0
+            # Launch inputs are not execution telemetry authority. A client,
+            # scheduler input, or represented workflow parameter must not be
+            # able to invent provider calls or monetary usage before the
+            # executor observes them.
+            for telemetry_key in (
+                "llm_calls",
+                "aux_llm_calls",
+                LLM_USAGE_COST_SUMMARY_KEY,
+            ):
+                context.pop(telemetry_key, None)
         persisted_checkpoint_state = instance.current_state
         persisted_checkpoint_step_index = instance.step_index
         lifecycle_context_keys = (
@@ -690,8 +705,8 @@ class DurableWorkflowExecutor(WorkflowExecutor):
 
         # Create execution environment
         from ...languagemodels.llm_interface import (
-            get_active_model_parameters,
             get_active_model_name,
+            get_active_model_parameters,
             get_llm_client,
             resolve_provider_from_model_concept,
         )
@@ -808,6 +823,39 @@ class DurableWorkflowExecutor(WorkflowExecutor):
             if resolved_provider:
                 trace.metadata["default_provider"] = resolved_provider
         persisted_execution_trace_id: str | None = None
+        cost_model_registry_snapshot: Any = None
+        cost_model_registry_loaded = False
+
+        def _refresh_llm_usage_cost_summary() -> dict[str, Any]:
+            """Persist actual usage and an honest registry-priced estimate."""
+
+            nonlocal cost_model_registry_loaded
+            nonlocal cost_model_registry_snapshot
+            recorded_calls = project_llm_calls_for_cost(context.get("llm_calls"))
+            if recorded_calls and not cost_model_registry_loaded:
+                cost_model_registry_loaded = True
+                try:
+                    from ...services.model_registry_service import (
+                        get_model_registry_snapshot,
+                    )
+
+                    cost_model_registry_snapshot = get_model_registry_snapshot()
+                except Exception:
+                    # Usage remains canonical even when the price authority is
+                    # unavailable. The summary will report an unavailable or
+                    # partial estimate instead of inventing zero cost.
+                    logger.warning(
+                        "[durable_workflow] Model pricing unavailable for %s",
+                        instance_id,
+                        exc_info=True,
+                    )
+                    cost_model_registry_snapshot = None
+            summary = build_durable_llm_usage_cost_summary(
+                {"llm_calls": recorded_calls},
+                model_registry=cost_model_registry_snapshot,
+            )
+            context[LLM_USAGE_COST_SUMMARY_KEY] = summary
+            return summary
 
         total_steps = max(1, len(definition.states))
         run_support = self._resolve_run_support(definition=definition)
@@ -820,6 +868,7 @@ class DurableWorkflowExecutor(WorkflowExecutor):
             checkpoint_step_index: int,
         ) -> tuple[dict[str, Any], dict[str, Any] | None]:
             _reassert_executed_definition_identity()
+            _refresh_llm_usage_cost_summary()
             if any(
                 context.get(key) is not None
                 for key in (
@@ -931,6 +980,7 @@ class DurableWorkflowExecutor(WorkflowExecutor):
         ) -> DurableWorkflowResult:
             nonlocal persisted_execution_trace_id
             _reassert_executed_definition_identity()
+            _refresh_llm_usage_cost_summary()
             result_envelope = build_workflow_result_envelope(
                 workflow_id=definition.workflow_id,
                 completed=completed,

--- a/src/backend/workflows/durable/execution_observability.py
+++ b/src/backend/workflows/durable/execution_observability.py
@@ -23,6 +23,7 @@ from ..terminal_outcome_receipts import (
     terminal_outcome_receipt_projection_from_record,
 )
 from ..trace_store import get_workflow_execution_trace
+from .llm_cost_tracking import LLM_USAGE_COST_SUMMARY_KEY
 from .workflow_instance_submission_service import (
     WorkflowInstanceSubmissionResult,
     build_verified_instance_launch_payload,
@@ -393,6 +394,10 @@ def build_workflow_execution_telemetry(
         },
         "progress": dict(instance_payload.get("progress") or {}),
         "execution_trace_id": instance_payload.get("execution_trace_id"),
+        LLM_USAGE_COST_SUMMARY_KEY: _mapping_or_none(
+            instance_payload.get(LLM_USAGE_COST_SUMMARY_KEY)
+            or workflow_context.get(LLM_USAGE_COST_SUMMARY_KEY)
+        ),
     }
     if include_step_result_envelopes:
         telemetry["step_result_envelopes"] = step_result_envelopes

--- a/src/backend/workflows/durable/failed_output_diagnostics.py
+++ b/src/backend/workflows/durable/failed_output_diagnostics.py
@@ -8,11 +8,12 @@ from typing import Any
 
 from ..execution_contracts import (
     LAST_WORKFLOW_STEP_RESULT_ENVELOPE_KEY,
-    WORKFLOW_RETURN_PAYLOAD_KEY,
     WORKFLOW_RESULT_ENVELOPE_KEY,
+    WORKFLOW_RETURN_PAYLOAD_KEY,
     WORKFLOW_STEP_RESULT_ENVELOPES_KEY,
 )
 from ..metadata_validation import LAST_METADATA_EVENT_KEY, WORKFLOW_METADATA_EVENTS_KEY
+from .llm_cost_tracking import LLM_USAGE_COST_SUMMARY_KEY
 
 COMPLETED_WORKFLOW_OUTPUTS_SCHEMA_VERSION = "workflow_completed_outputs.v1"
 FAILED_WORKFLOW_OUTPUTS_SCHEMA_VERSION = "workflow_failed_outputs.v1"
@@ -287,6 +288,9 @@ def build_completed_workflow_outputs(
         },
         "context_summary": _context_key_summary(context),
     }
+    llm_usage_cost_summary = _mapping(context.get(LLM_USAGE_COST_SUMMARY_KEY))
+    if llm_usage_cost_summary is not None:
+        outputs[LLM_USAGE_COST_SUMMARY_KEY] = llm_usage_cost_summary
 
     if isinstance(latest_step, Mapping):
         outputs["latest_step_result_summary"] = {
@@ -426,6 +430,9 @@ def build_failed_workflow_outputs(
             max_text_chars=max_text_chars,
         ),
     }
+    llm_usage_cost_summary = _mapping(context.get(LLM_USAGE_COST_SUMMARY_KEY))
+    if llm_usage_cost_summary is not None:
+        outputs[LLM_USAGE_COST_SUMMARY_KEY] = llm_usage_cost_summary
 
     if isinstance(latest_step, Mapping):
         outputs["failed_action_diagnostics"] = {

--- a/src/backend/workflows/durable/instance_manager.py
+++ b/src/backend/workflows/durable/instance_manager.py
@@ -37,12 +37,14 @@ from .authority_snapshot_attestation import (
     EXACT_AUTHORITY_SNAPSHOT_WORKER_CAPABILITY,
     validate_authority_checkpoint_attestation,
 )
+from .llm_cost_tracking import LLM_USAGE_COST_SUMMARY_KEY
 from .models import (
     EventWorkflowBinding,
     WorkflowInstance,
     WorkflowInstanceStatus,
     WorkflowSchedule,
 )
+from .vontology_schedule_repository import VontologyScheduleRepository
 from .worker_identity import (
     build_claim_provenance,
     get_configured_min_worker_build,
@@ -50,7 +52,6 @@ from .worker_identity import (
     worker_build_match_tokens,
     worker_satisfies_required_build,
 )
-from .vontology_schedule_repository import VontologyScheduleRepository
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +109,7 @@ _WORKFLOW_INSTANCE_STATUS_SUMMARY_PROJECTION: dict[str, Any] = {
     "source_event_id": 1,
     "event_idempotency_key": 1,
     "execution_trace_id": 1,
+    LLM_USAGE_COST_SUMMARY_KEY: 1,
     "has_outputs": {"$ne": [{"$ifNull": ["$outputs", None]}, None]},
 }
 
@@ -1914,6 +1916,13 @@ class WorkflowInstanceManager:
             },
             "$unset": {DURABLE_AUTHORITY_CHECKPOINT_ATTESTATION_FIELD: ""},
         }
+        llm_usage_cost_summary = compacted_workflow_data.get(
+            LLM_USAGE_COST_SUMMARY_KEY
+        )
+        if isinstance(llm_usage_cost_summary, Mapping):
+            update["$set"][LLM_USAGE_COST_SUMMARY_KEY] = dict(
+                llm_usage_cost_summary
+            )
         if step_index is not None:
             update["$set"]["step_index"] = step_index
         if error is not None:
@@ -2114,6 +2123,7 @@ class WorkflowInstanceManager:
         outputs: dict[str, Any] | None = None,
         final_state: str | None = None,
         execution_trace_id: str | None = None,
+        llm_usage_cost_summary: Mapping[str, Any] | None = None,
         worker_id: str | None = None,
         claim_token: str | None = None,
     ) -> bool:
@@ -2152,6 +2162,10 @@ class WorkflowInstanceManager:
             update["$set"]["current_state"] = final_state
         if execution_trace_id is not None:
             update["$set"]["execution_trace_id"] = execution_trace_id
+        if isinstance(llm_usage_cost_summary, Mapping):
+            update["$set"][LLM_USAGE_COST_SUMMARY_KEY] = dict(
+                llm_usage_cost_summary
+            )
 
         completion_query = self._claim_fence_query(
             instance_id=instance_id,
@@ -2190,6 +2204,11 @@ class WorkflowInstanceManager:
                     if execution_trace_id is not None
                     else instance_before.execution_trace_id
                 ),
+                llm_usage_cost_summary=(
+                    dict(llm_usage_cost_summary)
+                    if isinstance(llm_usage_cost_summary, Mapping)
+                    else instance_before.llm_usage_cost_summary
+                ),
             )
             self._broadcast_instance(completed_instance)
             self._reconcile_conversation_turn_terminal_effect(completed_instance)
@@ -2212,6 +2231,7 @@ class WorkflowInstanceManager:
         increment_retry: bool = True,
         outputs: dict[str, Any] | None = None,
         execution_trace_id: str | None = None,
+        llm_usage_cost_summary: Mapping[str, Any] | None = None,
         worker_id: str | None = None,
         claim_token: str | None = None,
     ) -> bool:
@@ -2271,6 +2291,10 @@ class WorkflowInstanceManager:
             )
         if execution_trace_id is not None:
             update["$set"]["execution_trace_id"] = execution_trace_id
+        if isinstance(llm_usage_cost_summary, Mapping):
+            update["$set"][LLM_USAGE_COST_SUMMARY_KEY] = dict(
+                llm_usage_cost_summary
+            )
         if increment_retry:
             update["$inc"] = {"retry_count": 1}
 
@@ -2323,6 +2347,11 @@ class WorkflowInstanceManager:
                     execution_trace_id
                     if execution_trace_id is not None
                     else instance_before.execution_trace_id
+                ),
+                llm_usage_cost_summary=(
+                    dict(llm_usage_cost_summary)
+                    if isinstance(llm_usage_cost_summary, Mapping)
+                    else instance_before.llm_usage_cost_summary
                 ),
             )
             self._broadcast_instance(failed_instance)
@@ -2582,6 +2611,11 @@ class WorkflowInstanceManager:
             "progress_updated_at": now,
             "execution_trace_id": execution_trace_id,
         }
+        llm_usage_cost_summary = compacted_workflow_data.get(
+            LLM_USAGE_COST_SUMMARY_KEY
+        )
+        if isinstance(llm_usage_cost_summary, Mapping):
+            set_fields[LLM_USAGE_COST_SUMMARY_KEY] = dict(llm_usage_cost_summary)
         if progress_current is not None:
             set_fields["progress_current"] = progress_current
         if progress_total is not None:
@@ -3170,6 +3204,19 @@ class WorkflowInstanceManager:
             True if updated.
         """
         return self._schedule_repo.update_schedule_after_run(
+            schedule_id=schedule_id,
+            next_run_at=next_run_at,
+        )
+
+    def update_schedule_next_run(
+        self,
+        schedule_id: str,
+        *,
+        next_run_at: datetime | None,
+    ) -> bool:
+        """Advance a schedule without recording a completed trigger."""
+
+        return self._schedule_repo.update_schedule_next_run(
             schedule_id=schedule_id,
             next_run_at=next_run_at,
         )

--- a/src/backend/workflows/durable/llm_cost_tracking.py
+++ b/src/backend/workflows/durable/llm_cost_tracking.py
@@ -1,0 +1,100 @@
+"""Content-free LLM usage collection for durable workflow executions.
+
+Durable workflows can contain nested represented subworkflows. The child
+runtime intentionally does not leak its general execution context into the
+parent, but provider usage must still be attributable to the top-level durable
+instance. This module keeps only the bounded fields consumed by the existing
+LLM usage/cost service and builds the same canonical summary used by chat
+turns.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping, Sequence
+from typing import Any
+
+from ...services.llm_usage_cost_service import build_llm_usage_cost_summary
+
+LLM_USAGE_COST_SUMMARY_KEY = "llm_usage_cost_summary"
+
+_COST_CALL_FIELDS = (
+    "call_id",
+    "type",
+    "call_type",
+    "stage",
+    "status",
+    "success",
+    "provider_request_sent",
+    "provider",
+    "requested_model",
+    "selected_model",
+    "effective_model",
+    "model_identity_source",
+    "effective_service_tier",
+    "connection_id",
+    "started_at_utc",
+    "ended_at_utc",
+    "duration_ms",
+    "usage",
+    "transport",
+)
+
+
+def project_llm_calls_for_cost(value: Any) -> list[dict[str, Any]]:
+    """Return a bounded, content-free projection of recorded model calls."""
+
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    projected: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        call = {
+            field: item.get(field)
+            for field in _COST_CALL_FIELDS
+            if item.get(field) is not None
+        }
+        if call:
+            projected.append(call)
+    return projected
+
+
+def merge_nested_llm_calls_for_cost(
+    parent_context: MutableMapping[str, Any],
+    child_context: Mapping[str, Any] | None,
+) -> None:
+    """Accumulate child model usage without copying child prompts or outputs."""
+
+    if not isinstance(child_context, Mapping):
+        return
+    child_calls = project_llm_calls_for_cost(child_context.get("llm_calls"))
+    if not child_calls:
+        return
+    parent_calls = parent_context.get("llm_calls")
+    if not isinstance(parent_calls, list):
+        parent_calls = []
+        parent_context["llm_calls"] = parent_calls
+    for child_call in child_calls:
+        if child_call not in parent_calls:
+            parent_calls.append(child_call)
+
+
+def build_durable_llm_usage_cost_summary(
+    context: Mapping[str, Any] | None,
+    *,
+    model_registry: Any = None,
+) -> dict[str, Any]:
+    """Build one canonical summary for a durable workflow context."""
+
+    calls = project_llm_calls_for_cost(
+        context.get("llm_calls") if isinstance(context, Mapping) else None
+    )
+    return build_llm_usage_cost_summary(calls, model_registry=model_registry)
+
+
+__all__ = [
+    "LLM_USAGE_COST_SUMMARY_KEY",
+    "build_durable_llm_usage_cost_summary",
+    "merge_nested_llm_calls_for_cost",
+    "project_llm_calls_for_cost",
+]

--- a/src/backend/workflows/durable/models.py
+++ b/src/backend/workflows/durable/models.py
@@ -251,6 +251,10 @@ class WorkflowInstance:
     # Tracing
     execution_trace_id: str | None = None
 
+    # Content-free provider usage and registry-priced cost estimate. The
+    # schedule/occurrence attribution remains on this instance record.
+    llm_usage_cost_summary: dict[str, Any] | None = None
+
     @classmethod
     def create(
         cls,
@@ -326,6 +330,7 @@ class WorkflowInstance:
             "max_retries": self.max_retries,
             "schedule_id": self.schedule_id,
             "execution_trace_id": self.execution_trace_id,
+            "llm_usage_cost_summary": self.llm_usage_cost_summary,
         }
 
         # Persist event linkage fields only when present so sparse/partial indexes
@@ -402,6 +407,11 @@ class WorkflowInstance:
             source_event_id=doc.get("source_event_id"),
             event_idempotency_key=doc.get("event_idempotency_key"),
             execution_trace_id=doc.get("execution_trace_id"),
+            llm_usage_cost_summary=(
+                dict(doc["llm_usage_cost_summary"])
+                if isinstance(doc.get("llm_usage_cost_summary"), dict)
+                else None
+            ),
         )
 
     @staticmethod
@@ -476,6 +486,11 @@ class WorkflowInstance:
             "source_event_id": doc.get("source_event_id"),
             "event_idempotency_key": doc.get("event_idempotency_key"),
             "execution_trace_id": doc.get("execution_trace_id"),
+            "llm_usage_cost_summary": (
+                dict(doc["llm_usage_cost_summary"])
+                if isinstance(doc.get("llm_usage_cost_summary"), dict)
+                else None
+            ),
         }
 
     def to_status_dict(self) -> dict[str, Any]:
@@ -513,6 +528,7 @@ class WorkflowInstance:
                 "source_event_id": self.source_event_id,
                 "event_idempotency_key": self.event_idempotency_key,
                 "execution_trace_id": self.execution_trace_id,
+                "llm_usage_cost_summary": self.llm_usage_cost_summary,
             }
         )
 

--- a/src/backend/workflows/durable/scheduler.py
+++ b/src/backend/workflows/durable/scheduler.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
 
 from .instance_manager import WorkflowInstanceManager
-from .models import WorkflowSchedule, ScheduleType
+from .models import ScheduleType, WorkflowInstanceStatus, WorkflowSchedule
 from .workflow_instance_submission_service import submit_verified_workflow_instance
 
 logger = logging.getLogger(__name__)
@@ -216,8 +216,9 @@ class WorkflowScheduler:
 
         for schedule in due_schedules:
             try:
-                self._trigger_schedule(schedule, now)
-                triggered_count += 1
+                instance_id = self._trigger_schedule(schedule, now)
+                if instance_id is not None:
+                    triggered_count += 1
             except Exception as e:
                 logger.exception(
                     "[scheduler] Failed to trigger schedule %s: %s",
@@ -247,22 +248,126 @@ class WorkflowScheduler:
                 total_ms,
             )
 
-    def _trigger_schedule(self, schedule: WorkflowSchedule, now: datetime) -> None:
+    def _active_instance_for_schedule(
+        self,
+        schedule: WorkflowSchedule,
+    ) -> Any | None:
+        """Return one active instance for this schedule, if present."""
+
+        instances = self._instance_manager.list_instances(
+            user_id=schedule.user_id,
+            namespace=schedule.namespace,
+            status=WorkflowInstanceStatus.active_values(),
+            workflow_id=schedule.workflow_id,
+            limit=100,
+        )
+        for instance in instances:
+            if getattr(instance, "schedule_id", None) == schedule.schedule_id:
+                return instance
+        return None
+
+    @staticmethod
+    def _occurrence_identity(
+        schedule: WorkflowSchedule,
+        now: datetime,
+        *,
+        manual: bool,
+    ) -> tuple[str, str, str]:
+        scheduled_for = now if manual else (schedule.next_run_at or now)
+        if scheduled_for.tzinfo is None:
+            scheduled_for = scheduled_for.replace(tzinfo=timezone.utc)
+        scheduled_for_utc = scheduled_for.astimezone(timezone.utc).isoformat()
+        occurrence_kind = "manual" if manual else "scheduled"
+        occurrence_id = (
+            f"{schedule.schedule_id}:{occurrence_kind}:{scheduled_for_utc}"
+        )
+        return (
+            scheduled_for_utc,
+            occurrence_id,
+            f"workflow_schedule_occurrence:{occurrence_id}",
+        )
+
+    def _advance_schedule_or_raise(
+        self,
+        schedule: WorkflowSchedule,
+        now: datetime,
+        *,
+        mark_run: bool = True,
+    ) -> None:
+        next_run = self._calculate_next_run(schedule, now)
+        update = (
+            self._instance_manager.update_schedule_after_run
+            if mark_run
+            else self._instance_manager.update_schedule_next_run
+        )
+        if not update(schedule.schedule_id, next_run_at=next_run):
+            raise RuntimeError(
+                f"schedule_next_run_update_failed:{schedule.schedule_id}"
+            )
+
+    def _trigger_schedule(
+        self,
+        schedule: WorkflowSchedule,
+        now: datetime,
+        *,
+        manual: bool = False,
+    ) -> str | None:
         """Trigger a single schedule.
 
         Args:
             schedule: The schedule to trigger.
             now: Current timestamp.
         """
-        # Create workflow instance via canonical verification pipeline.
+        scheduled_for_utc, occurrence_id, event_idempotency_key = (
+            self._occurrence_identity(schedule, now, manual=manual)
+        )
+        active_instance = self._active_instance_for_schedule(schedule)
+        if active_instance is not None:
+            active_instance_id = str(
+                getattr(active_instance, "instance_id", "") or ""
+            ).strip()
+            active_event_key = str(
+                getattr(active_instance, "event_idempotency_key", "") or ""
+            ).strip()
+            self._advance_schedule_or_raise(schedule, now, mark_run=False)
+            if active_event_key == event_idempotency_key and active_instance_id:
+                logger.info(
+                    "[scheduler] Reconciled schedule occurrence %s to active instance %s",
+                    occurrence_id,
+                    active_instance_id,
+                )
+                return active_instance_id
+            logger.info(
+                "[scheduler] Skipped overlapping occurrence %s; active instance=%s",
+                occurrence_id,
+                active_instance_id or "unknown",
+            )
+            return None
+
+        occurrence_inputs = dict(schedule.default_inputs)
+        occurrence_inputs.update(
+            {
+                "schedule_occurrence_id": occurrence_id,
+                "scheduled_for_utc": scheduled_for_utc,
+                "schedule_overlap_policy": "forbid",
+                "schedule_misfire_policy": "coalesce",
+            }
+        )
+
+        # Create workflow instance via canonical verification pipeline. The
+        # occurrence key is stable across scheduler retries and competing
+        # pollers, so the instance store provides the atomic deduplication point.
         submission = submit_verified_workflow_instance(
             manager=self._instance_manager,
             workflow_id=schedule.workflow_id,
             user_id=schedule.user_id,
             org_id=schedule.org_id,
             namespace=schedule.namespace,
-            inputs=schedule.default_inputs,
+            inputs=occurrence_inputs,
             schedule_id=schedule.schedule_id,
+            source_event_type="workflow.schedule.occurrence",
+            source_event_id=occurrence_id,
+            event_idempotency_key=event_idempotency_key,
         )
         if not submission.success or not submission.instance_id:
             raise RuntimeError(
@@ -277,21 +382,15 @@ class WorkflowScheduler:
             instance_id,
         )
 
-        # Calculate next run time
-        next_run = self._calculate_next_run(schedule, now)
-
-        # Update schedule
-        self._instance_manager.update_schedule_after_run(
-            schedule.schedule_id,
-            next_run_at=next_run,
-        )
+        self._advance_schedule_or_raise(schedule, now)
 
         # Notify callback
-        if self._on_schedule_triggered:
+        if self._on_schedule_triggered and submission.created_new is not False:
             try:
                 self._on_schedule_triggered(schedule, instance_id)
             except Exception:
                 pass
+        return instance_id
 
     def _calculate_next_run(
         self,
@@ -349,15 +448,7 @@ class WorkflowScheduler:
             return None
 
         now = datetime.now(timezone.utc)
-        self._trigger_schedule(schedule, now)
-
-        # Return the instance ID (we need to look it up)
-        instances = self._instance_manager.list_instances(
-            user_id=schedule.user_id,
-            workflow_id=schedule.workflow_id,
-            limit=1,
-        )
-        return instances[0].instance_id if instances else None
+        return self._trigger_schedule(schedule, now, manual=True)
 
 
 class AsyncWorkflowScheduler:

--- a/src/backend/workflows/durable/subworkflow_actions.py
+++ b/src/backend/workflows/durable/subworkflow_actions.py
@@ -18,7 +18,6 @@ from ..action_registry import (
     WorkflowActionRequest,
     WorkflowActionResult,
 )
-from ..engine import WorkflowDefinition, WorkflowExecutor
 from ..engine import (
     LAST_WORKFLOW_APPROVAL_GATE_KEY,
     LAST_WORKFLOW_IDEMPOTENCY_EVENT_KEY,
@@ -31,11 +30,8 @@ from ..engine import (
     WORKFLOW_RETRY_EVENTS_KEY,
     WORKFLOW_TERMINAL_EFFECT_EVENTS_KEY,
     WORKFLOW_TOOL_OUTPUT_MAPPING_EVENTS_KEY,
-)
-from ..subworkflow_contracts import (
-    WORKFLOW_SUBWORKFLOW_ACTION_ID,
-    WORKFLOW_SUBWORKFLOW_FAILURE_MODE_CAPTURE,
-    WORKFLOW_SUBWORKFLOW_FAILURE_MODE_PROPAGATE,
+    WorkflowDefinition,
+    WorkflowExecutor,
 )
 from ..execution_contracts import (
     LAST_CONTROL_SIGNAL_BREAK_KEY,
@@ -55,20 +51,21 @@ from ..execution_contracts import (
     increment_runtime_metric,
     normalise_control_signal,
 )
-from ..tool_invocation_evidence import (
-    derive_tool_invocation_records_from_step_envelopes,
-)
 from ..metadata_validation import LAST_METADATA_EVENT_KEY, WORKFLOW_METADATA_EVENTS_KEY
-from .nested_workflow_authority import (
-    NESTED_WORKFLOW_DEFINITION_NOT_FOUND,
-    resolve_nested_workflow_definition,
-)
 from ..plan_state_runtime import (
     LAST_WORKFLOW_COMPLETION_GATE_KEY,
     LAST_WORKFLOW_PLAN_STATE_EVENT_KEY,
     WORKFLOW_COMPLETION_GATE_KEY,
     WORKFLOW_PLAN_STATE_EVENTS_KEY,
     WORKFLOW_PLAN_STATE_KEY,
+)
+from ..subworkflow_contracts import (
+    WORKFLOW_SUBWORKFLOW_ACTION_ID,
+    WORKFLOW_SUBWORKFLOW_FAILURE_MODE_CAPTURE,
+    WORKFLOW_SUBWORKFLOW_FAILURE_MODE_PROPAGATE,
+)
+from ..tool_invocation_evidence import (
+    derive_tool_invocation_records_from_step_envelopes,
 )
 from ..trace_model import WorkflowExecutionTrace
 from ..vontology_loader import load_workflow_definition_from_vontology
@@ -77,6 +74,12 @@ from ..workflow_launch_input_contracts import (
     normalise_workflow_launch_input_contract,
     resolve_workflow_launch_inputs,
 )
+from .llm_cost_tracking import merge_nested_llm_calls_for_cost
+from .nested_workflow_authority import (
+    NESTED_WORKFLOW_DEFINITION_NOT_FOUND,
+    resolve_nested_workflow_definition,
+)
+
 _FAILURE_MODE_INPUT_KEYS: tuple[str, ...] = ("failure_mode", "__failure_mode")
 _RESERVED_SUBWORKFLOW_INPUT_KEYS: set[str] = {
     "workflow_id",
@@ -697,6 +700,7 @@ def _build_subworkflow_handler(
             trace=child_trace,
             _execution_scope=request.execution_scope,
         )
+        merge_nested_llm_calls_for_cost(request.data, child_result.data)
 
         invocation_event: Dict[str, Any] = {
             "parent_workflow_id": parent_workflow_id or None,

--- a/src/backend/workflows/durable/vontology_schedule_repository.py
+++ b/src/backend/workflows/durable/vontology_schedule_repository.py
@@ -145,10 +145,20 @@ class VontologyScheduleRepository:
                 )
 
         except Exception as e:
-            # Cleanup if partial failure? For now just log.
             logger.error(
                 f"Failed to set properties for schedule concept {concept_id}: {e}"
             )
+            try:
+                concept_service.delete_concept(concept_id)
+            except Exception as cleanup_error:
+                logger.error(
+                    "Failed to clean up partial schedule concept %s: %s",
+                    concept_id,
+                    cleanup_error,
+                )
+            raise RuntimeError(
+                f"Vontology schedule property creation failed: {e}"
+            ) from e
 
         return concept_id
 
@@ -407,6 +417,30 @@ class VontologyScheduleRepository:
             return True
         except Exception as e:
             logger.error(f"Failed to update schedule {schedule_id} after run: {e}")
+            return False
+
+    def update_schedule_next_run(
+        self,
+        schedule_id: str,
+        *,
+        next_run_at: datetime | None,
+    ) -> bool:
+        """Advance a schedule without claiming that a workflow run occurred."""
+
+        try:
+            if next_run_at:
+                self._set_next_run_timestamp(
+                    schedule_id,
+                    next_run_at,
+                    schedule_type_id=self._resolve_schedule_type_concept_id(
+                        schedule_id
+                    ),
+                )
+            else:
+                self._set_enabled_state(schedule_id, False)
+            return True
+        except Exception as e:
+            logger.error(f"Failed to advance schedule {schedule_id}: {e}")
             return False
 
     def set_schedule_enabled(self, schedule_id: str, enabled: bool) -> bool:

--- a/src/backend/workflows/durable/worker.py
+++ b/src/backend/workflows/durable/worker.py
@@ -18,7 +18,6 @@ from typing import Any, Callable, Mapping
 from ...db.transient_errors import run_with_transient_mongo_retry
 from ...security.access_control import override_current_actor
 from ..action_registry import ActionRegistry
-from .instance_manager import WorkflowInstanceManager
 from .durable_executor import (
     DurableWorkflowExecutor,
     DurableWorkflowResult,
@@ -27,6 +26,11 @@ from .durable_executor import (
 from .failed_output_diagnostics import (
     build_completed_workflow_outputs,
     build_failed_workflow_outputs,
+)
+from .instance_manager import WorkflowInstanceManager
+from .llm_cost_tracking import (
+    LLM_USAGE_COST_SUMMARY_KEY,
+    build_durable_llm_usage_cost_summary,
 )
 from .models import WorkflowInstance
 from .worker_identity import build_worker_build_identity
@@ -535,6 +539,7 @@ class DurableWorkflowWorker:
             increment_retry: bool = True,
             outputs: dict[str, Any] | None = None,
             execution_trace_id: str | None = None,
+            llm_usage_cost_summary: Mapping[str, Any] | None = None,
         ) -> bool:
             try:
                 return bool(
@@ -545,6 +550,7 @@ class DurableWorkflowWorker:
                         increment_retry=increment_retry,
                         outputs=outputs,
                         execution_trace_id=execution_trace_id,
+                        llm_usage_cost_summary=llm_usage_cost_summary,
                         worker_id=self._worker_id,
                         claim_token=claim_token,
                     )
@@ -626,6 +632,7 @@ class DurableWorkflowWorker:
                 failure_saved = _best_effort_mark_failed(
                     error=error,
                     increment_retry=False,
+                    llm_usage_cost_summary=build_durable_llm_usage_cost_summary({}),
                 )
                 if failure_saved and self._on_instance_failed:
                     try:
@@ -641,6 +648,9 @@ class DurableWorkflowWorker:
 
             # Update status based on result
             if result.completed:
+                llm_usage_cost_summary = result.data.get(
+                    LLM_USAGE_COST_SUMMARY_KEY
+                )
                 completed_outputs = build_completed_workflow_outputs(
                     result.data,
                     result_envelope=result.result_envelope,
@@ -654,6 +664,11 @@ class DurableWorkflowWorker:
                         outputs=completed_outputs,
                         final_state=result.final_state,
                         execution_trace_id=result.execution_trace_id,
+                        llm_usage_cost_summary=(
+                            llm_usage_cost_summary
+                            if isinstance(llm_usage_cost_summary, Mapping)
+                            else None
+                        ),
                         worker_id=self._worker_id,
                         claim_token=claim_token,
                     ),
@@ -692,6 +707,9 @@ class DurableWorkflowWorker:
                 )
 
             else:
+                llm_usage_cost_summary = result.data.get(
+                    LLM_USAGE_COST_SUMMARY_KEY
+                )
                 failed_outputs = build_failed_workflow_outputs(
                     result.data,
                     error=result.error or "unknown_error",
@@ -702,6 +720,11 @@ class DurableWorkflowWorker:
                     error_step=result.final_state,
                     outputs=failed_outputs,
                     execution_trace_id=result.execution_trace_id,
+                    llm_usage_cost_summary=(
+                        llm_usage_cost_summary
+                        if isinstance(llm_usage_cost_summary, Mapping)
+                        else None
+                    ),
                 )
                 if failure_saved and self._on_instance_failed:
                     try:

--- a/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "email_source_representation_convergence_workflow_seed_bundle",
   "managed_by": "email_source_representation_convergence_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "10",
+  "seed_version": "11",
   "source_tag": "JVNAUTOSCI-2335",
   "supported_action_ids": [
     "arxiv.inspect_existing_state",
@@ -18,11 +18,11 @@
     {
       "workflow_id": "#V#zhan_gmail_arxiv_ingestion_workflow",
       "display_name": "Zhan Gmail Arxiv Ingestion Workflow",
-      "description": "Explicit batch workflow for recurring Gmail-to-arXiv paper representation convergence. Every Gmail message returned up to gmail_max_results, and every supported arXiv reference in each message, may be processed into represented artefacts. Use read-only discovery followed by direct target representation and a source-processing marker when the request calls for one selected item. This workflow records durable source-message processing markers inside Vontology rather than mutating Gmail labels.",
+      "description": "Explicit batch workflow for recurring Gmail-to-arXiv paper representation convergence. It selects newest Inbox messages that do not have VON/PAPER/REPRESENTED, represents each supported arXiv reference, records current source-processing evidence, then atomically applies the represented label and removes INBOX with canonical Gmail read-back.",
       "text_relations": [
         {
           "predicate": "#V#hasWorkflowDiscoveryExemplarsJson",
-          "text": "{\"examples\": [\"Keep scanning Gmail for arXiv paper links, represent every returned unrepresented paper, and record represented processing evidence for source emails.\", \"Run the recurring email-to-representation convergence workflow for arXiv paper notifications.\"], \"keywords\": [\"batch email messages about arxiv papers\", \"represent arxiv papers from email\", \"gmail arxiv paper representation\", \"source email to paper representation convergence\", \"represented source processing marker\", \"recurring arxiv gmail ingestion workflow\"], \"required_query_cues\": [\"gmail\", \"email\", \"mail\", \"message\", \"messages\", \"mailbox\", \"inbox\", \"sender\", \"label\"], \"excluded_query_cues\": [\"which gmail profile\", \"what gmail profile\", \"profile did you use\", \"which mail profile\", \"what mail profile\", \"account did you use\"], \"routing_notes\": [\"This is an explicit batch convergence workflow: every Gmail message returned up to gmail_max_results, and every supported arXiv reference in each message, may produce representation effects.\", \"Do not route a singular newest or best request here; discover and select the exact source item read-only, invoke its matching representation capability, then record the source-processing marker.\", \"Do not choose this workflow for a question about which Gmail profile or account was used by a prior mail operation.\", \"Do not choose this workflow for source-neutral paper references or conversation-context paper lookups unless an email/Gmail/mail source cue is present.\", \"Do not mutate Gmail labels; use represented source-processing markers for completion and idempotence state.\"], \"schema_version\": \"workflow_discovery_exemplars.v1\"}",
+          "text": "{\"examples\": [\"Keep scanning Gmail for arXiv paper links, represent every returned unrepresented paper, label each verified source message VON/PAPER/REPRESENTED, and remove it from Inbox.\", \"Run the recurring email-to-representation convergence workflow for arXiv paper notifications.\"], \"keywords\": [\"batch email messages about arxiv papers\", \"represent arxiv papers from email\", \"gmail arxiv paper representation\", \"source email to paper representation convergence\", \"represented source processing marker\", \"recurring arxiv gmail ingestion workflow\"], \"required_query_cues\": [\"gmail\", \"email\", \"mail\", \"message\", \"messages\", \"mailbox\", \"inbox\", \"sender\", \"label\"], \"excluded_query_cues\": [\"which gmail profile\", \"what gmail profile\", \"profile did you use\", \"which mail profile\", \"what mail profile\", \"account did you use\"], \"routing_notes\": [\"This is an explicit batch convergence workflow: every Gmail message returned up to gmail_max_results, and every supported arXiv reference in each message, may produce representation and message-level Gmail label effects.\", \"Do not route a singular newest or best request here; discover and select the exact source item read-only, then invoke its matching representation capability.\", \"Do not choose this workflow for a question about which Gmail profile or account was used by a prior mail operation.\", \"Do not choose this workflow for source-neutral paper references or conversation-context paper lookups unless an email/Gmail/mail source cue is present.\", \"Only label and archive a source message after current represented-marker and artefact read-back succeeds.\"], \"schema_version\": \"workflow_discovery_exemplars.v1\"}",
           "lang": "en-NZ"
         },
         {
@@ -131,7 +131,7 @@
           {
             "action_id": "workflow_control.context_set",
             "execution_mode": "deterministic",
-            "next_state": "build_list_query",
+            "next_state": "resolve_represented_label",
             "on_failure_state": "failed",
             "state_id": "set_parent_defaults",
             "static_input_bindings": [
@@ -141,12 +141,12 @@
                   {
                     "key": "gmail_profile",
                     "preserve_existing": true,
-                    "value": "#V#gmail_profile_zhan_gmail"
+                    "value": "#V#gmail_profile_vonwitbrock_gmail"
                   },
                   {
                     "key": "base_gmail_query",
                     "preserve_existing": true,
-                    "value": "arxiv.org newer_than:365d"
+                    "value": "arxiv.org"
                   },
                   {
                     "key": "gmail_max_results",
@@ -155,6 +155,56 @@
                   }
                 ]
               ]
+            ]
+          },
+          {
+            "action_id": "workflow_mcp.invoke_tool",
+            "execution_mode": "deterministic",
+            "next_state": "build_list_query",
+            "on_failure_state": "failed",
+            "retry_policy": {
+              "backoff_policy": "fixed",
+              "initial_delay_ms": 1000,
+              "max_attempts": 2,
+              "max_delay_ms": 5000,
+              "retry_on_outcomes": [
+                "failure",
+                "unknown"
+              ],
+              "schema_version": "workflow_step_retry_policy.v1"
+            },
+            "state_id": "resolve_represented_label",
+            "static_input_bindings": [
+              [
+                "tool_arguments",
+                {
+                  "exact_name": "VON/PAPER/REPRESENTED",
+                  "profile": {
+                    "$context_key": "gmail_profile"
+                  },
+                  "require_exact_match": true
+                }
+              ],
+              [
+                "tool_name",
+                "gmail_list_labels"
+              ]
+            ],
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_zhan_gmail_arxiv_ingestion_workflow_resolve_represented_label_result_label_id_to_represented_label_id",
+                "context_key": "represented_label_id",
+                "tool_output_field": "result.label_id"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_zhan_gmail_arxiv_ingestion_workflow_resolve_represented_label_result_profile_to_gmail_profile",
+                "context_key": "gmail_profile",
+                "tool_output_field": "result.profile"
+              }
+            ],
+            "writes_context_keys": [
+              "represented_label_id",
+              "gmail_profile"
             ]
           },
           {
@@ -209,6 +259,9 @@
                   "max_results": {
                     "$context_key": "gmail_max_results"
                   },
+                  "label_ids": [
+                    "INBOX"
+                  ],
                   "profile": {
                     "$context_key": "gmail_profile"
                   },
@@ -237,12 +290,18 @@
                 "concept_id": "#V#workflow_mapping_tool_field_zhan_gmail_arxiv_ingestion_workflow_list_messages_result_messages_to_messages",
                 "context_key": "messages",
                 "tool_output_field": "result.messages"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_zhan_gmail_arxiv_ingestion_workflow_list_messages_result_profile_to_gmail_profile",
+                "context_key": "gmail_profile",
+                "tool_output_field": "result.profile"
               }
             ],
             "writes_context_keys": [
               "list_result",
               "messages",
-              "effective_gmail_query"
+              "effective_gmail_query",
+              "gmail_profile"
             ]
           },
           {
@@ -337,8 +396,12 @@
                 "messages"
               ],
               [
+                "include_tool_invocations_in_iteration_results",
+                false
+              ],
+              [
                 "max_transitions",
-                180
+                220
               ],
               [
                 "success_policy",
@@ -403,11 +466,11 @@
     {
       "workflow_id": "#V#email_arxiv_ingestion_from_message_workflow",
       "display_name": "Email Arxiv Ingestion From Message Workflow",
-      "description": "Processes one exact Gmail message selected by the caller: check for durable represented source-processing evidence, extract resource links when needed, ingest each arXiv reference through represented subworkflows, then record and canonically read back a Vontology source-processing marker only after successful arXiv ingestion. Use this after read-only discovery has selected the source message; it does not select mailbox messages or mutate Gmail.",
+      "description": "Processes one exact Gmail message selected by the caller: establish versioned source and processing-authority identity, reuse or upgrade current represented source-processing evidence when possible, ingest each arXiv reference when needed, canonically verify represented artefacts, then atomically apply VON/PAPER/REPRESENTED and remove INBOX with independent Gmail read-back.",
       "text_relations": [
         {
           "predicate": "#V#hasWorkflowDiscoveryExemplarsJson",
-          "text": "{\"examples\": [\"Represent the arXiv paper linked from this exact Gmail message and verify its represented processing marker.\", \"Process this selected Gmail message through the durable arXiv representation path without changing Gmail labels.\"], \"keywords\": [\"exact gmail message arxiv representation\", \"selected email arxiv paper ingestion\", \"represent paper from this message\", \"gmail message processing marker\"], \"required_query_cues\": [\"gmail\", \"email\", \"mail\", \"message\"], \"routing_notes\": [\"Use only after read-only discovery or explicit user context identifies one exact Gmail source message.\", \"Pass include_body explicitly on every gmail_get_message discovery read. When a Gmail search result matched the paper query but its subject or snippet does not expose the arXiv reference, use include_body=true and inspect the bounded message body before rejecting it or moving to an older message.\", \"The caller must supply the exact Gmail profile and current_message object; this workflow does not choose a message or scan a mailbox.\", \"Prefer this durable unit over a paper-only representation workflow when the user outcome also requires source-message processing evidence.\", \"Do not mutate Gmail labels; completion is an idempotent represented marker followed by canonical marker read-back.\"], \"schema_version\": \"workflow_discovery_exemplars.v1\"}",
+          "text": "{\"examples\": [\"Represent the arXiv paper linked from this exact Gmail message, verify its current represented processing marker, label it VON/PAPER/REPRESENTED, and remove it from Inbox.\", \"Converge this selected Gmail message through the durable arXiv representation and mailbox-cleanup path.\"], \"keywords\": [\"exact gmail message arxiv representation\", \"selected email arxiv paper ingestion\", \"represent paper from this message\", \"gmail message processing marker\"], \"required_query_cues\": [\"gmail\", \"email\", \"mail\", \"message\"], \"routing_notes\": [\"Use only after read-only discovery or explicit user context identifies one exact Gmail source message.\", \"Pass include_body explicitly on every gmail_get_message discovery read. When a Gmail search result matched the paper query but its subject or snippet does not expose the arXiv reference, use include_body=true and inspect the bounded message body before rejecting it or moving to an older message.\", \"The caller must supply the exact Gmail profile and current_message object; this workflow does not choose a message or scan a mailbox.\", \"Prefer this durable unit over a paper-only representation workflow when the user outcome also requires source-message and Gmail convergence evidence.\", \"Do not label or archive messages with no supported resource or without current marker and represented-artefact read-back.\"], \"schema_version\": \"workflow_discovery_exemplars.v1\"}",
           "lang": "en-NZ"
         },
         {
@@ -436,6 +499,13 @@
             "required": true,
             "source_expression": "inputs.current_message",
             "target_context_key": "current_message"
+          },
+          {
+            "description": "Optional mailbox-specific VON/PAPER/REPRESENTED label ID resolved once by a parent batch.",
+            "extractor": "identity",
+            "required": false,
+            "source_expression": "inputs.represented_label_id",
+            "target_context_key": "represented_label_id"
           }
         ],
         "required_inputs": [
@@ -466,7 +536,7 @@
           {
             "action_id": "workflow_control.context_set",
             "execution_mode": "deterministic",
-            "next_state": "check_processed_marker",
+            "next_state": "ensure_represented_label",
             "on_failure_state": "failed",
             "state_id": "normalise_message",
             "static_input_bindings": [
@@ -501,16 +571,150 @@
             ]
           },
           {
+            "action_id": "workflow_control.context_template",
+            "execution_mode": "deterministic",
+            "next_state": "check_processed_marker",
+            "on_failure_state": "failed",
+            "state_id": "build_processing_fingerprints",
+            "static_input_bindings": [
+              [
+                "assignments",
+                [
+                  {
+                    "key": "source_fingerprint",
+                    "template": "gmail-message-id:v1:{profile}:{message_id}",
+                    "variables": {
+                      "message_id": {
+                        "value_from_context": "message_id"
+                      },
+                      "profile": {
+                        "value_from_context": "gmail_profile"
+                      }
+                    }
+                  },
+                  {
+                    "key": "processing_authority_fingerprint",
+                    "template": "email-arxiv-ingestion:v2"
+                  }
+                ]
+              ]
+            ]
+          },
+          {
+            "action_id": "workflow_control.context_set",
+            "conditional_transitions": [
+              {
+                "condition_spec": {
+                  "expected": true,
+                  "key": "represented_label_id",
+                  "kind": "context_exists"
+                },
+                "reason": "represented_label_inherited_from_parent",
+                "to_state": "build_processing_fingerprints"
+              }
+            ],
+            "execution_mode": "deterministic",
+            "next_state": "resolve_represented_label",
+            "on_failure_state": "failed",
+            "state_id": "ensure_represented_label",
+            "static_input_bindings": [
+              [
+                "assignments",
+                [
+                  {
+                    "key": "represented_label_resolution_checked",
+                    "value": true
+                  }
+                ]
+              ]
+            ]
+          },
+          {
+            "action_id": "workflow_mcp.invoke_tool",
+            "execution_mode": "deterministic",
+            "next_state": "build_processing_fingerprints",
+            "on_failure_state": "failed",
+            "retry_policy": {
+              "backoff_policy": "fixed",
+              "initial_delay_ms": 1000,
+              "max_attempts": 2,
+              "max_delay_ms": 5000,
+              "retry_on_outcomes": [
+                "failure",
+                "unknown"
+              ],
+              "schema_version": "workflow_step_retry_policy.v1"
+            },
+            "state_id": "resolve_represented_label",
+            "static_input_bindings": [
+              [
+                "tool_arguments",
+                {
+                  "exact_name": "VON/PAPER/REPRESENTED",
+                  "profile": {
+                    "$context_key": "gmail_profile"
+                  },
+                  "require_exact_match": true
+                }
+              ],
+              [
+                "tool_name",
+                "gmail_list_labels"
+              ]
+            ],
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_resolve_represented_label_result_label_id_to_represented_label_id",
+                "context_key": "represented_label_id",
+                "tool_output_field": "result.label_id"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_resolve_represented_label_result_profile_to_gmail_profile",
+                "context_key": "gmail_profile",
+                "tool_output_field": "result.profile"
+              }
+            ],
+            "writes_context_keys": [
+              "represented_label_id",
+              "gmail_profile"
+            ]
+          },
+          {
             "action_id": "workflow_mcp.invoke_tool",
             "conditional_transitions": [
               {
                 "condition_spec": {
                   "expected": true,
-                  "key": "source_processing_marker_exists",
+                  "key": "source_processing_current",
                   "kind": "context_flag"
                 },
-                "reason": "source_message_already_processed",
-                "to_state": "done_already_processed"
+                "reason": "source_message_current_and_represented",
+                "to_state": "converge_gmail_labels"
+              },
+              {
+                "condition_spec": {
+                  "conditions": [
+                    {
+                      "expected": true,
+                      "key": "source_processing_marker_exists",
+                      "kind": "context_flag"
+                    },
+                    {
+                      "expected": true,
+                      "key": "represented_artifacts_exist",
+                      "kind": "context_flag"
+                    },
+                    {
+                      "key": "paper_concept_ids",
+                      "kind": "context_cardinality",
+                      "operator": "gt",
+                      "value": 0
+                    }
+                  ],
+                  "kind": "all"
+                },
+                "reason": "legacy_marker_has_verified_represented_artifacts",
+                "to_state": "upgrade_legacy_marker"
               }
             ],
             "execution_mode": "deterministic",
@@ -524,10 +728,17 @@
                   "source_item_id": {
                     "$context_key": "message_id"
                   },
+                  "source_fingerprint": {
+                    "$context_key": "source_fingerprint"
+                  },
                   "source_profile": {
                     "$context_key": "gmail_profile"
                   },
-                  "source_system": "gmail"
+                  "source_system": "gmail",
+                  "processing_authority_fingerprint": {
+                    "$context_key": "processing_authority_fingerprint"
+                  },
+                  "require_represented_artifacts": true
                 }
               ],
               [
@@ -565,6 +776,31 @@
                 "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_check_processed_marker_result_arxiv_id_to_arxiv_id",
                 "context_key": "arxiv_id",
                 "tool_output_field": "result.arxiv_id"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_check_processed_marker_result_source_processing_current_to_source_processing_current",
+                "context_key": "source_processing_current",
+                "tool_output_field": "result.source_processing_current"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_check_processed_marker_result_represented_artifacts_exist_to_represented_artifacts_exist",
+                "context_key": "represented_artifacts_exist",
+                "tool_output_field": "result.represented_artifacts_exist"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_check_processed_marker_result_paper_concept_ids_to_paper_concept_ids",
+                "context_key": "paper_concept_ids",
+                "tool_output_field": "result.paper_concept_ids"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_check_processed_marker_result_file_copy_concept_ids_to_file_copy_concept_ids",
+                "context_key": "file_copy_concept_ids",
+                "tool_output_field": "result.file_copy_concept_ids"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_check_processed_marker_result_arxiv_ids_to_arxiv_ids",
+                "context_key": "arxiv_ids",
+                "tool_output_field": "result.arxiv_ids"
               }
             ],
             "writes_context_keys": [
@@ -573,8 +809,62 @@
               "processed_message_id",
               "paper_concept_id",
               "file_copy_concept_id",
-              "arxiv_id"
+              "arxiv_id",
+              "source_processing_current",
+              "represented_artifacts_exist",
+              "paper_concept_ids",
+              "file_copy_concept_ids",
+              "arxiv_ids"
             ]
+          },
+          {
+            "action_id": "workflow_mcp.invoke_tool",
+            "execution_mode": "deterministic",
+            "mutation_authority": {
+              "maximum_level": "additive_vontology",
+              "reason_code": "upgrade_legacy_source_processing_marker",
+              "schema_version": "workflow_step_mutation_authority.v1"
+            },
+            "next_state": "verify_done_marker",
+            "on_failure_state": "failed_unmarked",
+            "state_id": "upgrade_legacy_marker",
+            "static_input_bindings": [
+              [
+                "tool_arguments",
+                {
+                  "arxiv_ids": {
+                    "$context_key": "arxiv_ids"
+                  },
+                  "file_copy_concept_ids": {
+                    "$context_key": "file_copy_concept_ids"
+                  },
+                  "processing_authority_fingerprint": {
+                    "$context_key": "processing_authority_fingerprint"
+                  },
+                  "processing_status": "processed",
+                  "represented_artifact_concept_ids": {
+                    "$context_key": "paper_concept_ids"
+                  },
+                  "require_represented_artifacts": true,
+                  "source_fingerprint": {
+                    "$context_key": "source_fingerprint"
+                  },
+                  "source_item_id": {
+                    "$context_key": "message_id"
+                  },
+                  "source_profile": {
+                    "$context_key": "gmail_profile"
+                  },
+                  "source_system": "gmail",
+                  "workflow_id": "#V#email_arxiv_ingestion_from_message_workflow"
+                }
+              ],
+              [
+                "tool_name",
+                "record_source_processing_marker"
+              ]
+            ],
+            "writes_context_keys": []
           },
           {
             "action_id": "workflow_invoke_subworkflow",
@@ -721,6 +1011,10 @@
                 "arxiv_resource_references"
               ],
               [
+                "include_tool_invocations_in_iteration_results",
+                false
+              ],
+              [
                 "max_items",
                 5
               ],
@@ -798,9 +1092,16 @@
               [
                 "tool_arguments",
                 {
+                  "processing_authority_fingerprint": {
+                    "$context_key": "processing_authority_fingerprint"
+                  },
                   "processing_status": "processed",
                   "represented_outputs": {
                     "$context_key": "arxiv_iteration_results"
+                  },
+                  "require_represented_artifacts": true,
+                  "source_fingerprint": {
+                    "$context_key": "source_fingerprint"
                   },
                   "source_item_id": {
                     "$context_key": "message_id"
@@ -864,11 +1165,11 @@
               {
                 "condition_spec": {
                   "expected": true,
-                  "key": "source_processing_marker_exists",
+                  "key": "source_processing_current",
                   "kind": "context_flag"
                 },
-                "reason": "source_processing_marker_canonically_verified",
-                "to_state": "done"
+                "reason": "source_processing_marker_and_artifacts_canonically_current",
+                "to_state": "converge_gmail_labels"
               }
             ],
             "execution_mode": "deterministic",
@@ -879,6 +1180,13 @@
               [
                 "tool_arguments",
                 {
+                  "processing_authority_fingerprint": {
+                    "$context_key": "processing_authority_fingerprint"
+                  },
+                  "require_represented_artifacts": true,
+                  "source_fingerprint": {
+                    "$context_key": "source_fingerprint"
+                  },
                   "source_item_id": {
                     "$context_key": "message_id"
                   },
@@ -923,6 +1231,16 @@
                 "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_verify_done_marker_result_arxiv_id_to_arxiv_id",
                 "context_key": "arxiv_id",
                 "tool_output_field": "result.arxiv_id"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_verify_done_marker_result_source_processing_current_to_source_processing_current",
+                "context_key": "source_processing_current",
+                "tool_output_field": "result.source_processing_current"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_verify_done_marker_result_represented_artifacts_exist_to_represented_artifacts_exist",
+                "context_key": "represented_artifacts_exist",
+                "tool_output_field": "result.represented_artifacts_exist"
               }
             ],
             "writes_context_keys": [
@@ -931,20 +1249,105 @@
               "processed_message_id",
               "paper_concept_id",
               "file_copy_concept_id",
-              "arxiv_id"
+              "arxiv_id",
+              "source_processing_current",
+              "represented_artifacts_exist"
+            ]
+          },
+          {
+            "action_id": "workflow_mcp.invoke_tool",
+            "conditional_transitions": [
+              {
+                "condition_spec": {
+                  "expected": true,
+                  "key": "gmail_label_state_verified",
+                  "kind": "context_flag"
+                },
+                "reason": "represented_label_present_and_inbox_absent",
+                "to_state": "done"
+              }
+            ],
+            "execution_mode": "deterministic",
+            "mutation_authority": {
+              "maximum_level": "external_system_guarded",
+              "reason_code": "verified_represented_message_label_and_archive",
+              "schema_version": "workflow_step_mutation_authority.v1"
+            },
+            "next_state": "failed_gmail_state",
+            "on_failure_state": "failed_gmail_state",
+            "retry_policy": {
+              "backoff_policy": "fixed",
+              "initial_delay_ms": 1000,
+              "max_attempts": 2,
+              "max_delay_ms": 5000,
+              "retry_on_outcomes": [
+                "failure",
+                "unknown"
+              ],
+              "schema_version": "workflow_step_retry_policy.v1"
+            },
+            "state_id": "converge_gmail_labels",
+            "static_input_bindings": [
+              [
+                "tool_arguments",
+                {
+                  "add_labels": [
+                    {
+                      "$context_key": "represented_label_id"
+                    }
+                  ],
+                  "allow_mutation": true,
+                  "message_id": {
+                    "$context_key": "message_id"
+                  },
+                  "profile": {
+                    "$context_key": "gmail_profile"
+                  },
+                  "remove_labels": [
+                    "INBOX"
+                  ],
+                  "verify_after": true
+                }
+              ],
+              [
+                "tool_name",
+                "gmail_modify_labels"
+              ]
+            ],
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_converge_gmail_labels_result_gmail_label_state_verified_to_gmail_label_state_verified",
+                "context_key": "gmail_label_state_verified",
+                "tool_output_field": "result.gmail_label_state_verified"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_converge_gmail_labels_result_readback_label_ids_to_gmail_readback_label_ids",
+                "context_key": "gmail_readback_label_ids",
+                "tool_output_field": "result.readback_label_ids"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_converge_gmail_labels_result_modify_reconciled_after_error_to_gmail_modify_reconciled_after_error",
+                "context_key": "gmail_modify_reconciled_after_error",
+                "tool_output_field": "result.modify_reconciled_after_error"
+              }
+            ],
+            "writes_context_keys": [
+              "gmail_label_state_verified",
+              "gmail_readback_label_ids",
+              "gmail_modify_reconciled_after_error"
             ]
           },
           {
             "state_id": "done"
           },
           {
-            "state_id": "done_already_processed"
-          },
-          {
             "state_id": "done_no_resources"
           },
           {
             "state_id": "failed_unmarked"
+          },
+          {
+            "state_id": "failed_gmail_state"
           },
           {
             "state_id": "failed"

--- a/src/backend/workflows/repo_seed_bundles/gmail_get_message_terminal_completion_hint_seed.json
+++ b/src/backend/workflows/repo_seed_bundles/gmail_get_message_terminal_completion_hint_seed.json
@@ -3,29 +3,34 @@
   "entries": [
     {
       "action_kind": "terminal_completion",
-      "description": "After a message's arXiv resources have been successfully ingested, record durable represented source-processing evidence for the source Gmail message.",
+      "description": "After a message's arXiv resources have been successfully represented and its current marker and artefacts have been read back, apply VON/PAPER/REPRESENTED and remove INBOX with canonical Gmail label-state verification.",
       "action": {
         "type": "workflow_mcp.invoke_tool",
-        "tool_name": "record_source_processing_marker",
-        "tool_concept_id": "#V#record_source_processing_marker_tool"
+        "tool_name": "gmail_modify_labels",
+        "tool_concept_id": "#V#gmail_modify_labels_tool"
       },
       "tool_arguments": {
-        "source_system": "gmail",
-        "source_profile_context_key": "gmail_profile",
-        "source_item_id_context_key": "message_id",
-        "represented_outputs_context_key": "arxiv_iteration_results",
-        "processing_status": "processed"
+        "profile_context_key": "gmail_profile",
+        "message_id_context_key": "message_id",
+        "add_label_id_context_key": "represented_label_id",
+        "remove_label_ids": [
+          "INBOX"
+        ],
+        "allow_mutation": true,
+        "verify_after": true
       },
       "represented_effects": [
         {
-          "effect_kind": "record_source_processing_marker",
-          "marker_type_concept_id": "#V#source_processing_marker",
-          "evidence_predicate_concept_id": "#V#hasSourceProcessingEvidenceJson"
+          "effect_kind": "verified_gmail_label_convergence",
+          "add_label_name": "VON/PAPER/REPRESENTED",
+          "remove_label_id": "INBOX",
+          "requires_current_source_processing_marker": true,
+          "requires_represented_artifact_readback": true
         }
       ],
       "upstream_filter": {
-        "query_fragment": "",
-        "rationale": "Gmail listing remains read-only; child workflows check represented source-processing markers before repeating source-message work."
+        "query_fragment": "-label:\"VON/PAPER/REPRESENTED\"",
+        "rationale": "Repeated bounded runs select newest Inbox messages that have not yet converged to the represented Gmail label state, so the backlog advances without a date cap."
       }
     }
   ]

--- a/tests/backend/test_durable_workflow_completed_outputs.py
+++ b/tests/backend/test_durable_workflow_completed_outputs.py
@@ -42,3 +42,19 @@ def test_completed_outputs_use_final_response_when_no_selected_workflow_answer()
     assert outputs["terminal_output_source"] == "workflow_result_envelope"
     assert outputs["final_response"] == "Final generated answer."
     assert outputs["response"] == "Final generated answer."
+
+
+def test_completed_outputs_expose_content_free_llm_usage_cost_summary() -> None:
+    summary = {
+        "schema_version": "llm_usage_cost_summary.v1",
+        "call_count": 0,
+        "usage": {"status": "not_applicable"},
+        "estimated_cost": {"status": "not_applicable", "amount": None},
+    }
+
+    outputs = build_completed_workflow_outputs(
+        {"llm_usage_cost_summary": summary},
+        final_state="done",
+    )
+
+    assert outputs["llm_usage_cost_summary"] == summary

--- a/tests/backend/test_durable_workflow_executor_safety.py
+++ b/tests/backend/test_durable_workflow_executor_safety.py
@@ -21,19 +21,22 @@ from src.backend.workflows.action_registry import (
     WorkflowActionResult,
     WorkflowEnvironment,
 )
-from src.backend.workflows.durable.durable_executor import (
-    DURABLE_EXECUTED_WORKFLOW_DEFINITION_IDENTITY_KEY,
-    DurableWorkflowExecutor,
-)
-from src.backend.workflows.durable.control_flow_actions import (
-    register_control_flow_actions,
-)
 from src.backend.workflows.durable.checkpoint_context_projection import (
     CHECKPOINT_CONTEXT_PROJECTION_KEY,
     CHECKPOINT_CONTEXT_PROJECTION_SCHEMA_VERSION,
     project_workflow_context_for_checkpoint,
 )
-from src.backend.workflows.durable.models import WorkflowInstance, WorkflowInstanceStatus
+from src.backend.workflows.durable.control_flow_actions import (
+    register_control_flow_actions,
+)
+from src.backend.workflows.durable.durable_executor import (
+    DURABLE_EXECUTED_WORKFLOW_DEFINITION_IDENTITY_KEY,
+    DurableWorkflowExecutor,
+)
+from src.backend.workflows.durable.models import (
+    WorkflowInstance,
+    WorkflowInstanceStatus,
+)
 from src.backend.workflows.engine import (
     WorkflowActionInvocation,
     WorkflowDefinition,
@@ -42,14 +45,14 @@ from src.backend.workflows.engine import (
     WorkflowTransitionSpec,
     build_transition_condition,
 )
-from src.backend.workflows.workflow_definition_identity_service import (
-    build_workflow_definition_identity,
-)
 from src.backend.workflows.execution_contracts import (
     WORKFLOW_CHECKPOINT_PAUSE_EVENTS_KEY,
     WORKFLOW_CHECKPOINT_PAUSE_RECEIPT_KEY,
     WORKFLOW_CHECKPOINT_RESUME_RECEIPT_KEY,
     WORKFLOW_RESULT_ENVELOPE_KEY,
+)
+from src.backend.workflows.workflow_definition_identity_service import (
+    build_workflow_definition_identity,
 )
 
 
@@ -92,7 +95,19 @@ def test_durable_executor_reports_explicit_failed_terminal_as_failure() -> None:
         termination_states=(failed_state,),
     )
     manager = MagicMock()
-    manager.get_instance.return_value = _build_instance(definition.workflow_id)
+    instance = _build_instance(definition.workflow_id)
+    instance.inputs = {
+        "llm_calls": [
+            {
+                "call_id": "forged-launch-input",
+                "provider": "openai",
+                "effective_model": "gpt-forged",
+                "model_identity_source": "provider_response",
+                "usage": {"prompt_tokens": 100, "completion_tokens": 50},
+            }
+        ]
+    }
+    manager.get_instance.return_value = instance
     manager.is_cancelled.return_value = False
     manager.extend_lock.return_value = True
     manager.checkpoint.return_value = True
@@ -121,8 +136,18 @@ def test_durable_executor_reports_explicit_failed_terminal_as_failure() -> None:
     assert result.final_state == failed_state
     assert result.error == "workflow_failed_terminal_state"
     assert result.data[WORKFLOW_RESULT_ENVELOPE_KEY]["terminal_status"] == "failed"
+    assert result.data["llm_usage_cost_summary"]["call_count"] == 0
+    assert result.data["llm_usage_cost_summary"]["usage"]["status"] == (
+        "not_applicable"
+    )
+    assert result.data["llm_usage_cost_summary"]["estimated_cost"]["status"] == (
+        "not_applicable"
+    )
     terminal_checkpoint = manager.checkpoint.call_args_list[-1].kwargs
     assert terminal_checkpoint["error"] == "workflow_failed_terminal_state"
+    assert terminal_checkpoint["workflow_data"]["llm_usage_cost_summary"] == (
+        result.data["llm_usage_cost_summary"]
+    )
 
 
 def test_durable_executor_atomically_pauses_at_successor_checkpoint() -> None:

--- a/tests/backend/test_durable_workflow_llm_cost_tracking.py
+++ b/tests/backend/test_durable_workflow_llm_cost_tracking.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from src.backend.workflows.durable.instance_manager import WorkflowInstanceManager
+from src.backend.workflows.durable.llm_cost_tracking import (
+    LLM_USAGE_COST_SUMMARY_KEY,
+    build_durable_llm_usage_cost_summary,
+    merge_nested_llm_calls_for_cost,
+    project_llm_calls_for_cost,
+)
+from src.backend.workflows.durable.models import WorkflowInstance
+
+
+def _registry() -> dict:
+    return {
+        "models": [
+            {
+                "provider": "openai",
+                "model_id": "gpt-5.6-terra",
+                "pricing": {
+                    "schema_version": "llm_model_pricing.v1",
+                    "version": "test-2026-08-09",
+                    "source": "test_fixture",
+                    "effective_at_utc": "2026-08-09T00:00:00Z",
+                    "model_id": "gpt-5.6-terra",
+                    "currency": "USD",
+                    "unit_tokens": 1_000_000,
+                    "rates": {
+                        "input_tokens": 2.0,
+                        "output_tokens": 12.0,
+                    },
+                },
+            }
+        ]
+    }
+
+
+def _priced_call(call_id: str) -> dict:
+    return {
+        "call_id": call_id,
+        "type": "llm.generate",
+        "stage": "paper_relevance",
+        "provider": "openai",
+        "requested_model": "gpt-5.6-terra",
+        "selected_model": "gpt-5.6-terra",
+        "effective_model": "gpt-5.6-terra",
+        "model_identity_source": "provider_response",
+        "provider_request_sent": True,
+        "usage": {"prompt_tokens": 1_000, "completion_tokens": 100},
+        "prompt": "must not cross the durable accounting boundary",
+        "response": "must not cross the durable accounting boundary",
+    }
+
+
+def test_deterministic_durable_run_records_no_model_calls_not_zero_cost() -> None:
+    summary = build_durable_llm_usage_cost_summary({})
+
+    assert summary["call_count"] == 0
+    assert summary["usage"]["status"] == "not_applicable"
+    assert summary["estimated_cost"]["status"] == "not_applicable"
+    assert summary["estimated_cost"]["amount"] is None
+
+
+def test_nested_model_calls_are_content_free_and_registry_priced() -> None:
+    parent: dict = {}
+    merge_nested_llm_calls_for_cost(parent, {"llm_calls": [_priced_call("child-1")]})
+
+    assert parent["llm_calls"] == project_llm_calls_for_cost(
+        [_priced_call("child-1")]
+    )
+    assert "prompt" not in parent["llm_calls"][0]
+    assert "response" not in parent["llm_calls"][0]
+
+    summary = build_durable_llm_usage_cost_summary(
+        parent,
+        model_registry=_registry(),
+    )
+    assert summary["call_count"] == 1
+    assert summary["usage"]["status"] == "reported"
+    assert summary["usage"]["total_tokens"] == 1_100
+    assert summary["estimated_cost"]["status"] == "estimated"
+    assert summary["estimated_cost"]["amount"] == 0.0032
+
+
+def test_nested_merge_does_not_recount_calls_inherited_from_parent() -> None:
+    inherited = _priced_call("parent-1")
+    child_only = _priced_call("child-1")
+    parent = {"llm_calls": project_llm_calls_for_cost([inherited])}
+
+    merge_nested_llm_calls_for_cost(
+        parent,
+        {"llm_calls": [inherited, child_only]},
+    )
+
+    assert [call["call_id"] for call in parent["llm_calls"]] == [
+        "parent-1",
+        "child-1",
+    ]
+
+
+def test_instance_round_trip_and_status_expose_canonical_cost_summary() -> None:
+    summary = build_durable_llm_usage_cost_summary({})
+    instance = WorkflowInstance.create(
+        "#V#scheduled_paper_workflow",
+        user_id="#V#user",
+        org_id="#V#org",
+        namespace="#V#user@org",
+        schedule_id="#V#paper_schedule",
+    )
+    instance.llm_usage_cost_summary = summary
+
+    restored = WorkflowInstance.from_doc(instance.to_doc())
+
+    assert restored.schedule_id == "#V#paper_schedule"
+    assert restored.llm_usage_cost_summary == summary
+    assert restored.to_status_dict()[LLM_USAGE_COST_SUMMARY_KEY] == summary
+
+
+def test_checkpoint_promotes_cost_summary_to_first_class_instance_field(
+    monkeypatch,
+) -> None:
+    summary = build_durable_llm_usage_cost_summary({})
+    instance = WorkflowInstance.create(
+        "#V#scheduled_paper_workflow",
+        user_id="#V#user",
+        org_id="#V#org",
+        namespace="#V#user@org",
+        schedule_id="#V#paper_schedule",
+    )
+    manager = object.__new__(WorkflowInstanceManager)
+    captured: dict = {}
+    monkeypatch.setattr(
+        manager,
+        "_compact_instance_payload_field",
+        lambda payload, **_kwargs: dict(payload),
+    )
+    monkeypatch.setattr(
+        manager,
+        "_claim_fence_query",
+        lambda **_kwargs: {"instance_id": instance.instance_id},
+    )
+
+    def _update(query, update, **_kwargs):
+        captured["query"] = query
+        captured["update"] = update
+        return instance
+
+    monkeypatch.setattr(manager, "_find_one_and_update_instance", _update)
+    monkeypatch.setattr(manager, "_broadcast_instance", lambda _instance: None)
+
+    saved = manager.checkpoint(
+        instance.instance_id,
+        current_state="done",
+        workflow_data={LLM_USAGE_COST_SUMMARY_KEY: summary},
+    )
+
+    assert saved is True
+    assert captured["update"]["$set"][LLM_USAGE_COST_SUMMARY_KEY] == summary

--- a/tests/backend/test_durable_workflow_system.py
+++ b/tests/backend/test_durable_workflow_system.py
@@ -2820,16 +2820,24 @@ class TestWorkflowScheduler:
         due_schedule.next_run_at = now
 
         manager.find_due_schedules.return_value = [due_schedule]
+        manager.list_instances.return_value = []
         manager.update_schedule_after_run.return_value = True
-        monkeypatch.setattr(
-            "src.backend.workflows.durable.scheduler.submit_verified_workflow_instance",
-            lambda **_kwargs: WorkflowInstanceSubmissionResult(
+        submitted: dict[str, Any] = {}
+
+        def fake_submit(**kwargs):
+            submitted.update(kwargs)
+            return WorkflowInstanceSubmissionResult(
                 success=True,
                 workflow_id="#V#enrichment_workflow",
                 status="accepted",
                 instance_id="instance-1",
                 verification={},
-            ),
+                created_new=True,
+            )
+
+        monkeypatch.setattr(
+            "src.backend.workflows.durable.scheduler.submit_verified_workflow_instance",
+            fake_submit,
         )
 
         scheduler = WorkflowScheduler(manager)
@@ -2846,6 +2854,94 @@ class TestWorkflowScheduler:
 
         manager.find_due_schedules.assert_called_once_with(limit=50)
         manager.update_schedule_after_run.assert_called_once()
+        assert submitted["source_event_type"] == "workflow.schedule.occurrence"
+        assert submitted["source_event_id"].startswith(
+            "#V#schedule_test_due_1:scheduled:"
+        )
+        assert submitted["event_idempotency_key"].startswith(
+            "workflow_schedule_occurrence:#V#schedule_test_due_1:scheduled:"
+        )
+        assert submitted["inputs"]["schedule_overlap_policy"] == "forbid"
+        assert submitted["inputs"]["schedule_misfire_policy"] == "coalesce"
+
+    def test_schedule_occurrence_key_is_stable_across_retry(self, monkeypatch) -> None:
+        from src.backend.workflows.durable.workflow_instance_submission_service import (
+            WorkflowInstanceSubmissionResult,
+        )
+
+        manager = MagicMock(spec=WorkflowInstanceManager)
+        manager.list_instances.return_value = []
+        manager.update_schedule_after_run.return_value = True
+        scheduled_for = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+        schedule = WorkflowSchedule.create_interval(
+            "#V#enrichment_workflow",
+            interval_seconds=3600,
+            user_id="user-1",
+            org_id="org-1",
+            namespace="user-1/org-1",
+            start_at=scheduled_for,
+        )
+        schedule.schedule_id = "#V#schedule_stable_occurrence"
+        schedule.next_run_at = scheduled_for
+        observed_keys: list[str] = []
+
+        def fake_submit(**kwargs):
+            observed_keys.append(kwargs["event_idempotency_key"])
+            return WorkflowInstanceSubmissionResult(
+                success=True,
+                workflow_id=schedule.workflow_id,
+                status="accepted",
+                instance_id="instance-stable",
+                verification={},
+                created_new=len(observed_keys) == 1,
+            )
+
+        monkeypatch.setattr(
+            "src.backend.workflows.durable.scheduler.submit_verified_workflow_instance",
+            fake_submit,
+        )
+        scheduler = WorkflowScheduler(manager)
+
+        first = scheduler._trigger_schedule(schedule, scheduled_for)
+        second = scheduler._trigger_schedule(schedule, scheduled_for)
+
+        assert first == second == "instance-stable"
+        assert len(set(observed_keys)) == 1
+
+    def test_overlapping_schedule_occurrence_is_coalesced(self, monkeypatch) -> None:
+        manager = MagicMock(spec=WorkflowInstanceManager)
+        now = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+        schedule = WorkflowSchedule.create_interval(
+            "#V#enrichment_workflow",
+            interval_seconds=3600,
+            user_id="user-1",
+            org_id="org-1",
+            namespace="user-1/org-1",
+            start_at=now,
+        )
+        schedule.schedule_id = "#V#schedule_overlap"
+        schedule.next_run_at = now
+        active = MagicMock()
+        active.schedule_id = schedule.schedule_id
+        active.instance_id = "instance-running"
+        active.event_idempotency_key = "different-occurrence"
+        manager.list_instances.return_value = [active]
+        manager.update_schedule_next_run.return_value = True
+        monkeypatch.setattr(
+            "src.backend.workflows.durable.scheduler.submit_verified_workflow_instance",
+            lambda **_kwargs: (_ for _ in ()).throw(
+                AssertionError("overlapping schedule submitted a second instance")
+            ),
+        )
+
+        result = WorkflowScheduler(manager)._trigger_schedule(schedule, now)
+
+        assert result is None
+        manager.update_schedule_next_run.assert_called_once_with(
+            schedule.schedule_id,
+            next_run_at=now + timedelta(seconds=3600),
+        )
+        manager.update_schedule_after_run.assert_not_called()
 
     def test_process_due_schedules_records_empty_poll(self) -> None:
         manager = MagicMock(spec=WorkflowInstanceManager)

--- a/tests/backend/test_durable_workflow_worker.py
+++ b/tests/backend/test_durable_workflow_worker.py
@@ -20,10 +20,10 @@ from src.backend.workflows.durable.models import (
     WorkflowInstance,
     WorkflowInstanceStatus,
 )
-from src.backend.workflows.durable.worker import DurableWorkflowWorker
 from src.backend.workflows.durable.registry_factory import (
     WorkflowDefinitionAuthorityTransientError,
 )
+from src.backend.workflows.durable.worker import DurableWorkflowWorker
 from src.backend.workflows.engine import (
     WorkflowActionInvocation,
     WorkflowDefinition,
@@ -554,6 +554,48 @@ def test_worker_rejects_stale_loaded_definition_identity() -> None:
     assert observed_identity == [None]
     assert manager.mark_completed_calls
     assert manager.mark_failed_calls == []
+
+
+def test_worker_persists_scheduled_instance_llm_usage_cost_summary() -> None:
+    manager = _WorkerManagerStub()
+    instance = _build_instance("worker-scheduled-cost")
+    instance.schedule_id = "#V#paper_ingestion_schedule"
+    definition = WorkflowDefinition(
+        workflow_id=instance.workflow_id,
+        initial_state="done",
+        states={"done": WorkflowStateSpec(state_id="done", terminal=True)},
+        termination_states=("done",),
+    )
+    summary = {
+        "schema_version": "llm_usage_cost_summary.v1",
+        "call_count": 0,
+        "usage": {"status": "not_applicable"},
+        "estimated_cost": {"status": "not_applicable", "amount": None},
+    }
+    worker = DurableWorkflowWorker(
+        worker_id="worker-scheduled-cost",
+        instance_manager=manager,  # type: ignore[arg-type]
+        registry=ActionRegistry(),
+        definition_loader=lambda _workflow_id, **_actor: definition,
+    )
+    worker._executor = cast(
+        Any,
+        SimpleNamespace(
+            run_durable=lambda *_args, **_kwargs: DurableWorkflowResult(
+                instance_id=instance.instance_id,
+                data={"llm_usage_cost_summary": summary},
+                completed=True,
+                final_state="done",
+            )
+        ),
+    )
+
+    worker._process_instance(instance)
+
+    assert manager.mark_completed_calls[0]["llm_usage_cost_summary"] == summary
+    assert manager.mark_completed_calls[0]["outputs"][
+        "llm_usage_cost_summary"
+    ] == summary
 
 
 @pytest.mark.parametrize("completed", [True, False])

--- a/tests/backend/test_email_source_representation_convergence_bootstrap.py
+++ b/tests/backend/test_email_source_representation_convergence_bootstrap.py
@@ -82,12 +82,14 @@ def test_email_source_workflow_bootstrap_materialises_bundle_and_hint(
     payload = json.loads(str(captured_hint["text"]))
     entry = payload["entries"][0]
     assert entry["action_kind"] == "terminal_completion"
-    assert entry["action"]["tool_name"] == "record_source_processing_marker"
-    assert entry["tool_arguments"]["source_system"] == "gmail"
-    assert entry["tool_arguments"]["source_item_id_context_key"] == "message_id"
-    assert entry["upstream_filter"]["query_fragment"] == ""
+    assert entry["action"]["tool_name"] == "gmail_modify_labels"
+    assert entry["tool_arguments"]["message_id_context_key"] == "message_id"
+    assert entry["tool_arguments"]["verify_after"] is True
+    assert entry["upstream_filter"]["query_fragment"] == (
+        '-label:"VON/PAPER/REPRESENTED"'
+    )
     assert entry["represented_effects"][0]["effect_kind"] == (
-        "record_source_processing_marker"
+        "verified_gmail_label_convergence"
     )
 
 
@@ -308,14 +310,14 @@ def test_email_source_seed_keeps_batch_effects_out_of_singular_routing() -> None
     assert any("Do not route a singular" in note for note in routing_notes)
 
 
-def test_email_source_seed_uses_represented_markers_instead_of_gmail_writes() -> None:
+def test_email_source_seed_requires_current_markers_before_verified_gmail_writes() -> None:
     from src.backend.services import (
         email_source_representation_convergence_workflow_vontology_service as mod,
     )
 
     payload = json.loads(mod._REPO_SEED_ASSET_PATH.read_text(encoding="utf-8"))
     seed_text = json.dumps(payload)
-    assert "gmail_modify_labels" not in seed_text
+    assert "gmail_modify_labels" in seed_text
     assert "vontology/ingested" not in seed_text
 
     workflows = {
@@ -334,6 +336,12 @@ def test_email_source_seed_uses_represented_markers_instead_of_gmail_writes() ->
         "tool_name",
         "get_source_processing_marker",
     ]
+    marker_arguments = steps["check_processed_marker"]["static_input_bindings"][0][
+        1
+    ]
+    assert marker_arguments["require_represented_artifacts"] is True
+    assert "source_fingerprint" in marker_arguments
+    assert "processing_authority_fingerprint" in marker_arguments
     mark_done = steps["mark_done"]
     assert mark_done["mutation_authority"]["maximum_level"] == "additive_vontology"
     assert mark_done["static_input_bindings"][1] == [
@@ -351,17 +359,29 @@ def test_email_source_seed_uses_represented_markers_instead_of_gmail_writes() ->
     ]
     assert verify_done_marker["on_failure_state"] == "failed_unmarked"
     assert verify_done_marker["next_state"] == "failed_unmarked"
-    assert verify_done_marker["conditional_transitions"] == [
-        {
-            "condition_spec": {
-                "expected": True,
-                "key": "source_processing_marker_exists",
-                "kind": "context_flag",
-            },
-            "reason": "source_processing_marker_canonically_verified",
-            "to_state": "done",
-        }
+    assert verify_done_marker["conditional_transitions"][0]["condition_spec"] == {
+        "expected": True,
+        "key": "source_processing_current",
+        "kind": "context_flag",
+    }
+    assert verify_done_marker["conditional_transitions"][0]["to_state"] == (
+        "converge_gmail_labels"
+    )
+
+    converge = steps["converge_gmail_labels"]
+    assert converge["mutation_authority"]["maximum_level"] == (
+        "external_system_guarded"
+    )
+    assert converge["static_input_bindings"][1] == [
+        "tool_name",
+        "gmail_modify_labels",
     ]
+    gmail_arguments = converge["static_input_bindings"][0][1]
+    assert gmail_arguments["add_labels"] == [
+        {"$context_key": "represented_label_id"}
+    ]
+    assert gmail_arguments["remove_labels"] == ["INBOX"]
+    assert gmail_arguments["verify_after"] is True
 
 
 def test_email_source_seed_routes_exact_message_unit_and_explicit_batch() -> None:
@@ -476,7 +496,12 @@ def _run_exact_message_slice(definition, handler):
         environment=WorkflowEnvironment(llm_client=None),
         data={
             "message_id": "gmail-message-1",
-            "gmail_profile": "#V#gmail_profile_vonwitbrock_gmail",
+            "gmail_profile": "vonwitbrock-gmail",
+            "represented_label_id": "Label_3",
+            "source_fingerprint": (
+                "gmail-message-id:v1:vonwitbrock-gmail:gmail-message-1"
+            ),
+            "processing_authority_fingerprint": "email-arxiv-ingestion:v2",
             "arxiv_iteration_results": [
                 {"paper_concept_id": "#V#paper_2606_12345", "arxiv_id": "2606.12345"}
             ],
@@ -503,6 +528,17 @@ def test_exact_message_workflow_records_then_reads_back_marker_before_success() 
                     }
                 },
             )
+        if tool_name == "gmail_modify_labels":
+            return WorkflowActionResult(
+                status="success",
+                outputs={
+                    "result": {
+                        "gmail_label_state_verified": True,
+                        "readback_label_ids": ["Label_3"],
+                        "modify_reconciled_after_error": False,
+                    }
+                },
+            )
         assert tool_name == "get_source_processing_marker"
         return WorkflowActionResult(
             status="success",
@@ -514,6 +550,8 @@ def test_exact_message_workflow_records_then_reads_back_marker_before_success() 
                     "paper_concept_id": "#V#paper_2606_12345",
                     "file_copy_concept_id": "#V#file_2606_12345",
                     "arxiv_id": "2606.12345",
+                    "source_processing_current": True,
+                    "represented_artifacts_exist": True,
                 }
             },
         )
@@ -521,8 +559,10 @@ def test_exact_message_workflow_records_then_reads_back_marker_before_success() 
     definition = _exact_message_definition(
         "mark_done",
         "verify_done_marker",
+        "converge_gmail_labels",
         "done",
         "failed_unmarked",
+        "failed_gmail_state",
         initial_state="mark_done",
     )
     result = _run_exact_message_slice(definition, handler)
@@ -532,6 +572,7 @@ def test_exact_message_workflow_records_then_reads_back_marker_before_success() 
     assert calls == [
         "record_source_processing_marker",
         "get_source_processing_marker",
+        "gmail_modify_labels",
     ]
     assert result.data["source_processing_marker_exists"] is True
     assert result.data["message_processing_marker"] == "#V#marker_1"
@@ -572,6 +613,8 @@ def test_exact_message_workflow_never_claims_success_without_verified_marker(
                     "paper_concept_id": None,
                     "file_copy_concept_id": None,
                     "arxiv_id": None,
+                    "source_processing_current": False,
+                    "represented_artifacts_exist": False,
                 }
             },
         )
@@ -594,12 +637,23 @@ def test_exact_message_workflow_never_claims_success_without_verified_marker(
     )
 
 
-def test_exact_message_workflow_reuses_existing_marker_without_representing_again() -> None:
+def test_exact_message_workflow_reuses_current_marker_then_converges_gmail() -> None:
     calls: list[str] = []
 
     def handler(request: WorkflowActionRequest) -> WorkflowActionResult:
         tool_name = str(request.inputs.get("tool_name") or "")
         calls.append(tool_name)
+        if tool_name == "gmail_modify_labels":
+            return WorkflowActionResult(
+                status="success",
+                outputs={
+                    "result": {
+                        "gmail_label_state_verified": True,
+                        "readback_label_ids": ["Label_3"],
+                        "modify_reconciled_after_error": False,
+                    }
+                },
+            )
         assert tool_name == "get_source_processing_marker"
         return WorkflowActionResult(
             status="success",
@@ -611,21 +665,116 @@ def test_exact_message_workflow_reuses_existing_marker_without_representing_agai
                     "paper_concept_id": "#V#paper_2606_12345",
                     "file_copy_concept_id": "#V#file_2606_12345",
                     "arxiv_id": "2606.12345",
+                    "source_processing_current": True,
+                    "represented_artifacts_exist": True,
+                    "paper_concept_ids": ["#V#paper_2606_12345"],
+                    "file_copy_concept_ids": ["#V#file_2606_12345"],
+                    "arxiv_ids": ["2606.12345"],
                 }
             },
         )
 
     definition = _exact_message_definition(
         "check_processed_marker",
-        "done_already_processed",
+        "converge_gmail_labels",
+        "done",
+        "failed_gmail_state",
         "failed",
         initial_state="check_processed_marker",
     )
     result = _run_exact_message_slice(definition, handler)
 
     assert result.completed is True
-    assert result.final_state == "done_already_processed"
-    assert calls == ["get_source_processing_marker"]
+    assert result.final_state == "done"
+    assert calls == ["get_source_processing_marker", "gmail_modify_labels"]
+
+
+def test_exact_message_workflow_upgrades_legacy_marker_before_gmail() -> None:
+    calls: list[str] = []
+    marker_reads = 0
+
+    def handler(request: WorkflowActionRequest) -> WorkflowActionResult:
+        nonlocal marker_reads
+        tool_name = str(request.inputs.get("tool_name") or "")
+        calls.append(tool_name)
+        if tool_name == "record_source_processing_marker":
+            assert request.inputs["tool_arguments"]["source_fingerprint"] == (
+                "gmail-message-id:v1:vonwitbrock-gmail:gmail-message-1"
+            )
+            return WorkflowActionResult(status="success", outputs={"result": {}})
+        if tool_name == "gmail_modify_labels":
+            return WorkflowActionResult(
+                status="success",
+                outputs={
+                    "result": {
+                        "gmail_label_state_verified": True,
+                        "readback_label_ids": ["Label_3"],
+                        "modify_reconciled_after_error": False,
+                    }
+                },
+            )
+        assert tool_name == "get_source_processing_marker"
+        marker_reads += 1
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "result": {
+                    "source_processing_marker_exists": True,
+                    "message_processing_marker": "#V#marker_existing",
+                    "processed_message_id": "gmail-message-1",
+                    "paper_concept_id": "#V#paper_2606_12345",
+                    "file_copy_concept_id": "#V#file_2606_12345",
+                    "arxiv_id": "2606.12345",
+                    "paper_concept_ids": ["#V#paper_2606_12345"],
+                    "file_copy_concept_ids": ["#V#file_2606_12345"],
+                    "arxiv_ids": ["2606.12345"],
+                    "represented_artifacts_exist": True,
+                    "source_processing_current": marker_reads > 1,
+                }
+            },
+        )
+
+    definition = _exact_message_definition(
+        "check_processed_marker",
+        "upgrade_legacy_marker",
+        "verify_done_marker",
+        "converge_gmail_labels",
+        "done",
+        "failed",
+        "failed_unmarked",
+        "failed_gmail_state",
+        initial_state="check_processed_marker",
+    )
+    result = _run_exact_message_slice(definition, handler)
+
+    assert result.completed is True
+    assert result.final_state == "done"
+    assert calls == [
+        "get_source_processing_marker",
+        "record_source_processing_marker",
+        "get_source_processing_marker",
+        "gmail_modify_labels",
+    ]
+
+
+def test_exact_message_workflow_does_not_succeed_when_gmail_readback_fails() -> None:
+    calls: list[str] = []
+
+    def handler(request: WorkflowActionRequest) -> WorkflowActionResult:
+        calls.append(str(request.inputs.get("tool_name") or ""))
+        return WorkflowActionResult(status="failure", error="gmail state unverified")
+
+    definition = _exact_message_definition(
+        "converge_gmail_labels",
+        "done",
+        "failed_gmail_state",
+        initial_state="converge_gmail_labels",
+    )
+    result = _run_exact_message_slice(definition, handler)
+
+    assert result.completed is True
+    assert result.final_state == "failed_gmail_state"
+    assert calls == ["gmail_modify_labels", "gmail_modify_labels"]
 
 
 def test_exact_message_workflow_does_not_mark_after_arxiv_ingestion_failure() -> None:
@@ -726,9 +875,14 @@ def test_email_arxiv_schedule_bootstrap_creates_managed_interval_schedule(
     assert schedule.default_inputs["managed_schedule_key"] == (
         mod.EMAIL_ARXIV_REPRESENTATION_CONVERGENCE_SCHEDULE_MANAGED_KEY
     )
-    assert schedule.default_inputs["gmail_profile"] == "#V#gmail_profile_zhan_gmail"
+    assert schedule.default_inputs["gmail_profile"] == (
+        "#V#gmail_profile_vonwitbrock_gmail"
+    )
+    assert schedule.default_inputs["base_gmail_query"] == "arxiv.org"
     assert schedule.default_inputs["gmail_max_results"] == 2
-    assert "arxiv papers" in schedule.default_inputs["prompt"]
+    assert "arxiv" in schedule.default_inputs["prompt"].lower()
+    assert schedule.enabled is False
+    assert report["schedule_enabled"] is False
 
 
 def test_email_arxiv_schedule_bootstrap_reuses_existing_matching_schedule(
@@ -754,7 +908,9 @@ def test_email_arxiv_schedule_bootstrap_reuses_existing_matching_schedule(
     monkeypatch.setattr(mod, "get_instance_manager", lambda: fake)
     monkeypatch.setenv("VON_EMAIL_ARXIV_CONVERGENCE_SCHEDULE_ENABLE", "1")
 
-    report = mod.ensure_email_arxiv_representation_convergence_schedule()
+    report = mod.ensure_email_arxiv_representation_convergence_schedule(
+        activate=True
+    )
 
     assert report["success"] is True
     assert report["created_count"] == 0
@@ -796,3 +952,41 @@ def test_email_arxiv_schedule_bootstrap_disables_mismatched_schedule(
     assert report["created_count"] == 1
     assert report["disabled_count"] == 1
     assert (mismatched.schedule_id, False) in fake.enabled_updates
+
+
+def test_email_arxiv_schedule_bootstrap_replaces_inert_legacy_schedule(
+    monkeypatch,
+) -> None:
+    from src.backend.services import (
+        email_source_representation_convergence_schedule_bootstrap_service as mod,
+    )
+
+    _reset_schedule_bootstrap_state(mod)
+    desired = mod._desired_schedule_config()
+    legacy = WorkflowSchedule.create_interval(
+        desired["workflow_id"],
+        interval_seconds=desired["interval_seconds"],
+        user_id=desired["user_id"],
+        org_id=desired["org_id"],
+        namespace=desired["namespace"],
+        default_inputs={
+            **dict(desired["default_inputs"]),
+            "managed_schedule_key": "email_arxiv_representation_convergence_v1",
+            "gmail_profile": "#V#gmail_profile_zhan_gmail",
+            "base_gmail_query": "arxiv.org newer_than:365d",
+        },
+        description="email_arxiv_representation_convergence_v1",
+    )
+    legacy.enabled = True
+    legacy.next_run_at = None
+    fake = _FakeManager([legacy])
+    monkeypatch.setattr(mod, "get_instance_manager", lambda: fake)
+
+    report = mod.ensure_email_arxiv_representation_convergence_schedule()
+
+    assert report["success"] is True
+    assert report["created_count"] == 1
+    assert report["disabled_count"] == 1
+    assert (legacy.schedule_id, False) in fake.enabled_updates
+    assert fake.created[0].enabled is False
+    assert fake.created[0].next_run_at is not None

--- a/tests/backend/test_gmail_service.py
+++ b/tests/backend/test_gmail_service.py
@@ -233,6 +233,54 @@ def test_list_and_get_message(mock_get_profile, mock_get_service):
     assert labels_result == {"labels": []}
 
 
+@patch("src.backend.integrations.google.gmail_service.get_service")
+@patch("src.backend.integrations.google.gmail_service.get_profile")
+def test_list_labels_resolves_one_exact_name(mock_get_profile, mock_get_service):
+    mock_get_profile.return_value = SimpleNamespace(
+        profile_id="test",
+        user_id="me",
+    )
+    labels_mock = MagicMock()
+    mock_get_service.return_value.users.return_value.labels.return_value = labels_mock
+    labels_mock.list.return_value.execute.return_value = {
+        "labels": [
+            {"id": "Label_2", "name": "VON/PAPER/ARXIV"},
+            {"id": "Label_3", "name": "VON/PAPER/REPRESENTED"},
+        ]
+    }
+
+    result = gs.list_labels(
+        "test",
+        exact_name="VON/PAPER/REPRESENTED",
+        require_exact_match=True,
+    )
+
+    assert result["exact_match_count"] == 1
+    assert result["label_id"] == "Label_3"
+    assert result["label_name"] == "VON/PAPER/REPRESENTED"
+
+
+@patch("src.backend.integrations.google.gmail_service.get_service")
+@patch("src.backend.integrations.google.gmail_service.get_profile")
+def test_list_labels_required_exact_name_fails_closed(
+    mock_get_profile, mock_get_service
+):
+    mock_get_profile.return_value = SimpleNamespace(
+        profile_id="test",
+        user_id="me",
+    )
+    labels_mock = MagicMock()
+    mock_get_service.return_value.users.return_value.labels.return_value = labels_mock
+    labels_mock.list.return_value.execute.return_value = {"labels": []}
+
+    with pytest.raises(ValueError, match="matched 0 labels"):
+        gs.list_labels(
+            "test",
+            exact_name="VON/PAPER/REPRESENTED",
+            require_exact_match=True,
+        )
+
+
 def test_decode_attachment_bytes_accepts_gmail_base64url_without_padding():
     source = b"%PDF-1.7\nresearch description"
     encoded = base64.urlsafe_b64encode(source).decode("ascii").rstrip("=")
@@ -301,6 +349,79 @@ def test_modify_labels_guard(monkeypatch):
 
         assert result == {"id": "mid"}
         svc.users.return_value.messages.return_value.modify.assert_called_once()
+
+
+def test_modify_labels_verifies_canonical_state(monkeypatch):
+    profiles = {
+        "p": gs.GmailProfile(
+            profile_id="p",
+            token_path="/tmp/token.json",
+            scopes=[gs.MUTATION_SCOPE],
+        )
+    }
+    with patch(
+        "src.backend.integrations.google.gmail_service.get_service"
+    ) as mock_service:
+        svc = MagicMock()
+        messages = svc.users.return_value.messages.return_value
+        messages.modify.return_value.execute.return_value = {"id": "mid"}
+        messages.get.return_value.execute.return_value = {
+            "id": "mid",
+            "labelIds": ["Label_3", "UNREAD"],
+        }
+        mock_service.return_value = svc
+
+        result = gs.modify_labels(
+            "p",
+            "mid",
+            add_labels=["Label_3"],
+            remove_labels=["INBOX"],
+            allow_mutation=True,
+            verify_after=True,
+            profiles=profiles,
+        )
+
+    assert result["success"] is True
+    assert result["gmail_label_state_verified"] is True
+    assert result["readback_label_ids"] == ["Label_3", "UNREAD"]
+    assert result["modify_reconciled_after_error"] is False
+    messages.get.assert_called_once_with(userId="me", id="mid", format="minimal")
+
+
+def test_modify_labels_reconciles_lost_modify_response(monkeypatch):
+    profiles = {
+        "p": gs.GmailProfile(
+            profile_id="p",
+            token_path="/tmp/token.json",
+            scopes=[gs.MUTATION_SCOPE],
+        )
+    }
+    with patch(
+        "src.backend.integrations.google.gmail_service.get_service"
+    ) as mock_service:
+        svc = MagicMock()
+        messages = svc.users.return_value.messages.return_value
+        messages.modify.return_value.execute.side_effect = TimeoutError(
+            "response lost"
+        )
+        messages.get.return_value.execute.return_value = {
+            "id": "mid",
+            "labelIds": ["Label_3"],
+        }
+        mock_service.return_value = svc
+
+        result = gs.modify_labels(
+            "p",
+            "mid",
+            add_labels=["Label_3"],
+            remove_labels=["INBOX"],
+            allow_mutation=True,
+            verify_after=True,
+            profiles=profiles,
+        )
+
+    assert result["gmail_label_state_verified"] is True
+    assert result["modify_reconciled_after_error"] is True
 
 
 def test_create_label_guard_and_calls_gmail_api(monkeypatch):

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -1128,12 +1128,43 @@ def test_gmail_modify_labels_resolves_represented_profile_resource_alias(monkeyp
         message_id="msg-1",
         add_labels=["Label_7"],
         allow_mutation=True,
+        verify_after=True,
     )
 
     assert payload["profile"] == "zhan-gmail"
     assert captured_kwargs["profile_id"] == "zhan-gmail"
     assert captured_kwargs["message_id"] == "msg-1"
     assert captured_kwargs["add_labels"] == ["Label_7"]
+    assert captured_kwargs["verify_after"] is True
+
+
+def test_gmail_list_labels_supports_required_exact_name_resolution(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as catalogue_module
+
+    captured_kwargs: dict = {}
+
+    def fake_list_labels(**kwargs):
+        captured_kwargs.update(kwargs)
+        return {
+            "label_id": "Label_3",
+            "label_name": "VON/PAPER/REPRESENTED",
+            "exact_match_count": 1,
+        }
+
+    monkeypatch.setattr(
+        "src.backend.integrations.google.gmail_service.list_labels",
+        fake_list_labels,
+    )
+
+    payload = catalogue_module._gmail_list_labels(
+        profile="vonwitbrock-gmail",
+        exact_name="VON/PAPER/REPRESENTED",
+        require_exact_match=True,
+    )
+
+    assert payload["label_id"] == "Label_3"
+    assert captured_kwargs["exact_name"] == "VON/PAPER/REPRESENTED"
+    assert captured_kwargs["require_exact_match"] is True
 
 
 def test_source_processing_marker_tools_registered_as_vontology_surfaces():

--- a/tests/backend/test_jvnautosci_2272_zhan_gmail_arxiv_workflow_repair.py
+++ b/tests/backend/test_jvnautosci_2272_zhan_gmail_arxiv_workflow_repair.py
@@ -9,6 +9,7 @@ from scripts.repair_jvnautosci_2272_zhan_gmail_arxiv_ingestion_workflow import (
     PARENT_PROCESS_MESSAGES_STEP_ID,
     build_email_message_launch_input_contract,
     build_zhan_launch_input_contract,
+    publish_jvnautosci_2272_repair,
     rewrite_email_message_workflow_spec,
     rewrite_gmail_completion_hint_payload,
     rewrite_zhan_parent_workflow_spec,
@@ -228,6 +229,17 @@ def test_launch_contracts_are_valid_and_mapping_backed() -> None:
         assert error is None
         assert normalised is not None
         assert normalised["input_mappings"]
+
+
+def test_legacy_repair_entry_point_delegates_to_current_canonical_seed() -> None:
+    report = publish_jvnautosci_2272_repair(dry_run=True)
+
+    assert report["success"] is True
+    assert report["deprecated_entry_point"] is True
+    assert report["seed_version"] == "11"
+    assert report["delegates_to"] == (
+        "bootstrap_canonical_email_source_representation_convergence_workflows"
+    )
 
 
 def test_zhan_launch_contract_uses_prior_arxiv_evidence_as_narrow_query() -> None:

--- a/tests/backend/test_source_processing_marker_service.py
+++ b/tests/backend/test_source_processing_marker_service.py
@@ -445,3 +445,47 @@ def test_spreadsheet_marker_requires_represented_outputs(monkeypatch) -> None:
 
     assert written["source_fingerprint_matches"] is True
     assert written["source_processing_current"] is False
+
+
+def test_gmail_marker_can_require_current_represented_artifacts(monkeypatch) -> None:
+    from src.backend.services import source_processing_marker_service as service
+
+    existing = {"#V#paper_2608_00038"}
+    monkeypatch.setattr(
+        service,
+        "_find_existing_concept_ids",
+        lambda concept_ids: set(concept_ids).intersection(existing),
+    )
+    payload = {
+        "source_system": "gmail",
+        "processing_status": "processed",
+        "source_fingerprint": "gmail-message-id:v1:profile:message-1",
+        "processing_authority_fingerprint": "email-arxiv-ingestion:v2",
+        "represented_artifact_concept_ids": ["#V#paper_2608_00038"],
+    }
+
+    current = service._marker_response_from_payload(
+        marker_concept_id="#V#marker",
+        source_item_id="message-1",
+        marker_exists=True,
+        evidence_payload=payload,
+        expected_source_fingerprint="gmail-message-id:v1:profile:message-1",
+        expected_processing_authority_fingerprint="email-arxiv-ingestion:v2",
+        require_represented_artifacts=True,
+    )
+    existing.clear()
+    missing_artifact = service._marker_response_from_payload(
+        marker_concept_id="#V#marker",
+        source_item_id="message-1",
+        marker_exists=True,
+        evidence_payload=payload,
+        expected_source_fingerprint="gmail-message-id:v1:profile:message-1",
+        expected_processing_authority_fingerprint="email-arxiv-ingestion:v2",
+        require_represented_artifacts=True,
+    )
+
+    assert current["represented_artifacts_required"] is True
+    assert current["represented_artifacts_exist"] is True
+    assert current["source_processing_current"] is True
+    assert missing_artifact["represented_artifacts_exist"] is False
+    assert missing_artifact["source_processing_current"] is False

--- a/tests/backend/test_subworkflow_actions.py
+++ b/tests/backend/test_subworkflow_actions.py
@@ -7,7 +7,9 @@ from src.backend.workflows.action_registry import (
     WorkflowActionResult,
     WorkflowEnvironment,
 )
-from src.backend.workflows.durable.subworkflow_actions import register_subworkflow_actions
+from src.backend.workflows.durable.subworkflow_actions import (
+    register_subworkflow_actions,
+)
 from src.backend.workflows.engine import (
     WorkflowActionInvocation,
     WorkflowDefinition,

--- a/tests/backend/test_utils_flask_identity_resolution_bootstrap.py
+++ b/tests/backend/test_utils_flask_identity_resolution_bootstrap.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
 
@@ -539,9 +540,22 @@ def test_start_durable_system_bootstraps_identity_schedule(monkeypatch) -> None:
     )
 
     app_logger = MagicMock()
-    result = utils_flask._start_durable_workflow_system(app_logger)
+    queue_ready_components: list[dict[str, Any]] = []
+    result = utils_flask._start_durable_workflow_system(
+        app_logger,
+        queue_ready_callback=lambda components: queue_ready_components.append(
+            dict(components)
+        ),
+    )
 
     assert isinstance(result, dict)
+    assert len(queue_ready_components) == 1
+    assert queue_ready_components[0].get("startup_queue_ready") == {
+        "stage": "before_canonical_bootstraps",
+        "recovered_orphaned_instances": 0,
+        "released_ineligible_worker_claims": 0,
+    }
+    assert "entity_workflow_bootstrap" not in queue_ready_components[0]
     assert startup_events[:2] == ["worker_started", "entity_bootstrap"]
     assert result.get("startup_queue_ready") == {
         "stage": "before_canonical_bootstraps",

--- a/tests/backend/test_utils_flask_orchestrator_startup.py
+++ b/tests/backend/test_utils_flask_orchestrator_startup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import threading
 import time
 import types
 
@@ -135,9 +136,15 @@ def test_create_flask_app_defers_durable_workflow_startup(monkeypatch):
 
     _install_internal_mcp_gateway_stubs(monkeypatch, internal_mcp)
 
-    def _slow_durable_startup(_app_logger):
+    maintenance_finished = threading.Event()
+
+    def _slow_durable_startup(_app_logger, *, queue_ready_callback=None):
+        components = {"worker_running": True, "scheduler_running": True}
+        assert queue_ready_callback is not None
+        queue_ready_callback(components)
         time.sleep(1.0)
-        return {"worker_running": True, "scheduler_running": True}
+        maintenance_finished.set()
+        return components
 
     monkeypatch.setattr(
         utils_flask, "_start_durable_workflow_system", _slow_durable_startup
@@ -165,9 +172,65 @@ def test_create_flask_app_defers_durable_workflow_startup(monkeypatch):
         time.sleep(0.02)
 
     assert app.config.get("DURABLE_WORKFLOW_COMPONENTS") is not None
+    core_ready_status = app.config.get("DURABLE_WORKFLOW_STARTUP_STATUS") or {}
+    assert core_ready_status.get("state") == "ready"
+    assert core_ready_status.get("ready") is True
+    assert core_ready_status.get("startup_phase") == "canonical_maintenance"
+    assert core_ready_status.get("maintenance_in_progress") is True
+    assert maintenance_finished.wait(3.0)
+
     final_status = app.config.get("DURABLE_WORKFLOW_STARTUP_STATUS") or {}
     assert final_status.get("state") == "ready"
     assert final_status.get("ready") is True
+    assert final_status.get("startup_phase") == "complete"
+    assert final_status.get("maintenance_in_progress") is False
+
+
+def test_durable_workflow_startup_keeps_core_ready_when_maintenance_fails(
+    monkeypatch,
+):
+    from flask import Flask
+
+    import src.backend.server.utils_flask as utils_flask
+
+    monkeypatch.setenv("VON_DURABLE_WORKFLOWS_BLOCKING_STARTUP", "0")
+    monkeypatch.setattr(utils_flask, "_is_running_under_pytest", lambda: False)
+    monkeypatch.setattr(utils_flask, "_is_agent_test_instance", lambda: False)
+    monkeypatch.setattr(utils_flask, "_stop_durable_workflow_system", lambda: None)
+
+    def _maintenance_failure(_app_logger, *, queue_ready_callback=None):
+        assert queue_ready_callback is not None
+        queue_ready_callback(
+            {"worker_running": True, "scheduler_running": True}
+        )
+        return None
+
+    monkeypatch.setattr(
+        utils_flask,
+        "_start_durable_workflow_system",
+        _maintenance_failure,
+    )
+
+    app = Flask(__name__)
+    utils_flask._configure_durable_workflow_startup(app)
+
+    deadline = time.time() + 2.0
+    while time.time() < deadline:
+        status = app.config.get("DURABLE_WORKFLOW_STARTUP_STATUS") or {}
+        if status.get("startup_phase") == "canonical_maintenance_failed":
+            break
+        time.sleep(0.01)
+
+    status = app.config.get("DURABLE_WORKFLOW_STARTUP_STATUS") or {}
+    assert status.get("state") == "ready"
+    assert status.get("ready") is True
+    assert status.get("startup_phase") == "canonical_maintenance_failed"
+    assert status.get("maintenance_in_progress") is False
+    assert status.get("maintenance_error") == "startup_maintenance_failed"
+    assert app.config.get("DURABLE_WORKFLOW_COMPONENTS") == {
+        "worker_running": True,
+        "scheduler_running": True,
+    }
 
 
 def test_build_durable_workflow_registry_uses_shared_deferred_read_only_builder(

--- a/tests/backend/test_workflow_capability_service.py
+++ b/tests/backend/test_workflow_capability_service.py
@@ -1675,14 +1675,27 @@ def test_startup_check_records_not_ready_report(
 
     reset_workflow_capability_index()
 
+    populate_calls: list[dict[str, Any]] = []
+
+    def _record_non_blocking_startup_check(**kwargs: Any) -> WorkflowCapabilityIndex:
+        populate_calls.append(dict(kwargs))
+        return capability_service.get_workflow_capability_index()
+
     monkeypatch.setattr(
         capability_service,
         "ensure_workflow_capability_index_populated",
-        lambda **_kwargs: capability_service.get_workflow_capability_index(),
+        _record_non_blocking_startup_check,
     )
 
     report = run_workflow_capability_index_startup_check(timeout_seconds=0.01)
 
+    assert populate_calls == [
+        {
+            "block": False,
+            "max_wait_seconds": 0.01,
+            "workflow_registry": None,
+        }
+    ]
     assert report["success"] is False
     assert report["ready"] is False
     assert report["status"] == "not_ready"


### PR DESCRIPTION
## What changed

- make durable workflow core readiness independent of slower canonical startup maintenance;
- repair managed schedule creation/next-run persistence, stable occurrence idempotency, overlap suppression and misfire coalescing;
- publish the current Gmail/arXiv convergence workflow: exact represented-label resolution, newest unrepresented INBOX search, fingerprinted marker currentness, represented-artifact verification, atomic label/archive mutation and independent Gmail read-back;
- retire the older marker-only repair entry point in favour of the canonical represented workflow seed;
- persist content-free LLM usage and registry-priced cost estimates on durable workflow instances, including nested subworkflows and deterministic no-LLM runs.

## Why

The existing managed paper-ingestion schedule could be inert because `next_run_at` was absent, and the prior workflow treated marker existence as sufficient while never applying the Gmail labels that drive backlog traversal. Startup also withheld durable readiness while unrelated maintenance continued. Scheduled workflow model usage was not durably attributable to the schedule occurrence.

## User impact

The scheduled Gmail/arXiv path can now move backwards through unrepresented INBOX papers in bounded batches, represent and verify them, add `VON/PAPER/REPRESENTED`, remove `INBOX`, retry safely, and expose honest per-instance model usage/cost accounting.

## Validation

- 345 affected tests passed on the original candidate worktree.
- 345 affected tests passed again from a clean worktree based directly on `origin/main`.
- JSON assets parse and `git diff --check` passes.
- A live scheduled batch processed three messages; independent Gmail reads confirmed the represented label and absence of INBOX, source-marker concepts were present, and the next unrepresented query advanced to older messages.
- No Sol-family model was selected or invoked.

## Scope

This PR covers the Gmail/arXiv scheduled-ingestion slice and generic durable schedule/cost support. DOI/publisher/PDF acquisition and personalised paper recommendations remain separately tracked.