### PR TITLE
Separate workflow parity failures from purity advisories

### DIFF
--- a/docs/engineering/workflow_authoritative_publication_process.md
+++ b/docs/engineering/workflow_authoritative_publication_process.md
@@ -102,9 +102,27 @@ startup under the `workflow_purity` logger key. The counters currently include:
 6. `builtin_capability_override_count`
 7. `non_vontology_discoverable_workflow_count`
 
-Parity enforcement now defaults to `fail`, not `warn`. Production startup should
-raise on authority drift unless a developer explicitly relaxes
-`VON_WORKFLOW_PARITY_ENFORCEMENT` for bounded local diagnostics.
+Parity enforcement defaults to `fail`, not `warn`, for executable-registry and
+authority defects: registry-only or Vontology-only workflow IDs, incomplete
+represented process graphs, missing authority concepts or types, and purity
+counters that identify a workflow source or policy violation. The deferred
+parity policy marks those defects failed and raises within its worker unless a
+developer explicitly relaxes `VON_WORKFLOW_PARITY_ENFORCEMENT` for bounded
+local diagnostics. The current deferred worker catches and records that
+failure; it does not retroactively make the already-running server unready.
+
+Two kinds of engineering debt are reported but are not runtime-readiness
+failures:
+
+- `synthesized_launch_contract_count`, including the exact sorted workflow IDs;
+- `monolith_line_count_*` source-size ratchets.
+
+An otherwise healthy registry with only those findings completes parity work as
+`completed_with_findings` and emits a `workflow_parity_advisory` warning. This
+keeps the debt visible without making a runnable workflow registry unavailable
+because of code-maintenance metrics. The standalone purity gate remains strict
+and returns non-zero for the authority and policy counters above; callers may
+still choose a warn-only integration policy.
 
 The runtime registry must also keep bootstrap-only workflow families separate
 from production registration authority. Python definitions that remain for
@@ -120,6 +138,14 @@ workflows must be skipped rather than receiving guessed fallback routing prose.
 The checked-in CI baseline lives at:
 
 - `tests/backend/fixtures/workflow_purity_baseline.json`
+
+The checked-in baseline is repository-observable and may be generated without
+a populated runtime registry. It therefore does not record an artificial zero
+for registry-dependent measurements such as synthesised launch contracts, nor
+does it use them as a historical ratchet. A complete live non-zero observation
+is reported separately as present advisory debt, with exact workflow IDs; an
+incomplete or empty observation is merely incomparable. Neither case is
+misreported as a static-baseline regression.
 
 To emit the current report locally:
 

--- a/scripts/check_workflow_purity.py
+++ b/scripts/check_workflow_purity.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 import argparse
 import importlib
 import json
-from pathlib import Path
 import sys
+from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 repo_root_str = str(REPO_ROOT)
@@ -45,9 +45,25 @@ def _print_regression_summary(
         comparison = {}
 
     regression_detected = bool(comparison.get("regression_detected"))
+    advisory_findings_detected = bool(
+        comparison.get("advisory_findings_detected")
+    )
+    partitioned_findings = any(
+        key in comparison
+        for key in (
+            "blocking_increased_counters",
+            "advisory_increased_counters",
+            "advisory_observed_counters",
+            "blocking_missing_counter_keys",
+            "advisory_missing_counter_keys",
+        )
+    )
 
     if quiet_on_pass and not regression_detected:
-        print("Workflow purity gate passed.")
+        if advisory_findings_detected:
+            print("Workflow purity gate passed with advisory findings.")
+        else:
+            print("Workflow purity gate passed.")
         return
 
     if not quiet:
@@ -59,7 +75,9 @@ def _print_regression_summary(
     if quiet:
         return
 
-    increased = comparison.get("increased_counters")
+    increased = comparison.get(
+        "blocking_increased_counters" if partitioned_findings else "increased_counters"
+    )
     if isinstance(increased, dict) and increased:
         print("Regressed counters:")
         for key in sorted(increased):
@@ -71,11 +89,42 @@ def _print_regression_summary(
                 f"current={delta.get('current')} delta={delta.get('delta')}"
             )
 
-    missing = comparison.get("missing_counter_keys")
+    missing = comparison.get(
+        "blocking_missing_counter_keys"
+        if partitioned_findings
+        else "missing_counter_keys"
+    )
     if isinstance(missing, list) and missing:
         print("Missing baseline counters:")
         for key in missing:
             print(f" - {key}")
+
+    advisory_increased = comparison.get("advisory_increased_counters")
+    advisory_observed = comparison.get("advisory_observed_counters")
+    advisory_missing = comparison.get("advisory_missing_counter_keys")
+    if advisory_findings_detected:
+        print("Advisory counter findings:")
+        if isinstance(advisory_increased, dict):
+            for key in sorted(advisory_increased):
+                delta = advisory_increased.get(key)
+                if not isinstance(delta, dict):
+                    continue
+                print(
+                    f" - {key}: baseline={delta.get('baseline')} "
+                    f"current={delta.get('current')} delta={delta.get('delta')}"
+                )
+        if isinstance(advisory_observed, dict):
+            for key in sorted(advisory_observed):
+                observation = advisory_observed.get(key)
+                if not isinstance(observation, dict):
+                    continue
+                print(
+                    f" - {key}: current={observation.get('current')} "
+                    f"reason={observation.get('reason')}"
+                )
+        if isinstance(advisory_missing, list):
+            for key in advisory_missing:
+                print(f" - {key}: baseline counter missing")
 
     if regression_detected:
         print(
@@ -88,6 +137,8 @@ def _print_regression_summary(
         if verbose:
             print("Full report:")
             print(json.dumps(report, indent=2, sort_keys=True))
+    elif advisory_findings_detected:
+        print("Workflow purity gate passed with advisory findings.")
     else:
         print("Workflow purity gate passed.")
 
@@ -129,19 +180,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     project_root = Path(args.project_root).resolve()
-    
-    # Try to include Vontology-backed workflows if DB is available
-    # so we can track synthesized launch contracts.
-    import os
-    if os.getenv("VON_DB_NAME"):
-        from src.backend.workflows.durable.registry_factory import build_vontology_workflow_registry_snapshot
-        try:
-            registry = build_vontology_workflow_registry_snapshot()
-        except Exception:
-            registry = build_workflow_purity_registry_snapshot()
-    else:
-        registry = build_workflow_purity_registry_snapshot()
 
+    # This gate owns repository-observable counters only. Runtime registry debt
+    # is reported by the live parity inventory with its own provenance.
+    registry = build_workflow_purity_registry_snapshot()
     report = build_workflow_purity_report(registry=registry, project_root=project_root)
 
     if args.refresh_baseline:

--- a/src/backend/workflows/durable/registry_factory.py
+++ b/src/backend/workflows/durable/registry_factory.py
@@ -972,6 +972,94 @@ def _durable_mcp_fallback_action(request: Any) -> WorkflowActionResult:
         )
 
 
+def _mapping_keys(value: Any) -> set[str]:
+    if not isinstance(value, Mapping):
+        return set()
+    return {key for key in value if isinstance(key, str) and key}
+
+
+def _string_items(value: Any) -> set[str]:
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        return set()
+    return {item for item in value if isinstance(item, str) and item}
+
+
+def _classify_workflow_purity_regression(
+    comparison: Any,
+) -> Dict[str, Any]:
+    """Split purity findings into enforceable and advisory counter changes.
+
+    The purity report's current comparison contract provides the partitioned
+    fields consumed here. The legacy fallback deliberately treats an
+    undifferentiated regression as blocking because only an explicit
+    counter-level partition can prove that a finding is advisory.
+    """
+
+    if not isinstance(comparison, Mapping):
+        return {
+            "detected": False,
+            "blocking_detected": False,
+            "advisory_detected": False,
+            "blocking_counter_keys": [],
+            "advisory_counter_keys": [],
+            "unclassified_blocking_regression": False,
+        }
+
+    partition_fields = {
+        "blocking_increased_counters",
+        "advisory_increased_counters",
+        "advisory_observed_counters",
+        "blocking_missing_counter_keys",
+        "advisory_missing_counter_keys",
+        "advisory_findings_detected",
+    }
+    has_partitioned_findings = any(
+        field_name in comparison for field_name in partition_fields
+    )
+    if has_partitioned_findings:
+        blocking_counter_keys = _mapping_keys(
+            comparison.get("blocking_increased_counters")
+        ) | _string_items(comparison.get("blocking_missing_counter_keys"))
+        advisory_counter_keys = _mapping_keys(
+            comparison.get("advisory_increased_counters")
+        ) | _mapping_keys(
+            comparison.get("advisory_observed_counters")
+        ) | _string_items(comparison.get("advisory_missing_counter_keys"))
+        blocking_detected = bool(
+            comparison.get("regression_detected") or blocking_counter_keys
+        )
+        advisory_detected = bool(
+            comparison.get("advisory_findings_detected") or advisory_counter_keys
+        )
+        unclassified_blocking = bool(
+            blocking_detected and not blocking_counter_keys
+        )
+    elif comparison.get("regression_detected"):
+        # Legacy reports did not distinguish maintenance counters from
+        # authority/policy counters. Preserve strict behaviour instead of
+        # guessing that their combined regression was harmless.
+        blocking_counter_keys = set()
+        advisory_counter_keys = set()
+        unclassified_blocking = True
+        blocking_detected = True
+        advisory_detected = False
+    else:
+        blocking_counter_keys = set()
+        advisory_counter_keys = set()
+        blocking_detected = False
+        advisory_detected = False
+        unclassified_blocking = False
+
+    return {
+        "detected": bool(blocking_detected or advisory_detected),
+        "blocking_detected": blocking_detected,
+        "advisory_detected": advisory_detected,
+        "blocking_counter_keys": sorted(blocking_counter_keys),
+        "advisory_counter_keys": sorted(advisory_counter_keys),
+        "unclassified_blocking_regression": unclassified_blocking,
+    }
+
+
 def _build_workflow_parity_inventory(
     *,
     registry: WorkflowRegistry,
@@ -1136,21 +1224,30 @@ def _build_workflow_parity_inventory(
         )
     )
 
-    diagnostics_reason_codes: list[str] = []
+    enforced_reason_codes: list[str] = []
+    advisory_reason_codes: list[str] = []
     if registry_only_ids:
-        diagnostics_reason_codes.append("registry_only")
+        enforced_reason_codes.append("registry_only")
     if vontology_only_ids:
-        diagnostics_reason_codes.append("vontology_only")
+        enforced_reason_codes.append("vontology_only")
     if identity_only_ids:
-        diagnostics_reason_codes.append("identity_only")
+        enforced_reason_codes.append("identity_only")
     if authority_drift:
-        diagnostics_reason_codes.append("workflow_authority")
-    if isinstance(workflow_purity_comparison, dict) and workflow_purity_comparison.get(
-        "regression_detected"
-    ):
-        diagnostics_reason_codes.append("workflow_purity_regression")
+        enforced_reason_codes.append("workflow_authority")
 
-    drift_detected = bool(diagnostics_reason_codes)
+    workflow_purity_regression = _classify_workflow_purity_regression(
+        workflow_purity_comparison
+    )
+    if workflow_purity_regression["blocking_detected"]:
+        enforced_reason_codes.append("workflow_purity_regression")
+    if workflow_purity_regression["advisory_detected"]:
+        advisory_reason_codes.append("workflow_purity_advisory")
+
+    diagnostics_reason_codes = list(
+        dict.fromkeys(enforced_reason_codes + advisory_reason_codes)
+    )
+    drift_detected = bool(enforced_reason_codes)
+    advisory_detected = bool(advisory_reason_codes)
 
     return {
         "generated_at_utc": _utc_now_iso(),
@@ -1186,8 +1283,12 @@ def _build_workflow_parity_inventory(
         "summary_text": "\n".join(summary_lines),
         "diagnostics": {
             "drift_detected": drift_detected,
-            "severity": "warning" if drift_detected else "ok",
+            "advisory_detected": advisory_detected,
+            "severity": "warning" if drift_detected or advisory_detected else "ok",
             "reason_codes": diagnostics_reason_codes,
+            "enforced_reason_codes": enforced_reason_codes,
+            "advisory_reason_codes": advisory_reason_codes,
+            "workflow_purity_regression": workflow_purity_regression,
         },
     }
 
@@ -1196,31 +1297,93 @@ def _apply_workflow_parity_policy(inventory_snapshot: Dict[str, Any]) -> None:
     """Apply warn/fail parity drift policy and annotate inventory diagnostics.
 
     ``VON_WORKFLOW_PARITY_ENFORCEMENT`` controls behaviour:
-    - ``warn``: log warning on drift
-    - ``fail`` / ``strict`` / ``error``: raise RuntimeError on drift
-    - ``off`` / ``none``: do not warn or fail
+    - ``warn``: log warning on enforceable drift
+    - ``fail`` / ``strict`` / ``error``: raise RuntimeError on enforceable drift
+    - ``off`` / ``none``: do not warn or fail on enforceable drift
+
+    Advisory purity findings remain visible regardless of this mode, but they
+    never turn an otherwise runnable registry into a parity-policy exception.
     """
     mode = os.getenv("VON_WORKFLOW_PARITY_ENFORCEMENT", "fail").strip().lower()
     diagnostics = inventory_snapshot.get("diagnostics")
-    drift_detected = bool(
-        isinstance(diagnostics, dict) and diagnostics.get("drift_detected")
-    )
     reason_codes: list[str] = []
+    enforced_reason_codes: list[str] = []
+    advisory_reason_codes: list[str] = []
     if isinstance(diagnostics, dict):
         maybe_reason_codes = diagnostics.get("reason_codes")
         if isinstance(maybe_reason_codes, list):
             reason_codes = [
                 item for item in maybe_reason_codes if isinstance(item, str)
             ]
-    reason_suffix = ",".join(reason_codes)
+
+        maybe_enforced_reason_codes = diagnostics.get("enforced_reason_codes")
+        if isinstance(maybe_enforced_reason_codes, list):
+            enforced_reason_codes = [
+                item
+                for item in maybe_enforced_reason_codes
+                if isinstance(item, str)
+            ]
+        else:
+            # Backwards-compatible handling for older inventory snapshots. An
+            # undifferentiated purity regression remains blocking unless its
+            # counter-level comparison proves it contains advisory findings only.
+            workflow_purity = inventory_snapshot.get("workflow_purity")
+            workflow_purity_baseline = (
+                workflow_purity.get("baseline", {})
+                if isinstance(workflow_purity, dict)
+                else {}
+            )
+            workflow_purity_comparison = (
+                workflow_purity_baseline.get("comparison", {})
+                if isinstance(workflow_purity_baseline, dict)
+                else {}
+            )
+            purity_classification = _classify_workflow_purity_regression(
+                workflow_purity_comparison
+            )
+            for reason_code in reason_codes:
+                if reason_code != "workflow_purity_regression":
+                    enforced_reason_codes.append(reason_code)
+                elif purity_classification["advisory_detected"] and not (
+                    purity_classification["blocking_detected"]
+                ):
+                    advisory_reason_codes.append(reason_code)
+                else:
+                    enforced_reason_codes.append(reason_code)
+            if diagnostics.get("drift_detected") and not reason_codes:
+                enforced_reason_codes.append("unknown")
+
+        maybe_advisory_reason_codes = diagnostics.get("advisory_reason_codes")
+        if isinstance(maybe_advisory_reason_codes, list):
+            advisory_reason_codes = [
+                item
+                for item in maybe_advisory_reason_codes
+                if isinstance(item, str)
+            ]
+
+    enforced_reason_codes = list(dict.fromkeys(enforced_reason_codes))
+    advisory_reason_codes = list(dict.fromkeys(advisory_reason_codes))
+    drift_detected = bool(enforced_reason_codes)
+    advisory_detected = bool(advisory_reason_codes)
+    reason_suffix = ",".join(enforced_reason_codes)
+    advisory_reason_suffix = ",".join(advisory_reason_codes)
     summary_text = inventory_snapshot.get(
         "summary_text", "workflow parity snapshot generated"
     )
     message = f"{summary_text}; drift_reasons={reason_suffix or 'none'}"
+    policy_outcome = (
+        "completed_with_findings"
+        if drift_detected or advisory_detected
+        else "completed"
+    )
 
     inventory_snapshot["parity_policy"] = {
         "mode": mode,
+        "outcome": policy_outcome,
         "drift_detected": drift_detected,
+        "advisory_detected": advisory_detected,
+        "enforced_reason_codes": enforced_reason_codes,
+        "advisory_reason_codes": advisory_reason_codes,
     }
 
     workflow_purity = inventory_snapshot.get("workflow_purity")
@@ -1234,6 +1397,14 @@ def _apply_workflow_parity_policy(inventory_snapshot: Dict[str, Any]) -> None:
             json.dumps(workflow_purity, sort_keys=True),
         )
 
+    if advisory_detected:
+        logger.warning(
+            "[workflow_parity_advisory] outcome=%s advisory_reasons=%s; %s",
+            policy_outcome,
+            advisory_reason_suffix or "unknown",
+            summary_text,
+        )
+
     if not drift_detected:
         logger.info("[workflow_parity] %s", summary_text)
         return
@@ -1244,6 +1415,7 @@ def _apply_workflow_parity_policy(inventory_snapshot: Dict[str, Any]) -> None:
 
     logger.warning("[workflow_parity] %s", message)
     if mode in {"fail", "strict", "error"}:
+        inventory_snapshot["parity_policy"]["outcome"] = "failed"
         raise RuntimeError(
             f"workflow_parity_drift_detected:{reason_suffix or 'unknown'}"
         )
@@ -1367,14 +1539,29 @@ def _build_pending_workflow_inventory_snapshot(
         "summary_text": "\n".join(summary_lines),
         "diagnostics": {
             "drift_detected": False,
+            "advisory_detected": False,
             "severity": "pending",
             "reason_codes": ["inventory_pending_background_build"],
+            "enforced_reason_codes": [],
+            "advisory_reason_codes": [],
+            "workflow_purity_regression": {
+                "detected": False,
+                "blocking_detected": False,
+                "advisory_detected": False,
+                "blocking_counter_keys": [],
+                "advisory_counter_keys": [],
+                "unclassified_blocking_regression": False,
+            },
         },
         "parity_policy": {
             "mode": os.getenv("VON_WORKFLOW_PARITY_ENFORCEMENT", "fail")
             .strip()
             .lower(),
+            "outcome": "pending_background_build",
             "drift_detected": False,
+            "advisory_detected": False,
+            "enforced_reason_codes": [],
+            "advisory_reason_codes": [],
         },
     }
 
@@ -1676,9 +1863,16 @@ def _launch_deferred_registry_work(
 
             _apply_workflow_parity_policy(inventory_snapshot)
 
+            parity_policy = inventory_snapshot.get("parity_policy")
+            completion_outcome = (
+                str(parity_policy.get("outcome") or "completed")
+                if isinstance(parity_policy, dict)
+                else "completed"
+            )
             logger.info(
-                "Deferred workflow registry work completed: "
+                "Deferred workflow registry work outcome=%s: "
                 "%d eager workflows after background loading.",
+                completion_outcome,
                 len(list(registry.eager_workflow_ids())),
             )
         except Exception as exc:

--- a/src/backend/workflows/workflow_purity_report.py
+++ b/src/backend/workflows/workflow_purity_report.py
@@ -29,6 +29,13 @@ WORKFLOW_PURITY_SUPPORT_FILE = "src/backend/workflows/workflow_purity_report.py"
 WORKFLOW_PURITY_BASELINE_REFRESH_COMMAND = (
     "pdm run python scripts/workflow_purity_report.py --refresh-baseline"
 )
+REGISTRY_DEPENDENT_COUNTER_KEYS = frozenset(
+    {
+        "synthesized_launch_contract_count",
+    }
+)
+ADVISORY_COUNTER_KEYS = REGISTRY_DEPENDENT_COUNTER_KEYS
+ADVISORY_COUNTER_PREFIXES = ("monolith_line_count_",)
 
 DIRECT_INSTANCE_CREATE_PATTERN = re.compile(r"\.create_instance(?:_for_event)?\(")
 ALLOWED_DIRECT_INSTANCE_CREATE_CALLSITES = frozenset(
@@ -1701,16 +1708,23 @@ def _collect_registry_sources(registry: Any | None) -> dict[str, Any]:
     if registry is None:
         return {
             "registry_available": False,
+            "registry_enumeration_succeeded": False,
+            "registry_workflow_definition_count": 0,
             "counts": {},
             "source_by_workflow_id": {},
+            "synthesized_launch_contract_workflow_ids": [],
         }
 
     source_counts: dict[str, int] = {}
     source_by_workflow_id: dict[str, str] = {}
+    synthesized_launch_contract_workflow_ids: list[str] = []
+    registry_workflow_definition_count = 0
     try:
         workflow_ids = sorted(set(registry.all_workflow_ids()))
+        registry_enumeration_succeeded = True
     except Exception:
         workflow_ids = []
+        registry_enumeration_succeeded = False
 
     for workflow_id in workflow_ids:
         source = "unknown"
@@ -1743,11 +1757,13 @@ def _collect_registry_sources(registry: Any | None) -> dict[str, Any]:
                 registration = registry.get_registration(workflow_id)
             definition = getattr(registration, "definition", None)
             if registration and definition is not None:
+                registry_workflow_definition_count += 1
                 metadata = getattr(definition, "metadata", None)
                 if isinstance(metadata, Mapping) and (
                     metadata.get("launch_contract_source")
                     == "synthesized_from_initial_state"
                 ):
+                    synthesized_launch_contract_workflow_ids.append(workflow_id)
                     source_counts["synthesized_launch_contract_count"] = (
                         source_counts.get("synthesized_launch_contract_count", 0) + 1
                     )
@@ -1756,17 +1772,23 @@ def _collect_registry_sources(registry: Any | None) -> dict[str, Any]:
 
     return {
         "registry_available": True,
+        "registry_enumeration_succeeded": registry_enumeration_succeeded,
+        "registry_workflow_definition_count": registry_workflow_definition_count,
         "counts": source_counts,
         "source_by_workflow_id": source_by_workflow_id,
+        "synthesized_launch_contract_workflow_ids": sorted(
+            set(synthesized_launch_contract_workflow_ids)
+        ),
     }
 
 
 def _scan_monolith_line_ratchet(project_root: Path) -> dict[str, Any]:
     """Measure the line counts of the named monolith files.
 
-    These counters ratchet through the baseline comparison: any growth beyond
-    the checked-in baseline is a regression, and deliberate reductions should
-    be locked in by refreshing the baseline. See JVNAUTOSCI-2497.
+    These counters ratchet through the advisory baseline comparison: growth is
+    reported without turning a code-maintenance metric into a runtime blocker.
+    Deliberate reductions should be locked in by refreshing the baseline. See
+    JVNAUTOSCI-2497.
     """
 
     files: list[dict[str, Any]] = []
@@ -1798,20 +1820,135 @@ def load_workflow_purity_baseline(
     return payload if isinstance(payload, dict) else None
 
 
+def _normalise_measurement_provenance(
+    provenance: Mapping[str, Any] | None,
+) -> dict[str, bool | int | str | None]:
+    raw = provenance if isinstance(provenance, Mapping) else {}
+    registry_supplied = raw.get("registry_supplied")
+    registry_enumeration_succeeded = raw.get("registry_enumeration_succeeded")
+    registry_workflow_count = raw.get("registry_workflow_count")
+    registry_workflow_definition_count = raw.get("registry_workflow_definition_count")
+    registry_workflow_population_observed = raw.get(
+        "registry_workflow_population_observed"
+    )
+    registry_snapshot_scope = raw.get("registry_snapshot_scope")
+    synthesized_launch_contract_measurement_complete = raw.get(
+        "synthesized_launch_contract_measurement_complete"
+    )
+    return {
+        "registry_supplied": (
+            registry_supplied if isinstance(registry_supplied, bool) else None
+        ),
+        "registry_enumeration_succeeded": (
+            registry_enumeration_succeeded
+            if isinstance(registry_enumeration_succeeded, bool)
+            else None
+        ),
+        "registry_workflow_count": (
+            registry_workflow_count
+            if isinstance(registry_workflow_count, int)
+            and not isinstance(registry_workflow_count, bool)
+            else None
+        ),
+        "registry_workflow_definition_count": (
+            registry_workflow_definition_count
+            if isinstance(registry_workflow_definition_count, int)
+            and not isinstance(registry_workflow_definition_count, bool)
+            else None
+        ),
+        "registry_workflow_population_observed": (
+            registry_workflow_population_observed
+            if isinstance(registry_workflow_population_observed, bool)
+            else None
+        ),
+        "registry_snapshot_scope": (
+            registry_snapshot_scope
+            if isinstance(registry_snapshot_scope, str)
+            and registry_snapshot_scope
+            in {"unavailable", "empty", "non_vontology_only", "vontology_inclusive"}
+            else None
+        ),
+        "synthesized_launch_contract_measurement_complete": (
+            synthesized_launch_contract_measurement_complete
+            if isinstance(synthesized_launch_contract_measurement_complete, bool)
+            else None
+        ),
+    }
+
+
+def _counter_is_advisory(counter_key: str) -> bool:
+    return counter_key in ADVISORY_COUNTER_KEYS or counter_key.startswith(
+        ADVISORY_COUNTER_PREFIXES
+    )
+
+
+def _advisory_observed_counters(
+    *,
+    counters: Mapping[str, Any],
+    measurement_provenance: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    if not (
+        measurement_provenance.get(
+            "synthesized_launch_contract_measurement_complete"
+        )
+        is True
+        and measurement_provenance.get("registry_workflow_population_observed")
+        is True
+    ):
+        return {}
+    return {
+        key: {
+            "current": value,
+            "reason": "nonzero_complete_registry_observation",
+        }
+        for key, value in counters.items()
+        if key in REGISTRY_DEPENDENT_COUNTER_KEYS
+        and _counter_is_advisory(key)
+        and isinstance(value, int)
+        and not isinstance(value, bool)
+        and value > 0
+    }
+
+
 def compare_workflow_purity_to_baseline(
     *,
     counters: Mapping[str, Any],
     baseline: Mapping[str, Any] | None,
+    current_measurement_provenance: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
+    current_provenance = _normalise_measurement_provenance(
+        current_measurement_provenance
+    )
+    advisory_observed = _advisory_observed_counters(
+        counters=counters,
+        measurement_provenance=current_provenance,
+    )
     if not isinstance(baseline, Mapping):
         return {
             "baseline_available": False,
             "baseline_schema_version": None,
+            "current_measurement_provenance": current_provenance,
+            "baseline_measurement_provenance": None,
+            "comparable_counter_keys": [],
+            "incomparable_counters": {},
+            "incomparable_measurements_detected": False,
+            "advisory_observed_counters": advisory_observed,
             "missing_counter_keys": [],
+            "blocking_missing_counter_keys": [],
+            "advisory_missing_counter_keys": [],
             "increased_counters": {},
+            "blocking_increased_counters": {},
+            "advisory_increased_counters": {},
+            "blocking_findings_detected": False,
+            "advisory_findings_detected": bool(advisory_observed),
             "regression_detected": False,
         }
 
+    baseline_provenance = _normalise_measurement_provenance(
+        baseline.get("measurement_provenance")
+        if isinstance(baseline.get("measurement_provenance"), Mapping)
+        else None
+    )
     baseline_counters = (
         baseline.get("counters", {}) if isinstance(baseline, Mapping) else {}
     )
@@ -1819,20 +1956,71 @@ def compare_workflow_purity_to_baseline(
         baseline_counters = {}
 
     increased: dict[str, dict[str, int]] = {}
+    blocking_increased: dict[str, dict[str, int]] = {}
+    advisory_increased: dict[str, dict[str, int]] = {}
+    comparable_counter_keys: list[str] = []
+    incomparable_counters: dict[str, dict[str, Any]] = {}
     missing_counter_keys: list[str] = []
+    blocking_missing_counter_keys: list[str] = []
+    advisory_missing_counter_keys: list[str] = []
     for key, value in counters.items():
         if not isinstance(value, int):
             continue
         baseline_value = baseline_counters.get(key)
+        if key in REGISTRY_DEPENDENT_COUNTER_KEYS:
+            incomparable_counters[key] = {
+                "baseline": baseline_value if isinstance(baseline_value, int) else None,
+                "current": value,
+                "reason": "registry_dependent_counter_not_owned_by_static_baseline",
+                "current_registry_workflow_population_observed": current_provenance.get(
+                    "registry_workflow_population_observed"
+                ),
+                "baseline_registry_workflow_population_observed": baseline_provenance.get(
+                    "registry_workflow_population_observed"
+                ),
+                "current_measurement_complete": current_provenance.get(
+                    "synthesized_launch_contract_measurement_complete"
+                ),
+                "baseline_measurement_complete": baseline_provenance.get(
+                    "synthesized_launch_contract_measurement_complete"
+                ),
+                "current_registry_snapshot_scope": current_provenance.get(
+                    "registry_snapshot_scope"
+                ),
+                "baseline_registry_snapshot_scope": baseline_provenance.get(
+                    "registry_snapshot_scope"
+                ),
+                "classification": (
+                    "advisory" if _counter_is_advisory(key) else "blocking"
+                ),
+            }
+            continue
         if not isinstance(baseline_value, int):
             missing_counter_keys.append(key)
+            if _counter_is_advisory(key):
+                advisory_missing_counter_keys.append(key)
+            else:
+                blocking_missing_counter_keys.append(key)
             continue
+        comparable_counter_keys.append(key)
         if value > baseline_value:
-            increased[key] = {
+            increase = {
                 "baseline": baseline_value,
                 "current": value,
                 "delta": value - baseline_value,
             }
+            increased[key] = increase
+            if _counter_is_advisory(key):
+                advisory_increased[key] = increase
+            else:
+                blocking_increased[key] = increase
+
+    blocking_findings_detected = bool(
+        blocking_increased or blocking_missing_counter_keys
+    )
+    advisory_findings_detected = bool(
+        advisory_increased or advisory_missing_counter_keys or advisory_observed
+    )
 
     return {
         "baseline_available": bool(isinstance(baseline, Mapping)),
@@ -1841,9 +2029,21 @@ def compare_workflow_purity_to_baseline(
             if isinstance(baseline, Mapping) and baseline.get("schema_version")
             else None
         ),
+        "current_measurement_provenance": current_provenance,
+        "baseline_measurement_provenance": baseline_provenance,
+        "comparable_counter_keys": sorted(comparable_counter_keys),
+        "incomparable_counters": incomparable_counters,
+        "incomparable_measurements_detected": bool(incomparable_counters),
+        "advisory_observed_counters": advisory_observed,
         "missing_counter_keys": sorted(missing_counter_keys),
+        "blocking_missing_counter_keys": sorted(blocking_missing_counter_keys),
+        "advisory_missing_counter_keys": sorted(advisory_missing_counter_keys),
         "increased_counters": increased,
-        "regression_detected": bool(increased or missing_counter_keys),
+        "blocking_increased_counters": blocking_increased,
+        "advisory_increased_counters": advisory_increased,
+        "blocking_findings_detected": blocking_findings_detected,
+        "advisory_findings_detected": advisory_findings_detected,
+        "regression_detected": blocking_findings_detected,
     }
 
 
@@ -1853,15 +2053,28 @@ def build_workflow_purity_baseline_snapshot(
     counters = report.get("counters", {})
     if not isinstance(counters, Mapping):
         counters = {}
+    measurement_provenance = _normalise_measurement_provenance(
+        report.get("measurement_provenance")
+        if isinstance(report.get("measurement_provenance"), Mapping)
+        else None
+    )
+    baseline_counters: dict[str, int] = {}
+    for key, value in counters.items():
+        if not isinstance(key, str) or not isinstance(value, int):
+            continue
+        if key in REGISTRY_DEPENDENT_COUNTER_KEYS:
+            # The checked-in baseline is repository-observable. A registry-
+            # dependent measurement belongs in the live report, with its own
+            # observation provenance, rather than in this static ratchet.
+            continue
+        baseline_counters[key] = int(value)
+
     return {
         "schema_version": WORKFLOW_PURITY_BASELINE_SCHEMA_VERSION,
         "generated_at_utc": _utc_now_iso(),
         "report_schema_version": report.get("schema_version"),
-        "counters": {
-            key: int(value)
-            for key, value in counters.items()
-            if isinstance(key, str) and isinstance(value, int)
-        },
+        "measurement_provenance": measurement_provenance,
+        "counters": baseline_counters,
     }
 
 
@@ -1895,6 +2108,42 @@ def build_workflow_purity_report(
         source_counts = {}
     if not isinstance(source_by_workflow_id, Mapping):
         source_by_workflow_id = {}
+    registry_enumeration_succeeded = bool(
+        runtime_sources.get("registry_enumeration_succeeded")
+    )
+    registry_workflow_count = len(source_by_workflow_id)
+    registry_workflow_definition_count = int(
+        runtime_sources.get("registry_workflow_definition_count", 0) or 0
+    )
+    registry_sources = {
+        source
+        for source in source_by_workflow_id.values()
+        if isinstance(source, str) and source
+    }
+    if registry is None or not registry_enumeration_succeeded:
+        registry_snapshot_scope = "unavailable"
+    elif registry_workflow_count == 0:
+        registry_snapshot_scope = "empty"
+    elif "vontology" in registry_sources:
+        registry_snapshot_scope = "vontology_inclusive"
+    else:
+        registry_snapshot_scope = "non_vontology_only"
+    registry_workflow_population_observed = bool(
+        registry_enumeration_succeeded and registry_workflow_count > 0
+    )
+    measurement_provenance = {
+        "registry_supplied": registry is not None,
+        "registry_enumeration_succeeded": registry_enumeration_succeeded,
+        "registry_workflow_count": registry_workflow_count,
+        "registry_workflow_definition_count": registry_workflow_definition_count,
+        # An empty DB-free snapshot cannot establish a runtime-backed zero.
+        "registry_workflow_population_observed": registry_workflow_population_observed,
+        "registry_snapshot_scope": registry_snapshot_scope,
+        "synthesized_launch_contract_measurement_complete": bool(
+            registry_workflow_population_observed
+            and registry_workflow_definition_count == registry_workflow_count
+        ),
+    }
 
     built_in_workflow_ids = sorted(
         workflow_id
@@ -1975,6 +2224,7 @@ def build_workflow_purity_report(
     comparison = compare_workflow_purity_to_baseline(
         counters=counters,
         baseline=baseline,
+        current_measurement_provenance=measurement_provenance,
     )
     summary_parts = [f"{key}={value}" for key, value in counters.items()]
     summary_text = "Workflow purity: " + " ".join(summary_parts)
@@ -1984,11 +2234,15 @@ def build_workflow_purity_report(
         "generated_at_utc": _utc_now_iso(),
         "summary_text": summary_text,
         "counters": counters,
+        "measurement_provenance": measurement_provenance,
         "details": {
             "registry_available": bool(runtime_sources.get("registry_available")),
             "registry_source_counts": dict(source_counts),
             "built_in_workflow_ids": built_in_workflow_ids,
             "non_vontology_discoverable_workflow_ids": non_vontology_discoverable_workflow_ids,
+            "synthesized_launch_contract_workflow_ids": list(
+                runtime_sources.get("synthesized_launch_contract_workflow_ids", [])
+            ),
             "remaining_python_workflow_family_files": copy.deepcopy(
                 python_workflow_families.get("family_files", [])
             ),
@@ -2023,6 +2277,8 @@ def build_workflow_purity_report(
 
 
 __all__ = [
+    "ADVISORY_COUNTER_KEYS",
+    "ADVISORY_COUNTER_PREFIXES",
     "ALLOWED_DIRECT_INSTANCE_CREATE_CALLSITES",
     "CORE_SUPPORT_POLICY_CONTRACTS",
     "CORE_SUPPORT_PROMPT_SOURCE_FILES",
@@ -2031,6 +2287,7 @@ __all__ = [
     "LEGACY_SELECTOR_CONSTRUCT_PATTERNS",
     "LEGACY_SELECTOR_FILE",
     "MONOLITH_RATCHET_FILES",
+    "REGISTRY_DEPENDENT_COUNTER_KEYS",
     "REPO_SEED_AUTHORITY_ALLOWED_PATHS",
     "REPO_SEED_AUTHORITY_PATTERNS",
     "SEED_FALLBACK_ORDER_CONTRACTS",

--- a/tests/backend/fixtures/workflow_purity_baseline.json
+++ b/tests/backend/fixtures/workflow_purity_baseline.json
@@ -15,11 +15,19 @@
     "remaining_python_workflow_family_count": 0,
     "repo_seed_authority_drift_path_count": 0,
     "support_surface_policy_contract_violation_count": 0,
-    "synthesized_launch_contract_count": 0,
     "vontology_first_seed_fallback_violation_count": 0,
     "workflow_id_special_case_count": 0
   },
   "generated_at_utc": "2026-07-23T09:46:26.558960+00:00",
+  "measurement_provenance": {
+    "registry_enumeration_succeeded": true,
+    "registry_snapshot_scope": "empty",
+    "registry_supplied": true,
+    "registry_workflow_count": 0,
+    "registry_workflow_definition_count": 0,
+    "registry_workflow_population_observed": false,
+    "synthesized_launch_contract_measurement_complete": false
+  },
   "report_schema_version": "workflow_purity_report.v1",
   "schema_version": "workflow_purity_baseline.v1"
 }

--- a/tests/backend/test_workflow_purity_report.py
+++ b/tests/backend/test_workflow_purity_report.py
@@ -4,19 +4,28 @@ from pathlib import Path
 from src.backend.services.workflow_capability_service import (
     BUILTIN_WORKFLOW_CAPABILITIES,
 )
+from src.backend.workflows.workflow_purity_report import (
+    build_workflow_purity_baseline_snapshot,
+    build_workflow_purity_report,
+    compare_workflow_purity_to_baseline,
+)
 from src.backend.workflows.workflow_registry import (
     LazyWorkflowRegistration,
     WorkflowRegistry,
 )
-from src.backend.workflows.workflow_purity_report import (
-    build_workflow_purity_report,
-    compare_workflow_purity_to_baseline,
-)
 
 
 class _DummyRegistry:
-    def __init__(self, source_by_workflow_id: dict[str, str]) -> None:
+    def __init__(
+        self,
+        source_by_workflow_id: dict[str, str],
+        *,
+        synthesized_launch_contract_workflow_ids: set[str] | None = None,
+    ) -> None:
         self._source_by_workflow_id = dict(source_by_workflow_id)
+        self._synthesized_launch_contract_workflow_ids = set(
+            synthesized_launch_contract_workflow_ids or set()
+        )
 
     def all_workflow_ids(self):
         return list(self._source_by_workflow_id)
@@ -25,7 +34,21 @@ class _DummyRegistry:
         source = self._source_by_workflow_id.get(workflow_id)
         if source is None:
             return None
-        return type("Registration", (), {"source": source})()
+        launch_contract_source = (
+            "synthesized_from_initial_state"
+            if workflow_id in self._synthesized_launch_contract_workflow_ids
+            else "represented"
+        )
+        definition = type(
+            "Definition",
+            (),
+            {"metadata": {"launch_contract_source": launch_contract_source}},
+        )()
+        return type(
+            "Registration",
+            (),
+            {"source": source, "definition": definition},
+        )()
 
 
 def _write(relative_path: str, text: str, *, root: Path) -> None:
@@ -253,6 +276,203 @@ def test_build_workflow_purity_report_counts_runtime_and_code_impurity(
     assert report["baseline"]["comparison"]["regression_detected"] is False
 
 
+def test_registry_measurement_is_visible_but_incomparable_to_legacy_baseline(
+    tmp_path: Path,
+) -> None:
+    baseline_path = _write_zero_baseline(tmp_path)
+    registry = _DummyRegistry(
+        {
+            "#V#zeta_workflow": "vontology",
+            "#V#alpha_workflow": "vontology",
+        },
+        synthesized_launch_contract_workflow_ids={
+            "#V#zeta_workflow",
+            "#V#alpha_workflow",
+        },
+    )
+
+    report = build_workflow_purity_report(
+        registry=registry,
+        project_root=tmp_path,
+        baseline_path=baseline_path,
+    )
+
+    assert report["counters"]["synthesized_launch_contract_count"] == 2
+    assert report["details"]["synthesized_launch_contract_workflow_ids"] == [
+        "#V#alpha_workflow",
+        "#V#zeta_workflow",
+    ]
+    assert report["measurement_provenance"] == {
+        "registry_supplied": True,
+        "registry_enumeration_succeeded": True,
+        "registry_workflow_count": 2,
+        "registry_workflow_definition_count": 2,
+        "registry_workflow_population_observed": True,
+        "registry_snapshot_scope": "vontology_inclusive",
+        "synthesized_launch_contract_measurement_complete": True,
+    }
+    comparison = report["baseline"]["comparison"]
+    assert comparison["regression_detected"] is False
+    assert comparison["advisory_findings_detected"] is True
+    assert comparison["incomparable_measurements_detected"] is True
+    assert (
+        comparison["incomparable_counters"]["synthesized_launch_contract_count"][
+            "baseline_registry_workflow_population_observed"
+        ]
+        is None
+    )
+    assert "synthesized_launch_contract_count" not in comparison["increased_counters"]
+    assert comparison["advisory_observed_counters"] == {
+        "synthesized_launch_contract_count": {
+            "current": 2,
+            "reason": "nonzero_complete_registry_observation",
+        }
+    }
+
+
+def test_baseline_snapshot_never_ratchets_registry_dependent_counter() -> None:
+    db_free_report = {
+        "schema_version": "workflow_purity_report.v1",
+        "measurement_provenance": {
+            "registry_supplied": True,
+            "registry_enumeration_succeeded": True,
+            "registry_workflow_count": 0,
+            "registry_workflow_definition_count": 0,
+            "registry_workflow_population_observed": False,
+            "registry_snapshot_scope": "empty",
+            "synthesized_launch_contract_measurement_complete": False,
+        },
+        "counters": {
+            "synthesized_launch_contract_count": 0,
+            "monolith_line_count_catalogue": 12,
+            "workflow_id_special_case_count": 1,
+        },
+    }
+
+    db_free_snapshot = build_workflow_purity_baseline_snapshot(db_free_report)
+
+    assert "synthesized_launch_contract_count" not in db_free_snapshot["counters"]
+    assert db_free_snapshot["counters"] == {
+        "monolith_line_count_catalogue": 12,
+        "workflow_id_special_case_count": 1,
+    }
+    assert (
+        db_free_snapshot["measurement_provenance"][
+            "registry_workflow_population_observed"
+        ]
+        is False
+    )
+
+    populated_report = {
+        **db_free_report,
+        "measurement_provenance": {
+            "registry_supplied": True,
+            "registry_enumeration_succeeded": True,
+            "registry_workflow_count": 20,
+            "registry_workflow_definition_count": 20,
+            "registry_workflow_population_observed": True,
+            "registry_snapshot_scope": "vontology_inclusive",
+            "synthesized_launch_contract_measurement_complete": True,
+        },
+        "counters": {
+            **db_free_report["counters"],
+            "synthesized_launch_contract_count": 3,
+        },
+    }
+    populated_snapshot = build_workflow_purity_baseline_snapshot(populated_report)
+
+    assert "synthesized_launch_contract_count" not in populated_snapshot["counters"]
+
+
+def test_advisory_counter_growth_does_not_set_blocking_regression() -> None:
+    provenance = {
+        "registry_supplied": True,
+        "registry_enumeration_succeeded": True,
+        "registry_workflow_count": 20,
+        "registry_workflow_definition_count": 20,
+        "registry_workflow_population_observed": True,
+        "registry_snapshot_scope": "vontology_inclusive",
+        "synthesized_launch_contract_measurement_complete": True,
+    }
+    comparison = compare_workflow_purity_to_baseline(
+        counters={
+            "synthesized_launch_contract_count": 3,
+            "monolith_line_count_catalogue": 12,
+            "workflow_id_special_case_count": 0,
+        },
+        baseline={
+            "schema_version": "workflow_purity_baseline.v1",
+            "measurement_provenance": provenance,
+            "counters": {
+                "synthesized_launch_contract_count": 2,
+                "monolith_line_count_catalogue": 10,
+                "workflow_id_special_case_count": 0,
+            },
+        },
+        current_measurement_provenance=provenance,
+    )
+
+    assert comparison["regression_detected"] is False
+    assert comparison["blocking_findings_detected"] is False
+    assert comparison["advisory_findings_detected"] is True
+    assert comparison["blocking_increased_counters"] == {}
+    assert set(comparison["advisory_increased_counters"]) == {
+        "monolith_line_count_catalogue",
+    }
+    assert set(comparison["increased_counters"]) == {
+        "monolith_line_count_catalogue",
+    }
+    assert comparison["advisory_observed_counters"] == {
+        "synthesized_launch_contract_count": {
+            "current": 3,
+            "reason": "nonzero_complete_registry_observation",
+        }
+    }
+
+
+def test_observed_registry_debt_is_advisory_without_a_baseline() -> None:
+    comparison = compare_workflow_purity_to_baseline(
+        counters={"synthesized_launch_contract_count": 2},
+        baseline=None,
+        current_measurement_provenance={
+            "registry_supplied": True,
+            "registry_enumeration_succeeded": True,
+            "registry_workflow_count": 20,
+            "registry_workflow_definition_count": 20,
+            "registry_workflow_population_observed": True,
+            "registry_snapshot_scope": "vontology_inclusive",
+            "synthesized_launch_contract_measurement_complete": True,
+        },
+    )
+
+    assert comparison["baseline_available"] is False
+    assert comparison["regression_detected"] is False
+    assert comparison["advisory_findings_detected"] is True
+    assert comparison["advisory_observed_counters"] == {
+        "synthesized_launch_contract_count": {
+            "current": 2,
+            "reason": "nonzero_complete_registry_observation",
+        }
+    }
+
+    incomplete = compare_workflow_purity_to_baseline(
+        counters={"synthesized_launch_contract_count": 2},
+        baseline=None,
+        current_measurement_provenance={
+            "registry_supplied": True,
+            "registry_enumeration_succeeded": True,
+            "registry_workflow_count": 20,
+            "registry_workflow_definition_count": 19,
+            "registry_workflow_population_observed": True,
+            "registry_snapshot_scope": "vontology_inclusive",
+            "synthesized_launch_contract_measurement_complete": False,
+        },
+    )
+
+    assert incomplete["advisory_findings_detected"] is False
+    assert incomplete["advisory_observed_counters"] == {}
+
+
 def test_build_workflow_purity_report_flags_agent_test_lexical_replay_drift(
     tmp_path: Path,
 ) -> None:
@@ -360,7 +580,15 @@ def test_build_workflow_purity_report_flags_baseline_regressions(
 
     comparison = report["baseline"]["comparison"]
     assert comparison["regression_detected"] is True
+    assert comparison["blocking_findings_detected"] is True
     assert comparison["increased_counters"]["built_in_registration_count"] == {
+        "baseline": 0,
+        "current": 1,
+        "delta": 1,
+    }
+    assert comparison["blocking_increased_counters"][
+        "built_in_registration_count"
+    ] == {
         "baseline": 0,
         "current": 1,
         "delta": 1,
@@ -1638,8 +1866,11 @@ def test_build_workflow_purity_report_ratchets_monolith_line_counts(
         counters=grown_counters,
         baseline=baseline,
     )
-    assert comparison["regression_detected"] is True
-    assert "monolith_line_count_orchestrator" in comparison["increased_counters"]
+    assert comparison["regression_detected"] is False
+    assert comparison["advisory_findings_detected"] is True
+    assert (
+        "monolith_line_count_orchestrator" in comparison["advisory_increased_counters"]
+    )
 
     shrunk_counters = dict(counters)
     shrunk_counters["monolith_line_count_orchestrator"] = 2
@@ -1648,3 +1879,4 @@ def test_build_workflow_purity_report_ratchets_monolith_line_counts(
         baseline=baseline,
     )
     assert comparison["regression_detected"] is False
+    assert comparison["advisory_findings_detected"] is False

--- a/tests/backend/test_workflow_registry_factory_parity.py
+++ b/tests/backend/test_workflow_registry_factory_parity.py
@@ -229,6 +229,8 @@ def test_workflow_parity_policy_fail_mode_raises_on_drift(monkeypatch):
     with pytest.raises(RuntimeError, match="workflow_parity_drift_detected"):
         registry_factory._apply_workflow_parity_policy(inventory)
 
+    assert inventory["parity_policy"]["outcome"] == "failed"
+
 
 def test_workflow_parity_policy_no_drift_does_not_raise(monkeypatch):
     inventory = {
@@ -244,6 +246,7 @@ def test_workflow_parity_policy_no_drift_does_not_raise(monkeypatch):
     registry_factory._apply_workflow_parity_policy(inventory)
     policy = inventory.get("parity_policy", {})
     assert policy.get("mode") == "fail"
+    assert policy.get("outcome") == "completed"
     assert policy.get("drift_detected") is False
 
 
@@ -298,7 +301,7 @@ def test_workflow_parity_inventory_includes_authority_drift_reason(monkeypatch):
     assert counts.get("authority_missing_required_type") == 1
 
 
-def test_workflow_parity_inventory_includes_workflow_purity_regression_reason(
+def test_workflow_parity_inventory_keeps_unclassified_purity_regression_strict(
     monkeypatch,
 ):
     monkeypatch.setattr(
@@ -341,8 +344,231 @@ def test_workflow_parity_inventory_includes_workflow_purity_regression_reason(
     )
 
     assert inventory["workflow_purity"]["baseline"]["comparison"]["regression_detected"] is True
-    reasons = inventory.get("diagnostics", {}).get("reason_codes", [])
+    diagnostics = inventory.get("diagnostics", {})
+    reasons = diagnostics.get("reason_codes", [])
     assert "workflow_purity_regression" in reasons
+    assert diagnostics["drift_detected"] is True
+    assert diagnostics["enforced_reason_codes"] == ["workflow_purity_regression"]
+    assert diagnostics["advisory_reason_codes"] == []
+    assert diagnostics["workflow_purity_regression"] == {
+        "detected": True,
+        "blocking_detected": True,
+        "advisory_detected": False,
+        "blocking_counter_keys": [],
+        "advisory_counter_keys": [],
+        "unclassified_blocking_regression": True,
+    }
+
+
+def test_workflow_parity_inventory_keeps_maintenance_purity_regressions_advisory(
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(
+        registry_factory,
+        "build_workflow_process_graph",
+        lambda _workflow_id: (
+            {"initial_step": "#V#step_1", "steps": [{"step_id": "#V#step_1"}]},
+            [],
+        ),
+    )
+    monkeypatch.setattr(
+        registry_factory,
+        "build_workflow_purity_report",
+        lambda registry: {
+            "summary_text": "Workflow purity maintenance warning",
+            "counters": {
+                "synthesized_launch_contract_count": 18,
+            },
+            "baseline": {
+                "comparison": {
+                    "regression_detected": False,
+                    "advisory_findings_detected": True,
+                    "blocking_increased_counters": {},
+                    "advisory_increased_counters": {},
+                    "advisory_observed_counters": {
+                        "synthesized_launch_contract_count": {
+                            "current": 18,
+                            "reason": "nonzero_complete_registry_observation",
+                        },
+                    },
+                    "blocking_missing_counter_keys": [],
+                    "advisory_missing_counter_keys": [],
+                }
+            },
+        },
+    )
+    dummy_registry = _DummyRegistry(
+        workflow_ids=["#V#wf_ok"],
+        sources={"#V#wf_ok": "vontology"},
+    )
+
+    inventory = registry_factory._build_workflow_parity_inventory(
+        registry=dummy_registry,  # type: ignore[arg-type]
+        discovered_workflow_ids=["#V#wf_ok"],
+    )
+
+    diagnostics = inventory["diagnostics"]
+    assert diagnostics["drift_detected"] is False
+    assert diagnostics["advisory_detected"] is True
+    assert diagnostics["enforced_reason_codes"] == []
+    assert diagnostics["advisory_reason_codes"] == ["workflow_purity_advisory"]
+    assert diagnostics["workflow_purity_regression"] == {
+        "detected": True,
+        "blocking_detected": False,
+        "advisory_detected": True,
+        "blocking_counter_keys": [],
+        "advisory_counter_keys": ["synthesized_launch_contract_count"],
+        "unclassified_blocking_regression": False,
+    }
+
+    monkeypatch.setenv("VON_WORKFLOW_PARITY_ENFORCEMENT", "fail")
+    with caplog.at_level("WARNING"):
+        registry_factory._apply_workflow_parity_policy(inventory)
+
+    assert "[workflow_parity_advisory]" in caplog.text
+    assert inventory["parity_policy"] == {
+        "mode": "fail",
+        "outcome": "completed_with_findings",
+        "drift_detected": False,
+        "advisory_detected": True,
+        "enforced_reason_codes": [],
+        "advisory_reason_codes": ["workflow_purity_advisory"],
+    }
+
+
+def test_workflow_parity_inventory_keeps_authority_purity_regression_strict(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        registry_factory,
+        "build_workflow_process_graph",
+        lambda _workflow_id: (
+            {"initial_step": "#V#step_1", "steps": [{"step_id": "#V#step_1"}]},
+            [],
+        ),
+    )
+    monkeypatch.setattr(
+        registry_factory,
+        "build_workflow_purity_report",
+        lambda registry: {
+            "summary_text": "Workflow purity mixed regression",
+            "counters": {
+                "repo_seed_authority_drift_path_count": 1,
+                "monolith_line_count_catalogue": 35_200,
+            },
+            "baseline": {
+                "comparison": {
+                    "regression_detected": True,
+                    "advisory_findings_detected": True,
+                    "blocking_increased_counters": {
+                        "repo_seed_authority_drift_path_count": {
+                            "baseline": 0,
+                            "current": 1,
+                            "delta": 1,
+                        }
+                    },
+                    "advisory_increased_counters": {
+                        "monolith_line_count_catalogue": {
+                            "baseline": 35_161,
+                            "current": 35_200,
+                            "delta": 39,
+                        }
+                    },
+                    "blocking_missing_counter_keys": [],
+                    "advisory_missing_counter_keys": [],
+                }
+            },
+        },
+    )
+    dummy_registry = _DummyRegistry(
+        workflow_ids=["#V#wf_ok"],
+        sources={"#V#wf_ok": "vontology"},
+    )
+    inventory = registry_factory._build_workflow_parity_inventory(
+        registry=dummy_registry,  # type: ignore[arg-type]
+        discovered_workflow_ids=["#V#wf_ok"],
+    )
+
+    diagnostics = inventory["diagnostics"]
+    assert diagnostics["drift_detected"] is True
+    assert diagnostics["advisory_detected"] is True
+    assert diagnostics["enforced_reason_codes"] == ["workflow_purity_regression"]
+    assert diagnostics["advisory_reason_codes"] == ["workflow_purity_advisory"]
+    assert diagnostics["workflow_purity_regression"]["blocking_counter_keys"] == [
+        "repo_seed_authority_drift_path_count"
+    ]
+    assert diagnostics["workflow_purity_regression"]["advisory_counter_keys"] == [
+        "monolith_line_count_catalogue"
+    ]
+
+    monkeypatch.setenv("VON_WORKFLOW_PARITY_ENFORCEMENT", "fail")
+    with pytest.raises(
+        RuntimeError,
+        match="workflow_parity_drift_detected:workflow_purity_regression",
+    ):
+        registry_factory._apply_workflow_parity_policy(inventory)
+
+
+def test_deferred_advisory_registry_work_reports_completed_with_findings(
+    monkeypatch,
+    caplog,
+):
+    registry = WorkflowRegistry()
+    registry.register(
+        _build_registration(
+            "#V#wf_ok",
+            source="vontology",
+            purpose="Runnable workflow",
+        )
+    )
+    inventory = {
+        "summary_text": "Workflow parity clean with purity maintenance findings",
+        "diagnostics": {
+            "drift_detected": False,
+            "advisory_detected": True,
+            "reason_codes": ["workflow_purity_advisory"],
+            "enforced_reason_codes": [],
+            "advisory_reason_codes": ["workflow_purity_advisory"],
+        },
+        "workflow_purity": {
+            "summary_text": "Workflow purity maintenance warning",
+        },
+    }
+    monkeypatch.setattr(registry_factory, "_last_inventory_snapshot", None)
+    monkeypatch.setattr(
+        registry_factory,
+        "build_workflow_concept_authority_report",
+        lambda *, registry: {"drift_detected": False, "counts": {}},
+    )
+    monkeypatch.setattr(
+        registry_factory,
+        "_build_expected_authoritative_workflow_report",
+        lambda *, workflow_ids: {"workflow_ids": list(workflow_ids)},
+    )
+    monkeypatch.setattr(
+        registry_factory,
+        "_build_workflow_parity_inventory",
+        lambda **_kwargs: inventory,
+    )
+    monkeypatch.setenv("VON_WORKFLOW_PARITY_ENFORCEMENT", "fail")
+
+    with caplog.at_level("INFO"):
+        registry_factory._launch_deferred_registry_work(
+            registry=registry,
+            discovered_workflow_ids=["#V#wf_ok"],
+            expected_authoritative_file_copy_workflow_ids=(),
+            expected_authoritative_reasoning_recovery_workflow_ids=(),
+            expected_authoritative_support_maintenance_workflow_ids=(),
+            requested_bootstrap=False,
+        )
+
+    assert inventory["parity_policy"]["outcome"] == "completed_with_findings"
+    assert (
+        "Deferred workflow registry work outcome=completed_with_findings"
+        in caplog.text
+    )
+    assert "Deferred workflow registry work failed" not in caplog.text
 
 
 def test_register_workflow_from_vontology_replaces_existing_registration(monkeypatch):

--- a/tests/test_check_workflow_purity_cli_output.py
+++ b/tests/test_check_workflow_purity_cli_output.py
@@ -39,3 +39,53 @@ def test_quiet_on_pass_keeps_failure_details(capsys) -> None:
     assert "Workflow purity: built_in_registration_count=1" in output
     assert "Regressed counters:" in output
     assert "Workflow purity gate failed." in output
+
+
+def test_advisory_findings_are_named_without_calling_them_regressions(capsys) -> None:
+    _print_regression_summary(
+        {
+            "summary_text": "Workflow purity: synthesized_launch_contract_count=2",
+            "baseline": {
+                "comparison": {
+                    "regression_detected": False,
+                    "advisory_findings_detected": True,
+                    "blocking_increased_counters": {},
+                    "advisory_increased_counters": {},
+                    "advisory_observed_counters": {
+                        "synthesized_launch_contract_count": {
+                            "current": 2,
+                            "reason": "nonzero_complete_registry_observation",
+                        }
+                    },
+                    "blocking_missing_counter_keys": [],
+                    "advisory_missing_counter_keys": [],
+                }
+            },
+        }
+    )
+
+    output = capsys.readouterr().out
+    assert "Advisory counter findings:" in output
+    assert "synthesized_launch_contract_count: current=2" in output
+    assert "Regressed counters:" not in output
+    assert "Workflow purity gate passed with advisory findings." in output
+
+
+def test_quiet_on_pass_still_surfaces_advisory_outcome(capsys) -> None:
+    _print_regression_summary(
+        {
+            "summary_text": "Workflow purity advisory",
+            "baseline": {
+                "comparison": {
+                    "regression_detected": False,
+                    "advisory_findings_detected": True,
+                }
+            },
+        },
+        quiet_on_pass=True,
+    )
+
+    assert (
+        capsys.readouterr().out
+        == "Workflow purity gate passed with advisory findings.\n"
+    )


### PR DESCRIPTION
## What changed

- Keep registry/Vontology identity, represented graph, workflow authority, and policy-source drift strict.
- Classify synthesised launch-contract debt and monolith line-count ratchets as advisory findings that produce `completed_with_findings`.
- Separate static repository baselines from live registry observations, preserve measurement provenance, and report exact synthesised-contract workflow IDs.
- Make the purity CLI distinguish blocking regressions from advisory findings.
- Correct the checked-in DB-free baseline and document the enforcement boundary.

## Why

The deferred parity inventory was reporting `workflow_purity_regression` even when all 102 runtime and Vontology workflows matched. The static baseline recorded an artificial zero for a live-only synthesised-contract measurement, and source-size debt was bundled into the same strict runtime policy as genuine authority drift.

## Impact

A healthy executable registry is no longer labelled failed because of engineering-maintenance debt. Genuine registry, represented-graph, authority, and blocking purity defects remain fail-closed. Advisory debt remains explicit and actionable without affecting runtime readiness.

## Validation

- 51 focused parity, purity-report, baseline, and CLI tests passed.
- Ruff F checks passed for all changed Python files; import-order checks passed for the changed clean-scope files.
- Pyright reported 0 errors.
- Python compilation and `git diff --check` passed.
- The real DB-free CLI reports: `Workflow purity gate passed with advisory findings.`