### PR TITLE
Coalesce Mongo reconnect recovery

### DIFF
--- a/src/backend/db/connection_manager.py
+++ b/src/backend/db/connection_manager.py
@@ -1,8 +1,10 @@
+import logging
+import random
 import threading
 import time
-import random
-import logging
-from typing import Optional, Dict, Any
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
 from pymongo.errors import ConnectionFailure
 
 from . import mongo_client as _mc
@@ -27,6 +29,35 @@ _state = {
 }
 
 
+@dataclass
+class _ReconnectAttempt:
+    """One physical reconnect attempt shared by concurrent callers."""
+
+    route_degraded: bool
+    degradation_reason: str | None
+    sequence: int
+    done: bool = False
+    followers: int = 0
+    reconnect_performed: bool = False
+    route_preference_applied: bool = False
+    connected: bool = False
+    error_message: str | None = None
+    error_type: str | None = None
+    transport_error: bool = False
+    error: BaseException | None = None
+
+
+_reconnect_condition = threading.Condition(_lock)
+_active_reconnect_attempt: _ReconnectAttempt | None = None
+_last_completed_reconnect_attempt: _ReconnectAttempt | None = None
+_reconnect_attempt_sequence = 0
+
+
+def _completed_reconnect_sequence() -> int:
+    completed = _last_completed_reconnect_attempt
+    return completed.sequence if completed is not None else 0
+
+
 def _now() -> float:
     return time.time()
 
@@ -38,20 +69,14 @@ def get_db():
     return db
 
 
-def health_summary() -> Dict[str, Any]:
-    db = get_db()
-    connected = False
-    route_degraded = False
-    health_error_type = None
-    if db is not None:
-        try:
-            # Use lightweight ping; ignore actual response object
-            db.command("ping")  # type: ignore[call-arg]
-            connected = True
-        except Exception as exc:
-            connected = False
-            route_degraded = is_mongo_transport_error(exc)
-            health_error_type = type(exc).__name__
+def _build_health_summary(
+    *,
+    connected: bool,
+    route_degraded: bool = False,
+    health_error_type: str | None = None,
+) -> Dict[str, Any]:
+    """Build the public health payload without issuing another Mongo probe."""
+
     uptime = None
     if connected and _state["last_connected_at"]:
         uptime = _now() - _state["last_connected_at"]
@@ -114,10 +139,92 @@ def health_summary() -> Dict[str, Any]:
     }
 
 
+def health_summary() -> Dict[str, Any]:
+    db = get_db()
+    connected = False
+    route_degraded = False
+    health_error_type = None
+    if db is not None:
+        try:
+            # Use lightweight ping; ignore actual response object
+            db.command("ping")  # type: ignore[call-arg]
+            connected = True
+        except Exception as exc:
+            connected = False
+            route_degraded = is_mongo_transport_error(exc)
+            health_error_type = type(exc).__name__
+    return _build_health_summary(
+        connected=connected,
+        route_degraded=route_degraded,
+        health_error_type=health_error_type,
+    )
+
+
 def _exponential_backoff(base_ms: int, attempt: int, max_ms: int) -> float:
     cap = min(max_ms, base_ms * (2 ** (attempt - 1)))
     jitter = random.uniform(0, cap)
     return jitter / 1000.0
+
+
+def _completed_attempt_satisfies_intent(
+    reconnect_attempt: _ReconnectAttempt,
+    *,
+    force: bool,
+    route_degraded: bool,
+) -> bool:
+    """Return whether a completed attempt fulfilled this caller's intent."""
+
+    if force and not reconnect_attempt.reconnect_performed:
+        return False
+    if route_degraded and not reconnect_attempt.route_preference_applied:
+        return False
+    return True
+
+
+def _new_reconnect_attempt(
+    *,
+    route_degraded: bool,
+    degradation_reason: str | None,
+    sequence: int,
+) -> _ReconnectAttempt:
+    return _ReconnectAttempt(
+        route_degraded=route_degraded,
+        degradation_reason=degradation_reason,
+        sequence=sequence,
+    )
+
+
+def _execute_reconnect_attempt(reconnect_attempt: _ReconnectAttempt) -> None:
+    with _lock:
+        _state["reconnect_attempts_total"] += 1
+        _state["last_attempt_started_at"] = _now()
+    try:
+        reconnect_attempt.reconnect_performed = True
+        if reconnect_attempt.route_degraded:
+            reconnect_attempt.route_preference_applied = True
+            _mc.invalidate_connection(
+                prefer_alternate_reason=reconnect_attempt.degradation_reason
+                or "transient operation transport failure"
+            )
+        else:
+            _mc.invalidate_connection()
+        db = _mc.get_db()
+        if db is None:
+            raise ConnectionFailure("get_db returned None")
+        db.command("ping")
+        reconnect_attempt.connected = True
+        with _lock:
+            _state["reconnect_success_total"] += 1
+            _state["consecutive_failures"] = 0
+            _state["last_connected_at"] = _now()
+    except Exception as exc:  # Broad catch; we classify as failure
+        reconnect_attempt.error_message = str(exc)
+        reconnect_attempt.error_type = type(exc).__name__
+        reconnect_attempt.transport_error = is_mongo_transport_error(exc)
+        with _lock:
+            _state["reconnect_failure_total"] += 1
+            _state["consecutive_failures"] += 1
+            _state["last_error"] = reconnect_attempt.error_message
 
 
 def attempt_reconnect(
@@ -128,61 +235,124 @@ def attempt_reconnect(
     route_degraded: bool = False,
     degradation_reason: str | None = None,
 ) -> Dict[str, Any]:
-    with _lock:
-        # If already healthy and not forced, short circuit
-        h = health_summary()
-        if h["connected"] and not force:
-            return {"skipped": True, "reason": "already_connected", **h}
-    # Outside lock to avoid blocking other threads while connecting
+    global _active_reconnect_attempt
+    global _last_completed_reconnect_attempt, _reconnect_attempt_sequence
+
+    with _reconnect_condition:
+        # Snapshot before any health preflight. A reconnect that completes
+        # while this caller is probing is fresh work that the caller should
+        # reuse instead of invalidating the recovered client again.
+        observed_sequence = _completed_reconnect_sequence()
+
+    # Forced and route-degraded callers must attempt recovery directly. A
+    # healthy non-forced caller retains the legacy short-circuit.
+    if not force and not route_degraded:
+        health = health_summary()
+        if health["connected"]:
+            return {"skipped": True, "reason": "already_connected", **health}
+
     attempt_num = 0
-    last_err = None
+    last_error = None
+    last_error_type = None
+    effective_route_degraded = route_degraded
+    effective_degradation_reason = degradation_reason
+
     while attempt_num < max_attempts:
+        requested_route_degraded = effective_route_degraded
+        with _reconnect_condition:
+            reconnect_attempt = _active_reconnect_attempt
+            if reconnect_attempt is not None:
+                reconnect_attempt.followers += 1
+                _reconnect_condition.notify_all()
+                is_leader = False
+            elif (
+                _last_completed_reconnect_attempt is not None
+                and _last_completed_reconnect_attempt.sequence > observed_sequence
+            ):
+                # A faster sibling may finish the attempt between this caller
+                # observing the previous result and reclaiming the condition.
+                # Reuse that fresh result instead of fanning out another probe.
+                reconnect_attempt = _last_completed_reconnect_attempt
+                is_leader = False
+            else:
+                _reconnect_attempt_sequence += 1
+                reconnect_attempt = _new_reconnect_attempt(
+                    route_degraded=requested_route_degraded,
+                    degradation_reason=effective_degradation_reason,
+                    sequence=_reconnect_attempt_sequence,
+                )
+                _active_reconnect_attempt = reconnect_attempt
+                is_leader = True
+
+            if not is_leader:
+                while not reconnect_attempt.done:
+                    _reconnect_condition.wait()
+                if reconnect_attempt.error is not None:
+                    raise reconnect_attempt.error
+                observed_sequence = max(
+                    observed_sequence,
+                    reconnect_attempt.sequence,
+                )
+                if not _completed_attempt_satisfies_intent(
+                    reconnect_attempt,
+                    force=force,
+                    route_degraded=requested_route_degraded,
+                ):
+                    # This physical attempt did not fulfil stronger force/route
+                    # intent. Start or join one suitable attempt before this
+                    # caller consumes an attempt from its own retry budget.
+                    continue
+
+        if is_leader:
+            try:
+                if attempt_num > 0:
+                    # Publish first, then let one leader own the backoff so all
+                    # concurrent callers join the same next physical attempt.
+                    time.sleep(_exponential_backoff(base_ms, attempt_num, max_ms))
+                _execute_reconnect_attempt(reconnect_attempt)
+                error = None
+            except BaseException as exc:  # noqa: BLE001 - release waiting callers
+                error = exc
+
+            with _reconnect_condition:
+                reconnect_attempt.error = error
+                reconnect_attempt.done = True
+                _last_completed_reconnect_attempt = reconnect_attempt
+                if _active_reconnect_attempt is reconnect_attempt:
+                    _active_reconnect_attempt = None
+                _reconnect_condition.notify_all()
+
+            if error is not None:
+                raise error
+
+        observed_sequence = max(observed_sequence, reconnect_attempt.sequence)
+
         attempt_num += 1
-        with _lock:
-            _state["reconnect_attempts_total"] += 1
-            _state["last_attempt_started_at"] = _now()
-        try:
-            if route_degraded:
-                prefer_alternate = getattr(
-                    _mc, "prefer_alternate_mongo_route", lambda _reason: None
-                )
-                prefer_alternate(
-                    degradation_reason or "transient operation transport failure"
-                )
-            _mc.invalidate_connection()
-            db = _mc.get_db()
-            if db is None:
-                raise ConnectionFailure("get_db returned None")
-            # Ping to confirm
-            db.command("ping")
-            with _lock:
-                _state["reconnect_success_total"] += 1
-                _state["consecutive_failures"] = 0
-                _state["last_connected_at"] = _now()
+        if reconnect_attempt.connected:
             return {
                 "skipped": False,
                 "reconnected": True,
                 "attempts": attempt_num,
-                **health_summary(),
+                **_build_health_summary(connected=True),
             }
-        except Exception as e:  # Broad catch; we classify as failure
-            last_err = str(e)
-            if is_mongo_transport_error(e):
-                route_degraded = True
-                degradation_reason = f"reconnect ping {type(e).__name__}"
-            with _lock:
-                _state["reconnect_failure_total"] += 1
-                _state["consecutive_failures"] += 1
-                _state["last_error"] = last_err
-            if attempt_num >= max_attempts:
-                break
-            time.sleep(_exponential_backoff(base_ms, attempt_num, max_ms))
-    # Failed
-    h2 = health_summary()
-    h2["last_error"] = last_err
-    h2["reconnected"] = False
-    h2["attempts"] = attempt_num
-    return h2
+
+        last_error = reconnect_attempt.error_message
+        last_error_type = reconnect_attempt.error_type
+        if reconnect_attempt.transport_error:
+            effective_route_degraded = True
+            effective_degradation_reason = f"reconnect ping {last_error_type}"
+
+    # Do not call health_summary here: its get_db/ping would exceed this
+    # caller's declared retry budget after the final failed shared attempt.
+    result = _build_health_summary(
+        connected=False,
+        route_degraded=effective_route_degraded,
+        health_error_type=last_error_type,
+    )
+    result["last_error"] = last_error
+    result["reconnected"] = False
+    result["attempts"] = attempt_num
+    return result
 
 
 def _monitor_loop(interval_sec: int, base_ms: int, max_ms: int, max_attempts: int):

--- a/src/backend/db/mongo_client.py
+++ b/src/backend/db/mongo_client.py
@@ -763,6 +763,33 @@ _last_auto_recovery_check_at = 0.0
 _dns_fallback_preferred_until_monotonic = 0.0
 _dns_fallback_preference_reason: str | None = None
 _preferred_fallback_kind: str | None = None
+
+
+@dataclass(frozen=True)
+class _MongoConnectionCandidate:
+    """A verified client and its route state, not yet visible to callers."""
+
+    client: MongoClient
+    uri: str
+    fallback_kind: str | None
+    preference_reason: str | None = None
+    clear_fallback_preference: bool = False
+
+
+@dataclass
+class _MongoConnectionWave:
+    """Single-flight state for one invalidation generation."""
+
+    done: bool = False
+    result: MongoClient | None = None
+    error: BaseException | None = None
+    waiter_count: int = 0
+
+
+_CONNECTION_CONDITION = threading.Condition()
+_connection_generation = 0
+_connection_waves: dict[int, _MongoConnectionWave] = {}
+_HEALTH_CHECK_LOCK = threading.Lock()
 _COLLECTION_INDEXES_LOCK = threading.Lock()
 _COLLECTION_INDEXES_READY: set[tuple[int, str, str]] = set()
 
@@ -854,15 +881,7 @@ def _clear_dns_fallback_preference() -> None:
     _preferred_fallback_kind = None
 
 
-def prefer_alternate_mongo_route(reason: str) -> str | None:
-    """Prefer a different configured route after an operation transport failure.
-
-    A route may still answer ``hello`` while real operations are timing out or
-    being reset. This bounded hint lets the normal reconnect path try the next
-    remote transport rather than repeatedly selecting the superficially
-    healthy route.
-    """
-
+def _prefer_alternate_mongo_route_locked(reason: str) -> str | None:
     current_kind = _active_fallback_kind_real if _using_fallback_real else None
     seen_kinds: set[str] = set()
     for target in _connection_fallback_targets(prefer_dns=False):
@@ -882,6 +901,19 @@ def prefer_alternate_mongo_route(reason: str) -> str | None:
             "next reconnect will probe the direct primary."
         )
     return None
+
+
+def prefer_alternate_mongo_route(reason: str) -> str | None:
+    """Prefer a different configured route after an operation transport failure.
+
+    A route may still answer ``hello`` while real operations are timing out or
+    being reset. This bounded hint lets the normal reconnect path try the next
+    remote transport rather than repeatedly selecting the superficially
+    healthy route.
+    """
+
+    with _CONNECTION_CONDITION:
+        return _prefer_alternate_mongo_route_locked(reason)
 
 
 def _try_connect_uri(
@@ -911,33 +943,41 @@ def _try_connect_uri(
     except Exception:
         client.close()
         raise
-    if (
-        fallback_label == "dns fallback"
-        and MONGO_DNS_FALLBACK_URI
-        and uri == MONGO_DNS_FALLBACK_URI
-    ):
-        _mark_dns_fallback_preferred(f"connected via {fallback_label}")
-    elif uri == MONGO_URI:
-        _clear_dns_fallback_preference()
     return client
 
 
-def _try_preferred_fallback_first() -> bool:
-    """Reconnect through the recent fallback kind during its recovery window."""
+def _fallback_candidate(
+    target: _MongoFallbackTarget,
+    *,
+    preference_reason: str | None,
+) -> _MongoConnectionCandidate:
+    client = _try_connect_uri(
+        target.uri,
+        fallback_label=f"{target.kind} fallback",
+        server_selection_timeout_ms=3000,
+        require_writable_primary=target.require_writable_primary,
+        expected_replica_set=target.expected_replica_set,
+    )
+    return _MongoConnectionCandidate(
+        client=client,
+        uri=target.uri,
+        fallback_kind=target.kind,
+        preference_reason=preference_reason,
+    )
 
-    global _mongo_client_real, _effective_uri_real, _using_fallback_real
-    global _active_fallback_kind_real, _preferred_fallback_kind
+
+def _try_preferred_fallback_candidate() -> (
+    tuple[_MongoConnectionCandidate | None, bool]
+):
+    """Build, but do not publish, a client for the recent fallback route."""
 
     preferred_kind = _preferred_fallback_kind
-    # Preserve compatibility with an already-established legacy DNS sticky
-    # window created before the fallback kind was recorded.
     if preferred_kind is None and _dns_fallback_is_preferred():
         preferred_kind = "dns"
-        _preferred_fallback_kind = preferred_kind
     if not preferred_kind or (
         _dns_fallback_preferred_until_monotonic <= time.monotonic()
     ):
-        return False
+        return None, False
 
     targets = [
         target
@@ -950,40 +990,28 @@ def _try_preferred_fallback_first() -> bool:
                 "[mongo_fallback] Preferring recent %s route during fallback recovery window.",
                 target.label,
             )
-            _mongo_client_real = _try_connect_uri(
-                target.uri,
-                fallback_label=f"{target.kind} fallback",
-                server_selection_timeout_ms=3000,
-                require_writable_primary=target.require_writable_primary,
-                expected_replica_set=target.expected_replica_set,
+            reason = (
+                f"connected via {target.kind} fallback"
+                if target.kind == "dns"
+                else None
             )
-            _effective_uri_real = target.uri
-            _using_fallback_real = True
-            _active_fallback_kind_real = target.kind
-            return True
+            return (
+                _fallback_candidate(target, preference_reason=reason),
+                True,
+            )
         except Exception as exc:
             logger.warning(
                 "[mongo_fallback] Preferred %s connection failed: %s",
                 target.label,
                 exc,
             )
-            _mongo_client_real = None
-
-    _clear_dns_fallback_preference()
-    return False
+    return None, True
 
 
-def _try_preferred_dns_fallback_first() -> bool:
-    """Compatibility alias for the general preferred-fallback recovery path."""
-
-    return _try_preferred_fallback_first()
-
-
-def _try_configured_fallbacks(*, reason: str, prefer_dns: bool) -> bool:
-    """Try each configured fallback, selecting a writable tunneled member."""
-
-    global _mongo_client_real, _effective_uri_real, _using_fallback_real
-    global _active_fallback_kind_real, _last_auto_recovery_check_at
+def _try_configured_fallback_candidate(
+    *, reason: str, prefer_dns: bool
+) -> _MongoConnectionCandidate | None:
+    """Build an unpublished client from configured recovery routes."""
 
     for target in _connection_fallback_targets(prefer_dns=prefer_dns):
         logger.warning(
@@ -992,12 +1020,9 @@ def _try_configured_fallbacks(*, reason: str, prefer_dns: bool) -> bool:
             reason,
         )
         try:
-            client = _try_connect_uri(
-                target.uri,
-                fallback_label=f"{target.kind} fallback",
-                server_selection_timeout_ms=3000,
-                require_writable_primary=target.require_writable_primary,
-                expected_replica_set=target.expected_replica_set,
+            candidate = _fallback_candidate(
+                target,
+                preference_reason=f"primary {reason}",
             )
         except Exception as exc:
             logger.warning(
@@ -1006,13 +1031,6 @@ def _try_configured_fallbacks(*, reason: str, prefer_dns: bool) -> bool:
                 exc,
             )
             continue
-
-        _mongo_client_real = client
-        _effective_uri_real = target.uri
-        _using_fallback_real = True
-        _active_fallback_kind_real = target.kind
-        _last_auto_recovery_check_at = time.monotonic()
-        _mark_fallback_preferred(target.kind, f"primary {reason}")
         logger.warning(
             "[mongo_fallback] Using %s Mongo URI instead of primary.",
             target.label,
@@ -1023,99 +1041,347 @@ def _try_configured_fallbacks(*, reason: str, prefer_dns: bool) -> bool:
                 target.kind,
                 _host_display_from_uri(target.uri),
             )
-        return True
-
-    _mongo_client_real = None
-    _effective_uri_real = MONGO_URI
-    _using_fallback_real = False
-    _active_fallback_kind_real = None
-    return False
+        return candidate
+    return None
 
 
-def _should_run_auto_recovery_check() -> bool:
+def _build_real_connection_candidate() -> tuple[_MongoConnectionCandidate | None, bool]:
+    """Run one complete route-selection wave without publishing partial state."""
+
+    preferred_candidate, preferred_failed = _try_preferred_fallback_candidate()
+    if preferred_candidate is not None:
+        return preferred_candidate, False
+
+    try:
+        client = _try_connect_uri(MONGO_URI)
+        return (
+            _MongoConnectionCandidate(
+                client=client,
+                uri=MONGO_URI,
+                fallback_kind=None,
+                clear_fallback_preference=True,
+            ),
+            False,
+        )
+    except ConnectionFailure as exc:
+        logger.warning("Error connecting to MongoDB (ConnectionFailure): %s", exc)
+        if "SSL" in str(exc) and "TLSV1_ALERT_INTERNAL_ERROR" in str(exc):
+            logger.warning(
+                "[VON_ASSISTANT_SUGGESTION] This appears to be an SSL/TLS handshake error. "
+                "This commonly occurs when the current IP address is not whitelisted in MongoDB Atlas. "
+                "IMPORTANT: IP whitelists are per-project, not per-organisation. "
+                "Verify your IP is whitelisted in the correct project: '%s'. "
+                "Steps: Atlas Console → Select correct Organisation → Select correct Project → Security → Network Access."
+                " Your IP should be listed as Active in the project that contains your cluster.",
+                os.environ.get("MONGO_PROJECT", "Unknown"),
+            )
+        is_ssl_error = (
+            "SSL" in str(exc) or "10054" in str(exc) or "handshake" in str(exc).lower()
+        )
+        is_dns_error = any(
+            marker in str(exc).lower()
+            for marker in ("dns", "resolution", "name does not exist", "srv")
+        )
+        if _debug_mongo_enabled():
+            logger.debug(
+                "[MongoConnect] Connection failed. is_ssl_error=%s", is_ssl_error
+            )
+            logger.debug(
+                "[MongoConnect] MONGO_ALLOW_LOCAL_FALLBACK=%s",
+                MONGO_ALLOW_LOCAL_FALLBACK,
+            )
+            logger.debug(
+                "[MongoConnect] MONGO_URI starts with mongodb+srv://: %s",
+                MONGO_URI.startswith("mongodb+srv://"),
+            )
+        should_try_fallback = (
+            bool(MONGO_SSH_TUNNEL_FALLBACK_ENDPOINTS)
+            or bool(MONGO_DNS_FALLBACK_URI)
+            or MONGO_ALLOW_LOCAL_FALLBACK
+            or MONGO_URI.strip("\"'").startswith("mongodb+srv://")
+            or is_ssl_error
+        )
+        candidate = (
+            _try_configured_fallback_candidate(
+                reason="connection failure",
+                prefer_dns=is_dns_error and not is_ssl_error,
+            )
+            if should_try_fallback
+            else None
+        )
+    except Exception as exc:
+        logger.warning(
+            "An unexpected error occurred during MongoDB client initialisation: %s",
+            exc,
+        )
+        is_dns_error = any(
+            marker in str(exc).lower()
+            for marker in ("dns", "resolution", "name does not exist", "srv")
+        )
+        should_try_fallback = (
+            bool(MONGO_SSH_TUNNEL_FALLBACK_ENDPOINTS)
+            or bool(MONGO_DNS_FALLBACK_URI)
+            or MONGO_ALLOW_LOCAL_FALLBACK
+            or is_dns_error
+        )
+        candidate = (
+            _try_configured_fallback_candidate(
+                reason=("DNS/SRV error" if is_dns_error else "initialisation failure"),
+                prefer_dns=is_dns_error,
+            )
+            if should_try_fallback
+            else None
+        )
+    return candidate, bool(preferred_failed and candidate is None)
+
+
+def _publish_connection_candidate_locked(candidate: _MongoConnectionCandidate) -> None:
+    """Atomically expose a client together with the route that created it."""
+
+    global _mongo_client_real, _effective_uri_real, _using_fallback_real
+    global _active_fallback_kind_real, _last_auto_recovery_check_at
+    _mongo_client_real = candidate.client
+    _effective_uri_real = candidate.uri
+    _using_fallback_real = candidate.fallback_kind is not None
+    _active_fallback_kind_real = candidate.fallback_kind
+    _last_auto_recovery_check_at = time.monotonic()
+    if candidate.clear_fallback_preference:
+        _clear_dns_fallback_preference()
+    elif candidate.fallback_kind and candidate.preference_reason:
+        _mark_fallback_preferred(
+            candidate.fallback_kind,
+            candidate.preference_reason,
+        )
+
+
+def _close_unpublished_candidate(candidate: _MongoConnectionCandidate) -> None:
+    try:
+        candidate.client.close()
+    except Exception as exc:  # pragma: no cover - defensive cleanup only
+        logger.warning(
+            "[mongo_recovery] Failed to close stale Mongo candidate: %s", exc
+        )
+
+
+def _get_or_connect_real_client() -> MongoClient | None:
+    """Return one shared result for each physical-client connection wave."""
+
+    while True:
+        with _CONNECTION_CONDITION:
+            if _mongo_client_real is not None:
+                return _mongo_client_real
+            generation = _connection_generation
+            wave = _connection_waves.get(generation)
+            if wave is not None:
+                wave.waiter_count += 1
+                _CONNECTION_CONDITION.notify_all()
+                while not wave.done and generation == _connection_generation:
+                    _CONNECTION_CONDITION.wait()
+                if generation != _connection_generation:
+                    continue
+                if wave.error is not None:
+                    raise wave.error
+                return wave.result
+            wave = _MongoConnectionWave()
+            _connection_waves[generation] = wave
+
+        candidate: _MongoConnectionCandidate | None = None
+        clear_preference_on_failure = False
+        build_error: BaseException | None = None
+        try:
+            candidate, clear_preference_on_failure = _build_real_connection_candidate()
+        except BaseException as exc:  # noqa: BLE001 - finalise cancellation waves
+            if isinstance(exc, Exception):
+                # Preserve the existing connection API: ordinary construction
+                # failures yield no client. Control-flow exceptions propagate
+                # after every waiter has been released.
+                logger.warning(
+                    "Unexpected error while building MongoDB connection candidate: %s",
+                    exc,
+                )
+            else:
+                build_error = exc
+        stale_candidate: _MongoConnectionCandidate | None = None
+        published = False
+        with _CONNECTION_CONDITION:
+            if generation == _connection_generation:
+                if candidate is not None and _mongo_client_real is None:
+                    _publish_connection_candidate_locked(candidate)
+                    published = True
+                elif candidate is not None:
+                    stale_candidate = candidate
+                elif clear_preference_on_failure:
+                    _clear_dns_fallback_preference()
+            elif candidate is not None:
+                stale_candidate = candidate
+            wave.result = _mongo_client_real
+            wave.error = build_error
+            wave.done = True
+            if _connection_waves.get(generation) is wave:
+                _connection_waves.pop(generation, None)
+            _CONNECTION_CONDITION.notify_all()
+            result = _mongo_client_real
+
+        if stale_candidate is not None:
+            _close_unpublished_candidate(stale_candidate)
+        if build_error is not None:
+            raise build_error
+        if generation != _connection_generation:
+            continue
+        if published:
+            print_connection_info()
+        return result
+
+
+def _claim_due_health_check() -> bool:
+    """Coalesce periodic probes without touching the ordinary healthy fast path."""
+
     global _last_auto_recovery_check_at
     if not _mongo_auto_recovery_enabled():
         return False
     now = time.monotonic()
     if (
         now - _last_auto_recovery_check_at
-    ) < _mongo_auto_recovery_check_interval_seconds():
+        < _mongo_auto_recovery_check_interval_seconds()
+    ):
+        return False
+    if not _HEALTH_CHECK_LOCK.acquire(blocking=False):
+        return False
+    now = time.monotonic()
+    if (
+        now - _last_auto_recovery_check_at
+        < _mongo_auto_recovery_check_interval_seconds()
+    ):
+        _HEALTH_CHECK_LOCK.release()
         return False
     _last_auto_recovery_check_at = now
     return True
 
 
-def _invalidate_real_client_for_recovery(reason: str) -> None:
-    """Drop the active client reference so the next get_db() call rebuilds it."""
+def _invalidate_real_client_for_recovery(
+    reason: str,
+    *,
+    expected_client: MongoClient,
+    expected_generation: int,
+) -> bool:
+    """CAS-invalidate a failed published client without closing it."""
+
     global _mongo_client_real, _effective_uri_real, _using_fallback_real
-    global _active_fallback_kind_real
-    logger.warning("[mongo_recovery] Invalidating Mongo client: %s", reason)
-    _mongo_client_real = None
-    if _fallback_is_preferred() and _active_fallback_kind_real:
-        _using_fallback_real = True
-    else:
-        _effective_uri_real = MONGO_URI
-        _using_fallback_real = False
-        _active_fallback_kind_real = None
-
-
-def _ensure_active_client_is_healthy() -> None:
-    global _mongo_client_real, _effective_uri_real, _using_fallback_real
-    global _active_fallback_kind_real
-    if _mongo_client_real is None:
-        return
-    if not _should_run_auto_recovery_check():
-        return
-    timeout_ms = _mongo_auto_recovery_ping_timeout_ms()
-
-    if _using_fallback_real and not _fallback_is_preferred():
-        fallback_kind = _active_fallback_kind_real
-        try:
-            primary_client = _try_connect_uri(
-                MONGO_URI,
-                server_selection_timeout_ms=3000,
-            )
-        except Exception as exc:
-            if fallback_kind:
-                _mark_fallback_preferred(
-                    fallback_kind,
-                    f"primary recovery probe failed: {type(exc).__name__}",
-                )
+    global _active_fallback_kind_real, _connection_generation
+    with _CONNECTION_CONDITION:
+        if (
+            _mongo_client_real is not expected_client
+            or _connection_generation != expected_generation
+        ):
+            return False
+        logger.warning("[mongo_recovery] Invalidating Mongo client: %s", reason)
+        _mongo_client_real = None
+        _connection_generation += 1
+        if _fallback_is_preferred() and _active_fallback_kind_real:
+            _using_fallback_real = True
         else:
-            _mongo_client_real = primary_client
             _effective_uri_real = MONGO_URI
             _using_fallback_real = False
             _active_fallback_kind_real = None
-            logger.info(
-                "[mongo_recovery] Direct primary Mongo route recovered; leaving fallback."
-            )
-            return
+        _CONNECTION_CONDITION.notify_all()
+        return True
 
+
+def _ensure_active_client_is_healthy() -> None:
+    if _mongo_client_real is None or not _claim_due_health_check():
+        return
     try:
-        tunnel_member_reselection_required = False
-        if _active_fallback_kind_real == "ssh_tunnel":
-            hello = _mongo_client_real.admin.command("hello", maxTimeMS=timeout_ms)
-            if not bool(hello.get("isWritablePrimary", hello.get("ismaster", False))):
-                tunnel_member_reselection_required = True
-                raise ConnectionFailure(
-                    "active SSH tunnel member is no longer writable"
+        with _CONNECTION_CONDITION:
+            client = _mongo_client_real
+            generation = _connection_generation
+            using_fallback = _using_fallback_real
+            active_fallback_kind = _active_fallback_kind_real
+        if client is None:
+            return
+        timeout_ms = _mongo_auto_recovery_ping_timeout_ms()
+
+        if using_fallback and not _fallback_is_preferred():
+            try:
+                primary_client = _try_connect_uri(
+                    MONGO_URI,
+                    server_selection_timeout_ms=3000,
                 )
-            expected_replica_set = _configured_replica_set_name()
-            if expected_replica_set and hello.get("setName") != expected_replica_set:
-                raise ConnectionFailure(
-                    "active SSH tunnel member has unexpected replica-set identity"
+            except Exception as exc:
+                with _CONNECTION_CONDITION:
+                    if (
+                        _mongo_client_real is client
+                        and _connection_generation == generation
+                        and active_fallback_kind
+                    ):
+                        _mark_fallback_preferred(
+                            active_fallback_kind,
+                            f"primary recovery probe failed: {type(exc).__name__}",
+                        )
+            else:
+                candidate = _MongoConnectionCandidate(
+                    client=primary_client,
+                    uri=MONGO_URI,
+                    fallback_kind=None,
+                    clear_fallback_preference=True,
                 )
-        else:
-            _mongo_client_real.admin.command("ping", maxTimeMS=timeout_ms)
-    except Exception as exc:
-        if (
-            not tunnel_member_reselection_required
-            and is_mongo_transport_error(exc)
-        ):
-            prefer_alternate_mongo_route(
-                f"periodic health check {type(exc).__name__}"
+                with _CONNECTION_CONDITION:
+                    if (
+                        _mongo_client_real is client
+                        and _connection_generation == generation
+                    ):
+                        _publish_connection_candidate_locked(candidate)
+                        logger.info(
+                            "[mongo_recovery] Direct primary Mongo route recovered; leaving fallback."
+                        )
+                        return
+                _close_unpublished_candidate(candidate)
+                return
+
+        with _CONNECTION_CONDITION:
+            if _mongo_client_real is not client or _connection_generation != generation:
+                return
+        try:
+            tunnel_member_reselection_required = False
+            if active_fallback_kind == "ssh_tunnel":
+                hello = client.admin.command("hello", maxTimeMS=timeout_ms)
+                if not bool(
+                    hello.get("isWritablePrimary", hello.get("ismaster", False))
+                ):
+                    tunnel_member_reselection_required = True
+                    raise ConnectionFailure(
+                        "active SSH tunnel member is no longer writable"
+                    )
+                expected_replica_set = _configured_replica_set_name()
+                if (
+                    expected_replica_set
+                    and hello.get("setName") != expected_replica_set
+                ):
+                    raise ConnectionFailure(
+                        "active SSH tunnel member has unexpected replica-set identity"
+                    )
+            else:
+                client.admin.command("ping", maxTimeMS=timeout_ms)
+        except Exception as exc:
+            with _CONNECTION_CONDITION:
+                still_current = (
+                    _mongo_client_real is client
+                    and _connection_generation == generation
+                )
+                if (
+                    still_current
+                    and not tunnel_member_reselection_required
+                    and is_mongo_transport_error(exc)
+                ):
+                    prefer_alternate_mongo_route(
+                        f"periodic health check {type(exc).__name__}"
+                    )
+            _invalidate_real_client_for_recovery(
+                f"periodic ping failed: {exc}",
+                expected_client=client,
+                expected_generation=generation,
             )
-        _invalidate_real_client_for_recovery(f"periodic ping failed: {exc}")
+    finally:
+        _HEALTH_CHECK_LOCK.release()
 
 
 def get_db() -> Database | None:
@@ -1123,9 +1389,7 @@ def get_db() -> Database | None:
     Establishes a connection to the MongoDB database if one doesn't exist,
     and returns the database instance.
     """
-    global _mongo_client_real, _mongo_client_mock
-    global _using_fallback_real, _effective_uri_real, _last_auto_recovery_check_at
-    global _active_fallback_kind_real
+    global _mongo_client_mock
     db_name = get_configured_database_name()
     assert_safe_database_name_for_pytest(db_name)
 
@@ -1139,111 +1403,14 @@ def get_db() -> Database | None:
             _mongo_client_mock = mongomock.MongoClient()
         return _mongo_client_mock[db_name]
 
-    _ensure_active_client_is_healthy()
-
-    if _mongo_client_real is None:
-        try:
-            if _try_preferred_dns_fallback_first():
-                _last_auto_recovery_check_at = time.monotonic()
-                if _mongo_client_real:
-                    print_connection_info()
-                    return _mongo_client_real[db_name]
-            # Create a fresh client when none exists, or when recovery invalidated it.
-            _mongo_client_real = _try_connect_uri(MONGO_URI)
-            _effective_uri_real = MONGO_URI
-            _using_fallback_real = False
-            _active_fallback_kind_real = None
-            _last_auto_recovery_check_at = time.monotonic()
-            if _debug_mongo_enabled():
-                try:
-                    logger.debug(
-                        "[MongoConnect] Connected primary URI host(s): %s",
-                        _host_display_from_uri(MONGO_URI),
-                    )
-                except Exception:
-                    # Never allow debug logging failures to affect connection behaviour.
-                    pass
-        except ConnectionFailure as e:
-            logger.warning("Error connecting to MongoDB (ConnectionFailure): %s", e)
-            if "SSL" in str(e) and "TLSV1_ALERT_INTERNAL_ERROR" in str(e):
-                logger.warning(
-                    "[VON_ASSISTANT_SUGGESTION] This appears to be an SSL/TLS handshake error. "
-                    "This commonly occurs when the current IP address is not whitelisted in MongoDB Atlas. "
-                    "IMPORTANT: IP whitelists are per-project, not per-organisation. "
-                    "Verify your IP is whitelisted in the correct project: '%s'. "
-                    "Steps: Atlas Console → Select correct Organisation → Select correct Project → Security → Network Access."
-                    " Your IP should be listed as Active in the project that contains your cluster.",
-                    os.environ.get("MONGO_PROJECT", "Unknown"),
-                )
-
-            _mongo_client_real = None  # Ensure client is None on failure
-
-            # Check for common SSL/Connection errors that warrant a fallback attempt
-            # WinError 10054: Connection reset by peer (common with IP whitelist blocks)
-            # SSL handshake failed: Generic SSL failure
-            is_ssl_error = (
-                "SSL" in str(e) or "10054" in str(e) or "handshake" in str(e).lower()
-            )
-            is_dns_error = any(
-                marker in str(e).lower()
-                for marker in ("dns", "resolution", "name does not exist", "srv")
-            )
-
-            # Debug logging for fallback logic
-            if _debug_mongo_enabled():
-                logger.debug(
-                    "[MongoConnect] Connection failed. is_ssl_error=%s", is_ssl_error
-                )
-                logger.debug(
-                    "[MongoConnect] MONGO_ALLOW_LOCAL_FALLBACK=%s",
-                    MONGO_ALLOW_LOCAL_FALLBACK,
-                )
-                logger.debug(
-                    "[MongoConnect] MONGO_URI starts with mongodb+srv://: %s",
-                    MONGO_URI.startswith("mongodb+srv://"),
-                )
-
-            should_try_fallback = (
-                bool(MONGO_SSH_TUNNEL_FALLBACK_ENDPOINTS)
-                or bool(MONGO_DNS_FALLBACK_URI)
-                or MONGO_ALLOW_LOCAL_FALLBACK
-                or MONGO_URI.strip("\"'").startswith("mongodb+srv://")
-                or is_ssl_error
-            )
-            if not should_try_fallback or not _try_configured_fallbacks(
-                reason="connection failure",
-                prefer_dns=is_dns_error and not is_ssl_error,
-            ):
-                return None
-        except Exception as e:
-            logger.warning(
-                "An unexpected error occurred during MongoDB client initialisation: %s",
-                e,
-            )
-            is_dns_error = (
-                "resolution" in str(e).lower()
-                or "dns" in str(e).lower()
-                or "name does not exist" in str(e).lower()
-                or "srv" in str(e).lower()
-            )
-            should_try_fallback = (
-                bool(MONGO_SSH_TUNNEL_FALLBACK_ENDPOINTS)
-                or bool(MONGO_DNS_FALLBACK_URI)
-                or MONGO_ALLOW_LOCAL_FALLBACK
-                or is_dns_error
-            )
-            if not should_try_fallback or not _try_configured_fallbacks(
-                reason=("DNS/SRV error" if is_dns_error else "initialisation failure"),
-                prefer_dns=is_dns_error,
-            ):
-                _mongo_client_real = None  # Ensure client is None on failure
-                return None
-
-        if _mongo_client_real:
-            print_connection_info()
-
-    if _mongo_client_real:
-        return _mongo_client_real[db_name]
+    client = _mongo_client_real
+    if client is not None:
+        _ensure_active_client_is_healthy()
+        client = _mongo_client_real
+    if client is None:
+        client = _get_or_connect_real_client()
+    if client is not None:
+        return client[db_name]
     return None
 
 
@@ -1265,87 +1432,108 @@ def print_connection_info():
 
 def get_effective_mongo_uri() -> str:
     """Return the URI that was effectively used to create the client (may be fallback)."""
-    return _effective_uri_real
+    with _CONNECTION_CONDITION:
+        return _effective_uri_real
 
 
 def is_using_fallback_uri() -> bool:
     """Return True when any fallback URI is used instead of primary MONGO_URI."""
-    return _using_fallback_real
+    with _CONNECTION_CONDITION:
+        return _using_fallback_real
 
 
 def get_mongo_fallback_policy_state() -> dict[str, object]:
     """Return paste-safe fallback/recovery state for operator diagnostics."""
 
-    remaining_seconds = max(
-        0.0, _dns_fallback_preferred_until_monotonic - time.monotonic()
-    )
-    return {
-        "active_fallback_kind": _active_fallback_kind_real,
-        "preferred_fallback_kind": _preferred_fallback_kind,
-        "fallback_sticky": bool(remaining_seconds > 0),
-        "fallback_sticky_seconds_remaining": round(remaining_seconds, 3),
-        "fallback_sticky_seconds_configured": _mongo_dns_fallback_sticky_seconds(),
-        "fallback_preference_reason": _dns_fallback_preference_reason,
-        "ssh_tunnel_fallback_configured": bool(MONGO_SSH_TUNNEL_FALLBACK_ENDPOINTS),
-        "ssh_tunnel_endpoint_count": len(MONGO_SSH_TUNNEL_FALLBACK_ENDPOINTS),
-        "ssh_tunnel_expected_replica_set_configured": bool(
-            _configured_replica_set_name()
-        ),
-        "dns_fallback_configured": bool(MONGO_DNS_FALLBACK_URI),
-        "dns_fallback_sticky": bool(
-            remaining_seconds > 0 and _preferred_fallback_kind in {None, "dns"}
-        ),
-        "dns_fallback_sticky_seconds_remaining": (
-            round(remaining_seconds, 3)
-            if _preferred_fallback_kind in {None, "dns"}
-            else 0.0
-        ),
-        "dns_fallback_sticky_seconds_configured": _mongo_dns_fallback_sticky_seconds(),
-        "dns_fallback_preference_reason": (
-            _dns_fallback_preference_reason
-            if _preferred_fallback_kind in {None, "dns"}
-            else None
-        ),
-        "local_fallback_allowed": MONGO_ALLOW_LOCAL_FALLBACK,
-    }
+    with _CONNECTION_CONDITION:
+        remaining_seconds = max(
+            0.0, _dns_fallback_preferred_until_monotonic - time.monotonic()
+        )
+        return {
+            "active_fallback_kind": _active_fallback_kind_real,
+            "preferred_fallback_kind": _preferred_fallback_kind,
+            "fallback_sticky": bool(remaining_seconds > 0),
+            "fallback_sticky_seconds_remaining": round(remaining_seconds, 3),
+            "fallback_sticky_seconds_configured": _mongo_dns_fallback_sticky_seconds(),
+            "fallback_preference_reason": _dns_fallback_preference_reason,
+            "ssh_tunnel_fallback_configured": bool(MONGO_SSH_TUNNEL_FALLBACK_ENDPOINTS),
+            "ssh_tunnel_endpoint_count": len(MONGO_SSH_TUNNEL_FALLBACK_ENDPOINTS),
+            "ssh_tunnel_expected_replica_set_configured": bool(
+                _configured_replica_set_name()
+            ),
+            "dns_fallback_configured": bool(MONGO_DNS_FALLBACK_URI),
+            "dns_fallback_sticky": bool(
+                remaining_seconds > 0 and _preferred_fallback_kind in {None, "dns"}
+            ),
+            "dns_fallback_sticky_seconds_remaining": (
+                round(remaining_seconds, 3)
+                if _preferred_fallback_kind in {None, "dns"}
+                else 0.0
+            ),
+            "dns_fallback_sticky_seconds_configured": (
+                _mongo_dns_fallback_sticky_seconds()
+            ),
+            "dns_fallback_preference_reason": (
+                _dns_fallback_preference_reason
+                if _preferred_fallback_kind in {None, "dns"}
+                else None
+            ),
+            "local_fallback_allowed": MONGO_ALLOW_LOCAL_FALLBACK,
+        }
 
 
 def close_connection():
     """Closes the MongoDB connection."""
     global _mongo_client_real, _mongo_client_mock, _last_auto_recovery_check_at
     global _using_fallback_real, _effective_uri_real, _active_fallback_kind_real
-    if _mongo_client_real:
-        _mongo_client_real.close()
+    global _connection_generation
+    with _CONNECTION_CONDITION:
+        client_to_close = _mongo_client_real
         _mongo_client_real = None
-    # mongomock doesn't require close(), but clear ref for correctness.
-    _mongo_client_mock = None
-    _using_fallback_real = False
-    _effective_uri_real = MONGO_URI
-    _active_fallback_kind_real = None
-    _last_auto_recovery_check_at = 0.0
-    _clear_dns_fallback_preference()
+        # mongomock doesn't require close(), but clear ref for correctness.
+        _mongo_client_mock = None
+        _using_fallback_real = False
+        _effective_uri_real = MONGO_URI
+        _active_fallback_kind_real = None
+        _last_auto_recovery_check_at = 0.0
+        _connection_generation += 1
+        _clear_dns_fallback_preference()
+        _CONNECTION_CONDITION.notify_all()
+    if client_to_close is not None:
+        client_to_close.close()
     with _COLLECTION_INDEXES_LOCK:
         _COLLECTION_INDEXES_READY.clear()
 
 
-def invalidate_connection():
+def invalidate_connection(*, prefer_alternate_reason: str | None = None):
     """Invalidate the MongoDB connection reference without calling close().
 
     This allows get_db() to create a fresh client on next call while avoiding
     a race condition where in-flight requests holding the old client reference
     would fail with 'Cannot use MongoClient after close'.
 
+    When ``prefer_alternate_reason`` is supplied, selecting the alternate route
+    and advancing the connection generation are one atomic operation. This
+    fences an in-flight builder from publishing its old route and clearing the
+    newly selected recovery route before invalidation completes.
+
     PyMongo's connection pool handles stale connections gracefully, so we can
     simply drop our reference and let GC clean up.
     """
     global _mongo_client_real, _mongo_client_mock, _last_auto_recovery_check_at
     global _using_fallback_real, _effective_uri_real, _active_fallback_kind_real
-    _mongo_client_real = None
-    _mongo_client_mock = None
-    _using_fallback_real = False
-    _effective_uri_real = MONGO_URI
-    _active_fallback_kind_real = None
-    _last_auto_recovery_check_at = 0.0
+    global _connection_generation
+    with _CONNECTION_CONDITION:
+        if prefer_alternate_reason is not None:
+            _prefer_alternate_mongo_route_locked(prefer_alternate_reason)
+        _mongo_client_real = None
+        _mongo_client_mock = None
+        _using_fallback_real = False
+        _effective_uri_real = MONGO_URI
+        _active_fallback_kind_real = None
+        _last_auto_recovery_check_at = 0.0
+        _connection_generation += 1
+        _CONNECTION_CONDITION.notify_all()
     with _COLLECTION_INDEXES_LOCK:
         _COLLECTION_INDEXES_READY.clear()
 

--- a/tests/backend/test_connection_manager_singleflight.py
+++ b/tests/backend/test_connection_manager_singleflight.py
@@ -1,0 +1,736 @@
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+
+import pytest
+from pymongo.errors import ConnectionFailure
+
+from src.backend.db import connection_manager as conn_mgr
+
+
+class _PingDb:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.pings = 0
+        self._lock = threading.Lock()
+
+    def command(self, name: str):
+        assert name == "ping"
+        with self._lock:
+            self.pings += 1
+        if self.fail:
+            raise ConnectionFailure("simulated ping failure")
+        return {"ok": 1}
+
+
+@pytest.fixture(autouse=True)
+def _restore_reconnect_state():
+    state_snapshot = dict(conn_mgr._state)
+    sequence_snapshot = conn_mgr._reconnect_attempt_sequence
+    completed_snapshot = conn_mgr._last_completed_reconnect_attempt
+    with conn_mgr._reconnect_condition:
+        assert conn_mgr._active_reconnect_attempt is None
+        conn_mgr._last_completed_reconnect_attempt = None
+    yield
+    with conn_mgr._reconnect_condition:
+        conn_mgr._active_reconnect_attempt = None
+        conn_mgr._last_completed_reconnect_attempt = completed_snapshot
+        conn_mgr._reconnect_attempt_sequence = sequence_snapshot
+        conn_mgr._reconnect_condition.notify_all()
+    conn_mgr._state.clear()
+    conn_mgr._state.update(state_snapshot)
+
+
+def _wait_for_active_followers(expected: int) -> None:
+    with conn_mgr._reconnect_condition:
+        reached = conn_mgr._reconnect_condition.wait_for(
+            lambda: conn_mgr._active_reconnect_attempt is not None
+            and conn_mgr._active_reconnect_attempt.followers >= expected,
+            timeout=5,
+        )
+    assert reached, f"reconnect wave did not acquire {expected} followers"
+
+
+def _run_threads(
+    calls: list[Callable[[], dict]],
+) -> tuple[list[dict], list[BaseException], list[threading.Thread]]:
+    results: list[dict] = []
+    errors: list[BaseException] = []
+    result_lock = threading.Lock()
+    ready = threading.Barrier(len(calls) + 1)
+
+    def _worker(call: Callable[[], dict]) -> None:
+        ready.wait()
+        try:
+            result = call()
+            with result_lock:
+                results.append(result)
+        except BaseException as exc:  # noqa: BLE001 - asserted by caller
+            with result_lock:
+                errors.append(exc)
+
+    threads = [
+        threading.Thread(target=_worker, args=(call,), daemon=True) for call in calls
+    ]
+    for thread in threads:
+        thread.start()
+    ready.wait()
+    return results, errors, threads
+
+
+def _join_threads(threads: list[threading.Thread]) -> None:
+    for thread in threads:
+        thread.join(timeout=5)
+        assert not thread.is_alive(), "reconnect test worker did not finish"
+
+
+def test_concurrent_forced_calls_share_one_successful_wave(monkeypatch) -> None:
+    db = _PingDb()
+    get_db_entered = threading.Event()
+    release_get_db = threading.Event()
+    calls = {"invalidate": 0, "get_db": 0}
+    counter_lock = threading.Lock()
+
+    def _invalidate(**_kwargs) -> None:
+        with counter_lock:
+            calls["invalidate"] += 1
+
+    def _get_db():
+        with counter_lock:
+            calls["get_db"] += 1
+        get_db_entered.set()
+        assert release_get_db.wait(timeout=5)
+        return db
+
+    monkeypatch.setattr(conn_mgr._mc, "invalidate_connection", _invalidate)
+    monkeypatch.setattr(conn_mgr._mc, "get_db", _get_db)
+    metric_before = conn_mgr._state["reconnect_attempts_total"]
+
+    call_count = 8
+    results, errors, threads = _run_threads(
+        [lambda: conn_mgr.attempt_reconnect(force=True)] * call_count
+    )
+    assert get_db_entered.wait(timeout=5)
+    _wait_for_active_followers(call_count - 1)
+    release_get_db.set()
+    _join_threads(threads)
+
+    assert errors == []
+    assert len(results) == call_count
+    assert calls == {"invalidate": 1, "get_db": 1}
+    assert db.pings == 1
+    assert conn_mgr._state["reconnect_attempts_total"] == metric_before + 1
+    assert all(result["reconnected"] is True for result in results)
+    assert all(result["attempts"] == 1 for result in results)
+
+
+def test_failed_wave_is_shared_but_a_later_call_retries_independently(
+    monkeypatch,
+) -> None:
+    get_db_entered = threading.Event()
+    release_get_db = threading.Event()
+    success_db = _PingDb()
+    calls = {"invalidate": 0, "get_db": 0}
+    failure_mode = {"enabled": True}
+    counter_lock = threading.Lock()
+
+    def _invalidate(**_kwargs) -> None:
+        with counter_lock:
+            calls["invalidate"] += 1
+
+    def _get_db():
+        with counter_lock:
+            calls["get_db"] += 1
+        if failure_mode["enabled"]:
+            get_db_entered.set()
+            assert release_get_db.wait(timeout=5)
+            raise ConnectionFailure("shared failure")
+        return success_db
+
+    monkeypatch.setattr(conn_mgr._mc, "invalidate_connection", _invalidate)
+    monkeypatch.setattr(conn_mgr._mc, "get_db", _get_db)
+
+    call_count = 6
+    results, errors, threads = _run_threads(
+        [lambda: conn_mgr.attempt_reconnect(force=True, max_attempts=1)] * call_count
+    )
+    assert get_db_entered.wait(timeout=5)
+    _wait_for_active_followers(call_count - 1)
+    release_get_db.set()
+    _join_threads(threads)
+
+    assert errors == []
+    assert len(results) == call_count
+    assert calls == {"invalidate": 1, "get_db": 1}
+    assert all(result["reconnected"] is False for result in results)
+    assert all(result["attempts"] == 1 for result in results)
+
+    failure_mode["enabled"] = False
+    later = conn_mgr.attempt_reconnect(force=True, max_attempts=1)
+
+    assert later["reconnected"] is True
+    assert calls == {"invalidate": 2, "get_db": 2}
+    assert success_db.pings == 1
+
+
+def test_larger_follower_budget_gets_one_follow_up_after_small_wave_fails(
+    monkeypatch,
+) -> None:
+    first_get_db_entered = threading.Event()
+    release_first_get_db = threading.Event()
+    db = _PingDb()
+    calls = {"get_db": 0}
+    counter_lock = threading.Lock()
+
+    def _get_db():
+        with counter_lock:
+            calls["get_db"] += 1
+            call_number = calls["get_db"]
+        if call_number == 1:
+            first_get_db_entered.set()
+            assert release_first_get_db.wait(timeout=5)
+            raise ConnectionFailure("small wave exhausted")
+        return db
+
+    monkeypatch.setattr(conn_mgr._mc, "invalidate_connection", lambda **_kwargs: None)
+    monkeypatch.setattr(conn_mgr._mc, "get_db", _get_db)
+
+    leader_result: list[dict] = []
+    follower_result: list[dict] = []
+    leader = threading.Thread(
+        target=lambda: leader_result.append(
+            conn_mgr.attempt_reconnect(force=True, max_attempts=1)
+        ),
+        daemon=True,
+    )
+    leader.start()
+    assert first_get_db_entered.wait(timeout=5)
+    follower = threading.Thread(
+        target=lambda: follower_result.append(
+            conn_mgr.attempt_reconnect(force=True, max_attempts=3)
+        ),
+        daemon=True,
+    )
+    follower.start()
+    _wait_for_active_followers(1)
+    release_first_get_db.set()
+    _join_threads([leader, follower])
+
+    assert leader_result[0]["reconnected"] is False
+    assert leader_result[0]["attempts"] == 1
+    assert follower_result[0]["reconnected"] is True
+    assert follower_result[0]["attempts"] == 2
+    assert calls["get_db"] == 2
+    assert db.pings == 1
+
+
+def test_smaller_follower_budget_returns_after_one_shared_failure(monkeypatch) -> None:
+    first_get_db_entered = threading.Event()
+    release_first_get_db = threading.Event()
+    third_get_db_entered = threading.Event()
+    release_third_get_db = threading.Event()
+    calls = {"get_db": 0}
+    counter_lock = threading.Lock()
+
+    def _get_db():
+        with counter_lock:
+            calls["get_db"] += 1
+            call_number = calls["get_db"]
+        if call_number == 1:
+            first_get_db_entered.set()
+            assert release_first_get_db.wait(timeout=5)
+        elif call_number == 3:
+            third_get_db_entered.set()
+            assert release_third_get_db.wait(timeout=5)
+        raise ConnectionFailure(f"failure {call_number}")
+
+    monkeypatch.setattr(conn_mgr._mc, "invalidate_connection", lambda **_kwargs: None)
+    monkeypatch.setattr(conn_mgr._mc, "get_db", _get_db)
+    monkeypatch.setattr(conn_mgr.time, "sleep", lambda _delay: None)
+
+    long_result: list[dict] = []
+    short_result: list[dict] = []
+    leader = threading.Thread(
+        target=lambda: long_result.append(
+            conn_mgr.attempt_reconnect(force=True, max_attempts=5)
+        ),
+        daemon=True,
+    )
+    leader.start()
+    assert first_get_db_entered.wait(timeout=5)
+    follower = threading.Thread(
+        target=lambda: short_result.append(
+            conn_mgr.attempt_reconnect(force=True, max_attempts=1)
+        ),
+        daemon=True,
+    )
+    follower.start()
+    _wait_for_active_followers(1)
+    release_first_get_db.set()
+
+    assert third_get_db_entered.wait(timeout=5)
+    follower.join(timeout=5)
+    assert not follower.is_alive()
+    assert short_result[0]["reconnected"] is False
+    assert short_result[0]["attempts"] == 1
+    assert calls["get_db"] == 3
+
+    release_third_get_db.set()
+    _join_threads([leader])
+    assert long_result[0]["reconnected"] is False
+    assert long_result[0]["attempts"] == 5
+    assert calls["get_db"] == 5
+
+
+def test_staggered_retry_callers_share_exactly_two_physical_attempts(
+    monkeypatch,
+) -> None:
+    first_get_db_entered = threading.Event()
+    release_first_get_db = threading.Event()
+    second_get_db_entered = threading.Event()
+    release_second_get_db = threading.Event()
+    calls = {"invalidate": 0, "get_db": 0}
+    counter_lock = threading.Lock()
+
+    def _invalidate(**_kwargs) -> None:
+        with counter_lock:
+            calls["invalidate"] += 1
+
+    def _get_db():
+        with counter_lock:
+            calls["get_db"] += 1
+            call_number = calls["get_db"]
+        if call_number == 1:
+            first_get_db_entered.set()
+            assert release_first_get_db.wait(timeout=5), "first get_db not released"
+        elif call_number == 2:
+            second_get_db_entered.set()
+            assert release_second_get_db.wait(timeout=5), "second get_db not released"
+        raise ConnectionFailure(f"failure {call_number}")
+
+    backoff_releases = [threading.Event() for _ in range(6)]
+    backoff_started = threading.Condition()
+    backoff_call_count = {"value": 0}
+
+    def _coordinated_sleep(_delay: float) -> None:
+        with backoff_started:
+            slot = backoff_call_count["value"]
+            backoff_call_count["value"] += 1
+            backoff_started.notify_all()
+        assert backoff_releases[slot].wait(timeout=5), f"extra backoff slot {slot}"
+
+    monkeypatch.setattr(conn_mgr._mc, "invalidate_connection", _invalidate)
+    monkeypatch.setattr(conn_mgr._mc, "get_db", _get_db)
+    monkeypatch.setattr(conn_mgr.time, "sleep", _coordinated_sleep)
+
+    caller_count = 6
+    results, errors, threads = _run_threads(
+        [lambda: conn_mgr.attempt_reconnect(force=True, max_attempts=2)] * caller_count
+    )
+    assert first_get_db_entered.wait(timeout=5)
+    _wait_for_active_followers(caller_count - 1)
+    release_first_get_db.set()
+
+    with backoff_started:
+        assert backoff_started.wait_for(
+            lambda: backoff_call_count["value"] == 1,
+            timeout=5,
+        )
+    backoff_releases[0].set()
+    assert second_get_db_entered.wait(timeout=5)
+    # Serially releasing the remaining per-caller controls would have produced
+    # one retry per caller before coordinated backoff was introduced. They are
+    # intentionally left unset: only the one attempt leader may sleep.
+    release_second_get_db.set()
+    _join_threads(threads)
+
+    assert errors == []
+    assert len(results) == caller_count
+    assert all(result["reconnected"] is False for result in results)
+    assert all(result["attempts"] == 2 for result in results)
+    assert calls == {"invalidate": 2, "get_db": 2}
+    assert backoff_call_count["value"] == 1
+
+
+def test_fresh_caller_racing_retry_joins_the_newer_attempt(monkeypatch) -> None:
+    first_get_db_entered = threading.Event()
+    release_first_get_db = threading.Event()
+    retry_backoff_entered = threading.Event()
+    release_retry_backoff = threading.Event()
+    db = _PingDb()
+    calls = {"invalidate": 0, "get_db": 0}
+
+    def _invalidate(**_kwargs) -> None:
+        calls["invalidate"] += 1
+
+    def _get_db():
+        calls["get_db"] += 1
+        if calls["get_db"] == 1:
+            first_get_db_entered.set()
+            assert release_first_get_db.wait(timeout=5)
+            raise ConnectionFailure("first failure")
+        return db
+
+    def _backoff(_delay: float) -> None:
+        retry_backoff_entered.set()
+        assert release_retry_backoff.wait(timeout=5)
+
+    monkeypatch.setattr(conn_mgr._mc, "invalidate_connection", _invalidate)
+    monkeypatch.setattr(conn_mgr._mc, "get_db", _get_db)
+    monkeypatch.setattr(conn_mgr.time, "sleep", _backoff)
+
+    retrying: list[dict] = []
+    fresh: list[dict] = []
+    first = threading.Thread(
+        target=lambda: retrying.append(
+            conn_mgr.attempt_reconnect(force=True, max_attempts=2)
+        ),
+        daemon=True,
+    )
+    first.start()
+    assert first_get_db_entered.wait(timeout=5)
+    release_first_get_db.set()
+    assert retry_backoff_entered.wait(timeout=5)
+
+    second = threading.Thread(
+        target=lambda: fresh.append(
+            conn_mgr.attempt_reconnect(force=True, max_attempts=1)
+        ),
+        daemon=True,
+    )
+    second.start()
+    _wait_for_active_followers(1)
+    release_retry_backoff.set()
+    _join_threads([first, second])
+
+    assert retrying[0]["reconnected"] is True
+    assert retrying[0]["attempts"] == 2
+    assert fresh[0]["reconnected"] is True
+    assert fresh[0]["attempts"] == 1
+    assert calls == {"invalidate": 2, "get_db": 2}
+    assert db.pings == 1
+
+
+def test_nonforced_caller_reuses_reconnect_completed_during_health_preflight(
+    monkeypatch,
+) -> None:
+    health_entered = threading.Event()
+    release_health = threading.Event()
+    db = _PingDb()
+    calls = {"invalidate": 0, "get_db": 0}
+
+    def _health_summary():
+        health_entered.set()
+        assert release_health.wait(timeout=5)
+        return {"connected": False, "route_degraded": False}
+
+    def _invalidate(**_kwargs) -> None:
+        calls["invalidate"] += 1
+
+    def _get_db():
+        calls["get_db"] += 1
+        return db
+
+    monkeypatch.setattr(conn_mgr, "health_summary", _health_summary)
+    monkeypatch.setattr(conn_mgr._mc, "invalidate_connection", _invalidate)
+    monkeypatch.setattr(conn_mgr._mc, "get_db", _get_db)
+
+    waiting_result: list[dict] = []
+    waiting = threading.Thread(
+        target=lambda: waiting_result.append(
+            conn_mgr.attempt_reconnect(force=False, max_attempts=1)
+        ),
+        daemon=True,
+    )
+    waiting.start()
+    assert health_entered.wait(timeout=5)
+
+    completed = conn_mgr.attempt_reconnect(force=True, max_attempts=1)
+    release_health.set()
+    _join_threads([waiting])
+
+    assert completed["reconnected"] is True
+    assert waiting_result[0]["reconnected"] is True
+    assert waiting_result[0]["attempts"] == 1
+    assert calls == {"invalidate": 1, "get_db": 1}
+    assert db.pings == 1
+
+
+def test_backoff_exception_releases_all_attempt_followers(monkeypatch) -> None:
+    first_get_db_entered = threading.Event()
+    release_first_get_db = threading.Event()
+    backoff_entered = threading.Event()
+    release_backoff = threading.Event()
+
+    class _BackoffAbort(BaseException):
+        pass
+
+    def _get_db():
+        first_get_db_entered.set()
+        assert release_first_get_db.wait(timeout=5)
+        raise ConnectionFailure("first failure")
+
+    def _abort_backoff(_delay: float) -> None:
+        backoff_entered.set()
+        assert release_backoff.wait(timeout=5)
+        raise _BackoffAbort("cancelled backoff")
+
+    monkeypatch.setattr(
+        conn_mgr._mc,
+        "invalidate_connection",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(conn_mgr._mc, "get_db", _get_db)
+    monkeypatch.setattr(conn_mgr.time, "sleep", _abort_backoff)
+
+    caller_count = 5
+    _results, errors, threads = _run_threads(
+        [lambda: conn_mgr.attempt_reconnect(force=True, max_attempts=2)] * caller_count
+    )
+    assert first_get_db_entered.wait(timeout=5)
+    _wait_for_active_followers(caller_count - 1)
+    release_first_get_db.set()
+    assert backoff_entered.wait(timeout=5)
+    _wait_for_active_followers(caller_count - 1)
+    release_backoff.set()
+    _join_threads(threads)
+
+    assert len(errors) == caller_count
+    assert all(isinstance(error, _BackoffAbort) for error in errors)
+    with conn_mgr._reconnect_condition:
+        assert conn_mgr._active_reconnect_attempt is None
+
+
+def test_late_force_follows_a_healthy_nonforced_skip(monkeypatch) -> None:
+    health_entered = threading.Event()
+    release_health = threading.Event()
+    db = _PingDb()
+    calls = {"invalidate": 0, "get_db": 0}
+
+    def _health_summary():
+        health_entered.set()
+        assert release_health.wait(timeout=5)
+        return {"connected": True, "route_degraded": False}
+
+    def _invalidate(**_kwargs) -> None:
+        calls["invalidate"] += 1
+
+    def _get_db():
+        calls["get_db"] += 1
+        return db
+
+    monkeypatch.setattr(conn_mgr, "health_summary", _health_summary)
+    monkeypatch.setattr(conn_mgr._mc, "invalidate_connection", _invalidate)
+    monkeypatch.setattr(conn_mgr._mc, "get_db", _get_db)
+
+    skipped: list[dict] = []
+    forced: list[dict] = []
+    first = threading.Thread(
+        target=lambda: skipped.append(conn_mgr.attempt_reconnect(force=False)),
+        daemon=True,
+    )
+    first.start()
+    assert health_entered.wait(timeout=5)
+    second = threading.Thread(
+        target=lambda: forced.append(conn_mgr.attempt_reconnect(force=True)),
+        daemon=True,
+    )
+    second.start()
+    release_health.set()
+    _join_threads([first, second])
+
+    assert skipped[0]["skipped"] is True
+    assert forced[0]["reconnected"] is True
+    assert calls == {"invalidate": 1, "get_db": 1}
+    assert db.pings == 1
+
+
+def test_late_force_joins_an_active_nonforced_reconnect(monkeypatch) -> None:
+    health_checked = threading.Event()
+    release_health = threading.Event()
+    first_get_db_entered = threading.Event()
+    release_first_get_db = threading.Event()
+    db = _PingDb()
+    calls = {"invalidate": 0, "get_db": 0}
+    counter_lock = threading.Lock()
+
+    def _health_summary():
+        health_checked.set()
+        assert release_health.wait(timeout=5)
+        return {"connected": False, "route_degraded": False}
+
+    def _invalidate(**_kwargs) -> None:
+        with counter_lock:
+            calls["invalidate"] += 1
+
+    def _get_db():
+        with counter_lock:
+            calls["get_db"] += 1
+            call_number = calls["get_db"]
+        if call_number == 1:
+            first_get_db_entered.set()
+            assert release_first_get_db.wait(timeout=5)
+        return db
+
+    monkeypatch.setattr(conn_mgr, "health_summary", _health_summary)
+    monkeypatch.setattr(conn_mgr._mc, "invalidate_connection", _invalidate)
+    monkeypatch.setattr(conn_mgr._mc, "get_db", _get_db)
+
+    ordinary: list[dict] = []
+    forced: list[dict] = []
+    first = threading.Thread(
+        target=lambda: ordinary.append(conn_mgr.attempt_reconnect(force=False)),
+        daemon=True,
+    )
+    first.start()
+    assert health_checked.wait(timeout=5)
+    release_health.set()
+    assert first_get_db_entered.wait(timeout=5)
+
+    second = threading.Thread(
+        target=lambda: forced.append(conn_mgr.attempt_reconnect(force=True)),
+        daemon=True,
+    )
+    second.start()
+    _wait_for_active_followers(1)
+    release_first_get_db.set()
+    _join_threads([first, second])
+
+    assert ordinary[0]["reconnected"] is True
+    assert forced[0]["reconnected"] is True
+    assert forced[0]["attempts"] == 1
+    assert calls == {"invalidate": 1, "get_db": 1}
+    assert db.pings == 1
+
+
+def test_late_route_degraded_callers_share_one_follow_up(monkeypatch) -> None:
+    first_get_db_entered = threading.Event()
+    release_first_get_db = threading.Event()
+    second_get_db_entered = threading.Event()
+    release_second_get_db = threading.Event()
+    db = _PingDb()
+    calls = {"invalidate": 0, "get_db": 0}
+    preferences: list[str] = []
+    counter_lock = threading.Lock()
+
+    def _invalidate(*, prefer_alternate_reason=None) -> None:
+        with counter_lock:
+            calls["invalidate"] += 1
+        if prefer_alternate_reason is not None:
+            preferences.append(prefer_alternate_reason)
+
+    def _get_db():
+        with counter_lock:
+            calls["get_db"] += 1
+            call_number = calls["get_db"]
+        if call_number == 1:
+            first_get_db_entered.set()
+            assert release_first_get_db.wait(timeout=5)
+        elif call_number == 2:
+            second_get_db_entered.set()
+            assert release_second_get_db.wait(timeout=5)
+        return db
+
+    monkeypatch.setattr(conn_mgr._mc, "invalidate_connection", _invalidate)
+    monkeypatch.setattr(conn_mgr._mc, "get_db", _get_db)
+
+    ordinary: list[dict] = []
+    leader = threading.Thread(
+        target=lambda: ordinary.append(conn_mgr.attempt_reconnect(force=True)),
+        daemon=True,
+    )
+    leader.start()
+    assert first_get_db_entered.wait(timeout=5)
+
+    degraded_count = 5
+    degraded_results, errors, followers = _run_threads(
+        [
+            lambda: conn_mgr.attempt_reconnect(
+                route_degraded=True,
+                degradation_reason="operation route failed",
+            )
+        ]
+        * degraded_count
+    )
+    _wait_for_active_followers(degraded_count)
+    release_first_get_db.set()
+    assert second_get_db_entered.wait(timeout=5)
+    _wait_for_active_followers(degraded_count - 1)
+    release_second_get_db.set()
+    _join_threads([leader, *followers])
+
+    assert errors == []
+    assert ordinary[0]["reconnected"] is True
+    assert len(degraded_results) == degraded_count
+    assert all(result["reconnected"] is True for result in degraded_results)
+    assert calls == {"invalidate": 2, "get_db": 2}
+    assert db.pings == 2
+    assert preferences == ["operation route failed"]
+
+
+def test_route_degraded_request_does_not_use_healthy_skip(monkeypatch) -> None:
+    db = _PingDb()
+    calls = {"invalidate": 0, "get_db": 0}
+    preferences: list[str] = []
+
+    def _unexpected_health_summary():
+        raise AssertionError("route-degraded recovery must not preflight-skip")
+
+    monkeypatch.setattr(conn_mgr, "health_summary", _unexpected_health_summary)
+    monkeypatch.setattr(
+        conn_mgr._mc,
+        "invalidate_connection",
+        lambda *, prefer_alternate_reason=None: (
+            calls.__setitem__("invalidate", calls["invalidate"] + 1),
+            (
+                preferences.append(prefer_alternate_reason)
+                if prefer_alternate_reason is not None
+                else None
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        conn_mgr._mc,
+        "get_db",
+        lambda: calls.__setitem__("get_db", calls["get_db"] + 1) or db,
+    )
+    result = conn_mgr.attempt_reconnect(
+        route_degraded=True,
+        degradation_reason="known degraded route",
+    )
+
+    assert result["reconnected"] is True
+    assert calls == {"invalidate": 1, "get_db": 1}
+    assert db.pings == 1
+    assert preferences == ["known degraded route"]
+
+
+def test_final_failure_does_not_probe_beyond_wave_retry_budget(monkeypatch) -> None:
+    db = _PingDb(fail=True)
+    calls = {"invalidate": 0, "get_db": 0}
+
+    def _unexpected_health_summary():
+        raise AssertionError("final failure must not issue a health probe")
+
+    monkeypatch.setattr(conn_mgr, "health_summary", _unexpected_health_summary)
+    monkeypatch.setattr(
+        conn_mgr._mc,
+        "invalidate_connection",
+        lambda **_kwargs: calls.__setitem__("invalidate", calls["invalidate"] + 1),
+    )
+    monkeypatch.setattr(
+        conn_mgr._mc,
+        "get_db",
+        lambda: calls.__setitem__("get_db", calls["get_db"] + 1) or db,
+    )
+    monkeypatch.setattr(conn_mgr.time, "sleep", lambda _delay: None)
+
+    result = conn_mgr.attempt_reconnect(force=True, max_attempts=3)
+
+    assert result["reconnected"] is False
+    assert result["attempts"] == 3
+    assert result["connected"] is False
+    assert result["health_error_type"] == "ConnectionFailure"
+    assert calls == {"invalidate": 3, "get_db": 3}
+    assert db.pings == 3

--- a/tests/backend/test_mongo_client_singleflight.py
+++ b/tests/backend/test_mongo_client_singleflight.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+from pymongo.errors import ConnectionFailure
+
+from src.backend.db import mongo_client as mc
+
+
+class _FakeAdmin:
+    def __init__(
+        self,
+        *,
+        ping_started: threading.Event | None = None,
+        release_ping: threading.Event | None = None,
+        fail_ping: bool = False,
+    ) -> None:
+        self.ping_started = ping_started
+        self.release_ping = release_ping
+        self.fail_ping = fail_ping
+        self.ping_count = 0
+
+    def command(self, name: str, **_kwargs):
+        if name == "hello":
+            return {"ok": 1, "isWritablePrimary": True}
+        if name == "ping":
+            self.ping_count += 1
+            if self.ping_started is not None:
+                self.ping_started.set()
+            if self.release_ping is not None:
+                assert self.release_ping.wait(timeout=2)
+            if self.fail_ping:
+                raise ConnectionFailure("simulated health failure")
+        return {"ok": 1}
+
+
+class _FakeClient:
+    def __init__(self, label: str, admin: _FakeAdmin | None = None) -> None:
+        self.label = label
+        self.admin = admin or _FakeAdmin()
+        self.closed = False
+
+    def __getitem__(self, db_name: str):
+        return {"label": self.label, "db_name": db_name, "client": self}
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _isolated_real_client_state(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(mc, "is_mock_db_enabled", lambda: False)
+    monkeypatch.setattr(mc, "assert_safe_database_name_for_pytest", lambda _: None)
+    monkeypatch.setattr(mc, "MONGO_URI", "mongodb://primary.example/von_db")
+    monkeypatch.setattr(mc, "MONGO_DNS_FALLBACK_URI", None)
+    monkeypatch.setattr(mc, "MONGO_SSH_TUNNEL_FALLBACK_ENDPOINTS", ())
+    monkeypatch.setattr(mc, "MONGO_ALLOW_LOCAL_FALLBACK", False)
+    monkeypatch.setenv("VON_DB_NAME", "test_von_db")
+    monkeypatch.setenv("VON_MONGO_AUTO_RECOVERY", "0")
+    with mc._CONNECTION_CONDITION:
+        snapshot = {
+            "client": mc._mongo_client_real,
+            "mock": mc._mongo_client_mock,
+            "using_fallback": mc._using_fallback_real,
+            "active_fallback_kind": mc._active_fallback_kind_real,
+            "effective_uri": mc._effective_uri_real,
+            "preferred_fallback_kind": mc._preferred_fallback_kind,
+            "preferred_until": mc._dns_fallback_preferred_until_monotonic,
+            "preference_reason": mc._dns_fallback_preference_reason,
+            "last_check": mc._last_auto_recovery_check_at,
+            "generation": mc._connection_generation,
+            "waves": dict(mc._connection_waves),
+        }
+        mc._mongo_client_real = None
+        mc._mongo_client_mock = None
+        mc._using_fallback_real = False
+        mc._active_fallback_kind_real = None
+        mc._effective_uri_real = mc.MONGO_URI
+        mc._preferred_fallback_kind = None
+        mc._dns_fallback_preferred_until_monotonic = 0.0
+        mc._dns_fallback_preference_reason = None
+        mc._last_auto_recovery_check_at = 0.0
+        mc._connection_generation += 1
+        mc._connection_waves.clear()
+    yield
+    assert not mc._HEALTH_CHECK_LOCK.locked()
+    with mc._CONNECTION_CONDITION:
+        mc._mongo_client_real = snapshot["client"]
+        mc._mongo_client_mock = snapshot["mock"]
+        mc._using_fallback_real = snapshot["using_fallback"]
+        mc._active_fallback_kind_real = snapshot["active_fallback_kind"]
+        mc._effective_uri_real = snapshot["effective_uri"]
+        mc._preferred_fallback_kind = snapshot["preferred_fallback_kind"]
+        mc._dns_fallback_preferred_until_monotonic = snapshot["preferred_until"]
+        mc._dns_fallback_preference_reason = snapshot["preference_reason"]
+        mc._last_auto_recovery_check_at = snapshot["last_check"]
+        mc._connection_generation = snapshot["generation"]
+        mc._connection_waves.clear()
+        mc._connection_waves.update(snapshot["waves"])
+
+
+def _wait_for_wave_waiters(expected: int) -> None:
+    with mc._CONNECTION_CONDITION:
+        assert mc._CONNECTION_CONDITION.wait_for(
+            lambda: any(
+                wave.waiter_count >= expected for wave in mc._connection_waves.values()
+            ),
+            timeout=2,
+        )
+
+
+def _run_concurrently(count: int, operation):
+    start = threading.Barrier(count + 1)
+    results: list[object] = []
+    errors: list[BaseException] = []
+
+    def _worker() -> None:
+        try:
+            start.wait(timeout=2)
+            results.append(operation())
+        except BaseException as exc:  # noqa: BLE001 - asserted by the test thread
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_worker) for _ in range(count)]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=2)
+    return threads, results, errors
+
+
+def _join(threads: list[threading.Thread], errors: list[BaseException]) -> None:
+    for thread in threads:
+        thread.join(timeout=3)
+        assert not thread.is_alive()
+    assert not errors
+
+
+def test_concurrent_cold_get_db_runs_one_connection_wave(monkeypatch) -> None:
+    connect_started = threading.Event()
+    release_connect = threading.Event()
+    client = _FakeClient("shared")
+    connect_count = 0
+    count_lock = threading.Lock()
+
+    def _connect(_uri: str, **_kwargs):
+        nonlocal connect_count
+        with count_lock:
+            connect_count += 1
+        connect_started.set()
+        assert release_connect.wait(timeout=2)
+        return client
+
+    monkeypatch.setattr(mc, "_try_connect_uri", _connect)
+    threads, results, errors = _run_concurrently(12, mc.get_db)
+    assert connect_started.wait(timeout=2)
+    _wait_for_wave_waiters(11)
+    assert connect_count == 1
+    release_connect.set()
+    _join(threads, errors)
+
+    assert len(results) == 12
+    assert {result["client"] for result in results} == {client}
+    assert connect_count == 1
+
+
+def test_failed_wave_is_shared_and_a_later_call_retries(monkeypatch) -> None:
+    connect_started = threading.Event()
+    release_failure = threading.Event()
+    recovered = _FakeClient("recovered")
+    connect_count = 0
+    count_lock = threading.Lock()
+
+    def _connect(_uri: str, **_kwargs):
+        nonlocal connect_count
+        with count_lock:
+            connect_count += 1
+            attempt = connect_count
+        if attempt == 1:
+            connect_started.set()
+            assert release_failure.wait(timeout=2)
+            raise ConnectionFailure("shared simulated outage")
+        return recovered
+
+    monkeypatch.setattr(mc, "_try_connect_uri", _connect)
+    threads, results, errors = _run_concurrently(10, mc.get_db)
+    assert connect_started.wait(timeout=2)
+    _wait_for_wave_waiters(9)
+    release_failure.set()
+    _join(threads, errors)
+
+    assert results == [None] * 10
+    assert connect_count == 1
+    retry = mc.get_db()
+    assert retry is not None
+    assert retry["client"] is recovered
+    assert connect_count == 2
+
+
+def test_cancelled_connection_wave_releases_waiters_and_later_call_retries(
+    monkeypatch,
+) -> None:
+    class _CancelledBuild(BaseException):
+        pass
+
+    build_started = threading.Event()
+    release_build = threading.Event()
+    recovered = _FakeClient("recovered-after-cancellation")
+    build_count = 0
+    count_lock = threading.Lock()
+
+    def _build_candidate():
+        nonlocal build_count
+        with count_lock:
+            build_count += 1
+            attempt = build_count
+        if attempt == 1:
+            build_started.set()
+            assert release_build.wait(timeout=2)
+            raise _CancelledBuild("cancelled connection construction")
+        return (
+            mc._MongoConnectionCandidate(
+                client=recovered,
+                uri=mc.MONGO_URI,
+                fallback_kind=None,
+            ),
+            False,
+        )
+
+    monkeypatch.setattr(mc, "_build_real_connection_candidate", _build_candidate)
+    threads, results, errors = _run_concurrently(2, mc.get_db)
+    assert build_started.wait(timeout=2)
+    _wait_for_wave_waiters(1)
+    release_build.set()
+    for thread in threads:
+        thread.join(timeout=3)
+        assert not thread.is_alive()
+
+    assert results == []
+    assert len(errors) == 2
+    assert all(isinstance(error, _CancelledBuild) for error in errors)
+    with mc._CONNECTION_CONDITION:
+        assert mc._connection_waves == {}
+
+    retry = mc.get_db()
+    assert retry is not None
+    assert retry["client"] is recovered
+    assert build_count == 2
+
+
+def test_invalidation_fences_and_closes_late_unpublished_candidate(
+    monkeypatch,
+) -> None:
+    old_published = _FakeClient("old-published")
+    with mc._CONNECTION_CONDITION:
+        mc._mongo_client_real = old_published
+    mc.invalidate_connection()
+    assert old_published.closed is False
+
+    first_started = threading.Event()
+    release_first = threading.Event()
+    stale_candidate = _FakeClient("stale-candidate")
+    replacement = _FakeClient("replacement")
+    connect_count = 0
+    count_lock = threading.Lock()
+
+    def _connect(_uri: str, **_kwargs):
+        nonlocal connect_count
+        with count_lock:
+            connect_count += 1
+            attempt = connect_count
+        if attempt == 1:
+            first_started.set()
+            assert release_first.wait(timeout=2)
+            return stale_candidate
+        return replacement
+
+    monkeypatch.setattr(mc, "_try_connect_uri", _connect)
+    worker_result: list[object] = []
+    worker = threading.Thread(target=lambda: worker_result.append(mc.get_db()))
+    worker.start()
+    assert first_started.wait(timeout=2)
+
+    mc.invalidate_connection()
+    current = mc.get_db()
+    assert current is not None
+    assert current["client"] is replacement
+    release_first.set()
+    worker.join(timeout=3)
+
+    assert not worker.is_alive()
+    assert worker_result[0]["client"] is replacement
+    assert stale_candidate.closed is True
+    assert replacement.closed is False
+    assert mc._mongo_client_real is replacement
+
+
+def test_atomic_degrade_invalidate_preserves_route_intent_across_late_builder(
+    monkeypatch,
+) -> None:
+    first_started = threading.Event()
+    release_first = threading.Event()
+    stale_primary = _FakeClient("stale-primary")
+    alternate = _FakeClient("alternate")
+    primary_uri = mc.MONGO_URI
+    attempted_uris: list[str] = []
+
+    monkeypatch.setattr(
+        mc,
+        "MONGO_SSH_TUNNEL_FALLBACK_ENDPOINTS",
+        ("127.0.0.1:27018",),
+    )
+    monkeypatch.setattr(mc, "MONGO_SSH_TUNNEL_EXPECTED_REPLICA_SET", None)
+
+    def _connect(uri: str, **_kwargs):
+        attempted_uris.append(uri)
+        if uri == primary_uri:
+            first_started.set()
+            assert release_first.wait(timeout=2)
+            return stale_primary
+        assert "127.0.0.1:27018" in uri
+        return alternate
+
+    monkeypatch.setattr(mc, "_try_connect_uri", _connect)
+    result: list[object] = []
+    worker = threading.Thread(target=lambda: result.append(mc.get_db()))
+    worker.start()
+    assert first_started.wait(timeout=2)
+
+    mc.invalidate_connection(prefer_alternate_reason="simulated route failure")
+    assert mc.get_mongo_fallback_policy_state()["preferred_fallback_kind"] == (
+        "ssh_tunnel"
+    )
+    release_first.set()
+    worker.join(timeout=3)
+
+    assert not worker.is_alive()
+    assert result[0]["client"] is alternate
+    assert attempted_uris[0] == primary_uri
+    assert "127.0.0.1:27018" in attempted_uris[1]
+    assert len(attempted_uris) == 2
+    assert stale_primary.closed is True
+    assert alternate.closed is False
+    policy = mc.get_mongo_fallback_policy_state()
+    assert policy["preferred_fallback_kind"] == "ssh_tunnel"
+    assert policy["active_fallback_kind"] == "ssh_tunnel"
+
+
+def test_fallback_route_metadata_is_published_with_its_client(monkeypatch) -> None:
+    build_started = threading.Event()
+    release_build = threading.Event()
+    fallback = _FakeClient("dns-fallback")
+    fallback_uri = "mongodb://direct.example:27017/?tls=true"
+
+    def _build_candidate():
+        build_started.set()
+        assert release_build.wait(timeout=2)
+        return (
+            mc._MongoConnectionCandidate(
+                client=fallback,
+                uri=fallback_uri,
+                fallback_kind="dns",
+                preference_reason="test fallback",
+            ),
+            False,
+        )
+
+    monkeypatch.setattr(mc, "_build_real_connection_candidate", _build_candidate)
+    result: list[object] = []
+    worker = threading.Thread(target=lambda: result.append(mc.get_db()))
+    worker.start()
+    assert build_started.wait(timeout=2)
+
+    assert mc._mongo_client_real is None
+    assert mc.get_effective_mongo_uri() == mc.MONGO_URI
+    assert mc.is_using_fallback_uri() is False
+    release_build.set()
+    worker.join(timeout=3)
+
+    assert not worker.is_alive()
+    assert result[0]["client"] is fallback
+    assert mc._mongo_client_real is fallback
+    assert mc.get_effective_mongo_uri() == fallback_uri
+    assert mc.is_using_fallback_uri() is True
+    assert mc.get_mongo_fallback_policy_state()["active_fallback_kind"] == "dns"
+
+
+def test_late_health_failure_cannot_erase_newer_client_and_probes_coalesce(
+    monkeypatch,
+) -> None:
+    ping_started = threading.Event()
+    release_ping = threading.Event()
+    stale = _FakeClient(
+        "stale",
+        _FakeAdmin(
+            ping_started=ping_started,
+            release_ping=release_ping,
+            fail_ping=True,
+        ),
+    )
+    replacement = _FakeClient("replacement")
+    with mc._CONNECTION_CONDITION:
+        mc._mongo_client_real = stale
+        mc._last_auto_recovery_check_at = 0.0
+    monkeypatch.setenv("VON_MONGO_AUTO_RECOVERY", "1")
+    monkeypatch.setenv("VON_MONGO_AUTO_RECOVERY_CHECK_INTERVAL_SECONDS", "0.001")
+    monkeypatch.setattr(mc, "_try_connect_uri", lambda _uri, **_kwargs: replacement)
+
+    probing_result: list[object] = []
+    probing = threading.Thread(target=lambda: probing_result.append(mc.get_db()))
+    probing.start()
+    assert ping_started.wait(timeout=2)
+
+    coalesced = mc.get_db()
+    assert coalesced is not None
+    assert coalesced["client"] is stale
+    assert stale.admin.ping_count == 1
+
+    mc.invalidate_connection()
+    current = mc.get_db()
+    assert current is not None
+    assert current["client"] is replacement
+    release_ping.set()
+    probing.join(timeout=3)
+
+    assert not probing.is_alive()
+    assert probing_result[0]["client"] is replacement
+    assert mc._mongo_client_real is replacement
+    assert replacement.closed is False
+
+
+def test_ordinary_healthy_get_db_does_not_enter_connection_condition(
+    monkeypatch,
+) -> None:
+    healthy = _FakeClient("healthy")
+    mc._mongo_client_real = healthy
+    mc._last_auto_recovery_check_at = time.monotonic()
+    monkeypatch.setenv("VON_MONGO_AUTO_RECOVERY", "1")
+    monkeypatch.setenv("VON_MONGO_AUTO_RECOVERY_CHECK_INTERVAL_SECONDS", "3600")
+
+    class _UnexpectedCondition:
+        def __enter__(self):
+            raise AssertionError(
+                "healthy fast path must not enter connection condition"
+            )
+
+        def __exit__(self, *_args):
+            return False
+
+    with monkeypatch.context() as context:
+        context.setattr(mc, "_CONNECTION_CONDITION", _UnexpectedCondition())
+        db = mc.get_db()
+
+    assert db is not None
+    assert db["client"] is healthy
+    assert healthy.admin.ping_count == 0


### PR DESCRIPTION
## What changed

- Single-flight physical Mongo client construction per invalidation generation.
- Fence and close stale unpublished clients without closing published clients still held by in-flight work.
- Make degraded-route selection and invalidation atomic.
- Coalesce explicit reconnect attempts and retry backoff while preserving each caller's retry budget.
- Add deterministic concurrency coverage for success, failure, retry, invalidation, route rotation, cancellation, and health-preflight races.

## Why

A transient Mongo or network failure could cause many concurrent requests and workers to independently invalidate the client, probe routes, and construct new clients. That multiplied a single outage into repeated Atlas handshakes, long request tails, and lease risk.

## Impact

Concurrent callers now share one physical recovery attempt at a time. A later independent call can still retry after a failed wave, and stronger degraded-route intent receives one bounded atomic follow-up. Existing direct, DNS fallback, SSH tunnel, writable-primary, replica-set, and invalidate-without-close behaviour is preserved.

## Validation

- 106 focused Mongo, reconnect, fallback, index-guard, startup, observability, diagnostics, URI-redaction, and admin-health tests passed.
- 56 neighbouring durable-workflow and execution recovery tests passed.
- Both new single-flight suites passed 10 consecutive local runs; independent stress review ran them 100 consecutive times.
- Black, Ruff on the new tests, Python compilation, and `git diff --check` passed.
- Two independent concurrency/compatibility reviews found no remaining stop-ship race.

## Residual limitation

A completion retained briefly for a lagging reconnect caller is not tagged with the Mongo generation. An unrelated direct invalidation in that tiny interval could yield a stale success receipt; the subsequent canonical operation detects it, and a fresh reconnect call cannot reuse that completion.

Jira: JVNAUTOSCI-2631