### PR TITLE
Improve natural mail continuity and projection latency

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -7558,9 +7558,32 @@ def _extract_tagged_block(text: str, tag: str) -> str | None:
     searchable, replacements = _mask_fenced_code_blocks(text)
     pattern = rf"<{re.escape(tag)}>\s*(.*?)\s*</{re.escape(tag)}>"
     match = re.search(pattern, searchable, flags=re.DOTALL | re.IGNORECASE)
-    if not match:
-        return None
-    value = match.group(1)
+    if match:
+        value = match.group(1)
+    else:
+        # A provider can occasionally omit only the closing tag on the final
+        # presenter block. Recover that terminal block when its boundary is
+        # unambiguous; otherwise leave the response to the normal backfill
+        # path. In particular, do not absorb another presenter block or a tag
+        # example from fenced content.
+        opening_pattern = rf"<{re.escape(tag)}>"
+        closing_pattern = rf"</{re.escape(tag)}>"
+        opening_matches = list(
+            re.finditer(opening_pattern, searchable, flags=re.IGNORECASE)
+        )
+        closing_matches = list(
+            re.finditer(closing_pattern, searchable, flags=re.IGNORECASE)
+        )
+        if len(opening_matches) != 1 or closing_matches:
+            return None
+        terminal_value = searchable[opening_matches[0].end() :]
+        if re.search(
+            r"</?(?:spoken|screen)>",
+            terminal_value,
+            flags=re.IGNORECASE,
+        ):
+            return None
+        value = terminal_value
     if not isinstance(value, str):
         return None
     value = _restore_masked_fenced_code_blocks(value, replacements).strip()

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -1755,10 +1755,13 @@ def _scope_message(
                 "one focused question only when the remaining private-corpus "
                 "difference is material. Do not ask merely because alternatives "
                 "exist when one of those grounds is sufficient.\n"
-                "- Briefly name the selected human-readable resource on first use "
-                "or when it changes if the user could reasonably confuse accounts. "
-                "The remembered situation is not authority; every dispatch is "
-                "rechecked against this turn's choices.\n"
+                "- When the request leaves the connector resource unqualified, "
+                "briefly name the selected human-readable resource in the first "
+                "answer unless that answer already makes it clear. Repeat it only "
+                "when the resource changes or the distinction becomes material; "
+                "never expose an internal resource ID or runtime alias. The "
+                "remembered situation is not authority; every dispatch is rechecked "
+                "against this turn's choices.\n"
                 "- Connector account and view scope are separate. For an "
                 "unqualified request for recent or 'my' mail, use whole_mailbox on "
                 "the selected account. Use profile_default_view for a named stream "
@@ -3845,6 +3848,10 @@ def execute_adaptive_turn(
         namespace=user_namespace,
     )
     evidence_store = TurnEvidenceStore(scope, turn_id or "ordinary-turn")
+    # One actor-scoped turn uses one represented projection snapshot per tool.
+    # This removes repeated contract-resolution reads without carrying authority
+    # or stale state across turns, actors, processes, or live revisions.
+    tool_projection_contracts: dict[str, Any] = {}
     trusted_values = dict(trusted_argument_values or {})
     trusted_values.update(
         {
@@ -6343,18 +6350,46 @@ def execute_adaptive_turn(
                     envelope_payload["workflow_progress_evidence"] = dict(
                         workflow_progress_evidence
                     )
+                projection_started = time.perf_counter()
+                projection_duration_ms = 0.0
                 if isinstance(raw_payload, Mapping):
                     try:
-                        from src.backend.services.tool_evidence_projection_service import (
+                        from .tool_evidence_projection_service import (
                             project_tool_payload_for_llm,
+                            resolve_tool_projection_contract,
                         )
 
-                        projected_payload = project_tool_payload_for_llm(
-                            canonical_name,
-                            raw_payload,
-                        )
+                        with override_current_actor(
+                            scope.user_concept_id,
+                            scope.organisation_concept_id,
+                        ):
+                            projection_contract_key = canonical_name.casefold()
+                            if (
+                                projection_contract_key
+                                not in tool_projection_contracts
+                            ):
+                                tool_projection_contracts[
+                                    projection_contract_key
+                                ] = resolve_tool_projection_contract(canonical_name)
+                            projection_contract = tool_projection_contracts[
+                                projection_contract_key
+                            ]
+                            projected_payload = (
+                                project_tool_payload_for_llm(
+                                    canonical_name,
+                                    raw_payload,
+                                    contract=projection_contract,
+                                )
+                                if projection_contract is not None
+                                else None
+                            )
                     except Exception:  # noqa: BLE001 - projection is advisory
                         projected_payload = None
+                    finally:
+                        projection_duration_ms = max(
+                            0.0,
+                            (time.perf_counter() - projection_started) * 1000.0,
+                        )
                     if projected_payload is not None:
                         envelope_payload["projected_payload"] = projected_payload
                 result_target_ids = _effect_result_target_ids(raw_payload)
@@ -6529,6 +6564,9 @@ def execute_adaptive_turn(
                                 invocation[receipt_key] = receipt_value
                 if transport_metadata:
                     invocation["transport"] = transport_metadata
+                invocation["result_projection_duration_ms"] = (
+                    projection_duration_ms
+                )
                 catalogued_capability = catalogued_capabilities_by_name.get(
                     canonical_name.lower()
                 )
@@ -6551,6 +6589,9 @@ def execute_adaptive_turn(
                     )
                     if transport_metadata.get(key) is not None
                 }
+                actual_cost["result_projection_duration_ms"] = (
+                    projection_duration_ms
+                )
                 aux_calls.append(
                     {
                         "type": "adaptive_turn_capability_selection",
@@ -6629,6 +6670,7 @@ def execute_adaptive_turn(
                     "success": status == "ok",
                     "result_summary": semantic_operation["summary"],
                     "semantic_operation": semantic_operation,
+                    "result_projection_duration_ms": projection_duration_ms,
                 }
                 if selected_workflow_execution_event is not None:
                     completed_progress["selected_workflow_execution_event"] = dict(

--- a/src/backend/services/tool_evidence_projection_service.py
+++ b/src/backend/services/tool_evidence_projection_service.py
@@ -993,6 +993,7 @@ def project_tool_payload_for_llm(
     payload: Mapping[str, Any],
     *,
     max_collection_items: int = 40,
+    contract: ToolProjectionContract | None = None,
 ) -> dict[str, Any] | None:
     """Return a compact Vontology-backed LLM payload, or None if no contract exists."""
 
@@ -1001,7 +1002,7 @@ def project_tool_payload_for_llm(
     if not isinstance(payload, Mapping):
         return None
 
-    contract = resolve_tool_projection_contract(tool_name)
+    contract = contract or resolve_tool_projection_contract(tool_name)
     if contract is None or not contract.fields:
         return None
 

--- a/src/backend/services/tool_observation_ledger_service.py
+++ b/src/backend/services/tool_observation_ledger_service.py
@@ -553,10 +553,10 @@ def build_tool_observation_ledger(
         ),
         "has_empty_observation": bool(status_counts.get("empty_result")),
         "has_non_empty_observation": bool(status_counts.get("non_empty_result")),
+        "has_pending_observation": bool(status_counts.get("pending")),
         "has_timeout_or_cancellation": bool(
             status_counts.get("timeout")
             or status_counts.get("cancelled")
-            or status_counts.get("pending")
         ),
         "observations": observations,
     }

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -8286,6 +8286,30 @@ def _turn_projection_match_tokens(value: Any) -> tuple[str, list[str]]:
     return normalised, _dedupe_string_sequence(tokens)
 
 
+def _turn_projection_partial_label_match_is_material(
+    *,
+    label_tokens: Sequence[str],
+    matched_tokens: Sequence[str],
+) -> bool:
+    """Return whether a non-exact label match is strong enough to retain.
+
+    One matchable token is enough when it is the label's whole usable identity
+    (for example ``RE: SciClaimEval``).  Longer labels require both multiple
+    matching tokens and at least half-token coverage.  This keeps useful
+    paraphrase tolerance without allowing an incidental word such as
+    ``booking`` to select an unrelated ``Time booking link`` message.
+    """
+
+    label_token_count = len(label_tokens)
+    matched_token_count = len(matched_tokens)
+    if label_token_count == 1:
+        return matched_token_count == 1
+    return bool(
+        matched_token_count >= 2
+        and matched_token_count * 2 >= label_token_count
+    )
+
+
 def _select_answer_material_referents(
     *,
     response_text: Any,
@@ -8326,22 +8350,40 @@ def _select_answer_material_referents(
         stable_id_normalised = stable_id.casefold()
         score = 0
         offsets: list[int] = []
-        if label_normalised and label_normalised in answer_normalised:
+        exact_label_match = bool(
+            label_normalised and label_normalised in answer_normalised
+        )
+        exact_id_match = bool(
+            stable_id_normalised and stable_id_normalised in answer_normalised
+        )
+        if exact_label_match:
             score += 10_000 + len(label_normalised)
             offsets.append(answer_normalised.index(label_normalised))
-        if stable_id_normalised and stable_id_normalised in answer_normalised:
+        if exact_id_match:
             score += 20_000 + len(stable_id_normalised)
             offsets.append(answer_normalised.index(stable_id_normalised))
+        matched_label_tokens: list[str] = []
         for token in label_tokens:
             if token not in answer_token_offsets:
                 continue
             if candidate_count > 1 and token_document_frequency.get(token, 0) != 1:
                 continue
+            matched_label_tokens.append(token)
             score += len(token)
             offsets.append(answer_token_offsets[token])
-        if score <= 0:
+        partial_label_match = _turn_projection_partial_label_match_is_material(
+            label_tokens=label_tokens,
+            matched_tokens=matched_label_tokens,
+        )
+        if not (exact_label_match or exact_id_match or partial_label_match):
             continue
-        matched.append((min(offsets) if offsets else len(answer_normalised), index, candidate))
+        matched.append(
+            (
+                min(offsets) if offsets else len(answer_normalised),
+                index,
+                candidate,
+            )
+        )
 
     matched.sort(key=lambda item: (item[0], item[1]))
     return [

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -5313,6 +5313,7 @@ def _summarise_tool_invocations(
             "handler_duration_ms",
             "handler_elapsed_ms",
             "transport_overhead_ms",
+            "result_projection_duration_ms",
             "timeout_sec",
             "advisory_timeout_sec",
         ):
@@ -8348,7 +8349,6 @@ def _select_answer_material_referents(
         label_normalised, label_tokens = parsed_label
         stable_id = normalise_exact_referent_id(candidate.get("stable_id")) or ""
         stable_id_normalised = stable_id.casefold()
-        score = 0
         offsets: list[int] = []
         exact_label_match = bool(
             label_normalised and label_normalised in answer_normalised
@@ -8357,10 +8357,8 @@ def _select_answer_material_referents(
             stable_id_normalised and stable_id_normalised in answer_normalised
         )
         if exact_label_match:
-            score += 10_000 + len(label_normalised)
             offsets.append(answer_normalised.index(label_normalised))
         if exact_id_match:
-            score += 20_000 + len(stable_id_normalised)
             offsets.append(answer_normalised.index(stable_id_normalised))
         matched_label_tokens: list[str] = []
         for token in label_tokens:
@@ -8369,7 +8367,6 @@ def _select_answer_material_referents(
             if candidate_count > 1 and token_document_frequency.get(token, 0) != 1:
                 continue
             matched_label_tokens.append(token)
-            score += len(token)
             offsets.append(answer_token_offsets[token])
         partial_label_match = _turn_projection_partial_label_match_is_material(
             label_tokens=label_tokens,
@@ -8588,6 +8585,23 @@ def build_conversation_situation_turn_projection(
                         candidate["resource_scope"] = resource_scope
                     if actor_scope_ref:
                         candidate["actor_scope_ref"] = actor_scope_ref
+                    previous_candidate = referent_candidates_by_key.get(
+                        candidate_key
+                    )
+                    previous_resource_scope = (
+                        previous_candidate.get("resource_scope")
+                        if isinstance(previous_candidate, Mapping)
+                        else None
+                    )
+                    if isinstance(previous_resource_scope, Mapping):
+                        candidate["resource_scope"] = {
+                            **previous_resource_scope,
+                            **(
+                                resource_scope
+                                if isinstance(resource_scope, Mapping)
+                                else {}
+                            ),
+                        }
                     referent_candidates_by_key[candidate_key] = candidate
 
             if not is_write:

--- a/src/backend/services/turn_timing_telemetry_service.py
+++ b/src/backend/services/turn_timing_telemetry_service.py
@@ -534,7 +534,14 @@ def _tool_spans(
     for index, entry in enumerate(tool_entries):
         if not isinstance(entry, Mapping):
             continue
-        duration_ms = _safe_int_ms(entry.get("duration_ms"))
+        raw_transport = entry.get("transport")
+        transport = raw_transport if isinstance(raw_transport, Mapping) else {}
+
+        def timing_value(key: str) -> Any:
+            direct_value = entry.get(key)
+            return direct_value if direct_value is not None else transport.get(key)
+
+        duration_ms = _safe_int_ms(timing_value("duration_ms"))
         if duration_ms is None:
             continue
         tool_name = _tool_name(entry)
@@ -565,7 +572,8 @@ def _tool_spans(
                     "tool": tool_name,
                     "method": _safe_str(entry.get("method")) or tool_name,
                     "call_id": _safe_str(entry.get("call_id")),
-                    "execution_id": _safe_str(entry.get("execution_id")),
+                    "execution_id": _safe_str(entry.get("execution_id"))
+                    or _safe_str(transport.get("execution_id")),
                     "workflow_id": _safe_str(entry.get("workflow_id")),
                     "workflow_state_id": _safe_str(entry.get("workflow_state_id")),
                     "workflow_action_id": _safe_str(entry.get("workflow_action_id")),
@@ -573,28 +581,51 @@ def _tool_spans(
                     "blocked": entry.get("blocked"),
                     "direct_user_call": entry.get("direct_user_call"),
                     "queue_duration_ms": _safe_int_ms(
-                        entry.get("queue_duration_ms")
+                        timing_value("queue_duration_ms")
                     ),
                     "handler_duration_ms": _safe_int_ms(
-                        entry.get("handler_duration_ms")
+                        timing_value("handler_duration_ms")
                     ),
                     "handler_elapsed_ms": _safe_int_ms(
-                        entry.get("handler_elapsed_ms")
+                        timing_value("handler_elapsed_ms")
                     ),
                     "transport_overhead_ms": _safe_int_ms(
-                        entry.get("transport_overhead_ms")
+                        timing_value("transport_overhead_ms")
                     ),
-                    "timeout_sec": _safe_number(entry.get("timeout_sec")),
+                    "result_projection_duration_ms": _safe_int_ms(
+                        entry.get("result_projection_duration_ms")
+                    ),
+                    "timeout_sec": _safe_number(timing_value("timeout_sec")),
                     "advisory_timeout_sec": _safe_number(
-                        entry.get("advisory_timeout_sec")
+                        timing_value("advisory_timeout_sec")
                     ),
-                    "advisory_budget_exceeded": entry.get(
+                    "advisory_budget_exceeded": timing_value(
                         "advisory_budget_exceeded"
                     ),
-                    "timeout_phase": _safe_str(entry.get("timeout_phase")),
+                    "timeout_phase": _safe_str(timing_value("timeout_phase")),
                 },
             }
         )
+        projection_duration_ms = _safe_int_ms(
+            entry.get("result_projection_duration_ms")
+        )
+        if projection_duration_ms is not None and projection_duration_ms > 0:
+            spans.append(
+                {
+                    "span_id": f"{spans[-1]['span_id']}:result_projection",
+                    "source": source,
+                    "stage_id": spans[-1]["stage_id"],
+                    "operation_kind": "support",
+                    "operation_name": f"{tool_name}:result_projection",
+                    "duration_ms": projection_duration_ms,
+                    "status": spans[-1]["status"],
+                    "attributes": {
+                        "tool": tool_name,
+                        "call_id": _safe_str(entry.get("call_id")),
+                        "support_kind": "tool_result_projection",
+                    },
+                }
+            )
     return spans
 
 
@@ -1067,6 +1098,15 @@ def build_turn_timing_trace(
                 for span in stored_spans
                 if _safe_str(span.get("operation_kind")) == "tool_call"
                 and isinstance(span.get("attributes"), Mapping)
+            ),
+            "tool_result_projection_elapsed_ms": sum(
+                int(span["duration_ms"])
+                for span in stored_spans
+                if isinstance(span.get("attributes"), Mapping)
+                and _safe_str(
+                    (span.get("attributes") or {}).get("support_kind")
+                )
+                == "tool_result_projection"
             ),
         },
         "stage_totals": _aggregate_stage_totals(stored_spans),

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import Mapping
 from threading import Event
 from types import SimpleNamespace
 from typing import Any
@@ -1511,6 +1512,10 @@ def test_authorised_resource_choice_maps_selector_and_records_scope() -> None:
     assert "zhan@example.test" in system_message
     assert "whole_mailbox" in system_message
     assert "profile_default_view" in system_message
+    assert "request leaves the connector resource unqualified" in system_message
+    assert "selected human-readable resource in the first answer" in system_message
+    assert "Repeat it only when the resource changes" in system_message
+    assert "never expose an internal resource ID or runtime alias" in system_message
     assert "zhan-runtime" not in system_message
     assert seen_arguments == {
         "profile": "zhan-runtime",
@@ -5546,7 +5551,7 @@ def test_model_can_invoke_any_delegated_read_without_a_prompt_classifier(
     monkeypatch.setattr(
         "src.backend.services.tool_evidence_projection_service."
         "project_tool_payload_for_llm",
-        lambda tool_name, payload: (
+        lambda tool_name, payload, **_kwargs: (
             {
                 "_llm_view": "test_projection.v1",
                 "relationships": {
@@ -5556,6 +5561,11 @@ def test_model_can_invoke_any_delegated_read_without_a_prompt_classifier(
             if tool_name == "general_read" and payload.get("answer") == "found"
             else None
         ),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.tool_evidence_projection_service."
+        "resolve_tool_projection_contract",
+        lambda _tool_name: object(),
     )
 
     def handler(**kwargs: Any) -> dict[str, Any]:
@@ -5633,6 +5643,101 @@ def test_model_can_invoke_any_delegated_read_without_a_prompt_classifier(
     assert raw_tail not in json.dumps(result.tool_invocations)
     assert all(
         invocation.get("tool") != "general_write"
+        for invocation in result.tool_invocations
+    )
+
+
+def test_repeated_tool_results_resolve_projection_contract_once_per_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    projection_contract = object()
+    resolve_calls: list[str] = []
+    resolve_actor_scopes: list[tuple[str | None, str | None]] = []
+    projection_calls: list[tuple[str, object | None]] = []
+
+    def resolve_contract(tool_name: str) -> object:
+        resolve_calls.append(tool_name)
+        resolve_actor_scopes.append(
+            (
+                get_effective_user_concept_id(),
+                get_effective_organisation_concept_id(),
+            )
+        )
+        return projection_contract
+
+    def project_payload(
+        tool_name: str,
+        payload: Mapping[str, Any],
+        *,
+        contract: object | None = None,
+    ) -> dict[str, Any]:
+        projection_calls.append((tool_name, contract))
+        return {"_llm_view": "test_projection.v1", "answer": payload["answer"]}
+
+    monkeypatch.setattr(
+        "src.backend.services.tool_evidence_projection_service."
+        "resolve_tool_projection_contract",
+        resolve_contract,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.tool_evidence_projection_service."
+        "project_tool_payload_for_llm",
+        project_payload,
+    )
+
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="call-projection-1",
+                    payload={
+                        "name": "general_read",
+                        "arguments": {"query": "first"},
+                    },
+                ),
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="call-projection-2",
+                    payload={
+                        "name": "general_read",
+                        "arguments": {"query": "second"},
+                    },
+                ),
+            ],
+        ),
+        LLMResponse(text_response="Both reads completed."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_gateway(
+            lambda **kwargs: {
+                "success": True,
+                "answer": str(kwargs.get("query") or ""),
+            }
+        ),
+        prompt="Read both candidates.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="turn-projection-cache",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert result.response_text == "Both reads completed."
+    assert resolve_calls == ["general_read"]
+    assert resolve_actor_scopes == [("#V#person", "#V#org")]
+    assert projection_calls == [
+        ("general_read", projection_contract),
+        ("general_read", projection_contract),
+    ]
+    assert all(
+        invocation["result_projection_duration_ms"] >= 0
         for invocation in result.tool_invocations
     )
 

--- a/tests/backend/test_conversation_situation_turn_projection.py
+++ b/tests/backend/test_conversation_situation_turn_projection.py
@@ -319,6 +319,133 @@ def test_simple_chat_without_tool_records_does_not_create_runtime_situation() ->
     )
 
 
+def _referent_read_invocation(
+    *,
+    stable_id: str,
+    display_label: str,
+    call_id: str,
+) -> dict[str, object]:
+    return {
+        "tool": "mail_get_item",
+        "capability_kind": "mcp_tool",
+        "call_id": call_id,
+        "status": "ok",
+        "evidence": {
+            "schema_version": "turn_evidence_envelope.v1",
+            "evidence_id": f"evidence-{call_id}",
+            "status": "ok",
+            "projected_payload": {
+                "_tool_evidence_projection": {
+                    "tool_concept_id": "#V#mail_get_item_tool",
+                    "referent_candidates": [
+                        {
+                            "schema_version": "tool_referent_candidate.v1",
+                            "stable_id": stable_id,
+                            "display_label": display_label,
+                            "source_kind": "#V#mail_message_result_entity_type",
+                            "identity_field_concept_id": (
+                                "#V#mail_message_id_field"
+                            ),
+                        }
+                    ],
+                }
+            },
+        },
+    }
+
+
+def test_selected_referent_capsule_rejects_live_booking_token_false_match() -> None:
+    projection = build_conversation_situation_turn_projection(
+        request_id="turn-flight-booking",
+        terminal_status="completed",
+        response_text=(
+            "## Flight booking to keep handy\n\n"
+            "The email subject is **Your trip confirmation (JFK – SFO)**."
+        ),
+        tool_invocations=[
+            _referent_read_invocation(
+                stable_id="19fb8acf0e68c2ee",
+                display_label="Time booking link",
+                call_id="call-time-booking",
+            ),
+            _referent_read_invocation(
+                stable_id="19febb3feda7b024",
+                display_label="Your trip confirmation (JFK - SFO)",
+                call_id="call-trip-confirmation",
+            ),
+        ],
+    )
+
+    assert projection is not None
+    assert [
+        referent["stable_id"] for referent in projection["selected_referents"]
+    ] == ["19febb3feda7b024"]
+
+
+def test_selected_referent_capsule_rejects_one_incidental_label_token() -> None:
+    projection = build_conversation_situation_turn_projection(
+        request_id="turn-generic-booking-word",
+        terminal_status="completed",
+        response_text="Was there a recent flight booking email?",
+        tool_invocations=[
+            _referent_read_invocation(
+                stable_id="message-time-booking",
+                display_label="Time booking link",
+                call_id="call-generic-booking",
+            )
+        ],
+    )
+
+    assert projection is None
+
+
+def test_selected_referent_capsule_keeps_exact_id_and_exact_label_matches() -> None:
+    projection = build_conversation_situation_turn_projection(
+        request_id="turn-exact-referents",
+        terminal_status="completed",
+        response_text=(
+            "Use opaque-message-123, then review the Quarterly planning memo."
+        ),
+        tool_invocations=[
+            _referent_read_invocation(
+                stable_id="opaque-message-123",
+                display_label="Unmentioned internal status note",
+                call_id="call-exact-id",
+            ),
+            _referent_read_invocation(
+                stable_id="opaque-message-456",
+                display_label="Quarterly planning memo",
+                call_id="call-exact-label",
+            ),
+        ],
+    )
+
+    assert projection is not None
+    assert [
+        referent["stable_id"] for referent in projection["selected_referents"]
+    ] == ["opaque-message-123", "opaque-message-456"]
+
+
+def test_selected_referent_capsule_keeps_whole_distinctive_single_token() -> None:
+    projection = build_conversation_situation_turn_projection(
+        request_id="turn-distinctive-single-token",
+        terminal_status="completed",
+        response_text="I recommend replying about SciClaimEval next",
+        tool_invocations=[
+            _referent_read_invocation(
+                stable_id="message-sciclaimeval",
+                display_label="RE: SciClaimEval",
+                call_id="call-sciclaimeval",
+            )
+        ],
+    )
+
+    assert projection is not None
+    assert projection["selected_referents"][0]["stable_id"] == (
+        "message-sciclaimeval"
+    )
+
+
 def test_selected_referent_capsule_does_not_require_opaque_id_in_visible_answer() -> None:
     projection = build_conversation_situation_turn_projection(
         request_id="turn-email-priority",

--- a/tests/backend/test_conversation_situation_turn_projection.py
+++ b/tests/backend/test_conversation_situation_turn_projection.py
@@ -589,6 +589,51 @@ def test_selected_referent_capsule_does_not_require_opaque_id_in_visible_answer(
     ) == projection["selected_referents"][0]["resource_scope"]
 
 
+def test_detail_referent_preserves_discovery_view_scope_for_same_resource() -> None:
+    discovery = _referent_read_invocation(
+        stable_id="message-trip-confirmation",
+        display_label="Your trip confirmation (JFK - SFO)",
+        call_id="call-list-trip",
+    )
+    discovery["resource_scope"] = {
+        "source_family": "gmail",
+        "resource_id": "#V#gmail_profile_vonwitbrock_gmail",
+        "runtime_alias": "vonwitbrock-gmail",
+        "display_label": "zhanvonwitbrock@gmail.com",
+        "selection_source": "represented_default",
+        "view_scope": "whole_mailbox",
+    }
+    detail = _referent_read_invocation(
+        stable_id="message-trip-confirmation",
+        display_label="Your trip confirmation (JFK - SFO)",
+        call_id="call-get-trip",
+    )
+    detail["resource_scope"] = {
+        "source_family": "gmail",
+        "resource_id": "#V#gmail_profile_vonwitbrock_gmail",
+        "runtime_alias": "vonwitbrock-gmail",
+        "display_label": "zhanvonwitbrock@gmail.com",
+        "selection_source": "represented_default",
+    }
+
+    projection = build_conversation_situation_turn_projection(
+        request_id="turn-trip-view-scope",
+        terminal_status="completed",
+        response_text="Keep Your trip confirmation (JFK - SFO) handy.",
+        tool_invocations=[discovery, detail],
+    )
+
+    assert projection is not None
+    assert projection["selected_referents"][0]["resource_scope"] == {
+        "source_family": "gmail",
+        "resource_id": "#V#gmail_profile_vonwitbrock_gmail",
+        "runtime_alias": "vonwitbrock-gmail",
+        "display_label": "zhanvonwitbrock@gmail.com",
+        "selection_source": "represented_default",
+        "view_scope": "whole_mailbox",
+    }
+
+
 def test_selected_referent_capsule_preserves_long_opaque_identity_exactly() -> None:
     stable_id = "opaque-attachment-" + ("x" * 700)
     projection = build_conversation_situation_turn_projection(

--- a/tests/backend/test_tool_evidence_projection_service.py
+++ b/tests/backend/test_tool_evidence_projection_service.py
@@ -22,6 +22,7 @@ from src.backend.services.tool_evidence_projection_service import (
     project_surfaceable_concept_evidence,
     project_tool_payload_for_llm,
     render_surfaceable_concept_lines,
+    resolve_tool_projection_contract,
     surfaceable_concept_ids_from_evidence,
 )
 
@@ -191,6 +192,33 @@ def test_projection_runtime_uses_represented_mock_contract_without_tool_branch(
         }
     ]
     assert telemetry["missing_required_fields"] == []
+
+
+def test_projection_runtime_uses_supplied_turn_snapshot_without_reresolving(
+    _reset_mock_db: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _materialise_mock_projection_contract()
+    contract = resolve_tool_projection_contract("example_projection_tool")
+    assert contract is not None
+
+    def fail_if_resolved(_tool_name: str) -> None:
+        raise AssertionError("supplied turn snapshot must bypass live resolution")
+
+    monkeypatch.setattr(
+        "src.backend.services.tool_evidence_projection_service."
+        "resolve_tool_projection_contract",
+        fail_if_resolved,
+    )
+
+    projected = project_tool_payload_for_llm(
+        "example_projection_tool",
+        {"headline": "Snapshot projection works"},
+        contract=contract,
+    )
+
+    assert projected is not None
+    assert projected["title"] == "Snapshot projection works"
 
 
 def test_projection_runtime_reports_missing_required_fields(

--- a/tests/backend/test_tool_observation_ledger_service.py
+++ b/tests/backend/test_tool_observation_ledger_service.py
@@ -116,6 +116,23 @@ def test_ledger_records_cancelled_pending_tool_from_runtime_diagnostics() -> Non
     assert ledger["observations"][0]["status"] == "cancelled"
 
 
+def test_pending_observation_is_not_misreported_as_timeout_or_cancellation() -> None:
+    ledger = build_tool_observation_ledger(
+        tool_observations=[
+            {
+                "source": "background_task_progress",
+                "tool": "gmail_get_message",
+                "status": "pending",
+                "call_id": "call-mail-pending",
+            }
+        ]
+    )
+
+    assert ledger["status_counts"] == {"pending": 1}
+    assert ledger["has_pending_observation"] is True
+    assert ledger["has_timeout_or_cancellation"] is False
+
+
 def test_turn_execution_record_projects_tool_observation_ledger() -> None:
     record = build_turn_execution_record(
         request_id="req-tool-ledger",

--- a/tests/backend/test_turn_execution_record_service_execution_summary.py
+++ b/tests/backend/test_turn_execution_record_service_execution_summary.py
@@ -702,6 +702,7 @@ def test_timeout_transport_metadata_survives_durable_turn_record_readback(
                 "handler_duration_ms": None,
                 "handler_elapsed_ms": 38.5,
                 "transport_overhead_ms": 0.5,
+                "result_projection_duration_ms": 24_000.0,
                 "timeout_sec": 0.04,
                 "advisory_timeout_sec": 0.01,
                 "advisory_budget_exceeded": True,
@@ -737,6 +738,7 @@ def test_timeout_transport_metadata_survives_durable_turn_record_readback(
     assert invocation["queue_duration_ms"] == 1.5
     assert invocation["handler_elapsed_ms"] == 38.5
     assert invocation["transport_overhead_ms"] == 0.5
+    assert invocation["result_projection_duration_ms"] == 24_000.0
     assert invocation["transport"] == transport_metadata
 
 

--- a/tests/backend/test_turn_timing_telemetry_service.py
+++ b/tests/backend/test_turn_timing_telemetry_service.py
@@ -154,6 +154,48 @@ def test_tool_timing_separates_queue_handler_transport_and_persistence() -> None
     )
 
 
+def test_tool_timing_reports_transport_and_result_projection_separately() -> None:
+    trace = build_turn_timing_trace(
+        request_id="req-tool-projection",
+        tool_invocations=[
+            {
+                "tool": "gmail_get_message",
+                "status": "completed",
+                "transport": {
+                    "execution_id": "mcp-gmail-read",
+                    "duration_ms": 2700,
+                    "handler_duration_ms": 2600,
+                    "transport_overhead_ms": 100,
+                    "advisory_budget_exceeded": False,
+                },
+                "result_projection_duration_ms": 24000,
+            }
+        ],
+    )
+
+    tool_span = next(
+        span for span in trace["spans"] if span["operation_kind"] == "tool_call"
+    )
+    projection_span = next(
+        span
+        for span in trace["spans"]
+        if span["operation_name"] == "gmail_get_message:result_projection"
+    )
+    assert tool_span["duration_ms"] == 2700
+    assert tool_span["attributes"]["execution_id"] == "mcp-gmail-read"
+    assert tool_span["attributes"]["handler_duration_ms"] == 2600
+    assert tool_span["attributes"]["transport_overhead_ms"] == 100
+    assert tool_span["attributes"]["result_projection_duration_ms"] == 24000
+    assert projection_span["operation_kind"] == "support"
+    assert projection_span["duration_ms"] == 24000
+    assert projection_span["attributes"]["support_kind"] == (
+        "tool_result_projection"
+    )
+    assert trace["summary"]["tool_elapsed_ms"] == 2700
+    assert trace["summary"]["tool_result_projection_elapsed_ms"] == 24000
+    assert trace["stage_totals"][0]["support_elapsed_ms"] == 24000
+
+
 def test_merge_timing_spans_deduplicates_and_bounds() -> None:
     merged = merge_timing_spans(
         [{"span_id": "a", "stage_id": "x", "operation_kind": "support", "duration_ms": 1}],

--- a/tests/backend/test_von_generate_workflow_instances.py
+++ b/tests/backend/test_von_generate_workflow_instances.py
@@ -441,6 +441,35 @@ def test_presenter_mode_projects_tagged_adaptive_answer(app: Flask) -> None:
     }
 
 
+def test_presenter_mode_recovers_unclosed_terminal_screen_block(app: Flask) -> None:
+    app.config["_ADAPTIVE_TURN_STATE"]["response_text"] = (
+        "<spoken>It was in the email itself, not an attachment.</spoken>\n"
+        "<screen>The message reported **0 attachments**. Its itinerary and "
+        "receipt were embedded in the email body."
+    )
+
+    response = app.test_client().post(
+        "/von/generate",
+        json={"prompt": "Was that an attachment?", "presenter_mode": True},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["response"] == (
+        "The message reported **0 attachments**. Its itinerary and receipt "
+        "were embedded in the email body."
+    )
+    assert payload["response_channels"] == {
+        "spoken": "It was in the email itself, not an attachment.",
+        "screen": (
+            "The message reported **0 attachments**. Its itinerary and receipt "
+            "were embedded in the email body."
+        ),
+        "format": "tagged_blocks_v1",
+    }
+    assert payload["llm_debug"]["screen_backfill_second_pass_attempted"] is False
+
+
 def test_effect_finality_fallback_is_presented_literally_without_model_backfill(
     app: Flask,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Release decision: ready for CI and merge.

Observed user-path repairs:
- reject incidental single-token referent matches while preserving exact and distinctive references
- retain connector view scope across discovery and detail reads
- memoise represented projection contracts within one actor-scoped turn
- report nested transport and result-projection timing honestly
- distinguish pending observations from timeout or cancellation
- recover one unambiguous terminal presenter block missing its closing tag
- ask the model to name an unqualified human-readable connector resource once

Validation:
- 290 affected tests passed
- one unrelated timing expectation deselected; the same mismatch is present on origin/main
- compile, Ruff F checks, and git diff check passed

No Gmail writes, attachment imports, file copies, Sol calls, or live knowledge mutations were used in validation.