### PR TITLE
Index exact legacy concept names

### DIFF
--- a/src/backend/db/mongo_client.py
+++ b/src/backend/db/mongo_client.py
@@ -1476,6 +1476,15 @@ def _ensure_concepts_collection_indexes(concepts_coll: Collection) -> None:
             )
         except Exception as _e:
             logger.warning("Unable to create text index on name: %s", _e)
+    if (
+        "legacy_name_exact_1" not in existing_indexes
+        and "name_1" not in existing_indexes
+    ):
+        concepts_coll.create_index(
+            [("name", ASCENDING)],
+            name="legacy_name_exact_1",
+            sparse=True,
+        )
     if "names.name_1" not in existing_indexes:
         concepts_coll.create_index([("names.name", ASCENDING)], name="names.name_1")
     if "names.text_1" not in existing_indexes:

--- a/tests/backend/test_concept_search_service_performance.py
+++ b/tests/backend/test_concept_search_service_performance.py
@@ -118,6 +118,46 @@ def test_modern_text_relation_hits_skip_legacy_regex_scan(monkeypatch) -> None:
     assert len(concept_find_calls) == 1
 
 
+def test_exact_instance_lookup_preserves_legacy_top_level_name(monkeypatch) -> None:
+    legacy_doc = {
+        "concept_id": "#V#legacy_person",
+        "name": "Legacy Person",
+        "relationships": {"is_an_instance_of": ["#V#person"]},
+    }
+    concept_find_calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(svc.TextValuesRepository, "find", lambda *args, **kwargs: [])
+    monkeypatch.setattr(svc.TextRelationsRepository, "find", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        svc,
+        "get_vontology_node_and_descendant_ids",
+        lambda _concept_id: ["#V#person"],
+    )
+
+    def fake_concepts_find(query, *args, **kwargs):
+        concept_find_calls.append(query)
+        return [legacy_doc]
+
+    monkeypatch.setattr(svc.ConceptsRepository, "find", fake_concepts_find)
+    monkeypatch.setattr(svc, "_determine_concept_kind", lambda _doc: "individual")
+
+    result = svc.search_concepts(
+        "Legacy Person",
+        instance_of="#V#person",
+        match_type="exact",
+        limit=10,
+    )
+
+    assert [item["concept_id"] for item in result["results"]] == [
+        "#V#legacy_person"
+    ]
+    assert len(concept_find_calls) == 1
+    assert concept_find_calls[0]["relationships.is_an_instance_of"] == {
+        "$in": ["#V#person"]
+    }
+    assert {"name": "Legacy Person"} in concept_find_calls[0]["$or"]
+
+
 def test_legacy_regex_fallback_filters_duplicates_without_mongo_nin(monkeypatch) -> None:
     concept_find_calls: list[dict[str, Any]] = []
     duplicate_doc = _concept("#V#duplicate", "duplicate")

--- a/tests/backend/test_mongo_collection_index_guards.py
+++ b/tests/backend/test_mongo_collection_index_guards.py
@@ -232,8 +232,31 @@ def test_concepts_indexes_are_guarded_per_database_key(monkeypatch):
         "relationships_has_initial_step_1",
         "relationships_v_evidence_view_applies_to_tool_1",
         "episode_critique_remediation_external_instance_lookup",
+        "legacy_name_exact_1",
         "updated_at_-1",
     }.issubset(concept_index_names)
+    concept_indexes_by_name = {
+        str(call["kwargs"].get("name") or ""): call
+        for call in db_one[mc.CONCEPTS_COLLECTION_NAME].create_index_calls
+    }
+    assert concept_indexes_by_name["legacy_name_exact_1"]["keys"] == [
+        ("name", mc.ASCENDING)
+    ]
+    assert concept_indexes_by_name["legacy_name_exact_1"]["kwargs"] == {
+        "name": "legacy_name_exact_1",
+        "sparse": True,
+    }
+
+
+def test_concepts_indexes_accept_existing_scalar_legacy_name_index() -> None:
+    coll = _FakeCollection(index_names=["name_1"])
+
+    mc._ensure_concepts_collection_indexes(cast(Any, coll))
+
+    created_names = {
+        str(call["kwargs"].get("name") or "") for call in coll.create_index_calls
+    }
+    assert "legacy_name_exact_1" not in created_names
 
 
 def test_invalidate_connection_clears_collection_index_cache(monkeypatch):


### PR DESCRIPTION
## What changed

- add a sparse scalar index for legacy top-level concept names
- preserve deployments that already have the conventional `name_1` index
- retain exact lookup compatibility for legacy name-only concept documents
- cover index initialisation and the legacy exact-lookup contract

## Why

Exact concept lookup uses an OR across `concept_id`, `names.name`, and the legacy top-level `name`. The first two branches were indexed, but the equality lookup on `name` only had a text index. This caused the combined query to fall back to a much broader plan.

This is deliberately narrow: it improves exact equality lookup and does not claim to optimise case-insensitive prefix or substring searches.

## Validation

- `22 passed` across:
  - `tests/backend/test_concept_search_service_performance.py`
  - `tests/backend/test_mongo_collection_index_guards.py`
- `git diff --check`
- live query-planner inspection showed the exact lookup using indexed OR branches after index activation