### PR TITLE
Repair frontend test and lint contracts

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,6 +53,7 @@ module.exports = [
         // Ignore patterns
         ignores: [
             "node_modules/**",
+            ".venv/**",
             "coverage/**",
             "**/*.min.js",
             "src/frontend/web/von_interface/static/js/lib/**",

--- a/src/frontend/web/von_interface/static/js/chat.js
+++ b/src/frontend/web/von_interface/static/js/chat.js
@@ -1,5 +1,10 @@
 import { annotateTurn, postJson } from './apiService.js';
-import { addMessageToChat, elements, renderSpanSuggestions } from './domUtils.js';
+import {
+  addMessageToChat,
+  elements,
+  getCurrentUser,
+  renderSpanSuggestions,
+} from './domUtils.js';
 
 /**
  * Show/hide the thinking card wrapper (or legacy loadingIndicator).

--- a/src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js
+++ b/src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js
@@ -62,9 +62,9 @@ async function conceptExists(conceptId, fetchFn) {
     let res;
     try {
         res = await fetchFn(url, { method: 'GET', headers: { 'Accept': 'application/json' } });
-    } catch (_) {
+    } catch (error) {
         // Network failures should not be treated as "missing".
-        throw new Error('Failed to check concept existence');
+        throw new Error('Failed to check concept existence', { cause: error });
     }
     if (res.ok) return true;
     if (res.status === 404) return false;
@@ -375,7 +375,7 @@ async function createConceptForId(conceptId, options, fetchFn) {
         const json = JSON.parse(text);
         resolvedId = json?.concept_id || json?.concept?.concept_id || id;
     } catch (_) {
-        resolvedId = id;
+        // Keep the requested identifier when the response is not JSON.
     }
     await updateConceptDescription(resolvedId, description, fetchFn);
     return resolvedId;
@@ -1137,7 +1137,7 @@ export async function handleSelectConceptByIdDetail(detail, deps) {
         // Best-effort; keep going.
     }
 
-    let exists = false;
+    let exists;
     try {
         exists = await conceptExists(id, fetchFn);
     } catch (err) {

--- a/src/frontend/web/von_interface/static/js/utils/serverHealthState.js
+++ b/src/frontend/web/von_interface/static/js/utils/serverHealthState.js
@@ -122,14 +122,11 @@ export function evaluateServerHealthState({
   const meetsFailureWindowThreshold =
     failureWindowMs >= downFailureWindowThresholdMs;
 
-  let state = "healthy";
-  if (safeFailureCount <= 0) {
-    state = safeSeenSuccess ? "healthy" : "waiting";
-  } else if (meetsFailureThreshold && meetsFailureWindowThreshold) {
-    state = "down";
-  } else {
-    state = safeSeenSuccess ? "degraded" : "waiting";
-  }
+  const state = safeFailureCount <= 0
+    ? (safeSeenSuccess ? "healthy" : "waiting")
+    : meetsFailureThreshold && meetsFailureWindowThreshold
+      ? "down"
+      : (safeSeenSuccess ? "degraded" : "waiting");
 
   return {
     state,

--- a/src/frontend/web/von_interface/static/js/vontology.js
+++ b/src/frontend/web/von_interface/static/js/vontology.js
@@ -3004,7 +3004,6 @@ async function ensurePathVisibleById(targetId) {
       li = await createTreeElement({ id: node.id, name: node.name, mongo_id: node.mongo_id, children: [] }, null);
       li.classList.add('vontology-temp');
       parentUl.appendChild(li);
-      span = li.querySelector('.vontology-node-name');
     } else {
       li = span.closest('li');
     }
@@ -3301,7 +3300,6 @@ export async function chooseBestTypeForIndividual(candidateTypeIds = []) {
         status: 'error',
         error: e
       });
-      countFetchTask = null;
     }
     console.error('Error choosing best type for individual:', e);
     // Defensive: clear any partial cache entry that may have been set just before error
@@ -4413,7 +4411,6 @@ export function preloadVontologyData() {
           status: 'error',
           error: err
         });
-        preloadTask = null;
       }
       console.warn('[preloadVontologyData] Preload failed:', err);
     }

--- a/tests/frontend/chatPresenterModeRequest.test.js
+++ b/tests/frontend/chatPresenterModeRequest.test.js
@@ -33,7 +33,8 @@ describe('chat.js presenter mode request', () => {
         expect(postJson).toHaveBeenCalledTimes(1);
         expect(postJson).toHaveBeenCalledWith('/von/generate', {
             prompt: 'Hello',
-            presenter_mode: true
+            presenter_mode: true,
+            thinking_card_mode: 'default'
         });
     });
 });

--- a/tests/frontend/chatTabPromptArrowUpRecall.test.js
+++ b/tests/frontend/chatTabPromptArrowUpRecall.test.js
@@ -99,16 +99,30 @@ describe('JVNAUTOSCI-2128: ArrowUp recall in Talk-with-Von composer', () => {
         expect(promptInput.value).toBe('');
     });
 
-    test('Modifier-held ArrowUp is a no-op', () => {
+    test('Ctrl, Alt, and Meta-held ArrowUp are no-ops', () => {
         __testOnly_rememberLastSubmittedUserPrompt('prior');
         const promptInput = buildPromptInput('');
 
-        for (const modifier of ['shiftKey', 'ctrlKey', 'altKey', 'metaKey']) {
+        for (const modifier of ['ctrlKey', 'altKey', 'metaKey']) {
             const event = makeArrowUpEvent(promptInput, { [modifier]: true });
             __testOnly_handlePromptInputArrowUpRecall(event);
             expect(event.preventDefault).not.toHaveBeenCalled();
             expect(promptInput.value).toBe('');
         }
+    });
+
+    test('Shift+ArrowUp jumps to the oldest submitted prompt', () => {
+        __testOnly_rememberLastSubmittedUserPrompt('oldest prompt');
+        __testOnly_rememberLastSubmittedUserPrompt('newest prompt');
+        const promptInput = buildPromptInput('');
+
+        const event = makeArrowUpEvent(promptInput, { shiftKey: true });
+        __testOnly_handlePromptInputArrowUpRecall(event);
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(promptInput.value).toBe('oldest prompt');
+        expect(promptInput.selectionStart).toBe(promptInput.value.length);
+        expect(promptInput.selectionEnd).toBe(promptInput.value.length);
     });
 
     test('Recall is per conversation: switching session hides the other session\'s buffer', () => {

--- a/tests/frontend/chatTabSpeechPlanning.test.js
+++ b/tests/frontend/chatTabSpeechPlanning.test.js
@@ -14,7 +14,13 @@ jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
     getCurrentUserConceptId: jest.fn(() => null)
 }));
 
-const { sendMessage, showLlmDebugPopup, __test_only__rehydrateHistory, __testOnly_resetChatTtsState } = require(chatTabModulePath);
+const {
+    sendMessage,
+    showLlmDebugPopup,
+    __test_only__rehydrateHistory,
+    __testOnly_resetChatTtsState,
+    __testOnly_setActiveChatSession
+} = require(chatTabModulePath);
 
 function advanceTimers(ms) {
     if (jest.isMockFunction(setTimeout)) {
@@ -139,6 +145,8 @@ describe('chat speech planning (presenter channels)', () => {
             <pre id="chatLlmDebugAux"></pre>
         `;
 
+        __testOnly_setActiveChatSession('speech-planning-test-session', 'Speech planning test');
+
         // Enable TTS in the environment.
         global.SpeechSynthesisUtterance = function (text) {
             this.text = text;
@@ -239,7 +247,7 @@ describe('chat speech planning (presenter channels)', () => {
         const assistantTurnId = assistantContainer?.dataset?.turnId;
         expect(assistantTurnId).toBeTruthy();
 
-        showLlmDebugPopup(assistantTurnId);
+        await showLlmDebugPopup(assistantTurnId);
         const popup = document.getElementById('chatLlmDebugPopup');
         const jsonText = popup.dataset.currentDebugData;
         expect(jsonText).toContain('speech_planning');
@@ -330,7 +338,7 @@ describe('chat speech planning (presenter channels)', () => {
         promptInput.value = 'show me task table';
 
         const displayElements = buildDisplayElementsContract({
-            screenText: 'Task summary',
+            screenText: '**Task summary**',
             spokenText: 'Here is the task summary table.',
             tablePayload: {
                 title: 'Predicate status matrix',
@@ -431,7 +439,7 @@ describe('chat speech planning (presenter channels)', () => {
         promptInput.value = 'show relation extent table';
 
         const displayElements = buildDisplayElementsContract({
-            screenText: 'Relation extent summary',
+            screenText: '**Relation extent summary**',
             spokenText: 'Here is the relation extent summary.',
             tablePayload: {
                 title: 'Relation extent',
@@ -546,7 +554,7 @@ describe('chat speech planning (presenter channels)', () => {
         promptInput.value = 'show sorted task table';
 
         const displayElements = buildDisplayElementsContract({
-            screenText: 'Sorted task summary',
+            screenText: '**Sorted task summary**',
             spokenText: 'Here is the sorted task summary table.',
             tablePayload: {
                 columns: [
@@ -662,7 +670,7 @@ describe('chat speech planning (presenter channels)', () => {
         promptInput.value = 'show workflow status';
 
         const displayElements = buildDisplayElementsContract({
-            screenText: 'Workflow summary',
+            screenText: '**Workflow summary**',
             spokenText: 'Here is the workflow summary.',
             workflowPayload: {
                 title: 'Workflow execution overview',
@@ -774,7 +782,7 @@ describe('chat speech planning (presenter channels)', () => {
         promptInput.value = 'show task timeline';
 
         const displayElements = buildDisplayElementsContract({
-            screenText: 'Timeline summary',
+            screenText: '**Timeline summary**',
             spokenText: 'Here is the task timeline.',
             timelinePayload: {
                 title: 'Task lifecycle timeline',
@@ -883,7 +891,7 @@ describe('chat speech planning (presenter channels)', () => {
         promptInput.value = 'show task cards';
 
         const displayElements = buildDisplayElementsContract({
-            screenText: 'Task summary',
+            screenText: '**Task summary**',
             spokenText: 'Here are the task cards.',
             taskViewPayload: {
                 title: 'Current action items',

--- a/tests/frontend/selectConceptByIdHandler.test.js
+++ b/tests/frontend/selectConceptByIdHandler.test.js
@@ -43,8 +43,20 @@ describe('handleSelectConceptByIdDetail', () => {
             { createOrActivateConceptTab, activateTab, selectVontologyNodeByIdentifier, fetchFn }
         );
 
-        expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#person', 'Loading…', false);
-        expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#person', 'Person', false);
+        expect(createOrActivateConceptTab).toHaveBeenNthCalledWith(
+            1,
+            '#V#person',
+            'Loading…',
+            false,
+            { kind: 'type' }
+        );
+        expect(createOrActivateConceptTab).toHaveBeenNthCalledWith(
+            2,
+            '#V#person',
+            'Person',
+            false,
+            { kind: 'type', forceKindUpdate: true }
+        );
         // Should not try to create.
         expect(fetchFn).toHaveBeenCalledTimes(2);
 
@@ -84,17 +96,19 @@ describe('handleSelectConceptByIdDetail', () => {
             { createOrActivateConceptTab, activateTab, selectVontologyNodeByIdentifier, fetchFn }
         );
 
-        expect(createOrActivateConceptTab).toHaveBeenCalledWith(
+        expect(createOrActivateConceptTab).toHaveBeenNthCalledWith(
+            1,
             '#V#person',
             'Loading…',
             false,
-            { promoteExistingTab: true }
+            { kind: 'type', promoteExistingTab: true }
         );
-        expect(createOrActivateConceptTab).toHaveBeenCalledWith(
+        expect(createOrActivateConceptTab).toHaveBeenNthCalledWith(
+            2,
             '#V#person',
             'Person',
             false,
-            { promoteExistingTab: true }
+            { kind: 'type', forceKindUpdate: true, promoteExistingTab: true }
         );
     });
 
@@ -129,8 +143,20 @@ describe('handleSelectConceptByIdDetail', () => {
             { createOrActivateConceptTab, activateTab, selectVontologyNodeByIdentifier, fetchFn }
         );
 
-        expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#person', 'Loading…', true);
-        expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#person', 'Person', true);
+        expect(createOrActivateConceptTab).toHaveBeenNthCalledWith(
+            1,
+            '#V#person',
+            'Loading…',
+            true,
+            { kind: 'type' }
+        );
+        expect(createOrActivateConceptTab).toHaveBeenNthCalledWith(
+            2,
+            '#V#person',
+            'Person',
+            true,
+            { kind: 'type', forceKindUpdate: true }
+        );
     });
 
     test('missing concept prompts and creates then opens', async () => {
@@ -178,8 +204,20 @@ describe('handleSelectConceptByIdDetail', () => {
         );
 
         expect(chooseCreateOptionsFn).toHaveBeenCalled();
-        expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#disambiguation_result', 'Loading…', false);
-        expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#disambiguation_result', 'Disambiguation result', false);
+        expect(createOrActivateConceptTab).toHaveBeenNthCalledWith(
+            1,
+            '#V#disambiguation_result',
+            'Loading…',
+            false,
+            { kind: 'type' }
+        );
+        expect(createOrActivateConceptTab).toHaveBeenNthCalledWith(
+            3,
+            '#V#disambiguation_result',
+            'Disambiguation result',
+            false,
+            { kind: 'type', forceKindUpdate: true }
+        );
         // Includes existence checks/create/metadata and proposal hydration fetches.
         expect(fetchFn.mock.calls.length).toBeGreaterThanOrEqual(4);
 
@@ -246,7 +284,13 @@ describe('handleSelectConceptByIdDetail', () => {
 
         expect(chooseCreateOptionsFn).toHaveBeenCalled();
         // Canonical tab id.
-        expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#foo_bar', 'Loading…', false);
+        expect(createOrActivateConceptTab).toHaveBeenNthCalledWith(
+            1,
+            '#V#foo_bar',
+            'Loading…',
+            false,
+            { kind: 'type' }
+        );
     });
 
     test('canonicalises accented IDs for lookup and create', async () => {
@@ -288,7 +332,13 @@ describe('handleSelectConceptByIdDetail', () => {
         );
 
         expect(chooseCreateOptionsFn).toHaveBeenCalled();
-        expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#cafe', 'Loading…', false);
+        expect(createOrActivateConceptTab).toHaveBeenNthCalledWith(
+            1,
+            '#V#cafe',
+            'Loading…',
+            false,
+            { kind: 'type' }
+        );
     });
 
     test('passes proposal payload to chooser and persists description when provided', async () => {
@@ -491,7 +541,13 @@ describe('handleSelectConceptByIdDetail', () => {
 
         expect(chooseCreateOptionsFn).toHaveBeenCalled();
         expect(existenceChecks).toBe(2);
-        expect(createOrActivateConceptTab).toHaveBeenCalledWith('#V#race_concept', 'Race concept', false);
+        expect(createOrActivateConceptTab).toHaveBeenNthCalledWith(
+            3,
+            '#V#race_concept',
+            'Race concept',
+            false,
+            { kind: 'type', forceKindUpdate: true }
+        );
     });
 
     test('hydrates implicit parent suggestions from annotation workflow when confidence passes threshold', async () => {


### PR DESCRIPTION
## What changed

- import the current user helper used by span-suggestion annotation
- align focused frontend tests with behaviour already present on `main`
- retain underlying network errors as causes in concept-selection failures
- apply semantics-preserving lint clean-up
- exclude the local virtual environment from ESLint discovery

## Why

The dirty worktree contained one runtime import repair plus a coherent test/lint compatibility pass. Most expectation updates cover behaviour that is already committed on `main`; this PR does not introduce a new frontend feature.

## Validation

- affected Jest suites: 4 passed, 37 tests passed
- static frontend lint: 0 errors (23 existing warnings)
- `node --check` passed for all four changed production modules
- `git diff --check`

The complete frontend suite currently has two failures outside this diff (`chatTabConversationLlmTelemetryCopy` and `chatTabThinkingDiagnosticsCopy`) caused by current-main test mocks returning undefined where the recently added runtime-cost refresh expects a promise. Those failures are recorded as baseline rather than folded into this PR.