### PR TITLE
Implement rate-limited Von agent email sending

### DIFF
--- a/src/backend/db/mongo_client.py
+++ b/src/backend/db/mongo_client.py
@@ -737,6 +737,11 @@ RELATIONSHIP_EXTENT_INDEX_COLLECTION_NAME = "relationship_extent_index"
 # Agent Gmail OAuth token storage (JVNAUTOSCI-801)
 AGENT_GMAIL_TOKENS_COLLECTION_NAME = "agent_gmail_tokens"
 
+# Atomic, mailbox-wide outbound Gmail operational state.  These collections do
+# not own Vontology-governed identity or authority.
+GMAIL_OUTBOUND_QUOTA_COLLECTION_NAME = "gmail_outbound_quota"
+GMAIL_OUTBOUND_DELIVERIES_COLLECTION_NAME = "gmail_outbound_deliveries"
+
 # Room device identity (JVNAUTOSCI-884)
 ROOM_DEVICES_COLLECTION_NAME = "room_devices"
 
@@ -1781,6 +1786,31 @@ def _ensure_chat_prompt_queue_indexes(coll: Collection) -> None:
         coll.create_index([("updated_at", DESCENDING)], name="updated_at_-1")
 
 
+def _ensure_gmail_outbound_quota_indexes(coll: Collection) -> None:
+    existing_indexes = {idx["name"] for idx in coll.list_indexes()}
+    if "expires_at_ttl" not in existing_indexes:
+        coll.create_index(
+            [("expires_at", ASCENDING)],
+            name="expires_at_ttl",
+            expireAfterSeconds=0,
+        )
+
+
+def _ensure_gmail_outbound_delivery_indexes(coll: Collection) -> None:
+    existing_indexes = {idx["name"] for idx in coll.list_indexes()}
+    if "delivery_fingerprint_1_unique" not in existing_indexes:
+        coll.create_index(
+            [("delivery_fingerprint", ASCENDING)],
+            name="delivery_fingerprint_1_unique",
+            unique=True,
+        )
+    if "status_1_updated_at_-1" not in existing_indexes:
+        coll.create_index(
+            [("status", ASCENDING), ("updated_at", DESCENDING)],
+            name="status_1_updated_at_-1",
+        )
+
+
 # --- Collection Access ---
 def get_people_collection() -> Collection | None:
     """DEPRECATED: Returns the 'people' collection instance. Will be replaced by get_entities_collection.
@@ -2026,6 +2056,32 @@ def get_chat_prompt_queue_collection() -> Collection | None:
             db,
             CHAT_PROMPT_QUEUE_COLLECTION_NAME,
             _ensure_chat_prompt_queue_indexes,
+        )
+    return None
+
+
+def get_gmail_outbound_quota_collection() -> Collection | None:
+    """Return atomic outbound Gmail counters with bounded TTL retention."""
+
+    db = get_db()
+    if db is not None:
+        return _ensure_collection_indexes_once(
+            db,
+            GMAIL_OUTBOUND_QUOTA_COLLECTION_NAME,
+            _ensure_gmail_outbound_quota_indexes,
+        )
+    return None
+
+
+def get_gmail_outbound_deliveries_collection() -> Collection | None:
+    """Return the durable, delivery-fingerprint-unique Gmail effect ledger."""
+
+    db = get_db()
+    if db is not None:
+        return _ensure_collection_indexes_once(
+            db,
+            GMAIL_OUTBOUND_DELIVERIES_COLLECTION_NAME,
+            _ensure_gmail_outbound_delivery_indexes,
         )
     return None
 

--- a/src/backend/integrations/google/gmail_service.py
+++ b/src/backend/integrations/google/gmail_service.py
@@ -9,13 +9,17 @@ the default posture; mutations require explicit opt-in flags and OAuth scopes.
 from __future__ import annotations
 
 import base64
+import hashlib
 import http.client
 import json
 import logging
 import os
 import socket
 from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
 from email.message import EmailMessage
+from email.parser import BytesParser
+from email.policy import default as default_email_policy
 from email.utils import formataddr, getaddresses
 from typing import Any, Dict, Iterable, List, Mapping, Optional
 
@@ -54,6 +58,11 @@ SEND_CAPABLE_SCOPES: set[str] = {
     MUTATION_SCOPE,
     FULL_MAIL_SCOPE,
 }
+SENT_READBACK_CAPABLE_SCOPES: set[str] = {
+    *DEFAULT_SCOPES,
+    MUTATION_SCOPE,
+    FULL_MAIL_SCOPE,
+}
 LABEL_LIST_VISIBILITY_VALUES: set[str] = {
     "labelShow",
     "labelShowIfUnread",
@@ -66,6 +75,19 @@ MESSAGE_LIST_VISIBILITY_VALUES: set[str] = {
 
 PROFILES_ENV_VAR = "VON_GMAIL_PROFILES"
 MAX_GMAIL_ATTACHMENT_MIME_PARTS = 256
+AI_AGENT_DISCLOSURE_TEXT = (
+    "AI-agent notice: This email was composed and sent by Von, an AI agent."
+)
+AI_AGENT_DISCLOSURE_HTML = (
+    '<p data-von-ai-agent-disclosure="true">'
+    f"{AI_AGENT_DISCLOSURE_TEXT}"
+    "</p>"
+)
+AI_AGENT_MACHINE_HEADER = "X-Von-AI-Agent"
+AI_AGENT_SENDER_DISPLAY_NAME = "Von AI Agent"
+DELIVERY_FINGERPRINT_HEADER = "X-Von-Delivery-Fingerprint"
+OUTBOUND_DELIVERY_FINGERPRINT_SCHEMA_VERSION = "gmail_outbound_delivery_key.v2"
+_DEFAULT_OUTBOUND_COLLECTION = object()
 
 
 class GmailAttachmentSizeLimitError(ValueError):
@@ -306,6 +328,7 @@ def _log_gmail_audit(
     allow_mutation: Optional[bool] = None,
     max_results: Optional[int] = None,
     recipient_count: Optional[int] = None,
+    delivery_fingerprint: Optional[str] = None,
 ) -> None:
     """Record a minimal audit trail for Gmail tool calls without leaking content.
 
@@ -327,6 +350,7 @@ def _log_gmail_audit(
             "allow_mutation": allow_mutation,
             "max_results": max_results,
             "recipient_count": recipient_count,
+            "delivery_fingerprint": delivery_fingerprint,
         }
         record = {k: v for k, v in record.items() if v is not None}
         if audit_context:
@@ -1165,10 +1189,38 @@ def _build_raw_message(
     bcc: list[str] | None = None,
     reply_to: list[str] | None = None,
     body_html: str | None = None,
+    delivery_fingerprint: str | None = None,
+    sender_email: str | None = None,
 ) -> str:
+    disclosed_body_text = (
+        f"{body_text.rstrip()}\n\n{AI_AGENT_DISCLOSURE_TEXT}"
+    )
+    disclosed_body_html: str | None = None
+    if isinstance(body_html, str) and body_html.strip():
+        stripped_html = body_html.rstrip()
+        closing_body_index = stripped_html.lower().rfind("</body>")
+        if closing_body_index >= 0:
+            disclosed_body_html = (
+                f"{stripped_html[:closing_body_index]}"
+                f"{AI_AGENT_DISCLOSURE_HTML}\n"
+                f"{stripped_html[closing_body_index:]}"
+            )
+        else:
+            disclosed_body_html = (
+                f"{stripped_html}\n{AI_AGENT_DISCLOSURE_HTML}"
+            )
+
     message = EmailMessage()
+    if isinstance(sender_email, str) and sender_email.strip():
+        message["From"] = formataddr(
+            (AI_AGENT_SENDER_DISPLAY_NAME, sender_email.strip())
+        )
     message["To"] = ", ".join(to)
     message["Subject"] = subject
+    message[AI_AGENT_MACHINE_HEADER] = "Von; disclosure=body"
+    if delivery_fingerprint:
+        message[DELIVERY_FINGERPRINT_HEADER] = delivery_fingerprint
+        message["Message-ID"] = _delivery_rfc822_message_id(delivery_fingerprint)
     if cc:
         message["Cc"] = ", ".join(cc)
     if bcc:
@@ -1176,11 +1228,497 @@ def _build_raw_message(
     if reply_to:
         message["Reply-To"] = ", ".join(reply_to)
 
-    message.set_content(body_text)
-    if isinstance(body_html, str) and body_html.strip():
-        message.add_alternative(body_html, subtype="html")
+    message.set_content(disclosed_body_text)
+    if disclosed_body_html is not None:
+        message.add_alternative(disclosed_body_html, subtype="html")
 
     return base64.urlsafe_b64encode(message.as_bytes()).decode("ascii")
+
+
+def _normalise_header_addresses(values: Iterable[str]) -> list[str]:
+    """Return comparable addresses without retaining display-name variation."""
+
+    return sorted(
+        address.strip().lower()
+        for _display_name, address in getaddresses(list(values))
+        if address.strip()
+    )
+
+
+def _decode_raw_gmail_message(raw_message: str) -> EmailMessage:
+    compact = raw_message.strip()
+    padding = "=" * (-len(compact) % 4)
+    decoded = base64.b64decode(
+        (compact + padding).encode("ascii"),
+        altchars=b"-_",
+        validate=True,
+    )
+    return BytesParser(policy=default_email_policy).parsebytes(decoded)
+
+
+def _message_part_text(message: EmailMessage, content_type: str) -> str | None:
+    for part in message.walk():
+        if part.is_multipart() or part.get_content_type() != content_type:
+            continue
+        content = part.get_content()
+        if isinstance(content, str):
+            return content
+    return None
+
+
+def _read_back_sent_message(
+    *,
+    service: Any,
+    profile: GmailProfile,
+    message_id: str,
+    expected_to: list[str],
+    expected_cc: list[str],
+    expected_bcc: list[str],
+    expected_subject: str,
+    expected_html: bool,
+    expected_delivery_fingerprint: str,
+) -> dict[str, Any]:
+    """Read back one sent message and return a body-free verification receipt."""
+
+    users_resource = service.users()
+    canonical_profile = (
+        users_resource.getProfile(userId=profile.user_id).execute() or {}
+    )
+    raw_readback = (
+        users_resource.messages()
+        .get(
+            userId=profile.user_id,
+            id=message_id,
+            format="raw",
+            fields="id,threadId,labelIds,raw",
+        )
+        .execute()
+        or {}
+    )
+    raw_message = raw_readback.get("raw")
+    if not isinstance(raw_message, str) or not raw_message.strip():
+        raise ValueError("Gmail sent-message read-back did not contain raw MIME")
+
+    parsed_message = _decode_raw_gmail_message(raw_message)
+    observed_sender = str(parsed_message.get("From") or "").strip()
+    observed_sender_addresses = _normalise_header_addresses([observed_sender])
+    authorised_sender = str(canonical_profile.get("emailAddress") or "").strip()
+    expected_sender_addresses = _normalise_header_addresses([authorised_sender])
+
+    observed_to = _normalise_header_addresses(parsed_message.get_all("To", []))
+    observed_cc = _normalise_header_addresses(parsed_message.get_all("Cc", []))
+    observed_bcc = _normalise_header_addresses(parsed_message.get_all("Bcc", []))
+    expected_to_addresses = _normalise_header_addresses(expected_to)
+    expected_cc_addresses = _normalise_header_addresses(expected_cc)
+    expected_bcc_addresses = _normalise_header_addresses(expected_bcc)
+
+    observed_subject = str(parsed_message.get("Subject") or "")
+    observed_agent_header = str(
+        parsed_message.get(AI_AGENT_MACHINE_HEADER) or ""
+    ).strip()
+    observed_delivery_fingerprint = str(
+        parsed_message.get(DELIVERY_FINGERPRINT_HEADER) or ""
+    ).strip()
+    label_ids = [
+        label_id
+        for label_id in (raw_readback.get("labelIds") or [])
+        if isinstance(label_id, str) and label_id.strip()
+    ]
+    canonical_message_id = str(raw_readback.get("id") or "").strip()
+    thread_id = str(raw_readback.get("threadId") or "").strip()
+    plain_body = _message_part_text(parsed_message, "text/plain")
+    html_body = _message_part_text(parsed_message, "text/html")
+
+    sent_label_verified = "SENT" in {label_id.upper() for label_id in label_ids}
+    message_id_verified = canonical_message_id == message_id
+    sender_verified = bool(expected_sender_addresses) and (
+        observed_sender_addresses == expected_sender_addresses
+    )
+    recipients_verified = (
+        observed_to == expected_to_addresses
+        and observed_cc == expected_cc_addresses
+        and observed_bcc == expected_bcc_addresses
+    )
+    subject_verified = observed_subject == expected_subject
+    text_disclosure_verified = (
+        isinstance(plain_body, str) and AI_AGENT_DISCLOSURE_TEXT in plain_body
+    )
+    html_disclosure_verified = (
+        not expected_html
+        or (
+            isinstance(html_body, str)
+            and AI_AGENT_DISCLOSURE_TEXT in html_body
+        )
+    )
+    disclosure_verified = (
+        text_disclosure_verified and html_disclosure_verified
+    )
+    machine_disclosure_verified = observed_agent_header.startswith("Von;")
+    delivery_fingerprint_verified = (
+        observed_delivery_fingerprint == expected_delivery_fingerprint
+    )
+    verified = all(
+        (
+            sent_label_verified,
+            message_id_verified,
+            sender_verified,
+            recipients_verified,
+            subject_verified,
+            disclosure_verified,
+            machine_disclosure_verified,
+            delivery_fingerprint_verified,
+        )
+    )
+
+    return {
+        "status": "verified" if verified else "mismatch",
+        "verified": verified,
+        "body_included": False,
+        "message_id": canonical_message_id or message_id,
+        "thread_id": thread_id or None,
+        "label_ids": label_ids,
+        "sent_label_verified": sent_label_verified,
+        "message_id_verified": message_id_verified,
+        "sender": observed_sender,
+        "sender_address": (
+            observed_sender_addresses[0] if len(observed_sender_addresses) == 1 else None
+        ),
+        "authorised_sender_address": (
+            expected_sender_addresses[0] if len(expected_sender_addresses) == 1 else None
+        ),
+        "sender_verified": sender_verified,
+        "to": observed_to,
+        "cc": observed_cc,
+        "bcc_count": len(observed_bcc),
+        "recipient_count": len(observed_to) + len(observed_cc) + len(observed_bcc),
+        "recipients_verified": recipients_verified,
+        "subject": observed_subject,
+        "subject_verified": subject_verified,
+        "text_disclosure_verified": text_disclosure_verified,
+        "html_disclosure_verified": html_disclosure_verified,
+        "disclosure_verified": disclosure_verified,
+        "machine_disclosure_verified": machine_disclosure_verified,
+        "delivery_fingerprint_verified": delivery_fingerprint_verified,
+    }
+
+
+def _delivery_rfc822_message_id(delivery_fingerprint: str) -> str:
+    return f"<von-{delivery_fingerprint[:40]}@agent.von.invalid>"
+
+
+def _reconcile_sent_delivery(
+    *,
+    service: Any,
+    profile: GmailProfile,
+    delivery_fingerprint: str,
+    expected_to: list[str],
+    expected_cc: list[str],
+    expected_bcc: list[str],
+    expected_subject: str,
+    expected_html: bool,
+    search_anchor: datetime | str | None = None,
+) -> dict[str, Any]:
+    """Find one fingerprinted Sent message and verify its canonical MIME.
+
+    Gmail rewrites caller-supplied RFC Message-ID values on API sends, so the
+    deterministic id cannot itself locate a lost send response. Instead, use a
+    narrow date/recipient/subject search and inspect the preserved private
+    delivery-fingerprint header on each bounded candidate. This remains a
+    read-only recovery path. An empty search is not proof of non-delivery
+    because Gmail indexing and remote responses may be delayed.
+    """
+
+    try:
+        anchor: datetime
+        if isinstance(search_anchor, datetime):
+            anchor = search_anchor
+        elif isinstance(search_anchor, str) and search_anchor.strip():
+            anchor = datetime.fromisoformat(
+                search_anchor.strip().replace("Z", "+00:00")
+            )
+        else:
+            anchor = datetime.now(UTC)
+        if anchor.tzinfo is None:
+            anchor = anchor.replace(tzinfo=UTC)
+        else:
+            anchor = anchor.astimezone(UTC)
+        now = datetime.now(UTC)
+        search_start = (anchor - timedelta(days=1)).strftime("%Y/%m/%d")
+        search_end = (max(anchor, now) + timedelta(days=2)).strftime(
+            "%Y/%m/%d"
+        )
+        query_parts = [
+            "in:sent",
+            f"after:{search_start}",
+            f"before:{search_end}",
+        ]
+        expected_to_addresses = _normalise_header_addresses(expected_to)
+        if expected_to_addresses:
+            query_parts.append(f"to:{expected_to_addresses[0]}")
+        subject_phrase = " ".join(expected_subject.replace('"', " ").split())
+        if subject_phrase:
+            query_parts.append(f'subject:"{subject_phrase}"')
+        search_query = " ".join(query_parts)
+
+        messages_resource = service.users().messages()
+        result = (
+            messages_resource.list(
+                userId=profile.user_id,
+                q=search_query,
+                maxResults=20,
+                fields="messages(id,threadId),resultSizeEstimate",
+            ).execute()
+            or {}
+        )
+        candidates = [
+            candidate
+            for candidate in (result.get("messages") or [])
+            if isinstance(candidate, Mapping)
+            and isinstance(candidate.get("id"), str)
+            and str(candidate.get("id")).strip()
+        ]
+        matching_candidates: list[Mapping[str, Any]] = []
+        for candidate in candidates:
+            candidate_id = str(candidate.get("id") or "").strip()
+            metadata = (
+                messages_resource.get(
+                    userId=profile.user_id,
+                    id=candidate_id,
+                    format="metadata",
+                    metadataHeaders=[DELIVERY_FINGERPRINT_HEADER],
+                    fields="id,threadId,labelIds,payload(headers)",
+                ).execute()
+                or {}
+            )
+            payload = metadata.get("payload")
+            headers = payload.get("headers") if isinstance(payload, Mapping) else []
+            observed_fingerprints = {
+                str(header.get("value") or "").strip()
+                for header in (headers or [])
+                if isinstance(header, Mapping)
+                and str(header.get("name") or "").strip().casefold()
+                == DELIVERY_FINGERPRINT_HEADER.casefold()
+            }
+            if delivery_fingerprint in observed_fingerprints:
+                matching_candidates.append(metadata)
+
+        if len(matching_candidates) != 1:
+            return {
+                "schema_version": "gmail_sent_delivery_reconciliation.v1",
+                "status": (
+                    "not_found" if not matching_candidates else "ambiguous"
+                ),
+                "verified": False,
+                "body_included": False,
+                "candidate_count": len(matching_candidates),
+                "scanned_candidate_count": len(candidates),
+                "delivery_fingerprint": delivery_fingerprint,
+            }
+        canonical = _read_back_sent_message(
+            service=service,
+            profile=profile,
+            message_id=str(matching_candidates[0]["id"]).strip(),
+            expected_to=expected_to,
+            expected_cc=expected_cc,
+            expected_bcc=expected_bcc,
+            expected_subject=expected_subject,
+            expected_html=expected_html,
+            expected_delivery_fingerprint=delivery_fingerprint,
+        )
+        return {
+            "schema_version": "gmail_sent_delivery_reconciliation.v1",
+            "status": (
+                "verified" if canonical.get("verified") is True else "mismatch"
+            ),
+            "verified": canonical.get("verified") is True,
+            "body_included": False,
+            "candidate_count": 1,
+            "scanned_candidate_count": len(candidates),
+            "delivery_fingerprint": delivery_fingerprint,
+            "canonical_readback": canonical,
+        }
+    except Exception as exc:  # noqa: BLE001 - recovery remains indeterminate
+        return {
+            "schema_version": "gmail_sent_delivery_reconciliation.v1",
+            "status": "unavailable",
+            "verified": False,
+            "body_included": False,
+            "candidate_count": None,
+            "delivery_fingerprint": delivery_fingerprint,
+            "error_code": "gmail_sent_delivery_reconciliation_unavailable",
+            "exception_type": type(exc).__name__,
+        }
+
+
+def _sha256_json(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _outbound_delivery_identity(
+    *,
+    canonical_mailbox_key: str,
+    request_id: str,
+    to: list[str],
+    cc: list[str],
+    bcc: list[str],
+    reply_to: list[str],
+    subject: str,
+    body_text: str,
+    body_html: str | None,
+) -> tuple[str, str, str, str]:
+    """Return a stable effect key plus privacy-preserving payload digests."""
+
+    from ...services.gmail_outbound_mailbox_identity_service import (
+        require_canonical_gmail_mailbox_key,
+    )
+
+    mailbox_key = require_canonical_gmail_mailbox_key(canonical_mailbox_key)
+    trusted_request_id = str(request_id or "").strip()
+    if not trusted_request_id:
+        raise ValueError("request_id is required")
+    if len(trusted_request_id) > 512:
+        raise ValueError("request_id is too long")
+    delivery_fingerprint = _sha256_json(
+        {
+            "schema_version": OUTBOUND_DELIVERY_FINGERPRINT_SCHEMA_VERSION,
+            "canonical_mailbox_key": mailbox_key,
+            "request_id": trusted_request_id,
+        }
+    )
+    recipients_sha256 = _sha256_json(
+        {
+            "to": to,
+            "cc": cc,
+            "bcc": bcc,
+            "reply_to": reply_to,
+        }
+    )
+    subject_sha256 = _sha256_json(subject)
+    content_sha256 = _sha256_json(
+        {
+            "body_text": body_text,
+            "body_html": body_html,
+        }
+    )
+    return (
+        delivery_fingerprint,
+        recipients_sha256,
+        subject_sha256,
+        content_sha256,
+    )
+
+
+def _safe_canonical_readback(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, Mapping):
+        return {
+            key: value[key]
+            for key in (
+                "status",
+                "verified",
+                "body_included",
+                "message_id",
+                "thread_id",
+                "label_ids",
+                "sent_label_verified",
+                "message_id_verified",
+                "sender_verified",
+                "bcc_count",
+                "recipient_count",
+                "recipients_verified",
+                "subject_verified",
+                "text_disclosure_verified",
+                "html_disclosure_verified",
+                "disclosure_verified",
+                "machine_disclosure_verified",
+                "delivery_fingerprint_verified",
+                "error_code",
+                "exception_type",
+            )
+            if key in value
+        }
+    return None
+
+
+def _safe_delivery_ledger_receipt(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Project a finality receipt that excludes subjects and addresses."""
+
+    receipt = {
+        key: payload[key]
+        for key in (
+            "message_id",
+            "thread_id",
+            "recipient_count",
+            "bcc_count",
+            "delivery_fingerprint",
+            "gmail_send_state_verified",
+            "effect_status",
+            "mutation_outcome",
+            "outcome_finality",
+            "error_code",
+            "provider_dispatch_attempted",
+        )
+        if key in payload
+    }
+    safe_canonical = _safe_canonical_readback(payload.get("canonical_readback"))
+    if safe_canonical is not None:
+        receipt["canonical_readback"] = safe_canonical
+    reconciliation = payload.get("delivery_reconciliation")
+    if isinstance(reconciliation, Mapping):
+        safe_reconciliation = {
+            key: reconciliation[key]
+            for key in (
+                "schema_version",
+                "status",
+                "verified",
+                "body_included",
+                "candidate_count",
+                "delivery_fingerprint",
+                "error_code",
+                "exception_type",
+            )
+            if key in reconciliation
+        }
+        safe_reconciled_readback = _safe_canonical_readback(
+            reconciliation.get("canonical_readback")
+        )
+        if safe_reconciled_readback is not None:
+            safe_reconciliation["canonical_readback"] = safe_reconciled_readback
+        receipt["delivery_reconciliation"] = safe_reconciliation
+    quota = payload.get("quota")
+    if isinstance(quota, Mapping):
+        receipt["quota"] = dict(quota)
+    return receipt
+
+
+def _outbound_not_started_payload(
+    *,
+    error_code: str,
+    message: str,
+    delivery_fingerprint: str | None = None,
+    quota: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "success": False,
+        "error_code": error_code,
+        "error": message,
+        "status": "not_started",
+        "effect_status": "not_started",
+        "mutation_outcome": "not_started",
+        "outcome_finality": "terminal_for_turn",
+        "changed": False,
+        "provider_dispatch_attempted": False,
+    }
+    if delivery_fingerprint:
+        payload["delivery_fingerprint"] = delivery_fingerprint
+    if quota is not None:
+        payload["quota"] = dict(quota)
+    return payload
 
 
 def send_message(
@@ -1194,14 +1732,29 @@ def send_message(
     reply_to: str | list[str] | None = None,
     body_html: str | None = None,
     allow_send: bool = False,
-    profiles: Optional[Dict[str, GmailProfile]] = None,
-    audit_context: Optional[Mapping[str, object]] = None,
-) -> Dict:
+    profiles: dict[str, GmailProfile] | None = None,
+    audit_context: Mapping[str, object] | None = None,
+    profile_resource_concept_id: str | None = None,
+    request_id: str | None = None,
+    acting_user_concept_id: str | None = None,
+    organisation_concept_id: str | None = None,
+    outbound_rate_limit_settings: Any = None,
+    outbound_quota_collection: Any = _DEFAULT_OUTBOUND_COLLECTION,
+    outbound_delivery_collection: Any = _DEFAULT_OUTBOUND_COLLECTION,
+) -> dict[str, Any]:
     """Send an email through a configured Gmail profile.
 
     Callers must set ``allow_send=True`` after an explicit user request or an
     authorised workflow gate. The helper also checks that the profile declares a
     Gmail scope accepted by ``users.messages.send`` before invoking the API.
+    The trusted caller must also provide the represented profile resource and a
+    stable request id. Before provider dispatch this boundary durably claims the
+    idempotency key and atomically reserves mailbox-wide quota. A human-visible
+    AI-agent disclosure is injected into every MIME alternative. After Gmail
+    accepts the message, the helper reads it back and returns a body-free
+    verification receipt. A completed send with unavailable or mismatched
+    read-back is reported as indeterminate, rather than encouraging a blind
+    retry.
     """
 
     if not allow_send:
@@ -1210,6 +1763,11 @@ def send_message(
         raise ValueError("subject is required")
     if not isinstance(body_text, str) or not body_text.strip():
         raise ValueError("body_text is required")
+    if body_html is not None:
+        raise ValueError(
+            "body_html is not supported for AI-agent outbound email; use the "
+            "plain-text body so the required disclosure cannot be visually hidden"
+        )
 
     to_addresses = _normalise_address_list(to, "to")
     cc_addresses = _normalise_address_list(cc, "cc")
@@ -1224,17 +1782,61 @@ def send_message(
         raise PermissionError(
             "Profile scopes do not include a Gmail send-capable scope"
         )
+    if not profile_scopes.intersection(SENT_READBACK_CAPABLE_SCOPES):
+        raise PermissionError(
+            "Profile scopes do not include a Gmail sent-message read-back scope"
+        )
+
+    resource_id = str(profile_resource_concept_id or "").strip()
+    trusted_request_id = str(request_id or "").strip()
+    if not resource_id:
+        raise ValueError("profile_resource_concept_id is required")
+    if not trusted_request_id:
+        raise ValueError("request_id is required")
+    if len(trusted_request_id) > 512:
+        raise ValueError("request_id is too long")
 
     recipient_count = len(to_addresses) + len(cc_addresses) + len(bcc_addresses)
-    _log_gmail_audit(
-        "send_message",
-        profile_id=profile.profile_id,
-        audit_context=audit_context,
-        allow_mutation=allow_send,
-        recipient_count=recipient_count,
-    )
+    try:
+        from ...services.gmail_outbound_mailbox_identity_service import (
+            derive_canonical_gmail_mailbox_key,
+            normalise_canonical_gmail_address,
+        )
 
-    raw_message = _build_raw_message(
+        service = get_service(profile_id, profiles)
+        canonical_profile = (
+            service.users().getProfile(userId=profile.user_id).execute() or {}
+        )
+        sender_email = normalise_canonical_gmail_address(
+            canonical_profile.get("emailAddress")
+        )
+        canonical_mailbox_key = derive_canonical_gmail_mailbox_key(sender_email)
+    except Exception as exc:  # noqa: BLE001 - no durable or provider effect begun
+        _log_gmail_audit(
+            "send_message_canonical_mailbox_preflight_failed",
+            profile_id=profile.profile_id,
+            audit_context=audit_context,
+            allow_mutation=allow_send,
+            recipient_count=recipient_count,
+        )
+        payload = _outbound_not_started_payload(
+            error_code="gmail_canonical_mailbox_preflight_failed",
+            message=(
+                "Outbound email was not sent because Gmail could not confirm the "
+                "canonical sending mailbox before delivery was claimed."
+            ),
+        )
+        payload["exception_type"] = type(exc).__name__
+        return payload
+
+    (
+        delivery_fingerprint,
+        recipients_sha256,
+        subject_sha256,
+        content_sha256,
+    ) = _outbound_delivery_identity(
+        canonical_mailbox_key=canonical_mailbox_key,
+        request_id=trusted_request_id,
         to=to_addresses,
         cc=cc_addresses,
         bcc=bcc_addresses,
@@ -1243,19 +1845,317 @@ def send_message(
         body_text=body_text,
         body_html=body_html,
     )
-
-    service = get_service(profile_id, profiles)
-    result = (
-        service.users()
-        .messages()
-        .send(userId=profile.user_id, body={"raw": raw_message})
-        .execute()
-        or {}
+    _log_gmail_audit(
+        "send_message",
+        profile_id=profile.profile_id,
+        audit_context=audit_context,
+        allow_mutation=allow_send,
+        recipient_count=recipient_count,
+        delivery_fingerprint=delivery_fingerprint,
     )
-    payload = dict(result)
+
+    from ...services.gmail_outbound_delivery_service import (
+        GmailOutboundDeliveryConflict,
+        GmailOutboundDeliveryLedgerUnavailable,
+        claim_gmail_outbound_delivery,
+        record_gmail_outbound_delivery_result,
+    )
+    from ...services.gmail_outbound_rate_limit_service import (
+        reserve_gmail_outbound_quota,
+    )
+
+    claim_kwargs: dict[str, Any] = {
+        "delivery_fingerprint": delivery_fingerprint,
+        "canonical_mailbox_key": canonical_mailbox_key,
+        "profile_resource_concept_id": str(profile_resource_concept_id),
+        "profile_id": profile.profile_id,
+        "actor_user_concept_id": acting_user_concept_id,
+        "actor_organisation_concept_id": organisation_concept_id,
+        "request_id": trusted_request_id,
+        "recipient_count": recipient_count,
+        "recipients_sha256": recipients_sha256,
+        "subject_sha256": subject_sha256,
+        "content_sha256": content_sha256,
+    }
+    if outbound_delivery_collection is not _DEFAULT_OUTBOUND_COLLECTION:
+        claim_kwargs["collection"] = outbound_delivery_collection
+    try:
+        delivery_claim = claim_gmail_outbound_delivery(**claim_kwargs)
+    except GmailOutboundDeliveryConflict:
+        return _outbound_not_started_payload(
+            error_code="gmail_outbound_idempotency_conflict",
+            message=(
+                "Outbound email was not sent because this request id was already "
+                "used for different message content."
+            ),
+            delivery_fingerprint=delivery_fingerprint,
+        )
+    except GmailOutboundDeliveryLedgerUnavailable:
+        return _outbound_not_started_payload(
+            error_code="gmail_outbound_delivery_ledger_unavailable",
+            message=(
+                "Outbound email was not sent because its durable delivery claim "
+                "could not be confirmed."
+            ),
+            delivery_fingerprint=delivery_fingerprint,
+        )
+
+    def _persist_delivery(status: str, payload: dict[str, Any]) -> None:
+        result_kwargs: dict[str, Any] = {
+            "delivery_fingerprint": delivery_fingerprint,
+            "status": status,
+            "message_id": payload.get("message_id"),
+            "thread_id": payload.get("thread_id"),
+            "receipt": _safe_delivery_ledger_receipt(payload),
+        }
+        if outbound_delivery_collection is not _DEFAULT_OUTBOUND_COLLECTION:
+            result_kwargs["collection"] = outbound_delivery_collection
+        try:
+            stored = record_gmail_outbound_delivery_result(**result_kwargs)
+            payload["delivery_ledger_status"] = stored.get("status")
+        except GmailOutboundDeliveryLedgerUnavailable:
+            # The initial claim remains a non-bypassable duplicate barrier. The
+            # Gmail canonical read-back, when present, still owns send finality.
+            payload["delivery_ledger_status"] = "persistence_indeterminate"
+            payload["delivery_ledger_error_code"] = (
+                "gmail_outbound_delivery_result_persistence_unavailable"
+            )
+
+    if delivery_claim.duplicate:
+        stored_projection = delivery_claim.receipt or {}
+        stored_receipt = stored_projection.get("receipt")
+        payload = (
+            dict(stored_receipt)
+            if isinstance(stored_receipt, Mapping)
+            else {}
+        )
+        payload.update(
+            {
+                "delivery_fingerprint": delivery_fingerprint,
+                "delivery_ledger_status": delivery_claim.status,
+                "idempotent_replay": True,
+                "changed": False,
+            }
+        )
+        if delivery_claim.status == "succeeded":
+            payload.update(
+                success=True,
+                effect_status="succeeded",
+                mutation_outcome="completed",
+                outcome_finality="durable_idempotent_replay",
+            )
+        elif delivery_claim.status in {"not_started", "failed"}:
+            payload.update(
+                success=False,
+                status="not_started",
+                effect_status="not_started",
+                mutation_outcome="not_started",
+                outcome_finality="terminal_for_turn",
+                error_code=payload.get("error_code")
+                or "gmail_outbound_prior_attempt_not_started",
+                error=(
+                    "Outbound email was not sent; this request repeats a prior "
+                    "terminal non-send."
+                ),
+            )
+        else:
+            # A previous provider attempt may still be in flight or may have
+            # lost its response. Never re-dispatch this idempotency key; use the
+            # deterministic RFC Message-ID for a read-only Sent reconciliation.
+            try:
+                reconciliation = _reconcile_sent_delivery(
+                    service=service,
+                    profile=profile,
+                    delivery_fingerprint=delivery_fingerprint,
+                    expected_to=to_addresses,
+                    expected_cc=cc_addresses,
+                    expected_bcc=bcc_addresses,
+                    expected_subject=subject.strip(),
+                    expected_html=(
+                        isinstance(body_html, str) and bool(body_html.strip())
+                    ),
+                    search_anchor=stored_projection.get("created_at"),
+                )
+            except Exception as exc:  # noqa: BLE001 - still never re-dispatch
+                reconciliation = {
+                    "schema_version": "gmail_sent_delivery_reconciliation.v1",
+                    "status": "unavailable",
+                    "verified": False,
+                    "body_included": False,
+                    "delivery_fingerprint": delivery_fingerprint,
+                    "error_code": (
+                        "gmail_sent_delivery_reconciliation_unavailable"
+                    ),
+                    "exception_type": type(exc).__name__,
+                }
+            canonical = reconciliation.get("canonical_readback")
+            if reconciliation.get("verified") is True and isinstance(
+                canonical, Mapping
+            ):
+                payload.update(
+                    success=True,
+                    status="succeeded",
+                    message_id=canonical.get("message_id"),
+                    thread_id=canonical.get("thread_id"),
+                    canonical_readback=dict(canonical),
+                    gmail_send_state_verified=True,
+                    effect_status="succeeded",
+                    mutation_outcome="completed",
+                    outcome_finality="gmail_sent_reconciled_idempotent_replay",
+                    provider_dispatch_attempted=True,
+                    delivery_reconciliation=reconciliation,
+                    changed=False,
+                )
+                _persist_delivery("succeeded", payload)
+            else:
+                payload.pop("changed", None)
+                payload.update(
+                    success=False,
+                    status="indeterminate",
+                    effect_status="indeterminate",
+                    mutation_outcome="unknown",
+                    outcome_finality="durable_delivery_reconciliation_required",
+                    error_code="gmail_outbound_prior_attempt_indeterminate",
+                    error=(
+                        "Outbound email was not retried because the prior delivery "
+                        "outcome is not yet final."
+                    ),
+                    delivery_reconciliation=reconciliation,
+                    recovery_affordances=[
+                        "Retry this same request only to re-run Gmail Sent reconciliation; Von will not re-dispatch it."
+                    ],
+                )
+        return payload
+
+    quota_kwargs: dict[str, Any] = {
+        "canonical_mailbox_key": canonical_mailbox_key,
+        "reservation_id": delivery_fingerprint,
+        "recipient_count": recipient_count,
+    }
+    if outbound_rate_limit_settings is not None:
+        quota_kwargs["settings"] = outbound_rate_limit_settings
+    if outbound_quota_collection is not _DEFAULT_OUTBOUND_COLLECTION:
+        quota_kwargs["collection"] = outbound_quota_collection
+    quota_decision = reserve_gmail_outbound_quota(**quota_kwargs)
+    quota_receipt = quota_decision.as_dict()
+    if not quota_decision.allowed:
+        payload = _outbound_not_started_payload(
+            error_code=quota_decision.code,
+            message=quota_decision.message,
+            delivery_fingerprint=delivery_fingerprint,
+            quota=quota_receipt,
+        )
+        _persist_delivery("not_started", payload)
+        return payload
+
+    try:
+        raw_message = _build_raw_message(
+            to=to_addresses,
+            cc=cc_addresses,
+            bcc=bcc_addresses,
+            reply_to=reply_to_addresses,
+            subject=subject.strip(),
+            body_text=body_text,
+            body_html=body_html,
+            delivery_fingerprint=delivery_fingerprint,
+            sender_email=sender_email,
+        )
+        messages_resource = service.users().messages()
+        send_request = messages_resource.send(
+            userId=profile.user_id,
+            body={"raw": raw_message},
+        )
+    except Exception as exc:  # noqa: BLE001 - provider dispatch not attempted
+        payload = _outbound_not_started_payload(
+            error_code="gmail_provider_dispatch_preparation_failed",
+            message=(
+                "Outbound email was not sent because Gmail dispatch could not be "
+                "prepared."
+            ),
+            delivery_fingerprint=delivery_fingerprint,
+            quota=quota_receipt,
+        )
+        payload["exception_type"] = type(exc).__name__
+        _persist_delivery("not_started", payload)
+        return payload
+
+    try:
+        result = send_request.execute() or {}
+    except Exception as exc:  # noqa: BLE001 - request may have reached Gmail
+        reconciliation = _reconcile_sent_delivery(
+            service=service,
+            profile=profile,
+            delivery_fingerprint=delivery_fingerprint,
+            expected_to=to_addresses,
+            expected_cc=cc_addresses,
+            expected_bcc=bcc_addresses,
+            expected_subject=subject.strip(),
+            expected_html=(
+                isinstance(body_html, str) and bool(body_html.strip())
+            ),
+        )
+        canonical = reconciliation.get("canonical_readback")
+        if reconciliation.get("verified") is True and isinstance(
+            canonical, Mapping
+        ):
+            payload = {
+                "success": True,
+                "message_id": canonical.get("message_id"),
+                "thread_id": canonical.get("thread_id"),
+                "profile": profile.profile_id,
+                "recipient_count": recipient_count,
+                "bcc_count": len(bcc_addresses),
+                "delivery_fingerprint": delivery_fingerprint,
+                "quota": quota_receipt,
+                "canonical_readback": dict(canonical),
+                "delivery_reconciliation": reconciliation,
+                "gmail_send_state_verified": True,
+                "effect_status": "succeeded",
+                "mutation_outcome": "completed",
+                "outcome_finality": "gmail_sent_reconciled_after_provider_error",
+                "provider_dispatch_attempted": True,
+                "changed": True,
+            }
+            _persist_delivery("succeeded", payload)
+            return payload
+        payload = {
+            "success": False,
+            "error_code": "gmail_send_outcome_indeterminate",
+            "error": (
+                "Gmail dispatch was attempted but its delivery outcome is not "
+                "known; the same request will not be sent again automatically."
+            ),
+            "status": "indeterminate",
+            "effect_status": "indeterminate",
+            "mutation_outcome": "unknown",
+            "outcome_finality": "provider_response_indeterminate",
+            "provider_dispatch_attempted": True,
+            "delivery_fingerprint": delivery_fingerprint,
+            "quota": quota_receipt,
+            "exception_type": type(exc).__name__,
+            "delivery_reconciliation": reconciliation,
+            "recovery_affordances": [
+                "Reconcile the delivery fingerprint against Gmail Sent before any new send request."
+            ],
+        }
+        _persist_delivery("indeterminate", payload)
+        return payload
+
+    provider_result = result if isinstance(result, Mapping) else {}
+    # Gmail's send response is documented as a Message resource. Project only
+    # the identifiers/state needed by the effect receipt so a future response
+    # expansion cannot return MIME payload or body content to the caller.
+    payload = {
+        key: provider_result[key]
+        for key in ("id", "threadId", "labelIds")
+        if key in provider_result
+    }
     message_id = payload.get("id")
     if isinstance(message_id, str) and message_id.strip():
         payload.setdefault("message_id", message_id.strip())
+    thread_id = payload.get("threadId")
+    if isinstance(thread_id, str) and thread_id.strip():
+        payload.setdefault("thread_id", thread_id.strip())
     payload.setdefault("profile", profile.profile_id)
     payload.setdefault("to", to_addresses)
     if cc_addresses:
@@ -1264,6 +2164,75 @@ def send_message(
         payload.setdefault("bcc_count", len(bcc_addresses))
     payload.setdefault("recipient_count", recipient_count)
     payload.setdefault("subject", subject.strip())
+    payload.setdefault("changed", True)
+    payload.setdefault("provider_dispatch_attempted", True)
+    payload.setdefault("delivery_fingerprint", delivery_fingerprint)
+    payload.setdefault("quota", quota_receipt)
+    payload.setdefault(
+        "ai_agent_disclosure",
+        {
+            "schema_version": "gmail_ai_agent_disclosure.v1",
+            "visible_text": AI_AGENT_DISCLOSURE_TEXT,
+            "plain_text_part": True,
+            "html_part": isinstance(body_html, str) and bool(body_html.strip()),
+            "machine_header": AI_AGENT_MACHINE_HEADER,
+        },
+    )
+
+    canonical_readback: dict[str, Any]
+    if isinstance(message_id, str) and message_id.strip():
+        try:
+            canonical_readback = _read_back_sent_message(
+                service=service,
+                profile=profile,
+                message_id=message_id.strip(),
+                expected_to=to_addresses,
+                expected_cc=cc_addresses,
+                expected_bcc=bcc_addresses,
+                expected_subject=subject.strip(),
+                expected_html=isinstance(body_html, str) and bool(body_html.strip()),
+                expected_delivery_fingerprint=delivery_fingerprint,
+            )
+        except Exception as exc:  # noqa: BLE001 - send already completed
+            canonical_readback = {
+                "status": "unavailable",
+                "verified": False,
+                "body_included": False,
+                "message_id": message_id.strip(),
+                "error_code": "gmail_sent_message_readback_unavailable",
+                "exception_type": type(exc).__name__,
+            }
+    else:
+        canonical_readback = {
+            "status": "unavailable",
+            "verified": False,
+            "body_included": False,
+            "message_id": None,
+            "error_code": "gmail_send_response_missing_message_id",
+        }
+
+    send_state_verified = canonical_readback.get("verified") is True
+    payload["canonical_readback"] = canonical_readback
+    payload["success"] = send_state_verified
+    payload["status"] = (
+        "succeeded" if send_state_verified else "indeterminate"
+    )
+    payload["gmail_send_state_verified"] = send_state_verified
+    payload["effect_status"] = (
+        "succeeded" if send_state_verified else "indeterminate"
+    )
+    payload["mutation_outcome"] = (
+        "completed" if send_state_verified else "unknown"
+    )
+    payload["outcome_finality"] = (
+        "canonical_durable_readback"
+        if send_state_verified
+        else "canonical_readback_indeterminate"
+    )
+    _persist_delivery(
+        "succeeded" if send_state_verified else "indeterminate",
+        payload,
+    )
     return payload
 
 

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -26571,6 +26571,10 @@ def _gmail_send_message(**kwargs):
     body_text_value = (
         body_text if isinstance(body_text, str) and body_text.strip() else None
     )
+    request_id = kwargs.get("request_id")
+    request_id_value = (
+        request_id if isinstance(request_id, str) and request_id.strip() else None
+    )
     allow_send = bool(kwargs.get("allow_send"))
     missing = [
         field
@@ -26579,6 +26583,7 @@ def _gmail_send_message(**kwargs):
             ("to", to_value),
             ("subject", subject_text),
             ("body_text", body_text_value),
+            ("request_id", request_id_value),
         )
         if value in (None, "")
     ]
@@ -26588,13 +26593,14 @@ def _gmail_send_message(**kwargs):
             "Missing required parameters for Gmail send",
             details={"missing": missing},
             suggestions=[
-                "Provide profile, to, subject, body_text, and allow_send=true",
+                "Provide profile, to, subject, body_text, request_id, and allow_send=true",
             ],
         )
     assert profile_text is not None
     assert to_value is not None
     assert subject_text is not None
     assert body_text_value is not None
+    assert request_id_value is not None
     if not allow_send:
         return make_error_response(
             "send_not_allowed",
@@ -26611,6 +26617,33 @@ def _gmail_send_message(**kwargs):
         return authority_error
     assert profile_authority is not None
     profile_text = profile_authority.profile_id
+    from ...services.coding_agent_identity_bootstrap_service import VON_SYSTEM_ID
+    from ...services.mail_profile_resource_vontology_service import (
+        mail_profile_resource_represents_identity,
+    )
+
+    profile_resource_id = profile_authority.profile_resource_concept_id
+    if not (
+        isinstance(profile_resource_id, str)
+        and mail_profile_resource_represents_identity(
+            profile_resource_concept_id=profile_resource_id,
+            identity_concept_id=VON_SYSTEM_ID,
+        )
+    ):
+        return make_error_response(
+            "gmail_agent_identity_not_represented",
+            (
+                "The selected Gmail profile is not represented as a Von "
+                "AI-agent mailbox, so sending is disabled for this profile."
+            ),
+            suggestions=[
+                (
+                    "Represent the configured agent mailbox as the Von system "
+                    "identity before enabling outbound sends"
+                ),
+            ],
+        )
+    principal = profile_authority.principal
 
     try:
         return gs.send_message(
@@ -26621,12 +26654,18 @@ def _gmail_send_message(**kwargs):
             cc=kwargs.get("cc"),
             bcc=kwargs.get("bcc"),
             reply_to=kwargs.get("reply_to"),
-            body_html=kwargs.get("body_html"),
             allow_send=allow_send,
+            profile_resource_concept_id=profile_resource_id,
+            request_id=request_id_value,
+            acting_user_concept_id=principal.user_concept_id,
+            organisation_concept_id=principal.organisation_concept_id,
             audit_context={
                 "namespace": profile_authority.audit_namespace,
                 "source": "internal_mcp_gateway",
                 "tool": "gmail_send_message",
+                "request_id": request_id_value,
+                "acting_user_concept_id": principal.user_concept_id,
+                "organisation_concept_id": principal.organisation_concept_id,
             },
         )
     except Exception as exc:  # noqa: BLE001
@@ -36755,13 +36794,15 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             "subject": str,
             "body_text": str,
             "allow_send": bool,
+            "request_id": str,
         },
         optional={
             "cc": (str, list),
             "bcc": (str, list),
             "reply_to": (str, list),
-            "body_html": str,
             "namespace": (str, type(None)),
+            "acting_user_concept_id": (str, type(None)),
+            "organisation_concept_id": (str, type(None)),
         },
         allow_unknown=False,
         description=(
@@ -37414,14 +37455,35 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             input_schema=gmail_send_message_input_schema,
             output_schema=_gmail_send_message_output_schema(),
             category="write",
+            ordinary_turn_effect=True,
+            ordinary_turn_trusted_argument_bindings={
+                "acting_user_concept_id": "actor_user_concept_id",
+                "organisation_concept_id": "actor_organisation_concept_id",
+                "request_id": "turn_id",
+                "namespace": "turn_namespace",
+            },
+            ordinary_turn_trusted_argument_choice_bindings={
+                "profile": "gmail_profile",
+            },
+            ordinary_turn_fixed_arguments={
+                "allow_send": True,
+            },
+            write_guardrail={
+                "ordinary_turn_explicit_request": True,
+            },
             timeout_sec=20.0,
             description=(
-                "Send an outbound Gmail message from a configured profile "
-                "alias or authorised Gmail address. Use when the user has "
-                "explicitly asked Von to send email, not for drafts, reading, "
-                "or label changes. Required inputs are profile, to, subject, "
-                "body_text, and allow_send=true. Optional cc, bcc, reply_to, "
-                "and body_html are supported. The profile must have a "
+                "Send an outbound Gmail message from an actor-authorised "
+                "profile. Use only when the current user request, or bounded "
+                "recent request context, explicitly asks Von to send email; "
+                "the ordinary-turn runtime verifies that request evidence "
+                "before dispatch and supplies allow_send=true. This is not a "
+                "draft, read, or label-change capability. Required model "
+                "inputs are to, subject, and body_text; profile is selected "
+                "only from server-supplied authorised resources. Optional cc, "
+                "bcc, and reply_to are supported. HTML bodies are deliberately "
+                "unsupported so the mandatory AI-agent disclosure cannot be "
+                "visually hidden. The profile must have a "
                 "send-capable Gmail OAuth scope such as gmail.send, "
                 "gmail.compose, gmail.modify, or mail.google.com. The tool "
                 "returns Gmail send metadata and does not return the sent body."
@@ -38282,7 +38344,7 @@ def _build_default_catalogue_diagnostics_and_research_definitions() -> (
             input_schema=Schema(
                 required={},
                 optional={
-                    "conversation_ref": (dict,),
+                    "conversation_ref": (dict, type(None)),
                     "session_id": (str, type(None)),
                     "namespace": (str, type(None)),
                     "user_concept_id": (str, type(None)),
@@ -38302,11 +38364,26 @@ def _build_default_catalogue_diagnostics_and_research_definitions() -> (
             ),
             output_schema=None,
             category="read",
+            ordinary_turn_trusted_argument_bindings={
+                "session_id": "conversation_id",
+                "namespace": "turn_namespace",
+                "user_concept_id": "actor_user_concept_id",
+                "organisation_concept_id": "actor_organisation_concept_id",
+            },
+            ordinary_turn_fixed_arguments={
+                "conversation_ref": None,
+                "include_debug": False,
+            },
             description=(
-                "Fetch the bounded stored conversation carrier: transcript segments, inspectable "
-                "situation text, exact observations, and optional assistant llm_debug_data with "
-                "history_location locators. Prefer conversation_ref over raw session_id on "
-                "model-driven paths; use offset/limit when a delegated response is paged."
+                "Fetch the bounded stored conversation carrier: transcript "
+                "segments, inspectable situation text, and exact observations. "
+                "On an ordinary turn, the server binds this read to the active "
+                "conversation and authenticated actor, and excludes assistant "
+                "llm_debug_data; the model cannot redirect it to another "
+                "session or supply a conversation reference. Direct diagnostic "
+                "callers may still use an authoritative conversation_ref and "
+                "history_location locators. Use offset/limit when a delegated "
+                "response is paged."
             ),
         ),
         MethodDefinition(

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -3076,6 +3076,10 @@ async def _handle_gmail_send_message(arguments: dict[str, Any]) -> list[TextCont
     body_text_value = (
         body_text if isinstance(body_text, str) and body_text.strip() else None
     )
+    request_id = arguments.get("request_id")
+    request_id_value = (
+        request_id if isinstance(request_id, str) and request_id.strip() else None
+    )
     allow_send = bool(arguments.get("allow_send"))
     missing = [
         field
@@ -3084,6 +3088,7 @@ async def _handle_gmail_send_message(arguments: dict[str, Any]) -> list[TextCont
             ("to", to_value),
             ("subject", subject_text),
             ("body_text", body_text_value),
+            ("request_id", request_id_value),
         )
         if value in (None, "")
     ]
@@ -3093,7 +3098,7 @@ async def _handle_gmail_send_message(arguments: dict[str, Any]) -> list[TextCont
                 "Missing required parameters for Gmail send",
                 error_code="missing_parameter",
                 suggestions=[
-                    "Provide profile, to, subject, body_text, and allow_send=true",
+                    "Provide profile, to, subject, body_text, request_id, and allow_send=true",
                 ],
             )
         ]
@@ -3101,6 +3106,7 @@ async def _handle_gmail_send_message(arguments: dict[str, Any]) -> list[TextCont
     assert to_value is not None
     assert subject_text is not None
     assert body_text_value is not None
+    assert request_id_value is not None
     if not allow_send:
         return [
             _json_error(
@@ -3112,17 +3118,11 @@ async def _handle_gmail_send_message(arguments: dict[str, Any]) -> list[TextCont
             )
         ]
     try:
-        result = gmail_service.send_message(
-            profile_id=profile_text,
-            to=cast(str | list[str], to_value),
-            subject=subject_text,
-            body_text=body_text_value,
-            cc=arguments.get("cc"),
-            bcc=arguments.get("bcc"),
-            reply_to=arguments.get("reply_to"),
-            body_html=arguments.get("body_html"),
-            allow_send=allow_send,
-            audit_context=_gmail_audit_context("gmail_send_message"),
+        # Reuse the canonical catalogue handler so the trusted-local operator
+        # path receives the same represented-identity, quota, idempotency and
+        # finality controls as ordinary Von conversations.
+        result = internal_mcp_catalogue_module._gmail_send_message(
+            **arguments,
         )
         return [_json_text(result)]
     except Exception as exc:

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -228,12 +228,15 @@
         },
         {
             "name": "chat_history_get_segments",
-            "description": "Fetch the bounded stored conversation carrier: transcript segments, inspectable situation text, exact observations, and optional assistant llm_debug_data with history_location locators. Prefer conversation_ref over raw session_id on model-driven paths; use offset/limit when a delegated response is paged.",
+            "description": "Fetch the bounded stored conversation carrier: transcript segments, inspectable situation text, and exact observations. On an ordinary turn, the server binds this read to the active conversation and authenticated actor, and excludes assistant llm_debug_data; the model cannot redirect it to another session or supply a conversation reference. Direct diagnostic callers may still use an authoritative conversation_ref and history_location locators. Use offset/limit when a delegated response is paged.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "conversation_ref": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "additionalProperties": true
                     },
                     "session_id": {
@@ -2937,7 +2940,7 @@
         },
         {
             "name": "gmail_send_message",
-            "description": "Send an outbound Gmail message from a configured profile alias or authorised Gmail address. Use when the user has explicitly asked Von to send email, not for drafts, reading, or label changes. Required inputs are profile, to, subject, body_text, and allow_send=true. Optional cc, bcc, reply_to, and body_html are supported. The profile must have a send-capable Gmail OAuth scope such as gmail.send, gmail.compose, gmail.modify, or mail.google.com. The tool returns Gmail send metadata and does not return the sent body.",
+            "description": "Send an outbound Gmail message from an actor-authorised profile. Use only when the current user request, or bounded recent request context, explicitly asks Von to send email; the ordinary-turn runtime verifies that request evidence before dispatch and supplies allow_send=true. This is not a draft, read, or label-change capability. Required model inputs are to, subject, and body_text; profile is selected only from server-supplied authorised resources. Optional cc, bcc, and reply_to are supported. HTML bodies are deliberately unsupported so the mandatory AI-agent disclosure cannot be visually hidden. The profile must have a send-capable Gmail OAuth scope such as gmail.send, gmail.compose, gmail.modify, or mail.google.com. The tool returns Gmail send metadata and does not return the sent body.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -2960,6 +2963,9 @@
                     "allow_send": {
                         "type": "boolean"
                     },
+                    "request_id": {
+                        "type": "string"
+                    },
                     "cc": {
                         "type": [
                             "string",
@@ -2981,10 +2987,19 @@
                         ],
                         "items": {}
                     },
-                    "body_html": {
-                        "type": "string"
-                    },
                     "namespace": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "acting_user_concept_id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "organisation_concept_id": {
                         "type": [
                             "string",
                             "null"
@@ -2996,7 +3011,8 @@
                     "to",
                     "subject",
                     "body_text",
-                    "allow_send"
+                    "allow_send",
+                    "request_id"
                 ],
                 "additionalProperties": false,
                 "description": "Send an email through a configured Gmail profile. Requires allow_send=true after explicit user or workflow authorisation, and a profile with a Gmail send-capable OAuth scope.",

--- a/src/backend/server/routes/settings_routes.py
+++ b/src/backend/server/routes/settings_routes.py
@@ -34,6 +34,9 @@ from ...services.settings_service import (
     INTERNAL_MCP_MAX_TOOL_INVOCATIONS_MAX,
     INTERNAL_MCP_TOOL_BATCH_CAP_MIN,
     INTERNAL_MCP_TOOL_BATCH_CAP_MAX,
+    get_gmail_outbound_rate_limit_settings,
+    parse_gmail_outbound_rate_limit_settings,
+    set_gmail_outbound_rate_limit_settings,
     get_disable_write_tool_conservatism,
     set_disable_write_tool_conservatism,
     get_global_mutation_authority_level,
@@ -256,6 +259,7 @@ _ADMIN_ONLY_SETTING_KEYS = _SHARED_RUNTIME_MODEL_SETTING_KEYS | frozenset(
     {
         "disable_write_tool_conservatism",
         "require_human_review_for_high_impact_kb_writes",
+        "gmail_outbound_rate_limits",
     }
 )
 
@@ -1031,10 +1035,14 @@ def get_all_settings():
             settings["require_human_review_for_high_impact_kb_writes"] = (
                 get_require_human_review_for_high_impact_kb_writes()
             )
+            settings["gmail_outbound_rate_limits"] = (
+                get_gmail_outbound_rate_limit_settings().as_dict()
+            )
         else:
             # Remove admin-only setting if it leaked via batch query
             settings.pop("disable_write_tool_conservatism", None)
             settings.pop("require_human_review_for_high_impact_kb_writes", None)
+            settings.pop("gmail_outbound_rate_limits", None)
         selected_model_scope = str(request.args.get("model_scope") or "").strip()
         if selected_model_scope and selected_model_scope not in {
             "user",
@@ -1282,12 +1290,49 @@ def save_all_settings():
         resolved_mutation_authority = None
         resolved_rag_embedder = None
         resolved_rag_llm = None
+        resolved_gmail_outbound_rate_limits = None
         prior_global_rag_embedder = resolve_rag_embedder_setting()
         prior_embedder_signature = _build_runtime_component_signature_from_resolution(
             "embedder",
             prior_global_rag_embedder,
         )
         internal_mcp_caps_updated = False
+        if "gmail_outbound_rate_limits" in data:
+            try:
+                resolved_gmail_outbound_rate_limits = (
+                    parse_gmail_outbound_rate_limit_settings(
+                        data.get("gmail_outbound_rate_limits"),
+                        current=get_gmail_outbound_rate_limit_settings(),
+                    )
+                )
+            except ValueError as exc:
+                return (
+                    jsonify(
+                        {
+                            "status": "error",
+                            "message": str(exc),
+                        }
+                    ),
+                    400,
+                )
+            if not set_gmail_outbound_rate_limit_settings(
+                resolved_gmail_outbound_rate_limits
+            ):
+                return (
+                    jsonify(
+                        {
+                            "status": "error",
+                            "message": (
+                                "Failed to persist gmail_outbound_rate_limits."
+                            ),
+                        }
+                    ),
+                    500,
+                )
+            current_app.logger.warning(
+                "gmail_outbound_rate_limits updated: enabled=%s",
+                resolved_gmail_outbound_rate_limits.enabled,
+            )
         if "disable_write_tool_conservatism" in data:
             try:
                 disabled = bool(data.get("disable_write_tool_conservatism"))
@@ -1671,6 +1716,11 @@ def save_all_settings():
                     "server_default_llm": get_server_default_llm_setting(),
                     "resolved_rag_embedder": resolved_rag_embedder,
                     "resolved_rag_llm": resolved_rag_llm,
+                    "gmail_outbound_rate_limits": (
+                        resolved_gmail_outbound_rate_limits.as_dict()
+                        if resolved_gmail_outbound_rate_limits is not None
+                        else None
+                    ),
                 }
             ),
             200,

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -3112,20 +3112,307 @@ def _ordinary_effect_argument_denial(
     capability_name: str,
     arguments: Mapping[str, Any],
 ) -> dict[str, Any] | None:
-    """Deny the one relationship family that can widen represented visibility."""
+    """Deny relationship families that ordinary actors must not self-grant."""
 
     if capability_name != "add_relationship":
         return None
     from src.backend.security.visibility_predicates import (
         VISIBILITY_PREDICATE_ALIAS_TO_CANONICAL,
     )
+    from src.backend.services.mail_profile_resource_vontology_service import (
+        HAS_AUTHORISED_MAIL_PROFILE_PREDICATE_ID,
+        HAS_DEFAULT_MAIL_PROFILE_PREDICATE_ID,
+        HAS_OAUTH_SCOPE_PREDICATE_ID,
+        HAS_RUNTIME_PROFILE_ALIAS_PREDICATE_ID,
+        MAIL_PROFILE_REPRESENTS_IDENTITY_PREDICATE_ID,
+    )
 
     predicate = str(arguments.get("predicate") or "").strip()
+    predicate_ref = arguments.get("predicate_ref")
+    predicate_references = [predicate]
+    if isinstance(predicate_ref, Mapping):
+        predicate_references.extend(
+            str(predicate_ref.get(field_name) or "").strip()
+            for field_name in ("concept_id", "name")
+        )
+
+    def _normalise_predicate_reference(value: str) -> str:
+        cleaned = value.strip().casefold().removeprefix("#v#")
+        return re.sub(r"[^a-z0-9]+", "_", cleaned).strip("_")
+
+    reserved_mail_profile_predicates = {
+        _normalise_predicate_reference(predicate_id)
+        for predicate_id in (
+            HAS_AUTHORISED_MAIL_PROFILE_PREDICATE_ID,
+            HAS_DEFAULT_MAIL_PROFILE_PREDICATE_ID,
+            HAS_RUNTIME_PROFILE_ALIAS_PREDICATE_ID,
+            HAS_OAUTH_SCOPE_PREDICATE_ID,
+            MAIL_PROFILE_REPRESENTS_IDENTITY_PREDICATE_ID,
+        )
+    }
+    if any(
+        _normalise_predicate_reference(reference)
+        in reserved_mail_profile_predicates
+        for reference in predicate_references
+        if reference
+    ):
+        return _error_payload(
+            "mail_profile_authority_effect_not_delegated",
+            (
+                "Ordinary-turn relationship effects cannot grant or alter "
+                "mail-profile authority or agent-mailbox identity."
+            ),
+        )
     if predicate not in VISIBILITY_PREDICATE_ALIAS_TO_CANONICAL:
         return None
     return _error_payload(
         "visibility_effect_not_delegated",
         "Ordinary-turn relationship effects cannot change visibility scope.",
+    )
+
+
+def _bounded_recent_user_prompts(
+    context: Sequence[Mapping[str, Any]] | None,
+    *,
+    max_items: int = 3,
+    max_chars: int = 4_000,
+) -> list[str]:
+    """Return a small user-authored continuation window for request evidence.
+
+    Only user-role conversation messages can carry recent request context. Tool,
+    system, assistant, and caller-supplied structured turn-input messages are
+    deliberately excluded so retrieved or runtime-injected content cannot grant
+    an external effect.
+    """
+
+    retained_reversed: list[str] = []
+    retained_chars = 0
+    for message in reversed(tuple(context or ())):
+        if str(message.get("role") or "").strip().lower() != "user":
+            continue
+        content = message.get("content")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        cleaned = content.strip()
+        if (
+            '"type":"authorised_turn_inputs"' in cleaned.replace(" ", "")
+            or '"type": "authorised_turn_inputs"' in cleaned
+        ):
+            continue
+        remaining = max_chars - retained_chars
+        if remaining <= 0:
+            break
+        bounded = cleaned[-min(len(cleaned), remaining, 2_000) :]
+        retained_reversed.append(bounded)
+        retained_chars += len(bounded)
+        if len(retained_reversed) >= max_items:
+            break
+    retained_reversed.reverse()
+    return retained_reversed
+
+
+def _ordinary_turn_effect_request_guardrail(
+    *,
+    definition: Any,
+    capability_name: str,
+    arguments: Mapping[str, Any],
+    prompt: str,
+    context: Sequence[Mapping[str, Any]] | None,
+    llm_client: Any,
+    model: str | None,
+    user_concept_id: str | None,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Enforce an opt-in explicit-request boundary before effect dispatch.
+
+    ``ordinary_turn_effect`` establishes only the maximum effect capability.
+    External commitments that opt into this guard still require structured
+    request evidence inferred from the current user prompt (plus a bounded
+    user-role continuation window). Inference failure is a typed no-effect
+    result and occurs before the durable dispatch-intent journal entry.
+    """
+
+    guardrail = getattr(definition, "write_guardrail", None)
+    if not isinstance(guardrail, Mapping) or guardrail.get(
+        "ordinary_turn_explicit_request"
+    ) is not True:
+        return None, None
+
+    recent_user_prompts = _bounded_recent_user_prompts(context)
+    payload_summary = {
+        "provided_fields": sorted(
+            str(field_name)
+            for field_name in arguments
+            if isinstance(field_name, str) and field_name
+        )
+    }
+    try:
+        from src.backend.services.write_tool_request_evidence_vontology_service import (
+            infer_write_tool_request_evidence,
+        )
+
+        request_evidence_raw, diagnostics_raw = infer_write_tool_request_evidence(
+            llm_client=llm_client,
+            model=model,
+            prompt=prompt,
+            recent_user_prompts=recent_user_prompts,
+            requested_tools=[capability_name],
+            requested_tool_payloads={capability_name: payload_summary},
+        )
+    except Exception as exc:  # noqa: BLE001 - fail closed before dispatch
+        request_evidence_raw = {}
+        diagnostics_raw = {
+            "schema_version": "write_tool_request_evidence.v1",
+            "status": "inference_error",
+            "error_class": type(exc).__name__,
+        }
+
+    request_evidence = (
+        dict(request_evidence_raw)
+        if isinstance(request_evidence_raw, Mapping)
+        else {}
+    )
+    diagnostics = (
+        dict(diagnostics_raw)
+        if isinstance(diagnostics_raw, Mapping)
+        else {
+            "schema_version": "write_tool_request_evidence.v1",
+            "status": "invalid_inference_result",
+        }
+    )
+
+    inference_status = str(diagnostics.get("status") or "unknown").strip()
+    evidence = request_evidence.get(capability_name.lower())
+    evidence = dict(evidence) if isinstance(evidence, Mapping) else {}
+    request_state = str(evidence.get("request_state") or "").strip().lower()
+    event: dict[str, Any] = {
+        "type": "ordinary_turn_effect_request_guardrail",
+        "schema_version": "ordinary_turn_effect_request_guardrail.v1",
+        "capability_name": capability_name,
+        "inference_status": inference_status,
+        "request_state": request_state or None,
+        "recent_user_prompt_count": len(recent_user_prompts),
+    }
+
+    if inference_status != "ok":
+        event.update(status="blocked", reason="request_evidence_unavailable")
+        return (
+            {
+                **_error_payload(
+                    "ordinary_turn_request_evidence_unavailable",
+                    (
+                        "The external effect was not started because explicit "
+                        "user-request evidence could not be verified."
+                    ),
+                ),
+                "status": "not_started",
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "outcome_finality": "terminal_for_turn",
+                "changed": False,
+                "request_evidence_status": inference_status,
+            },
+            event,
+        )
+
+    try:
+        from src.backend.services.settings_service import (
+            get_global_mutation_authority_level,
+            get_user_mutation_authority_level,
+        )
+        from src.backend.workflows.write_tool_policy import (
+            compute_allowed_write_tools,
+        )
+
+        user_mutation_authority = (
+            get_user_mutation_authority_level(user_concept_id)
+            if isinstance(user_concept_id, str) and user_concept_id.strip()
+            else None
+        )
+        global_mutation_authority = get_global_mutation_authority_level()
+        decision = compute_allowed_write_tools(
+            prompt=prompt,
+            requested_tools=[capability_name],
+            requested_tool_payloads={capability_name: payload_summary},
+            request_evidence={capability_name: evidence},
+            request_evidence_diagnostics=diagnostics,
+            recent_user_prompts=recent_user_prompts,
+            user_mutation_authority=user_mutation_authority,
+            global_mutation_authority=global_mutation_authority,
+        )
+    except Exception as exc:  # noqa: BLE001 - fail closed before dispatch
+        event.update(
+            status="blocked",
+            reason="write_policy_unavailable",
+            error_class=type(exc).__name__,
+        )
+        return (
+            {
+                **_error_payload(
+                    "ordinary_turn_write_policy_unavailable",
+                    (
+                        "The external effect was not started because its write "
+                        "policy could not be evaluated."
+                    ),
+                ),
+                "status": "not_started",
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "outcome_finality": "terminal_for_turn",
+                "changed": False,
+            },
+            event,
+        )
+
+    tool_decision = decision.decision_for_tool(capability_name)
+    event.update(
+        decision_basis=decision.decision_basis,
+        policy_outcome=(tool_decision.outcome if tool_decision is not None else None),
+        effective_mutation_authority=decision.effective_mutation_authority,
+    )
+    if capability_name in decision.allowed_tools and request_state in {
+        "explicit_request",
+        "recent_request_context",
+    }:
+        event.update(status="allowed", reason=decision.reason)
+        return None, event
+
+    blocked_reason = (
+        tool_decision.blocked_reason
+        if tool_decision is not None and tool_decision.blocked_reason
+        else decision.reason
+    )
+    event.update(status="blocked", reason=blocked_reason)
+    explicit_request_state = request_state in {
+        "explicit_request",
+        "recent_request_context",
+    }
+    return (
+        {
+            **_error_payload(
+                (
+                    "ordinary_turn_write_policy_blocked"
+                    if explicit_request_state
+                    else "external_write_requires_explicit_request"
+                ),
+                (
+                    "The external effect was not started because it exceeds "
+                    "the effective mutation authority."
+                    if explicit_request_state
+                    else (
+                        "The external effect was not started because the current "
+                        "request does not explicitly authorise it."
+                    )
+                ),
+            ),
+            "status": "not_started",
+            "effect_status": "not_started",
+            "mutation_outcome": "not_started",
+            "outcome_finality": "terminal_for_turn",
+            "changed": False,
+            "write_policy_reason": blocked_reason,
+            "request_state": request_state or "low_confidence",
+        },
+        event,
     )
 
 
@@ -3163,6 +3450,7 @@ def _effect_result_target_ids(raw_payload: Any) -> list[str]:
         "existing_concept_id",
         "file_copy_concept_id",
         "instance_id",
+        "message_id",
         "object_id",
         "relation_id",
         "source_concept_id",
@@ -3170,6 +3458,8 @@ def _effect_result_target_ids(raw_payload: Any) -> list[str]:
         "subject_id",
         "target_concept_id",
         "target_id",
+        "thread_id",
+        "delivery_fingerprint",
     }
     sequence_fields = {
         "concept_ids",
@@ -3233,6 +3523,42 @@ def _effect_result_target_ids(raw_payload: Any) -> list[str]:
     return collected
 
 
+def _canonical_effect_readback_receipt(raw_payload: Any) -> dict[str, Any] | None:
+    """Project an embedded canonical read-back without private message fields."""
+
+    if not isinstance(raw_payload, Mapping):
+        return None
+    readback = raw_payload.get("canonical_readback")
+    if not isinstance(readback, Mapping):
+        return None
+    projected = {
+        key: readback[key]
+        for key in (
+            "status",
+            "verified",
+            "body_included",
+            "message_id",
+            "thread_id",
+            "label_ids",
+            "sent_label_verified",
+            "message_id_verified",
+            "sender_verified",
+            "recipient_count",
+            "bcc_count",
+            "recipients_verified",
+            "subject_verified",
+            "text_disclosure_verified",
+            "html_disclosure_verified",
+            "disclosure_verified",
+            "machine_disclosure_verified",
+            "delivery_fingerprint_verified",
+            "error_code",
+        )
+        if key in readback
+    }
+    return projected or None
+
+
 _EXACT_READBACK_ARGUMENT_FIELDS = (
     "concept_id",
     "document_id",
@@ -3294,6 +3620,14 @@ def _canonically_verified_material_effect_ids(
         ):
             continue
         material_effect_ids.add(effect_id)
+        embedded_readback = state.get("canonical_readback")
+        if isinstance(embedded_readback, Mapping) and (
+            embedded_readback.get("verified") is True
+            and str(embedded_readback.get("status") or "").strip().lower()
+            == "verified"
+        ):
+            verified_effect_ids.add(effect_id)
+            continue
         effect_targets = {
             str(item).strip()
             for item in invocation.get("result_target_ids") or ()
@@ -4141,6 +4475,7 @@ def execute_adaptive_turn(
         execution_id: str | None = None,
         instance_id: str | None = None,
         workflow_id: str | None = None,
+        canonical_readback: Mapping[str, Any] | None = None,
         late_observation: Mapping[str, Any] | None = None,
         evidence_id: str | None = None,
     ) -> None:
@@ -4160,6 +4495,8 @@ def execute_adaptive_turn(
                 "workflow_id": workflow_id,
                 "evidence_id": evidence_id,
             }
+            if canonical_readback is not None:
+                state["canonical_readback"] = dict(canonical_readback)
             if late_observation is not None:
                 state["late_observation"] = {
                     key: late_observation.get(key)
@@ -4182,6 +4519,7 @@ def execute_adaptive_turn(
                     "execution_id",
                     "instance_id",
                     "workflow_id",
+                    "canonical_readback",
                 ):
                     if not state.get(identity_field) and existing.get(identity_field):
                         state[identity_field] = existing[identity_field]
@@ -4378,6 +4716,7 @@ def execute_adaptive_turn(
                     if isinstance(payload, Mapping)
                     else None
                 ),
+                canonical_readback=_canonical_effect_readback_receipt(payload),
                 late_observation=observed,
                 evidence_id=envelope.evidence_id,
             )
@@ -5839,6 +6178,27 @@ def execute_adaptive_turn(
                         )
                     )
 
+            request_guardrail_denial: dict[str, Any] | None = None
+            request_guardrail_event: dict[str, Any] | None = None
+            if is_effect and definition is not None:
+                (
+                    request_guardrail_denial,
+                    request_guardrail_event,
+                ) = _ordinary_turn_effect_request_guardrail(
+                    definition=definition,
+                    capability_name=canonical_name,
+                    arguments=arguments,
+                    prompt=prompt,
+                    context=current_context,
+                    llm_client=llm_client,
+                    model=model,
+                    user_concept_id=scope.user_concept_id,
+                )
+            if request_guardrail_event is not None:
+                aux_calls.append(request_guardrail_event)
+            if request_guardrail_denial is not None:
+                return index, contained(request_guardrail_denial)
+
             effect_request_signature = (
                 _effect_request_signature(canonical_name, arguments)
                 if is_effect
@@ -6393,8 +6753,15 @@ def execute_adaptive_turn(
                     if projected_payload is not None:
                         envelope_payload["projected_payload"] = projected_payload
                 result_target_ids = _effect_result_target_ids(raw_payload)
+                canonical_effect_readback = _canonical_effect_readback_receipt(
+                    raw_payload
+                )
                 if result_target_ids:
                     envelope_payload["result_target_ids"] = result_target_ids
+                if canonical_effect_readback is not None:
+                    envelope_payload["canonical_readback"] = dict(
+                        canonical_effect_readback
+                    )
                 if is_effect:
                     remember_effect_state(
                         effect_identifier,
@@ -6424,6 +6791,7 @@ def execute_adaptive_turn(
                             if isinstance(raw_payload, Mapping)
                             else None
                         ),
+                        canonical_readback=canonical_effect_readback,
                     )
                     remember_recovery_affordance(
                         effect_id=effect_identifier,
@@ -6562,6 +6930,10 @@ def execute_adaptive_turn(
                             receipt_value = raw_payload.get(receipt_key)
                             if isinstance(receipt_value, (str, int, float, bool)):
                                 invocation[receipt_key] = receipt_value
+                    if canonical_effect_readback is not None:
+                        invocation["canonical_readback"] = dict(
+                            canonical_effect_readback
+                        )
                 if transport_metadata:
                     invocation["transport"] = transport_metadata
                 invocation["result_projection_duration_ms"] = (

--- a/src/backend/services/gmail_outbound_delivery_service.py
+++ b/src/backend/services/gmail_outbound_delivery_service.py
@@ -1,0 +1,374 @@
+"""Durable idempotency and finality ledger for outbound Gmail effects.
+
+The Gmail API does not accept an application idempotency key for message
+submission.  This ledger therefore owns one delivery fingerprint before quota
+reservation or provider dispatch, records the provider receipt, and gives
+callers an explicit ``indeterminate`` state instead of encouraging a blind
+retry after a lost response.
+
+Message bodies and recipient addresses are deliberately excluded.  The caller
+computes a fingerprint from the exact delivery request and may persist only
+bounded hashes/counts alongside trusted actor/profile provenance.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from pymongo import ReturnDocument
+from pymongo.errors import DuplicateKeyError
+
+from ..db.mongo_client import get_gmail_outbound_deliveries_collection
+from ..utils.time_utils import utc_now
+from .gmail_outbound_mailbox_identity_service import (
+    require_canonical_gmail_mailbox_key,
+)
+
+DELIVERY_LEDGER_SCHEMA_VERSION = "gmail_outbound_delivery.v2"
+_TERMINAL_STATUSES = frozenset(
+    {"succeeded", "indeterminate", "failed", "not_started"}
+)
+_KNOWN_STATUSES = frozenset({"dispatch_claimed", *_TERMINAL_STATUSES})
+_ALLOWED_PREDECESSOR_STATUSES: Mapping[str, frozenset[str]] = {
+    "indeterminate": frozenset({"dispatch_claimed", "indeterminate"}),
+    "failed": frozenset({"dispatch_claimed", "indeterminate", "failed"}),
+    "not_started": frozenset(
+        {"dispatch_claimed", "indeterminate", "not_started"}
+    ),
+    # A canonically verified delivery is the strongest finality observation and
+    # may repair any weaker state. Once stored, no non-success result may erase it.
+    "succeeded": _KNOWN_STATUSES,
+}
+
+
+class GmailOutboundDeliveryLedgerUnavailable(RuntimeError):
+    """Raised when a delivery effect cannot be made durably observable."""
+
+
+class GmailOutboundDeliveryConflict(RuntimeError):
+    """Raised when one idempotency key is reused for a different message."""
+
+
+@dataclass(frozen=True)
+class GmailOutboundDeliveryClaim:
+    claimed: bool
+    duplicate: bool
+    delivery_fingerprint: str
+    status: str
+    receipt: Mapping[str, Any] | None = None
+
+
+def _clean_required(value: Any, field_name: str) -> str:
+    cleaned = str(value or "").strip()
+    if not cleaned:
+        raise ValueError(f"{field_name} is required")
+    return cleaned
+
+
+def _normalise_now(value: datetime | None) -> datetime:
+    resolved = value or utc_now()
+    if resolved.tzinfo is None:
+        return resolved.replace(tzinfo=UTC)
+    return resolved.astimezone(UTC)
+
+
+def _alias_digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _project(document: Mapping[str, Any]) -> dict[str, Any]:
+    receipt = document.get("receipt")
+    return {
+        "schema_version": DELIVERY_LEDGER_SCHEMA_VERSION,
+        "delivery_fingerprint": str(document.get("delivery_fingerprint") or ""),
+        "status": str(document.get("status") or "unknown"),
+        "canonical_mailbox_key": document.get("canonical_mailbox_key"),
+        "profile_resource_concept_id": document.get("profile_resource_concept_id"),
+        "profile_alias_digest": document.get("profile_alias_digest"),
+        "observed_profile_resource_concept_ids": list(
+            document.get("observed_profile_resource_concept_ids") or []
+        ),
+        "observed_profile_alias_digests": list(
+            document.get("observed_profile_alias_digests") or []
+        ),
+        "actor_user_concept_id": document.get("actor_user_concept_id"),
+        "actor_organisation_concept_id": document.get(
+            "actor_organisation_concept_id"
+        ),
+        "request_id": document.get("request_id"),
+        "recipient_count": document.get("recipient_count"),
+        "message_id": document.get("message_id"),
+        "thread_id": document.get("thread_id"),
+        "created_at": document.get("created_at"),
+        "updated_at": document.get("updated_at"),
+        "receipt": dict(receipt) if isinstance(receipt, Mapping) else None,
+    }
+
+
+def claim_gmail_outbound_delivery(
+    *,
+    delivery_fingerprint: str,
+    canonical_mailbox_key: str,
+    profile_resource_concept_id: str,
+    profile_id: str,
+    actor_user_concept_id: str | None,
+    actor_organisation_concept_id: str | None,
+    request_id: str,
+    recipient_count: int,
+    recipients_sha256: str,
+    subject_sha256: str,
+    content_sha256: str,
+    collection: Any = None,
+    now: datetime | None = None,
+) -> GmailOutboundDeliveryClaim:
+    """Claim one exact delivery before quota reservation and Gmail dispatch."""
+
+    fingerprint = _clean_required(delivery_fingerprint, "delivery_fingerprint")
+    mailbox_key = require_canonical_gmail_mailbox_key(canonical_mailbox_key)
+    resource_id = _clean_required(
+        profile_resource_concept_id, "profile_resource_concept_id"
+    )
+    runtime_profile = _clean_required(profile_id, "profile_id")
+    profile_alias_digest = _alias_digest(runtime_profile)
+    trusted_request_id = _clean_required(request_id, "request_id")
+    recipients_digest = _clean_required(recipients_sha256, "recipients_sha256")
+    subject_digest = _clean_required(subject_sha256, "subject_sha256")
+    content_digest = _clean_required(content_sha256, "content_sha256")
+    if not isinstance(recipient_count, int) or isinstance(recipient_count, bool):
+        raise TypeError("recipient_count must be an integer")
+    if recipient_count <= 0:
+        raise ValueError("recipient_count must be positive")
+
+    ledger = (
+        collection
+        if collection is not None
+        else get_gmail_outbound_deliveries_collection()
+    )
+    if ledger is None:
+        raise GmailOutboundDeliveryLedgerUnavailable(
+            "Outbound Gmail delivery ledger is unavailable"
+        )
+    timestamp = _normalise_now(now)
+    document = {
+        # Mongo guarantees _id uniqueness independently of optional secondary
+        # index bootstrap. This is the actual dispatch-ownership boundary.
+        "_id": fingerprint,
+        "schema_version": DELIVERY_LEDGER_SCHEMA_VERSION,
+        "delivery_fingerprint": fingerprint,
+        "status": "dispatch_claimed",
+        "canonical_mailbox_key": mailbox_key,
+        "profile_resource_concept_id": resource_id,
+        "profile_alias_digest": profile_alias_digest,
+        "observed_profile_resource_concept_ids": [resource_id],
+        "observed_profile_alias_digests": [profile_alias_digest],
+        "actor_user_concept_id": (
+            str(actor_user_concept_id).strip() if actor_user_concept_id else None
+        ),
+        "actor_organisation_concept_id": (
+            str(actor_organisation_concept_id).strip()
+            if actor_organisation_concept_id
+            else None
+        ),
+        "request_id": trusted_request_id,
+        "recipient_count": recipient_count,
+        "recipients_sha256": recipients_digest,
+        "subject_sha256": subject_digest,
+        "content_sha256": content_digest,
+        "created_at": timestamp,
+        "updated_at": timestamp,
+    }
+    try:
+        ledger.insert_one(document)
+        return GmailOutboundDeliveryClaim(
+            claimed=True,
+            duplicate=False,
+            delivery_fingerprint=fingerprint,
+            status="dispatch_claimed",
+        )
+    except DuplicateKeyError:
+        existing = ledger.find_one({"_id": fingerprint})
+        if not isinstance(existing, Mapping):
+            # Read-only compatibility for any pre-_id ledger record. New claims
+            # are always intrinsically unique by fingerprint above.
+            existing = ledger.find_one({"delivery_fingerprint": fingerprint})
+        if not isinstance(existing, Mapping):
+            raise GmailOutboundDeliveryLedgerUnavailable(
+                "Duplicate Gmail delivery claim could not be read back"
+            )
+        expected_payload_identity = {
+            "canonical_mailbox_key": mailbox_key,
+            "request_id": trusted_request_id,
+            "recipient_count": recipient_count,
+            "recipients_sha256": recipients_digest,
+            "subject_sha256": subject_digest,
+            "content_sha256": content_digest,
+        }
+        if any(
+            existing.get(field_name) != expected_value
+            for field_name, expected_value in expected_payload_identity.items()
+        ):
+            raise GmailOutboundDeliveryConflict(
+                "Outbound Gmail request_id was reused for different delivery content"
+            )
+        try:
+            updated = ledger.find_one_and_update(
+                {"_id": fingerprint},
+                {
+                    "$addToSet": {
+                        "observed_profile_resource_concept_ids": resource_id,
+                        "observed_profile_alias_digests": profile_alias_digest,
+                    },
+                    "$set": {"updated_at": timestamp},
+                },
+                return_document=ReturnDocument.AFTER,
+            )
+        except Exception as exc:
+            raise GmailOutboundDeliveryLedgerUnavailable(
+                "Duplicate Gmail delivery provenance could not be persisted"
+            ) from exc
+        if not isinstance(updated, Mapping):
+            raise GmailOutboundDeliveryLedgerUnavailable(
+                "Duplicate Gmail delivery provenance could not be read back"
+            )
+        existing = updated
+        projected = _project(existing)
+        return GmailOutboundDeliveryClaim(
+            claimed=False,
+            duplicate=True,
+            delivery_fingerprint=fingerprint,
+            status=str(projected.get("status") or "unknown"),
+            receipt=projected,
+        )
+    except Exception as exc:  # fail closed before provider dispatch
+        raise GmailOutboundDeliveryLedgerUnavailable(
+            f"Outbound Gmail delivery claim failed: {type(exc).__name__}"
+        ) from exc
+
+
+def record_gmail_outbound_delivery_result(
+    *,
+    delivery_fingerprint: str,
+    status: str,
+    message_id: str | None = None,
+    thread_id: str | None = None,
+    receipt: Mapping[str, Any] | None = None,
+    collection: Any = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Persist one monotonic terminal result and return it canonically.
+
+    Updates use compare-and-set status transitions. In particular, a canonical
+    ``succeeded`` observation is absorbing: a slower worker reporting
+    ``indeterminate``, ``failed``, or ``not_started`` cannot overwrite its
+    verified receipt.
+    """
+
+    fingerprint = _clean_required(delivery_fingerprint, "delivery_fingerprint")
+    resolved_status = str(status or "").strip().lower()
+    if resolved_status not in _TERMINAL_STATUSES:
+        raise ValueError(
+            "status must be one of: " + ", ".join(sorted(_TERMINAL_STATUSES))
+        )
+    ledger = (
+        collection
+        if collection is not None
+        else get_gmail_outbound_deliveries_collection()
+    )
+    if ledger is None:
+        raise GmailOutboundDeliveryLedgerUnavailable(
+            "Outbound Gmail delivery ledger is unavailable"
+        )
+    timestamp = _normalise_now(now)
+    update: dict[str, Any] = {
+        "status": resolved_status,
+        "updated_at": timestamp,
+        "receipt": dict(receipt or {}),
+    }
+    if isinstance(message_id, str) and message_id.strip():
+        update["message_id"] = message_id.strip()
+    if isinstance(thread_id, str) and thread_id.strip():
+        update["thread_id"] = thread_id.strip()
+    allowed_predecessors = _ALLOWED_PREDECESSOR_STATUSES[resolved_status]
+    try:
+        stored = ledger.find_one_and_update(
+            {
+                "_id": fingerprint,
+                "status": {"$in": sorted(allowed_predecessors)},
+            },
+            {"$set": update},
+            return_document=ReturnDocument.AFTER,
+        )
+        if not isinstance(stored, Mapping):
+            existing = ledger.find_one({"_id": fingerprint})
+            if not isinstance(existing, Mapping):
+                # Read-only compatibility for records claimed before the
+                # fingerprint became the intrinsic Mongo identity.
+                existing = ledger.find_one({"delivery_fingerprint": fingerprint})
+                if isinstance(existing, Mapping) and existing.get("_id") is not None:
+                    stored = ledger.find_one_and_update(
+                        {
+                            "_id": existing["_id"],
+                            "status": {"$in": sorted(allowed_predecessors)},
+                        },
+                        {"$set": update},
+                        return_document=ReturnDocument.AFTER,
+                    )
+                    if isinstance(stored, Mapping):
+                        existing = stored
+            if not isinstance(existing, Mapping):
+                raise GmailOutboundDeliveryLedgerUnavailable(
+                    "Outbound Gmail delivery claim disappeared before result persistence"
+                )
+            existing_status = str(existing.get("status") or "").strip().lower()
+            if existing_status not in _KNOWN_STATUSES:
+                raise GmailOutboundDeliveryLedgerUnavailable(
+                    "Outbound Gmail delivery claim has an invalid finality state"
+                )
+            # The CAS was rejected because another worker already stored an
+            # equal or stronger terminal observation. Return that canonical
+            # state without modifying its status, receipt, or identifiers.
+            stored = existing
+    except GmailOutboundDeliveryLedgerUnavailable:
+        raise
+    except Exception as exc:  # effect finality must remain honest
+        raise GmailOutboundDeliveryLedgerUnavailable(
+            f"Outbound Gmail delivery result persistence failed: {type(exc).__name__}"
+        ) from exc
+    assert isinstance(stored, Mapping)
+    return _project(stored)
+
+
+def get_gmail_outbound_delivery(
+    delivery_fingerprint: str,
+    *,
+    collection: Any = None,
+) -> dict[str, Any] | None:
+    fingerprint = _clean_required(delivery_fingerprint, "delivery_fingerprint")
+    ledger = (
+        collection
+        if collection is not None
+        else get_gmail_outbound_deliveries_collection()
+    )
+    if ledger is None:
+        raise GmailOutboundDeliveryLedgerUnavailable(
+            "Outbound Gmail delivery ledger is unavailable"
+        )
+    document = ledger.find_one({"_id": fingerprint})
+    if not isinstance(document, Mapping):
+        document = ledger.find_one({"delivery_fingerprint": fingerprint})
+    return _project(document) if isinstance(document, Mapping) else None
+
+
+__all__ = [
+    "DELIVERY_LEDGER_SCHEMA_VERSION",
+    "GmailOutboundDeliveryClaim",
+    "GmailOutboundDeliveryConflict",
+    "GmailOutboundDeliveryLedgerUnavailable",
+    "claim_gmail_outbound_delivery",
+    "get_gmail_outbound_delivery",
+    "record_gmail_outbound_delivery_result",
+]

--- a/src/backend/services/gmail_outbound_mailbox_identity_service.py
+++ b/src/backend/services/gmail_outbound_mailbox_identity_service.py
@@ -1,0 +1,80 @@
+"""Privacy-preserving identity for one canonical Gmail mailbox.
+
+Gmail runtime profile names and represented profile resources are authority and
+audit aliases, not durable mailbox identity.  This module converts the primary
+address returned by Gmail ``users.getProfile`` into an opaque, stable key.  The
+raw address must remain transient at the integration boundary and must never be
+written to the outbound delivery or quota collections.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from email.utils import getaddresses
+from typing import Any
+
+GMAIL_CANONICAL_MAILBOX_KEY_SCHEMA_VERSION = "gmail_canonical_mailbox_key.v1"
+GMAIL_CANONICAL_MAILBOX_KEY_PREFIX = "gmail-mailbox-sha256:"
+_GMAIL_CANONICAL_MAILBOX_KEY_PATTERN = re.compile(
+    rf"^{re.escape(GMAIL_CANONICAL_MAILBOX_KEY_PREFIX)}[0-9a-f]{{64}}$"
+)
+
+
+def normalise_canonical_gmail_address(value: Any) -> str:
+    """Validate and normalise Gmail's primary-address response in memory only."""
+
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("Gmail profile did not expose its canonical sender")
+    parsed = [
+        address.strip().casefold()
+        for _display_name, address in getaddresses([value.strip()])
+        if address.strip()
+    ]
+    if len(parsed) != 1:
+        raise ValueError("Gmail profile exposed an invalid canonical sender")
+    address = parsed[0]
+    local_part, separator, domain = address.rpartition("@")
+    if (
+        separator != "@"
+        or not local_part
+        or not domain
+        or any(character.isspace() for character in address)
+    ):
+        raise ValueError("Gmail profile exposed an invalid canonical sender")
+    return address
+
+
+def derive_canonical_gmail_mailbox_key(value: Any) -> str:
+    """Derive an opaque deterministic key from Gmail's canonical address."""
+
+    canonical_address = normalise_canonical_gmail_address(value)
+    encoded = json.dumps(
+        {
+            "schema_version": GMAIL_CANONICAL_MAILBOX_KEY_SCHEMA_VERSION,
+            "canonical_address": canonical_address,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return GMAIL_CANONICAL_MAILBOX_KEY_PREFIX + hashlib.sha256(encoded).hexdigest()
+
+
+def require_canonical_gmail_mailbox_key(value: Any) -> str:
+    """Accept only keys produced by :func:`derive_canonical_gmail_mailbox_key`."""
+
+    cleaned = str(value or "").strip()
+    if not _GMAIL_CANONICAL_MAILBOX_KEY_PATTERN.fullmatch(cleaned):
+        raise ValueError("canonical_mailbox_key must be an opaque Gmail mailbox key")
+    return cleaned
+
+
+__all__ = [
+    "GMAIL_CANONICAL_MAILBOX_KEY_PREFIX",
+    "GMAIL_CANONICAL_MAILBOX_KEY_SCHEMA_VERSION",
+    "derive_canonical_gmail_mailbox_key",
+    "normalise_canonical_gmail_address",
+    "require_canonical_gmail_mailbox_key",
+]

--- a/src/backend/services/gmail_outbound_rate_limit_service.py
+++ b/src/backend/services/gmail_outbound_rate_limit_service.py
@@ -1,0 +1,536 @@
+"""Durable, mailbox-wide outbound Gmail rate limiting.
+
+The limiter uses one Mongo document per canonical Gmail mailbox key and UTC day.
+Daily message and recipient-delivery counters, plus every fixed ten-minute
+message bucket for that day, are incremented in one ``find_one_and_update``.
+Consequently concurrent workers cannot independently pass one limit while
+overshooting another.  The settings and UI are control surfaces only: every
+send path must reserve here immediately before dispatching to Gmail.
+
+The caller supplies the already-claimed delivery fingerprint as
+``reservation_id``.  Its SHA-256 key is added to the same daily document in the
+atomic counter update, so concurrent retries within that UTC day consume one
+quota slot.  The list is bounded by the maximum 1,000 messages/day setting.
+Cross-day/global duplicate suppression remains the responsibility of the
+unique ``gmail_outbound_deliveries`` ledger, which callers must claim first;
+duplicate non-claimants must not call this quota service or dispatch Gmail.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from pymongo import ReturnDocument
+from pymongo.errors import DuplicateKeyError
+
+from ..db.mongo_client import get_gmail_outbound_quota_collection
+from ..utils.time_utils import utc_now
+from .gmail_outbound_mailbox_identity_service import (
+    require_canonical_gmail_mailbox_key,
+)
+from .settings_service import (
+    GmailOutboundRateLimitSettings,
+    get_gmail_outbound_rate_limit_settings,
+)
+
+logger = logging.getLogger(__name__)
+
+GMAIL_OUTBOUND_RATE_LIMIT_WINDOW_SECONDS = 10 * 60
+GMAIL_OUTBOUND_RATE_LIMIT_RETENTION_DAYS = 2
+_DEFAULT_COLLECTION = object()
+
+
+@dataclass(frozen=True)
+class GmailOutboundQuotaDecision:
+    """Structured result of an outbound quota reservation attempt."""
+
+    allowed: bool
+    code: str
+    message: str
+    policy: GmailOutboundRateLimitSettings
+    usage: Mapping[str, int]
+    exhausted_limits: tuple[str, ...] = ()
+    retry_at: datetime | None = None
+    reservation_id: str | None = None
+    mailbox_key_digest: str | None = None
+    daily_window_start: datetime | None = None
+    daily_window_end: datetime | None = None
+    short_window_start: datetime | None = None
+    short_window_end: datetime | None = None
+
+    @property
+    def retry_after_seconds(self) -> int | None:
+        if self.retry_at is None:
+            return None
+        return max(1, math.ceil((self.retry_at - utc_now()).total_seconds()))
+
+    def as_dict(self, *, now: datetime | None = None) -> dict[str, Any]:
+        """Return a JSON-safe, body- and recipient-free decision receipt."""
+
+        reference_now = _normalise_utc_datetime(now or utc_now())
+        retry_after_seconds = None
+        if self.retry_at is not None:
+            retry_after_seconds = max(
+                1,
+                math.ceil((self.retry_at - reference_now).total_seconds()),
+            )
+        return {
+            "schema_version": "gmail_outbound_quota_decision.v1",
+            "allowed": self.allowed,
+            "code": self.code,
+            "message": self.message,
+            "policy": self.policy.as_dict(),
+            "usage": dict(self.usage),
+            "exhausted_limits": list(self.exhausted_limits),
+            "retry_at": _isoformat_z(self.retry_at),
+            "retry_after_seconds": retry_after_seconds,
+            "reservation_id": self.reservation_id,
+            "mailbox_key_digest": self.mailbox_key_digest,
+            "windows": {
+                "daily_start": _isoformat_z(self.daily_window_start),
+                "daily_end": _isoformat_z(self.daily_window_end),
+                "ten_minute_start": _isoformat_z(self.short_window_start),
+                "ten_minute_end": _isoformat_z(self.short_window_end),
+            },
+        }
+
+
+def _normalise_utc_datetime(value: datetime) -> datetime:
+    if not isinstance(value, datetime):
+        raise TypeError("now must be a datetime")
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _isoformat_z(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return _normalise_utc_datetime(value).isoformat().replace("+00:00", "Z")
+
+
+def _window_bounds(now: datetime) -> tuple[datetime, datetime, datetime, datetime]:
+    day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    day_end = day_start + timedelta(days=1)
+    short_start = now.replace(
+        minute=(now.minute // 10) * 10,
+        second=0,
+        microsecond=0,
+    )
+    short_end = short_start + timedelta(
+        seconds=GMAIL_OUTBOUND_RATE_LIMIT_WINDOW_SECONDS
+    )
+    return day_start, day_end, short_start, short_end
+
+
+def _safe_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _nested_int(document: Mapping[str, Any], path: str) -> int:
+    current: Any = document
+    for segment in path.split("."):
+        if not isinstance(current, Mapping):
+            return 0
+        current = current.get(segment)
+    return _safe_int(current)
+
+
+def _usage_from_document(
+    document: Mapping[str, Any] | None,
+    *,
+    short_bucket_field: str,
+) -> dict[str, int]:
+    payload = document or {}
+    return {
+        "messages_in_10_minute_window": _nested_int(
+            payload,
+            f"ten_minute_buckets.{short_bucket_field}",
+        ),
+        "messages_in_day": _safe_int(payload.get("messages_in_day")),
+        "recipient_deliveries_in_day": _safe_int(
+            payload.get("recipient_deliveries_in_day")
+        ),
+    }
+
+
+def _mailbox_key(value: Any) -> tuple[str, str]:
+    canonical = require_canonical_gmail_mailbox_key(value)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return canonical, digest
+
+
+def _reservation_key(value: Any) -> tuple[str, str]:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("reservation_id is required")
+    reservation_id = value.strip()
+    if len(reservation_id) > 512:
+        raise ValueError("reservation_id is too long")
+    return reservation_id, hashlib.sha256(reservation_id.encode("utf-8")).hexdigest()
+
+
+def _quota_filter(
+    *,
+    document_id: str,
+    short_bucket_path: str,
+    policy: GmailOutboundRateLimitSettings,
+    recipient_count: int,
+    reservation_key: str,
+) -> dict[str, Any]:
+    return {
+        "_id": document_id,
+        "$and": [
+            {"reservation_keys": {"$ne": reservation_key}},
+            {
+                "$or": [
+                    {"messages_in_day": {"$exists": False}},
+                    {"messages_in_day": {"$lte": policy.max_messages_per_day - 1}},
+                ]
+            },
+            {
+                "$or": [
+                    {"recipient_deliveries_in_day": {"$exists": False}},
+                    {
+                        "recipient_deliveries_in_day": {
+                            "$lte": (
+                                policy.max_recipient_deliveries_per_day
+                                - recipient_count
+                            )
+                        }
+                    },
+                ]
+            },
+            {
+                "$or": [
+                    {short_bucket_path: {"$exists": False}},
+                    {
+                        short_bucket_path: {
+                            "$lte": policy.max_messages_per_10_minutes - 1
+                        }
+                    },
+                ]
+            },
+        ],
+    }
+
+
+def _quota_update(
+    *,
+    canonical_mailbox_key: str,
+    mailbox_key_digest: str,
+    day_start: datetime,
+    day_end: datetime,
+    short_start: datetime,
+    short_bucket_path: str,
+    recipient_count: int,
+    reservation_key: str,
+    now: datetime,
+) -> dict[str, Any]:
+    return {
+        "$setOnInsert": {
+            "canonical_mailbox_key": canonical_mailbox_key,
+            "mailbox_key_digest": mailbox_key_digest,
+            "daily_window_start": day_start,
+            "daily_window_end": day_end,
+            "created_at": now,
+        },
+        "$set": {
+            "updated_at": now,
+            "expires_at": day_end
+            + timedelta(days=GMAIL_OUTBOUND_RATE_LIMIT_RETENTION_DAYS),
+            f"ten_minute_window_starts.{short_bucket_path.rsplit('.', 1)[-1]}": (
+                short_start
+            ),
+        },
+        "$inc": {
+            "messages_in_day": 1,
+            "recipient_deliveries_in_day": recipient_count,
+            short_bucket_path: 1,
+        },
+        "$addToSet": {"reservation_keys": reservation_key},
+    }
+
+
+def _rate_limit_decision(
+    *,
+    policy: GmailOutboundRateLimitSettings,
+    document: Mapping[str, Any] | None,
+    recipient_count: int,
+    reservation_id: str,
+    reservation_key: str,
+    mailbox_key_digest: str,
+    short_bucket_field: str,
+    day_start: datetime,
+    day_end: datetime,
+    short_start: datetime,
+    short_end: datetime,
+) -> GmailOutboundQuotaDecision:
+    usage = _usage_from_document(
+        document,
+        short_bucket_field=short_bucket_field,
+    )
+    existing_reservations = (
+        document.get("reservation_keys") if isinstance(document, Mapping) else None
+    )
+    if isinstance(existing_reservations, list) and reservation_key in (
+        str(item) for item in existing_reservations
+    ):
+        return GmailOutboundQuotaDecision(
+            allowed=True,
+            code="gmail_outbound_quota_already_reserved",
+            message="Outbound Gmail quota was already reserved for this delivery.",
+            policy=policy,
+            usage=usage,
+            reservation_id=reservation_id,
+            mailbox_key_digest=mailbox_key_digest,
+            daily_window_start=day_start,
+            daily_window_end=day_end,
+            short_window_start=short_start,
+            short_window_end=short_end,
+        )
+    exhausted: list[str] = []
+    retry_candidates: list[datetime] = []
+    if usage["messages_in_10_minute_window"] + 1 > (policy.max_messages_per_10_minutes):
+        exhausted.append("messages_per_10_minutes")
+        retry_candidates.append(short_end)
+    if usage["messages_in_day"] + 1 > policy.max_messages_per_day:
+        exhausted.append("messages_per_day")
+        retry_candidates.append(day_end)
+    if usage["recipient_deliveries_in_day"] + recipient_count > (
+        policy.max_recipient_deliveries_per_day
+    ):
+        exhausted.append("recipient_deliveries_per_day")
+        retry_candidates.append(day_end)
+
+    if not exhausted:
+        return GmailOutboundQuotaDecision(
+            allowed=False,
+            code="gmail_outbound_quota_store_unavailable",
+            message=(
+                "Outbound email was not sent because the durable quota reservation "
+                "could not be confirmed."
+            ),
+            policy=policy,
+            usage=usage,
+            mailbox_key_digest=mailbox_key_digest,
+            daily_window_start=day_start,
+            daily_window_end=day_end,
+            short_window_start=short_start,
+            short_window_end=short_end,
+        )
+
+    retry_at = max(retry_candidates)
+    return GmailOutboundQuotaDecision(
+        allowed=False,
+        code="gmail_outbound_rate_limit_exceeded",
+        message="Outbound email was not sent because its mailbox quota is exhausted.",
+        policy=policy,
+        usage=usage,
+        exhausted_limits=tuple(exhausted),
+        retry_at=retry_at,
+        mailbox_key_digest=mailbox_key_digest,
+        daily_window_start=day_start,
+        daily_window_end=day_end,
+        short_window_start=short_start,
+        short_window_end=short_end,
+    )
+
+
+def reserve_gmail_outbound_quota(
+    *,
+    canonical_mailbox_key: str,
+    reservation_id: str,
+    recipient_count: int,
+    settings: GmailOutboundRateLimitSettings | None = None,
+    collection: Any = _DEFAULT_COLLECTION,
+    now: datetime | None = None,
+) -> GmailOutboundQuotaDecision:
+    """Atomically reserve one message and all recipient deliveries.
+
+    ``canonical_mailbox_key`` must be the privacy-preserving stable key derived
+    from Gmail ``users.getProfile`` by the trusted send boundary. It must not
+    come from model output, an unverified client alias, or a represented profile
+    resource id. ``recipient_count`` must include To,
+    Cc and Bcc deliveries after address normalisation.  ``reservation_id`` is
+    the delivery-ledger fingerprint already claimed by this caller; repeats in
+    the same UTC-day document return ``gmail_outbound_quota_already_reserved``
+    without changing either counter.
+
+    Expected policy denials and persistence failures return structured denied
+    decisions.  Invalid programmer inputs raise ``ValueError`` before storage.
+    """
+
+    canonical_mailbox_key, mailbox_key_digest = _mailbox_key(
+        canonical_mailbox_key
+    )
+    reservation_id, reservation_key = _reservation_key(reservation_id)
+    if isinstance(recipient_count, bool) or not isinstance(recipient_count, int):
+        raise TypeError("recipient_count must be an integer")
+    if recipient_count < 1:
+        raise ValueError("recipient_count must be at least 1")
+
+    policy = settings or get_gmail_outbound_rate_limit_settings()
+    if not isinstance(policy, GmailOutboundRateLimitSettings):
+        raise TypeError("settings must be GmailOutboundRateLimitSettings")
+
+    effective_now = _normalise_utc_datetime(now or utc_now())
+    day_start, day_end, short_start, short_end = _window_bounds(effective_now)
+    short_bucket_field = "b" + short_start.strftime("%Y%m%dT%H%MZ")
+    short_bucket_path = f"ten_minute_buckets.{short_bucket_field}"
+    usage = {
+        "messages_in_10_minute_window": 0,
+        "messages_in_day": 0,
+        "recipient_deliveries_in_day": 0,
+    }
+
+    common_decision_fields = {
+        "policy": policy,
+        "usage": usage,
+        "mailbox_key_digest": mailbox_key_digest,
+        "daily_window_start": day_start,
+        "daily_window_end": day_end,
+        "short_window_start": short_start,
+        "short_window_end": short_end,
+    }
+    if not policy.enabled:
+        return GmailOutboundQuotaDecision(
+            allowed=False,
+            code="gmail_outbound_disabled",
+            message="Outbound email is disabled by the administrator setting.",
+            **common_decision_fields,
+        )
+    if recipient_count > policy.max_recipients_per_message:
+        return GmailOutboundQuotaDecision(
+            allowed=False,
+            code="gmail_outbound_recipient_limit_exceeded",
+            message=(
+                "Outbound email was not sent because the message has more "
+                "recipients than the configured per-message limit."
+            ),
+            exhausted_limits=("recipients_per_message",),
+            **common_decision_fields,
+        )
+
+    quota_collection = (
+        get_gmail_outbound_quota_collection()
+        if collection is _DEFAULT_COLLECTION
+        else collection
+    )
+    if quota_collection is None:
+        return GmailOutboundQuotaDecision(
+            allowed=False,
+            code="gmail_outbound_quota_store_unavailable",
+            message=(
+                "Outbound email was not sent because the durable quota store is "
+                "unavailable."
+            ),
+            **common_decision_fields,
+        )
+
+    document_id = (
+        f"gmail-outbound:{mailbox_key_digest}:{day_start.strftime('%Y-%m-%d')}"
+    )
+    query = _quota_filter(
+        document_id=document_id,
+        short_bucket_path=short_bucket_path,
+        policy=policy,
+        recipient_count=recipient_count,
+        reservation_key=reservation_key,
+    )
+    update = _quota_update(
+        canonical_mailbox_key=canonical_mailbox_key,
+        mailbox_key_digest=mailbox_key_digest,
+        day_start=day_start,
+        day_end=day_end,
+        short_start=short_start,
+        short_bucket_path=short_bucket_path,
+        recipient_count=recipient_count,
+        reservation_key=reservation_key,
+        now=effective_now,
+    )
+
+    try:
+        try:
+            document = quota_collection.find_one_and_update(
+                query,
+                update,
+                upsert=True,
+                return_document=ReturnDocument.AFTER,
+            )
+        except DuplicateKeyError:
+            # Two first reservations can race to upsert the daily document.  A
+            # non-upserting retry still applies the same atomic limit filter.
+            # It also turns the duplicate-key signal used by a capped existing
+            # document into a normal no-match decision.
+            document = quota_collection.find_one_and_update(
+                query,
+                update,
+                upsert=False,
+                return_document=ReturnDocument.AFTER,
+            )
+        if document is None:
+            current_document = quota_collection.find_one({"_id": document_id})
+            return _rate_limit_decision(
+                policy=policy,
+                document=current_document,
+                recipient_count=recipient_count,
+                reservation_id=reservation_id,
+                reservation_key=reservation_key,
+                mailbox_key_digest=mailbox_key_digest,
+                short_bucket_field=short_bucket_field,
+                day_start=day_start,
+                day_end=day_end,
+                short_start=short_start,
+                short_end=short_end,
+            )
+    except Exception as exc:  # noqa: BLE001 - fail closed before Gmail dispatch
+        logger.error(
+            "Outbound Gmail quota reservation failed for profile digest %s: %s",
+            mailbox_key_digest[:12],
+            type(exc).__name__,
+        )
+        return GmailOutboundQuotaDecision(
+            allowed=False,
+            code="gmail_outbound_quota_store_unavailable",
+            message=(
+                "Outbound email was not sent because the durable quota reservation "
+                "failed."
+            ),
+            **common_decision_fields,
+        )
+
+    post_usage = _usage_from_document(
+        document,
+        short_bucket_field=short_bucket_field,
+    )
+    return GmailOutboundQuotaDecision(
+        allowed=True,
+        code="gmail_outbound_quota_reserved",
+        message="Outbound Gmail quota reserved.",
+        policy=policy,
+        usage=post_usage,
+        reservation_id=reservation_id,
+        mailbox_key_digest=mailbox_key_digest,
+        daily_window_start=day_start,
+        daily_window_end=day_end,
+        short_window_start=short_start,
+        short_window_end=short_end,
+    )
+
+
+__all__ = [
+    "GMAIL_OUTBOUND_RATE_LIMIT_WINDOW_SECONDS",
+    "GmailOutboundQuotaDecision",
+    "reserve_gmail_outbound_quota",
+]

--- a/src/backend/services/mail_profile_resource_vontology_service.py
+++ b/src/backend/services/mail_profile_resource_vontology_service.py
@@ -204,6 +204,35 @@ def gmail_profile_alias_concept_id(profile_id: str) -> str:
     return f"#V#gmail_runtime_profile_alias_{normalise_profile_id_for_concept_id(profile_id)}"
 
 
+def mail_profile_resource_represents_identity(
+    *,
+    profile_resource_concept_id: str,
+    identity_concept_id: str,
+) -> bool:
+    """Return whether one represented mail profile denotes ``identity_concept_id``.
+
+    Runtime aliases and actor-to-profile authority do not establish mailbox
+    identity.  Callers that depend on that meaning must read the dedicated
+    relation from the canonical profile resource and fail closed when the
+    resource or relation is unavailable.
+    """
+
+    resource_id = str(profile_resource_concept_id or "").strip()
+    identity_id = str(identity_concept_id or "").strip()
+    if not resource_id.startswith("#V#") or not identity_id.startswith("#V#"):
+        return False
+
+    resource_doc = load_concept(resource_id)
+    if not isinstance(resource_doc, Mapping):
+        return False
+    relationships = resource_doc.get("relationships")
+    relation_map = relationships if isinstance(relationships, Mapping) else {}
+    represented_identity_ids = normalise_relationship_targets(
+        relation_map.get(MAIL_PROFILE_REPRESENTS_IDENTITY_PREDICATE_ID)
+    )
+    return identity_id in represented_identity_ids
+
+
 def list_authorised_gmail_profiles_for_user(
     *,
     user_concept_id: str,
@@ -703,6 +732,7 @@ __all__ = [
     "gmail_profile_alias_concept_id",
     "gmail_profile_resource_concept_id",
     "list_authorised_gmail_profiles_for_user",
+    "mail_profile_resource_represents_identity",
     "materialise_gmail_profile_resources_for_user",
     "normalise_profile_id_for_concept_id",
     "resolve_authorised_gmail_profile_for_user",

--- a/src/backend/services/settings_service.py
+++ b/src/backend/services/settings_service.py
@@ -2,6 +2,7 @@ import logging
 import json
 import os
 import time
+from dataclasses import dataclass
 from typing import Any, Callable, Optional, Dict, List, Mapping, Sequence
 from pymongo.results import UpdateResult
 from pymongo.errors import DuplicateKeyError, OperationFailure
@@ -214,6 +215,60 @@ INTERNAL_MCP_MAX_TOOL_INVOCATIONS_MAX = 500
 INTERNAL_MCP_TOOL_BATCH_CAP_DEFAULT = 10
 INTERNAL_MCP_TOOL_BATCH_CAP_MIN = 1
 INTERNAL_MCP_TOOL_BATCH_CAP_MAX = 20
+
+# Admin-governed outbound Gmail limits.  These limits are enforced again at
+# the canonical Gmail dispatch boundary; the Settings UI is only a control
+# surface and is not itself a security boundary.
+GMAIL_OUTBOUND_RATE_LIMITS_SETTING_NAME = "gmail_outbound_rate_limits"
+GMAIL_OUTBOUND_RATE_LIMITS_SCHEMA_VERSION = "gmail_outbound_rate_limits.v1"
+GMAIL_OUTBOUND_ENABLED_DEFAULT = False
+GMAIL_OUTBOUND_MAX_MESSAGES_PER_10_MINUTES_DEFAULT = 5
+GMAIL_OUTBOUND_MAX_MESSAGES_PER_DAY_DEFAULT = 25
+GMAIL_OUTBOUND_MAX_RECIPIENTS_PER_MESSAGE_DEFAULT = 10
+GMAIL_OUTBOUND_MAX_RECIPIENT_DELIVERIES_PER_DAY_DEFAULT = 50
+GMAIL_OUTBOUND_MAX_MESSAGES_PER_10_MINUTES_MIN = 1
+GMAIL_OUTBOUND_MAX_MESSAGES_PER_10_MINUTES_MAX = 100
+GMAIL_OUTBOUND_MAX_MESSAGES_PER_DAY_MIN = 1
+GMAIL_OUTBOUND_MAX_MESSAGES_PER_DAY_MAX = 1_000
+GMAIL_OUTBOUND_MAX_RECIPIENTS_PER_MESSAGE_MIN = 1
+GMAIL_OUTBOUND_MAX_RECIPIENTS_PER_MESSAGE_MAX = 100
+GMAIL_OUTBOUND_MAX_RECIPIENT_DELIVERIES_PER_DAY_MIN = 1
+GMAIL_OUTBOUND_MAX_RECIPIENT_DELIVERIES_PER_DAY_MAX = 5_000
+
+
+@dataclass(frozen=True)
+class GmailOutboundRateLimitSettings:
+    """Typed, application-wide policy for agent Gmail dispatch.
+
+    ``enabled`` defaults to false so adding a configured OAuth profile does not
+    silently release a new external-effect capability.  The remaining defaults
+    are deliberately useful but conservative for a research-team mailbox.
+    """
+
+    enabled: bool = GMAIL_OUTBOUND_ENABLED_DEFAULT
+    max_messages_per_10_minutes: int = (
+        GMAIL_OUTBOUND_MAX_MESSAGES_PER_10_MINUTES_DEFAULT
+    )
+    max_messages_per_day: int = GMAIL_OUTBOUND_MAX_MESSAGES_PER_DAY_DEFAULT
+    max_recipients_per_message: int = (
+        GMAIL_OUTBOUND_MAX_RECIPIENTS_PER_MESSAGE_DEFAULT
+    )
+    max_recipient_deliveries_per_day: int = (
+        GMAIL_OUTBOUND_MAX_RECIPIENT_DELIVERIES_PER_DAY_DEFAULT
+    )
+    schema_version: str = GMAIL_OUTBOUND_RATE_LIMITS_SCHEMA_VERSION
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "enabled": self.enabled,
+            "max_messages_per_10_minutes": self.max_messages_per_10_minutes,
+            "max_messages_per_day": self.max_messages_per_day,
+            "max_recipients_per_message": self.max_recipients_per_message,
+            "max_recipient_deliveries_per_day": (
+                self.max_recipient_deliveries_per_day
+            ),
+        }
 
 # Chat UI: show tool use during the “Thinking…” indicator (JVNAUTOSCI-942)
 SHOW_TOOL_USE_DURING_THINKING_SETTING_NAME = "show_tool_use_during_thinking"
@@ -497,6 +552,7 @@ def get_all_settings_batch() -> Dict[str, Any]:
         AUTO_PROCEED_MINIMAL_IMPOSITION_ENABLED_SETTING_NAME,
         INTERNAL_MCP_MAX_TOOL_INVOCATIONS_SETTING_NAME,
         INTERNAL_MCP_TOOL_BATCH_CAP_SETTING_NAME,
+        GMAIL_OUTBOUND_RATE_LIMITS_SETTING_NAME,
         DISABLE_WRITE_TOOL_CONSERVATISM_SETTING_NAME,
         REQUIRE_HUMAN_REVIEW_FOR_HIGH_IMPACT_KB_WRITES_SETTING_NAME,
         MODEL_LLM_TIMEOUT_OVERRIDES_SETTING_NAME,
@@ -549,6 +605,11 @@ def get_all_settings_batch() -> Dict[str, Any]:
             default=INTERNAL_MCP_TOOL_BATCH_CAP_DEFAULT,
             min_value=INTERNAL_MCP_TOOL_BATCH_CAP_MIN,
             max_value=INTERNAL_MCP_TOOL_BATCH_CAP_MAX,
+        ),
+        "gmail_outbound_rate_limits": (
+            normalise_gmail_outbound_rate_limit_settings(
+                raw.get(GMAIL_OUTBOUND_RATE_LIMITS_SETTING_NAME)
+            ).as_dict()
         ),
         "disable_write_tool_conservatism": _coerce_bool(
             raw.get(DISABLE_WRITE_TOOL_CONSERVATISM_SETTING_NAME), default=False
@@ -2181,6 +2242,178 @@ def _coerce_int_setting(
         return default
 
     return max(min_value, min(max_value, parsed))
+
+
+_GMAIL_OUTBOUND_RATE_LIMIT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "enabled",
+        "max_messages_per_10_minutes",
+        "max_messages_per_day",
+        "max_recipients_per_message",
+        "max_recipient_deliveries_per_day",
+    }
+)
+
+
+def normalise_gmail_outbound_rate_limit_settings(
+    value: Any,
+) -> GmailOutboundRateLimitSettings:
+    """Return a safe policy for stored or otherwise untrusted setting data.
+
+    Invalid values fall back to conservative defaults and numeric values are
+    clamped.  Settings writes use the stricter parser below so an administrator
+    sees a typo instead of silently persisting a different policy.
+    """
+
+    raw = value if isinstance(value, Mapping) else {}
+    max_deliveries = _coerce_int_setting(
+        raw.get("max_recipient_deliveries_per_day"),
+        default=GMAIL_OUTBOUND_MAX_RECIPIENT_DELIVERIES_PER_DAY_DEFAULT,
+        min_value=GMAIL_OUTBOUND_MAX_RECIPIENT_DELIVERIES_PER_DAY_MIN,
+        max_value=GMAIL_OUTBOUND_MAX_RECIPIENT_DELIVERIES_PER_DAY_MAX,
+    )
+    max_recipients = _coerce_int_setting(
+        raw.get("max_recipients_per_message"),
+        default=GMAIL_OUTBOUND_MAX_RECIPIENTS_PER_MESSAGE_DEFAULT,
+        min_value=GMAIL_OUTBOUND_MAX_RECIPIENTS_PER_MESSAGE_MIN,
+        max_value=GMAIL_OUTBOUND_MAX_RECIPIENTS_PER_MESSAGE_MAX,
+    )
+    return GmailOutboundRateLimitSettings(
+        enabled=_coerce_bool(
+            raw.get("enabled"),
+            default=GMAIL_OUTBOUND_ENABLED_DEFAULT,
+        ),
+        max_messages_per_10_minutes=_coerce_int_setting(
+            raw.get("max_messages_per_10_minutes"),
+            default=GMAIL_OUTBOUND_MAX_MESSAGES_PER_10_MINUTES_DEFAULT,
+            min_value=GMAIL_OUTBOUND_MAX_MESSAGES_PER_10_MINUTES_MIN,
+            max_value=GMAIL_OUTBOUND_MAX_MESSAGES_PER_10_MINUTES_MAX,
+        ),
+        max_messages_per_day=_coerce_int_setting(
+            raw.get("max_messages_per_day"),
+            default=GMAIL_OUTBOUND_MAX_MESSAGES_PER_DAY_DEFAULT,
+            min_value=GMAIL_OUTBOUND_MAX_MESSAGES_PER_DAY_MIN,
+            max_value=GMAIL_OUTBOUND_MAX_MESSAGES_PER_DAY_MAX,
+        ),
+        max_recipients_per_message=min(max_recipients, max_deliveries),
+        max_recipient_deliveries_per_day=max_deliveries,
+    )
+
+
+def parse_gmail_outbound_rate_limit_settings(
+    value: Any,
+    *,
+    current: GmailOutboundRateLimitSettings | None = None,
+) -> GmailOutboundRateLimitSettings:
+    """Strictly validate an admin-supplied outbound Gmail policy payload.
+
+    Partial objects are supported and inherit omitted values from ``current``.
+    The schema version is server-owned and may only be supplied with its exact
+    current value.
+    """
+
+    if not isinstance(value, Mapping):
+        raise ValueError("gmail_outbound_rate_limits must be an object")
+    unknown_fields = sorted(set(value) - _GMAIL_OUTBOUND_RATE_LIMIT_FIELDS)
+    if unknown_fields:
+        raise ValueError(
+            "gmail_outbound_rate_limits contains unknown field(s): "
+            + ", ".join(str(field) for field in unknown_fields)
+        )
+    supplied_schema = value.get("schema_version")
+    if supplied_schema is not None and supplied_schema != (
+        GMAIL_OUTBOUND_RATE_LIMITS_SCHEMA_VERSION
+    ):
+        raise ValueError(
+            "gmail_outbound_rate_limits.schema_version must be "
+            f"{GMAIL_OUTBOUND_RATE_LIMITS_SCHEMA_VERSION!r}"
+        )
+
+    base = current or GmailOutboundRateLimitSettings()
+    enabled = value.get("enabled", base.enabled)
+    if not isinstance(enabled, bool):
+        raise ValueError("gmail_outbound_rate_limits.enabled must be a boolean")
+
+    def _bounded_int(
+        field_name: str,
+        default: int,
+        minimum: int,
+        maximum: int,
+    ) -> int:
+        raw_value = value.get(field_name, default)
+        if isinstance(raw_value, bool) or not isinstance(raw_value, int):
+            raise ValueError(
+                f"gmail_outbound_rate_limits.{field_name} must be an integer"
+            )
+        if raw_value < minimum or raw_value > maximum:
+            raise ValueError(
+                f"gmail_outbound_rate_limits.{field_name} must be between "
+                f"{minimum} and {maximum}"
+            )
+        return raw_value
+
+    max_messages_per_10_minutes = _bounded_int(
+        "max_messages_per_10_minutes",
+        base.max_messages_per_10_minutes,
+        GMAIL_OUTBOUND_MAX_MESSAGES_PER_10_MINUTES_MIN,
+        GMAIL_OUTBOUND_MAX_MESSAGES_PER_10_MINUTES_MAX,
+    )
+    max_messages_per_day = _bounded_int(
+        "max_messages_per_day",
+        base.max_messages_per_day,
+        GMAIL_OUTBOUND_MAX_MESSAGES_PER_DAY_MIN,
+        GMAIL_OUTBOUND_MAX_MESSAGES_PER_DAY_MAX,
+    )
+    max_recipients_per_message = _bounded_int(
+        "max_recipients_per_message",
+        base.max_recipients_per_message,
+        GMAIL_OUTBOUND_MAX_RECIPIENTS_PER_MESSAGE_MIN,
+        GMAIL_OUTBOUND_MAX_RECIPIENTS_PER_MESSAGE_MAX,
+    )
+    max_recipient_deliveries_per_day = _bounded_int(
+        "max_recipient_deliveries_per_day",
+        base.max_recipient_deliveries_per_day,
+        GMAIL_OUTBOUND_MAX_RECIPIENT_DELIVERIES_PER_DAY_MIN,
+        GMAIL_OUTBOUND_MAX_RECIPIENT_DELIVERIES_PER_DAY_MAX,
+    )
+    if max_recipients_per_message > max_recipient_deliveries_per_day:
+        raise ValueError(
+            "gmail_outbound_rate_limits.max_recipients_per_message cannot exceed "
+            "max_recipient_deliveries_per_day"
+        )
+
+    return GmailOutboundRateLimitSettings(
+        enabled=enabled,
+        max_messages_per_10_minutes=max_messages_per_10_minutes,
+        max_messages_per_day=max_messages_per_day,
+        max_recipients_per_message=max_recipients_per_message,
+        max_recipient_deliveries_per_day=max_recipient_deliveries_per_day,
+    )
+
+
+def get_gmail_outbound_rate_limit_settings() -> GmailOutboundRateLimitSettings:
+    """Return the effective application-wide outbound Gmail policy."""
+
+    return normalise_gmail_outbound_rate_limit_settings(
+        get_setting(GMAIL_OUTBOUND_RATE_LIMITS_SETTING_NAME)
+    )
+
+
+def set_gmail_outbound_rate_limit_settings(
+    value: GmailOutboundRateLimitSettings | Mapping[str, Any],
+) -> bool:
+    """Persist a validated canonical outbound Gmail policy."""
+
+    settings = (
+        value
+        if isinstance(value, GmailOutboundRateLimitSettings)
+        else parse_gmail_outbound_rate_limit_settings(value)
+    )
+    return update_setting(
+        GMAIL_OUTBOUND_RATE_LIMITS_SETTING_NAME,
+        settings.as_dict(),
+    )
 
 
 def get_internal_mcp_max_tool_invocations() -> int:

--- a/src/frontend/web/von_interface/static/js/settingsPage.js
+++ b/src/frontend/web/von_interface/static/js/settingsPage.js
@@ -112,6 +112,15 @@ const INTERNAL_MCP_MAX_TOOL_INVOCATIONS_MAX = 500;
 const INTERNAL_MCP_TOOL_BATCH_CAP_DEFAULT = 10;
 const INTERNAL_MCP_TOOL_BATCH_CAP_MIN = 1;
 const INTERNAL_MCP_TOOL_BATCH_CAP_MAX = 20;
+const GMAIL_OUTBOUND_RATE_LIMITS_SCHEMA_VERSION = 'gmail_outbound_rate_limits.v1';
+const GMAIL_OUTBOUND_RATE_LIMIT_DEFAULTS = Object.freeze({
+  schema_version: GMAIL_OUTBOUND_RATE_LIMITS_SCHEMA_VERSION,
+  enabled: false,
+  max_messages_per_10_minutes: 5,
+  max_messages_per_day: 25,
+  max_recipients_per_message: 10,
+  max_recipient_deliveries_per_day: 50,
+});
 const OPENAI_MODEL_COST_SUMMARY_SCHEMA_VERSION = 'llm_model_turn_cost_summary.v1';
 const OPENAI_MODEL_COST_SUMMARY_ENDPOINT = '/api/settings/llm/cost_summary';
 
@@ -151,6 +160,7 @@ let currentActorOrganisationRole = '';
 
 let __vonIsAdminOrOwner = false;
 let __canPersistWriteConservatism = false;
+let __canPersistGmailOutboundRateLimits = false;
 let availableGmailProfiles = [];
 let gmailProfileAuthorisedEmailByProfile = {};
 
@@ -1514,6 +1524,10 @@ function applySettingsActorRole(role) {
   if (conservatismContainer) {
     conservatismContainer.classList.toggle('hidden', !__vonIsAdminOrOwner);
   }
+  if (!__vonIsAdminOrOwner) {
+    __canPersistGmailOutboundRateLimits = false;
+  }
+  syncGmailOutboundRateLimitWriteAccess();
   applySharedRuntimeModelWriteAccess(__vonIsAdminOrOwner);
   setOllamaHostManagementWritable(__vonIsAdminOrOwner);
   syncModelPoolTargetScopeControls();
@@ -2994,6 +3008,90 @@ function clampNumber(value, minValue, maxValue, fallbackValue) {
   return Math.min(Math.max(num, minValue), maxValue);
 }
 
+
+function normaliseGmailOutboundRateLimitSettings(settings = {}) {
+  const source = settings?.gmail_outbound_rate_limits || settings || {};
+  const integer = (field, minimum, maximum) => Math.trunc(clampNumber(
+    source[field],
+    minimum,
+    maximum,
+    GMAIL_OUTBOUND_RATE_LIMIT_DEFAULTS[field],
+  ));
+  const maxRecipientDeliveries = integer('max_recipient_deliveries_per_day', 1, 5000);
+  return {
+    schema_version: GMAIL_OUTBOUND_RATE_LIMITS_SCHEMA_VERSION,
+    enabled: Object.prototype.hasOwnProperty.call(source, 'enabled')
+      ? !!source.enabled
+      : GMAIL_OUTBOUND_RATE_LIMIT_DEFAULTS.enabled,
+    max_messages_per_10_minutes: integer('max_messages_per_10_minutes', 1, 100),
+    max_messages_per_day: integer('max_messages_per_day', 1, 1000),
+    max_recipients_per_message: Math.min(
+      integer('max_recipients_per_message', 1, 100),
+      maxRecipientDeliveries,
+    ),
+    max_recipient_deliveries_per_day: maxRecipientDeliveries,
+  };
+}
+
+function readGmailOutboundRateLimitSettingsFromForm() {
+  return normaliseGmailOutboundRateLimitSettings({
+    enabled: !!document.getElementById('gmailOutboundEnabled')?.checked,
+    max_messages_per_10_minutes: document.getElementById('gmailOutboundMaxMessagesPer10Minutes')?.value,
+    max_messages_per_day: document.getElementById('gmailOutboundMaxMessagesPerDay')?.value,
+    max_recipients_per_message: document.getElementById('gmailOutboundMaxRecipientsPerMessage')?.value,
+    max_recipient_deliveries_per_day: document.getElementById('gmailOutboundMaxRecipientDeliveriesPerDay')?.value,
+  });
+}
+
+function populateGmailOutboundRateLimitInputs(settings = {}) {
+  const policy = normaliseGmailOutboundRateLimitSettings(settings);
+  const enabled = document.getElementById('gmailOutboundEnabled');
+  const maxTenMinutes = document.getElementById('gmailOutboundMaxMessagesPer10Minutes');
+  const maxDay = document.getElementById('gmailOutboundMaxMessagesPerDay');
+  const maxRecipients = document.getElementById('gmailOutboundMaxRecipientsPerMessage');
+  const maxRecipientDeliveries = document.getElementById('gmailOutboundMaxRecipientDeliveriesPerDay');
+  if (enabled) enabled.checked = policy.enabled;
+  if (maxTenMinutes) maxTenMinutes.value = String(policy.max_messages_per_10_minutes);
+  if (maxDay) maxDay.value = String(policy.max_messages_per_day);
+  if (maxRecipients) maxRecipients.value = String(policy.max_recipients_per_message);
+  if (maxRecipientDeliveries) maxRecipientDeliveries.value = String(policy.max_recipient_deliveries_per_day);
+  const status = document.getElementById('gmailOutboundRateLimitStatus');
+  if (status) {
+    status.textContent = policy.enabled
+      ? `Outbound email enabled: ${policy.max_messages_per_10_minutes}/10 min, ${policy.max_messages_per_day}/day.`
+      : 'Outbound email is disabled.';
+  }
+  return policy;
+}
+
+function syncGmailOutboundRateLimitWriteAccess() {
+  const container = document.getElementById('gmailOutboundRateLimitContainer');
+  if (container) {
+    container.classList.toggle('hidden', !__vonIsAdminOrOwner);
+  }
+  [
+    'gmailOutboundEnabled',
+    'gmailOutboundMaxMessagesPer10Minutes',
+    'gmailOutboundMaxMessagesPerDay',
+    'gmailOutboundMaxRecipientsPerMessage',
+    'gmailOutboundMaxRecipientDeliveriesPerDay',
+    'saveGmailOutboundRateLimitsButton',
+  ].forEach((id) => {
+    const element = document.getElementById(id);
+    if (element) element.disabled = !__canPersistGmailOutboundRateLimits;
+  });
+}
+
+async function persistGmailOutboundRateLimitSettings() {
+  if (!__canPersistGmailOutboundRateLimits) {
+    throw new Error('Admin or owner privileges are required to update outbound email limits.');
+  }
+  populateGmailOutboundRateLimitInputs(readGmailOutboundRateLimitSettingsFromForm());
+  const saved = await saveAllSettings({ includeGmailOutboundRateLimits: true });
+  if (!saved) throw new Error('Settings save did not complete.');
+  showStatusMessage('gmailOutboundRateLimitStatus', 'Outbound email limits saved.', false);
+}
+
 function normaliseInternalMcpCapSettings(settings = {}) {
   const maxInvocationsRaw = Object.prototype.hasOwnProperty.call(settings, 'internal_mcp_max_tool_invocations')
     ? settings.internal_mcp_max_tool_invocations
@@ -4034,6 +4132,18 @@ export function __testOnly_setupInternalMcpCapAutoSave(options = {}) {
   return setupInternalMcpCapAutoSave(options);
 }
 
+export function __testOnly_normaliseGmailOutboundRateLimitSettings(settings = {}) {
+  return normaliseGmailOutboundRateLimitSettings(settings);
+}
+
+export function __testOnly_readGmailOutboundRateLimitSettingsFromForm() {
+  return readGmailOutboundRateLimitSettingsFromForm();
+}
+
+export function __testOnly_populateGmailOutboundRateLimitInputs(settings = {}) {
+  return populateGmailOutboundRateLimitInputs(settings);
+}
+
 function isSettingsRuntimePanelVisible() {
   try {
     if (document.hidden) return false;
@@ -4806,6 +4916,20 @@ if (autoProceedMinimalImpositionToggle) {
   });
 }
 
+const saveGmailOutboundRateLimitsButton = document.getElementById('saveGmailOutboundRateLimitsButton');
+if (saveGmailOutboundRateLimitsButton) {
+  saveGmailOutboundRateLimitsButton.addEventListener('click', () => {
+    Promise.resolve(persistGmailOutboundRateLimitSettings()).catch((error) => {
+      console.warn('Failed to save Gmail outbound rate limits', error);
+      showStatusMessage(
+        'gmailOutboundRateLimitStatus',
+        error?.message || 'Failed to save outbound email limits.',
+        true,
+      );
+    });
+  });
+}
+
 const buttonifyPromptLink = document.getElementById('buttonifyPromptLink');
 if (buttonifyPromptLink) {
   buttonifyPromptLink.addEventListener('click', (event) => {
@@ -4970,9 +5094,14 @@ async function loadAndDisplaySettings() {
       applySettingsActorRole(role);
       __canPersistWriteConservatism = __vonIsAdminOrOwner
         && Object.prototype.hasOwnProperty.call(settings, 'disable_write_tool_conservatism');
+      __canPersistGmailOutboundRateLimits = __vonIsAdminOrOwner
+        && Object.prototype.hasOwnProperty.call(settings, 'gmail_outbound_rate_limits');
+      syncGmailOutboundRateLimitWriteAccess();
     } catch {
       applySettingsActorRole('');
       __canPersistWriteConservatism = false;
+      __canPersistGmailOutboundRateLimits = false;
+      syncGmailOutboundRateLimitWriteAccess();
     }
 
     // The selector should reflect the resolved active model for the provider in scope,
@@ -5202,6 +5331,16 @@ async function loadAndDisplaySettings() {
       }
     } catch (error) {
       console.warn('Failed to render Gmail profiles', error);
+    }
+
+    // Populate admin-only outbound Gmail dispatch limits.
+    try {
+      if (Object.prototype.hasOwnProperty.call(settings, 'gmail_outbound_rate_limits')) {
+        populateGmailOutboundRateLimitInputs(settings);
+      }
+      syncGmailOutboundRateLimitWriteAccess();
+    } catch (error) {
+      console.warn('Failed to render Gmail outbound rate limits', error);
     }
 
     // Populate fetch_counts_on_load toggle
@@ -5466,8 +5605,14 @@ async function loadAndDisplayDbInfo() {
   }
 }
 
-async function saveAllSettings({ includeChatModels = false, includeRuntimeModels = false } = {}) {
-  const concernSpecificSave = includeChatModels || includeRuntimeModels;
+async function saveAllSettings({
+  includeChatModels = false,
+  includeRuntimeModels = false,
+  includeGmailOutboundRateLimits = false,
+} = {}) {
+  const concernSpecificSave = includeChatModels
+    || includeRuntimeModels
+    || includeGmailOutboundRateLimits;
   // Actor-scoped and shared-runtime Save buttons deliberately send only their
   // own concern. General auto-saves continue to use the ordinary settings payload.
   const settings = concernSpecificSave
@@ -5482,6 +5627,13 @@ async function saveAllSettings({ includeChatModels = false, includeRuntimeModels
       buttonify_model_enabled: !!document.getElementById('buttonifyModelEnabledToggle')?.checked,
       auto_proceed_minimal_imposition_enabled: !!document.getElementById('autoProceedMinimalImpositionToggle')?.checked,
     };
+
+  if (
+    __canPersistGmailOutboundRateLimits
+    && (!concernSpecificSave || includeGmailOutboundRateLimits)
+  ) {
+    settings.gmail_outbound_rate_limits = readGmailOutboundRateLimitSettingsFromForm();
+  }
 
   if (!concernSpecificSave && __canPersistWriteConservatism) {
     const adminToggleEl = document.getElementById('disableWriteToolConservatismToggle');

--- a/src/frontend/web/von_interface/static/js/test/settingsPageRagStatus.test.js
+++ b/src/frontend/web/von_interface/static/js/test/settingsPageRagStatus.test.js
@@ -7,8 +7,11 @@ import {
     __testOnly_formatServerDefaultSummary,
     __testOnly_formatRagSummaryForSettings,
     __testOnly_getPreferredRagNamespace,
+    __testOnly_normaliseGmailOutboundRateLimitSettings,
     __testOnly_normaliseInternalMcpCapSettings,
+    __testOnly_populateGmailOutboundRateLimitInputs,
     __testOnly_populateInternalMcpCapInputs,
+    __testOnly_readGmailOutboundRateLimitSettingsFromForm,
     __testOnly_readInternalMcpCapSettingsFromForm,
     __testOnly_populateServerDefaultLlmForm,
     __testOnly_readRuntimeModelSettingFromForm,
@@ -483,6 +486,79 @@ describe('settingsPage RAG status summary', () => {
             internal_mcp_max_tool_invocations: 500,
             internal_mcp_tool_batch_cap: 20,
         });
+    });
+
+    test('Gmail outbound limits default disabled and clamp to the backend contract', () => {
+        expect(__testOnly_normaliseGmailOutboundRateLimitSettings({})).toEqual({
+            schema_version: 'gmail_outbound_rate_limits.v1',
+            enabled: false,
+            max_messages_per_10_minutes: 5,
+            max_messages_per_day: 25,
+            max_recipients_per_message: 10,
+            max_recipient_deliveries_per_day: 50,
+        });
+
+        expect(__testOnly_normaliseGmailOutboundRateLimitSettings({
+            enabled: true,
+            max_messages_per_10_minutes: 999,
+            max_messages_per_day: 9999,
+            max_recipients_per_message: 100,
+            max_recipient_deliveries_per_day: 4,
+        })).toEqual({
+            schema_version: 'gmail_outbound_rate_limits.v1',
+            enabled: true,
+            max_messages_per_10_minutes: 100,
+            max_messages_per_day: 1000,
+            max_recipients_per_message: 4,
+            max_recipient_deliveries_per_day: 4,
+        });
+    });
+
+    test('Gmail outbound limit form counts messages and recipient deliveries separately', () => {
+        document.body.innerHTML = `
+            <input type="checkbox" id="gmailOutboundEnabled" checked />
+            <input id="gmailOutboundMaxMessagesPer10Minutes" value="4" />
+            <input id="gmailOutboundMaxMessagesPerDay" value="20" />
+            <input id="gmailOutboundMaxRecipientsPerMessage" value="8" />
+            <input id="gmailOutboundMaxRecipientDeliveriesPerDay" value="40" />
+        `;
+
+        expect(__testOnly_readGmailOutboundRateLimitSettingsFromForm()).toEqual({
+            schema_version: 'gmail_outbound_rate_limits.v1',
+            enabled: true,
+            max_messages_per_10_minutes: 4,
+            max_messages_per_day: 20,
+            max_recipients_per_message: 8,
+            max_recipient_deliveries_per_day: 40,
+        });
+    });
+
+    test('Gmail outbound limit inputs show the effective admin policy', () => {
+        document.body.innerHTML = `
+            <input type="checkbox" id="gmailOutboundEnabled" />
+            <input id="gmailOutboundMaxMessagesPer10Minutes" />
+            <input id="gmailOutboundMaxMessagesPerDay" />
+            <input id="gmailOutboundMaxRecipientsPerMessage" />
+            <input id="gmailOutboundMaxRecipientDeliveriesPerDay" />
+            <div id="gmailOutboundRateLimitStatus"></div>
+        `;
+
+        __testOnly_populateGmailOutboundRateLimitInputs({
+            gmail_outbound_rate_limits: {
+                enabled: true,
+                max_messages_per_10_minutes: 3,
+                max_messages_per_day: 15,
+                max_recipients_per_message: 5,
+                max_recipient_deliveries_per_day: 30,
+            },
+        });
+
+        expect(document.getElementById('gmailOutboundEnabled').checked).toBe(true);
+        expect(document.getElementById('gmailOutboundMaxMessagesPer10Minutes').value).toBe('3');
+        expect(document.getElementById('gmailOutboundMaxMessagesPerDay').value).toBe('15');
+        expect(document.getElementById('gmailOutboundMaxRecipientsPerMessage').value).toBe('5');
+        expect(document.getElementById('gmailOutboundMaxRecipientDeliveriesPerDay').value).toBe('30');
+        expect(document.getElementById('gmailOutboundRateLimitStatus').textContent).toContain('enabled');
     });
 
     test('internal MCP cap form values can persist 100 and 10', () => {

--- a/src/frontend/web/von_interface/templates/settings_tab.html
+++ b/src/frontend/web/von_interface/templates/settings_tab.html
@@ -701,6 +701,40 @@
             <div id="gmailProfileStatus" class="settings-note">Gmail profile target: unknown</div>
             <div id="gmailProfilesStatus" class="settings-note">Gmail profiles: unknown</div>
 
+            <div id="gmailOutboundRateLimitContainer" class="hidden mt-2">
+                <h4>Agent outbound email limits</h4>
+                <p class="settings-note">Admin-only, mailbox-wide limits enforced by the backend immediately before
+                    Gmail dispatch. Quota persistence fails closed.</p>
+                <div class="inline-form inline-form-tight">
+                    <input type="checkbox" id="gmailOutboundEnabled" />
+                    <label for="gmailOutboundEnabled" class="ml-1 mr-2">Enable agent outbound email</label>
+
+                    <label for="gmailOutboundMaxMessagesPer10Minutes" class="mr-1">Messages / 10 min:</label>
+                    <input type="number" id="gmailOutboundMaxMessagesPer10Minutes" min="1" max="100" step="1"
+                        value="5" class="mr-2" />
+
+                    <label for="gmailOutboundMaxMessagesPerDay" class="mr-1">Messages / day:</label>
+                    <input type="number" id="gmailOutboundMaxMessagesPerDay" min="1" max="1000" step="1"
+                        value="25" />
+                </div>
+                <div class="inline-form inline-form-tight mt-1">
+                    <label for="gmailOutboundMaxRecipientsPerMessage" class="mr-1">Recipients / message:</label>
+                    <input type="number" id="gmailOutboundMaxRecipientsPerMessage" min="1" max="100" step="1"
+                        value="10" class="mr-2" />
+
+                    <label for="gmailOutboundMaxRecipientDeliveriesPerDay" class="mr-1">Recipient deliveries /
+                        day:</label>
+                    <input type="number" id="gmailOutboundMaxRecipientDeliveriesPerDay" min="1" max="5000"
+                        step="1" value="50" class="mr-2" />
+
+                    <button type="button" id="saveGmailOutboundRateLimitsButton" class="btn-secondary">Save outbound
+                        limits</button>
+                </div>
+                <small class="settings-note">To, Cc and Bcc all count. Ten-minute limits use fixed UTC buckets; daily
+                    limits reset at 00:00 UTC.</small>
+                <div id="gmailOutboundRateLimitStatus" class="settings-note">Outbound email limits: not loaded</div>
+            </div>
+
             <h3 class="mt-3">Tool Execution Caps</h3>
             <p class="settings-note">Controls internal MCP tool chaining. Changes apply immediately for new chat turns.
                 Larger values can increase latency and tool load.</p>

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -39,6 +39,8 @@ from src.backend.services.adaptive_turn_service import (
     _CONVERSATION_SITUATION_MAX_CHARS,
     _bound_tool_results_for_model,
     _bounded_conversation_observation_projection,
+    _canonical_effect_readback_receipt,
+    _canonically_verified_material_effect_ids,
     _capability_catalogue,
     _compact_context_after_limit,
     _compact_evidence_envelope,
@@ -49,6 +51,7 @@ from src.backend.services.adaptive_turn_service import (
     _extract_conversation_situation_sidecar,
     _final_synthesis_context,
     _json_bytes,
+    _ordinary_effect_argument_denial,
     _scope_message,
     _trusted_tool_payload,
     execute_adaptive_turn,
@@ -117,6 +120,62 @@ def test_effect_receipt_targets_require_explicit_generic_target_fields() -> None
         "#V#created_b",
         "#V#nested_result",
     ]
+
+
+def test_embedded_gmail_readback_is_canonical_without_private_fields() -> None:
+    receipt = _canonical_effect_readback_receipt(
+        {
+            "canonical_readback": {
+                "status": "verified",
+                "verified": True,
+                "message_id": "gmail-message-1",
+                "thread_id": "gmail-thread-1",
+                "sender": "Von AI Agent <agent@example.test>",
+                "to": ["recipient@example.test"],
+                "subject": "Private subject",
+                "body_included": False,
+                "disclosure_verified": True,
+                "delivery_fingerprint_verified": True,
+            }
+        }
+    )
+
+    assert receipt == {
+        "status": "verified",
+        "verified": True,
+        "body_included": False,
+        "message_id": "gmail-message-1",
+        "thread_id": "gmail-thread-1",
+        "disclosure_verified": True,
+        "delivery_fingerprint_verified": True,
+    }
+    assert _effect_result_target_ids(
+        {
+            "message_id": "gmail-message-1",
+            "thread_id": "gmail-thread-1",
+            "delivery_fingerprint": "delivery-1",
+        }
+    ) == ["gmail-message-1", "gmail-thread-1", "delivery-1"]
+
+    material, verified = _canonically_verified_material_effect_ids(
+        [
+            {
+                "effect_id": "effect-1",
+                "status": "ok",
+                "result_target_ids": ["gmail-message-1"],
+            }
+        ],
+        {
+            "effect-1": {
+                "effect_status": "succeeded",
+                "changed": True,
+                "turn_finality_required": True,
+                "canonical_readback": receipt,
+            }
+        },
+    )
+    assert material == {"effect-1"}
+    assert verified == {"effect-1"}
 
 
 def _gateway(handler: Any) -> InternalMCPGateway:
@@ -322,6 +381,57 @@ def _gmail_choice_gateway(handler: Any) -> InternalMCPGateway:
     return InternalMCPGateway(
         catalogue=catalogue,
         transport=InternalMCPTransport(read_timeout_sec=1.0),
+        enabled=True,
+    )
+
+
+def _gmail_send_gateway(handler: Any) -> InternalMCPGateway:
+    catalogue = MethodCatalogue()
+    catalogue.register(
+        MethodDefinition(
+            name="gmail_send_message",
+            handler=handler,
+            input_schema=Schema(
+                required={
+                    "profile": str,
+                    "to": (str, list),
+                    "subject": str,
+                    "body_text": str,
+                    "allow_send": bool,
+                },
+                optional={
+                    "namespace": (str, type(None)),
+                    "acting_user_concept_id": (str, type(None)),
+                    "organisation_concept_id": (str, type(None)),
+                    "request_id": (str, type(None)),
+                },
+                aliases={
+                    "profile_id": "profile",
+                    "identity": "profile",
+                    "allow_mutation": "allow_send",
+                },
+                allow_unknown=False,
+                description="Send Gmail after verified explicit request evidence.",
+            ),
+            category="write",
+            ordinary_turn_effect=True,
+            ordinary_turn_trusted_argument_bindings={
+                "acting_user_concept_id": "actor_user_concept_id",
+                "organisation_concept_id": "actor_organisation_concept_id",
+                "request_id": "turn_id",
+                "namespace": "turn_namespace",
+            },
+            ordinary_turn_trusted_argument_choice_bindings={
+                "profile": "gmail_profile",
+            },
+            ordinary_turn_fixed_arguments={"allow_send": True},
+            write_guardrail={"ordinary_turn_explicit_request": True},
+            description="Send Gmail after verified explicit request evidence.",
+        )
+    )
+    return InternalMCPGateway(
+        catalogue=catalogue,
+        transport=InternalMCPTransport(write_timeout_sec=1.0),
         enabled=True,
     )
 
@@ -3724,6 +3834,107 @@ def test_ordinary_relationship_effect_cannot_widen_visibility(
     assert "visibility_effect_not_delegated" in (
         result.tool_invocations[0]["evidence"]["preview"]
     )
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    [
+        "#V#has_authorised_mail_profile",
+        "#V#has_default_mail_profile",
+        "#V#has_runtime_profile_alias",
+        "#V#has_oauth_scope",
+        "#V#mail_profile_represents_identity",
+    ],
+)
+def test_ordinary_relationship_effect_reserves_mail_profile_control_predicates(
+    predicate: str,
+) -> None:
+    denial = _ordinary_effect_argument_denial(
+        "add_relationship",
+        {
+            "source_id": "#V#person",
+            "predicate_ref": {"concept_id": predicate},
+            "target": "#V#gmail_profile_vonwitbrock_gmail",
+        },
+    )
+
+    assert denial is not None
+    assert denial["error_code"] == "mail_profile_authority_effect_not_delegated"
+
+
+def test_ordinary_actor_cannot_self_grant_mail_profile_but_safe_relation_runs() -> None:
+    invoked: list[tuple[str, dict[str, Any]]] = []
+
+    def handler(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        invoked.append((name, dict(arguments)))
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+        }
+
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="self-grant-mail-profile",
+                    payload={
+                        "name": "add_relationship",
+                        "arguments": {
+                            "source_id": "#V#person",
+                            "predicate": "#V#has_authorised_mail_profile",
+                            "target": "#V#gmail_profile_vonwitbrock_gmail",
+                        },
+                    },
+                ),
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="safe-research-interest",
+                    payload={
+                        "name": "add_relationship",
+                        "arguments": {
+                            "source_id": "#V#person",
+                            "predicate": "#V#hasResearchInterest",
+                            "target": "#V#knowledge_representation",
+                        },
+                    },
+                ),
+            ],
+        ),
+        LLMResponse(text_response="The safe relationship was recorded."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_effect_gateway(handler),
+        prompt="Authorise that Gmail profile and record my research interest.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="mail-profile-self-grant",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert invoked == [
+        (
+            "add_relationship",
+            {
+                "source_id": "#V#person",
+                "predicate": "#V#hasResearchInterest",
+                "target": "#V#knowledge_representation",
+            },
+        )
+    ]
+    assert result.tool_invocations[0]["effect_status"] == "failed"
+    assert "mail_profile_authority_effect_not_delegated" in (
+        result.tool_invocations[0]["evidence"]["preview"]
+    )
+    assert result.tool_invocations[1]["effect_status"] == "succeeded"
 
 
 def test_capability_query_ranks_without_eliminating_the_delegated_set(
@@ -7158,6 +7369,307 @@ def test_trusted_gmail_profile_overrides_model_profile_and_aliases() -> None:
     assert invocation["effective_arguments"] == seen_arguments
 
 
+def test_explicit_request_guard_allows_actor_bound_gmail_send(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.services import write_tool_request_evidence_vontology_service
+
+    inferred: dict[str, Any] = {}
+    seen_arguments: dict[str, Any] = {}
+
+    def infer_request_evidence(**kwargs: Any):
+        inferred.update(kwargs)
+        return (
+            {
+                "gmail_send_message": {
+                    "schema_version": "write_tool_request_evidence.v1",
+                    "tool_name": "gmail_send_message",
+                    "request_state": "explicit_request",
+                    "confirmation_state": "low_confidence",
+                    "denial_state": "low_confidence",
+                    "rationale": "The current prompt explicitly asks Von to send email.",
+                }
+            },
+            {
+                "schema_version": "write_tool_request_evidence.v1",
+                "status": "ok",
+                "parse_mode": "json",
+            },
+        )
+
+    monkeypatch.setattr(
+        write_tool_request_evidence_vontology_service,
+        "infer_write_tool_request_evidence",
+        infer_request_evidence,
+    )
+    monkeypatch.setattr(
+        "src.backend.workflows.write_tool_policy."
+        "resolve_runtime_profile_write_tool_risk_class",
+        lambda *_args, **_kwargs: "external_non_vontology",
+    )
+    monkeypatch.setattr(
+        "src.backend.services.tool_evidence_projection_service."
+        "resolve_tool_projection_contract",
+        lambda _tool_name: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.settings_service."
+        "get_user_mutation_authority_level",
+        lambda _user_id: "external_system_guarded",
+    )
+    monkeypatch.setattr(
+        "src.backend.services.settings_service."
+        "get_global_mutation_authority_level",
+        lambda: "external_system_guarded",
+    )
+
+    def handler(**kwargs: Any) -> dict[str, Any]:
+        seen_arguments.update(kwargs)
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "message_id": "gmail-message-1",
+        }
+
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="send-gmail",
+                    payload={
+                        "name": "gmail_send_message",
+                        "arguments": {
+                            "profile": "#V#gmail_profile_zhan",
+                            "profile_id": "foreign-runtime",
+                            "to": "recipient@example.test",
+                            "subject": "Requested note",
+                            "body_text": "The requested body.",
+                            "allow_send": False,
+                            "allow_mutation": False,
+                            "namespace": "#V#spoof@other",
+                            "acting_user_concept_id": "#V#spoof",
+                            "organisation_concept_id": "#V#other",
+                            "request_id": "spoofed-request",
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response="The requested email was submitted."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_gmail_send_gateway(handler),
+        prompt="Send this email now.",
+        context=[
+            {"role": "user", "content": "Draft a short note first."},
+            {"role": "assistant", "content": "Here is a draft."},
+        ],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        trusted_argument_values={
+            "gmail_profile": _gmail_profile_choices(
+                default="#V#gmail_profile_zhan"
+            ),
+        },
+        turn_id="turn-send-gmail",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert seen_arguments == {
+        "profile": "zhan-runtime",
+        "to": ["recipient@example.test"],
+        "subject": "Requested note",
+        "body_text": "The requested body.",
+        "allow_send": True,
+        "namespace": "#V#person@org",
+        "acting_user_concept_id": "#V#person",
+        "organisation_concept_id": "#V#org",
+        "request_id": "turn-send-gmail",
+    }
+    assert inferred["prompt"] == "Send this email now."
+    assert inferred["recent_user_prompts"] == ["Draft a short note first."]
+    assert inferred["requested_tools"] == ["gmail_send_message"]
+    payload_summary = inferred["requested_tool_payloads"]["gmail_send_message"]
+    assert set(payload_summary) == {"provided_fields"}
+    assert "The requested body." not in json.dumps(payload_summary)
+    invocation = result.tool_invocations[0]
+    assert invocation["effect_status"] == "succeeded"
+    assert invocation["effective_arguments"] == {
+        **seen_arguments,
+        "to": "recipient@example.test",
+    }
+    guardrail_event = next(
+        item
+        for item in result.aux_llm_calls
+        if item.get("type") == "ordinary_turn_effect_request_guardrail"
+    )
+    assert guardrail_event["status"] == "allowed"
+    assert guardrail_event["request_state"] == "explicit_request"
+
+
+def test_gmail_send_fails_closed_before_dispatch_when_request_evidence_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.services import (
+        turn_execution_record_service,
+        write_tool_request_evidence_vontology_service,
+    )
+
+    dispatches: list[dict[str, Any]] = []
+    handler_calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        turn_execution_record_service,
+        "record_effect_observation_phase",
+        lambda **kwargs: dispatches.append(dict(kwargs)) or {"updated": True},
+    )
+    monkeypatch.setattr(
+        write_tool_request_evidence_vontology_service,
+        "infer_write_tool_request_evidence",
+        lambda **_kwargs: (
+            {},
+            {
+                "schema_version": "write_tool_request_evidence.v1",
+                "status": "llm_unavailable",
+            },
+        ),
+    )
+
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="blocked-gmail-send",
+                    payload={
+                        "name": "gmail_send_message",
+                        "arguments": {
+                            "to": "recipient@example.test",
+                            "subject": "Not dispatched",
+                            "body_text": "No message must be sent.",
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response="I could not verify permission to send."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_gmail_send_gateway(
+            lambda **kwargs: handler_calls.append(dict(kwargs))
+            or {"success": True}
+        ),
+        prompt="Please send this email.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        trusted_argument_values={
+            "gmail_profile": _gmail_profile_choices(
+                default="#V#gmail_profile_zhan"
+            ),
+        },
+        turn_id="turn-blocked-gmail-send",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert handler_calls == []
+    assert dispatches == []
+    invocation = result.tool_invocations[0]
+    assert invocation["effect_status"] == "not_started"
+    denial = json.loads(invocation["evidence"]["preview"])
+    assert denial["error_code"] == "ordinary_turn_request_evidence_unavailable"
+    assert denial["changed"] is False
+    guardrail_event = next(
+        item
+        for item in result.aux_llm_calls
+        if item.get("type") == "ordinary_turn_effect_request_guardrail"
+    )
+    assert guardrail_event["status"] == "blocked"
+    assert guardrail_event["reason"] == "request_evidence_unavailable"
+
+
+def test_explicit_gmail_request_does_not_override_actor_mutation_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.services import (
+        adaptive_turn_service,
+        write_tool_request_evidence_vontology_service,
+    )
+
+    monkeypatch.setattr(
+        write_tool_request_evidence_vontology_service,
+        "infer_write_tool_request_evidence",
+        lambda **_kwargs: (
+            {
+                "gmail_send_message": {
+                    "schema_version": "write_tool_request_evidence.v1",
+                    "tool_name": "gmail_send_message",
+                    "request_state": "explicit_request",
+                    "confirmation_state": "low_confidence",
+                    "denial_state": "low_confidence",
+                    "rationale": "The current prompt asks to send email.",
+                }
+            },
+            {"schema_version": "write_tool_request_evidence.v1", "status": "ok"},
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.settings_service."
+        "get_user_mutation_authority_level",
+        lambda _user_id: "read_only",
+    )
+    monkeypatch.setattr(
+        "src.backend.services.settings_service."
+        "get_global_mutation_authority_level",
+        lambda: "external_system_guarded",
+    )
+    monkeypatch.setattr(
+        "src.backend.workflows.write_tool_policy."
+        "resolve_runtime_profile_write_tool_risk_class",
+        lambda *_args, **_kwargs: "external_non_vontology",
+    )
+
+    denial, event = adaptive_turn_service._ordinary_turn_effect_request_guardrail(
+        definition=SimpleNamespace(
+            write_guardrail={"ordinary_turn_explicit_request": True}
+        ),
+        capability_name="gmail_send_message",
+        arguments={
+            "profile": "zhan-runtime",
+            "to": "recipient@example.test",
+            "subject": "Requested note",
+            "body_text": "Requested body",
+            "allow_send": True,
+        },
+        prompt="Send this email now.",
+        context=[],
+        llm_client=object(),
+        model="test-model",
+        user_concept_id="#V#person",
+    )
+
+    assert denial is not None
+    assert denial["error_code"] == "ordinary_turn_write_policy_blocked"
+    assert denial["status"] == "not_started"
+    assert denial["changed"] is False
+    assert event is not None
+    assert event["status"] == "blocked"
+    assert event["effective_mutation_authority"] == "read_only"
+
+
 def test_model_cannot_select_gmail_profile_without_a_trusted_binding() -> None:
     seen_arguments: dict[str, Any] = {}
 
@@ -7203,6 +7715,98 @@ def test_model_cannot_select_gmail_profile_without_a_trusted_binding() -> None:
         result.tool_invocations[0]["effective_payload"]["error_code"]
         == "capability_not_delegated"
     )
+
+
+def test_current_conversation_history_read_cannot_be_redirected_by_model() -> None:
+    seen_arguments: dict[str, Any] = {}
+    catalogue = MethodCatalogue()
+    catalogue.register(
+        MethodDefinition(
+            name="chat_history_get_segments",
+            handler=lambda **kwargs: seen_arguments.update(kwargs)
+            or {"success": True, "segments": []},
+            input_schema=Schema(
+                optional={
+                    "conversation_ref": (dict, type(None)),
+                    "session_id": (str, type(None)),
+                    "namespace": (str, type(None)),
+                    "user_concept_id": (str, type(None)),
+                    "organisation_concept_id": (str, type(None)),
+                    "include_debug": bool,
+                    "segment_size": int,
+                },
+                allow_unknown=False,
+            ),
+            category="read",
+            ordinary_turn_trusted_argument_bindings={
+                "session_id": "conversation_id",
+                "namespace": "turn_namespace",
+                "user_concept_id": "actor_user_concept_id",
+                "organisation_concept_id": "actor_organisation_concept_id",
+            },
+            ordinary_turn_fixed_arguments={
+                "conversation_ref": None,
+                "include_debug": False,
+            },
+            description="Read only the active conversation carrier.",
+        )
+    )
+    gateway = InternalMCPGateway(
+        catalogue=catalogue,
+        transport=InternalMCPTransport(read_timeout_sec=1.0),
+        enabled=True,
+    )
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="read-current-carrier",
+                    payload={
+                        "name": "chat_history_get_segments",
+                        "arguments": {
+                            "conversation_ref": {
+                                "session_id": "foreign-conversation"
+                            },
+                            "session_id": "foreign-conversation",
+                            "namespace": "#V#foreign@foreign_org",
+                            "user_concept_id": "#V#foreign",
+                            "organisation_concept_id": "#V#foreign_org",
+                            "include_debug": True,
+                            "segment_size": 10,
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response="The active conversation carrier was read."),
+    )
+
+    execute_adaptive_turn(
+        gateway=gateway,
+        prompt="Recover the exact table from this conversation.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="turn-read-current-carrier",
+        conversation_id="current-conversation",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert seen_arguments == {
+        "conversation_ref": None,
+        "session_id": "current-conversation",
+        "namespace": "#V#person@org",
+        "user_concept_id": "#V#person",
+        "organisation_concept_id": "#V#org",
+        "include_debug": False,
+        "segment_size": 10,
+    }
 
 
 def test_represented_workflow_is_discovered_and_invoked_as_bound_capability(

--- a/tests/backend/test_gmail_outbound_delivery_service.py
+++ b/tests/backend/test_gmail_outbound_delivery_service.py
@@ -1,0 +1,284 @@
+import hashlib
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from threading import Barrier
+
+import mongomock
+import pytest
+
+from src.backend.services.gmail_outbound_delivery_service import (
+    GmailOutboundDeliveryConflict,
+    GmailOutboundDeliveryLedgerUnavailable,
+    claim_gmail_outbound_delivery,
+    get_gmail_outbound_delivery,
+    record_gmail_outbound_delivery_result,
+)
+from src.backend.services.gmail_outbound_mailbox_identity_service import (
+    derive_canonical_gmail_mailbox_key,
+)
+
+MAILBOX_KEY = derive_canonical_gmail_mailbox_key("von@example.test")
+
+
+def _collection(*, create_secondary_unique_index=True):
+    collection = mongomock.MongoClient().von_test.gmail_outbound_deliveries
+    if create_secondary_unique_index:
+        collection.create_index("delivery_fingerprint", unique=True)
+    return collection
+
+
+def _claim(collection, *, fingerprint="delivery-1"):
+    return claim_gmail_outbound_delivery(
+        delivery_fingerprint=fingerprint,
+        canonical_mailbox_key=MAILBOX_KEY,
+        profile_resource_concept_id="#V#gmail_profile_vonwitbrock_gmail",
+        profile_id="vonwitbrock-gmail",
+        actor_user_concept_id="#V#michael_witbrock",
+        actor_organisation_concept_id="#V#strong_ai_lab",
+        request_id="request-1",
+        recipient_count=2,
+        recipients_sha256="recipients-digest",
+        subject_sha256="subject-digest",
+        content_sha256="content-digest",
+        collection=collection,
+        now=datetime(2026, 8, 12, 9, 0, tzinfo=UTC),
+    )
+
+
+def test_claim_is_unique_and_duplicate_returns_existing_receipt():
+    collection = _collection()
+
+    first = _claim(collection)
+    duplicate = _claim(collection)
+
+    assert first.claimed is True
+    assert first.duplicate is False
+    assert duplicate.claimed is False
+    assert duplicate.duplicate is True
+    assert duplicate.status == "dispatch_claimed"
+    assert duplicate.receipt is not None
+    assert duplicate.receipt["request_id"] == "request-1"
+    assert collection.count_documents({}) == 1
+
+
+def test_duplicate_alias_preserves_provenance_without_changing_effect_identity():
+    collection = _collection()
+    _claim(collection)
+
+    duplicate = claim_gmail_outbound_delivery(
+        delivery_fingerprint="delivery-1",
+        canonical_mailbox_key=MAILBOX_KEY,
+        profile_resource_concept_id="#V#gmail_profile_second_alias",
+        profile_id="second-runtime-alias",
+        actor_user_concept_id="#V#michael_witbrock",
+        actor_organisation_concept_id="#V#strong_ai_lab",
+        request_id="request-1",
+        recipient_count=2,
+        recipients_sha256="recipients-digest",
+        subject_sha256="subject-digest",
+        content_sha256="content-digest",
+        collection=collection,
+    )
+
+    assert duplicate.duplicate is True
+    assert duplicate.receipt["profile_resource_concept_id"] == (
+        "#V#gmail_profile_vonwitbrock_gmail"
+    )
+    assert duplicate.receipt["observed_profile_resource_concept_ids"] == [
+        "#V#gmail_profile_vonwitbrock_gmail",
+        "#V#gmail_profile_second_alias",
+    ]
+    assert duplicate.receipt["observed_profile_alias_digests"] == [
+        hashlib.sha256(b"vonwitbrock-gmail").hexdigest(),
+        hashlib.sha256(b"second-runtime-alias").hexdigest(),
+    ]
+
+
+def test_concurrent_claim_is_intrinsically_unique_without_secondary_index():
+    collection = _collection(create_secondary_unique_index=False)
+    worker_count = 8
+    start = Barrier(worker_count)
+
+    def claim_once():
+        start.wait()
+        return _claim(collection)
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        claims = list(executor.map(lambda _index: claim_once(), range(worker_count)))
+
+    assert sum(claim.claimed for claim in claims) == 1
+    assert sum(claim.duplicate for claim in claims) == worker_count - 1
+    assert collection.count_documents({}) == 1
+    stored = collection.find_one({})
+    assert stored is not None
+    assert stored["_id"] == "delivery-1"
+    assert stored["delivery_fingerprint"] == "delivery-1"
+
+
+def test_terminal_result_is_persisted_and_read_back_without_private_content():
+    collection = _collection()
+    _claim(collection)
+
+    stored = record_gmail_outbound_delivery_result(
+        delivery_fingerprint="delivery-1",
+        status="succeeded",
+        message_id="gmail-message-1",
+        thread_id="gmail-thread-1",
+        receipt={
+            "effect_status": "succeeded",
+            "canonical_readback": {"status": "verified", "verified": True},
+        },
+        collection=collection,
+        now=datetime(2026, 8, 12, 9, 1, tzinfo=UTC),
+    )
+
+    assert stored["status"] == "succeeded"
+    assert stored["message_id"] == "gmail-message-1"
+    assert stored["receipt"]["canonical_readback"]["verified"] is True
+    assert "_id" not in stored
+    assert "subject_sha256" not in stored
+    assert "content_sha256" not in stored
+    assert get_gmail_outbound_delivery(
+        "delivery-1", collection=collection
+    ) == stored
+
+
+@pytest.mark.parametrize("later_status", ["indeterminate", "failed", "not_started"])
+def test_succeeded_result_is_absorbing(later_status):
+    collection = _collection(create_secondary_unique_index=False)
+    _claim(collection)
+    succeeded_at = datetime(2026, 8, 12, 9, 1, tzinfo=UTC)
+    succeeded = record_gmail_outbound_delivery_result(
+        delivery_fingerprint="delivery-1",
+        status="succeeded",
+        message_id="gmail-message-1",
+        thread_id="gmail-thread-1",
+        receipt={
+            "effect_status": "succeeded",
+            "canonical_readback": {"status": "verified", "verified": True},
+        },
+        collection=collection,
+        now=succeeded_at,
+    )
+
+    observed = record_gmail_outbound_delivery_result(
+        delivery_fingerprint="delivery-1",
+        status=later_status,
+        receipt={"effect_status": later_status, "error_code": "late-weaker-state"},
+        collection=collection,
+        now=datetime(2026, 8, 12, 9, 2, tzinfo=UTC),
+    )
+
+    assert observed == succeeded
+    assert observed["status"] == "succeeded"
+    assert observed["receipt"]["canonical_readback"]["verified"] is True
+    assert "late-weaker-state" not in str(observed)
+
+
+def test_succeeded_promotes_prior_indeterminate_result():
+    collection = _collection(create_secondary_unique_index=False)
+    _claim(collection)
+    record_gmail_outbound_delivery_result(
+        delivery_fingerprint="delivery-1",
+        status="indeterminate",
+        receipt={"effect_status": "indeterminate"},
+        collection=collection,
+    )
+
+    promoted = record_gmail_outbound_delivery_result(
+        delivery_fingerprint="delivery-1",
+        status="succeeded",
+        message_id="gmail-message-1",
+        receipt={
+            "effect_status": "succeeded",
+            "canonical_readback": {"status": "verified", "verified": True},
+        },
+        collection=collection,
+    )
+
+    assert promoted["status"] == "succeeded"
+    assert promoted["message_id"] == "gmail-message-1"
+    assert promoted["receipt"]["canonical_readback"]["verified"] is True
+
+
+def test_concurrent_succeeded_and_indeterminate_writers_finish_succeeded():
+    collection = _collection(create_secondary_unique_index=False)
+    _claim(collection)
+    start = Barrier(2)
+
+    def record(status):
+        start.wait()
+        return record_gmail_outbound_delivery_result(
+            delivery_fingerprint="delivery-1",
+            status=status,
+            message_id=("gmail-message-1" if status == "succeeded" else None),
+            receipt=(
+                {
+                    "effect_status": "succeeded",
+                    "canonical_readback": {
+                        "status": "verified",
+                        "verified": True,
+                    },
+                }
+                if status == "succeeded"
+                else {
+                    "effect_status": "indeterminate",
+                    "error_code": "late-weaker-state",
+                }
+            ),
+            collection=collection,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        list(executor.map(record, ("succeeded", "indeterminate")))
+
+    stored = get_gmail_outbound_delivery("delivery-1", collection=collection)
+    assert stored is not None
+    assert stored["status"] == "succeeded"
+    assert stored["message_id"] == "gmail-message-1"
+    assert stored["receipt"]["canonical_readback"]["verified"] is True
+    assert "late-weaker-state" not in str(stored)
+
+
+def test_duplicate_request_with_different_content_is_rejected():
+    collection = _collection()
+    _claim(collection)
+
+    with pytest.raises(GmailOutboundDeliveryConflict):
+        claim_gmail_outbound_delivery(
+            delivery_fingerprint="delivery-1",
+            canonical_mailbox_key=MAILBOX_KEY,
+            profile_resource_concept_id="#V#gmail_profile_vonwitbrock_gmail",
+            profile_id="vonwitbrock-gmail",
+            actor_user_concept_id="#V#michael_witbrock",
+            actor_organisation_concept_id="#V#strong_ai_lab",
+            request_id="request-1",
+            recipient_count=2,
+            recipients_sha256="different-recipients",
+            subject_sha256="subject-digest",
+            content_sha256="content-digest",
+            collection=collection,
+        )
+
+
+def test_missing_ledger_fails_closed(monkeypatch):
+    monkeypatch.setattr(
+        "src.backend.services.gmail_outbound_delivery_service."
+        "get_gmail_outbound_deliveries_collection",
+        lambda: None,
+    )
+
+    with pytest.raises(GmailOutboundDeliveryLedgerUnavailable):
+        claim_gmail_outbound_delivery(
+            delivery_fingerprint="delivery-1",
+            canonical_mailbox_key=MAILBOX_KEY,
+            profile_resource_concept_id="#V#gmail_profile_vonwitbrock_gmail",
+            profile_id="vonwitbrock-gmail",
+            actor_user_concept_id="#V#michael_witbrock",
+            actor_organisation_concept_id="#V#strong_ai_lab",
+            request_id="request-1",
+            recipient_count=1,
+            recipients_sha256="recipients-digest",
+            subject_sha256="subject-digest",
+            content_sha256="content-digest",
+        )

--- a/tests/backend/test_gmail_outbound_rate_limit_service.py
+++ b/tests/backend/test_gmail_outbound_rate_limit_service.py
@@ -1,0 +1,218 @@
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+
+import mongomock
+import pytest
+
+from src.backend.services.gmail_outbound_mailbox_identity_service import (
+    derive_canonical_gmail_mailbox_key,
+)
+from src.backend.services.gmail_outbound_rate_limit_service import (
+    reserve_gmail_outbound_quota,
+)
+from src.backend.services.settings_service import GmailOutboundRateLimitSettings
+
+NOW = datetime(2026, 8, 12, 9, 5, tzinfo=UTC)
+CANONICAL_EMAIL = "von@example.test"
+MAILBOX_KEY = derive_canonical_gmail_mailbox_key(CANONICAL_EMAIL)
+
+
+def _collection():
+    return mongomock.MongoClient().von_test.gmail_outbound_quota
+
+
+def _policy(**overrides):
+    values = {
+        "enabled": True,
+        "max_messages_per_10_minutes": 5,
+        "max_messages_per_day": 25,
+        "max_recipients_per_message": 10,
+        "max_recipient_deliveries_per_day": 50,
+    }
+    values.update(overrides)
+    return GmailOutboundRateLimitSettings(**values)
+
+
+def _reserve(collection, reservation_id, *, recipient_count=1, policy=None, now=NOW):
+    return reserve_gmail_outbound_quota(
+        canonical_mailbox_key=MAILBOX_KEY,
+        reservation_id=reservation_id,
+        recipient_count=recipient_count,
+        settings=policy or _policy(),
+        collection=collection,
+        now=now,
+    )
+
+
+def test_disabled_policy_and_unavailable_store_fail_closed():
+    disabled = _reserve(
+        None,
+        "delivery-disabled",
+        policy=_policy(enabled=False),
+    )
+    unavailable = _reserve(None, "delivery-unavailable")
+
+    assert disabled.allowed is False
+    assert disabled.code == "gmail_outbound_disabled"
+    assert unavailable.allowed is False
+    assert unavailable.code == "gmail_outbound_quota_store_unavailable"
+
+
+def test_quota_boundary_rejects_raw_mailbox_address():
+    collection = _collection()
+
+    with pytest.raises(ValueError, match="opaque Gmail mailbox key"):
+        reserve_gmail_outbound_quota(
+            canonical_mailbox_key=CANONICAL_EMAIL,
+            reservation_id="delivery-raw-address",
+            recipient_count=1,
+            settings=_policy(),
+            collection=collection,
+            now=NOW,
+        )
+
+    assert collection.count_documents({}) == 0
+
+
+def test_one_atomic_document_counts_message_and_all_to_cc_bcc_deliveries():
+    collection = _collection()
+
+    decision = _reserve(collection, "delivery-1", recipient_count=4)
+
+    assert decision.allowed is True
+    assert decision.usage == {
+        "messages_in_10_minute_window": 1,
+        "messages_in_day": 1,
+        "recipient_deliveries_in_day": 4,
+    }
+    document = collection.find_one({})
+    assert document is not None
+    assert document["canonical_mailbox_key"] == MAILBOX_KEY
+    assert CANONICAL_EMAIL not in str(document)
+    assert document["messages_in_day"] == 1
+    assert document["recipient_deliveries_in_day"] == 4
+    assert len(document["reservation_keys"]) == 1
+
+
+def test_same_delivery_reservation_is_idempotent_and_consumes_quota_once():
+    collection = _collection()
+
+    first = _reserve(collection, "delivery-same", recipient_count=3)
+    duplicate = _reserve(collection, "delivery-same", recipient_count=3)
+
+    assert first.code == "gmail_outbound_quota_reserved"
+    assert duplicate.allowed is True
+    assert duplicate.code == "gmail_outbound_quota_already_reserved"
+    assert duplicate.reservation_id == "delivery-same"
+    assert duplicate.usage["messages_in_day"] == 1
+    assert duplicate.usage["recipient_deliveries_in_day"] == 3
+
+
+def test_ten_minute_limit_returns_structured_retry_information():
+    collection = _collection()
+    policy = _policy(max_messages_per_10_minutes=2)
+    assert _reserve(collection, "delivery-1", policy=policy).allowed is True
+    assert _reserve(collection, "delivery-2", policy=policy).allowed is True
+
+    denied = _reserve(collection, "delivery-3", policy=policy)
+    receipt = denied.as_dict(now=NOW)
+
+    assert denied.allowed is False
+    assert denied.code == "gmail_outbound_rate_limit_exceeded"
+    assert denied.exhausted_limits == ("messages_per_10_minutes",)
+    assert receipt["retry_at"] == "2026-08-12T09:10:00Z"
+    assert receipt["retry_after_seconds"] == 300
+    assert receipt["usage"]["messages_in_10_minute_window"] == 2
+
+
+def test_daily_recipient_delivery_limit_is_separate_from_message_limit():
+    collection = _collection()
+    policy = _policy(
+        max_messages_per_10_minutes=10,
+        max_messages_per_day=10,
+        max_recipients_per_message=4,
+        max_recipient_deliveries_per_day=5,
+    )
+    assert _reserve(collection, "delivery-1", recipient_count=3, policy=policy).allowed
+    assert _reserve(collection, "delivery-2", recipient_count=2, policy=policy).allowed
+
+    denied = _reserve(collection, "delivery-3", recipient_count=1, policy=policy)
+
+    assert denied.allowed is False
+    assert denied.exhausted_limits == ("recipient_deliveries_per_day",)
+    assert denied.as_dict(now=NOW)["retry_at"] == "2026-08-13T00:00:00Z"
+
+
+def test_per_message_recipient_limit_does_not_touch_quota_store():
+    collection = _collection()
+
+    denied = _reserve(
+        collection,
+        "delivery-too-wide",
+        recipient_count=3,
+        policy=_policy(max_recipients_per_message=2),
+    )
+
+    assert denied.allowed is False
+    assert denied.code == "gmail_outbound_recipient_limit_exceeded"
+    assert collection.count_documents({}) == 0
+
+
+def test_concurrent_unique_reservations_cannot_exceed_message_limit():
+    collection = _collection()
+    policy = _policy(max_messages_per_10_minutes=5)
+
+    def reserve(index):
+        return _reserve(collection, f"delivery-{index}", policy=policy)
+
+    with ThreadPoolExecutor(max_workers=12) as executor:
+        decisions = list(executor.map(reserve, range(30)))
+
+    assert sum(decision.allowed for decision in decisions) == 5
+    document = collection.find_one({})
+    assert document is not None
+    assert document["messages_in_day"] == 5
+
+
+def test_concurrent_duplicate_reservations_consume_one_slot():
+    collection = _collection()
+
+    def reserve(_index):
+        return _reserve(collection, "delivery-identical", recipient_count=2)
+
+    with ThreadPoolExecutor(max_workers=12) as executor:
+        decisions = list(executor.map(reserve, range(30)))
+
+    assert all(decision.allowed for decision in decisions)
+    assert (
+        sum(decision.code == "gmail_outbound_quota_reserved" for decision in decisions)
+        == 1
+    )
+    document = collection.find_one({})
+    assert document is not None
+    assert document["messages_in_day"] == 1
+    assert document["recipient_deliveries_in_day"] == 2
+
+
+def test_new_ten_minute_bucket_and_utc_day_receive_fresh_capacity():
+    collection = _collection()
+    policy = _policy(max_messages_per_10_minutes=1, max_messages_per_day=2)
+    assert _reserve(collection, "delivery-1", policy=policy).allowed
+    assert not _reserve(collection, "delivery-2", policy=policy).allowed
+
+    next_bucket = datetime(2026, 8, 12, 9, 10, tzinfo=UTC)
+    assert _reserve(
+        collection,
+        "delivery-2",
+        policy=policy,
+        now=next_bucket,
+    ).allowed
+
+    next_day = datetime(2026, 8, 13, 0, 0, tzinfo=UTC)
+    assert _reserve(
+        collection,
+        "delivery-3",
+        policy=policy,
+        now=next_day,
+    ).allowed
+    assert collection.count_documents({}) == 2

--- a/tests/backend/test_gmail_outbound_rate_limit_settings.py
+++ b/tests/backend/test_gmail_outbound_rate_limit_settings.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from flask import Flask
+
+from src.backend.server.routes import settings_routes
+from src.backend.server.routes.settings_routes import settings_bp
+from src.backend.services import settings_service
+
+
+def _make_settings_app() -> Flask:
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.config["TESTING"] = True
+    app.register_blueprint(settings_bp, url_prefix="/api/settings")
+    return app
+
+
+def _policy(**overrides) -> settings_service.GmailOutboundRateLimitSettings:
+    values: dict[str, Any] = {
+        "enabled": False,
+        "max_messages_per_10_minutes": 5,
+        "max_messages_per_day": 25,
+        "max_recipients_per_message": 10,
+        "max_recipient_deliveries_per_day": 50,
+    }
+    values.update(overrides)
+    return settings_service.GmailOutboundRateLimitSettings(**values)
+
+
+def _patch_unrelated_settings_reads(monkeypatch) -> None:
+    monkeypatch.setattr(settings_routes, "resolve_rag_embedder_setting", lambda: None)
+    monkeypatch.setattr(settings_routes, "resolve_rag_llm_setting", lambda: None)
+    monkeypatch.setattr(settings_routes, "get_server_default_llm_setting", lambda: None)
+
+
+def test_policy_defaults_disabled_with_conservative_limits(monkeypatch):
+    monkeypatch.setattr(settings_service, "get_setting", lambda _name: None)
+
+    policy = settings_service.get_gmail_outbound_rate_limit_settings()
+
+    assert policy.as_dict() == {
+        "schema_version": "gmail_outbound_rate_limits.v1",
+        "enabled": False,
+        "max_messages_per_10_minutes": 5,
+        "max_messages_per_day": 25,
+        "max_recipients_per_message": 10,
+        "max_recipient_deliveries_per_day": 50,
+    }
+
+
+def test_stored_policy_is_typed_clamped_and_internally_consistent():
+    policy = settings_service.normalise_gmail_outbound_rate_limit_settings(
+        {
+            "enabled": "yes",
+            "max_messages_per_10_minutes": 999,
+            "max_messages_per_day": -2,
+            "max_recipients_per_message": 100,
+            "max_recipient_deliveries_per_day": 4,
+        }
+    )
+
+    assert policy.enabled is True
+    assert policy.max_messages_per_10_minutes == 100
+    assert policy.max_messages_per_day == 1
+    assert policy.max_recipients_per_message == 4
+    assert policy.max_recipient_deliveries_per_day == 4
+
+
+@pytest.mark.parametrize(
+    "payload, error_fragment",
+    [
+        ({"enabled": "yes"}, "enabled must be a boolean"),
+        ({"max_messages_per_day": True}, "must be an integer"),
+        ({"max_messages_per_day": 0}, "must be between 1 and 1000"),
+        ({"typo": 3}, "unknown field"),
+        (
+            {"schema_version": "gmail_outbound_rate_limits.v999"},
+            "schema_version",
+        ),
+        (
+            {
+                "max_recipients_per_message": 11,
+                "max_recipient_deliveries_per_day": 10,
+            },
+            "cannot exceed",
+        ),
+    ],
+)
+def test_strict_admin_policy_parser_rejects_ambiguous_values(payload, error_fragment):
+    with pytest.raises(ValueError, match=error_fragment):
+        settings_service.parse_gmail_outbound_rate_limit_settings(payload)
+
+
+def test_partial_admin_policy_inherits_current_values():
+    parsed = settings_service.parse_gmail_outbound_rate_limit_settings(
+        {"enabled": True},
+        current=_policy(max_messages_per_day=40),
+    )
+
+    assert parsed.enabled is True
+    assert parsed.max_messages_per_day == 40
+    assert parsed.max_messages_per_10_minutes == 5
+
+
+def test_batch_settings_exposes_canonical_policy(monkeypatch):
+    monkeypatch.setattr(
+        settings_service,
+        "get_settings_batch",
+        lambda _names: {
+            settings_service.GMAIL_OUTBOUND_RATE_LIMITS_SETTING_NAME: {
+                "enabled": True,
+                "max_messages_per_day": 30,
+            }
+        },
+    )
+
+    result = settings_service.get_all_settings_batch()
+
+    assert result["gmail_outbound_rate_limits"]["enabled"] is True
+    assert result["gmail_outbound_rate_limits"]["max_messages_per_day"] == 30
+
+
+def test_non_admin_cannot_update_outbound_email_policy(monkeypatch):
+    app = _make_settings_app()
+    called = {"value": False}
+    monkeypatch.setattr(
+        settings_routes,
+        "set_gmail_outbound_rate_limit_settings",
+        lambda _value: called.update(value=True) or True,
+    )
+
+    with app.test_client() as client:
+        with client.session_transaction() as session:
+            session["role_in_org"] = "member"
+        response = client.post(
+            "/api/settings/",
+            json={"gmail_outbound_rate_limits": {"enabled": True}},
+        )
+
+    assert response.status_code == 403
+    assert called["value"] is False
+
+
+def test_admin_can_update_valid_outbound_email_policy(monkeypatch):
+    app = _make_settings_app()
+    _patch_unrelated_settings_reads(monkeypatch)
+    captured = {}
+    monkeypatch.setattr(
+        settings_routes,
+        "get_gmail_outbound_rate_limit_settings",
+        lambda: _policy(),
+    )
+
+    def persist(value):
+        captured["policy"] = value
+        return True
+
+    monkeypatch.setattr(
+        settings_routes,
+        "set_gmail_outbound_rate_limit_settings",
+        persist,
+    )
+
+    with app.test_client() as client:
+        with client.session_transaction() as session:
+            session["role_in_org"] = "admin"
+        response = client.post(
+            "/api/settings/",
+            json={
+                "gmail_outbound_rate_limits": {
+                    "enabled": True,
+                    "max_messages_per_10_minutes": 4,
+                    "max_messages_per_day": 20,
+                    "max_recipients_per_message": 8,
+                    "max_recipient_deliveries_per_day": 40,
+                }
+            },
+        )
+
+    assert response.status_code == 200
+    assert captured["policy"].enabled is True
+    assert captured["policy"].max_messages_per_10_minutes == 4
+    assert response.get_json()["gmail_outbound_rate_limits"]["enabled"] is True
+
+
+def test_admin_endpoint_rejects_invalid_policy_without_persisting(monkeypatch):
+    app = _make_settings_app()
+    _patch_unrelated_settings_reads(monkeypatch)
+    called = {"value": False}
+    monkeypatch.setattr(
+        settings_routes,
+        "get_gmail_outbound_rate_limit_settings",
+        lambda: _policy(),
+    )
+    monkeypatch.setattr(
+        settings_routes,
+        "set_gmail_outbound_rate_limit_settings",
+        lambda _value: called.update(value=True) or True,
+    )
+
+    with app.test_client() as client:
+        with client.session_transaction() as session:
+            session["role_in_org"] = "owner"
+        response = client.post(
+            "/api/settings/",
+            json={"gmail_outbound_rate_limits": {"max_messages_per_10_minutes": 0}},
+        )
+
+    assert response.status_code == 400
+    assert called["value"] is False
+
+
+def test_policy_is_only_returned_to_admin_or_owner(monkeypatch):
+    app = _make_settings_app()
+    _patch_unrelated_settings_reads(monkeypatch)
+    monkeypatch.setattr(
+        settings_routes,
+        "get_all_settings_data",
+        lambda: {"gmail_outbound_rate_limits": _policy(enabled=True).as_dict()},
+    )
+    monkeypatch.setattr(
+        settings_routes,
+        "get_gmail_outbound_rate_limit_settings",
+        lambda: _policy(enabled=True),
+    )
+
+    with app.test_client() as client:
+        with client.session_transaction() as session:
+            session["role_in_org"] = "member"
+        member_response = client.get("/api/settings/")
+
+        with client.session_transaction() as session:
+            session["role_in_org"] = "owner"
+        owner_response = client.get("/api/settings/")
+
+    assert member_response.status_code == 200
+    assert "gmail_outbound_rate_limits" not in member_response.get_json()
+    assert owner_response.status_code == 200
+    assert owner_response.get_json()["gmail_outbound_rate_limits"]["enabled"] is True

--- a/tests/backend/test_gmail_profile_invocation_authority_service.py
+++ b/tests/backend/test_gmail_profile_invocation_authority_service.py
@@ -135,6 +135,92 @@ def test_trusted_local_operator_can_select_configured_profile(monkeypatch):
     assert authority.principal.kind == "trusted_local_operator"
 
 
+def test_actor_send_requires_selected_profile_to_represent_von_system(monkeypatch):
+    from src.backend.integrations.google import gmail_service
+    from src.backend.integrations.internal_mcp import catalogue
+    from src.backend.security.access_control import override_current_actor
+    from src.backend.services import mail_profile_resource_vontology_service
+
+    monkeypatch.setattr(
+        mail_profile_resource_vontology_service,
+        "resolve_authorised_gmail_profile_for_user",
+        lambda **_kwargs: {
+            "success": True,
+            "reason_code": "authorised_mail_profile_resolved",
+            "profile_id": "actor-mail",
+            "profile_resource_concept_id": "#V#gmail_profile_actor_mail",
+        },
+    )
+    monkeypatch.setattr(
+        gmail_service,
+        "load_profiles_from_env",
+        lambda: _runtime_profiles("actor-mail"),
+    )
+    monkeypatch.setattr(
+        mail_profile_resource_vontology_service,
+        "mail_profile_resource_represents_identity",
+        lambda **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        gmail_service,
+        "send_message",
+        lambda **_kwargs: pytest.fail("identity denial must precede Gmail send"),
+    )
+
+    with override_current_actor("#V#actor", "#V#org"):
+        result = catalogue._gmail_send_message(
+            profile="#V#gmail_profile_actor_mail",
+            to="recipient@example.test",
+            subject="Identity boundary",
+            body_text="This must not be sent.",
+            allow_send=True,
+            request_id="actor-identity-denial-1",
+        )
+
+    assert result["error_code"] == "gmail_agent_identity_not_represented"
+
+
+def test_trusted_operator_send_requires_configured_profile_to_represent_von_system(
+    monkeypatch,
+):
+    from src.backend.integrations.google import gmail_service
+    from src.backend.integrations.internal_mcp import catalogue
+    from src.backend.integrations.internal_mcp.gateway import (
+        bind_internal_mcp_actor_context_source,
+    )
+    from src.backend.services import mail_profile_resource_vontology_service
+
+    monkeypatch.setattr(
+        gmail_service,
+        "load_profiles_from_env",
+        lambda: _runtime_profiles("operator-profile"),
+    )
+    monkeypatch.setattr(
+        mail_profile_resource_vontology_service,
+        "mail_profile_resource_represents_identity",
+        lambda **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        gmail_service,
+        "send_message",
+        lambda **_kwargs: pytest.fail("identity denial must precede Gmail send"),
+    )
+
+    with bind_internal_mcp_actor_context_source(
+        "trusted_operator_payload_fallback"
+    ):
+        result = catalogue._gmail_send_message(
+            profile="operator-profile",
+            to="recipient@example.test",
+            subject="Identity boundary",
+            body_text="This must not be sent.",
+            allow_send=True,
+            request_id="operator-identity-denial-1",
+        )
+
+    assert result["error_code"] == "gmail_agent_identity_not_represented"
+
+
 def test_unscoped_direct_call_is_not_implicitly_operator():
     from src.backend.services.gmail_profile_invocation_authority_service import (
         GmailInvocationAuthorityError,
@@ -215,9 +301,10 @@ def test_catalogue_global_profile_listing_is_operator_only(monkeypatch):
                 "profile": "victim-profile",
                 "to": "recipient@example.test",
                 "subject": "Forged actor check",
-                "body_text": "This must not be sent.",
-                "allow_send": True,
-                "namespace": "#V#victim@victim_org",
+                    "body_text": "This must not be sent.",
+                    "allow_send": True,
+                    "request_id": "forged-actor-send-1",
+                    "namespace": "#V#victim@victim_org",
             },
         ),
     ),

--- a/tests/backend/test_gmail_service.py
+++ b/tests/backend/test_gmail_service.py
@@ -1,13 +1,59 @@
 import base64
+import hashlib
 import json
 import socket
 from datetime import datetime, timezone
+from email.message import EmailMessage
+from email.parser import BytesParser
+from email.policy import default as default_email_policy
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import mongomock
 import pytest
 
 from src.backend.integrations.google import gmail_service as gs
+from src.backend.services.gmail_outbound_mailbox_identity_service import (
+    derive_canonical_gmail_mailbox_key,
+)
+from src.backend.services.settings_service import GmailOutboundRateLimitSettings
+
+
+def _outbound_test_collections():
+    database = mongomock.MongoClient().von_test
+    deliveries = database.gmail_outbound_deliveries
+    deliveries.create_index("delivery_fingerprint", unique=True)
+    return database.gmail_outbound_quota, deliveries
+
+
+def _enabled_outbound_settings(**overrides):
+    values = {
+        "enabled": True,
+        "max_messages_per_10_minutes": 5,
+        "max_messages_per_day": 25,
+        "max_recipients_per_message": 10,
+        "max_recipient_deliveries_per_day": 50,
+    }
+    values.update(overrides)
+    return GmailOutboundRateLimitSettings(**values)
+
+
+def _outbound_send_kwargs(
+    *,
+    quota_collection,
+    delivery_collection,
+    request_id,
+    profile_resource_concept_id="#V#gmail_profile_zhan_gmail",
+):
+    return {
+        "profile_resource_concept_id": profile_resource_concept_id,
+        "request_id": request_id,
+        "acting_user_concept_id": "#V#michael_witbrock",
+        "organisation_concept_id": "#V#strong_ai_lab",
+        "outbound_rate_limit_settings": _enabled_outbound_settings(),
+        "outbound_quota_collection": quota_collection,
+        "outbound_delivery_collection": delivery_collection,
+    }
 
 
 class _FakeSocket:
@@ -565,6 +611,645 @@ def test_find_attachment_part_metadata_bounds_mime_traversal():
         )
         == {}
     )
+
+
+def test_send_message_rejects_html_that_could_hide_agent_disclosure():
+    quota_collection, delivery_collection = _outbound_test_collections()
+
+    with pytest.raises(ValueError, match="body_html is not supported"):
+        gs.send_message(
+            profile_id="zhan-gmail",
+            to="recipient@example.test",
+            subject="Agent message",
+            body_text="Private research summary.",
+            body_html="<style>p{display:none}</style><p>Hidden notice</p>",
+            allow_send=True,
+            profiles={},
+            **_outbound_send_kwargs(
+                quota_collection=quota_collection,
+                delivery_collection=delivery_collection,
+                request_id="turn-hidden-disclosure-1",
+            ),
+        )
+
+    assert quota_collection.count_documents({}) == 0
+    assert delivery_collection.count_documents({}) == 0
+
+
+def test_send_message_returns_verified_body_free_canonical_readback(monkeypatch):
+    captured: dict = {}
+    monkeypatch.setattr(gs, "_resolve_vontology_profile_scopes", lambda _profile: None)
+    quota_collection, delivery_collection = _outbound_test_collections()
+    request_id = "turn-verified-1"
+    expected_fingerprint = gs._outbound_delivery_identity(
+        canonical_mailbox_key=derive_canonical_gmail_mailbox_key(
+            "zhan@example.test"
+        ),
+        request_id=request_id,
+        to=["recipient@example.test"],
+        cc=["copy@example.test"],
+        bcc=["blind-copy@example.test"],
+        reply_to=[],
+        subject="Agent message",
+        body_text="Private research summary.",
+        body_html=None,
+    )[0]
+    canonical_message = EmailMessage()
+    canonical_message["From"] = "Zhan (Von AI Agent) <zhan@example.test>"
+    canonical_message["To"] = "recipient@example.test"
+    canonical_message["Cc"] = "copy@example.test"
+    canonical_message["Bcc"] = "blind-copy@example.test"
+    canonical_message["Subject"] = "Agent message"
+    canonical_message[gs.AI_AGENT_MACHINE_HEADER] = "Von; disclosure=body"
+    canonical_message[gs.DELIVERY_FINGERPRINT_HEADER] = expected_fingerprint
+    canonical_message["Message-ID"] = (
+        "<provider-rewritten-message-id@example.test>"
+    )
+    canonical_message.set_content(
+        "Private research summary.\n\n" + gs.AI_AGENT_DISCLOSURE_TEXT
+    )
+    canonical_raw = base64.urlsafe_b64encode(
+        canonical_message.as_bytes()
+    ).decode("ascii")
+
+    class _Request:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def execute(self):
+            return self.payload
+
+    class _Messages:
+        def send(self, **kwargs):
+            captured["send_kwargs"] = kwargs
+            captured["send_count"] = captured.get("send_count", 0) + 1
+            return _Request(
+                {
+                    "id": "sent-1",
+                    "threadId": "thread-1",
+                    "raw": "private-provider-body",
+                    "payload": {"body": {"data": "private-provider-body"}},
+                }
+            )
+
+        def get(self, **kwargs):
+            captured["get_kwargs"] = kwargs
+            return _Request(
+                {
+                    "id": "sent-1",
+                    "threadId": "thread-1",
+                    "labelIds": ["SENT"],
+                    "raw": canonical_raw,
+                }
+            )
+
+    class _Users:
+        def __init__(self):
+            self._messages = _Messages()
+
+        def messages(self):
+            return self._messages
+
+        def getProfile(self, **kwargs):
+            captured["profile_kwargs"] = kwargs
+            return _Request({"emailAddress": "zhan@example.test"})
+
+    class _Service:
+        def __init__(self):
+            self._users = _Users()
+
+        def users(self):
+            return self._users
+
+    profiles = {
+        "zhan-gmail": gs.GmailProfile(
+            profile_id="zhan-gmail",
+            token_path="/tmp/fake-token.json",
+            scopes=[gs.MUTATION_SCOPE],
+        )
+    }
+    monkeypatch.setattr(gs, "get_service", lambda *_args, **_kwargs: _Service())
+
+    result = gs.send_message(
+        profile_id="zhan-gmail",
+        to="recipient@example.test",
+        cc="copy@example.test",
+        bcc="blind-copy@example.test",
+        subject="Agent message",
+        body_text="Private research summary.",
+        allow_send=True,
+        profiles=profiles,
+        **_outbound_send_kwargs(
+            quota_collection=quota_collection,
+            delivery_collection=delivery_collection,
+            request_id=request_id,
+        ),
+    )
+
+    sent_message = BytesParser(policy=default_email_policy).parsebytes(
+        base64.urlsafe_b64decode(
+            captured["send_kwargs"]["body"]["raw"].encode("ascii")
+        )
+    )
+    assert gs.AI_AGENT_DISCLOSURE_TEXT in sent_message.get_body(
+        preferencelist=("plain",)
+    ).get_content()
+    assert sent_message.get_body(preferencelist=("html",)) is None
+    assert sent_message["From"] == "Von AI Agent <zhan@example.test>"
+    assert captured["profile_kwargs"] == {"userId": "me"}
+    assert captured["get_kwargs"] == {
+        "userId": "me",
+        "id": "sent-1",
+        "format": "raw",
+        "fields": "id,threadId,labelIds,raw",
+    }
+
+    readback = result["canonical_readback"]
+    assert result["success"] is True
+    assert result["status"] == "succeeded"
+    assert result["gmail_send_state_verified"] is True
+    assert result["effect_status"] == "succeeded"
+    assert result["outcome_finality"] == "canonical_durable_readback"
+    assert readback["verified"] is True
+    assert readback["body_included"] is False
+    assert readback["sent_label_verified"] is True
+    assert readback["sender_address"] == "zhan@example.test"
+    assert readback["sender_verified"] is True
+    assert readback["to"] == ["recipient@example.test"]
+    assert readback["cc"] == ["copy@example.test"]
+    assert readback["bcc_count"] == 1
+    assert readback["recipients_verified"] is True
+    assert readback["subject_verified"] is True
+    assert readback["disclosure_verified"] is True
+    assert readback["machine_disclosure_verified"] is True
+    assert readback["delivery_fingerprint_verified"] is True
+    assert result["delivery_ledger_status"] == "succeeded"
+    assert result["quota"]["allowed"] is True
+    assert "Private research summary." not in json.dumps(readback)
+    assert "raw" not in readback
+    assert "private-provider-body" not in json.dumps(result)
+    assert "payload" not in result
+
+    replay = gs.send_message(
+        profile_id="zhan-gmail",
+        to="recipient@example.test",
+        cc="copy@example.test",
+        bcc="blind-copy@example.test",
+        subject="Agent message",
+        body_text="Private research summary.",
+        allow_send=True,
+        profiles=profiles,
+        **_outbound_send_kwargs(
+            quota_collection=quota_collection,
+            delivery_collection=delivery_collection,
+            request_id=request_id,
+        ),
+    )
+
+    assert captured["send_count"] == 1
+    assert replay["success"] is True
+    assert replay["idempotent_replay"] is True
+    assert replay["changed"] is False
+    assert replay["outcome_finality"] == "durable_idempotent_replay"
+
+
+def test_send_message_aliases_share_mailbox_delivery_and_quota_identity(monkeypatch):
+    """Two authorised aliases for one Gmail mailbox cannot bypass controls."""
+
+    quota_collection, delivery_collection = _outbound_test_collections()
+    monkeypatch.setattr(gs, "_resolve_vontology_profile_scopes", lambda _profile: None)
+    canonical_address = "shared-mailbox@example.test"
+    mailbox_key = derive_canonical_gmail_mailbox_key(canonical_address)
+    request_id = "turn-same-mailbox-two-aliases-1"
+    expected_fingerprint = gs._outbound_delivery_identity(
+        canonical_mailbox_key=mailbox_key,
+        request_id=request_id,
+        to=["recipient@example.test"],
+        cc=[],
+        bcc=[],
+        reply_to=[],
+        subject="Alias-safe agent message",
+        body_text="Private research summary.",
+        body_html=None,
+    )[0]
+    canonical_message = EmailMessage()
+    canonical_message["From"] = f"Von AI Agent <{canonical_address}>"
+    canonical_message["To"] = "recipient@example.test"
+    canonical_message["Subject"] = "Alias-safe agent message"
+    canonical_message[gs.AI_AGENT_MACHINE_HEADER] = "Von; disclosure=body"
+    canonical_message[gs.DELIVERY_FINGERPRINT_HEADER] = expected_fingerprint
+    canonical_message["Message-ID"] = (
+        "<provider-rewritten-message-id@example.test>"
+    )
+    canonical_message.set_content(
+        "Private research summary.\n\n" + gs.AI_AGENT_DISCLOSURE_TEXT
+    )
+    canonical_raw = base64.urlsafe_b64encode(
+        canonical_message.as_bytes()
+    ).decode("ascii")
+    captured = {"send_count": 0, "messages_calls": 0, "profile_reads": 0}
+
+    class _Request:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def execute(self):
+            return self.payload
+
+    class _Messages:
+        def send(self, **_kwargs):
+            captured["send_count"] += 1
+            return _Request({"id": "sent-alias-1", "threadId": "thread-alias-1"})
+
+        def get(self, **_kwargs):
+            return _Request(
+                {
+                    "id": "sent-alias-1",
+                    "threadId": "thread-alias-1",
+                    "labelIds": ["SENT"],
+                    "raw": canonical_raw,
+                }
+            )
+
+    class _Users:
+        def __init__(self):
+            self._messages = _Messages()
+
+        def getProfile(self, **_kwargs):
+            captured["profile_reads"] += 1
+            return _Request({"emailAddress": canonical_address})
+
+        def messages(self):
+            captured["messages_calls"] += 1
+            return self._messages
+
+    class _Service:
+        def __init__(self):
+            self._users = _Users()
+
+        def users(self):
+            return self._users
+
+    profiles = {
+        "alias-a": gs.GmailProfile(
+            profile_id="alias-a",
+            token_path="/tmp/fake-a.json",
+            scopes=[gs.MUTATION_SCOPE],
+        ),
+        "alias-b": gs.GmailProfile(
+            profile_id="alias-b",
+            token_path="/tmp/fake-b.json",
+            scopes=[gs.MUTATION_SCOPE],
+        ),
+    }
+    service = _Service()
+    monkeypatch.setattr(gs, "get_service", lambda *_args, **_kwargs: service)
+
+    common = {
+        "to": "recipient@example.test",
+        "subject": "Alias-safe agent message",
+        "body_text": "Private research summary.",
+        "allow_send": True,
+        "profiles": profiles,
+    }
+    first = gs.send_message(
+        profile_id="alias-a",
+        **common,
+        **_outbound_send_kwargs(
+            quota_collection=quota_collection,
+            delivery_collection=delivery_collection,
+            request_id=request_id,
+            profile_resource_concept_id="#V#gmail_profile_alias_a",
+        ),
+    )
+    replay = gs.send_message(
+        profile_id="alias-b",
+        **common,
+        **_outbound_send_kwargs(
+            quota_collection=quota_collection,
+            delivery_collection=delivery_collection,
+            request_id=request_id,
+            profile_resource_concept_id="#V#gmail_profile_alias_b",
+        ),
+    )
+    rate_limited_kwargs = _outbound_send_kwargs(
+        quota_collection=quota_collection,
+        delivery_collection=delivery_collection,
+        request_id="turn-same-mailbox-two-aliases-2",
+        profile_resource_concept_id="#V#gmail_profile_alias_b",
+    )
+    rate_limited_kwargs["outbound_rate_limit_settings"] = (
+        _enabled_outbound_settings(max_messages_per_10_minutes=1)
+    )
+    denied = gs.send_message(
+        profile_id="alias-b",
+        **common,
+        **rate_limited_kwargs,
+    )
+
+    assert first["effect_status"] == "succeeded"
+    assert replay["success"] is True
+    assert replay["idempotent_replay"] is True
+    assert replay["delivery_fingerprint"] == first["delivery_fingerprint"]
+    assert denied["error_code"] == "gmail_outbound_rate_limit_exceeded"
+    assert denied["effect_status"] == "not_started"
+    assert captured["send_count"] == 1
+    assert captured["profile_reads"] == 4
+    assert quota_collection.count_documents({}) == 1
+    quota_document = quota_collection.find_one({})
+    assert quota_document["messages_in_day"] == 1
+    assert quota_document["canonical_mailbox_key"] == mailbox_key
+    assert delivery_collection.count_documents({}) == 2
+    delivery_document = delivery_collection.find_one(
+        {"delivery_fingerprint": first["delivery_fingerprint"]}
+    )
+    assert delivery_document["canonical_mailbox_key"] == mailbox_key
+    assert delivery_document["observed_profile_resource_concept_ids"] == [
+        "#V#gmail_profile_alias_a",
+        "#V#gmail_profile_alias_b",
+    ]
+    assert delivery_document["observed_profile_alias_digests"] == [
+        hashlib.sha256(b"alias-a").hexdigest(),
+        hashlib.sha256(b"alias-b").hexdigest(),
+    ]
+    assert canonical_address not in str(quota_document)
+    assert canonical_address not in str(list(delivery_collection.find({})))
+
+
+def test_send_message_canonical_mailbox_preflight_failure_has_no_effect(
+    monkeypatch,
+):
+    quota_collection, delivery_collection = _outbound_test_collections()
+    monkeypatch.setattr(gs, "_resolve_vontology_profile_scopes", lambda _profile: None)
+    captured = {"messages_calls": 0}
+
+    class _FailedRequest:
+        def execute(self):
+            raise TimeoutError("canonical Gmail profile lookup timed out")
+
+    class _Users:
+        def getProfile(self, **_kwargs):
+            return _FailedRequest()
+
+        def messages(self):
+            captured["messages_calls"] += 1
+            raise AssertionError("messages resource must not be accessed")
+
+    class _Service:
+        def users(self):
+            return _Users()
+
+    profiles = {
+        "alias-a": gs.GmailProfile(
+            profile_id="alias-a",
+            token_path="/tmp/fake-a.json",
+            scopes=[gs.MUTATION_SCOPE],
+        )
+    }
+    monkeypatch.setattr(gs, "get_service", lambda *_args, **_kwargs: _Service())
+
+    result = gs.send_message(
+        profile_id="alias-a",
+        to="recipient@example.test",
+        subject="Preflight failure",
+        body_text="This must not be sent.",
+        allow_send=True,
+        profiles=profiles,
+        **_outbound_send_kwargs(
+            quota_collection=quota_collection,
+            delivery_collection=delivery_collection,
+            request_id="turn-preflight-failure-1",
+            profile_resource_concept_id="#V#gmail_profile_alias_a",
+        ),
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "gmail_canonical_mailbox_preflight_failed"
+    assert result["effect_status"] == "not_started"
+    assert result["provider_dispatch_attempted"] is False
+    assert "delivery_fingerprint" not in result
+    assert captured["messages_calls"] == 0
+    assert quota_collection.count_documents({}) == 0
+    assert delivery_collection.count_documents({}) == 0
+
+
+def test_send_message_reports_completed_send_with_failed_readback_as_indeterminate(
+    monkeypatch,
+):
+    quota_collection, delivery_collection = _outbound_test_collections()
+    monkeypatch.setattr(gs, "_resolve_vontology_profile_scopes", lambda _profile: None)
+    class _Request:
+        def __init__(self, payload=None, error=None):
+            self.payload = payload
+            self.error = error
+
+        def execute(self):
+            if self.error is not None:
+                raise self.error
+            return self.payload
+
+    class _Messages:
+        def send(self, **_kwargs):
+            return _Request({"id": "sent-1"})
+
+        def get(self, **_kwargs):
+            return _Request(error=TimeoutError("read-back timed out"))
+
+    class _Users:
+        def messages(self):
+            return _Messages()
+
+        def getProfile(self, **_kwargs):
+            return _Request({"emailAddress": "zhan@example.test"})
+
+    class _Service:
+        def users(self):
+            return _Users()
+
+    profiles = {
+        "zhan-gmail": gs.GmailProfile(
+            profile_id="zhan-gmail",
+            token_path="/tmp/fake-token.json",
+            scopes=[gs.MUTATION_SCOPE],
+        )
+    }
+    monkeypatch.setattr(gs, "get_service", lambda *_args, **_kwargs: _Service())
+
+    result = gs.send_message(
+        profile_id="zhan-gmail",
+        to="recipient@example.test",
+        subject="Agent message",
+        body_text="Private research summary.",
+        allow_send=True,
+        profiles=profiles,
+        **_outbound_send_kwargs(
+            quota_collection=quota_collection,
+            delivery_collection=delivery_collection,
+            request_id="turn-indeterminate-1",
+        ),
+    )
+
+    assert result["changed"] is True
+    assert result["success"] is False
+    assert result["status"] == "indeterminate"
+    assert result["gmail_send_state_verified"] is False
+    assert result["effect_status"] == "indeterminate"
+    assert result["mutation_outcome"] == "unknown"
+    assert result["outcome_finality"] == "canonical_readback_indeterminate"
+    assert result["delivery_ledger_status"] == "indeterminate"
+    assert result["canonical_readback"] == {
+        "status": "unavailable",
+        "verified": False,
+        "body_included": False,
+        "message_id": "sent-1",
+        "error_code": "gmail_sent_message_readback_unavailable",
+        "exception_type": "TimeoutError",
+    }
+
+
+def test_send_message_reconciles_lost_provider_response_without_redispatch(
+    monkeypatch,
+):
+    quota_collection, delivery_collection = _outbound_test_collections()
+    monkeypatch.setattr(gs, "_resolve_vontology_profile_scopes", lambda _profile: None)
+    request_id = "turn-provider-response-lost-1"
+    expected_fingerprint = gs._outbound_delivery_identity(
+        canonical_mailbox_key=derive_canonical_gmail_mailbox_key(
+            "zhan@example.test"
+        ),
+        request_id=request_id,
+        to=["recipient@example.test"],
+        cc=[],
+        bcc=[],
+        reply_to=[],
+        subject="Reconciled agent message",
+        body_text="Private research summary.",
+        body_html=None,
+    )[0]
+    canonical_message = EmailMessage()
+    canonical_message["From"] = "Von AI Agent <zhan@example.test>"
+    canonical_message["To"] = "recipient@example.test"
+    canonical_message["Subject"] = "Reconciled agent message"
+    canonical_message[gs.AI_AGENT_MACHINE_HEADER] = "Von; disclosure=body"
+    canonical_message[gs.DELIVERY_FINGERPRINT_HEADER] = expected_fingerprint
+    canonical_message["Message-ID"] = (
+        "<provider-rewritten-message-id@example.test>"
+    )
+    canonical_message.set_content(
+        "Private research summary.\n\n" + gs.AI_AGENT_DISCLOSURE_TEXT
+    )
+    canonical_raw = base64.urlsafe_b64encode(
+        canonical_message.as_bytes()
+    ).decode("ascii")
+    captured = {"send_count": 0, "list_count": 0, "metadata_get_count": 0}
+
+    class _Request:
+        def __init__(self, payload=None, error=None):
+            self.payload = payload
+            self.error = error
+
+        def execute(self):
+            if self.error is not None:
+                raise self.error
+            return self.payload
+
+    class _Messages:
+        def send(self, **_kwargs):
+            captured["send_count"] += 1
+            return _Request(error=TimeoutError("provider response lost"))
+
+        def list(self, **kwargs):
+            captured["list_count"] += 1
+            captured["list_kwargs"] = kwargs
+            return _Request({"messages": [{"id": "sent-1"}]})
+
+        def get(self, **kwargs):
+            if kwargs.get("format") == "metadata":
+                captured["metadata_get_count"] += 1
+                return _Request(
+                    {
+                        "id": "sent-1",
+                        "threadId": "thread-1",
+                        "labelIds": ["SENT"],
+                        "payload": {
+                            "headers": [
+                                {
+                                    "name": gs.DELIVERY_FINGERPRINT_HEADER,
+                                    "value": expected_fingerprint,
+                                }
+                            ]
+                        },
+                    }
+                )
+            return _Request(
+                {
+                    "id": "sent-1",
+                    "threadId": "thread-1",
+                    "labelIds": ["SENT"],
+                    "raw": canonical_raw,
+                }
+            )
+
+    class _Users:
+        def messages(self):
+            return _Messages()
+
+        def getProfile(self, **_kwargs):
+            return _Request({"emailAddress": "zhan@example.test"})
+
+    class _Service:
+        def users(self):
+            return _Users()
+
+    profiles = {
+        "zhan-gmail": gs.GmailProfile(
+            profile_id="zhan-gmail",
+            token_path="/tmp/fake-token.json",
+            scopes=[gs.MUTATION_SCOPE],
+        )
+    }
+    monkeypatch.setattr(gs, "get_service", lambda *_args, **_kwargs: _Service())
+
+    send_kwargs = _outbound_send_kwargs(
+        quota_collection=quota_collection,
+        delivery_collection=delivery_collection,
+        request_id=request_id,
+    )
+    result = gs.send_message(
+        profile_id="zhan-gmail",
+        to="recipient@example.test",
+        subject="Reconciled agent message",
+        body_text="Private research summary.",
+        allow_send=True,
+        profiles=profiles,
+        **send_kwargs,
+    )
+    replay = gs.send_message(
+        profile_id="zhan-gmail",
+        to="recipient@example.test",
+        subject="Reconciled agent message",
+        body_text="Private research summary.",
+        allow_send=True,
+        profiles=profiles,
+        **send_kwargs,
+    )
+
+    assert captured["send_count"] == 1
+    assert captured["list_count"] == 1
+    assert captured["metadata_get_count"] == 1
+    assert "rfc822msgid:" not in captured["list_kwargs"]["q"]
+    assert "subject:\"Reconciled agent message\"" in (
+        captured["list_kwargs"]["q"]
+    )
+    assert "to:recipient@example.test" in captured["list_kwargs"]["q"]
+    assert result["effect_status"] == "succeeded"
+    assert result["outcome_finality"] == (
+        "gmail_sent_reconciled_after_provider_error"
+    )
+    assert result["delivery_ledger_status"] == "succeeded"
+    assert result["delivery_reconciliation"]["verified"] is True
+    assert replay["idempotent_replay"] is True
+    assert replay["changed"] is False
 
 
 def test_modify_labels_guard(monkeypatch):

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -348,6 +348,7 @@ def test_ordinary_turn_read_projection_follows_capability_authority_metadata():
         "upsert_uncertain_relationship_assertion",
         "add_relationship",
         "gmail_import_attachment",
+        "gmail_send_message",
         "message_send_direct",
         "task_create",
         "task_update_status",
@@ -499,6 +500,72 @@ def test_ordinary_turn_read_projection_follows_capability_authority_metadata():
     }
     assert gmail_import_definition.ordinary_turn_trusted_argument_choice_bindings == {
         "profile": "gmail_profile",
+    }
+
+    gmail_send_definition = catalogue.get("gmail_send_message")
+    assert gmail_send_definition.category == "write"
+    assert gmail_send_definition.ordinary_turn_effect is True
+    assert gmail_send_definition.ordinary_turn_trusted_argument_bindings == {
+        "acting_user_concept_id": "actor_user_concept_id",
+        "organisation_concept_id": "actor_organisation_concept_id",
+        "request_id": "turn_id",
+        "namespace": "turn_namespace",
+    }
+    assert gmail_send_definition.ordinary_turn_trusted_argument_choice_bindings == {
+        "profile": "gmail_profile",
+    }
+    assert gmail_send_definition.ordinary_turn_fixed_arguments == {
+        "allow_send": True,
+    }
+    assert gmail_send_definition.write_guardrail == {
+        "ordinary_turn_explicit_request": True,
+    }
+
+    # Exact history recovery is constrained to the active conversation carrier.
+    # The model cannot redirect the session, actor, namespace, or signed-ref path.
+    assert "chat_history_get_segments" not in actor_reads
+    assert "chat_history_get_segments" in actor_mail_reads
+    history_definition = catalogue.get("chat_history_get_segments")
+    assert history_definition.ordinary_turn_trusted_argument_bindings == {
+        "session_id": "conversation_id",
+        "namespace": "turn_namespace",
+        "user_concept_id": "actor_user_concept_id",
+        "organisation_concept_id": "actor_organisation_concept_id",
+    }
+    assert history_definition.ordinary_turn_fixed_arguments == {
+        "conversation_ref": None,
+        "include_debug": False,
+    }
+
+    from src.backend.services.adaptive_turn_service import _trusted_tool_payload
+
+    history_payload = _trusted_tool_payload(
+        gateway=gateway,
+        tool_name="chat_history_get_segments",
+        model_payload={
+            "session_id": "foreign-conversation",
+            "conversation_ref": {"session_id": "foreign-conversation"},
+            "namespace": "#V#foreign@foreign_org",
+            "user_concept_id": "#V#foreign",
+            "organisation_concept_id": "#V#foreign_org",
+            "include_debug": True,
+            "segment_size": 10,
+        },
+        trusted_argument_values={
+            "conversation_id": "conversation-1",
+            "turn_namespace": "#V#ordinary_actor@ordinary_org",
+            "actor_user_concept_id": "#V#ordinary_actor",
+            "actor_organisation_concept_id": "#V#ordinary_org",
+        },
+    )
+    assert history_payload == {
+        "session_id": "conversation-1",
+        "conversation_ref": None,
+        "namespace": "#V#ordinary_actor@ordinary_org",
+        "user_concept_id": "#V#ordinary_actor",
+        "organisation_concept_id": "#V#ordinary_org",
+        "include_debug": False,
+        "segment_size": 10,
     }
 
     # These are mechanism-level exclusions: they expose ambient deployment
@@ -1680,6 +1747,11 @@ def test_gmail_send_message_registered_and_gateway_invokes(
         "src.backend.integrations.google.gmail_service.send_message",
         fake_send_message,
     )
+    monkeypatch.setattr(
+        "src.backend.services.mail_profile_resource_vontology_service."
+        "mail_profile_resource_represents_identity",
+        lambda **_kwargs: True,
+    )
 
     catalogue = build_default_catalogue()
     method = catalogue.get("gmail_send_message")
@@ -1701,6 +1773,7 @@ def test_gmail_send_message_registered_and_gateway_invokes(
             "subject": "Hi From Von",
             "body": "An interesting body.",
             "allow_send": True,
+            "request_id": "turn-send-1",
         },
     ).payload
 
@@ -1709,6 +1782,11 @@ def test_gmail_send_message_registered_and_gateway_invokes(
     assert captured["to"] == ["witbrock@gmail.com"]
     assert captured["body_text"] == "An interesting body."
     assert captured["allow_send"] is True
+    assert captured["request_id"] == "turn-send-1"
+    assert (
+        captured["profile_resource_concept_id"]
+        == "#V#gmail_profile_zhan_gmail"
+    )
     assert captured["audit_context"]["tool"] == "gmail_send_message"
 
 
@@ -1744,6 +1822,7 @@ def test_gmail_send_message_gateway_fails_closed_without_allow_send(monkeypatch)
             "subject": "Hi From Von",
             "body_text": "An interesting body.",
             "allow_send": False,
+            "request_id": "turn-send-denied-1",
         },
     ).payload
 
@@ -1901,9 +1980,13 @@ def test_gmail_service_send_message_builds_raw_mime_and_checks_scope(monkeypatch
     from email import message_from_bytes
     from email.policy import default as email_policy
 
+    import mongomock
     import pytest
 
     from src.backend.integrations.google import gmail_service as gs
+    from src.backend.services.settings_service import (
+        GmailOutboundRateLimitSettings,
+    )
 
     captured: dict = {}
 
@@ -1920,6 +2003,13 @@ def test_gmail_service_send_message_builds_raw_mime_and_checks_scope(monkeypatch
         def messages(self):
             return _FakeMessages()
 
+        def getProfile(self, **_kwargs):
+            class _ProfileReq:
+                def execute(self):
+                    return {"emailAddress": "zhan@example.test"}
+
+            return _ProfileReq()
+
     class _FakeService:
         def users(self):
             return _FakeUsers()
@@ -1927,19 +2017,29 @@ def test_gmail_service_send_message_builds_raw_mime_and_checks_scope(monkeypatch
     send_profile = gs.GmailProfile(
         profile_id="zhan-gmail",
         token_path="/tmp/fake-token.json",
-        scopes=[gs.SEND_SCOPE],
+        scopes=[gs.SEND_SCOPE, *gs.DEFAULT_SCOPES],
     )
     read_profile = gs.GmailProfile(
         profile_id="read-only-gmail",
         token_path="/tmp/fake-token.json",
         scopes=list(gs.DEFAULT_SCOPES),
     )
+    send_only_profile = gs.GmailProfile(
+        profile_id="send-only-gmail",
+        token_path="/tmp/fake-token.json",
+        scopes=[gs.SEND_SCOPE],
+    )
     profiles = {
         "zhan-gmail": send_profile,
         "read-only-gmail": read_profile,
+        "send-only-gmail": send_only_profile,
     }
 
     monkeypatch.setattr(gs, "get_service", lambda *_a, **_kw: _FakeService())
+    monkeypatch.setattr(gs, "_resolve_vontology_profile_scopes", lambda _profile: None)
+    test_database = mongomock.MongoClient().von_test
+    delivery_collection = test_database.gmail_outbound_deliveries
+    delivery_collection.create_index("delivery_fingerprint", unique=True)
 
     payload = gs.send_message(
         profile_id="zhan-gmail",
@@ -1948,6 +2048,11 @@ def test_gmail_service_send_message_builds_raw_mime_and_checks_scope(monkeypatch
         body_text="Here is a small interesting thought.",
         allow_send=True,
         profiles=profiles,
+        profile_resource_concept_id="#V#gmail_profile_zhan_gmail",
+        request_id="test-gmail-service-send",
+        outbound_rate_limit_settings=GmailOutboundRateLimitSettings(enabled=True),
+        outbound_quota_collection=test_database.gmail_outbound_quota,
+        outbound_delivery_collection=delivery_collection,
     )
 
     assert payload["message_id"] == "gmail-sent-1"
@@ -1959,8 +2064,10 @@ def test_gmail_service_send_message_builds_raw_mime_and_checks_scope(monkeypatch
     message = message_from_bytes(decoded, policy=email_policy)
     assert message["To"] == "witbrock@gmail.com"
     assert message["Subject"] == "Hi From Von"
+    assert message["From"] == "Von AI Agent <zhan@example.test>"
     assert message.get_body(preferencelist=("plain",)).get_content().strip() == (
-        "Here is a small interesting thought."
+        "Here is a small interesting thought.\n\n"
+        f"{gs.AI_AGENT_DISCLOSURE_TEXT}"
     )
 
     with pytest.raises(ValueError, match="allow_send"):
@@ -1976,6 +2083,16 @@ def test_gmail_service_send_message_builds_raw_mime_and_checks_scope(monkeypatch
     with pytest.raises(PermissionError, match="send-capable"):
         gs.send_message(
             profile_id="read-only-gmail",
+            to="witbrock@gmail.com",
+            subject="Hi From Von",
+            body_text="Body",
+            allow_send=True,
+            profiles=profiles,
+        )
+
+    with pytest.raises(PermissionError, match="read-back"):
+        gs.send_message(
+            profile_id="send-only-gmail",
             to="witbrock@gmail.com",
             subject="Hi From Von",
             body_text="Body",

--- a/tests/backend/test_mail_profile_resource_vontology_service.py
+++ b/tests/backend/test_mail_profile_resource_vontology_service.py
@@ -81,12 +81,14 @@ def test_materialise_gmail_profile_resources_links_user_profiles_and_aliases(
     user_concept_id = "#V#michael_witbrock"
     _create_user(user_concept_id)
     _create_user("#V#zhan_vonwitbrock")
+    _create_user("#V#von_system")
 
     report = service.materialise_gmail_profile_resources_for_user(
         user_concept_id=user_concept_id,
         profile_ids=["vonwitbrock-gmail", "zhan-gmail"],
         default_profile_id="vonwitbrock-gmail",
         profile_identity_concept_ids={
+            "vonwitbrock-gmail": "#V#von_system",
             "zhan-gmail": "#V#zhan_vonwitbrock",
         },
     )
@@ -116,6 +118,18 @@ def test_materialise_gmail_profile_resources_links_user_profiles_and_aliases(
         service.MAIL_PROFILE_REPRESENTS_IDENTITY_PREDICATE_ID,
     )
     assert identity_targets == {"#V#zhan_vonwitbrock"}
+    assert service.mail_profile_resource_represents_identity(
+        profile_resource_concept_id=von_profile,
+        identity_concept_id="#V#von_system",
+    )
+    assert not service.mail_profile_resource_represents_identity(
+        profile_resource_concept_id=von_profile,
+        identity_concept_id="#V#zhan_vonwitbrock",
+    )
+    assert not service.mail_profile_resource_represents_identity(
+        profile_resource_concept_id="#V#gmail_profile_missing",
+        identity_concept_id="#V#von_system",
+    )
 
     alias_targets = _targets(
         von_profile,
@@ -146,7 +160,7 @@ def test_materialise_gmail_profile_resources_links_user_profiles_and_aliases(
                 "profile_id": "vonwitbrock-gmail",
                 "profile_resource_concept_id": von_profile,
                 "is_default": True,
-                "represented_identity_concept_ids": [],
+                "represented_identity_concept_ids": ["#V#von_system"],
             },
             {
                 "profile_id": "zhan-gmail",

--- a/tests/backend/test_mongo_collection_index_guards.py
+++ b/tests/backend/test_mongo_collection_index_guards.py
@@ -193,6 +193,45 @@ def test_application_settings_index_is_ensured_once_per_database(monkeypatch):
     assert coll_first.create_index_calls[0]["kwargs"] == {"unique": True}
 
 
+def test_gmail_outbound_operational_indexes_are_ensured_once(monkeypatch):
+    _reset_collection_index_state(monkeypatch)
+    db = _FakeDb("test_von_db", client=object())
+    monkeypatch.setattr(mc, "get_db", lambda: db)
+
+    quota_first = cast(_FakeCollection, mc.get_gmail_outbound_quota_collection())
+    quota_second = cast(_FakeCollection, mc.get_gmail_outbound_quota_collection())
+    deliveries_first = cast(
+        _FakeCollection,
+        mc.get_gmail_outbound_deliveries_collection(),
+    )
+    deliveries_second = cast(
+        _FakeCollection,
+        mc.get_gmail_outbound_deliveries_collection(),
+    )
+
+    assert quota_first is quota_second
+    assert deliveries_first is deliveries_second
+    assert quota_first.create_index_calls == [
+        {
+            "keys": [("expires_at", mc.ASCENDING)],
+            "kwargs": {"name": "expires_at_ttl", "expireAfterSeconds": 0},
+        }
+    ]
+    assert deliveries_first.create_index_calls == [
+        {
+            "keys": [("delivery_fingerprint", mc.ASCENDING)],
+            "kwargs": {
+                "name": "delivery_fingerprint_1_unique",
+                "unique": True,
+            },
+        },
+        {
+            "keys": [("status", mc.ASCENDING), ("updated_at", mc.DESCENDING)],
+            "kwargs": {"name": "status_1_updated_at_-1"},
+        },
+    ]
+
+
 def test_concepts_indexes_are_guarded_per_database_key(monkeypatch):
     _reset_collection_index_state(monkeypatch)
     shared_client = object()


### PR DESCRIPTION
## Outcome

Enables ordinary Von conversations to send authorised Gmail messages from the configured agent mailbox with an unavoidable AI-agent disclosure, durable delivery finality, canonical read-back, and administrator-controlled rate limits.

## Key controls

- binds actor, organisation, namespace, request, and authorised Gmail profile from trusted server context
- requires the mailbox profile to represent the Von system identity and prevents ordinary relationship writes from self-granting mail authority
- injects visible and machine-readable AI-agent disclosure; rejects caller-supplied HTML in v1
- resolves a canonical mailbox identity before idempotency, quota, or provider dispatch
- records an absorbing delivery ledger and reconciles ambiguous responses through bounded Sent-mail fingerprint read-back
- exposes owner/admin settings for per-window, daily, per-message-recipient, and daily-recipient limits

## Validation

- 145 impacted backend tests passed before the final reconciliation adjustment
- 102 relevant backend tests passed after the reconciliation adjustment
- final Gmail suite: 32 passed
- selected adaptive-turn suite: 12 passed
- settings UI Jest suite: 30 passed
- targeted Pyright: 0 errors
- focused Ruff, compilation, manifest parity, and git diff checks passed
- one authorised self-send was canonically read back; replay with the same request ID was a no-op

No model invocation was used for implementation or verification.