### PR TITLE
JVNAUTOSCI-2632: implement governed ontology administration

### DIFF
--- a/docs/design_index.md
+++ b/docs/design_index.md
@@ -6,7 +6,7 @@
   override current user direction, `AGENTS.md`, live represented authority, or
   live evidence
 - **Owner:** Von maintainers
-- **Last reviewed:** 1 August 2026
+- **Last reviewed:** 13 August 2026
 - **Review trigger:** Any change to `AGENTS.md` reading routes, canonical
   document selection, or document supersession
 - **Scope:** Tracked design, engineering, operational, review, and generated
@@ -85,7 +85,7 @@ live.
 | Workflow or orchestration | Relevant vocabulary/semantics in the [VWL manual](engineering/von_workflow_language_manual.md); domain examples and appendices are reference material |
 | Prompts, models, routing, optimisation, or fine-tuning | [prompt programmes and model routing](engineering/prompt_programs_and_model_routing_playbook.md) |
 | Retrieval, memory, RAG, KB growth, or long-horizon state | [agent memory and enduring knowledge](engineering/agent_memory_and_enduring_knowledge.md) |
-| Durable assertions, context-sensitive retrieval, hypotheses, publication or promotion, or user-, organisation-, project-, source-, theory-, or time-relative knowledge | [contextual knowledge evolution](engineering/contextual_knowledge_evolution.md) |
+| Durable assertions, context-sensitive retrieval, hypotheses, publication or promotion, or user-, organisation-, project-, source-, theory-, or time-relative knowledge | [contextual knowledge evolution](engineering/contextual_knowledge_evolution.md); for canonical ontology publication or scope change, the candidate [ontology publication authority boundary](engineering/ontology_publication_authority.md) |
 | Evaluation, benchmarks, or research-sensitive architecture | [agent evaluation and research uptake](engineering/agent_evaluation_and_research_uptake.md) |
 | Minimal imposition, elicitation, or write policy | [minimal-imposition principle](engineering/minimal_imposition_design_principle.md) |
 | Frontend or browser acceptance | [Frontend browser validation](engineering/frontend_browser_user_view_validation.md), at the validation tier justified by the claim |
@@ -109,6 +109,7 @@ from `AGENTS.md`.
 | [Prompt programmes and model routing](engineering/prompt_programs_and_model_routing_playbook.md) | Active playbook | Normative only within its stated prompt/model scope |
 | [Agent memory and enduring knowledge](engineering/agent_memory_and_enduring_knowledge.md) | Active design guide | Normative only within its stated memory/retrieval scope |
 | [Contextual knowledge evolution](engineering/contextual_knowledge_evolution.md) | Active design guide | Advisory under `AGENTS.md` when assertion/context distinctions are material; it does not select a microtheory formalism or prove present implementation |
+| [Ontology publication authority](engineering/ontology_publication_authority.md) | Draft candidate design/implementation boundary | Candidate reference for `JVNAUTOSCI-2632`; distinguish semantic publication from visibility and operational administration, and verify target-environment implementation before relying on it |
 | [Agent evaluation and research uptake](engineering/agent_evaluation_and_research_uptake.md) | Active protocol/design guide | Normative only for the evaluation or research claim being made |
 | [Minimal-imposition principle](engineering/minimal_imposition_design_principle.md) | Active principle | Explanatory guidance under `AGENTS.md`; it adds no independent per-task gates |
 | [Frontend browser validation](engineering/frontend_browser_user_view_validation.md) | Active practical guide | Risk-tiered reference; browser evidence needs a dated locator when used |

--- a/docs/engineering/access_control_and_namespaces.md
+++ b/docs/engineering/access_control_and_namespaces.md
@@ -155,6 +155,17 @@ must not be treated as a general authoring role.
 
 ## 3) Roles and permissions (RBAC)
 
+### Visibility is not semantic publication authority
+
+Concept visibility answers whether a caller may discover or read a concept. It
+does not authorise canonical publication, retraction, identity consolidation,
+or a change to its user/organisation/global publication scope. Those effects
+need a separate semantic-authority decision against the relevant publication
+context; `#V#von_administrator` is operational administration, not global
+semantic authority. The candidate boundary and its delegation/receipt
+requirements are recorded in
+[Ontology publication authority](ontology_publication_authority.md).
+
 ### Current status
 
 RBAC is present but **not a complete system** yet.

--- a/docs/engineering/ontology_publication_authority.md
+++ b/docs/engineering/ontology_publication_authority.md
@@ -1,0 +1,186 @@
+# Ontology Publication Authority
+
+- **Kind:** Design and implementation-boundary reference
+- **Lifecycle:** Draft candidate
+- **Authority:** Candidate reference for the `JVNAUTOSCI-2632` branch; it does
+  not prove deployment, represented role assignment, or live authorisation
+- **Authority scope:** Canonical Vontology publication, retraction, identity
+  consolidation, and publication-scope change
+- **Owner:** Von maintainers
+- **Last reviewed:** 13 August 2026
+- **Review trigger:** Merge, deployment, a role-lifecycle change, or a new
+  canonical ontology mutation entry point
+- **Live authority or implementation evidence:** Revalidate the governed
+  mutation service, invocation boundaries, represented role relations, and
+  receipts in the target environment
+- **Open questions:** Long-term role-assignment lifecycle and any broader
+  theory/context model remain separate work
+
+## 1. Purpose and boundary
+
+This candidate addresses a specific failure mode: historical visibility of a
+concept must not decide who may alter its canonical meaning or move it between
+publication contexts. Visibility, provenance, scoped assertions, canonical
+publication, and operational administration remain separate facts.
+
+The authority decision is made against the source and destination publication
+contexts of the intended effect. A visible concept is not thereby mutable. An
+ordinary actor can still use the existing bounded, provenance-bearing
+actor/organisation assertion path where that is the appropriate outcome;
+canonical publication is a different capability.
+
+This guide concerns represented knowledge. It does not turn a conversation,
+session ID, namespace, workflow visibility, or a model/tool argument into
+semantic authority.
+
+## 2. Authority meanings
+
+Two represented semantic roles are recognised:
+
+- An **organisation ontology administrator** may make covered canonical
+  changes in that exact organisation publication context.
+- A **global ontology administrator** may make covered canonical changes in
+  the global publication context. It is also required for the controlled
+  adoption of historical or mixed scope.
+
+An authenticated actor retains the existing bounded ability to create and edit
+canonical material in that actor's exact user-private publication context. That
+does not confer authority over an organisation, global publication, mixed
+history, or an inverse target in another context.
+
+`#V#von_administrator` remains an operational role. Its represented assignment
+uses a dedicated operational-administrator lifecycle and can authorise bounded
+deployment, diagnostic, or bootstrap control-plane operations. The existing
+operator token remains a separate bootstrap and recovery credential. Neither
+form implies a semantic role, reveals private organisation knowledge, or can by
+itself publish or change ontology scope.
+
+The role assertions are represented knowledge with explicit organisation or
+global context. The authority decision resolves them live for the effect; a
+cached label, client payload, session reference, or legacy role resolver is not
+an adequate substitute. Grant-specific actor, request, and reason provenance is
+stored on the exact subject-role relation rather than on its deduplicated role
+text value, and a grant succeeds only when that exact relation is read back.
+
+## 3. Agent delegation
+
+An authorised human may authorise an agent to carry out one already-authorised
+ontology effect. The resulting capability is deliberately narrow:
+
+- server-issued from the grantor's trusted identity and current role evidence;
+- bound to one agent, audience, tool, operation, target/delta fingerprint, and
+  effect identifier;
+- short-lived, revocable, non-recursive, and non-amplifying; and
+- rechecked against the grantor's live semantic authority when used.
+
+There is no standing agent delegation. An agent, workflow, client, model, or
+tool payload cannot create, enlarge, or relay a semantic delegation. Sessionless
+gateway and stdio mutations are currently denied before target-sensitive reads;
+they must not recover a grantor's private visibility merely from an opaque grant.
+
+## 4. Governed effects and scope transition
+
+The candidate centralises authority decisions for the supported canonical
+concept, text, and relationship mutations, including promotion/retraction. The
+chat/adaptive turn, workflow, authenticated HTTP, and internal MCP entry points
+enter that governed path rather than each treating visibility as mutation
+permission. Identity consolidation is a dedicated governed effect: it uses a
+server-built complete affected-graph plan, requires authority for every
+affected publication context, preserves the target's publication scope, and
+claims success only after exact canonical read-back. Sessionless stdio writes
+and graph-wide rename and delete execution remain fail-closed until they can
+carry an equivalent complete effect plan; their read or preview paths remain
+available where safe.
+
+Governed creation defaults to the actor's exact user-private publication
+context. Organisation publication must be requested explicitly as
+`organisation_general` and requires that organisation's semantic authority.
+The legacy dual user-and-organisation visibility mode is rejected at this
+boundary because that visibility shape is mixed, not a canonical ownership or
+publication context.
+
+Authority and visibility predicates are reserved to dedicated governance
+operations. Generic mutation is denied for unresolved historical or mixed
+scope. The dedicated scope-change path first exposes a scope read-back and
+preview, then requires an optimistic scope fingerprint, explicit destination,
+source-and-destination authority, and a request identifier. It is the only
+candidate path that may adopt legacy/mixed scope; it must never silently
+reinterpret malformed legacy data as global publication.
+
+Undo is deliberately fail-closed until it can carry an equally exact target,
+authority decision, receipt, and canonical read-back. This is preferable to a
+plausible-looking inverse effect whose publication boundary cannot be proved.
+
+## 5. Evidence, recovery, and failure semantics
+
+Every governed mutation is associated with an authority decision and a durable
+receipt. The receipt records the bounded intent, authority evidence, effect
+state, and canonical read-back. Idempotency is keyed to the authorised effect:
+retries may return the already-recorded result, while a conflicting reuse or an
+effect still in progress must not execute a second mutation.
+
+Success requires canonical read-back, not merely a handler response. If a
+write outcome or read-back is uncertain, the receipt must report an honest
+non-success or indeterminate state with enough information for bounded
+reconciliation. Scope transitions use compensation where possible, but
+compensation is not a substitute for reporting the final canonical state.
+
+Denials are typed and non-leaking: callers receive the missing authority or
+delegation condition without disclosure of inaccessible concepts, roles, or
+contexts.
+
+## 6. Bootstrap and operational limits
+
+Initial role creation is a one-time, explicitly enabled local operator
+bootstrap for the first global semantic administrator and the first represented
+Von operational administrator. The principal must be an existing canonical
+concept, and each bootstrap is successful only after the exact represented role
+is read back. These are distinct one-time roots: the operator token does not
+become a permanent route around semantic governance, and semantic authority
+does not open operational controls. A global semantic administrator may then
+establish only the first administrator root for an actor-visible organisation;
+after that, administrators for that exact organisation govern its role
+lifecycle. Neither the last global semantic root nor the last represented
+operational root can be removed.
+
+The candidate also contains one inventory-bound initial migration fixed to
+`#V#michael_witbrock`. Its dry run inventories legacy elevated roles,
+represented memberships, semantic roles, and operational roles across all
+subjects. Apply requires both the configured bootstrap credential and
+Michael's authenticated human session, and refuses to start if anyone else is
+an elevated holder. It represents Michael as the Von operational
+administrator, global ontology administrator, exact-organisation ontology
+administrator, and organisation owner for every represented membership. Each
+effect is read back exactly; interrupted application is recorded as partial
+and can resume only against the same safe inventory. This candidate mechanism
+does not imply that the migration has been run in any live environment.
+
+This candidate does not select a universal microtheory, organisation-membership
+model, or context formalism. It also does not grant a global administrator
+visibility into private material merely because it grants global publication
+authority. Those boundaries remain governed by the existing access-control and
+contextual-knowledge guidance.
+
+## 7. Validation boundary
+
+This is an authority-release change and requires Tier 3 evidence before any
+release claim. The material cases are: positive and negative organisation and
+global authority; operational-admin non-equivalence; expiry, revocation,
+tampering, and cross-audience delegation denial; alternate entry-point
+enforcement; private-context non-leakage; retry/concurrency behaviour; and
+receipt-backed canonical read-back of successful and partial effects.
+
+The motivating historical changes are evidence targets, not permission to
+alter live Vontology during implementation or test work. Applying any such
+change still requires a deployed authority configuration and a separately
+authorised actor/effect.
+
+## Related guidance
+
+- [Access control and namespaces](access_control_and_namespaces.md) explains
+  trusted identity and visibility; it does not grant semantic publication.
+- [Contextual knowledge evolution](contextual_knowledge_evolution.md) explains
+  why assertion context, authority, provenance, and publication must remain
+  distinguishable.
+- [Security considerations](security_considerations.md) governs the
+  authentication, delegation, private-data, and operator-security posture.

--- a/docs/engineering/security_considerations.md
+++ b/docs/engineering/security_considerations.md
@@ -3,7 +3,7 @@
 - **Kind:** Security guidance with dated deployment-posture observations
 - **Lifecycle:** Active
 - **Authority:** Canonical security guidance routed by [`AGENTS.md`](../../AGENTS.md)
-- **Last reviewed:** 27 July 2026
+- **Last reviewed:** 13 August 2026
 - **Evidence boundary:** Statements about current users, deployments, and
   implemented controls are dated observations and must be revalidated; the
   security requirements do not expire merely because implementation evidence
@@ -99,7 +99,7 @@ Use different controls for different data and capability classes.
 | SAIL internal operational data | Jira tasks, SAIL project notes, internal telemetry | SAIL-authenticated or trusted local operator only |
 | User/org private data | chat history, uploaded files, private RAG chunks, partner data | Authenticated, namespace-scoped, fail closed on missing or conflicting scope |
 | Secrets and credentials | `.env`, API keys, OAuth tokens, DB URIs, device secrets | Never printed, never committed, redacted in diagnostics |
-| Authority-bearing artefacts | Vontology prompts/workflows/policies, publication gates, MCP write tools | Keep effects within authenticated standing delegation; use provenance, read-back, recovery, and additional approval in proportion to the concrete commitment |
+| Authority-bearing artefacts | Vontology prompts/workflows/policies, publication gates, MCP write tools | Keep effects within authenticated standing delegation; for canonical ontology publication or scope changes, require the separate semantic-authority and exact-delegation boundary, plus provenance, read-back, and recovery appropriate to the commitment |
 | Admin/operator actions | sync, reindex, DB reconnect, shutdown, imports, backups | Admin auth or local trusted operator profile only |
 
 ## Known Security Limitations
@@ -232,6 +232,15 @@ Current implementation details:
 - Add session timeout and idle timeout
 
 ### 4. MCP Tool Access Control and Agentic-AI Threats
+
+Canonical ontology publication is not part of an ordinary tool's visibility
+aperture. The `JVNAUTOSCI-2632` candidate separates organisation/global
+semantic roles from Von operational administration and requires an exact,
+server-issued, short-lived, non-recursive delegation when an agent performs a
+covered ontology effect. Its current design/implementation boundary is
+[Ontology publication authority](ontology_publication_authority.md). This is a
+candidate branch reference, not evidence that a deployment has represented
+roles or released the capability.
 
 **Current as of 11 August 2026**: When internal MCP is enabled, authenticated
 ordinary turns receive a bounded additive representation aperture. Trusted
@@ -594,6 +603,12 @@ be added before broader external contribution or partner deployment.
 
 ## Change Log
 
+- **2026-08-13**: Added the candidate boundary for canonical ontology
+  publication authority
+  - Distinguished organisation/global semantic roles from Von operational
+    administration
+  - Recorded exact short-lived agent delegation and receipt/read-back
+    expectations for covered ontology effects
 - **2026-07-27**: Distinguished logical read semantics from physical write
   purity and documented the bounded ordinary-turn representation-effect
   aperture

--- a/src/backend/db/mongo_client.py
+++ b/src/backend/db/mongo_client.py
@@ -731,6 +731,8 @@ TEXT_RELATIONS_COLLECTION_NAME = (
     "text_relations"  # New collection linking concepts to text values
 )
 SCOPED_KNOWLEDGE_ASSERTIONS_COLLECTION_NAME = "scoped_knowledge_assertions"
+ONTOLOGY_AUTHORITY_DELEGATIONS_COLLECTION_NAME = "ontology_authority_delegations"
+ONTOLOGY_MUTATION_RECEIPTS_COLLECTION_NAME = "ontology_mutation_receipts"
 META_RELATIONS_COLLECTION_NAME = "meta_relations"  # New collection for relation elicitation meta-data (JVNAUTOSCI-371)
 RELATIONSHIP_EXTENT_INDEX_COLLECTION_NAME = "relationship_extent_index"
 
@@ -1894,6 +1896,79 @@ def _ensure_meta_relations_indexes(coll: Collection) -> None:
         coll.create_index([("updated_at", DESCENDING)], name="updated_at_-1")
 
 
+def _ensure_ontology_authority_delegation_indexes(coll: Collection) -> None:
+    """Ensure short-lived semantic-authority grants remain exact and auditable."""
+
+    coll.create_index(
+        [("delegation_id", ASCENDING)],
+        name="delegation_id_unique",
+        unique=True,
+    )
+    coll.create_index(
+        [
+            ("grantor_actor_concept_id", ASCENDING),
+            ("status", ASCENDING),
+            ("expires_at", ASCENDING),
+        ],
+        name="grantor_status_expiry",
+    )
+    coll.create_index(
+        [
+            ("delegate_concept_id", ASCENDING),
+            ("audience", ASCENDING),
+            ("status", ASCENDING),
+            ("expires_at", ASCENDING),
+        ],
+        name="delegate_audience_status_expiry",
+    )
+    coll.create_index([("issued_at", DESCENDING)], name="issued_at_desc")
+
+
+def _ensure_ontology_mutation_receipt_indexes(coll: Collection) -> None:
+    """Ensure mutation decisions and canonical read-backs are retrievable."""
+
+    coll.create_index(
+        [("receipt_id", ASCENDING)],
+        name="receipt_id_unique",
+        unique=True,
+    )
+    # The first candidate indexed key+fingerprint, which allowed one actor to
+    # reuse a key for a different effect and accidentally made identical keys
+    # collide across actors. This collection is introduced with the authority
+    # feature, so replace that unreleased shape with an actor-bound claim.
+    existing_indexes = coll.index_information()
+    if "idempotency_intent_unique" in existing_indexes:
+        coll.drop_index("idempotency_intent_unique")
+    coll.create_index(
+        [
+            ("actor_concept_id", ASCENDING),
+            ("idempotency_key", ASCENDING),
+        ],
+        name="actor_idempotency_unique",
+        unique=True,
+        partialFilterExpression={
+            "idempotency_key": {"$exists": True, "$type": "string"},
+        },
+    )
+    coll.create_index(
+        [
+            ("actor_concept_id", ASCENDING),
+            ("created_at", DESCENDING),
+        ],
+        name="actor_created_at_desc",
+    )
+    coll.create_index(
+        [
+            ("publication_context.kind", ASCENDING),
+            ("publication_context.concept_id", ASCENDING),
+            ("created_at", DESCENDING),
+        ],
+        name="publication_context_created_at_desc",
+    )
+    coll.create_index([("status", ASCENDING)], name="status_1")
+    coll.create_index([("updated_at", DESCENDING)], name="updated_at_desc")
+
+
 def _ensure_relationship_extent_index_indexes(coll: Collection) -> None:
     existing = [idx for idx in coll.list_indexes() if isinstance(idx, Mapping)]
     existing_names = {str(idx.get("name") or "") for idx in existing if idx.get("name")}
@@ -2194,6 +2269,32 @@ def get_scoped_knowledge_assertions_collection() -> Collection | None:
             db,
             SCOPED_KNOWLEDGE_ASSERTIONS_COLLECTION_NAME,
             _ensure_scoped_knowledge_assertions_indexes,
+        )
+    return None
+
+
+def get_ontology_authority_delegations_collection() -> Collection | None:
+    """Return revocable, bounded ontology-authority delegation records."""
+
+    db = get_db()
+    if db is not None:
+        return _ensure_collection_indexes_once(
+            db,
+            ONTOLOGY_AUTHORITY_DELEGATIONS_COLLECTION_NAME,
+            _ensure_ontology_authority_delegation_indexes,
+        )
+    return None
+
+
+def get_ontology_mutation_receipts_collection() -> Collection | None:
+    """Return provenance-bearing semantic mutation decision receipts."""
+
+    db = get_db()
+    if db is not None:
+        return _ensure_collection_indexes_once(
+            db,
+            ONTOLOGY_MUTATION_RECEIPTS_COLLECTION_NAME,
+            _ensure_ontology_mutation_receipt_indexes,
         )
     return None
 

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -32,6 +32,7 @@ import os
 import re
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from functools import wraps
 from pathlib import Path
 from typing import Any, List, Mapping, Sequence, cast
 
@@ -54,6 +55,69 @@ _JIRA_ISSUE_KEY_PATTERN = re.compile(
 )
 _DEFAULT_JIRA_BASE_URL = "https://naoinstitute.atlassian.net"
 _WORKFLOW_OBSERVATION_MAX_SECONDS = 90.0
+
+
+def _governed_ontology_mutation(method_name: str):
+    """Route a generic canonical write through the shared authority command."""
+
+    def decorate(handler):
+        @wraps(handler)
+        def governed(**kwargs):
+            from ...services.ontology_mutation_command_service import (
+                execute_governed_ontology_method,
+                normalise_governed_ontology_arguments,
+                resolve_governed_ontology_arguments,
+            )
+
+            if method_name == "create_concepts":
+                input_error = _create_concepts_input_placement_error(kwargs)
+                if input_error is not None:
+                    return input_error
+            governed_arguments = normalise_governed_ontology_arguments(
+                method_name,
+                kwargs,
+            )
+            try:
+                governed_arguments = resolve_governed_ontology_arguments(
+                    method_name,
+                    governed_arguments,
+                )
+            except Exception as exc:
+                from ...services.ontology_mutation_command_service import (
+                    OntologyMutationCommandError,
+                )
+
+                if isinstance(exc, OntologyMutationCommandError):
+                    return {
+                        "success": False,
+                        "effect_status": "not_started",
+                        "mutation_outcome": "not_started",
+                        "changed": False,
+                        "error_code": exc.reason_code,
+                        "error": exc.public_message,
+                    }
+                raise
+            preview = bool(
+                (
+                    method_name
+                    in {"delete_concept", "merge_concepts", "rename_concept"}
+                    and governed_arguments.get("simulate", True)
+                )
+                or (
+                    method_name in {"remove_relationship", "remove_relationships_bulk"}
+                    and governed_arguments.get("dry_run", False)
+                )
+            )
+            return execute_governed_ontology_method(
+                method_name=method_name,
+                arguments=governed_arguments,
+                mutate=lambda: handler(**governed_arguments),
+                preview=preview,
+            )
+
+        return governed
+
+    return decorate
 
 
 def _utc_now_iso() -> str:
@@ -170,12 +234,9 @@ def _resolve_internal_mcp_scoped_assertion_actor_scope(
     try:
         source = get_internal_mcp_actor_context_source()
         preexisting_actor = get_internal_mcp_preexisting_actor_context()
-        payload_claims_are_trusted = (
-            source == "trusted_operator_payload_fallback"
-        )
+        payload_claims_are_trusted = source == "trusted_operator_payload_fallback"
         discard_payload_claims = (
-            ignore_untrusted_payload_identity
-            and not payload_claims_are_trusted
+            ignore_untrusted_payload_identity and not payload_claims_are_trusted
         )
         if discard_payload_claims:
             claimed_user = None
@@ -242,14 +303,10 @@ def _resolve_internal_mcp_scoped_assertion_actor_scope(
                 }
                 allow_unscoped_claims = True
             else:
-                raise WorkflowActorScopeError(
-                    "workflow_actor_authority_required"
-                )
+                raise WorkflowActorScopeError("workflow_actor_authority_required")
         elif source == "tool_payload_fallback" and not has_identity_claim:
             if require_actor:
-                raise WorkflowActorScopeError(
-                    "workflow_actor_authority_required"
-                )
+                raise WorkflowActorScopeError("workflow_actor_authority_required")
             # Actorless generic reads retain their established base-publication
             # behaviour. With no audience keys, lower services cannot expose
             # scoped rows.
@@ -265,15 +322,14 @@ def _resolve_internal_mcp_scoped_assertion_actor_scope(
             raise WorkflowActorScopeError("workflow_actor_authority_required")
 
         actor_scope = resolve_authoritative_workflow_actor_scope(
-                claimed_user_id=claimed_user,
-                claimed_org_id=claimed_org,
-                claimed_namespace=claimed_namespace,
-                allow_unscoped_claims=allow_unscoped_claims,
-                **ambient_kwargs,
+            claimed_user_id=claimed_user,
+            claimed_org_id=claimed_org,
+            claimed_namespace=claimed_namespace,
+            allow_unscoped_claims=allow_unscoped_claims,
+            **ambient_kwargs,
         )
         if require_actor and not bool(
-            actor_scope.user_concept_id
-            or actor_scope.organisation_concept_id
+            actor_scope.user_concept_id or actor_scope.organisation_concept_id
         ):
             raise WorkflowActorScopeError("workflow_actor_authority_required")
         return actor_scope, None
@@ -447,6 +503,157 @@ def _get_vontology_tree(**kwargs):
     return get_vontology_tree(**kwargs)
 
 
+def _get_concept_publication_scope(**kwargs):
+    from ...services.ontology_scope_change_service import (
+        get_concept_publication_scope,
+    )
+
+    actor_scope, denial = _resolve_internal_mcp_scoped_assertion_actor_scope(
+        kwargs,
+        surface="ontology publication scope",
+        ignore_untrusted_payload_identity=True,
+    )
+    if denial is not None:
+        return denial
+    try:
+        with _bind_internal_mcp_scoped_assertion_actor(actor_scope):
+            snapshot = get_concept_publication_scope(kwargs.get("concept_id"))
+    except (LookupError, PermissionError):
+        return make_error_response(
+            "ontology_scope_target_not_found",
+            "The requested ontology scope target is unavailable.",
+        )
+    except ValueError as exc:
+        return make_error_response("invalid_ontology_scope_read", str(exc))
+    return {"success": True, **snapshot}
+
+
+def _scope_change_request_id(kwargs: Mapping[str, Any]) -> str:
+    supplied = kwargs.get("request_id")
+    if isinstance(supplied, str) and supplied.strip():
+        return supplied.strip()
+    from ...services.ontology_publication_authority_service import (
+        current_ontology_invocation,
+    )
+
+    invocation = current_ontology_invocation()
+    return (
+        str(invocation.effect_id).strip()
+        if invocation is not None and invocation.effect_id
+        else ""
+    )
+
+
+def _scope_change_payload_provenance_denial(
+    kwargs: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Reject payload-established identity before any scope snapshot read."""
+
+    from ...services.ontology_publication_authority_service import (
+        current_ontology_invocation,
+    )
+    from .gateway import get_internal_mcp_actor_context_source
+
+    def denied(error_code: str, message: str) -> dict[str, Any]:
+        return {
+            "success": False,
+            "effect_status": "not_started",
+            "mutation_outcome": "not_started",
+            "changed": False,
+            "error_code": error_code,
+            "error": message,
+        }
+
+    source = get_internal_mcp_actor_context_source()
+    has_payload_identity_claim = any(
+        isinstance(kwargs.get(field_name), str)
+        and bool(str(kwargs.get(field_name)).strip())
+        for field_name in (
+            "actor_concept_id",
+            "organisation_concept_id",
+            "organization_concept_id",
+            "org_id",
+            "user_concept_id",
+            "user_id",
+        )
+    )
+    if source == "tool_payload_fallback" and has_payload_identity_claim:
+        return denied(
+            "client_supplied_identity_is_not_authority",
+            "Client or model supplied identity cannot authorise publication.",
+        )
+    if source == "trusted_operator_payload_fallback":
+        return denied(
+            "von_operator_is_not_semantic_ontology_authority",
+            "Von operational authority does not confer semantic ontology authority.",
+        )
+    invocation = current_ontology_invocation()
+    if (
+        invocation is not None
+        and invocation.executing_agent_concept_id
+        and not invocation.delegation_id
+    ):
+        return denied(
+            "ontology_agent_delegation_required",
+            "An executing agent needs an exact server-issued ontology delegation.",
+        )
+    return None
+
+
+def _run_concept_publication_scope_change(
+    *,
+    preview: bool,
+    invocation_tool_name: str,
+    kwargs: Mapping[str, Any],
+) -> dict[str, Any]:
+    from ...services.ontology_scope_change_service import (
+        change_concept_publication_scope,
+    )
+
+    provenance_denial = _scope_change_payload_provenance_denial(kwargs)
+    if provenance_denial is not None:
+        return provenance_denial
+    try:
+        return change_concept_publication_scope(
+            concept_id=kwargs.get("concept_id"),
+            destination_kind=kwargs.get("destination_kind"),
+            destination_concept_id=kwargs.get("destination_concept_id"),
+            expected_scope_fingerprint=kwargs.get("expected_scope_fingerprint"),
+            request_id=_scope_change_request_id(kwargs),
+            preview=preview,
+            reason=kwargs.get("reason"),
+            invocation_tool_name=invocation_tool_name,
+        )
+    except (LookupError, PermissionError):
+        return make_error_response(
+            "ontology_scope_target_not_found",
+            "The requested ontology scope target is unavailable.",
+        )
+    except ValueError as exc:
+        return make_error_response("invalid_ontology_scope_change", str(exc))
+    except RuntimeError:
+        return make_error_response(
+            "ontology_authority_store_unavailable",
+            "Ontology authority verification or durable receipts are unavailable.",
+        )
+
+
+def _preview_concept_publication_scope_change(**kwargs):
+    return _run_concept_publication_scope_change(
+        preview=True,
+        invocation_tool_name="preview_concept_publication_scope_change",
+        kwargs=kwargs,
+    )
+
+
+def _change_concept_publication_scope(**kwargs):
+    return _run_concept_publication_scope_change(
+        preview=False,
+        invocation_tool_name="change_concept_publication_scope",
+        kwargs=kwargs,
+    )
+
+
 def _get_concept_by_concept_id(**kwargs):
     from ...security.access_control import describe_concept_access
     from ...services.concept_relation_service import build_concept_relations_payload
@@ -546,9 +753,7 @@ def _get_concept_by_concept_id(**kwargs):
         concept["scoped_assertions"] = scoped_assertions
         concept["scoped_assertion_count"] = len(scoped_assertions)
         concept["scoped_assertions_truncated"] = scoped_assertions_truncated
-        concept["scoped_assertion_count_is_lower_bound"] = (
-            scoped_assertions_truncated
-        )
+        concept["scoped_assertion_count_is_lower_bound"] = scoped_assertions_truncated
 
         # Detect vacuous typing (soft warning for agents to repair)
         vacuous_warning = detect_vacuous_typing(concept)
@@ -1277,6 +1482,7 @@ def _coerce_scholarly_materialisation_metadata(
 
 
 _CREATE_CONCEPTS_SCOPE_DEFAULT = "user_org_default"
+_CREATE_CONCEPTS_SCOPE_USER_ONLY = "user_only_default"
 _CREATE_CONCEPTS_SCOPE_ORGANISATION_GENERAL = "organisation_general"
 _CREATE_CONCEPTS_SCOPE_GLOBAL_GENERAL = "global_general"
 _CREATE_CONCEPTS_DUPLICATE_RESOLUTION_CANONICAL_ID_ONLY = "canonical_id_only"
@@ -1288,7 +1494,9 @@ _CREATE_CONCEPTS_SCOPE_MODE_ALIASES: dict[str, str] = {
     "default": _CREATE_CONCEPTS_SCOPE_DEFAULT,
     "user_org_default": _CREATE_CONCEPTS_SCOPE_DEFAULT,
     "user_org": _CREATE_CONCEPTS_SCOPE_DEFAULT,
-    "private": _CREATE_CONCEPTS_SCOPE_DEFAULT,
+    "private": _CREATE_CONCEPTS_SCOPE_USER_ONLY,
+    "user_only": _CREATE_CONCEPTS_SCOPE_USER_ONLY,
+    "user_only_default": _CREATE_CONCEPTS_SCOPE_USER_ONLY,
     "organisation_general": _CREATE_CONCEPTS_SCOPE_ORGANISATION_GENERAL,
     "organization_general": _CREATE_CONCEPTS_SCOPE_ORGANISATION_GENERAL,
     "org_general": _CREATE_CONCEPTS_SCOPE_ORGANISATION_GENERAL,
@@ -1296,6 +1504,75 @@ _CREATE_CONCEPTS_SCOPE_MODE_ALIASES: dict[str, str] = {
     "global": _CREATE_CONCEPTS_SCOPE_GLOBAL_GENERAL,
     "public": _CREATE_CONCEPTS_SCOPE_GLOBAL_GENERAL,
 }
+
+
+def _create_concepts_input_placement_error(
+    arguments: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Reject deterministic create-input errors before canonical lookups."""
+
+    misplaced_fields = [
+        field_name
+        for field_name in _CREATE_CONCEPTS_PER_ITEM_IDENTITY_REVIEW_FIELDS
+        if field_name in arguments
+    ]
+    if misplaced_fields:
+        expected_paths = [
+            f"concepts[i].{field_name}" for field_name in misplaced_fields
+        ]
+        return make_error_response(
+            "invalid_parameter",
+            (
+                "Identity candidate review fields apply to one concept item and "
+                "cannot be supplied at the create_concepts top level. Move them "
+                f"to {', '.join(expected_paths)}. No concepts were created."
+            ),
+            details={
+                "misplaced_top_level_fields": misplaced_fields,
+                "expected_concept_item_paths": expected_paths,
+            },
+            suggestions=[
+                (
+                    f"Move {field_name} into the relevant concept object at "
+                    f"concepts[i].{field_name}"
+                )
+                for field_name in misplaced_fields
+            ],
+        )
+
+    duplicate_resolution_mode = arguments.get("duplicate_resolution_mode")
+    if (
+        duplicate_resolution_mode is not None
+        and duplicate_resolution_mode
+        != _CREATE_CONCEPTS_DUPLICATE_RESOLUTION_CANONICAL_ID_ONLY
+    ):
+        return make_error_response(
+            "invalid_parameter",
+            (
+                "Invalid duplicate_resolution_mode "
+                f"'{duplicate_resolution_mode}'."
+            ),
+            details={
+                "duplicate_resolution_mode": duplicate_resolution_mode,
+                "supported_duplicate_resolution_modes": [
+                    _CREATE_CONCEPTS_DUPLICATE_RESOLUTION_CANONICAL_ID_ONLY
+                ],
+                "default_behaviour": (
+                    "canonical identity then semantic name resolution"
+                ),
+            },
+            suggestions=[
+                (
+                    "Omit duplicate_resolution_mode to preserve semantic "
+                    "duplicate resolution"
+                ),
+                (
+                    "Use duplicate_resolution_mode='canonical_id_only' only "
+                    "for deterministic stable identities"
+                ),
+            ],
+        )
+    return None
 
 
 def _normalise_create_concepts_scope_mode(raw_value: Any) -> str | None:
@@ -1307,6 +1584,7 @@ def _normalise_create_concepts_scope_mode(raw_value: Any) -> str | None:
     return _CREATE_CONCEPTS_SCOPE_MODE_ALIASES.get(cleaned)
 
 
+@_governed_ontology_mutation("create_concepts")
 def _create_concepts(**kwargs):
     from .transport import (
         InternalMCPHandlerCancelled,
@@ -1317,35 +1595,9 @@ def _create_concepts(**kwargs):
     # deadline. Never begin a write-side preflight in that state.
     raise_if_internal_mcp_cancelled()
 
-    misplaced_identity_review_fields = [
-        field_name
-        for field_name in _CREATE_CONCEPTS_PER_ITEM_IDENTITY_REVIEW_FIELDS
-        if field_name in kwargs
-    ]
-    if misplaced_identity_review_fields:
-        expected_paths = [
-            f"concepts[i].{field_name}"
-            for field_name in misplaced_identity_review_fields
-        ]
-        return make_error_response(
-            "invalid_parameter",
-            (
-                "Identity candidate review fields apply to one concept item and "
-                "cannot be supplied at the create_concepts top level. Move them "
-                f"to {', '.join(expected_paths)}. No concepts were created."
-            ),
-            details={
-                "misplaced_top_level_fields": misplaced_identity_review_fields,
-                "expected_concept_item_paths": expected_paths,
-            },
-            suggestions=[
-                (
-                    f"Move {field_name} into the relevant concept object at "
-                    f"concepts[i].{field_name}"
-                )
-                for field_name in misplaced_identity_review_fields
-            ],
-        )
+    input_error = _create_concepts_input_placement_error(kwargs)
+    if input_error is not None:
+        return input_error
 
     from ...vontology.utils_vontology import create_vontology_concept
     from ...vontology.code_concepts_registry import PREDICATE_TYPE_ID
@@ -1435,12 +1687,13 @@ def _create_concepts(**kwargs):
                 "scope_mode": raw_scope_mode,
                 "supported_scope_modes": [
                     _CREATE_CONCEPTS_SCOPE_DEFAULT,
+                    _CREATE_CONCEPTS_SCOPE_USER_ONLY,
                     _CREATE_CONCEPTS_SCOPE_ORGANISATION_GENERAL,
                     _CREATE_CONCEPTS_SCOPE_GLOBAL_GENERAL,
                 ],
             },
             suggestions=[
-                "Use scope_mode='user_org_default' for authenticated default scoping",
+                "Use scope_mode='user_only_default' for actor-private concepts",
                 "Use scope_mode='organisation_general' for organisation-scoped shared concepts",
                 "Use scope_mode='global_general' for broadly visible concepts",
             ],
@@ -1469,7 +1722,7 @@ def _create_concepts(**kwargs):
             suggestions=[
                 "Provide namespace in #V#user@org form",
                 "Or include organisation_concept_id in the tool payload",
-                "Or use scope_mode='user_org_default' or 'global_general'",
+                "Or use scope_mode='user_only_default' or 'global_general'",
             ],
         )
 
@@ -1576,6 +1829,23 @@ def _create_concepts(**kwargs):
         )
     assert parent_resolution.resolved_parent_id is not None
     validated_parent_id: str = parent_resolution.resolved_parent_id
+    authority_resolved_parent_id = kwargs.get("authority_resolved_parent_id")
+    if (
+        isinstance(authority_resolved_parent_id, str)
+        and authority_resolved_parent_id.strip()
+        and validated_parent_id != authority_resolved_parent_id.strip()
+    ):
+        return make_error_response(
+            "create_parent_precondition_changed",
+            (
+                "The canonical parent changed after the create effect was "
+                "authorised. No concepts were created."
+            ),
+            details={
+                "authorised_parent_id": authority_resolved_parent_id.strip(),
+                "current_parent_id": validated_parent_id,
+            },
+        )
     if not concepts or not isinstance(concepts, list):
         return make_error_response(
             "missing_parameter",
@@ -1969,30 +2239,24 @@ def _create_concepts(**kwargs):
                         match_source=duplicate_match.match_source,
                     )
                     if duplicate_match.match_source.startswith("external_identifier:"):
-                        # Duplicate resolution is read-only and may consume the
-                        # remaining transport budget. Do not begin the marker
-                        # repair after cancellation.
-                        if _cancelled_after_completed_items():
-                            break
-                        identity_persistence = persist_external_identity_markers(
-                            concept_id=duplicate_match.existing_concept_id,
-                            identifiers=external_identifiers,
-                        )
-                        (
-                            identity_effect_status,
-                            identity_changed,
-                            identity_failures,
-                            identity_indeterminate_failures,
-                        ) = _identity_persistence_outcome(identity_persistence)
-                        result["effect_status"] = identity_effect_status
-                        result["changed"] = identity_changed
+                        # A create grant authorises a new concept only. Reusing an
+                        # existing identity is therefore strictly read-only: marker
+                        # repair would be an edit to a target and publication context
+                        # absent from this create intent.
                         result["external_identity"] = {
                             "identifiers": [
                                 identifier.to_dict()
                                 for identifier in external_identifiers
                             ],
-                            "persistence": identity_persistence,
+                            "persistence": {
+                                "success": True,
+                                "effect_status": "not_started",
+                                "changed": False,
+                                "reason_code": "duplicate_reuse_is_read_only",
+                            },
                         }
+                        result["effect_status"] = "not_started"
+                        result["changed"] = False
                         result["requested_parent_id"] = (
                             duplicate_match.requested_parent_id
                         )
@@ -2004,50 +2268,6 @@ def _create_concepts(**kwargs):
                             and duplicate_match.requested_parent_id
                             in set(duplicate_match.existing_parent_ids)
                         )
-                        if identity_effect_status == "indeterminate":
-                            result.update(
-                                {
-                                    "success": False,
-                                    "error_code": (
-                                        "external_identity_persistence_indeterminate"
-                                    ),
-                                    "indeterminate_failures": (
-                                        identity_indeterminate_failures
-                                        or [
-                                            {
-                                                "stage": (
-                                                    "external_identity_persistence"
-                                                ),
-                                                "outcome": "indeterminate",
-                                            }
-                                        ]
-                                    ),
-                                }
-                            )
-                        elif identity_failures or identity_effect_status in {
-                            "failed",
-                            "partial",
-                        }:
-                            persistence_failures = identity_failures or [
-                                {
-                                    "stage": "external_identity_persistence",
-                                    "outcome": identity_effect_status,
-                                }
-                            ]
-                            result.update(
-                                {
-                                    "success": False,
-                                    "effect_status": (
-                                        "partial"
-                                        if identity_changed is True
-                                        else "failed"
-                                    ),
-                                    "error_code": (
-                                        "external_identity_persistence_failed"
-                                    ),
-                                    "partial_failures": persistence_failures,
-                                }
-                            )
                 if duplicate_match.resolution_source:
                     result["external_identity_resolution_source"] = (
                         duplicate_match.resolution_source
@@ -2067,11 +2287,18 @@ def _create_concepts(**kwargs):
                 allow_duplicate_instance_suffix=allow_duplicate_instances,
                 description=concept_data.get("description"),
                 notes=concept_data.get("notes"),
+                vontology_path=concept_data.get("vontology_path"),
+                instance_of_type=concept_data.get("instance_of_type")
+                or kwargs.get("instance_of_type"),
                 created_by_concept_id=actor_user_id,
                 organisation_concept_id=actor_org_id,
                 event_namespace=namespace,
                 visibility_scope_mode=scope_mode,
-                canonical_concept_id_override=canonical_concept_id_override,
+                canonical_concept_id_override=(
+                    canonical_concept_id_override or concept_data.get("concept_id")
+                ),
+                maintain_relationship_inverses=False,
+                resolve_visibility_from_event_namespace=False,
             )
             if (
                 external_identifiers
@@ -2423,6 +2650,7 @@ def _indeterminate_effect_error(
     return response
 
 
+@_governed_ontology_mutation("upsert_text_relation")
 def _upsert_text_relation(**kwargs):
     from ...services.text_value_service import upsert_text_for_concept
     from ...services.text_relation_predicate_validation_service import (
@@ -2604,8 +2832,7 @@ def _upsert_scoped_assertion(**kwargs):
                 # Derived-index maintenance must not turn that durable receipt
                 # into an indeterminate write result.
                 logger.warning(
-                    "Scoped assertion persisted but RAG refresh scheduling "
-                    "failed: %s",
+                    "Scoped assertion persisted but RAG refresh scheduling failed: %s",
                     exc,
                 )
                 derived_maintenance = {
@@ -2697,8 +2924,7 @@ def _retract_scoped_assertion(**kwargs):
                 )
             except Exception as exc:
                 logger.warning(
-                    "Scoped assertion retracted but RAG refresh scheduling "
-                    "failed: %s",
+                    "Scoped assertion retracted but RAG refresh scheduling failed: %s",
                     exc,
                 )
                 derived_maintenance = {
@@ -2785,9 +3011,7 @@ def _list_scoped_assertions(**kwargs):
             "counts_are_lower_bounds": counts_are_lower_bounds,
         },
         **(
-            {"assertions_found_is_lower_bound": True}
-            if counts_are_lower_bounds
-            else {}
+            {"assertions_found_is_lower_bound": True} if counts_are_lower_bounds else {}
         ),
         "canonical_publication": False,
     }
@@ -2857,6 +3081,7 @@ def _get_text_relations(**kwargs):
         )
 
 
+@_governed_ontology_mutation("update_text_relation")
 def _update_text_relation(**kwargs):
     from ...services.text_value_service import update_text_relation_text
     from ...services.rag_text_relation_change_hook_service import (
@@ -2923,6 +3148,7 @@ def _update_text_relation(**kwargs):
         )
 
 
+@_governed_ontology_mutation("delete_text_relation")
 def _delete_text_relation(**kwargs):
     from ...services.text_value_service import (
         delete_text_relation,
@@ -3055,6 +3281,7 @@ def _get_text_relations_summary(**kwargs):
         )
 
 
+@_governed_ontology_mutation("upsert_singleton_text_relation")
 def _upsert_singleton_text_relation(**kwargs):
     from ...services.text_value_service import upsert_singleton_text_relation
     from ...services.text_relation_predicate_validation_service import (
@@ -3234,6 +3461,7 @@ def _fetch_concept_content(**kwargs):
         )
 
 
+@_governed_ontology_mutation("add_names_to_concept")
 def _add_names_to_concept(**kwargs):
     from ...services.text_value_service import upsert_text_for_concept
     from ...db.repositories.concepts_repository import ConceptsRepository
@@ -3330,6 +3558,7 @@ def _add_names_to_concept(**kwargs):
     }
 
 
+@_governed_ontology_mutation("add_relationship")
 def _add_relationship(**kwargs):
     """Add a relationship between two concepts or from concept to text value."""
     from ...db.repositories.concepts_repository import ConceptsRepository
@@ -3387,7 +3616,7 @@ def _add_relationship(**kwargs):
         if has_concept_id == has_name:
             return make_error_response(
                 "invalid_predicate_reference",
-                ("predicate_ref must provide exactly one of concept_id or " "name."),
+                ("predicate_ref must provide exactly one of concept_id or name."),
                 details={
                     "required_choice": ["concept_id", "name"],
                 },
@@ -4199,6 +4428,7 @@ def _add_relationship(**kwargs):
         return response
 
 
+@_governed_ontology_mutation("remove_relationship")
 def _remove_relationship(**kwargs):
     """Remove one concept-to-concept relationship via the canonical service path."""
     from ...services.relationship_removal_service import remove_relationship
@@ -4344,6 +4574,7 @@ def _list_uncertain_relationship_assertions(**kwargs):
         )
 
 
+@_governed_ontology_mutation("promote_uncertain_relationship_assertion")
 def _promote_uncertain_relationship_assertion(**kwargs):
     from ...services.uncertain_relationship_service import (
         promote_uncertain_relationship_assertion,
@@ -4467,6 +4698,7 @@ def _preview_remove_relationship(**kwargs):
         )
 
 
+@_governed_ontology_mutation("remove_relationships_bulk")
 def _remove_relationships_bulk(**kwargs):
     from ...services.relationship_removal_service import remove_relationships_bulk
 
@@ -4493,31 +4725,18 @@ def _remove_relationships_bulk(**kwargs):
 
 
 def _undo_relationship_removal(**kwargs):
-    from ...services.relationship_removal_service import undo_relationship_removal
+    """Fail closed until tombstone restoration has an exact authority intent."""
 
-    undo_token = kwargs.get("undo_token")
-    if not undo_token:
-        return make_error_response(
-            "missing_parameter",
-            "Missing 'undo_token' parameter",
-            details={"missing": ["undo_token"]},
-            suggestions=[
-                "Provide the undo_token returned by remove_relationship(s)_bulk"
-            ],
-        )
-
-    try:
-        return undo_relationship_removal(
-            undo_token=undo_token,
-            request_id=kwargs.get("request_id"),
-            confirmed=kwargs.get("confirmed", True),
-        )
-    except Exception as e:
-        return make_error_response(
-            "exception",
-            f"Exception: {str(e)}",
-            details={"exception_type": type(e).__name__},
-        )
+    return make_error_response(
+        "ontology_mutation_not_governed",
+        (
+            "Relationship restoration is temporarily unavailable on this "
+            "generic surface because an undo token does not itself establish "
+            "semantic authority over every restored source."
+        ),
+        details={"changed": False, "mutation_outcome": "not_started"},
+        suggestions=["Use a governed ontology restoration endpoint when available"],
+    )
 
 
 # arXiv MCP proxy handlers
@@ -7065,7 +7284,18 @@ def _interpret_file_copy(**kwargs):
             )
 
     allow_large = bool(kwargs.get("allow_large", False))
-    persist = bool(kwargs.get("persist", True))
+    persist = bool(kwargs.get("persist", False))
+    if persist:
+        return make_error_response(
+            "file_copy_interpretation_persistence_not_governed",
+            (
+                "File-copy interpretation is read-only until each materialised "
+                "ontology effect uses an exact governed command."
+            ),
+            suggestions=[
+                "Call interpret_file_copy with persist=false and review the proposed interpretation."
+            ],
+        )
     persist_description = bool(kwargs.get("persist_description", True))
     persist_content = bool(kwargs.get("persist_content", True))
     persist_interpretation_json = bool(kwargs.get("persist_interpretation_json", True))
@@ -9278,6 +9508,7 @@ def _resilient_extract_url(**kwargs):
     }
 
 
+@_governed_ontology_mutation("delete_concept")
 def _delete_concept(**kwargs):
     from ...vontology.utils_vontology import simulate_or_delete_concept
 
@@ -9295,12 +9526,14 @@ def _delete_concept(**kwargs):
     return simulate_or_delete_concept(concept_id, execute=not simulate)
 
 
+@_governed_ontology_mutation("merge_concepts")
 def _merge_concepts(**kwargs):
     from ...services.concept_merge_service import merge_concepts
 
     source_id = kwargs.get("source_id")
     target_id = kwargs.get("target_id")
     simulate = kwargs.get("simulate", True)
+    exact_plan = kwargs.get("exact_plan")
 
     if not source_id or not target_id:
         missing = []
@@ -9317,9 +9550,15 @@ def _merge_concepts(**kwargs):
             ],
         )
 
-    return merge_concepts(source_id, target_id, simulate=simulate)
+    return merge_concepts(
+        source_id,
+        target_id,
+        simulate=simulate,
+        exact_plan=exact_plan,
+    )
 
 
+@_governed_ontology_mutation("rename_concept")
 def _rename_concept(**kwargs):
     """Rename a concept's ID while preserving its GUID (JVNAUTOSCI-945).
 
@@ -9357,6 +9596,7 @@ def _rename_concept(**kwargs):
     )
 
 
+@_governed_ontology_mutation("update_concept")
 def _update_concept(**kwargs):
     from ...services.concept_service import update_concept
 
@@ -9499,8 +9739,9 @@ def _concepts_create_input_schema() -> Schema:
             "set allow_duplicate_instances=true to opt into legacy instance suffixing. "
             "For deterministic stable identities, set duplicate_resolution_mode='canonical_id_only' "
             "to skip semantic name resolution after an exact concept-id miss; omitting it preserves the default semantic fallback. "
-            "Scope defaults to authenticated user+organisation visibility when context is available. "
-            "Use scope_mode='organisation_general' for organisation-shared concepts, or scope_mode='global_general' "
+            "Governed creation defaults to actor-private visibility. "
+            "Use scope_mode='user_only_default' for an actor-private concept, "
+            "scope_mode='organisation_general' for organisation-shared concepts, or scope_mode='global_general' "
             "for broadly visible concepts. organisation_general requires organisation context (namespace #V#user@org or organisation_concept_id). "
             "Optional namespace is accepted and propagated into event-triggered workflow launches for tenancy attribution. "
             "Unknown top-level fields are still tolerated for orchestrator-added context."
@@ -10515,6 +10756,97 @@ def _resolve_concept_by_text_relation_output_schema() -> Schema:
             "resolve_concept_by_text_relation output: status in {resolved, "
             "ambiguous, not_found}; only a complete singleton exact match is "
             "resolved, and bounded incomplete scans remain ambiguous."
+        ),
+    )
+
+
+def _get_concept_publication_scope_input_schema() -> Schema:
+    return Schema(
+        required={"concept_id": str},
+        optional={"namespace": (str, type(None))},
+        allow_unknown=True,
+        description=(
+            "Read the exact actor-visible publication context, visibility edges, "
+            "and optimistic scope fingerprint for one concept. Actor and "
+            "organisation identity are taken only from trusted server context."
+        ),
+    )
+
+
+def _get_concept_publication_scope_output_schema() -> Schema:
+    return Schema(
+        required={
+            "success": bool,
+            "concept_id": str,
+            "publication_context": dict,
+            "scope_edges": dict,
+            "scope_fingerprint": (str, type(None)),
+        },
+        optional={},
+        allow_unknown=True,
+        description=(
+            "Canonical publication-scope snapshot and fingerprint for optimistic "
+            "preview or execution."
+        ),
+    )
+
+
+def _concept_publication_scope_change_input_schema() -> Schema:
+    return Schema(
+        required={
+            "concept_id": str,
+            "destination_kind": str,
+            "expected_scope_fingerprint": str,
+        },
+        optional={
+            "destination_concept_id": (str, type(None)),
+            "request_id": (str, type(None)),
+            "reason": (str, type(None)),
+            "namespace": (str, type(None)),
+        },
+        allow_unknown=True,
+        enum_values={
+            "destination_kind": (
+                "global",
+                "organisation",
+                "organization",
+                "org",
+            )
+        },
+        description=(
+            "Preview or execute one exact publication-scope transition from a "
+            "canonical fingerprint. destination_concept_id is required for an "
+            "organisation destination. Actor, organisation, administrator, and "
+            "operator payload claims are ignored; an agent effect requires an "
+            "opaque exact server-issued delegation."
+        ),
+    )
+
+
+def _concept_publication_scope_change_output_schema() -> Schema:
+    return Schema(
+        required={
+            "success": bool,
+            "effect_status": str,
+            "mutation_outcome": str,
+            "changed": bool,
+        },
+        optional={
+            "preview": (bool, type(None)),
+            "from": (dict, type(None)),
+            "to": (dict, type(None)),
+            "scope_delta": (dict, type(None)),
+            "authority_decision": (dict, type(None)),
+            "receipt": (dict, type(None)),
+            "canonical_read_back": (dict, type(None)),
+            "outcome_finality": (str, type(None)),
+            "error": (str, type(None)),
+            "error_code": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "Authority decision, durable receipt, and canonical scope read-back; "
+            "preview reports no scope mutation."
         ),
     )
 
@@ -11630,12 +11962,12 @@ def _interpret_file_copy_input_schema() -> Schema:
         allow_unknown=True,
         description=(
             "interpret_file_copy input: concept_id for a #V#computer_file_copy instance. "
-            "Optionally pass namespace, max_bytes/allow_large, and persistence controls. "
+            "Optionally pass namespace and max_bytes/allow_large; persist must remain false. "
             "For image files (including screenshots, faces, and building photos), this tool "
             "extracts OCR and semantic descriptions. For PDF documents, it can also perform "
             "diagram-aware organisation candidate extraction with provenance (candidate-only; "
-            "human confirmation required) and persists canonical hasDescription/hasContent "
-            "plus structured interpretation metadata."
+            "human confirmation required), returning proposed description/content and structured "
+            "interpretation metadata without canonical mutation."
         ),
     )
 
@@ -12531,9 +12863,7 @@ def _resolve_rag_namespace_from_kwargs(kwargs: dict) -> dict:
             {
                 "namespace": None,
                 "namespace_source": "untrusted_payload_rejected",
-                "namespace_resolution_note": (
-                    "authenticated_actor_context_required"
-                ),
+                "namespace_resolution_note": ("authenticated_actor_context_required"),
                 "namespace_mismatch": False,
                 "provided_namespace": explicit_namespace,
                 "derived_namespace": None,
@@ -18688,13 +19018,8 @@ def _search_knowledge_base(**kwargs):
             and resolved_user_concept_id.strip()
         ):
             permissions_context["user_id"] = resolved_user_concept_id.strip()
-        resolved_org_concept_id = ns_report.get(
-            "derived_organisation_concept_id"
-        )
-        if (
-            isinstance(resolved_org_concept_id, str)
-            and resolved_org_concept_id.strip()
-        ):
+        resolved_org_concept_id = ns_report.get("derived_organisation_concept_id")
+        if isinstance(resolved_org_concept_id, str) and resolved_org_concept_id.strip():
             permissions_context["organisation_concept_id"] = (
                 resolved_org_concept_id.strip()
             )
@@ -18713,9 +19038,7 @@ def _search_knowledge_base(**kwargs):
             ) and flask_session.get("user_id"):
                 # Backwards compatibility: some sessions store a non-concept user_id.
                 session_user_concept_id = flask_session.get("user_id")
-            session_org_concept_id = flask_session.get(
-                "organisation_concept_id"
-            )
+            session_org_concept_id = flask_session.get("organisation_concept_id")
             if not session_org_concept_id:
                 # Backwards compatibility for older session key.
                 session_org_concept_id = flask_session.get("org_id")
@@ -20282,6 +20605,17 @@ def _internal_mcp_global_workflow_admin_authorised() -> bool:
     source = get_internal_mcp_actor_context_source()
     if source == "trusted_operator_payload_fallback":
         return True
+    if source == "preexisting_authenticated_or_workflow_context":
+        preexisting = get_internal_mcp_preexisting_actor_context()
+        actor_id = preexisting[0] if preexisting is not None else None
+        if actor_id:
+            from ...services.von_operational_administrator_service import (
+                is_live_von_operational_administrator,
+            )
+
+            # This lookup is deliberately operational-only. It does not bind a
+            # bypass, organisation, or semantic-publication capability.
+            return is_live_von_operational_administrator(actor_id)
     if source is not None or get_internal_mcp_preexisting_actor_context() is not None:
         return False
     # Preserve deliberately direct operator/startup calls, while refusing a
@@ -20873,14 +21207,10 @@ def _workflow_execute(**kwargs):
                 )
                 observation_advisory_exceeded = bool(
                     getattr(wait_result, "advisory_exceeded", False)
-                    or (
-                        wait_result.timed_out
-                        and observation_enforcement == "advisory"
-                    )
+                    or (wait_result.timed_out and observation_enforcement == "advisory")
                 )
                 timed_out = bool(
-                    wait_result.timed_out
-                    and observation_enforcement != "advisory"
+                    wait_result.timed_out and observation_enforcement != "advisory"
                 )
                 if timed_out:
                     try:
@@ -21384,10 +21714,7 @@ def _workflow_get_instance(**kwargs):
         )
         observation_advisory_exceeded = bool(
             getattr(wait_result, "advisory_exceeded", False)
-            or (
-                wait_result.timed_out
-                and observation_enforcement == "advisory"
-            )
+            or (wait_result.timed_out and observation_enforcement == "advisory")
         )
         timed_out = bool(
             wait_result.timed_out and observation_enforcement != "advisory"
@@ -21419,9 +21746,7 @@ def _workflow_get_instance(**kwargs):
                 "timed_out": timed_out,
                 "elapsed_time_enforcement": observation_enforcement,
                 "advisory_exceeded": observation_advisory_exceeded,
-                "hard_timeout_seconds": (
-                    timeout_seconds if timed_out else None
-                ),
+                "hard_timeout_seconds": (timeout_seconds if timed_out else None),
             }
         )
 
@@ -24621,9 +24946,11 @@ def _rag_list_indexed(**kwargs):
                 if isinstance(discovery_payload_raw, Mapping)
                 else {}
             )
-            discovery_elapsed_time_enforcement = str(
-                discovery_payload.get("elapsed_time_enforcement") or "legacy_hard"
-            ).strip().lower()
+            discovery_elapsed_time_enforcement = (
+                str(discovery_payload.get("elapsed_time_enforcement") or "legacy_hard")
+                .strip()
+                .lower()
+            )
             discovery_budget_exhausted = bool(
                 discovery_payload.get("hard_timeout_exceeded")
             ) or (
@@ -24631,9 +24958,9 @@ def _rag_list_indexed(**kwargs):
                 and (
                     bool(discovery_payload.get("budget_exhausted"))
                     or (
-                        str(
-                            discovery_payload.get("match_absence_reason") or ""
-                        ).strip().lower()
+                        str(discovery_payload.get("match_absence_reason") or "")
+                        .strip()
+                        .lower()
                         == "workflow_discovery_budget_exhausted"
                     )
                 )
@@ -25124,9 +25451,7 @@ def _rag_list_indexed(**kwargs):
                 items.append(
                     {
                         "collection": collection,
-                        "session_id": (
-                            relation_id or assertion_id or index_item_id
-                        ),
+                        "session_id": (relation_id or assertion_id or index_item_id),
                         "index_item_id": index_item_id,
                         "row_kind": row_kind,
                         "relation_id": relation_id,
@@ -25509,9 +25834,11 @@ def _rag_get_item(**kwargs):
         discovery_payload: Mapping[str, Any] = (
             discovery_payload_raw if isinstance(discovery_payload_raw, Mapping) else {}
         )
-        discovery_elapsed_time_enforcement = str(
-            discovery_payload.get("elapsed_time_enforcement") or "legacy_hard"
-        ).strip().lower()
+        discovery_elapsed_time_enforcement = (
+            str(discovery_payload.get("elapsed_time_enforcement") or "legacy_hard")
+            .strip()
+            .lower()
+        )
         discovery_budget_exhausted = bool(
             discovery_payload.get("hard_timeout_exceeded")
         ) or (
@@ -25770,9 +26097,7 @@ def _rag_get_item(**kwargs):
             **collection_report,
             "session_id": session_id,
             "index_item_id": doc.doc_id,
-            "row_kind": (
-                doc.metadata.get("row_kind") or "base_text_relation"
-            ),
+            "row_kind": (doc.metadata.get("row_kind") or "base_text_relation"),
             "relation_id": doc.metadata.get("relation_id"),
             "assertion_id": doc.metadata.get("assertion_id"),
             "subject_concept_id": doc.metadata.get("subject_concept_id"),
@@ -26328,7 +26653,9 @@ def _gmail_api_error_response(
         "gmail_api_error",
         f"Gmail {operation} failed: {error_text}",
         details=details,
-        suggestions=list(suggestions or ["Check Gmail API connectivity and credentials"]),
+        suggestions=list(
+            suggestions or ["Check Gmail API connectivity and credentials"]
+        ),
     )
 
 
@@ -26463,9 +26790,7 @@ def _gmail_list_messages(**kwargs):
         # semantic scope values above rather than depend on this mechanism.
         bypass_profile_query_prefix = legacy_bypass
         effective_scope = (
-            "whole_mailbox"
-            if bypass_profile_query_prefix
-            else "profile_default_view"
+            "whole_mailbox" if bypass_profile_query_prefix else "profile_default_view"
         )
         scope_source = (
             "legacy_bypass_profile_query_prefix"
@@ -26530,9 +26855,7 @@ def _gmail_list_messages(**kwargs):
             else None
         )
         if applied_query_prefix and caller_query_text:
-            effective_query_string = (
-                f"({applied_query_prefix}) ({caller_query_text})"
-            )
+            effective_query_string = f"({applied_query_prefix}) ({caller_query_text})"
         else:
             effective_query_string = applied_query_prefix or caller_query_text
 
@@ -26578,9 +26901,7 @@ def _gmail_list_messages(**kwargs):
             effective_query=effective_query,
             notes=notes or None,
             requested_metadata_fields=(
-                kwargs.get("include_metadata")
-                if "include_metadata" in kwargs
-                else None
+                kwargs.get("include_metadata") if "include_metadata" in kwargs else None
             ),
         )
     except Exception as exc:  # noqa: BLE001
@@ -26920,9 +27241,7 @@ def _gmail_attachment_source_payload(
 
     filename = part_metadata.get("filename")
     if not isinstance(filename, str) or not filename.strip():
-        message_slug = re.sub(
-            r"[^A-Za-z0-9._-]+", "_", str(message_id)
-        ).strip("._")
+        message_slug = re.sub(r"[^A-Za-z0-9._-]+", "_", str(message_id)).strip("._")
         message_slug = message_slug or "message"
         suffix = ".pdf" if content_type == "application/pdf" else ".bin"
         filename = f"gmail-attachment-{message_slug}-{content_sha256[:12]}{suffix}"
@@ -27154,9 +27473,7 @@ def _gmail_import_attachment(**kwargs):
         attachment_id_sha256 = hashlib.sha256(
             str(attachment_id).encode("utf-8")
         ).hexdigest()
-        source_identifier = (
-            f"{profile}:{message_id}:content-sha256:{content_sha256}"
-        )
+        source_identifier = f"{profile}:{message_id}:content-sha256:{content_sha256}"
         source_uri = f"gmail://{profile}/messages/{message_id}"
         import_result = import_bytes_file_copy(
             data=attachment_bytes,
@@ -27211,9 +27528,7 @@ def _gmail_import_attachment(**kwargs):
                 },
             )
             if isinstance(import_result, Mapping):
-                effect_status = str(
-                    import_result.get("effect_status") or ""
-                ).strip()
+                effect_status = str(import_result.get("effect_status") or "").strip()
                 if effect_status in {"partial", "indeterminate"}:
                     mutation_outcome = str(
                         import_result.get("mutation_outcome") or "unknown"
@@ -27229,9 +27544,7 @@ def _gmail_import_attachment(**kwargs):
                             "mutation_outcome": mutation_outcome,
                             "outcome_finality": outcome_finality,
                             "effect": {
-                                "schema_version": (
-                                    "gmail_attachment_import_effect.v1"
-                                ),
+                                "schema_version": ("gmail_attachment_import_effect.v1"),
                                 "effect_type": "computer_file_copy_import",
                                 "status": effect_status,
                                 **(
@@ -27260,13 +27573,10 @@ def _gmail_import_attachment(**kwargs):
                         failure["changed"] = changed
                     record_internal_mcp_effect_receipt(
                         {
-                            "schema_version": (
-                                "gmail_attachment_import_receipt.v1"
-                            ),
+                            "schema_version": ("gmail_attachment_import_receipt.v1"),
                             "success": False,
                             "status": str(
-                                import_result.get("error")
-                                or "attachment_import_failed"
+                                import_result.get("error") or "attachment_import_failed"
                             ),
                             "effect_status": effect_status,
                             "mutation_outcome": mutation_outcome,
@@ -27443,9 +27753,7 @@ def _gmail_import_attachment(**kwargs):
                 "effect_status": (
                     "succeeded" if readback_succeeded else "indeterminate"
                 ),
-                "mutation_outcome": (
-                    "completed" if readback_succeeded else "unknown"
-                ),
+                "mutation_outcome": ("completed" if readback_succeeded else "unknown"),
                 "outcome_finality": (
                     "canonical_durable_readback"
                     if readback_succeeded
@@ -31549,19 +31857,27 @@ def _authorise_task_actor_mutation(
         return None, None, scope_error
     task_id = kwargs.get("task_concept_id") or kwargs.get("task_id")
     if not isinstance(task_id, str) or not task_id.strip():
-        return actor_scope, None, make_error_response(
-            "MISSING_PARAM",
-            "Missing required parameter: task_concept_id",
-            suggestions=["Provide the task's concept_id"],
+        return (
+            actor_scope,
+            None,
+            make_error_response(
+                "MISSING_PARAM",
+                "Missing required parameter: task_concept_id",
+                suggestions=["Provide the task's concept_id"],
+            ),
         )
     try:
         task = get_task(task_id.strip())
     except TaskNotFoundError as exc:
         return actor_scope, None, make_error_response("NOT_FOUND", str(exc))
     except Exception as exc:
-        return actor_scope, None, make_error_response(
-            "UNEXPECTED_ERROR",
-            f"Unable to verify task authority: {exc}",
+        return (
+            actor_scope,
+            None,
+            make_error_response(
+                "UNEXPECTED_ERROR",
+                f"Unable to verify task authority: {exc}",
+            ),
         )
 
     assert actor_scope is not None
@@ -31573,11 +31889,15 @@ def _authorise_task_actor_mutation(
         str(task.get("created_by_concept_id") or "").strip(),
     }
     if task_org_id != actor_org_id or not actor_controls_task:
-        return actor_scope, None, make_error_response(
-            "task_actor_scope_denied",
-            (
-                "An ordinary-turn agent may change only a task in its authenticated "
-                "organisation that it created or is assigned to."
+        return (
+            actor_scope,
+            None,
+            make_error_response(
+                "task_actor_scope_denied",
+                (
+                    "An ordinary-turn agent may change only a task in its authenticated "
+                    "organisation that it created or is assigned to."
+                ),
             ),
         )
     return actor_scope, task, None
@@ -31871,9 +32191,8 @@ def _task_create(**kwargs):
         required_text_persistence_failures = result.get(
             "required_text_persistence_failures"
         )
-        if (
-            required_text_persistence_failures
-            or _canonical_read_back_mismatches(canonical_read_back)
+        if required_text_persistence_failures or _canonical_read_back_mismatches(
+            canonical_read_back
         ):
             return _incomplete_canonical_read_back_response(
                 task_concept_id=task_concept_id,
@@ -36205,6 +36524,52 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             ),
         ),
         MethodDefinition(
+            name="get_concept_publication_scope",
+            handler=_get_concept_publication_scope,
+            input_schema=_get_concept_publication_scope_input_schema(),
+            output_schema=_get_concept_publication_scope_output_schema(),
+            category="read",
+            hard_timeout_enabled=False,
+            description=(
+                "Read the exact actor-visible publication scope and optimistic "
+                "fingerprint for one concept before a dedicated scope preview or "
+                "execution. Payload identity claims cannot widen the read."
+            ),
+        ),
+        MethodDefinition(
+            name="preview_concept_publication_scope_change",
+            handler=_preview_concept_publication_scope_change,
+            input_schema=_concept_publication_scope_change_input_schema(),
+            output_schema=_concept_publication_scope_change_output_schema(),
+            category="write",
+            ordinary_turn_effect=True,
+            ordinary_turn_mutation_subject_argument="concept_id",
+            hard_timeout_enabled=False,
+            description=(
+                "Preview one exact organisation/global publication-scope change "
+                "against a canonical fingerprint. The preview is authority-checked "
+                "and receipted but does not change visibility edges."
+            ),
+        ),
+        MethodDefinition(
+            name="change_concept_publication_scope",
+            handler=_change_concept_publication_scope,
+            input_schema=_concept_publication_scope_change_input_schema(),
+            output_schema=_concept_publication_scope_change_output_schema(),
+            category="write",
+            ordinary_turn_effect=True,
+            ordinary_turn_mutation_subject_argument="concept_id",
+            hard_timeout_enabled=False,
+            write_guardrail={"ordinary_turn_explicit_request": True},
+            description=(
+                "Execute one explicitly requested, exact organisation/global "
+                "publication-scope transition after preview. The server requires "
+                "live source and destination semantic authority, an unchanged "
+                "fingerprint, exact same-turn agent delegation, a durable receipt, "
+                "and canonical read-back."
+            ),
+        ),
+        MethodDefinition(
             name="find_relations_with_argument",
             handler=_find_relations_with_argument,
             input_schema=_find_relations_with_argument_input_schema(),
@@ -36247,7 +36612,7 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             ordinary_turn_fixed_arguments={
                 "organisation_concept_id": None,
                 "org_id": None,
-                "scope_mode": _CREATE_CONCEPTS_SCOPE_DEFAULT,
+                "scope_mode": _CREATE_CONCEPTS_SCOPE_USER_ONLY,
                 "visibility_scope_mode": None,
             },
             ordinary_turn_effect=True,
@@ -36268,9 +36633,9 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
                 "in identity_rejected_candidate_concept_ids. For deterministic stable "
                 "identities, duplicate_resolution_mode='canonical_id_only' skips "
                 "semantic name resolution after an exact concept-id miss; "
-                "omitting it preserves the default semantic fallback. Default "
-                "visibility is user+organisation scoped when authenticated "
-                "context exists. Override with "
+                "omitting it preserves the default semantic fallback. Ordinary-turn "
+                "creation and direct governed creation default to actor-private "
+                "visibility. Use "
                 "scope_mode='organisation_general' for organisation-shared "
                 "concepts, or scope_mode='global_general' for broadly visible "
                 "concepts when the concept is clearly general. Supports "
@@ -36858,7 +37223,7 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             "query uses Gmail q grammar and is otherwise passed through unchanged: "
             "adjacent clauses mean AND, uppercase OR or braces express a union, "
             "and quotes delimit a phrase. Example: newer_than:2d "
-            "from:airline@example.com subject:\"booking confirmation\". "
+            'from:airline@example.com subject:"booking confirmation". '
             "Set include_metadata to a list containing sender/from, subject, date, "
             "snippet, or label_ids to project those fields for the returned rows "
             "using Gmail metadata reads only; id/message_id and threadId/thread_id "
@@ -37515,7 +37880,7 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
                 "clauses "
                 "mean AND, uppercase OR or braces express a union, and quotes "
                 "delimit a phrase. For example, newer_than:2d "
-                "from:airline@example.com subject:\"booking confirmation\" is one "
+                'from:airline@example.com subject:"booking confirmation" is one '
                 "sender-and-recency-and-subject query. Returned rows include a message_id alias for "
                 "Gmail's id and a thread_id alias for threadId. Set include_metadata "
                 "to any of sender/from, subject, date, snippet, or label_ids when "
@@ -37725,9 +38090,7 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             ordinary_turn_trusted_argument_bindings={
                 "namespace": "turn_namespace",
                 "user_concept_id": "actor_user_concept_id",
-                "organisation_concept_id": (
-                    "actor_organisation_concept_id"
-                ),
+                "organisation_concept_id": ("actor_organisation_concept_id"),
             },
             description="Search the internal knowledge base (RAG) for documents and indexed content. Use when user asks about internal documents, policies, or specific indexed knowledge that is not in the ontology or on the public web. Returns semantically relevant text chunks.",
         ),
@@ -37742,9 +38105,7 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             ordinary_turn_trusted_argument_bindings={
                 "namespace": "turn_namespace",
                 "user_concept_id": "actor_user_concept_id",
-                "organisation_concept_id": (
-                    "actor_organisation_concept_id"
-                ),
+                "organisation_concept_id": ("actor_organisation_concept_id"),
             },
             description=(
                 "Semantic search over concept descriptions only (hasDescription text relations) for the current namespace. "
@@ -37762,9 +38123,7 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             ordinary_turn_trusted_argument_bindings={
                 "namespace": "turn_namespace",
                 "user_concept_id": "actor_user_concept_id",
-                "organisation_concept_id": (
-                    "actor_organisation_concept_id"
-                ),
+                "organisation_concept_id": ("actor_organisation_concept_id"),
             },
             description=(
                 "Find concepts with similar descriptions (vector similarity) within the current namespace. "
@@ -37788,9 +38147,9 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
     return definitions
 
 
-def _build_default_catalogue_external_integration_definitions() -> (
-    List[MethodDefinition]
-):
+def _build_default_catalogue_external_integration_definitions() -> List[
+    MethodDefinition
+]:
     jira_search_output_schema = _jira_generic_output_schema("search")
     jira_get_issue_output_schema = _jira_generic_output_schema("get_issue")
     jira_get_project_issue_types_output_schema = (
@@ -38312,9 +38671,9 @@ def _build_default_catalogue_external_integration_definitions() -> (
     return definitions
 
 
-def _build_default_catalogue_diagnostics_and_research_definitions() -> (
-    List[MethodDefinition]
-):
+def _build_default_catalogue_diagnostics_and_research_definitions() -> List[
+    MethodDefinition
+]:
     definitions: List[MethodDefinition] = [
         MethodDefinition(
             name="rag_get_status",

--- a/src/backend/integrations/internal_mcp/gateway.py
+++ b/src/backend/integrations/internal_mcp/gateway.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import math
 import time
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from contextvars import ContextVar
 from dataclasses import dataclass
 from threading import Lock
@@ -40,6 +40,12 @@ _SUCCESSFUL_DURATION_ADVISORY_MULTIPLIER = 1.25
 _SUCCESSFUL_DURATION_HARD_MULTIPLIER = 2.0
 INTERNAL_MCP_UNTRUSTED_PAYLOAD_ACTOR_SOURCE = "tool_payload_fallback"
 INTERNAL_MCP_TRUSTED_LOCAL_OPERATOR_SOURCE = "trusted_operator_payload_fallback"
+# Internal-MCP is an agent execution surface, not a direct human publication
+# surface.  These are deliberately fixed server-side rather than accepted from
+# a tool payload.  A more specific adaptive-turn, workflow, or HTTP invocation
+# context takes precedence when it is already bound by its trusted entry point.
+INTERNAL_MCP_ONTOLOGY_AGENT_CONCEPT_ID = "#V#von_system"
+INTERNAL_MCP_ONTOLOGY_AUDIENCE = "internal_mcp"
 _ACTOR_CONTEXT_SOURCE: ContextVar[str | None] = ContextVar(
     "internal_mcp_actor_context_source",
     default=None,
@@ -533,6 +539,51 @@ class InternalMCPGateway:
         with override_current_user(user_id), override_current_organisation(org_id):
             yield
 
+    @staticmethod
+    def _ontology_mutation_invocation_context(
+        *,
+        method_name: str,
+        delegation_id: Any,
+        effect_id: Any,
+    ):
+        """Bind default agent provenance for unlabelled canonical writes.
+
+        Specific trusted surfaces bind their own invocation before calling the
+        gateway.  Their context is intentionally preserved.  In every other
+        case, an internal-MCP canonical write is an agent effect and therefore
+        needs an exact server-issued delegation; merely presenting actor or
+        administrator fields in the tool payload cannot turn it into a direct
+        human publication.
+        """
+
+        from src.backend.services.ontology_mutation_command_service import (
+            is_ontology_mutation_method,
+        )
+        from src.backend.services.ontology_publication_authority_service import (
+            bind_ontology_invocation,
+            current_ontology_invocation,
+        )
+
+        if not is_ontology_mutation_method(method_name):
+            return nullcontext()
+        if current_ontology_invocation() is not None:
+            return nullcontext()
+        return bind_ontology_invocation(
+            surface="internal_mcp_gateway",
+            executing_agent_concept_id=INTERNAL_MCP_ONTOLOGY_AGENT_CONCEPT_ID,
+            audience=INTERNAL_MCP_ONTOLOGY_AUDIENCE,
+            delegation_id=(
+                delegation_id.strip()
+                if isinstance(delegation_id, str) and delegation_id.strip()
+                else None
+            ),
+            effect_id=(
+                effect_id.strip()
+                if isinstance(effect_id, str) and effect_id.strip()
+                else None
+            ),
+        )
+
     def invoke(
         self,
         method_name: str,
@@ -546,6 +597,16 @@ class InternalMCPGateway:
             raise GatewayDisabledError("Internal MCP gateway is disabled.")
 
         payload_dict: MutableMapping[str, Any] = dict(payload or {})
+        # Delegation credentials are invocation metadata, never handler
+        # arguments.  Extract them before schema validation so all governed
+        # methods have one consistent gateway-level path without widening each
+        # method's public argument schema.  An existing trusted invocation
+        # context below wins over these caller-provided opaque values.
+        supplied_ontology_delegation_id = payload_dict.pop(
+            "ontology_delegation_id",
+            None,
+        )
+        supplied_ontology_effect_id = payload_dict.pop("ontology_effect_id", None)
         definition = self._catalogue.get(method_name)
         self.register_metrics_if_missing(method_name)
 
@@ -685,6 +746,14 @@ class InternalMCPGateway:
 
             existing_user_id = get_effective_user_concept_id()
             existing_org_id = get_effective_organisation_concept_id()
+            from src.backend.services.ontology_mutation_command_service import (
+                is_ontology_mutation_method,
+            )
+
+            has_ontology_delegation = bool(
+                supplied_ontology_delegation_id
+                and is_ontology_mutation_method(method_name)
+            )
             payload_user_id, payload_org_id = self._resolve_access_actor_context(
                 payload_dict
             )
@@ -693,6 +762,29 @@ class InternalMCPGateway:
                 if existing_user_id or existing_org_id
                 else None
             )
+            if has_ontology_delegation and preexisting_actor_context is None:
+                # Binding a grantor before the caller's proposed arguments are
+                # matched to the stored exact intent creates a temporary private
+                # read oracle. Sessionless execution remains closed until it can
+                # execute server-stored canonical arguments; adaptive/workflow
+                # surfaces already carry their trusted actor context.
+                payload = {
+                    "success": False,
+                    "effect_status": "not_started",
+                    "mutation_outcome": "not_started",
+                    "changed": False,
+                    "error_code": "ontology_sessionless_delegation_not_supported",
+                    "error": (
+                        "Sessionless ontology delegation execution is unavailable; "
+                        "use an actor-bound trusted surface."
+                    ),
+                }
+                self._record_failure(
+                    method_name,
+                    payload["error_code"],
+                    duration_ms=0.0,
+                )
+                return TransportResult(payload=payload, duration_ms=0.0)
             if preexisting_actor_context is not None:
                 # Ambient authentication/workflow authority is one indivisible
                 # actor scope.  Do not let a tool payload fill a missing user or
@@ -716,47 +808,55 @@ class InternalMCPGateway:
             )
             try:
                 with self._access_actor_context(user_id, org_id):
-                    # A trusted in-process AgentTest harness may bind a
-                    # represented, context-scoped fault plan.  Resolve and bind
-                    # the exact authenticated actor before applying it so a
-                    # synthetic transport fact cannot bypass actor-scope
-                    # establishment.  The hook owns no scenario or recovery
-                    # policy and accepts no payload control fields.
-                    from .agent_test_fault_plan import (
-                        maybe_inject_agent_test_mcp_fault,
+                    ontology_invocation_context = (
+                        self._ontology_mutation_invocation_context(
+                            method_name=method_name,
+                            delegation_id=supplied_ontology_delegation_id,
+                            effect_id=supplied_ontology_effect_id,
+                        )
                     )
+                    with ontology_invocation_context:
+                        # A trusted in-process AgentTest harness may bind a
+                        # represented, context-scoped fault plan.  Resolve and bind
+                        # the exact authenticated actor before applying it so a
+                        # synthetic transport fact cannot bypass actor-scope
+                        # establishment.  The hook owns no scenario or recovery
+                        # policy and accepts no payload control fields.
+                        from .agent_test_fault_plan import (
+                            maybe_inject_agent_test_mcp_fault,
+                        )
 
-                    injected_fault = maybe_inject_agent_test_mcp_fault(method_name)
-                    if injected_fault is not None:
-                        self._record_failure(
-                            method_name,
-                            injected_fault.error_code,
+                        injected_fault = maybe_inject_agent_test_mcp_fault(method_name)
+                        if injected_fault is not None:
+                            self._record_failure(
+                                method_name,
+                                injected_fault.error_code,
+                            )
+                            logger.warning(
+                                "%s AgentTest fault plan injected %s for %s "
+                                "(fault_id=%s)",
+                                self._log_tag,
+                                injected_fault.event.get("fault_class"),
+                                method_name,
+                                injected_fault.event.get("fault_id"),
+                            )
+                            return TransportResult(
+                                payload=dict(injected_fault.payload),
+                                duration_ms=0.0,
+                            )
+                        transport_result = self._transport.execute(
+                            method_name=definition.name,
+                            handler=definition.handler,
+                            payload=dict(payload_dict),
+                            timeout_sec=timeout,
+                            category=definition.category,
+                            advisory_timeout_sec=advisory_timeout,
+                            deadline_monotonic=deadline_monotonic,
+                            minimum_execution_window_sec=minimum_execution_window,
+                            log_tag=self._log_tag,
+                            late_completion_observer=observed_late_completion,
+                            hard_timeout_enabled=definition.hard_timeout_enabled,
                         )
-                        logger.warning(
-                            "%s AgentTest fault plan injected %s for %s "
-                            "(fault_id=%s)",
-                            self._log_tag,
-                            injected_fault.event.get("fault_class"),
-                            method_name,
-                            injected_fault.event.get("fault_id"),
-                        )
-                        return TransportResult(
-                            payload=dict(injected_fault.payload),
-                            duration_ms=0.0,
-                        )
-                    transport_result = self._transport.execute(
-                        method_name=definition.name,
-                        handler=definition.handler,
-                        payload=dict(payload_dict),
-                        timeout_sec=timeout,
-                        category=definition.category,
-                        advisory_timeout_sec=advisory_timeout,
-                        deadline_monotonic=deadline_monotonic,
-                        minimum_execution_window_sec=minimum_execution_window,
-                        log_tag=self._log_tag,
-                        late_completion_observer=observed_late_completion,
-                        hard_timeout_enabled=definition.hard_timeout_enabled,
-                    )
             finally:
                 _PREEXISTING_ACTOR_CONTEXT.reset(preexisting_actor_token)
                 _ACTOR_CONTEXT_SOURCE.reset(actor_source_token)

--- a/src/backend/integrations/internal_mcp/tool_contract_registry.py
+++ b/src/backend/integrations/internal_mcp/tool_contract_registry.py
@@ -42,6 +42,95 @@ KNOWN_SURFACES: tuple[str, ...] = (
     SURFACE_JIRA_FAMILY_SERVER,
 )
 
+# Opaque, server-issued execution data accepted only by direct stdio canonical
+# ontology writes.  These are not identity, organisation, or role parameters:
+# the mutation boundary validates a delegation against its exact intent and
+# effect before invoking a write primitive.
+_STDIO_GOVERNED_ONTOLOGY_MUTATION_TOOLS = frozenset(
+    {
+        "add_names",
+        "add_relationship",
+        "change_concept_publication_scope",
+        "create_concepts",
+        "delete_concept",
+        "delete_text_relation",
+        "merge_concepts",
+        "preview_concept_publication_scope_change",
+        "remove_relationship",
+        "remove_relationships_bulk",
+        "update_concept",
+        "update_text_relation",
+        "upsert_singleton_text_relation",
+        "upsert_text_relation",
+    }
+)
+
+_STDIO_UNTRUSTED_ONTOLOGY_AUTHORITY_CONTRACT_FIELDS = frozenset(
+    {
+        "actor",
+        "actor_concept_id",
+        "actor_id",
+        "admin",
+        "administrator",
+        "allow_admin",
+        "authority",
+        "authority_role",
+        "created_by",
+        "created_by_concept_id",
+        "namespace",
+        "global_admin",
+        "is_admin",
+        "is_operator",
+        "organisation_concept_id",
+        "organisation_id",
+        "organization_concept_id",
+        "organization_id",
+        "org_id",
+        "operator",
+        "operator_override",
+        "role",
+        "roles",
+        "user",
+        "user_concept_id",
+        "user_id",
+    }
+)
+
+
+def _with_stdio_ontology_delegation_contract(
+    tool_name: str,
+    input_schema: dict[str, Any],
+) -> dict[str, Any]:
+    """Expose opaque delegation carriers without adding identity claims."""
+
+    if tool_name not in _STDIO_GOVERNED_ONTOLOGY_MUTATION_TOOLS:
+        return input_schema
+
+    payload = dict(input_schema)
+    properties = dict(payload.get("properties") or {})
+    for field_name in _STDIO_UNTRUSTED_ONTOLOGY_AUTHORITY_CONTRACT_FIELDS:
+        properties.pop(field_name, None)
+    properties.update(
+        {
+            "ontology_delegation_id": {
+                "type": "string",
+                "description": (
+                    "Opaque server-issued delegation for this exact canonical "
+                    "ontology mutation. It does not identify or authenticate a user."
+                ),
+            },
+            "ontology_effect_id": {
+                "type": "string",
+                "description": (
+                    "Opaque server-issued effect identifier bound to the delegation. "
+                    "It is used for exact authorisation and idempotent receipts."
+                ),
+            },
+        }
+    )
+    payload["properties"] = properties
+    return payload
+
 
 @dataclass(frozen=True)
 class ToolSurfaceExposure:
@@ -193,7 +282,10 @@ def _contract_from_method_definition(
             )
             or f"Execute {definition.name}."
         ),
-        input_schema=schema_to_json_schema(definition.input_schema),
+        input_schema=_with_stdio_ontology_delegation_contract(
+            definition.name,
+            schema_to_json_schema(definition.input_schema),
+        ),
         output_schema=(
             schema_to_json_schema(definition.output_schema)
             if definition.output_schema is not None

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -15,21 +15,19 @@ import logging
 import threading
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, cast
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 if TYPE_CHECKING:
     from datetime import datetime, timezone
     from src.backend.vontology.utils_vontology import (
         get_vontology_node_content,
         get_vontology_tree,
-        simulate_or_delete_concept,
     )
     from src.backend.db.repositories.concepts_repository import ConceptsRepository
     from src.backend.services.concept_service import (
         enrich_concept_with_text_relations,
         get_concept_by_concept_id,
         get_concept_display_name_with_names_fallback,
-        update_concept,
     )
     from src.backend.services.concept_relation_service import (
         build_concept_relations_payload,
@@ -47,24 +45,10 @@ if TYPE_CHECKING:
         derive_actor_context_from_namespace,
     )
     from src.backend.services.text_value_service import (
-        delete_text_relation,
-        delete_text_relation_by_predicate_and_text,
         get_text_relations_summary,
         get_texts_for_concept,
-        update_text_relation_text,
-        upsert_singleton_text_relation,
-        upsert_text_for_concept,
-    )
-    from src.backend.services.text_relation_predicate_validation_service import (
-        TextRelationPredicateResolutionError,
-        resolve_text_relation_predicate_for_write,
-    )
-    from src.backend.services.rag_text_relation_change_hook_service import (
-        maybe_delete_text_relation_doc_from_rag,
-        maybe_sync_concept_text_relations_to_rag,
     )
     from src.backend.services.annotation_extraction_service import extract_annotations
-    from src.backend.services.concept_merge_service import merge_concepts
     from src.backend.services.settings_service import (
         get_preferred_language,
         get_setting,
@@ -265,7 +249,6 @@ _bind_imports(
     [
         "get_vontology_node_content",
         "get_vontology_tree",
-        "simulate_or_delete_concept",
     ],
 )
 _bind_imports(
@@ -278,7 +261,6 @@ _bind_imports(
         "get_concept_display_name_with_names_fallback",
         "get_concept_by_concept_id",
         "enrich_concept_with_text_relations",
-        "update_concept",
     ],
 )
 _bind_imports(
@@ -305,34 +287,14 @@ _bind_imports(
 _bind_imports(
     "src.backend.services.text_value_service",
     [
-        "upsert_text_for_concept",
         "get_texts_for_concept",
         "get_text_relations_summary",
-        "upsert_singleton_text_relation",
-        "update_text_relation_text",
-        "delete_text_relation",
-        "delete_text_relation_by_predicate_and_text",
-    ],
-)
-_bind_imports(
-    "src.backend.services.text_relation_predicate_validation_service",
-    [
-        "TextRelationPredicateResolutionError",
-        "resolve_text_relation_predicate_for_write",
-    ],
-)
-_bind_imports(
-    "src.backend.services.rag_text_relation_change_hook_service",
-    [
-        "maybe_delete_text_relation_doc_from_rag",
-        "maybe_sync_concept_text_relations_to_rag",
     ],
 )
 _bind_imports(
     "src.backend.services.annotation_extraction_service",
     ["extract_annotations"],
 )
-_bind_imports("src.backend.services.concept_merge_service", ["merge_concepts"])
 _bind_imports(
     "src.backend.services.settings_service",
     [
@@ -1031,12 +993,79 @@ _TRUSTED_LOCAL_OPERATOR_GMAIL_TOOLS = frozenset(
     }
 )
 
+_STDIO_GOVERNED_ONTOLOGY_METHODS = {
+    "create_concepts": "create_concepts",
+    "upsert_text_relation": "upsert_text_relation",
+    "update_text_relation": "update_text_relation",
+    "delete_text_relation": "delete_text_relation",
+    "upsert_singleton_text_relation": "upsert_singleton_text_relation",
+    "add_names": "add_names_to_concept",
+    "add_relationship": "add_relationship",
+    "remove_relationship": "remove_relationship",
+    "remove_relationships_bulk": "remove_relationships_bulk",
+    "delete_concept": "delete_concept",
+    "merge_concepts": "merge_concepts",
+    "update_concept": "update_concept",
+}
+
+# A direct stdio client has no authenticated user or organisation session. Do
+# not let an MCP payload make its eventual artefacts appear to have been
+# created by, scoped to, or authorised by an arbitrary person or organisation.
+# The shared authority resolver derives any actual actor from trusted server
+# context; here the only admissible authority carrier is the opaque,
+# server-issued delegation above.
+_STDIO_UNTRUSTED_ONTOLOGY_AUTHORITY_FIELDS = frozenset(
+    {
+        "actor",
+        "actor_concept_id",
+        "actor_id",
+        "admin",
+        "administrator",
+        "allow_admin",
+        "authority",
+        "authority_role",
+        "created_by",
+        "created_by_concept_id",
+        "namespace",
+        "global_admin",
+        "is_admin",
+        "is_operator",
+        "organisation_concept_id",
+        "organisation_id",
+        "organization_concept_id",
+        "organization_id",
+        "org_id",
+        "operator",
+        "operator_override",
+        "role",
+        "roles",
+        "user",
+        "user_concept_id",
+        "user_id",
+    }
+)
+
+
+def _strip_untrusted_ontology_authority_payload(
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Drop client-supplied identity/scope claims before a canonical write."""
+
+    return {
+        key: value
+        for key, value in arguments.items()
+        if key not in _STDIO_UNTRUSTED_ONTOLOGY_AUTHORITY_FIELDS
+    }
+
 
 @app.call_tool()
 async def call_tool(name: str, arguments: Any) -> list[TextContent]:  # type: ignore[misc]
     """Handle tool calls by delegating to specific handlers."""
 
-    parsed_arguments = arguments if isinstance(arguments, dict) else {}
+    # Never mutate the object supplied by the MCP implementation/caller: the
+    # authority carrier is removed before dispatch and should not leak into
+    # nested handler use or caller-side retry state.
+    parsed_arguments = dict(arguments) if isinstance(arguments, dict) else {}
     handler = _TOOL_HANDLERS.get(name)
     if not handler:
         surface_diagnostic = classify_stdio_missing_tool(name)
@@ -1096,7 +1125,48 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:  # type: ig
                 )
             ]
 
+    if name == "undo_relationship_removal":
+        # This action currently resolves its target only from an undo token;
+        # stdio must not execute it until that selector is bound to the shared
+        # ontology-mutation authority decision.  Keeping the operator write
+        # toggle above is intentional: it remains a defence-in-depth safety
+        # gate, never semantic authority.
+        return [
+            _json_error(
+                "Relationship undo is unavailable on direct stdio until its target is governed.",
+                error_code="ontology_mutation_not_governed",
+                suggestions=[
+                    "Use a governed HTTP or internal-MCP mutation path that can bind the undo token to its canonical target.",
+                    "Use preview_remove_relationship or canonical read-back to inspect the relationship first.",
+                ],
+            )
+        ]
+
     try:
+        governed_method = _STDIO_GOVERNED_ONTOLOGY_METHODS.get(name)
+        if governed_method:
+            # Stdio has no independently authenticated actor context. Binding
+            # a delegation grantor before matching caller arguments to the
+            # stored exact intent would expose a private read oracle, so this
+            # surface remains fail-closed until it executes server-stored
+            # canonical arguments directly.
+            return [
+                _json_text(
+                    {
+                        "success": False,
+                        "effect_status": "not_started",
+                        "mutation_outcome": "not_started",
+                        "changed": False,
+                        "error_code": (
+                            "ontology_sessionless_delegation_not_supported"
+                        ),
+                        "error": (
+                            "Sessionless ontology delegation execution is "
+                            "unavailable; use an actor-bound trusted surface."
+                        ),
+                    }
+                )
+            ]
         if name in _TRUSTED_LOCAL_OPERATOR_GMAIL_TOOLS:
             # This stdio server is the deliberately local coding/operator
             # surface.  Bind that provenance only around its direct Gmail
@@ -1666,70 +1736,11 @@ async def _handle_von_chat_run(arguments: dict[str, Any]) -> list[TextContent]:
 
 
 async def _handle_upsert_text_relation(arguments: dict[str, Any]) -> list[TextContent]:
-    """Handle upsert_text_relation tool call."""
-    namespace = (
-        arguments.get("namespace")
-        if isinstance(arguments.get("namespace"), str)
-        else None
-    )
-    concept_id = arguments.get("concept_id")
-    predicate = arguments.get("predicate")
-    text = arguments.get("text")
-    language = arguments.get("language", "en-NZ")
-    context = arguments.get("context")
+    """Use the same governed command as chat, workflow, and internal MCP."""
 
-    if not concept_id:
-        return [_json_text({"success": False, "error": "Missing concept_id parameter"})]
-    if not predicate:
-        return [_json_text({"success": False, "error": "Missing predicate parameter"})]
-    if not text:
-        return [_json_text({"success": False, "error": "Missing text parameter"})]
-
-    try:
-        predicate_resolution = resolve_text_relation_predicate_for_write(predicate)
-        storage_predicate = predicate_resolution.storage_predicate
-        result = upsert_text_for_concept(
-            subject_concept_id=concept_id,
-            predicate=storage_predicate,
-            text=text,
-            lang=language,
-            context=context,
-        )
-
-        maybe_sync_concept_text_relations_to_rag(
-            namespace=namespace,
-            concept_id=concept_id,
-            predicate=storage_predicate,
-        )
-
-        text_preview = text[:100] + "..." if len(text) > 100 else text
-        payload = {
-            "success": True,
-            "text_value_id": str(result.get("text_value_id")),
-            "relation_id": str(result.get("relation_id")),
-            "relation_created": result.get("relation_created"),
-            "predicate": storage_predicate,
-            "input_predicate": predicate_resolution.input_predicate,
-            "predicate_concept_id": predicate_resolution.predicate_concept_id,
-            "text_preview": text_preview,
-            "language": language,
-        }
-        return [_json_text(payload)]
-    except TextRelationPredicateResolutionError as exc:
-        return [
-            _json_error(
-                str(exc),
-                error_code=exc.error_code,
-                details=exc.details,
-                suggestions=exc.suggestions,
-            )
-        ]
-    except Exception as exc:
-        return [
-            _json_text(
-                {"success": False, "error": f"Failed to upsert text relation: {exc}"}
-            )
-        ]
+    return [
+        _json_text(internal_mcp_catalogue_module._upsert_text_relation(**arguments))
+    ]
 
 
 async def _handle_get_text_relations(arguments: dict[str, Any]) -> list[TextContent]:
@@ -1802,284 +1813,25 @@ def _warn_if_underscore_replaced(old_text: str, new_text: str) -> list[str]:
 
 
 async def _handle_update_text_relation(arguments: dict[str, Any]) -> list[TextContent]:
-    """Handle update_text_relation tool call."""
-    namespace = (
-        arguments.get("namespace")
-        if isinstance(arguments.get("namespace"), str)
-        else None
-    )
-    concept_id = arguments.get("concept_id")
-    relation_id = arguments.get("relation_id")
-    new_text = arguments.get("new_text")
-    language = arguments.get("language", "en-NZ")
+    """Use the shared canonical mutation command once catalogue-governed."""
 
-    if not concept_id:
-        return [
-            _json_error(
-                "Missing concept_id parameter",
-                error_code="missing_parameter",
-                suggestions=[
-                    "Provide the concept_id that owns the text relation",
-                    "Use fetch_concept with include_text_relations_arg1=true to see available relations",
-                ],
-            )
-        ]
-    if not relation_id:
-        return [
-            _json_error(
-                "Missing relation_id parameter",
-                error_code="missing_parameter",
-                suggestions=[
-                    "Provide the relation_id of the text relation to update",
-                    "Use fetch_concept with include_text_relations_arg1=true to find relation IDs",
-                ],
-            )
-        ]
-    if not new_text:
-        return [
-            _json_error(
-                "Missing new_text parameter",
-                error_code="missing_parameter",
-                suggestions=[
-                    "Provide the new_text content to replace the existing text"
-                ],
-            )
-        ]
-
-    try:
-        result = update_text_relation_text(
-            subject_concept_id=concept_id,
-            relation_id=relation_id,
-            new_text=new_text,
-            lang=language,
-        )
-
-        maybe_sync_concept_text_relations_to_rag(
-            namespace=namespace,
-            concept_id=concept_id,
-        )
-
-        old_text = str(result.get("old_text", ""))
-        old_preview = old_text[:100]
-        new_preview = new_text[:100] + "..." if len(new_text) > 100 else new_text
-        warnings = _warn_if_underscore_replaced(old_text, new_text)
-
-        payload = {
-            "success": True,
-            "relation_id": relation_id,
-            "old_text_preview": old_preview,
-            "new_text_preview": new_preview,
-            "text_value_id": str(result.get("text_value_id")),
-        }
-        if warnings:
-            payload["warnings"] = warnings
-        return [_json_text(payload)]
-    except Exception as exc:
-        return [
-            _json_error(
-                f"Failed to update text relation: {exc}",
-                error_code="update_failed",
-                suggestions=[
-                    "Verify the concept_id and relation_id exist",
-                    "Check that new_text is a valid string",
-                ],
-                related_concept_ids=[concept_id] if concept_id else None,
-            )
-        ]
+    return [
+        _json_text(internal_mcp_catalogue_module._update_text_relation(**arguments))
+    ]
 
 
 async def _handle_delete_text_relation(arguments: dict[str, Any]) -> list[TextContent]:
-    """Handle delete_text_relation tool call."""
-    namespace = (
-        arguments.get("namespace")
-        if isinstance(arguments.get("namespace"), str)
-        else None
-    )
-    concept_id = arguments.get("concept_id")
-    relation_id = arguments.get("relation_id")
-    predicate = arguments.get("predicate")
-    text = arguments.get("text")
-    language = arguments.get("language")
-    garbage_collect = bool(arguments.get("garbage_collect"))
+    """Use the same governed command as chat, workflow, and internal MCP."""
 
-    if not concept_id:
-        return [
-            _json_error(
-                "Missing concept_id parameter",
-                error_code="missing_parameter",
-                suggestions=[
-                    "Provide the concept_id that owns the text relation",
-                    "Use fetch_concept with include_text_relations_arg1=true to see available relations",
-                ],
-            )
-        ]
-
-    try:
-        if relation_id:
-            # Delete by relation ID (preferred)
-            result = delete_text_relation(
-                subject_concept_id=concept_id,
-                relation_id=relation_id,
-                garbage_collect=garbage_collect,
-            )
-
-            maybe_delete_text_relation_doc_from_rag(
-                namespace=namespace,
-                relation_id=relation_id,
-            )
-
-            payload = {
-                "success": True,
-                "deleted_relation_id": relation_id,
-                "deleted_text_preview": None,
-                "text_value_cleaned_up": bool(
-                    result.get(
-                        "orphaned_text_value_deleted",
-                        result.get("text_value_cleaned_up", False),
-                    )
-                ),
-            }
-        elif predicate and text:
-            # Delete by predicate + text match
-            result = delete_text_relation_by_predicate_and_text(
-                subject_concept_id=concept_id,
-                predicate=predicate,
-                text=text,
-                lang=language,
-                garbage_collect=garbage_collect,
-            )
-
-            maybe_delete_text_relation_doc_from_rag(
-                namespace=namespace,
-                relation_id=result.get("relation_id"),
-            )
-
-            payload = {
-                "success": True,
-                "deleted_relation_id": result.get("relation_id"),
-                "deleted_text_preview": text[:100],
-                "text_value_cleaned_up": result.get(
-                    "orphaned_text_value_deleted", False
-                ),
-            }
-        else:
-            return [
-                _json_error(
-                    "Must provide either relation_id or both predicate and text",
-                    error_code="invalid_parameter",
-                    suggestions=[
-                        "Provide relation_id for exact deletion",
-                        "Or provide both predicate and text for pattern match deletion",
-                    ],
-                )
-            ]
-
-        return [_json_text(payload)]
-    except Exception as exc:
-        return [
-            _json_error(
-                f"Failed to delete text relation: {exc}",
-                error_code="operation_failed",
-                suggestions=["Verify the concept_id and identifiers are correct"],
-                related_concept_ids=[concept_id] if concept_id else None,
-            )
-        ]
+    return [
+        _json_text(internal_mcp_catalogue_module._delete_text_relation(**arguments))
+    ]
 
 
 async def _handle_add_names(arguments: dict[str, Any]) -> list[TextContent]:
-    concept_id = arguments.get("concept_id")
-    names = arguments.get("names")
-    if not concept_id:
-        return [
-            _json_error(
-                "Missing concept_id parameter",
-                error_code="missing_parameter",
-                suggestions=[
-                    "Provide the concept_id of the concept to add names to",
-                    "Use search_concepts to find the concept first",
-                ],
-            )
-        ]
-    if not names or not isinstance(names, list):
-        return [
-            _json_error(
-                "Missing or invalid names array",
-                error_code="invalid_parameter",
-                suggestions=[
-                    "Provide names as an array of strings or objects with name, language, name_type",
-                    "Example: ['Name1', {'name': 'Name2', 'language': 'en-NZ', 'name_type': 'NL'}]",
-                ],
-            )
-        ]
-
-    concept = ConceptsRepository.find_one({"concept_id": concept_id})
-    if not concept:
-        return [
-            _json_error(
-                f"Concept '{concept_id}' not found",
-                error_code="concept_not_found",
-                suggestions=[
-                    "Check the concept_id spelling",
-                    "Use search_concepts to verify the concept exists",
-                ],
-                related_concept_ids=[concept_id],
-            )
-        ]
-
-    results: list[dict[str, Any]] = []
-    errors: list[dict[str, Any]] = []
-    for idx, name_obj in enumerate(names):
-        if isinstance(name_obj, str):
-            name_text = name_obj
-            language = "en-NZ"
-            name_type = "NL"
-        elif isinstance(name_obj, dict):
-            name_text = name_obj.get("name")
-            language = name_obj.get("language", "en-NZ")
-            name_type = name_obj.get("name_type", "NL")
-        else:
-            errors.append({"index": idx, "error": "Invalid name format"})
-            continue
-
-        if not name_text or not isinstance(name_text, str) or not name_text.strip():
-            errors.append({"index": idx, "error": "Missing or invalid name text"})
-            continue
-
-        try:
-            result = upsert_text_for_concept(
-                subject_concept_id=concept_id,
-                predicate="hasName",
-                text=name_text.strip(),
-                lang=language,
-                context={"name_type": name_type},
-            )
-            if result:
-                results.append(
-                    {
-                        "index": idx,
-                        "name": name_text.strip(),
-                        "language": language,
-                        "name_type": name_type,
-                        "text_value_id": str(result.get("text_value_id")),
-                        "relation_id": str(result.get("relation_id")),
-                    }
-                )
-            else:
-                errors.append(
-                    {"index": idx, "name": name_text, "error": "Failed to add"}
-                )
-        except Exception as exc:
-            errors.append({"index": idx, "name": name_text, "error": str(exc)})
-
-    payload = {
-        "success": len(errors) == 0,
-        "concept_id": concept_id,
-        "added_count": len(results),
-        "error_count": len(errors),
-        "results": results,
-        "errors": errors if errors else [],
-    }
-    return [_json_text(payload)]
+    return [
+        _json_text(internal_mcp_catalogue_module._add_names_to_concept(**arguments))
+    ]
 
 
 async def _handle_get_tree(arguments: dict[str, Any]) -> list[TextContent]:
@@ -2412,77 +2164,13 @@ async def _handle_get_text_relations_summary(
 async def _handle_upsert_singleton_text_relation(
     arguments: dict[str, Any],
 ) -> list[TextContent]:
-    concept_id = arguments.get("concept_id")
-    predicate = arguments.get("predicate")
-    text = arguments.get("text")
-
-    if not concept_id:
-        return [
-            _json_error(
-                "Missing concept_id parameter",
-                error_code="missing_parameter",
-                suggestions=[
-                    "Provide the concept_id to add the text relation to",
-                    "Use search_concepts to find the concept first",
-                ],
+    return [
+        _json_text(
+            internal_mcp_catalogue_module._upsert_singleton_text_relation(
+                **arguments
             )
-        ]
-    if not predicate:
-        return [
-            _json_error(
-                "Missing predicate parameter",
-                error_code="missing_parameter",
-                suggestions=[
-                    "Provide a predicate (e.g. 'hasDescription', 'hasContent', 'hasName')",
-                    "Use search_concepts to find predicate concepts",
-                ],
-            )
-        ]
-    if not text:
-        return [
-            _json_error(
-                "Missing text parameter",
-                error_code="missing_parameter",
-                suggestions=["Provide the text content to associate with the concept"],
-            )
-        ]
-
-    try:
-        predicate_resolution = resolve_text_relation_predicate_for_write(predicate)
-        payload = upsert_singleton_text_relation(
-            subject_concept_id=concept_id,
-            predicate=predicate_resolution.storage_predicate,
-            text=text,
-            lang=arguments.get("language", "en-NZ"),
-            policy=arguments.get("policy", "replace_others"),
-            provenance=arguments.get("provenance"),
-            context=arguments.get("context"),
-            garbage_collect=arguments.get("garbage_collect", True),
         )
-        payload["input_predicate"] = predicate_resolution.input_predicate
-        payload["predicate_concept_id"] = predicate_resolution.predicate_concept_id
-        return [_json_text(payload)]
-    except TextRelationPredicateResolutionError as exc:
-        return [
-            _json_error(
-                str(exc),
-                error_code=exc.error_code,
-                details=exc.details,
-                suggestions=exc.suggestions,
-            )
-        ]
-    except Exception as exc:
-        return [
-            _json_error(
-                f"Failed to upsert singleton text relation: {exc}",
-                error_code="operation_failed",
-                suggestions=[
-                    "Verify the concept_id exists",
-                    "Check that predicate is a valid predicate concept_id or name",
-                ],
-                related_concept_ids=[concept_id],
-            )
-        ]
+    ]
 
 
 async def _handle_audit_concept_text_relations(
@@ -3560,7 +3248,10 @@ async def _handle_delete_concept(arguments: dict[str, Any]) -> list[TextContent]
                 ],
             )
         ]
-    result = simulate_or_delete_concept(concept_id, execute=not simulate)
+    result = internal_mcp_catalogue_module._delete_concept(
+        concept_id=concept_id,
+        simulate=simulate,
+    )
     return [_json_text(result)]
 
 
@@ -3579,7 +3270,11 @@ async def _handle_merge_concepts(arguments: dict[str, Any]) -> list[TextContent]
                 ],
             )
         ]
-    result = merge_concepts(source_id, target_id, simulate=simulate)
+    result = internal_mcp_catalogue_module._merge_concepts(
+        source_id=source_id,
+        target_id=target_id,
+        simulate=simulate,
+    )
     return [_json_text(result)]
 
 
@@ -3609,22 +3304,11 @@ async def _handle_update_concept(arguments: dict[str, Any]) -> list[TextContent]
             )
         ]
     try:
-        result = update_concept(concept_id=concept_id, update_data=update_data)
-        if result:
-            return [
-                _json_text(
-                    {
-                        "success": True,
-                        "concept_id": concept_id,
-                        "updated_fields": list(update_data.keys()),
-                    }
-                )
-            ]
-        return [
-            _json_text(
-                {"error": "Update failed or concept not found", "success": False}
-            )
-        ]
+        result = internal_mcp_catalogue_module._update_concept(
+            concept_id=concept_id,
+            update_data=update_data,
+        )
+        return [_json_text(result)]
     except Exception as exc:
         return [_json_text({"error": str(exc), "success": False})]
 

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -13,6 +13,14 @@
                     "names": {
                         "type": "array",
                         "items": {}
+                    },
+                    "ontology_delegation_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued delegation for this exact canonical ontology mutation. It does not identify or authenticate a user."
+                    },
+                    "ontology_effect_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued effect identifier bound to the delegation. It is used for exact authorisation and idempotent receipts."
                     }
                 },
                 "required": [
@@ -55,11 +63,13 @@
                         ],
                         "additionalProperties": true
                     },
-                    "namespace": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
+                    "ontology_delegation_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued delegation for this exact canonical ontology mutation. It does not identify or authenticate a user."
+                    },
+                    "ontology_effect_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued effect identifier bound to the delegation. It is used for exact authorisation and idempotent receipts."
                     }
                 },
                 "required": [
@@ -827,12 +837,6 @@
                             null
                         ]
                     },
-                    "namespace": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
                     "scope_mode": {
                         "type": [
                             "string",
@@ -845,17 +849,13 @@
                             "null"
                         ]
                     },
-                    "created_by_concept_id": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
+                    "ontology_delegation_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued delegation for this exact canonical ontology mutation. It does not identify or authenticate a user."
                     },
-                    "organisation_concept_id": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
+                    "ontology_effect_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued effect identifier bound to the delegation. It is used for exact authorisation and idempotent receipts."
                     }
                 },
                 "required": [
@@ -929,6 +929,14 @@
                     },
                     "simulate": {
                         "type": "boolean"
+                    },
+                    "ontology_delegation_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued delegation for this exact canonical ontology mutation. It does not identify or authenticate a user."
+                    },
+                    "ontology_effect_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued effect identifier bound to the delegation. It is used for exact authorisation and idempotent receipts."
                     }
                 },
                 "required": [
@@ -973,6 +981,14 @@
                     },
                     "garbage_collect": {
                         "type": "boolean"
+                    },
+                    "ontology_delegation_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued delegation for this exact canonical ontology mutation. It does not identify or authenticate a user."
+                    },
+                    "ontology_effect_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued effect identifier bound to the delegation. It is used for exact authorisation and idempotent receipts."
                     }
                 },
                 "required": [
@@ -3805,6 +3821,14 @@
                     },
                     "simulate": {
                         "type": "boolean"
+                    },
+                    "ontology_delegation_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued delegation for this exact canonical ontology mutation. It does not identify or authenticate a user."
+                    },
+                    "ontology_effect_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued effect identifier bound to the delegation. It is used for exact authorisation and idempotent receipts."
                     }
                 },
                 "required": [
@@ -4223,12 +4247,6 @@
                             "null"
                         ]
                     },
-                    "operator_override": {
-                        "type": [
-                            "boolean",
-                            "null"
-                        ]
-                    },
                     "reason": {
                         "type": [
                             "string",
@@ -4240,6 +4258,14 @@
                             "string",
                             "null"
                         ]
+                    },
+                    "ontology_delegation_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued delegation for this exact canonical ontology mutation. It does not identify or authenticate a user."
+                    },
+                    "ontology_effect_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued effect identifier bound to the delegation. It is used for exact authorisation and idempotent receipts."
                     }
                 },
                 "required": [],
@@ -4298,12 +4324,6 @@
                             "null"
                         ]
                     },
-                    "operator_override": {
-                        "type": [
-                            "boolean",
-                            "null"
-                        ]
-                    },
                     "reason": {
                         "type": [
                             "string",
@@ -4321,6 +4341,14 @@
                             "boolean",
                             "null"
                         ]
+                    },
+                    "ontology_delegation_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued delegation for this exact canonical ontology mutation. It does not identify or authenticate a user."
+                    },
+                    "ontology_effect_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued effect identifier bound to the delegation. It is used for exact authorisation and idempotent receipts."
                     }
                 },
                 "required": [],
@@ -6157,6 +6185,14 @@
                     "update_data": {
                         "type": "object",
                         "additionalProperties": true
+                    },
+                    "ontology_delegation_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued delegation for this exact canonical ontology mutation. It does not identify or authenticate a user."
+                    },
+                    "ontology_effect_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued effect identifier bound to the delegation. It is used for exact authorisation and idempotent receipts."
                     }
                 },
                 "required": [
@@ -6215,6 +6251,14 @@
                             "string",
                             "null"
                         ]
+                    },
+                    "ontology_delegation_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued delegation for this exact canonical ontology mutation. It does not identify or authenticate a user."
+                    },
+                    "ontology_effect_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued effect identifier bound to the delegation. It is used for exact authorisation and idempotent receipts."
                     }
                 },
                 "required": [
@@ -6323,6 +6367,14 @@
                             "null"
                         ],
                         "additionalProperties": true
+                    },
+                    "ontology_delegation_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued delegation for this exact canonical ontology mutation. It does not identify or authenticate a user."
+                    },
+                    "ontology_effect_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued effect identifier bound to the delegation. It is used for exact authorisation and idempotent receipts."
                     }
                 },
                 "required": [
@@ -6349,12 +6401,6 @@
                     "text": {
                         "type": "string"
                     },
-                    "namespace": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
                     "language": {
                         "type": "string"
                     },
@@ -6364,6 +6410,14 @@
                             "null"
                         ],
                         "additionalProperties": true
+                    },
+                    "ontology_delegation_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued delegation for this exact canonical ontology mutation. It does not identify or authenticate a user."
+                    },
+                    "ontology_effect_id": {
+                        "type": "string",
+                        "description": "Opaque server-issued effect identifier bound to the delegation. It is used for exact authorisation and idempotent receipts."
                     }
                 },
                 "required": [

--- a/src/backend/security/role_resolver.py
+++ b/src/backend/security/role_resolver.py
@@ -16,7 +16,9 @@ Phase 3 Will Replace:
 - Add permission-based access control
 """
 
-from typing import Dict, Set
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 # Hardcoded role mappings for Phase 1
@@ -39,6 +41,31 @@ DEFAULT_ROLE = "member"
 
 # Available roles in stub system (will be expanded in Phase 3)
 AVAILABLE_ROLES = {"viewer", "member", "contributor", "admin", "owner"}
+_INITIAL_ROLE_MIGRATION_USER = "michael_witbrock"
+
+
+def _legacy_fallback_allowed(user_slug: str) -> bool:
+    """Retire Michael's stub once his separate operational role is represented.
+
+    If migration-state read-back itself is unavailable, fail closed for this
+    one authority-bearing compatibility entry rather than resurrecting admin.
+    Other ordinary compatibility mappings retain their existing behaviour.
+    """
+
+    if user_slug != _INITIAL_ROLE_MIGRATION_USER:
+        return True
+    try:
+        from ..services.von_operational_administrator_service import (
+            is_live_von_operational_administrator,
+        )
+
+        return not is_live_von_operational_administrator(f"#V#{user_slug}")
+    except Exception as exc:  # noqa: BLE001 - fail-closed authority boundary
+        logger.warning(
+            "Could not verify legacy administrator retirement; failing closed: %s",
+            type(exc).__name__,
+        )
+        return False
 
 
 def get_user_role(user_id: str, org_id: str) -> str:
@@ -62,16 +89,49 @@ def get_user_role(user_id: str, org_id: str) -> str:
     if not user_id or not org_id:
         return DEFAULT_ROLE
 
+    user_slug = str(user_id).strip().removeprefix("#V#")
+    organisation_slug = str(org_id).strip().removeprefix("#V#")
+
+    # Represented membership is authoritative when its store is readable. The lazy import
+    # avoids making this compatibility resolver a dependency of the membership
+    # service itself. A storage outage retains the existing stub fallback; an
+    # explicit represented role, including owner, is never overwritten by it.
+    # A successful "not a member" read is also authoritative: falling through
+    # to the stub there would resurrect removed administrator authority.
+    try:
+        from ..services.organisation_membership_service import (
+            resolve_user_organisation_membership,
+        )
+
+        membership = resolve_user_organisation_membership(
+            f"#V#{user_slug}",
+            f"#V#{organisation_slug}",
+        )
+        if isinstance(membership, dict):
+            represented_role = str(membership.get("role") or "").strip()
+            if represented_role in AVAILABLE_ROLES:
+                return represented_role
+        return DEFAULT_ROLE
+    except Exception as exc:  # noqa: BLE001 - compatibility fallback boundary
+        logger.debug(
+            "Represented organisation-role resolution unavailable; using compatibility fallback: %s",
+            type(exc).__name__,
+        )
+
     # Check hardcoded mappings
-    if user_id in STUB_ROLE_MAPPINGS:
-        if org_id in STUB_ROLE_MAPPINGS[user_id]:
-            return STUB_ROLE_MAPPINGS[user_id][org_id]
+    if (
+        _legacy_fallback_allowed(user_slug)
+        and
+        user_slug in STUB_ROLE_MAPPINGS
+        and organisation_slug in STUB_ROLE_MAPPINGS[user_slug]
+    ):
+        return STUB_ROLE_MAPPINGS[user_slug][organisation_slug]
 
     # Default to member role for unmapped users
     return DEFAULT_ROLE
 
 
-def get_effective_permissions(role: str) -> Set[str]:
+def get_effective_permissions(role: str) -> set[str]:
     """
     Get the set of permissions for a role.
 
@@ -132,7 +192,7 @@ def has_permission(user_id: str, org_id: str, permission: str) -> bool:
 
 
 # Migration helper for Phase 2
-def get_all_user_organisations(user_id: str) -> Dict[str, str]:
+def get_all_user_organisations(user_id: str) -> dict[str, str]:
     """
     Get all organisations a user is a member of and their roles.
 
@@ -146,7 +206,27 @@ def get_all_user_organisations(user_id: str) -> Dict[str, str]:
         Dictionary mapping org_id to role_name
         Empty dict if user has no organisation memberships
     """
-    return STUB_ROLE_MAPPINGS.get(user_id, {})
+    user_slug = str(user_id or "").strip().removeprefix("#V#")
+    try:
+        from ..services.organisation_membership_service import get_user_memberships
+
+        represented = get_user_memberships(f"#V#{user_slug}")
+        memberships = {
+            str(item["organisation_concept_id"])[3:]: str(item.get("role") or "member")
+            for item in represented.get("memberships", [])
+            if isinstance(item, dict)
+            and isinstance(item.get("organisation_concept_id"), str)
+            and str(item["organisation_concept_id"]).startswith("#V#")
+        }
+        return memberships
+    except Exception as exc:  # noqa: BLE001 - compatibility fallback boundary
+        logger.debug(
+            "Represented organisation list unavailable; using compatibility fallback: %s",
+            type(exc).__name__,
+        )
+    if not _legacy_fallback_allowed(user_slug):
+        return {}
+    return STUB_ROLE_MAPPINGS.get(user_slug, {})
 
 
 # Phase 3 Note: This module will be significantly refactored to:

--- a/src/backend/server/routes/admin_routes.py
+++ b/src/backend/server/routes/admin_routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import hmac
 import os
 
-from flask import Blueprint, current_app, jsonify, request
+from flask import Blueprint, current_app, jsonify, request, session
 from ...db import connection_manager as conn_mgr
 from ...services.mongo_startup_config import run_mongo_startup_probe
 from ...services.workflow_materialisation_diagnostics_service import (
@@ -24,6 +24,30 @@ def _trusted_operator_token_authorised() -> bool:
         "X-Admin-Token"
     )
     return bool(provided) and hmac.compare_digest(provided, expected)
+
+
+def _represented_operational_administrator_authorised() -> bool:
+    """Resolve only the logged-in human's dedicated operational role."""
+
+    actor_id = str(session.get("user_concept_id") or "").strip()
+    if not actor_id:
+        return False
+    if not actor_id.startswith("#"):
+        actor_id = f"#V#{actor_id}"
+    from ...services.von_operational_administrator_service import (
+        is_live_von_operational_administrator,
+    )
+
+    return is_live_von_operational_administrator(actor_id)
+
+
+def _trusted_operator_authorised() -> bool:
+    """Accept the existing token or a live represented operational role."""
+
+    return (
+        _trusted_operator_token_authorised()
+        or _represented_operational_administrator_authorised()
+    )
 
 
 @admin_bp.route("/db/health", methods=["GET"])
@@ -64,7 +88,7 @@ def _collect_required_concept_ids_from_query() -> list[str]:
 
 @admin_bp.route("/workflow_materialisation_diagnostics", methods=["GET"])
 def workflow_materialisation_diagnostics():
-    if not _trusted_operator_token_authorised():
+    if not _trusted_operator_authorised():
         return jsonify({"error": "trusted_operator_authority_required"}), 403
     include_present_raw = (
         (request.args.get("include_present_concepts") or "").strip().lower()

--- a/src/backend/server/routes/annotations_routes.py
+++ b/src/backend/server/routes/annotations_routes.py
@@ -10,9 +10,6 @@ from ...services.annotation_extraction_service import (
     build_prompt_preview_with_output,
     get_last_llm_io,
 )
-from ...db.mongo_client import get_text_relations_collection
-from datetime import datetime, timezone
-
 annotations_bp = Blueprint("annotations", __name__)
 
 
@@ -78,6 +75,20 @@ def annotate_turn_route():
     suggestions = []
     auto_generated = False
     metadata = payload.get("metadata") or {}
+    if metadata.get("auto_upsert"):
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "error_code": "annotation_auto_upsert_not_governed",
+                    "error": (
+                        "Annotation auto-upsert is unavailable until it uses the "
+                        "trusted governed concept-creation path."
+                    ),
+                }
+            ),
+            410,
+        )
 
     def _norm_flag(val):
         if isinstance(val, bool):
@@ -198,25 +209,6 @@ def annotate_turn_route():
 
     response["suggestions"] = suggestions
 
-    # Optionally, the caller can request auto-upsert via a flag in metadata
-    if metadata.get("auto_upsert"):
-        # For now, only attempt to upsert if a single span and no candidates
-        try:
-            for s in suggestions:
-                if not s.get("candidates"):
-                    span = s.get("span")
-                    # Build a basic concept record
-                    concept_payload = {
-                        "name": span.get("text"),
-                        "concept_id": None,
-                        "vontology_path": metadata.get("vontology_path"),
-                    }
-                    if hasattr(concept_service, "create_concept"):
-                        created = concept_service.create_concept(**concept_payload)
-                        s["created"] = created
-        except Exception as e:
-            current_app.logger.exception(f"Error during auto_upsert: {e}")
-
     return jsonify(response), 200
 
 
@@ -226,53 +218,19 @@ def accept_annotation_route():
 
     Expected JSON: { turn_id: str, span: {start, end, text}, candidate: {id|concept_id|name}, user_id?: str }
     """
-    payload = request.get_json(silent=True)
-    if not payload:
-        return jsonify(error="Request body must be JSON"), 400
-
-    # Extract user context for request-scoped identity
-    user_ctx = _extract_user_context(payload)
-
-    # Basic validation
-    turn_id = payload.get("turn_id")
-    span = payload.get("span")
-    candidate = payload.get("candidate")
-    # Use context user_id if available, fallback to legacy user_id field
-    user_id = user_ctx.get("user_id") or payload.get("user_id") or "unknown"
-    if not turn_id or not span or not candidate:
-        return jsonify(error="turn_id, span and candidate are required"), 400
-
-    # Log context for audit trail
-    current_app.logger.info(
-        f"[annotations/accept] user={user_id} org={user_ctx.get('org_id')} turn={turn_id} concept={candidate.get('concept_id')}"
+    return (
+        jsonify(
+            {
+                "status": "error",
+                "error_code": "annotation_assertion_mutation_not_governed",
+                "error": (
+                    "Annotation assertion persistence is unavailable until it uses "
+                    "the actor-scoped assertion lifecycle."
+                ),
+            }
+        ),
+        410,
     )
-
-    # Build a relation doc to store in text_relations collection
-    try:
-        coll = get_text_relations_collection()
-        if coll is None:
-            return jsonify(error="Database not available"), 500
-
-        relation = {
-            "subject_concept_id": candidate.get("concept_id")
-            or candidate.get("id")
-            or candidate.get("conceptId"),
-            "predicate": "mentioned_in_text",
-            "object_text": span.get("text"),
-            "object_span": {"start": span.get("start"), "end": span.get("end")},
-            "source": {
-                "turn_id": turn_id,
-                "user_id": user_id,
-            },
-            "created_at": datetime.now(timezone.utc),
-            "updated_at": datetime.now(timezone.utc),
-        }
-        coll.insert_one(relation)
-    except Exception as e:
-        current_app.logger.exception(f"Error persisting annotation accept: {e}")
-        return jsonify(error="failed to persist annotation"), 500
-
-    return jsonify({"status": "accepted"}), 200
 
 
 @annotations_bp.route("/revoke", methods=["POST"])
@@ -281,47 +239,19 @@ def revoke_annotation_route():
 
     Expected JSON: { turn_id?: str, candidate_id?: str, object_text?: str }
     """
-    payload = request.get_json(silent=True)
-    if not payload:
-        return jsonify(error="Request body must be JSON"), 400
-
-    turn_id = payload.get("turn_id")
-    candidate_id = payload.get("candidate_id")
-    object_text = payload.get("object_text")
-
-    if not (turn_id or candidate_id or object_text):
-        return (
-            jsonify(
-                error="must provide turn_id or candidate_id or object_text to revoke"
-            ),
-            400,
-        )
-
-    try:
-        coll = get_text_relations_collection()
-        if coll is None:
-            return jsonify(error="Database not available"), 500
-
-        query = {}
-        if turn_id:
-            query["source.turn_id"] = turn_id
-        if candidate_id:
-            query["subject_concept_id"] = str(candidate_id)
-        if object_text and not candidate_id:
-            # if object_text provided and no candidate specified, match by object_text
-            query["object_text"] = object_text
-
-        if not query:
-            return jsonify(error="no valid filter for revoke"), 400
-
-        result = coll.delete_many(query)
-        return (
-            jsonify({"status": "revoked", "deleted_count": result.deleted_count}),
-            200,
-        )
-    except Exception as e:
-        current_app.logger.exception(f"Error revoking annotation: {e}")
-        return jsonify(error="failed to revoke annotation"), 500
+    return (
+        jsonify(
+            {
+                "status": "error",
+                "error_code": "annotation_assertion_mutation_not_governed",
+                "error": (
+                    "Annotation assertion revocation is unavailable until it uses "
+                    "the actor-scoped assertion lifecycle."
+                ),
+            }
+        ),
+        410,
+    )
 
 
 @annotations_bp.route("/manual_instance", methods=["POST"])

--- a/src/backend/server/routes/concept_routes.py
+++ b/src/backend/server/routes/concept_routes.py
@@ -18,7 +18,10 @@ from ...services.text_value_service import (
     RelationPredicate,
     update_text_relation_text,
     delete_text_relation,
-    delete_text_relation_by_predicate_and_text,
+)
+from ...services.text_relation_predicate_validation_service import (
+    TextRelationPredicateResolutionError,
+    resolve_text_relation_predicate_for_write,
 )
 from ...services.rag_text_relation_change_hook_service import (
     maybe_delete_text_relation_doc_from_rag,
@@ -40,6 +43,88 @@ from ...vontology.utils_vontology import (
 from ...db.mongo_client import get_db
 
 concept_bp = Blueprint("concepts", __name__)  # Define blueprint
+
+
+def _governed_mutation_response(
+    result: dict[str, Any], *, success_status: int = 200
+) -> ResponseReturnValue:
+    """Render a shared governed-command outcome without recreating policy here."""
+
+    if result.get("success") is not False and not result.get("error_code"):
+        return jsonify(result), success_status
+
+    error_code = str(result.get("error_code") or "")
+    authority_denials = {
+        "authenticated_actor_context_required",
+        "client_supplied_identity_is_not_authority",
+        "von_operator_is_not_semantic_ontology_authority",
+        "global_ontology_admin_authority_required",
+        "organisation_ontology_admin_authority_required",
+        "ontology_publication_authority_required",
+        "private_scope_canonical_publication_not_delegated",
+        "dedicated_ontology_governance_operation_required",
+        "explicit_scope_adoption_required",
+        "ontology_mutation_target_not_accessible",
+    }
+    authority_decision = result.get("authority_decision")
+    decision_denied = isinstance(authority_decision, dict) and (
+        authority_decision.get("allowed") is False
+    )
+    if error_code in authority_denials or decision_denied:
+        return jsonify(result), 403
+    if error_code.endswith("not_found"):
+        return jsonify(result), 404
+    if error_code in {
+        "ontology_authority_store_unavailable",
+        "ontology_mutation_receipt_store_unavailable",
+        "ontology_mutation_store_unavailable",
+        "ontology_mutation_receipt_finalisation_failed",
+        "ontology_mutation_postcondition_failed",
+        "canonical_read_back_failed",
+        "ontology_mutation_replay_projection_unavailable",
+    }:
+        return jsonify(result), 503
+    return jsonify(result), 400
+
+
+def _execute_governed_http_mutation(
+    *,
+    method_name: str,
+    arguments: dict[str, Any],
+    mutate: Any,
+    preview: bool = False,
+) -> dict[str, Any]:
+    """Use the canonical command boundary with Flask's trusted actor context."""
+
+    from ...services.ontology_mutation_command_service import (
+        execute_governed_ontology_method,
+    )
+
+    try:
+        return execute_governed_ontology_method(
+            method_name=method_name,
+            arguments=arguments,
+            mutate=mutate,
+            preview=preview,
+        )
+    except LookupError:
+        return {
+            "success": False,
+            "effect_status": "not_started",
+            "mutation_outcome": "not_started",
+            "changed": False,
+            "error_code": "ontology_mutation_target_not_found",
+            "error": "The requested ontology target was not found.",
+        }
+    except (ConnectionError, TimeoutError):
+        return {
+            "success": False,
+            "effect_status": "not_started",
+            "mutation_outcome": "not_started",
+            "changed": False,
+            "error_code": "ontology_mutation_store_unavailable",
+            "error": "The ontology mutation store is temporarily unavailable.",
+        }
 
 
 def _get_request_namespace() -> str | None:
@@ -309,26 +394,87 @@ def create_concept_route():
     system_tags = data.get("system_tags")
     user_tags = data.get("user_tags")
     linked_concepts = data.get("linked_concepts")
+    parent_concept_ids = data.get("parent_concept_ids")
 
     if not name:
         return jsonify(error="concept name is required"), 400
     if not concept_id and not vontology_path:
         return jsonify(error="Either concept_id or vontology_path is required"), 400
+    if parent_concept_ids is not None and not isinstance(parent_concept_ids, list):
+        return jsonify(error="parent_concept_ids must be a list"), 400
 
     try:
-        new_concept = concept_service.create_concept(
-            name=name,
-            concept_id=concept_id,
-            vontology_path=vontology_path,
-            description=description,
-            notes=notes,
-            attributes=attributes,
-            system_tags=system_tags,
-            user_tags=user_tags,
-            linked_concepts=linked_concepts,
+        trusted_actor = _get_current_user_concept_id()
+        trusted_org = _get_current_org_concept_id()
+        scope_mode = data.get("visibility_scope_mode") or data.get("scope_mode")
+        from ...services.ontology_mutation_command_service import (
+            resolve_governed_ontology_arguments,
         )
-        # Service layer should return id as string
-        return jsonify(new_concept), 201
+
+        create_arguments = resolve_governed_ontology_arguments(
+            "create_concepts",
+            {
+                "concepts": [
+                    {
+                        "concept_id": concept_id,
+                        "name": name,
+                        "description": description,
+                        "notes": notes,
+                        "attributes": attributes,
+                        "system_tags": system_tags,
+                        "user_tags": user_tags,
+                        "linked_concepts": linked_concepts,
+                        "create_as_instance": data.get("create_as_instance", True),
+                        "instance_of_type": data.get("instance_of_type"),
+                        "vontology_path": vontology_path,
+                    }
+                ],
+                "scope_mode": scope_mode,
+                "parent_id": (
+                    (parent_concept_ids or [None])[0]
+                    if isinstance(parent_concept_ids, list)
+                    else None
+                ),
+                "parent_concept_ids": parent_concept_ids,
+                "instance_of_type": data.get("instance_of_type"),
+                "linked_concepts": linked_concepts,
+                "attributes": attributes,
+                "system_tags": system_tags,
+                "user_tags": user_tags,
+                "create_as_instance": data.get("create_as_instance", True),
+                "vontology_path": vontology_path,
+                "description": description,
+                "notes": notes,
+                "request_id": data.get("request_id"),
+            },
+        )
+        resolved_concept = create_arguments["concepts"][0]
+        resolved_parent_ids = create_arguments.get("parent_concept_ids")
+        result = _execute_governed_http_mutation(
+            method_name="create_concepts",
+            arguments=create_arguments,
+            mutate=lambda: concept_service.create_concept(
+                name=resolved_concept.get("name"),
+                concept_id=resolved_concept.get("concept_id"),
+                vontology_path=resolved_concept.get("vontology_path"),
+                description=resolved_concept.get("description"),
+                notes=resolved_concept.get("notes"),
+                attributes=resolved_concept.get("attributes"),
+                system_tags=resolved_concept.get("system_tags"),
+                user_tags=resolved_concept.get("user_tags"),
+                linked_concepts=resolved_concept.get("linked_concepts"),
+                parent_concept_ids=resolved_parent_ids,
+                create_as_instance=resolved_concept.get("create_as_instance", True),
+                instance_of_type=resolved_concept.get("instance_of_type"),
+                created_by_concept_id=trusted_actor,
+                organisation_concept_id=trusted_org,
+                event_namespace=_get_request_namespace(),
+                visibility_scope_mode=create_arguments.get("scope_mode"),
+                maintain_relationship_inverses=False,
+                resolve_visibility_from_event_namespace=False,
+            ),
+        )
+        return _governed_mutation_response(result, success_status=201)
     except InvalidConceptDataError as e:
         current_app.logger.warning(f"Invalid data for creating concept: {e}")
         return jsonify(error=str(e)), 400
@@ -439,9 +585,24 @@ def single_concept_route(concept_id: str) -> ResponseReturnValue:
             # Check if this is a notes-only or description-only update and handle it properly
             if "notes" in data and len(data) == 1:
                 # This is a notes-only update, use the proper notes update function
-                success = concept_service.update_concept_notes(
-                    concept_id, data["notes"]
+                governed = _execute_governed_http_mutation(
+                    method_name="upsert_singleton_text_relation",
+                    arguments={
+                        "concept_id": concept_id,
+                        "predicate": "hasNote",
+                        "text": data["notes"],
+                    },
+                    mutate=lambda: {
+                        "success": bool(
+                            concept_service.update_concept_notes(
+                                concept_id, data["notes"]
+                            )
+                        )
+                    },
                 )
+                if governed.get("success") is False:
+                    return _governed_mutation_response(governed)
+                success = True
                 if success:
                     # Return the updated concept with proper notes access
                     if concept_id.startswith("#V#"):
@@ -458,9 +619,24 @@ def single_concept_route(concept_id: str) -> ResponseReturnValue:
                 else:
                     return jsonify(error="Failed to update notes"), 500
             elif "description" in data and len(data) == 1:
-                success = concept_service.update_concept_description(
-                    concept_id, data["description"]
+                governed = _execute_governed_http_mutation(
+                    method_name="upsert_singleton_text_relation",
+                    arguments={
+                        "concept_id": concept_id,
+                        "predicate": "hasDescription",
+                        "text": data["description"],
+                    },
+                    mutate=lambda: {
+                        "success": bool(
+                            concept_service.update_concept_description(
+                                concept_id, data["description"]
+                            )
+                        )
+                    },
                 )
+                if governed.get("success") is False:
+                    return _governed_mutation_response(governed)
+                success = True
                 if success:
                     if concept_id.startswith("#V#"):
                         updated_concept = concept_service.get_concept_by_concept_id(
@@ -477,7 +653,19 @@ def single_concept_route(concept_id: str) -> ResponseReturnValue:
                     return jsonify(error="Failed to update description"), 500
             else:
                 # For other updates, use the generic function but fix notes field after
-                updated_concept = concept_service.update_concept(concept_id, data)
+                governed = _execute_governed_http_mutation(
+                    method_name="update_concept",
+                    arguments={"concept_id": concept_id, "update_data": data},
+                    mutate=lambda: {
+                        "success": True,
+                        "updated_concept": concept_service.update_concept(
+                            concept_id, data
+                        ),
+                    },
+                )
+                if governed.get("success") is False:
+                    return _governed_mutation_response(governed)
+                updated_concept = governed.get("updated_concept")
                 # Ensure notes field uses proper getter function for consistency
                 if updated_concept and "notes" in updated_concept:
                     updated_concept["notes"] = get_concept_notes(updated_concept)
@@ -505,7 +693,16 @@ def single_concept_route(concept_id: str) -> ResponseReturnValue:
 
     elif request.method == "DELETE":
         try:
-            success = concept_service.delete_concept(concept_id)
+            governed = _execute_governed_http_mutation(
+                method_name="delete_concept",
+                arguments={"concept_id": concept_id, "simulate": False},
+                mutate=lambda: {
+                    "success": bool(concept_service.delete_concept(concept_id))
+                },
+            )
+            if governed.get("success") is False:
+                return _governed_mutation_response(governed)
+            success = True
             if success:
                 return (
                     jsonify(message="concept deleted successfully"),
@@ -641,6 +838,20 @@ def import_concepts_route():
       - validate_concepts: 'true' | 'false' (default: 'true')
       - dry_run: 'true' | 'false' (default: 'false')
     """
+    return (
+        jsonify(
+            {
+                "success": False,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "error_code": "governed_ontology_mutation_required",
+                "error": "Concept imports require a governed ontology import command.",
+            }
+        ),
+        410,
+    )
+
+    # Retained below temporarily for source-history readability; unreachable.
     try:
         if "file" not in request.files:
             return jsonify(error="Missing 'file' in multipart form-data"), 400
@@ -872,7 +1083,22 @@ def update_concept_notes_route(concept_id: str):
         )
     try:
         # Use the specific notes update function instead of generic update_concept
-        success = concept_service.update_concept_notes(concept_id, data["notes"])
+        governed = _execute_governed_http_mutation(
+            method_name="upsert_singleton_text_relation",
+            arguments={
+                "concept_id": concept_id,
+                "predicate": "hasNote",
+                "text": data["notes"],
+            },
+            mutate=lambda: {
+                "success": bool(
+                    concept_service.update_concept_notes(concept_id, data["notes"])
+                )
+            },
+        )
+        if governed.get("success") is False:
+            return _governed_mutation_response(governed)
+        success = True
         if success:
             # Return the updated concept with proper notes access
             if concept_id.startswith("#V#"):
@@ -924,9 +1150,24 @@ def update_concept_description_route(concept_id: str):
             400,
         )
     try:
-        success = concept_service.update_concept_description(
-            concept_id, data["description"]
+        governed = _execute_governed_http_mutation(
+            method_name="upsert_singleton_text_relation",
+            arguments={
+                "concept_id": concept_id,
+                "predicate": "hasDescription",
+                "text": data["description"],
+            },
+            mutate=lambda: {
+                "success": bool(
+                    concept_service.update_concept_description(
+                        concept_id, data["description"]
+                    )
+                )
+            },
         )
+        if governed.get("success") is False:
+            return _governed_mutation_response(governed)
+        success = True
         if success:
             if concept_id.startswith("#V#"):
                 updated_concept = concept_service.get_concept_by_concept_id(concept_id)
@@ -979,16 +1220,6 @@ def rename_concept_route(concept_id: str):
     """
     from ...services.concept_rename_service import rename_concept
 
-    if not _can_rename_concept_id():
-        return (
-            jsonify(
-                error=(
-                    "Forbidden: concept ID rename requires an admin or owner session"
-                )
-            ),
-            403,
-        )
-
     data = request.get_json(silent=True) or {}
     if not isinstance(data, dict):
         return jsonify(error="JSON object body required"), 400
@@ -1004,13 +1235,28 @@ def rename_concept_route(concept_id: str):
     skip_inaccessible = _coerce_json_bool(data.get("skip_inaccessible"), default=False)
 
     try:
-        result = rename_concept(
-            old_id=concept_id,
-            new_id=new_id,
-            simulate=simulate,
-            preserve_alias=preserve_alias,
-            skip_inaccessible=skip_inaccessible,
+        result = _execute_governed_http_mutation(
+            method_name="rename_concept",
+            arguments={
+                "concept_id": concept_id,
+                "new_id": new_id,
+                "simulate": simulate,
+                "request_id": data.get("request_id"),
+            },
+            mutate=lambda: rename_concept(
+                old_id=concept_id,
+                new_id=new_id,
+                simulate=simulate,
+                preserve_alias=preserve_alias,
+                skip_inaccessible=skip_inaccessible,
+            ),
+            preview=simulate,
         )
+
+        if result.get("success") is False and (
+            result.get("authority_decision") or result.get("error_code")
+        ):
+            return _governed_mutation_response(result)
 
         if not result.get("success"):
             errors = result.get("errors", [])
@@ -1311,9 +1557,16 @@ def upsert_concept_text_route(concept_id: str):
         return jsonify(error="text (string) is required"), 400
     if not isinstance(lang, str) or not lang.strip():
         return jsonify(error="lang must be a non-empty string if provided"), 400
+    if not isinstance(provenance, dict):
+        return jsonify(error="provenance must be an object if provided"), 400
+    if not isinstance(context, dict):
+        return jsonify(error="context must be an object if provided"), 400
 
     predicate = predicate.strip()
+    text = text.strip()
     lang = lang.strip()
+    provenance = dict(provenance)
+    context = dict(context)
 
     allowed_predicates = {
         RelationPredicate.HAS_NAME,
@@ -1325,9 +1578,7 @@ def upsert_concept_text_route(concept_id: str):
     if predicate not in allowed_predicates and not predicate.startswith("#V#"):
         return jsonify(error=f"Unsupported predicate '{predicate}'"), 400
 
-    if predicate == RelationPredicate.HAS_NAME:
-        if not isinstance(context, dict):
-            context = {}
+    if predicate in {RelationPredicate.HAS_NAME, "#V#hasName"}:
         name_type = context.get("name_type")
         if name_type is None:
             context["name_type"] = "NL"
@@ -1339,24 +1590,37 @@ def upsert_concept_text_route(concept_id: str):
                     400,
                 )
             context["name_type"] = name_type_normalised
-    elif not isinstance(context, dict):
-        # Non-name predicates can omit context, normalise to empty dict for downstream consumers
-        context = {}
-
     try:
-        result = upsert_text_for_concept(
-            subject_concept_id=concept_id,
-            predicate=predicate,
-            text=text,
-            lang=lang,
-            provenance=provenance,
-            context=context,
+        predicate_resolution = resolve_text_relation_predicate_for_write(predicate)
+        canonical_predicate = predicate_resolution.storage_predicate
+        result = _execute_governed_http_mutation(
+            method_name="upsert_text_relation",
+            arguments={
+                "concept_id": concept_id,
+                "predicate": canonical_predicate,
+                "text": text,
+                "language": lang,
+                "provenance": provenance,
+                "context": context,
+                "request_id": payload.get("request_id"),
+            },
+            mutate=lambda: upsert_text_for_concept(
+                subject_concept_id=concept_id,
+                predicate=canonical_predicate,
+                text=text,
+                lang=lang,
+                provenance=provenance,
+                context=context,
+            ),
         )
+
+        if result.get("success") is False:
+            return _governed_mutation_response(result)
 
         maybe_sync_concept_text_relations_to_rag(
             namespace=_get_request_namespace(),
             concept_id=concept_id,
-            predicate=predicate,
+            predicate=canonical_predicate,
         )
         status = 201 if result.get("relation_created") else 200
         if result.get("context_updated"):
@@ -1367,6 +1631,8 @@ def upsert_concept_text_route(concept_id: str):
             else ("context-updated" if result.get("context_updated") else "exists")
         )
         return jsonify(result), status
+    except TextRelationPredicateResolutionError as exc:
+        return jsonify(error_code=exc.error_code, error=str(exc)), 400
     except PermissionError as pe:
         return jsonify(error=str(pe)), 403
     except Exception as e:
@@ -1384,14 +1650,33 @@ def update_concept_text_relation_route(concept_id: str, relation_id: str):
     lang = payload.get("lang") or "en"
     if not isinstance(new_text, str) or not new_text.strip():
         return jsonify(error="text (string) is required"), 400
+    if not isinstance(lang, str) or not lang.strip():
+        return jsonify(error="lang must be a non-empty string if provided"), 400
+    new_text = new_text.strip()
+    lang = lang.strip()
+    provenance = {"source": "update_text_relation"}
     try:
-        result = update_text_relation_text(
-            subject_concept_id=concept_id,
-            relation_id=relation_id,
-            new_text=new_text,
-            lang=lang,
-            provenance={"source": "update_text_relation"},
+        result = _execute_governed_http_mutation(
+            method_name="update_text_relation",
+            arguments={
+                "concept_id": concept_id,
+                "relation_id": relation_id,
+                "new_text": new_text,
+                "language": lang,
+                "provenance": provenance,
+                "request_id": payload.get("request_id"),
+            },
+            mutate=lambda: update_text_relation_text(
+                subject_concept_id=concept_id,
+                relation_id=relation_id,
+                new_text=new_text,
+                lang=lang,
+                provenance=provenance,
+            ),
         )
+
+        if result.get("success") is False:
+            return _governed_mutation_response(result)
 
         maybe_sync_concept_text_relations_to_rag(
             namespace=_get_request_namespace(),
@@ -1410,56 +1695,54 @@ def update_concept_text_relation_route(concept_id: str, relation_id: str):
 
 @concept_bp.route("/<string:concept_id>/texts", methods=["DELETE"])
 def delete_concept_text_by_predicate_route(concept_id: str):
-    """Delete a text relation by predicate and text value.
+    """Fail closed: predicate/text is not an exact mutation selector."""
 
-    Body JSON:
-      - predicate: string (required)
-      - text: string (required)
-    """
-    payload = request.get_json(silent=True) or {}
-    predicate = payload.get("predicate")
-    text = payload.get("text")
-    lang = payload.get("lang")
-    context = (
-        payload.get("context") if isinstance(payload.get("context"), dict) else None
+    return (
+        jsonify(
+            success=False,
+            effect_status="not_started",
+            mutation_outcome="not_started",
+            changed=False,
+            error_code="exact_text_relation_id_required",
+            error=(
+                "Predicate and text do not identify one immutable relation. "
+                "List the concept's text relations, then delete the selected "
+                "relation by its exact relation ID."
+            ),
+            concept_id=concept_id,
+            recovery_affordances=[
+                {
+                    "action_type": "list_text_relations",
+                    "method": "GET",
+                    "path": f"/api/concepts/{concept_id}/texts",
+                },
+                {
+                    "action_type": "delete_exact_text_relation",
+                    "method": "DELETE",
+                    "path_template": f"/api/concepts/{concept_id}/texts/<relation_id>",
+                },
+            ],
+        ),
+        410,
     )
-
-    if not isinstance(predicate, str) or not predicate.strip():
-        return jsonify(error="predicate (string) is required"), 400
-    if not isinstance(text, str) or not text.strip():
-        return jsonify(error="text (string) is required"), 400
-
-    predicate = predicate.strip()
-
-    try:
-        result = delete_text_relation_by_predicate_and_text(
-            concept_id,
-            predicate,
-            text,
-            lang=lang,
-            context=context,
-        )
-
-        maybe_delete_text_relation_doc_from_rag(
-            namespace=_get_request_namespace(),
-            relation_id=result.get("relation_id"),
-        )
-        return jsonify(result), 200
-    except ValueError as ve:
-        return jsonify(error=str(ve)), 404
-    except Exception as e:
-        current_app.logger.error(
-            f"Error deleting text relation by predicate {predicate} and text '{text}' for concept {concept_id}: {e}",
-            exc_info=True,
-        )
-        return jsonify(error="Failed to delete text relation"), 500
 
 
 @concept_bp.route("/<string:concept_id>/texts/<string:relation_id>", methods=["DELETE"])
 def delete_concept_text_relation_route(concept_id: str, relation_id: str):
     """Delete a specific text relation (e.g., remove a note)."""
     try:
-        result = delete_text_relation(concept_id, relation_id)
+        result = _execute_governed_http_mutation(
+            method_name="delete_text_relation",
+            arguments={
+                "concept_id": concept_id,
+                "relation_id": relation_id,
+                "request_id": (request.get_json(silent=True) or {}).get("request_id"),
+            },
+            mutate=lambda: delete_text_relation(concept_id, relation_id),
+        )
+
+        if result.get("success") is False:
+            return _governed_mutation_response(result)
 
         maybe_delete_text_relation_doc_from_rag(
             namespace=_get_request_namespace(),

--- a/src/backend/server/routes/ontology_authority_routes.py
+++ b/src/backend/server/routes/ontology_authority_routes.py
@@ -1,0 +1,540 @@
+"""Authenticated management surface for bounded ontology publication authority."""
+
+from __future__ import annotations
+
+import hmac
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from flask import Blueprint, jsonify, request, session
+
+from ...security.access_control import (
+    can_access_concept,
+    get_effective_organisation_concept_id,
+    get_effective_user_concept_id,
+)
+from ...services.ontology_authority_role_migration_service import (
+    ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+    OntologyAuthorityRoleMigrationError,
+    apply_ontology_authority_role_migration,
+    plan_ontology_authority_role_migration,
+)
+from ...services.ontology_authority_role_service import (
+    grant_ontology_authority_role,
+    list_manageable_ontology_authority_roles,
+    revoke_ontology_authority_role,
+)
+from ...services.ontology_authority_vocabulary_service import (
+    ONTOLOGY_AUTHORITY_VOCABULARY,
+    bootstrap_first_semantic_authority,
+)
+from ...services.ontology_mutation_command_service import (
+    OntologyMutationCommandError,
+    build_ontology_mutation_intent,
+    is_ontology_mutation_method,
+    scope_read_back,
+)
+from ...services.ontology_publication_authority_service import (
+    MAX_INTERACTIVE_DELEGATION_TTL_SECONDS,
+    get_mutation_receipt_for_actor,
+    issue_agent_delegation,
+    list_actor_delegations,
+    list_actor_semantic_authority,
+    revoke_agent_delegation,
+)
+from ...services.ontology_scope_change_service import (
+    change_concept_publication_scope,
+)
+from ...services.von_operational_administrator_service import (
+    bind_von_operational_administrator_bootstrap,
+    bootstrap_first_von_operational_administrator,
+    grant_von_operational_administrator,
+    revoke_von_operational_administrator,
+    von_operational_administrator_read_back,
+)
+from ...services.window_session_context_service import (
+    delete_all_window_contexts_owned_by,
+)
+
+ontology_authority_bp = Blueprint(
+    "ontology_authority", __name__, url_prefix="/api/ontology-authority"
+)
+
+
+def _payload() -> Mapping[str, Any]:
+    raw = request.get_json(silent=True)
+    return raw if isinstance(raw, Mapping) else {}
+
+
+def _authenticated_actor() -> str | None:
+    return get_effective_user_concept_id()
+
+
+def _authenticated_session_actor() -> str | None:
+    """Return only login-session identity; legacy identity headers do not qualify."""
+
+    actor_id = _clean(session.get("user_concept_id"))
+    if not actor_id:
+        return None
+    return actor_id if actor_id.startswith("#") else f"#V#{actor_id}"
+
+
+def _actor_required_response():
+    return jsonify({"error": "authenticated_actor_context_required"}), 401
+
+
+def _clean(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _enabled(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _public_authority_error(exc: Exception, *, default: str) -> str:
+    value = _clean(exc)
+    return value if value and " " not in value else default
+
+
+def _bootstrap_operator_authorised() -> bool:
+    """Bootstrap is an explicit local operator action, never semantic authority."""
+
+    if not _enabled(os.getenv("VON_ALLOW_ONTOLOGY_AUTHORITY_BOOTSTRAP")):
+        return False
+    expected = os.getenv("VON_ADMIN_TOKEN")
+    provided = request.headers.get("X-Von-Admin-Token") or request.headers.get(
+        "X-Admin-Token"
+    )
+    return bool(expected and provided and hmac.compare_digest(provided, expected))
+
+
+def _intent_from_delegation_payload(payload: Mapping[str, Any]):
+    method_name = _clean(payload.get("method_name"))
+    arguments = payload.get("arguments")
+    if not is_ontology_mutation_method(method_name):
+        raise OntologyMutationCommandError(
+            "ontology_mutation_method_not_governed",
+            "Delegation is available only for a governed ontology mutation method.",
+        )
+    if not isinstance(arguments, Mapping):
+        raise OntologyMutationCommandError(
+            "ontology_mutation_arguments_required",
+            "Delegation requires the exact governed method arguments.",
+        )
+    # The command builder derives actor, organisation, targets, and scope from
+    # trusted server context and canonical reads.  Payload identities are unused.
+    return build_ontology_mutation_intent(
+        method_name=method_name,
+        arguments=arguments,
+        idempotency_key=_clean(payload.get("idempotency_key")) or None,
+    )
+
+
+@ontology_authority_bp.route("/me", methods=["GET"])
+def current_semantic_authority():
+    actor_id = _authenticated_actor()
+    if not actor_id:
+        return _actor_required_response()
+    payload = list_actor_semantic_authority(actor_id)
+    payload["vocabulary"] = ONTOLOGY_AUTHORITY_VOCABULARY
+    return jsonify(payload)
+
+
+@ontology_authority_bp.route("/operational-administrator/me", methods=["GET"])
+def current_operational_administrator():
+    """Read the caller's distinct operational role without exposing semantics."""
+
+    actor_id = _authenticated_session_actor()
+    if not actor_id:
+        return _actor_required_response()
+    return jsonify(von_operational_administrator_read_back(subject_concept_id=actor_id))
+
+
+@ontology_authority_bp.route("/operational-administrators", methods=["POST"])
+def grant_operational_administrator():
+    """Use the dedicated lifecycle; generic ontology writes cannot grant it."""
+
+    if not _authenticated_session_actor():
+        return _actor_required_response()
+    payload = _payload()
+    try:
+        if _bootstrap_operator_authorised():
+            with bind_von_operational_administrator_bootstrap():
+                result = bootstrap_first_von_operational_administrator(
+                    subject_concept_id=_clean(payload.get("subject_concept_id")),
+                )
+        else:
+            result = grant_von_operational_administrator(
+                subject_concept_id=_clean(payload.get("subject_concept_id")),
+                reason=_clean(payload.get("reason")) or None,
+            )
+    except ValueError as exc:
+        return jsonify(
+            {"error": "invalid_von_operational_administrator", "message": str(exc)}
+        ), 400
+    except PermissionError as exc:
+        return jsonify(
+            {
+                "error": _public_authority_error(
+                    exc,
+                    default="von_operational_administrator_required",
+                )
+            }
+        ), 403
+    except RuntimeError:
+        return jsonify({"error": "von_operational_administrator_read_back_failed"}), 503
+    return jsonify(result), 201
+
+
+@ontology_authority_bp.route("/operational-administrators/revoke", methods=["POST"])
+def revoke_operational_administrator():
+    if not _authenticated_session_actor():
+        return _actor_required_response()
+    payload = _payload()
+    try:
+        result = revoke_von_operational_administrator(
+            subject_concept_id=_clean(payload.get("subject_concept_id")),
+            reason=_clean(payload.get("reason")) or None,
+        )
+    except ValueError as exc:
+        return jsonify(
+            {"error": "invalid_von_operational_administrator", "message": str(exc)}
+        ), 400
+    except PermissionError as exc:
+        return jsonify(
+            {
+                "error": _public_authority_error(
+                    exc,
+                    default="von_operational_administrator_required",
+                )
+            }
+        ), 403
+    except RuntimeError:
+        return jsonify({"error": "von_operational_administrator_read_back_failed"}), 503
+    return jsonify(result), 200
+
+
+@ontology_authority_bp.route("/delegations", methods=["GET"])
+def actor_delegations():
+    actor_id = _authenticated_actor()
+    if not actor_id:
+        return _actor_required_response()
+    include_inactive = _clean(
+        request.args.get("include_inactive", "true")
+    ).lower() not in {
+        "0",
+        "false",
+        "no",
+    }
+    try:
+        limit = int(request.args.get("limit", 100))
+    except (TypeError, ValueError):
+        limit = 100
+    return jsonify(
+        {
+            "delegations": list_actor_delegations(
+                actor_concept_id=actor_id,
+                include_inactive=include_inactive,
+                limit=max(1, min(limit, 250)),
+            )
+        }
+    )
+
+
+@ontology_authority_bp.route("/delegations", methods=["POST"])
+def issue_delegation():
+    actor_id = _authenticated_actor()
+    if not actor_id:
+        return _actor_required_response()
+    payload = _payload()
+    try:
+        intent = _intent_from_delegation_payload(payload)
+        delegate_id = _clean(payload.get("delegate_concept_id"))
+        audience = _clean(payload.get("audience"))
+        effect_id = _clean(payload.get("effect_id"))
+        if not delegate_id or not audience or not effect_id:
+            return jsonify(
+                {"error": "exact_delegate_audience_and_effect_required"}
+            ), 400
+        ttl_seconds = int(payload.get("ttl_seconds", 300))
+        delegation = issue_agent_delegation(
+            intent=intent,
+            grantor_actor_concept_id=actor_id,
+            grantor_organisation_concept_id=get_effective_organisation_concept_id(),
+            delegate_concept_id=delegate_id,
+            audience=audience,
+            tool_name=intent.tool_name or _clean(payload.get("method_name")),
+            effect_id=effect_id,
+            ttl_seconds=ttl_seconds,
+            turn_id=_clean(payload.get("turn_id")) or None,
+            workflow_id=_clean(payload.get("workflow_id")) or None,
+        )
+    except OntologyMutationCommandError as exc:
+        return jsonify({"error": exc.reason_code, "message": exc.public_message}), 400
+    except ValueError as exc:
+        return jsonify(
+            {"error": "invalid_ontology_delegation", "message": str(exc)}
+        ), 400
+    except PermissionError as exc:
+        return jsonify({"error": str(exc)}), 403
+    except RuntimeError:
+        return jsonify({"error": "ontology_authority_store_unavailable"}), 503
+    return jsonify(
+        {
+            "delegation": delegation,
+            "max_ttl_seconds": MAX_INTERACTIVE_DELEGATION_TTL_SECONDS,
+        }
+    ), 201
+
+
+@ontology_authority_bp.route("/delegations/<delegation_id>/revoke", methods=["POST"])
+def revoke_delegation(delegation_id: str):
+    actor_id = _authenticated_actor()
+    if not actor_id:
+        return _actor_required_response()
+    try:
+        delegation = revoke_agent_delegation(
+            delegation_id=delegation_id,
+            acting_actor_concept_id=actor_id,
+            reason=_clean(_payload().get("reason")) or "revoked_by_actor",
+        )
+    except LookupError:
+        return jsonify({"error": "ontology_delegation_not_found"}), 404
+    except PermissionError as exc:
+        return jsonify({"error": str(exc)}), 403
+    except RuntimeError:
+        return jsonify({"error": "ontology_authority_store_unavailable"}), 503
+    return jsonify({"delegation": delegation})
+
+
+@ontology_authority_bp.route("/receipts/<receipt_id>", methods=["GET"])
+def mutation_receipt(receipt_id: str):
+    actor_id = _authenticated_actor()
+    if not actor_id:
+        return _actor_required_response()
+    try:
+        receipt = get_mutation_receipt_for_actor(
+            receipt_id=receipt_id,
+            actor_concept_id=actor_id,
+        )
+    except RuntimeError:
+        return jsonify({"error": "ontology_authority_store_unavailable"}), 503
+    if receipt is None:
+        # Do not disclose whether another actor owns this receipt.
+        return jsonify({"error": "ontology_mutation_receipt_not_found"}), 404
+    return jsonify({"receipt": receipt})
+
+
+@ontology_authority_bp.route("/roles", methods=["GET"])
+def manageable_roles():
+    if not _authenticated_actor():
+        return _actor_required_response()
+    try:
+        roles = list_manageable_ontology_authority_roles()
+    except PermissionError as exc:
+        return jsonify(
+            {
+                "error": _public_authority_error(
+                    exc, default="ontology_authority_required"
+                )
+            }
+        ), 403
+    except RuntimeError:
+        return jsonify({"error": "ontology_authority_store_unavailable"}), 503
+    return jsonify({"roles": roles})
+
+
+@ontology_authority_bp.route("/roles", methods=["POST"])
+def grant_role():
+    if not _authenticated_actor():
+        return _actor_required_response()
+    payload = _payload()
+    try:
+        result = grant_ontology_authority_role(
+            subject_concept_id=_clean(payload.get("subject_concept_id")),
+            role=_clean(payload.get("role")),
+            organisation_concept_id=(
+                _clean(payload.get("organisation_concept_id")) or None
+            ),
+            request_id=_clean(payload.get("request_id")),
+            reason=_clean(payload.get("reason")) or None,
+        )
+    except ValueError as exc:
+        return jsonify(
+            {"error": "invalid_ontology_authority_role", "message": str(exc)}
+        ), 400
+    except PermissionError as exc:
+        return jsonify(
+            {
+                "error": _public_authority_error(
+                    exc, default="ontology_authority_required"
+                )
+            }
+        ), 403
+    except RuntimeError:
+        return jsonify({"error": "ontology_authority_store_unavailable"}), 503
+    status = 201 if result.get("success") else 403
+    return jsonify(result), status
+
+
+@ontology_authority_bp.route("/roles/revoke", methods=["POST"])
+def revoke_role():
+    if not _authenticated_actor():
+        return _actor_required_response()
+    payload = _payload()
+    try:
+        result = revoke_ontology_authority_role(
+            subject_concept_id=_clean(payload.get("subject_concept_id")),
+            role=_clean(payload.get("role")),
+            organisation_concept_id=(
+                _clean(payload.get("organisation_concept_id")) or None
+            ),
+            request_id=_clean(payload.get("request_id")),
+            reason=_clean(payload.get("reason")) or None,
+        )
+    except ValueError as exc:
+        return jsonify(
+            {"error": "invalid_ontology_authority_role", "message": str(exc)}
+        ), 400
+    except PermissionError as exc:
+        return jsonify(
+            {
+                "error": _public_authority_error(
+                    exc, default="ontology_authority_required"
+                )
+            }
+        ), 403
+    except RuntimeError:
+        return jsonify({"error": "ontology_authority_store_unavailable"}), 503
+    return jsonify(result), (200 if result.get("success") else 409)
+
+
+@ontology_authority_bp.route("/concepts/<path:concept_id>/scope", methods=["GET"])
+def concept_scope(concept_id: str):
+    if not _authenticated_actor():
+        return _actor_required_response()
+    if not can_access_concept(concept_id):
+        return jsonify({"error": "ontology_scope_target_not_found"}), 404
+    try:
+        return jsonify(scope_read_back(concept_id))
+    except LookupError:
+        return jsonify({"error": "ontology_scope_target_not_found"}), 404
+    except RuntimeError:
+        return jsonify({"error": "ontology_authority_store_unavailable"}), 503
+
+
+@ontology_authority_bp.route("/concepts/<path:concept_id>/scope", methods=["POST"])
+def change_concept_scope(concept_id: str):
+    if not _authenticated_actor():
+        return _actor_required_response()
+    payload = _payload()
+    try:
+        result = change_concept_publication_scope(
+            concept_id=concept_id,
+            destination_kind=_clean(payload.get("destination_kind")),
+            destination_concept_id=(
+                _clean(payload.get("destination_concept_id")) or None
+            ),
+            expected_scope_fingerprint=_clean(
+                payload.get("expected_scope_fingerprint")
+            ),
+            request_id=_clean(payload.get("request_id")),
+            preview=bool(payload.get("preview", True)),
+            reason=_clean(payload.get("reason")) or None,
+        )
+    except ValueError as exc:
+        return jsonify(
+            {"error": "invalid_ontology_scope_change", "message": str(exc)}
+        ), 400
+    except PermissionError:
+        return jsonify({"error": "ontology_scope_target_not_found"}), 404
+    except LookupError:
+        return jsonify({"error": "ontology_scope_target_not_found"}), 404
+    except RuntimeError:
+        return jsonify({"error": "ontology_authority_store_unavailable"}), 503
+    return jsonify(result), (200 if result.get("success") else 409)
+
+
+@ontology_authority_bp.route("/bootstrap", methods=["POST"])
+def bootstrap_authority_vocabulary():
+    """Opt-in operational bootstrap for one explicit first represented role."""
+
+    if not _bootstrap_operator_authorised():
+        return jsonify({"error": "ontology_authority_bootstrap_not_authorised"}), 403
+    payload = _payload()
+    try:
+        result = bootstrap_first_semantic_authority(
+            subject_concept_id=_clean(payload.get("subject_concept_id")),
+            role=_clean(payload.get("role")),
+            organisation_concept_id=_clean(payload.get("organisation_concept_id"))
+            or None,
+        )
+    except ValueError as exc:
+        return jsonify(
+            {"error": "invalid_ontology_authority_bootstrap", "message": str(exc)}
+        ), 400
+    except PermissionError as exc:
+        return jsonify({"error": str(exc)}), 409
+    except RuntimeError:
+        return jsonify({"error": "ontology_authority_bootstrap_read_back_failed"}), 503
+    return jsonify(result), 201
+
+
+@ontology_authority_bp.route("/bootstrap/role-migration", methods=["GET", "POST"])
+def migrate_initial_administrator_roles():
+    """Dry-run or apply the fixed, inventory-bound initial role migration."""
+
+    if not _bootstrap_operator_authorised():
+        return jsonify({"error": "ontology_authority_bootstrap_not_authorised"}), 403
+    if request.method == "GET":
+        try:
+            return jsonify(plan_ontology_authority_role_migration())
+        except RuntimeError:
+            return jsonify({"error": "ontology_authority_store_unavailable"}), 503
+
+    payload = _payload()
+    if _clean(payload.get("mode")).lower() != "apply":
+        return jsonify({"error": "ontology_authority_role_migration_mode_required"}), 400
+    # The target is fixed in server code. Client-supplied actor or subject fields
+    # are ignored and can neither redirect nor broaden the migration.
+    if _authenticated_session_actor() != ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET:
+        return jsonify(
+            {"error": "ontology_authority_role_migration_target_actor_required"}
+        ), 403
+    try:
+        # Only this route binds the already-verified operator bootstrap control.
+        # The migration and lifecycle services cannot self-authorise it.
+        with bind_von_operational_administrator_bootstrap():
+            result = apply_ontology_authority_role_migration(
+                expected_inventory_fingerprint=_clean(
+                    payload.get("expected_inventory_fingerprint")
+                )
+            )
+        session.pop("role_in_org", None)
+        result["derived_role_cache_invalidation"] = {
+            "flask_session_role_cleared": True,
+            "window_contexts_deleted": delete_all_window_contexts_owned_by(
+                ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET
+            ),
+        }
+    except OntologyAuthorityRoleMigrationError as exc:
+        status = (
+            403
+            if exc.reason_code
+            in {
+                "ontology_authority_role_migration_target_actor_required",
+                "ontology_authority_role_migration_human_actor_required",
+            }
+            else 409
+        )
+        response: dict[str, Any] = {
+            "error": exc.reason_code,
+            "message": exc.public_message,
+        }
+        if exc.report is not None:
+            response["report"] = exc.report
+        return jsonify(response), status
+    except RuntimeError:
+        return jsonify({"error": "ontology_authority_store_unavailable"}), 503
+    return jsonify(result), 200

--- a/src/backend/server/routes/settings_routes.py
+++ b/src/backend/server/routes/settings_routes.py
@@ -747,7 +747,6 @@ def get_db_guardrails():
     """Return redacted MongoDB cost/latency guardrails for operators."""
     try:
         effective_uri = get_effective_mongo_uri()
-        sanitized_uri = _sanitize_mongo_uri_for_display(effective_uri)
         fallback_policy = get_mongo_fallback_policy_state()
         connection_location = build_safe_mongo_connection_location(
             effective_uri,
@@ -2013,7 +2012,19 @@ def get_user_prefs(user_concept_id: str):
     try:
         if not user_concept_id:
             return jsonify({"error": "Missing user_concept_id"}), 400
+        actor_id = get_effective_user_concept_id()
+        if not actor_id:
+            return jsonify({"error": "authenticated_actor_context_required"}), 401
+        normalised_actor = actor_id if actor_id.startswith("#") else f"#V#{actor_id}"
+        normalised_subject = (
+            user_concept_id
+            if user_concept_id.startswith("#")
+            else f"#V#{user_concept_id}"
+        )
+        if normalised_subject != normalised_actor:
+            return jsonify({"error": "user_preferences_subject_mismatch"}), 403
         from ...services.concept_service import get_concept_by_concept_id
+        from ...services.text_value_service import get_texts_for_concept
 
         concept = get_concept_by_concept_id(concept_id=user_concept_id)
         if not concept:
@@ -2028,6 +2039,15 @@ def get_user_prefs(user_concept_id: str):
             return v if isinstance(v, str) and v else None
 
         preferred_language = first_val(lang_raw)
+        if preferred_language is None:
+            language_rows = get_texts_for_concept(
+                normalised_subject,
+                predicate=USER_PREF_LANG_PREDICATE,
+                limit=1,
+                recent_first=True,
+            )
+            if language_rows:
+                preferred_language = language_rows[0].get("text")
         organisation_concept_id = first_val(org_raw)
         return (
             jsonify(
@@ -2048,70 +2068,99 @@ def get_user_prefs(user_concept_id: str):
 
 @settings_bp.route("/user_prefs/<path:user_concept_id>", methods=["POST"])
 def set_user_prefs(user_concept_id: str):
-    """Upsert preferred language & organisation for a user concept.
-    Body: { preferred_language?: str|null, organisation_concept_id?: str|null }
-    Stores values in the concept's relationships dict under predicates defined above.
-    """
+    """Update only the authenticated user's non-authority preferences."""
     try:
         data = request.get_json(silent=True) or {}
-        preferred_language = data.get("preferred_language")
-        organisation_concept_id = data.get("organisation_concept_id")
-        from ...services.concept_service import (
-            get_concept_by_concept_id,
-            update_concept,
+        actor_id = get_effective_user_concept_id()
+        if not actor_id:
+            return jsonify({"error": "authenticated_actor_context_required"}), 401
+        normalised_actor = actor_id if actor_id.startswith("#") else f"#V#{actor_id}"
+        normalised_subject = (
+            user_concept_id
+            if user_concept_id.startswith("#")
+            else f"#V#{user_concept_id}"
         )
+        if normalised_subject != normalised_actor:
+            return jsonify({"error": "user_preferences_subject_mismatch"}), 403
+        if "organisation_concept_id" in data:
+            return (
+                jsonify(
+                    {
+                        "error": "organisation_membership_requires_dedicated_lifecycle",
+                        "message": (
+                            "Organisation membership is authority-bearing and cannot "
+                            "be changed through user preferences."
+                        ),
+                    }
+                ),
+                400,
+            )
+        preferred_language = data.get("preferred_language")
+        from ...services.concept_service import get_concept_by_concept_id
+        from ...services.ontology_mutation_command_service import (
+            execute_governed_ontology_method,
+        )
+        from ...services.text_value_service import upsert_singleton_text_relation
 
         concept = get_concept_by_concept_id(concept_id=user_concept_id)
         if not concept:
             return jsonify({"error": "User concept not found"}), 404
-        rel = _normalize_relationships(concept.get("relationships", {}))
-
-        def _as_list(value) -> list[str]:
-            if isinstance(value, list):
-                return [v for v in value if isinstance(v, str) and v]
-            if isinstance(value, str) and value:
-                return [value]
-            return []
-
-        # Preferred language update (single value)
-        existing_lang = _as_list(rel.get(USER_PREF_LANG_PREDICATE))
         desired_lang = (
             preferred_language.strip() if isinstance(preferred_language, str) else None
         )
         desired_lang = desired_lang or None
-
-        existing_lang = [desired_lang] if desired_lang else []
-        if existing_lang:
-            rel[USER_PREF_LANG_PREDICATE] = existing_lang
-        else:
-            rel.pop(USER_PREF_LANG_PREDICATE, None)
-
-        # Organisation membership update (single value)
-        existing_org = _as_list(rel.get(USER_PREF_ORG_PREDICATE))
-        desired_org = (
-            organisation_concept_id.strip()
-            if isinstance(organisation_concept_id, str)
-            else None
-        )
-        desired_org = desired_org or None
-
-        existing_org = [desired_org] if desired_org else []
-        if existing_org:
-            rel[USER_PREF_ORG_PREDICATE] = existing_org
-        else:
-            rel.pop(USER_PREF_ORG_PREDICATE, None)
-
-        # Persist updated relationships via the normal concept service update path.
-        update_concept(user_concept_id, {"relationships": rel})
+        governed: dict[str, Any] | None = None
+        if desired_lang:
+            preference_context = {"preference": "preferred_language"}
+            preference_provenance = {
+                "source": "user_preferences",
+                "actor_concept_id": normalised_actor,
+            }
+            governed = execute_governed_ontology_method(
+                method_name="upsert_singleton_text_relation",
+                arguments={
+                    "concept_id": normalised_subject,
+                    "predicate": USER_PREF_LANG_PREDICATE,
+                    "text": desired_lang,
+                    "language": "en-NZ",
+                    "context": preference_context,
+                    "provenance": preference_provenance,
+                    "request_id": data.get("request_id"),
+                },
+                mutate=lambda: upsert_singleton_text_relation(
+                    subject_concept_id=normalised_subject,
+                    predicate=USER_PREF_LANG_PREDICATE,
+                    text=desired_lang,
+                    lang="en-NZ",
+                    context=preference_context,
+                    provenance=preference_provenance,
+                ),
+            )
+            if governed.get("success") is False:
+                status = (
+                    503
+                    if governed.get("error_code")
+                    in {
+                        "ontology_mutation_receipt_store_unavailable",
+                        "ontology_mutation_receipt_finalisation_failed",
+                        "canonical_read_back_failed",
+                    }
+                    else 400
+                )
+                return jsonify(governed), status
 
         return (
             jsonify(
                 {
                     "status": "success",
                     "user_concept_id": user_concept_id,
-                    "preferred_language": existing_lang[0] if existing_lang else None,
-                    "organisation_concept_id": (
-                        existing_org[0] if existing_org else None
+                    "preferred_language": desired_lang,
+                    "organisation_concept_id": None,
+                    "authority_receipt": (
+                        governed.get("authority_receipt") if governed else None
+                    ),
+                    "canonical_read_back": (
+                        governed.get("canonical_read_back") if governed else None
                     ),
                 }
             ),
@@ -2673,6 +2722,22 @@ def _repair_concept_id(doc, index):
 @settings_bp.route("/export-ontology", methods=["GET"])
 def export_ontology():
     """API endpoint to export the entire concepts collection as JSON."""
+    return (
+        jsonify(
+            {
+                "success": False,
+                "error_code": "ontology_bulk_export_not_governed",
+                "error": (
+                    "Whole-ontology HTTP export is unavailable because it cannot "
+                    "preserve actor-scoped visibility."
+                ),
+            }
+        ),
+        410,
+    )
+
+    # Unreachable legacy implementation retained temporarily for compatibility
+    # archaeology; it must not be re-enabled without a scope-partitioned export.
     try:
         current_app.logger.info("Starting ontology export...")
 
@@ -2764,6 +2829,22 @@ def export_ontology():
 @settings_bp.route("/repair-ontology", methods=["POST"])
 def repair_ontology():
     """API endpoint to repair missing concept_ids in the database."""
+    return (
+        jsonify(
+            {
+                "success": False,
+                "error_code": "ontology_bulk_repair_not_governed",
+                "error": (
+                    "Whole-ontology HTTP repair is unavailable until it has an "
+                    "exact global-authority plan, receipt, and canonical read-back."
+                ),
+            }
+        ),
+        410,
+    )
+
+    # Unreachable legacy implementation retained temporarily for compatibility
+    # archaeology.
     try:
         current_app.logger.info("Starting ontology repair...")
 
@@ -2865,6 +2946,22 @@ def repair_ontology():
 @settings_bp.route("/import-ontology", methods=["POST"])
 def import_ontology():
     """API endpoint to import ontology JSON and replace the concepts collection."""
+    return (
+        jsonify(
+            {
+                "success": False,
+                "error_code": "ontology_bulk_import_not_governed",
+                "error": (
+                    "Whole-ontology HTTP import is unavailable until it has an "
+                    "exact global-authority plan, receipt, and canonical read-back."
+                ),
+            }
+        ),
+        410,
+    )
+
+    # Unreachable legacy implementation retained temporarily for compatibility
+    # archaeology.
     try:
         current_app.logger.info("Starting ontology import...")
 

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -21,7 +21,6 @@ from urllib.parse import unquote
 from dataclasses import asdict, is_dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterator, Mapping, Sequence, cast
-from ...security.visibility_predicates import CANONICAL_SPECIFIC_TO_USER_PREDICATE
 from ...workflows.durable.registry_factory import build_workflow_registry_read_only
 from ...workflows.durable.startup import get_instance_manager
 from ...workflows.durable.models import WorkflowInstanceStatus
@@ -4592,6 +4591,48 @@ def upload_file_to_blob_store_and_vontology():
             401,
         )
 
+    # An ordinary upload may create a private file-copy instance, but it must
+    # never bootstrap or repair the global ontology type as a side effect.
+    # Check this before storing bytes so a missing release prerequisite cannot
+    # leave an unreferenced blob behind.
+    from ...db.repositories.concepts_repository import ConceptsRepository
+    from ...security.access_control import bypass_access_control
+
+    type_concept_id = "#V#computer_file_copy"
+    try:
+        with bypass_access_control():
+            file_copy_type = ConceptsRepository.find_one(
+                {"concept_id": type_concept_id}
+            )
+    except Exception as exc:
+        current_app.logger.warning(
+            "[files/upload] File-copy type read failed: %s",
+            exc,
+        )
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "ontology_store_unavailable",
+                }
+            ),
+            503,
+        )
+    if not file_copy_type:
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "file_copy_type_not_provisioned",
+                    "message": (
+                        "The computer-file-copy ontology type is not provisioned; "
+                        "upload cannot create global ontology infrastructure."
+                    ),
+                }
+            ),
+            503,
+        )
+
     # Ensure the upload is associated with a stable chat session so it becomes part
     # of the same persisted history that /von/generate uses.
     if "session_id" not in session:
@@ -4663,59 +4704,11 @@ def upload_file_to_blob_store_and_vontology():
 
     blob_ref = stored.ref
 
-    # --- Ensure KR infrastructure exists ---
-    type_concept_id = "#V#computer_file_copy"
-
-    try:
-        from ...db.repositories.concepts_repository import ConceptsRepository
-        from ...vontology.utils_vontology import (
-            THING_PRIMARY_ID,
-            create_vontology_concept,
-            ensure_thing_exists_and_link_orphans,
-        )
-
-        if not ConceptsRepository.find_one({"concept_id": type_concept_id}):
-            # Prefer a store-of-information parent if present; otherwise fall back to Thing.
-            parent_id = (
-                "#V#store_of_information"
-                if ConceptsRepository.find_one(
-                    {"concept_id": "#V#store_of_information"}
-                )
-                else THING_PRIMARY_ID
-            )
-            if parent_id == THING_PRIMARY_ID:
-                # Best-effort: ensure Thing exists.
-                ensure_thing_exists_and_link_orphans()
-
-            created = create_vontology_concept(
-                parent_id=parent_id,
-                new_concept_name="Computer File Copy",
-                create_as_instance=False,
-                description=(
-                    "A computer file copy is an information-bearing artefact representing a specific stored byte sequence "
-                    "(for example an uploaded file stored in Von's blob store)."
-                ),
-                notes=(
-                    "Created on-demand by Von's chat file upload flow. Instances typically have blob store metadata "
-                    "(URI, key, content type, size, and hash) recorded as text relations."
-                ),
-            )
-            if not created.get("success"):
-                current_app.logger.warning(
-                    "[files/upload] Failed to create Computer File Copy type: %s",
-                    created.get("message"),
-                )
-    except Exception as exc:
-        current_app.logger.warning(
-            f"[files/upload] KR type ensure failed (continuing): {exc}"
-        )
-
     # --- Create the file-copy instance concept ---
     instance_concept_id = f"#V#uploaded_file_copy_{uuid.uuid4().hex}"
 
     try:
         from ...services import concept_service
-        from ...db.repositories.concepts_repository import ConceptsRepository
         from ...services.text_value_service import upsert_text_for_concept
 
         concept_service.create_concept(
@@ -4732,18 +4725,10 @@ def upload_file_to_blob_store_and_vontology():
                 "blob_key": blob_ref.key,
                 "blob_uri": blob_ref.uri,
             },
-        )
-
-        # Scope visibility to the current user.
-        ConceptsRepository.update_one(
-            {"concept_id": instance_concept_id},
-            {
-                "$set": {
-                    f"relationships.{CANONICAL_SPECIFIC_TO_USER_PREDICATE}": [
-                        user_concept_id.strip()
-                    ]
-                }
-            },
+            created_by_concept_id=user_concept_id.strip(),
+            visibility_scope_mode="user_only_default",
+            maintain_relationship_inverses=False,
+            resolve_visibility_from_event_namespace=False,
         )
 
         # Attach blob + metadata as text relations (authoritative)

--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -7,7 +7,7 @@ import uuid
 import time
 import logging
 from collections import defaultdict
-from typing import Any
+from typing import Any, Mapping
 
 try:
     from bson import ObjectId  # type: ignore
@@ -65,6 +65,47 @@ from ...services.window_session_context_service import get_effective_context
 from ...utilities.salient_recompute import recompute_salient_predicates
 
 vontology_bp = Blueprint("vontology", __name__)
+
+
+def _governed_mutation_response(
+    result: Mapping[str, Any], *, success_status: int = 200
+):
+    """Render the authority-command result; policy stays in the shared service."""
+
+    if result.get("success") is not False and not result.get("error_code"):
+        return jsonify(dict(result)), success_status
+    error_code = str(result.get("error_code") or "")
+    authority_denials = {
+        "authenticated_actor_context_required",
+        "client_supplied_identity_is_not_authority",
+        "von_operator_is_not_semantic_ontology_authority",
+        "global_ontology_admin_authority_required",
+        "organisation_ontology_admin_authority_required",
+        "ontology_publication_authority_required",
+        "private_scope_canonical_publication_not_delegated",
+        "dedicated_ontology_governance_operation_required",
+        "explicit_scope_adoption_required",
+        "ontology_mutation_target_not_accessible",
+    }
+    authority_decision = result.get("authority_decision")
+    decision_denied = isinstance(authority_decision, Mapping) and (
+        authority_decision.get("allowed") is False
+    )
+    if error_code in authority_denials or decision_denied:
+        return jsonify(dict(result)), 403
+    if error_code.endswith("not_found"):
+        return jsonify(dict(result)), 404
+    if error_code in {
+        "ontology_authority_store_unavailable",
+        "ontology_mutation_receipt_store_unavailable",
+        "ontology_mutation_store_unavailable",
+        "ontology_mutation_receipt_finalisation_failed",
+        "ontology_mutation_postcondition_failed",
+        "canonical_read_back_failed",
+        "ontology_mutation_replay_projection_unavailable",
+    }:
+        return jsonify(dict(result)), 503
+    return jsonify(dict(result)), 400
 
 # Simple in-memory TTL cache for instance counts: { key: (timestamp, payload) }
 # Key is a comma-joined sorted list of type ids. TTL is small to keep values fresh.
@@ -595,7 +636,7 @@ def get_tree():
 
 @vontology_bp.route("/ensure_thing", methods=["POST"])
 def ensure_thing_route():
-    """Endpoint to ensure Thing root concept exists and link any orphan concepts.
+    """Fail closed until root/orphan repair has an exact governed command.
 
     This is called automatically by the frontend when it detects an empty or incomplete ontology.
     It will:
@@ -605,6 +646,20 @@ def ensure_thing_route():
     Returns:
         JSON with thing_created, thing_concept_id, orphans_linked, orphan_ids
     """
+    return (
+        jsonify(
+            {
+                "success": False,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "error_code": "governed_ontology_mutation_required",
+                "error": "Root and orphan repair requires a governed ontology command.",
+            }
+        ),
+        410,
+    )
+
+    # Retained below temporarily for source-history readability; unreachable.
     current_app.logger.info("Received request for /api/vontology/ensure_thing")
 
     try:
@@ -790,7 +845,24 @@ def unified_delete_node():
     current_app.logger.info(
         f"[unified_delete:start] corr={correlation_id} simulate={simulate} concept={concept_id}"
     )
-    result = simulate_or_delete_concept(concept_id, execute=not simulate)
+    from ...services.ontology_mutation_command_service import (
+        execute_governed_ontology_method,
+    )
+
+    result = execute_governed_ontology_method(
+        method_name="delete_concept",
+        arguments={
+            "concept_id": concept_id,
+            "simulate": simulate,
+            "request_id": correlation_id,
+        },
+        mutate=lambda: simulate_or_delete_concept(concept_id, execute=not simulate),
+        preview=simulate,
+    )
+    if result.get("success") is False and result.get("authority_decision"):
+        response, status = _governed_mutation_response(result)
+        response.headers["X-Correlation-ID"] = correlation_id
+        return response, status
 
     status = 200
     if not result.get("success", False):
@@ -1134,7 +1206,26 @@ def update_description_route():
                 "Error resolving identifier to concept_id in update_description_route; using original"
             )
 
-        ok = update_concept_description(resolved_concept_id, description)
+        from ...services.ontology_mutation_command_service import (
+            execute_governed_ontology_method,
+        )
+
+        governed = execute_governed_ontology_method(
+            method_name="update_concept",
+            arguments={
+                "concept_id": resolved_concept_id,
+                "update_data": {"description": description},
+                "request_id": data.get("request_id"),
+            },
+            mutate=lambda: {
+                "success": bool(
+                    update_concept_description(resolved_concept_id, description)
+                )
+            },
+        )
+        if governed.get("success") is False:
+            return _governed_mutation_response(governed)
+        ok = True
         if not ok:
             return (
                 jsonify(
@@ -1164,7 +1255,21 @@ def update_description_route():
 
 @vontology_bp.route("/create_concept", methods=["POST"])
 def create_concept_route():
-    """Endpoint to create a new Vontology concept."""
+    """Deprecated unscoped creation path; use the governed concepts command."""
+    return (
+        jsonify(
+            {
+                "success": False,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "error_code": "governed_ontology_mutation_required",
+                "error": "Use the governed ontology concept creation API.",
+            }
+        ),
+        410,
+    )
+
+    # Retained below temporarily for source-history readability; unreachable.
     current_app.logger.info("Received request for /api/vontology/create_concept")
     data = request.get_json()
     if data is None:
@@ -1268,7 +1373,21 @@ def create_concept_route():
 
 @vontology_bp.route("/add_closure", methods=["POST"])
 def add_closure_route():
-    """API endpoint to add upward closure nodes for a Vontology concept."""
+    """Fail closed: closure materialisation needs an exact governed command."""
+    return (
+        jsonify(
+            {
+                "success": False,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "error_code": "governed_ontology_mutation_required",
+                "error": "Upward-closure materialisation requires a governed ontology command.",
+            }
+        ),
+        410,
+    )
+
+    # Retained below temporarily for source-history readability; unreachable.
     current_app.logger.info("Received request for /api/vontology/add_closure")
     data = request.get_json()
     if not data:
@@ -1342,6 +1461,20 @@ def import_nodes_route():
     2. Von format: A JSON object with concept_id keys.
     3. OpenCyc format: A JSON object with "nodes" and "edges" keys.
     """
+    return (
+        jsonify(
+            {
+                "success": False,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "error_code": "governed_ontology_mutation_required",
+                "error": "Ontology imports require a governed import command.",
+            }
+        ),
+        410,
+    )
+
+    # Retained below temporarily for source-history readability; unreachable.
     current_app.logger.info("Received request for /import_nodes")
 
     # Check if this is a file upload (FormData) or JSON
@@ -2412,9 +2545,21 @@ def debug_database():
 
 @vontology_bp.route("/delete_node", methods=["DELETE"])
 def delete_node():
-    """
-    Delete a specific node by concept_id.
-    """
+    """Deprecated unsafe delete path; use the governed /node endpoint."""
+    return (
+        jsonify(
+            {
+                "success": False,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "error_code": "governed_ontology_mutation_required",
+                "error": "Use DELETE /api/vontology/node for a governed ontology deletion.",
+            }
+        ),
+        410,
+    )
+
+    # Retained below temporarily for source-history readability; unreachable.
     current_app.logger.info("Received request for /api/vontology/delete_node")
 
     data = request.get_json()
@@ -3710,6 +3855,20 @@ def promote_uncertain_relationship_route():
         return jsonify({"success": False, "error": "Missing 'assertion_id'."}), 400
 
     try:
+        from ...integrations.internal_mcp.catalogue import (
+            _promote_uncertain_relationship_assertion,
+        )
+
+        return _governed_mutation_response(
+            _promote_uncertain_relationship_assertion(
+                source_id=source_id,
+                assertion_id=assertion_id,
+                # Do not treat the UI's descriptive operator field as authority.
+                operator="http",
+                request_id=data.get("request_id"),
+            )
+        )
+
         from ...services.uncertain_relationship_service import (
             promote_uncertain_relationship_assertion,
         )
@@ -3750,7 +3909,21 @@ def promote_uncertain_relationship_route():
 
 @vontology_bp.route("/relationships/uncertain/reject", methods=["POST"])
 def reject_uncertain_relationship_route():
-    """Reject an uncertain relationship assertion with an operator reason."""
+    """Fail closed until candidate rejection has an exact governed command."""
+    return (
+        jsonify(
+            {
+                "success": False,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "error_code": "governed_ontology_mutation_required",
+                "error": "Uncertain-assertion rejection requires a governed ontology command.",
+            }
+        ),
+        410,
+    )
+
+    # Retained below temporarily for source-history readability; unreachable.
     data = request.get_json(silent=True) or {}
     source_id = str(data.get("source_id") or "").strip()
     assertion_id = str(data.get("assertion_id") or "").strip()
@@ -3817,6 +3990,21 @@ def add_relationship_route():
     target_id = data.get("target_id")
     current_app.logger.info(
         f"Received request for /api/vontology/relationships/add: {data}"
+    )
+
+    # This legacy HTTP surface deliberately delegates all canonical writes to
+    # the catalogue command.  It derives actor/organisation from Flask's
+    # trusted context and ignores any identity fields in the JSON body.
+    from ...integrations.internal_mcp.catalogue import _add_relationship
+
+    return _governed_mutation_response(
+        _add_relationship(
+            source_id=source_id,
+            predicate=kind,
+            target=target_id,
+            request_id=data.get("request_id"),
+            namespace=None,
+        )
     )
 
     if not source_id or not target_id or not kind:
@@ -4664,6 +4852,25 @@ def remove_relationship_route():
         f"Received request for /api/vontology/relationships/remove: {data}"
     )
 
+    from ...integrations.internal_mcp.catalogue import _remove_relationship
+
+    return _governed_mutation_response(
+        _remove_relationship(
+            relation_id=relation_id,
+            source_id=source_id,
+            predicate=kind,
+            target=target_id,
+            mode=mode,
+            cascade=cascade,
+            dry_run=dry_run,
+            confirmed=confirmed,
+            # Client-controlled operator override cannot widen semantic authority.
+            operator_override=False,
+            reason=reason,
+            request_id=request_id,
+        )
+    )
+
     if not relation_id and (not source_id or not target_id or not kind):
         return (
             jsonify(
@@ -4946,9 +5153,9 @@ def preview_remove_relationship_route():
 def remove_relationships_bulk_route():
     """Bulk-remove relationships with deterministic summary reporting."""
     data = request.get_json() or {}
-    from ...services.relationship_removal_service import remove_relationships_bulk
+    from ...integrations.internal_mcp.catalogue import _remove_relationships_bulk
 
-    result = remove_relationships_bulk(
+    result = _remove_relationships_bulk(
         relation_ids=data.get("relation_ids"),
         relations=data.get("relations"),
         filter=data.get("filter"),
@@ -4956,45 +5163,29 @@ def remove_relationships_bulk_route():
         cascade=data.get("cascade"),
         dry_run=data.get("dry_run", False),
         confirmed=data.get("confirmed", False),
-        operator_override=data.get("operator_override", False),
+        operator_override=False,
         reason=data.get("reason"),
         request_id=data.get("request_id"),
         stop_on_error=data.get("stop_on_error", False),
     )
-
-    status_name = str(result.get("status") or "")
-    if status_name == "forbidden":
-        return jsonify(result), 403
-    if status_name == "confirmation_required":
-        return jsonify(result), 400
-    if status_name == "error":
-        return jsonify(result), 500 if not result.get("success") else 200
-    return jsonify(result), 200
+    return _governed_mutation_response(result)
 
 
 @vontology_bp.route("/relationships/remove/undo", methods=["POST"])
 def undo_relationship_removal_route():
-    """Restore a prior soft-delete relationship removal by undo_token."""
-    data = request.get_json() or {}
-    undo_token = data.get("undo_token")
-    if not undo_token:
-        return jsonify({"success": False, "error": "undo_token required"}), 400
-
-    from ...services.relationship_removal_service import undo_relationship_removal
-
-    result = undo_relationship_removal(
-        undo_token=undo_token,
-        request_id=data.get("request_id"),
-        confirmed=data.get("confirmed", True),
+    """Fail closed until relationship restoration has an exact governed command."""
+    return (
+        jsonify(
+            {
+                "success": False,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "error_code": "governed_relationship_restore_required",
+                "error": "Relationship restoration requires a governed ontology command.",
+            }
+        ),
+        410,
     )
-    status_name = str(result.get("status") or "")
-    if status_name == "not_found":
-        return jsonify(result), 404
-    if status_name == "confirmation_required":
-        return jsonify(result), 400
-    if status_name == "error":
-        return jsonify(result), 500
-    return jsonify(result), 200
 
 
 @vontology_bp.route("/concept/flag", methods=["POST"])
@@ -5008,14 +5199,23 @@ def toggle_concept_flag():
         concept_id = data["concept_id"]
         flagged = data.get("flagged", True)  # Default to True if not specified
         from ...db.repositories.concepts_repository import ConceptsRepository
-
-        # Update the concept with the flagged status
-        result = ConceptsRepository.update_one(
-            {"concept_id": concept_id}, {"$set": {"flagged": flagged}}
+        from ...services.ontology_mutation_command_service import (
+            execute_governed_ontology_method,
         )
 
-        if result.matched_count == 0:
-            return jsonify({"success": False, "error": "Concept not found"}), 404
+        governed = execute_governed_ontology_method(
+            method_name="update_concept",
+            arguments={"concept_id": concept_id, "update_data": {"flagged": flagged}},
+            mutate=lambda: {
+                "success": bool(
+                    ConceptsRepository.update_one(
+                        {"concept_id": concept_id}, {"$set": {"flagged": flagged}}
+                    ).matched_count
+                )
+            },
+        )
+        if governed.get("success") is False:
+            return _governed_mutation_response(governed)
 
         return (
             jsonify(
@@ -5038,7 +5238,28 @@ def toggle_concept_flag():
 
 @vontology_bp.route("/concept/organization-relation", methods=["POST"])
 def toggle_organization_relation():
-    """Toggle the specific_to_organisation relationship for a concept."""
+    """Deprecated: publication scope must use the dedicated governed command."""
+    return (
+        jsonify(
+            {
+                "success": False,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "error_code": "governed_scope_change_required",
+                "error": (
+                    "Concept publication scope changes require the governed "
+                    "scope-change API with an explicit preview fingerprint."
+                ),
+                "recovery_affordances": [
+                    {"action_type": "preview_concept_publication_scope"},
+                    {"action_type": "change_concept_publication_scope"},
+                ],
+            }
+        ),
+        410,
+    )
+
+    # Kept below temporarily for source-history readability; unreachable.
     try:
         data = request.get_json() or {}
         concept_id = data.get("concept_id")
@@ -5145,7 +5366,28 @@ def toggle_organization_relation():
 
 @vontology_bp.route("/concept/user-relation", methods=["POST"])
 def toggle_user_relation():
-    """Toggle the specific_to_user relationship for a concept."""
+    """Deprecated: publication scope must use the dedicated governed command."""
+    return (
+        jsonify(
+            {
+                "success": False,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "error_code": "governed_scope_change_required",
+                "error": (
+                    "Concept publication scope changes require the governed "
+                    "scope-change API with an explicit preview fingerprint."
+                ),
+                "recovery_affordances": [
+                    {"action_type": "preview_concept_publication_scope"},
+                    {"action_type": "change_concept_publication_scope"},
+                ],
+            }
+        ),
+        410,
+    )
+
+    # Kept below temporarily for source-history readability; unreachable.
     try:
         data = request.get_json() or {}
         concept_id = data.get("concept_id")
@@ -5248,13 +5490,10 @@ def toggle_key_concept():
     try:
         data = request.get_json()
         concept_id = data.get("concept_id")
-        user_concept_id = data.get("user_concept_id")
         action = data.get("action", "add")
 
         if not concept_id:
             return jsonify({"success": False, "error": "concept_id required"}), 400
-        if not user_concept_id:
-            return jsonify({"success": False, "error": "user_concept_id required"}), 400
         if action not in ["add", "remove"]:
             return (
                 jsonify(
@@ -5264,6 +5503,10 @@ def toggle_key_concept():
             )
 
         from ...db.repositories.concepts_repository import ConceptsRepository
+        from ...integrations.internal_mcp.catalogue import (
+            _add_relationship,
+            _remove_relationship,
+        )
 
         # Verify target concept exists
         target_concept = ConceptsRepository.find_one({"concept_id": concept_id})
@@ -5275,66 +5518,24 @@ def toggle_key_concept():
                 404,
             )
 
-        # Verify user concept exists
-        user_concept = ConceptsRepository.find_one({"concept_id": user_concept_id})
-        if not user_concept:
-            return (
-                jsonify(
-                    {
-                        "success": False,
-                        "error": f"User concept '{user_concept_id}' not found",
-                    }
-                ),
-                404,
-            )
-
         if action == "add":
-            # Add #V#vontologykeyconcept to is_an_instance_of relationship
-            result = ConceptsRepository.update_one(
-                {"concept_id": concept_id},
-                {
-                    "$addToSet": {
-                        "relationships.is_an_instance_of": "#V#vontologykeyconcept"
-                    }
-                },
+            result = _add_relationship(
+                source_id=concept_id,
+                predicate="is_an_instance_of",
+                target="#V#vontologykeyconcept",
+                request_id=data.get("request_id"),
             )
-
-            return (
-                jsonify(
-                    {
-                        "success": True,
-                        "action": "add",
-                        "concept_id": concept_id,
-                        "user_concept_id": user_concept_id,
-                        "modified": result.modified_count > 0,
-                    }
-                ),
-                200,
-            )
+            return _governed_mutation_response(result)
 
         else:  # remove
-            # Remove #V#vontologykeyconcept from is_an_instance_of relationship
-            result = ConceptsRepository.update_one(
-                {"concept_id": concept_id},
-                {
-                    "$pull": {
-                        "relationships.is_an_instance_of": "#V#vontologykeyconcept"
-                    }
-                },
+            result = _remove_relationship(
+                source_id=concept_id,
+                predicate="is_an_instance_of",
+                target="#V#vontologykeyconcept",
+                confirmed=bool(data.get("confirmed", False)),
+                request_id=data.get("request_id"),
             )
-
-            return (
-                jsonify(
-                    {
-                        "success": True,
-                        "action": "remove",
-                        "concept_id": concept_id,
-                        "user_concept_id": user_concept_id,
-                        "modified": result.modified_count > 0,
-                    }
-                ),
-                200,
-            )
+            return _governed_mutation_response(result)
 
     except Exception as e:
         current_app.logger.error(f"Error toggling key concept: {e}", exc_info=True)

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from .routes.speech_routes import speech_bp
     from .routes.task_routes import task_bp
     from .routes.message_routes import message_bp
+    from .routes.ontology_authority_routes import ontology_authority_bp
     from ..db.connection_manager import ensure_monitor_started, get_db
     from ..services.annotation_extraction_service import (
         PROMPT_CONCEPT_ID,
@@ -118,6 +119,10 @@ _bind_imports(
 _bind_imports("src.backend.server.routes.speech_routes", ["speech_bp"])
 _bind_imports("src.backend.server.routes.task_routes", ["task_bp"])
 _bind_imports("src.backend.server.routes.message_routes", ["message_bp"])
+_bind_imports(
+    "src.backend.server.routes.ontology_authority_routes",
+    ["ontology_authority_bp"],
+)
 _bind_imports(
     "src.backend.db.connection_manager",
     ["ensure_monitor_started", "get_db"],
@@ -2429,6 +2434,7 @@ def _register_default_blueprints(app: Flask) -> None:
     app.register_blueprint(admin_bp, url_prefix="/admin")
     app.register_blueprint(task_bp, url_prefix="/api/tasks")
     app.register_blueprint(message_bp, url_prefix="/api/messages")
+    app.register_blueprint(ontology_authority_bp)
     app.register_blueprint(auth_bp, url_prefix="/von")
     app.register_blueprint(agent_gmail_oauth_bp, url_prefix="/von")
 

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -6150,6 +6150,13 @@ def execute_adaptive_turn(
 
             assert gateway is not None
             definition = gateway.get_method_definition(execution_method_name)
+            from src.backend.services.ontology_mutation_command_service import (
+                is_ontology_mutation_method,
+            )
+
+            governed_ontology_method = bool(
+                is_effect and is_ontology_mutation_method(execution_method_name)
+            )
             subject_argument = (
                 definition.ordinary_turn_mutation_subject_argument
                 if definition is not None and is_effect
@@ -6162,7 +6169,7 @@ def execute_adaptive_turn(
             )
             if effect_denial is not None:
                 return index, contained(effect_denial)
-            if subject_argument:
+            if subject_argument and not governed_ontology_method:
                 if not _effect_subject_authorised(
                     arguments.get(subject_argument),
                     scope,
@@ -6244,6 +6251,7 @@ def execute_adaptive_turn(
                 if is_effect
                 else None
             )
+            ontology_delegation: Mapping[str, Any] | None = None
             if effect_identifier is not None:
                 dispatch_outcome = persist_effect_observation_phase(
                     effect_id=effect_identifier,
@@ -6314,6 +6322,40 @@ def execute_adaptive_turn(
                             }
                         )
                     return index, contained(denial_payload)
+            if governed_ontology_method and effect_identifier is not None:
+                from src.backend.services.ontology_mutation_command_service import (
+                    issue_same_turn_method_delegation,
+                )
+
+                with override_current_actor(
+                    scope.user_concept_id,
+                    scope.organisation_concept_id,
+                ):
+                    delegation_result = issue_same_turn_method_delegation(
+                        method_name=execution_method_name,
+                        arguments=arguments,
+                        actor_concept_id=scope.user_concept_id or "",
+                        organisation_concept_id=scope.organisation_concept_id,
+                        delegate_concept_id="#V#von_system",
+                        audience="adaptive_turn",
+                        effect_id=effect_identifier,
+                        turn_id=turn_id,
+                    )
+                if not isinstance(delegation_result.get("delegation_id"), str):
+                    persist_effect_observation_phase(
+                        effect_id=effect_identifier,
+                        phase="turn_terminal",
+                        observation={
+                            "call_id": call.call_id,
+                            "capability_name": canonical_name,
+                            "effect_status": "failed",
+                            "changed": False,
+                            "transport": {},
+                            "receipt": dict(delegation_result),
+                        },
+                    )
+                    return index, contained(delegation_result)
+                ontology_delegation = delegation_result
             try:
                 semantic_operation = build_semantic_operation_projection(
                     operation_id=call.call_id,
@@ -6353,11 +6395,9 @@ def execute_adaptive_turn(
                     scope.user_concept_id,
                     scope.organisation_concept_id,
                 ):
-                    transport_result = gateway.invoke(
-                        execution_method_name,
-                        arguments,
-                        deadline_monotonic=deadline_monotonic,
-                        late_completion_observer=(
+                    invoke_kwargs = {
+                        "deadline_monotonic": deadline_monotonic,
+                        "late_completion_observer": (
                             late_effect_observer(
                                 effect_id=effect_identifier,
                                 call_id=call.call_id,
@@ -6368,8 +6408,34 @@ def execute_adaptive_turn(
                             if effect_identifier is not None
                             else None
                         ),
-                        require_effect_admission_window=is_effect,
-                    )
+                        "require_effect_admission_window": is_effect,
+                    }
+                    if ontology_delegation is not None:
+                        from src.backend.services.ontology_publication_authority_service import (
+                            bind_ontology_invocation,
+                        )
+
+                        with bind_ontology_invocation(
+                            surface="ordinary_turn",
+                            executing_agent_concept_id="#V#von_system",
+                            audience="adaptive_turn",
+                            delegation_id=str(
+                                ontology_delegation.get("delegation_id") or ""
+                            ),
+                            effect_id=effect_identifier,
+                            turn_id=turn_id,
+                        ):
+                            transport_result = gateway.invoke(
+                                execution_method_name,
+                                arguments,
+                                **invoke_kwargs,
+                            )
+                    else:
+                        transport_result = gateway.invoke(
+                            execution_method_name,
+                            arguments,
+                            **invoke_kwargs,
+                        )
                 raw_payload = transport_result.payload
             except SchemaValidationError as exc:
                 output_invalid = exc.stage == "output_schema"

--- a/src/backend/services/concept_merge_service.py
+++ b/src/backend/services/concept_merge_service.py
@@ -1,24 +1,126 @@
-import logging
-from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+"""Exact, authority-bound concept identity consolidation.
 
-from pymongo.errors import DuplicateKeyError
+The public ``merge_concepts`` function remains the compatibility entry point,
+but execution now requires a server-built plan covered by the current governed
+ontology intent.  Preview is read-only.  The plan enumerates every concept
+document whose relationships would change, every source text relation, and the
+complete source/target documents.  Execution is conditionally idempotent: each
+step may be in its exact before or exact after state and any third state stops
+the merge with an honest partial/indeterminate result.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from collections.abc import Iterable, Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
 
 from ..db.repositories.concepts_repository import ConceptsRepository
-from ..db.repositories.text_value_repository import TextRelationsRepository
-from ..services.concept_service import get_concept_by_id, delete_concept
+from ..db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
+from ..security.access_control import bypass_access_control, can_access_concept
+from ..security.visibility_predicates import (
+    SPECIFIC_TO_ORG_PREDICATES_READ,
+    SPECIFIC_TO_USER_PREDICATES,
+)
+from .ontology_publication_authority_service import (
+    RESERVED_GENERIC_MUTATION_PREDICATES,
+    current_authorised_ontology_intent,
+)
+from .text_value_service import upsert_text_for_concept
 
 logger = logging.getLogger(__name__)
 
 PROTECTED_CONCEPTS = {"#V#Thing", "#V#Root", "#V#System"}
+MERGE_PLAN_SCHEMA_VERSION = "ontology_identity_consolidation_plan.v1"
+_SCOPE_PREDICATES = frozenset(
+    {*SPECIFIC_TO_USER_PREDICATES, *SPECIFIC_TO_ORG_PREDICATES_READ}
+)
+_AUTHORITY_PREDICATES = (
+    frozenset(RESERVED_GENERIC_MUTATION_PREDICATES) - _SCOPE_PREDICATES
+)
+_TARGET_IDENTITY_FIELDS = frozenset(
+    {
+        "_id",
+        "concept_id",
+        "guid",
+        "created_at",
+        "updated_at",
+        "embedding_status",
+        "relationships",
+        "names",
+        "name",
+        "attributes",
+        "system_tags",
+        "user_tags",
+    }
+)
 
 
-def _now() -> datetime:
-    return datetime.now(timezone.utc)
+@dataclass(frozen=True)
+class ConceptMergePlanError(ValueError):
+    reason_code: str
+    public_message: str
+
+    def __str__(self) -> str:
+        return self.public_message
 
 
-def _ordered_unique(values: Iterable[str]) -> List[str]:
-    result: List[str] = []
+class _ConceptMergeApplyError(RuntimeError):
+    def __init__(self, reason_code: str, public_message: str, *, changed: bool):
+        super().__init__(public_message)
+        self.reason_code = reason_code
+        self.public_message = public_message
+        self.changed = changed
+
+
+def _normalise_concept_id(value: Any) -> str | None:
+    cleaned = value.strip() if isinstance(value, str) else ""
+    if not cleaned:
+        return None
+    return cleaned if cleaned.startswith("#") else f"#V#{cleaned}"
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    ):
+        return [_json_safe(item) for item in value]
+    if hasattr(value, "isoformat"):
+        try:
+            return value.isoformat()
+        except Exception:  # noqa: BLE001 - stable string fallback below
+            return str(value)
+    return str(value)
+
+
+def _sha256(value: Any) -> str:
+    encoded = json.dumps(
+        _json_safe(value),
+        sort_keys=True,
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _plan_hash(plan: Mapping[str, Any]) -> str:
+    return _sha256({key: value for key, value in plan.items() if key != "plan_sha256"})
+
+
+def _ordered_unique(values: Iterable[str]) -> list[str]:
+    result: list[str] = []
     seen: set[str] = set()
     for raw in values:
         if not isinstance(raw, str):
@@ -31,427 +133,1044 @@ def _ordered_unique(values: Iterable[str]) -> List[str]:
     return result
 
 
-def _replace_value(value: Any, source_id: str, target_id: str) -> Tuple[Any, bool]:
-    """Replace occurrences of source_id with target_id within relationship values."""
-
+def _replace_value(value: Any, source_id: str, target_id: str) -> tuple[Any, bool]:
     if isinstance(value, str):
-        if value == source_id:
-            return target_id, True
-        return value, False
-
+        return (target_id, True) if value == source_id else (value, False)
     if isinstance(value, list):
         changed = False
-        replaced_list: List[Any] = []
+        replaced: list[Any] = []
         for item in value:
-            new_item, item_changed = _replace_value(item, source_id, target_id)
+            next_item, item_changed = _replace_value(item, source_id, target_id)
+            replaced.append(next_item)
             changed = changed or item_changed
-            replaced_list.append(new_item)
-
-        # Relationship lists are expected to be strings; enforce de-dup on strings.
-        if all(isinstance(x, str) for x in replaced_list):
-            deduped = _ordered_unique([x for x in replaced_list if isinstance(x, str)])
-            return deduped, changed or (deduped != replaced_list)
-
-        return replaced_list, changed
-
-    if isinstance(value, dict):
+        if all(isinstance(item, str) for item in replaced):
+            deduped = _ordered_unique(replaced)
+            return deduped, changed or deduped != replaced
+        return replaced, changed
+    if isinstance(value, Mapping):
         changed = False
-        out: Dict[str, Any] = {}
-        for k, v in value.items():
-            new_v, v_changed = _replace_value(v, source_id, target_id)
-            changed = changed or v_changed
-            out[k] = new_v
-        return out, changed
-
+        replaced_map: dict[str, Any] = {}
+        for key, item in value.items():
+            next_item, item_changed = _replace_value(item, source_id, target_id)
+            replaced_map[str(key)] = next_item
+            changed = changed or item_changed
+        return replaced_map, changed
     return value, False
 
 
 def _replace_relationships(
-    relationships: Any, source_id: str, target_id: str
-) -> Tuple[Dict[str, Any], bool]:
-    if not isinstance(relationships, dict):
+    relationships: Any,
+    source_id: str,
+    target_id: str,
+) -> tuple[dict[str, Any], bool]:
+    if not isinstance(relationships, Mapping):
         return {}, False
     changed = False
-    new_rels: Dict[str, Any] = {}
+    replaced: dict[str, Any] = {}
     for predicate, targets in relationships.items():
-        new_targets, targets_changed = _replace_value(targets, source_id, target_id)
+        next_targets, targets_changed = _replace_value(
+            targets,
+            source_id,
+            target_id,
+        )
+        replaced[str(predicate)] = next_targets
         changed = changed or targets_changed
-        new_rels[predicate] = new_targets
-    return new_rels, changed
+    return replaced, changed
 
 
 def _merge_relationship_maps(
-    target_relationships: Dict[str, Any], source_relationships: Dict[str, Any]
-) -> Tuple[Dict[str, Any], bool]:
-    """Merge source relationships into target; keep target ordering and add new uniques."""
-    merged: Dict[str, Any] = dict(target_relationships)
-    changed = False
-
+    target_relationships: Mapping[str, Any],
+    source_relationships: Mapping[str, Any],
+) -> dict[str, Any]:
+    merged: dict[str, Any] = deepcopy(dict(target_relationships))
     for predicate, source_targets in source_relationships.items():
-        if predicate not in merged:
-            merged[predicate] = source_targets
-            changed = True
+        if predicate in _SCOPE_PREDICATES:
+            # Publication scope belongs to the surviving identity. Source scope
+            # is authorised as a retraction, never copied into the destination.
             continue
-
+        if predicate in _AUTHORITY_PREDICATES and source_targets:
+            raise ConceptMergePlanError(
+                "identity_consolidation_authority_lifecycle_required",
+                (
+                    "An identity carrying authority or membership state must be "
+                    "migrated through its dedicated role lifecycle before merge."
+                ),
+            )
+        if predicate not in merged:
+            merged[predicate] = deepcopy(source_targets)
+            continue
         target_targets = merged.get(predicate)
         if isinstance(target_targets, list) or isinstance(source_targets, list):
-            t_list = (
-                target_targets
+            target_list = (
+                list(target_targets)
                 if isinstance(target_targets, list)
                 else ([target_targets] if isinstance(target_targets, str) else [])
             )
-            s_list = (
-                source_targets
+            source_list = (
+                list(source_targets)
                 if isinstance(source_targets, list)
                 else ([source_targets] if isinstance(source_targets, str) else [])
             )
-            if all(isinstance(x, str) for x in t_list + s_list):
-                combined = _ordered_unique([*t_list, *s_list])
-                if combined != t_list:
-                    merged[predicate] = combined
-                    changed = True
-            else:
-                # Fallback: keep target value.
-                pass
-        else:
-            # Both scalars
-            if target_targets != source_targets:
-                merged[predicate] = [target_targets, source_targets]
-                changed = True
-
-    return merged, changed
+            if all(isinstance(item, str) for item in (*target_list, *source_list)):
+                merged[predicate] = _ordered_unique([*target_list, *source_list])
+            elif target_targets != source_targets:
+                raise ConceptMergePlanError(
+                    "identity_consolidation_relationship_conflict",
+                    (
+                        "The source and target contain incompatible structured "
+                        "relationship values."
+                    ),
+                )
+        elif target_targets != source_targets:
+            merged[predicate] = [target_targets, source_targets]
+    return merged
 
 
 def _merge_legacy_names(
-    target_doc: Dict[str, Any], source_doc: Dict[str, Any]
-) -> Tuple[List[Dict[str, Any]], bool]:
-    """Merge legacy `names` entries (if present) without duplication."""
-    target_names = target_doc.get("names")
-    source_names = source_doc.get("names")
+    target_doc: Mapping[str, Any],
+    source_doc: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    seen: set[tuple[str, str, str]] = set()
+    merged: list[dict[str, Any]] = []
 
-    target_list = target_names if isinstance(target_names, list) else []
-    source_list = source_names if isinstance(source_names, list) else []
-
-    seen: set[Tuple[str, str, str]] = set()
-    merged: List[Dict[str, Any]] = []
-
-    def _normalise_entry(entry: Any) -> Optional[Dict[str, Any]]:
-        if not isinstance(entry, dict):
-            return None
-        name = entry.get("name")
-        if not isinstance(name, str) or not name.strip():
-            return None
-        language = entry.get("language")
-        if not isinstance(language, str) or not language.strip():
-            language = "en"
-        kind = entry.get("type")
-        if not isinstance(kind, str) or not kind.strip():
-            kind = "NL"
-        return {
-            "name": name.strip(),
-            "language": language.strip(),
-            "type": kind.strip(),
-        }
-
-    for entry in target_list:
-        norm = _normalise_entry(entry)
-        if not norm:
-            continue
-        key = (norm["name"], norm["language"], norm["type"])
+    def add(entry: Any) -> None:
+        if not isinstance(entry, Mapping):
+            return
+        name = str(entry.get("name") or "").strip()
+        if not name:
+            return
+        language = str(entry.get("language") or "en").strip() or "en"
+        kind = str(entry.get("type") or "NL").strip() or "NL"
+        key = (name, language, kind)
         if key in seen:
-            continue
+            return
         seen.add(key)
-        merged.append(norm)
+        merged.append({"name": name, "language": language, "type": kind})
 
-    changed = False
-    for entry in source_list:
-        norm = _normalise_entry(entry)
-        if not norm:
+    for entry in target_doc.get("names") or []:
+        add(entry)
+    for entry in source_doc.get("names") or []:
+        add(entry)
+    source_name = str(source_doc.get("name") or "").strip()
+    if source_name and source_name != str(target_doc.get("name") or "").strip():
+        add({"name": source_name, "language": "en", "type": "NL"})
+    return merged
+
+
+def _merge_mapping_without_conflict(
+    target_value: Any,
+    source_value: Any,
+    *,
+    field_name: str,
+) -> dict[str, Any]:
+    target = dict(target_value) if isinstance(target_value, Mapping) else {}
+    source = dict(source_value) if isinstance(source_value, Mapping) else {}
+    merged = deepcopy(target)
+    for key, value in source.items():
+        if key in merged and merged[key] != value:
+            raise ConceptMergePlanError(
+                "identity_consolidation_metadata_conflict",
+                f"Source and target have conflicting {field_name} metadata.",
+            )
+        merged.setdefault(str(key), deepcopy(value))
+    return merged
+
+
+def _merge_target_document(
+    *,
+    source_doc: Mapping[str, Any],
+    target_doc: Mapping[str, Any],
+    target_relationships: Mapping[str, Any],
+) -> dict[str, Any]:
+    merged = deepcopy(dict(target_doc))
+    merged["relationships"] = deepcopy(dict(target_relationships))
+    names = _merge_legacy_names(target_doc, source_doc)
+    if names or "names" in target_doc or "names" in source_doc:
+        merged["names"] = names
+    merged["attributes"] = _merge_mapping_without_conflict(
+        target_doc.get("attributes"),
+        source_doc.get("attributes"),
+        field_name="attribute",
+    )
+    merged["system_tags"] = _ordered_unique(
+        [*(target_doc.get("system_tags") or []), *(source_doc.get("system_tags") or [])]
+    )
+    merged["user_tags"] = _ordered_unique(
+        [*(target_doc.get("user_tags") or []), *(source_doc.get("user_tags") or [])]
+    )
+    merged["embedding_status"] = "pending"
+
+    legacy_description = str(source_doc.get("description") or "").strip()
+    if legacy_description:
+        raise ConceptMergePlanError(
+            "identity_consolidation_legacy_text_migration_required",
+            (
+                "The source still carries legacy inline descriptive text; migrate "
+                "it to canonical text relations before identity consolidation."
+            ),
+        )
+
+    for key, value in source_doc.items():
+        if key in _TARGET_IDENTITY_FIELDS or key == "description":
             continue
-        key = (norm["name"], norm["language"], norm["type"])
-        if key in seen:
+        if key not in merged:
+            merged[key] = deepcopy(value)
+        elif merged[key] != value:
+            raise ConceptMergePlanError(
+                "identity_consolidation_metadata_conflict",
+                "Source and target have conflicting canonical metadata.",
+            )
+    return merged
+
+
+def _raw_concept(concept_id: str) -> dict[str, Any] | None:
+    with bypass_access_control():
+        document = ConceptsRepository.find_one({"concept_id": concept_id})
+    return dict(document) if isinstance(document, Mapping) else None
+
+
+def _raw_concepts() -> list[dict[str, Any]]:
+    with bypass_access_control():
+        return [
+            dict(document)
+            for document in ConceptsRepository.find({})
+            if isinstance(document, Mapping)
+        ]
+
+
+def _raw_text_relations(subject_id: str) -> list[dict[str, Any]]:
+    return [
+        dict(relation)
+        for relation in TextRelationsRepository.find({"subject_concept_id": subject_id})
+        if isinstance(relation, Mapping)
+    ]
+
+
+def _relation_snapshot(relation: Mapping[str, Any]) -> dict[str, Any]:
+    return deepcopy(dict(relation))
+
+
+def _raw_text_value(object_text_id: Any) -> dict[str, Any] | None:
+    text_value = TextValuesRepository.find_one({"_id": object_text_id})
+    if not isinstance(text_value, Mapping):
+        try:
+            from bson import ObjectId
+
+            text_value = TextValuesRepository.find_one(
+                {"_id": ObjectId(str(object_text_id))}
+            )
+        except Exception:  # string identifiers are valid in fixtures
+            text_value = None
+    return dict(text_value) if isinstance(text_value, Mapping) else None
+
+
+def _text_assertion_precondition(relation: Mapping[str, Any]) -> dict[str, Any]:
+    relation_id = _relation_id(relation.get("_id"))
+    text_value = _raw_text_value(relation.get("object_text_id"))
+    if not relation_id or text_value is None:
+        raise ConceptMergePlanError(
+            "identity_consolidation_unaddressable_text_state",
+            "A text assertion cannot be addressed and read exactly.",
+        )
+    relation_snapshot = _relation_snapshot(relation)
+    text_value_snapshot = deepcopy(text_value)
+    return {
+        "relation_id": relation_id,
+        "relation": relation_snapshot,
+        "relation_sha256": _sha256(relation_snapshot),
+        "text_value": text_value_snapshot,
+        "text_value_sha256": _sha256(text_value_snapshot),
+    }
+
+
+def _relation_id(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _document_step(
+    before_document: Mapping[str, Any],
+    after_document: Mapping[str, Any],
+) -> dict[str, Any]:
+    concept_id = _normalise_concept_id(before_document.get("concept_id"))
+    if not concept_id:
+        raise ConceptMergePlanError(
+            "identity_consolidation_unaddressable_affected_state",
+            "An affected ontology record has no canonical concept identity.",
+        )
+    return {
+        "concept_id": concept_id,
+        "before_document": deepcopy(dict(before_document)),
+        "after_document": deepcopy(dict(after_document)),
+        "before_sha256": _sha256(before_document),
+        "after_sha256": _sha256(after_document),
+    }
+
+
+def build_concept_merge_plan(source_id: str, target_id: str) -> dict[str, Any]:
+    """Build a complete, non-disclosing identity-consolidation plan."""
+
+    source = _normalise_concept_id(source_id)
+    target = _normalise_concept_id(target_id)
+    if not source or not target:
+        raise ConceptMergePlanError(
+            "ontology_mutation_subject_required",
+            "Concept merge requires exact source and target identities.",
+        )
+    if source == target:
+        raise ConceptMergePlanError(
+            "identity_consolidation_same_identity",
+            "Source and target concepts must be different.",
+        )
+    if source in PROTECTED_CONCEPTS:
+        raise ConceptMergePlanError(
+            "identity_consolidation_protected_source",
+            "The requested source concept is protected from consolidation.",
+        )
+    if not can_access_concept(source) or not can_access_concept(target):
+        raise ConceptMergePlanError(
+            "ontology_mutation_target_not_accessible",
+            "The requested identity consolidation is not accessible in this context.",
+        )
+
+    source_doc = _raw_concept(source)
+    target_doc = _raw_concept(target)
+    if source_doc is None or target_doc is None:
+        raise ConceptMergePlanError(
+            "ontology_mutation_target_not_found",
+            "The requested identity consolidation target was not found.",
+        )
+
+    concept_steps_by_id: dict[str, dict[str, Any]] = {}
+    target_replaced_relationships, target_refs_changed = _replace_relationships(
+        target_doc.get("relationships"), source, target
+    )
+    if target_refs_changed:
+        for predicate in RESERVED_GENERIC_MUTATION_PREDICATES:
+            before_value = (target_doc.get("relationships") or {}).get(predicate)
+            after_value = target_replaced_relationships.get(predicate)
+            if before_value != after_value:
+                raise ConceptMergePlanError(
+                    "identity_consolidation_authority_lifecycle_required",
+                    (
+                        "Identity consolidation cannot rewrite authority, membership, "
+                        "or publication-scope principals."
+                    ),
+                )
+
+    for document in _raw_concepts():
+        concept_id = _normalise_concept_id(document.get("concept_id"))
+        if concept_id == source:
             continue
-        seen.add(key)
-        merged.append(norm)
-        changed = True
+        replaced, changed = _replace_relationships(
+            document.get("relationships"), source, target
+        )
+        if not changed:
+            continue
+        if not concept_id:
+            raise ConceptMergePlanError(
+                "identity_consolidation_unaddressable_affected_state",
+                "An affected ontology record has no canonical concept identity.",
+            )
+        for predicate in RESERVED_GENERIC_MUTATION_PREDICATES:
+            before_value = (document.get("relationships") or {}).get(predicate)
+            after_value = replaced.get(predicate)
+            if before_value != after_value:
+                raise ConceptMergePlanError(
+                    "identity_consolidation_authority_lifecycle_required",
+                    (
+                        "Identity consolidation cannot rewrite authority, membership, "
+                        "or publication-scope principals."
+                    ),
+                )
+        if concept_id == target:
+            target_replaced_relationships = replaced
+            continue
+        after = deepcopy(document)
+        after["relationships"] = replaced
+        concept_steps_by_id[concept_id] = _document_step(document, after)
 
-    # Also add source top-level name as an alias when distinct.
-    source_top = source_doc.get("name")
-    if isinstance(source_top, str) and source_top.strip():
-        source_top = source_top.strip()
-        target_top = target_doc.get("name")
-        if source_top != target_top:
-            key = (source_top, "en", "NL")
-            if key not in seen:
-                merged.append({"name": source_top, "language": "en", "type": "NL"})
-                changed = True
+    source_relationships, _ = _replace_relationships(
+        source_doc.get("relationships"), source, target
+    )
+    merged_relationships = _merge_relationship_maps(
+        target_replaced_relationships,
+        source_relationships,
+    )
+    target_after = _merge_target_document(
+        source_doc=source_doc,
+        target_doc=target_doc,
+        target_relationships=merged_relationships,
+    )
+    concept_steps_by_id[target] = _document_step(target_doc, target_after)
 
-    return merged, changed
+    affected_ids = tuple(sorted({source, target, *concept_steps_by_id.keys()}))
+    if not all(can_access_concept(concept_id) for concept_id in affected_ids):
+        raise ConceptMergePlanError(
+            "identity_consolidation_inaccessible_affected_state",
+            (
+                "Identity consolidation cannot proceed because its complete "
+                "affected graph is not accessible to the current actor."
+            ),
+        )
+
+    source_relations = _raw_text_relations(source)
+    target_relations = _raw_text_relations(target)
+    for relation in source_relations:
+        if str(relation.get("predicate") or "").strip() in (
+            RESERVED_GENERIC_MUTATION_PREDICATES
+        ):
+            raise ConceptMergePlanError(
+                "identity_consolidation_authority_lifecycle_required",
+                (
+                    "An identity carrying authority, membership, or scope state "
+                    "must be migrated through its dedicated lifecycle first."
+                ),
+            )
+
+    target_preconditions = [
+        _text_assertion_precondition(relation)
+        for relation in sorted(
+            target_relations,
+            key=lambda row: _relation_id(row.get("_id")),
+        )
+    ]
+    target_keys = {
+        (
+            str(relation.get("predicate") or "").strip(),
+            str(relation.get("object_text_id") or ""),
+        )
+        for relation in target_relations
+        if str(relation.get("predicate") or "").strip()
+        and relation.get("object_text_id") is not None
+    }
+    text_steps: list[dict[str, Any]] = []
+    for relation in sorted(
+        source_relations, key=lambda row: _relation_id(row.get("_id"))
+    ):
+        relation_id = _relation_id(relation.get("_id"))
+        predicate = str(relation.get("predicate") or "").strip()
+        object_text_id = relation.get("object_text_id")
+        if not relation_id or not predicate or object_text_id is None:
+            raise ConceptMergePlanError(
+                "identity_consolidation_unaddressable_text_state",
+                "A source text relation cannot be addressed exactly.",
+            )
+        key = (predicate, str(object_text_id))
+        action = "delete_duplicate" if key in target_keys else "move"
+        before = _relation_snapshot(relation)
+        assertion_precondition = _text_assertion_precondition(relation)
+        after = None
+        if action == "move":
+            after = deepcopy(before)
+            after["subject_concept_id"] = target
+            target_keys.add(key)
+        text_steps.append(
+            {
+                "relation_id": relation_id,
+                "action": action,
+                "before_relation": before,
+                "after_relation": after,
+                "before_sha256": _sha256(before),
+                "after_sha256": _sha256(after) if after is not None else None,
+                "text_value": assertion_precondition["text_value"],
+                "text_value_sha256": assertion_precondition["text_value_sha256"],
+            }
+        )
+
+    aliases = _ordered_unique([source, str(source_doc.get("guid") or "").strip()])
+    for alias in aliases:
+        matching_target_names = []
+        for relation in target_relations:
+            if str(relation.get("predicate") or "") not in {"hasName", "#V#hasName"}:
+                continue
+            text_value = _raw_text_value(relation.get("object_text_id"))
+            if (
+                isinstance(text_value, Mapping)
+                and str(text_value.get("text") or "") == alias
+            ):
+                matching_target_names.append(relation)
+        if matching_target_names and not any(
+            isinstance(relation.get("context"), Mapping)
+            and relation["context"].get("name_type") == "CODE"
+            for relation in matching_target_names
+        ):
+            raise ConceptMergePlanError(
+                "identity_consolidation_alias_context_conflict",
+                (
+                    "A required source identifier already exists on the target "
+                    "with incompatible name context. Resolve that name explicitly "
+                    "before identity consolidation."
+                ),
+            )
+    plan: dict[str, Any] = {
+        "schema_version": MERGE_PLAN_SCHEMA_VERSION,
+        "source_id": source,
+        "target_id": target,
+        "source_before_document": deepcopy(source_doc),
+        "source_before_sha256": _sha256(source_doc),
+        "concept_steps": [
+            concept_steps_by_id[concept_id]
+            for concept_id in sorted(concept_steps_by_id)
+        ],
+        "text_relation_steps": text_steps,
+        "target_text_relation_preconditions": target_preconditions,
+        "required_code_aliases": aliases,
+        "affected_concept_ids": list(affected_ids),
+        # Lock every existing source and target text relation while the exact
+        # plan is rechecked and applied.  Target rows participate in duplicate
+        # resolution even when they do not themselves become mutation steps.
+        "affected_text_relation_ids": sorted(
+            {
+                *(
+                    step["relation_id"]
+                    for step in text_steps
+                    if step.get("relation_id")
+                ),
+                *(
+                    relation_id
+                    for relation in target_relations
+                    if (relation_id := _relation_id(relation.get("_id")))
+                ),
+            }
+        ),
+    }
+    plan["plan_sha256"] = _plan_hash(plan)
+    return plan
 
 
-def merge_concepts(
-    source_id: str, target_id: str, simulate: bool = True
-) -> Dict[str, Any]:
-    """
-    Merges source_concept into target_concept.
-
-    1. Moves all relationships from source to target.
-    2. Moves all names/aliases from source to target.
-    3. Moves all text values (notes, etc) from source to target.
-    4. Deletes source concept.
-
-    Args:
-        source_id: The concept_id of the concept to be merged and deleted.
-        target_id: The concept_id of the concept to receive the data.
-        simulate: If True, only returns a report of what would happen.
-
-    Returns:
-        Dict containing the merge report/result.
-    """
-    report = {
-        "success": False,
+def _public_plan_report(plan: Mapping[str, Any], *, simulate: bool) -> dict[str, Any]:
+    concept_steps = list(plan.get("concept_steps") or [])
+    text_steps = list(plan.get("text_relation_steps") or [])
+    incoming_count = sum(
+        1
+        for step in concept_steps
+        if isinstance(step, Mapping) and step.get("concept_id") != plan.get("target_id")
+    )
+    return {
+        "success": True,
         "simulate": simulate,
-        "source_id": source_id,
-        "target_id": target_id,
-        "operations": [],
+        "executed": False,
+        "changed": False,
+        "source_id": plan.get("source_id"),
+        "target_id": plan.get("target_id"),
+        "plan_sha256": plan.get("plan_sha256"),
+        "affected_concept_count": len(plan.get("affected_concept_ids") or []),
+        "operations": [
+            {
+                "type": "rewrite_incoming_relationship_references",
+                "count": incoming_count,
+            },
+            {"type": "merge_source_into_target", "count": 1},
+            {
+                "type": "migrate_text_relations",
+                "move_count": sum(
+                    1
+                    for step in text_steps
+                    if isinstance(step, Mapping) and step.get("action") == "move"
+                ),
+                "duplicate_count": sum(
+                    1
+                    for step in text_steps
+                    if isinstance(step, Mapping)
+                    and step.get("action") == "delete_duplicate"
+                ),
+            },
+            {"type": "delete_source", "count": 1},
+        ],
         "warnings": [],
         "errors": [],
     }
 
-    if source_id in PROTECTED_CONCEPTS:
-        report["errors"].append(
-            f"Source concept {source_id} is protected and cannot be merged."
+
+def _validate_plan(plan: Mapping[str, Any], source_id: str, target_id: str) -> None:
+    if plan.get("schema_version") != MERGE_PLAN_SCHEMA_VERSION:
+        raise _ConceptMergeApplyError(
+            "identity_consolidation_plan_invalid",
+            "The identity-consolidation plan version is invalid.",
+            changed=False,
         )
-        return report
+    if (
+        _normalise_concept_id(plan.get("source_id")) != source_id
+        or _normalise_concept_id(plan.get("target_id")) != target_id
+        or str(plan.get("plan_sha256") or "") != _plan_hash(plan)
+    ):
+        raise _ConceptMergeApplyError(
+            "identity_consolidation_plan_invalid",
+            "The identity-consolidation plan does not match this exact effect.",
+            changed=False,
+        )
+    intent = current_authorised_ontology_intent()
+    if (
+        intent is None
+        or intent.operation != "concept.merge"
+        or str(intent.delta.get("merge_plan_sha256") or "")
+        != str(plan.get("plan_sha256") or "")
+        or set(intent.target_concept_ids) != set(plan.get("affected_concept_ids") or [])
+    ):
+        raise _ConceptMergeApplyError(
+            "ontology_identity_consolidation_authority_required",
+            (
+                "Identity consolidation requires an exact currently authorised "
+                "merge plan."
+            ),
+            changed=False,
+        )
 
-    if source_id == target_id:
-        report["errors"].append("Source and target concepts must be different.")
-        return report
 
-    source_doc = get_concept_by_id(source_id)
-    target_doc = get_concept_by_id(target_id)
+def _raw_relation_by_id(relation_id: Any) -> dict[str, Any] | None:
+    raw_id = relation_id
+    try:
+        from bson import ObjectId
 
-    if not source_doc:
-        report["errors"].append(f"Source concept {source_id} not found.")
-        return report
-    if not target_doc:
-        report["errors"].append(f"Target concept {target_id} not found.")
-        return report
+        raw_id = ObjectId(str(relation_id))
+    except Exception:  # noqa: BLE001 - string IDs are valid in fixtures
+        raw_id = relation_id
+    relation = TextRelationsRepository.find_one({"_id": raw_id})
+    return dict(relation) if isinstance(relation, Mapping) else None
 
-    # 1. Analyse relationship references across all concepts.
-    source_rels_raw = source_doc.get("relationships", {})
-    target_rels_raw = target_doc.get("relationships", {})
 
-    source_rels, _ = _replace_relationships(source_rels_raw, source_id, target_id)
-    target_rels, _ = _replace_relationships(target_rels_raw, source_id, target_id)
+def _conditional_update_document(step: Mapping[str, Any]) -> bool:
+    concept_id = _normalise_concept_id(step.get("concept_id"))
+    before = step.get("before_document")
+    after = step.get("after_document")
+    if (
+        not concept_id
+        or not isinstance(before, Mapping)
+        or not isinstance(after, Mapping)
+    ):
+        raise _ConceptMergeApplyError(
+            "identity_consolidation_plan_invalid",
+            "An affected concept step is incomplete.",
+            changed=False,
+        )
+    current = _raw_concept(concept_id)
+    if current is not None and _sha256(current) == step.get("after_sha256"):
+        return False
+    if current is None or _sha256(current) != step.get("before_sha256"):
+        raise _ConceptMergeApplyError(
+            "identity_consolidation_precondition_failed",
+            "An affected concept changed after the merge plan was authorised.",
+            changed=False,
+        )
+    update_fields = {
+        key: deepcopy(value) for key, value in after.items() if key != "_id"
+    }
+    result = ConceptsRepository.update_one(
+        deepcopy(dict(before)),
+        {"$set": update_fields},
+    )
+    if int(getattr(result, "modified_count", 0) or 0) != 1:
+        refreshed = _raw_concept(concept_id)
+        if refreshed is None or _sha256(refreshed) != step.get("after_sha256"):
+            raise _ConceptMergeApplyError(
+                "identity_consolidation_precondition_failed",
+                "An affected concept could not be conditionally updated.",
+                changed=False,
+            )
+        return False
+    return True
 
-    concepts_cursor = ConceptsRepository.find({}, {"concept_id": 1, "relationships": 1})
-    affected_concepts: List[str] = []
-    for doc in concepts_cursor:
-        cid = doc.get("concept_id")
-        if not isinstance(cid, str) or not cid:
+
+def _conditional_apply_text_step(step: Mapping[str, Any]) -> bool:
+    relation_id = str(step.get("relation_id") or "")
+    before = step.get("before_relation")
+    after = step.get("after_relation")
+    action = str(step.get("action") or "")
+    if not relation_id or not isinstance(before, Mapping):
+        raise _ConceptMergeApplyError(
+            "identity_consolidation_plan_invalid",
+            "A text-relation merge step is incomplete.",
+            changed=False,
+        )
+    current = _raw_relation_by_id(before.get("_id") or relation_id)
+    if action == "delete_duplicate":
+        if current is None:
+            return False
+        current_text_value = _raw_text_value(current.get("object_text_id"))
+        if current_text_value is None or _sha256(current_text_value) != step.get(
+            "text_value_sha256"
+        ):
+            raise _ConceptMergeApplyError(
+                "identity_consolidation_precondition_failed",
+                "A source text value changed after merge authorisation.",
+                changed=False,
+            )
+        if _sha256(current) != step.get("before_sha256"):
+            raise _ConceptMergeApplyError(
+                "identity_consolidation_precondition_failed",
+                "A source text relation changed after merge authorisation.",
+                changed=False,
+            )
+        result = TextRelationsRepository.delete_one(deepcopy(dict(before)))
+        if int(getattr(result, "deleted_count", 0) or 0) != 1:
+            if _raw_relation_by_id(before.get("_id") or relation_id) is not None:
+                raise _ConceptMergeApplyError(
+                    "identity_consolidation_precondition_failed",
+                    "A duplicate source text relation could not be removed.",
+                    changed=False,
+                )
+            return False
+        return True
+    if action != "move" or not isinstance(after, Mapping):
+        raise _ConceptMergeApplyError(
+            "identity_consolidation_plan_invalid",
+            "A text-relation merge action is invalid.",
+            changed=False,
+        )
+    current_text_value = (
+        _raw_text_value(current.get("object_text_id")) if current is not None else None
+    )
+    if current_text_value is None or _sha256(current_text_value) != step.get(
+        "text_value_sha256"
+    ):
+        raise _ConceptMergeApplyError(
+            "identity_consolidation_precondition_failed",
+            "A source text value changed after merge authorisation.",
+            changed=False,
+        )
+    if _sha256(current) == step.get("after_sha256"):
+        return False
+    if current is None or _sha256(current) != step.get("before_sha256"):
+        raise _ConceptMergeApplyError(
+            "identity_consolidation_precondition_failed",
+            "A source text relation changed after merge authorisation.",
+            changed=False,
+        )
+    result = TextRelationsRepository.update_one(
+        deepcopy(dict(before)),
+        {"$set": {"subject_concept_id": after.get("subject_concept_id")}},
+    )
+    if int(getattr(result, "modified_count", 0) or 0) != 1:
+        refreshed = _raw_relation_by_id(before.get("_id") or relation_id)
+        if refreshed is None or _sha256(refreshed) != step.get("after_sha256"):
+            raise _ConceptMergeApplyError(
+                "identity_consolidation_precondition_failed",
+                "A source text relation could not be conditionally moved.",
+                changed=False,
+            )
+        return False
+    return True
+
+
+def _target_has_code_alias(target_id: str, alias: str) -> bool:
+    for relation in _raw_text_relations(target_id):
+        if str(relation.get("predicate") or "") not in {"hasName", "#V#hasName"}:
             continue
-        if cid == source_id:
+        context = relation.get("context")
+        if not isinstance(context, Mapping) or context.get("name_type") != "CODE":
             continue
-        new_rels, changed = _replace_relationships(
-            doc.get("relationships"), source_id, target_id
+        text_value = TextValuesRepository.find_one(
+            {"_id": relation.get("object_text_id")}
+        )
+        if (
+            isinstance(text_value, Mapping)
+            and str(text_value.get("text") or "") == alias
+        ):
+            return True
+    return False
+
+
+def _ensure_code_alias(target_id: str, alias: str, source_id: str) -> bool:
+    if _target_has_code_alias(target_id, alias):
+        return False
+    result = upsert_text_for_concept(
+        subject_concept_id=target_id,
+        predicate="hasName",
+        text=alias,
+        lang="en-NZ",
+        context={"name_type": "CODE"},
+        provenance={
+            "source": "ontology_identity_consolidation",
+            "source_concept_id": source_id,
+        },
+    )
+    if not bool(result.get("success", True)) or not _target_has_code_alias(
+        target_id, alias
+    ):
+        raise _ConceptMergeApplyError(
+            "identity_consolidation_alias_read_back_failed",
+            "A source identity alias could not be canonically read back.",
+            changed=True,
+        )
+    return True
+
+
+def _conditional_delete_source(plan: Mapping[str, Any]) -> bool:
+    source_id = _normalise_concept_id(plan.get("source_id"))
+    before = plan.get("source_before_document")
+    if not source_id or not isinstance(before, Mapping):
+        raise _ConceptMergeApplyError(
+            "identity_consolidation_plan_invalid",
+            "The source deletion precondition is incomplete.",
+            changed=False,
+        )
+    current = _raw_concept(source_id)
+    if current is None:
+        return False
+    if _sha256(current) != plan.get("source_before_sha256"):
+        raise _ConceptMergeApplyError(
+            "identity_consolidation_precondition_failed",
+            "The source concept changed after merge authorisation.",
+            changed=False,
+        )
+    result = ConceptsRepository.delete_one(deepcopy(dict(before)))
+    if int(getattr(result, "deleted_count", 0) or 0) != 1:
+        if _raw_concept(source_id) is not None:
+            raise _ConceptMergeApplyError(
+                "identity_consolidation_precondition_failed",
+                "The source concept could not be conditionally deleted.",
+                changed=False,
+            )
+        return False
+    return True
+
+
+def read_concept_merge_postcondition(plan: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a bounded complete read-back without disclosing unexpected records."""
+
+    plan_hash = str(plan.get("plan_sha256") or "")
+    concept_steps = list(plan.get("concept_steps") or [])
+    concept_matches = 0
+    for step in concept_steps:
+        if not isinstance(step, Mapping):
+            continue
+        concept_id = _normalise_concept_id(step.get("concept_id"))
+        current = _raw_concept(concept_id or "") if concept_id else None
+        if current is not None and _sha256(current) == step.get("after_sha256"):
+            concept_matches += 1
+
+    text_steps = list(plan.get("text_relation_steps") or [])
+    text_matches = 0
+    for step in text_steps:
+        if not isinstance(step, Mapping):
+            continue
+        before = step.get("before_relation")
+        relation_id = (
+            before.get("_id")
+            if isinstance(before, Mapping)
+            else step.get("relation_id")
+        )
+        current = _raw_relation_by_id(relation_id)
+        if step.get("action") == "delete_duplicate":
+            matched = current is None
+        else:
+            matched = current is not None and _sha256(current) == step.get(
+                "after_sha256"
+            )
+        if matched:
+            text_matches += 1
+
+    target_text_preconditions = list(
+        plan.get("target_text_relation_preconditions") or []
+    )
+    target_text_precondition_matches = 0
+    for precondition in target_text_preconditions:
+        if not isinstance(precondition, Mapping):
+            continue
+        relation = precondition.get("relation")
+        relation_id = (
+            relation.get("_id")
+            if isinstance(relation, Mapping)
+            else precondition.get("relation_id")
+        )
+        current_relation = _raw_relation_by_id(relation_id)
+        current_text_value = (
+            _raw_text_value(current_relation.get("object_text_id"))
+            if current_relation is not None
+            else None
+        )
+        if (
+            current_relation is not None
+            and current_text_value is not None
+            and _sha256(current_relation) == precondition.get("relation_sha256")
+            and _sha256(current_text_value) == precondition.get("text_value_sha256")
+        ):
+            target_text_precondition_matches += 1
+
+    source_id = _normalise_concept_id(plan.get("source_id")) or ""
+    target_id = _normalise_concept_id(plan.get("target_id")) or ""
+    aliases = [
+        alias
+        for alias in plan.get("required_code_aliases") or []
+        if isinstance(alias, str) and alias
+    ]
+    alias_matches = sum(
+        1 for alias in aliases if _target_has_code_alias(target_id, alias)
+    )
+    residual_reference_count = 0
+    for document in _raw_concepts():
+        _replaced, changed = _replace_relationships(
+            document.get("relationships"), source_id, target_id
         )
         if changed:
-            affected_concepts.append(cid)
-
-    if affected_concepts:
-        report["operations"].append(
-            {
-                "type": "rewrite_incoming_relationship_references",
-                "count": len(affected_concepts),
-                "concept_ids": affected_concepts[:50],
-                "detail": f"Replace references to {source_id} with {target_id} across concepts",
-            }
-        )
-        if len(affected_concepts) > 50:
-            report["warnings"].append(
-                f"Relationship rewrite affects {len(affected_concepts)} concepts; report truncated to 50 ids"
-            )
-
-    merged_rels_preview, rels_changed = _merge_relationship_maps(
-        target_rels, source_rels
+            residual_reference_count += 1
+    residual_source_text_count = len(_raw_text_relations(source_id))
+    source_absent = _raw_concept(source_id) is None
+    matches = (
+        bool(plan_hash)
+        and source_absent
+        and concept_matches == len(concept_steps)
+        and text_matches == len(text_steps)
+        and target_text_precondition_matches == len(target_text_preconditions)
+        and alias_matches == len(aliases)
+        and residual_reference_count == 0
+        and residual_source_text_count == 0
     )
-    if rels_changed:
-        report["operations"].append(
-            {
-                "type": "merge_outgoing_relationships",
-                "detail": "Merge source outgoing relationships into target",
-            }
-        )
+    return {
+        "schema_version": "ontology_identity_consolidation_read_back.v1",
+        "plan_sha256": plan_hash,
+        "source_id": source_id,
+        "target_id": target_id,
+        "source_absent": source_absent,
+        "concept_step_count": len(concept_steps),
+        "concept_step_match_count": concept_matches,
+        "text_relation_step_count": len(text_steps),
+        "text_relation_step_match_count": text_matches,
+        "target_text_precondition_count": len(target_text_preconditions),
+        "target_text_precondition_match_count": target_text_precondition_matches,
+        "required_alias_count": len(aliases),
+        "required_alias_match_count": alias_matches,
+        "residual_source_reference_count": residual_reference_count,
+        "residual_source_text_relation_count": residual_source_text_count,
+        "matches_exact_plan": matches,
+    }
 
-    # 2. Analyse legacy names field (if present)
-    merged_names_preview, names_changed = _merge_legacy_names(target_doc, source_doc)
-    if names_changed:
-        report["operations"].append(
-            {
-                "type": "merge_legacy_names",
-                "detail": "Merge legacy name/alias entries from source into target",
-                "added_count": max(
-                    0,
-                    len(merged_names_preview)
-                    - (
-                        len(target_doc.get("names") or [])
-                        if isinstance(target_doc.get("names"), list)
-                        else 0
-                    ),
-                ),
-            }
-        )
 
-    # 3. Analyse text relations
-    source_text_relations = list(
-        TextRelationsRepository.find({"subject_concept_id": source_id})
-    )
-    target_text_relations = list(
-        TextRelationsRepository.find({"subject_concept_id": target_id})
-    )
-    target_keys: set[Tuple[str, Any]] = set()
-    for rel in target_text_relations:
-        pred = rel.get("predicate")
-        obj = rel.get("object_text_id")
-        if isinstance(pred, str) and pred and obj is not None:
-            target_keys.add((pred, obj))
-
-    move_count = 0
-    dup_count = 0
-    for rel in source_text_relations:
-        pred = rel.get("predicate")
-        obj = rel.get("object_text_id")
-        if not isinstance(pred, str) or not pred or obj is None:
-            continue
-        if (pred, obj) in target_keys:
-            dup_count += 1
-        else:
-            move_count += 1
-
-    if move_count or dup_count:
-        report["operations"].append(
-            {
-                "type": "migrate_text_relations",
-                "move_count": move_count,
-                "duplicate_count": dup_count,
-                "detail": "Reassign text_relations from source to target (de-dup on conflicts)",
-            }
-        )
-
-    # 4. Deletion
-    report["operations"].append(
-        {
-            "type": "delete_source",
-            "concept_id": source_id,
-            "detail": "Delete the source concept after migration",
-        }
-    )
-
-    if simulate:
-        report["success"] = True
-        return report
-
-    # EXECUTION
+def _execute_plan(plan: Mapping[str, Any]) -> dict[str, Any]:
+    source_id = _normalise_concept_id(plan.get("source_id")) or ""
+    target_id = _normalise_concept_id(plan.get("target_id")) or ""
+    changed = False
     try:
-        # Refresh documents
-        source_doc = get_concept_by_id(source_id)
-        target_doc = get_concept_by_id(target_id)
-        if source_doc is None:
-            raise ValueError(f"Source concept '{source_id}' no longer exists")
-        if target_doc is None:
-            raise ValueError(f"Target concept '{target_id}' no longer exists")
-
-        # 1. Rewrite relationship references in all concepts except the source.
-        concepts_cursor = ConceptsRepository.find(
-            {}, {"concept_id": 1, "relationships": 1}
-        )
-        for doc in concepts_cursor:
-            cid = doc.get("concept_id")
-            if not isinstance(cid, str) or not cid:
-                continue
-            if cid == source_id:
-                continue
-
-            new_rels, changed = _replace_relationships(
-                doc.get("relationships"), source_id, target_id
-            )
-            if changed:
-                ConceptsRepository.update_one(
-                    {"concept_id": cid}, {"$set": {"relationships": new_rels}}
+        _validate_plan(plan, source_id, target_id)
+        for step in plan.get("concept_steps") or []:
+            if not isinstance(step, Mapping):
+                raise _ConceptMergeApplyError(
+                    "identity_consolidation_plan_invalid",
+                    "An affected concept step is invalid.",
+                    changed=changed,
                 )
-
-        # 2. Merge source outgoing relationships into the target.
-        source_rels, _ = _replace_relationships(
-            source_doc.get("relationships", {}), source_id, target_id
-        )
-        target_rels, _ = _replace_relationships(
-            target_doc.get("relationships", {}), source_id, target_id
-        )
-        merged_rels, rels_changed = _merge_relationship_maps(target_rels, source_rels)
-        if rels_changed:
-            ConceptsRepository.update_one(
-                {"concept_id": target_id}, {"$set": {"relationships": merged_rels}}
-            )
-
-        # 3. Merge legacy names (if used)
-        merged_names, names_changed = _merge_legacy_names(target_doc, source_doc)
-        if names_changed:
-            ConceptsRepository.update_one(
-                {"concept_id": target_id}, {"$set": {"names": merged_names}}
-            )
-
-        # 4. Migrate text relations from source -> target (de-dup on unique index conflicts)
-        target_text_relations = list(
-            TextRelationsRepository.find({"subject_concept_id": target_id})
-        )
-        target_keys: set[Tuple[str, Any]] = set()
-        for rel in target_text_relations:
-            pred = rel.get("predicate")
-            obj = rel.get("object_text_id")
-            if isinstance(pred, str) and pred and obj is not None:
-                target_keys.add((pred, obj))
-
-        source_text_relations = list(
-            TextRelationsRepository.find({"subject_concept_id": source_id})
-        )
-        for rel in source_text_relations:
-            rel_id = rel.get("_id")
-            pred = rel.get("predicate")
-            obj = rel.get("object_text_id")
-            if rel_id is None or not isinstance(pred, str) or not pred or obj is None:
-                continue
-
-            if (pred, obj) in target_keys:
-                TextRelationsRepository.delete_one({"_id": rel_id})
-                continue
-
             try:
-                TextRelationsRepository.update_one(
-                    {"_id": rel_id},
-                    {
-                        "$set": {
-                            "subject_concept_id": target_id,
-                            "updated_at": _now(),
-                        }
-                    },
+                changed = _conditional_update_document(step) or changed
+            except _ConceptMergeApplyError as exc:
+                raise _ConceptMergeApplyError(
+                    exc.reason_code,
+                    exc.public_message,
+                    changed=changed or exc.changed,
+                ) from exc
+        for step in plan.get("text_relation_steps") or []:
+            if not isinstance(step, Mapping):
+                raise _ConceptMergeApplyError(
+                    "identity_consolidation_plan_invalid",
+                    "A text-relation step is invalid.",
+                    changed=changed,
                 )
-                target_keys.add((pred, obj))
-            except DuplicateKeyError:
-                # If another process created the relation on target between fetch and update.
-                TextRelationsRepository.delete_one({"_id": rel_id})
+            try:
+                changed = _conditional_apply_text_step(step) or changed
+            except _ConceptMergeApplyError as exc:
+                raise _ConceptMergeApplyError(
+                    exc.reason_code,
+                    exc.public_message,
+                    changed=changed or exc.changed,
+                ) from exc
+        for alias in plan.get("required_code_aliases") or []:
+            if isinstance(alias, str) and alias:
+                changed = _ensure_code_alias(target_id, alias, source_id) or changed
+        try:
+            changed = _conditional_delete_source(plan) or changed
+        except _ConceptMergeApplyError as exc:
+            raise _ConceptMergeApplyError(
+                exc.reason_code,
+                exc.public_message,
+                changed=changed or exc.changed,
+            ) from exc
+    except _ConceptMergeApplyError as exc:
+        return {
+            "success": False,
+            "simulate": False,
+            "executed": changed,
+            "changed": changed,
+            "mutation_outcome": "partial" if changed else "not_started",
+            "source_id": source_id,
+            "target_id": target_id,
+            "plan_sha256": plan.get("plan_sha256"),
+            "error_code": exc.reason_code,
+            "error": exc.public_message,
+            "errors": [exc.public_message],
+        }
 
-        # 5. Delete Source (use canonical delete helper for consistent cleanup semantics)
-        delete_concept(source_id)
+    try:
+        from .concept_service import _invalidate_concept_mutation_caches
 
-        report["success"] = True
-        report["executed"] = True
-
-    except Exception as e:
-        logger.error(
-            f"Error merging concepts {source_id} -> {target_id}: {e}", exc_info=True
+        _invalidate_concept_mutation_caches()
+    except Exception:  # read-back still decides effect success
+        logger.warning(
+            "Identity consolidation cache invalidation failed",
+            exc_info=True,
         )
-        report["errors"].append(str(e))
-        report["success"] = False
+    return {
+        **_public_plan_report(plan, simulate=False),
+        "success": True,
+        "executed": True,
+        "changed": changed,
+        "mutation_outcome": "succeeded",
+    }
 
-    return report
+
+def merge_concepts(
+    source_id: str,
+    target_id: str,
+    simulate: bool = True,
+    *,
+    exact_plan: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Preview or execute one exact governed identity consolidation."""
+
+    try:
+        plan = (
+            dict(exact_plan)
+            if isinstance(exact_plan, Mapping)
+            else build_concept_merge_plan(source_id, target_id)
+        )
+        if simulate:
+            return _public_plan_report(plan, simulate=True)
+        if exact_plan is None:
+            return {
+                "success": False,
+                "simulate": False,
+                "executed": False,
+                "changed": False,
+                "mutation_outcome": "not_started",
+                "source_id": _normalise_concept_id(source_id),
+                "target_id": _normalise_concept_id(target_id),
+                "error_code": "ontology_identity_consolidation_authority_required",
+                "error": (
+                    "Identity consolidation execution requires a server-built "
+                    "plan covered by the governed ontology command."
+                ),
+                "errors": [
+                    "Identity consolidation execution requires a governed plan."
+                ],
+            }
+        return _execute_plan(plan)
+    except ConceptMergePlanError as exc:
+        return {
+            "success": False,
+            "simulate": bool(simulate),
+            "executed": False,
+            "changed": False,
+            "mutation_outcome": "not_started",
+            "source_id": _normalise_concept_id(source_id),
+            "target_id": _normalise_concept_id(target_id),
+            "error_code": exc.reason_code,
+            "error": exc.public_message,
+            "errors": [exc.public_message],
+        }
+
+
+__all__ = [
+    "ConceptMergePlanError",
+    "MERGE_PLAN_SCHEMA_VERSION",
+    "build_concept_merge_plan",
+    "merge_concepts",
+    "read_concept_merge_postcondition",
+]

--- a/src/backend/services/concept_service.py
+++ b/src/backend/services/concept_service.py
@@ -183,7 +183,9 @@ _CONCEPT_SCOPE_MODE_ALIASES: Dict[str, str] = {
     "default": CONCEPT_SCOPE_USER_ORG_DEFAULT,
     "user_org_default": CONCEPT_SCOPE_USER_ORG_DEFAULT,
     "user_org": CONCEPT_SCOPE_USER_ORG_DEFAULT,
-    "private": CONCEPT_SCOPE_USER_ORG_DEFAULT,
+    "private": CONCEPT_SCOPE_USER_ONLY_DEFAULT,
+    "user_only": CONCEPT_SCOPE_USER_ONLY_DEFAULT,
+    "user_only_default": CONCEPT_SCOPE_USER_ONLY_DEFAULT,
     "organisation_general": CONCEPT_SCOPE_ORGANISATION_GENERAL,
     "organization_general": CONCEPT_SCOPE_ORGANISATION_GENERAL,
     "org_general": CONCEPT_SCOPE_ORGANISATION_GENERAL,
@@ -381,7 +383,10 @@ def _resolve_creation_visibility_scope(
             relationships,
             [actor_user_id],
         )
-        if actor_org_id:
+        if (
+            actor_org_id
+            and mode_for_resolution != CONCEPT_SCOPE_USER_ONLY_DEFAULT
+        ):
             relationships = set_specific_to_org_values(
                 relationships,
                 [actor_org_id],
@@ -527,6 +532,8 @@ def create_concept(
     event_namespace: Optional[str] = None,
     visibility_scope_mode: Optional[str] = None,
     defer_text_relations: bool = False,
+    maintain_relationship_inverses: bool = True,
+    resolve_visibility_from_event_namespace: bool = True,
 ) -> Dict[str, Any]:
     """Creates a new concept in the 'concepts' collection.
     REFACTORING_NOTE: This is the first CRUD operation for the new generalized concept model.
@@ -542,6 +549,17 @@ def create_concept(
     that create non-user-facing graph artefacts and immediately store their
     authoritative payload in concept_data. Normal concept creation should leave
     this false so canonical names/descriptions are attached as text relations.
+
+    maintain_relationship_inverses controls whether creation also mutates each
+    referenced target concept with structural reverse edges. Governed external
+    creation sets this false because its create authority covers the new child,
+    not pre-existing parent concepts; reverse traversal remains available from
+    the derived relationship extent.
+
+    resolve_visibility_from_event_namespace permits legacy internal callers to
+    derive missing actor scope from their trusted event namespace. Governed
+    external callers set this false so event attribution cannot alter the exact
+    scope authorised from trusted actor context.
     """
     # Use repository for concepts collection access
     concepts_coll = ConceptsRepository.collection()
@@ -601,7 +619,9 @@ def create_concept(
     visibility_scope = _resolve_creation_visibility_scope(
         created_by_concept_id=created_by_concept_id,
         organisation_concept_id=organisation_concept_id,
-        event_namespace=event_namespace,
+        event_namespace=(
+            event_namespace if resolve_visibility_from_event_namespace else None
+        ),
         visibility_scope_mode=visibility_scope_mode,
     )
     visibility_relationships = visibility_scope.get("relationships") or {}
@@ -725,7 +745,7 @@ def create_concept(
                 )
 
         try:
-            if concept_identifier:
+            if concept_identifier and maintain_relationship_inverses:
                 ConceptsRepository.reconcile_relationships(
                     concept_identifier,
                     concept_doc.get("relationships") or {},

--- a/src/backend/services/ontology_authority_membership_coordination_service.py
+++ b/src/backend/services/ontology_authority_membership_coordination_service.py
@@ -1,0 +1,43 @@
+"""Shared concurrency boundary for membership and semantic-role lifecycle writes.
+
+Organisation membership is a prerequisite for exact-organisation ontology
+authority.  Writers for the two representations therefore share one short
+cross-process barrier.  The barrier is re-entrant within a request so the
+one-time migration can hold it across inventory validation while continuing to
+use the canonical membership and role services for each individual effect.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+from .ontology_publication_authority_service import (
+    ontology_mutation_resource_lock,
+)
+
+_COORDINATION_RESOURCE_KEY = "ontology-authority-membership-lifecycle:v1"
+_COORDINATION_DEPTH: ContextVar[int] = ContextVar(
+    "ontology_authority_membership_coordination_depth",
+    default=0,
+)
+
+
+@contextmanager
+def ontology_authority_membership_mutation_barrier() -> Iterator[None]:
+    """Serialise authority-relevant membership and semantic-role mutations."""
+
+    depth = _COORDINATION_DEPTH.get()
+    token = _COORDINATION_DEPTH.set(depth + 1)
+    try:
+        if depth:
+            yield
+            return
+        with ontology_mutation_resource_lock(_COORDINATION_RESOURCE_KEY):
+            yield
+    finally:
+        _COORDINATION_DEPTH.reset(token)
+
+
+__all__ = ["ontology_authority_membership_mutation_barrier"]

--- a/src/backend/services/ontology_authority_role_migration_service.py
+++ b/src/backend/services/ontology_authority_role_migration_service.py
@@ -1,0 +1,1438 @@
+"""One-time, inventory-bound migration of Michael's administrator authority.
+
+The migration is deliberately specific rather than a reusable elevation API.
+It preserves legacy operational and organisation-role representations, adds
+semantic ontology authority through the canonical role lifecycle, and refuses
+to start if the live inventory contradicts the authorised sole-holder premise.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from pymongo.errors import DuplicateKeyError
+
+from ..db.mongo_client import get_migrations_log_collection
+from ..db.repositories.concepts_repository import ConceptsRepository
+from ..db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
+from ..security.access_control import (
+    bypass_access_control,
+    get_effective_user_concept_id,
+    override_current_organisation,
+)
+from ..security.role_resolver import STUB_ROLE_MAPPINGS, get_effective_permissions
+from .ontology_authority_membership_coordination_service import (
+    ontology_authority_membership_mutation_barrier,
+)
+from .ontology_authority_role_service import (
+    authority_role_read_back,
+    grant_ontology_authority_role,
+)
+from .ontology_authority_vocabulary_service import (
+    bootstrap_first_semantic_authority,
+)
+from .ontology_publication_authority_service import (
+    AUTHORITY_ROLE_PREDICATE,
+    GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+    ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+    VON_ADMINISTRATOR_CONCEPT_ID,
+    OntologyMutationResourceBusy,
+    current_ontology_invocation,
+    ontology_mutation_resource_lock,
+    parse_authority_role_storage_text,
+)
+from .organisation_membership_service import (
+    ROLE_PREDICATE,
+    get_user_memberships,
+    organisation_role_storage_text,
+    parse_organisation_role_storage_text,
+)
+from .text_value_service import delete_text_relation, upsert_text_for_concept
+from .von_operational_administrator_service import (
+    VON_OPERATIONAL_ADMINISTRATOR_ROLE,
+    bootstrap_first_von_operational_administrator,
+    list_von_operational_administrators,
+    von_operational_administrator_read_back,
+)
+
+ONTOLOGY_AUTHORITY_ROLE_MIGRATION_SCHEMA_VERSION = (
+    "ontology_authority_role_migration.v1"
+)
+ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET = "#V#michael_witbrock"
+
+_MIGRATION_RESOURCE_KEY = "ontology-authority-role-migration:michael-witbrock:v1"
+_MIGRATION_OPERATION_NAME = "jvnautosci-2632-initial-administrator-roles-v1"
+_MIGRATION_REASON = "JVNAUTOSCI-2632 authorised administrator-role migration"
+_OWNER_ROLE = "owner"
+_NON_PRIVILEGED_ORGANISATION_ROLES = frozenset(
+    {"", "user", "viewer", "member"}
+)
+_OPERATIONAL_ROLE_TOKENS = frozenset(
+    {
+        "von administrator",
+        "von_administrator",
+        VON_ADMINISTRATOR_CONCEPT_ID.lower(),
+        "operator",
+        "system",
+    }
+)
+
+
+class OntologyAuthorityRoleMigrationError(RuntimeError):
+    """Typed refusal or partial result from the one-time role migration."""
+
+    def __init__(
+        self,
+        reason_code: str,
+        message: str,
+        *,
+        report: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.public_message = message
+        self.report = dict(report) if isinstance(report, Mapping) else None
+
+
+def _clean(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _normalise_concept_id(value: object) -> str | None:
+    cleaned = _clean(value)
+    if not cleaned:
+        return None
+    return cleaned if cleaned.startswith("#") else f"#V#{cleaned}"
+
+
+def _normalise_role(value: object) -> str:
+    return " ".join(_clean(value).lower().replace("-", "_").split())
+
+
+def _stable_fingerprint(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _migration_log_collection():
+    collection = get_migrations_log_collection()
+    if collection is None:
+        raise RuntimeError("migration log store unavailable")
+    return collection
+
+
+def _action_key(action: Mapping[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        _clean(action.get("operation")),
+        _clean(action.get("subject_concept_id")),
+        _normalise_role(action.get("role")),
+        _clean(_normalise_concept_id(action.get("organisation_concept_id"))),
+    )
+
+
+def _plan_organisation_ids(plan: Mapping[str, Any]) -> set[str]:
+    inventory = plan.get("inventory")
+    inventory_map = inventory if isinstance(inventory, Mapping) else {}
+    return {
+        _clean(_normalise_concept_id(row.get("organisation_concept_id")))
+        for row in inventory_map.get("memberships") or []
+        if isinstance(row, Mapping)
+        and _normalise_concept_id(row.get("organisation_concept_id"))
+    }
+
+
+def _continuation_is_safe(
+    source_plan: Mapping[str, Any],
+    current_plan: Mapping[str, Any],
+) -> bool:
+    """Allow only expected migration deltas when resuming one fingerprint."""
+
+    if current_plan.get("ready_to_apply") is not True:
+        return False
+    if _plan_organisation_ids(source_plan) != _plan_organisation_ids(current_plan):
+        return False
+    source_actions = {
+        _action_key(action)
+        for action in source_plan.get("actions") or []
+        if isinstance(action, Mapping)
+    }
+    current_actions = {
+        _action_key(action)
+        for action in current_plan.get("actions") or []
+        if isinstance(action, Mapping)
+    }
+    return bool(source_actions) and source_actions == current_actions
+
+
+def _load_migration_operation() -> dict[str, Any] | None:
+    value = _migration_log_collection().find_one(
+        {"migration_name": _MIGRATION_OPERATION_NAME}
+    )
+    return dict(value) if isinstance(value, Mapping) else None
+
+
+def _start_migration_operation(
+    *,
+    source_plan: Mapping[str, Any],
+    source_fingerprint: str,
+) -> dict[str, Any]:
+    operation = {
+        "migration_name": _MIGRATION_OPERATION_NAME,
+        "schema_version": ONTOLOGY_AUTHORITY_ROLE_MIGRATION_SCHEMA_VERSION,
+        "target_concept_id": ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+        "source_inventory_fingerprint": source_fingerprint,
+        "source_plan": dict(source_plan),
+        "status": "in_progress",
+        "completed_effects": [],
+        "started_at": _now(),
+        "updated_at": _now(),
+    }
+    try:
+        _migration_log_collection().insert_one(operation)
+        return operation
+    except DuplicateKeyError:
+        existing = _load_migration_operation()
+        if existing is None:
+            raise RuntimeError("migration operation record unreadable")
+        return existing
+
+
+def _update_migration_operation(**values: Any) -> None:
+    result = _migration_log_collection().update_one(
+        {"migration_name": _MIGRATION_OPERATION_NAME},
+        {"$set": {**values, "updated_at": _now()}},
+    )
+    if int(getattr(result, "matched_count", 0) or 0) != 1:
+        raise RuntimeError("migration operation record unavailable")
+
+
+def _assignment(
+    *,
+    source: str,
+    subject_concept_id: object,
+    role: object,
+    organisation_concept_id: object = None,
+    relation_id: object = None,
+) -> dict[str, Any] | None:
+    subject_id = _normalise_concept_id(subject_concept_id)
+    if not subject_id:
+        return None
+    return {
+        "source": source,
+        "subject_concept_id": subject_id,
+        "role": _normalise_role(role),
+        "organisation_concept_id": _normalise_concept_id(
+            organisation_concept_id
+        ),
+        "relation_id": _clean(relation_id) or None,
+    }
+
+
+def _is_privileged_legacy_role(
+    role: object,
+    *,
+    organisation_concept_id: object = None,
+) -> bool:
+    role_value = _normalise_role(role)
+    if role_value in _OPERATIONAL_ROLE_TOKENS:
+        return True
+    if _normalise_concept_id(organisation_concept_id):
+        # Unknown organisation roles are treated as privileged for migration
+        # precondition purposes. A new/custom role must not be silently assumed
+        # harmless while deciding who already has elevated authority.
+        return role_value not in _NON_PRIVILEGED_ORGANISATION_ROLES
+    return False
+
+
+def _stub_privileged_role_assignments() -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for raw_subject, raw_memberships in STUB_ROLE_MAPPINGS.items():
+        if not isinstance(raw_memberships, Mapping):
+            continue
+        for raw_organisation, raw_role in raw_memberships.items():
+            if not _is_privileged_legacy_role(
+                raw_role,
+                organisation_concept_id=raw_organisation,
+            ):
+                continue
+            row = _assignment(
+                source="legacy_stub_role_mapping",
+                subject_concept_id=raw_subject,
+                role=raw_role,
+                organisation_concept_id=raw_organisation,
+            )
+            if row:
+                rows.append(row)
+    return rows
+
+
+def _text_privileged_role_assignments() -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for relation in TextRelationsRepository.find({"predicate": ROLE_PREDICATE}):
+        if not isinstance(relation, Mapping):
+            continue
+        text_value = TextValuesRepository.find_one(
+            {"_id": relation.get("object_text_id")}
+        )
+        if not isinstance(text_value, Mapping):
+            continue
+        context = relation.get("context")
+        context_map = context if isinstance(context, Mapping) else {}
+        organisation_id = context_map.get("organisation_concept_id") or context_map.get(
+            "organisation_id"
+        )
+        role, stored_organisation_id = parse_organisation_role_storage_text(
+            text_value.get("text"),
+            dict(context_map),
+        )
+        organisation_id = stored_organisation_id or organisation_id
+        if not role and not organisation_id:
+            raw_role = _normalise_role(text_value.get("text"))
+            if raw_role in _OPERATIONAL_ROLE_TOKENS:
+                role = raw_role
+        if not _is_privileged_legacy_role(
+            role,
+            organisation_concept_id=organisation_id,
+        ):
+            continue
+        row = _assignment(
+            source="represented_legacy_text_role",
+            subject_concept_id=relation.get("subject_concept_id"),
+            role=role,
+            organisation_concept_id=organisation_id,
+            relation_id=relation.get("_id"),
+        )
+        if row:
+            rows.append(row)
+    return rows
+
+
+def _relationship_operational_role_assignments() -> list[dict[str, Any]]:
+    predicate_names = ("#V#hasRole", "hasRole")
+    role_tokens = tuple(
+        sorted({*_OPERATIONAL_ROLE_TOKENS, VON_ADMINISTRATOR_CONCEPT_ID})
+    )
+    query = {
+        "$or": [
+            {f"relationships.{predicate}": {"$in": list(role_tokens)}}
+            for predicate in predicate_names
+        ]
+    }
+    rows: list[dict[str, Any]] = []
+    with bypass_access_control():
+        concepts = ConceptsRepository.find(
+            query,
+            projection={"concept_id": 1, "relationships": 1},
+        )
+        for concept in concepts:
+            if not isinstance(concept, Mapping):
+                continue
+            relationships = concept.get("relationships")
+            relationship_map = (
+                relationships if isinstance(relationships, Mapping) else {}
+            )
+            for predicate in predicate_names:
+                raw_values = relationship_map.get(predicate)
+                values = raw_values if isinstance(raw_values, list) else [raw_values]
+                for raw_role in values:
+                    if _normalise_role(raw_role) not in _OPERATIONAL_ROLE_TOKENS:
+                        continue
+                    row = _assignment(
+                        source="represented_operational_role_relationship",
+                        subject_concept_id=concept.get("concept_id"),
+                        role=raw_role,
+                    )
+                    if row:
+                        rows.append(row)
+    return rows
+
+
+def _legacy_privileged_role_assignments() -> list[dict[str, Any]]:
+    rows = [
+        *_stub_privileged_role_assignments(),
+        *_text_privileged_role_assignments(),
+        *_relationship_operational_role_assignments(),
+    ]
+    deduplicated: dict[tuple[str, str, str, str, str], dict[str, Any]] = {}
+    for row in rows:
+        key = (
+            _clean(row.get("source")),
+            _clean(row.get("subject_concept_id")),
+            _clean(row.get("role")),
+            _clean(row.get("organisation_concept_id")),
+            _clean(row.get("relation_id")),
+        )
+        deduplicated[key] = row
+    return sorted(
+        deduplicated.values(),
+        key=lambda row: (
+            _clean(row.get("subject_concept_id")),
+            _clean(row.get("organisation_concept_id")),
+            _clean(row.get("role")),
+            _clean(row.get("source")),
+            _clean(row.get("relation_id")),
+        ),
+    )
+
+
+def _semantic_role_assignments() -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for relation in TextRelationsRepository.find(
+        {"predicate": AUTHORITY_ROLE_PREDICATE}
+    ):
+        if not isinstance(relation, Mapping):
+            continue
+        text_value = TextValuesRepository.find_one(
+            {"_id": relation.get("object_text_id")}
+        )
+        if not isinstance(text_value, Mapping):
+            continue
+        context = relation.get("context")
+        context_map = context if isinstance(context, Mapping) else {}
+        role, organisation_id = parse_authority_role_storage_text(
+            text_value.get("text"),
+            context_map,
+        )
+        if not role:
+            continue
+        row = _assignment(
+            source="represented_semantic_authority_role",
+            subject_concept_id=relation.get("subject_concept_id"),
+            role=role,
+            organisation_concept_id=organisation_id,
+            relation_id=relation.get("_id"),
+        )
+        if row:
+            rows.append(row)
+    return sorted(
+        rows,
+        key=lambda row: (
+            _clean(row.get("subject_concept_id")),
+            _clean(row.get("role")),
+            _clean(row.get("organisation_concept_id")),
+            _clean(row.get("relation_id")),
+        ),
+    )
+
+
+def _target_membership_role_assignments() -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for relation in TextRelationsRepository.find(
+        {
+            "subject_concept_id": ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+            "predicate": ROLE_PREDICATE,
+        }
+    ):
+        if not isinstance(relation, Mapping):
+            continue
+        context = relation.get("context")
+        context_map = context if isinstance(context, Mapping) else {}
+        organisation_id = _normalise_concept_id(
+            context_map.get("organisation_concept_id")
+            or context_map.get("organisation_id")
+        )
+        if not organisation_id:
+            continue
+        text_value = TextValuesRepository.find_one(
+            {"_id": relation.get("object_text_id")}
+        )
+        if not isinstance(text_value, Mapping):
+            continue
+        role, stored_organisation_id = parse_organisation_role_storage_text(
+            text_value.get("text"),
+            dict(context_map),
+        )
+        if not role or stored_organisation_id != organisation_id:
+            continue
+        row = _assignment(
+            source="represented_organisation_membership_role",
+            subject_concept_id=ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+            role=role,
+            organisation_concept_id=organisation_id,
+            relation_id=relation.get("_id"),
+        )
+        if row:
+            rows.append(row)
+    return sorted(
+        rows,
+        key=lambda row: (
+            _clean(row.get("organisation_concept_id")),
+            _clean(row.get("role")),
+            _clean(row.get("relation_id")),
+        ),
+    )
+
+
+def _target_memberships() -> tuple[list[dict[str, Any]], list[str]]:
+    membership_payload = get_user_memberships(
+        ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET
+    )
+    memberships: list[dict[str, Any]] = []
+    missing_organisations: list[str] = []
+    seen: set[str] = set()
+    for raw_membership in membership_payload.get("memberships", []):
+        if not isinstance(raw_membership, Mapping):
+            continue
+        organisation_id = _normalise_concept_id(
+            raw_membership.get("organisation_concept_id")
+        )
+        if not organisation_id or organisation_id in seen:
+            continue
+        seen.add(organisation_id)
+        with bypass_access_control():
+            organisation = ConceptsRepository.find_one(
+                {"concept_id": organisation_id},
+                projection={"concept_id": 1},
+            )
+        if not isinstance(organisation, Mapping):
+            missing_organisations.append(organisation_id)
+        memberships.append(
+            {
+                "organisation_concept_id": organisation_id,
+                "legacy_role": _normalise_role(raw_membership.get("role"))
+                or "member",
+            }
+        )
+    memberships.sort(key=lambda row: row["organisation_concept_id"])
+    missing_organisations.sort()
+    return memberships, missing_organisations
+
+
+def _collect_inventory() -> dict[str, Any]:
+    with bypass_access_control():
+        target = ConceptsRepository.find_one(
+            {"concept_id": ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET},
+            projection={"concept_id": 1},
+        )
+    target_exists = isinstance(target, Mapping)
+    memberships: list[dict[str, Any]] = []
+    missing_organisations: list[str] = []
+    if target_exists:
+        memberships, missing_organisations = _target_memberships()
+    return {
+        "target_concept_id": ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+        "target_exists": target_exists,
+        "memberships": memberships,
+        "missing_membership_organisations": missing_organisations,
+        "legacy_privileged_role_assignments": (
+            _legacy_privileged_role_assignments()
+        ),
+        "target_membership_role_assignments": (
+            _target_membership_role_assignments()
+        ),
+        "semantic_role_assignments": _semantic_role_assignments(),
+        "operational_role_assignments": list_von_operational_administrators(),
+    }
+
+
+def _inventory_conflicts(inventory: Mapping[str, Any]) -> list[dict[str, Any]]:
+    conflicts: list[dict[str, Any]] = []
+    target_id = ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET
+    if inventory.get("target_exists") is not True:
+        conflicts.append(
+            {
+                "reason_code": "migration_target_not_found",
+                "message": "The canonical Michael Witbrock concept does not exist.",
+            }
+        )
+    missing_orgs = list(inventory.get("missing_membership_organisations") or [])
+    if missing_orgs:
+        conflicts.append(
+            {
+                "reason_code": "membership_organisation_not_found",
+                "message": "A represented membership names a missing organisation.",
+                "organisation_concept_ids": missing_orgs,
+            }
+        )
+
+    legacy_rows = list(inventory.get("legacy_privileged_role_assignments") or [])
+    legacy_subjects = sorted(
+        {
+            _clean(row.get("subject_concept_id"))
+            for row in legacy_rows
+            if isinstance(row, Mapping) and _clean(row.get("subject_concept_id"))
+        }
+    )
+    if target_id not in legacy_subjects:
+        conflicts.append(
+            {
+                "reason_code": "expected_sole_privileged_holder_not_found",
+                "message": (
+                    "The inventory does not show Michael as an existing privileged "
+                    "legacy role holder."
+                ),
+            }
+        )
+    represented_membership_orgs = {
+        _clean(row.get("organisation_concept_id"))
+        for row in (inventory.get("memberships") or [])
+        if isinstance(row, Mapping) and _clean(row.get("organisation_concept_id"))
+    }
+    target_legacy_orgs = sorted(
+        {
+            _clean(row.get("organisation_concept_id"))
+            for row in legacy_rows
+            if isinstance(row, Mapping)
+            and _clean(row.get("subject_concept_id")) == target_id
+            and _clean(row.get("organisation_concept_id"))
+        }
+    )
+    missing_legacy_memberships = [
+        organisation_id
+        for organisation_id in target_legacy_orgs
+        if organisation_id not in represented_membership_orgs
+    ]
+    if missing_legacy_memberships:
+        conflicts.append(
+            {
+                "reason_code": "privileged_legacy_role_without_membership",
+                "message": (
+                    "Michael has a privileged legacy organisation role without "
+                    "a matching represented membership."
+                ),
+                "organisation_concept_ids": missing_legacy_memberships,
+            }
+        )
+    unexpected_legacy_subjects = [
+        subject for subject in legacy_subjects if subject != target_id
+    ]
+    if unexpected_legacy_subjects:
+        conflicts.append(
+            {
+                "reason_code": "unexpected_privileged_role_holder",
+                "message": (
+                    "A legacy privileged role is held by someone other than the "
+                    "authorised migration target."
+                ),
+                "subject_concept_ids": unexpected_legacy_subjects,
+            }
+        )
+
+    semantic_rows = list(inventory.get("semantic_role_assignments") or [])
+    unexpected_semantic_subjects = sorted(
+        {
+            _clean(row.get("subject_concept_id"))
+            for row in semantic_rows
+            if isinstance(row, Mapping)
+            and _clean(row.get("subject_concept_id"))
+            and _clean(row.get("subject_concept_id")) != target_id
+        }
+    )
+    if unexpected_semantic_subjects:
+        conflicts.append(
+            {
+                "reason_code": "unexpected_semantic_administrator",
+                "message": (
+                    "A represented semantic administrator other than Michael "
+                    "already exists."
+                ),
+                "subject_concept_ids": unexpected_semantic_subjects,
+            }
+        )
+
+    operational_rows = list(inventory.get("operational_role_assignments") or [])
+    operational_subjects = sorted(
+        {
+            _clean(row.get("subject_concept_id"))
+            for row in operational_rows
+            if isinstance(row, Mapping) and _clean(row.get("subject_concept_id"))
+        }
+    )
+    unexpected_operational_subjects = [
+        subject for subject in operational_subjects if subject != target_id
+    ]
+    if unexpected_operational_subjects:
+        conflicts.append(
+            {
+                "reason_code": "unexpected_von_operational_administrator",
+                "message": (
+                    "A represented Von operational administrator other than "
+                    "Michael already exists."
+                ),
+                "subject_concept_ids": unexpected_operational_subjects,
+            }
+        )
+    if len(operational_rows) > 1:
+        conflicts.append(
+            {
+                "reason_code": "duplicate_von_operational_administrator_assignment",
+                "message": (
+                    "The represented Von operational role has duplicate assignments "
+                    "and requires reconciliation before migration."
+                ),
+            }
+        )
+
+    semantic_grant_counts: dict[tuple[str, str, str], int] = {}
+    for row in semantic_rows:
+        if not isinstance(row, Mapping):
+            continue
+        key = (
+            _clean(row.get("subject_concept_id")),
+            _normalise_role(row.get("role")),
+            _clean(row.get("organisation_concept_id")),
+        )
+        semantic_grant_counts[key] = semantic_grant_counts.get(key, 0) + 1
+    duplicate_semantic_grants = [
+        {
+            "subject_concept_id": subject_id,
+            "role": role,
+            "organisation_concept_id": organisation_id or None,
+            "count": count,
+        }
+        for (subject_id, role, organisation_id), count in sorted(
+            semantic_grant_counts.items()
+        )
+        if count > 1
+    ]
+    if duplicate_semantic_grants:
+        conflicts.append(
+            {
+                "reason_code": "duplicate_semantic_role_assignment",
+                "message": (
+                    "A semantic administrator role has more than one canonical "
+                    "assignment and requires reconciliation before migration."
+                ),
+                "assignments": duplicate_semantic_grants,
+            }
+        )
+
+    membership_orgs = represented_membership_orgs
+    target_extra_org_roles = sorted(
+        {
+            _clean(row.get("organisation_concept_id"))
+            for row in semantic_rows
+            if isinstance(row, Mapping)
+            and _clean(row.get("subject_concept_id")) == target_id
+            and _normalise_role(row.get("role"))
+            == ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE
+            and _clean(row.get("organisation_concept_id")) not in membership_orgs
+        }
+    )
+    if target_extra_org_roles:
+        conflicts.append(
+            {
+                "reason_code": "semantic_role_without_membership",
+                "message": (
+                    "Michael already has organisation semantic authority outside "
+                    "his represented memberships."
+                ),
+                "organisation_concept_ids": target_extra_org_roles,
+            }
+        )
+
+    ambiguous_target_membership_roles = [
+        dict(row)
+        for row in inventory.get("target_membership_role_assignments") or []
+        if isinstance(row, Mapping)
+        and _normalise_role(row.get("role"))
+        not in {"viewer", "member", "contributor", "admin", "owner"}
+    ]
+    if ambiguous_target_membership_roles:
+        conflicts.append(
+            {
+                "reason_code": "orthogonal_or_custom_membership_role_requires_review",
+                "message": (
+                    "A contextual role is not a recognised organisation membership "
+                    "rank and will not be replaced automatically."
+                ),
+                "assignments": ambiguous_target_membership_roles,
+            }
+        )
+
+    global_roles = [
+        row
+        for row in semantic_rows
+        if isinstance(row, Mapping)
+        and _normalise_role(row.get("role"))
+        == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE
+    ]
+    if semantic_rows and not global_roles:
+        conflicts.append(
+            {
+                "reason_code": "semantic_roles_exist_without_global_root",
+                "message": (
+                    "Semantic organisation roles exist without a global root, so "
+                    "the one-time bootstrap cannot safely proceed."
+                ),
+            }
+        )
+    return conflicts
+
+
+def _role_is_present(
+    semantic_rows: list[Any],
+    *,
+    role: str,
+    organisation_concept_id: str | None,
+) -> bool:
+    return any(
+        isinstance(row, Mapping)
+        and _clean(row.get("subject_concept_id"))
+        == ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET
+        and _normalise_role(row.get("role")) == role
+        and _normalise_concept_id(row.get("organisation_concept_id"))
+        == organisation_concept_id
+        for row in semantic_rows
+    )
+
+
+def plan_ontology_authority_role_migration() -> dict[str, Any]:
+    """Return a stable, non-mutating migration plan bound to current inventory."""
+
+    inventory = _collect_inventory()
+    fingerprint = _stable_fingerprint(inventory)
+    conflicts = _inventory_conflicts(inventory)
+    semantic_rows = list(inventory.get("semantic_role_assignments") or [])
+    operational_rows = list(inventory.get("operational_role_assignments") or [])
+    target_operational_role_present = len(operational_rows) == 1 and _clean(
+        operational_rows[0].get("subject_concept_id")
+    ) == ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET
+    actions: list[dict[str, Any]] = [
+        {
+            "operation": "bootstrap_von_operational_administrator",
+            "subject_concept_id": ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+            "role": VON_OPERATIONAL_ADMINISTRATOR_ROLE,
+            "organisation_concept_id": None,
+            "status": (
+                "already_satisfied" if target_operational_role_present else "required"
+            ),
+        },
+        {
+            "operation": "bootstrap_global_ontology_administrator",
+            "subject_concept_id": ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+            "role": GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+            "organisation_concept_id": None,
+            "status": (
+                "already_satisfied"
+                if _role_is_present(
+                    semantic_rows,
+                    role=GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+                    organisation_concept_id=None,
+                )
+                else "required"
+            ),
+        }
+    ]
+    for membership in inventory.get("memberships") or []:
+        if not isinstance(membership, Mapping):
+            continue
+        organisation_id = _normalise_concept_id(
+            membership.get("organisation_concept_id")
+        )
+        if not organisation_id:
+            continue
+        actions.append(
+            {
+                "operation": "grant_organisation_ontology_administrator",
+                "subject_concept_id": ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+                "role": ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+                "organisation_concept_id": organisation_id,
+                "status": (
+                    "already_satisfied"
+                    if _role_is_present(
+                        semantic_rows,
+                        role=ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+                        organisation_concept_id=organisation_id,
+                    )
+                    else "required"
+                ),
+            }
+        )
+    membership_role_rows = list(
+        inventory.get("target_membership_role_assignments") or []
+    )
+    for membership in inventory.get("memberships") or []:
+        if not isinstance(membership, Mapping):
+            continue
+        organisation_id = _normalise_concept_id(
+            membership.get("organisation_concept_id")
+        )
+        if not organisation_id:
+            continue
+        exact_rows = [
+            row
+            for row in membership_role_rows
+            if isinstance(row, Mapping)
+            and _normalise_concept_id(row.get("organisation_concept_id"))
+            == organisation_id
+        ]
+        exact_owner = len(exact_rows) == 1 and _normalise_role(
+            exact_rows[0].get("role")
+        ) == _OWNER_ROLE
+        actions.append(
+            {
+                "operation": "replace_legacy_organisation_role_with_owner",
+                "subject_concept_id": ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+                "role": _OWNER_ROLE,
+                "organisation_concept_id": organisation_id,
+                "status": "already_satisfied" if exact_owner else "required",
+                "runs_after_semantic_role_verification": True,
+            }
+        )
+    return {
+        "schema_version": ONTOLOGY_AUTHORITY_ROLE_MIGRATION_SCHEMA_VERSION,
+        "mode": "dry_run",
+        "target_concept_id": ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+        "inventory_fingerprint": fingerprint,
+        "ready_to_apply": not conflicts,
+        "conflicts": conflicts,
+        "inventory": inventory,
+        "actions": actions,
+        "operational_authority": {
+            "role_concept_id": VON_ADMINISTRATOR_CONCEPT_ID,
+            "represented_assignment_mechanism": "dedicated_role_lifecycle",
+            "migration_behaviour": (
+                "preserve_existing_operator_controls_and_represent_michael_as_"
+                "von_operational_administrator_separately_from_semantic_authority"
+            ),
+            "semantic_authority_predicate": AUTHORITY_ROLE_PREDICATE,
+            "kept_separate_from_semantic_authority": True,
+            "not_inferred_from_semantic_roles": True,
+            "owner_permissions": sorted(get_effective_permissions(_OWNER_ROLE)),
+        },
+        "elevation_boundary": {
+            "allowed_subject_concept_ids": [
+                ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET
+            ],
+            "other_subjects_elevated": False,
+        },
+    }
+
+
+def _request_id(role: str, organisation_concept_id: str | None) -> str:
+    digest = hashlib.sha256(
+        "|".join(
+            (
+                ONTOLOGY_AUTHORITY_ROLE_MIGRATION_SCHEMA_VERSION,
+                ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+                role,
+                organisation_concept_id or "global",
+            )
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"ontology-authority-role-migration-{digest}"
+
+
+def _verified_read_back(
+    *,
+    role: str,
+    organisation_concept_id: str | None,
+) -> dict[str, Any]:
+    read_back = authority_role_read_back(
+        subject_concept_id=ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+        role=role,
+        organisation_concept_id=organisation_concept_id,
+    )
+    if read_back.get("active") is not True or not list(read_back.get("grants") or []):
+        raise OntologyAuthorityRoleMigrationError(
+            "ontology_authority_role_migration_read_back_failed",
+            "The exact migrated semantic role could not be read back.",
+            report={"canonical_read_back": read_back},
+        )
+    return read_back
+
+
+def _verified_operational_read_back() -> dict[str, Any]:
+    read_back = von_operational_administrator_read_back(
+        subject_concept_id=ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+    )
+    if read_back.get("active") is not True or len(read_back.get("grants") or []) != 1:
+        raise OntologyAuthorityRoleMigrationError(
+            "ontology_authority_role_migration_operational_read_back_failed",
+            "The exact Von operational administrator role could not be read back.",
+            report={"canonical_read_back": read_back},
+        )
+    return read_back
+
+
+def _membership_role_read_back(organisation_concept_id: str) -> dict[str, Any]:
+    organisation_id = _normalise_concept_id(organisation_concept_id)
+    rows = [
+        row
+        for row in _target_membership_role_assignments()
+        if _normalise_concept_id(row.get("organisation_concept_id"))
+        == organisation_id
+    ]
+    exact_owner = len(rows) == 1 and _normalise_role(rows[0].get("role")) == _OWNER_ROLE
+    return {
+        "subject_concept_id": ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+        "organisation_concept_id": organisation_id,
+        "role": _OWNER_ROLE if exact_owner else None,
+        "exact_owner": exact_owner,
+        "role_assignments": rows,
+        "permissions": (
+            sorted(get_effective_permissions(_OWNER_ROLE)) if exact_owner else []
+        ),
+    }
+
+
+def _replace_membership_role_with_owner(
+    organisation_concept_id: str,
+) -> dict[str, Any]:
+    """Replace exact-org legacy role text only after semantic-role verification."""
+
+    organisation_id = _normalise_concept_id(organisation_concept_id)
+    if not organisation_id:
+        raise OntologyAuthorityRoleMigrationError(
+            "ontology_authority_role_migration_membership_required",
+            "An exact represented organisation membership is required.",
+        )
+    before = _membership_role_read_back(organisation_id)
+    if before["exact_owner"] is True:
+        return {
+            "success": True,
+            "changed": False,
+            "canonical_read_back": before,
+        }
+
+    with override_current_organisation(organisation_id):
+        owner_result = upsert_text_for_concept(
+            subject_concept_id=ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+            predicate=ROLE_PREDICATE,
+            text=organisation_role_storage_text(_OWNER_ROLE, organisation_id),
+            lang="en",
+            provenance={"source": ONTOLOGY_AUTHORITY_ROLE_MIGRATION_SCHEMA_VERSION},
+            context={
+                "organisation_id": organisation_id,
+                "role_migration": {
+                    "schema_version": (
+                        ONTOLOGY_AUTHORITY_ROLE_MIGRATION_SCHEMA_VERSION
+                    ),
+                    "reason": _MIGRATION_REASON,
+                },
+            },
+        )
+        owner_relation_id = _clean(owner_result.get("relation_id"))
+        after_owner_insert = _membership_role_read_back(organisation_id)
+        if not owner_relation_id or not any(
+            _clean(row.get("relation_id")) == owner_relation_id
+            and _normalise_role(row.get("role")) == _OWNER_ROLE
+            for row in after_owner_insert.get("role_assignments") or []
+            if isinstance(row, Mapping)
+        ):
+            raise OntologyAuthorityRoleMigrationError(
+                "ontology_authority_role_migration_owner_read_back_failed",
+                "The owner role was not readable before legacy role removal.",
+                report={"canonical_read_back": after_owner_insert},
+            )
+
+        deleted_relation_ids: list[str] = []
+        for row in after_owner_insert.get("role_assignments") or []:
+            if not isinstance(row, Mapping):
+                continue
+            relation_id = _clean(row.get("relation_id"))
+            if (
+                _normalise_role(row.get("role")) == _OWNER_ROLE
+                and relation_id == owner_relation_id
+            ):
+                continue
+            if not relation_id:
+                raise OntologyAuthorityRoleMigrationError(
+                    "ontology_authority_role_migration_legacy_role_unaddressable",
+                    "A legacy organisation role has no canonical relation identifier.",
+                    report={"legacy_role": dict(row)},
+                )
+            deletion = delete_text_relation(
+                subject_concept_id=ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+                relation_id=relation_id,
+                garbage_collect=False,
+            )
+            if deletion.get("deleted") is not True:
+                raise OntologyAuthorityRoleMigrationError(
+                    "ontology_authority_role_migration_legacy_role_delete_failed",
+                    "A superseded organisation role could not be removed.",
+                    report={"legacy_role": dict(row)},
+                )
+            deleted_relation_ids.append(relation_id)
+
+    after = _membership_role_read_back(organisation_id)
+    if after["exact_owner"] is not True:
+        raise OntologyAuthorityRoleMigrationError(
+            "ontology_authority_role_migration_owner_read_back_failed",
+            "The exact organisation owner role could not be read back.",
+            report={"canonical_read_back": after},
+        )
+    return {
+        "success": True,
+        "changed": True,
+        "owner_relation_id": owner_relation_id,
+        "deleted_relation_ids": deleted_relation_ids,
+        "canonical_read_back": after,
+    }
+
+
+def _canonical_action_read_back(action: Mapping[str, Any]) -> dict[str, Any]:
+    operation = _clean(action.get("operation"))
+    organisation_id = _normalise_concept_id(
+        action.get("organisation_concept_id")
+    )
+    if operation == "bootstrap_von_operational_administrator":
+        return _verified_operational_read_back()
+    if operation == "replace_legacy_organisation_role_with_owner":
+        return _membership_role_read_back(str(organisation_id or ""))
+    return _verified_read_back(
+        role=_normalise_role(action.get("role")),
+        organisation_concept_id=organisation_id,
+    )
+
+
+def _execute_migration_action(action: Mapping[str, Any]) -> dict[str, Any]:
+    operation = _clean(action.get("operation"))
+    role = _normalise_role(action.get("role"))
+    organisation_id = _normalise_concept_id(
+        action.get("organisation_concept_id")
+    )
+    if operation == "bootstrap_von_operational_administrator":
+        result = bootstrap_first_von_operational_administrator(
+            subject_concept_id=ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+        )
+    elif operation == "replace_legacy_organisation_role_with_owner":
+        result = _replace_membership_role_with_owner(str(organisation_id or ""))
+    elif role == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE:
+        result = bootstrap_first_semantic_authority(
+            subject_concept_id=ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+            role=GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+        )
+    elif role == ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE and organisation_id:
+        with override_current_organisation(organisation_id):
+            result = grant_ontology_authority_role(
+                subject_concept_id=ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+                role=ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+                organisation_concept_id=organisation_id,
+                request_id=_request_id(role, organisation_id),
+                reason=_MIGRATION_REASON,
+            )
+        if result.get("success") is not True:
+            raise OntologyAuthorityRoleMigrationError(
+                "ontology_authority_role_migration_semantic_grant_failed",
+                "A semantic role grant did not complete successfully.",
+                report={"canonical_result": result},
+            )
+    else:
+        raise OntologyAuthorityRoleMigrationError(
+            "ontology_authority_role_migration_unknown_action",
+            "The migration plan contains an unsupported action.",
+            report={"action": dict(action)},
+        )
+    return {
+        **dict(action),
+        "effect_status": "succeeded",
+        "canonical_result": result,
+        "canonical_read_back": _canonical_action_read_back(action),
+    }
+
+
+def _ordered_effects(
+    actions: list[Any],
+    effects_by_key: Mapping[tuple[str, str, str, str], Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    return [
+        dict(effects_by_key[_action_key(action)])
+        for action in actions
+        if isinstance(action, Mapping) and _action_key(action) in effects_by_key
+    ]
+
+
+def _record_partial_safely(report: Mapping[str, Any]) -> None:
+    try:
+        _update_migration_operation(
+            status="partial",
+            completed_effects=list(report.get("completed_effects") or []),
+            last_failure=dict(report),
+        )
+    except Exception:  # noqa: BLE001 - never obscure canonical partial evidence
+        return
+
+
+def apply_ontology_authority_role_migration(
+    *,
+    expected_inventory_fingerprint: str,
+) -> dict[str, Any]:
+    """Apply the inventory-bound migration through canonical role services.
+
+    The first apply records its source plan before any authority effect. A retry
+    with that same fingerprint resumes only if the membership/action inventory
+    differs by already-satisfied migration effects and no conflicting holder
+    has appeared. Each completed effect carries canonical exact-role read-back.
+    """
+
+    actor_id = _normalise_concept_id(get_effective_user_concept_id())
+    if actor_id != ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET:
+        raise OntologyAuthorityRoleMigrationError(
+            "ontology_authority_role_migration_target_actor_required",
+            "The migration must run in Michael's trusted actor context.",
+        )
+    invocation = current_ontology_invocation()
+    if invocation and invocation.executing_agent_concept_id:
+        raise OntologyAuthorityRoleMigrationError(
+            "ontology_authority_role_migration_human_actor_required",
+            "An executing agent cannot perform the administrator-role migration.",
+        )
+    expected_fingerprint = _clean(expected_inventory_fingerprint)
+    if not expected_fingerprint:
+        raise OntologyAuthorityRoleMigrationError(
+            "ontology_authority_role_migration_fingerprint_required",
+            "Apply requires the exact fingerprint from a current dry-run.",
+        )
+
+    plan: dict[str, Any] | None = None
+    effects_by_key: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+    current_action: dict[str, Any] | None = None
+    try:
+        # Lock ordering is always shared barrier -> migration lock -> dedicated
+        # role lock. Canonical role/membership writers enter the same barrier,
+        # whose ContextVar makes the migration's nested service calls re-entrant.
+        with ontology_authority_membership_mutation_barrier():  # noqa: SIM117
+            with ontology_mutation_resource_lock(_MIGRATION_RESOURCE_KEY):
+                plan = plan_ontology_authority_role_migration()
+                operation = _load_migration_operation()
+                if operation is None:
+                    if plan["inventory_fingerprint"] != expected_fingerprint:
+                        raise OntologyAuthorityRoleMigrationError(
+                            "ontology_authority_role_migration_inventory_changed",
+                            "The live role inventory changed after the dry-run.",
+                            report=plan,
+                        )
+                    if plan.get("ready_to_apply") is not True:
+                        raise OntologyAuthorityRoleMigrationError(
+                            "ontology_authority_role_migration_inventory_conflict",
+                            "The live role inventory contradicts the migration premise.",
+                            report=plan,
+                        )
+                    operation = _start_migration_operation(
+                        source_plan=plan,
+                        source_fingerprint=expected_fingerprint,
+                    )
+                else:
+                    source_plan_value = operation.get("source_plan")
+                    source_plan = (
+                        source_plan_value
+                        if isinstance(source_plan_value, Mapping)
+                        else None
+                    )
+                    source_fingerprint = _clean(
+                        operation.get("source_inventory_fingerprint")
+                    )
+                    accepted_fingerprint = expected_fingerprint in {
+                        source_fingerprint,
+                        _clean(plan.get("inventory_fingerprint")),
+                    }
+                    completed_state_still_exact = not (
+                        operation.get("status") == "completed"
+                        and any(
+                            isinstance(action, Mapping)
+                            and action.get("status") != "already_satisfied"
+                            for action in plan.get("actions") or []
+                        )
+                    )
+                    if (
+                        source_plan is None
+                        or not accepted_fingerprint
+                        or not _continuation_is_safe(source_plan, plan)
+                        or not completed_state_still_exact
+                    ):
+                        reason_code = (
+                            "ontology_authority_role_migration_completed_state_changed"
+                            if operation.get("status") == "completed"
+                            else "ontology_authority_role_migration_inventory_changed"
+                        )
+                        raise OntologyAuthorityRoleMigrationError(
+                            reason_code,
+                            "The live role inventory is not a safe continuation of the dry-run.",
+                            report={
+                                "source_plan": dict(source_plan or {}),
+                                "current_plan": plan,
+                                "operation_status": operation.get("status"),
+                            },
+                        )
+
+                for effect in operation.get("completed_effects") or []:
+                    if isinstance(effect, Mapping):
+                        effects_by_key[_action_key(effect)] = dict(effect)
+
+                changed = False
+                actions = list(plan.get("actions") or [])
+                for raw_action in actions:
+                    if not isinstance(raw_action, Mapping):
+                        continue
+                    current_action = dict(raw_action)
+                    key = _action_key(current_action)
+                    if current_action.get("status") == "already_satisfied":
+                        existing_effect = effects_by_key.get(key, {})
+                        effects_by_key[key] = {
+                            **current_action,
+                            **{
+                                name: value
+                                for name, value in existing_effect.items()
+                                if name not in {"status", "canonical_read_back"}
+                            },
+                            "effect_status": existing_effect.get(
+                                "effect_status", "already_satisfied"
+                            ),
+                            "canonical_read_back": _canonical_action_read_back(
+                                current_action
+                            ),
+                        }
+                    else:
+                        effect = _execute_migration_action(current_action)
+                        effects_by_key[key] = effect
+                        result = effect.get("canonical_result")
+                        result_map = result if isinstance(result, Mapping) else {}
+                        changed = changed or bool(result_map.get("changed", True))
+
+                    completed_effects = _ordered_effects(actions, effects_by_key)
+                    _update_migration_operation(
+                        status="in_progress",
+                        completed_effects=completed_effects,
+                        last_completed_action=list(key),
+                    )
+
+                effects = _ordered_effects(actions, effects_by_key)
+                final_plan = plan_ontology_authority_role_migration()
+                remaining = [
+                    action
+                    for action in final_plan.get("actions") or []
+                    if isinstance(action, Mapping)
+                    and action.get("status") != "already_satisfied"
+                ]
+                if (
+                    final_plan.get("ready_to_apply") is not True
+                    or remaining
+                    or not _continuation_is_safe(plan, final_plan)
+                ):
+                    raise OntologyAuthorityRoleMigrationError(
+                        "ontology_authority_role_migration_final_read_back_failed",
+                        "Final inventory does not contain exactly the required roles.",
+                        report={
+                            "plan_before": plan,
+                            "completed_effects": effects,
+                            "plan_after": final_plan,
+                        },
+                    )
+
+                semantic_read_backs = [
+                    effect["canonical_read_back"]
+                    for effect in effects
+                    if _normalise_role(effect.get("role"))
+                    in {
+                        GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+                        ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+                    }
+                ]
+                owner_read_backs = [
+                    effect["canonical_read_back"]
+                    for effect in effects
+                    if _clean(effect.get("operation"))
+                    == "replace_legacy_organisation_role_with_owner"
+                ]
+                result = {
+                    "schema_version": ONTOLOGY_AUTHORITY_ROLE_MIGRATION_SCHEMA_VERSION,
+                    "mode": "apply",
+                    "success": True,
+                    "changed": changed,
+                    "replayed": _clean(
+                        operation.get("source_inventory_fingerprint")
+                    )
+                    != _clean(plan.get("inventory_fingerprint")),
+                    "target_concept_id": ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+                    "inventory_fingerprint_before": _clean(
+                        operation.get("source_inventory_fingerprint")
+                    ),
+                    "inventory_fingerprint_after": final_plan[
+                        "inventory_fingerprint"
+                    ],
+                    "effects": effects,
+                    "canonical_read_back": {
+                        "von_operational_administrator": (
+                            _verified_operational_read_back()
+                        ),
+                        "semantic_role_grants": semantic_read_backs,
+                        "organisation_owner_roles": owner_read_backs,
+                        "semantic_role_assignments": final_plan["inventory"][
+                            "semantic_role_assignments"
+                        ],
+                        "operational_role_assignments": final_plan["inventory"][
+                            "operational_role_assignments"
+                        ],
+                        "memberships": final_plan["inventory"]["memberships"],
+                    },
+                }
+                _update_migration_operation(
+                    status="completed",
+                    completed_effects=effects,
+                    completed_at=_now(),
+                    result=result,
+                )
+                return result
+    except OntologyMutationResourceBusy as exc:
+        raise OntologyAuthorityRoleMigrationError(
+            "ontology_mutation_resource_busy",
+            "Another administrator-role migration is already in progress.",
+        ) from exc
+    except OntologyAuthorityRoleMigrationError as exc:
+        if exc.reason_code in {
+            "ontology_authority_role_migration_inventory_changed",
+            "ontology_authority_role_migration_inventory_conflict",
+            "ontology_authority_role_migration_completed_state_changed",
+        } and not effects_by_key:
+            raise
+        completed_effects = _ordered_effects(
+            list(plan.get("actions") or []) if isinstance(plan, Mapping) else [],
+            effects_by_key,
+        )
+        report = {
+            "plan": plan,
+            "completed_effects": completed_effects,
+            "failed_effect": current_action,
+            "failure_reason_code": exc.reason_code,
+            "failure_report": exc.report,
+        }
+        _record_partial_safely(report)
+        raise OntologyAuthorityRoleMigrationError(
+            "ontology_authority_role_migration_partial",
+            "The migration did not complete; verified effects are safe to resume.",
+            report=report,
+        ) from exc
+    except (PermissionError, ValueError, RuntimeError) as exc:
+        completed_effects = _ordered_effects(
+            list(plan.get("actions") or []) if isinstance(plan, Mapping) else [],
+            effects_by_key,
+        )
+        report = {
+            "plan": plan,
+            "completed_effects": completed_effects,
+            "failed_effect": current_action,
+            "failure_type": type(exc).__name__,
+        }
+        _record_partial_safely(report)
+        raise OntologyAuthorityRoleMigrationError(
+            "ontology_authority_role_migration_partial",
+            "The migration did not complete; verified effects are safe to resume.",
+            report=report,
+        ) from exc
+
+
+__all__ = [
+    "ONTOLOGY_AUTHORITY_ROLE_MIGRATION_SCHEMA_VERSION",
+    "ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET",
+    "OntologyAuthorityRoleMigrationError",
+    "apply_ontology_authority_role_migration",
+    "plan_ontology_authority_role_migration",
+]

--- a/src/backend/services/ontology_authority_role_service.py
+++ b/src/backend/services/ontology_authority_role_service.py
@@ -1,0 +1,537 @@
+"""Dedicated lifecycle for represented semantic ontology administrator roles."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ..db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
+from ..security.access_control import (
+    can_access_concept,
+    get_effective_user_concept_id,
+)
+from .ontology_authority_membership_coordination_service import (
+    ontology_authority_membership_mutation_barrier,
+)
+from .ontology_publication_authority_service import (
+    AUTHORITY_ROLE_PREDICATE,
+    GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+    ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+    OntologyMutationIntent,
+    OntologyMutationResourceBusy,
+    PublicationContext,
+    authorise_ontology_mutation,
+    authority_role_storage_text,
+    current_ontology_invocation,
+    execute_authorised_ontology_mutation,
+    ontology_mutation_resource_lock,
+    parse_authority_role_storage_text,
+    resolve_live_semantic_roles,
+)
+from .organisation_membership_service import is_user_member_of_organisation
+from .text_value_service import delete_text_relation, upsert_text_for_concept
+
+
+def _clean(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _normalise_concept_id(value: object) -> str | None:
+    cleaned = _clean(value)
+    if not cleaned:
+        return None
+    return cleaned if cleaned.startswith("#") else f"#V#{cleaned}"
+
+
+def _normalise_role(
+    role: object,
+    organisation_concept_id: object = None,
+) -> tuple[str, str | None]:
+    role_value = _clean(role).lower()
+    organisation_id = _normalise_concept_id(organisation_concept_id)
+    if role_value == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE:
+        if organisation_id:
+            raise ValueError("global authority may not have an organisation context")
+        return role_value, None
+    if role_value == ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE:
+        if not organisation_id:
+            raise ValueError(
+                "organisation_concept_id is required for organisation authority"
+            )
+        return role_value, organisation_id
+    raise ValueError("unsupported_ontology_authority_role")
+
+
+def _assert_direct_human_administrator() -> str:
+    actor_id = _normalise_concept_id(get_effective_user_concept_id())
+    if not actor_id:
+        raise PermissionError("authenticated_actor_context_required")
+    invocation = current_ontology_invocation()
+    if invocation and invocation.executing_agent_concept_id:
+        raise PermissionError("ontology_authority_role_human_administrator_required")
+    return actor_id
+
+
+def _role_context(role: str, organisation_id: str | None) -> dict[str, str]:
+    if role == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE:
+        return {"authority_scope": "global"}
+    return {"organisation_concept_id": str(organisation_id)}
+
+
+def _grant_provenance(
+    *,
+    actor_concept_id: str,
+    request_id: str,
+    reason: str | None,
+) -> dict[str, Any]:
+    return {
+        "source": "ontology_authority_role_grant",
+        "granted_by_actor_concept_id": actor_concept_id,
+        "request_id": request_id,
+        "reason": _clean(reason) or None,
+    }
+
+
+def _role_resource_key(role: str, organisation_id: str | None) -> str:
+    return f"ontology-authority-role:{role}:{organisation_id or 'global'}"
+
+
+def _role_resource_busy() -> dict[str, Any]:
+    return {
+        "success": False,
+        "effect_status": "not_started",
+        "mutation_outcome": "not_started",
+        "changed": False,
+        "retryable": True,
+        "error_code": "ontology_mutation_resource_busy",
+        "error": "Another role lifecycle effect is already in progress.",
+    }
+
+
+def _live_role_reauthorisation_failure(
+    intent: OntologyMutationIntent,
+) -> dict[str, Any] | None:
+    """Re-check the exact lifecycle authority while holding its root lock."""
+
+    decision = authorise_ontology_mutation(intent)
+    if decision.allowed:
+        return None
+    return {
+        "success": False,
+        "effect_status": "not_started",
+        "mutation_outcome": "not_started",
+        "changed": False,
+        "error_code": decision.reason_code,
+        "error": decision.message,
+        "authority_decision": decision.public_projection(),
+    }
+
+
+def _role_publication_context(
+    role: str,
+    organisation_id: str | None,
+) -> PublicationContext:
+    if role == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE:
+        return PublicationContext.global_context(source="authority_role_lifecycle")
+    return PublicationContext.organisation(
+        str(organisation_id),
+        source="authority_role_lifecycle",
+    )
+
+
+def _role_rows(subject_concept_id: str | None = None) -> list[dict[str, Any]]:
+    query: dict[str, Any] = {"predicate": AUTHORITY_ROLE_PREDICATE}
+    if subject_concept_id:
+        query["subject_concept_id"] = subject_concept_id
+    rows: list[dict[str, Any]] = []
+    for relation in TextRelationsRepository.find(query):
+        if not isinstance(relation, Mapping):
+            continue
+        text_value = TextValuesRepository.find_one(
+            {"_id": relation.get("object_text_id")}
+        )
+        if not isinstance(text_value, Mapping):
+            continue
+        relation_context = (
+            relation.get("context")
+            if isinstance(relation.get("context"), Mapping)
+            else {}
+        )
+        role, organisation_id = parse_authority_role_storage_text(
+            text_value.get("text"),
+            relation_context,
+        )
+        if not role:
+            continue
+        rows.append(
+            {
+                "relation_id": str(relation.get("_id") or ""),
+                "subject_concept_id": _normalise_concept_id(
+                    relation.get("subject_concept_id")
+                ),
+                "role": role,
+                "organisation_concept_id": organisation_id,
+                "context": dict(relation_context),
+                "grant_provenance": (
+                    dict(relation_context.get("grant_provenance"))
+                    if isinstance(relation_context.get("grant_provenance"), Mapping)
+                    else None
+                ),
+                "updated_at": str(relation.get("updated_at") or "") or None,
+            }
+        )
+    rows.sort(
+        key=lambda item: (
+            str(item.get("role") or ""),
+            str(item.get("organisation_concept_id") or ""),
+            str(item.get("subject_concept_id") or ""),
+            str(item.get("relation_id") or ""),
+        )
+    )
+    return rows
+
+
+def _matching_role_rows(
+    *,
+    subject_concept_id: str,
+    role: str,
+    organisation_concept_id: str | None,
+) -> list[dict[str, Any]]:
+    return [
+        row
+        for row in _role_rows(subject_concept_id)
+        if row["role"] == role
+        and row.get("organisation_concept_id") == organisation_concept_id
+    ]
+
+
+def authority_role_read_back(
+    *,
+    subject_concept_id: str,
+    role: str,
+    organisation_concept_id: str | None,
+) -> dict[str, Any]:
+    rows = _matching_role_rows(
+        subject_concept_id=subject_concept_id,
+        role=role,
+        organisation_concept_id=organisation_concept_id,
+    )
+    return {
+        "subject_concept_id": subject_concept_id,
+        "role": role,
+        "organisation_concept_id": organisation_concept_id,
+        "active": bool(rows),
+        "grants": rows,
+    }
+
+
+def _role_intent(
+    *,
+    operation: str,
+    subject_concept_id: str,
+    role: str,
+    organisation_concept_id: str | None,
+    request_id: str,
+    reason: str | None,
+) -> OntologyMutationIntent:
+    targets = tuple(
+        value for value in (subject_concept_id, organisation_concept_id) if value
+    )
+    return OntologyMutationIntent(
+        operation=operation,
+        publication_context=_role_publication_context(role, organisation_concept_id),
+        target_concept_ids=targets,
+        tool_name=(
+            "grant_ontology_authority_role"
+            if operation == "authority.role.grant"
+            else "revoke_ontology_authority_role"
+        ),
+        predicate=AUTHORITY_ROLE_PREDICATE,
+        delta={
+            "subject_concept_id": subject_concept_id,
+            "role": role,
+            "organisation_concept_id": organisation_concept_id,
+            "reason": _clean(reason) or None,
+        },
+        idempotency_key=request_id,
+    )
+
+
+def _validate_role_change(
+    *,
+    subject_concept_id: object,
+    role: object,
+    organisation_concept_id: object,
+    request_id: object,
+) -> tuple[str, str, str | None, str]:
+    _assert_direct_human_administrator()
+    subject_id = _normalise_concept_id(subject_concept_id)
+    if not subject_id:
+        raise ValueError("subject_concept_id is required")
+    role_value, organisation_id = _normalise_role(role, organisation_concept_id)
+    request_key = _clean(request_id)
+    if not request_key:
+        raise ValueError("request_id is required")
+    if not can_access_concept(subject_id):
+        raise PermissionError("ontology_authority_role_target_not_accessible")
+    if organisation_id and not can_access_concept(organisation_id):
+        raise PermissionError("ontology_authority_role_target_not_accessible")
+    return subject_id, role_value, organisation_id, request_key
+
+
+def grant_ontology_authority_role(
+    *,
+    subject_concept_id: str,
+    role: str,
+    organisation_concept_id: str | None = None,
+    request_id: str,
+    reason: str | None = None,
+) -> dict[str, Any]:
+    """Grant one represented role without allowing semantic amplification."""
+
+    actor_id = _assert_direct_human_administrator()
+    subject_id, role_value, organisation_id, request_key = _validate_role_change(
+        subject_concept_id=subject_concept_id,
+        role=role,
+        organisation_concept_id=organisation_concept_id,
+        request_id=request_id,
+    )
+    intent = _role_intent(
+        operation="authority.role.grant",
+        subject_concept_id=subject_id,
+        role=role_value,
+        organisation_concept_id=organisation_id,
+        request_id=request_key,
+        reason=reason,
+    )
+    expected_grant_provenance = _grant_provenance(
+        actor_concept_id=actor_id,
+        request_id=request_key,
+        reason=reason,
+    )
+
+    def mutate() -> Mapping[str, Any]:
+        try:
+            with ontology_authority_membership_mutation_barrier():  # noqa: SIM117
+                with ontology_mutation_resource_lock(
+                    _role_resource_key(role_value, organisation_id)
+                ):
+                    live_denial = _live_role_reauthorisation_failure(intent)
+                    if live_denial is not None:
+                        return live_denial
+                    if organisation_id and not is_user_member_of_organisation(
+                        subject_id,
+                        organisation_id,
+                    ):
+                        return {
+                            "success": False,
+                            "effect_status": "not_started",
+                            "mutation_outcome": "not_started",
+                            "changed": False,
+                            "error_code": (
+                                "organisation_membership_required_for_"
+                                "ontology_authority"
+                            ),
+                            "error": (
+                                "Exact organisation membership is required before "
+                                "granting ontology publication authority."
+                            ),
+                        }
+                    result = upsert_text_for_concept(
+                        subject_concept_id=subject_id,
+                        predicate=AUTHORITY_ROLE_PREDICATE,
+                        text=authority_role_storage_text(role_value, organisation_id),
+                        lang="en-NZ",
+                        # Text values are globally deduplicated by text/language,
+                        # so grant-specific evidence belongs on this subject's
+                        # relation context rather than the shared value.
+                        provenance={"source": "ontology_authority_role_vocabulary"},
+                        context={
+                            **_role_context(role_value, organisation_id),
+                            "grant_provenance": expected_grant_provenance,
+                        },
+                    )
+        except OntologyMutationResourceBusy:
+            return _role_resource_busy()
+        changed = bool(result.get("relation_created") or result.get("context_updated"))
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "mutation_outcome": "succeeded",
+            "changed": changed,
+            "relation_id": result.get("relation_id"),
+            "subject_concept_id": subject_id,
+            "role": role_value,
+            "organisation_concept_id": organisation_id,
+            "grant_provenance": expected_grant_provenance,
+        }
+
+    return execute_authorised_ontology_mutation(
+        intent=intent,
+        mutate=mutate,
+        read_before=lambda: authority_role_read_back(
+            subject_concept_id=subject_id,
+            role=role_value,
+            organisation_concept_id=organisation_id,
+        ),
+        read_back=lambda: authority_role_read_back(
+            subject_concept_id=subject_id,
+            role=role_value,
+            organisation_concept_id=organisation_id,
+        ),
+        verify_read_back=lambda result, state: (
+            isinstance(state, Mapping)
+            and state.get("active") is True
+            and any(
+                isinstance(row, Mapping)
+                and _clean(row.get("relation_id")) == _clean(result.get("relation_id"))
+                and row.get("grant_provenance") == expected_grant_provenance
+                for row in (state.get("grants") or [])
+            )
+        ),
+    )
+
+
+def revoke_ontology_authority_role(
+    *,
+    subject_concept_id: str,
+    role: str,
+    organisation_concept_id: str | None = None,
+    request_id: str,
+    reason: str | None = None,
+) -> dict[str, Any]:
+    """Revoke one exact role and preserve at least one global recovery root."""
+
+    subject_id, role_value, organisation_id, request_key = _validate_role_change(
+        subject_concept_id=subject_concept_id,
+        role=role,
+        organisation_concept_id=organisation_concept_id,
+        request_id=request_id,
+    )
+    intent = _role_intent(
+        operation="authority.role.revoke",
+        subject_concept_id=subject_id,
+        role=role_value,
+        organisation_concept_id=organisation_id,
+        request_id=request_key,
+        reason=reason,
+    )
+
+    def mutate() -> Mapping[str, Any]:
+        try:
+            with ontology_authority_membership_mutation_barrier():  # noqa: SIM117
+                with ontology_mutation_resource_lock(
+                    _role_resource_key(role_value, organisation_id)
+                ):
+                    live_denial = _live_role_reauthorisation_failure(intent)
+                    if live_denial is not None:
+                        return live_denial
+                    matches = _matching_role_rows(
+                        subject_concept_id=subject_id,
+                        role=role_value,
+                        organisation_concept_id=organisation_id,
+                    )
+                    if role_value == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE and matches:
+                        all_global = [
+                            row
+                            for row in _role_rows()
+                            if row["role"] == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE
+                        ]
+                        if len(all_global) <= len(matches):
+                            return {
+                                "success": False,
+                                "effect_status": "not_started",
+                                "mutation_outcome": "not_started",
+                                "changed": False,
+                                "error_code": (
+                                    "last_global_ontology_administrator_cannot_be_revoked"
+                                ),
+                                "error": (
+                                    "At least one represented global semantic administrator "
+                                    "is required."
+                                ),
+                            }
+                    deleted_ids: list[str] = []
+                    for row in matches:
+                        relation_id = _clean(row.get("relation_id"))
+                        if not relation_id:
+                            continue
+                        result = delete_text_relation(
+                            subject_concept_id=subject_id,
+                            relation_id=relation_id,
+                            garbage_collect=False,
+                        )
+                        if result.get("deleted"):
+                            deleted_ids.append(relation_id)
+        except OntologyMutationResourceBusy:
+            return _role_resource_busy()
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "mutation_outcome": "succeeded",
+            "changed": bool(deleted_ids),
+            "deleted_relation_ids": deleted_ids,
+            "subject_concept_id": subject_id,
+            "role": role_value,
+            "organisation_concept_id": organisation_id,
+            "reason": _clean(reason) or None,
+        }
+
+    return execute_authorised_ontology_mutation(
+        intent=intent,
+        mutate=mutate,
+        read_before=lambda: authority_role_read_back(
+            subject_concept_id=subject_id,
+            role=role_value,
+            organisation_concept_id=organisation_id,
+        ),
+        read_back=lambda: authority_role_read_back(
+            subject_concept_id=subject_id,
+            role=role_value,
+            organisation_concept_id=organisation_id,
+        ),
+        verify_read_back=lambda _result, state: (
+            isinstance(state, Mapping) and state.get("active") is False
+        ),
+    )
+
+
+def list_manageable_ontology_authority_roles() -> list[dict[str, Any]]:
+    """List only role grants in contexts the current human actor administers."""
+
+    actor_id = _assert_direct_human_administrator()
+    evidence = resolve_live_semantic_roles(actor_id)
+    manages_global = any(
+        item.role == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE for item in evidence
+    )
+    managed_organisations = {
+        item.organisation_concept_id
+        for item in evidence
+        if item.role == ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE
+        and item.organisation_concept_id
+    }
+    rows: list[dict[str, Any]] = []
+    for row in _role_rows():
+        role = row.get("role")
+        organisation_id = row.get("organisation_concept_id")
+        manageable = (
+            role == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE and manages_global
+        ) or (
+            role == ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE
+            and organisation_id in managed_organisations
+        )
+        subject_id = _normalise_concept_id(row.get("subject_concept_id"))
+        if manageable and subject_id and can_access_concept(subject_id):
+            rows.append(row)
+    return rows
+
+
+__all__ = [
+    "authority_role_read_back",
+    "grant_ontology_authority_role",
+    "list_manageable_ontology_authority_roles",
+    "revoke_ontology_authority_role",
+]

--- a/src/backend/services/ontology_authority_vocabulary_service.py
+++ b/src/backend/services/ontology_authority_vocabulary_service.py
@@ -1,0 +1,234 @@
+"""Vocabulary and one-time global bootstrap for ontology publication authority.
+
+The vocabulary itself is a read-only code registry.  The only persistent
+bootstrap operation is deliberately narrow: when no global semantic
+administrator exists, a locally enabled trusted operator may record the first
+global role. Represented administrators then establish organisation roles
+through the normal lifecycle. An operator token is not otherwise semantic
+publication authority.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ..db.repositories.concepts_repository import ConceptsRepository
+from ..db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
+from ..security.access_control import bypass_access_control
+from .ontology_authority_membership_coordination_service import (
+    ontology_authority_membership_mutation_barrier,
+)
+from .ontology_publication_authority_service import (
+    AUTHORITY_ROLE_PREDICATE,
+    GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+    ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+    OntologyMutationResourceBusy,
+    authority_role_storage_text,
+    ontology_mutation_resource_lock,
+    parse_authority_role_storage_text,
+    resolve_live_semantic_roles,
+)
+from .text_value_service import delete_text_relation, upsert_text_for_concept
+
+ONTOLOGY_AUTHORITY_VOCABULARY = {
+    "predicate": AUTHORITY_ROLE_PREDICATE,
+    "roles": {
+        "organisation_ontology_administrator": ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+        "global_ontology_administrator": GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+    },
+    "von_administrator": {
+        "concept_id": "#V#von_administrator",
+        "authority": "operational_only",
+        "implies_semantic_ontology_authority": False,
+    },
+}
+
+
+def _clean_identifier(value: object) -> str | None:
+    candidate = str(value or "").strip()
+    return candidate or None
+
+
+def _normalise_concept_id(value: object) -> str | None:
+    candidate = _clean_identifier(value)
+    if not candidate:
+        return None
+    return candidate if candidate.startswith("#") else f"#V#{candidate}"
+
+
+def _recognised_role_texts() -> set[str]:
+    return {
+        ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+        GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+    }
+
+
+def semantic_authority_has_been_bootstrapped() -> bool:
+    """Return whether any recognised represented semantic role already exists."""
+
+    relations = TextRelationsRepository.find({"predicate": AUTHORITY_ROLE_PREDICATE})
+    for relation in relations:
+        if not isinstance(relation, Mapping):
+            continue
+        text_id = relation.get("object_text_id")
+        text_value = TextValuesRepository.find_one({"_id": text_id})
+        if not isinstance(text_value, Mapping):
+            continue
+        role, _organisation_id = parse_authority_role_storage_text(
+            text_value.get("text"),
+            relation.get("context")
+            if isinstance(relation.get("context"), Mapping)
+            else {},
+        )
+        if role in _recognised_role_texts():
+            return True
+    return False
+
+
+def semantic_authority_scope_has_been_bootstrapped(
+    *,
+    role: str,
+    organisation_concept_id: str | None,
+) -> bool:
+    """Return whether this independent semantic authority root has a grant."""
+
+    role_value = str(role or "").strip().lower()
+    organisation_id = _clean_identifier(organisation_concept_id)
+    relations = TextRelationsRepository.find({"predicate": AUTHORITY_ROLE_PREDICATE})
+    for relation in relations:
+        if not isinstance(relation, Mapping):
+            continue
+        text_value = TextValuesRepository.find_one(
+            {"_id": relation.get("object_text_id")}
+        )
+        if not isinstance(text_value, Mapping):
+            continue
+        stored_role, stored_org = parse_authority_role_storage_text(
+            text_value.get("text"),
+            relation.get("context")
+            if isinstance(relation.get("context"), Mapping)
+            else {},
+        )
+        if stored_role != role_value:
+            continue
+        if role_value == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE or (
+            stored_org == organisation_id
+        ):
+            return True
+    return False
+
+
+def bootstrap_first_semantic_authority(
+    *,
+    subject_concept_id: str,
+    role: str,
+    organisation_concept_id: str | None = None,
+) -> dict[str, Any]:
+    """Persist exactly the first global semantic administrator.
+
+    This is intentionally not a general role-assignment API. Once a global
+    root exists, every further global or organisation role change uses the
+    represented administrator lifecycle.
+    """
+
+    subject_id = _normalise_concept_id(subject_concept_id)
+    role_value = str(role or "").strip().lower()
+    organisation_id = _clean_identifier(organisation_concept_id)
+    if not subject_id:
+        raise ValueError("subject_concept_id is required")
+    if role_value not in _recognised_role_texts():
+        raise ValueError("unsupported_ontology_authority_role")
+    if role_value != GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE:
+        raise ValueError("bootstrap_requires_global_ontology_administrator")
+    if role_value == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE and organisation_id:
+        raise ValueError("global authority may not have an organisation context")
+    try:
+        with ontology_authority_membership_mutation_barrier():  # noqa: SIM117
+            with ontology_mutation_resource_lock(
+                f"ontology-authority-role:{role_value}:{organisation_id or 'global'}"
+            ):
+                if semantic_authority_has_been_bootstrapped():
+                    raise PermissionError("ontology_authority_bootstrap_already_completed")
+                with bypass_access_control():
+                    subject = ConceptsRepository.find_one({"concept_id": subject_id})
+                if not isinstance(subject, Mapping):
+                    raise ValueError(  # noqa: TRY004
+                        "ontology_authority_bootstrap_subject_not_found"
+                    )
+
+                context = (
+                    {"organisation_concept_id": organisation_id}
+                    if organisation_id
+                    else {"authority_scope": "global"}
+                )
+                result = upsert_text_for_concept(
+                    subject_concept_id=subject_id,
+                    predicate=AUTHORITY_ROLE_PREDICATE,
+                    text=authority_role_storage_text(role_value, organisation_id),
+                    lang="en-NZ",
+                    provenance={
+                        "source": "ontology_authority_role_vocabulary",
+                    },
+                    context={
+                        **context,
+                        "grant_provenance": {
+                            "source": "ontology_authority_bootstrap",
+                            "operator_authority": "bootstrap_only",
+                        },
+                    },
+                )
+                relation_id = str(result.get("relation_id") or "")
+                try:
+                    matching_roles = [
+                        item
+                        for item in resolve_live_semantic_roles(subject_id)
+                        if item.role == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE
+                        and item.relation_id == relation_id
+                    ]
+                except Exception as exc:
+                    if relation_id:
+                        try:
+                            delete_text_relation(
+                                subject_concept_id=subject_id,
+                                relation_id=relation_id,
+                                garbage_collect=False,
+                            )
+                        except Exception as compensation_exc:
+                            raise RuntimeError(
+                                "ontology_authority_bootstrap_reconciliation_required"
+                            ) from compensation_exc
+                    raise RuntimeError(
+                        "ontology_authority_bootstrap_read_back_failed"
+                    ) from exc
+                if not relation_id or not matching_roles:
+                    if relation_id:
+                        delete_text_relation(
+                            subject_concept_id=subject_id,
+                            relation_id=relation_id,
+                            garbage_collect=False,
+                        )
+                    raise RuntimeError("ontology_authority_bootstrap_read_back_failed")
+    except OntologyMutationResourceBusy as exc:
+        raise PermissionError("ontology_mutation_resource_busy") from exc
+    return {
+        "vocabulary": ONTOLOGY_AUTHORITY_VOCABULARY,
+        "first_grant": {
+            "subject_concept_id": subject_id,
+            "role": role_value,
+            "organisation_concept_id": organisation_id,
+            "relation_id": result.get("relation_id"),
+            "revision": matching_roles[0].revision,
+        },
+    }
+
+
+__all__ = [
+    "ONTOLOGY_AUTHORITY_VOCABULARY",
+    "bootstrap_first_semantic_authority",
+    "semantic_authority_has_been_bootstrapped",
+    "semantic_authority_scope_has_been_bootstrapped",
+]

--- a/src/backend/services/ontology_mutation_command_service.py
+++ b/src/backend/services/ontology_mutation_command_service.py
@@ -1,0 +1,2334 @@
+"""Shared command adapter for externally reachable canonical ontology writes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import ExitStack
+from dataclasses import dataclass
+from typing import Any
+
+from ..db.repositories.concepts_repository import ConceptsRepository
+from ..db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
+from ..security.access_control import (
+    bypass_access_control,
+    can_access_concept,
+    get_effective_organisation_concept_id,
+    get_effective_user_concept_id,
+)
+from ..security.visibility_predicates import (
+    SPECIFIC_TO_ORG_PREDICATES_READ,
+    SPECIFIC_TO_USER_PREDICATES,
+)
+from .ontology_publication_authority_service import (
+    RESERVED_GENERIC_MUTATION_PREDICATES,
+    OntologyMutationIntent,
+    OntologyMutationResourceBusy,
+    PublicationContext,
+    actor_can_access_intent_targets,
+    authorise_ontology_mutation,
+    concept_publication_context,
+    current_ontology_invocation,
+    execute_authorised_ontology_mutation,
+    issue_agent_delegation,
+    ontology_authority_denial_payload,
+    ontology_authority_resource_keys,
+    ontology_mutation_resource_lock,
+    publication_context_for_creation,
+)
+from .concept_predicate_metadata_service import get_structural_inverse_map
+from .relationship_write_service import (
+    CORE_RELATIONSHIP_TEXT_PREDICATES,
+    is_structural_predicate,
+    normalise_structural_predicate,
+)
+from .text_relation_predicate_validation_service import (
+    TextRelationPredicateResolutionError,
+    resolve_text_relation_predicate_for_write,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OntologyMutationCommandError(Exception):
+    reason_code: str
+    public_message: str
+
+    def __str__(self) -> str:
+        return self.public_message
+
+
+_METHOD_OPERATION = {
+    "create_concepts": "concept.create",
+    "upsert_text_relation": "text.upsert",
+    "update_text_relation": "text.update",
+    "upsert_singleton_text_relation": "text.upsert",
+    "add_names_to_concept": "text.upsert",
+    "delete_text_relation": "text.delete",
+    "add_relationship": "relationship.add",
+    "remove_relationship": "relationship.remove",
+    "remove_relationships_bulk": "relationship.remove",
+    "promote_uncertain_relationship_assertion": "relationship.promote",
+    "delete_concept": "concept.delete",
+    "merge_concepts": "concept.merge",
+    "rename_concept": "concept.rename",
+    "update_concept": "concept.update",
+    "preview_concept_publication_scope_change": "scope.change",
+    "change_concept_publication_scope": "scope.change",
+}
+
+_UNTRUSTED_ONTOLOGY_IDENTITY_FIELDS = frozenset(
+    {
+        "actor",
+        "actor_concept_id",
+        "actor_id",
+        "admin",
+        "administrator",
+        "allow_admin",
+        "authority",
+        "authority_role",
+        "authority_resolved_parent_id",
+        "created_by",
+        "created_by_concept_id",
+        "global_admin",
+        "is_admin",
+        "is_operator",
+        "namespace",
+        "organisation_concept_id",
+        "organisation_id",
+        "organization_concept_id",
+        "organization_id",
+        "org_id",
+        "operator",
+        "operator_override",
+        "roles",
+        "user",
+        "user_concept_id",
+        "user_id",
+    }
+)
+
+_INTENT_TRANSPORT_FIELDS = frozenset(
+    {
+        "effect_id",
+        "idempotency_key",
+        "ontology_delegation_id",
+        "ontology_effect_id",
+        "operator",
+        "request_id",
+    }
+)
+
+
+def is_ontology_mutation_method(method_name: str) -> bool:
+    return str(method_name or "").strip() in _METHOD_OPERATION
+
+
+def _clean_text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _normalise_concept_id(value: Any) -> str | None:
+    cleaned = _clean_text(value)
+    if not cleaned:
+        return None
+    return cleaned if cleaned.startswith("#") else f"#V#{cleaned}"
+
+
+def _target_is_concept(value: Any) -> bool:
+    return bool(_clean_text(value).startswith("#V#"))
+
+
+def _normalise_predicate(value: Any) -> str | None:
+    cleaned = _clean_text(value)
+    return cleaned or None
+
+
+def _text_value_snapshot(object_text_id: Any) -> Mapping[str, Any] | None:
+    if object_text_id is None:
+        return None
+    try:
+        from bson import ObjectId
+
+        query_id = (
+            object_text_id
+            if isinstance(object_text_id, ObjectId)
+            else ObjectId(str(object_text_id))
+        )
+    except Exception:  # noqa: BLE001 - fixtures may use string identifiers
+        query_id = object_text_id
+    value = TextValuesRepository.find_one({"_id": query_id})
+    return value if isinstance(value, Mapping) else None
+
+
+def _text_relation_snapshot(
+    *,
+    subject_concept_id: str,
+    relation_id: str,
+) -> dict[str, Any]:
+    """Resolve an opaque relation ID to its canonical subject and predicate."""
+
+    cleaned_relation_id = _clean_text(relation_id)
+    if not cleaned_relation_id:
+        raise OntologyMutationCommandError(
+            "text_relation_id_required",
+            "An exact text relation ID is required.",
+        )
+    try:
+        from bson import ObjectId
+
+        relation_query: dict[str, Any] = {"_id": ObjectId(cleaned_relation_id)}
+    except Exception:  # noqa: BLE001 - fixtures may use string identifiers
+        relation_query = {"_id": cleaned_relation_id}
+    relation = TextRelationsRepository.find_one(relation_query)
+    if not isinstance(relation, Mapping):
+        raise OntologyMutationCommandError(
+            "ontology_mutation_target_not_found",
+            "The requested text relation was not found.",
+        )
+    stored_subject = _normalise_concept_id(relation.get("subject_concept_id"))
+    stored_predicate = _normalise_predicate(relation.get("predicate"))
+    if not stored_subject or stored_subject != subject_concept_id:
+        raise OntologyMutationCommandError(
+            "ontology_mutation_target_not_found",
+            "The requested text relation was not found for this concept.",
+        )
+    if not stored_predicate:
+        raise OntologyMutationCommandError(
+            "text_relation_predicate_unavailable",
+            "The stored text relation predicate is unavailable.",
+        )
+    text_value = _text_value_snapshot(relation.get("object_text_id"))
+    snapshot = {
+        "relation_id": str(relation.get("_id") or cleaned_relation_id),
+        "subject_concept_id": stored_subject,
+        "predicate": stored_predicate,
+        "object_text_id": str(relation.get("object_text_id") or "") or None,
+        "current_text_sha256": (
+            _text_sha256(text_value.get("text"))
+            if isinstance(text_value, Mapping)
+            else None
+        ),
+        "current_language": (
+            _clean_text(text_value.get("lang"))
+            if isinstance(text_value, Mapping)
+            else None
+        ),
+        "current_context_sha256": _canonical_json_sha256(relation.get("context") or {}),
+        "current_provenance_sha256": _canonical_json_sha256(
+            text_value.get("provenance") or {}
+            if isinstance(text_value, Mapping)
+            else {}
+        ),
+        "updated_at": str(relation.get("updated_at") or "") or None,
+    }
+    snapshot["revision"] = _effect_arguments_sha256(snapshot)
+    return snapshot
+
+
+def normalise_governed_ontology_arguments(
+    method_name: str,
+    arguments: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Remove authority claims and inject only server-established provenance."""
+
+    method = _clean_text(method_name)
+    normalised = {
+        key: value
+        for key, value in arguments.items()
+        if key not in _UNTRUSTED_ONTOLOGY_IDENTITY_FIELDS
+        and key not in {"ontology_delegation_id", "ontology_effect_id"}
+    }
+    actor_id = get_effective_user_concept_id()
+    organisation_id = get_effective_organisation_concept_id()
+    invocation = current_ontology_invocation()
+    if method == "create_concepts":
+        if actor_id:
+            normalised["created_by_concept_id"] = actor_id
+        if organisation_id:
+            normalised["organisation_concept_id"] = organisation_id
+        # Canonical create authority is confined to the new child documents.
+        # Existing referenced concepts must not be changed as an implicit
+        # inverse side effect.
+        normalised["maintain_relationship_inverses"] = False
+        normalised["resolve_visibility_from_event_namespace"] = False
+    if method == "promote_uncertain_relationship_assertion":
+        operator_id = (
+            invocation.executing_agent_concept_id
+            if invocation and invocation.executing_agent_concept_id
+            else actor_id
+        )
+        normalised["operator"] = operator_id or "governed_ontology_mutation"
+    if method in {"remove_relationship", "remove_relationships_bulk"}:
+        normalised["operator_override"] = False
+    return normalised
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    ):
+        return [_json_safe(item) for item in value]
+    return str(value)
+
+
+def _effect_arguments_sha256(arguments: Mapping[str, Any]) -> str:
+    effect_arguments = {
+        key: value
+        for key, value in arguments.items()
+        if key not in _INTENT_TRANSPORT_FIELDS
+    }
+    encoded = json.dumps(
+        _json_safe(effect_arguments),
+        sort_keys=True,
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _canonical_json_sha256(value: Any) -> str:
+    """Hash one JSON-safe semantic value without exposing it in receipts."""
+
+    encoded = json.dumps(
+        _json_safe(value),
+        sort_keys=True,
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _uncertain_assertion_snapshot(
+    *,
+    source_id: str,
+    assertion_id: str,
+) -> dict[str, Any]:
+    from .uncertain_relationship_service import (
+        list_uncertain_relationship_assertions,
+    )
+
+    rows = list_uncertain_relationship_assertions(
+        source_id=source_id,
+        include_legacy=True,
+    )
+    assertion = next(
+        (
+            dict(row)
+            for row in rows
+            if _clean_text(row.get("assertion_id")) == assertion_id
+        ),
+        None,
+    )
+    if assertion is None:
+        raise OntologyMutationCommandError(
+            "uncertain_relationship_assertion_not_found",
+            "The requested uncertain relationship assertion is unavailable.",
+        )
+    snapshot = {
+        key: assertion.get(key)
+        for key in (
+            "assertion_id",
+            "source_id",
+            "predicate",
+            "target",
+            "target_kind",
+            "status",
+            "updated_at_utc",
+        )
+    }
+    snapshot["revision"] = _effect_arguments_sha256(snapshot)
+    return snapshot
+
+
+def _idempotency_key(
+    arguments: Mapping[str, Any],
+    explicit: str | None,
+) -> str | None:
+    invocation = current_ontology_invocation()
+    # An agent delegation is one exact effect. Caller-supplied request IDs are
+    # transport labels and must not turn the same grant into multiple writes.
+    if invocation and invocation.executing_agent_concept_id and invocation.effect_id:
+        return _clean_text(invocation.effect_id)
+    if _clean_text(explicit):
+        return _clean_text(explicit)
+    for key in ("idempotency_key", "request_id", "effect_id"):
+        value = _clean_text(arguments.get(key))
+        if value:
+            return value
+    return invocation.effect_id if invocation and invocation.effect_id else None
+
+
+def _visible_or_fail(concept_ids: Sequence[str]) -> None:
+    for concept_id in concept_ids:
+        if not can_access_concept(concept_id):
+            raise OntologyMutationCommandError(
+                "ontology_mutation_target_not_accessible",
+                "The requested ontology target is not accessible in this context.",
+            )
+
+
+def _concept_exists_unfiltered(concept_id: str) -> bool:
+    """Check an exact ID without exposing the matching document to the caller."""
+
+    with bypass_access_control():
+        document = ConceptsRepository.find_one({"concept_id": concept_id})
+    return isinstance(document, Mapping)
+
+
+def _concepts_from_create_arguments(arguments: Mapping[str, Any]) -> tuple[str, ...]:
+    concept_ids: list[str] = []
+    for item in arguments.get("concepts") or []:
+        if not isinstance(item, Mapping):
+            continue
+        concept_id = _normalise_concept_id(item.get("concept_id") or item.get("id"))
+        if concept_id:
+            concept_ids.append(concept_id)
+    parent_id = _normalise_concept_id(arguments.get("parent_id"))
+    if parent_id:
+        concept_ids.append(parent_id)
+    return tuple(dict.fromkeys(concept_ids))
+
+
+def _create_intent_concepts(arguments: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return a bounded exact projection of every requested concept delta."""
+
+    projected: list[dict[str, Any]] = []
+    for item in arguments.get("concepts") or []:
+        if not isinstance(item, Mapping):
+            projected.append(
+                {"invalid_item_sha256": _effect_arguments_sha256({"item": item})}
+            )
+            continue
+        projected.append(
+            {
+                key: _json_safe(value)
+                for key, value in item.items()
+                if key not in _UNTRUSTED_ONTOLOGY_IDENTITY_FIELDS
+                and key not in _INTENT_TRANSPORT_FIELDS
+            }
+        )
+    return projected
+
+
+def _creation_scope_projection(
+    *,
+    scope_mode: Any,
+    actor_concept_id: str | None,
+    organisation_concept_id: str | None,
+) -> dict[str, Any]:
+    """Project the exact visibility edges the canonical create service stores."""
+
+    mode = (_clean_text(scope_mode) or "user_org_default").lower().replace("-", "_")
+    actor_id = _normalise_concept_id(actor_concept_id)
+    organisation_id = _normalise_concept_id(organisation_concept_id)
+    supported_modes = {
+        "default",
+        "user_org_default",
+        "user_org",
+        "private",
+        "user_only",
+        "user_only_default",
+        "organisation_general",
+        "organization_general",
+        "org_general",
+        "global",
+        "global_general",
+        "public",
+    }
+    if mode not in supported_modes:
+        raise OntologyMutationCommandError(
+            "invalid_create_scope_mode",
+            "The requested concept creation scope mode is unsupported.",
+        )
+    if mode in {"global", "global_general", "public"}:
+        return {
+            "effective_scope_mode": "global_general",
+            "specific_to_user_concept_ids": [],
+            "specific_to_organisation_concept_ids": [],
+        }
+    if mode in {"organisation_general", "organization_general", "org_general"}:
+        if organisation_id is None:
+            raise OntologyMutationCommandError(
+                "missing_organisation_context",
+                "organisation_general scope requires trusted organisation context.",
+            )
+        return {
+            "effective_scope_mode": "organisation_general",
+            "specific_to_user_concept_ids": [],
+            "specific_to_organisation_concept_ids": [organisation_id],
+        }
+    if actor_id is None:
+        raise OntologyMutationCommandError(
+            "authenticated_actor_context_required",
+            "Trusted actor context is required to derive concept creation scope.",
+        )
+    user_only = mode in {"private", "user_only", "user_only_default"}
+    return {
+        "effective_scope_mode": (
+            "user_only_default"
+            if user_only or organisation_id is None
+            else "user_org_default"
+        ),
+        "specific_to_user_concept_ids": [actor_id],
+        "specific_to_organisation_concept_ids": (
+            [] if user_only or organisation_id is None else [organisation_id]
+        ),
+    }
+
+
+def _create_reference_concept_ids(arguments: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return every pre-existing concept referenced by a create effect."""
+
+    references: list[str] = []
+    for value in (
+        arguments.get("parent_id"),
+        *(arguments.get("parent_concept_ids") or []),
+        arguments.get("instance_of_type"),
+    ):
+        concept_id = _normalise_concept_id(value)
+        if concept_id:
+            references.append(concept_id)
+    for item in arguments.get("linked_concepts") or []:
+        if isinstance(item, str):
+            concept_id = _normalise_concept_id(item)
+        elif isinstance(item, Mapping):
+            concept_id = _normalise_concept_id(
+                item.get("concept_id")
+                or item.get("target_concept_id")
+                or item.get("target_id")
+            )
+        else:
+            concept_id = None
+        if concept_id:
+            references.append(concept_id)
+    # Predicate creation deterministically types the child under this canonical
+    # parent even though the caller supplies a general semantic parent.
+    if any(
+        isinstance(item, Mapping)
+        and _clean_text(item.get("kind")).lower() == "predicate"
+        for item in arguments.get("concepts") or []
+    ):
+        from ..vontology.code_concepts_registry import PREDICATE_TYPE_ID
+
+        references.append(PREDICATE_TYPE_ID)
+    return tuple(dict.fromkeys(references))
+
+
+def _relationship_arguments_with_resolved_selector(
+    method_name: str,
+    arguments: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Resolve opaque relation IDs without treating the token as authority."""
+
+    resolved = dict(arguments)
+    if method_name not in {"remove_relationship", "remove_relationships_bulk"}:
+        return resolved
+    from .relationship_removal_service import parse_relationship_relation_id
+
+    def exact_selector(row: Mapping[str, Any]) -> dict[str, Any]:
+        canonical = dict(row)
+        relation_id = canonical.get("relation_id")
+        if not _clean_text(relation_id):
+            return canonical
+        parsed = parse_relationship_relation_id(relation_id)
+        if not parsed:
+            raise OntologyMutationCommandError(
+                "invalid_relationship_relation_id",
+                "The relationship relation ID is invalid.",
+            )
+        for key in ("source_id", "predicate", "target"):
+            supplied = _clean_text(canonical.get(key))
+            expected = _clean_text(parsed.get(key))
+            if supplied and supplied != expected:
+                raise OntologyMutationCommandError(
+                    "relationship_selector_conflict",
+                    (
+                        "The supplied relationship selector does not match its "
+                        "canonical relation ID."
+                    ),
+                )
+        canonical.update(parsed)
+        return canonical
+
+    if method_name == "remove_relationship":
+        canonical = exact_selector(resolved)
+        predicate = _clean_text(canonical.get("predicate"))
+        if predicate:
+            canonical["predicate"] = normalise_structural_predicate(predicate)
+        return canonical
+
+    if resolved.get("filter") is not None:
+        raise OntologyMutationCommandError(
+            "bulk_relationship_filter_requires_exact_preview",
+            (
+                "Governed bulk removal requires exact relation IDs or triples; "
+                "a broad filter must first be resolved through a read-only preview."
+            ),
+        )
+
+    rows: list[Any] = []
+    for raw_row in resolved.get("relationships") or resolved.get("relations") or []:
+        if not isinstance(raw_row, Mapping):
+            raise OntologyMutationCommandError(
+                "invalid_bulk_relationship_selector",
+                "Every bulk relationship selector must be an object.",
+            )
+        row = exact_selector(raw_row)
+        if not all(
+            _clean_text(row.get(key)) for key in ("source_id", "predicate", "target")
+        ):
+            raise OntologyMutationCommandError(
+                "invalid_bulk_relationship_selector",
+                (
+                    "Every bulk relationship selector requires an exact source, "
+                    "predicate, and target before any write starts."
+                ),
+            )
+        predicate = _clean_text(row.get("predicate"))
+        if predicate:
+            row["predicate"] = normalise_structural_predicate(predicate)
+        rows.append(row)
+    for relation_id in resolved.get("relation_ids") or []:
+        parsed = parse_relationship_relation_id(relation_id)
+        if not parsed:
+            raise OntologyMutationCommandError(
+                "invalid_relationship_relation_id",
+                "A bulk relationship relation ID is invalid.",
+            )
+        parsed["predicate"] = normalise_structural_predicate(parsed["predicate"])
+        rows.append(parsed)
+    for row in rows:
+        if _clean_text(row.get("predicate")) in RESERVED_GENERIC_MUTATION_PREDICATES:
+            raise OntologyMutationCommandError(
+                "dedicated_ontology_governance_operation_required",
+                (
+                    "Authority, membership, and visibility relations may only be "
+                    "changed through their dedicated operation."
+                ),
+            )
+    if rows:
+        resolved["relationships"] = rows
+        # The catalogue handler consumes ``relations``. Use the same immutable
+        # canonical selector set for the authority decision and actual write.
+        resolved["relations"] = rows
+        resolved["relation_ids"] = []
+        resolved["filter"] = None
+    return resolved
+
+
+def resolve_governed_ontology_arguments(
+    method_name: str,
+    arguments: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Resolve canonical selectors before both authorisation and mutation."""
+
+    resolved = _relationship_arguments_with_resolved_selector(
+        _clean_text(method_name),
+        normalise_governed_ontology_arguments(method_name, arguments),
+    )
+    if _clean_text(method_name) == "merge_concepts":
+        from .concept_merge_service import (
+            ConceptMergePlanError,
+            build_concept_merge_plan,
+        )
+
+        try:
+            # A plan is always rebuilt from canonical state. A client- or
+            # model-supplied plan can neither select affected records nor
+            # become the mutation precondition.
+            resolved["exact_plan"] = build_concept_merge_plan(
+                _normalise_concept_id(resolved.get("source_id")) or "",
+                _normalise_concept_id(resolved.get("target_id")) or "",
+            )
+        except ConceptMergePlanError as exc:
+            raise OntologyMutationCommandError(
+                exc.reason_code,
+                exc.public_message,
+            ) from exc
+    if _clean_text(method_name) == "create_concepts":
+        from .create_concepts_parent_resolution_service import (
+            resolve_parent_for_create_concepts,
+        )
+
+        def resolve_parent(value: Any) -> str | None:
+            parent_id = _normalise_concept_id(value)
+            if parent_id is None:
+                return None
+            resolution = resolve_parent_for_create_concepts(parent_id)
+            if not resolution.success or not resolution.resolved_parent_id:
+                raise OntologyMutationCommandError(
+                    "ontology_mutation_target_not_found",
+                    "The requested concept parent is unavailable.",
+                )
+            return resolution.resolved_parent_id
+
+        raw_scope_mode = resolved.get("scope_mode")
+        raw_visibility_scope_mode = resolved.get("visibility_scope_mode")
+        supplied_scope_modes = {
+            _clean_text(value).lower().replace("-", "_")
+            for value in (raw_scope_mode, raw_visibility_scope_mode)
+            if _clean_text(value)
+        }
+        if len(supplied_scope_modes) > 1:
+            raise OntologyMutationCommandError(
+                "conflicting_create_scope_mode",
+                "A governed create requires one consistent exact scope mode.",
+            )
+        scope_mode = next(iter(supplied_scope_modes), "user_only_default")
+        if scope_mode in {"default", "user_org_default", "user_org"}:
+            if supplied_scope_modes:
+                raise OntologyMutationCommandError(
+                    "ambiguous_create_scope_mode",
+                    (
+                        "Dual user-and-organisation visibility is not a canonical "
+                        "publication context; use user_only_default or "
+                        "organisation_general."
+                    ),
+                )
+            scope_mode = "user_only_default"
+        scope_aliases = {
+            "private": "user_only_default",
+            "user_only": "user_only_default",
+            "user_only_default": "user_only_default",
+            "organisation_general": "organisation_general",
+            "organization_general": "organisation_general",
+            "org_general": "organisation_general",
+            "global": "global_general",
+            "global_general": "global_general",
+            "public": "global_general",
+        }
+        canonical_scope_mode = scope_aliases.get(scope_mode)
+        if canonical_scope_mode is None:
+            raise OntologyMutationCommandError(
+                "invalid_create_scope_mode",
+                "The requested concept creation scope mode is unsupported.",
+            )
+        resolved["scope_mode"] = canonical_scope_mode
+        resolved.pop("visibility_scope_mode", None)
+
+        raw_concepts = resolved.get("concepts")
+        if not isinstance(raw_concepts, list):
+            raise OntologyMutationCommandError(
+                "invalid_create_concepts",
+                "concepts must be a list of exact create specifications.",
+            )
+        from ..utils.concept_id_utils import canonicalise_vontology_concept_id
+
+        canonical_concepts: list[Any] = []
+        for raw_item in raw_concepts:
+            if not isinstance(raw_item, Mapping):
+                canonical_concepts.append(raw_item)
+                continue
+            item = dict(raw_item)
+            supplied_id = _clean_text(item.get("concept_id") or item.get("id"))
+            if supplied_id:
+                canonical_id = canonicalise_vontology_concept_id(supplied_id)
+                if not canonical_id:
+                    raise OntologyMutationCommandError(
+                        "invalid_create_concept_id",
+                        "A supplied concept ID is invalid after canonicalisation.",
+                    )
+                item["concept_id"] = canonical_id
+                item.pop("id", None)
+            else:
+                canonical_id = canonicalise_vontology_concept_id(item.get("name"))
+                if not canonical_id:
+                    raise OntologyMutationCommandError(
+                        "invalid_create_concept_id",
+                        "A concept name must resolve to one exact canonical ID.",
+                    )
+                item["concept_id"] = canonical_id
+            if not _clean_text(item.get("kind")):
+                requested_instance = item.get("create_as_instance")
+                if requested_instance is None:
+                    requested_instance = resolved.get("create_as_instance")
+                item["kind"] = "instance" if requested_instance is True else "type"
+            canonical_concepts.append(item)
+        resolved["concepts"] = canonical_concepts
+
+        parent_id = resolve_parent(resolved.get("parent_id"))
+        if parent_id:
+            resolved["parent_id"] = parent_id
+            resolved["authority_resolved_parent_id"] = parent_id
+        raw_parent_ids = resolved.get("parent_concept_ids")
+        if raw_parent_ids is not None:
+            if not isinstance(raw_parent_ids, list):
+                raise OntologyMutationCommandError(
+                    "invalid_create_parent_concept_ids",
+                    "parent_concept_ids must be a list of exact concept IDs.",
+                )
+            resolved["parent_concept_ids"] = list(
+                dict.fromkeys(
+                    parent
+                    for parent in (resolve_parent(item) for item in raw_parent_ids)
+                    if parent
+                )
+            )
+            resolved_parent_ids = resolved["parent_concept_ids"]
+            if parent_id and resolved_parent_ids and resolved_parent_ids != [parent_id]:
+                raise OntologyMutationCommandError(
+                    "conflicting_create_parent",
+                    "A governed create requires one consistent exact parent.",
+                )
+            if not parent_id and resolved_parent_ids:
+                resolved["parent_id"] = resolved_parent_ids[0]
+                resolved["authority_resolved_parent_id"] = resolved_parent_ids[0]
+    if _clean_text(method_name) == "add_relationship":
+        predicate_ref = resolved.get("predicate_ref")
+        if predicate_ref is not None:
+            if not isinstance(predicate_ref, Mapping):
+                raise OntologyMutationCommandError(
+                    "invalid_predicate_reference",
+                    "predicate_ref must be an object.",
+                )
+            predicate_concept_id = _clean_text(predicate_ref.get("concept_id"))
+            if not predicate_concept_id or _clean_text(predicate_ref.get("name")):
+                raise OntologyMutationCommandError(
+                    "exact_predicate_concept_id_required",
+                    "A governed write requires one exact predicate concept ID.",
+                )
+            resolved["predicate"] = predicate_concept_id
+            resolved.pop("predicate_ref", None)
+        if resolved.get("predicate_if_missing") is not None:
+            raise OntologyMutationCommandError(
+                "predicate_dependency_requires_separate_governed_creation",
+                (
+                    "Create a missing predicate through its own exact governed "
+                    "effect before adding the relationship."
+                ),
+            )
+        predicate = _clean_text(resolved.get("predicate"))
+        if not predicate:
+            raise OntologyMutationCommandError(
+                "exact_predicate_concept_id_required",
+                "A governed write requires one exact predicate.",
+            )
+        canonical = normalise_structural_predicate(predicate)
+        core_text = canonical[3:] if canonical.startswith("#V#") else canonical
+        if not (
+            is_structural_predicate(canonical)
+            or core_text in CORE_RELATIONSHIP_TEXT_PREDICATES
+            or canonical.startswith("#V#")
+        ):
+            raise OntologyMutationCommandError(
+                "exact_predicate_concept_id_required",
+                (
+                    "Natural-language predicate resolution is read-only; retry "
+                    "with the exact predicate concept ID."
+                ),
+            )
+        resolved["predicate"] = canonical
+    if _clean_text(method_name) in {
+        "upsert_text_relation",
+        "upsert_singleton_text_relation",
+    } or (
+        _clean_text(method_name) == "delete_text_relation"
+        and not _clean_text(resolved.get("relation_id"))
+    ):
+        try:
+            predicate_resolution = resolve_text_relation_predicate_for_write(
+                resolved.get("predicate")
+            )
+        except TextRelationPredicateResolutionError as exc:
+            raise OntologyMutationCommandError(exc.error_code, str(exc)) from exc
+        resolved["predicate"] = predicate_resolution.storage_predicate
+    return resolved
+
+
+def build_ontology_mutation_intent(
+    *,
+    method_name: str,
+    arguments: Mapping[str, Any],
+    idempotency_key: str | None = None,
+) -> OntologyMutationIntent:
+    """Derive target and publication context; never trust payload actor scope."""
+
+    method = _clean_text(method_name)
+    arguments = resolve_governed_ontology_arguments(method, arguments)
+    operation = _METHOD_OPERATION.get(method)
+    if not operation:
+        raise OntologyMutationCommandError(
+            "ontology_mutation_method_not_governed",
+            "This method is not a governed canonical ontology mutation.",
+        )
+
+    if method in {
+        "preview_concept_publication_scope_change",
+        "change_concept_publication_scope",
+    }:
+        from .ontology_scope_change_service import (
+            OntologyScopeChangePreconditionError,
+            build_concept_publication_scope_change_intent,
+        )
+
+        try:
+            return build_concept_publication_scope_change_intent(
+                concept_id=_clean_text(arguments.get("concept_id")),
+                destination_kind=_clean_text(arguments.get("destination_kind")),
+                destination_concept_id=(
+                    _clean_text(arguments.get("destination_concept_id")) or None
+                ),
+                expected_scope_fingerprint=_clean_text(
+                    arguments.get("expected_scope_fingerprint")
+                ),
+                request_id=(
+                    _clean_text(arguments.get("request_id"))
+                    or _clean_text(idempotency_key)
+                ),
+                preview=method == "preview_concept_publication_scope_change",
+                reason=_clean_text(arguments.get("reason")) or None,
+                invocation_tool_name=method,
+                idempotency_key=idempotency_key,
+            )
+        except OntologyScopeChangePreconditionError as exc:
+            raise OntologyMutationCommandError(
+                exc.reason_code,
+                exc.public_message,
+            ) from exc
+
+    if method == "add_relationship":
+        predicate_ref = arguments.get("predicate_ref")
+        creates_predicate_dependency = arguments.get("predicate_if_missing") is not None
+        if isinstance(predicate_ref, Mapping):
+            creates_predicate_dependency = creates_predicate_dependency or (
+                _clean_text(predicate_ref.get("on_missing")).lower()
+                == "create_typed_predicate"
+            )
+        if creates_predicate_dependency:
+            raise OntologyMutationCommandError(
+                "predicate_dependency_requires_separate_governed_creation",
+                (
+                    "A canonical predicate dependency must be created through its "
+                    "own exact governed effect before adding the relationship."
+                ),
+            )
+        if isinstance(predicate_ref, Mapping):
+            predicate_concept_id = _normalise_predicate(predicate_ref.get("concept_id"))
+            if not predicate_concept_id:
+                raise OntologyMutationCommandError(
+                    "exact_predicate_concept_id_required",
+                    (
+                        "A governed canonical relationship write requires an "
+                        "exact predicate concept ID."
+                    ),
+                )
+            arguments["predicate"] = predicate_concept_id
+            arguments.pop("predicate_ref", None)
+
+    if method == "update_concept":
+        update_data = arguments.get("update_data")
+        if isinstance(update_data, Mapping) and any(
+            str(key) == "relationships" or str(key).startswith("relationships.")
+            for key in update_data
+        ):
+            raise OntologyMutationCommandError(
+                "relationship_mutation_requires_dedicated_command",
+                (
+                    "Canonical relationships, including visibility, must be "
+                    "changed through their dedicated governed operation."
+                ),
+            )
+    if method == "add_names_to_concept":
+        raise OntologyMutationCommandError(
+            "batch_names_require_individual_effects",
+            (
+                "Batch name publication is unavailable at the ontology authority "
+                "boundary; publish each exact name as its own governed effect."
+            ),
+        )
+
+    actor_id = get_effective_user_concept_id()
+    organisation_id = get_effective_organisation_concept_id()
+    predicate = _normalise_predicate(arguments.get("predicate"))
+    targets: tuple[str, ...]
+    source_contexts: tuple[PublicationContext, ...] = ()
+    delta: dict[str, Any] = {}
+
+    if method == "create_concepts":
+        concept_specs = arguments.get("concepts") or []
+        if len(concept_specs) != 1 or not isinstance(concept_specs[0], Mapping):
+            raise OntologyMutationCommandError(
+                "multi_create_requires_individual_effects",
+                (
+                    "Governed creation accepts one exact concept per effect so "
+                    "partial batch outcomes cannot cross the authority boundary."
+                ),
+            )
+        concept_spec = concept_specs[0]
+        unsupported_create_fields = {
+            "attributes": concept_spec.get("attributes") or arguments.get("attributes"),
+            "system_tags": concept_spec.get("system_tags")
+            or arguments.get("system_tags"),
+            "user_tags": concept_spec.get("user_tags") or arguments.get("user_tags"),
+            "linked_concepts": concept_spec.get("linked_concepts")
+            or arguments.get("linked_concepts"),
+            "external_identifiers": concept_spec.get("external_identifiers"),
+            "identity_candidate_concept_ids": concept_spec.get(
+                "identity_candidate_concept_ids"
+            ),
+            "identity_rejected_candidate_concept_ids": concept_spec.get(
+                "identity_rejected_candidate_concept_ids"
+            ),
+        }
+        unsupported_present = sorted(
+            key for key, value in unsupported_create_fields.items() if value
+        )
+        if bool(arguments.get("allow_duplicate_instances")):
+            unsupported_present.append("allow_duplicate_instances")
+        parent_concept_ids = list(arguments.get("parent_concept_ids") or [])
+        if len(parent_concept_ids) > 1:
+            unsupported_present.append("parent_concept_ids")
+        if unsupported_present:
+            raise OntologyMutationCommandError(
+                "complex_create_requires_typed_effects",
+                (
+                    "This governed create path currently supports one exact core "
+                    "concept only; ancillary or multi-parent effects require "
+                    "separate typed commands."
+                ),
+            )
+        scope_mode = arguments.get("scope_mode") or arguments.get(
+            "visibility_scope_mode"
+        )
+        try:
+            publication_context = publication_context_for_creation(
+                scope_mode=scope_mode,
+                actor_concept_id=actor_id,
+                organisation_concept_id=organisation_id,
+            )
+        except ValueError as exc:
+            raise OntologyMutationCommandError(
+                "authenticated_actor_context_required",
+                "Trusted actor context is required to derive concept creation scope.",
+            ) from exc
+        scope_projection = _creation_scope_projection(
+            scope_mode=scope_mode,
+            actor_concept_id=actor_id,
+            organisation_concept_id=organisation_id,
+        )
+        expected_concept_id = _normalise_concept_id(concept_spec.get("concept_id"))
+        if not expected_concept_id:
+            raise OntologyMutationCommandError(
+                "invalid_create_concept_id",
+                "A governed create requires one exact canonical concept ID.",
+            )
+        if _concept_exists_unfiltered(expected_concept_id):
+            # Existing visible and inaccessible IDs deliberately share one
+            # non-disclosing conflict. A create effect never reads or reuses
+            # the colliding concept.
+            raise OntologyMutationCommandError(
+                "ontology_create_concept_id_conflict",
+                "The requested concept ID cannot be created.",
+            )
+        reference_ids = _create_reference_concept_ids(arguments)
+        _visible_or_fail(reference_ids)
+        targets = tuple(
+            dict.fromkeys((*_concepts_from_create_arguments(arguments), *reference_ids))
+        )
+        parent_id = _normalise_concept_id(arguments.get("parent_id"))
+        if _clean_text(concept_spec.get("kind")).lower() == "predicate":
+            from ..vontology.code_concepts_registry import PREDICATE_TYPE_ID
+
+            parent_id = PREDICATE_TYPE_ID
+        delta = {
+            "concept_count": len(arguments.get("concepts") or []),
+            "concepts": _create_intent_concepts(arguments),
+            "expected_concept_id": expected_concept_id,
+            "parent_id": parent_id,
+            "parent_concept_ids": list(arguments.get("parent_concept_ids") or []),
+            "instance_of_type": _normalise_concept_id(
+                arguments.get("instance_of_type")
+            ),
+            "referenced_concept_ids": list(reference_ids),
+            "scope_mode": scope_projection["effective_scope_mode"],
+            "stored_scope": scope_projection,
+            # Parent inverses are deliberately not canonical side effects of
+            # governed creation. The child's exact forward typing assertion is
+            # authoritative; reverse traversal belongs to the derived extent.
+            "maintain_parent_inverse": False,
+        }
+    elif method in {
+        "upsert_text_relation",
+        "update_text_relation",
+        "upsert_singleton_text_relation",
+        "add_names_to_concept",
+        "delete_text_relation",
+        "update_concept",
+    }:
+        subject_id = _normalise_concept_id(
+            arguments.get("concept_id") or arguments.get("subject_concept_id")
+        )
+        if not subject_id:
+            raise OntologyMutationCommandError(
+                "ontology_mutation_subject_required",
+                "A canonical ontology mutation subject is required.",
+            )
+        if method == "update_concept":
+            raise OntologyMutationCommandError(
+                "typed_concept_update_required",
+                (
+                    "Generic concept updates are unavailable at the ontology "
+                    "authority boundary; use a dedicated typed text or relation "
+                    "command with exact read-back."
+                ),
+            )
+        _visible_or_fail((subject_id,))
+        relation_snapshot: dict[str, Any] | None = None
+        relation_id = _clean_text(arguments.get("relation_id"))
+        if method in {"update_text_relation", "delete_text_relation"} and relation_id:
+            relation_snapshot = _text_relation_snapshot(
+                subject_concept_id=subject_id,
+                relation_id=relation_id,
+            )
+            predicate = _normalise_predicate(relation_snapshot.get("predicate"))
+            # The canonical row, not a caller-supplied predicate, decides
+            # whether this is a generic text edit or a dedicated authority
+            # lifecycle operation.
+            arguments["predicate"] = predicate
+            if predicate in RESERVED_GENERIC_MUTATION_PREDICATES:
+                raise OntologyMutationCommandError(
+                    "dedicated_ontology_governance_operation_required",
+                    (
+                        "Authority, membership, and visibility relations may "
+                        "only be changed through their dedicated operation."
+                    ),
+                )
+        publication_context = concept_publication_context(subject_id)
+        targets = (subject_id,)
+        delta = {
+            "relation_id": relation_id or None,
+            "relation_revision": (
+                relation_snapshot.get("revision") if relation_snapshot else None
+            ),
+            "stored_predicate": (
+                relation_snapshot.get("predicate") if relation_snapshot else predicate
+            ),
+            "current_text_sha256": (
+                relation_snapshot.get("current_text_sha256")
+                if relation_snapshot
+                else None
+            ),
+            "text_sha256": _text_sha256(
+                arguments.get("new_text")
+                if method == "update_text_relation"
+                else arguments.get("text")
+            ),
+            "language": (
+                _clean_text(arguments.get("language") or arguments.get("lang"))
+                or "en-NZ"
+            ),
+            "context_sha256": (
+                _canonical_json_sha256(arguments.get("context") or {})
+                if method in {"upsert_text_relation", "upsert_singleton_text_relation"}
+                else None
+            ),
+            "provenance_sha256": (
+                _canonical_json_sha256(arguments.get("provenance") or {})
+                if method
+                in {
+                    "upsert_text_relation",
+                    "update_text_relation",
+                    "upsert_singleton_text_relation",
+                }
+                else None
+            ),
+            "update_data": (
+                _json_safe(arguments.get("update_data"))
+                if method == "update_concept"
+                else None
+            ),
+        }
+    elif method in {
+        "add_relationship",
+        "remove_relationship",
+        "promote_uncertain_relationship_assertion",
+    }:
+        source_id = _normalise_concept_id(arguments.get("source_id"))
+        if not source_id:
+            raise OntologyMutationCommandError(
+                "ontology_mutation_subject_required",
+                "A canonical relationship source is required.",
+            )
+        assertion_snapshot: dict[str, Any] | None = None
+        if method == "promote_uncertain_relationship_assertion":
+            assertion_id = _clean_text(arguments.get("assertion_id"))
+            if not assertion_id:
+                raise OntologyMutationCommandError(
+                    "uncertain_relationship_assertion_required",
+                    "An exact uncertain relationship assertion is required.",
+                )
+            assertion_snapshot = _uncertain_assertion_snapshot(
+                source_id=source_id,
+                assertion_id=assertion_id,
+            )
+            predicate = _normalise_predicate(assertion_snapshot.get("predicate"))
+            arguments["predicate"] = predicate
+            arguments["target"] = assertion_snapshot.get("target")
+        target_id = (
+            _normalise_concept_id(arguments.get("target"))
+            if _target_is_concept(arguments.get("target"))
+            else None
+        )
+        visible_targets = (source_id, target_id) if target_id else (source_id,)
+        _visible_or_fail(tuple(item for item in visible_targets if item))
+        publication_context = concept_publication_context(source_id)
+        normalised_structural_predicate = (
+            normalise_structural_predicate(predicate or "") if predicate else ""
+        )
+        inverse_predicate = get_structural_inverse_map().get(
+            normalised_structural_predicate
+        )
+        if target_id and inverse_predicate:
+            source_contexts = (concept_publication_context(target_id),)
+        targets = tuple(item for item in visible_targets if item)
+        delta = {
+            "target_concept_id": target_id,
+            "target_text_sha256": (
+                None if target_id else _text_sha256(arguments.get("target"))
+            ),
+            "assertion_id": _clean_text(arguments.get("assertion_id")) or None,
+            "relation_id": _clean_text(arguments.get("relation_id")) or None,
+            "assertion_revision": (
+                assertion_snapshot.get("revision") if assertion_snapshot else None
+            ),
+            "maintain_inverse": bool(target_id and inverse_predicate),
+            "inverse_predicate": inverse_predicate,
+        }
+    elif method == "remove_relationships_bulk":
+        bulk_rows = arguments.get("relationships") or arguments.get("relations") or []
+        source_ids = tuple(
+            dict.fromkeys(
+                item
+                for item in (
+                    _normalise_concept_id(row.get("source_id"))
+                    for row in bulk_rows
+                    if isinstance(row, Mapping)
+                )
+                if item
+            )
+        )
+        if not source_ids:
+            raise OntologyMutationCommandError(
+                "ontology_mutation_subject_required",
+                "Bulk canonical relationship removal requires explicit sources.",
+            )
+        target_ids = tuple(
+            dict.fromkeys(
+                item
+                for item in (
+                    _normalise_concept_id(row.get("target"))
+                    for row in bulk_rows
+                    if isinstance(row, Mapping)
+                    and _target_is_concept(row.get("target"))
+                    and get_structural_inverse_map().get(
+                        normalise_structural_predicate(
+                            _normalise_predicate(row.get("predicate")) or ""
+                        )
+                    )
+                )
+                if item
+            )
+        )
+        all_affected_ids = tuple(dict.fromkeys((*source_ids, *target_ids)))
+        _visible_or_fail(all_affected_ids)
+        contexts = tuple(
+            dict.fromkeys(
+                concept_publication_context(item) for item in all_affected_ids
+            )
+        )
+        publication_context = contexts[-1]
+        source_contexts = contexts[:-1]
+        targets = all_affected_ids
+        delta = {
+            "relationship_count": len(bulk_rows),
+            "selectors_sha256": _effect_arguments_sha256({"relationships": bulk_rows}),
+            "selector_projection_sha256": _effect_arguments_sha256(
+                {
+                    "relationships": [
+                        {
+                            "source_id": row.get("source_id"),
+                            "predicate": row.get("predicate"),
+                            "target": row.get("target"),
+                        }
+                        for row in bulk_rows
+                        if isinstance(row, Mapping)
+                    ]
+                }
+            ),
+            "inverse_target_concept_ids": list(target_ids),
+        }
+    elif method in {"delete_concept", "rename_concept"}:
+        source_id = _normalise_concept_id(
+            arguments.get("concept_id") or arguments.get("old_id")
+        )
+        if not source_id:
+            raise OntologyMutationCommandError(
+                "ontology_mutation_subject_required",
+                "A concept identity is required.",
+            )
+        if not bool(arguments.get("simulate", True)):
+            raise OntologyMutationCommandError(
+                "graph_rewrite_exact_plan_required",
+                (
+                    "Executing this graph-wide rewrite is unavailable until its "
+                    "complete affected-scope plan can be authorised and verified."
+                ),
+            )
+        _visible_or_fail((source_id,))
+        publication_context = concept_publication_context(source_id)
+        targets = (source_id,)
+        delta = {
+            "new_id": _normalise_concept_id(arguments.get("new_id")),
+            "simulate": bool(arguments.get("simulate", True)),
+        }
+    elif method == "merge_concepts":
+        source_id = _normalise_concept_id(arguments.get("source_id"))
+        target_id = _normalise_concept_id(arguments.get("target_id"))
+        if not source_id or not target_id:
+            raise OntologyMutationCommandError(
+                "ontology_mutation_subject_required",
+                "Concept merge requires exact source and target identities.",
+            )
+        exact_plan = arguments.get("exact_plan")
+        if not isinstance(exact_plan, Mapping):
+            raise OntologyMutationCommandError(
+                "identity_consolidation_plan_required",
+                "A server-built identity-consolidation plan is required.",
+            )
+        affected_ids = tuple(
+            dict.fromkeys(
+                concept_id
+                for concept_id in (
+                    _normalise_concept_id(item)
+                    for item in exact_plan.get("affected_concept_ids") or []
+                )
+                if concept_id
+            )
+        )
+        if (
+            not affected_ids
+            or source_id not in affected_ids
+            or target_id not in affected_ids
+        ):
+            raise OntologyMutationCommandError(
+                "identity_consolidation_plan_invalid",
+                "The identity-consolidation affected set is invalid.",
+            )
+        _visible_or_fail(affected_ids)
+        context_by_key: dict[tuple[str, str | None], PublicationContext] = {}
+        for concept_id in affected_ids:
+            context = concept_publication_context(concept_id)
+            context_by_key.setdefault(
+                (context.kind.value, context.concept_id),
+                context,
+            )
+        publication_context = concept_publication_context(target_id)
+        target_context_key = (
+            publication_context.kind.value,
+            publication_context.concept_id,
+        )
+        source_contexts = tuple(
+            context
+            for key, context in context_by_key.items()
+            if key != target_context_key
+        )
+        targets = affected_ids
+        delta = {
+            "simulate": bool(arguments.get("simulate", True)),
+            "source_id": source_id,
+            "target_id": target_id,
+            "merge_plan_sha256": _clean_text(exact_plan.get("plan_sha256")),
+            "affected_set_sha256": _effect_arguments_sha256(
+                {"affected_concept_ids": sorted(affected_ids)}
+            ),
+            "affected_concept_count": len(affected_ids),
+            "affected_text_relation_count": len(
+                exact_plan.get("affected_text_relation_ids") or []
+            ),
+            "merge_text_relation_ids": list(
+                exact_plan.get("affected_text_relation_ids") or []
+            ),
+        }
+    else:  # pragma: no cover - mapping above makes this defensive only
+        raise OntologyMutationCommandError(
+            "ontology_mutation_method_not_governed",
+            "Unsupported ontology mutation method.",
+        )
+
+    delta["effect_arguments_sha256"] = _effect_arguments_sha256(arguments)
+    affected_scope_fingerprints: dict[str, str] = {}
+    for target_concept_id in sorted(set(targets)):
+        try:
+            snapshot = scope_read_back(target_concept_id)
+        except LookupError:
+            # New concept identifiers do not exist yet. Their exact requested
+            # publication context is already bound above.
+            continue
+        affected_scope_fingerprints[target_concept_id] = _clean_text(
+            snapshot.get("scope_fingerprint")
+        )
+    if affected_scope_fingerprints:
+        delta["affected_scope_fingerprints"] = affected_scope_fingerprints
+    return OntologyMutationIntent(
+        operation=operation,
+        publication_context=publication_context,
+        target_concept_ids=targets,
+        tool_name=method,
+        predicate=predicate,
+        source_contexts=source_contexts,
+        delta=delta,
+        idempotency_key=_idempotency_key(arguments, idempotency_key),
+    )
+
+
+def _text_sha256(value: Any) -> str | None:
+    cleaned = _clean_text(value)
+    if not cleaned:
+        return None
+    import hashlib
+
+    return hashlib.sha256(cleaned.encode("utf-8")).hexdigest()
+
+
+def _concept_read_back(concept_id: str) -> dict[str, Any]:
+    if not can_access_concept(concept_id):
+        return {"concept_id": concept_id, "exists": False, "accessible": False}
+    concept = ConceptsRepository.find_one({"concept_id": concept_id})
+    if not isinstance(concept, Mapping):
+        return {"concept_id": concept_id, "exists": False}
+    relationships = concept.get("relationships")
+    relationship_map = relationships if isinstance(relationships, Mapping) else {}
+    scope_edges: dict[str, list[str]] = {}
+    for predicate_name in (
+        *SPECIFIC_TO_USER_PREDICATES,
+        *SPECIFIC_TO_ORG_PREDICATES_READ,
+    ):
+        raw_values = relationship_map.get(predicate_name)
+        if isinstance(raw_values, str):
+            values = [raw_values] if raw_values.strip() else []
+        elif isinstance(raw_values, Sequence):
+            values = [
+                str(value).strip()
+                for value in raw_values
+                if isinstance(value, str) and value.strip()
+            ]
+        else:
+            values = []
+        if values:
+            scope_edges[predicate_name] = values
+    text_relations: list[dict[str, Any]] = []
+    for relation in TextRelationsRepository.find({"subject_concept_id": concept_id}):
+        if not isinstance(relation, Mapping):
+            continue
+        text_value = TextValuesRepository.find_one(
+            {"_id": relation.get("object_text_id")}
+        )
+        if not isinstance(text_value, Mapping):
+            continue
+        text_relations.append(
+            {
+                "predicate": _clean_text(relation.get("predicate")),
+                "text": text_value.get("text"),
+                "language": text_value.get("lang"),
+                "context": _json_safe(relation.get("context") or {}),
+            }
+        )
+    text_relations.sort(key=lambda item: json_dumps_sorted(item))
+    return {
+        "concept_id": concept_id,
+        "exists": True,
+        "publication_context": concept_publication_context(concept_id).to_mapping(),
+        "publication_scope_edges": scope_edges,
+        "forward_relationships": {
+            key: _json_safe(relationship_map.get(key) or [])
+            for key in ("is_a_type_of", "is_an_instance_of", "linked_to")
+        },
+        "attributes": _json_safe(concept.get("attributes") or {}),
+        "system_tags": _json_safe(concept.get("system_tags") or []),
+        "user_tags": _json_safe(concept.get("user_tags") or []),
+        "vontology_path": concept.get("vontology_path"),
+        "text_relations": text_relations,
+        "relationship_keys": sorted(str(key) for key in relationship_map),
+        "updated_at": str(concept.get("updated_at") or "") or None,
+    }
+
+
+def _create_read_back_concept_ids(
+    *,
+    arguments: Mapping[str, Any],
+    result: Mapping[str, Any],
+) -> list[str]:
+    """Resolve created or reused subjects without mistaking parents for output."""
+
+    if result.get("success") is False or result.get("changed") is False:
+        return []
+    candidates: list[Any] = list(result.get("created_concept_ids") or [])
+    for row in result.get("results") or []:
+        if (
+            not isinstance(row, Mapping)
+            or not bool(row.get("success"))
+            or row.get("changed") is False
+        ):
+            continue
+        candidates.extend(
+            (
+                row.get("concept_id"),
+                (row.get("concept") or {}).get("concept_id")
+                if isinstance(row.get("concept"), Mapping)
+                else None,
+            )
+        )
+    return list(
+        dict.fromkeys(
+            concept_id
+            for concept_id in (_normalise_concept_id(item) for item in candidates)
+            if concept_id
+        )
+    )
+
+
+def _relationship_read_back(
+    *,
+    source_id: str,
+    predicate: str | None,
+    target: Any,
+) -> dict[str, Any]:
+    source = ConceptsRepository.find_one({"concept_id": source_id})
+    if not isinstance(source, Mapping):
+        return {"source_id": source_id, "source_exists": False}
+    predicate_value = _clean_text(predicate)
+    target_value = _clean_text(target)
+    relationships = source.get("relationships")
+    relation_map = relationships if isinstance(relationships, Mapping) else {}
+    candidates = {predicate_value}
+    if predicate_value.startswith("#V#"):
+        candidates.add(predicate_value[3:])
+    else:
+        candidates.add(f"#V#{predicate_value}")
+    values: list[str] = []
+    for candidate in candidates:
+        raw = relation_map.get(candidate)
+        if isinstance(raw, str):
+            values.append(raw)
+        elif isinstance(raw, list):
+            values.extend(str(item) for item in raw if isinstance(item, str))
+    inverse_predicate = get_structural_inverse_map().get(
+        normalise_structural_predicate(predicate_value)
+    )
+    inverse_present: bool | None = None
+    if inverse_predicate and target_value.startswith("#V#"):
+        target_document = ConceptsRepository.find_one({"concept_id": target_value})
+        target_relationships = (
+            target_document.get("relationships")
+            if isinstance(target_document, Mapping)
+            and isinstance(target_document.get("relationships"), Mapping)
+            else {}
+        )
+        inverse_raw = target_relationships.get(inverse_predicate)
+        inverse_values = (
+            [inverse_raw] if isinstance(inverse_raw, str) else list(inverse_raw or [])
+        )
+        inverse_present = source_id in inverse_values
+    return {
+        "source_id": source_id,
+        "source_exists": True,
+        "predicate": predicate_value,
+        "target": target_value,
+        "relationship_present": target_value in values,
+        "inverse_predicate": inverse_predicate,
+        "inverse_relationship_present": inverse_present,
+        "publication_context": concept_publication_context(source_id).to_mapping(),
+    }
+
+
+def _text_read_back(
+    *,
+    concept_id: str,
+    predicate: str | None,
+    result: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    relation_id = _clean_text((result or {}).get("relation_id"))
+    query: dict[str, Any] = {"subject_concept_id": concept_id}
+    if relation_id:
+        try:
+            from bson import ObjectId
+
+            query = {"_id": ObjectId(relation_id), "subject_concept_id": concept_id}
+        except Exception:  # noqa: BLE001 - relation IDs can be non-ObjectId fixtures
+            query = {"_id": relation_id, "subject_concept_id": concept_id}
+    elif predicate:
+        query["predicate"] = predicate
+    relation = TextRelationsRepository.find_one(query)
+    text_value = (
+        _text_value_snapshot(relation.get("object_text_id"))
+        if isinstance(relation, Mapping)
+        else None
+    )
+    return {
+        "concept_id": concept_id,
+        "predicate": (
+            _normalise_predicate(relation.get("predicate"))
+            if isinstance(relation, Mapping)
+            else predicate
+        ),
+        "relation_id": str(relation.get("_id"))
+        if isinstance(relation, Mapping)
+        else None,
+        "relation_present": isinstance(relation, Mapping),
+        "text_sha256": (
+            _text_sha256(text_value.get("text"))
+            if isinstance(text_value, Mapping)
+            else None
+        ),
+        "language": (
+            _clean_text(text_value.get("lang"))
+            if isinstance(text_value, Mapping)
+            else None
+        ),
+        "context_sha256": (
+            _canonical_json_sha256(relation.get("context") or {})
+            if isinstance(relation, Mapping)
+            else None
+        ),
+        "provenance_sha256": (
+            _canonical_json_sha256(text_value.get("provenance") or {})
+            if isinstance(text_value, Mapping)
+            else None
+        ),
+        "publication_context": concept_publication_context(concept_id).to_mapping(),
+    }
+
+
+def _uncertain_promotion_read_back(
+    *,
+    source_id: str,
+    assertion_id: str,
+) -> dict[str, Any]:
+    try:
+        snapshot = _uncertain_assertion_snapshot(
+            source_id=source_id,
+            assertion_id=assertion_id,
+        )
+    except OntologyMutationCommandError:
+        return {
+            "source_id": source_id,
+            "assertion_id": assertion_id,
+            "assertion_present": False,
+        }
+    predicate = _normalise_predicate(snapshot.get("predicate"))
+    target = snapshot.get("target")
+    if _target_is_concept(target):
+        relation = _relationship_read_back(
+            source_id=source_id,
+            predicate=predicate,
+            target=target,
+        )
+    else:
+        relation = _text_read_back(
+            concept_id=source_id,
+            predicate=predicate,
+        )
+    return {
+        "source_id": source_id,
+        "assertion_id": assertion_id,
+        "assertion_present": True,
+        "assertion_status": snapshot.get("status"),
+        "assertion_revision": snapshot.get("revision"),
+        "predicate": predicate,
+        "target_concept_id": target if _target_is_concept(target) else None,
+        "target_text_sha256": None
+        if _target_is_concept(target)
+        else _text_sha256(target),
+        "canonical_relation": relation,
+    }
+
+
+def _bulk_relationship_read_back(arguments: Mapping[str, Any]) -> dict[str, Any]:
+    resolved = _relationship_arguments_with_resolved_selector(
+        "remove_relationships_bulk",
+        arguments,
+    )
+    rows = resolved.get("relationships") or resolved.get("relations") or []
+    read_backs = [
+        _relationship_read_back(
+            source_id=_normalise_concept_id(row.get("source_id")) or "",
+            predicate=_normalise_predicate(row.get("predicate")),
+            target=row.get("target"),
+        )
+        for row in rows
+        if isinstance(row, Mapping) and _normalise_concept_id(row.get("source_id"))
+    ]
+    return {
+        "relationship_count": len(read_backs),
+        "relationships": read_backs,
+        "selector_projection_sha256": _effect_arguments_sha256(
+            {
+                "relationships": [
+                    {
+                        "source_id": row.get("source_id"),
+                        "predicate": row.get("predicate"),
+                        "target": row.get("target"),
+                    }
+                    for row in read_backs
+                ]
+            }
+        ),
+    }
+
+
+def canonical_read_back_for_method(
+    *,
+    method_name: str,
+    arguments: Mapping[str, Any],
+    result: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    method = _clean_text(method_name)
+    arguments = _relationship_arguments_with_resolved_selector(method, arguments)
+    if method == "promote_uncertain_relationship_assertion":
+        return _uncertain_promotion_read_back(
+            source_id=_normalise_concept_id(arguments.get("source_id")) or "",
+            assertion_id=_clean_text(arguments.get("assertion_id")),
+        )
+    if method in {"add_relationship", "remove_relationship"}:
+        return _relationship_read_back(
+            source_id=_normalise_concept_id(arguments.get("source_id")) or "",
+            predicate=_normalise_predicate(arguments.get("predicate"))
+            or _normalise_predicate((result or {}).get("predicate")),
+            target=arguments.get("target") or (result or {}).get("target"),
+        )
+    if method == "remove_relationships_bulk":
+        return _bulk_relationship_read_back(arguments)
+    if method in {
+        "upsert_text_relation",
+        "update_text_relation",
+        "upsert_singleton_text_relation",
+        "add_names_to_concept",
+        "delete_text_relation",
+    }:
+        return _text_read_back(
+            concept_id=_normalise_concept_id(
+                arguments.get("concept_id") or arguments.get("subject_concept_id")
+            )
+            or "",
+            predicate=_normalise_predicate(arguments.get("predicate")),
+            result=result,
+        )
+    if method == "create_concepts":
+        concept_ids = _create_read_back_concept_ids(
+            arguments=arguments,
+            result=result or {},
+        )
+        return {
+            "concepts": [
+                _concept_read_back(item)
+                for item in concept_ids
+                if _normalise_concept_id(item)
+            ]
+        }
+    if method == "rename_concept":
+        new_id = _normalise_concept_id(arguments.get("new_id"))
+        return _concept_read_back(new_id) if new_id else {"exists": False}
+    if method == "merge_concepts":
+        from .concept_merge_service import read_concept_merge_postcondition
+
+        exact_plan = arguments.get("exact_plan")
+        if not isinstance(exact_plan, Mapping):
+            return {
+                "matches_exact_plan": False,
+                "error_code": "identity_consolidation_plan_required",
+            }
+        return read_concept_merge_postcondition(exact_plan)
+    concept_id = _normalise_concept_id(
+        arguments.get("concept_id") or arguments.get("old_id")
+    )
+    return _concept_read_back(concept_id) if concept_id else {"exists": False}
+
+
+def _safe_command_error(exc: OntologyMutationCommandError) -> dict[str, Any]:
+    return {
+        "success": False,
+        "effect_status": "not_started",
+        "mutation_outcome": "not_started",
+        "changed": False,
+        "error_code": exc.reason_code,
+        "error": exc.public_message,
+        "recovery_affordances": [
+            {"action_type": "create_scoped_assertion"},
+            {"action_type": "request_ontology_administrator_delegation"},
+        ],
+    }
+
+
+def _verify_method_postcondition(
+    *,
+    method_name: str,
+    intent: OntologyMutationIntent,
+    result: Mapping[str, Any],
+    canonical_state: Any,
+) -> bool:
+    """Prove the smallest exact postcondition needed to claim success."""
+
+    if not isinstance(canonical_state, Mapping):
+        return False
+    method = _clean_text(method_name)
+    if method == "add_relationship":
+        if canonical_state.get("relationship_present") is not True:
+            return False
+        if intent.delta.get("maintain_inverse"):
+            return canonical_state.get("inverse_relationship_present") is True
+        return True
+    if method == "remove_relationship":
+        if canonical_state.get("relationship_present") is not False:
+            return False
+        if intent.delta.get("maintain_inverse"):
+            return canonical_state.get("inverse_relationship_present") is False
+        return True
+    if method == "remove_relationships_bulk":
+        rows = canonical_state.get("relationships")
+        return (
+            result.get("success") is True
+            and str(result.get("status") or "").lower() != "partial"
+            and canonical_state.get("relationship_count")
+            == intent.delta.get("relationship_count")
+            and canonical_state.get("selector_projection_sha256")
+            == intent.delta.get("selector_projection_sha256")
+            and isinstance(rows, list)
+            and len(rows) == int(intent.delta.get("relationship_count") or 0)
+            and all(
+                isinstance(row, Mapping)
+                and row.get("relationship_present") is False
+                and (row.get("inverse_relationship_present") in {False, None})
+                for row in rows
+            )
+        )
+    if method in {
+        "upsert_text_relation",
+        "update_text_relation",
+        "upsert_singleton_text_relation",
+    }:
+        expected_hash = intent.delta.get("text_sha256")
+        exact_relation = (
+            canonical_state.get("relation_present") is True
+            and canonical_state.get("text_sha256") == expected_hash
+            and canonical_state.get("predicate") == intent.predicate
+            and canonical_state.get("language") == intent.delta.get("language")
+            and canonical_state.get("provenance_sha256")
+            == intent.delta.get("provenance_sha256")
+        )
+        if method in {"upsert_text_relation", "upsert_singleton_text_relation"}:
+            exact_relation = exact_relation and (
+                canonical_state.get("context_sha256")
+                == intent.delta.get("context_sha256")
+            )
+        return bool(expected_hash) and exact_relation
+    if method == "delete_text_relation":
+        return canonical_state.get("relation_present") is False
+    if method == "create_concepts":
+        concepts = canonical_state.get("concepts")
+        expected_context = intent.publication_context.to_mapping()
+        specs = intent.delta.get("concepts")
+        if (
+            not isinstance(concepts, list)
+            or len(concepts) != 1
+            or not isinstance(specs, list)
+            or len(specs) != 1
+            or not isinstance(concepts[0], Mapping)
+            or not isinstance(specs[0], Mapping)
+        ):
+            return False
+        actual = concepts[0]
+        spec = specs[0]
+        expected_id = _normalise_concept_id(spec.get("concept_id"))
+        if (
+            actual.get("exists") is not True
+            or actual.get("concept_id") != expected_id
+            or not isinstance(actual.get("publication_context"), Mapping)
+            or actual["publication_context"].get("kind") != expected_context.get("kind")
+            or actual["publication_context"].get("concept_id")
+            != expected_context.get("concept_id")
+        ):
+            return False
+        parent_id = _normalise_concept_id(intent.delta.get("parent_id"))
+        instance_of_type = _normalise_concept_id(
+            intent.delta.get("instance_of_type") or spec.get("instance_of_type")
+        )
+        kind = _clean_text(spec.get("kind")).lower()
+        if kind == "individual":
+            kind = "instance"
+        if instance_of_type:
+            expected_type_parents = [parent_id] if parent_id else []
+            expected_instance_types = [instance_of_type]
+        elif kind in {"instance", "predicate"}:
+            expected_type_parents = []
+            expected_instance_types = [parent_id] if parent_id else []
+        else:
+            expected_type_parents = [parent_id] if parent_id else []
+            expected_instance_types = []
+        relationships = actual.get("forward_relationships")
+        if not isinstance(relationships, Mapping) or (
+            relationships.get("is_a_type_of") != expected_type_parents
+            or relationships.get("is_an_instance_of") != expected_instance_types
+            or relationships.get("linked_to") != []
+        ):
+            return False
+        if (
+            actual.get("attributes") != {}
+            or actual.get("system_tags") != []
+            or actual.get("user_tags") != []
+            or actual.get("vontology_path") != spec.get("vontology_path")
+        ):
+            return False
+        texts = actual.get("text_relations")
+        if not isinstance(texts, list):
+            return False
+
+        def has_text(
+            predicate: str, value: Any, *, name_type: str | None = None
+        ) -> bool:
+            if not isinstance(value, str) or not value.strip():
+                return True
+            return any(
+                isinstance(row, Mapping)
+                and row.get("predicate") == predicate
+                and row.get("text") == value.strip()
+                and (
+                    name_type is None
+                    or (
+                        isinstance(row.get("context"), Mapping)
+                        and row["context"].get("name_type") == name_type
+                    )
+                )
+                for row in texts
+            )
+
+        return (
+            has_text("hasName", spec.get("name"), name_type="NL")
+            and has_text("hasDescription", spec.get("description"))
+            and has_text("hasNote", spec.get("notes"))
+        )
+    if method == "promote_uncertain_relationship_assertion":
+        relation = canonical_state.get("canonical_relation")
+        return (
+            canonical_state.get("assertion_status") == "promoted"
+            and isinstance(relation, Mapping)
+            and (
+                relation.get("relationship_present") is True
+                or relation.get("relation_present") is True
+            )
+        )
+    if method == "update_concept":
+        # The command read-back at minimum proves the same canonical target and
+        # publication context remained present. Field-specific values are bound
+        # in the intent and specialised text updates use dedicated commands.
+        return (
+            canonical_state.get("exists") is True
+            and isinstance(canonical_state.get("publication_context"), Mapping)
+            and canonical_state["publication_context"].get("kind")
+            == intent.publication_context.kind.value
+            and canonical_state["publication_context"].get("concept_id")
+            == intent.publication_context.concept_id
+        )
+    if method == "add_names_to_concept":
+        # The handler reports one result per requested name; no partial result
+        # is a successful postcondition.
+        return bool(result.get("success")) and int(result.get("error_count") or 0) == 0
+    if method == "merge_concepts":
+        return (
+            result.get("success") is True
+            and canonical_state.get("matches_exact_plan") is True
+            and canonical_state.get("plan_sha256")
+            == intent.delta.get("merge_plan_sha256")
+            and canonical_state.get("source_id") == intent.delta.get("source_id")
+            and canonical_state.get("target_id") == intent.delta.get("target_id")
+        )
+    # Rename and delete remain preview-only at this boundary.
+    return False
+
+
+def execute_governed_ontology_method(
+    *,
+    method_name: str,
+    arguments: Mapping[str, Any],
+    mutate: Callable[[], Mapping[str, Any]],
+    preview: bool = False,
+) -> dict[str, Any]:
+    try:
+        intent = build_ontology_mutation_intent(
+            method_name=method_name,
+            arguments=arguments,
+        )
+    except OntologyMutationCommandError as exc:
+        return _safe_command_error(exc)
+    except LookupError:
+        return _safe_command_error(
+            OntologyMutationCommandError(
+                "ontology_mutation_target_not_found",
+                "The requested ontology target was not found.",
+            )
+        )
+    except ValueError:
+        return _safe_command_error(
+            OntologyMutationCommandError(
+                "invalid_ontology_mutation",
+                "The requested ontology mutation is invalid.",
+            )
+        )
+    except Exception:
+        # Intent construction is read-only. An unexpected repository or
+        # resolver failure here is therefore a definite pre-effect failure,
+        # not an indeterminate mutation. Keep the public response non-leaking
+        # while retaining the exception in server diagnostics.
+        logger.exception("Governed ontology mutation preflight failed")
+        return {
+            "success": False,
+            "error_code": "exception",
+            "error": "Ontology mutation preflight failed before any effect.",
+        }
+    result_holder: dict[str, Mapping[str, Any]] = {}
+
+    def perform_locked() -> Mapping[str, Any]:
+        if method_name == "merge_concepts":
+            from .concept_merge_service import (
+                ConceptMergePlanError,
+                build_concept_merge_plan,
+            )
+
+            try:
+                current_plan = build_concept_merge_plan(
+                    _normalise_concept_id(arguments.get("source_id")) or "",
+                    _normalise_concept_id(arguments.get("target_id")) or "",
+                )
+            except ConceptMergePlanError as exc:
+                return _safe_command_error(
+                    OntologyMutationCommandError(
+                        exc.reason_code,
+                        exc.public_message,
+                    )
+                )
+            expected_plan = arguments.get("exact_plan")
+            if (
+                not isinstance(expected_plan, Mapping)
+                or _clean_text(current_plan.get("plan_sha256"))
+                != _clean_text(expected_plan.get("plan_sha256"))
+                or _clean_text(current_plan.get("plan_sha256"))
+                != _clean_text(intent.delta.get("merge_plan_sha256"))
+            ):
+                return {
+                    "success": False,
+                    "effect_status": "not_started",
+                    "mutation_outcome": "not_started",
+                    "changed": False,
+                    "error_code": "identity_consolidation_precondition_failed",
+                    "error": (
+                        "The affected identity graph changed after merge "
+                        "authority was resolved."
+                    ),
+                }
+        if method_name in {
+            "update_text_relation",
+            "delete_text_relation",
+        } and _clean_text(arguments.get("relation_id")):
+            try:
+                relation_id = _clean_text(arguments.get("relation_id"))
+                with ontology_mutation_resource_lock(
+                    f"ontology-text-relation:{relation_id}"
+                ):
+                    current_relation = _text_relation_snapshot(
+                        subject_concept_id=(
+                            _normalise_concept_id(
+                                arguments.get("concept_id")
+                                or arguments.get("subject_concept_id")
+                            )
+                            or ""
+                        ),
+                        relation_id=relation_id,
+                    )
+                    if current_relation.get("revision") != intent.delta.get(
+                        "relation_revision"
+                    ):
+                        return {
+                            "success": False,
+                            "effect_status": "not_started",
+                            "mutation_outcome": "not_started",
+                            "changed": False,
+                            "error_code": "text_relation_precondition_failed",
+                            "error": (
+                                "The text relation changed after authority was "
+                                "resolved; obtain a new exact delegation."
+                            ),
+                        }
+                    result = mutate()
+                    result_holder["result"] = result
+                    return result
+            except OntologyMutationCommandError as exc:
+                return _safe_command_error(exc)
+            except OntologyMutationResourceBusy:
+                return {
+                    "success": False,
+                    "effect_status": "not_started",
+                    "mutation_outcome": "not_started",
+                    "changed": False,
+                    "retryable": True,
+                    "error_code": "ontology_mutation_resource_busy",
+                    "error": "Another text relation mutation is already in progress.",
+                }
+        if method_name == "promote_uncertain_relationship_assertion":
+            try:
+                current_assertion = _uncertain_assertion_snapshot(
+                    source_id=_normalise_concept_id(arguments.get("source_id")) or "",
+                    assertion_id=_clean_text(arguments.get("assertion_id")),
+                )
+            except OntologyMutationCommandError as exc:
+                return _safe_command_error(exc)
+            if current_assertion.get("revision") != intent.delta.get(
+                "assertion_revision"
+            ):
+                return {
+                    "success": False,
+                    "effect_status": "not_started",
+                    "mutation_outcome": "not_started",
+                    "changed": False,
+                    "error_code": "uncertain_assertion_precondition_failed",
+                    "error": (
+                        "The uncertain assertion changed after authority was "
+                        "resolved; obtain a new exact delegation."
+                    ),
+                }
+        result = mutate()
+        if method_name == "create_concepts" and "success" not in result:
+            expected_concept_id = _normalise_concept_id(
+                intent.delta.get("expected_concept_id")
+            )
+            result = {
+                "success": True,
+                "changed": True,
+                "created_concept_ids": (
+                    [expected_concept_id] if expected_concept_id else []
+                ),
+                "concept": dict(result),
+            }
+        result_holder["result"] = result
+        return result
+
+    def perform() -> Mapping[str, Any]:
+        scope_fingerprints = intent.delta.get("affected_scope_fingerprints")
+        expected = (
+            dict(scope_fingerprints) if isinstance(scope_fingerprints, Mapping) else {}
+        )
+        try:
+            with ExitStack() as locks:
+                resource_keys = {
+                    *(f"ontology-publication-scope:{item}" for item in expected),
+                    *ontology_authority_resource_keys(intent),
+                }
+                if method_name == "merge_concepts":
+                    resource_keys.update(
+                        f"ontology-text-relation:{relation_id}"
+                        for relation_id in intent.delta.get("merge_text_relation_ids")
+                        or []
+                        if _clean_text(relation_id)
+                    )
+                if method_name == "create_concepts":
+                    expected_concept_id = _normalise_concept_id(
+                        intent.delta.get("expected_concept_id")
+                    )
+                    if expected_concept_id:
+                        resource_keys.add(
+                            f"ontology-publication-scope:{expected_concept_id}"
+                        )
+                for resource_key in sorted(resource_keys):
+                    locks.enter_context(ontology_mutation_resource_lock(resource_key))
+                for concept_id, expected_fingerprint in expected.items():
+                    try:
+                        current = scope_read_back(concept_id)
+                    except LookupError:
+                        return _safe_command_error(
+                            OntologyMutationCommandError(
+                                "ontology_mutation_target_not_found",
+                                "An affected ontology target is no longer available.",
+                            )
+                        )
+                    if _clean_text(current.get("scope_fingerprint")) != _clean_text(
+                        expected_fingerprint
+                    ):
+                        return {
+                            "success": False,
+                            "effect_status": "not_started",
+                            "mutation_outcome": "not_started",
+                            "changed": False,
+                            "error_code": "ontology_mutation_scope_precondition_failed",
+                            "error": (
+                                "An affected publication scope changed after "
+                                "authority was resolved."
+                            ),
+                        }
+                if method_name == "create_concepts":
+                    expected_concept_id = _normalise_concept_id(
+                        intent.delta.get("expected_concept_id")
+                    )
+                    if expected_concept_id and _concept_exists_unfiltered(
+                        expected_concept_id
+                    ):
+                        return _safe_command_error(
+                            OntologyMutationCommandError(
+                                "ontology_create_concept_id_conflict",
+                                "The requested concept ID cannot be created.",
+                            )
+                        )
+                live_decision = authorise_ontology_mutation(intent)
+                if not live_decision.allowed:
+                    return ontology_authority_denial_payload(live_decision, intent)
+                return perform_locked()
+        except OntologyMutationResourceBusy:
+            return {
+                "success": False,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "changed": False,
+                "retryable": True,
+                "error_code": "ontology_mutation_resource_busy",
+                "error": "Another ontology mutation is already in progress.",
+            }
+
+    return execute_authorised_ontology_mutation(
+        intent=intent,
+        mutate=perform,
+        read_before=lambda: canonical_read_back_for_method(
+            method_name=method_name,
+            arguments=arguments,
+        ),
+        read_back=lambda: canonical_read_back_for_method(
+            method_name=method_name,
+            arguments=arguments,
+            result=result_holder.get("result"),
+        ),
+        verify_read_back=lambda result, state: _verify_method_postcondition(
+            method_name=method_name,
+            intent=intent,
+            result=result,
+            canonical_state=state,
+        ),
+        preview=preview,
+    )
+
+
+def issue_same_turn_method_delegation(
+    *,
+    method_name: str,
+    arguments: Mapping[str, Any],
+    actor_concept_id: str,
+    organisation_concept_id: str | None,
+    delegate_concept_id: str,
+    audience: str,
+    effect_id: str,
+    turn_id: str | None,
+) -> dict[str, Any]:
+    try:
+        intent = build_ontology_mutation_intent(
+            method_name=method_name,
+            arguments=arguments,
+            idempotency_key=effect_id,
+        )
+        if method_name != "create_concepts" and not actor_can_access_intent_targets(
+            actor_concept_id=actor_concept_id,
+            organisation_concept_id=organisation_concept_id,
+            target_concept_ids=intent.target_concept_ids,
+        ):
+            raise OntologyMutationCommandError(
+                "ontology_mutation_target_not_accessible",
+                "The requested ontology target is not accessible in this context.",
+            )
+        return issue_agent_delegation(
+            intent=intent,
+            grantor_actor_concept_id=actor_concept_id,
+            grantor_organisation_concept_id=organisation_concept_id,
+            delegate_concept_id=delegate_concept_id,
+            audience=audience,
+            tool_name=method_name,
+            effect_id=effect_id,
+            turn_id=turn_id,
+        )
+    except OntologyMutationCommandError as exc:
+        return _safe_command_error(exc)
+    except PermissionError as exc:
+        return {
+            "success": False,
+            "effect_status": "not_started",
+            "mutation_outcome": "not_started",
+            "changed": False,
+            "error_code": str(exc),
+            "error": "Semantic ontology authority is required for this effect.",
+            "recovery_affordances": [
+                {"action_type": "create_scoped_assertion"},
+                {"action_type": "request_ontology_administrator_delegation"},
+            ],
+        }
+    except (RuntimeError, ValueError) as exc:
+        return {
+            "success": False,
+            "effect_status": "not_started",
+            "mutation_outcome": "not_started",
+            "changed": False,
+            "error_code": "ontology_delegation_not_issued",
+            "error": "The exact ontology delegation could not be issued.",
+            "details": {"exception_type": type(exc).__name__},
+        }
+
+
+def scope_read_back(concept_id: str) -> dict[str, Any]:
+    """Return exact scope edges for optimistic scope-change commands."""
+
+    normalised = _normalise_concept_id(concept_id)
+    if not normalised:
+        raise ValueError("concept_id is required")
+    with bypass_access_control():
+        document = ConceptsRepository.find_one({"concept_id": normalised})
+    if not isinstance(document, Mapping):
+        raise LookupError("Concept not found")  # noqa: TRY004
+    relationships = document.get("relationships")
+    relation_map = relationships if isinstance(relationships, Mapping) else {}
+    scope_edges = {
+        predicate: list(value) if isinstance(value, list) else [value]
+        for predicate in (
+            *SPECIFIC_TO_USER_PREDICATES,
+            *SPECIFIC_TO_ORG_PREDICATES_READ,
+        )
+        if (value := relation_map.get(predicate)) is not None
+    }
+    return {
+        "concept_id": normalised,
+        "publication_context": concept_publication_context(normalised).to_mapping(),
+        "scope_edges": scope_edges,
+        "scope_fingerprint": _text_sha256(json_dumps_sorted(scope_edges)),
+    }
+
+
+def json_dumps_sorted(value: Any) -> str:
+    import json
+
+    return json.dumps(value, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
+
+
+__all__ = [
+    "OntologyMutationCommandError",
+    "build_ontology_mutation_intent",
+    "canonical_read_back_for_method",
+    "execute_governed_ontology_method",
+    "is_ontology_mutation_method",
+    "issue_same_turn_method_delegation",
+    "normalise_governed_ontology_arguments",
+    "resolve_governed_ontology_arguments",
+    "scope_read_back",
+]

--- a/src/backend/services/ontology_publication_authority_service.py
+++ b/src/backend/services/ontology_publication_authority_service.py
@@ -1,0 +1,2155 @@
+"""Central authority and receipt contract for canonical ontology publication.
+
+Visibility answers who may read a represented artefact.  It is deliberately not
+used as a proxy for who may publish, retract, consolidate, or change its scope.
+This service resolves semantic authority from live represented role relations,
+binds a server-issued delegation to one exact agent effect, and records a
+durable decision/read-back receipt.
+
+The role vocabulary is represented in Vontology.  Short-lived delegations and
+effect receipts are transactional operational records linked back to those
+represented roles; they are not domain assertions and are therefore kept in
+fit-for-purpose collections.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import secrets
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from typing import Any, TypeVar
+
+from flask import has_request_context
+from pymongo import ReturnDocument
+from pymongo.errors import DuplicateKeyError
+
+from ..db.mongo_client import (
+    get_ontology_authority_delegations_collection,
+    get_ontology_mutation_receipts_collection,
+)
+from ..db.repositories.concepts_repository import ConceptsRepository
+from ..db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
+from ..security.access_control import (
+    bypass_access_control,
+    can_access_concept,
+    get_effective_organisation_concept_id,
+    get_effective_user_concept_id,
+    override_current_actor,
+)
+from ..security.visibility_predicates import (
+    SPECIFIC_TO_ORG_PREDICATES_READ,
+    SPECIFIC_TO_USER_PREDICATES,
+    get_specific_to_org_values,
+    get_specific_to_user_values,
+)
+
+logger = logging.getLogger(__name__)
+
+AUTHORITY_SCHEMA_VERSION = "ontology_publication_authority.v1"
+DELEGATION_SCHEMA_VERSION = "ontology_authority_delegation.v1"
+RECEIPT_SCHEMA_VERSION = "ontology_mutation_receipt.v1"
+
+AUTHORITY_ROLE_PREDICATE = "#V#has_ontology_authority_role"
+ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE = "organisation_ontology_administrator"
+GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE = "global_ontology_administrator"
+VON_ADMINISTRATOR_CONCEPT_ID = "#V#von_administrator"
+_ORGANISATION_ROLE_STORAGE_SEPARATOR = "::"
+
+DEFAULT_AGENT_DELEGATION_TTL_SECONDS = 300
+MAX_INTERACTIVE_DELEGATION_TTL_SECONDS = 900
+DEFAULT_MUTATION_RESOURCE_LOCK_SECONDS = 300
+
+RESERVED_AUTHORITY_PREDICATES = frozenset(
+    {
+        AUTHORITY_ROLE_PREDICATE,
+        "#V#has_von_operational_administrator",
+        "#V#hasRole",
+        "#V#memberOf",
+        "memberOf",
+        "#V#member_of_organisation",
+    }
+)
+RESERVED_SCOPE_PREDICATES = frozenset(
+    {
+        *SPECIFIC_TO_USER_PREDICATES,
+        *SPECIFIC_TO_ORG_PREDICATES_READ,
+    }
+)
+RESERVED_GENERIC_MUTATION_PREDICATES = (
+    RESERVED_AUTHORITY_PREDICATES | RESERVED_SCOPE_PREDICATES
+)
+
+
+class PublicationContextKind(StrEnum):
+    USER = "user"
+    ORGANISATION = "organisation"
+    GLOBAL = "global"
+    HISTORICAL = "historical"
+    MIXED = "mixed"
+
+
+class OntologyMutationResourceBusy(RuntimeError):
+    """Another governed effect currently owns an exact mutation resource."""
+
+
+@dataclass(frozen=True)
+class PublicationContext:
+    kind: PublicationContextKind
+    concept_id: str | None = None
+    source: str = "resolved"
+    historical_predicates: tuple[str, ...] = ()
+
+    def to_mapping(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "kind": self.kind.value,
+            "concept_id": self.concept_id,
+            "source": self.source,
+        }
+        if self.historical_predicates:
+            payload["historical_predicates"] = list(self.historical_predicates)
+        return payload
+
+    @classmethod
+    def global_context(cls, *, source: str = "explicit") -> PublicationContext:
+        return cls(PublicationContextKind.GLOBAL, None, source)
+
+    @classmethod
+    def organisation(
+        cls,
+        organisation_concept_id: str,
+        *,
+        source: str = "explicit",
+    ) -> PublicationContext:
+        return cls(
+            PublicationContextKind.ORGANISATION,
+            _normalise_concept_id(organisation_concept_id),
+            source,
+        )
+
+    @classmethod
+    def user(
+        cls,
+        user_concept_id: str,
+        *,
+        source: str = "explicit",
+    ) -> PublicationContext:
+        return cls(
+            PublicationContextKind.USER,
+            _normalise_concept_id(user_concept_id),
+            source,
+        )
+
+
+@dataclass(frozen=True)
+class OntologyMutationIntent:
+    operation: str
+    publication_context: PublicationContext
+    target_concept_ids: tuple[str, ...]
+    tool_name: str | None = None
+    predicate: str | None = None
+    source_contexts: tuple[PublicationContext, ...] = ()
+    delta: Mapping[str, Any] = field(default_factory=dict)
+    idempotency_key: str | None = None
+
+    def canonical_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": AUTHORITY_SCHEMA_VERSION,
+            "operation": _clean_text(self.operation),
+            "publication_context": self.publication_context.to_mapping(),
+            "source_contexts": [item.to_mapping() for item in self.source_contexts],
+            "target_concept_ids": sorted(
+                {
+                    value
+                    for value in (
+                        _normalise_concept_id(item) for item in self.target_concept_ids
+                    )
+                    if value
+                }
+            ),
+            "tool_name": _clean_text(self.tool_name) or None,
+            "predicate": _normalise_predicate(self.predicate),
+            "delta": _json_safe(dict(self.delta)),
+        }
+
+    @property
+    def fingerprint(self) -> str:
+        return _sha256_json(self.canonical_payload())
+
+
+@dataclass(frozen=True)
+class OntologyInvocationContext:
+    surface: str
+    executing_agent_concept_id: str | None = None
+    audience: str | None = None
+    delegation_id: str | None = None
+    effect_id: str | None = None
+    turn_id: str | None = None
+    workflow_id: str | None = None
+
+
+@dataclass(frozen=True)
+class AuthorityRoleEvidence:
+    role: str
+    actor_concept_id: str
+    organisation_concept_id: str | None
+    relation_id: str
+    revision: str
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "role": self.role,
+            "actor_concept_id": self.actor_concept_id,
+            "organisation_concept_id": self.organisation_concept_id,
+            "relation_id": self.relation_id,
+            "revision": self.revision,
+        }
+
+
+@dataclass(frozen=True)
+class OntologyAuthorityDecision:
+    allowed: bool
+    decision_id: str
+    reason_code: str
+    message: str
+    actor_concept_id: str | None
+    organisation_concept_id: str | None
+    intent_fingerprint: str
+    role_evidence: tuple[AuthorityRoleEvidence, ...] = ()
+    delegation_id: str | None = None
+    executing_agent_concept_id: str | None = None
+    audience: str | None = None
+    trust_source: str | None = None
+
+    def public_projection(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": AUTHORITY_SCHEMA_VERSION,
+            "decision_id": self.decision_id,
+            "allowed": self.allowed,
+            "reason_code": self.reason_code,
+            "actor_concept_id": self.actor_concept_id,
+            "organisation_concept_id": self.organisation_concept_id,
+            "executing_agent_concept_id": self.executing_agent_concept_id,
+            "delegation_id": self.delegation_id,
+            "audience": self.audience,
+            "intent_fingerprint": self.intent_fingerprint,
+            "authority_evidence": [
+                {
+                    "role": item.role,
+                    "organisation_concept_id": item.organisation_concept_id,
+                    "relation_id": item.relation_id,
+                    "revision": item.revision,
+                }
+                for item in self.role_evidence
+            ],
+        }
+        return payload
+
+
+@dataclass(frozen=True)
+class MutationReceiptHandle:
+    receipt_id: str
+    replay: bool = False
+    stored_response: Mapping[str, Any] | None = None
+    stored_receipt: Mapping[str, Any] | None = None
+    existing_status: str | None = None
+    intent_conflict: bool = False
+
+
+_ONTOLOGY_INVOCATION: ContextVar[OntologyInvocationContext | None] = ContextVar(
+    "ontology_publication_invocation",
+    default=None,
+)
+_AUTHORISED_MUTATION_DECISION: ContextVar[OntologyAuthorityDecision | None] = (
+    ContextVar(
+        "ontology_authorised_mutation_decision",
+        default=None,
+    )
+)
+_AUTHORISED_MUTATION_INTENT: ContextVar[OntologyMutationIntent | None] = ContextVar(
+    "ontology_authorised_mutation_intent",
+    default=None,
+)
+
+T = TypeVar("T")
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Normalise PyMongo's commonly naive UTC datetimes for comparisons."""
+
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _clean_text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _normalise_concept_id(value: Any) -> str | None:
+    cleaned = _clean_text(value)
+    if not cleaned:
+        return None
+    return cleaned if cleaned.startswith("#") else f"#V#{cleaned}"
+
+
+def _normalise_predicate(value: Any) -> str | None:
+    cleaned = _clean_text(value)
+    if not cleaned:
+        return None
+    return cleaned
+
+
+def authority_role_storage_text(
+    role: str,
+    organisation_concept_id: str | None = None,
+) -> str:
+    """Return a scope-distinct text token for one represented authority role.
+
+    Text-relation uniqueness is subject/predicate/object rather than context.
+    Including the exact organisation in the object token therefore permits one
+    person to administer more than one organisation without overwriting a
+    prior role context.  Legacy plain organisation-role text remains readable.
+    """
+
+    role_value = _clean_text(role).lower()
+    organisation_id = _normalise_concept_id(organisation_concept_id)
+    if role_value == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE:
+        if organisation_id:
+            raise ValueError("Global ontology authority cannot have an organisation")
+        return role_value
+    if role_value == ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE:
+        if not organisation_id:
+            raise ValueError("Organisation ontology authority requires an organisation")
+        return f"{role_value}{_ORGANISATION_ROLE_STORAGE_SEPARATOR}{organisation_id}"
+    raise ValueError("Unsupported ontology authority role")
+
+
+def parse_authority_role_storage_text(
+    stored_text: object,
+    relation_context: Mapping[str, Any] | None = None,
+) -> tuple[str | None, str | None]:
+    """Decode current scope-distinct and legacy single-organisation role text."""
+
+    raw_text = _clean_text(stored_text)
+    text = raw_text.lower()
+    context = relation_context if isinstance(relation_context, Mapping) else {}
+    context_org = _normalise_concept_id(
+        context.get("organisation_concept_id") or context.get("organisation_id")
+    )
+    if text == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE:
+        # A global role has no organisation context.  Treating an org-scoped
+        # row as global would turn malformed or forged context into broader
+        # authority.
+        if context_org:
+            return None, None
+        return GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE, None
+    prefix = (
+        ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE + _ORGANISATION_ROLE_STORAGE_SEPARATOR
+    )
+    if text.startswith(prefix):
+        stored_org = _normalise_concept_id(raw_text[len(prefix) :])
+        if not stored_org or (context_org and context_org != stored_org):
+            return None, None
+        return ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE, stored_org
+    if text == ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE and context_org:
+        return ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE, context_org
+    return None, None
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, datetime):
+        return value.astimezone(UTC).isoformat()
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    ):
+        return [_json_safe(item) for item in value]
+    return str(value)
+
+
+def _sha256_json(value: Any) -> str:
+    encoded = json.dumps(
+        _json_safe(value),
+        sort_keys=True,
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _new_identifier(prefix: str) -> str:
+    return f"{prefix}_{secrets.token_urlsafe(18)}"
+
+
+def _release_identity() -> dict[str, Any]:
+    return {
+        "runtime_code_version": _clean_text(os.getenv("VON_RUNTIME_CODE_VERSION"))
+        or None,
+        "release_id": _clean_text(os.getenv("VON_RELEASE_ID")) or None,
+        "deployment": _clean_text(os.getenv("VON_DEPLOYMENT_NAME")) or None,
+    }
+
+
+@contextmanager
+def bind_ontology_invocation(
+    *,
+    surface: str,
+    executing_agent_concept_id: str | None = None,
+    audience: str | None = None,
+    delegation_id: str | None = None,
+    effect_id: str | None = None,
+    turn_id: str | None = None,
+    workflow_id: str | None = None,
+) -> Iterator[OntologyInvocationContext]:
+    """Bind server-established execution provenance around one exact effect."""
+
+    invocation = OntologyInvocationContext(
+        surface=_clean_text(surface) or "unknown",
+        executing_agent_concept_id=_normalise_concept_id(executing_agent_concept_id),
+        audience=_clean_text(audience) or None,
+        delegation_id=_clean_text(delegation_id) or None,
+        effect_id=_clean_text(effect_id) or None,
+        turn_id=_clean_text(turn_id) or None,
+        workflow_id=_normalise_concept_id(workflow_id)
+        or _clean_text(workflow_id)
+        or None,
+    )
+    token = _ONTOLOGY_INVOCATION.set(invocation)
+    try:
+        yield invocation
+    finally:
+        _ONTOLOGY_INVOCATION.reset(token)
+
+
+def current_ontology_invocation() -> OntologyInvocationContext | None:
+    return _ONTOLOGY_INVOCATION.get()
+
+
+@contextmanager
+def bind_authorised_ontology_mutation(
+    decision: OntologyAuthorityDecision,
+    intent: OntologyMutationIntent | None = None,
+) -> Iterator[None]:
+    """Mark nested canonical primitives as covered by one exact decision."""
+
+    if not decision.allowed:
+        raise PermissionError(decision.reason_code)
+    decision_token = _AUTHORISED_MUTATION_DECISION.set(decision)
+    intent_token = _AUTHORISED_MUTATION_INTENT.set(intent)
+    try:
+        yield
+    finally:
+        _AUTHORISED_MUTATION_INTENT.reset(intent_token)
+        _AUTHORISED_MUTATION_DECISION.reset(decision_token)
+
+
+def current_authorised_ontology_mutation() -> OntologyAuthorityDecision | None:
+    return _AUTHORISED_MUTATION_DECISION.get()
+
+
+def current_authorised_ontology_intent() -> OntologyMutationIntent | None:
+    """Return the exact intent covering the current canonical primitive."""
+
+    return _AUTHORISED_MUTATION_INTENT.get()
+
+
+def concept_publication_context(concept_id: str) -> PublicationContext:
+    """Resolve publication context without treating malformed history as global."""
+
+    normalised = _normalise_concept_id(concept_id)
+    if normalised is None:
+        raise ValueError("concept_id must be a non-empty concept identifier")
+    with bypass_access_control():
+        concept = ConceptsRepository.find_one({"concept_id": normalised})
+    if not isinstance(concept, Mapping):
+        raise LookupError(f"Concept '{normalised}' not found")  # noqa: TRY004
+
+    relationships = concept.get("relationships")
+    relationship_map = relationships if isinstance(relationships, Mapping) else {}
+    user_ids = tuple(get_specific_to_user_values(dict(relationship_map)))
+    organisation_ids = tuple(get_specific_to_org_values(dict(relationship_map)))
+    historical_predicates: list[str] = []
+    for predicate in (*SPECIFIC_TO_USER_PREDICATES, *SPECIFIC_TO_ORG_PREDICATES_READ):
+        if predicate not in relationship_map:
+            continue
+        raw = relationship_map.get(predicate)
+        raw_values = raw if isinstance(raw, list) else [raw]
+        if any(
+            isinstance(item, str)
+            and item.strip()
+            and not item.strip().startswith("#V#")
+            for item in raw_values
+        ):
+            historical_predicates.append(predicate)
+
+    if historical_predicates:
+        return PublicationContext(
+            PublicationContextKind.HISTORICAL,
+            None,
+            "historical_visibility",
+            tuple(sorted(set(historical_predicates))),
+        )
+    if user_ids and organisation_ids:
+        # Visibility shared by a user and organisation is not evidence that the
+        # organisation owns canonical publication. Historical dual-scope rows
+        # need explicit administrator adoption instead of silent authority
+        # inference.
+        return PublicationContext(
+            PublicationContextKind.MIXED,
+            None,
+            "multi_principal_visibility",
+        )
+    if len(user_ids) == 1:
+        return PublicationContext.user(user_ids[0], source="concept_visibility")
+    if len(organisation_ids) == 1:
+        return PublicationContext.organisation(
+            organisation_ids[0],
+            source="concept_visibility",
+        )
+    if len(user_ids) > 1 or len(organisation_ids) > 1:
+        return PublicationContext(
+            PublicationContextKind.MIXED,
+            None,
+            "multi_principal_visibility",
+        )
+    return PublicationContext.global_context(source="concept_visibility")
+
+
+def publication_context_for_creation(
+    *,
+    scope_mode: str | None,
+    actor_concept_id: str | None,
+    organisation_concept_id: str | None,
+) -> PublicationContext:
+    mode = (_clean_text(scope_mode) or "user_org_default").lower().replace("-", "_")
+    if mode in {"global", "global_general", "public"}:
+        return PublicationContext.global_context(source="creation_scope")
+    if mode in {
+        "organisation_general",
+        "organization_general",
+        "org_general",
+    }:
+        organisation_id = _normalise_concept_id(organisation_concept_id)
+        if organisation_id is None:
+            raise ValueError("organisation_general requires an organisation")
+        return PublicationContext.organisation(
+            organisation_id,
+            source="creation_scope",
+        )
+    actor_id = _normalise_concept_id(actor_concept_id)
+    if actor_id is None:
+        raise ValueError("Authenticated actor required for default concept scope")
+    if mode in {"private", "user_only", "user_only_default"}:
+        return PublicationContext.user(actor_id, source="creation_scope_user_only")
+    if mode in {"user_org_default", "user_org", "default"}:
+        organisation_id = _normalise_concept_id(organisation_concept_id)
+        if organisation_id is not None:
+            return PublicationContext.organisation(
+                organisation_id,
+                source="creation_scope_user_org_default",
+            )
+    return PublicationContext.user(actor_id, source="creation_scope")
+
+
+def _relation_revision(relation: Mapping[str, Any], role_text: str) -> str:
+    return _sha256_json(
+        {
+            "relation_id": relation.get("_id"),
+            "subject_concept_id": relation.get("subject_concept_id"),
+            "predicate": relation.get("predicate"),
+            "object_text_id": relation.get("object_text_id"),
+            "context": relation.get("context"),
+            "role": role_text,
+            "updated_at": relation.get("updated_at"),
+        }
+    )
+
+
+def resolve_live_semantic_roles(
+    actor_concept_id: str,
+) -> tuple[AuthorityRoleEvidence, ...]:
+    """Read represented semantic roles afresh for every authority decision."""
+
+    actor_id = _normalise_concept_id(actor_concept_id)
+    if actor_id is None:
+        return ()
+    relations = TextRelationsRepository.find(
+        {
+            "subject_concept_id": actor_id,
+            "predicate": AUTHORITY_ROLE_PREDICATE,
+        }
+    )
+    evidence: list[AuthorityRoleEvidence] = []
+    for relation in relations:
+        if not isinstance(relation, Mapping):
+            continue
+        object_text_id = relation.get("object_text_id")
+        if object_text_id is None:
+            continue
+        text_value = TextValuesRepository.find_one({"_id": object_text_id})
+        if not isinstance(text_value, Mapping):
+            continue
+        context = relation.get("context")
+        context_map = context if isinstance(context, Mapping) else {}
+        role, organisation_id = parse_authority_role_storage_text(
+            text_value.get("text"),
+            context_map,
+        )
+        if not role:
+            continue
+        evidence.append(
+            AuthorityRoleEvidence(
+                role=role,
+                actor_concept_id=actor_id,
+                organisation_concept_id=organisation_id,
+                relation_id=str(relation.get("_id") or ""),
+                revision=_relation_revision(
+                    relation,
+                    _clean_text(text_value.get("text")),
+                ),
+            )
+        )
+    evidence.sort(
+        key=lambda item: (
+            item.role,
+            item.organisation_concept_id or "",
+            item.relation_id,
+        )
+    )
+    return tuple(evidence)
+
+
+def _role_evidence_for_context(
+    actor_concept_id: str,
+    publication_context: PublicationContext,
+) -> tuple[AuthorityRoleEvidence, ...]:
+    roles = resolve_live_semantic_roles(actor_concept_id)
+    if publication_context.kind == PublicationContextKind.GLOBAL:
+        return tuple(
+            role for role in roles if role.role == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE
+        )
+    if publication_context.kind == PublicationContextKind.ORGANISATION:
+        return tuple(
+            role
+            for role in roles
+            if role.role == ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE
+            and role.organisation_concept_id == publication_context.concept_id
+        )
+    return ()
+
+
+def _organisation_authority_root_exists(organisation_concept_id: str) -> bool:
+    organisation_id = _normalise_concept_id(organisation_concept_id)
+    if not organisation_id:
+        return False
+    relations = TextRelationsRepository.find({"predicate": AUTHORITY_ROLE_PREDICATE})
+    for relation in relations:
+        if not isinstance(relation, Mapping):
+            continue
+        text_value = TextValuesRepository.find_one(
+            {"_id": relation.get("object_text_id")}
+        )
+        if not isinstance(text_value, Mapping):
+            continue
+        role, role_org = parse_authority_role_storage_text(
+            text_value.get("text"),
+            relation.get("context")
+            if isinstance(relation.get("context"), Mapping)
+            else {},
+        )
+        if (
+            role == ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE
+            and role_org == organisation_id
+        ):
+            return True
+    return False
+
+
+def _gateway_actor_trust_source() -> str | None:
+    try:
+        from ..integrations.internal_mcp.gateway import (
+            get_internal_mcp_actor_context_source,
+        )
+
+        return get_internal_mcp_actor_context_source()
+    except Exception:  # noqa: BLE001 - optional integration provenance probe
+        return None
+
+
+def _decision(
+    *,
+    allowed: bool,
+    reason_code: str,
+    message: str,
+    intent: OntologyMutationIntent,
+    actor_concept_id: str | None,
+    organisation_concept_id: str | None,
+    role_evidence: Sequence[AuthorityRoleEvidence] = (),
+    delegation_id: str | None = None,
+    invocation: OntologyInvocationContext | None = None,
+    trust_source: str | None = None,
+) -> OntologyAuthorityDecision:
+    return OntologyAuthorityDecision(
+        allowed=allowed,
+        decision_id=_new_identifier("oad"),
+        reason_code=reason_code,
+        message=message,
+        actor_concept_id=_normalise_concept_id(actor_concept_id),
+        organisation_concept_id=_normalise_concept_id(organisation_concept_id),
+        intent_fingerprint=intent.fingerprint,
+        role_evidence=tuple(role_evidence),
+        delegation_id=_clean_text(delegation_id) or None,
+        executing_agent_concept_id=(
+            invocation.executing_agent_concept_id if invocation else None
+        ),
+        audience=invocation.audience if invocation else None,
+        trust_source=trust_source,
+    )
+
+
+def _direct_authority_decision(
+    *,
+    intent: OntologyMutationIntent,
+    actor_concept_id: str | None,
+    organisation_concept_id: str | None,
+    invocation: OntologyInvocationContext | None,
+    trust_source: str | None,
+) -> OntologyAuthorityDecision:
+    actor_id = _normalise_concept_id(actor_concept_id)
+    active_org_id = _normalise_concept_id(organisation_concept_id)
+    if actor_id is None:
+        return _decision(
+            allowed=False,
+            reason_code="authenticated_actor_context_required",
+            message="Canonical ontology publication requires a trusted actor.",
+            intent=intent,
+            actor_concept_id=None,
+            organisation_concept_id=active_org_id,
+            invocation=invocation,
+            trust_source=trust_source,
+        )
+
+    predicate = _normalise_predicate(intent.predicate)
+    dedicated_authority_operation = intent.operation in {
+        "authority.role.grant",
+        "authority.role.revoke",
+    }
+    if predicate in RESERVED_GENERIC_MUTATION_PREDICATES and not (
+        dedicated_authority_operation and predicate == AUTHORITY_ROLE_PREDICATE
+    ):
+        return _decision(
+            allowed=False,
+            reason_code="dedicated_ontology_governance_operation_required",
+            message=(
+                "Authority, membership, and visibility predicates may only be "
+                "changed through their dedicated governed operations."
+            ),
+            intent=intent,
+            actor_concept_id=actor_id,
+            organisation_concept_id=active_org_id,
+            invocation=invocation,
+            trust_source=trust_source,
+        )
+
+    contexts = (*intent.source_contexts, intent.publication_context)
+    unresolved_contexts = tuple(
+        item
+        for item in contexts
+        if item.kind
+        in {PublicationContextKind.HISTORICAL, PublicationContextKind.MIXED}
+    )
+    if unresolved_contexts and intent.operation != "scope.change":
+        return _decision(
+            allowed=False,
+            reason_code="explicit_scope_adoption_required",
+            message=(
+                "Historical or mixed scope must be previewed and adopted through "
+                "the dedicated scope-change operation before canonical mutation."
+            ),
+            intent=intent,
+            actor_concept_id=actor_id,
+            organisation_concept_id=active_org_id,
+            invocation=invocation,
+            trust_source=trust_source,
+        )
+
+    # A dedicated, optimistic scope adoption is the one operation that may
+    # start from legacy/mixed visibility.  It requires global semantic
+    # authority over that unresolved source as well as authority over the
+    # explicit destination.  This avoids silently treating malformed history
+    # as global publication while still leaving a controlled repair path.
+    historical_adoption_evidence: tuple[AuthorityRoleEvidence, ...] = ()
+    if unresolved_contexts:
+        historical_adoption_evidence = tuple(
+            role
+            for role in resolve_live_semantic_roles(actor_id)
+            if role.role == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE
+        )
+        if not historical_adoption_evidence:
+            return _decision(
+                allowed=False,
+                reason_code="global_ontology_admin_authority_required",
+                message=(
+                    "Global ontology authority is required to adopt historical "
+                    "or mixed publication scope."
+                ),
+                intent=intent,
+                actor_concept_id=actor_id,
+                organisation_concept_id=active_org_id,
+                invocation=invocation,
+                trust_source=trust_source,
+            )
+
+    gathered: list[AuthorityRoleEvidence] = list(historical_adoption_evidence)
+    seen_contexts: set[tuple[str, str | None]] = set()
+    for context in contexts:
+        if context.kind in {
+            PublicationContextKind.HISTORICAL,
+            PublicationContextKind.MIXED,
+        }:
+            continue
+        key = (context.kind.value, context.concept_id)
+        if key in seen_contexts:
+            continue
+        seen_contexts.add(key)
+        if (
+            context.kind == PublicationContextKind.USER
+            and context.concept_id == actor_id
+        ):
+            # Preserve the pre-existing private-owner capability. It authorises
+            # only the actor's exact user context; any inverse target or
+            # destination context is still checked independently below.
+            continue
+        context_evidence = _role_evidence_for_context(actor_id, context)
+        if (
+            not context_evidence
+            and intent.operation == "authority.role.grant"
+            and context.kind == PublicationContextKind.ORGANISATION
+            and context.concept_id
+            and not _organisation_authority_root_exists(context.concept_id)
+        ):
+            # After the single global bootstrap, a represented global semantic
+            # administrator may establish the first administrator for an
+            # actor-visible organisation. This is a root-creation ceremony,
+            # not standing global authority over the organisation: once the
+            # root exists, exact organisation authority is required.
+            context_evidence = tuple(
+                role
+                for role in resolve_live_semantic_roles(actor_id)
+                if role.role == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE
+            )
+        if not context_evidence:
+            if context.kind == PublicationContextKind.GLOBAL:
+                reason_code = "global_ontology_admin_authority_required"
+                message = "Global ontology publication authority is required."
+            elif context.kind == PublicationContextKind.ORGANISATION:
+                reason_code = "organisation_ontology_admin_authority_required"
+                message = (
+                    "Ontology publication authority for the exact organisation "
+                    "context is required."
+                )
+            elif context.kind == PublicationContextKind.USER:
+                reason_code = "private_scope_canonical_publication_not_delegated"
+                message = (
+                    "Canonical mutation requires ownership of the exact private "
+                    "publication context."
+                )
+            else:
+                reason_code = "ontology_publication_authority_required"
+                message = "Ontology publication authority is required."
+            return _decision(
+                allowed=False,
+                reason_code=reason_code,
+                message=message,
+                intent=intent,
+                actor_concept_id=actor_id,
+                organisation_concept_id=active_org_id,
+                invocation=invocation,
+                trust_source=trust_source,
+            )
+        gathered.extend(context_evidence)
+
+    return _decision(
+        allowed=True,
+        reason_code="semantic_ontology_authority_verified",
+        message="Live semantic ontology authority verified.",
+        intent=intent,
+        actor_concept_id=actor_id,
+        organisation_concept_id=active_org_id,
+        role_evidence=gathered,
+        invocation=invocation,
+        trust_source=trust_source,
+    )
+
+
+def _delegation_collection():
+    collection = get_ontology_authority_delegations_collection()
+    if collection is None:
+        raise RuntimeError("ontology authority delegation store unavailable")
+    return collection
+
+
+def _receipt_collection():
+    collection = get_ontology_mutation_receipts_collection()
+    if collection is None:
+        raise RuntimeError("ontology mutation receipt store unavailable")
+    return collection
+
+
+@contextmanager
+def ontology_mutation_resource_lock(
+    resource_key: str,
+    *,
+    lease_seconds: int = DEFAULT_MUTATION_RESOURCE_LOCK_SECONDS,
+) -> Iterator[None]:
+    """Hold a short cross-process lease for one authority-sensitive resource.
+
+    Receipt persistence is already a prerequisite for every governed mutation,
+    so its collection also owns these small, explicitly non-receipt lease
+    records.  The lease prevents two distinct request IDs from passing the same
+    read/check/write boundary concurrently.  It never grants authority and an
+    abandoned lease expires without operator intervention.
+    """
+
+    cleaned_key = _clean_text(resource_key)
+    if not cleaned_key:
+        raise ValueError("ontology mutation resource key is required")
+    try:
+        lease_length = max(1, min(int(lease_seconds), 900))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("ontology mutation lock lease must be an integer") from exc
+
+    collection = _receipt_collection()
+    lock_id = "oml_" + hashlib.sha256(cleaned_key.encode("utf-8")).hexdigest()
+    owner_token = secrets.token_urlsafe(24)
+    now = _now()
+    expires_at = now + timedelta(seconds=lease_length)
+    try:
+        claimed = collection.find_one_and_update(
+            {
+                "_id": lock_id,
+                "$or": [
+                    {"lock_owner_token": {"$exists": False}},
+                    {"lock_expires_at": {"$lte": now}},
+                ],
+            },
+            {
+                "$setOnInsert": {
+                    "schema_version": "ontology_mutation_resource_lock.v1",
+                    "receipt_id": lock_id,
+                    "record_kind": "resource_lock",
+                    "created_at": now,
+                },
+                "$set": {
+                    "resource_key_sha256": hashlib.sha256(
+                        cleaned_key.encode("utf-8")
+                    ).hexdigest(),
+                    "lock_owner_token": owner_token,
+                    "lock_expires_at": expires_at,
+                    "updated_at": now,
+                },
+            },
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+    except DuplicateKeyError as exc:
+        raise OntologyMutationResourceBusy("ontology_mutation_resource_busy") from exc
+    if (
+        not isinstance(claimed, Mapping)
+        or claimed.get("lock_owner_token") != owner_token
+    ):
+        raise OntologyMutationResourceBusy("ontology_mutation_resource_busy")
+
+    try:
+        yield
+    finally:
+        released = collection.delete_one(
+            {"_id": lock_id, "lock_owner_token": owner_token}
+        )
+        if int(getattr(released, "deleted_count", 0) or 0) != 1:
+            raise RuntimeError("ontology mutation resource lock release failed")
+
+
+def issue_agent_delegation(
+    *,
+    intent: OntologyMutationIntent,
+    grantor_actor_concept_id: str,
+    grantor_organisation_concept_id: str | None,
+    delegate_concept_id: str,
+    audience: str,
+    tool_name: str,
+    effect_id: str,
+    ttl_seconds: int = DEFAULT_AGENT_DELEGATION_TTL_SECONDS,
+    turn_id: str | None = None,
+    workflow_id: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Issue one non-amplifying, exact, interactive agent delegation."""
+
+    issued_at = now or _now()
+    if issued_at.tzinfo is None:
+        issued_at = issued_at.replace(tzinfo=UTC)
+    ttl = int(ttl_seconds)
+    if ttl <= 0 or ttl > MAX_INTERACTIVE_DELEGATION_TTL_SECONDS:
+        raise ValueError(
+            "Interactive ontology delegation ttl_seconds must be between 1 and "
+            f"{MAX_INTERACTIVE_DELEGATION_TTL_SECONDS}."
+        )
+    delegate_id = _normalise_concept_id(delegate_concept_id)
+    grantor_id = _normalise_concept_id(grantor_actor_concept_id)
+    if not delegate_id or not grantor_id:
+        raise ValueError("grantor and delegate concept identifiers are required")
+    audience_value = _clean_text(audience)
+    tool_value = _clean_text(tool_name)
+    effect_value = _clean_text(effect_id)
+    if not audience_value or not tool_value or not effect_value:
+        raise ValueError("audience, tool_name, and effect_id are required")
+
+    direct = _direct_authority_decision(
+        intent=intent,
+        actor_concept_id=grantor_id,
+        organisation_concept_id=grantor_organisation_concept_id,
+        invocation=None,
+        trust_source="server_issued_delegation",
+    )
+    if not direct.allowed:
+        raise PermissionError(direct.reason_code)
+
+    collection = _delegation_collection()
+    exact_grant_key = _sha256_json(
+        {
+            "grantor_actor_concept_id": grantor_id,
+            "delegate_concept_id": delegate_id,
+            "audience": audience_value,
+            "effect_id": effect_value,
+            "turn_id": _clean_text(turn_id) or None,
+            "workflow_id": _normalise_concept_id(workflow_id)
+            or _clean_text(workflow_id)
+            or None,
+        }
+    )
+    document = {
+        "schema_version": DELEGATION_SCHEMA_VERSION,
+        "delegation_id": f"oag_{exact_grant_key}",
+        "exact_grant_key": exact_grant_key,
+        "grantor_actor_concept_id": grantor_id,
+        "grantor_organisation_concept_id": _normalise_concept_id(
+            grantor_organisation_concept_id
+        ),
+        "delegate_concept_id": delegate_id,
+        "audience": audience_value,
+        "tool_name": tool_value,
+        "effect_id": effect_value,
+        "turn_id": _clean_text(turn_id) or None,
+        "workflow_id": _normalise_concept_id(workflow_id)
+        or _clean_text(workflow_id)
+        or None,
+        "intent_fingerprint": intent.fingerprint,
+        "intent": intent.canonical_payload(),
+        "authority_evidence": [item.to_mapping() for item in direct.role_evidence],
+        "authority_decision_id": direct.decision_id,
+        "issued_at": issued_at,
+        "expires_at": issued_at + timedelta(seconds=ttl),
+        "status": "active",
+        "revoked_at": None,
+        "revoked_by_actor_concept_id": None,
+        "revocation_reason": None,
+        "non_recursive": True,
+        "standing_delegation": False,
+    }
+    try:
+        collection.insert_one(document)
+    except DuplicateKeyError:
+        existing = collection.find_one({"delegation_id": document["delegation_id"]})
+        if not isinstance(existing, Mapping):
+            raise
+        if (
+            existing.get("status") == "active"
+            and isinstance(existing.get("expires_at"), datetime)
+            and _as_utc(existing["expires_at"]) > issued_at
+        ):
+            if (
+                _clean_text(existing.get("tool_name")) == tool_value
+                and _clean_text(existing.get("intent_fingerprint"))
+                == intent.fingerprint
+            ):
+                return _public_delegation_projection(existing)
+            raise PermissionError("ontology_delegation_effect_intent_conflict")
+        # A revoked/expired exact effect cannot be silently re-issued under the
+        # same identity; issue a new effect ID instead.
+        raise PermissionError("ontology_delegation_effect_already_finalised")
+    stored = collection.find_one({"delegation_id": document["delegation_id"]})
+    if not isinstance(stored, Mapping):
+        raise LookupError("Delegation canonical read-back failed")  # noqa: TRY004
+    return _public_delegation_projection(stored)
+
+
+def _public_delegation_projection(document: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": str(document.get("schema_version") or ""),
+        "delegation_id": str(document.get("delegation_id") or ""),
+        "grantor_actor_concept_id": document.get("grantor_actor_concept_id"),
+        "grantor_organisation_concept_id": document.get(
+            "grantor_organisation_concept_id"
+        ),
+        "delegate_concept_id": document.get("delegate_concept_id"),
+        "audience": document.get("audience"),
+        "tool_name": document.get("tool_name"),
+        "effect_id": document.get("effect_id"),
+        "turn_id": document.get("turn_id"),
+        "workflow_id": document.get("workflow_id"),
+        "intent_fingerprint": document.get("intent_fingerprint"),
+        "publication_context": (
+            (document.get("intent") or {}).get("publication_context")
+            if isinstance(document.get("intent"), Mapping)
+            else None
+        ),
+        "target_concept_ids": (
+            list((document.get("intent") or {}).get("target_concept_ids") or [])
+            if isinstance(document.get("intent"), Mapping)
+            else []
+        ),
+        "operation": (
+            (document.get("intent") or {}).get("operation")
+            if isinstance(document.get("intent"), Mapping)
+            else None
+        ),
+        "issued_at": _json_safe(document.get("issued_at")),
+        "expires_at": _json_safe(document.get("expires_at")),
+        "status": document.get("status"),
+        "non_recursive": document.get("non_recursive") is True,
+        "standing_delegation": document.get("standing_delegation") is True,
+    }
+
+
+def resolve_delegation_principal(
+    delegation_id: str | None,
+    *,
+    delegate_concept_id: str | None = None,
+    audience: str | None = None,
+    tool_name: str | None = None,
+    effect_id: str | None = None,
+    now: datetime | None = None,
+) -> tuple[str | None, str | None]:
+    """Resolve only the stored grantor context used to rebuild an exact intent.
+
+    This is not an authority decision: callers must still bind the opaque
+    delegation and pass through :func:`verify_agent_delegation`.  It exists for
+    sessionless server surfaces such as stdio, where accepting a client-supplied
+    actor would be unsafe but rebuilding the originally granted creation scope
+    requires the server-stored principal.
+    """
+
+    delegation_value = _clean_text(delegation_id)
+    if not delegation_value:
+        return None, None
+    delegate_id = _normalise_concept_id(delegate_concept_id)
+    audience_value = _clean_text(audience)
+    tool_value = _clean_text(tool_name)
+    effect_value = _clean_text(effect_id)
+    if not all((delegate_id, audience_value, tool_value, effect_value)):
+        return None, None
+    checked_at = _as_utc(now or _now())
+    try:
+        document = _delegation_collection().find_one(
+            {
+                "delegation_id": delegation_value,
+                "status": "active",
+                "expires_at": {"$gt": checked_at},
+                "delegate_concept_id": delegate_id,
+                "audience": audience_value,
+                "tool_name": tool_value,
+                "effect_id": effect_value,
+            },
+            {
+                "grantor_actor_concept_id": 1,
+                "grantor_organisation_concept_id": 1,
+            },
+        )
+    except RuntimeError:
+        # Intent rebuilding can proceed actorless; the later authoritative
+        # verification still fails closed with store-unavailable semantics.
+        return None, None
+    if not isinstance(document, Mapping):
+        return None, None
+    return (
+        _normalise_concept_id(document.get("grantor_actor_concept_id")),
+        _normalise_concept_id(document.get("grantor_organisation_concept_id")),
+    )
+
+
+def verify_agent_delegation(
+    *,
+    delegation_id: str,
+    intent: OntologyMutationIntent,
+    invocation: OntologyInvocationContext,
+    actor_concept_id: str | None,
+    organisation_concept_id: str | None,
+    now: datetime | None = None,
+) -> OntologyAuthorityDecision:
+    checked_at = _as_utc(now or _now())
+    collection = _delegation_collection()
+    delegation = collection.find_one({"delegation_id": _clean_text(delegation_id)})
+    if not isinstance(delegation, Mapping):
+        return _decision(
+            allowed=False,
+            reason_code="ontology_delegation_invalid",
+            message="The ontology delegation is invalid or unavailable.",
+            intent=intent,
+            actor_concept_id=actor_concept_id,
+            organisation_concept_id=organisation_concept_id,
+            delegation_id=delegation_id,
+            invocation=invocation,
+            trust_source="server_delegation",
+        )
+    if delegation.get("status") != "active":
+        return _decision(
+            allowed=False,
+            reason_code="ontology_delegation_revoked",
+            message="The ontology delegation is no longer active.",
+            intent=intent,
+            actor_concept_id=actor_concept_id,
+            organisation_concept_id=organisation_concept_id,
+            delegation_id=delegation_id,
+            invocation=invocation,
+            trust_source="server_delegation",
+        )
+    expires_at = delegation.get("expires_at")
+    if not isinstance(expires_at, datetime) or _as_utc(expires_at) <= checked_at:
+        return _decision(
+            allowed=False,
+            reason_code="ontology_delegation_expired",
+            message="The ontology delegation has expired.",
+            intent=intent,
+            actor_concept_id=actor_concept_id,
+            organisation_concept_id=organisation_concept_id,
+            delegation_id=delegation_id,
+            invocation=invocation,
+            trust_source="server_delegation",
+        )
+
+    exact_pairs = {
+        "delegate_concept_id": invocation.executing_agent_concept_id,
+        "audience": invocation.audience,
+        "tool_name": intent.tool_name,
+        "effect_id": invocation.effect_id,
+        "intent_fingerprint": intent.fingerprint,
+    }
+    for field_name, expected in exact_pairs.items():
+        if _clean_text(delegation.get(field_name)) != _clean_text(expected):
+            return _decision(
+                allowed=False,
+                reason_code=f"ontology_delegation_{field_name}_mismatch",
+                message="The ontology delegation does not cover this exact effect.",
+                intent=intent,
+                actor_concept_id=actor_concept_id,
+                organisation_concept_id=organisation_concept_id,
+                delegation_id=delegation_id,
+                invocation=invocation,
+                trust_source="server_delegation",
+            )
+    expected_turn_id = _clean_text(delegation.get("turn_id"))
+    if expected_turn_id and expected_turn_id != _clean_text(invocation.turn_id):
+        return _decision(
+            allowed=False,
+            reason_code="ontology_delegation_turn_mismatch",
+            message="The ontology delegation does not cover this turn.",
+            intent=intent,
+            actor_concept_id=actor_concept_id,
+            organisation_concept_id=organisation_concept_id,
+            delegation_id=delegation_id,
+            invocation=invocation,
+            trust_source="server_delegation",
+        )
+    expected_workflow_id = _clean_text(delegation.get("workflow_id"))
+    if expected_workflow_id and expected_workflow_id != _clean_text(
+        invocation.workflow_id
+    ):
+        return _decision(
+            allowed=False,
+            reason_code="ontology_delegation_workflow_mismatch",
+            message="The ontology delegation does not cover this workflow.",
+            intent=intent,
+            actor_concept_id=actor_concept_id,
+            organisation_concept_id=organisation_concept_id,
+            delegation_id=delegation_id,
+            invocation=invocation,
+            trust_source="server_delegation",
+        )
+
+    grantor_id = _normalise_concept_id(delegation.get("grantor_actor_concept_id"))
+    grantor_org_id = _normalise_concept_id(
+        delegation.get("grantor_organisation_concept_id")
+    )
+    supplied_actor_id = _normalise_concept_id(actor_concept_id)
+    if supplied_actor_id is not None and supplied_actor_id != grantor_id:
+        return _decision(
+            allowed=False,
+            reason_code="ontology_delegation_actor_mismatch",
+            message="The ontology delegation belongs to another actor.",
+            intent=intent,
+            actor_concept_id=supplied_actor_id,
+            organisation_concept_id=organisation_concept_id,
+            delegation_id=delegation_id,
+            invocation=invocation,
+            trust_source="server_delegation",
+        )
+
+    live = _direct_authority_decision(
+        intent=intent,
+        actor_concept_id=grantor_id,
+        organisation_concept_id=grantor_org_id,
+        invocation=invocation,
+        trust_source="server_delegation_live_recheck",
+    )
+    if not live.allowed:
+        return _decision(
+            allowed=False,
+            reason_code="ontology_delegation_grantor_authority_revoked",
+            message="The delegator no longer has the authority required.",
+            intent=intent,
+            actor_concept_id=grantor_id,
+            organisation_concept_id=grantor_org_id,
+            delegation_id=delegation_id,
+            invocation=invocation,
+            trust_source="server_delegation_live_recheck",
+        )
+    return _decision(
+        allowed=True,
+        reason_code="ontology_agent_delegation_verified",
+        message="Exact live ontology agent delegation verified.",
+        intent=intent,
+        actor_concept_id=grantor_id,
+        organisation_concept_id=grantor_org_id,
+        role_evidence=live.role_evidence,
+        delegation_id=delegation_id,
+        invocation=invocation,
+        trust_source="server_delegation_live_recheck",
+    )
+
+
+def authorise_ontology_mutation(
+    intent: OntologyMutationIntent,
+) -> OntologyAuthorityDecision:
+    """Resolve direct or delegated semantic authority from trusted context."""
+
+    invocation = current_ontology_invocation()
+    actor_id = get_effective_user_concept_id()
+    organisation_id = get_effective_organisation_concept_id()
+    trust_source = _gateway_actor_trust_source()
+
+    if invocation and invocation.delegation_id:
+        try:
+            return verify_agent_delegation(
+                delegation_id=invocation.delegation_id,
+                intent=intent,
+                invocation=invocation,
+                actor_concept_id=actor_id,
+                organisation_concept_id=organisation_id,
+            )
+        except RuntimeError:
+            return _decision(
+                allowed=False,
+                reason_code="ontology_authority_store_unavailable",
+                message="Ontology delegation verification is unavailable.",
+                intent=intent,
+                actor_concept_id=actor_id,
+                organisation_concept_id=organisation_id,
+                delegation_id=invocation.delegation_id,
+                invocation=invocation,
+                trust_source=trust_source,
+            )
+
+    if invocation and invocation.executing_agent_concept_id:
+        return _decision(
+            allowed=False,
+            reason_code="ontology_agent_delegation_required",
+            message=(
+                "An executing agent needs a server-issued delegation bound to "
+                "this exact ontology effect."
+            ),
+            intent=intent,
+            actor_concept_id=actor_id,
+            organisation_concept_id=organisation_id,
+            invocation=invocation,
+            trust_source=trust_source,
+        )
+
+    if trust_source == "tool_payload_fallback":
+        return _decision(
+            allowed=False,
+            reason_code="client_supplied_identity_is_not_authority",
+            message="Client or model supplied identity cannot authorise publication.",
+            intent=intent,
+            actor_concept_id=None,
+            organisation_concept_id=None,
+            invocation=invocation,
+            trust_source=trust_source,
+        )
+    if trust_source == "trusted_operator_payload_fallback":
+        return _decision(
+            allowed=False,
+            reason_code="von_operator_is_not_semantic_ontology_authority",
+            message=(
+                "Von operational authority does not confer semantic ontology "
+                "publication authority."
+            ),
+            intent=intent,
+            actor_concept_id=actor_id,
+            organisation_concept_id=organisation_id,
+            invocation=invocation,
+            trust_source=trust_source,
+        )
+
+    return _direct_authority_decision(
+        intent=intent,
+        actor_concept_id=actor_id,
+        organisation_concept_id=organisation_id,
+        invocation=invocation,
+        trust_source=(
+            trust_source
+            or (
+                "authenticated_http_context"
+                if has_request_context()
+                else "trusted_in_process_actor"
+            )
+        ),
+    )
+
+
+def ontology_authority_resource_keys(
+    intent: OntologyMutationIntent,
+) -> tuple[str, ...]:
+    """Return locks whose lifecycle can invalidate this exact authority."""
+
+    keys: set[str] = set()
+    invocation = current_ontology_invocation()
+    if invocation and invocation.delegation_id:
+        keys.add(f"ontology-delegation:{_clean_text(invocation.delegation_id)}")
+    for context in (*intent.source_contexts, intent.publication_context):
+        if context.kind == PublicationContextKind.ORGANISATION and context.concept_id:
+            keys.add(
+                "ontology-authority-role:"
+                f"{ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE}:"
+                f"{context.concept_id}"
+            )
+        elif context.kind in {
+            PublicationContextKind.GLOBAL,
+            PublicationContextKind.HISTORICAL,
+            PublicationContextKind.MIXED,
+        }:
+            keys.add(
+                f"ontology-authority-role:{GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE}:global"
+            )
+    return tuple(sorted(keys))
+
+
+def ontology_authority_denial_payload(
+    decision: OntologyAuthorityDecision,
+    intent: OntologyMutationIntent,
+) -> dict[str, Any]:
+    return {
+        "success": False,
+        "effect_status": "not_started",
+        "mutation_outcome": "not_started",
+        "outcome_finality": "terminal_for_turn",
+        "changed": False,
+        "error_code": decision.reason_code,
+        "error": decision.message,
+        "authority_decision": decision.public_projection(),
+        "publication_context": intent.publication_context.to_mapping(),
+        "recovery_affordances": [
+            {"action_type": "create_scoped_assertion"},
+            {"action_type": "request_ontology_administrator_delegation"},
+        ],
+    }
+
+
+def _bounded_projection(value: Any, *, max_chars: int = 16_000) -> Any:
+    safe = _json_safe(value)
+    rendered = json.dumps(safe, sort_keys=True, ensure_ascii=True)
+    if len(rendered) <= max_chars:
+        return safe
+    return {
+        "truncated": True,
+        "sha256": hashlib.sha256(rendered.encode("utf-8")).hexdigest(),
+        "size_chars": len(rendered),
+    }
+
+
+def _receipt_public_projection(document: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": document.get("schema_version"),
+        "receipt_id": document.get("receipt_id"),
+        "decision_id": document.get("decision_id"),
+        "status": document.get("status"),
+        "changed": document.get("changed"),
+        "mutation_outcome": document.get("mutation_outcome"),
+        "actor_concept_id": document.get("actor_concept_id"),
+        "executing_agent_concept_id": document.get("executing_agent_concept_id"),
+        "delegation_id": document.get("delegation_id"),
+        "publication_context": document.get("publication_context"),
+        "operation": document.get("operation"),
+        "target_concept_ids": list(document.get("target_concept_ids") or []),
+        "intent_fingerprint": document.get("intent_fingerprint"),
+        "idempotency_key": document.get("idempotency_key"),
+        "created_at": _json_safe(document.get("created_at")),
+        "completed_at": _json_safe(document.get("completed_at")),
+        "canonical_read_back": document.get("canonical_read_back"),
+        "response_projection_truncated": bool(
+            document.get("response_projection_truncated")
+        ),
+        "response_success": document.get("response_success"),
+        "response_effect_status": document.get("response_effect_status"),
+        "response_error_code": document.get("response_error_code"),
+    }
+
+
+def begin_mutation_receipt(
+    *,
+    decision: OntologyAuthorityDecision,
+    intent: OntologyMutationIntent,
+    before_state: Any = None,
+) -> MutationReceiptHandle:
+    collection = _receipt_collection()
+    idempotency_key = _clean_text(intent.idempotency_key) or None
+    receipt_id = _new_identifier("omr")
+    if idempotency_key:
+        # The deterministic receipt identity makes one actor's idempotency key
+        # an atomic claim even while older deployments still have the original
+        # compound key/fingerprint index.  A changed intent must never turn the
+        # same effect key into a second canonical write.
+        receipt_id = (
+            "omr_"
+            + hashlib.sha256(
+                f"{decision.actor_concept_id or ''}\0{idempotency_key}".encode()
+            ).hexdigest()
+        )
+        existing = collection.find_one(
+            {
+                "receipt_id": receipt_id,
+                "actor_concept_id": decision.actor_concept_id,
+                "idempotency_key": idempotency_key,
+            }
+        )
+        if isinstance(existing, Mapping):
+            existing_status = _clean_text(existing.get("status")) or "authorised"
+            return MutationReceiptHandle(
+                receipt_id=str(existing.get("receipt_id") or ""),
+                replay=True,
+                stored_response=(
+                    existing.get("response_projection")
+                    if isinstance(existing.get("response_projection"), Mapping)
+                    else None
+                ),
+                stored_receipt=_receipt_public_projection(existing),
+                existing_status=existing_status,
+                intent_conflict=(
+                    _clean_text(existing.get("intent_fingerprint"))
+                    != intent.fingerprint
+                ),
+            )
+
+    now = _now()
+    invocation = current_ontology_invocation()
+    document: dict[str, Any] = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "receipt_id": receipt_id,
+        "decision_id": decision.decision_id,
+        "decision_reason_code": decision.reason_code,
+        "status": "authorised",
+        "mutation_outcome": "not_started",
+        "changed": False,
+        "actor_concept_id": decision.actor_concept_id,
+        "organisation_concept_id": decision.organisation_concept_id,
+        "executing_agent_concept_id": decision.executing_agent_concept_id,
+        "delegation_id": decision.delegation_id,
+        "audience": decision.audience,
+        "surface": invocation.surface if invocation else None,
+        "turn_id": invocation.turn_id if invocation else None,
+        "workflow_id": invocation.workflow_id if invocation else None,
+        "effect_id": invocation.effect_id if invocation else None,
+        "operation": intent.operation,
+        "tool_name": intent.tool_name,
+        "predicate": intent.predicate,
+        "publication_context": intent.publication_context.to_mapping(),
+        "source_contexts": [item.to_mapping() for item in intent.source_contexts],
+        "target_concept_ids": list(intent.target_concept_ids),
+        "intent_fingerprint": intent.fingerprint,
+        "authority_evidence": [item.to_mapping() for item in decision.role_evidence],
+        "before_state": _bounded_projection(before_state),
+        "canonical_read_back": None,
+        "response_projection": None,
+        "release": _release_identity(),
+        "created_at": now,
+        "updated_at": now,
+        "completed_at": None,
+    }
+    if idempotency_key:
+        document["idempotency_key"] = idempotency_key
+    try:
+        collection.insert_one(document)
+    except DuplicateKeyError:
+        existing = collection.find_one(
+            {
+                "receipt_id": receipt_id,
+                "actor_concept_id": decision.actor_concept_id,
+            }
+        )
+        if not isinstance(existing, Mapping):
+            raise
+        existing_status = _clean_text(existing.get("status")) or "authorised"
+        return MutationReceiptHandle(
+            receipt_id=str(existing.get("receipt_id") or ""),
+            replay=True,
+            stored_response=(
+                existing.get("response_projection")
+                if isinstance(existing.get("response_projection"), Mapping)
+                else None
+            ),
+            stored_receipt=_receipt_public_projection(existing),
+            existing_status=existing_status,
+            intent_conflict=(
+                _clean_text(existing.get("intent_fingerprint")) != intent.fingerprint
+            ),
+        )
+    return MutationReceiptHandle(receipt_id=document["receipt_id"])
+
+
+def finalise_mutation_receipt(
+    *,
+    receipt_id: str,
+    status: str,
+    mutation_outcome: str,
+    changed: bool | None,
+    canonical_read_back: Any,
+    response_projection: Any,
+    error_code: str | None = None,
+) -> dict[str, Any]:
+    collection = _receipt_collection()
+    now = _now()
+    bounded_response = _bounded_projection(response_projection)
+    updated = collection.find_one_and_update(
+        {"receipt_id": receipt_id},
+        {
+            "$set": {
+                "status": status,
+                "mutation_outcome": mutation_outcome,
+                "changed": changed,
+                "canonical_read_back": _bounded_projection(canonical_read_back),
+                "canonical_read_back_sha256": _sha256_json(canonical_read_back),
+                "response_projection": bounded_response,
+                "response_projection_truncated": bool(
+                    isinstance(bounded_response, Mapping)
+                    and bounded_response.get("truncated")
+                ),
+                "response_success": (
+                    bool(response_projection.get("success", True))
+                    if isinstance(response_projection, Mapping)
+                    else False
+                ),
+                "response_effect_status": (
+                    _clean_text(response_projection.get("effect_status")) or None
+                    if isinstance(response_projection, Mapping)
+                    else None
+                ),
+                "response_error_code": (
+                    _clean_text(response_projection.get("error_code")) or None
+                    if isinstance(response_projection, Mapping)
+                    else None
+                ),
+                "error_code": _clean_text(error_code) or None,
+                "updated_at": now,
+                "completed_at": now,
+            }
+        },
+        return_document=ReturnDocument.AFTER,
+    )
+    if not isinstance(updated, Mapping):
+        raise LookupError(  # noqa: TRY004
+            "Ontology mutation receipt read-back failed"
+        )
+    return _receipt_public_projection(updated)
+
+
+def get_mutation_receipt_for_actor(
+    *,
+    receipt_id: str,
+    actor_concept_id: str,
+) -> dict[str, Any] | None:
+    actor_id = _normalise_concept_id(actor_concept_id)
+    if not actor_id:
+        return None
+    document = _receipt_collection().find_one(
+        {"receipt_id": _clean_text(receipt_id), "actor_concept_id": actor_id}
+    )
+    return (
+        _receipt_public_projection(document) if isinstance(document, Mapping) else None
+    )
+
+
+def _receipt_finalisation_failure_response(
+    *,
+    decision: OntologyAuthorityDecision,
+    handle: MutationReceiptHandle,
+    canonical_state: Any,
+    exception: Exception,
+    result: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Report a post-effect receipt failure without making a success claim."""
+
+    return {
+        **dict(result or {}),
+        "success": False,
+        "effect_status": "indeterminate",
+        "mutation_outcome": "unknown",
+        "outcome_finality": "requires_receipt_reconciliation",
+        "changed": None,
+        "retryable": False,
+        "error_code": "ontology_mutation_receipt_finalisation_failed",
+        "error": (
+            "The effect may have occurred, but its durable receipt could not be "
+            "finalised. Inspect canonical state and the existing receipt before "
+            "any retry."
+        ),
+        "details": {"exception_type": type(exception).__name__},
+        "authority_decision": decision.public_projection(),
+        "authority_receipt": {
+            "schema_version": RECEIPT_SCHEMA_VERSION,
+            "receipt_id": handle.receipt_id,
+            "status": "authorised",
+            "durable_finalisation": False,
+            "intent_fingerprint": decision.intent_fingerprint,
+        },
+        "canonical_read_back": _bounded_projection(canonical_state),
+    }
+
+
+def execute_authorised_ontology_mutation(
+    *,
+    intent: OntologyMutationIntent,
+    mutate: Callable[[], Mapping[str, Any]],
+    read_back: Callable[[], Any],
+    read_before: Callable[[], Any] | None = None,
+    verify_read_back: Callable[[Mapping[str, Any], Any], bool] | None = None,
+    preview: bool = False,
+) -> dict[str, Any]:
+    """Authorise, execute once, and reconcile through canonical read-back."""
+
+    decision = authorise_ontology_mutation(intent)
+    if not decision.allowed:
+        return ontology_authority_denial_payload(decision, intent)
+
+    try:
+        before_state = read_before() if read_before is not None else None
+        handle = begin_mutation_receipt(
+            decision=decision,
+            intent=intent,
+            before_state=before_state,
+        )
+    except Exception as exc:  # noqa: BLE001 - fail closed before mutation
+        return {
+            "success": False,
+            "effect_status": "not_started",
+            "mutation_outcome": "not_started",
+            "changed": False,
+            "error_code": "ontology_mutation_receipt_store_unavailable",
+            "error": (
+                "The mutation was not started because its receipt could not be stored."
+            ),
+            "details": {"exception_type": type(exc).__name__},
+            "authority_decision": decision.public_projection(),
+        }
+
+    if handle.intent_conflict:
+        return {
+            "success": False,
+            "effect_status": "not_started",
+            "mutation_outcome": "not_started",
+            "outcome_finality": "terminal_for_effect_key",
+            "changed": False,
+            "idempotent_replay": True,
+            "error_code": "ontology_mutation_idempotency_intent_conflict",
+            "error": (
+                "This idempotency key is already bound to a different ontology "
+                "mutation intent."
+            ),
+            "authority_decision": decision.public_projection(),
+            "authority_receipt": dict(handle.stored_receipt or {}),
+        }
+
+    if handle.replay and handle.stored_response is not None:
+        if bool((handle.stored_receipt or {}).get("response_projection_truncated")):
+            return {
+                "success": False,
+                "effect_status": "indeterminate",
+                "mutation_outcome": "unknown",
+                "outcome_finality": "requires_receipt_reconciliation",
+                "changed": None,
+                "idempotent_replay": True,
+                "retryable": False,
+                "error_code": "ontology_mutation_replay_projection_unavailable",
+                "error": (
+                    "The stored response was too large to replay safely; inspect "
+                    "the receipt and canonical read-back."
+                ),
+                "authority_receipt": dict(handle.stored_receipt or {}),
+            }
+        replay = dict(handle.stored_response)
+        replay["idempotent_replay"] = True
+        stored_receipt = dict(handle.stored_receipt or {})
+        replay["authority_receipt"] = stored_receipt or {
+            "receipt_id": handle.receipt_id,
+            "status": handle.existing_status,
+            "intent_fingerprint": intent.fingerprint,
+        }
+        if "canonical_read_back" not in replay and stored_receipt:
+            replay["canonical_read_back"] = stored_receipt.get("canonical_read_back")
+        if handle.existing_status == "indeterminate":
+            replay.update(
+                {
+                    "success": False,
+                    "effect_status": "indeterminate",
+                    "mutation_outcome": "unknown",
+                    "changed": None,
+                    "error_code": "ontology_mutation_outcome_unknown",
+                }
+            )
+        return replay
+
+    if handle.replay:
+        # Another caller owns the one durable effect claim and has not yet
+        # published a terminal response.  Returning immediately avoids both a
+        # duplicate write and a lock-step wait that could deadlock a caller
+        # coordinating the original effect.  The receipt endpoint provides the
+        # eventual canonical read-back.
+        return {
+            "success": False,
+            "effect_status": "in_progress",
+            "mutation_outcome": "not_started",
+            "outcome_finality": "pending_receipt_reconciliation",
+            "changed": False,
+            "idempotent_replay": True,
+            "retryable": True,
+            "error_code": "ontology_mutation_in_progress",
+            "error": (
+                "This exact ontology effect is already in progress; inspect its "
+                "receipt for the terminal canonical read-back."
+            ),
+            "authority_decision": decision.public_projection(),
+            "authority_receipt": dict(handle.stored_receipt or {}),
+        }
+
+    try:
+        with bind_authorised_ontology_mutation(decision, intent):
+            raw_result = mutate()
+        result = dict(raw_result)
+    except Exception as exc:  # noqa: BLE001 - effect boundary reconciles outcome
+        try:
+            canonical_state = read_back()
+        except Exception:  # noqa: BLE001 - preserve unknown outcome receipt
+            canonical_state = {"read_back_failed": True}
+        try:
+            receipt = finalise_mutation_receipt(
+                receipt_id=handle.receipt_id,
+                status="indeterminate",
+                mutation_outcome="unknown",
+                changed=None,
+                canonical_read_back=canonical_state,
+                response_projection={"exception_type": type(exc).__name__},
+                error_code="ontology_mutation_outcome_unknown",
+            )
+        except Exception as receipt_exc:  # noqa: BLE001 - effect already crossed
+            return _receipt_finalisation_failure_response(
+                decision=decision,
+                handle=handle,
+                canonical_state=canonical_state,
+                exception=receipt_exc,
+                result={"mutation_exception_type": type(exc).__name__},
+            )
+        return {
+            "success": False,
+            "effect_status": "indeterminate",
+            "mutation_outcome": "unknown",
+            "changed": None,
+            "error_code": "ontology_mutation_outcome_unknown",
+            "error": (
+                "The canonical mutation raised unexpectedly; the read-back receipt "
+                "must be inspected before retrying."
+            ),
+            "authority_decision": decision.public_projection(),
+            "authority_receipt": receipt,
+        }
+
+    try:
+        canonical_state = read_back()
+    except Exception as exc:  # noqa: BLE001 - read-back failure is typed below
+        try:
+            receipt = finalise_mutation_receipt(
+                receipt_id=handle.receipt_id,
+                status="indeterminate",
+                mutation_outcome="unknown",
+                changed=None,
+                canonical_read_back={"read_back_failed": True},
+                response_projection=result,
+                error_code="canonical_read_back_failed",
+            )
+        except Exception as receipt_exc:  # noqa: BLE001 - effect already crossed
+            return _receipt_finalisation_failure_response(
+                decision=decision,
+                handle=handle,
+                canonical_state={"read_back_failed": True},
+                exception=receipt_exc,
+                result=result,
+            )
+        return {
+            **result,
+            "success": False,
+            "effect_status": "indeterminate",
+            "mutation_outcome": "unknown",
+            "changed": None,
+            "error_code": "canonical_read_back_failed",
+            "error": "Canonical read-back failed; success cannot be claimed.",
+            "details": {"exception_type": type(exc).__name__},
+            "authority_decision": decision.public_projection(),
+            "authority_receipt": receipt,
+        }
+
+    successful = bool(result.get("success", True))
+    if successful and not preview and verify_read_back is not None:
+        try:
+            postcondition_verified = bool(verify_read_back(result, canonical_state))
+        except Exception:  # noqa: BLE001 - a verifier failure cannot imply success
+            postcondition_verified = False
+        if not postcondition_verified:
+            result = {
+                **result,
+                "success": False,
+                "effect_status": "indeterminate",
+                "mutation_outcome": "unknown",
+                "outcome_finality": "requires_canonical_reconciliation",
+                "changed": None,
+                "retryable": False,
+                "error_code": "ontology_mutation_postcondition_failed",
+                "error": (
+                    "The canonical read-back did not prove the requested effect; "
+                    "success cannot be claimed."
+                ),
+            }
+            successful = False
+    changed_value = result.get("changed")
+    changed = changed_value if isinstance(changed_value, bool) else successful
+    if preview:
+        status = "previewed"
+        mutation_outcome = "not_started"
+        changed = False
+    elif successful:
+        status = "succeeded"
+        mutation_outcome = "succeeded"
+    elif result.get("error_code") == "ontology_mutation_postcondition_failed":
+        status = "indeterminate"
+        mutation_outcome = "unknown"
+        changed = None
+    else:
+        reported_outcome = str(result.get("mutation_outcome") or "").strip()
+        reported_changed = result.get("changed")
+        if reported_changed is True or reported_outcome in {"partial", "unknown"}:
+            status = "indeterminate"
+            mutation_outcome = (
+                reported_outcome
+                if reported_outcome in {"partial", "unknown"}
+                else "unknown"
+            )
+            changed = None
+            result = {
+                **result,
+                "effect_status": "indeterminate",
+                "mutation_outcome": mutation_outcome,
+                "outcome_finality": "requires_canonical_reconciliation",
+                "changed": None,
+                "retryable": False,
+            }
+        else:
+            status = "failed"
+            mutation_outcome = reported_outcome or "not_started"
+    try:
+        receipt = finalise_mutation_receipt(
+            receipt_id=handle.receipt_id,
+            status=status,
+            mutation_outcome=mutation_outcome,
+            changed=changed,
+            canonical_read_back=canonical_state,
+            response_projection=result,
+            error_code=(str(result.get("error_code")) if not successful else None),
+        )
+    except Exception as exc:  # noqa: BLE001 - effect already crossed
+        return _receipt_finalisation_failure_response(
+            decision=decision,
+            handle=handle,
+            canonical_state=canonical_state,
+            exception=exc,
+            result=result,
+        )
+    return {
+        **result,
+        "authority_decision": decision.public_projection(),
+        "authority_receipt": receipt,
+        "canonical_read_back": canonical_state,
+    }
+
+
+def revoke_agent_delegation(
+    *,
+    delegation_id: str,
+    acting_actor_concept_id: str,
+    reason: str,
+) -> dict[str, Any]:
+    actor_id = _normalise_concept_id(acting_actor_concept_id)
+    if not actor_id:
+        raise PermissionError("authenticated_actor_context_required")
+    collection = _delegation_collection()
+    existing = collection.find_one(
+        {
+            "delegation_id": _clean_text(delegation_id),
+            "grantor_actor_concept_id": actor_id,
+        }
+    )
+    if not isinstance(existing, Mapping):
+        raise PermissionError("ontology_delegation_revoke_authority_required")
+    grantor_id = _normalise_concept_id(existing.get("grantor_actor_concept_id"))
+    if actor_id != grantor_id:
+        raise PermissionError("ontology_delegation_revoke_authority_required")
+    try:
+        with ontology_mutation_resource_lock(
+            f"ontology-delegation:{_clean_text(delegation_id)}"
+        ):
+            now = _now()
+            updated = collection.find_one_and_update(
+                {"delegation_id": _clean_text(delegation_id), "status": "active"},
+                {
+                    "$set": {
+                        "status": "revoked",
+                        "revoked_at": now,
+                        "revoked_by_actor_concept_id": actor_id,
+                        "revocation_reason": _clean_text(reason) or "revoked",
+                    }
+                },
+                return_document=ReturnDocument.AFTER,
+            )
+    except OntologyMutationResourceBusy as exc:
+        raise PermissionError("ontology_mutation_resource_busy") from exc
+    if updated is None:
+        updated = collection.find_one({"delegation_id": _clean_text(delegation_id)})
+    if not isinstance(updated, Mapping):
+        raise LookupError("Delegation revocation read-back failed")  # noqa: TRY004
+    return _public_delegation_projection(updated)
+
+
+def list_actor_delegations(
+    *,
+    actor_concept_id: str,
+    include_inactive: bool = True,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    actor_id = _normalise_concept_id(actor_concept_id)
+    if not actor_id:
+        return []
+    query: dict[str, Any] = {"grantor_actor_concept_id": actor_id}
+    if not include_inactive:
+        query.update({"status": "active", "expires_at": {"$gt": _now()}})
+    rows = (
+        _delegation_collection()
+        .find(query)
+        .sort("issued_at", -1)
+        .limit(max(1, min(int(limit), 250)))
+    )
+    return [_public_delegation_projection(row) for row in rows]
+
+
+def list_actor_semantic_authority(actor_concept_id: str) -> dict[str, Any]:
+    actor_id = _normalise_concept_id(actor_concept_id)
+    roles = resolve_live_semantic_roles(actor_id or "")
+    return {
+        "schema_version": AUTHORITY_SCHEMA_VERSION,
+        "actor_concept_id": actor_id,
+        "roles": [item.to_mapping() for item in roles],
+        "von_administrator_semantics": {
+            "concept_id": VON_ADMINISTRATOR_CONCEPT_ID,
+            "authority": "operational_only",
+            "implies_semantic_ontology_authority": False,
+        },
+    }
+
+
+def actor_can_access_intent_targets(
+    *,
+    actor_concept_id: str,
+    organisation_concept_id: str | None,
+    target_concept_ids: Sequence[str],
+) -> bool:
+    """Check target visibility as the trusted principal without leaking details."""
+
+    actor_id = _normalise_concept_id(actor_concept_id)
+    if not actor_id:
+        return False
+    with override_current_actor(actor_id, organisation_concept_id):
+        return all(can_access_concept(item) for item in target_concept_ids)
+
+
+__all__ = [
+    "AUTHORITY_ROLE_PREDICATE",
+    "AUTHORITY_SCHEMA_VERSION",
+    "GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE",
+    "MAX_INTERACTIVE_DELEGATION_TTL_SECONDS",
+    "ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE",
+    "RESERVED_GENERIC_MUTATION_PREDICATES",
+    "VON_ADMINISTRATOR_CONCEPT_ID",
+    "OntologyAuthorityDecision",
+    "OntologyInvocationContext",
+    "OntologyMutationResourceBusy",
+    "OntologyMutationIntent",
+    "PublicationContext",
+    "PublicationContextKind",
+    "actor_can_access_intent_targets",
+    "authority_role_storage_text",
+    "authorise_ontology_mutation",
+    "bind_authorised_ontology_mutation",
+    "bind_ontology_invocation",
+    "concept_publication_context",
+    "current_authorised_ontology_intent",
+    "current_authorised_ontology_mutation",
+    "current_ontology_invocation",
+    "execute_authorised_ontology_mutation",
+    "get_mutation_receipt_for_actor",
+    "issue_agent_delegation",
+    "list_actor_delegations",
+    "list_actor_semantic_authority",
+    "ontology_authority_denial_payload",
+    "ontology_mutation_resource_lock",
+    "ontology_authority_resource_keys",
+    "publication_context_for_creation",
+    "parse_authority_role_storage_text",
+    "resolve_live_semantic_roles",
+    "resolve_delegation_principal",
+    "revoke_agent_delegation",
+    "verify_agent_delegation",
+]

--- a/src/backend/services/ontology_scope_change_service.py
+++ b/src/backend/services/ontology_scope_change_service.py
@@ -1,0 +1,477 @@
+"""Dedicated, optimistic, provenance-bearing ontology scope transitions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextlib import ExitStack
+from dataclasses import dataclass
+from typing import Any
+
+from ..security.access_control import can_access_concept
+from ..security.visibility_predicates import (
+    CANONICAL_SPECIFIC_TO_ORG_PREDICATE,
+    CANONICAL_SPECIFIC_TO_USER_PREDICATE,
+)
+from .ontology_mutation_command_service import scope_read_back
+from .ontology_publication_authority_service import (
+    OntologyMutationIntent,
+    OntologyMutationResourceBusy,
+    PublicationContext,
+    PublicationContextKind,
+    authorise_ontology_mutation,
+    execute_authorised_ontology_mutation,
+    current_ontology_invocation,
+    ontology_authority_denial_payload,
+    ontology_authority_resource_keys,
+    ontology_mutation_resource_lock,
+)
+from .relationship_removal_service import remove_relationship
+from .relationship_write_service import add_relationship
+
+PREVIEW_SCOPE_CHANGE_TOOL_NAME = "preview_concept_publication_scope_change"
+EXECUTE_SCOPE_CHANGE_TOOL_NAME = "change_concept_publication_scope"
+
+
+@dataclass(frozen=True)
+class OntologyScopeChangePreconditionError(Exception):
+    """Typed no-effect result when an optimistic scope snapshot is stale."""
+
+    expected_scope_fingerprint: str
+    actual_scope_fingerprint: str
+    canonical_read_back: Mapping[str, Any]
+
+    @property
+    def reason_code(self) -> str:
+        return "scope_precondition_failed"
+
+    @property
+    def public_message(self) -> str:
+        return "The concept scope changed after the preview was obtained."
+
+
+@dataclass(frozen=True)
+class _PreparedScopeChange:
+    concept_id: str
+    before: Mapping[str, Any]
+    source: PublicationContext
+    destination: PublicationContext
+    intent: OntologyMutationIntent
+
+
+def _clean_text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _normalise_concept_id(value: Any) -> str | None:
+    cleaned = _clean_text(value)
+    if not cleaned:
+        return None
+    return cleaned if cleaned.startswith("#") else f"#V#{cleaned}"
+
+
+def _destination_context(
+    *,
+    destination_kind: str,
+    destination_concept_id: str | None,
+) -> PublicationContext:
+    kind = _clean_text(destination_kind).lower().replace("-", "_")
+    if kind in {"global", "base", "base_publication"}:
+        return PublicationContext.global_context(source="scope_change_request")
+    if kind in {"organisation", "organization", "org"}:
+        organisation_id = _normalise_concept_id(destination_concept_id)
+        if not organisation_id:
+            raise ValueError("Organisation destination requires a concept ID")
+        return PublicationContext.organisation(
+            organisation_id,
+            source="scope_change_request",
+        )
+    if kind in {"user", "private_user"}:
+        user_id = _normalise_concept_id(destination_concept_id)
+        if not user_id:
+            raise ValueError("User destination requires a concept ID")
+        return PublicationContext.user(user_id, source="scope_change_request")
+    raise ValueError("Unsupported destination_kind")
+
+
+def _scope_edges(read_back: Mapping[str, Any]) -> list[tuple[str, str]]:
+    edges: list[tuple[str, str]] = []
+    raw_edges = read_back.get("scope_edges")
+    if not isinstance(raw_edges, Mapping):
+        return edges
+    for predicate, targets in raw_edges.items():
+        values = targets if isinstance(targets, list) else [targets]
+        for target in values:
+            if (
+                isinstance(predicate, str)
+                and isinstance(target, str)
+                and predicate.strip()
+                and target.strip()
+            ):
+                edges.append((predicate.strip(), target.strip()))
+    return edges
+
+
+def _destination_edge(
+    destination: PublicationContext,
+) -> tuple[str, str] | None:
+    if destination.kind == PublicationContextKind.GLOBAL:
+        return None
+    if destination.kind == PublicationContextKind.ORGANISATION:
+        return (
+            CANONICAL_SPECIFIC_TO_ORG_PREDICATE,
+            str(destination.concept_id),
+        )
+    if destination.kind == PublicationContextKind.USER:
+        return (
+            CANONICAL_SPECIFIC_TO_USER_PREDICATE,
+            str(destination.concept_id),
+        )
+    raise ValueError("Historical or mixed destination is not valid")
+
+
+def get_concept_publication_scope(concept_id: str) -> dict[str, Any]:
+    """Read one exact actor-visible scope snapshot without widening access."""
+
+    normalised_concept_id = _normalise_concept_id(concept_id)
+    if not normalised_concept_id:
+        raise ValueError("concept_id is required")
+    if not can_access_concept(normalised_concept_id):
+        raise PermissionError("ontology_scope_target_not_accessible")
+    return scope_read_back(normalised_concept_id)
+
+
+def _prepare_scope_change(
+    *,
+    concept_id: str,
+    destination_kind: str,
+    destination_concept_id: str | None,
+    expected_scope_fingerprint: str,
+    request_id: str,
+    preview: bool,
+    reason: str | None,
+    invocation_tool_name: str,
+    idempotency_key: str | None = None,
+) -> _PreparedScopeChange:
+    normalised_concept_id = _normalise_concept_id(concept_id)
+    if not normalised_concept_id:
+        raise ValueError("concept_id is required")
+    if not can_access_concept(normalised_concept_id):
+        raise PermissionError("ontology_scope_target_not_accessible")
+    expected_fingerprint = _clean_text(expected_scope_fingerprint)
+    if not expected_fingerprint:
+        raise ValueError("expected_scope_fingerprint is required")
+    request_key = _clean_text(request_id)
+    if not request_key:
+        raise ValueError("request_id is required")
+
+    before = scope_read_back(normalised_concept_id)
+    actual_fingerprint = _clean_text(before.get("scope_fingerprint"))
+    if actual_fingerprint != expected_fingerprint:
+        raise OntologyScopeChangePreconditionError(
+            expected_scope_fingerprint=expected_fingerprint,
+            actual_scope_fingerprint=actual_fingerprint,
+            canonical_read_back=before,
+        )
+
+    destination = _destination_context(
+        destination_kind=destination_kind,
+        destination_concept_id=destination_concept_id,
+    )
+    raw_source_context = before.get("publication_context")
+    source_map = raw_source_context if isinstance(raw_source_context, Mapping) else {}
+    source_kind = PublicationContextKind(
+        str(source_map.get("kind") or PublicationContextKind.HISTORICAL.value)
+    )
+    source = PublicationContext(
+        source_kind,
+        _normalise_concept_id(source_map.get("concept_id")),
+        str(source_map.get("source") or "scope_read_back"),
+        tuple(source_map.get("historical_predicates") or ()),
+    )
+    tool_name = _clean_text(invocation_tool_name)
+    if tool_name not in {
+        PREVIEW_SCOPE_CHANGE_TOOL_NAME,
+        EXECUTE_SCOPE_CHANGE_TOOL_NAME,
+    }:
+        raise ValueError("Unsupported scope-change invocation tool")
+    intent = OntologyMutationIntent(
+        operation="scope.change",
+        publication_context=destination,
+        source_contexts=(source,),
+        target_concept_ids=tuple(
+            item
+            for item in (
+                normalised_concept_id,
+                destination.concept_id,
+            )
+            if item
+        ),
+        tool_name=tool_name,
+        delta={
+            "from": source.to_mapping(),
+            "to": destination.to_mapping(),
+            "expected_scope_fingerprint": expected_fingerprint,
+            "reason": _clean_text(reason) or None,
+        },
+        # A preview is an auditable decision but not the claimed write. Keep
+        # its receipt distinct so a subsequent execution can use the same
+        # caller request ID without replaying the preview.
+        idempotency_key=(
+            (
+                _clean_text(current_ontology_invocation().effect_id)
+                if current_ontology_invocation()
+                and current_ontology_invocation().executing_agent_concept_id
+                else ""
+            )
+            or _clean_text(idempotency_key)
+            or (f"{request_key}:preview" if preview else request_key)
+        ),
+    )
+    return _PreparedScopeChange(
+        concept_id=normalised_concept_id,
+        before=before,
+        source=source,
+        destination=destination,
+        intent=intent,
+    )
+
+
+def build_concept_publication_scope_change_intent(
+    *,
+    concept_id: str,
+    destination_kind: str,
+    destination_concept_id: str | None = None,
+    expected_scope_fingerprint: str,
+    request_id: str,
+    preview: bool,
+    reason: str | None = None,
+    invocation_tool_name: str,
+    idempotency_key: str | None = None,
+) -> OntologyMutationIntent:
+    """Build the exact intent shared by delegation issuance and execution."""
+
+    return _prepare_scope_change(
+        concept_id=concept_id,
+        destination_kind=destination_kind,
+        destination_concept_id=destination_concept_id,
+        expected_scope_fingerprint=expected_scope_fingerprint,
+        request_id=request_id,
+        preview=preview,
+        reason=reason,
+        invocation_tool_name=invocation_tool_name,
+        idempotency_key=idempotency_key,
+    ).intent
+
+
+def change_concept_publication_scope(
+    *,
+    concept_id: str,
+    destination_kind: str,
+    destination_concept_id: str | None = None,
+    expected_scope_fingerprint: str,
+    request_id: str,
+    preview: bool = True,
+    reason: str | None = None,
+    invocation_tool_name: str = EXECUTE_SCOPE_CHANGE_TOOL_NAME,
+) -> dict[str, Any]:
+    """Preview or perform one exact scope transition with exact authority."""
+
+    try:
+        prepared = _prepare_scope_change(
+            concept_id=concept_id,
+            destination_kind=destination_kind,
+            destination_concept_id=destination_concept_id,
+            expected_scope_fingerprint=expected_scope_fingerprint,
+            request_id=request_id,
+            preview=preview,
+            reason=reason,
+            invocation_tool_name=invocation_tool_name,
+        )
+    except OntologyScopeChangePreconditionError as exc:
+        return {
+            "success": False,
+            "effect_status": "not_started",
+            "mutation_outcome": "not_started",
+            "changed": False,
+            "error_code": exc.reason_code,
+            "error": exc.public_message,
+            "expected_scope_fingerprint": exc.expected_scope_fingerprint,
+            "actual_scope_fingerprint": exc.actual_scope_fingerprint,
+            "canonical_read_back": dict(exc.canonical_read_back),
+        }
+    normalised_concept_id = prepared.concept_id
+    before = prepared.before
+    source = prepared.source
+    destination = prepared.destination
+    intent = prepared.intent
+    request_key = _clean_text(request_id)
+    expected_fingerprint = _clean_text(expected_scope_fingerprint)
+
+    def mutate() -> Mapping[str, Any]:
+        new_edge = _destination_edge(destination)
+        if preview:
+            return {
+                "success": True,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "changed": False,
+                "preview": True,
+                "from": source.to_mapping(),
+                "to": destination.to_mapping(),
+                "scope_delta": {
+                    "remove": [
+                        {"predicate": predicate, "target": target}
+                        for predicate, target in _scope_edges(before)
+                    ],
+                    "add": (
+                        [{"predicate": new_edge[0], "target": new_edge[1]}]
+                        if new_edge
+                        else []
+                    ),
+                },
+            }
+
+        try:
+            with ExitStack() as locks:
+                resource_keys = {
+                    f"ontology-publication-scope:{normalised_concept_id}",
+                    *ontology_authority_resource_keys(intent),
+                }
+                for resource_key in sorted(resource_keys):
+                    locks.enter_context(ontology_mutation_resource_lock(resource_key))
+                current = scope_read_back(normalised_concept_id)
+                current_fingerprint = _clean_text(current.get("scope_fingerprint"))
+                if current_fingerprint != expected_fingerprint:
+                    return {
+                        "success": False,
+                        "effect_status": "not_started",
+                        "mutation_outcome": "not_started",
+                        "changed": False,
+                        "error_code": "scope_precondition_failed",
+                        "error": (
+                            "The concept scope changed after authority was resolved."
+                        ),
+                        "expected_scope_fingerprint": expected_fingerprint,
+                        "actual_scope_fingerprint": current_fingerprint,
+                    }
+                live_decision = authorise_ontology_mutation(intent)
+                if not live_decision.allowed:
+                    return ontology_authority_denial_payload(live_decision, intent)
+
+                removed: list[tuple[str, str]] = []
+                destination_added = False
+                try:
+                    # Add a restrictive destination before removing any source
+                    # restriction. A cross-org transition may be temporarily
+                    # visible to both contexts, but it must never pass through
+                    # an unintended globally visible interval.
+                    if new_edge and new_edge not in _scope_edges(current):
+                        result = add_relationship(
+                            normalised_concept_id,
+                            new_edge[0],
+                            new_edge[1],
+                        )
+                        if not result.get("success"):
+                            raise RuntimeError(
+                                str(result.get("error") or "scope_edge_add_failed")
+                            )
+                        destination_added = bool(
+                            result.get("forward_modified") or result.get("modified")
+                        )
+
+                    for predicate, target in _scope_edges(current):
+                        if new_edge == (predicate, target):
+                            continue
+                        result = remove_relationship(
+                            source_id=normalised_concept_id,
+                            predicate=predicate,
+                            target=target,
+                            mode="soft_delete",
+                            cascade="warn",
+                            dry_run=False,
+                            confirmed=True,
+                            reason=_clean_text(reason) or "ontology scope transition",
+                            request_id=f"{request_key}:remove:{len(removed)}",
+                        )
+                        if not result.get("success"):
+                            raise RuntimeError(
+                                str(
+                                    result.get("error_code")
+                                    or "scope_edge_remove_failed"
+                                )
+                            )
+                        if result.get("removed"):
+                            removed.append((predicate, target))
+
+                    return {
+                        "success": True,
+                        "effect_status": "succeeded",
+                        "mutation_outcome": "succeeded",
+                        "changed": bool(removed or destination_added),
+                        "from": source.to_mapping(),
+                        "to": destination.to_mapping(),
+                        "removed_scope_edges": [
+                            {"predicate": predicate, "target": target}
+                            for predicate, target in removed
+                        ],
+                        "destination_edge_added": destination_added,
+                    }
+                except Exception:
+                    # Best-effort compensation keeps the old publication boundary
+                    # if a later edge fails. The outer command still reports an
+                    # indeterminate outcome and preserves canonical read-back.
+                    compensation_edge = _destination_edge(destination)
+                    if destination_added and compensation_edge:
+                        remove_relationship(
+                            source_id=normalised_concept_id,
+                            predicate=compensation_edge[0],
+                            target=compensation_edge[1],
+                            dry_run=False,
+                            confirmed=True,
+                            reason="scope transition compensation",
+                            request_id=f"{request_key}:compensate-destination",
+                        )
+                    for predicate, target in removed:
+                        add_relationship(normalised_concept_id, predicate, target)
+                    raise
+        except OntologyMutationResourceBusy:
+            return {
+                "success": False,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "changed": False,
+                "retryable": True,
+                "error_code": "ontology_mutation_resource_busy",
+                "error": "Another scope transition is already in progress.",
+            }
+
+    return execute_authorised_ontology_mutation(
+        intent=intent,
+        mutate=mutate,
+        read_before=lambda: before,
+        read_back=lambda: scope_read_back(normalised_concept_id),
+        verify_read_back=lambda _result, state: (
+            isinstance(state, Mapping)
+            and (
+                (
+                    destination.kind == PublicationContextKind.GLOBAL
+                    and not _scope_edges(state)
+                )
+                or (
+                    destination.kind != PublicationContextKind.GLOBAL
+                    and _scope_edges(state) == [_destination_edge(destination)]
+                )
+            )
+        ),
+        preview=preview,
+    )
+
+
+__all__ = [
+    "EXECUTE_SCOPE_CHANGE_TOOL_NAME",
+    "PREVIEW_SCOPE_CHANGE_TOOL_NAME",
+    "OntologyScopeChangePreconditionError",
+    "build_concept_publication_scope_change_intent",
+    "change_concept_publication_scope",
+    "get_concept_publication_scope",
+]

--- a/src/backend/services/organisation_membership_service.py
+++ b/src/backend/services/organisation_membership_service.py
@@ -7,11 +7,15 @@ user concepts and organisation concepts, including role associations.
 from __future__ import annotations
 
 import logging
-from typing import Dict, Any, Optional, Set
+from functools import wraps
+from typing import Any
 
 from ..db.repositories.concepts_repository import ConceptsRepository
 from ..security.access_control import bypass_access_control, can_access_concept
 from ..services.text_value_service import upsert_text_for_concept
+from .ontology_authority_membership_coordination_service import (
+    ontology_authority_membership_mutation_barrier,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +23,18 @@ logger = logging.getLogger(__name__)
 MEMBERSHIP_RELATIONSHIP_KIND = "memberOf"
 ALT_MEMBERSHIP_RELATIONSHIP = "#V#member_of_organisation"
 ROLE_PREDICATE = "#V#hasRole"
+_ROLE_STORAGE_SEPARATOR = "::"
+
+
+def _coordinated_membership_mutation(function):
+    """Keep all membership lifecycle writes inside the shared authority barrier."""
+
+    @wraps(function)
+    def coordinated(*args, **kwargs):
+        with ontology_authority_membership_mutation_barrier():
+            return function(*args, **kwargs)
+
+    return coordinated
 
 
 def _normalise_concept_id(value: Any) -> str | None:
@@ -30,10 +46,59 @@ def _normalise_concept_id(value: Any) -> str | None:
     return text if text.startswith("#") else f"#V#{text}"
 
 
+def organisation_role_storage_text(
+    role: str,
+    organisation_concept_id: str,
+) -> str:
+    """Return a scope-distinct token for one organisation membership role.
+
+    Text relation uniqueness is subject/predicate/object rather than context.
+    Including the organisation in the value prevents equal roles in two
+    organisations from overwriting one another's relation context.
+    """
+
+    role_value = str(role or "").strip()
+    organisation_id = _normalise_concept_id(organisation_concept_id)
+    if not role_value:
+        raise ValueError("role must be a non-empty string")
+    if not organisation_id:
+        raise ValueError("organisation_concept_id must be a non-empty string")
+    if _ROLE_STORAGE_SEPARATOR in role_value:
+        raise ValueError("role may not contain the organisation-role separator")
+    return f"{role_value}{_ROLE_STORAGE_SEPARATOR}{organisation_id}"
+
+
+def parse_organisation_role_storage_text(
+    stored_text: object,
+    relation_context: dict[str, Any] | None = None,
+) -> tuple[str | None, str | None]:
+    """Decode scope-distinct roles while retaining legacy plain-role reads."""
+
+    raw_text = str(stored_text or "").strip()
+    if not raw_text:
+        return None, None
+    context = relation_context if isinstance(relation_context, dict) else {}
+    context_org = _normalise_concept_id(
+        context.get("organisation_concept_id") or context.get("organisation_id")
+    )
+    if _ROLE_STORAGE_SEPARATOR not in raw_text:
+        return (raw_text, context_org) if context_org else (None, None)
+    role, raw_organisation_id = raw_text.rsplit(_ROLE_STORAGE_SEPARATOR, 1)
+    role = role.strip()
+    stored_org = _normalise_concept_id(raw_organisation_id)
+    if not role or not stored_org:
+        return None, None
+    if context_org and context_org != stored_org:
+        # Context disagreement is malformed and must not be interpreted as a
+        # role for either organisation.
+        return None, None
+    return role, stored_org
+
+
 def resolve_user_organisation_membership(
     user_concept_id: str,
     organisation_concept_id: str,
-) -> Dict[str, Any] | None:
+) -> dict[str, Any] | None:
     """Return the represented membership record for an exact user/org pair."""
 
     user_id = _normalise_concept_id(user_concept_id)
@@ -71,9 +136,10 @@ def is_user_member_of_organisation(
     )
 
 
+@_coordinated_membership_mutation
 def create_organisation_membership(
     user_concept_id: str, organisation_concept_id: str, role: str = "member"
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Create a memberOf relationship between a user and an organisation.
 
     Stores the relationship in the Vontology as a concept edge, with the role
@@ -145,7 +211,7 @@ def create_organisation_membership(
     role_result = upsert_text_for_concept(
         subject_concept_id=user_concept_id,
         predicate=ROLE_PREDICATE,
-        text=role,
+        text=organisation_role_storage_text(role, organisation_concept_id),
         lang="en",
         context={"organisation_id": organisation_concept_id},
     )
@@ -161,7 +227,7 @@ def create_organisation_membership(
     }
 
 
-def get_user_memberships(user_concept_id: str) -> Dict[str, Any]:
+def get_user_memberships(user_concept_id: str) -> dict[str, Any]:
     """Retrieve all organisations a user is a member of and their roles.
 
     Args:
@@ -199,7 +265,7 @@ def get_user_memberships(user_concept_id: str) -> Dict[str, Any]:
         alt_org_ids = []
 
     merged_org_ids = []
-    seen_orgs: Set[str] = set()
+    seen_orgs: set[str] = set()
     for value in [*org_ids, *alt_org_ids]:
         if not isinstance(value, str):
             continue
@@ -233,7 +299,13 @@ def get_user_memberships(user_concept_id: str) -> Dict[str, Any]:
 
                 tv = TextValuesRepository.find_one({"_id": text_value_id})
                 if tv:
-                    org_role_map[org_id] = tv.get("text", "member")
+                    role, stored_org = parse_organisation_role_storage_text(
+                        tv.get("text"),
+                        context,
+                    )
+                    normalised_org_id = _normalise_concept_id(org_id)
+                    if role and stored_org == normalised_org_id:
+                        org_role_map[normalised_org_id] = role
 
     # Build result
     memberships = []
@@ -251,8 +323,8 @@ def get_user_memberships(user_concept_id: str) -> Dict[str, Any]:
 
 
 def get_organisation_members(
-    organisation_concept_id: str, role_filter: Optional[str] = None
-) -> Dict[str, Any]:
+    organisation_concept_id: str, role_filter: str | None = None
+) -> dict[str, Any]:
     """Retrieve all members of an organisation, optionally filtered by role.
 
     Args:
@@ -287,8 +359,8 @@ def get_organisation_members(
         }
     )
 
-    user_role_map: Dict[str, str] = {}
-    user_ids: Set[str] = set()
+    user_role_map: dict[str, str] = {}
+    user_ids: set[str] = set()
 
     for rel in role_relations:
         user_id = rel.get("subject_concept_id")
@@ -300,9 +372,16 @@ def get_organisation_members(
 
                 tv = TextValuesRepository.find_one({"_id": text_value_id})
                 if tv:
-                    user_role_map[user_id] = tv.get("text", "member")
-                else:
-                    user_role_map[user_id] = "member"
+                    role, stored_org = parse_organisation_role_storage_text(
+                        tv.get("text"),
+                        rel.get("context")
+                        if isinstance(rel.get("context"), dict)
+                        else {},
+                    )
+                    if role and stored_org == _normalise_concept_id(
+                        organisation_concept_id
+                    ):
+                        user_role_map[user_id] = role
 
     # Fallback: include concepts with membership edges even if no role text relation.
     org_id_variants = {organisation_concept_id}
@@ -349,9 +428,10 @@ def get_organisation_members(
     }
 
 
+@_coordinated_membership_mutation
 def update_user_role(
     user_concept_id: str, organisation_concept_id: str, new_role: str
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Update a user's role in an organisation.
 
     Args:
@@ -423,7 +503,7 @@ def update_user_role(
     upsert_text_for_concept(
         subject_concept_id=user_concept_id,
         predicate=ROLE_PREDICATE,
-        text=new_role,
+        text=organisation_role_storage_text(new_role, organisation_concept_id),
         lang="en",
         context={"organisation_id": organisation_concept_id},
     )
@@ -442,9 +522,13 @@ def update_user_role(
     }
 
 
+@_coordinated_membership_mutation
 def remove_organisation_membership(
-    user_concept_id: str, organisation_concept_id: str
-) -> Dict[str, Any]:
+    user_concept_id: str,
+    organisation_concept_id: str,
+    *,
+    semantic_authority_revoked: bool = False,
+) -> dict[str, Any]:
     """Remove a user from an organisation.
 
     Args:
@@ -468,6 +552,27 @@ def remove_organisation_membership(
         raise PermissionError(
             f"Cannot access organisation concept '{organisation_concept_id}'"
         )
+
+    # Membership and semantic publication authority are separate represented
+    # assertions, but leaving an organisation must not silently leave the
+    # stronger authority behind. The caller must revoke the semantic role via
+    # its governed lifecycle first, then attest that exact result here.
+    from .ontology_authority_role_service import authority_role_read_back
+    from .ontology_publication_authority_service import (
+        ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+    )
+
+    authority_read_back = authority_role_read_back(
+        subject_concept_id=user_concept_id,
+        role=ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+        organisation_concept_id=organisation_concept_id,
+    )
+    if authority_read_back.get("active") is True:
+        raise PermissionError(
+            "organisation_ontology_authority_must_be_revoked_before_membership"
+        )
+    if semantic_authority_revoked and authority_read_back.get("active") is not False:
+        raise RuntimeError("organisation_ontology_authority_revocation_not_verified")
 
     # Remove the memberOf relationship
     ConceptsRepository.mutate_relationship_edge(
@@ -518,8 +623,12 @@ def _check_relationship_exists(
 
 __all__ = [
     "create_organisation_membership",
-    "get_user_memberships",
     "get_organisation_members",
-    "update_user_role",
+    "get_user_memberships",
+    "is_user_member_of_organisation",
+    "organisation_role_storage_text",
+    "parse_organisation_role_storage_text",
     "remove_organisation_membership",
+    "resolve_user_organisation_membership",
+    "update_user_role",
 ]

--- a/src/backend/services/von_operational_administrator_service.py
+++ b/src/backend/services/von_operational_administrator_service.py
@@ -1,0 +1,279 @@
+"""Dedicated represented lifecycle for Von operational administrators.
+
+This is deliberately not part of ontology publication authority.  A live
+assignment permits access to bounded operational control-plane surfaces only;
+it neither changes concept visibility nor grants semantic ontology authority.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any
+
+from ..db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
+from ..security.access_control import can_access_concept, get_effective_user_concept_id
+from .ontology_authority_membership_coordination_service import (
+    ontology_authority_membership_mutation_barrier,
+)
+from .ontology_publication_authority_service import (
+    OntologyMutationResourceBusy,
+    current_ontology_invocation,
+    ontology_mutation_resource_lock,
+)
+from .text_value_service import delete_text_relation, upsert_text_for_concept
+
+VON_OPERATIONAL_ADMINISTRATOR_PREDICATE = "#V#has_von_operational_administrator"
+VON_OPERATIONAL_ADMINISTRATOR_ROLE = "von_operational_administrator"
+_ROLE_STORAGE_TEXT = "von_operational_administrator::global"
+_BOOTSTRAP_CONTEXT: ContextVar[bool] = ContextVar(
+    "von_operational_administrator_bootstrap", default=False
+)
+_LIFECYCLE_RESOURCE_KEY = "von-operational-administrator-lifecycle:v1"
+
+
+def _normalise_concept_id(value: object) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    return text if text.startswith("#") else f"#V#{text}"
+
+
+def _current_direct_human_actor() -> str:
+    actor_id = _normalise_concept_id(get_effective_user_concept_id())
+    if not actor_id:
+        raise PermissionError("authenticated_actor_context_required")
+    invocation = current_ontology_invocation()
+    if invocation and invocation.executing_agent_concept_id:
+        raise PermissionError("von_operational_administrator_human_required")
+    return actor_id
+
+
+@contextmanager
+def bind_von_operational_administrator_bootstrap() -> Iterator[None]:
+    """Bind a route-verified existing operator credential for first grant only."""
+
+    token = _BOOTSTRAP_CONTEXT.set(True)
+    try:
+        yield
+    finally:
+        _BOOTSTRAP_CONTEXT.reset(token)
+
+
+def _role_rows(subject_concept_id: str | None = None) -> list[dict[str, Any]]:
+    query: dict[str, Any] = {"predicate": VON_OPERATIONAL_ADMINISTRATOR_PREDICATE}
+    if subject_concept_id:
+        query["subject_concept_id"] = subject_concept_id
+    rows: list[dict[str, Any]] = []
+    for relation in TextRelationsRepository.find(query):
+        if not isinstance(relation, Mapping):
+            continue
+        text = TextValuesRepository.find_one({"_id": relation.get("object_text_id")})
+        if not isinstance(text, Mapping) or text.get("text") != _ROLE_STORAGE_TEXT:
+            continue
+        subject_id = _normalise_concept_id(relation.get("subject_concept_id"))
+        relation_id = str(relation.get("_id") or "")
+        if subject_id and relation_id:
+            rows.append(
+                {
+                    "subject_concept_id": subject_id,
+                    "relation_id": relation_id,
+                    "updated_at": str(relation.get("updated_at") or "") or None,
+                    "grant_provenance": (
+                        dict(relation.get("context", {}).get("grant_provenance"))
+                        if isinstance(relation.get("context"), Mapping)
+                        and isinstance(
+                            relation.get("context", {}).get("grant_provenance"),
+                            Mapping,
+                        )
+                        else None
+                    ),
+                }
+            )
+    return sorted(
+        rows,
+        key=lambda item: (item["subject_concept_id"], item["relation_id"]),
+    )
+
+
+def von_operational_administrator_read_back(
+    *, subject_concept_id: str
+) -> dict[str, Any]:
+    """Return only exact operational-role evidence for one named subject."""
+
+    subject_id = _normalise_concept_id(subject_concept_id)
+    if not subject_id:
+        raise ValueError("subject_concept_id is required")
+    grants = _role_rows(subject_id)
+    return {
+        "subject_concept_id": subject_id,
+        "role": VON_OPERATIONAL_ADMINISTRATOR_ROLE,
+        "active": bool(grants),
+        "grants": grants,
+    }
+
+
+def list_von_operational_administrators() -> list[dict[str, Any]]:
+    """Inventory all exact represented operational-role assignments.
+
+    This is evidence only: reading the inventory grants no operational or
+    semantic authority.  Migration preflight uses it to enforce the authorised
+    sole-holder premise before any elevation begins.
+    """
+
+    return _role_rows()
+
+
+def is_live_von_operational_administrator(actor_concept_id: object) -> bool:
+    """Resolve the dedicated role without widening the caller's data scope."""
+
+    actor_id = _normalise_concept_id(actor_concept_id)
+    return bool(actor_id and _role_rows(actor_id))
+
+
+def _can_manage_operational_administrators(actor_id: str) -> bool:
+    return _BOOTSTRAP_CONTEXT.get() or is_live_von_operational_administrator(actor_id)
+
+
+def _grant(
+    *, subject_concept_id: str, reason: str | None, bootstrap_only: bool
+) -> dict[str, Any]:
+    actor_id = _current_direct_human_actor()
+    subject_id = _normalise_concept_id(subject_concept_id)
+    if not subject_id:
+        raise ValueError("subject_concept_id is required")
+    if not can_access_concept(subject_id):
+        raise PermissionError("von_operational_administrator_target_not_accessible")
+    if bootstrap_only:
+        if not _BOOTSTRAP_CONTEXT.get():
+            raise PermissionError("von_operational_administrator_bootstrap_required")
+        if _role_rows():
+            raise PermissionError("von_operational_administrator_already_initialised")
+    elif not _can_manage_operational_administrators(actor_id):
+        raise PermissionError("von_operational_administrator_required")
+    try:
+        with ontology_authority_membership_mutation_barrier():  # noqa: SIM117
+            with ontology_mutation_resource_lock(_LIFECYCLE_RESOURCE_KEY):
+                if bootstrap_only and _role_rows():
+                    raise PermissionError(
+                        "von_operational_administrator_already_initialised"
+                    )
+                result = upsert_text_for_concept(
+                    subject_concept_id=subject_id,
+                    predicate=VON_OPERATIONAL_ADMINISTRATOR_PREDICATE,
+                    text=_ROLE_STORAGE_TEXT,
+                    lang="en-NZ",
+                    provenance={"source": "von_operational_administrator_lifecycle"},
+                    context={
+                        "operational_scope": "von",
+                        "grant_provenance": {
+                            "source": "von_operational_administrator_lifecycle",
+                            "granted_by_actor_concept_id": actor_id,
+                            "reason": str(reason or "").strip() or None,
+                        },
+                    },
+                )
+    except OntologyMutationResourceBusy as exc:
+        raise RuntimeError("von_operational_administrator_resource_busy") from exc
+    read_back = von_operational_administrator_read_back(subject_concept_id=subject_id)
+    relation_id = str(result.get("relation_id") or "")
+    if not relation_id or not any(
+        row.get("relation_id") == relation_id for row in read_back["grants"]
+    ):
+        raise RuntimeError("von_operational_administrator_read_back_failed")
+    return {
+        "success": True,
+        "changed": bool(
+            result.get("relation_created") or result.get("context_updated")
+        ),
+        "effect_status": "succeeded",
+        "relation_id": relation_id,
+        "canonical_read_back": read_back,
+    }
+
+
+def bootstrap_first_von_operational_administrator(
+    *, subject_concept_id: str
+) -> dict[str, Any]:
+    """Establish the first root only inside a route-verified token context."""
+
+    return _grant(
+        subject_concept_id=subject_concept_id,
+        reason="bootstrap",
+        bootstrap_only=True,
+    )
+
+
+def grant_von_operational_administrator(
+    *, subject_concept_id: str, reason: str | None = None
+) -> dict[str, Any]:
+    return _grant(
+        subject_concept_id=subject_concept_id,
+        reason=reason,
+        bootstrap_only=False,
+    )
+
+
+def revoke_von_operational_administrator(
+    *, subject_concept_id: str, reason: str | None = None
+) -> dict[str, Any]:
+    actor_id = _current_direct_human_actor()
+    if not _can_manage_operational_administrators(actor_id):
+        raise PermissionError("von_operational_administrator_required")
+    subject_id = _normalise_concept_id(subject_concept_id)
+    if not subject_id:
+        raise ValueError("subject_concept_id is required")
+    if not can_access_concept(subject_id):
+        raise PermissionError("von_operational_administrator_target_not_accessible")
+    rows = _role_rows(subject_id)
+    all_rows = _role_rows()
+    if rows and len(all_rows) <= len(rows):
+        raise PermissionError("last_von_operational_administrator_cannot_be_revoked")
+    deleted: list[str] = []
+    try:
+        with ontology_authority_membership_mutation_barrier():  # noqa: SIM117
+            with ontology_mutation_resource_lock(_LIFECYCLE_RESOURCE_KEY):
+                rows = _role_rows(subject_id)
+                all_rows = _role_rows()
+                if rows and len(all_rows) <= len(rows):
+                    raise PermissionError(
+                        "last_von_operational_administrator_cannot_be_revoked"
+                    )
+                for row in rows:
+                    result = delete_text_relation(
+                        subject_concept_id=subject_id,
+                        relation_id=row["relation_id"],
+                        garbage_collect=False,
+                    )
+                    if result.get("deleted"):
+                        deleted.append(row["relation_id"])
+    except OntologyMutationResourceBusy as exc:
+        raise RuntimeError("von_operational_administrator_resource_busy") from exc
+    read_back = von_operational_administrator_read_back(subject_concept_id=subject_id)
+    if read_back["active"]:
+        raise RuntimeError("von_operational_administrator_read_back_failed")
+    return {
+        "success": True,
+        "changed": bool(deleted),
+        "effect_status": "succeeded",
+        "deleted_relation_ids": deleted,
+        "reason": str(reason or "").strip() or None,
+        "canonical_read_back": read_back,
+    }
+
+
+__all__ = [
+    "VON_OPERATIONAL_ADMINISTRATOR_PREDICATE",
+    "VON_OPERATIONAL_ADMINISTRATOR_ROLE",
+    "bind_von_operational_administrator_bootstrap",
+    "bootstrap_first_von_operational_administrator",
+    "grant_von_operational_administrator",
+    "is_live_von_operational_administrator",
+    "list_von_operational_administrators",
+    "revoke_von_operational_administrator",
+    "von_operational_administrator_read_back",
+]

--- a/src/backend/services/window_session_context_service.py
+++ b/src/backend/services/window_session_context_service.py
@@ -230,6 +230,22 @@ class WindowSessionStore:
             del self._sessions[window_session_id]
             return True
 
+    def delete_all_owned(self, user_id: Optional[str]) -> int:
+        """Delete every live window context owned by one exact actor."""
+
+        requested_owner = _normalise_owner_id(user_id)
+        if not requested_owner:
+            return 0
+        with self._lock:
+            matching_ids = [
+                window_session_id
+                for window_session_id, ctx in self._sessions.items()
+                if _normalise_owner_id(ctx.user_id) == requested_owner
+            ]
+            for window_session_id in matching_ids:
+                del self._sessions[window_session_id]
+            return len(matching_ids)
+
     def cleanup_expired(self) -> int:
         """Remove all expired sessions. Returns count removed."""
         with self._lock:
@@ -410,6 +426,12 @@ def delete_window_context_if_owned(
     if not isinstance(window_session_id, str) or not window_session_id.strip():
         return False
     return get_window_session_store().delete_if_owned(window_session_id.strip(), user_id)
+
+
+def delete_all_window_contexts_owned_by(user_id: Optional[str]) -> int:
+    """Invalidate all derived per-window role caches for one actor."""
+
+    return get_window_session_store().delete_all_owned(user_id)
 
 
 def set_window_chat_session(

--- a/src/backend/vontology/code_concepts_registry.py
+++ b/src/backend/vontology/code_concepts_registry.py
@@ -262,7 +262,44 @@ _OTHER_PREDICATE_IDS = [
     "#V#member_of_organisation",
     "#V#has_birthplace",
     "#V#has_occupation",
+    "#V#has_ontology_authority_role",
+    "#V#has_von_operational_administrator",
 ]
+
+_ONTOLOGY_AUTHORITY_ROLE_CONCEPTS = {
+    "#V#organisation_ontology_administrator": CodeConcept(
+        concept_id="#V#organisation_ontology_administrator",
+        display_name="organisation ontology administrator",
+        kind="authority_role",
+        md_content=(
+            "# Organisation ontology administrator\n\n"
+            "A represented semantic role that permits canonical publication only "
+            "within its exact organisation context. It is not an operational "
+            "Von administrator role.\n"
+        ),
+    ),
+    "#V#global_ontology_administrator": CodeConcept(
+        concept_id="#V#global_ontology_administrator",
+        display_name="global ontology administrator",
+        kind="authority_role",
+        md_content=(
+            "# Global ontology administrator\n\n"
+            "A represented semantic role that permits canonical global ontology "
+            "publication. It is not conferred by #V#von_administrator.\n"
+        ),
+    ),
+    "#V#von_operational_administrator": CodeConcept(
+        concept_id="#V#von_operational_administrator",
+        display_name="Von operational administrator",
+        kind="authority_role",
+        md_content=(
+            "# Von operational administrator\n\n"
+            "A represented operational role for bounded Von control-plane "
+            "surfaces. It does not grant semantic ontology authority or "
+            "private concept visibility."
+        ),
+    ),
+}
 
 # Task management predicates (JVNAUTOSCI-1040)
 _TASK_PREDICATE_IDS = [
@@ -339,10 +376,14 @@ _CODE_PREDICATE_CONCEPTS: Dict[str, CodeConcept] = {
     )
     for concept_id in _CODE_PREDICATE_IDS
 }
+_CODE_CONCEPTS: Dict[str, CodeConcept] = {
+    **_CODE_PREDICATE_CONCEPTS,
+    **_ONTOLOGY_AUTHORITY_ROLE_CONCEPTS,
+}
 
 
 def iter_code_concepts() -> Iterable[CodeConcept]:
-    return _CODE_PREDICATE_CONCEPTS.values()
+    return _CODE_CONCEPTS.values()
 
 
 def list_code_predicate_ids() -> list[str]:
@@ -350,11 +391,11 @@ def list_code_predicate_ids() -> list[str]:
 
 
 def is_code_concept_id(concept_id: str) -> bool:
-    return concept_id in _CODE_PREDICATE_CONCEPTS
+    return concept_id in _CODE_CONCEPTS
 
 
 def get_code_concept(concept_id: str) -> Optional[CodeConcept]:
-    return _CODE_PREDICATE_CONCEPTS.get(concept_id)
+    return _CODE_CONCEPTS.get(concept_id)
 
 
 def build_virtual_concept_doc(concept_id: str) -> Optional[dict]:

--- a/src/backend/vontology/utils_vontology.py
+++ b/src/backend/vontology/utils_vontology.py
@@ -3734,6 +3734,7 @@ def create_vontology_concept(
     create_as_instance: bool = False,
     notes: Optional[str] = None,
     description: Optional[str] = None,
+    vontology_path: Optional[str] = None,
     instance_of_type: Optional[str] = None,
     created_by_concept_id: Optional[str] = None,
     organisation_concept_id: Optional[str] = None,
@@ -3741,6 +3742,8 @@ def create_vontology_concept(
     visibility_scope_mode: Optional[str] = None,
     allow_duplicate_instance_suffix: bool = True,
     canonical_concept_id_override: Optional[str] = None,
+    maintain_relationship_inverses: bool = True,
+    resolve_visibility_from_event_namespace: bool = True,
 ) -> Dict[str, Any]:
     """
     Creates a new concept in the Vontology.
@@ -3758,8 +3761,14 @@ def create_vontology_concept(
             selected by an authoritative mechanical identity rule. When set,
             instance suffix allocation is disabled so the concept ID uniqueness
             constraint provides atomic race handling.
+        maintain_relationship_inverses: Whether creation may also update parent
+            concepts with reverse structural edges. Governed external creation
+            disables this because its authority is confined to the new child.
+        resolve_visibility_from_event_namespace: Whether legacy trusted event
+            context may fill missing visibility principals.
         notes: Optional notes for the new concept
         description: Optional description for the new concept
+        vontology_path: Optional legacy path metadata bound into the create effect.
         instance_of_type: Optional concept_id to create an is_an_instance_of relationship.
                          When provided, the concept will be BOTH a subtype of parent_id
                          AND an instance of instance_of_type. This is useful for predicates
@@ -3857,6 +3866,7 @@ def create_vontology_concept(
             created_concept = create_concept(
                 name=new_concept_name,
                 concept_id=candidate_concept_id,
+                vontology_path=vontology_path,
                 parent_concept_ids=parent_concept_ids,
                 create_as_instance=create_as_instance,
                 description=description,
@@ -3866,6 +3876,10 @@ def create_vontology_concept(
                 organisation_concept_id=organisation_concept_id,
                 event_namespace=event_namespace,
                 visibility_scope_mode=visibility_scope_mode,
+                maintain_relationship_inverses=maintain_relationship_inverses,
+                resolve_visibility_from_event_namespace=(
+                    resolve_visibility_from_event_namespace
+                ),
             )
         except InvalidConceptDataError as exc:
             if "duplicate key" not in str(exc).lower():

--- a/src/backend/workflows/action_registry.py
+++ b/src/backend/workflows/action_registry.py
@@ -125,6 +125,10 @@ class WorkflowEnvironment:
     # LLM selection, namespace resolution, and access filtering work correctly.
     user_concept_id: str | None = None
     org_concept_id: str | None = None
+    # Server-issued, exact semantic-ontology delegation for an agent effect.
+    # Workflow definitions and model output may reference this value but cannot
+    # create it or widen its bound operation, target, audience, or expiry.
+    ontology_delegation_id: str | None = None
     step_callback: Callable[[Mapping[str, Any]], None] | None = None
 
 

--- a/src/backend/workflows/durable/entity_identity_resolution_workflow.py
+++ b/src/backend/workflows/durable/entity_identity_resolution_workflow.py
@@ -31,7 +31,6 @@ from ...security.visibility_predicates import (
     get_specific_to_org_values,
     get_specific_to_user_values,
 )
-from ...services.concept_merge_service import merge_concepts
 from ...services.entity_identity_evidence_service import (
     build_candidate_evidence_pairs,
     DEFAULT_AUTHORED_PAPER_LIMIT,
@@ -62,7 +61,9 @@ IDENTITY_REVIEW_PREDICATE = "#V#potential_duplicate_of"
 IDENTITY_POLICY_VERSION = "entity_identity_resolution_policy.v2_llm_rumination"
 
 ENTITY_DUPLICATE_REASONING_PROMPT_CONCEPT_ID = "#V#entity_duplicate_reasoning_prompt"
-ENTITY_DUPLICATE_REASONING_PROMPT_LINK_PREDICATE = "#V#hasEntityDuplicateReasoningPrompt"
+ENTITY_DUPLICATE_REASONING_PROMPT_LINK_PREDICATE = (
+    "#V#hasEntityDuplicateReasoningPrompt"
+)
 
 DEFAULT_SCAN_LIMIT = 300
 DEFAULT_FOCUSED_SCAN_LIMIT = 1000
@@ -77,6 +78,52 @@ VALID_LLM_ACTIONS = {
     "insufficient_evidence",
 }
 ACTIONABLE_LLM_ACTIONS = {"auto_merge", "queue_review"}
+
+
+def merge_concepts(
+    source_id: str,
+    target_id: str,
+    *,
+    simulate: bool,
+    request: WorkflowActionRequest | None = None,
+) -> dict[str, Any]:
+    """Enter identity consolidation through the governed MCP command boundary."""
+
+    # Import lazily: the catalogue also discovers durable workflow actions at
+    # startup. The decorated handler binds the exact plan, delegation, receipt,
+    # locks and canonical read-back that a direct primitive call would bypass.
+    from ...integrations.internal_mcp.catalogue import _merge_concepts
+    from ...services.ontology_publication_authority_service import (
+        bind_ontology_invocation,
+    )
+
+    if request is None:
+        # Compatibility callers and tests still enter the governed handler, but
+        # a durable auto-merge needs the request below so its workflow-agent
+        # provenance and exact server-issued delegation are bound.
+        return _merge_concepts(
+            source_id=source_id,
+            target_id=target_id,
+            simulate=simulate,
+        )
+    workflow_id = _as_text(request.workflow_id) or (
+        ENTITY_IDENTITY_RESOLUTION_WORKFLOW_ID
+    )
+    state_id = _as_text(request.workflow_state_id) or "apply"
+    effect_id = f"workflow:{workflow_id}:{state_id}:merge_concepts"
+    with bind_ontology_invocation(
+        surface="workflow",
+        executing_agent_concept_id="#V#von_system",
+        audience="workflow",
+        delegation_id=request.environment.ontology_delegation_id,
+        effect_id=effect_id,
+        workflow_id=workflow_id,
+    ):
+        return _merge_concepts(
+            source_id=source_id,
+            target_id=target_id,
+            simulate=simulate,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -482,11 +529,7 @@ def _record_merge_audit(
     }
     ConceptsRepository.update_one(
         {"concept_id": target_id},
-        {
-            "$push": {
-                "identity_resolution_audit": {"$each": [event], "$slice": -400}
-            }
-        },
+        {"$push": {"identity_resolution_audit": {"$each": [event], "$slice": -400}}},
     )
 
 
@@ -574,7 +617,7 @@ def build_entity_identity_resolution_workflow_test_definition() -> WorkflowDefin
                     ],
                     "response_contract_text": (
                         "Return JSON of the form "
-                        "{\"identity_recommendations\": [...]}, where each "
+                        '{"identity_recommendations": [...]}, where each '
                         "recommendation has pair_ids, action (auto_merge | "
                         "queue_review | leave_distinct | insufficient_evidence), "
                         "source_id, target_id, confidence (0..1), rationale, "
@@ -839,7 +882,12 @@ def _handle_apply_resolutions(request: WorkflowActionRequest) -> WorkflowActionR
                 would_merge_count += 1
                 detail["outcome"] = "would_merge"
             else:
-                merge_result = merge_concepts(source_id, target_id, simulate=False)
+                merge_result = merge_concepts(
+                    source_id,
+                    target_id,
+                    simulate=False,
+                    request=request,
+                )
                 if bool(merge_result.get("success")):
                     merged_count += 1
                     consumed_sources.add(source_id)
@@ -859,9 +907,9 @@ def _handle_apply_resolutions(request: WorkflowActionRequest) -> WorkflowActionR
                 else:
                     failed_count += 1
                     detail["outcome"] = "merge_failed"
-                    detail["merge_error"] = (
-                        merge_result.get("errors") or merge_result.get("error")
-                    )
+                    detail["merge_error"] = merge_result.get(
+                        "errors"
+                    ) or merge_result.get("error")
                     queue_result = _queue_uncertain(source_id, target_id, rec)
                     if bool(queue_result.get("success")):
                         queued_count += 1
@@ -940,7 +988,9 @@ def _handle_finalise(request: WorkflowActionRequest) -> WorkflowActionResult:
 # ---------------------------------------------------------------------------
 
 
-def build_entity_identity_resolution_workflow_test_registration() -> WorkflowRegistration:
+def build_entity_identity_resolution_workflow_test_registration() -> (
+    WorkflowRegistration
+):
     return WorkflowRegistration(
         workflow_id=ENTITY_IDENTITY_RESOLUTION_WORKFLOW_ID,
         definition=build_entity_identity_resolution_workflow_test_definition(),

--- a/src/backend/workflows/durable/registry_factory.py
+++ b/src/backend/workflows/durable/registry_factory.py
@@ -929,9 +929,17 @@ def _durable_mcp_fallback_action(request: Any) -> WorkflowActionResult:
         )
         if blocked_result is not None:
             return blocked_result
-        with override_current_actor(
-            getattr(environment, "user_concept_id", None),
-            getattr(environment, "org_concept_id", None),
+        from ..workflow_mcp_tool_actions import _ontology_invocation_context
+
+        with (
+            override_current_actor(
+                getattr(environment, "user_concept_id", None),
+                getattr(environment, "org_concept_id", None),
+            ),
+            _ontology_invocation_context(
+                request=request,
+                resolved_tool_name=resolved_tool_name,
+            ),
         ):
             result = gateway.invoke(resolved_tool_name, payload)
         try:

--- a/src/backend/workflows/workflow_mcp_tool_actions.py
+++ b/src/backend/workflows/workflow_mcp_tool_actions.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
+from contextlib import nullcontext
 from functools import lru_cache
 from typing import Any
 
@@ -363,6 +364,40 @@ def _runtime_write_policy_missing(
     return not _has_explicit_write_policy(metadata)
 
 
+def _ontology_invocation_context(
+    *,
+    request: WorkflowActionRequest,
+    resolved_tool_name: str,
+):
+    """Bind workflow-agent provenance even when no delegation was supplied."""
+
+    from ..services.ontology_mutation_command_service import (
+        is_ontology_mutation_method,
+    )
+
+    if not is_ontology_mutation_method(resolved_tool_name):
+        return nullcontext()
+    from ..services.ontology_publication_authority_service import (
+        bind_ontology_invocation,
+    )
+
+    workflow_id = _clean_text(request.workflow_id) or None
+    state_id = _clean_text(request.workflow_state_id) or "unbound_state"
+    effect_id = f"workflow:{workflow_id or 'unbound_workflow'}:{state_id}:{resolved_tool_name}"
+    return bind_ontology_invocation(
+        surface="workflow",
+        executing_agent_concept_id="#V#von_system",
+        audience="workflow",
+        delegation_id=getattr(
+            request.environment,
+            "ontology_delegation_id",
+            None,
+        ),
+        effect_id=effect_id,
+        workflow_id=workflow_id,
+    )
+
+
 def _handle_workflow_mcp_invoke_tool(
     request: WorkflowActionRequest,
 ) -> WorkflowActionResult:
@@ -487,9 +522,15 @@ def _handle_workflow_mcp_invoke_tool(
 
         from ..security.access_control import override_current_actor
 
-        with override_current_actor(
-            getattr(request.environment, "user_concept_id", None),
-            getattr(request.environment, "org_concept_id", None),
+        with (
+            override_current_actor(
+                getattr(request.environment, "user_concept_id", None),
+                getattr(request.environment, "org_concept_id", None),
+            ),
+            _ontology_invocation_context(
+                request=request,
+                resolved_tool_name=resolved_tool_name,
+            ),
         ):
             if event_launch_suppression_requested:
                 from ..services.workflow_event_integration_service import (

--- a/tests/backend/test_admin_workflow_materialisation_diagnostics_route.py
+++ b/tests/backend/test_admin_workflow_materialisation_diagnostics_route.py
@@ -107,3 +107,75 @@ def test_org_admin_cannot_probe_global_workflow_concept_ids(
         "error": "trusted_operator_authority_required"
     }
     assert calls == []
+
+
+def test_global_semantic_ontology_admin_cannot_use_operator_only_diagnostics(
+    monkeypatch,
+) -> None:
+    from src.backend.services import ontology_publication_authority_service as authority
+
+    client = _build_test_client()
+    calls: list[object] = []
+    semantic_admin = "#V#semantic_global_admin"
+    global_role = authority.AuthorityRoleEvidence(
+        role=authority.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+        actor_concept_id=semantic_admin,
+        organisation_concept_id=None,
+        relation_id="role:semantic-global-admin",
+        revision="operator-separation-test",
+    )
+    monkeypatch.setattr(
+        authority,
+        "resolve_live_semantic_roles",
+        lambda actor: (global_role,) if actor == semantic_admin else (),
+    )
+    monkeypatch.setattr(
+        admin_routes,
+        "build_workflow_materialisation_diagnostics",
+        lambda **_kwargs: calls.append(object()),
+    )
+    # Configure the distinct operator credential, but do not give it to the
+    # represented global semantic administrator.
+    monkeypatch.setenv("VON_ADMIN_TOKEN", "operator-token")
+    with client.session_transaction() as flask_session:
+        flask_session["user_concept_id"] = semantic_admin
+
+    authority_summary = authority.list_actor_semantic_authority(semantic_admin)
+    assert [item["role"] for item in authority_summary["roles"]] == [
+        authority.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE
+    ]
+
+    response = client.get("/admin/workflow_materialisation_diagnostics")
+
+    assert response.status_code == 403
+    assert response.get_json() == {
+        "error": "trusted_operator_authority_required"
+    }
+    assert calls == []
+
+
+def test_represented_operational_administrator_can_use_diagnostics(
+    monkeypatch,
+) -> None:
+    from src.backend.services import von_operational_administrator_service as operators
+
+    client = _build_test_client()
+    calls: list[object] = []
+    monkeypatch.setattr(
+        operators,
+        "is_live_von_operational_administrator",
+        lambda actor: actor == "#V#operational_admin",
+    )
+    monkeypatch.setattr(
+        admin_routes,
+        "build_workflow_materialisation_diagnostics",
+        lambda **_kwargs: calls.append(object()) or {"success": True},
+    )
+    with client.session_transaction() as flask_session:
+        flask_session["user_concept_id"] = "#V#operational_admin"
+
+    response = client.get("/admin/workflow_materialisation_diagnostics")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"success": True}
+    assert len(calls) == 1

--- a/tests/backend/test_code_concepts_registry.py
+++ b/tests/backend/test_code_concepts_registry.py
@@ -76,6 +76,12 @@ def test_workflow_runtime_policy_predicates_are_registered():
     assert "#V#hasWorkflowTerminalSuccessContractJson" in ids
     assert "#V#has_workflow_terminal_success_contract_json" in ids
     assert "#V#hasWorkflowRequiredEffectsContractJson" in ids
+
+
+def test_operational_administrator_predicate_is_registered():
+    ids = set(list_code_predicate_ids())
+
+    assert "#V#has_von_operational_administrator" in ids
     assert "#V#has_workflow_required_effects_contract_json" in ids
 
 

--- a/tests/backend/test_concept_merge_service_text_relations.py
+++ b/tests/backend/test_concept_merge_service_text_relations.py
@@ -1,146 +1,350 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
-from unittest.mock import MagicMock, patch
+from datetime import UTC, datetime
+from typing import Any
 
-from src.backend.services.concept_merge_service import merge_concepts
+import mongomock
+import pytest
+
+from src.backend.services import concept_merge_service as merge_service
+from src.backend.services import ontology_publication_authority_service as authority
+
+
+@pytest.fixture
+def merge_store(monkeypatch: pytest.MonkeyPatch):
+    database = mongomock.MongoClient()["concept_merge"]
+    concepts = database["concepts"]
+    text_relations = database["text_relations"]
+    text_values = database["text_values"]
+
+    from src.backend.db.repositories import concepts_repository
+    from src.backend.db.repositories import text_value_repository
+
+    monkeypatch.setattr(
+        concepts_repository,
+        "get_concepts_collection",
+        lambda: concepts,
+    )
+    monkeypatch.setattr(
+        text_value_repository,
+        "get_text_relations_collection",
+        lambda: text_relations,
+    )
+    monkeypatch.setattr(
+        text_value_repository,
+        "get_text_values_collection",
+        lambda: text_values,
+    )
+    monkeypatch.setattr(merge_service, "can_access_concept", lambda _item: True)
+    return concepts, text_relations, text_values
 
 
 def _concept(
-    concept_id: str, *, relationships: Dict[str, Any] | None = None
-) -> Dict[str, Any]:
+    concept_id: str,
+    *,
+    relationships: dict[str, Any] | None = None,
+    guid: str | None = None,
+    attributes: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    now = datetime(2026, 8, 13, tzinfo=UTC)
     return {
         "concept_id": concept_id,
-        "name": concept_id.replace("#V#", ""),
+        "guid": guid or f"guid:{concept_id}",
+        "created_at": now,
+        "updated_at": now,
+        "embedding_status": "ready",
+        "attributes": attributes or {},
+        "system_tags": [],
+        "user_tags": [],
         "relationships": relationships or {},
     }
 
 
-def test_merge_concepts_simulate_reports_text_relation_migration() -> None:
+def _insert_text_relation(
+    text_relations,
+    text_values,
+    *,
+    relation_id: str,
+    subject_id: str,
+    predicate: str,
+    text_id: str,
+    text: str,
+    context: dict[str, Any] | None = None,
+) -> None:
+    text_values.update_one(
+        {"_id": text_id},
+        {"$setOnInsert": {"_id": text_id, "text": text, "lang": "en-NZ"}},
+        upsert=True,
+    )
+    text_relations.insert_one(
+        {
+            "_id": relation_id,
+            "subject_concept_id": subject_id,
+            "predicate": predicate,
+            "object_text_id": text_id,
+            "context": context or {},
+        }
+    )
+
+
+def _allowed_decision(intent: authority.OntologyMutationIntent):
+    return authority.OntologyAuthorityDecision(
+        allowed=True,
+        decision_id="decision:merge",
+        reason_code="semantic_ontology_authority_verified",
+        message="allowed",
+        actor_concept_id="#V#admin",
+        organisation_concept_id=None,
+        intent_fingerprint=intent.fingerprint,
+    )
+
+
+def test_merge_preview_reports_exact_text_actions(merge_store) -> None:
+    concepts, text_relations, text_values = merge_store
     source_id = "#V#A"
     target_id = "#V#a"
+    concepts.insert_many([_concept(source_id), _concept(target_id)])
+    _insert_text_relation(
+        text_relations,
+        text_values,
+        relation_id="r1",
+        subject_id=source_id,
+        predicate="hasNote",
+        text_id="t1",
+        text="note",
+    )
+    _insert_text_relation(
+        text_relations,
+        text_values,
+        relation_id="r2",
+        subject_id=source_id,
+        predicate="hasDescription",
+        text_id="t2",
+        text="description",
+    )
+    _insert_text_relation(
+        text_relations,
+        text_values,
+        relation_id="r3",
+        subject_id=target_id,
+        predicate="hasNote",
+        text_id="t1",
+        text="note",
+    )
 
-    def fake_get(cid: str) -> Dict[str, Any] | None:
-        if cid == source_id:
-            return _concept(source_id)
-        if cid == target_id:
-            return _concept(target_id)
-        return None
-
-    source_relations: List[Dict[str, Any]] = [
-        {
-            "_id": "r1",
-            "subject_concept_id": source_id,
-            "predicate": "hasNote",
-            "object_text_id": "t1",
-        },
-        {
-            "_id": "r2",
-            "subject_concept_id": source_id,
-            "predicate": "hasDescription",
-            "object_text_id": "t2",
-        },
-    ]
-    target_relations: List[Dict[str, Any]] = [
-        {
-            "_id": "r3",
-            "subject_concept_id": target_id,
-            "predicate": "hasNote",
-            "object_text_id": "t1",
-        },
-    ]
-
-    with (
-        patch(
-            "src.backend.services.concept_merge_service.get_concept_by_id",
-            side_effect=fake_get,
-        ),
-        patch(
-            "src.backend.services.concept_merge_service.ConceptsRepository"
-        ) as mock_concepts_repo,
-        patch(
-            "src.backend.services.concept_merge_service.TextRelationsRepository"
-        ) as mock_text_rel_repo,
-    ):
-        mock_concepts_repo.find.return_value = []
-
-        def fake_find(filter: Dict[str, Any], *args: Any, **kwargs: Any):
-            if filter == {"subject_concept_id": source_id}:
-                return list(source_relations)
-            if filter == {"subject_concept_id": target_id}:
-                return list(target_relations)
-            return []
-
-        mock_text_rel_repo.find.side_effect = fake_find
-
-        report = merge_concepts(source_id, target_id, simulate=True)
+    report = merge_service.merge_concepts(source_id, target_id, simulate=True)
 
     assert report["success"] is True
-    ops = report["operations"]
-    migrate = [op for op in ops if op.get("type") == "migrate_text_relations"]
-    assert migrate
-    assert migrate[0]["move_count"] == 1
-    assert migrate[0]["duplicate_count"] == 1
+    assert report["simulate"] is True
+    migrate = next(
+        item
+        for item in report["operations"]
+        if item["type"] == "migrate_text_relations"
+    )
+    assert migrate["move_count"] == 1
+    assert migrate["duplicate_count"] == 1
+    assert report["plan_sha256"]
 
 
-def test_merge_concepts_apply_updates_text_relations_and_deletes_source() -> None:
+def test_direct_merge_execution_fails_before_any_write(merge_store) -> None:
+    concepts, _text_relations, _text_values = merge_store
     source_id = "#V#A"
     target_id = "#V#a"
+    concepts.insert_many([_concept(source_id), _concept(target_id)])
 
-    def fake_get(cid: str) -> Dict[str, Any] | None:
-        if cid == source_id:
-            return _concept(source_id)
-        if cid == target_id:
-            return _concept(target_id)
-        return None
+    result = merge_service.merge_concepts(source_id, target_id, simulate=False)
 
-    other_doc = {
-        "concept_id": "#V#Other",
-        "relationships": {"related_to": [source_id]},
+    assert result["success"] is False
+    assert result["changed"] is False
+    assert result["error_code"] == "ontology_identity_consolidation_authority_required"
+    assert concepts.find_one({"concept_id": source_id}) is not None
+
+
+def test_exact_authorised_merge_moves_graph_and_text_and_deletes_source(
+    merge_store,
+) -> None:
+    concepts, text_relations, text_values = merge_store
+    source_id = "#V#A"
+    target_id = "#V#a"
+    source = _concept(
+        source_id,
+        relationships={
+            "related_to": ["#V#Else"],
+            "#V#specific_to_user": ["#V#admin"],
+        },
+        guid="source-guid",
+        attributes={"source_only": True},
+    )
+    target = _concept(
+        target_id,
+        relationships={"#V#specific_to_user": ["#V#admin"]},
+        guid="target-guid",
+        attributes={"target_only": True},
+    )
+    other = _concept(
+        "#V#Other",
+        relationships={"related_to": [source_id]},
+    )
+    concepts.insert_many([source, target, other, _concept("#V#Else")])
+    _insert_text_relation(
+        text_relations,
+        text_values,
+        relation_id="name-source-id",
+        subject_id=source_id,
+        predicate="hasName",
+        text_id="text-source-id",
+        text=source_id,
+        context={"name_type": "CODE"},
+    )
+    _insert_text_relation(
+        text_relations,
+        text_values,
+        relation_id="name-source-guid",
+        subject_id=source_id,
+        predicate="hasName",
+        text_id="text-source-guid",
+        text="source-guid",
+        context={"name_type": "CODE"},
+    )
+    _insert_text_relation(
+        text_relations,
+        text_values,
+        relation_id="note-source",
+        subject_id=source_id,
+        predicate="hasNote",
+        text_id="text-note",
+        text="source note",
+    )
+
+    plan = merge_service.build_concept_merge_plan(source_id, target_id)
+    intent = authority.OntologyMutationIntent(
+        operation="concept.merge",
+        publication_context=authority.PublicationContext.user("#V#admin"),
+        target_concept_ids=tuple(plan["affected_concept_ids"]),
+        tool_name="merge_concepts",
+        delta={"merge_plan_sha256": plan["plan_sha256"]},
+    )
+    with authority.bind_authorised_ontology_mutation(
+        _allowed_decision(intent),
+        intent,
+    ):
+        result = merge_service.merge_concepts(
+            source_id,
+            target_id,
+            simulate=False,
+            exact_plan=plan,
+        )
+
+    assert result["success"] is True
+    assert result["changed"] is True
+    assert concepts.find_one({"concept_id": source_id}) is None
+    merged_target = concepts.find_one({"concept_id": target_id})
+    assert merged_target["relationships"]["#V#specific_to_user"] == ["#V#admin"]
+    assert merged_target["relationships"]["related_to"] == ["#V#Else"]
+    assert merged_target["attributes"] == {
+        "source_only": True,
+        "target_only": True,
     }
+    assert concepts.find_one({"concept_id": "#V#Other"})["relationships"] == {
+        "related_to": [target_id]
+    }
+    assert text_relations.count_documents({"subject_concept_id": source_id}) == 0
+    assert text_relations.count_documents({"subject_concept_id": target_id}) == 3
+    read_back = merge_service.read_concept_merge_postcondition(plan)
+    assert read_back["matches_exact_plan"] is True
 
-    source_relations: List[Dict[str, Any]] = [
-        {
-            "_id": "r1",
-            "subject_concept_id": source_id,
-            "predicate": "hasNote",
-            "object_text_id": "t1",
-        },
-    ]
 
-    with (
-        patch(
-            "src.backend.services.concept_merge_service.get_concept_by_id",
-            side_effect=fake_get,
-        ),
-        patch(
-            "src.backend.services.concept_merge_service.delete_concept",
-            return_value=True,
-        ) as mock_delete_concept,
-        patch(
-            "src.backend.services.concept_merge_service.ConceptsRepository"
-        ) as mock_concepts_repo,
-        patch(
-            "src.backend.services.concept_merge_service.TextRelationsRepository"
-        ) as mock_text_rel_repo,
-    ):
-        mock_concepts_repo.find.return_value = [other_doc]
-        mock_concepts_repo.update_one = MagicMock()
-        mock_concepts_repo.delete_one = MagicMock()
+def test_merge_plan_rejects_authority_role_transfer(merge_store) -> None:
+    concepts, text_relations, text_values = merge_store
+    source_id = "#V#admin_duplicate"
+    target_id = "#V#admin"
+    concepts.insert_many([_concept(source_id), _concept(target_id)])
+    _insert_text_relation(
+        text_relations,
+        text_values,
+        relation_id="role",
+        subject_id=source_id,
+        predicate="#V#has_ontology_authority_role",
+        text_id="role-text",
+        text="global_ontology_administrator",
+    )
 
-        def fake_find(filter: Dict[str, Any], *args: Any, **kwargs: Any):
-            if filter == {"subject_concept_id": target_id}:
-                return []
-            if filter == {"subject_concept_id": source_id}:
-                return list(source_relations)
-            return []
+    result = merge_service.merge_concepts(source_id, target_id, simulate=True)
 
-        mock_text_rel_repo.find.side_effect = fake_find
-        mock_text_rel_repo.update_one = MagicMock()
-        mock_text_rel_repo.delete_one = MagicMock()
+    assert result["success"] is False
+    assert result["error_code"] == "identity_consolidation_authority_lifecycle_required"
 
-        report = merge_concepts(source_id, target_id, simulate=False)
 
-    assert report["success"] is True
-    mock_text_rel_repo.update_one.assert_called()
-    mock_delete_concept.assert_called_with(source_id)
+def test_merge_plan_fails_non_disclosing_when_hidden_reference_would_change(
+    merge_store,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    concepts, _text_relations, _text_values = merge_store
+    source_id = "#V#A"
+    target_id = "#V#a"
+    hidden_id = "#V#hidden"
+    concepts.insert_many(
+        [
+            _concept(source_id),
+            _concept(target_id),
+            _concept(hidden_id, relationships={"related_to": [source_id]}),
+        ]
+    )
+    monkeypatch.setattr(
+        merge_service,
+        "can_access_concept",
+        lambda concept_id: concept_id != hidden_id,
+    )
+
+    result = merge_service.merge_concepts(source_id, target_id, simulate=True)
+
+    assert result["success"] is False
+    assert result["error_code"] == "identity_consolidation_inaccessible_affected_state"
+    assert hidden_id not in str(result)
+
+
+def test_merge_plan_enumerates_every_incoming_reference_beyond_preview_limits(
+    merge_store,
+) -> None:
+    concepts, _text_relations, _text_values = merge_store
+    source_id = "#V#A"
+    target_id = "#V#a"
+    incoming_ids = [f"#V#incoming_{index:03d}" for index in range(75)]
+    concepts.insert_many(
+        [
+            _concept(source_id),
+            _concept(target_id),
+            *[
+                _concept(concept_id, relationships={"related_to": [source_id]})
+                for concept_id in incoming_ids
+            ],
+        ]
+    )
+
+    plan = merge_service.build_concept_merge_plan(source_id, target_id)
+
+    assert set(incoming_ids).issubset(plan["affected_concept_ids"])
+    assert len(plan["affected_concept_ids"]) == len(incoming_ids) + 2
+    assert len(plan["concept_steps"]) == len(incoming_ids) + 1
+
+
+def test_merge_plan_rejects_implicit_target_name_context_rewrite(merge_store) -> None:
+    concepts, text_relations, text_values = merge_store
+    source_id = "#V#A"
+    target_id = "#V#a"
+    concepts.insert_many([_concept(source_id), _concept(target_id)])
+    _insert_text_relation(
+        text_relations,
+        text_values,
+        relation_id="target-nl-alias",
+        subject_id=target_id,
+        predicate="hasName",
+        text_id="source-id-text",
+        text=source_id,
+        context={"name_type": "NL"},
+    )
+
+    result = merge_service.merge_concepts(source_id, target_id, simulate=True)
+
+    assert result["success"] is False
+    assert result["error_code"] == "identity_consolidation_alias_context_conflict"

--- a/tests/backend/test_concept_rename_routes.py
+++ b/tests/backend/test_concept_rename_routes.py
@@ -13,7 +13,7 @@ def _make_concept_app() -> Flask:
     return app
 
 
-def test_concept_rename_route_forbids_non_admin_session(monkeypatch):
+def test_concept_rename_route_returns_semantic_authority_denial(monkeypatch):
     app = _make_concept_app()
     called = {"hit": False}
 
@@ -22,14 +22,19 @@ def test_concept_rename_route_forbids_non_admin_session(monkeypatch):
         return {"success": True}
 
     monkeypatch.setattr(
-        "src.backend.services.concept_rename_service.rename_concept",
-        _fake_rename,
+        "src.backend.server.routes.concept_routes._execute_governed_http_mutation",
+        lambda **_kwargs: {
+            "success": False,
+            "error_code": "organisation_ontology_admin_authority_required",
+            "authority_decision": {"allowed": False},
+        },
     )
+    monkeypatch.setattr("src.backend.services.concept_rename_service.rename_concept", _fake_rename)
 
     with app.test_client() as client:
         with client.session_transaction() as sess:
             sess["user_concept_id"] = "#V#member"
-            sess["role_in_org"] = "member"
+            sess["role_in_org"] = "admin"  # Deliberately not semantic authority.
 
         response = client.post(
             "/api/concepts/%23V%23old_name/rename",
@@ -40,29 +45,29 @@ def test_concept_rename_route_forbids_non_admin_session(monkeypatch):
     assert called["hit"] is False
 
 
-def test_concept_rename_route_defaults_to_preview_for_admin(monkeypatch):
+def test_concept_rename_route_uses_governed_semantic_command(monkeypatch):
     app = _make_concept_app()
     captured: dict[str, object] = {}
 
-    def _fake_rename(**kwargs):
+    def _fake_governed(**kwargs):
         captured.update(kwargs)
         return {
             "success": True,
-            "simulate": kwargs["simulate"],
-            "old_id": kwargs["old_id"],
-            "new_id": "#V#new_name",
-            "operations": [{"type": "update_concept_id"}],
+            "simulate": kwargs["arguments"]["simulate"],
+            "new_id": kwargs["arguments"]["new_id"],
+            "authority_decision": {"allowed": True},
         }
 
+    # The transport route is tested against a result already authorised by the
+    # shared command service; session role labels no longer decide authority.
     monkeypatch.setattr(
-        "src.backend.services.concept_rename_service.rename_concept",
-        _fake_rename,
+        "src.backend.server.routes.concept_routes._execute_governed_http_mutation",
+        _fake_governed,
     )
 
     with app.test_client() as client:
         with client.session_transaction() as sess:
-            sess["user_concept_id"] = "#V#admin"
-            sess["role_in_org"] = "admin"
+            sess["user_concept_id"] = "#V#semantic_admin"
 
         response = client.post(
             "/api/concepts/%23V%23old_name/rename",
@@ -73,67 +78,30 @@ def test_concept_rename_route_defaults_to_preview_for_admin(monkeypatch):
     payload = response.get_json() or {}
     assert payload["success"] is True
     assert payload["simulate"] is True
-    assert captured == {
-        "old_id": "#V#old_name",
+    assert captured["arguments"] == {
+        "concept_id": "#V#old_name",
         "new_id": "#V#new_name",
         "simulate": True,
-        "preserve_alias": True,
-        "skip_inaccessible": False,
+        "request_id": None,
     }
 
 
-def test_concept_rename_route_allows_owner_execution(monkeypatch):
+def test_concept_rename_route_coerces_string_booleans_for_governed_command(monkeypatch):
     app = _make_concept_app()
     captured: dict[str, object] = {}
 
-    def _fake_rename(**kwargs):
+    def _fake_governed(**kwargs):
         captured.update(kwargs)
-        return {
-            "success": True,
-            "simulate": kwargs["simulate"],
-            "executed": not kwargs["simulate"],
-            "old_id": kwargs["old_id"],
-            "new_id": "#V#new_name",
-        }
+        return {"success": True, "simulate": kwargs["arguments"]["simulate"]}
 
     monkeypatch.setattr(
-        "src.backend.services.concept_rename_service.rename_concept",
-        _fake_rename,
+        "src.backend.server.routes.concept_routes._execute_governed_http_mutation",
+        _fake_governed,
     )
 
     with app.test_client() as client:
         with client.session_transaction() as sess:
-            sess["user_concept_id"] = "#V#owner"
-            sess["role_in_org"] = "owner"
-
-        response = client.post(
-            "/api/concepts/%23V%23old_name/rename",
-            json={"new_id": "#V#new_name", "simulate": False},
-        )
-
-    assert response.status_code == 200
-    payload = response.get_json() or {}
-    assert payload["executed"] is True
-    assert captured["simulate"] is False
-
-
-def test_concept_rename_route_coerces_string_booleans(monkeypatch):
-    app = _make_concept_app()
-    captured: dict[str, object] = {}
-
-    def _fake_rename(**kwargs):
-        captured.update(kwargs)
-        return {"success": True, "simulate": kwargs["simulate"]}
-
-    monkeypatch.setattr(
-        "src.backend.services.concept_rename_service.rename_concept",
-        _fake_rename,
-    )
-
-    with app.test_client() as client:
-        with client.session_transaction() as sess:
-            sess["user_concept_id"] = "#V#admin"
-            sess["role_in_org"] = "admin"
+            sess["user_concept_id"] = "#V#semantic_admin"
 
         response = client.post(
             "/api/concepts/%23V%23old_name/rename",
@@ -146,6 +114,50 @@ def test_concept_rename_route_coerces_string_booleans(monkeypatch):
         )
 
     assert response.status_code == 200
-    assert captured["simulate"] is False
-    assert captured["preserve_alias"] is False
-    assert captured["skip_inaccessible"] is True
+    assert captured["arguments"] == {
+        "concept_id": "#V#old_name",
+        "new_id": "#V#new_name",
+        "simulate": False,
+        "request_id": None,
+    }
+    assert captured["preview"] is False
+
+
+def test_concept_rename_route_maps_canonical_lookup_failure_to_typed_not_found(monkeypatch):
+    app = _make_concept_app()
+
+    def _raise_lookup_error(**_kwargs):
+        raise LookupError("concept store unavailable")
+
+    monkeypatch.setattr(
+        "src.backend.services.ontology_mutation_command_service.execute_governed_ontology_method",
+        _raise_lookup_error,
+    )
+
+    response = app.test_client().post(
+        "/api/concepts/%23V%23old_name/rename",
+        json={"new_id": "#V#new_name"},
+    )
+
+    assert response.status_code == 404
+    assert response.get_json()["error_code"] == "ontology_mutation_target_not_found"
+
+
+def test_concept_rename_route_maps_store_failure_to_typed_unavailable(monkeypatch):
+    app = _make_concept_app()
+
+    def _raise_store_error(**_kwargs):
+        raise ConnectionError("ontology store unavailable")
+
+    monkeypatch.setattr(
+        "src.backend.services.ontology_mutation_command_service.execute_governed_ontology_method",
+        _raise_store_error,
+    )
+
+    response = app.test_client().post(
+        "/api/concepts/%23V%23old_name/rename",
+        json={"new_id": "#V#new_name"},
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error_code"] == "ontology_mutation_store_unavailable"

--- a/tests/backend/test_entity_identity_resolution_workflow.py
+++ b/tests/backend/test_entity_identity_resolution_workflow.py
@@ -51,14 +51,10 @@ def test_workflow_definition_structure() -> None:
     action = reason_state.actions[0]
     assert action.action_id == "llm.action"
     assert action.execution_mode == "llm"
-    prompt_ids = (action.prompt_contract or {}).get(
-        "requested_prompt_concept_ids", []
-    )
+    prompt_ids = (action.prompt_contract or {}).get("requested_prompt_concept_ids", [])
     assert ENTITY_DUPLICATE_REASONING_PROMPT_CONCEPT_ID in prompt_ids
     assert (action.validation_policy or {}).get("output_format") == "json_value"
-    mappings = (reason_state.metadata or {}).get(
-        "tool_output_context_mappings", []
-    )
+    mappings = (reason_state.metadata or {}).get("tool_output_context_mappings", [])
     assert any(
         m.get("context_key") == "identity_reasoning_payload"
         and m.get("tool_output_field") == "validated_json"
@@ -452,10 +448,64 @@ def test_apply_handler_consumes_llm_recommendations_and_dispatches() -> None:
     assert summary["skipped_count"] == 1  # leave_distinct
     assert summary["recommendation_count"] == 3
     assert "v2_llm_rumination" in summary["policy_version"]
-    merge_mock.assert_called_once_with(
-        "#V#person_alice_dup", "#V#person_alice", simulate=False
+    merge_mock.assert_called_once()
+    merge_call = merge_mock.call_args
+    assert merge_call.args == ("#V#person_alice_dup", "#V#person_alice")
+    assert merge_call.kwargs["simulate"] is False
+    assert merge_call.kwargs["request"].action_id == (
+        "identity_resolution.apply_resolutions"
     )
     queue_mock.assert_called_once()
+
+
+def test_durable_merge_binds_workflow_agent_and_exact_delegation(monkeypatch) -> None:
+    from src.backend.services import ontology_publication_authority_service as authority
+    from src.backend.workflows.action_registry import WorkflowEnvironment
+    from src.backend.workflows.durable import entity_identity_resolution_workflow as mod
+
+    captured = {}
+
+    def governed_merge(**kwargs):
+        captured["kwargs"] = kwargs
+        captured["invocation"] = authority.current_ontology_invocation()
+        return {"success": False, "error_code": "test_stop"}
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.catalogue._merge_concepts",
+        governed_merge,
+    )
+    request = _request("identity_resolution.apply_resolutions", {})
+    request = type(request)(
+        **{
+            **request.__dict__,
+            "environment": WorkflowEnvironment(
+                llm_client=None,
+                ontology_delegation_id="delegation:exact",
+            ),
+            "workflow_id": mod.ENTITY_IDENTITY_RESOLUTION_WORKFLOW_ID,
+            "workflow_state_id": "apply",
+        }
+    )
+
+    result = mod.merge_concepts(
+        "#V#duplicate",
+        "#V#canonical",
+        simulate=False,
+        request=request,
+    )
+
+    assert result["error_code"] == "test_stop"
+    assert captured["kwargs"] == {
+        "source_id": "#V#duplicate",
+        "target_id": "#V#canonical",
+        "simulate": False,
+    }
+    invocation = captured["invocation"]
+    assert invocation.surface == "workflow"
+    assert invocation.executing_agent_concept_id == "#V#von_system"
+    assert invocation.audience == "workflow"
+    assert invocation.delegation_id == "delegation:exact"
+    assert invocation.effect_id.endswith(":apply:merge_concepts")
 
 
 def test_apply_handler_dry_run_does_not_write() -> None:

--- a/tests/backend/test_internal_mcp_add_relationship_inverse.py
+++ b/tests/backend/test_internal_mcp_add_relationship_inverse.py
@@ -44,7 +44,9 @@ def test_add_relationship_adds_inverse_for_structural_predicates(monkeypatch):
         _fake_update_one,
     )
 
-    result = catalogue._add_relationship(
+    # Exercise the relationship handler itself; governed entrypoint authority
+    # is covered by the ontology-authority gateway tests.
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source", predicate="typeOf", target="#V#target"
     )
 
@@ -107,7 +109,7 @@ def test_add_relationship_when_forward_exists_still_ensures_inverse(monkeypatch)
         _fake_update_one,
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source", predicate="typeOf", target="#V#target"
     )
 
@@ -135,7 +137,7 @@ def test_add_relationship_surfaces_inverse_failure_as_partial(monkeypatch):
         },
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source",
         predicate="typeOf",
         target="#V#target",

--- a/tests/backend/test_internal_mcp_add_relationship_predicate_validation.py
+++ b/tests/backend/test_internal_mcp_add_relationship_predicate_validation.py
@@ -32,7 +32,8 @@ def test_add_relationship_returns_typed_recovery_for_unknown_predicate_name(
         _fake_update_one,
     )
 
-    result = catalogue._add_relationship(
+    # Exercise handler resolution below the separately tested authority wrapper.
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source", predicate="has_item", target="#V#target"
     )
 
@@ -91,7 +92,7 @@ def test_add_relationship_resolves_accessible_predicate_name_before_write(
         _add_edge,
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source",
         predicate="Depends on",
         target="#V#target",
@@ -138,7 +139,7 @@ def test_add_relationship_returns_candidates_for_ambiguous_predicate_name(
         ),
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source",
         predicate="about",
         target="#V#target",
@@ -231,7 +232,7 @@ def test_add_relationship_typed_reference_can_create_text_predicate(
         _upsert_text,
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source",
         target="A concise summary",
         predicate_ref={
@@ -266,7 +267,7 @@ def test_add_relationship_rejects_missing_dynamic_predicate_concepts(monkeypatch
         _fake_find_one,
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source", predicate="#V#has_item", target="#V#target"
     )
 
@@ -296,7 +297,7 @@ def test_add_relationship_rejects_dynamic_concepts_that_are_not_predicates(monke
         _fake_find_one,
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source", predicate="#V#has_todo_item", target="#V#target"
     )
 
@@ -337,7 +338,7 @@ def test_add_relationship_returns_structured_error_for_missing_source(monkeypatc
         _fake_find_one,
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source", predicate="typeOf", target="#V#target"
     )
 
@@ -361,7 +362,7 @@ def test_add_relationship_returns_structured_error_for_missing_target(monkeypatc
         _fake_find_one,
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source", predicate="typeOf", target="#V#target"
     )
 
@@ -391,7 +392,7 @@ def test_add_relationship_commit_then_raise_is_indeterminate(monkeypatch):
         _commit_then_raise,
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source",
         predicate="typeOf",
         target="#V#target",
@@ -421,7 +422,7 @@ def test_add_relationship_unexpected_pre_dispatch_failure_remains_definite(
         ),
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source",
         predicate="typeOf",
         target="#V#target",
@@ -521,7 +522,7 @@ def test_add_relationship_creates_and_verifies_exact_missing_predicate_before_ed
     )
 
     with override_current_actor("#V#user", "#V#org"):
-        result = catalogue._add_relationship(
+        result = catalogue._add_relationship.__wrapped__(
             source_id="#V#source",
             predicate="#V#depends_on",
             target="#V#target",
@@ -572,7 +573,7 @@ def test_add_relationship_reuses_verified_predicate_without_creation(monkeypatch
         },
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source",
         predicate="#V#depends_on",
         target="#V#target",
@@ -630,7 +631,7 @@ def test_add_relationship_fails_closed_when_predicate_creation_is_indeterminate(
         ),
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source",
         predicate="#V#depends_on",
         target="#V#target",
@@ -708,7 +709,7 @@ def test_add_relationship_stops_after_persisted_predicate_when_cancelled(
         ),
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source",
         predicate="#V#depends_on",
         target="#V#target",
@@ -778,7 +779,7 @@ def test_add_relationship_reports_partial_when_predicate_persists_but_edge_fails
         },
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source",
         predicate="#V#depends_on",
         target="#V#target",
@@ -859,7 +860,7 @@ def test_add_relationship_cancellation_preserves_unchanged_dependency_failure(
         ),
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source",
         predicate="#V#depends_on",
         target="#V#target",
@@ -926,7 +927,7 @@ def test_add_relationship_edge_failure_preserves_unchanged_dependency_failure(
         },
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source",
         predicate="#V#depends_on",
         target="#V#target",
@@ -995,7 +996,7 @@ def test_add_relationship_preserves_created_dependency_when_validation_raises(
         ),
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source",
         predicate="#V#depends_on",
         target="#V#target",
@@ -1046,7 +1047,7 @@ def test_add_relationship_does_not_create_predicate_when_target_is_missing(
         ),
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source",
         predicate="#V#depends_on",
         target="#V#missing_target",
@@ -1089,7 +1090,7 @@ def test_add_relationship_propagates_cancellation_without_dependency(
     )
 
     with pytest.raises(InternalMCPHandlerCancelled, match="deadline elapsed"):
-        catalogue._add_relationship(
+        catalogue._add_relationship.__wrapped__(
             source_id="#V#source",
             predicate="typeOf",
             target="#V#target",
@@ -1132,7 +1133,7 @@ def test_add_relationship_propagates_cancellation_from_predicate_create(
     )
 
     with pytest.raises(InternalMCPHandlerCancelled, match="nested create cancelled"):
-        catalogue._add_relationship(
+        catalogue._add_relationship.__wrapped__(
             source_id="#V#source",
             predicate="#V#depends_on",
             target="#V#target",
@@ -1187,7 +1188,7 @@ def test_add_relationship_preserves_known_dependency_when_edge_is_indeterminate(
         ),
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source",
         predicate="#V#depends_on",
         target="#V#target",
@@ -1227,7 +1228,7 @@ def test_add_relationship_rejects_predicate_dependency_name_mismatch(monkeypatch
         ),
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source",
         predicate="#V#depends_on",
         target="#V#target",

--- a/tests/backend/test_internal_mcp_add_relationship_text_predicates.py
+++ b/tests/backend/test_internal_mcp_add_relationship_text_predicates.py
@@ -34,7 +34,8 @@ def test_add_relationship_treats_prefixed_hascontent_as_text_relation(monkeypatc
         _fake_upsert_text_for_concept,
     )
 
-    result = catalogue._add_relationship(
+    # Exercise handler semantics below the separately tested authority wrapper.
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source", predicate="#V#hasContent", target="Hello"
     )
 
@@ -70,7 +71,7 @@ def test_add_relationship_treats_plain_hasdescription_as_text_relation(monkeypat
         _fake_upsert_text_for_concept,
     )
 
-    result = catalogue._add_relationship(
+    result = catalogue._add_relationship.__wrapped__(
         source_id="#V#source", predicate="hasDescription", target="Desc"
     )
 

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -341,7 +341,9 @@ def test_ordinary_turn_read_projection_follows_capability_authority_metadata():
     }.isdisjoint(actor_mail_reads)
     assert delegated_effects == {
         "create_concepts",
+        "change_concept_publication_scope",
         "record_source_processing_marker",
+        "preview_concept_publication_scope_change",
         "retract_scoped_assertion",
         "upsert_scoped_assertion",
         "upsert_text_relation",
@@ -413,7 +415,7 @@ def test_ordinary_turn_read_projection_follows_capability_authority_metadata():
     assert create_definition.ordinary_turn_fixed_arguments == {
         "organisation_concept_id": None,
         "org_id": None,
-        "scope_mode": "user_org_default",
+        "scope_mode": "user_only_default",
         "visibility_scope_mode": None,
     }
     marker_definition = catalogue.get("record_source_processing_marker")

--- a/tests/backend/test_internal_mcp_error_responses.py
+++ b/tests/backend/test_internal_mcp_error_responses.py
@@ -117,7 +117,9 @@ class TestHandlerErrorStructure:
         assert method_def is not None
 
         # Missing source_concept_id - access handler via method_def.handler
-        result = method_def.handler(
+        # Exercise handler validation below the separately tested governed
+        # authority wrapper.
+        result = method_def.handler.__wrapped__(
             target_concept_id="#V#target", predicate_id="#V#pred"
         )
 
@@ -137,7 +139,7 @@ class TestHandlerErrorStructure:
         assert method_def is not None
 
         # Missing all required params
-        result = method_def.handler()
+        result = method_def.handler.__wrapped__()
 
         assert result["success"] is False
         assert "error_code" in result

--- a/tests/backend/test_internal_mcp_ontology_gateway_provenance.py
+++ b/tests/backend/test_internal_mcp_ontology_gateway_provenance.py
@@ -1,0 +1,173 @@
+"""Gateway-level provenance for canonical ontology mutations."""
+
+from __future__ import annotations
+
+from src.backend.integrations.internal_mcp.gateway import (
+    InternalMCPGateway,
+    MethodCatalogue,
+    MethodDefinition,
+)
+from src.backend.integrations.internal_mcp.schemas import Schema
+from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+
+
+def _gateway(handler) -> InternalMCPGateway:
+    catalogue = MethodCatalogue()
+    catalogue.register(
+        MethodDefinition(
+            # This exact canonical mutation name is deliberately used so the
+            # gateway takes the production governed-write path.
+            name="add_relationship",
+            handler=handler,
+            input_schema=Schema(
+                required={},
+                optional={
+                    "ontology_delegation_id": str,
+                    "ontology_effect_id": str,
+                    "executing_agent_concept_id": str,
+                    "audience": str,
+                    "user_concept_id": str,
+                },
+                allow_unknown=False,
+            ),
+            category="write",
+        )
+    )
+    return InternalMCPGateway(
+        catalogue=catalogue,
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+
+
+def test_sessionless_internal_mcp_delegation_fails_before_handler_dispatch() -> None:
+    captured = {}
+
+    def handler(**kwargs):
+        captured["arguments"] = kwargs
+        return {"success": True}
+
+    result = (
+        _gateway(handler)
+        .invoke(
+            "add_relationship",
+            {
+                "ontology_delegation_id": "oag_server_issued",
+                "ontology_effect_id": "effect-123",
+                # These are a model/client forgery attempt.  They remain ordinary
+                # handler data and cannot set execution provenance.
+                "executing_agent_concept_id": "#V#forged_administrator_agent",
+                "audience": "forged_audience",
+                "user_concept_id": "#V#forged_user",
+            },
+        )
+        .payload
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "ontology_sessionless_delegation_not_supported"
+    assert captured == {}
+
+
+def test_unlabelled_internal_mcp_ontology_write_without_delegation_is_denied() -> None:
+    from src.backend.services.ontology_publication_authority_service import (
+        OntologyMutationIntent,
+        PublicationContext,
+        authorise_ontology_mutation,
+    )
+
+    def handler(**_kwargs):
+        decision = authorise_ontology_mutation(
+            OntologyMutationIntent(
+                operation="relationship.add",
+                publication_context=PublicationContext.global_context(),
+                target_concept_ids=("#V#source", "#V#target"),
+                tool_name="add_relationship",
+                predicate="#V#is_a",
+                delta={"target_concept_id": "#V#target"},
+            )
+        )
+        return {"success": False, "error_code": decision.reason_code}
+
+    result = _gateway(handler).invoke("add_relationship", {}).payload
+
+    assert result["error_code"] == "ontology_agent_delegation_required"
+
+
+def test_prebound_trusted_invocation_cannot_be_overridden_by_gateway_payload() -> None:
+    from src.backend.services.ontology_publication_authority_service import (
+        bind_ontology_invocation,
+        current_ontology_invocation,
+        override_current_actor,
+    )
+
+    def handler(**_kwargs):
+        invocation = current_ontology_invocation()
+        assert invocation is not None
+        return {
+            "success": True,
+            "surface": invocation.surface,
+            "agent": invocation.executing_agent_concept_id,
+            "audience": invocation.audience,
+            "delegation_id": invocation.delegation_id,
+            "effect_id": invocation.effect_id,
+        }
+
+    with (
+        override_current_actor("#V#trusted_actor", "#V#trusted_org"),
+        bind_ontology_invocation(
+            surface="ordinary_turn",
+            executing_agent_concept_id="#V#von_system",
+            audience="adaptive_turn",
+            delegation_id="oag_adaptive",
+            effect_id="adaptive-effect",
+            turn_id="turn-1",
+        ),
+    ):
+        result = (
+            _gateway(handler)
+            .invoke(
+                "add_relationship",
+                {
+                    "ontology_delegation_id": "oag_forged",
+                    "ontology_effect_id": "forged-effect",
+                },
+            )
+            .payload
+        )
+
+    assert result == {
+        "success": True,
+        "surface": "ordinary_turn",
+        "agent": "#V#von_system",
+        "audience": "adaptive_turn",
+        "delegation_id": "oag_adaptive",
+        "effect_id": "adaptive-effect",
+    }
+
+
+def test_prebound_direct_human_invocation_is_preserved() -> None:
+    from src.backend.services.ontology_publication_authority_service import (
+        bind_ontology_invocation,
+        current_ontology_invocation,
+    )
+
+    def handler(**_kwargs):
+        invocation = current_ontology_invocation()
+        assert invocation is not None
+        return {
+            "success": True,
+            "surface": invocation.surface,
+            "agent": invocation.executing_agent_concept_id,
+            "delegation_id": invocation.delegation_id,
+        }
+
+    with bind_ontology_invocation(surface="trusted_http_handoff"):
+        result = _gateway(handler).invoke("add_relationship", {}).payload
+
+    assert result == {
+        "success": True,
+        "surface": "trusted_http_handoff",
+        "agent": None,
+        "delegation_id": None,
+    }

--- a/tests/backend/test_internal_mcp_ontology_scope_change.py
+++ b/tests/backend/test_internal_mcp_ontology_scope_change.py
@@ -1,0 +1,418 @@
+"""Exact Internal-MCP delegation for ontology publication-scope changes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mongomock
+import pytest
+
+from src.backend.integrations.internal_mcp.gateway import (
+    InternalMCPGateway,
+    MethodCatalogue,
+)
+from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+
+
+@pytest.fixture(scope="module")
+def scope_method_definitions():
+    from src.backend.integrations.internal_mcp.catalogue import (
+        build_default_catalogue,
+    )
+
+    catalogue = build_default_catalogue()
+    names = (
+        "get_concept_publication_scope",
+        "preview_concept_publication_scope_change",
+        "change_concept_publication_scope",
+    )
+    return {name: catalogue.get(name) for name in names}
+
+
+@pytest.fixture
+def gateway(scope_method_definitions) -> InternalMCPGateway:
+    catalogue = MethodCatalogue()
+    for definition in scope_method_definitions.values():
+        catalogue.register(definition)
+    return InternalMCPGateway(
+        catalogue=catalogue,
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+
+
+@pytest.fixture
+def authority_stores(monkeypatch):
+    from src.backend.services import ontology_publication_authority_service as service
+
+    database = mongomock.MongoClient()["internal_mcp_scope_authority"]
+    delegations = database["delegations"]
+    receipts = database["receipts"]
+    delegations.create_index("delegation_id", unique=True)
+    receipts.create_index("receipt_id", unique=True)
+    receipts.create_index(
+        [("actor_concept_id", 1), ("idempotency_key", 1)],
+        unique=True,
+        partialFilterExpression={"idempotency_key": {"$exists": True}},
+    )
+    monkeypatch.setattr(
+        service,
+        "get_ontology_authority_delegations_collection",
+        lambda: delegations,
+    )
+    monkeypatch.setattr(
+        service,
+        "get_ontology_mutation_receipts_collection",
+        lambda: receipts,
+    )
+    monkeypatch.setattr(service, "_gateway_actor_trust_source", lambda: None)
+    monkeypatch.setattr(service, "can_access_concept", lambda _concept_id: True)
+
+    global_role = service.AuthorityRoleEvidence(
+        role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+        actor_concept_id="#V#semantic_admin",
+        organisation_concept_id=None,
+        relation_id="role:global",
+        revision="global-revision",
+    )
+    organisation_role = service.AuthorityRoleEvidence(
+        role=service.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+        actor_concept_id="#V#semantic_admin",
+        organisation_concept_id="#V#organisation_a",
+        relation_id="role:organisation-a",
+        revision="organisation-revision",
+    )
+    monkeypatch.setattr(
+        service,
+        "resolve_live_semantic_roles",
+        lambda actor: (
+            (global_role, organisation_role) if actor == "#V#semantic_admin" else ()
+        ),
+    )
+    return service, delegations, receipts
+
+
+@pytest.fixture
+def scope_state(monkeypatch):
+    from src.backend.services import ontology_scope_change_service as scope
+
+    state: dict[str, Any] = {
+        "concept_id": "#V#research_concept",
+        "publication_context": {
+            "kind": "global",
+            "concept_id": None,
+            "source": "concept_visibility",
+            "historical_predicates": [],
+        },
+        "scope_edges": {},
+        "scope_fingerprint": "scope-before",
+    }
+    mutations: list[tuple[Any, ...]] = []
+
+    def read_back(_concept_id: str) -> dict[str, Any]:
+        return {
+            **state,
+            "publication_context": dict(state["publication_context"]),
+            "scope_edges": {
+                key: list(values) for key, values in state["scope_edges"].items()
+            },
+        }
+
+    def add_relationship(source_id: str, predicate: str, target: str):
+        mutations.append((source_id, predicate, target))
+        state.update(
+            {
+                "publication_context": {
+                    "kind": "organisation",
+                    "concept_id": "#V#organisation_a",
+                    "source": "concept_visibility",
+                    "historical_predicates": [],
+                },
+                "scope_edges": {predicate: [target]},
+                "scope_fingerprint": "scope-after",
+            }
+        )
+        return {"success": True, "forward_modified": True}
+
+    monkeypatch.setattr(scope, "can_access_concept", lambda _concept_id: True)
+    monkeypatch.setattr(scope, "scope_read_back", read_back)
+    monkeypatch.setattr(scope, "add_relationship", add_relationship)
+    monkeypatch.setattr(
+        scope,
+        "remove_relationship",
+        lambda **_kwargs: pytest.fail("global source has no scope edge to remove"),
+    )
+    return scope, state, mutations
+
+
+def _arguments() -> dict[str, Any]:
+    return {
+        "concept_id": "#V#research_concept",
+        "destination_kind": "organisation",
+        "destination_concept_id": "#V#organisation_a",
+        "expected_scope_fingerprint": "scope-before",
+        "reason": "publish for the research organisation",
+    }
+
+
+def _issue(
+    *,
+    service,
+    method_name: str,
+    arguments: dict[str, Any],
+    effect_id: str,
+) -> dict[str, Any]:
+    from src.backend.services.ontology_mutation_command_service import (
+        issue_same_turn_method_delegation,
+    )
+
+    with service.override_current_actor(
+        "#V#semantic_admin",
+        "#V#organisation_a",
+    ):
+        return issue_same_turn_method_delegation(
+            method_name=method_name,
+            arguments=arguments,
+            actor_concept_id="#V#semantic_admin",
+            organisation_concept_id="#V#organisation_a",
+            delegate_concept_id="#V#von_system",
+            audience="adaptive_turn",
+            effect_id=effect_id,
+            turn_id="turn-scope-change",
+        )
+
+
+def _invoke_delegated(
+    *,
+    gateway: InternalMCPGateway,
+    service,
+    method_name: str,
+    arguments: dict[str, Any],
+    delegation_id: str,
+    effect_id: str,
+) -> dict[str, Any]:
+    with (
+        service.override_current_actor(
+            "#V#semantic_admin",
+            "#V#organisation_a",
+        ),
+        service.bind_ontology_invocation(
+            surface="ordinary_turn",
+            executing_agent_concept_id="#V#von_system",
+            audience="adaptive_turn",
+            delegation_id=delegation_id,
+            effect_id=effect_id,
+            turn_id="turn-scope-change",
+        ),
+    ):
+        return gateway.invoke(method_name, arguments).payload
+
+
+def test_scope_methods_are_bounded_ordinary_turn_contracts(
+    scope_method_definitions,
+) -> None:
+    read = scope_method_definitions["get_concept_publication_scope"]
+    preview = scope_method_definitions["preview_concept_publication_scope_change"]
+    execute = scope_method_definitions["change_concept_publication_scope"]
+
+    assert read.category == "read"
+    assert read.ordinary_turn_effect is False
+    assert preview.category == "write"
+    assert preview.ordinary_turn_effect is True
+    assert execute.category == "write"
+    assert execute.ordinary_turn_effect is True
+    assert execute.write_guardrail == {"ordinary_turn_explicit_request": True}
+    for definition in (preview, execute):
+        assert "actor_concept_id" not in definition.input_schema.required
+        assert "actor_concept_id" not in definition.input_schema.optional
+        assert "organisation_concept_id" not in definition.input_schema.required
+        assert "organisation_concept_id" not in definition.input_schema.optional
+
+
+def test_preview_then_execute_uses_exact_same_turn_delegations_and_read_back(
+    authority_stores,
+    gateway,
+    scope_state,
+) -> None:
+    service, _delegations, _receipts = authority_stores
+    _scope, state, mutations = scope_state
+    arguments = _arguments()
+
+    preview_effect = "effect-scope-preview"
+    preview_grant = _issue(
+        service=service,
+        method_name="preview_concept_publication_scope_change",
+        arguments=arguments,
+        effect_id=preview_effect,
+    )
+    preview = _invoke_delegated(
+        gateway=gateway,
+        service=service,
+        method_name="preview_concept_publication_scope_change",
+        arguments={
+            **arguments,
+            "actor_concept_id": "#V#forged_actor",
+            "organisation_concept_id": "#V#forged_organisation",
+            "global_admin": True,
+        },
+        delegation_id=preview_grant["delegation_id"],
+        effect_id=preview_effect,
+    )
+    assert preview["success"] is True
+    assert preview["preview"] is True
+    assert preview["changed"] is False
+    assert preview["canonical_read_back"]["scope_fingerprint"] == "scope-before"
+    assert mutations == []
+
+    execute_effect = "effect-scope-execute"
+    execute_grant = _issue(
+        service=service,
+        method_name="change_concept_publication_scope",
+        arguments=arguments,
+        effect_id=execute_effect,
+    )
+    result = _invoke_delegated(
+        gateway=gateway,
+        service=service,
+        method_name="change_concept_publication_scope",
+        arguments={
+            **arguments,
+            "actor_concept_id": "#V#forged_actor",
+            "organisation_concept_id": "#V#forged_organisation",
+            "is_operator": True,
+        },
+        delegation_id=execute_grant["delegation_id"],
+        effect_id=execute_effect,
+    )
+
+    assert result["success"] is True
+    assert result["effect_status"] == "succeeded"
+    assert result["authority_decision"]["actor_concept_id"] == "#V#semantic_admin"
+    assert (
+        result["authority_decision"]["delegation_id"] == execute_grant["delegation_id"]
+    )
+    assert result["canonical_read_back"]["scope_fingerprint"] == "scope-after"
+    assert result["canonical_read_back"]["publication_context"] == {
+        "kind": "organisation",
+        "concept_id": "#V#organisation_a",
+        "source": "concept_visibility",
+        "historical_predicates": [],
+    }
+    assert state["scope_fingerprint"] == "scope-after"
+    assert len(mutations) == 1
+
+
+@pytest.mark.parametrize("mode", ("missing", "wrong_effect"))
+def test_scope_execute_without_the_exact_delegation_cannot_mutate(
+    authority_stores,
+    gateway,
+    scope_state,
+    mode: str,
+) -> None:
+    service, _delegations, _receipts = authority_stores
+    _scope, _state, mutations = scope_state
+    arguments = _arguments()
+
+    if mode == "missing":
+        with service.override_current_actor(
+            "#V#semantic_admin",
+            "#V#organisation_a",
+        ):
+            result = gateway.invoke(
+                "change_concept_publication_scope",
+                arguments,
+            ).payload
+        expected_code = "ontology_agent_delegation_required"
+    else:
+        grant = _issue(
+            service=service,
+            method_name="change_concept_publication_scope",
+            arguments=arguments,
+            effect_id="effect-correct",
+        )
+        result = _invoke_delegated(
+            gateway=gateway,
+            service=service,
+            method_name="change_concept_publication_scope",
+            arguments=arguments,
+            delegation_id=grant["delegation_id"],
+            effect_id="effect-wrong",
+        )
+        expected_code = "ontology_delegation_effect_id_mismatch"
+
+    assert result["success"] is False
+    assert result["effect_status"] == "not_started"
+    assert result["error_code"] == expected_code
+    assert mutations == []
+
+
+def test_scope_execute_rejects_a_stale_fingerprint_before_mutation(
+    authority_stores,
+    gateway,
+    scope_state,
+) -> None:
+    service, _delegations, _receipts = authority_stores
+    _scope, state, mutations = scope_state
+    arguments = _arguments()
+    grant = _issue(
+        service=service,
+        method_name="change_concept_publication_scope",
+        arguments=arguments,
+        effect_id="effect-stale",
+    )
+    state["scope_fingerprint"] = "scope-concurrently-changed"
+
+    result = _invoke_delegated(
+        gateway=gateway,
+        service=service,
+        method_name="change_concept_publication_scope",
+        arguments=arguments,
+        delegation_id=grant["delegation_id"],
+        effect_id="effect-stale",
+    )
+
+    assert result["success"] is False
+    assert result["effect_status"] == "not_started"
+    assert result["error_code"] == "scope_precondition_failed"
+    assert result["canonical_read_back"]["scope_fingerprint"] == (
+        "scope-concurrently-changed"
+    )
+    assert mutations == []
+
+
+def test_scope_read_ignores_payload_actor_and_organisation(
+    gateway,
+    monkeypatch,
+) -> None:
+    from src.backend.security.access_control import get_effective_user_concept_id
+    from src.backend.services import ontology_scope_change_service as scope
+
+    observed_actors: list[str | None] = []
+
+    def accessible(_concept_id: str) -> bool:
+        observed_actors.append(get_effective_user_concept_id())
+        return True
+
+    monkeypatch.setattr(scope, "can_access_concept", accessible)
+    monkeypatch.setattr(
+        scope,
+        "scope_read_back",
+        lambda concept_id: {
+            "concept_id": concept_id,
+            "publication_context": {"kind": "global", "concept_id": None},
+            "scope_edges": {},
+            "scope_fingerprint": "scope-public",
+        },
+    )
+
+    result = gateway.invoke(
+        "get_concept_publication_scope",
+        {
+            "concept_id": "#V#public_concept",
+            "actor_concept_id": "#V#forged_actor",
+            "organisation_concept_id": "#V#forged_organisation",
+        },
+    ).payload
+
+    assert result["success"] is True
+    assert observed_actors == [None]

--- a/tests/backend/test_internal_mcp_relationship_removal_tools.py
+++ b/tests/backend/test_internal_mcp_relationship_removal_tools.py
@@ -43,7 +43,9 @@ class _FakeCollection:
         self.rows.append(dict(payload))
         return {"inserted_id": len(self.rows)}
 
-    def find(self, filter_doc: dict[str, Any], projection: dict[str, Any] | None = None):
+    def find(
+        self, filter_doc: dict[str, Any], projection: dict[str, Any] | None = None
+    ):
         undo_token = filter_doc.get("undo_token")
         matches = []
         for row in self.rows:
@@ -178,35 +180,9 @@ def test_relationship_removal_methods_registered() -> None:
     assert "undo_relationship_removal" in methods
 
 
-def test_remove_relationship_gateway_creates_audit_records(monkeypatch):
-    from src.backend.services.relationship_removal_service import (
-        build_relationship_relation_id,
-    )
-
+def test_sessionless_remove_relationship_gateway_fails_before_audit(monkeypatch):
     gateway = _build_gateway()
     fake_db = _install_fake_db(monkeypatch)
-    _state, _mutate_calls = _install_relationship_state(monkeypatch)
-
-    payload = gateway.invoke(
-        "remove_relationship",
-        {"source_id": "#V#source", "predicate": "typeOf", "target": "#V#target"},
-    ).payload
-
-    assert payload.get("success") is True
-    assert payload.get("removed") is True
-    assert payload.get("relation_id") == build_relationship_relation_id(
-        "#V#source", "is_a_type_of", "#V#target"
-    )
-    assert isinstance(payload.get("audit_record_id"), str)
-    phases = [row.get("phase") for row in fake_db.audit.rows]
-    assert "attempt" in phases
-    assert "result" in phases
-    _assert_schema_conformance(gateway, "remove_relationship", payload)
-
-
-def test_remove_relationship_gateway_fails_closed_when_audit_insert_fails(monkeypatch):
-    gateway = _build_gateway()
-    _fake_db = _install_fake_db(monkeypatch, fail_audit_insert=True)
     _state, mutate_calls = _install_relationship_state(monkeypatch)
 
     payload = gateway.invoke(
@@ -215,7 +191,31 @@ def test_remove_relationship_gateway_fails_closed_when_audit_insert_fails(monkey
     ).payload
 
     assert payload.get("success") is False
-    assert payload.get("error_code") == "audit_persistence_failed"
+    assert payload.get("error_code") == "ontology_agent_delegation_required"
+    assert payload.get("effect_status") == "not_started"
+    assert payload.get("mutation_outcome") == "not_started"
+    assert payload.get("changed") is False
+    assert fake_db.audit.rows == []
+    assert mutate_calls == []
+    _assert_schema_conformance(gateway, "remove_relationship", payload)
+
+
+def test_sessionless_remove_relationship_does_not_reach_audit_failure(monkeypatch):
+    gateway = _build_gateway()
+    fake_db = _install_fake_db(monkeypatch, fail_audit_insert=True)
+    _state, mutate_calls = _install_relationship_state(monkeypatch)
+
+    payload = gateway.invoke(
+        "remove_relationship",
+        {"source_id": "#V#source", "predicate": "typeOf", "target": "#V#target"},
+    ).payload
+
+    assert payload.get("success") is False
+    assert payload.get("error_code") == "ontology_agent_delegation_required"
+    assert payload.get("effect_status") == "not_started"
+    assert payload.get("mutation_outcome") == "not_started"
+    assert payload.get("changed") is False
+    assert fake_db.audit.rows == []
     assert mutate_calls == []
     _assert_schema_conformance(gateway, "remove_relationship", payload)
 
@@ -237,14 +237,14 @@ def test_preview_remove_relationship_gateway_has_no_mutation_side_effects(monkey
     _assert_schema_conformance(gateway, "preview_remove_relationship", payload)
 
 
-def test_bulk_remove_gateway_reports_partial_failures(monkeypatch):
+def test_bulk_remove_gateway_rejects_invalid_batch_before_any_effect(monkeypatch):
     from src.backend.services.relationship_removal_service import (
         build_relationship_relation_id,
     )
 
     gateway = _build_gateway()
-    _install_fake_db(monkeypatch)
-    _state, _mutate_calls = _install_relationship_state(monkeypatch)
+    fake_db = _install_fake_db(monkeypatch)
+    _state, mutate_calls = _install_relationship_state(monkeypatch)
 
     valid_relation_id = build_relationship_relation_id(
         "#V#source", "is_a_type_of", "#V#target"
@@ -257,32 +257,32 @@ def test_bulk_remove_gateway_reports_partial_failures(monkeypatch):
         },
     ).payload
 
-    assert payload.get("success") is True
-    assert payload.get("status") == "partial"
-    summary = payload.get("summary", {})
-    assert summary.get("removed_count") == 1
-    assert summary.get("error_count") >= 1
-    assert isinstance(payload.get("undo_token"), str)
+    assert payload.get("success") is False
+    assert payload.get("error_code") == "invalid_relationship_relation_id"
+    assert payload.get("effect_status") == "not_started"
+    assert payload.get("mutation_outcome") == "not_started"
+    assert payload.get("changed") is False
+    assert payload.get("undo_token") is None
+    assert fake_db.audit.rows == []
+    assert mutate_calls == []
     _assert_schema_conformance(gateway, "remove_relationships_bulk", payload)
 
 
-def test_undo_relationship_removal_gateway_restores_soft_deleted_edges(monkeypatch):
+def test_sessionless_remove_cannot_obtain_an_undo_token(monkeypatch):
     gateway = _build_gateway()
-    _install_fake_db(monkeypatch)
-    _state, _mutate_calls = _install_relationship_state(monkeypatch)
+    fake_db = _install_fake_db(monkeypatch)
+    _state, mutate_calls = _install_relationship_state(monkeypatch)
 
     remove_payload = gateway.invoke(
         "remove_relationship",
         {"source_id": "#V#source", "predicate": "typeOf", "target": "#V#target"},
     ).payload
-    undo_token = remove_payload.get("undo_token")
-    assert isinstance(undo_token, str) and undo_token
-
-    undo_payload = gateway.invoke(
-        "undo_relationship_removal",
-        {"undo_token": undo_token, "confirmed": True},
-    ).payload
-
-    assert undo_payload.get("success") is True
-    assert undo_payload.get("restored_count") == 1
-    _assert_schema_conformance(gateway, "undo_relationship_removal", undo_payload)
+    assert remove_payload.get("success") is False
+    assert remove_payload.get("error_code") == "ontology_agent_delegation_required"
+    assert remove_payload.get("effect_status") == "not_started"
+    assert remove_payload.get("mutation_outcome") == "not_started"
+    assert remove_payload.get("changed") is False
+    assert remove_payload.get("undo_token") is None
+    assert fake_db.audit.rows == []
+    assert mutate_calls == []
+    _assert_schema_conformance(gateway, "remove_relationship", remove_payload)

--- a/tests/backend/test_internal_mcp_remove_relationship_errors.py
+++ b/tests/backend/test_internal_mcp_remove_relationship_errors.py
@@ -21,7 +21,8 @@ def test_remove_relationship_rejects_non_vontology_predicate_keys(monkeypatch):
         _fake_update_one,
     )
 
-    result = catalogue._remove_relationship(
+    # Exercise handler validation below the separately tested authority wrapper.
+    result = catalogue._remove_relationship.__wrapped__(
         source_id="#V#source", predicate="has_item", target="#V#target"
     )
 
@@ -44,7 +45,7 @@ def test_remove_relationship_rejects_missing_dynamic_predicate_concepts(monkeypa
         _fake_find_one,
     )
 
-    result = catalogue._remove_relationship(
+    result = catalogue._remove_relationship.__wrapped__(
         source_id="#V#source", predicate="#V#has_item", target="#V#target"
     )
 
@@ -65,7 +66,7 @@ def test_remove_relationship_returns_structured_error_for_missing_source(monkeyp
         _fake_find_one,
     )
 
-    result = catalogue._remove_relationship(
+    result = catalogue._remove_relationship.__wrapped__(
         source_id="#V#source", predicate="typeOf", target="#V#target"
     )
 
@@ -87,7 +88,7 @@ def test_remove_relationship_rejects_text_relation_predicates(monkeypatch):
         _fake_find_one,
     )
 
-    result = catalogue._remove_relationship(
+    result = catalogue._remove_relationship.__wrapped__(
         source_id="#V#source", predicate="hasContent", target="hello"
     )
 

--- a/tests/backend/test_internal_mcp_text_relation_predicate_guard.py
+++ b/tests/backend/test_internal_mcp_text_relation_predicate_guard.py
@@ -4,20 +4,16 @@ import asyncio
 import json
 from typing import Any
 
-from src.backend.integrations.internal_mcp import (
-    InternalMCPGateway,
-    InternalMCPTransport,
-    build_default_catalogue,
-)
+from src.backend.integrations.internal_mcp import build_default_catalogue
 from src.backend.mcp_server import mcp_stdio_server
 
 
-def _build_gateway() -> InternalMCPGateway:
-    return InternalMCPGateway(
-        catalogue=build_default_catalogue(),
-        transport=InternalMCPTransport(),
-        enabled=True,
-    )
+def _invoke_handler(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Exercise predicate semantics below the governed authority wrapper."""
+
+    method = build_default_catalogue().get(name)
+    assert method is not None
+    return method.handler.__wrapped__(**arguments)
 
 
 def _decode_stdio_payload(result: object) -> dict[str, Any]:
@@ -29,8 +25,6 @@ def _decode_stdio_payload(result: object) -> dict[str, Any]:
 def test_upsert_singleton_text_relation_rejects_missing_vontology_predicate(
     monkeypatch,
 ) -> None:
-    gateway = _build_gateway()
-
     def _missing_concept(_concept_id: str) -> dict[str, Any]:
         raise RuntimeError("concept not found")
 
@@ -46,14 +40,14 @@ def test_upsert_singleton_text_relation_rejects_missing_vontology_predicate(
         _unexpected_upsert,
     )
 
-    payload = gateway.invoke(
+    payload = _invoke_handler(
         "upsert_singleton_text_relation",
         {
             "concept_id": "#V#target_concept",
             "predicate": "#V#made_up_field_name",
             "text": "Supplied metadata value",
         },
-    ).payload
+    )
 
     assert payload["success"] is False
     assert payload["error_code"] == "predicate_concept_not_found"
@@ -66,7 +60,6 @@ def test_upsert_singleton_text_relation_rejects_missing_vontology_predicate(
 def test_upsert_singleton_text_relation_accepts_core_predicate_concept_alias(
     monkeypatch,
 ) -> None:
-    gateway = _build_gateway()
     calls: list[dict[str, Any]] = []
 
     def _fake_upsert(**kwargs: Any) -> dict[str, Any]:
@@ -88,14 +81,14 @@ def test_upsert_singleton_text_relation_accepts_core_predicate_concept_alias(
         _fake_upsert,
     )
 
-    payload = gateway.invoke(
+    payload = _invoke_handler(
         "upsert_singleton_text_relation",
         {
             "concept_id": "#V#represented_item",
             "predicate": "#V#hasDescription",
             "text": "Abstract text.",
         },
-    ).payload
+    )
 
     assert payload["success"] is True
     assert payload["predicate"] == "hasDescription"
@@ -107,7 +100,6 @@ def test_upsert_singleton_text_relation_accepts_core_predicate_concept_alias(
 def test_upsert_text_relation_accepts_existing_custom_predicate_concept(
     monkeypatch,
 ) -> None:
-    gateway = _build_gateway()
     calls: list[dict[str, Any]] = []
 
     def _get_concept(concept_id: str) -> dict[str, Any]:
@@ -138,14 +130,14 @@ def test_upsert_text_relation_accepts_existing_custom_predicate_concept(
         lambda **_kwargs: None,
     )
 
-    payload = gateway.invoke(
+    payload = _invoke_handler(
         "upsert_text_relation",
         {
             "concept_id": "#V#represented_item",
             "predicate": "#V#has_external_identifier",
             "text": "external-id-123",
         },
-    ).payload
+    )
 
     assert payload["success"] is True
     assert payload["predicate"] == "#V#has_external_identifier"
@@ -153,7 +145,7 @@ def test_upsert_text_relation_accepts_existing_custom_predicate_concept(
     assert calls[0]["predicate"] == "#V#has_external_identifier"
 
 
-def test_stdio_upsert_singleton_text_relation_rejects_missing_vontology_predicate(
+def test_sessionless_stdio_text_write_fails_before_predicate_resolution(
     monkeypatch,
 ) -> None:
     def _missing_concept(_concept_id: str) -> dict[str, Any]:
@@ -167,13 +159,22 @@ def test_stdio_upsert_singleton_text_relation_rejects_missing_vontology_predicat
         _missing_concept,
     )
     monkeypatch.setattr(
-        mcp_stdio_server,
-        "upsert_singleton_text_relation",
+        "src.backend.services.text_value_service.upsert_singleton_text_relation",
         _unexpected_upsert,
+    )
+    monkeypatch.setattr(
+        mcp_stdio_server,
+        "_evaluate_stdio_write_access",
+        lambda *_args, **_kwargs: (
+            True,
+            {},
+            {"write_category_tools_allowed": True},
+        ),
     )
 
     async def _runner() -> dict[str, Any]:
-        result = await mcp_stdio_server._handle_upsert_singleton_text_relation(
+        result = await mcp_stdio_server.call_tool(
+            "upsert_singleton_text_relation",
             {
                 "concept_id": "#V#target_concept",
                 "predicate": "#V#made_up_field_name",
@@ -185,5 +186,7 @@ def test_stdio_upsert_singleton_text_relation_rejects_missing_vontology_predicat
     payload = asyncio.run(_runner())
 
     assert payload["success"] is False
-    assert payload["error_code"] == "predicate_concept_not_found"
-    assert payload["error_details"]["predicate"] == "#V#made_up_field_name"
+    assert payload["error_code"] == "ontology_sessionless_delegation_not_supported"
+    assert payload["effect_status"] == "not_started"
+    assert payload["mutation_outcome"] == "not_started"
+    assert payload["changed"] is False

--- a/tests/backend/test_internal_mcp_uncertain_relationship_tools.py
+++ b/tests/backend/test_internal_mcp_uncertain_relationship_tools.py
@@ -32,7 +32,7 @@ def _build_gateway() -> InternalMCPGateway:
     )
 
 
-def test_uncertain_relationship_tools_gateway_create_list_promote_flow() -> None:
+def test_uncertain_relationship_tools_gateway_denies_sessionless_promotion() -> None:
     gateway = _build_gateway()
 
     ConceptsRepository.insert_one({"concept_id": "#V#alice", "relationships": {}})
@@ -64,12 +64,20 @@ def test_uncertain_relationship_tools_gateway_create_list_promote_flow() -> None
         "promote_uncertain_relationship_assertion",
         {"source_id": "#V#alice", "assertion_id": assertion_id},
     ).payload
-    assert promoted.get("success") is True
-    assert (promoted.get("assertion") or {}).get("status") == "promoted"
+    assert promoted.get("success") is False
+    assert promoted.get("error_code") == "ontology_agent_delegation_required"
+    assert promoted.get("effect_status") == "not_started"
+    assert promoted.get("changed") is False
 
     source_doc = ConceptsRepository.find_one({"concept_id": "#V#alice"})
     relationships = (source_doc or {}).get("relationships") or {}
-    assert "#V#strong_ai_lab" in (relationships.get("related_to") or [])
+    assert "#V#strong_ai_lab" not in (relationships.get("related_to") or [])
+
+    unchanged = gateway.invoke(
+        "list_uncertain_relationship_assertions",
+        {"source_id": "#V#alice", "predicate": "#V#related_to"},
+    ).payload
+    assert (unchanged.get("assertions") or [{}])[0].get("status") == "proposed"
 
 
 def test_uncertain_relationship_tools_gateway_reject_and_migrate_legacy() -> None:
@@ -104,4 +112,3 @@ def test_uncertain_relationship_tools_gateway_reject_and_migrate_legacy() -> Non
     ).payload
     assert rejected.get("success") is True
     assert (rejected.get("assertion") or {}).get("status") == "rejected"
-

--- a/tests/backend/test_mcp_create_concepts_duplicate_guard.py
+++ b/tests/backend/test_mcp_create_concepts_duplicate_guard.py
@@ -9,8 +9,14 @@ from typing import Any, cast
 import pytest
 
 from src.backend.db.repositories.concepts_repository import ConceptsRepository
-from src.backend.integrations.internal_mcp.catalogue import _create_concepts
+from src.backend.integrations.internal_mcp.catalogue import (
+    _create_concepts as _governed_create_concepts,
+)
 from src.backend.mcp_server import mcp_stdio_server
+
+# These tests exercise duplicate handling in the core create handler. The
+# governed gateway and stdio authority boundaries are covered separately.
+_create_concepts = _governed_create_concepts.__wrapped__
 
 
 @pytest.fixture(autouse=True)

--- a/tests/backend/test_mcp_create_concepts_duplicate_resolution_mode.py
+++ b/tests/backend/test_mcp_create_concepts_duplicate_resolution_mode.py
@@ -8,7 +8,7 @@ import pytest
 
 from src.backend.integrations.internal_mcp.catalogue import (
     _concepts_create_input_schema,
-    _create_concepts,
+    _create_concepts as _governed_create_concepts,
 )
 from src.backend.integrations.internal_mcp.schemas import validate_payload
 from src.backend.integrations.internal_mcp.transport import (
@@ -21,6 +21,8 @@ from src.backend.services.concept_external_identity_service import (
     ExternalIdentityResolution,
 )
 from src.backend.utils.concept_id_utils import canonicalise_vontology_concept_id
+
+_create_concepts = _governed_create_concepts.__wrapped__
 
 _PARENT_ID = "#V#abstract_object"
 _EXTERNAL_IDENTITY_PARENT_ID = "#V#archival_record"
@@ -828,49 +830,8 @@ def test_external_identity_reuses_same_kind_across_parent_classifications(
     assert create_calls == []
 
 
-@pytest.mark.parametrize(
-    ("persistence_receipt", "expected_status", "expected_success"),
-    [
-        (
-            {
-                "success": False,
-                "effect_status": "indeterminate",
-                "changed": None,
-                "writes": [],
-                "failures": [],
-                "indeterminate_failures": [
-                    {
-                        "stage": "external_identity_persistence",
-                        "outcome": "indeterminate",
-                    }
-                ],
-            },
-            "indeterminate",
-            False,
-        ),
-        (
-            {
-                "success": True,
-                "effect_status": "succeeded",
-                "changed": None,
-                "writes": [
-                    {
-                        "write_outcome": "readback_verified_after_exception",
-                    }
-                ],
-                "failures": [],
-                "indeterminate_failures": [],
-            },
-            "succeeded",
-            True,
-        ),
-    ],
-)
-def test_external_identity_reuse_preserves_marker_write_finality(
+def test_external_identity_reuse_is_read_only(
     monkeypatch: pytest.MonkeyPatch,
-    persistence_receipt: dict[str, Any],
-    expected_status: str,
-    expected_success: bool,
 ) -> None:
     _patch_external_identity_preflights(monkeypatch)
     existing_id = "#V#existing_catalogued_entity"
@@ -899,10 +860,11 @@ def test_external_identity_reuse_preserves_marker_write_finality(
             resolution_source="persisted_identity_marker",
         ),
     )
+    persistence_calls: list[dict[str, Any]] = []
     monkeypatch.setattr(
         "src.backend.services.concept_external_identity_service."
         "persist_external_identity_markers",
-        lambda **_kwargs: dict(persistence_receipt),
+        lambda **kwargs: persistence_calls.append(dict(kwargs)),
     )
     monkeypatch.setattr(
         "src.backend.vontology.utils_vontology.create_vontology_concept",
@@ -924,17 +886,17 @@ def test_external_identity_reuse_preserves_marker_write_finality(
         ],
     )
 
-    assert result["effect_status"] == expected_status
-    assert result["success"] is expected_success
-    assert result["changed"] is None
-    if expected_status == "indeterminate":
-        assert result["already_existed"] == 0
-        assert result["indeterminate_failure_count"] == 1
-        assert result["results"][0]["error_code"] == (
-            "external_identity_persistence_indeterminate"
-        )
-    else:
-        assert result["already_existed"] == 1
+    assert result["success"] is True
+    assert result["effect_status"] == "succeeded"
+    assert result["changed"] is False
+    assert result["already_existed"] == 1
+    assert result["results"][0]["external_identity"]["persistence"] == {
+        "success": True,
+        "effect_status": "not_started",
+        "changed": False,
+        "reason_code": "duplicate_reuse_is_read_only",
+    }
+    assert persistence_calls == []
 
 
 def test_external_identity_reuse_does_not_start_marker_repair_after_cancellation(
@@ -1943,7 +1905,7 @@ def test_external_identity_marker_uncertainty_propagates_to_batch_receipt(
     assert result["results"][0]["effect_status"] == "indeterminate"
 
 
-def test_marker_repair_reuses_explicit_stable_candidate_without_second_create(
+def test_explicit_stable_candidate_reuse_does_not_repair_markers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from src.backend.services import concept_external_identity_service as identity_service
@@ -2085,10 +2047,10 @@ def test_marker_repair_reuses_explicit_stable_candidate_without_second_create(
     assert first["created_concept_ids"] == [stable_id]
     assert repaired["success"] is True
     assert repaired["effect_status"] == "succeeded"
-    assert repaired["changed"] is True
+    assert repaired["changed"] is False
     assert repaired["already_existed"] == 1
     assert repaired["results"][0]["external_identity_resolution_source"] == (
         "caller_confirmed_stable_identity"
     )
     assert create_calls == [stable_id]
-    assert persistence_calls == [stable_id, stable_id]
+    assert persistence_calls == [stable_id]

--- a/tests/backend/test_mcp_create_concepts_enhanced_responses.py
+++ b/tests/backend/test_mcp_create_concepts_enhanced_responses.py
@@ -8,7 +8,11 @@ including canonical IDs, input names, and actionable suggestions.
 import pytest
 import uuid
 from src.backend.db.repositories.concepts_repository import ConceptsRepository
-from src.backend.integrations.internal_mcp.catalogue import _create_concepts
+from src.backend.integrations.internal_mcp.catalogue import (
+    _create_concepts as _governed_create_concepts,
+)
+
+_create_concepts = _governed_create_concepts.__wrapped__
 
 
 @pytest.fixture(autouse=True)

--- a/tests/backend/test_mcp_create_concepts_extent_batching.py
+++ b/tests/backend/test_mcp_create_concepts_extent_batching.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import pytest
 
-from src.backend.integrations.internal_mcp.catalogue import _create_concepts
+from src.backend.integrations.internal_mcp.catalogue import (
+    _create_concepts as _governed_create_concepts,
+)
 from src.backend.services import (
     create_concepts_duplicate_guard_service,
     create_concepts_parent_resolution_service,
@@ -13,6 +15,8 @@ from src.backend.services.create_concepts_parent_resolution_service import (
     ParentResolutionResult,
 )
 from src.backend.vontology import utils_vontology
+
+_create_concepts = _governed_create_concepts.__wrapped__
 
 
 def test_create_concepts_coalesces_relationship_extent_sync_for_the_batch(

--- a/tests/backend/test_mcp_create_concepts_parent_recovery.py
+++ b/tests/backend/test_mcp_create_concepts_parent_recovery.py
@@ -7,13 +7,15 @@ import json
 from typing import Any
 
 from src.backend.integrations.internal_mcp.catalogue import (
-    _create_concepts,
+    _create_concepts as _governed_create_concepts,
     build_default_catalogue,
 )
 from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
 from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
 from src.backend.mcp_server import mcp_stdio_server
 from src.backend.security.access_control import is_bypass_enabled
+
+_create_concepts = _governed_create_concepts.__wrapped__
 
 
 def _patch_create_concept_success(monkeypatch):
@@ -259,7 +261,7 @@ def test_create_concepts_rejects_relationship_derived_predicate_parent(monkeypat
     assert created == []
 
 
-def test_create_concepts_recovery_works_through_gateway(monkeypatch):
+def test_sessionless_gateway_create_fails_before_parent_recovery(monkeypatch):
     _patch_create_concept_success(monkeypatch)
     monkeypatch.setattr(
         "src.backend.services.create_concepts_parent_resolution_service.resolve_available_workflow_type_ids",
@@ -288,14 +290,14 @@ def test_create_concepts_recovery_works_through_gateway(monkeypatch):
         },
     ).payload
 
-    assert payload.get("successful") == 1
-    assert payload.get("created_concept_ids") == ["#V#gateway_workflow_recovery_type"]
-    assert (payload.get("results") or [{}])[0].get("concept_id") == "#V#gateway_workflow_recovery_type"
-    assert payload.get("parent_id_used") == "#V#durable_workflow"
-    assert (payload.get("parent_resolution") or {}).get("fallback_used") is True
+    assert payload.get("success") is False
+    assert payload.get("error_code") == "authenticated_actor_context_required"
+    assert payload.get("effect_status") == "not_started"
+    assert payload.get("mutation_outcome") == "not_started"
+    assert payload.get("changed") is False
 
 
-def test_stdio_create_concepts_recovery_uses_same_parent_logic(monkeypatch):
+def test_sessionless_stdio_create_fails_before_parent_recovery(monkeypatch):
     _patch_create_concept_success(monkeypatch)
     monkeypatch.setattr(
         "src.backend.services.create_concepts_parent_resolution_service.resolve_available_workflow_type_ids",
@@ -322,8 +324,10 @@ def test_stdio_create_concepts_recovery_uses_same_parent_logic(monkeypatch):
     response = asyncio.run(_invoke())
     assert response
     payload = json.loads(response[0].text)
-    assert payload.get("successful") == 1
-    assert payload.get("created_concept_ids") == ["#V#stdio_workflow_recovery_type"]
-    assert (payload.get("results") or [{}])[0].get("concept_id") == "#V#stdio_workflow_recovery_type"
-    assert payload.get("parent_id_used") == "#V#durable_workflow"
-    assert (payload.get("parent_resolution") or {}).get("fallback_used") is True
+    assert payload.get("success") is False
+    assert payload.get("error_code") == (
+        "ontology_sessionless_delegation_not_supported"
+    )
+    assert payload.get("effect_status") == "not_started"
+    assert payload.get("mutation_outcome") == "not_started"
+    assert payload.get("changed") is False

--- a/tests/backend/test_mcp_create_concepts_parent_validation.py
+++ b/tests/backend/test_mcp_create_concepts_parent_validation.py
@@ -8,7 +8,11 @@ and correctly canonicalises parent IDs.
 import pytest
 import uuid
 from src.backend.db.repositories.concepts_repository import ConceptsRepository
-from src.backend.integrations.internal_mcp.catalogue import _create_concepts
+from src.backend.integrations.internal_mcp.catalogue import (
+    _create_concepts as _governed_create_concepts,
+)
+
+_create_concepts = _governed_create_concepts.__wrapped__
 
 
 @pytest.fixture(autouse=True)

--- a/tests/backend/test_mcp_create_concepts_unknown_fields.py
+++ b/tests/backend/test_mcp_create_concepts_unknown_fields.py
@@ -7,11 +7,15 @@ when callers included additional top-level context.
 
 import pytest
 from src.backend.db.repositories.concepts_repository import ConceptsRepository
-from src.backend.integrations.internal_mcp.catalogue import _create_concepts
+from src.backend.integrations.internal_mcp.catalogue import (
+    _create_concepts as _governed_create_concepts,
+)
 from src.backend.security.visibility_predicates import (
     CANONICAL_SPECIFIC_TO_ORG_PREDICATE,
     CANONICAL_SPECIFIC_TO_USER_PREDICATE,
 )
+
+_create_concepts = _governed_create_concepts.__wrapped__
 
 
 @pytest.fixture(autouse=True)

--- a/tests/backend/test_mcp_stdio_ontology_authority.py
+++ b/tests/backend/test_mcp_stdio_ontology_authority.py
@@ -1,0 +1,175 @@
+"""Direct-stdio authority containment for canonical ontology mutations."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, cast
+
+from src.backend.integrations.internal_mcp.tool_contract_registry import (
+    SURFACE_MANIFEST,
+    SURFACE_VONTOLOGY_STDIO,
+    get_surface_tool_payloads,
+)
+from src.backend.mcp_server import mcp_stdio_server
+from src.backend.services.ontology_publication_authority_service import (
+    OntologyMutationIntent,
+    PublicationContext,
+    PublicationContextKind,
+    authorise_ontology_mutation,
+    current_ontology_invocation,
+)
+
+
+def _call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    async def invoke() -> Any:
+        return await mcp_stdio_server.call_tool(name, arguments)
+
+    response = cast(list[Any], asyncio.run(invoke()))
+    assert response
+    text = getattr(response[0], "text", None)
+    assert isinstance(text, str)
+    payload = json.loads(text)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _allow_writes(
+    *_args: Any, **_kwargs: Any
+) -> tuple[bool, dict[str, Any], dict[str, Any]]:
+    return True, {}, {"write_category_tools_allowed": True}
+
+
+def test_stdio_governed_contracts_expose_only_opaque_delegation_carriers() -> None:
+    governed_tools = {
+        "add_names",
+        "add_relationship",
+        "create_concepts",
+        "delete_concept",
+        "delete_text_relation",
+        "merge_concepts",
+        "remove_relationship",
+        "remove_relationships_bulk",
+        "update_concept",
+        "update_text_relation",
+        "upsert_singleton_text_relation",
+        "upsert_text_relation",
+    }
+
+    for surface in (SURFACE_VONTOLOGY_STDIO, SURFACE_MANIFEST):
+        contracts = {item["name"]: item for item in get_surface_tool_payloads(surface)}
+        for tool_name in governed_tools:
+            properties = contracts[tool_name]["inputSchema"]["properties"]
+            assert "ontology_delegation_id" in properties
+            assert "ontology_effect_id" in properties
+            assert "user_concept_id" not in properties
+            assert "organisation_concept_id" not in properties
+
+
+def test_each_stdio_canonical_mutation_dispatches_to_a_governed_catalogue_method() -> (
+    None
+):
+    for (
+        _tool_name,
+        method_name,
+    ) in mcp_stdio_server._STDIO_GOVERNED_ONTOLOGY_METHODS.items():
+        catalogue_handler = getattr(
+            mcp_stdio_server.internal_mcp_catalogue_module,
+            f"_{method_name}",
+        )
+        assert hasattr(catalogue_handler, "__wrapped__"), method_name
+
+    assert (
+        "undo_relationship_removal"
+        not in mcp_stdio_server._STDIO_GOVERNED_ONTOLOGY_METHODS
+    )
+
+
+def test_stdio_sessionless_delegation_fails_before_handler_dispatch(
+    monkeypatch,
+) -> None:
+    observed: dict[str, Any] = {}
+
+    async def handler(arguments: dict[str, Any]) -> list[Any]:
+        observed["arguments"] = arguments
+        observed["invocation"] = current_ontology_invocation()
+        return [mcp_stdio_server._json_text({"success": True})]
+
+    monkeypatch.setattr(mcp_stdio_server, "_evaluate_stdio_write_access", _allow_writes)
+    monkeypatch.setitem(mcp_stdio_server._TOOL_HANDLERS, "create_concepts", handler)
+    supplied = {
+        "parent_id": "#V#thing",
+        "concepts": [{"name": "Scoped test"}],
+        "ontology_delegation_id": "delegation_server_issued",
+        "ontology_effect_id": "effect_server_issued",
+        "actor_concept_id": "#V#forged_actor",
+        "created_by_concept_id": "#V#forged_creator",
+        "user_concept_id": "#V#forged_user",
+        "organisation_concept_id": "#V#forged_org",
+        "namespace": "#V#forged_user@forged_org",
+        "operator_override": True,
+        "roles": ["global_ontology_administrator"],
+    }
+
+    payload = _call_tool("create_concepts", supplied)
+
+    assert payload["success"] is False
+    assert payload["error_code"] == "ontology_sessionless_delegation_not_supported"
+    assert supplied["actor_concept_id"] == "#V#forged_actor"
+    assert observed == {}
+
+
+def test_stdio_raw_role_payload_cannot_substitute_for_delegation(monkeypatch) -> None:
+    async def authority_probe(_arguments: dict[str, Any]) -> list[Any]:
+        decision = authorise_ontology_mutation(
+            OntologyMutationIntent(
+                operation="concept.create",
+                publication_context=PublicationContext(
+                    kind=PublicationContextKind.GLOBAL,
+                ),
+                target_concept_ids=(),
+                tool_name="create_concepts",
+            )
+        )
+        return [mcp_stdio_server._json_text(decision.public_projection())]
+
+    monkeypatch.setattr(mcp_stdio_server, "_evaluate_stdio_write_access", _allow_writes)
+    monkeypatch.setitem(
+        mcp_stdio_server._TOOL_HANDLERS,
+        "create_concepts",
+        authority_probe,
+    )
+
+    payload = _call_tool(
+        "create_concepts",
+        {
+            "parent_id": "#V#thing",
+            "concepts": [{"name": "Forged global edit"}],
+            "user_concept_id": "#V#global_admin",
+            "organisation_concept_id": "#V#any_org",
+            "roles": ["global_ontology_administrator"],
+        },
+    )
+
+    assert payload["success"] is False
+    assert payload["error_code"] == "ontology_sessionless_delegation_not_supported"
+
+
+def test_stdio_undo_fails_closed_until_its_target_is_governed(monkeypatch) -> None:
+    monkeypatch.setattr(mcp_stdio_server, "_evaluate_stdio_write_access", _allow_writes)
+
+    payload = _call_tool(
+        "undo_relationship_removal",
+        {"undo_token": "undo_untrusted"},
+    )
+
+    assert payload["success"] is False
+    assert payload["error_code"] == "ontology_mutation_not_governed"
+
+
+def test_stdio_has_no_retained_unchecked_legacy_write_handlers() -> None:
+    assert not any(
+        name.endswith("_legacy_unchecked")
+        for name in vars(mcp_stdio_server)
+        if name.startswith("_handle_")
+    )

--- a/tests/backend/test_ontology_authority_role_migration_service.py
+++ b/tests/backend/test_ontology_authority_role_migration_service.py
@@ -1,0 +1,630 @@
+"""Focused contract tests for the fixed initial administrator migration."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import mongomock
+import pytest
+
+from src.backend.services import (
+    ontology_authority_role_migration_service as migration,
+)
+
+TARGET = migration.ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET
+GLOBAL_ROLE = migration.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE
+ORG_ROLE = migration.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE
+
+
+@pytest.fixture(autouse=True)
+def isolated_migration_coordination_and_log(monkeypatch):
+    """Focused migration tests never touch live locks or migration storage."""
+
+    collection = mongomock.MongoClient()["role_migration_tests"]["migrations"]
+    collection.create_index("migration_name", unique=True)
+    monkeypatch.setattr(migration, "get_migrations_log_collection", lambda: collection)
+    monkeypatch.setattr(
+        migration,
+        "ontology_authority_membership_mutation_barrier",
+        nullcontext,
+    )
+    yield collection
+
+
+def _semantic_row(role: str, organisation_id: str | None = None) -> dict:
+    return {
+        "source": "represented_semantic_authority_role",
+        "subject_concept_id": TARGET,
+        "role": role,
+        "organisation_concept_id": organisation_id,
+        "relation_id": f"semantic:{role}:{organisation_id or 'global'}",
+    }
+
+
+def _inventory(
+    *,
+    semantic_rows: list[dict] | None = None,
+    membership_roles: dict[str, str] | None = None,
+    extra_legacy_rows: list[dict] | None = None,
+    operational_rows: list[dict] | None = None,
+) -> dict:
+    roles = membership_roles or {"#V#org_a": "admin", "#V#org_b": "member"}
+    return {
+        "target_concept_id": TARGET,
+        "target_exists": True,
+        "memberships": [
+            {"organisation_concept_id": org_id, "legacy_role": role}
+            for org_id, role in sorted(roles.items())
+        ],
+        "missing_membership_organisations": [],
+        "legacy_privileged_role_assignments": [
+            {
+                "source": "legacy_stub_role_mapping",
+                "subject_concept_id": TARGET,
+                "role": "admin",
+                "organisation_concept_id": "#V#org_a",
+                "relation_id": None,
+            },
+            *(extra_legacy_rows or []),
+        ],
+        "target_membership_role_assignments": [
+            {
+                "source": "represented_organisation_membership_role",
+                "subject_concept_id": TARGET,
+                "role": role,
+                "organisation_concept_id": org_id,
+                "relation_id": f"legacy:{org_id}:{role}",
+            }
+            for org_id, role in sorted(roles.items())
+        ],
+        "semantic_role_assignments": list(semantic_rows or []),
+        "operational_role_assignments": list(operational_rows or []),
+    }
+
+
+def test_dry_run_is_fixed_to_michael_and_makes_no_writes(monkeypatch) -> None:
+    monkeypatch.setattr(migration, "_collect_inventory", _inventory)
+    monkeypatch.setattr(
+        migration,
+        "bootstrap_first_semantic_authority",
+        lambda **_kwargs: pytest.fail("dry-run must not bootstrap"),
+    )
+    monkeypatch.setattr(
+        migration,
+        "grant_ontology_authority_role",
+        lambda **_kwargs: pytest.fail("dry-run must not grant"),
+    )
+    monkeypatch.setattr(
+        migration,
+        "upsert_text_for_concept",
+        lambda **_kwargs: pytest.fail("dry-run must not replace legacy roles"),
+    )
+
+    plan = migration.plan_ontology_authority_role_migration()
+
+    assert plan["target_concept_id"] == TARGET
+    assert plan["ready_to_apply"] is True
+    assert [item["operation"] for item in plan["actions"]] == [
+        "bootstrap_von_operational_administrator",
+        "bootstrap_global_ontology_administrator",
+        "grant_organisation_ontology_administrator",
+        "grant_organisation_ontology_administrator",
+        "replace_legacy_organisation_role_with_owner",
+        "replace_legacy_organisation_role_with_owner",
+    ]
+    assert plan["operational_authority"]["represented_assignment_mechanism"] == (
+        "dedicated_role_lifecycle"
+    )
+    assert plan["operational_authority"]["kept_separate_from_semantic_authority"]
+    assert set(plan["operational_authority"]["owner_permissions"]) == {
+        "READ_ORG_CONTENT",
+        "WRITE_ORG_CONTENT",
+        "MANAGE_MEMBERS",
+        "MANAGE_ROLES",
+        "DELETE_ORG",
+    }
+
+
+def test_inventory_uses_represented_memberships_and_ignores_ordinary_members(
+    monkeypatch,
+) -> None:
+    text_values = {
+        "michael-admin": {"text": "admin"},
+        "archivist-member": {"text": "member"},
+    }
+    relations = [
+        {
+            "_id": "michael-role",
+            "subject_concept_id": TARGET,
+            "predicate": migration.ROLE_PREDICATE,
+            "object_text_id": "michael-admin",
+            "context": {"organisation_id": "#V#org_a"},
+        },
+        {
+            "_id": "archivist-role",
+            "subject_concept_id": "#V#von_archivist",
+            "predicate": migration.ROLE_PREDICATE,
+            "object_text_id": "archivist-member",
+            "context": {"organisation_id": "#V#org_a"},
+        },
+    ]
+
+    monkeypatch.setattr(migration, "bypass_access_control", nullcontext)
+    monkeypatch.setattr(
+        migration.ConceptsRepository,
+        "find_one",
+        lambda query, projection=None: {"concept_id": query["concept_id"]},
+    )
+
+    def find_concepts(query, projection=None):
+        query_text = repr(query)
+        assert migration.VON_ADMINISTRATOR_CONCEPT_ID in query_text
+        return []
+
+    monkeypatch.setattr(migration.ConceptsRepository, "find", find_concepts)
+    monkeypatch.setattr(
+        migration.TextRelationsRepository,
+        "find",
+        lambda query: [
+            row
+            for row in relations
+            if query.get("predicate") == migration.ROLE_PREDICATE
+            and (
+                not query.get("subject_concept_id")
+                or row["subject_concept_id"] == query["subject_concept_id"]
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        migration.TextValuesRepository,
+        "find_one",
+        lambda query: text_values.get(query.get("_id")),
+    )
+    monkeypatch.setattr(
+        migration,
+        "get_user_memberships",
+        lambda _target: {
+            "memberships": [
+                {"organisation_concept_id": "#V#org_a", "role": "admin"}
+            ]
+        },
+    )
+    monkeypatch.setattr(migration, "list_von_operational_administrators", list)
+
+    inventory = migration._collect_inventory()
+
+    assert inventory["memberships"] == [
+        {"organisation_concept_id": "#V#org_a", "legacy_role": "admin"}
+    ]
+    assert {
+        row["subject_concept_id"]
+        for row in inventory["legacy_privileged_role_assignments"]
+    } == {TARGET}
+    assert inventory["target_membership_role_assignments"][0]["role"] == "admin"
+
+
+def test_unexpected_privileged_holder_blocks_before_first_write(monkeypatch) -> None:
+    inventory = _inventory(
+        extra_legacy_rows=[
+            {
+                "source": "represented_legacy_text_role",
+                "subject_concept_id": "#V#other_person",
+                "role": "owner",
+                "organisation_concept_id": "#V#org_a",
+                "relation_id": "unexpected",
+            }
+        ]
+    )
+    monkeypatch.setattr(migration, "_collect_inventory", lambda: inventory)
+    monkeypatch.setattr(migration, "get_effective_user_concept_id", lambda: TARGET)
+    monkeypatch.setattr(migration, "current_ontology_invocation", lambda: None)
+    monkeypatch.setattr(
+        migration, "ontology_mutation_resource_lock", lambda _key: nullcontext()
+    )
+    monkeypatch.setattr(
+        migration,
+        "bootstrap_first_semantic_authority",
+        lambda **_kwargs: pytest.fail("conflicting inventory must not write"),
+    )
+
+    plan = migration.plan_ontology_authority_role_migration()
+    assert plan["ready_to_apply"] is False
+    assert any(
+        item["reason_code"] == "unexpected_privileged_role_holder"
+        for item in plan["conflicts"]
+    )
+    with pytest.raises(
+        migration.OntologyAuthorityRoleMigrationError,
+        match="contradicts the migration premise",
+    ) as raised:
+        migration.apply_ontology_authority_role_migration(
+            expected_inventory_fingerprint=plan["inventory_fingerprint"]
+        )
+    assert raised.value.reason_code == (
+        "ontology_authority_role_migration_inventory_conflict"
+    )
+
+
+def test_unexpected_represented_operational_holder_blocks_plan(monkeypatch) -> None:
+    inventory = _inventory(
+        operational_rows=[
+            {"subject_concept_id": "#V#other_person", "relation_id": "operator:other"}
+        ]
+    )
+    monkeypatch.setattr(migration, "_collect_inventory", lambda: inventory)
+
+    plan = migration.plan_ontology_authority_role_migration()
+
+    assert plan["ready_to_apply"] is False
+    assert any(
+        item["reason_code"] == "unexpected_von_operational_administrator"
+        for item in plan["conflicts"]
+    )
+
+
+def test_apply_is_exact_read_back_verified_and_idempotent(monkeypatch) -> None:
+    membership_roles = {"#V#org_a": "admin", "#V#org_b": "member"}
+    semantic_rows: list[dict] = []
+    operational_rows: list[dict] = []
+    calls: list[tuple[str, str | None]] = []
+
+    monkeypatch.setattr(
+        migration,
+        "_collect_inventory",
+        lambda: _inventory(
+            semantic_rows=semantic_rows,
+            membership_roles=membership_roles,
+            operational_rows=operational_rows,
+        ),
+    )
+    monkeypatch.setattr(migration, "get_effective_user_concept_id", lambda: TARGET)
+    monkeypatch.setattr(migration, "current_ontology_invocation", lambda: None)
+    monkeypatch.setattr(
+        migration, "ontology_mutation_resource_lock", lambda _key: nullcontext()
+    )
+    monkeypatch.setattr(
+        migration, "override_current_organisation", lambda _org: nullcontext()
+    )
+
+    def bootstrap(**kwargs):
+        assert kwargs["subject_concept_id"] == TARGET
+        semantic_rows.append(_semantic_row(GLOBAL_ROLE))
+        calls.append((GLOBAL_ROLE, None))
+        return {"first_grant": kwargs}
+
+    def bootstrap_operational(**kwargs):
+        assert kwargs["subject_concept_id"] == TARGET
+        operational_rows.append(
+            {"subject_concept_id": TARGET, "relation_id": "operational:target"}
+        )
+        calls.append((migration.VON_OPERATIONAL_ADMINISTRATOR_ROLE, None))
+        return {"success": True, "changed": True}
+
+    def grant(**kwargs):
+        assert kwargs["subject_concept_id"] == TARGET
+        organisation_id = kwargs["organisation_concept_id"]
+        semantic_rows.append(_semantic_row(ORG_ROLE, organisation_id))
+        calls.append((ORG_ROLE, organisation_id))
+        return {"success": True, "changed": True, "relation_id": "role"}
+
+    def read_back(*, role, organisation_concept_id, **_kwargs):
+        matching = [
+            row
+            for row in semantic_rows
+            if row["role"] == role
+            and row["organisation_concept_id"] == organisation_concept_id
+        ]
+        return {"active": bool(matching), "grants": matching}
+
+    def replace(organisation_id):
+        calls.append(("owner", organisation_id))
+        membership_roles[organisation_id] = "owner"
+        return {
+            "success": True,
+            "changed": True,
+            "canonical_read_back": {
+                "exact_owner": True,
+                "organisation_concept_id": organisation_id,
+            },
+        }
+
+    monkeypatch.setattr(migration, "bootstrap_first_semantic_authority", bootstrap)
+    monkeypatch.setattr(
+        migration,
+        "bootstrap_first_von_operational_administrator",
+        bootstrap_operational,
+    )
+    monkeypatch.setattr(migration, "grant_ontology_authority_role", grant)
+    monkeypatch.setattr(migration, "authority_role_read_back", read_back)
+    monkeypatch.setattr(
+        migration,
+        "von_operational_administrator_read_back",
+        lambda **_kwargs: {
+            "active": bool(operational_rows),
+            "grants": list(operational_rows),
+            "subject_concept_id": TARGET,
+        },
+    )
+    monkeypatch.setattr(migration, "_replace_membership_role_with_owner", replace)
+    monkeypatch.setattr(
+        migration,
+        "_membership_role_read_back",
+        lambda organisation_id: {
+            "exact_owner": membership_roles[organisation_id] == "owner",
+            "organisation_concept_id": organisation_id,
+        },
+    )
+
+    before = migration.plan_ontology_authority_role_migration()
+    applied = migration.apply_ontology_authority_role_migration(
+        expected_inventory_fingerprint=before["inventory_fingerprint"]
+    )
+
+    assert applied["success"] is True
+    assert applied["changed"] is True
+    assert calls == [
+        (migration.VON_OPERATIONAL_ADMINISTRATOR_ROLE, None),
+        (GLOBAL_ROLE, None),
+        (ORG_ROLE, "#V#org_a"),
+        (ORG_ROLE, "#V#org_b"),
+        ("owner", "#V#org_a"),
+        ("owner", "#V#org_b"),
+    ]
+    assert {row["subject_concept_id"] for row in semantic_rows} == {TARGET}
+
+    calls.clear()
+    repeated = migration.apply_ontology_authority_role_migration(
+        expected_inventory_fingerprint=before["inventory_fingerprint"]
+    )
+    assert repeated["success"] is True
+    assert repeated["changed"] is False
+    assert repeated["replayed"] is True
+    assert calls == []
+
+    # A later, intentional role change is external state, not an invitation for
+    # an old completed request to re-elevate the user.
+    membership_roles["#V#org_a"] = "member"
+    with pytest.raises(migration.OntologyAuthorityRoleMigrationError) as changed:
+        migration.apply_ontology_authority_role_migration(
+            expected_inventory_fingerprint=before["inventory_fingerprint"]
+        )
+    assert changed.value.reason_code.endswith("completed_state_changed")
+    assert calls == []
+
+
+def test_apply_requires_current_inventory_and_target_human(monkeypatch) -> None:
+    monkeypatch.setattr(migration, "_collect_inventory", _inventory)
+    monkeypatch.setattr(
+        migration, "ontology_mutation_resource_lock", lambda _key: nullcontext()
+    )
+    plan = migration.plan_ontology_authority_role_migration()
+
+    monkeypatch.setattr(
+        migration, "get_effective_user_concept_id", lambda: "#V#other_person"
+    )
+    with pytest.raises(migration.OntologyAuthorityRoleMigrationError) as actor_error:
+        migration.apply_ontology_authority_role_migration(
+            expected_inventory_fingerprint=plan["inventory_fingerprint"]
+        )
+    assert actor_error.value.reason_code.endswith("target_actor_required")
+
+    monkeypatch.setattr(migration, "get_effective_user_concept_id", lambda: None)
+    with pytest.raises(migration.OntologyAuthorityRoleMigrationError) as anonymous:
+        migration.apply_ontology_authority_role_migration(
+            expected_inventory_fingerprint=plan["inventory_fingerprint"]
+        )
+    assert anonymous.value.reason_code.endswith("target_actor_required")
+
+    monkeypatch.setattr(migration, "get_effective_user_concept_id", lambda: TARGET)
+    monkeypatch.setattr(migration, "current_ontology_invocation", lambda: None)
+    with pytest.raises(migration.OntologyAuthorityRoleMigrationError) as stale_error:
+        migration.apply_ontology_authority_role_migration(
+            expected_inventory_fingerprint="stale"
+        )
+    assert stale_error.value.reason_code.endswith("inventory_changed")
+
+
+def test_owner_replacement_writes_owner_before_removing_old_roles(monkeypatch) -> None:
+    rows = [
+        {
+            "subject_concept_id": TARGET,
+            "role": "admin",
+            "organisation_concept_id": "#V#org_a",
+            "relation_id": "old-admin",
+        }
+    ]
+    call_order: list[str] = []
+    monkeypatch.setattr(
+        migration, "_target_membership_role_assignments", lambda: list(rows)
+    )
+    monkeypatch.setattr(
+        migration, "override_current_organisation", lambda _org: nullcontext()
+    )
+
+    def upsert(**kwargs):
+        assert kwargs["text"] == "owner::#V#org_a"
+        call_order.append("owner-written")
+        rows.append(
+            {
+                "subject_concept_id": TARGET,
+                "role": "owner",
+                "organisation_concept_id": "#V#org_a",
+                "relation_id": "new-owner",
+            }
+        )
+        return {"relation_id": "new-owner"}
+
+    def delete(**kwargs):
+        assert call_order == ["owner-written"]
+        call_order.append("old-role-deleted")
+        rows[:] = [row for row in rows if row["relation_id"] != kwargs["relation_id"]]
+        return {"deleted": True}
+
+    monkeypatch.setattr(migration, "upsert_text_for_concept", upsert)
+    monkeypatch.setattr(migration, "delete_text_relation", delete)
+
+    result = migration._replace_membership_role_with_owner("#V#org_a")
+
+    assert result["success"] is True
+    assert result["canonical_read_back"]["exact_owner"] is True
+    assert result["canonical_read_back"]["permissions"] == sorted(
+        migration.get_effective_permissions("owner")
+    )
+    assert call_order == ["owner-written", "old-role-deleted"]
+
+
+def test_owner_replacement_reconciles_duplicate_owner_rows(monkeypatch) -> None:
+    rows = [
+        {
+            "subject_concept_id": TARGET,
+            "role": "owner",
+            "organisation_concept_id": "#V#org_a",
+            "relation_id": "legacy-owner",
+        },
+        {
+            "subject_concept_id": TARGET,
+            "role": "owner",
+            "organisation_concept_id": "#V#org_a",
+            "relation_id": "canonical-owner",
+        },
+    ]
+    monkeypatch.setattr(
+        migration, "_target_membership_role_assignments", lambda: list(rows)
+    )
+    monkeypatch.setattr(
+        migration, "override_current_organisation", lambda _org: nullcontext()
+    )
+    monkeypatch.setattr(
+        migration,
+        "upsert_text_for_concept",
+        lambda **_kwargs: {"relation_id": "canonical-owner"},
+    )
+
+    def delete(**kwargs):
+        rows[:] = [row for row in rows if row["relation_id"] != kwargs["relation_id"]]
+        return {"deleted": True}
+
+    monkeypatch.setattr(migration, "delete_text_relation", delete)
+
+    result = migration._replace_membership_role_with_owner("#V#org_a")
+
+    assert result["canonical_read_back"]["exact_owner"] is True
+    assert result["deleted_relation_ids"] == ["legacy-owner"]
+
+
+def test_raw_partial_failure_reports_effects_and_resumes_same_fingerprint(
+    monkeypatch,
+) -> None:
+    membership_roles = {"#V#org_a": "admin"}
+    semantic_rows: list[dict] = []
+    operational_rows: list[dict] = []
+    calls: list[str] = []
+    fail_grant = True
+
+    monkeypatch.setattr(
+        migration,
+        "_collect_inventory",
+        lambda: _inventory(
+            semantic_rows=semantic_rows,
+            membership_roles=membership_roles,
+            operational_rows=operational_rows,
+        ),
+    )
+    monkeypatch.setattr(migration, "get_effective_user_concept_id", lambda: TARGET)
+    monkeypatch.setattr(migration, "current_ontology_invocation", lambda: None)
+    monkeypatch.setattr(
+        migration, "ontology_mutation_resource_lock", lambda _key: nullcontext()
+    )
+    monkeypatch.setattr(
+        migration, "override_current_organisation", lambda _org: nullcontext()
+    )
+
+    def bootstrap_operational(**_kwargs):
+        calls.append("operational")
+        operational_rows.append(
+            {"subject_concept_id": TARGET, "relation_id": "operational:target"}
+        )
+        return {"success": True, "changed": True}
+
+    def bootstrap_semantic(**_kwargs):
+        calls.append("global")
+        semantic_rows.append(_semantic_row(GLOBAL_ROLE))
+        return {"changed": True}
+
+    def grant(**kwargs):
+        calls.append("org")
+        if fail_grant:
+            raise RuntimeError("simulated write interruption")
+        semantic_rows.append(_semantic_row(ORG_ROLE, kwargs["organisation_concept_id"]))
+        return {"success": True, "changed": True}
+
+    def replace(organisation_id):
+        calls.append("owner")
+        membership_roles[organisation_id] = "owner"
+        return {
+            "success": True,
+            "changed": True,
+            "canonical_read_back": {
+                "exact_owner": True,
+                "organisation_concept_id": organisation_id,
+            },
+        }
+
+    monkeypatch.setattr(
+        migration,
+        "bootstrap_first_von_operational_administrator",
+        bootstrap_operational,
+    )
+    monkeypatch.setattr(migration, "bootstrap_first_semantic_authority", bootstrap_semantic)
+    monkeypatch.setattr(migration, "grant_ontology_authority_role", grant)
+    monkeypatch.setattr(migration, "_replace_membership_role_with_owner", replace)
+    monkeypatch.setattr(
+        migration,
+        "von_operational_administrator_read_back",
+        lambda **_kwargs: {"active": True, "grants": list(operational_rows)},
+    )
+    monkeypatch.setattr(
+        migration,
+        "authority_role_read_back",
+        lambda *, role, organisation_concept_id, **_kwargs: {
+            "active": any(
+                row["role"] == role
+                and row["organisation_concept_id"] == organisation_concept_id
+                for row in semantic_rows
+            ),
+            "grants": [
+                row
+                for row in semantic_rows
+                if row["role"] == role
+                and row["organisation_concept_id"] == organisation_concept_id
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        migration,
+        "_membership_role_read_back",
+        lambda organisation_id: {
+            "exact_owner": membership_roles[organisation_id] == "owner",
+            "organisation_concept_id": organisation_id,
+        },
+    )
+
+    before = migration.plan_ontology_authority_role_migration()
+    with pytest.raises(migration.OntologyAuthorityRoleMigrationError) as partial:
+        migration.apply_ontology_authority_role_migration(
+            expected_inventory_fingerprint=before["inventory_fingerprint"]
+        )
+    assert partial.value.reason_code == "ontology_authority_role_migration_partial"
+    assert [item["operation"] for item in partial.value.report["completed_effects"]] == [
+        "bootstrap_von_operational_administrator",
+        "bootstrap_global_ontology_administrator",
+    ]
+
+    fail_grant = False
+    resumed = migration.apply_ontology_authority_role_migration(
+        expected_inventory_fingerprint=before["inventory_fingerprint"]
+    )
+
+    assert resumed["success"] is True
+    assert resumed["replayed"] is True
+    assert calls == ["operational", "global", "org", "org", "owner"]

--- a/tests/backend/test_ontology_authority_role_service.py
+++ b/tests/backend/test_ontology_authority_role_service.py
@@ -1,0 +1,447 @@
+"""Focused Tier-3 checks for represented semantic-authority role lifecycle."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import mongomock
+import pytest
+
+from src.backend.security.access_control import override_current_actor
+from src.backend.services import ontology_authority_role_service as roles
+from src.backend.services import ontology_publication_authority_service as authority
+
+
+def _evidence(
+    actor_id: str,
+    role: str,
+    organisation_id: str | None = None,
+) -> authority.AuthorityRoleEvidence:
+    return authority.AuthorityRoleEvidence(
+        role=role,
+        actor_concept_id=actor_id,
+        organisation_concept_id=organisation_id,
+        relation_id=f"role:{actor_id}:{role}:{organisation_id or 'global'}",
+        revision="test",
+    )
+
+
+@pytest.fixture
+def role_lifecycle(monkeypatch):
+    database = mongomock.MongoClient()["ontology_authority_role_lifecycle"]
+    receipts = database["receipts"]
+    receipts.create_index("receipt_id", unique=True)
+    receipts.create_index(
+        [("actor_concept_id", 1), ("idempotency_key", 1)],
+        unique=True,
+        partialFilterExpression={"idempotency_key": {"$exists": True}},
+    )
+    monkeypatch.setattr(
+        authority, "get_ontology_mutation_receipts_collection", lambda: receipts
+    )
+    monkeypatch.setattr(authority, "_gateway_actor_trust_source", lambda: None)
+    monkeypatch.setattr(roles, "can_access_concept", lambda _concept_id: True)
+    monkeypatch.setattr(
+        roles,
+        "is_user_member_of_organisation",
+        lambda _subject_id, _organisation_id: True,
+    )
+
+    grants: list[dict[str, object]] = []
+
+    def read_rows(subject_concept_id: str | None = None):
+        return [
+            dict(item)
+            for item in grants
+            if subject_concept_id is None
+            or item["subject_concept_id"] == subject_concept_id
+        ]
+
+    def upsert(**kwargs):
+        relation_id = f"role-relation-{len(grants) + 1}"
+        grants.append(
+            {
+                "relation_id": relation_id,
+                "subject_concept_id": kwargs["subject_concept_id"],
+                "role": kwargs["text"].split("::", 1)[0],
+                "organisation_concept_id": kwargs["context"].get(
+                    "organisation_concept_id"
+                ),
+                "context": dict(kwargs["context"]),
+                "grant_provenance": dict(
+                    kwargs["context"].get("grant_provenance") or {}
+                ),
+                "updated_at": "test",
+                "storage_text": kwargs["text"],
+            }
+        )
+        return {
+            "relation_created": True,
+            "context_updated": False,
+            "relation_id": relation_id,
+        }
+
+    def delete(**kwargs):
+        relation_id = kwargs["relation_id"]
+        before = len(grants)
+        grants[:] = [item for item in grants if item["relation_id"] != relation_id]
+        return {"deleted": len(grants) != before}
+
+    monkeypatch.setattr(roles, "_role_rows", read_rows)
+    monkeypatch.setattr(
+        authority,
+        "_organisation_authority_root_exists",
+        lambda organisation_id: any(
+            item["role"] == authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE
+            and item.get("organisation_concept_id") == organisation_id
+            for item in grants
+        ),
+    )
+    monkeypatch.setattr(roles, "upsert_text_for_concept", upsert)
+    monkeypatch.setattr(roles, "delete_text_relation", delete)
+    return grants, receipts
+
+
+def _with_roles(
+    monkeypatch,
+    role_lookup: Callable[[str], tuple[authority.AuthorityRoleEvidence, ...]],
+) -> None:
+    monkeypatch.setattr(authority, "resolve_live_semantic_roles", role_lookup)
+    monkeypatch.setattr(roles, "resolve_live_semantic_roles", role_lookup)
+
+
+def test_exact_org_admin_grants_and_revokes_only_its_own_org(
+    role_lifecycle, monkeypatch
+) -> None:
+    grants, receipts = role_lifecycle
+    admin = "#V#org_a_admin"
+
+    _with_roles(
+        monkeypatch,
+        lambda actor: (
+            (
+                _evidence(
+                    admin,
+                    authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+                    "#V#org_a",
+                ),
+            )
+            if actor == admin
+            else ()
+        ),
+    )
+
+    with override_current_actor(admin, "#V#org_a"):
+        granted = roles.grant_ontology_authority_role(
+            subject_concept_id="#V#member",
+            role=authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+            organisation_concept_id="#V#org_a",
+            request_id="grant-org-a",
+        )
+        denied = roles.grant_ontology_authority_role(
+            subject_concept_id="#V#member",
+            role=authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+            organisation_concept_id="#V#org_b",
+            request_id="grant-org-b",
+        )
+        revoked = roles.revoke_ontology_authority_role(
+            subject_concept_id="#V#member",
+            role=authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+            organisation_concept_id="#V#org_a",
+            request_id="revoke-org-a",
+        )
+
+    assert granted["success"] is True
+    assert granted["canonical_read_back"]["active"] is True
+    assert granted["authority_receipt"]["actor_concept_id"] == admin
+    assert denied["success"] is False
+    assert denied["error_code"] == "organisation_ontology_admin_authority_required"
+    assert revoked["success"] is True
+    assert revoked["canonical_read_back"]["active"] is False
+    assert grants == []
+    assert receipts.count_documents({}) == 2
+
+
+def test_global_admin_establishes_only_the_first_organisation_role_root(
+    role_lifecycle, monkeypatch
+) -> None:
+    grants, _receipts = role_lifecycle
+    global_admin = "#V#global_admin"
+    grants.append(
+        {
+            "relation_id": "global-root",
+            "subject_concept_id": global_admin,
+            "role": authority.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+            "organisation_concept_id": None,
+            "context": {"authority_scope": "global"},
+            "updated_at": "test",
+            "storage_text": authority.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+        }
+    )
+    _with_roles(
+        monkeypatch,
+        lambda actor: (
+            (
+                _evidence(
+                    global_admin,
+                    authority.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+                ),
+            )
+            if actor == global_admin
+            else ()
+        ),
+    )
+
+    with override_current_actor(global_admin, None):
+        global_grant = roles.grant_ontology_authority_role(
+            subject_concept_id="#V#other_global_admin",
+            role=authority.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+            request_id="global-grant",
+        )
+        first_org_root = roles.grant_ontology_authority_role(
+            subject_concept_id="#V#org_member",
+            role=authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+            organisation_concept_id="#V#org_a",
+            request_id="global-to-org",
+        )
+        later_org_grant = roles.grant_ontology_authority_role(
+            subject_concept_id="#V#other_org_member",
+            role=authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+            organisation_concept_id="#V#org_a",
+            request_id="global-to-existing-org",
+        )
+        global_revoked = roles.revoke_ontology_authority_role(
+            subject_concept_id="#V#other_global_admin",
+            role=authority.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+            request_id="global-revoke",
+        )
+
+    assert global_grant["success"] is True
+    assert global_revoked["success"] is True
+    assert global_revoked["canonical_read_back"]["active"] is False
+    assert first_org_root["success"] is True
+    assert first_org_root["canonical_read_back"]["active"] is True
+    assert later_org_grant["success"] is False
+    assert (
+        later_org_grant["error_code"]
+        == "organisation_ontology_admin_authority_required"
+    )
+
+
+def test_roles_for_two_organisations_use_distinct_storage_values(
+    role_lifecycle, monkeypatch
+) -> None:
+    grants, _receipts = role_lifecycle
+    admin = "#V#dual_org_admin"
+    _with_roles(
+        monkeypatch,
+        lambda actor: (
+            tuple(
+                _evidence(
+                    admin,
+                    authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+                    organisation,
+                )
+                for organisation in ("#V#org_a", "#V#org_b")
+            )
+            if actor == admin
+            else ()
+        ),
+    )
+    with override_current_actor(admin, "#V#org_a"):
+        first = roles.grant_ontology_authority_role(
+            subject_concept_id="#V#member",
+            role=authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+            organisation_concept_id="#V#org_a",
+            request_id="two-org-a",
+        )
+    with override_current_actor(admin, "#V#org_b"):
+        second = roles.grant_ontology_authority_role(
+            subject_concept_id="#V#member",
+            role=authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+            organisation_concept_id="#V#org_b",
+            request_id="two-org-b",
+        )
+
+    assert first["success"] and second["success"]
+    assert {item["storage_text"] for item in grants} == {
+        "organisation_ontology_administrator::#V#org_a",
+        "organisation_ontology_administrator::#V#org_b",
+    }
+    assert {item["organisation_concept_id"] for item in grants} == {
+        "#V#org_a",
+        "#V#org_b",
+    }
+
+
+def test_each_role_relation_keeps_its_exact_grant_provenance(
+    role_lifecycle,
+    monkeypatch,
+) -> None:
+    grants, _receipts = role_lifecycle
+    admins = {"#V#admin_a", "#V#admin_b"}
+    _with_roles(
+        monkeypatch,
+        lambda actor: (
+            (
+                _evidence(
+                    actor,
+                    authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+                    "#V#org_a",
+                ),
+            )
+            if actor in admins
+            else ()
+        ),
+    )
+
+    with override_current_actor("#V#admin_a", "#V#org_a"):
+        first = roles.grant_ontology_authority_role(
+            subject_concept_id="#V#member_a",
+            role=authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+            organisation_concept_id="#V#org_a",
+            request_id="grant-by-a",
+            reason="first reason",
+        )
+    with override_current_actor("#V#admin_b", "#V#org_a"):
+        second = roles.grant_ontology_authority_role(
+            subject_concept_id="#V#member_b",
+            role=authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+            organisation_concept_id="#V#org_a",
+            request_id="grant-by-b",
+            reason="second reason",
+        )
+
+    assert first["success"] is True
+    assert second["success"] is True
+    assert [item["grant_provenance"] for item in grants] == [
+        {
+            "source": "ontology_authority_role_grant",
+            "granted_by_actor_concept_id": "#V#admin_a",
+            "request_id": "grant-by-a",
+            "reason": "first reason",
+        },
+        {
+            "source": "ontology_authority_role_grant",
+            "granted_by_actor_concept_id": "#V#admin_b",
+            "request_id": "grant-by-b",
+            "reason": "second reason",
+        },
+    ]
+
+
+def test_member_and_executing_agent_cannot_manage_roles(
+    role_lifecycle, monkeypatch
+) -> None:
+    _grants, _receipts = role_lifecycle
+    _with_roles(monkeypatch, lambda _actor: ())
+
+    with override_current_actor("#V#member", "#V#org_a"):
+        denied = roles.grant_ontology_authority_role(
+            subject_concept_id="#V#target",
+            role=authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+            organisation_concept_id="#V#org_a",
+            request_id="member-denied",
+        )
+    assert denied["success"] is False
+    assert denied["error_code"] == "organisation_ontology_admin_authority_required"
+
+    with (
+        override_current_actor("#V#admin", "#V#org_a"),
+        authority.bind_ontology_invocation(
+            surface="test",
+            executing_agent_concept_id="#V#agent",
+            audience="test",
+            effect_id="role-management",
+        ),
+        pytest.raises(
+            PermissionError,
+            match="ontology_authority_role_human_administrator_required",
+        ),
+    ):
+        roles.grant_ontology_authority_role(
+            subject_concept_id="#V#target",
+            role=authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+            organisation_concept_id="#V#org_a",
+            request_id="agent-denied",
+        )
+
+
+def test_organisation_role_grant_requires_live_exact_membership(
+    role_lifecycle, monkeypatch
+) -> None:
+    _grants, _receipts = role_lifecycle
+    admin = "#V#org_admin"
+    _with_roles(
+        monkeypatch,
+        lambda actor: (
+            (
+                _evidence(
+                    admin,
+                    authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+                    "#V#org_a",
+                ),
+            )
+            if actor == admin
+            else ()
+        ),
+    )
+    monkeypatch.setattr(
+        roles,
+        "is_user_member_of_organisation",
+        lambda _subject, _organisation: False,
+    )
+
+    with override_current_actor(admin, "#V#org_a"):
+        denied = roles.grant_ontology_authority_role(
+            subject_concept_id="#V#former_member",
+            role=authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+            organisation_concept_id="#V#org_a",
+            request_id="membership-required",
+        )
+
+    assert denied["success"] is False
+    assert denied["error_code"] == (
+        "organisation_membership_required_for_ontology_authority"
+    )
+
+
+def test_last_global_role_is_not_revoked_and_receipt_reads_back_active(
+    role_lifecycle, monkeypatch
+) -> None:
+    grants, receipts = role_lifecycle
+    admin = "#V#only_global_admin"
+    grants.append(
+        {
+            "relation_id": "global-role",
+            "subject_concept_id": admin,
+            "role": authority.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+            "organisation_concept_id": None,
+            "context": {"authority_scope": "global"},
+            "updated_at": "test",
+            "storage_text": authority.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+        }
+    )
+    _with_roles(
+        monkeypatch,
+        lambda actor: (
+            (_evidence(admin, authority.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE),)
+            if actor == admin
+            else ()
+        ),
+    )
+
+    with override_current_actor(admin, None):
+        result = roles.revoke_ontology_authority_role(
+            subject_concept_id=admin,
+            role=authority.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+            request_id="cannot-remove-root",
+        )
+
+    assert result["success"] is False
+    assert (
+        result["error_code"] == "last_global_ontology_administrator_cannot_be_revoked"
+    )
+    assert result["canonical_read_back"]["active"] is True
+    assert result["authority_receipt"]["status"] == "failed"
+    assert receipts.count_documents({}) == 1

--- a/tests/backend/test_ontology_authority_routes.py
+++ b/tests/backend/test_ontology_authority_routes.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+from flask import Flask
+
+from src.backend.server.routes import ontology_authority_routes as routes
+from src.backend.services.ontology_publication_authority_service import (
+    OntologyMutationIntent,
+    PublicationContext,
+)
+
+
+def _app() -> Flask:
+    app = Flask(__name__)
+    app.secret_key = "ontology-authority-route-tests"
+    app.register_blueprint(routes.ontology_authority_bp)
+    return app
+
+
+def test_authority_summary_uses_server_actor_and_states_operator_separation(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(routes, "get_effective_user_concept_id", lambda: "#V#server")
+    monkeypatch.setattr(
+        routes,
+        "list_actor_semantic_authority",
+        lambda actor: {
+            "actor_concept_id": actor,
+            "roles": [],
+            "von_administrator_semantics": {
+                "implies_semantic_ontology_authority": False
+            },
+        },
+    )
+
+    response = _app().test_client().get("/api/ontology-authority/me")
+
+    assert response.status_code == 200
+    assert response.get_json()["actor_concept_id"] == "#V#server"
+    assert (
+        response.get_json()["von_administrator_semantics"][
+            "implies_semantic_ontology_authority"
+        ]
+        is False
+    )
+
+
+def test_delegation_ignores_payload_grantor_and_requires_exact_effect(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(routes, "get_effective_user_concept_id", lambda: "#V#server")
+    monkeypatch.setattr(
+        routes, "get_effective_organisation_concept_id", lambda: "#V#org"
+    )
+    intent = OntologyMutationIntent(
+        operation="text.upsert",
+        publication_context=PublicationContext.organisation("#V#org"),
+        target_concept_ids=("#V#concept",),
+        tool_name="upsert_text_relation",
+    )
+    monkeypatch.setattr(routes, "build_ontology_mutation_intent", lambda **_: intent)
+    captured = {}
+
+    def issue(**kwargs):
+        captured.update(kwargs)
+        return {"delegation_id": "oag-1", "status": "active"}
+
+    monkeypatch.setattr(routes, "issue_agent_delegation", issue)
+    response = (
+        _app()
+        .test_client()
+        .post(
+            "/api/ontology-authority/delegations",
+            json={
+                "method_name": "upsert_text_relation",
+                "arguments": {"concept_id": "#V#concept"},
+                "grantor_actor_concept_id": "#V#attacker",
+                "delegate_concept_id": "#V#agent",
+                "audience": "adaptive_turn",
+                "effect_id": "effect-1",
+            },
+        )
+    )
+
+    assert response.status_code == 201
+    assert captured["grantor_actor_concept_id"] == "#V#server"
+    assert captured["effect_id"] == "effect-1"
+    assert captured["tool_name"] == "upsert_text_relation"
+
+
+def test_bootstrap_needs_explicit_opt_in_and_token(monkeypatch) -> None:
+    monkeypatch.delenv("VON_ALLOW_ONTOLOGY_AUTHORITY_BOOTSTRAP", raising=False)
+    monkeypatch.setenv("VON_ADMIN_TOKEN", "operator-secret")
+    client = _app().test_client()
+    denied = client.post(
+        "/api/ontology-authority/bootstrap",
+        json={
+            "subject_concept_id": "#V#first",
+            "role": "global_ontology_administrator",
+        },
+        headers={"X-Von-Admin-Token": "operator-secret"},
+    )
+    assert denied.status_code == 403
+
+    monkeypatch.setenv("VON_ALLOW_ONTOLOGY_AUTHORITY_BOOTSTRAP", "1")
+    captured = {}
+    monkeypatch.setattr(
+        routes,
+        "bootstrap_first_semantic_authority",
+        lambda **kwargs: captured.update(kwargs) or {"first_grant": kwargs},
+    )
+    granted = client.post(
+        "/api/ontology-authority/bootstrap",
+        json={
+            "subject_concept_id": "#V#first",
+            "role": "global_ontology_administrator",
+        },
+        headers={"X-Von-Admin-Token": "operator-secret"},
+    )
+    assert granted.status_code == 201
+    assert captured["subject_concept_id"] == "#V#first"
+
+
+def test_receipt_read_does_not_disclose_another_actors_receipt(monkeypatch) -> None:
+    monkeypatch.setattr(routes, "get_effective_user_concept_id", lambda: "#V#server")
+    monkeypatch.setattr(routes, "get_mutation_receipt_for_actor", lambda **_: None)
+
+    response = _app().test_client().get("/api/ontology-authority/receipts/secret")
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "ontology_mutation_receipt_not_found"}
+
+
+def test_role_route_uses_only_server_identity_not_forged_payload_identity(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(routes, "get_effective_user_concept_id", lambda: "#V#member")
+    captured = {}
+
+    def grant(**kwargs):
+        captured.update(kwargs)
+        raise PermissionError("organisation_ontology_admin_authority_required")
+
+    monkeypatch.setattr(routes, "grant_ontology_authority_role", grant)
+    response = (
+        _app()
+        .test_client()
+        .post(
+            "/api/ontology-authority/roles",
+            json={
+                "subject_concept_id": "#V#target",
+                "role": "organisation_ontology_administrator",
+                "organisation_concept_id": "#V#org_a",
+                "request_id": "forged-identity",
+                "actor_concept_id": "#V#global_admin",
+                "grantor_actor_concept_id": "#V#global_admin",
+                "organisation_id": "#V#global_org",
+            },
+        )
+    )
+
+    assert response.status_code == 403
+    assert (
+        response.get_json()["error"] == "organisation_ontology_admin_authority_required"
+    )
+    assert captured == {
+        "subject_concept_id": "#V#target",
+        "role": "organisation_ontology_administrator",
+        "organisation_concept_id": "#V#org_a",
+        "request_id": "forged-identity",
+        "reason": None,
+    }
+
+
+def test_scope_read_returns_not_found_without_disclosing_inaccessible_concept(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(routes, "get_effective_user_concept_id", lambda: "#V#member")
+    monkeypatch.setattr(routes, "can_access_concept", lambda _concept_id: False)
+    monkeypatch.setattr(
+        routes,
+        "scope_read_back",
+        lambda _concept_id: AssertionError("must not read inaccessible scope"),
+    )
+
+    response = (
+        _app()
+        .test_client()
+        .get("/api/ontology-authority/concepts/%23V%23historical-secret/scope")
+    )
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "ontology_scope_target_not_found"}
+
+
+def test_scope_preview_and_execute_are_distinct_effects(monkeypatch) -> None:
+    monkeypatch.setattr(routes, "get_effective_user_concept_id", lambda: "#V#admin")
+    calls = []
+
+    def change(**kwargs):
+        calls.append(kwargs)
+        return {
+            "success": True,
+            "authority_receipt": {"receipt_id": f"receipt-{kwargs['request_id']}"},
+            "canonical_read_back": {"scope_fingerprint": "after"},
+        }
+
+    monkeypatch.setattr(routes, "change_concept_publication_scope", change)
+    client = _app().test_client()
+    preview = client.post(
+        "/api/ontology-authority/concepts/%23V%23legacy/scope",
+        json={
+            "destination_kind": "organisation",
+            "destination_concept_id": "#V#org_a",
+            "expected_scope_fingerprint": "before",
+            "request_id": "scope-preview",
+            "preview": True,
+        },
+    )
+    execute = client.post(
+        "/api/ontology-authority/concepts/%23V%23legacy/scope",
+        json={
+            "destination_kind": "organisation",
+            "destination_concept_id": "#V#org_a",
+            "expected_scope_fingerprint": "before",
+            "request_id": "scope-execute",
+            "preview": False,
+        },
+    )
+
+    assert preview.status_code == 200
+    assert execute.status_code == 200
+    assert [call["request_id"] for call in calls] == ["scope-preview", "scope-execute"]
+    assert [call["preview"] for call in calls] == [True, False]
+    assert (
+        preview.get_json()["authority_receipt"]
+        != execute.get_json()["authority_receipt"]
+    )
+
+
+def test_scope_route_drops_forged_legacy_authority_payload(monkeypatch) -> None:
+    monkeypatch.setattr(routes, "get_effective_user_concept_id", lambda: "#V#member")
+    captured = {}
+
+    def change(**kwargs):
+        captured.update(kwargs)
+        return {
+            "success": False,
+            "error_code": "global_ontology_admin_authority_required",
+        }
+
+    monkeypatch.setattr(routes, "change_concept_publication_scope", change)
+    response = (
+        _app()
+        .test_client()
+        .post(
+            "/api/ontology-authority/concepts/%23V%23legacy/scope",
+            json={
+                "destination_kind": "global",
+                "expected_scope_fingerprint": "before",
+                "request_id": "forged-legacy-scope",
+                "preview": False,
+                "actor_concept_id": "#V#global_admin",
+                "organisation_concept_id": "#V#global_org",
+                "legacy_scope_override": True,
+            },
+        )
+    )
+
+    assert response.status_code == 409
+    assert (
+        response.get_json()["error_code"] == "global_ontology_admin_authority_required"
+    )
+    assert captured == {
+        "concept_id": "#V#legacy",
+        "destination_kind": "global",
+        "destination_concept_id": None,
+        "expected_scope_fingerprint": "before",
+        "request_id": "forged-legacy-scope",
+        "preview": False,
+        "reason": None,
+    }
+
+
+def test_role_migration_dry_run_requires_explicit_operator_bootstrap_token(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("VON_ALLOW_ONTOLOGY_AUTHORITY_BOOTSTRAP", raising=False)
+    monkeypatch.setenv("VON_ADMIN_TOKEN", "operator-secret")
+    monkeypatch.setattr(
+        routes,
+        "plan_ontology_authority_role_migration",
+        lambda: {"mode": "dry_run", "ready_to_apply": True},
+    )
+
+    response = _app().test_client().get(
+        "/api/ontology-authority/bootstrap/role-migration",
+        headers={"X-Von-Admin-Token": "operator-secret"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_role_migration_apply_is_fixed_to_michael_and_inventory_fingerprint(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("VON_ALLOW_ONTOLOGY_AUTHORITY_BOOTSTRAP", "true")
+    monkeypatch.setenv("VON_ADMIN_TOKEN", "operator-secret")
+    monkeypatch.setattr(
+        routes,
+        "get_effective_user_concept_id",
+        lambda: routes.ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+    )
+    captured = {}
+    invalidated: list[str] = []
+
+    def apply(**kwargs):
+        captured.update(kwargs)
+        return {
+            "mode": "apply",
+            "success": True,
+            "target_concept_id": routes.ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+        }
+
+    monkeypatch.setattr(routes, "apply_ontology_authority_role_migration", apply)
+    monkeypatch.setattr(
+        routes,
+        "delete_all_window_contexts_owned_by",
+        lambda user_id: invalidated.append(user_id) or 2,
+    )
+    client = _app().test_client()
+    with client.session_transaction() as flask_session:
+        flask_session["user_concept_id"] = (
+            routes.ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET
+        )
+        flask_session["role_in_org"] = "admin"
+    response = client.post(
+        "/api/ontology-authority/bootstrap/role-migration",
+        json={
+            "mode": "apply",
+            "expected_inventory_fingerprint": "dry-run-fingerprint",
+            "target_concept_id": "#V#attacker_selected_target",
+            "actor_concept_id": "#V#attacker",
+        },
+        headers={"X-Von-Admin-Token": "operator-secret"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["target_concept_id"] == (
+        routes.ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET
+    )
+    assert captured == {
+        "expected_inventory_fingerprint": "dry-run-fingerprint"
+    }
+    assert invalidated == [routes.ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET]
+    assert response.get_json()["derived_role_cache_invalidation"] == {
+        "flask_session_role_cleared": True,
+        "window_contexts_deleted": 2,
+    }
+    with client.session_transaction() as flask_session:
+        assert "role_in_org" not in flask_session
+
+
+def test_role_migration_apply_rejects_non_target_actor_before_service(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("VON_ALLOW_ONTOLOGY_AUTHORITY_BOOTSTRAP", "true")
+    monkeypatch.setenv("VON_ADMIN_TOKEN", "operator-secret")
+    monkeypatch.setattr(
+        routes, "get_effective_user_concept_id", lambda: "#V#other_person"
+    )
+    monkeypatch.setattr(
+        routes,
+        "apply_ontology_authority_role_migration",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("wrong actor must not reach migration service")
+        ),
+    )
+
+    client = _app().test_client()
+    with client.session_transaction() as flask_session:
+        flask_session["user_concept_id"] = "#V#other_person"
+    response = client.post(
+        "/api/ontology-authority/bootstrap/role-migration",
+        json={"mode": "apply", "expected_inventory_fingerprint": "current"},
+        headers={"X-Von-Admin-Token": "operator-secret"},
+    )
+
+    assert response.status_code == 403
+    assert response.get_json()["error"] == (
+        "ontology_authority_role_migration_target_actor_required"
+    )
+
+
+def test_role_migration_apply_does_not_accept_legacy_identity_header(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("VON_ALLOW_ONTOLOGY_AUTHORITY_BOOTSTRAP", "true")
+    monkeypatch.setenv("VON_ADMIN_TOKEN", "operator-secret")
+    monkeypatch.setattr(
+        routes,
+        "get_effective_user_concept_id",
+        lambda: routes.ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+    )
+    monkeypatch.setattr(
+        routes,
+        "apply_ontology_authority_role_migration",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("identity header must not authorise migration")
+        ),
+    )
+
+    response = _app().test_client().post(
+        "/api/ontology-authority/bootstrap/role-migration",
+        json={"mode": "apply", "expected_inventory_fingerprint": "current"},
+        headers={
+            "X-Von-Admin-Token": "operator-secret",
+            "X-User-Concept-ID": routes.ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
+        },
+    )
+
+    assert response.status_code == 403

--- a/tests/backend/test_ontology_authority_tier3_regressions.py
+++ b/tests/backend/test_ontology_authority_tier3_regressions.py
@@ -1,0 +1,876 @@
+"""Tier-3 authority regressions for JVNAUTOSCI-2632.
+
+These examples are deterministic reconstructions of the blocked 12 August
+2026 candidature classifications.  They exercise only in-memory authority
+stores; no test reads or mutates live Vontology data.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from threading import Event, Lock, Thread
+from typing import Any
+
+import mongomock
+import pytest
+
+BLOCKED_CANDIDATURE_SOURCE_IDS = (
+    "#V#andrew_probert",
+    "#V#andrey_borro",
+    "#V#bin_zhang",
+    "#V#gael_gendron",
+    "#V#gibran_zazueta_cruz",
+    "#V#i_chieh_wei",
+    "#V#jian_cheng",
+    "#V#junchen_liu",
+    "#V#kobe_knowles",
+    "#V#minjung_kim",
+    "#V#nathan_young",
+    "#V#neset_tan",
+    "#V#rebecca_allcock",
+    "#V#shaoxin_zhong",
+    "#V#stefan_fuchs",
+    "#V#tim_hartill",
+    "#V#timothy_pistotti",
+    "#V#xianda_zheng",
+    "#V#yaotian_shi",
+    "#V#yonghua_zhu",
+    "#V#yuchen_su",
+    "#V#yueying_zhou",
+    "#V#ziqin_zhu",
+)
+
+BLOCKED_CANDIDATURE_TUPLES = tuple(
+    (source_id, "#V#is_an_instance_of", "#V#student")
+    for source_id in BLOCKED_CANDIDATURE_SOURCE_IDS
+)
+GRADUATE_STUDENT_TAXONOMY_TUPLE = (
+    "#V#graduate_student",
+    "#V#is_a_type_of",
+    "#V#university_student",
+)
+
+
+@pytest.fixture
+def authority_service(monkeypatch):
+    from src.backend.services import ontology_publication_authority_service as service
+
+    database = mongomock.MongoClient()["tier3_ontology_authority"]
+    delegations = database["delegations"]
+    receipts = database["receipts"]
+    delegations.create_index("delegation_id", unique=True)
+    receipts.create_index("receipt_id", unique=True)
+    receipts.create_index(
+        [("actor_concept_id", 1), ("idempotency_key", 1)],
+        unique=True,
+        partialFilterExpression={"idempotency_key": {"$exists": True}},
+    )
+    monkeypatch.setattr(
+        service,
+        "get_ontology_authority_delegations_collection",
+        lambda: delegations,
+    )
+    monkeypatch.setattr(
+        service,
+        "get_ontology_mutation_receipts_collection",
+        lambda: receipts,
+    )
+    monkeypatch.setattr(service, "_gateway_actor_trust_source", lambda: None)
+    return service, delegations, receipts
+
+
+def _role(service, *, role: str, organisation: str | None = None):
+    return service.AuthorityRoleEvidence(
+        role=role,
+        actor_concept_id="#V#semantic_admin",
+        organisation_concept_id=organisation,
+        relation_id=f"role:{role}:{organisation or 'global'}",
+        revision="tier3",
+    )
+
+
+def _intent(
+    service,
+    *,
+    source_id: str = "#V#graduate_student",
+    predicate: str = "#V#is_a_type_of",
+    target_id: str = "#V#university_student",
+    context=None,
+    source_contexts=(),
+    idempotency_key: str | None = None,
+):
+    return service.OntologyMutationIntent(
+        operation="relationship.add",
+        publication_context=context or service.PublicationContext.global_context(),
+        source_contexts=tuple(source_contexts),
+        target_concept_ids=(source_id, target_id),
+        tool_name="add_relationship",
+        predicate=predicate,
+        delta={"target_concept_id": target_id},
+        idempotency_key=idempotency_key,
+    )
+
+
+def test_motivating_candidature_fixture_is_complete_and_exact() -> None:
+    assert len(BLOCKED_CANDIDATURE_TUPLES) == 23
+    assert len(set(BLOCKED_CANDIDATURE_SOURCE_IDS)) == 23
+    assert all(
+        predicate == "#V#is_an_instance_of" and target == "#V#student"
+        for _source, predicate, target in BLOCKED_CANDIDATURE_TUPLES
+    )
+    assert GRADUATE_STUDENT_TAXONOMY_TUPLE == (
+        "#V#graduate_student",
+        "#V#is_a_type_of",
+        "#V#university_student",
+    )
+
+
+@pytest.mark.parametrize("source_id,predicate,target_id", BLOCKED_CANDIDATURE_TUPLES)
+def test_global_semantic_admin_can_authorise_each_previously_blocked_candidature(
+    authority_service,
+    monkeypatch,
+    source_id: str,
+    predicate: str,
+    target_id: str,
+) -> None:
+    service, _delegations, _receipts = authority_service
+    global_role = _role(
+        service,
+        role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+    )
+    monkeypatch.setattr(
+        service,
+        "resolve_live_semantic_roles",
+        lambda _actor: (global_role,),
+    )
+    with service.override_current_actor("#V#semantic_admin", None):
+        decision = service.authorise_ontology_mutation(
+            _intent(
+                service,
+                source_id=source_id,
+                predicate=predicate,
+                target_id=target_id,
+            )
+        )
+    assert decision.allowed is True
+    assert decision.reason_code == "semantic_ontology_authority_verified"
+
+
+def test_global_semantic_admin_can_authorise_the_blocked_taxonomy_edge(
+    authority_service,
+    monkeypatch,
+) -> None:
+    service, _delegations, _receipts = authority_service
+    global_role = _role(service, role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE)
+    monkeypatch.setattr(
+        service, "resolve_live_semantic_roles", lambda _actor: (global_role,)
+    )
+    with service.override_current_actor("#V#semantic_admin", None):
+        decision = service.authorise_ontology_mutation(
+            _intent(service, source_id=GRADUATE_STUDENT_TAXONOMY_TUPLE[0])
+        )
+    assert decision.allowed is True
+
+
+def test_motivating_candidature_and_taxonomy_changes_execute_with_read_back(
+    authority_service,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prove the original 24 effects, not merely their policy decisions."""
+
+    from src.backend.db.repositories import concepts_repository
+    from src.backend.integrations.internal_mcp import catalogue
+    from src.backend.security import access_control
+    from src.backend.services import ontology_mutation_command_service as command
+    from src.backend.services import relationship_write_service as relationship
+
+    service, _delegations, _receipts = authority_service
+    database = mongomock.MongoClient()["tier3_motivating_canonical_effects"]
+    concepts = database["concepts"]
+    concept_ids = {
+        *BLOCKED_CANDIDATURE_SOURCE_IDS,
+        "#V#student",
+        "#V#graduate_student",
+        "#V#university_student",
+    }
+    concepts.insert_many(
+        [
+            {"concept_id": concept_id, "relationships": {}}
+            for concept_id in sorted(concept_ids)
+        ]
+    )
+    monkeypatch.setattr(
+        concepts_repository,
+        "get_concepts_collection",
+        lambda: concepts,
+    )
+    monkeypatch.setattr(access_control, "get_concepts_collection", lambda: concepts)
+    monkeypatch.setattr(command, "can_access_concept", lambda _item: True)
+
+    aliases = {
+        "#V#is_an_instance_of": "is_an_instance_of",
+        "#V#is_a_type_of": "is_a_type_of",
+        "#V#has_instance": "has_instance",
+        "#V#has_subtype": "has_subtype",
+    }
+    inverse_map = {
+        "is_an_instance_of": "has_instance",
+        "has_instance": "is_an_instance_of",
+        "is_a_type_of": "has_subtype",
+        "has_subtype": "is_a_type_of",
+    }
+    relationship_kinds = frozenset(inverse_map)
+
+    def normalise(predicate: str) -> str:
+        return aliases.get(predicate, predicate)
+
+    monkeypatch.setattr(relationship, "normalise_structural_predicate", normalise)
+    monkeypatch.setattr(
+        relationship,
+        "is_structural_predicate",
+        lambda predicate: normalise(predicate) in relationship_kinds,
+    )
+    monkeypatch.setattr(
+        relationship,
+        "get_relationship_kinds_set",
+        lambda: relationship_kinds,
+    )
+    monkeypatch.setattr(
+        relationship,
+        "get_structural_inverse_map",
+        lambda: inverse_map,
+    )
+    monkeypatch.setattr(command, "normalise_structural_predicate", normalise)
+    monkeypatch.setattr(
+        command,
+        "is_structural_predicate",
+        lambda predicate: normalise(predicate) in relationship_kinds,
+    )
+    monkeypatch.setattr(command, "get_structural_inverse_map", lambda: inverse_map)
+    monkeypatch.setattr(
+        relationship,
+        "_sync_relationship_extent_index_for_sources",
+        lambda _items: None,
+    )
+    monkeypatch.setattr(
+        relationship,
+        "_invalidate_workflow_routing_projection_for_relationship_change",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        relationship,
+        "_emit_relationship_mutation_event",
+        lambda **_kwargs: None,
+    )
+
+    global_role = _role(service, role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE)
+    monkeypatch.setattr(
+        service,
+        "resolve_live_semantic_roles",
+        lambda _actor: (global_role,),
+    )
+
+    results = []
+    with service.override_current_actor("#V#semantic_admin", None):
+        for index, (source_id, predicate, target_id) in enumerate(
+            (*BLOCKED_CANDIDATURE_TUPLES, GRADUATE_STUDENT_TAXONOMY_TUPLE)
+        ):
+            results.append(
+                catalogue._add_relationship(
+                    source_id=source_id,
+                    predicate=predicate,
+                    target=target_id,
+                    request_id=f"tier3-motivating-effect:{index}",
+                )
+            )
+
+    assert len(results) == 24
+    assert all(result.get("success") is True for result in results)
+    assert all(
+        result.get("authority_receipt", {}).get("status") == "succeeded"
+        and result.get("canonical_read_back", {}).get("relationship_present") is True
+        and result.get("canonical_read_back", {}).get("inverse_relationship_present")
+        is True
+        for result in results
+    )
+    for source_id in BLOCKED_CANDIDATURE_SOURCE_IDS:
+        assert concepts.find_one({"concept_id": source_id})["relationships"][
+            "is_an_instance_of"
+        ] == ["#V#student"]
+    assert set(
+        concepts.find_one({"concept_id": "#V#student"})["relationships"]["has_instance"]
+    ) == set(BLOCKED_CANDIDATURE_SOURCE_IDS)
+    assert concepts.find_one({"concept_id": "#V#graduate_student"})["relationships"][
+        "is_a_type_of"
+    ] == ["#V#university_student"]
+    assert concepts.find_one({"concept_id": "#V#university_student"})["relationships"][
+        "has_subtype"
+    ] == ["#V#graduate_student"]
+
+
+@pytest.mark.parametrize(
+    ("source_context", "destination"),
+    (
+        (
+            "historical",
+            ("global", None),
+        ),
+        (
+            "mixed",
+            ("organisation", "#V#organisation_a"),
+        ),
+    ),
+)
+def test_historical_or_mixed_scope_adoption_requires_global_source_authority(
+    authority_service,
+    monkeypatch,
+    source_context: str,
+    destination: tuple[str, str | None],
+) -> None:
+    service, _delegations, _receipts = authority_service
+    if source_context == "historical":
+        source = service.PublicationContext(
+            service.PublicationContextKind.HISTORICAL,
+            source="legacy_specific_to_org",
+            historical_predicates=("specific_to_org",),
+        )
+    else:
+        source = service.PublicationContext(
+            service.PublicationContextKind.MIXED,
+            source="conflicting_scope_edges",
+            historical_predicates=("#V#specific_to_organisation", "specific_to_org"),
+        )
+    destination_context = (
+        service.PublicationContext.global_context()
+        if destination[0] == "global"
+        else service.PublicationContext.organisation(str(destination[1]))
+    )
+    intent = service.OntologyMutationIntent(
+        operation="scope.change",
+        publication_context=destination_context,
+        source_contexts=(source,),
+        target_concept_ids=("#V#legacy_concept",),
+        tool_name="change_concept_publication_scope",
+        delta={"fixture": source_context},
+    )
+
+    org_only = _role(
+        service,
+        role=service.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+        organisation="#V#organisation_a",
+    )
+    monkeypatch.setattr(
+        service, "resolve_live_semantic_roles", lambda _actor: (org_only,)
+    )
+    with service.override_current_actor("#V#semantic_admin", "#V#organisation_a"):
+        denied = service.authorise_ontology_mutation(intent)
+    assert denied.allowed is False
+    assert denied.reason_code == "global_ontology_admin_authority_required"
+
+    global_role = _role(service, role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE)
+    if destination[0] == "organisation":
+        roles = (global_role, org_only)
+    else:
+        roles = (global_role,)
+    monkeypatch.setattr(service, "resolve_live_semantic_roles", lambda _actor: roles)
+    with service.override_current_actor("#V#semantic_admin", "#V#organisation_a"):
+        allowed = service.authorise_ontology_mutation(intent)
+    assert allowed.allowed is True
+    assert allowed.reason_code == "semantic_ontology_authority_verified"
+
+
+def test_scope_change_does_not_leak_inaccessible_historical_target(monkeypatch) -> None:
+    from src.backend.services import ontology_scope_change_service as scope
+
+    monkeypatch.setattr(scope, "can_access_concept", lambda _concept_id: False)
+    monkeypatch.setattr(
+        scope,
+        "scope_read_back",
+        lambda _concept_id: pytest.fail("must not inspect an inaccessible target"),
+    )
+
+    with pytest.raises(PermissionError, match="ontology_scope_target_not_accessible"):
+        scope.change_concept_publication_scope(
+            concept_id="#V#historical_concept",
+            destination_kind="global",
+            expected_scope_fingerprint="opaque-fingerprint",
+            request_id="fixture-no-leak",
+        )
+
+
+def test_global_admin_can_adopt_historical_scope_with_canonical_read_back(
+    authority_service,
+    monkeypatch,
+) -> None:
+    """The repair path removes legacy scope only after explicit global authority."""
+
+    from src.backend.services import ontology_scope_change_service as scope
+
+    service, _delegations, _receipts = authority_service
+    global_role = _role(service, role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE)
+    monkeypatch.setattr(
+        service, "resolve_live_semantic_roles", lambda _actor: (global_role,)
+    )
+    monkeypatch.setattr(scope, "can_access_concept", lambda _concept_id: True)
+    before = {
+        "concept_id": "#V#legacy_concept",
+        "publication_context": {
+            "kind": "historical",
+            "concept_id": None,
+            "source": "legacy_specific_to_org",
+            "historical_predicates": ["specific_to_org"],
+        },
+        "scope_edges": {"specific_to_org": ["#V#organisation_a"]},
+        "scope_fingerprint": "scope-before",
+    }
+    after = {
+        **before,
+        "publication_context": {
+            "kind": "global",
+            "concept_id": None,
+            "source": "resolved",
+        },
+        "scope_edges": {},
+        "scope_fingerprint": "scope-after",
+    }
+    # The execution lock rechecks the optimistic snapshot immediately before
+    # crossing the first visibility-edge mutation boundary.
+    reads = iter((before, before, after))
+    removed: list[dict[str, Any]] = []
+    monkeypatch.setattr(scope, "scope_read_back", lambda _concept_id: next(reads))
+    monkeypatch.setattr(
+        scope,
+        "remove_relationship",
+        lambda **kwargs: removed.append(kwargs) or {"success": True, "removed": True},
+    )
+
+    with service.override_current_actor("#V#semantic_admin", None):
+        result = scope.change_concept_publication_scope(
+            concept_id="#V#legacy_concept",
+            destination_kind="global",
+            expected_scope_fingerprint="scope-before",
+            request_id="adopt-historical-fixture",
+            preview=False,
+        )
+
+    assert result["success"] is True
+    assert result["authority_decision"]["allowed"] is True
+    assert result["canonical_read_back"] == after
+    assert removed == [
+        {
+            "source_id": "#V#legacy_concept",
+            "predicate": "specific_to_org",
+            "target": "#V#organisation_a",
+            "mode": "soft_delete",
+            "cascade": "warn",
+            "dry_run": False,
+            "confirmed": True,
+            "reason": "ontology scope transition",
+            "request_id": "adopt-historical-fixture:remove:0",
+        }
+    ]
+
+
+def _issue_delegation(service, *, issued_at: datetime):
+    global_role = _role(service, role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE)
+    intent = _intent(service)
+    return (
+        intent,
+        global_role,
+        service.issue_agent_delegation(
+            intent=intent,
+            grantor_actor_concept_id="#V#semantic_admin",
+            grantor_organisation_concept_id=None,
+            delegate_concept_id="#V#von_system",
+            audience="adaptive_turn",
+            tool_name="add_relationship",
+            effect_id="tier3-effect",
+            turn_id="tier3-turn",
+            now=issued_at,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("override", "expected_reason"),
+    (
+        ({"audience": "wrong"}, "ontology_delegation_audience_mismatch"),
+        ({"effect_id": "wrong-effect"}, "ontology_delegation_effect_id_mismatch"),
+        (
+            {"tool_name": "remove_relationship"},
+            "ontology_delegation_tool_name_mismatch",
+        ),
+        (
+            {"target_id": "#V#different_target"},
+            "ontology_delegation_intent_fingerprint_mismatch",
+        ),
+    ),
+)
+def test_delegation_is_exact_over_audience_effect_tool_and_target(
+    authority_service,
+    monkeypatch,
+    override: dict[str, str],
+    expected_reason: str,
+) -> None:
+    service, _delegations, _receipts = authority_service
+    issued_at = datetime(2026, 8, 13, 9, 0, tzinfo=UTC)
+    global_role = _role(service, role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE)
+    monkeypatch.setattr(
+        service, "resolve_live_semantic_roles", lambda _actor: (global_role,)
+    )
+    _issued_intent, _role_evidence, grant = _issue_delegation(
+        service,
+        issued_at=issued_at,
+    )
+    attempted_intent = _intent(
+        service,
+        target_id=override.get("target_id", "#V#university_student"),
+    )
+    invocation = service.OntologyInvocationContext(
+        surface="ordinary_turn",
+        executing_agent_concept_id="#V#von_system",
+        audience=override.get("audience", "adaptive_turn"),
+        delegation_id=grant["delegation_id"],
+        effect_id=override.get("effect_id", "tier3-effect"),
+    )
+    if "tool_name" in override:
+        attempted_intent = service.OntologyMutationIntent(
+            **{**attempted_intent.__dict__, "tool_name": override["tool_name"]}
+        )
+    decision = service.verify_agent_delegation(
+        delegation_id=grant["delegation_id"],
+        intent=attempted_intent,
+        invocation=invocation,
+        actor_concept_id="#V#semantic_admin",
+        organisation_concept_id=None,
+        now=issued_at + timedelta(seconds=1),
+    )
+    assert decision.allowed is False
+    assert decision.reason_code == expected_reason
+
+
+def test_delegation_rejects_a_different_actor_even_when_the_agent_is_exact(
+    authority_service,
+    monkeypatch,
+) -> None:
+    service, _delegations, _receipts = authority_service
+    issued_at = datetime(2026, 8, 13, 9, 0, tzinfo=UTC)
+    global_role = _role(service, role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE)
+    monkeypatch.setattr(
+        service, "resolve_live_semantic_roles", lambda _actor: (global_role,)
+    )
+    intent, _role_evidence, grant = _issue_delegation(service, issued_at=issued_at)
+    decision = service.verify_agent_delegation(
+        delegation_id=grant["delegation_id"],
+        intent=intent,
+        invocation=service.OntologyInvocationContext(
+            surface="ordinary_turn",
+            executing_agent_concept_id="#V#von_system",
+            audience="adaptive_turn",
+            delegation_id=grant["delegation_id"],
+            effect_id="tier3-effect",
+            turn_id="tier3-turn",
+        ),
+        actor_concept_id="#V#other_actor",
+        organisation_concept_id=None,
+        now=issued_at + timedelta(seconds=1),
+    )
+    assert decision.allowed is False
+    assert decision.reason_code == "ontology_delegation_actor_mismatch"
+
+
+@pytest.mark.parametrize("turn_id", (None, "different-turn"))
+def test_same_turn_delegation_rejects_missing_or_different_turn(
+    authority_service,
+    monkeypatch,
+    turn_id: str | None,
+) -> None:
+    service, _delegations, _receipts = authority_service
+    issued_at = datetime(2026, 8, 13, 9, 0, tzinfo=UTC)
+    global_role = _role(service, role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE)
+    monkeypatch.setattr(
+        service, "resolve_live_semantic_roles", lambda _actor: (global_role,)
+    )
+    intent, _role_evidence, grant = _issue_delegation(service, issued_at=issued_at)
+
+    decision = service.verify_agent_delegation(
+        delegation_id=grant["delegation_id"],
+        intent=intent,
+        invocation=service.OntologyInvocationContext(
+            surface="ordinary_turn",
+            executing_agent_concept_id="#V#von_system",
+            audience="adaptive_turn",
+            delegation_id=grant["delegation_id"],
+            effect_id="tier3-effect",
+            turn_id=turn_id,
+        ),
+        actor_concept_id="#V#semantic_admin",
+        organisation_concept_id=None,
+        now=issued_at + timedelta(seconds=1),
+    )
+
+    assert decision.allowed is False
+    assert decision.reason_code == "ontology_delegation_turn_mismatch"
+
+
+def test_explicitly_revoked_delegation_cannot_start_the_next_agent_effect(
+    authority_service,
+    monkeypatch,
+) -> None:
+    service, _delegations, _receipts = authority_service
+    issued_at = datetime(2026, 8, 13, 9, 0, tzinfo=UTC)
+    global_role = _role(service, role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE)
+    monkeypatch.setattr(
+        service, "resolve_live_semantic_roles", lambda _actor: (global_role,)
+    )
+    intent, _role_evidence, grant = _issue_delegation(service, issued_at=issued_at)
+    revoked = service.revoke_agent_delegation(
+        delegation_id=grant["delegation_id"],
+        acting_actor_concept_id="#V#semantic_admin",
+        reason="tier3-revocation",
+    )
+    assert revoked["status"] == "revoked"
+    decision = service.verify_agent_delegation(
+        delegation_id=grant["delegation_id"],
+        intent=intent,
+        invocation=service.OntologyInvocationContext(
+            surface="ordinary_turn",
+            executing_agent_concept_id="#V#von_system",
+            audience="adaptive_turn",
+            delegation_id=grant["delegation_id"],
+            effect_id="tier3-effect",
+        ),
+        actor_concept_id="#V#semantic_admin",
+        organisation_concept_id=None,
+        now=issued_at + timedelta(seconds=1),
+    )
+    assert decision.allowed is False
+    assert decision.reason_code == "ontology_delegation_revoked"
+
+
+def test_only_the_exact_grantor_can_revoke_a_delegation_without_disclosure(
+    authority_service,
+    monkeypatch,
+) -> None:
+    service, delegations, _receipts = authority_service
+    issued_at = datetime(2026, 8, 13, 9, 0, tzinfo=UTC)
+    global_role = _role(service, role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE)
+    monkeypatch.setattr(
+        service, "resolve_live_semantic_roles", lambda _actor: (global_role,)
+    )
+    _intent_value, _role_evidence, grant = _issue_delegation(
+        service, issued_at=issued_at
+    )
+
+    for delegation_id in (grant["delegation_id"], "unknown-delegation"):
+        with pytest.raises(
+            PermissionError,
+            match="ontology_delegation_revoke_authority_required",
+        ):
+            service.revoke_agent_delegation(
+                delegation_id=delegation_id,
+                acting_actor_concept_id="#V#different_global_admin",
+                reason="foreign-revocation-attempt",
+            )
+
+    stored = delegations.find_one({"delegation_id": grant["delegation_id"]})
+    assert stored is not None
+    assert stored["status"] == "active"
+
+    revoked = service.revoke_agent_delegation(
+        delegation_id=grant["delegation_id"],
+        acting_actor_concept_id="#V#semantic_admin",
+        reason="grantor-revocation",
+    )
+    assert revoked["status"] == "revoked"
+
+
+def test_workflow_and_internal_gateway_surfaces_bind_the_same_agent_authority_contract(
+    authority_service,
+    monkeypatch,
+) -> None:
+    """Both routes must deny a canonical mutation without an exact delegation."""
+
+    service, _delegations, _receipts = authority_service
+    global_role = _role(service, role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE)
+    monkeypatch.setattr(
+        service, "resolve_live_semantic_roles", lambda _actor: (global_role,)
+    )
+    intent = _intent(service)
+    contexts = (
+        service.OntologyInvocationContext(
+            surface="workflow",
+            executing_agent_concept_id="#V#von_system",
+            audience="workflow",
+            effect_id="workflow:fixture:state:add_relationship",
+            workflow_id="#V#fixture_workflow",
+        ),
+        service.OntologyInvocationContext(
+            surface="internal_mcp",
+            executing_agent_concept_id="#V#von_system",
+            audience="internal_mcp",
+            effect_id="mcp:fixture:add_relationship",
+        ),
+    )
+    for invocation in contexts:
+        with (
+            service.override_current_actor("#V#semantic_admin", None),
+            service.bind_ontology_invocation(**invocation.__dict__),
+        ):
+            decision = service.authorise_ontology_mutation(intent)
+        assert decision.allowed is False
+        assert decision.reason_code == "ontology_agent_delegation_required"
+
+
+def test_workflow_binds_a_stable_effect_identity_and_passes_the_grant_opaquely() -> (
+    None
+):
+    from src.backend.services.ontology_publication_authority_service import (
+        current_ontology_invocation,
+    )
+    from src.backend.workflows.action_registry import (
+        WorkflowActionRequest,
+        WorkflowEnvironment,
+    )
+    from src.backend.workflows.workflow_mcp_tool_actions import (
+        _ontology_invocation_context,
+    )
+
+    request = WorkflowActionRequest(
+        action_id="workflow_mcp.invoke_tool",
+        inputs={},
+        environment=WorkflowEnvironment(
+            llm_client=object(),
+            ontology_delegation_id="server-issued-only",
+        ),
+        data={},
+        workflow_id="#V#publication_workflow",
+        workflow_state_id="publish-edge",
+    )
+    with _ontology_invocation_context(
+        request=request,
+        resolved_tool_name="add_relationship",
+    ):
+        invocation = current_ontology_invocation()
+    assert invocation is not None
+    assert invocation.executing_agent_concept_id == "#V#von_system"
+    assert invocation.audience == "workflow"
+    assert invocation.delegation_id == "server-issued-only"
+    assert invocation.effect_id == (
+        "workflow:#V#publication_workflow:publish-edge:add_relationship"
+    )
+    assert invocation.workflow_id == "#V#publication_workflow"
+
+
+def test_concurrent_same_idempotency_key_executes_the_canonical_effect_once(
+    authority_service,
+    monkeypatch,
+) -> None:
+    """A second caller must reconcile the receipt, never replay an in-flight write."""
+
+    service, _delegations, receipts = authority_service
+    global_role = _role(service, role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE)
+    monkeypatch.setattr(
+        service, "resolve_live_semantic_roles", lambda _actor: (global_role,)
+    )
+    intent = _intent(service, idempotency_key="same-effect-under-concurrency")
+    first_mutation_started = Event()
+    release_first_mutation = Event()
+    calls = {"count": 0}
+    calls_lock = Lock()
+    results: list[dict[str, Any]] = []
+
+    def mutate() -> dict[str, Any]:
+        with calls_lock:
+            calls["count"] += 1
+            ordinal = calls["count"]
+        if ordinal == 1:
+            first_mutation_started.set()
+            assert release_first_mutation.wait(timeout=2)
+        return {"success": True, "changed": True, "ordinal": ordinal}
+
+    def invoke() -> None:
+        with service.override_current_actor("#V#semantic_admin", None):
+            results.append(
+                service.execute_authorised_ontology_mutation(
+                    intent=intent,
+                    mutate=mutate,
+                    read_before=lambda: {"present": False},
+                    read_back=lambda: {"present": True},
+                )
+            )
+
+    first = Thread(target=invoke)
+    second = Thread(target=invoke)
+    first.start()
+    assert first_mutation_started.wait(timeout=2)
+    second.start()
+    second.join(timeout=2)
+    release_first_mutation.set()
+    first.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert calls["count"] == 1
+    assert receipts.count_documents({}) == 1
+    assert any(result.get("idempotent_replay") is True for result in results)
+
+
+def test_authority_is_rechecked_immediately_before_the_canonical_effect(
+    authority_service,
+    monkeypatch,
+) -> None:
+    from src.backend.services import ontology_mutation_command_service as command
+
+    service, _delegations, _receipts = authority_service
+    intent = _intent(service, idempotency_key="live-reauthorisation-fixture")
+    role = _role(service, role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE)
+    initially_allowed = service.OntologyAuthorityDecision(
+        allowed=True,
+        decision_id="initial-authority",
+        reason_code="semantic_ontology_authority_verified",
+        message="Initially authorised.",
+        actor_concept_id="#V#semantic_admin",
+        organisation_concept_id=None,
+        intent_fingerprint=intent.fingerprint,
+        role_evidence=(role,),
+    )
+    revoked_before_effect = service.OntologyAuthorityDecision(
+        allowed=False,
+        decision_id="effect-boundary-authority",
+        reason_code="global_ontology_admin_authority_required",
+        message="Authority was revoked before the effect.",
+        actor_concept_id="#V#semantic_admin",
+        organisation_concept_id=None,
+        intent_fingerprint=intent.fingerprint,
+    )
+    monkeypatch.setattr(
+        service, "authorise_ontology_mutation", lambda _intent: initially_allowed
+    )
+    monkeypatch.setattr(
+        command, "authorise_ontology_mutation", lambda _intent: revoked_before_effect
+    )
+    monkeypatch.setattr(command, "build_ontology_mutation_intent", lambda **_kw: intent)
+    monkeypatch.setattr(
+        command,
+        "canonical_read_back_for_method",
+        lambda **_kw: {"relationship_present": False},
+    )
+    monkeypatch.setattr(command, "ontology_authority_resource_keys", lambda _intent: ())
+    mutate_calls = {"count": 0}
+
+    def mutate() -> dict[str, Any]:
+        mutate_calls["count"] += 1
+        return {"success": True, "changed": True}
+
+    with service.override_current_actor("#V#semantic_admin", None):
+        result = command.execute_governed_ontology_method(
+            method_name="add_relationship",
+            arguments={},
+            mutate=mutate,
+        )
+
+    assert result["success"] is False
+    assert result["effect_status"] == "not_started"
+    assert result["error_code"] == "global_ontology_admin_authority_required"
+    assert mutate_calls["count"] == 0

--- a/tests/backend/test_ontology_authority_vocabulary_service.py
+++ b/tests/backend/test_ontology_authority_vocabulary_service.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import pytest
+
+from src.backend.services import ontology_authority_vocabulary_service as vocabulary
+from src.backend.services.ontology_publication_authority_service import (
+    AuthorityRoleEvidence,
+    GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+    ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+    authority_role_storage_text,
+    parse_authority_role_storage_text,
+)
+
+
+def test_bootstrap_only_records_first_explicit_role(monkeypatch) -> None:
+    monkeypatch.setattr(
+        vocabulary,
+        "ontology_authority_membership_mutation_barrier",
+        nullcontext,
+    )
+    monkeypatch.setattr(
+        vocabulary,
+        "semantic_authority_has_been_bootstrapped",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        vocabulary, "ontology_mutation_resource_lock", lambda _key: nullcontext()
+    )
+    monkeypatch.setattr(
+        vocabulary,
+        "upsert_text_for_concept",
+        lambda **_: pytest.fail("must not write after bootstrap"),
+    )
+
+    with pytest.raises(
+        PermissionError, match="ontology_authority_bootstrap_already_completed"
+    ):
+        vocabulary.bootstrap_first_semantic_authority(
+            subject_concept_id="#V#another",
+            role="global_ontology_administrator",
+        )
+
+
+def test_bootstrap_rejects_an_organisation_role_root() -> None:
+    with pytest.raises(
+        ValueError, match="bootstrap_requires_global_ontology_administrator"
+    ):
+        vocabulary.bootstrap_first_semantic_authority(
+            subject_concept_id="#V#org-admin",
+            role="organisation_ontology_administrator",
+        )
+
+
+def test_bootstrap_canonicalises_existing_subject_and_verifies_live_role(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        vocabulary,
+        "ontology_authority_membership_mutation_barrier",
+        nullcontext,
+    )
+    captured = {}
+    monkeypatch.setattr(
+        vocabulary,
+        "semantic_authority_has_been_bootstrapped",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        vocabulary, "ontology_mutation_resource_lock", lambda _key: nullcontext()
+    )
+    monkeypatch.setattr(
+        vocabulary.ConceptsRepository,
+        "find_one",
+        lambda query: (
+            {"concept_id": query["concept_id"]}
+            if query["concept_id"] == "#V#michael_witbrock"
+            else None
+        ),
+    )
+
+    def upsert(**kwargs):
+        captured.update(kwargs)
+        return {"relation_id": "bootstrap-relation"}
+
+    monkeypatch.setattr(vocabulary, "upsert_text_for_concept", upsert)
+    monkeypatch.setattr(
+        vocabulary,
+        "resolve_live_semantic_roles",
+        lambda actor: (
+            AuthorityRoleEvidence(
+                role=GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+                actor_concept_id=actor,
+                organisation_concept_id=None,
+                relation_id="bootstrap-relation",
+                revision="bootstrap-revision",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        vocabulary,
+        "delete_text_relation",
+        lambda **_kwargs: pytest.fail("verified bootstrap must not compensate"),
+    )
+
+    result = vocabulary.bootstrap_first_semantic_authority(
+        subject_concept_id="michael_witbrock",
+        role=GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+    )
+
+    assert captured["subject_concept_id"] == "#V#michael_witbrock"
+    assert captured["context"]["grant_provenance"]["operator_authority"] == (
+        "bootstrap_only"
+    )
+    assert result["first_grant"]["revision"] == "bootstrap-revision"
+
+
+def test_bootstrap_rejects_a_missing_subject_before_writing(monkeypatch) -> None:
+    monkeypatch.setattr(
+        vocabulary,
+        "ontology_authority_membership_mutation_barrier",
+        nullcontext,
+    )
+    monkeypatch.setattr(
+        vocabulary,
+        "semantic_authority_has_been_bootstrapped",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        vocabulary, "ontology_mutation_resource_lock", lambda _key: nullcontext()
+    )
+    monkeypatch.setattr(vocabulary.ConceptsRepository, "find_one", lambda _query: None)
+    monkeypatch.setattr(
+        vocabulary,
+        "upsert_text_for_concept",
+        lambda **_kwargs: pytest.fail("missing subject must not be written"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="ontology_authority_bootstrap_subject_not_found",
+    ):
+        vocabulary.bootstrap_first_semantic_authority(
+            subject_concept_id="typo_subject",
+            role=GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+        )
+
+
+def test_organisation_role_storage_keeps_each_organisation_distinct() -> None:
+    first = authority_role_storage_text(
+        ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+        "#V#org_a",
+    )
+    second = authority_role_storage_text(
+        ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+        "#V#org_b",
+    )
+
+    assert first != second
+    assert parse_authority_role_storage_text(first, {}) == (
+        ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+        "#V#org_a",
+    )
+    assert parse_authority_role_storage_text(second, {}) == (
+        ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+        "#V#org_b",
+    )

--- a/tests/backend/test_ontology_create_authority_containment.py
+++ b/tests/backend/test_ontology_create_authority_containment.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from flask import Flask
+
+
+def _parent_resolution(parent_id: str):
+    from src.backend.services.create_concepts_parent_resolution_service import (
+        ParentResolutionResult,
+    )
+
+    return ParentResolutionResult(
+        requested_parent_id=parent_id,
+        canonical_parent_id=parent_id,
+        resolved_parent_id=parent_id,
+        fallback_used=False,
+        fallback_candidates_checked=(),
+        fallback_selected_parent_id=None,
+        resolved_parent_kind="type",
+    )
+
+
+def test_ordinary_create_is_explicitly_actor_private() -> None:
+    from src.backend.integrations.internal_mcp.catalogue import build_default_catalogue
+
+    definition = build_default_catalogue().get("create_concepts")
+
+    assert definition.ordinary_turn_fixed_arguments["scope_mode"] == (
+        "user_only_default"
+    )
+
+
+def test_governed_create_preserves_default_type_and_one_exact_parent(
+    monkeypatch,
+) -> None:
+    from src.backend.services import ontology_mutation_command_service as command
+
+    monkeypatch.setattr(
+        "src.backend.services.create_concepts_parent_resolution_service."
+        "resolve_parent_for_create_concepts",
+        _parent_resolution,
+    )
+    resolved = command.resolve_governed_ontology_arguments(
+        "create_concepts",
+        {
+            "concepts": [{"name": "Default type"}],
+            "parent_concept_ids": ["#V#parent"],
+        },
+    )
+    assert resolved["concepts"][0]["kind"] == "type"
+    assert resolved["scope_mode"] == "user_only_default"
+    assert resolved["parent_id"] == "#V#parent"
+    assert resolved["parent_concept_ids"] == ["#V#parent"]
+
+    with pytest.raises(
+        command.OntologyMutationCommandError,
+        match="one consistent exact parent",
+    ):
+        command.resolve_governed_ontology_arguments(
+            "create_concepts",
+            {
+                "concepts": [{"name": "Conflicting parent"}],
+                "parent_id": "#V#parent_a",
+                "parent_concept_ids": ["#V#parent_b"],
+            },
+        )
+
+
+def test_create_intent_fingerprints_exact_scope_and_complete_effect(
+    monkeypatch,
+) -> None:
+    from src.backend.services import ontology_mutation_command_service as command
+    from src.backend.services import ontology_publication_authority_service as authority
+
+    monkeypatch.setattr(
+        "src.backend.services.create_concepts_parent_resolution_service."
+        "resolve_parent_for_create_concepts",
+        _parent_resolution,
+    )
+    monkeypatch.setattr(command, "can_access_concept", lambda _concept_id: True)
+
+    base_arguments = {
+        "parent_id": "#V#research_object",
+        "concepts": [
+            {
+                "concept_id": "#V#candidate_record",
+                "name": "Candidate record",
+                "kind": "instance",
+                "description": "Exact description",
+                "notes": "Exact note",
+            }
+        ],
+        "scope_mode": "user_only_default",
+        "create_as_instance": True,
+        "instance_of_type": "#V#record_type",
+        "maintain_relationship_inverses": True,
+    }
+    with authority.override_current_actor("#V#member", "#V#organisation_a"):
+        intent = command.build_ontology_mutation_intent(
+            method_name="create_concepts",
+            arguments=base_arguments,
+        )
+        changed = command.build_ontology_mutation_intent(
+            method_name="create_concepts",
+            arguments={
+                **base_arguments,
+                "concepts": [
+                    {
+                        **base_arguments["concepts"][0],
+                        "notes": "A different exact note",
+                    }
+                ],
+            },
+        )
+
+    assert intent.publication_context.kind == authority.PublicationContextKind.USER
+    assert intent.publication_context.concept_id == "#V#member"
+    assert intent.delta["stored_scope"] == {
+        "effective_scope_mode": "user_only_default",
+        "specific_to_user_concept_ids": ["#V#member"],
+        "specific_to_organisation_concept_ids": [],
+    }
+    assert intent.delta["maintain_parent_inverse"] is False
+    assert "#V#research_object" in intent.delta["referenced_concept_ids"]
+    assert "#V#record_type" in intent.delta["referenced_concept_ids"]
+    assert intent.fingerprint != changed.fingerprint
+
+    with (
+        authority.override_current_actor("#V#member", "#V#organisation_a"),
+        pytest.raises(
+            command.OntologyMutationCommandError,
+            match="ancillary or multi-parent effects",
+        ),
+    ):
+        command.build_ontology_mutation_intent(
+            method_name="create_concepts",
+            arguments={
+                **base_arguments,
+                "concepts": [
+                    {
+                        **base_arguments["concepts"][0],
+                        "attributes": {"source": "registry"},
+                    }
+                ],
+            },
+        )
+
+
+def test_dual_user_org_create_is_rejected_and_org_publication_is_explicit(
+    monkeypatch,
+) -> None:
+    from src.backend.services import ontology_mutation_command_service as command
+    from src.backend.services import ontology_publication_authority_service as authority
+
+    monkeypatch.setattr(
+        "src.backend.services.create_concepts_parent_resolution_service."
+        "resolve_parent_for_create_concepts",
+        _parent_resolution,
+    )
+    monkeypatch.setattr(command, "can_access_concept", lambda _concept_id: True)
+    monkeypatch.setattr(authority, "resolve_live_semantic_roles", lambda _actor: ())
+    with (
+        authority.override_current_actor("#V#member", "#V#organisation_a"),
+        pytest.raises(
+            command.OntologyMutationCommandError,
+            match="Dual user-and-organisation visibility",
+        ),
+    ):
+        command.build_ontology_mutation_intent(
+            method_name="create_concepts",
+            arguments={
+                "parent_id": "#V#research_object",
+                "concepts": [{"name": "Ambiguous record", "kind": "type"}],
+                "scope_mode": "user_org_default",
+            },
+        )
+
+    with authority.override_current_actor("#V#member", "#V#organisation_a"):
+        intent = command.build_ontology_mutation_intent(
+            method_name="create_concepts",
+            arguments={
+                "parent_id": "#V#research_object",
+                "concepts": [{"name": "Organisation record", "kind": "type"}],
+                "scope_mode": "organisation_general",
+            },
+        )
+        decision = authority.authorise_ontology_mutation(intent)
+
+    assert intent.publication_context.kind == (
+        authority.PublicationContextKind.ORGANISATION
+    )
+    assert decision.allowed is False
+    assert decision.reason_code == "organisation_ontology_admin_authority_required"
+
+
+def test_duplicate_reuse_cannot_repair_existing_identity_markers(
+    monkeypatch,
+) -> None:
+    from src.backend.integrations.internal_mcp import catalogue
+    from src.backend.services.create_concepts_duplicate_guard_service import (
+        CreateConceptDuplicateGuardMatch,
+    )
+    from src.backend.services.concept_external_identity_service import (
+        ExternalIdentifier,
+    )
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.transport."
+        "raise_if_internal_mcp_cancelled",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.create_concepts_parent_resolution_service."
+        "resolve_parent_for_create_concepts",
+        _parent_resolution,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.workflow_event_integration_service."
+        "resolve_event_actor_context",
+        lambda **_kwargs: ("#V#member", "#V#organisation_a"),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_external_identity_service."
+        "normalise_create_external_identifiers",
+        lambda **_kwargs: (
+            ExternalIdentifier(
+                scheme="catalogue",
+                value="record-42",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_external_identity_service."
+        "canonical_concept_id_for_external_identifiers",
+        lambda *_args, **_kwargs: "#V#stable_record_42",
+    )
+    monkeypatch.setattr(
+        "src.backend.services.create_concepts_duplicate_guard_service."
+        "find_existing_concept_for_create_concepts",
+        lambda **_kwargs: CreateConceptDuplicateGuardMatch(
+            existing_concept_id="#V#existing_record",
+            match_source="external_identifier:catalogue",
+            guard_scope="instance",
+            existing_kind="instance",
+            requested_kind="instance",
+            existing_parent_ids=("#V#record",),
+            requested_parent_id="#V#record",
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_external_identity_service."
+        "persist_external_identity_markers",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("duplicate reuse must not write identity markers")
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("duplicate reuse must not create another concept")
+        ),
+    )
+
+    result = catalogue._create_concepts.__wrapped__(
+        parent_id="#V#record",
+        concepts=[
+            {
+                "name": "Existing record",
+                "kind": "instance",
+                "external_identifiers": [
+                    {"scheme": "catalogue", "canonical_value": "record-42"}
+                ],
+            }
+        ],
+        scope_mode="user_only_default",
+    )
+
+    item = result["results"][0]
+    assert item["existing_concept_id"] == "#V#existing_record"
+    assert item["changed"] is False
+    assert item["external_identity"]["persistence"] == {
+        "success": True,
+        "effect_status": "not_started",
+        "changed": False,
+        "reason_code": "duplicate_reuse_is_read_only",
+    }
+
+
+def test_http_create_binds_every_actual_field_and_disables_inverse_writes(
+    monkeypatch,
+) -> None:
+    from src.backend.server.routes import concept_routes
+    from src.backend.services import ontology_mutation_command_service as command
+
+    captured: dict[str, Any] = {}
+    mutation_kwargs: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        command,
+        "resolve_governed_ontology_arguments",
+        lambda _method, arguments: dict(arguments),
+    )
+    monkeypatch.setattr(
+        concept_routes,
+        "_get_current_user_concept_id",
+        lambda: "#V#member",
+    )
+    monkeypatch.setattr(
+        concept_routes,
+        "_get_current_org_concept_id",
+        lambda: "#V#organisation_a",
+    )
+    monkeypatch.setattr(concept_routes, "_get_request_namespace", lambda: "trusted")
+    monkeypatch.setattr(
+        concept_routes.concept_service,
+        "create_concept",
+        lambda **kwargs: (
+            mutation_kwargs.update(kwargs) or {"concept_id": kwargs["concept_id"]}
+        ),
+    )
+
+    def execute(**kwargs):
+        captured.update(kwargs["arguments"])
+        kwargs["mutate"]()
+        return {"success": True, "created_concept_ids": ["#V#record"]}
+
+    monkeypatch.setattr(concept_routes, "_execute_governed_http_mutation", execute)
+    app = Flask(__name__)
+    app.secret_key = "test"
+    app.register_blueprint(concept_routes.concept_bp, url_prefix="/api/concepts")
+
+    response = app.test_client().post(
+        "/api/concepts/",
+        json={
+            "name": "Record",
+            "concept_id": "#V#record",
+            "description": "description",
+            "notes": "notes",
+            "attributes": {"source": "catalogue"},
+            "system_tags": ["system"],
+            "user_tags": ["user"],
+            "linked_concepts": [{"concept_id": "#V#linked"}],
+            "parent_concept_ids": ["#V#record_type", "#V#research_object"],
+            "create_as_instance": False,
+            "instance_of_type": "#V#represented_entity",
+            "scope_mode": "organisation_general",
+            "request_id": "create-record-1",
+        },
+    )
+
+    assert response.status_code == 201
+    assert captured["parent_concept_ids"] == [
+        "#V#record_type",
+        "#V#research_object",
+    ]
+    assert captured["linked_concepts"] == [{"concept_id": "#V#linked"}]
+    assert captured["attributes"] == {"source": "catalogue"}
+    assert captured["concepts"][0]["instance_of_type"] == ("#V#represented_entity")
+    assert mutation_kwargs["maintain_relationship_inverses"] is False
+    assert mutation_kwargs["parent_concept_ids"] == captured["parent_concept_ids"]
+    assert mutation_kwargs["linked_concepts"] == captured["linked_concepts"]
+
+
+def test_failed_create_readback_never_follows_an_existing_concept_id(
+    monkeypatch,
+) -> None:
+    from src.backend.services import ontology_mutation_command_service as command
+    from src.backend.services import ontology_publication_authority_service as authority
+
+    documents = {
+        "#V#existing_record": {
+            "concept_id": "#V#existing_record",
+            "relationships": {
+                "#V#specific_to_user": ["#V#member"],
+                "is_an_instance_of": ["#V#record_type"],
+            },
+        },
+        "#V#record_type": {
+            "concept_id": "#V#record_type",
+            "relationships": {},
+        },
+    }
+    monkeypatch.setattr(
+        command.ConceptsRepository,
+        "find_one",
+        lambda query: documents.get(query.get("concept_id")),
+    )
+    monkeypatch.setattr(
+        authority.ConceptsRepository,
+        "find_one",
+        lambda query: documents.get(query.get("concept_id")),
+    )
+
+    readback = command.canonical_read_back_for_method(
+        method_name="create_concepts",
+        arguments={
+            "parent_id": "#V#record_type",
+            "concepts": [{"name": "Existing record", "kind": "instance"}],
+        },
+        result={
+            "created_concept_ids": [],
+            "results": [
+                {
+                    "error_code": "already_exists",
+                    "existing_concept_id": "#V#existing_record",
+                }
+            ],
+        },
+    )
+
+    assert readback["concepts"] == []
+
+
+def test_inaccessible_create_collision_is_non_disclosing(monkeypatch) -> None:
+    from src.backend.services import ontology_mutation_command_service as command
+    from src.backend.services import ontology_publication_authority_service as authority
+
+    secret = {
+        "concept_id": "#V#secret",
+        "relationships": {
+            "#V#specific_to_user": ["#V#other_user"],
+            "is_an_instance_of": ["#V#private_parent"],
+        },
+        "attributes": {"secret": "LEAK"},
+        "system_tags": ["private-tag"],
+    }
+    monkeypatch.setattr(
+        command.ConceptsRepository,
+        "find_one",
+        lambda query: secret if query.get("concept_id") == "#V#secret" else None,
+    )
+    mutate_calls = {"count": 0}
+
+    def mutate() -> dict[str, Any]:
+        mutate_calls["count"] += 1
+        return {"success": True, "changed": True}
+
+    with authority.override_current_actor("#V#attacker", None):
+        result = command.execute_governed_ontology_method(
+            method_name="create_concepts",
+            arguments={
+                "concepts": [
+                    {
+                        "concept_id": "#V#secret",
+                        "name": "Secret",
+                        "kind": "instance",
+                    }
+                ],
+                "scope_mode": "user_only_default",
+            },
+            mutate=mutate,
+        )
+
+    assert result["success"] is False
+    assert result["effect_status"] == "not_started"
+    assert result["mutation_outcome"] == "not_started"
+    assert result["changed"] is False
+    assert result["error_code"] == "ontology_create_concept_id_conflict"
+    assert result["error"] == "The requested concept ID cannot be created."
+    assert "LEAK" not in repr(result)
+    assert "private_parent" not in repr(result)
+    assert mutate_calls["count"] == 0

--- a/tests/backend/test_ontology_http_mutation_authority_routes.py
+++ b/tests/backend/test_ontology_http_mutation_authority_routes.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from flask import Flask
+import pytest
+
+from src.backend.integrations.internal_mcp import catalogue
+from src.backend.server.routes.vontology_routes import vontology_bp
+
+
+def _client():
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.register_blueprint(vontology_bp, url_prefix="/api/vontology")
+    return app.test_client()
+
+
+def test_legacy_scope_route_fails_closed_even_with_forged_force_and_org():
+    response = _client().post(
+        "/api/vontology/concept/organization-relation",
+        json={
+            "concept_id": "#V#historical_concept",
+            "organisation_concept_id": "#V#forged_organisation",
+            "action": "remove",
+            "force": True,
+        },
+    )
+
+    assert response.status_code == 410
+    payload = response.get_json()
+    assert payload["error_code"] == "governed_scope_change_required"
+    assert payload["effect_status"] == "not_started"
+
+
+def test_legacy_user_scope_route_fails_closed_even_with_forged_user_and_force():
+    response = _client().post(
+        "/api/vontology/concept/user-relation",
+        json={
+            "concept_id": "#V#historical_concept",
+            "user_concept_id": "#V#someone_else",
+            "action": "remove",
+            "force": "true",
+        },
+    )
+
+    assert response.status_code == 410
+    assert response.get_json()["error_code"] == "governed_scope_change_required"
+
+
+def test_relationship_route_does_not_forward_client_identity_or_override(monkeypatch):
+    seen: dict[str, object] = {}
+
+    def fake_add_relationship(**kwargs):
+        seen.update(kwargs)
+        return {
+            "success": False,
+            "error_code": "organisation_ontology_admin_authority_required",
+            "authority_decision": {"allowed": False},
+        }
+
+    monkeypatch.setattr(catalogue, "_add_relationship", fake_add_relationship)
+
+    response = _client().post(
+        "/api/vontology/relationships/add",
+        json={
+            "source_id": "#V#source",
+            "kind": "#V#predicate",
+            "target_id": "#V#target",
+            "user_concept_id": "#V#forged_user",
+            "organisation_concept_id": "#V#forged_organisation",
+            "operator_override": True,
+        },
+    )
+
+    assert response.status_code == 403
+    assert seen == {
+        "source_id": "#V#source",
+        "predicate": "#V#predicate",
+        "target": "#V#target",
+        "request_id": None,
+        "namespace": None,
+    }
+
+
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        ("/api/vontology/ensure_thing", {}),
+        (
+            "/api/vontology/relationships/uncertain/reject",
+            {
+                "source_id": "#V#source",
+                "assertion_id": "forged-assertion",
+                "reason": "forged operator request",
+            },
+        ),
+        (
+            "/api/vontology/relationships/remove/undo",
+            {"undo_token": "forged-undo-token"},
+        ),
+    ],
+)
+def test_unsafe_legacy_mutation_routes_fail_closed(path, payload):
+    response = _client().post(path, json=payload)
+
+    assert response.status_code == 410
+    result = response.get_json()
+    assert result["effect_status"] == "not_started"
+    assert result["mutation_outcome"] == "not_started"

--- a/tests/backend/test_ontology_http_text_relation_containment.py
+++ b/tests/backend/test_ontology_http_text_relation_containment.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+from typing import Any
+
+from bson import ObjectId
+from flask import Flask
+
+from src.backend.server.routes import concept_routes
+from src.backend.services import ontology_mutation_command_service as command
+from src.backend.services import ontology_publication_authority_service as authority
+
+
+def _client():
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.register_blueprint(concept_routes.concept_bp, url_prefix="/api/concepts")
+    return app.test_client()
+
+
+def test_http_text_post_binds_the_exact_canonical_arguments_to_the_write(
+    monkeypatch,
+) -> None:
+    authorised: dict[str, Any] = {}
+    mutated: dict[str, Any] = {}
+
+    def execute(**kwargs: Any) -> dict[str, Any]:
+        authorised.update(kwargs["arguments"])
+        result = dict(kwargs["mutate"]())
+        return {"success": True, **result}
+
+    def upsert(**kwargs: Any) -> dict[str, Any]:
+        mutated.update(kwargs)
+        return {
+            "relation_id": "relation-1",
+            "relation_created": True,
+            "context_updated": False,
+        }
+
+    monkeypatch.setattr(concept_routes, "_execute_governed_http_mutation", execute)
+    monkeypatch.setattr(concept_routes, "upsert_text_for_concept", upsert)
+    monkeypatch.setattr(
+        concept_routes,
+        "maybe_sync_concept_text_relations_to_rag",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(concept_routes, "_get_request_namespace", lambda: None)
+
+    response = _client().post(
+        "/api/concepts/%23V%23record/texts",
+        json={
+            "predicate": "#V#hasName",
+            "text": "  Exact name  ",
+            "lang": "mi-NZ",
+            "context": {"name_type": "abbr", "register": "formal"},
+            "provenance": {"source": "curated_import", "record": "17"},
+            "request_id": "text-effect-1",
+        },
+    )
+
+    assert response.status_code == 201
+    assert authorised == {
+        "concept_id": "#V#record",
+        "predicate": "hasName",
+        "text": "Exact name",
+        "language": "mi-NZ",
+        "context": {"name_type": "ABBR", "register": "formal"},
+        "provenance": {"source": "curated_import", "record": "17"},
+        "request_id": "text-effect-1",
+    }
+    assert mutated == {
+        "subject_concept_id": authorised["concept_id"],
+        "predicate": authorised["predicate"],
+        "text": authorised["text"],
+        "lang": authorised["language"],
+        "context": authorised["context"],
+        "provenance": authorised["provenance"],
+    }
+
+
+def test_http_text_patch_binds_server_provenance_and_language_to_the_write(
+    monkeypatch,
+) -> None:
+    authorised: dict[str, Any] = {}
+    mutated: dict[str, Any] = {}
+
+    def execute(**kwargs: Any) -> dict[str, Any]:
+        authorised.update(kwargs["arguments"])
+        result = dict(kwargs["mutate"]())
+        return {"success": True, **result}
+
+    def update(**kwargs: Any) -> dict[str, Any]:
+        mutated.update(kwargs)
+        return {"relation_id": kwargs["relation_id"], "updated": True}
+
+    monkeypatch.setattr(concept_routes, "_execute_governed_http_mutation", execute)
+    monkeypatch.setattr(concept_routes, "update_text_relation_text", update)
+    monkeypatch.setattr(
+        concept_routes,
+        "maybe_sync_concept_text_relations_to_rag",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(concept_routes, "_get_request_namespace", lambda: None)
+
+    response = _client().patch(
+        "/api/concepts/%23V%23record/texts/relation-2",
+        json={
+            "text": "  Revised text  ",
+            "lang": "en-NZ",
+            "provenance": {"source": "forged-client-source"},
+            "request_id": "text-effect-2",
+        },
+    )
+
+    assert response.status_code == 200
+    assert authorised == {
+        "concept_id": "#V#record",
+        "relation_id": "relation-2",
+        "new_text": "Revised text",
+        "language": "en-NZ",
+        "provenance": {"source": "update_text_relation"},
+        "request_id": "text-effect-2",
+    }
+    assert mutated == {
+        "subject_concept_id": authorised["concept_id"],
+        "relation_id": authorised["relation_id"],
+        "new_text": authorised["new_text"],
+        "lang": authorised["language"],
+        "provenance": authorised["provenance"],
+    }
+
+
+def test_http_text_delete_by_predicate_and_text_fails_closed(monkeypatch) -> None:
+    monkeypatch.setattr(
+        concept_routes,
+        "_execute_governed_http_mutation",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("ambiguous deletion must not reach the mutation boundary")
+        ),
+    )
+
+    response = _client().delete(
+        "/api/concepts/%23V%23record/texts",
+        json={
+            "predicate": "hasNote",
+            "text": "duplicate text",
+            "lang": "en",
+            "context": {"position": 1},
+        },
+    )
+
+    assert response.status_code == 410
+    payload = response.get_json()
+    assert payload["error_code"] == "exact_text_relation_id_required"
+    assert payload["effect_status"] == "not_started"
+    assert payload["changed"] is False
+    assert payload["recovery_affordances"][1]["action_type"] == (
+        "delete_exact_text_relation"
+    )
+
+
+def test_http_relation_id_cannot_patch_an_ontology_role_relation(monkeypatch) -> None:
+    mutation_called = False
+
+    def relation_find_one(_query: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "_id": "role-relation",
+            "subject_concept_id": "#V#administrator",
+            "predicate": "#V#has_ontology_authority_role",
+            "object_text_id": "role-text",
+            "context": {},
+        }
+
+    def update(**_kwargs: Any) -> dict[str, Any]:
+        nonlocal mutation_called
+        mutation_called = True
+        return {"updated": True}
+
+    monkeypatch.setattr(command, "can_access_concept", lambda _concept_id: True)
+    monkeypatch.setattr(command.TextRelationsRepository, "find_one", relation_find_one)
+    monkeypatch.setattr(
+        command.TextValuesRepository,
+        "find_one",
+        lambda _query: {"_id": "role-text", "text": "global", "lang": "en"},
+    )
+    monkeypatch.setattr(concept_routes, "update_text_relation_text", update)
+
+    response = _client().patch(
+        "/api/concepts/%23V%23administrator/texts/role-relation",
+        json={"text": "no longer an administrator", "lang": "en"},
+    )
+
+    assert response.status_code == 403
+    payload = response.get_json()
+    assert payload["error_code"] == ("dedicated_ontology_governance_operation_required")
+    assert payload["effect_status"] == "not_started"
+    assert mutation_called is False
+
+
+def test_text_postcondition_requires_exact_language_context_and_provenance() -> None:
+    intent = authority.OntologyMutationIntent(
+        operation="text.upsert",
+        publication_context=authority.PublicationContext(
+            authority.PublicationContextKind.ORGANISATION,
+            "#V#organisation_a",
+        ),
+        target_concept_ids=("#V#record",),
+        tool_name="upsert_text_relation",
+        predicate="hasDescription",
+        delta={
+            "text_sha256": command._text_sha256("A description"),
+            "language": "en-NZ",
+            "context_sha256": command._canonical_json_sha256({"kind": "summary"}),
+            "provenance_sha256": command._canonical_json_sha256({"source": "curated"}),
+        },
+    )
+    exact_state = {
+        "relation_present": True,
+        "predicate": "hasDescription",
+        "text_sha256": intent.delta["text_sha256"],
+        "language": "en-NZ",
+        "context_sha256": intent.delta["context_sha256"],
+        "provenance_sha256": intent.delta["provenance_sha256"],
+    }
+
+    assert command._verify_method_postcondition(
+        method_name="upsert_text_relation",
+        intent=intent,
+        result={"success": True},
+        canonical_state=exact_state,
+    )
+    for changed_field in ("language", "context_sha256", "provenance_sha256"):
+        mismatched = {**exact_state, changed_field: "not-the-authorised-value"}
+        assert not command._verify_method_postcondition(
+            method_name="upsert_text_relation",
+            intent=intent,
+            result={"success": True},
+            canonical_state=mismatched,
+        )
+
+
+def test_text_readback_proves_exact_relation_metadata(monkeypatch) -> None:
+    relation_id = ObjectId()
+    text_value_id = ObjectId()
+    relation_queries: list[dict[str, Any]] = []
+    value_queries: list[dict[str, Any]] = []
+
+    def relation_find_one(query: dict[str, Any]) -> dict[str, Any]:
+        relation_queries.append(query)
+        return {
+            "_id": relation_id,
+            "subject_concept_id": "#V#record",
+            "predicate": "hasDescription",
+            "object_text_id": str(text_value_id),
+            "context": {"kind": "summary"},
+        }
+
+    def value_find_one(query: dict[str, Any]) -> dict[str, Any]:
+        value_queries.append(query)
+        return {
+            "_id": text_value_id,
+            "text": "A description",
+            "lang": "en-NZ",
+            "provenance": {"source": "curated"},
+        }
+
+    monkeypatch.setattr(command.TextRelationsRepository, "find_one", relation_find_one)
+    monkeypatch.setattr(command.TextValuesRepository, "find_one", value_find_one)
+    monkeypatch.setattr(
+        command,
+        "concept_publication_context",
+        lambda _concept_id: authority.PublicationContext(
+            authority.PublicationContextKind.ORGANISATION,
+            "#V#organisation_a",
+        ),
+    )
+
+    state = command.canonical_read_back_for_method(
+        method_name="upsert_text_relation",
+        arguments={
+            "concept_id": "#V#record",
+            "predicate": "hasDescription",
+        },
+        result={"relation_id": str(relation_id)},
+    )
+
+    assert relation_queries == [{"_id": relation_id, "subject_concept_id": "#V#record"}]
+    assert value_queries == [{"_id": text_value_id}]
+    assert state == {
+        "concept_id": "#V#record",
+        "predicate": "hasDescription",
+        "relation_id": str(relation_id),
+        "relation_present": True,
+        "text_sha256": command._text_sha256("A description"),
+        "language": "en-NZ",
+        "context_sha256": command._canonical_json_sha256({"kind": "summary"}),
+        "provenance_sha256": command._canonical_json_sha256({"source": "curated"}),
+        "publication_context": {
+            "kind": "organisation",
+            "concept_id": "#V#organisation_a",
+            "source": "resolved",
+        },
+    }

--- a/tests/backend/test_ontology_identity_consolidation_authority.py
+++ b/tests/backend/test_ontology_identity_consolidation_authority.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import mongomock
+import pytest
+
+
+@pytest.fixture
+def consolidation_runtime(monkeypatch: pytest.MonkeyPatch):
+    from src.backend.db.repositories import concepts_repository
+    from src.backend.db.repositories import text_value_repository
+    from src.backend.services import concept_merge_service as merge
+    from src.backend.services import ontology_mutation_command_service as command
+    from src.backend.services import ontology_publication_authority_service as authority
+
+    database = mongomock.MongoClient()["identity_consolidation_authority"]
+    concepts = database["concepts"]
+    text_relations = database["text_relations"]
+    text_values = database["text_values"]
+    delegations = database["delegations"]
+    receipts = database["receipts"]
+    delegations.create_index("delegation_id", unique=True)
+    receipts.create_index("receipt_id", unique=True)
+    receipts.create_index(
+        [("actor_concept_id", 1), ("idempotency_key", 1)],
+        unique=True,
+        partialFilterExpression={"idempotency_key": {"$exists": True}},
+    )
+    monkeypatch.setattr(
+        concepts_repository,
+        "get_concepts_collection",
+        lambda: concepts,
+    )
+    monkeypatch.setattr(
+        text_value_repository,
+        "get_text_relations_collection",
+        lambda: text_relations,
+    )
+    monkeypatch.setattr(
+        text_value_repository,
+        "get_text_values_collection",
+        lambda: text_values,
+    )
+    monkeypatch.setattr(
+        authority,
+        "get_ontology_authority_delegations_collection",
+        lambda: delegations,
+    )
+    monkeypatch.setattr(
+        authority,
+        "get_ontology_mutation_receipts_collection",
+        lambda: receipts,
+    )
+    monkeypatch.setattr(authority, "_gateway_actor_trust_source", lambda: None)
+    monkeypatch.setattr(authority, "resolve_live_semantic_roles", lambda _actor: ())
+    monkeypatch.setattr(
+        "src.backend.services.concept_service._invalidate_concept_mutation_caches",
+        lambda: None,
+    )
+    # Access filtering itself is exercised by the authority service tests. Keep
+    # this fixture focused on exact plan/receipt execution.
+    monkeypatch.setattr(merge, "can_access_concept", lambda _item: True)
+    monkeypatch.setattr(command, "can_access_concept", lambda _item: True)
+    return authority, merge, concepts, text_relations, text_values, receipts
+
+
+def _concept(
+    concept_id: str,
+    *,
+    relationships: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    now = datetime(2026, 8, 13, tzinfo=UTC)
+    return {
+        "concept_id": concept_id,
+        "guid": f"guid:{concept_id}",
+        "created_at": now,
+        "updated_at": now,
+        "embedding_status": "ready",
+        "attributes": {},
+        "system_tags": [],
+        "user_tags": [],
+        "relationships": relationships or {},
+    }
+
+
+def _insert_code_alias(
+    text_relations,
+    text_values,
+    *,
+    relation_id: str,
+    subject_id: str,
+    text: str,
+) -> None:
+    text_id = f"text:{relation_id}"
+    text_values.insert_one({"_id": text_id, "text": text, "lang": "en-NZ"})
+    text_relations.insert_one(
+        {
+            "_id": relation_id,
+            "subject_concept_id": subject_id,
+            "predicate": "hasName",
+            "object_text_id": text_id,
+            "context": {"name_type": "CODE"},
+        }
+    )
+
+
+def _seed_private_merge(concepts, text_relations, text_values) -> tuple[str, str]:
+    source_id = "#V#duplicate"
+    target_id = "#V#canonical"
+    scope = {"#V#specific_to_user": ["#V#admin"]}
+    concepts.insert_many(
+        [
+            _concept(source_id, relationships={**scope, "related_to": ["#V#topic"]}),
+            _concept(target_id, relationships=scope),
+            _concept(
+                "#V#incoming",
+                relationships={**scope, "related_to": [source_id]},
+            ),
+            _concept("#V#topic"),
+        ]
+    )
+    _insert_code_alias(
+        text_relations,
+        text_values,
+        relation_id="source-id",
+        subject_id=source_id,
+        text=source_id,
+    )
+    _insert_code_alias(
+        text_relations,
+        text_values,
+        relation_id="source-guid",
+        subject_id=source_id,
+        text=f"guid:{source_id}",
+    )
+    return source_id, target_id
+
+
+def test_governed_identity_consolidation_has_receipt_and_exact_read_back(
+    consolidation_runtime,
+) -> None:
+    from src.backend.services import ontology_mutation_command_service as command
+
+    authority, merge, concepts, text_relations, text_values, receipts = (
+        consolidation_runtime
+    )
+    source_id, target_id = _seed_private_merge(
+        concepts,
+        text_relations,
+        text_values,
+    )
+    with authority.override_current_actor("#V#admin", None):
+        arguments = command.resolve_governed_ontology_arguments(
+            "merge_concepts",
+            {
+                "source_id": source_id,
+                "target_id": target_id,
+                "simulate": False,
+                "request_id": "merge:one",
+            },
+        )
+        result = command.execute_governed_ontology_method(
+            method_name="merge_concepts",
+            arguments=arguments,
+            mutate=lambda: merge.merge_concepts(
+                source_id,
+                target_id,
+                simulate=False,
+                exact_plan=arguments["exact_plan"],
+            ),
+        )
+
+    assert result["success"] is True
+    assert result["authority_receipt"]["status"] == "succeeded"
+    assert result["canonical_read_back"]["matches_exact_plan"] is True
+    assert concepts.find_one({"concept_id": source_id}) is None
+    assert receipts.count_documents({"record_kind": {"$ne": "resource_lock"}}) == 1
+
+
+def test_graph_drift_after_resolution_fails_before_merge_write(
+    consolidation_runtime,
+) -> None:
+    from src.backend.services import ontology_mutation_command_service as command
+
+    authority, merge, concepts, text_relations, text_values, _receipts = (
+        consolidation_runtime
+    )
+    source_id, target_id = _seed_private_merge(
+        concepts,
+        text_relations,
+        text_values,
+    )
+    with authority.override_current_actor("#V#admin", None):
+        arguments = command.resolve_governed_ontology_arguments(
+            "merge_concepts",
+            {
+                "source_id": source_id,
+                "target_id": target_id,
+                "simulate": False,
+                "request_id": "merge:drift",
+            },
+        )
+        concepts.insert_one(
+            _concept(
+                "#V#late_reference",
+                relationships={
+                    "#V#specific_to_user": ["#V#admin"],
+                    "related_to": [source_id],
+                },
+            )
+        )
+        result = command.execute_governed_ontology_method(
+            method_name="merge_concepts",
+            arguments=arguments,
+            mutate=lambda: merge.merge_concepts(
+                source_id,
+                target_id,
+                simulate=False,
+                exact_plan=arguments["exact_plan"],
+            ),
+        )
+
+    assert result["success"] is False
+    assert result["changed"] is False
+    assert result["error_code"] == "identity_consolidation_precondition_failed"
+    assert concepts.find_one({"concept_id": source_id}) is not None
+    assert concepts.find_one({"concept_id": "#V#incoming"})["relationships"][
+        "related_to"
+    ] == [source_id]
+
+
+def test_client_supplied_merge_plan_is_ignored(consolidation_runtime) -> None:
+    from src.backend.services import ontology_mutation_command_service as command
+
+    _authority, _merge, concepts, text_relations, text_values, _receipts = (
+        consolidation_runtime
+    )
+    source_id, target_id = _seed_private_merge(
+        concepts,
+        text_relations,
+        text_values,
+    )
+
+    resolved = command.resolve_governed_ontology_arguments(
+        "merge_concepts",
+        {
+            "source_id": source_id,
+            "target_id": target_id,
+            "simulate": False,
+            "exact_plan": {
+                "plan_sha256": "attacker",
+                "affected_concept_ids": [source_id, target_id],
+            },
+        },
+    )
+
+    assert resolved["exact_plan"]["plan_sha256"] != "attacker"
+    assert "#V#incoming" in resolved["exact_plan"]["affected_concept_ids"]
+
+
+def test_merge_requires_authority_for_an_incoming_reference_context(
+    consolidation_runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.services import ontology_mutation_command_service as command
+
+    authority, _merge, concepts, text_relations, text_values, _receipts = (
+        consolidation_runtime
+    )
+    source_id, target_id = _seed_private_merge(
+        concepts,
+        text_relations,
+        text_values,
+    )
+    concepts.update_many(
+        {"concept_id": {"$in": [source_id, target_id, "#V#incoming"]}},
+        {"$unset": {"relationships.#V#specific_to_user": ""}},
+    )
+    concepts.update_many(
+        {"concept_id": {"$in": [source_id, target_id]}},
+        {"$set": {"relationships.#V#specific_to_organisation": ["#V#org_a"]}},
+    )
+    concepts.update_one(
+        {"concept_id": "#V#incoming"},
+        {"$set": {"relationships.#V#specific_to_organisation": ["#V#org_b"]}},
+    )
+    org_a_role = authority.AuthorityRoleEvidence(
+        role=authority.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+        actor_concept_id="#V#admin",
+        organisation_concept_id="#V#org_a",
+        relation_id="role:org-a",
+        revision="1",
+    )
+    monkeypatch.setattr(
+        authority,
+        "resolve_live_semantic_roles",
+        lambda _actor: (org_a_role,),
+    )
+    monkeypatch.setattr(command, "can_access_concept", lambda _item: True)
+
+    with authority.override_current_actor("#V#admin", "#V#org_a"):
+        intent = command.build_ontology_mutation_intent(
+            method_name="merge_concepts",
+            arguments={
+                "source_id": source_id,
+                "target_id": target_id,
+                "simulate": False,
+            },
+        )
+        decision = authority.authorise_ontology_mutation(intent)
+
+    assert set(intent.target_concept_ids) == {
+        source_id,
+        target_id,
+        "#V#incoming",
+    }
+    assert decision.allowed is False
+    assert decision.reason_code == "organisation_ontology_admin_authority_required"
+
+
+def test_partial_identity_consolidation_is_receipted_as_indeterminate(
+    consolidation_runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.services import ontology_mutation_command_service as command
+
+    authority, merge, concepts, text_relations, text_values, _receipts = (
+        consolidation_runtime
+    )
+    source_id, target_id = _seed_private_merge(
+        concepts,
+        text_relations,
+        text_values,
+    )
+
+    def fail_after_concept_steps(_step):
+        raise merge._ConceptMergeApplyError(
+            "forced_text_failure",
+            "forced test failure",
+            changed=False,
+        )
+
+    monkeypatch.setattr(merge, "_conditional_apply_text_step", fail_after_concept_steps)
+    with authority.override_current_actor("#V#admin", None):
+        arguments = command.resolve_governed_ontology_arguments(
+            "merge_concepts",
+            {
+                "source_id": source_id,
+                "target_id": target_id,
+                "simulate": False,
+                "request_id": "merge:partial",
+            },
+        )
+        result = command.execute_governed_ontology_method(
+            method_name="merge_concepts",
+            arguments=arguments,
+            mutate=lambda: merge.merge_concepts(
+                source_id,
+                target_id,
+                simulate=False,
+                exact_plan=arguments["exact_plan"],
+            ),
+        )
+
+    assert result["success"] is False
+    assert result["effect_status"] == "indeterminate"
+    assert result["mutation_outcome"] == "partial"
+    assert result["changed"] is None
+    assert result["authority_receipt"]["status"] == "indeterminate"
+    assert result["canonical_read_back"]["matches_exact_plan"] is False
+    assert concepts.find_one({"concept_id": "#V#incoming"})["relationships"][
+        "related_to"
+    ] == [target_id]

--- a/tests/backend/test_ontology_publication_authority_service.py
+++ b/tests/backend/test_ontology_publication_authority_service.py
@@ -1,0 +1,445 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import mongomock
+import pytest
+
+
+@pytest.fixture
+def authority_stores(monkeypatch):
+    from src.backend.services import ontology_publication_authority_service as service
+
+    database = mongomock.MongoClient()["von_authority_test"]
+    delegations = database["ontology_authority_delegations"]
+    receipts = database["ontology_mutation_receipts"]
+    delegations.create_index("delegation_id", unique=True)
+    receipts.create_index("receipt_id", unique=True)
+    receipts.create_index(
+        [("actor_concept_id", 1), ("idempotency_key", 1)],
+        unique=True,
+        partialFilterExpression={"idempotency_key": {"$exists": True}},
+    )
+    monkeypatch.setattr(
+        service,
+        "get_ontology_authority_delegations_collection",
+        lambda: delegations,
+    )
+    monkeypatch.setattr(
+        service,
+        "get_ontology_mutation_receipts_collection",
+        lambda: receipts,
+    )
+    monkeypatch.setattr(service, "_gateway_actor_trust_source", lambda: None)
+    return service, delegations, receipts
+
+
+def _evidence(
+    service,
+    *,
+    actor: str = "#V#admin",
+    role: str,
+    organisation: str | None = None,
+):
+    return service.AuthorityRoleEvidence(
+        role=role,
+        actor_concept_id=actor,
+        organisation_concept_id=organisation,
+        relation_id=f"rel:{actor}:{role}:{organisation or 'global'}",
+        revision="role-revision-1",
+    )
+
+
+def _intent(
+    service,
+    *,
+    context=None,
+    operation: str = "relationship.add",
+    predicate: str = "#V#is_a_type_of",
+    idempotency_key: str | None = None,
+):
+    return service.OntologyMutationIntent(
+        operation=operation,
+        publication_context=context or service.PublicationContext.global_context(),
+        target_concept_ids=("#V#graduate_student", "#V#university_student"),
+        tool_name="add_relationship",
+        predicate=predicate,
+        delta={"target": "#V#university_student"},
+        idempotency_key=idempotency_key,
+    )
+
+
+def test_concept_publication_context_does_not_globalise_malformed_history(
+    monkeypatch,
+):
+    from src.backend.services import ontology_publication_authority_service as service
+
+    concepts: dict[str, dict[str, Any]] = {
+        "#V#global": {"concept_id": "#V#global", "relationships": {}},
+        "#V#org": {
+            "concept_id": "#V#org",
+            "relationships": {"#V#specific_to_organisation": ["#V#organisation_a"]},
+        },
+        "#V#legacy": {
+            "concept_id": "#V#legacy",
+            "relationships": {"specific_to_org": ["organisation_a"]},
+        },
+    }
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find_one",
+        lambda query: concepts.get(query.get("concept_id")),
+    )
+
+    assert (
+        service.concept_publication_context("#V#global").kind
+        == service.PublicationContextKind.GLOBAL
+    )
+    organisation = service.concept_publication_context("#V#org")
+    assert organisation.kind == service.PublicationContextKind.ORGANISATION
+    assert organisation.concept_id == "#V#organisation_a"
+    historical = service.concept_publication_context("#V#legacy")
+    assert historical.kind == service.PublicationContextKind.HISTORICAL
+    assert historical.historical_predicates == ("specific_to_org",)
+
+
+def test_organisation_authority_is_exact_and_does_not_imply_global(
+    authority_stores,
+    monkeypatch,
+):
+    service, _delegations, _receipts = authority_stores
+    org_a_role = _evidence(
+        service,
+        role=service.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+        organisation="#V#organisation_a",
+    )
+    monkeypatch.setattr(
+        service,
+        "resolve_live_semantic_roles",
+        lambda actor: (org_a_role,) if actor == "#V#admin" else (),
+    )
+
+    with service.override_current_actor("#V#admin", "#V#organisation_a"):
+        allowed = service.authorise_ontology_mutation(
+            _intent(
+                service,
+                context=service.PublicationContext.organisation("#V#organisation_a"),
+            )
+        )
+        wrong_org = service.authorise_ontology_mutation(
+            _intent(
+                service,
+                context=service.PublicationContext.organisation("#V#organisation_b"),
+            )
+        )
+        global_attempt = service.authorise_ontology_mutation(_intent(service))
+
+    assert allowed.allowed is True
+    assert allowed.reason_code == "semantic_ontology_authority_verified"
+    assert wrong_org.allowed is False
+    assert wrong_org.reason_code == ("organisation_ontology_admin_authority_required")
+    assert global_attempt.allowed is False
+    assert global_attempt.reason_code == "global_ontology_admin_authority_required"
+
+
+def test_global_semantic_authority_and_von_operator_remain_separate(
+    authority_stores,
+    monkeypatch,
+):
+    service, _delegations, _receipts = authority_stores
+    global_role = _evidence(
+        service,
+        role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+    )
+    monkeypatch.setattr(
+        service,
+        "resolve_live_semantic_roles",
+        lambda actor: (global_role,) if actor == "#V#admin" else (),
+    )
+    with service.override_current_actor("#V#admin", None):
+        global_decision = service.authorise_ontology_mutation(_intent(service))
+    assert global_decision.allowed is True
+
+    monkeypatch.setattr(
+        service,
+        "_gateway_actor_trust_source",
+        lambda: "trusted_operator_payload_fallback",
+    )
+    with service.override_current_actor("#V#admin", None):
+        operator_decision = service.authorise_ontology_mutation(_intent(service))
+    assert operator_decision.allowed is False
+    assert operator_decision.reason_code == (
+        "von_operator_is_not_semantic_ontology_authority"
+    )
+
+
+def test_ordinary_actor_keeps_exact_private_creation_and_edit_authority(
+    authority_stores,
+    monkeypatch,
+):
+    service, _delegations, _receipts = authority_stores
+    monkeypatch.setattr(service, "resolve_live_semantic_roles", lambda _actor: ())
+    private_context = service.PublicationContext.user("#V#member")
+    private_create = _intent(
+        service,
+        context=private_context,
+        operation="concept.create",
+        predicate=None,
+    )
+    private_edit = _intent(service, context=private_context)
+
+    with service.override_current_actor("#V#member", "#V#organisation_a"):
+        create_decision = service.authorise_ontology_mutation(private_create)
+        edit_decision = service.authorise_ontology_mutation(private_edit)
+
+    assert create_decision.allowed is True
+    assert create_decision.reason_code == "semantic_ontology_authority_verified"
+    assert edit_decision.allowed is True
+    assert edit_decision.reason_code == "semantic_ontology_authority_verified"
+
+
+def test_reserved_predicates_cannot_be_changed_by_generic_write(
+    authority_stores,
+    monkeypatch,
+):
+    service, _delegations, _receipts = authority_stores
+    global_role = _evidence(
+        service,
+        role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+    )
+    monkeypatch.setattr(
+        service, "resolve_live_semantic_roles", lambda _actor: (global_role,)
+    )
+    with service.override_current_actor("#V#admin", None):
+        decision = service.authorise_ontology_mutation(
+            _intent(service, predicate=service.AUTHORITY_ROLE_PREDICATE)
+        )
+    assert decision.allowed is False
+    assert decision.reason_code == ("dedicated_ontology_governance_operation_required")
+
+
+def test_exact_agent_delegation_rechecks_live_role_and_binds_audience_target(
+    authority_stores,
+    monkeypatch,
+):
+    service, delegations, _receipts = authority_stores
+    global_role = _evidence(
+        service,
+        role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+    )
+    live_roles = {"#V#admin": (global_role,)}
+    monkeypatch.setattr(
+        service,
+        "resolve_live_semantic_roles",
+        lambda actor: live_roles.get(actor, ()),
+    )
+    intent = _intent(service)
+    issued_at = datetime(2026, 8, 13, 8, 0, tzinfo=UTC)
+    grant = service.issue_agent_delegation(
+        intent=intent,
+        grantor_actor_concept_id="#V#admin",
+        grantor_organisation_concept_id=None,
+        delegate_concept_id="#V#von_system",
+        audience="adaptive_turn",
+        tool_name="add_relationship",
+        effect_id="effect-1",
+        turn_id="turn-1",
+        now=issued_at,
+    )
+
+    with (
+        service.override_current_actor("#V#admin", None),
+        service.bind_ontology_invocation(
+            surface="ordinary_turn",
+            executing_agent_concept_id="#V#von_system",
+            audience="adaptive_turn",
+            delegation_id=grant["delegation_id"],
+            effect_id="effect-1",
+            turn_id="turn-1",
+        ),
+    ):
+        valid = service.verify_agent_delegation(
+            delegation_id=grant["delegation_id"],
+            intent=intent,
+            invocation=service.current_ontology_invocation(),
+            actor_concept_id="#V#admin",
+            organisation_concept_id=None,
+            now=issued_at + timedelta(seconds=1),
+        )
+        with service.bind_ontology_invocation(
+            surface="ordinary_turn",
+            executing_agent_concept_id="#V#von_system",
+            audience="wrong_audience",
+            delegation_id=grant["delegation_id"],
+            effect_id="effect-1",
+        ):
+            wrong_audience = service.verify_agent_delegation(
+                delegation_id=grant["delegation_id"],
+                intent=intent,
+                invocation=service.current_ontology_invocation(),
+                actor_concept_id="#V#admin",
+                organisation_concept_id=None,
+                now=issued_at + timedelta(seconds=1),
+            )
+
+    assert valid.allowed is True
+    assert wrong_audience.allowed is False
+    assert wrong_audience.reason_code == "ontology_delegation_audience_mismatch"
+
+    live_roles.clear()
+    stored = delegations.find_one({"delegation_id": grant["delegation_id"]})
+    assert stored is not None
+    with service.bind_ontology_invocation(
+        surface="ordinary_turn",
+        executing_agent_concept_id="#V#von_system",
+        audience="adaptive_turn",
+        delegation_id=grant["delegation_id"],
+        effect_id="effect-1",
+        turn_id="turn-1",
+    ):
+        revoked_role = service.verify_agent_delegation(
+            delegation_id=grant["delegation_id"],
+            intent=intent,
+            invocation=service.current_ontology_invocation(),
+            actor_concept_id="#V#admin",
+            organisation_concept_id=None,
+            now=issued_at + timedelta(seconds=2),
+        )
+    assert revoked_role.allowed is False
+    assert revoked_role.reason_code == ("ontology_delegation_grantor_authority_revoked")
+
+
+def test_expired_and_explicitly_revoked_delegations_fail_next_effect(
+    authority_stores,
+    monkeypatch,
+):
+    service, _delegations, _receipts = authority_stores
+    global_role = _evidence(
+        service,
+        role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+    )
+    monkeypatch.setattr(
+        service, "resolve_live_semantic_roles", lambda _actor: (global_role,)
+    )
+    intent = _intent(service)
+    issued_at = datetime(2026, 8, 13, 8, 0, tzinfo=UTC)
+    grant = service.issue_agent_delegation(
+        intent=intent,
+        grantor_actor_concept_id="#V#admin",
+        grantor_organisation_concept_id=None,
+        delegate_concept_id="#V#von_system",
+        audience="adaptive_turn",
+        tool_name="add_relationship",
+        effect_id="effect-expiry",
+        ttl_seconds=1,
+        now=issued_at,
+    )
+    with service.bind_ontology_invocation(
+        surface="ordinary_turn",
+        executing_agent_concept_id="#V#von_system",
+        audience="adaptive_turn",
+        delegation_id=grant["delegation_id"],
+        effect_id="effect-expiry",
+    ):
+        expired = service.verify_agent_delegation(
+            delegation_id=grant["delegation_id"],
+            intent=intent,
+            invocation=service.current_ontology_invocation(),
+            actor_concept_id="#V#admin",
+            organisation_concept_id=None,
+            now=issued_at + timedelta(seconds=2),
+        )
+    assert expired.reason_code == "ontology_delegation_expired"
+
+    active = service.issue_agent_delegation(
+        intent=intent,
+        grantor_actor_concept_id="#V#admin",
+        grantor_organisation_concept_id=None,
+        delegate_concept_id="#V#von_system",
+        audience="adaptive_turn",
+        tool_name="add_relationship",
+        effect_id="effect-revoke",
+        now=issued_at,
+    )
+    revoked = service.revoke_agent_delegation(
+        delegation_id=active["delegation_id"],
+        acting_actor_concept_id="#V#admin",
+        reason="test revocation",
+    )
+    assert revoked["status"] == "revoked"
+
+
+def test_mutation_receipt_reconciles_and_replays_idempotently(
+    authority_stores,
+    monkeypatch,
+):
+    service, _delegations, receipts = authority_stores
+    global_role = _evidence(
+        service,
+        role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+    )
+    monkeypatch.setattr(
+        service, "resolve_live_semantic_roles", lambda _actor: (global_role,)
+    )
+    intent = _intent(service, idempotency_key="effect:stable-1")
+    calls = {"mutate": 0}
+    canonical_state = {"relationship_present": False}
+
+    def mutate():
+        calls["mutate"] += 1
+        canonical_state["relationship_present"] = True
+        return {"success": True, "changed": True, "added": True}
+
+    with service.override_current_actor("#V#admin", None):
+        first = service.execute_authorised_ontology_mutation(
+            intent=intent,
+            mutate=mutate,
+            read_back=lambda: dict(canonical_state),
+            read_before=lambda: dict(canonical_state),
+        )
+        second = service.execute_authorised_ontology_mutation(
+            intent=intent,
+            mutate=mutate,
+            read_back=lambda: dict(canonical_state),
+            read_before=lambda: dict(canonical_state),
+        )
+
+    assert calls["mutate"] == 1
+    assert first["success"] is True
+    assert first["canonical_read_back"]["relationship_present"] is True
+    assert second["idempotent_replay"] is True
+    assert first["authority_receipt"]["actor_concept_id"] == "#V#admin"
+    assert receipts.count_documents({}) == 1
+
+
+def test_agent_without_delegation_and_raw_payload_actor_fail_closed(
+    authority_stores,
+    monkeypatch,
+):
+    service, _delegations, _receipts = authority_stores
+    global_role = _evidence(
+        service,
+        role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+    )
+    monkeypatch.setattr(
+        service, "resolve_live_semantic_roles", lambda _actor: (global_role,)
+    )
+    with (
+        service.override_current_actor("#V#admin", None),
+        service.bind_ontology_invocation(
+            surface="workflow",
+            executing_agent_concept_id="#V#workflow_agent",
+            audience="workflow",
+            effect_id="effect-no-grant",
+        ),
+    ):
+        missing = service.authorise_ontology_mutation(_intent(service))
+    assert missing.reason_code == "ontology_agent_delegation_required"
+
+    monkeypatch.setattr(
+        service, "_gateway_actor_trust_source", lambda: "tool_payload_fallback"
+    )
+    with service.override_current_actor("#V#spoofed_admin", None):
+        spoofed = service.authorise_ontology_mutation(_intent(service))
+    assert spoofed.reason_code == "client_supplied_identity_is_not_authority"

--- a/tests/backend/test_organisation_membership_service.py
+++ b/tests/backend/test_organisation_membership_service.py
@@ -4,22 +4,37 @@ Tests the Vontology-based membership model that stores user-organisation
 relationships and roles using the memberOf predicate and hasRole text relations.
 """
 
-import pytest
 import sys
+from contextlib import nullcontext
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from src.backend.services.organisation_membership_service import (
-    create_organisation_membership,
-    get_user_memberships,
-    get_organisation_members,
-    update_user_role,
-    remove_organisation_membership,
     MEMBERSHIP_RELATIONSHIP_KIND,
+    create_organisation_membership,
+    get_organisation_members,
+    get_user_memberships,
+    organisation_role_storage_text,
+    parse_organisation_role_storage_text,
+    remove_organisation_membership,
+    update_user_role,
 )
+
+
+@pytest.fixture(autouse=True)
+def mock_membership_authority_barrier(monkeypatch):
+    """Keep unit tests off live coordination storage."""
+
+    monkeypatch.setattr(
+        "src.backend.services.organisation_membership_service."
+        "ontology_authority_membership_mutation_barrier",
+        nullcontext,
+    )
 
 
 @pytest.fixture
@@ -124,7 +139,7 @@ class TestCreateOrganisationMembership:
         assert call_args[1]["subject_concept_id"] == user_id
         # Predicate is stored as namespaced concept identifier
         assert call_args[1]["predicate"] == "#V#hasRole"
-        assert call_args[1]["text"] == role
+        assert call_args[1]["text"] == f"{role}::{org_id}"
 
     def test_create_membership_already_exists(
         self, mock_concepts_repo, mock_text_value_service, mock_access_control
@@ -286,6 +301,40 @@ class TestGetUserMemberships:
         assert result["total_memberships"] == 0
         assert result["memberships"] == []
 
+    def test_get_memberships_decodes_scope_distinct_equal_roles(
+        self, mock_concepts_repo, mock_access_control, mock_text_repos
+    ):
+        user_id = "#V#michael_witbrock"
+        orgs = ["#V#org_a", "#V#org_b"]
+        mock_concepts_repo.find_one.return_value = {
+            "concept_id": user_id,
+            "relationships": {"memberOf": orgs},
+        }
+        text_rels, text_vals = mock_text_repos
+        text_rels.find.return_value = [
+            {
+                "subject_concept_id": user_id,
+                "object_text_id": "owner-a",
+                "context": {"organisation_id": "#V#org_a"},
+            },
+            {
+                "subject_concept_id": user_id,
+                "object_text_id": "owner-b",
+                "context": {"organisation_id": "#V#org_b"},
+            },
+        ]
+        text_vals.find_one.side_effect = [
+            {"text": "owner::#V#org_a"},
+            {"text": "owner::#V#org_b"},
+        ]
+
+        result = get_user_memberships(user_id)
+
+        assert result["memberships"] == [
+            {"organisation_concept_id": "#V#org_a", "role": "owner"},
+            {"organisation_concept_id": "#V#org_b", "role": "owner"},
+        ]
+
     def test_get_memberships_invalid_user_id(self, mock_access_control):
         """Test retrieval with invalid user_id."""
         with pytest.raises(
@@ -293,6 +342,21 @@ class TestGetUserMemberships:
         ):
             get_user_memberships("")
 
+
+def test_organisation_role_storage_is_scope_distinct_and_legacy_readable():
+    first = organisation_role_storage_text("owner", "#V#org_a")
+    second = organisation_role_storage_text("owner", "#V#org_b")
+
+    assert first != second
+    assert parse_organisation_role_storage_text(
+        first, {"organisation_id": "#V#org_a"}
+    ) == ("owner", "#V#org_a")
+    assert parse_organisation_role_storage_text(
+        "admin", {"organisation_id": "#V#org_a"}
+    ) == ("admin", "#V#org_a")
+    assert parse_organisation_role_storage_text(
+        first, {"organisation_id": "#V#org_b"}
+    ) == (None, None)
 
 # --- Tests for get_organisation_members ---
 
@@ -484,7 +548,7 @@ class TestRemoveOrganisationMembership:
     """Tests for removing memberships."""
 
     def test_remove_membership_success(
-        self, mock_concepts_repo, mock_access_control, mock_text_repos
+        self, mock_concepts_repo, mock_access_control, mock_text_repos, monkeypatch
     ):
         """Test successful removal of membership."""
         user_id = "#V#michael_witbrock"
@@ -499,6 +563,10 @@ class TestRemoveOrganisationMembership:
             "predicate": "hasRole",
             "context": {"organisation_id": org_id},
         }
+        monkeypatch.setattr(
+            "src.backend.services.ontology_authority_role_service.authority_role_read_back",
+            lambda **_kwargs: {"active": False, "grants": []},
+        )
 
         # Execute
         result = remove_organisation_membership(user_id, org_id)
@@ -510,6 +578,22 @@ class TestRemoveOrganisationMembership:
 
         # Verify mutate_relationship_edge was called
         mock_concepts_repo.mutate_relationship_edge.assert_called_once()
+
+    def test_remove_membership_requires_semantic_authority_revocation_first(
+        self, mock_concepts_repo, mock_access_control, mock_text_repos, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "src.backend.services.ontology_authority_role_service.authority_role_read_back",
+            lambda **_kwargs: {"active": True, "grants": [{"relation_id": "role"}]},
+        )
+
+        with pytest.raises(
+            PermissionError,
+            match="organisation_ontology_authority_must_be_revoked",
+        ):
+            remove_organisation_membership("#V#admin", "#V#org")
+
+        mock_concepts_repo.mutate_relationship_edge.assert_not_called()
 
     def test_remove_membership_invalid_user_id(self, mock_access_control):
         """Test removal with invalid user_id."""

--- a/tests/backend/test_role_resolver_represented_membership.py
+++ b/tests/backend/test_role_resolver_represented_membership.py
@@ -1,0 +1,110 @@
+"""Represented organisation roles take precedence over compatibility stubs."""
+
+from __future__ import annotations
+
+from src.backend.security import role_resolver
+from src.backend.services import organisation_membership_service
+
+
+def test_represented_owner_precedes_legacy_admin_stub(monkeypatch) -> None:
+    monkeypatch.setattr(
+        organisation_membership_service,
+        "resolve_user_organisation_membership",
+        lambda user_id, organisation_id: {
+            "user_concept_id": user_id,
+            "organisation_concept_id": organisation_id,
+            "role": "owner",
+        },
+    )
+
+    role = role_resolver.get_user_role(
+        "michael_witbrock",
+        "university_of_auckland_strong_ai_lab",
+    )
+
+    assert role == "owner"
+    assert role_resolver.get_effective_permissions(role) == {
+        "READ_ORG_CONTENT",
+        "WRITE_ORG_CONTENT",
+        "MANAGE_MEMBERS",
+        "MANAGE_ROLES",
+        "DELETE_ORG",
+    }
+
+
+def test_storage_failure_retains_legacy_stub_fallback(monkeypatch) -> None:
+    monkeypatch.setattr(
+        organisation_membership_service,
+        "resolve_user_organisation_membership",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("store unavailable")),
+    )
+    monkeypatch.setattr(role_resolver, "_legacy_fallback_allowed", lambda _user: True)
+
+    assert role_resolver.get_user_role(
+        "michael_witbrock",
+        "university_of_auckland_strong_ai_lab",
+    ) == "admin"
+
+
+def test_migrated_operational_role_retires_stub_during_membership_read_failure(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        organisation_membership_service,
+        "resolve_user_organisation_membership",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("store unavailable")),
+    )
+    monkeypatch.setattr(role_resolver, "_legacy_fallback_allowed", lambda _user: False)
+
+    assert role_resolver.get_user_role(
+        "michael_witbrock",
+        "university_of_auckland_strong_ai_lab",
+    ) == role_resolver.DEFAULT_ROLE
+
+
+def test_authoritative_non_membership_does_not_resurrect_admin_stub(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        organisation_membership_service,
+        "resolve_user_organisation_membership",
+        lambda *_args: None,
+    )
+
+    assert role_resolver.get_user_role(
+        "michael_witbrock",
+        "university_of_auckland_strong_ai_lab",
+    ) == role_resolver.DEFAULT_ROLE
+
+
+def test_represented_membership_list_precedes_stub(monkeypatch) -> None:
+    monkeypatch.setattr(
+        organisation_membership_service,
+        "get_user_memberships",
+        lambda _user_id: {
+            "memberships": [
+                {
+                    "organisation_concept_id": (
+                        "#V#university_of_auckland_strong_ai_lab"
+                    ),
+                    "role": "owner",
+                }
+            ]
+        },
+    )
+
+    assert role_resolver.get_all_user_organisations("michael_witbrock") == {
+        "university_of_auckland_strong_ai_lab": "owner"
+    }
+
+
+def test_authoritative_empty_membership_list_does_not_resurrect_stub(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        organisation_membership_service,
+        "get_user_memberships",
+        lambda _user_id: {"memberships": [], "total_memberships": 0},
+    )
+
+    assert role_resolver.get_all_user_organisations("michael_witbrock") == {}

--- a/tests/backend/test_user_prefs_routes.py
+++ b/tests/backend/test_user_prefs_routes.py
@@ -1,8 +1,8 @@
-"""Tests for per-user preference (language & organisation) routes.
+"""Tests for actor-owned, non-authority user preference routes.
 
 Covers /api/settings/user_prefs/<user_concept_id> GET/POST behaviour while
-stubbing out DB access. These preferences are stored as relationships on the
-user concept.
+stubbing out DB access. Organisation membership has its own lifecycle and is
+never writable through this surface.
 """
 
 from __future__ import annotations
@@ -95,8 +95,14 @@ def app_client(monkeypatch):
 def test_get_user_prefs_returns_404_when_user_concept_missing(app_client, monkeypatch):
     _, client = app_client
 
+    import src.backend.server.routes.settings_routes as settings_routes
     import src.backend.services.concept_service as concept_service
 
+    monkeypatch.setattr(
+        settings_routes,
+        "get_effective_user_concept_id",
+        lambda: "#V#missing_user",
+    )
     monkeypatch.setattr(concept_service, "get_concept_by_concept_id", lambda **_: None)
 
     resp = client.get("/api/settings/user_prefs/%23V%23missing_user")
@@ -108,6 +114,7 @@ def test_get_user_prefs_returns_404_when_user_concept_missing(app_client, monkey
 def test_get_user_prefs_reads_relationship_values(app_client, monkeypatch):
     _, client = app_client
 
+    import src.backend.server.routes.settings_routes as settings_routes
     import src.backend.services.concept_service as concept_service
 
     def _fake_get_concept_by_concept_id(*, concept_id: str, **_kwargs):
@@ -123,6 +130,11 @@ def test_get_user_prefs_reads_relationship_values(app_client, monkeypatch):
     monkeypatch.setattr(
         concept_service, "get_concept_by_concept_id", _fake_get_concept_by_concept_id
     )
+    monkeypatch.setattr(
+        settings_routes,
+        "get_effective_user_concept_id",
+        lambda: "#V#lu_yunli",
+    )
 
     resp = client.get("/api/settings/user_prefs/%23V%23lu_yunli")
 
@@ -132,51 +144,88 @@ def test_get_user_prefs_reads_relationship_values(app_client, monkeypatch):
     assert data["organisation_concept_id"] == "#V#the_lu_witbrock_household"
 
 
-def test_set_user_prefs_updates_relationships_via_concept_service(
-    app_client, monkeypatch
-):
+def test_set_user_language_uses_governed_text_effect(app_client, monkeypatch):
     _, client = app_client
 
+    import src.backend.server.routes.settings_routes as settings_routes
     import src.backend.services.concept_service as concept_service
+    import src.backend.services.ontology_mutation_command_service as command
 
     def _fake_get_concept_by_concept_id(*, concept_id: str, **_kwargs):
+        return {"concept_id": concept_id, "relationships": {}}
+
+    captured: dict = {}
+
+    def _fake_execute(**kwargs):
+        captured["arguments"] = kwargs["arguments"]
+        captured["mutation"] = kwargs["mutate"]()
         return {
-            "concept_id": concept_id,
-            "relationships": {
-                "#V#some_other_predicate": ["#V#untouched"],
-                "#V#preferred_language": ["en"],
-                "#V#member_of_organisation": ["#V#old_org"],
-            },
+            "success": True,
+            "changed": True,
+            "authority_receipt": {"receipt_id": "receipt-language"},
+            "canonical_read_back": {"text_sha256": "exact"},
         }
 
-    captured = {}
-
-    def _fake_update_concept(concept_id: str, update_data):
-        captured["concept_id"] = concept_id
-        captured["update_data"] = update_data
-        return {"concept_id": concept_id}
-
+    monkeypatch.setattr(
+        settings_routes,
+        "get_effective_user_concept_id",
+        lambda: "#V#lu_yunli",
+    )
     monkeypatch.setattr(
         concept_service, "get_concept_by_concept_id", _fake_get_concept_by_concept_id
     )
-    monkeypatch.setattr(concept_service, "update_concept", _fake_update_concept)
+    monkeypatch.setattr(command, "execute_governed_ontology_method", _fake_execute)
+    monkeypatch.setattr(
+        "src.backend.services.text_value_service.upsert_singleton_text_relation",
+        lambda **kwargs: captured.setdefault("text_write", kwargs) or {"success": True},
+    )
 
     resp = client.post(
         "/api/settings/user_prefs/%23V%23lu_yunli",
-        json={
-            "preferred_language": "en-NZ",
-            "organisation_concept_id": "#V#the_lu_witbrock_household",
-        },
+        json={"preferred_language": "en-NZ", "request_id": "pref-language-1"},
     )
 
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["status"] == "success"
     assert data["preferred_language"] == "en-NZ"
-    assert data["organisation_concept_id"] == "#V#the_lu_witbrock_household"
+    assert data["organisation_concept_id"] is None
+    assert data["authority_receipt"] == {"receipt_id": "receipt-language"}
 
-    assert captured["concept_id"] == "#V#lu_yunli"
-    rel = captured["update_data"]["relationships"]
-    assert rel["#V#some_other_predicate"] == ["#V#untouched"]
-    assert rel["#V#preferred_language"] == ["en-NZ"]
-    assert rel["#V#member_of_organisation"] == ["#V#the_lu_witbrock_household"]
+    assert captured["arguments"] == {
+        "concept_id": "#V#lu_yunli",
+        "predicate": "#V#preferred_language",
+        "text": "en-NZ",
+        "language": "en-NZ",
+        "context": {"preference": "preferred_language"},
+        "provenance": {
+            "source": "user_preferences",
+            "actor_concept_id": "#V#lu_yunli",
+        },
+        "request_id": "pref-language-1",
+    }
+    assert captured["text_write"]["subject_concept_id"] == "#V#lu_yunli"
+
+
+def test_set_user_prefs_cannot_change_organisation_membership(
+    app_client,
+    monkeypatch,
+):
+    _, client = app_client
+
+    import src.backend.server.routes.settings_routes as settings_routes
+
+    monkeypatch.setattr(
+        settings_routes,
+        "get_effective_user_concept_id",
+        lambda: "#V#lu_yunli",
+    )
+    response = client.post(
+        "/api/settings/user_prefs/%23V%23lu_yunli",
+        json={"organisation_concept_id": "#V#forged_org"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == (
+        "organisation_membership_requires_dedicated_lifecycle"
+    )

--- a/tests/backend/test_von_file_upload_endpoint.py
+++ b/tests/backend/test_von_file_upload_endpoint.py
@@ -120,10 +120,15 @@ def app(monkeypatch):
         created.append(kwargs)
         concept_id = kwargs.get("concept_id")
         if concept_id:
+            relationships = {}
+            if kwargs.get("visibility_scope_mode") == "user_only_default":
+                relationships[CANONICAL_SPECIFIC_TO_USER_PREDICATE] = [
+                    kwargs["created_by_concept_id"]
+                ]
             concept_docs[concept_id] = {
                 "concept_id": concept_id,
                 "name": kwargs.get("name") or kwargs.get("concept_id"),
-                "relationships": {},
+                "relationships": relationships,
             }
         return {"success": True, "concept": {"concept_id": kwargs.get("concept_id")}}
 
@@ -240,6 +245,25 @@ def test_upload_requires_user_session(app):
     body = resp.get_json()
     assert body["success"] is False
     assert body["error"] == "missing_user_context"
+
+
+def test_upload_does_not_bootstrap_missing_global_file_copy_type(app):
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#user"
+        sess["session_id"] = "test-session"
+    app.config["TEST_CONCEPT_DOCS"].pop("#V#computer_file_copy")
+
+    response = client.post(
+        "/von/api/files/upload",
+        data={"file": (io.BytesIO(b"hello"), "hello.txt")},
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "file_copy_type_not_provisioned"
+    assert app.config["TEST_FAKE_STORE"].last_put is None
+    assert app.config["TEST_CREATED"] == []
 
 
 def test_upload_stores_bytes_and_registers_concept(app):

--- a/tests/backend/test_von_file_upload_scholarly_integration.py
+++ b/tests/backend/test_von_file_upload_scholarly_integration.py
@@ -349,6 +349,24 @@ def test_upload_event_workflow_materialises_scholarly_representation_in_ontology
         "errors_by_workflow_id"
     ) or {}
     assert graph_errors == {}
+    # The upload route deliberately no longer bootstraps global ontology
+    # infrastructure. Model the release prerequisite explicitly in this
+    # isolated integration database.
+    active_db = mongo_client_module.get_db()
+    assert active_db is not None
+    active_db["concepts"].update_one(
+        {"concept_id": "#V#computer_file_copy"},
+        {
+            "$setOnInsert": {
+                "concept_id": "#V#computer_file_copy",
+                "relationships": {
+                    "is_a_type_of": ["#V#store_of_information"],
+                    "is_an_instance_of": [],
+                },
+            }
+        },
+        upsert=True,
+    )
 
     from src.backend.services import workflow_event_integration_service
 
@@ -398,7 +416,7 @@ def test_upload_event_workflow_materialises_scholarly_representation_in_ontology
         data={"file": (io.BytesIO(upload_payload), "2502.14996.pdf")},
         content_type="multipart/form-data",
     )
-    assert first_upload.status_code == 200
+    assert first_upload.status_code == 200, first_upload.get_json()
     first_body = first_upload.get_json()
     assert isinstance(first_body, dict)
     assert first_body.get("success") is True

--- a/tests/backend/test_von_operational_administrator_service.py
+++ b/tests/backend/test_von_operational_administrator_service.py
@@ -1,0 +1,153 @@
+"""Reciprocal authority contracts for the represented operational role."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import pytest
+
+from src.backend.services import von_operational_administrator_service as service
+
+
+def _stores(monkeypatch):
+    relations: list[dict] = []
+    texts: dict[str, dict] = {}
+
+    def find_relations(query):
+        return [
+            dict(row)
+            for row in relations
+            if all(row.get(key) == value for key, value in query.items())
+        ]
+
+    monkeypatch.setattr(service.TextRelationsRepository, "find", find_relations)
+    monkeypatch.setattr(
+        service.TextValuesRepository,
+        "find_one",
+        lambda query: texts.get(query.get("_id")),
+    )
+    monkeypatch.setattr(service, "can_access_concept", lambda _concept_id: True)
+    monkeypatch.setattr(service, "current_ontology_invocation", lambda: None)
+    monkeypatch.setattr(
+        service,
+        "ontology_mutation_resource_lock",
+        lambda _resource_key: nullcontext(),
+    )
+    monkeypatch.setattr(
+        service,
+        "ontology_authority_membership_mutation_barrier",
+        nullcontext,
+    )
+
+    def upsert(**kwargs):
+        relation_id = f"operator:{kwargs['subject_concept_id']}"
+        text_id = f"text:{relation_id}"
+        texts[text_id] = {"text": kwargs["text"]}
+        existing = next(
+            (item for item in relations if item["_id"] == relation_id), None
+        )
+        row = {
+            "_id": relation_id,
+            "subject_concept_id": kwargs["subject_concept_id"],
+            "predicate": kwargs["predicate"],
+            "object_text_id": text_id,
+            "context": kwargs["context"],
+        }
+        if existing is None:
+            relations.append(row)
+        else:
+            existing.update(row)
+        return {"relation_id": relation_id, "relation_created": existing is None}
+
+    def delete(**kwargs):
+        for index, row in enumerate(relations):
+            if row["_id"] == kwargs["relation_id"]:
+                relations.pop(index)
+                return {"deleted": True}
+        return {"deleted": False}
+
+    monkeypatch.setattr(service, "upsert_text_for_concept", upsert)
+    monkeypatch.setattr(service, "delete_text_relation", delete)
+    return relations
+
+
+def test_semantic_role_alone_does_not_create_operational_authority(monkeypatch) -> None:
+    _stores(monkeypatch)
+    monkeypatch.setattr(service, "get_effective_user_concept_id", lambda: "#V#semantic")
+
+    assert service.is_live_von_operational_administrator("#V#semantic") is False
+    with pytest.raises(PermissionError, match="von_operational_administrator_required"):
+        service.grant_von_operational_administrator(subject_concept_id="#V#other")
+
+
+def test_bootstrap_grant_and_revoke_have_exact_read_back(monkeypatch) -> None:
+    _stores(monkeypatch)
+    monkeypatch.setattr(service, "get_effective_user_concept_id", lambda: "#V#michael")
+
+    with service.bind_von_operational_administrator_bootstrap():
+        granted = service.bootstrap_first_von_operational_administrator(
+            subject_concept_id="#V#michael"
+        )
+    assert granted["canonical_read_back"]["active"] is True
+    assert service.is_live_von_operational_administrator("#V#michael") is True
+
+    added = service.grant_von_operational_administrator(subject_concept_id="#V#other")
+    assert added["canonical_read_back"]["active"] is True
+    revoked = service.revoke_von_operational_administrator(
+        subject_concept_id="#V#other"
+    )
+    assert revoked["canonical_read_back"]["active"] is False
+
+
+def test_last_operational_administrator_cannot_be_revoked(monkeypatch) -> None:
+    _stores(monkeypatch)
+    monkeypatch.setattr(service, "get_effective_user_concept_id", lambda: "#V#michael")
+    with service.bind_von_operational_administrator_bootstrap():
+        service.bootstrap_first_von_operational_administrator(
+            subject_concept_id="#V#michael"
+        )
+
+    with pytest.raises(
+        PermissionError, match="last_von_operational_administrator_cannot_be_revoked"
+    ):
+        service.revoke_von_operational_administrator(subject_concept_id="#V#michael")
+
+
+def test_agent_invocation_cannot_manage_represented_operational_role(
+    monkeypatch,
+) -> None:
+    _stores(monkeypatch)
+    monkeypatch.setattr(service, "get_effective_user_concept_id", lambda: "#V#michael")
+    monkeypatch.setattr(
+        service,
+        "current_ontology_invocation",
+        lambda: type("Invocation", (), {"executing_agent_concept_id": "#V#agent"})(),
+    )
+
+    with pytest.raises(PermissionError, match="human_required"):
+        service.grant_von_operational_administrator(subject_concept_id="#V#other")
+
+
+def test_represented_operator_opens_only_the_operational_control_plane(
+    monkeypatch,
+) -> None:
+    from src.backend.integrations.internal_mcp import catalogue
+    from src.backend.integrations.internal_mcp.gateway import (
+        bind_internal_mcp_actor_context_source,
+    )
+
+    monkeypatch.setattr(
+        service,
+        "is_live_von_operational_administrator",
+        lambda actor: actor == "#V#operator",
+    )
+    with bind_internal_mcp_actor_context_source(
+        "preexisting_authenticated_or_workflow_context",
+        preexisting_actor_context=("#V#operator", "#V#organisation"),
+    ):
+        assert catalogue._internal_mcp_global_workflow_admin_authorised() is True
+    with bind_internal_mcp_actor_context_source(
+        "preexisting_authenticated_or_workflow_context",
+        preexisting_actor_context=("#V#semantic_only", "#V#organisation"),
+    ):
+        assert catalogue._internal_mcp_global_workflow_admin_authorised() is False

--- a/tests/backend/test_vontology_relationship_remove_routes.py
+++ b/tests/backend/test_vontology_relationship_remove_routes.py
@@ -46,68 +46,57 @@ def test_preview_remove_relationship_route_contract(monkeypatch):
     assert payload["relation_id"] == "rel:abc.def.ghi"
 
 
-def test_bulk_remove_relationship_route_contract(monkeypatch):
+def test_bulk_remove_relationship_route_rejects_invalid_selector_before_effect(
+    monkeypatch,
+):
     client = _build_client()
+    calls = []
 
     monkeypatch.setattr(
         "src.backend.services.relationship_removal_service.remove_relationships_bulk",
-        lambda **_kwargs: {
-            "success": True,
-            "status": "partial",
-            "correlation_id": "corr-2",
-            "summary": {
-                "total_requested": 2,
-                "total_valid": 1,
-                "removed_count": 1,
-                "already_absent_count": 0,
-                "error_count": 1,
-            },
-            "results": [],
-            "undo_token": "undo:corr-2",
-        },
+        lambda **kwargs: calls.append(kwargs),
     )
 
     response = client.post(
         "/api/vontology/relationships/remove/bulk",
         json={"relation_ids": ["rel:one.two.three"], "confirmed": True},
     )
-    assert response.status_code == 200
+    assert response.status_code == 400
     payload = response.get_json()
-    assert payload["success"] is True
-    assert payload["status"] == "partial"
-    assert payload["summary"]["removed_count"] == 1
-    assert payload["undo_token"] == "undo:corr-2"
+    assert payload["success"] is False
+    assert payload["error_code"] == "invalid_relationship_relation_id"
+    assert payload["effect_status"] == "not_started"
+    assert payload["changed"] is False
+    assert calls == []
 
 
-def test_undo_remove_relationship_route_contract(monkeypatch):
+def test_undo_remove_relationship_route_fails_closed_until_governed(monkeypatch):
     client = _build_client()
+    calls = []
 
     monkeypatch.setattr(
         "src.backend.services.relationship_removal_service.undo_relationship_removal",
-        lambda **_kwargs: {
-            "success": True,
-            "status": "ok",
-            "undo_token": "undo:corr-3",
-            "restored_count": 1,
-            "already_restored_count": 0,
-            "error_count": 0,
-            "errors": [],
-        },
+        lambda **kwargs: calls.append(kwargs),
     )
 
     response = client.post(
         "/api/vontology/relationships/remove/undo",
         json={"undo_token": "undo:corr-3"},
     )
-    assert response.status_code == 200
+    assert response.status_code == 410
     payload = response.get_json()
-    assert payload["success"] is True
-    assert payload["status"] == "ok"
-    assert payload["restored_count"] == 1
+    assert payload["success"] is False
+    assert payload["error_code"] == "governed_relationship_restore_required"
+    assert payload["effect_status"] == "not_started"
+    assert payload["mutation_outcome"] == "not_started"
+    assert calls == []
 
 
-def test_remove_relationship_route_uses_canonical_service(monkeypatch):
+def test_sessionless_remove_relationship_route_fails_before_canonical_service(
+    monkeypatch,
+):
     client = _build_client()
+    calls = []
 
     monkeypatch.setattr(
         "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
@@ -115,26 +104,18 @@ def test_remove_relationship_route_uses_canonical_service(monkeypatch):
     )
     monkeypatch.setattr(
         "src.backend.services.relationship_removal_service.remove_relationship",
-        lambda **_kwargs: {
-            "success": True,
-            "status": "ok",
-            "source_id": "#V#source",
-            "predicate": "is_a_type_of",
-            "target": "#V#target",
-            "relation_id": "rel:abc.def.ghi",
-            "removed": True,
-            "mode_returned": "soft_delete",
-            "cascade_policy": "warn",
-            "correlation_id": "corr-4",
-        },
+        lambda **kwargs: calls.append(kwargs),
     )
 
     response = client.post(
         "/api/vontology/relationships/remove",
         json={"source_id": "#V#source", "kind": "is_a_type_of", "target_id": "#V#target"},
     )
-    assert response.status_code == 200
+    assert response.status_code == 403
     payload = response.get_json()
-    assert payload["success"] is True
-    assert payload["status"] == "ok"
-    assert payload["relation_id"] == "rel:abc.def.ghi"
+    assert payload["success"] is False
+    assert payload["error_code"] == "authenticated_actor_context_required"
+    assert payload["effect_status"] == "not_started"
+    assert payload["mutation_outcome"] == "not_started"
+    assert payload["changed"] is False
+    assert calls == []

--- a/tests/backend/test_window_session_multi_org_isolation.py
+++ b/tests/backend/test_window_session_multi_org_isolation.py
@@ -709,6 +709,21 @@ class TestWindowSessionStoreIsolation:
         assert preserved.user_id == "#V#owner"
         assert preserved.organisation_concept_id == "owner_org"
 
+    def test_store_invalidates_all_and_only_one_users_window_role_caches(self):
+        from src.backend.services.window_session_context_service import (
+            WindowSessionStore,
+        )
+
+        store = WindowSessionStore()
+        store.get_or_create("michael_a", "#V#michael_witbrock")
+        store.get_or_create("michael_b", "#V#michael_witbrock")
+        store.get_or_create("other", "#V#other_person")
+
+        assert store.delete_all_owned("#V#michael_witbrock") == 2
+        assert store.get("michael_a") is None
+        assert store.get("michael_b") is None
+        assert store.get("other") is not None
+
     def test_get_effective_context_prefers_window_session(self):
         """get_effective_context should prefer window session over Flask session."""
         from src.backend.services.window_session_context_service import (


### PR DESCRIPTION
## Summary

Implements the organisation/global ontology-administrator capability tracked by [JVNAUTOSCI-2632](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2632).

- represents organisation and global semantic authority separately from Von operational administration
- supports exact, revocable agent delegation with durable receipts and canonical read-back
- applies the same authority semantics across chat, workflows, internal MCP, stdio, and HTTP mutation entry points
- adds actor-visible scope read, receipted preview, and governed scope-change execution
- adds exact-plan identity consolidation with complete affected-context authorisation and honest partial/indeterminate outcomes
- adds a guarded Michael-only migration that inventories all elevated holders and grants Michael operational, global semantic, and exact per-organisation authority
- fails closed or retires ambiguous legacy mutation paths that cannot meet the governed command contract

## Why

Legitimate canonical corrections were blocked when concepts carried historical or different publication scopes, while several alternate mutation entry points could bypass the conversational guard. Historical visibility was being used as a proxy for semantic authority, and Von operational control was not represented separately.

This change makes destination publication context, represented role, and exact delegation determine authority. Visibility alone no longer grants publication rights, and operational administration does not imply semantic ontology authority.

## User and developer impact

Authenticated organisation administrators can govern their organisation's ontology; global administrators can maintain the shared ontology without acquiring private organisation visibility; agents can act only under an exact server-issued delegation.

Ordinary actor-owned creation and scoped assertions remain available. Generic role, visibility, membership, merge, scope, and reserved-predicate mutations are denied or routed through dedicated lifecycle commands.

No live role migration, ontology change, deployment, or activation is performed by this PR.

## Validation

- Tier-3 authority and affected integration suite: **210 passed**
- affected relationship/create families: **118 passed**, **24 conditional skips**
- independent security re-audit: no deterministic stop-ship in the delivered scope
- changed Python files: Ruff `F,E9` clean and byte-compilation clean
- `git diff --check` clean

One broader scholarly-upload replay reaches an existing downstream durable-workflow lock failure also present on `main`; the upload authority path itself passes its focused suite.

## Release boundary

This is ready for review. Release still requires target-environment migration dry-run, guarded application, exact represented-role read-back, and replay of the motivating canonical outcomes.

[JVNAUTOSCI-2632]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ