### PR TITLE
Reduce workflow status and parity Atlas work

### DIFF
--- a/src/backend/workflows/durable/registry_factory.py
+++ b/src/backend/workflows/durable/registry_factory.py
@@ -36,6 +36,8 @@ from ..mcp_tool_bridge import (
 )
 from ..workflow_side_effect_guardrails import enforce_workflow_mcp_write_guardrails
 from ..vontology_loader import (
+    WORKFLOW_DESCRIPTION_SOURCE_DEFINITION,
+    best_effort_workflow_narrative_text,
     build_workflow_process_graph,
     discover_workflow_ids,
     load_workflow_definition_from_vontology,
@@ -1111,7 +1113,11 @@ def _build_workflow_parity_inventory(
         source = "unknown"
         registration = None
         try:
-            registration = registry.get_registration(workflow_id)
+            # Parity has already inspected the authoritative process graph above.
+            # Do not resolve a lazy registration merely to read its source and
+            # optional purpose: resolution rebuilds that graph and eagerly loads
+            # every workflow in what should remain a diagnostic inventory pass.
+            registration = registry.peek_registration(workflow_id)
             if (
                 registration
                 and isinstance(registration.source, str)
@@ -1131,6 +1137,13 @@ def _build_workflow_parity_inventory(
             registration_purpose=registration_purpose,
             definition_purpose=definition_purpose,
         )
+        if not description and isinstance(registration, LazyWorkflowRegistration):
+            # Preserve the former lazy-definition purpose fallback without
+            # rebuilding the complete workflow graph and executable definition.
+            narrative_description = best_effort_workflow_narrative_text(workflow_id)
+            if narrative_description:
+                description = narrative_description
+                description_source = WORKFLOW_DESCRIPTION_SOURCE_DEFINITION
         description_records.append(
             {
                 "workflow_id": workflow_id,

--- a/src/backend/workflows/durable/startup.py
+++ b/src/backend/workflows/durable/startup.py
@@ -266,6 +266,7 @@ def get_system_status(*, include_counts: bool = True) -> dict[str, Any]:
         WORKFLOW_SCHEDULES_COLLECTION,
         WORKFLOW_WORKERS_COLLECTION,
     )
+    from .models import WorkflowInstanceStatus
 
     db = get_db()
     status: dict[str, Any] = {
@@ -283,8 +284,16 @@ def get_system_status(*, include_counts: bool = True) -> dict[str, Any]:
             schedules_coll = db[WORKFLOW_SCHEDULES_COLLECTION]
             workers_coll = db[WORKFLOW_WORKERS_COLLECTION]
 
-            # Count instances by status
-            pipeline = [{"$group": {"_id": "$status", "count": {"$sum": 1}}}]
+            # Restrict the aggregation to recognised statuses so MongoDB can use
+            # the existing status-leading worker index as a covered scan instead
+            # of reading every workflow instance document.
+            instance_status_values = [
+                instance_status.value for instance_status in WorkflowInstanceStatus
+            ]
+            pipeline = [
+                {"$match": {"status": {"$in": instance_status_values}}},
+                {"$group": {"_id": "$status", "count": {"$sum": 1}}},
+            ]
             status_counts = {
                 doc["_id"]: doc["count"] for doc in instances_coll.aggregate(pipeline)
             }

--- a/tests/backend/test_durable_workflow_status.py
+++ b/tests/backend/test_durable_workflow_status.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.backend.workflows.durable.models import WorkflowInstanceStatus
+from src.backend.workflows.durable.startup import get_system_status
+
+
+def test_get_system_status_matches_recognised_statuses_before_grouping(
+    monkeypatch,
+) -> None:
+    """Status counts should use the existing status-leading index as a covered scan."""
+
+    captured: dict[str, Any] = {}
+    status_rows = [
+        {"_id": status.value, "count": index}
+        for index, status in enumerate(WorkflowInstanceStatus, start=1)
+    ]
+    status_rows.append({"_id": "legacy_unknown", "count": 99})
+
+    class _InstancesCollection:
+        def aggregate(self, pipeline):
+            captured["pipeline"] = pipeline
+            return status_rows
+
+    class _CountCollection:
+        def count_documents(self, _query):
+            return 0
+
+    collections = {
+        "workflow_instances": _InstancesCollection(),
+        "workflow_schedules": _CountCollection(),
+        "workflow_workers": _CountCollection(),
+    }
+
+    class _Database:
+        def __getitem__(self, collection_name):
+            return collections[collection_name]
+
+    monkeypatch.setattr(
+        "src.backend.db.mongo_client.get_db",
+        lambda: _Database(),
+    )
+
+    result = get_system_status()
+
+    recognised_statuses = [status.value for status in WorkflowInstanceStatus]
+    assert captured["pipeline"] == [
+        {"$match": {"status": {"$in": recognised_statuses}}},
+        {"$group": {"_id": "$status", "count": {"$sum": 1}}},
+    ]
+    assert result["instances"] == {
+        "pending": 1,
+        "running": 2,
+        "completed": 3,
+        "failed": 4,
+        "cancelled": 5,
+        "paused": 6,
+    }

--- a/tests/backend/test_workflow_registry_factory_parity.py
+++ b/tests/backend/test_workflow_registry_factory_parity.py
@@ -4,7 +4,11 @@ import pytest
 
 from src.backend.workflows.engine import WorkflowDefinition, WorkflowStateSpec
 from src.backend.workflows.definitions import TOOL_CALLING_WORKFLOW_ID
-from src.backend.workflows.workflow_registry import WorkflowRegistration, WorkflowRegistry
+from src.backend.workflows.workflow_registry import (
+    LazyWorkflowRegistration,
+    WorkflowRegistration,
+    WorkflowRegistry,
+)
 from src.backend.workflows.durable import registry_factory
 
 
@@ -21,6 +25,9 @@ class _DummyRegistry:
         if source is None:
             return None
         return SimpleNamespace(source=source)
+
+    def peek_registration(self, workflow_id: str):
+        return self.get_registration(workflow_id)
 
 
 def _build_definition(workflow_id: str, purpose: str) -> WorkflowDefinition:
@@ -213,6 +220,70 @@ def test_workflow_parity_inventory_includes_drift_reason_codes(monkeypatch):
     assert "registry_only" in reasons
     assert "vontology_only" in reasons
     assert "identity_only" in reasons
+
+
+def test_workflow_parity_inventory_does_not_resolve_lazy_definitions(monkeypatch):
+    workflow_id = "#V#wf_lazy"
+    loader_calls: list[str] = []
+
+    def _unexpected_loader(requested_workflow_id: str):
+        loader_calls.append(requested_workflow_id)
+        raise AssertionError("parity inventory must not resolve lazy definitions")
+
+    registry = WorkflowRegistry(definition_loader=_unexpected_loader)
+    registry.register_lazy(
+        LazyWorkflowRegistration(
+            workflow_id=workflow_id,
+            source="vontology",
+        )
+    )
+    monkeypatch.setattr(
+        registry_factory,
+        "build_workflow_process_graph",
+        lambda _workflow_id: (
+            {
+                "initial_step": "#V#step_1",
+                "steps": [{"step_id": "#V#step_1"}],
+            },
+            [],
+        ),
+    )
+    monkeypatch.setattr(
+        registry_factory,
+        "resolve_workflow_description",
+        lambda *_args, **_kwargs: ("", "text_relation.none"),
+    )
+    monkeypatch.setattr(
+        registry_factory,
+        "best_effort_workflow_narrative_text",
+        lambda _workflow_id: "Lazy workflow narrative",
+    )
+    monkeypatch.setattr(
+        registry_factory,
+        "build_workflow_purity_report",
+        lambda registry: {
+            "counters": {},
+            "baseline": {"comparison": {"regression_detected": False}},
+        },
+    )
+
+    inventory = registry_factory._build_workflow_parity_inventory(
+        registry=registry,
+        discovered_workflow_ids=[workflow_id],
+    )
+
+    assert inventory["registry_sources"]["source_by_workflow_id"] == {
+        workflow_id: "vontology"
+    }
+    assert inventory["counts"]["graph_complete"] == 1
+    description_quality = inventory["workflow_description_quality"]
+    assert description_quality["counts"]["total"] == 1
+    assert description_quality["counts"]["missing"] == 0
+    assert description_quality["counts_by_source"] == {
+        "definition.purpose": 1
+    }
+    assert loader_calls == []
+    assert registry.lazy_registration_count() == 1
 
 
 def test_workflow_parity_policy_fail_mode_raises_on_drift(monkeypatch):


### PR DESCRIPTION
## Outcome

Reduce two measured shared-path sources of Atlas work without changing workflow authority, actor scope, or the public status schema.

- Durable workflow status counting now constrains aggregation to the six server-owned statuses, making the existing `status_lock_expires` index eligible for a covered scan.
- Workflow parity inventory inspects lazy registration metadata without materialising every executable definition a second time.
- The previous narrative-purpose fallback is preserved with a direct narrative read only when the shorter represented description is absent.

## Evidence

- Live planner baseline: `GROUP -> COLLSCAN` with no index.
- Live candidate plan: `GROUP -> PROJECTION_COVERED -> IXSCAN` on `status_lock_expires`.
- One bounded candidate execution completed in 246 ms over 396,476 index keys, examined 0 documents, and returned 6 groups. The expensive baseline execution was not repeated after a bounded attempt timed out, so this PR does not claim a speed-up ratio.
- The parity regression proves the lazy definition loader is not invoked and the diagnostic narrative fallback remains available.
- 78 focused workflow status, parity, lazy-loading, purity, baseline, and health tests pass.
- `git diff --check`, changed-code compilation, and candidate-attributable Ruff checks pass.

## Deliberate scope boundary

The review rejected and removed three riskier adjacent changes before publication: actor-shared SSE registry reuse, snapshot-based relationship-extent deltas, and Mongo reconnect coalescing. The Vontology async tree path also remains unchanged because its actor-context boundary needs separate design. These remain Jira limitations rather than hidden partial fixes.

Merge decision does not change: this four-file candidate is ready. It materially improves the selected shared paths, preserves compatibility, and introduces no demonstrated authority or stale-state regression.

Jira: [JVNAUTOSCI-2631](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2631)

[JVNAUTOSCI-2631]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ