### PR TITLE
Refine footer cost display

### DIFF
--- a/src/frontend/web/von_interface/static/js/domUtils.js
+++ b/src/frontend/web/von_interface/static/js/domUtils.js
@@ -388,28 +388,54 @@ function getConversationRuntimeCostSnapshot() {
 function applyConversationRuntimeCostFooterSnapshot(button, snapshot = getConversationRuntimeCostSnapshot()) {
   if (!button) return;
   const presentation = formatConversationRuntimeCostFooter(snapshot);
+  const isRuntimeCost = button.dataset.costScope === 'runtime';
+  const visible = isRuntimeCost ? presentation.runtimeVisible : presentation.visible;
+  const state = isRuntimeCost ? presentation.runtimeState : presentation.state;
+  const desktopText = isRuntimeCost ? presentation.runtimeText : presentation.desktopText;
+  const mobileText = isRuntimeCost ? presentation.runtimeText : presentation.mobileText;
+  const detailLines = isRuntimeCost ? presentation.runtimeDetails : presentation.details;
+  const ariaLabel = isRuntimeCost ? presentation.runtimeAriaLabel : presentation.ariaLabel;
+  const title = isRuntimeCost ? presentation.runtimeTitle : presentation.title;
   const segment = button.closest('.conversation-runtime-cost-segment');
-  if (segment) segment.hidden = presentation.visible !== true;
+  if (segment) segment.hidden = visible !== true;
   const desktop = button.querySelector('.conversation-runtime-cost-desktop');
   const mobile = button.querySelector('.conversation-runtime-cost-mobile');
   const details = button.parentElement?.querySelector('.conversation-runtime-cost-details');
-  if (desktop) desktop.textContent = presentation.desktopText;
-  if (mobile) mobile.textContent = presentation.mobileText;
+  if (desktop) desktop.textContent = desktopText;
+  if (mobile) mobile.textContent = mobileText;
   if (details) {
-    details.replaceChildren(...presentation.details.map((detail) => {
+    details.replaceChildren(...detailLines.map((detail) => {
       const line = document.createElement('div');
       line.textContent = detail;
       return line;
     }));
   }
-  button.setAttribute('aria-label', presentation.ariaLabel);
-  setKeptNativeTitle(button, presentation.title);
-  button.dataset.costState = presentation.state;
-  button.dataset.costDetails = presentation.details.join('\n');
-  if (presentation.visible !== true) {
+  button.setAttribute('aria-label', ariaLabel);
+  setKeptNativeTitle(button, title);
+  button.dataset.costState = state;
+  button.dataset.costDetails = detailLines.join('\n');
+  if (visible !== true) {
     button.setAttribute('aria-expanded', 'false');
     if (details) details.hidden = true;
   }
+}
+
+function closeConversationRuntimeCostDetails() {
+  document.querySelectorAll('.conversation-runtime-cost-details').forEach((panel) => {
+    panel.hidden = true;
+    const control = panel.parentElement?.querySelector('.conversation-runtime-cost-button');
+    if (control) control.setAttribute('aria-expanded', 'false');
+  });
+}
+
+function toggleConversationRuntimeCostDetails(button) {
+  const segment = button?.closest?.('.conversation-runtime-cost-segment');
+  const details = button?.parentElement?.querySelector('.conversation-runtime-cost-details');
+  if (!button || !details || segment?.hidden) return;
+  const nextOpen = details.hidden;
+  closeConversationRuntimeCostDetails();
+  details.hidden = !nextOpen;
+  button.setAttribute('aria-expanded', nextOpen ? 'true' : 'false');
 }
 
 function makeConversationRuntimeCostFooterSegment() {
@@ -418,6 +444,7 @@ function makeConversationRuntimeCostFooterSegment() {
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'conversation-runtime-cost-button';
+  button.dataset.costScope = 'conversation';
   button.setAttribute('aria-live', 'polite');
   button.setAttribute('aria-expanded', 'false');
   const desktop = document.createElement('span');
@@ -433,18 +460,6 @@ function makeConversationRuntimeCostFooterSegment() {
   details.setAttribute('aria-label', 'Conversation cost estimate details');
   details.hidden = true;
   button.setAttribute('aria-controls', details.id);
-  button.addEventListener('click', (event) => {
-    event.stopPropagation();
-    if (segment.hidden) return;
-    const nextOpen = details.hidden;
-    document.querySelectorAll('.conversation-runtime-cost-details').forEach((panel) => {
-      panel.hidden = true;
-      const control = panel.parentElement?.querySelector('.conversation-runtime-cost-button');
-      if (control) control.setAttribute('aria-expanded', 'false');
-    });
-    details.hidden = !nextOpen;
-    button.setAttribute('aria-expanded', nextOpen ? 'true' : 'false');
-  });
   segment.append(button, details);
   applyConversationRuntimeCostFooterSnapshot(button);
   return segment;
@@ -466,20 +481,17 @@ if (typeof document !== 'undefined' && !document.__vonConversationRuntimeCostFoo
     refreshConversationRuntimeCostFooter(event?.detail || null);
   });
   document.addEventListener('click', (event) => {
+    const costButton = event.target?.closest?.('.conversation-runtime-cost-button');
+    if (costButton) {
+      toggleConversationRuntimeCostDetails(costButton);
+      return;
+    }
     if (event.target?.closest?.('.conversation-runtime-cost-segment')) return;
-    document.querySelectorAll('.conversation-runtime-cost-details').forEach((panel) => {
-      panel.hidden = true;
-      const control = panel.parentElement?.querySelector('.conversation-runtime-cost-button');
-      if (control) control.setAttribute('aria-expanded', 'false');
-    });
+    closeConversationRuntimeCostDetails();
   });
   document.addEventListener('keydown', (event) => {
     if (event.key !== 'Escape') return;
-    document.querySelectorAll('.conversation-runtime-cost-details').forEach((panel) => {
-      panel.hidden = true;
-      const control = panel.parentElement?.querySelector('.conversation-runtime-cost-button');
-      if (control) control.setAttribute('aria-expanded', 'false');
-    });
+    closeConversationRuntimeCostDetails();
   });
 }
 const FOOTER_WORKFLOW_CAPABILITY_RETRY_MS = 60000;
@@ -1650,6 +1662,7 @@ export async function setModelInfoFooterText() {
       footer.appendChild(sep);
     }
   });
+  refreshConversationRuntimeCostFooter();
 
   // If authenticated, highlight the User button (visual cue) BEFORE any long-latency calls (DB info) so tests see it.
   try {
@@ -1726,7 +1739,7 @@ export async function setModelInfoFooterText() {
   footer.style.cursor = 'pointer';
   setKeptNativeTitle(footer, 'Click empty area to open settings');
   footer.addEventListener('click', (ev) => {
-    if (ev.target.closest('.concept-footer-button')) { return; }
+    if (ev.target.closest('.concept-footer-button, .conversation-runtime-cost-button')) { return; }
     const settingsTabButton = document.querySelector('.tab-button[data-tab="settingsTab"]');
     if (settingsTabButton) { settingsTabButton.click(); }
   });

--- a/src/frontend/web/von_interface/static/js/test/conversationRuntimeCost.test.js
+++ b/src/frontend/web/von_interface/static/js/test/conversationRuntimeCost.test.js
@@ -35,9 +35,26 @@ describe('conversation runtime cost footer presentation', () => {
 
     expect(result.visible).toBe(true);
     expect(result.desktopText).toContain('Est. cost: Chat US$0.013472');
-    expect(result.desktopText).toContain('Since restart US$0.0428');
+    expect(result.desktopText).not.toContain('Since restart');
+    expect(result.runtimeText).toBe('Est. US$0.04');
     expect(result.mobileText).toContain('Chat US$0.013472');
-    expect(result.mobileText).toContain('Run US$0.0428');
+    expect(result.mobileText).not.toContain('Run');
+  });
+
+  test('keeps sub-cent precision through two cents, then rounds to the nearest cent', () => {
+    const atThreshold = formatConversationRuntimeCostFooter(snapshot({
+      conversation: summary('estimated', 0.019876),
+      sinceRestart: summary('estimated', 0.02),
+    }));
+    const aboveThreshold = formatConversationRuntimeCostFooter(snapshot({
+      conversation: summary('estimated', 0.020001),
+      sinceRestart: summary('estimated', 0.025),
+    }));
+
+    expect(atThreshold.desktopText).toContain('US$0.019876');
+    expect(atThreshold.runtimeText).toBe('Est. US$0.02');
+    expect(aboveThreshold.desktopText).toContain('US$0.02');
+    expect(aboveThreshold.runtimeText).toBe('Est. US$0.03');
   });
 
   test('keeps a priced baseline as a partial known subtotal when the active summary is unavailable', () => {
@@ -48,7 +65,7 @@ describe('conversation runtime cost footer presentation', () => {
     }));
 
     expect(result.desktopText).toContain('Chat known US$0.01 (partial)');
-    expect(result.desktopText).toContain('Since restart known US$0.02 (partial)');
+    expect(result.runtimeText).toContain('Est. known US$0.02 (partial)');
     expect(result.desktopText).not.toContain('US$0.0000');
   });
 
@@ -60,7 +77,7 @@ describe('conversation runtime cost footer presentation', () => {
     }));
 
     expect(result.desktopText).toContain('Chat known US$0.01 (partial)');
-    expect(result.desktopText).toContain('Since restart known US$0.02 (partial)');
+    expect(result.runtimeText).toContain('Est. known US$0.02 (partial)');
     expect(result.details).toContain('Latest refresh unavailable; showing retained evidence as a known subtotal.');
   });
 
@@ -72,7 +89,7 @@ describe('conversation runtime cost footer presentation', () => {
     }));
 
     expect(result.desktopText).toContain('Chat estimate unavailable');
-    expect(result.desktopText).toContain('Since restart estimate unavailable');
+    expect(result.runtimeText).toContain('Est. unavailable');
   });
 
   test('treats a live-only priced result as a partial subtotal until the baseline arrives', () => {
@@ -82,7 +99,7 @@ describe('conversation runtime cost footer presentation', () => {
     }));
 
     expect(result.desktopText).toContain('Chat known US$0.0030 (partial)');
-    expect(result.desktopText).toContain('Since restart known US$0.0030 (partial)');
+    expect(result.runtimeText).toContain('Est. known US$0.0030 (partial)');
     expect(result.desktopText).not.toContain('Chat US$0.0030 ·');
   });
 
@@ -107,7 +124,7 @@ describe('conversation runtime cost footer presentation', () => {
     }));
 
     expect(result.desktopText).toContain('Chat No billable model calls');
-    expect(result.desktopText).toContain('Since restart No billable model calls');
+    expect(result.runtimeText).toContain('Est. no billable calls');
     expect(result.desktopText).not.toContain('US$0');
   });
 });

--- a/src/frontend/web/von_interface/static/js/utils/conversationRuntimeCost.js
+++ b/src/frontend/web/von_interface/static/js/utils/conversationRuntimeCost.js
@@ -55,15 +55,17 @@ function mergeCost(base, overlay) {
 
 function formatAmount(amount, currency) {
   if (amount === null) return '';
+  const roundToCents = amount > 0.02;
   try {
     return new Intl.NumberFormat('en-NZ', {
       style: 'currency',
       currency,
-      minimumFractionDigits: amount > 0 && amount < 0.01 ? 4 : 2,
-      maximumFractionDigits: 6,
+      minimumFractionDigits: roundToCents ? 2 : (amount > 0 && amount < 0.01 ? 4 : 2),
+      maximumFractionDigits: roundToCents ? 2 : 6,
     }).format(amount);
   } catch (_) {
-    return `${currency === 'USD' ? 'US$' : `${currency} `}${amount.toFixed(6)}`;
+    const fractionDigits = roundToCents ? 2 : 6;
+    return `${currency === 'USD' ? 'US$' : `${currency} `}${amount.toFixed(fractionDigits)}`;
   }
 }
 
@@ -153,56 +155,86 @@ export function formatConversationRuntimeCostFooter(snapshot) {
   if (!context?.conversation_session_id) {
     return {
       visible: false,
+      runtimeVisible: false,
       state: 'unavailable',
+      runtimeState: 'unavailable',
       desktopText: '',
       mobileText: '',
+      runtimeText: '',
       ariaLabel: '',
+      runtimeAriaLabel: '',
       title: '',
+      runtimeTitle: '',
       details: [],
+      runtimeDetails: [],
     };
   }
 
   if (!baseline && !isLoading && !live && !source.error) {
     return {
       visible: false,
+      runtimeVisible: false,
       state: 'unavailable',
+      runtimeState: 'unavailable',
       desktopText: '',
       mobileText: '',
+      runtimeText: '',
       ariaLabel: '',
+      runtimeAriaLabel: '',
       title: '',
+      runtimeTitle: '',
       details: [],
+      runtimeDetails: [],
     };
   }
 
   if (!baseline && (isLoading || liveCalculating)) {
     return {
       visible: true,
+      runtimeVisible: true,
       state: 'calculating',
+      runtimeState: 'calculating',
       desktopText: 'Est. cost: calculating…',
       mobileText: 'Cost calculating…',
+      runtimeText: 'Est. calculating…',
       ariaLabel: 'Estimated conversation cost is calculating.',
+      runtimeAriaLabel: 'Estimated cost since server restart is calculating.',
       title: 'Estimated cost is calculating from provider-reported usage. It is not a provider invoice.',
+      runtimeTitle: 'Estimated cost since server restart is calculating from provider-reported usage. It is not a provider invoice.',
       details: [],
+      runtimeDetails: [],
     };
   }
 
-  const desktopText = `Est. cost: Chat ${describeCost(chatCost)} · Since restart ${describeCost(restartCost)}`;
-  const mobileText = `Chat ${describeCost(chatCost, { compact: true })} · Run ${describeCost(restartCost, { compact: true })}`;
+  const desktopText = `Est. cost: Chat ${describeCost(chatCost)}`;
+  const mobileText = `Chat ${describeCost(chatCost, { compact: true })}`;
+  const runtimeText = `Est. ${describeCost(restartCost, { compact: true })}`;
+  const sharedDetails = [];
+  if (live?.request_id) sharedDetails.push(`Current request: ${live.request_id}`);
+  if (source.error) sharedDetails.push('Latest refresh unavailable; showing retained evidence as a known subtotal.');
+  sharedDetails.push('Estimate from provider-reported usage; not a provider invoice.');
   const details = [
     ...summaryDetailLines('Chat', conversationBase, chatCost),
-    ...summaryDetailLines('Since restart', restartBase, restartCost),
+    ...sharedDetails,
   ];
-  if (live?.request_id) details.push(`Current request: ${live.request_id}`);
-  if (source.runtime?.started_at_utc) details.push(`Runtime started: ${source.runtime.started_at_utc}`);
-  if (source.error) details.push('Latest refresh unavailable; showing retained evidence as a known subtotal.');
-  details.push('Estimate from provider-reported usage; not a provider invoice.');
+  const runtimeDetails = [
+    ...summaryDetailLines('Since restart', restartBase, restartCost),
+    ...(source.runtime?.started_at_utc ? [`Runtime started: ${source.runtime.started_at_utc}`] : []),
+    ...sharedDetails,
+  ];
   return {
     visible: true,
+    runtimeVisible: true,
     state: chatCost.state === 'estimated' && restartCost.state === 'estimated' ? 'estimated' : chatCost.state,
+    runtimeState: restartCost.state,
     desktopText,
     mobileText,
+    runtimeText,
     ariaLabel: `${desktopText}. ${details.join('. ')}`,
+    runtimeAriaLabel: `Estimated cost since server restart: ${describeCost(restartCost)}. ${runtimeDetails.join('. ')}`,
     title: details.join('\n'),
+    runtimeTitle: runtimeDetails.join('\n'),
     details,
+    runtimeDetails,
   };
 }

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -6055,6 +6055,23 @@ footer {
     box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.4);
 }
 
+.conversation-runtime-cost-button--runtime {
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    padding: 0;
+}
+
+.conversation-runtime-cost-button--runtime:hover,
+.conversation-runtime-cost-button--runtime:active {
+    background: transparent;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+    transform: none;
+}
+
 .conversation-runtime-cost-mobile {
     display: none;
 }
@@ -6078,6 +6095,11 @@ footer {
     color: #334155;
     font-size: 0.75rem;
     line-height: 1.45;
+}
+
+.server-runtime-cost-segment .conversation-runtime-cost-details {
+    right: 0;
+    left: auto;
 }
 
 .footer-separator:has(+ .conversation-runtime-cost-segment[hidden]),
@@ -10919,6 +10941,10 @@ button.prompt-vontology-cartouche {
     background: #f3f4f6;
     border-radius: 12px;
     border: 1px solid #e5e7eb;
+}
+
+#serverUptimeFooter {
+    white-space: nowrap;
 }
 
 .pid-indicator.pid-error {

--- a/src/frontend/web/von_interface/templates/von_interface.html
+++ b/src/frontend/web/von_interface/templates/von_interface.html
@@ -163,6 +163,18 @@
     <p id="languageIndicator" class="language-indicator">🌐 en-NZ</p>
     <p id="serverUptimeFooter" class="pid-indicator" title="Process uptime">
       <span class="footer-label">Uptime:</span> <span id="serverUptimeValue" title="Process uptime">-</span>
+      <span id="serverRuntimeCostInfo" class="conversation-runtime-cost-segment server-runtime-cost-segment" hidden>
+        <span class="footer-separator">|</span>
+        <button id="serverRuntimeCostButton"
+          class="conversation-runtime-cost-button conversation-runtime-cost-button--runtime" type="button"
+          data-cost-scope="runtime" aria-live="polite" aria-expanded="false"
+          aria-controls="serverRuntimeCostDetails">
+          <span class="conversation-runtime-cost-desktop"></span>
+          <span class="conversation-runtime-cost-mobile" aria-hidden="true"></span>
+        </button>
+        <span id="serverRuntimeCostDetails" class="conversation-runtime-cost-details" role="region"
+          aria-label="Cost estimate since server restart details" hidden></span>
+      </span>
       <span id="serverBuildInfo" class="server-build-info" hidden><span class="footer-separator">|</span>
         <span class="footer-label">Build:</span> <span id="serverBuildValue">-</span></span>
     </p>

--- a/tests/frontend/footerBuildInfo.test.js
+++ b/tests/frontend/footerBuildInfo.test.js
@@ -15,12 +15,19 @@ const styles = fs.readFileSync(
 );
 
 describe('footer build information', () => {
-    test('places compact build information immediately after uptime', () => {
+    test('places the restart estimate between uptime and compact build information', () => {
         const uptimeFooter = template.match(/<p id="serverUptimeFooter"[\s\S]*?<\/p>/)?.[0] || '';
 
         expect(uptimeFooter.indexOf('id="serverUptimeValue"')).toBeGreaterThanOrEqual(0);
-        expect(uptimeFooter.indexOf('id="serverBuildInfo"'))
+        expect(uptimeFooter.indexOf('id="serverRuntimeCostInfo"'))
             .toBeGreaterThan(uptimeFooter.indexOf('id="serverUptimeValue"'));
+        expect(uptimeFooter.indexOf('id="serverBuildInfo"'))
+            .toBeGreaterThan(uptimeFooter.indexOf('id="serverRuntimeCostInfo"'));
+        expect(uptimeFooter).toContain('data-cost-scope="runtime"');
+        expect(uptimeFooter).not.toContain('Since restart');
+        expect(styles).toMatch(
+            /\.conversation-runtime-cost-button--runtime:hover,[\s\S]*?background:\s*transparent;[\s\S]*?transform:\s*none;/
+        );
         expect(mainSource).toContain('versionDetails.git_short_commit');
         expect(mainSource).toContain('versionDetails.git_commit_timestamp');
         expect(mainSource).toContain("shortCommit.slice(0, 8)");
@@ -49,5 +56,6 @@ describe('footer build information', () => {
         expect(styles).not.toMatch(
             /@media \(max-width:\s*760px\)[\s\S]*?#serverUptimeFooter\s*\{\s*display:\s*none;/
         );
+        expect(styles).toMatch(/#serverUptimeFooter\s*\{\s*white-space:\s*nowrap;/);
     });
 });


### PR DESCRIPTION
## What changed

- round estimated costs above US$0.02 to the nearest cent while retaining precision for smaller amounts
- keep the conversation estimate beside the model
- move the since-restart estimate into the uptime/build cartouche as a compact `Est.` value
- preserve accessible details and prevent wrapping or inherited blue hover/active styling

## Why

The original footer combined conversation and since-restart totals in one long badge. The runtime total belongs with runtime identity, and high-precision fractions become visual noise once the estimate exceeds two cents.

## User impact

The footer now reads `Uptime … | Est. … | Build …`, while the model-side badge shows only the current chat estimate. Both controls retain click and keyboard details.

## Validation

- 273 focused Jest tests passed across cost presentation, footer build placement, and chat cost lifecycle
- 33 final adjacent footer regression tests passed
- frontend static lint passed
- Node syntax checks passed
- `git diff --check` passed
- desktop and 600px browser checks confirmed placement, rounding, no overflow, and accessible details