### PR TITLE
Fix non-converging paper mail review disposition

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -30642,6 +30642,7 @@ def _task_create(**kwargs):
     notes = kwargs.get("notes")
     reference_code = kwargs.get("reference_code")
     request_id = str(kwargs.get("request_id") or "").strip()
+    idempotency_key = str(kwargs.get("idempotency_key") or "").strip()
 
     actor_id = str(actor_scope.user_concept_id)
     actor_org_id = str(actor_scope.organisation_concept_id)
@@ -30657,10 +30658,18 @@ def _task_create(**kwargs):
                 "authenticated actor in the authenticated organisation."
             ),
         )
-    if not request_id:
+    if len(idempotency_key) > 512:
+        return make_error_response(
+            "INVALID_PARAM",
+            "idempotency_key must be at most 512 characters.",
+        )
+    if not request_id and not idempotency_key:
         return make_error_response(
             "authenticated_request_context_required",
-            "Task creation requires the trusted conversation-turn request identity.",
+            (
+                "Task creation requires either the trusted conversation-turn "
+                "request identity or an actor-scoped idempotency_key."
+            ),
         )
 
     start_date, start_error = _parse_optional_iso_datetime_param(
@@ -30676,30 +30685,43 @@ def _task_create(**kwargs):
     if due_error:
         return due_error
 
-    creation_fingerprint_payload = {
-        "request_id": request_id,
-        "actor_id": actor_id,
-        "organisation_concept_id": actor_org_id,
-        "title": title.strip(),
-        "description": description.strip(),
-        "originating_session_id": session_id,
-        "priority": priority,
-        "start_date": start_date.isoformat() if start_date else None,
-        "due_date": due_date.isoformat() if due_date else None,
-        "epic_task_concept_id": epic_task_concept_id,
-        "components": components,
-        "fix_versions": fix_versions,
-        "sprint_values": sprint_values,
-        "backlog_rank": backlog_rank,
-        "task_type_ids": task_type_ids,
-        "task_source_id": task_source_id,
-        "task_role": task_role,
-        "next_checkpoint": next_checkpoint,
-        "progress_signal": progress_signal,
-        "evidence": evidence,
-        "notes": notes,
-        "reference_code": reference_code,
-    }
+    if idempotency_key:
+        # A durable workflow does not necessarily originate in a conversation
+        # turn.  Let it ensure one actor-owned task for a stable source item
+        # without making the task identity depend on mutable presentation text.
+        # Actor and organisation remain part of the server-issued fingerprint,
+        # so a represented key cannot cross either authority boundary.
+        creation_fingerprint_payload = {
+            "schema_version": "actor_scoped_task_idempotency.v1",
+            "actor_id": actor_id,
+            "organisation_concept_id": actor_org_id,
+            "idempotency_key": idempotency_key,
+        }
+    else:
+        creation_fingerprint_payload = {
+            "request_id": request_id,
+            "actor_id": actor_id,
+            "organisation_concept_id": actor_org_id,
+            "title": title.strip(),
+            "description": description.strip(),
+            "originating_session_id": session_id,
+            "priority": priority,
+            "start_date": start_date.isoformat() if start_date else None,
+            "due_date": due_date.isoformat() if due_date else None,
+            "epic_task_concept_id": epic_task_concept_id,
+            "components": components,
+            "fix_versions": fix_versions,
+            "sprint_values": sprint_values,
+            "backlog_rank": backlog_rank,
+            "task_type_ids": task_type_ids,
+            "task_source_id": task_source_id,
+            "task_role": task_role,
+            "next_checkpoint": next_checkpoint,
+            "progress_signal": progress_signal,
+            "evidence": evidence,
+            "notes": notes,
+            "reference_code": reference_code,
+        }
     creation_fingerprint = hashlib.sha256(
         json.dumps(
             creation_fingerprint_payload,
@@ -30816,7 +30838,11 @@ def _task_create(**kwargs):
                 notes=notes,
                 reference_code=reference_code,
                 agent_creation_fingerprint=creation_fingerprint,
-                agent_creation_request_id=request_id,
+                agent_creation_request_id=(
+                    request_id
+                    or "idempotency:"
+                    + hashlib.sha256(idempotency_key.encode("utf-8")).hexdigest()
+                ),
             )
         except InvalidTaskDataError:
             raise
@@ -38733,6 +38759,7 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
                     "evidence": (str, type(None)),
                     "notes": (str, type(None)),
                     "reference_code": (str, type(None)),
+                    "idempotency_key": (str, type(None)),
                     "acting_user_concept_id": (str, type(None)),
                     "organisation_concept_id": (str, type(None)),
                     "request_id": (str, type(None)),
@@ -38766,7 +38793,9 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
                 "Create a self-assigned Von task (stored as a Vontology concept) for "
                 "the authenticated actor and organisation, linked to the current "
                 "conversation. Identical retries in the same turn reuse the canonical "
-                "task. Use this to track work items, action items, or to-dos. "
+                "task. A durable workflow may instead provide a stable idempotency_key "
+                "to ensure one task within the authenticated actor and organisation. "
+                "Use this to track work items, action items, or to-dos. "
                 "Priority: low, medium, high, critical. Tasks start in 'pending' status and can include "
                 "planning metadata (components, fix versions, sprint values, backlog rank), canonical "
                 "task categories, source semantics, and richer task-detail fields."

--- a/src/backend/workflows/durable/control_flow_actions.py
+++ b/src/backend/workflows/durable/control_flow_actions.py
@@ -826,6 +826,10 @@ def _build_for_each_handler(
             for item in iteration_results
             if not item["completed"]
         ]
+        final_state_counts: dict[str, int] = {}
+        for item in iteration_results:
+            final_state = _normalise_text(item.get("final_state")) or "unknown"
+            final_state_counts[final_state] = final_state_counts.get(final_state, 0) + 1
         outputs: Dict[str, Any] = {
             "items_source": items_source or None,
             "for_each_item_count": len(iteration_results),
@@ -843,6 +847,7 @@ def _build_for_each_handler(
             "for_each_success_count": success_count,
             "for_each_error_count": error_count,
             "for_each_partial_success": success_count > 0 and error_count > 0,
+            "for_each_final_state_counts": final_state_counts,
             "for_each_authority_resolution": authority_resolution.to_projection(),
             "iteration_results": iteration_results,
             "iteration_errors": iteration_errors,

--- a/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
@@ -2,12 +2,13 @@
   "family_id": "email_source_representation_convergence_workflow_seed_bundle",
   "managed_by": "email_source_representation_convergence_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "11",
+  "seed_version": "13",
   "source_tag": "JVNAUTOSCI-2335",
   "supported_action_ids": [
     "arxiv.inspect_existing_state",
     "extract_signals_from_tool_result",
     "resolve_tool_output_followup_hint",
+    "workflow_control.context_project",
     "workflow_control.context_set",
     "workflow_control.context_template",
     "workflow_control.for_each",
@@ -18,7 +19,7 @@
     {
       "workflow_id": "#V#zhan_gmail_arxiv_ingestion_workflow",
       "display_name": "Zhan Gmail Arxiv Ingestion Workflow",
-      "description": "Explicit batch workflow for recurring Gmail-to-arXiv paper representation convergence. It selects newest Inbox messages that do not have VON/PAPER/REPRESENTED, represents each supported arXiv reference, records current source-processing evidence, then atomically applies the represented label and removes INBOX with canonical Gmail read-back.",
+      "description": "Explicit batch workflow for recurring Gmail-to-arXiv paper representation convergence. It selects newest Inbox messages that are neither represented nor dispositioned, represents each supported arXiv reference, records current source-processing evidence, then atomically applies the represented label and removes INBOX with canonical Gmail read-back. Messages with no supported reference instead receive one actor-scoped review task and VON/PAPER/NEEDS_REVIEW while remaining in Inbox.",
       "text_relations": [
         {
           "predicate": "#V#hasWorkflowDiscoveryExemplarsJson",
@@ -341,6 +342,27 @@
                 "condition_spec": {
                   "conditions": [
                     {
+                      "key": "message_final_state_counts.#V#workflow_step_email_arxiv_ingestion_from_message_workflow_done_needs_review",
+                      "kind": "context_compare",
+                      "operator": "gt",
+                      "value": 0
+                    },
+                    {
+                      "key": "message_error_count",
+                      "kind": "context_compare",
+                      "operator": "eq",
+                      "value": 0
+                    }
+                  ],
+                  "kind": "all"
+                },
+                "reason": "batch_completed_with_human_review_dispositions",
+                "to_state": "done_with_review_required"
+              },
+              {
+                "condition_spec": {
+                  "conditions": [
+                    {
                       "key": "message_success_count",
                       "kind": "context_compare",
                       "operator": "gt",
@@ -437,10 +459,16 @@
                 "concept_id": "#V#workflow_mapping_tool_field_zhan_gmail_arxiv_ingestion_workflow_process_messages_iteration_results_to_message_iteration_results",
                 "context_key": "message_iteration_results",
                 "tool_output_field": "iteration_results"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_zhan_gmail_arxiv_ingestion_workflow_process_messages_for_each_final_state_counts_to_message_final_state_counts",
+                "context_key": "message_final_state_counts",
+                "tool_output_field": "for_each_final_state_counts"
               }
             ],
             "writes_context_keys": [
               "message_iteration_results",
+              "message_final_state_counts",
               "message_success_count",
               "message_error_count",
               "message_partial_success",
@@ -449,6 +477,9 @@
           },
           {
             "state_id": "done"
+          },
+          {
+            "state_id": "done_with_review_required"
           },
           {
             "state_id": "done_no_messages"
@@ -466,11 +497,11 @@
     {
       "workflow_id": "#V#email_arxiv_ingestion_from_message_workflow",
       "display_name": "Email Arxiv Ingestion From Message Workflow",
-      "description": "Processes one exact Gmail message selected by the caller: establish versioned source and processing-authority identity, reuse or upgrade current represented source-processing evidence when possible, ingest each arXiv reference when needed, canonically verify represented artefacts, then atomically apply VON/PAPER/REPRESENTED and remove INBOX with independent Gmail read-back.",
+      "description": "Processes one exact Gmail message selected by the caller: establish versioned source and processing-authority identity, reuse or upgrade current represented source-processing evidence when possible, ingest each arXiv reference when needed, canonically verify represented artefacts, then atomically apply VON/PAPER/REPRESENTED and remove INBOX with independent Gmail read-back. If no supported arXiv reference is found, create or reuse one actor-scoped review task, apply VON/PAPER/NEEDS_REVIEW, and preserve INBOX.",
       "text_relations": [
         {
           "predicate": "#V#hasWorkflowDiscoveryExemplarsJson",
-          "text": "{\"examples\": [\"Represent the arXiv paper linked from this exact Gmail message, verify its current represented processing marker, label it VON/PAPER/REPRESENTED, and remove it from Inbox.\", \"Converge this selected Gmail message through the durable arXiv representation and mailbox-cleanup path.\"], \"keywords\": [\"exact gmail message arxiv representation\", \"selected email arxiv paper ingestion\", \"represent paper from this message\", \"gmail message processing marker\"], \"required_query_cues\": [\"gmail\", \"email\", \"mail\", \"message\"], \"routing_notes\": [\"Use only after read-only discovery or explicit user context identifies one exact Gmail source message.\", \"Pass include_body explicitly on every gmail_get_message discovery read. When a Gmail search result matched the paper query but its subject or snippet does not expose the arXiv reference, use include_body=true and inspect the bounded message body before rejecting it or moving to an older message.\", \"The caller must supply the exact Gmail profile and current_message object; this workflow does not choose a message or scan a mailbox.\", \"Prefer this durable unit over a paper-only representation workflow when the user outcome also requires source-message and Gmail convergence evidence.\", \"Do not label or archive messages with no supported resource or without current marker and represented-artefact read-back.\"], \"schema_version\": \"workflow_discovery_exemplars.v1\"}",
+          "text": "{\"examples\": [\"Represent the arXiv paper linked from this exact Gmail message, verify its current represented processing marker, label it VON/PAPER/REPRESENTED, and remove it from Inbox.\", \"Converge this selected Gmail message through the durable arXiv representation and mailbox-cleanup path.\"], \"keywords\": [\"exact gmail message arxiv representation\", \"selected email arxiv paper ingestion\", \"represent paper from this message\", \"gmail message processing marker\"], \"required_query_cues\": [\"gmail\", \"email\", \"mail\", \"message\"], \"routing_notes\": [\"Use only after read-only discovery or explicit user context identifies one exact Gmail source message.\", \"Pass include_body explicitly on every gmail_get_message discovery read. When a Gmail search result matched the paper query but its subject or snippet does not expose the arXiv reference, use include_body=true and inspect the bounded message body before rejecting it or moving to an older message.\", \"The caller must supply the exact Gmail profile and current_message object; this workflow does not choose a message or scan a mailbox.\", \"Prefer this durable unit over a paper-only representation workflow when the user outcome also requires source-message and Gmail convergence evidence.\", \"Do not apply VON/PAPER/REPRESENTED or remove INBOX for messages with no supported resource or without current marker and represented-artefact read-back; no-resource messages instead require a review task and VON/PAPER/NEEDS_REVIEW.\"], \"schema_version\": \"workflow_discovery_exemplars.v1\"}",
           "lang": "en-NZ"
         },
         {
@@ -506,6 +537,27 @@
             "required": false,
             "source_expression": "inputs.represented_label_id",
             "target_context_key": "represented_label_id"
+          },
+          {
+            "description": "Optional trusted workflow actor used for a self-assigned review task when the source does not converge.",
+            "extractor": "identity",
+            "required": false,
+            "source_expression": "inputs.user_concept_id",
+            "target_context_key": "user_concept_id"
+          },
+          {
+            "description": "Optional trusted workflow organisation used to scope a review task when the source does not converge.",
+            "extractor": "identity",
+            "required": false,
+            "source_expression": "inputs.org_concept_id",
+            "target_context_key": "org_concept_id"
+          },
+          {
+            "description": "Optional mailbox-specific VON/PAPER/NEEDS_REVIEW label ID inherited by a parent batch.",
+            "extractor": "identity",
+            "required": false,
+            "source_expression": "inputs.needs_review_label_id",
+            "target_context_key": "needs_review_label_id"
           }
         ],
         "required_inputs": [
@@ -942,7 +994,7 @@
               }
             ],
             "execution_mode": "deterministic",
-            "next_state": "done_no_resources",
+            "next_state": "build_review_task",
             "on_failure_state": "failed",
             "state_id": "decide_arxiv_resources",
             "static_input_bindings": [
@@ -955,6 +1007,342 @@
                   }
                 ]
               ]
+            ]
+          },
+          {
+            "action_id": "workflow_control.context_template",
+            "execution_mode": "deterministic",
+            "next_state": "create_review_task",
+            "on_failure_state": "failed",
+            "state_id": "build_review_task",
+            "static_input_bindings": [
+              [
+                "assignments",
+                [
+                  {
+                    "key": "review_task_title",
+                    "template": "Review unrecognised paper-ingestion mail {message_id}",
+                    "variables": {
+                      "message_id": {
+                        "value_from_context": "message_id"
+                      }
+                    }
+                  },
+                  {
+                    "key": "review_task_description",
+                    "template": "Von found no supported arXiv paper reference in Gmail message {message_id} from profile {profile}. Review the source message and decide whether its paper reference needs representation or the message should be skipped.",
+                    "variables": {
+                      "message_id": {
+                        "value_from_context": "message_id"
+                      },
+                      "profile": {
+                        "value_from_context": "gmail_profile"
+                      }
+                    }
+                  },
+                  {
+                    "key": "review_task_idempotency_key",
+                    "template": "paper-ingestion-review:v1:gmail:{profile}:{message_id}",
+                    "variables": {
+                      "message_id": {
+                        "value_from_context": "message_id"
+                      },
+                      "profile": {
+                        "value_from_context": "gmail_profile"
+                      }
+                    }
+                  },
+                  {
+                    "key": "review_task_evidence",
+                    "template": "source_system=gmail; source_profile={profile}; source_item_id={message_id}; reason_code=no_supported_arxiv_resource",
+                    "variables": {
+                      "message_id": {
+                        "value_from_context": "message_id"
+                      },
+                      "profile": {
+                        "value_from_context": "gmail_profile"
+                      }
+                    }
+                  }
+                ]
+              ]
+            ]
+          },
+          {
+            "action_id": "workflow_mcp.invoke_tool",
+            "execution_mode": "deterministic",
+            "mutation_authority": {
+              "maximum_level": "additive_vontology",
+              "reason_code": "create_actor_scoped_paper_ingestion_review_task",
+              "schema_version": "workflow_step_mutation_authority.v1"
+            },
+            "next_state": "ensure_needs_review_label",
+            "on_failure_state": "failed",
+            "retry_policy": {
+              "backoff_policy": "fixed",
+              "initial_delay_ms": 1000,
+              "max_attempts": 2,
+              "max_delay_ms": 5000,
+              "retry_on_outcomes": [
+                "failure",
+                "unknown"
+              ],
+              "schema_version": "workflow_step_retry_policy.v1"
+            },
+            "state_id": "create_review_task",
+            "static_input_bindings": [
+              [
+                "tool_arguments",
+                {
+                  "assignee_id": {
+                    "$context_key": "user_concept_id"
+                  },
+                  "created_by_concept_id": {
+                    "$context_key": "user_concept_id"
+                  },
+                  "description": {
+                    "$context_key": "review_task_description"
+                  },
+                  "evidence": {
+                    "$context_key": "review_task_evidence"
+                  },
+                  "idempotency_key": {
+                    "$context_key": "review_task_idempotency_key"
+                  },
+                  "next_checkpoint": "Review the Gmail source and either repair its paper representation or apply VON/PAPER/SKIP.",
+                  "notes": "The source message remains in Inbox. VON/PAPER/NEEDS_REVIEW removes it from automatic ingestion selection without claiming that it was represented.",
+                  "organisation_concept_id": {
+                    "$context_key": "org_concept_id"
+                  },
+                  "priority": "medium",
+                  "progress_signal": "awaiting_human_review",
+                  "reference_code": {
+                    "$context_key": "message_id"
+                  },
+                  "task_role": "human_review",
+                  "title": {
+                    "$context_key": "review_task_title"
+                  }
+                }
+              ],
+              [
+                "tool_name",
+                "task_create"
+              ]
+            ],
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_create_review_task_result_task_concept_id_to_review_task_concept_id",
+                "context_key": "review_task_concept_id",
+                "tool_output_field": "result.task_concept_id"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_create_review_task_result_idempotent_replay_to_review_task_idempotent_replay",
+                "context_key": "review_task_idempotent_replay",
+                "tool_output_field": "result.idempotent_replay"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_create_review_task_result_canonical_read_back_to_review_task_canonical_read_back",
+                "context_key": "review_task_canonical_read_back",
+                "tool_output_field": "result.canonical_read_back"
+              }
+            ],
+            "writes_context_keys": [
+              "review_task_concept_id",
+              "review_task_idempotent_replay",
+              "review_task_canonical_read_back"
+            ]
+          },
+          {
+            "action_id": "workflow_control.context_set",
+            "conditional_transitions": [
+              {
+                "condition_spec": {
+                  "expected": true,
+                  "key": "needs_review_label_id",
+                  "kind": "context_exists"
+                },
+                "reason": "needs_review_label_inherited_from_parent",
+                "to_state": "mark_needs_review"
+              }
+            ],
+            "execution_mode": "deterministic",
+            "next_state": "resolve_needs_review_label",
+            "on_failure_state": "failed",
+            "state_id": "ensure_needs_review_label",
+            "static_input_bindings": [
+              [
+                "assignments",
+                [
+                  {
+                    "key": "needs_review_label_resolution_checked",
+                    "value": true
+                  }
+                ]
+              ]
+            ]
+          },
+          {
+            "action_id": "workflow_mcp.invoke_tool",
+            "execution_mode": "deterministic",
+            "next_state": "mark_needs_review",
+            "on_failure_state": "failed",
+            "retry_policy": {
+              "backoff_policy": "fixed",
+              "initial_delay_ms": 1000,
+              "max_attempts": 2,
+              "max_delay_ms": 5000,
+              "retry_on_outcomes": [
+                "failure",
+                "unknown"
+              ],
+              "schema_version": "workflow_step_retry_policy.v1"
+            },
+            "state_id": "resolve_needs_review_label",
+            "static_input_bindings": [
+              [
+                "tool_arguments",
+                {
+                  "exact_name": "VON/PAPER/NEEDS_REVIEW",
+                  "profile": {
+                    "$context_key": "gmail_profile"
+                  },
+                  "require_exact_match": true
+                }
+              ],
+              [
+                "tool_name",
+                "gmail_list_labels"
+              ]
+            ],
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_resolve_needs_review_label_result_label_id_to_needs_review_label_id",
+                "context_key": "needs_review_label_id",
+                "tool_output_field": "result.label_id"
+              }
+            ],
+            "writes_context_keys": [
+              "needs_review_label_id"
+            ]
+          },
+          {
+            "action_id": "workflow_mcp.invoke_tool",
+            "conditional_transitions": [
+              {
+                "condition_spec": {
+                  "expected": true,
+                  "key": "needs_review_gmail_label_state_verified",
+                  "kind": "context_flag"
+                },
+                "reason": "needs_review_label_present_and_inbox_preserved",
+                "to_state": "project_needs_review_result"
+              }
+            ],
+            "execution_mode": "deterministic",
+            "mutation_authority": {
+              "maximum_level": "external_system_guarded",
+              "reason_code": "verified_needs_review_message_label_without_archive",
+              "schema_version": "workflow_step_mutation_authority.v1"
+            },
+            "next_state": "failed",
+            "on_failure_state": "failed",
+            "retry_policy": {
+              "backoff_policy": "fixed",
+              "initial_delay_ms": 1000,
+              "max_attempts": 2,
+              "max_delay_ms": 5000,
+              "retry_on_outcomes": [
+                "failure",
+                "unknown"
+              ],
+              "schema_version": "workflow_step_retry_policy.v1"
+            },
+            "state_id": "mark_needs_review",
+            "static_input_bindings": [
+              [
+                "tool_arguments",
+                {
+                  "add_labels": [
+                    {
+                      "$context_key": "needs_review_label_id"
+                    }
+                  ],
+                  "allow_mutation": true,
+                  "message_id": {
+                    "$context_key": "message_id"
+                  },
+                  "profile": {
+                    "$context_key": "gmail_profile"
+                  },
+                  "remove_labels": [],
+                  "verify_after": true
+                }
+              ],
+              [
+                "tool_name",
+                "gmail_modify_labels"
+              ]
+            ],
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_mark_needs_review_result_gmail_label_state_verified_to_needs_review_gmail_label_state_verified",
+                "context_key": "needs_review_gmail_label_state_verified",
+                "tool_output_field": "result.gmail_label_state_verified"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_mark_needs_review_result_readback_label_ids_to_needs_review_gmail_readback_label_ids",
+                "context_key": "needs_review_gmail_readback_label_ids",
+                "tool_output_field": "result.readback_label_ids"
+              }
+            ],
+            "writes_context_keys": [
+              "needs_review_gmail_label_state_verified",
+              "needs_review_gmail_readback_label_ids"
+            ]
+          },
+          {
+            "action_id": "workflow_control.context_project",
+            "execution_mode": "deterministic",
+            "next_state": "done_needs_review",
+            "on_failure_state": "failed",
+            "state_id": "project_needs_review_result",
+            "static_input_bindings": [
+              [
+                "field_sources",
+                {
+                  "disposition": "needs_review",
+                  "gmail_readback_label_ids": {
+                    "$context_key": "needs_review_gmail_readback_label_ids"
+                  },
+                  "review_task_concept_id": {
+                    "$context_key": "review_task_concept_id"
+                  },
+                  "source_item_id": {
+                    "$context_key": "message_id"
+                  },
+                  "source_profile": {
+                    "$context_key": "gmail_profile"
+                  }
+                }
+              ],
+              [
+                "required_fields",
+                [
+                  "source_item_id",
+                  "source_profile",
+                  "disposition",
+                  "review_task_concept_id",
+                  "gmail_readback_label_ids"
+                ]
+              ],
+              [
+                "target_key",
+                "result"
+              ]
+            ],
+            "writes_context_keys": [
+              "result"
             ]
           },
           {
@@ -1341,7 +1729,7 @@
             "state_id": "done"
           },
           {
-            "state_id": "done_no_resources"
+            "state_id": "done_needs_review"
           },
           {
             "state_id": "failed_unmarked"

--- a/src/backend/workflows/repo_seed_bundles/gmail_get_message_terminal_completion_hint_seed.json
+++ b/src/backend/workflows/repo_seed_bundles/gmail_get_message_terminal_completion_hint_seed.json
@@ -29,8 +29,8 @@
         }
       ],
       "upstream_filter": {
-        "query_fragment": "-label:\"VON/PAPER/REPRESENTED\"",
-        "rationale": "Repeated bounded runs select newest Inbox messages that have not yet converged to the represented Gmail label state, so the backlog advances without a date cap."
+        "query_fragment": "-label:\"VON/PAPER/REPRESENTED\" -label:\"VON/PAPER/NEEDS_REVIEW\" -label:\"VON/PAPER/FAILED\" -label:\"VON/PAPER/SKIP\"",
+        "rationale": "Repeated bounded runs select newest Inbox messages that are neither represented nor already dispositioned for human review, failure handling, or skip, so the backlog advances without a date cap."
       }
     }
   ]

--- a/tests/backend/test_control_flow_actions.py
+++ b/tests/backend/test_control_flow_actions.py
@@ -232,6 +232,7 @@ def test_for_each_action_executes_child_workflow_per_item() -> None:
     assert result.outputs.get("for_each_max_concurrency") == 2
     assert result.outputs.get("for_each_success_count") == 2
     assert result.outputs.get("for_each_error_count") == 0
+    assert result.outputs.get("for_each_final_state_counts") == {"start": 2}
     results = result.outputs.get("iteration_results")
     assert isinstance(results, list)
     assert results[0]["result"] == {"item_value": "A", "item_index": 0}
@@ -311,6 +312,7 @@ def test_for_each_action_respects_partial_success_policy() -> None:
     assert result.outputs.get("for_each_success_count") == 1
     assert result.outputs.get("for_each_error_count") == 1
     assert result.outputs.get("for_each_partial_success") is True
+    assert result.outputs.get("for_each_final_state_counts") == {"start": 2}
     assert result.outputs.get("successful_results") == [{"item_value": "good"}]
     assert result.outputs.get("iteration_errors") == [
         {

--- a/tests/backend/test_email_source_representation_convergence_bootstrap.py
+++ b/tests/backend/test_email_source_representation_convergence_bootstrap.py
@@ -86,7 +86,10 @@ def test_email_source_workflow_bootstrap_materialises_bundle_and_hint(
     assert entry["tool_arguments"]["message_id_context_key"] == "message_id"
     assert entry["tool_arguments"]["verify_after"] is True
     assert entry["upstream_filter"]["query_fragment"] == (
-        '-label:"VON/PAPER/REPRESENTED"'
+        '-label:"VON/PAPER/REPRESENTED" '
+        '-label:"VON/PAPER/NEEDS_REVIEW" '
+        '-label:"VON/PAPER/FAILED" '
+        '-label:"VON/PAPER/SKIP"'
     )
     assert entry["represented_effects"][0]["effect_kind"] == (
         "verified_gmail_label_convergence"
@@ -382,6 +385,212 @@ def test_email_source_seed_requires_current_markers_before_verified_gmail_writes
     ]
     assert gmail_arguments["remove_labels"] == ["INBOX"]
     assert gmail_arguments["verify_after"] is True
+
+
+def test_email_source_seed_dispositions_non_converging_mail_for_human_review() -> None:
+    from src.backend.services import (
+        email_source_representation_convergence_workflow_vontology_service as mod,
+    )
+
+    payload = json.loads(mod._REPO_SEED_ASSET_PATH.read_text(encoding="utf-8"))
+    workflows = {
+        item["workflow_id"]: item
+        for item in payload.get("workflows") or []
+        if isinstance(item, dict)
+    }
+    child = workflows[mod.EMAIL_ARXIV_INGESTION_FROM_MESSAGE_WORKFLOW_ID]
+    steps = {
+        step["state_id"]: step
+        for step in child["publication_spec"]["steps"]
+        if isinstance(step, dict)
+    }
+
+    assert steps["decide_arxiv_resources"]["next_state"] == "build_review_task"
+    create_review = steps["create_review_task"]
+    assert create_review["mutation_authority"]["maximum_level"] == (
+        "additive_vontology"
+    )
+    assert create_review["static_input_bindings"][1] == [
+        "tool_name",
+        "task_create",
+    ]
+    task_arguments = create_review["static_input_bindings"][0][1]
+    assert task_arguments["idempotency_key"] == {
+        "$context_key": "review_task_idempotency_key"
+    }
+    assert task_arguments["assignee_id"] == {"$context_key": "user_concept_id"}
+    assert task_arguments["created_by_concept_id"] == {
+        "$context_key": "user_concept_id"
+    }
+
+    mark_review = steps["mark_needs_review"]
+    assert mark_review["mutation_authority"]["maximum_level"] == (
+        "external_system_guarded"
+    )
+    assert mark_review["static_input_bindings"][1] == [
+        "tool_name",
+        "gmail_modify_labels",
+    ]
+    gmail_arguments = mark_review["static_input_bindings"][0][1]
+    assert gmail_arguments["add_labels"] == [
+        {"$context_key": "needs_review_label_id"}
+    ]
+    assert gmail_arguments["remove_labels"] == []
+    assert gmail_arguments["verify_after"] is True
+    assert mark_review["conditional_transitions"][0]["to_state"] == (
+        "project_needs_review_result"
+    )
+    assert steps["project_needs_review_result"]["next_state"] == (
+        "done_needs_review"
+    )
+    assert "done_needs_review" in steps
+    assert "done_no_resources" not in steps
+
+
+def test_non_converging_message_creates_one_review_task_and_preserves_inbox() -> None:
+    calls: list[str] = []
+    observed_task_arguments: dict[str, object] = {}
+    observed_gmail_arguments: dict[str, object] = {}
+
+    def handler(request: WorkflowActionRequest) -> WorkflowActionResult:
+        tool_name = str(request.inputs.get("tool_name") or "")
+        calls.append(tool_name)
+        arguments = dict(request.inputs.get("tool_arguments") or {})
+        if tool_name == "task_create":
+            observed_task_arguments.update(arguments)
+            return WorkflowActionResult(
+                status="success",
+                outputs={
+                    "result": {
+                        "success": True,
+                        "task_concept_id": "#V#task_review_message_1",
+                        "changed": True,
+                        "idempotent_replay": False,
+                        "canonical_read_back": {
+                            "task_concept_id": "#V#task_review_message_1",
+                            "status": "pending",
+                        },
+                    }
+                },
+            )
+        if tool_name == "gmail_list_labels":
+            return WorkflowActionResult(
+                status="success",
+                outputs={
+                    "result": {
+                        "label_id": "Label_NEEDS_REVIEW",
+                        "label_name": "VON/PAPER/NEEDS_REVIEW",
+                    }
+                },
+            )
+        assert tool_name == "gmail_modify_labels"
+        observed_gmail_arguments.update(arguments)
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "result": {
+                    "gmail_label_state_verified": True,
+                    "readback_label_ids": [
+                        "INBOX",
+                        "UNREAD",
+                        "Label_NEEDS_REVIEW",
+                    ],
+                }
+            },
+        )
+
+    definition = _exact_message_definition(
+        "decide_arxiv_resources",
+        "build_review_task",
+        "create_review_task",
+        "ensure_needs_review_label",
+        "resolve_needs_review_label",
+        "mark_needs_review",
+        "project_needs_review_result",
+        "done_needs_review",
+        "failed",
+        initial_state="decide_arxiv_resources",
+    )
+    registry = ActionRegistry()
+    register_control_flow_actions(registry)
+    registry.register(ActionSpec(action_id="workflow_mcp.invoke_tool", handler=handler))
+    result = WorkflowExecutor(registry=registry, max_transitions=12).run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={
+            "arxiv_resource_references": [],
+            "message_id": "gmail-message-1",
+            "gmail_profile": "vonwitbrock-gmail",
+            "user_concept_id": "#V#michael_witbrock",
+            "org_concept_id": "#V#university_of_auckland_strong_ai_lab",
+        },
+    )
+
+    assert result.completed is True
+    assert result.final_state == "done_needs_review"
+    assert calls == ["task_create", "gmail_list_labels", "gmail_modify_labels"]
+    assert observed_task_arguments["idempotency_key"] == (
+        "paper-ingestion-review:v1:gmail:vonwitbrock-gmail:gmail-message-1"
+    )
+    assert observed_task_arguments["assignee_id"] == "#V#michael_witbrock"
+    assert observed_task_arguments["organisation_concept_id"] == (
+        "#V#university_of_auckland_strong_ai_lab"
+    )
+    assert observed_gmail_arguments["add_labels"] == ["Label_NEEDS_REVIEW"]
+    assert observed_gmail_arguments["remove_labels"] == []
+    assert "INBOX" in result.data["needs_review_gmail_readback_label_ids"]
+    assert result.data["review_task_concept_id"] == "#V#task_review_message_1"
+    assert result.data["result"] == {
+        "source_item_id": "gmail-message-1",
+        "source_profile": "vonwitbrock-gmail",
+        "disposition": "needs_review",
+        "review_task_concept_id": "#V#task_review_message_1",
+        "gmail_readback_label_ids": [
+            "INBOX",
+            "UNREAD",
+            "Label_NEEDS_REVIEW",
+        ],
+    }
+
+
+def test_parent_batch_surfaces_human_review_disposition_count() -> None:
+    from src.backend.services import (
+        email_source_representation_convergence_workflow_vontology_service as mod,
+    )
+    from src.backend.workflows.engine import evaluate_transition_condition_spec
+
+    payload = json.loads(mod._REPO_SEED_ASSET_PATH.read_text(encoding="utf-8"))
+    parent = next(
+        item
+        for item in payload.get("workflows") or []
+        if item.get("workflow_id") == mod.ZHAN_GMAIL_ARXIV_INGESTION_WORKFLOW_ID
+    )
+    process = next(
+        step
+        for step in parent["publication_spec"]["steps"]
+        if step.get("state_id") == "process_messages"
+    )
+
+    mappings = {
+        item["context_key"]: item["tool_output_field"]
+        for item in process["tool_output_mapping_specs"]
+    }
+    assert mappings["message_final_state_counts"] == "for_each_final_state_counts"
+    review_transition = process["conditional_transitions"][0]
+    assert review_transition["to_state"] == "done_with_review_required"
+    assert review_transition["condition_spec"]["conditions"][0]["key"] == (
+        "message_final_state_counts.#V#workflow_step_email_arxiv_ingestion_from_message_workflow_done_needs_review"
+    )
+    assert evaluate_transition_condition_spec(
+        context={
+            "message_final_state_counts": {
+                "#V#workflow_step_email_arxiv_ingestion_from_message_workflow_done": 2,
+                "#V#workflow_step_email_arxiv_ingestion_from_message_workflow_done_needs_review": 1,
+            },
+            "message_error_count": 0,
+        },
+        condition_spec=review_transition["condition_spec"],
+    )
 
 
 def test_email_source_seed_routes_exact_message_unit_and_explicit_batch() -> None:

--- a/tests/backend/test_internal_mcp_direct_message_tools.py
+++ b/tests/backend/test_internal_mcp_direct_message_tools.py
@@ -471,6 +471,126 @@ def test_task_create_retry_reuses_canonical_task(monkeypatch):
     assert create_calls["count"] == 1
 
 
+def test_task_create_actor_scoped_idempotency_key_reuses_task_without_turn(
+    monkeypatch,
+):
+    from src.backend.integrations.internal_mcp import catalogue as catalogue_module
+    from src.backend.security.access_control import override_current_actor
+    from src.backend.services import task_management_service
+
+    persisted: dict[str, Any] = {}
+    create_calls = {"count": 0}
+
+    def fake_find(**kwargs):
+        if persisted.get("fingerprint") == kwargs["creation_fingerprint"]:
+            return persisted.get("task")
+        return None
+
+    def fake_create(**kwargs):
+        create_calls["count"] += 1
+        task = {
+            **_owned_task(),
+            "title": kwargs["title"],
+            "description": kwargs["description"],
+        }
+        persisted.update(
+            {
+                "task": task,
+                "fingerprint": kwargs["agent_creation_fingerprint"],
+                "request_id": kwargs["agent_creation_request_id"],
+            }
+        )
+        return task
+
+    monkeypatch.setattr(
+        task_management_service,
+        "find_task_by_agent_creation_fingerprint",
+        fake_find,
+    )
+    monkeypatch.setattr(task_management_service, "create_task", fake_create)
+    monkeypatch.setattr(
+        task_management_service,
+        "get_task",
+        lambda _task_id: persisted.get("task"),
+    )
+    base_arguments = {
+        "title": "Review source item",
+        "description": "Initial task text",
+        "assignee_id": "#V#user_alice",
+        "created_by_concept_id": "#V#user_alice",
+        "idempotency_key": "paper-review:gmail:profile-a:message-1",
+        **_task_actor_arguments(),
+    }
+    with override_current_actor("#V#user_alice", "#V#org_test"):
+        first = catalogue_module._task_create(**base_arguments)
+        second = catalogue_module._task_create(
+            **{
+                **base_arguments,
+                "title": "Changed presentation text",
+                "description": "A later workflow release may phrase this differently.",
+            }
+        )
+
+    assert first["success"] is True
+    assert first["changed"] is True
+    assert second["success"] is True
+    assert second["changed"] is False
+    assert second["idempotent_replay"] is True
+    assert create_calls["count"] == 1
+    assert str(persisted["request_id"]).startswith("idempotency:")
+
+
+def test_task_create_actor_scoped_idempotency_key_does_not_cross_actor(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as catalogue_module
+    from src.backend.security.access_control import override_current_actor
+    from src.backend.services import task_management_service
+
+    fingerprints: list[str] = []
+    tasks: dict[str, dict[str, Any]] = {}
+
+    monkeypatch.setattr(
+        task_management_service,
+        "find_task_by_agent_creation_fingerprint",
+        lambda **_kwargs: None,
+    )
+
+    def fake_create(**kwargs):
+        fingerprints.append(kwargs["agent_creation_fingerprint"])
+        task = {
+            **_owned_task(),
+            "task_concept_id": f"#V#task_{len(fingerprints)}",
+            "title": kwargs["title"],
+            "description": kwargs["description"],
+            "assignee_concept_id": kwargs["assignee_concept_id"],
+            "created_by_concept_id": kwargs["created_by_concept_id"],
+        }
+        tasks[task["task_concept_id"]] = task
+        return task
+
+    monkeypatch.setattr(task_management_service, "create_task", fake_create)
+    monkeypatch.setattr(
+        task_management_service,
+        "get_task",
+        lambda task_id: tasks[task_id],
+    )
+
+    for actor in ("#V#user_alice", "#V#user_bob"):
+        with override_current_actor(actor, "#V#org_test"):
+            result = catalogue_module._task_create(
+                title="Review source item",
+                description="Review it",
+                assignee_id=actor,
+                created_by_concept_id=actor,
+                acting_user_concept_id=actor,
+                organisation_concept_id="#V#org_test",
+                idempotency_key="paper-review:gmail:profile-a:message-1",
+            )
+        assert result["success"] is True
+
+    assert len(fingerprints) == 2
+    assert fingerprints[0] != fingerprints[1]
+
+
 def test_task_create_reconciles_late_first_write_after_create_failure(monkeypatch):
     """A retry must read back a task committed after its first lookup."""
     from src.backend.integrations.internal_mcp import catalogue as catalogue_module

--- a/tests/backend/test_jvnautosci_2272_zhan_gmail_arxiv_workflow_repair.py
+++ b/tests/backend/test_jvnautosci_2272_zhan_gmail_arxiv_workflow_repair.py
@@ -236,7 +236,7 @@ def test_legacy_repair_entry_point_delegates_to_current_canonical_seed() -> None
 
     assert report["success"] is True
     assert report["deprecated_entry_point"] is True
-    assert report["seed_version"] == "11"
+    assert report["seed_version"] == "13"
     assert report["delegates_to"] == (
         "bootstrap_canonical_email_source_representation_convergence_workflows"
     )


### PR DESCRIPTION
## What changed

- add actor/org-scoped idempotency keys to the generic `task_create` surface
- expose generic `for_each_final_state_counts`
- route paper-ingestion messages with no supported arXiv resource to one pending human-review task
- apply `VON/PAPER/NEEDS_REVIEW` with canonical Gmail read-back while retaining `INBOX`
- exclude REPRESENTED, NEEDS_REVIEW, FAILED, and SKIP messages from later backlog searches
- surface a parent `done_with_review_required` terminal outcome
- bump the represented workflow seed to v13

## Why

A non-converging message at the head of the Gmail search could consume every periodic batch without being represented, dispositioned, or made visible to a human. The prior workflow also had no durable, idempotent task handoff for this case.

## Root cause

The workflow's no-resource state was terminal and had no effect. During live validation, the first aggregate transition also used a short child-state key while the durable iterator emitted canonical full state IDs; v13 uses the observed full state ID and tests the executable condition.

## User impact

Unsupported mail is now removed from the automated backlog cursor without being falsely marked represented or archived. It remains in Inbox, carries the review label, and produces exactly one pending Von task for the owning actor. Replays reuse the same task.

## Validation

- 279 focused tests passed before the final aggregate-key correction
- 60 focused workflow tests passed after the correction
- 96 seed/version/authority guard tests passed after the correction
- live three-message browser replay: one review disposition plus two represented/archive successes, 0 workflow errors
- live v13 one-message idempotency replay: durable instance `698204e7-f646-4bf9-9711-80ea9821d28e` completed at `done_with_review_required`
- canonical read-back: exactly one pending task `#V#task_agent_26421de3647c5f4358ee479f35b1cad0`; Gmail message `19ee9287004e1e63` retained INBOX and gained NEEDS_REVIEW; no REPRESENTED label
- Luna only; no Sol-family model call