### PR TITLE
Require trusted identity for ontology authority

### DIFF
--- a/src/backend/integrations/internal_mcp/gateway.py
+++ b/src/backend/integrations/internal_mcp/gateway.py
@@ -740,12 +740,21 @@ class InternalMCPGateway:
             observed_late_completion = _observe_validated_late_completion
         try:
             from src.backend.security.access_control import (
+                LEGACY_IDENTITY_HEADER_ACTOR_SOURCE,
                 get_effective_organisation_concept_id,
                 get_effective_user_concept_id,
+                get_effective_user_concept_id_with_source,
             )
 
             existing_user_id = get_effective_user_concept_id()
             existing_org_id = get_effective_organisation_concept_id()
+            _, existing_actor_source = get_effective_user_concept_id_with_source()
+            if existing_actor_source == LEGACY_IDENTITY_HEADER_ACTOR_SOURCE:
+                # A validated legacy header is still only a compatibility read
+                # claim.  Do not relabel it (or an org selected through it) as
+                # pre-existing authenticated/workflow authority.
+                existing_user_id = None
+                existing_org_id = None
             from src.backend.services.ontology_mutation_command_service import (
                 is_ontology_mutation_method,
             )

--- a/src/backend/security/access_control.py
+++ b/src/backend/security/access_control.py
@@ -35,6 +35,11 @@ _EVALUATOR: ContextVar["AccessEvaluator | None"] = ContextVar(
 
 _REMOVE = object()
 
+TRUSTED_IN_PROCESS_ACTOR_SOURCE = "trusted_in_process_actor"
+AUTHENTICATED_SESSION_ACTOR_SOURCE = "authenticated_session"
+AUTHENTICATED_SESSION_DERIVED_ACTOR_SOURCE = "authenticated_session_derived"
+LEGACY_IDENTITY_HEADER_ACTOR_SOURCE = "legacy_identity_header"
+
 
 def _normalise_concept_id(value: Any) -> Optional[str]:
     """Return a normalised concept id if the value resembles one."""
@@ -345,18 +350,25 @@ def _validate_person_concept(concept_id: Optional[str]) -> Optional[str]:
     return None
 
 
-def get_effective_user_concept_id() -> Optional[str]:
+def get_effective_user_concept_id_with_source() -> tuple[str | None, str | None]:
+    """Resolve the effective actor and identify how that identity was obtained.
+
+    Legacy identity headers remain a compatibility input for actor-scoped reads.
+    Callers that authorise effects must inspect the source instead of treating a
+    validated person concept as proof of authentication.
+    """
+
     manual = _MANUAL_USER.get()
     if manual is not None:
-        return manual
+        return manual, TRUSTED_IN_PROCESS_ACTOR_SOURCE
     if not has_request_context():
-        return None
+        return None, None
 
     # Primary authority is the server-side session which is populated during the
     # authenticated login flow.
     session_user = _normalise_concept_id(session.get("user_concept_id"))
     if session_user:
-        return session_user
+        return session_user, AUTHENTICATED_SESSION_ACTOR_SOURCE
 
     # Fallback: derive a candidate concept id from session user_id/email when
     # user_concept_id is missing (e.g. older login flow or partial session).
@@ -370,11 +382,11 @@ def get_effective_user_concept_id() -> Optional[str]:
         if candidate:
             validated = _validate_person_concept(candidate)
             if validated:
-                return validated
+                return validated, AUTHENTICATED_SESSION_DERIVED_ACTOR_SOURCE
 
     cached_header = getattr(g, "_von_access_header_user", None)
     if cached_header:
-        return cached_header
+        return cached_header, LEGACY_IDENTITY_HEADER_ACTOR_SOURCE
 
     # Allow a guarded per-request override via headers for trusted automation
     # clients (legacy behaviour relied on this pathway). We validate that the
@@ -387,8 +399,15 @@ def get_effective_user_concept_id() -> Optional[str]:
         validated = _validate_person_concept(header_user)
         if validated:
             g._von_access_header_user = validated
-            return validated
-    return None
+            return validated, LEGACY_IDENTITY_HEADER_ACTOR_SOURCE
+    return None, None
+
+
+def get_effective_user_concept_id() -> Optional[str]:
+    """Return the effective actor, retaining legacy header support for reads."""
+
+    actor_id, _source = get_effective_user_concept_id_with_source()
+    return actor_id
 
 
 def get_effective_organisation_concept_id() -> Optional[str]:

--- a/src/backend/server/routes/ontology_authority_routes.py
+++ b/src/backend/server/routes/ontology_authority_routes.py
@@ -12,7 +12,6 @@ from flask import Blueprint, jsonify, request, session
 from ...security.access_control import (
     can_access_concept,
     get_effective_organisation_concept_id,
-    get_effective_user_concept_id,
 )
 from ...services.ontology_authority_role_migration_service import (
     ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
@@ -68,7 +67,9 @@ def _payload() -> Mapping[str, Any]:
 
 
 def _authenticated_actor() -> str | None:
-    return get_effective_user_concept_id()
+    """Return the session-authenticated actor for semantic-authority routes."""
+
+    return _authenticated_session_actor()
 
 
 def _authenticated_session_actor() -> str | None:

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -10375,14 +10375,25 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
     )
     _check_background_cancellation("authentication context")
     try:
-        from ...security.access_control import get_effective_user_concept_id
+        from ...security.access_control import (
+            LEGACY_IDENTITY_HEADER_ACTOR_SOURCE,
+            get_effective_user_concept_id,
+            get_effective_user_concept_id_with_source,
+        )
 
+        # Legacy identity headers remain available to compatibility reads, but
+        # they are not authentication. Never promote one into the signed Flask
+        # session or into adaptive-turn authority.
         user_concept_id = get_effective_user_concept_id()
+        _, actor_identity_source = get_effective_user_concept_id_with_source()
+        if actor_identity_source == LEGACY_IDENTITY_HEADER_ACTOR_SOURCE:
+            user_concept_id = None
 
         # SECURITY: Do NOT trust client-provided user_id - require proper authentication
         # User must be authenticated via:
         # 1. Server-side session (populated during login flow)
-        # 2. Validated headers (X-User-Concept-ID with concept validation)
+        # Legacy validated identity headers are intentionally excluded here:
+        # they are compatibility read scope, not authenticated turn authority.
         # If no authenticated user, user_concept_id will be None and RAG tools will be unavailable
         if not user_concept_id:
             current_app.logger.info(
@@ -15488,7 +15499,10 @@ def set_user_concept():
     """
     try:
         from ...services.namespace_service import derive_namespace
-        from ...security.access_control import get_effective_user_concept_id
+        from ...security.access_control import (
+            LEGACY_IDENTITY_HEADER_ACTOR_SOURCE,
+            get_effective_user_concept_id_with_source,
+        )
 
         data = request.get_json(silent=True) or {}
         user_concept_id = data.get("user_concept_id")
@@ -15503,7 +15517,11 @@ def set_user_concept():
         # authenticated session, but it is not an account switcher. Resolve the
         # server-side login identity (including its durable email relation) and
         # require an exact match before changing any actor/session scope.
-        authenticated_id = get_effective_user_concept_id()
+        authenticated_id, authenticated_id_source = (
+            get_effective_user_concept_id_with_source()
+        )
+        if authenticated_id_source == LEGACY_IDENTITY_HEADER_ACTOR_SOURCE:
+            authenticated_id = None
         if not authenticated_id:
             stored_concept_id = session.get("user_concept_id")
             if isinstance(stored_concept_id, str) and stored_concept_id.strip():

--- a/src/backend/services/ontology_publication_authority_service.py
+++ b/src/backend/services/ontology_publication_authority_service.py
@@ -41,10 +41,11 @@ from ..db.repositories.text_value_repository import (
     TextValuesRepository,
 )
 from ..security.access_control import (
+    LEGACY_IDENTITY_HEADER_ACTOR_SOURCE,
     bypass_access_control,
     can_access_concept,
     get_effective_organisation_concept_id,
-    get_effective_user_concept_id,
+    get_effective_user_concept_id_with_source,
     override_current_actor,
 )
 from ..security.visibility_predicates import (
@@ -1353,7 +1354,7 @@ def authorise_ontology_mutation(
     """Resolve direct or delegated semantic authority from trusted context."""
 
     invocation = current_ontology_invocation()
-    actor_id = get_effective_user_concept_id()
+    actor_id, actor_identity_source = get_effective_user_concept_id_with_source()
     organisation_id = get_effective_organisation_concept_id()
     trust_source = _gateway_actor_trust_source()
 
@@ -1418,6 +1419,18 @@ def authorise_ontology_mutation(
             organisation_concept_id=organisation_id,
             invocation=invocation,
             trust_source=trust_source,
+        )
+
+    if actor_identity_source == LEGACY_IDENTITY_HEADER_ACTOR_SOURCE:
+        return _decision(
+            allowed=False,
+            reason_code="client_supplied_identity_is_not_authority",
+            message="Client-supplied identity cannot authorise ontology publication.",
+            intent=intent,
+            actor_concept_id=None,
+            organisation_concept_id=None,
+            invocation=invocation,
+            trust_source=actor_identity_source,
         )
 
     return _direct_authority_decision(

--- a/tests/backend/test_internal_mcp_ontology_gateway_provenance.py
+++ b/tests/backend/test_internal_mcp_ontology_gateway_provenance.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from flask import Flask
+
 from src.backend.integrations.internal_mcp.gateway import (
     InternalMCPGateway,
     MethodCatalogue,
@@ -171,3 +173,90 @@ def test_prebound_direct_human_invocation_is_preserved() -> None:
         "agent": None,
         "delegation_id": None,
     }
+
+
+def test_legacy_header_is_untrusted_gateway_provenance_and_cannot_authorise_write(
+    monkeypatch,
+) -> None:
+    from src.backend.integrations.internal_mcp.gateway import (
+        get_internal_mcp_actor_context_source,
+        get_internal_mcp_preexisting_actor_context,
+    )
+    from src.backend.services.ontology_publication_authority_service import (
+        OntologyMutationIntent,
+        PublicationContext,
+        authorise_ontology_mutation,
+    )
+    import src.backend.security.access_control as access_control
+
+    monkeypatch.setattr(
+        access_control,
+        "_validate_person_concept",
+        lambda concept_id: concept_id,
+    )
+    observed = {}
+
+    def handler(**_kwargs):
+        observed["source"] = get_internal_mcp_actor_context_source()
+        observed["preexisting"] = get_internal_mcp_preexisting_actor_context()
+        decision = authorise_ontology_mutation(
+            OntologyMutationIntent(
+                operation="relationship.add",
+                publication_context=PublicationContext.global_context(),
+                target_concept_ids=("#V#source", "#V#target"),
+                tool_name="add_relationship",
+                predicate="#V#is_a",
+                delta={"target_concept_id": "#V#target"},
+            )
+        )
+        return {
+            "success": False,
+            "error_code": decision.reason_code,
+            "trust_source": decision.trust_source,
+        }
+
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/internal-mcp",
+        headers={"X-User-Concept-ID": "#V#claimed_semantic_admin"},
+    ):
+        result = _gateway(handler).invoke("add_relationship", {}).payload
+
+    assert observed == {
+        "source": "tool_payload_fallback",
+        "preexisting": None,
+    }
+    assert result["error_code"] == "ontology_agent_delegation_required"
+    assert result["trust_source"] == "tool_payload_fallback"
+
+
+def test_legacy_header_cannot_execute_a_supplied_ontology_delegation(
+    monkeypatch,
+) -> None:
+    import src.backend.security.access_control as access_control
+
+    monkeypatch.setattr(
+        access_control,
+        "_validate_person_concept",
+        lambda concept_id: concept_id,
+    )
+    dispatched = []
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/internal-mcp",
+        headers={"X-User-Client-ID": "#V#claimed_semantic_admin"},
+    ):
+        result = (
+            _gateway(lambda **kwargs: dispatched.append(kwargs) or {"success": True})
+            .invoke(
+                "add_relationship",
+                {
+                    "ontology_delegation_id": "oag_claimed",
+                    "ontology_effect_id": "effect-claimed",
+                },
+            )
+            .payload
+        )
+
+    assert result["error_code"] == "ontology_sessionless_delegation_not_supported"
+    assert dispatched == []

--- a/tests/backend/test_ontology_authority_routes.py
+++ b/tests/backend/test_ontology_authority_routes.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import pytest
 from flask import Flask
 
+from src.backend.security import access_control
 from src.backend.server.routes import ontology_authority_routes as routes
 from src.backend.services.ontology_publication_authority_service import (
     OntologyMutationIntent,
@@ -16,10 +18,26 @@ def _app() -> Flask:
     return app
 
 
+def _authenticated_client(actor_concept_id: str = "#V#server"):
+    client = _app().test_client()
+    with client.session_transaction() as flask_session:
+        flask_session["user_concept_id"] = actor_concept_id
+    return client
+
+
+def _accept_legacy_identity_header_for_regression(monkeypatch) -> None:
+    """Make the legacy resolver accept the spoof so route isolation is tested."""
+
+    monkeypatch.setattr(
+        access_control,
+        "_validate_person_concept",
+        lambda actor_concept_id: actor_concept_id,
+    )
+
+
 def test_authority_summary_uses_server_actor_and_states_operator_separation(
     monkeypatch,
 ) -> None:
-    monkeypatch.setattr(routes, "get_effective_user_concept_id", lambda: "#V#server")
     monkeypatch.setattr(
         routes,
         "list_actor_semantic_authority",
@@ -32,7 +50,7 @@ def test_authority_summary_uses_server_actor_and_states_operator_separation(
         },
     )
 
-    response = _app().test_client().get("/api/ontology-authority/me")
+    response = _authenticated_client().get("/api/ontology-authority/me")
 
     assert response.status_code == 200
     assert response.get_json()["actor_concept_id"] == "#V#server"
@@ -47,7 +65,6 @@ def test_authority_summary_uses_server_actor_and_states_operator_separation(
 def test_delegation_ignores_payload_grantor_and_requires_exact_effect(
     monkeypatch,
 ) -> None:
-    monkeypatch.setattr(routes, "get_effective_user_concept_id", lambda: "#V#server")
     monkeypatch.setattr(
         routes, "get_effective_organisation_concept_id", lambda: "#V#org"
     )
@@ -66,8 +83,7 @@ def test_delegation_ignores_payload_grantor_and_requires_exact_effect(
 
     monkeypatch.setattr(routes, "issue_agent_delegation", issue)
     response = (
-        _app()
-        .test_client()
+        _authenticated_client()
         .post(
             "/api/ontology-authority/delegations",
             json={
@@ -85,6 +101,47 @@ def test_delegation_ignores_payload_grantor_and_requires_exact_effect(
     assert captured["grantor_actor_concept_id"] == "#V#server"
     assert captured["effect_id"] == "effect-1"
     assert captured["tool_name"] == "upsert_text_relation"
+
+
+@pytest.mark.parametrize(
+    "header_name", ["X-User-Concept-ID", "X-User-Client-ID"]
+)
+def test_delegation_rejects_spoofed_legacy_identity_headers(
+    monkeypatch,
+    header_name: str,
+) -> None:
+    _accept_legacy_identity_header_for_regression(monkeypatch)
+    intent = OntologyMutationIntent(
+        operation="text.upsert",
+        publication_context=PublicationContext.global_context(),
+        target_concept_ids=("#V#concept",),
+        tool_name="upsert_text_relation",
+    )
+    monkeypatch.setattr(routes, "build_ontology_mutation_intent", lambda **_: intent)
+    issued = []
+    monkeypatch.setattr(
+        routes,
+        "issue_agent_delegation",
+        lambda **kwargs: issued.append(kwargs) or {"delegation_id": "spoofed"},
+    )
+
+    response = _app().test_client().post(
+        "/api/ontology-authority/delegations",
+        headers={header_name: "#V#spoofed_semantic_admin"},
+        json={
+            "method_name": "upsert_text_relation",
+            "arguments": {"concept_id": "#V#concept"},
+            "delegate_concept_id": "#V#agent",
+            "audience": "adaptive_turn",
+            "effect_id": "effect-spoofed",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.get_json() == {
+        "error": "authenticated_actor_context_required"
+    }
+    assert issued == []
 
 
 def test_bootstrap_needs_explicit_opt_in_and_token(monkeypatch) -> None:
@@ -121,10 +178,11 @@ def test_bootstrap_needs_explicit_opt_in_and_token(monkeypatch) -> None:
 
 
 def test_receipt_read_does_not_disclose_another_actors_receipt(monkeypatch) -> None:
-    monkeypatch.setattr(routes, "get_effective_user_concept_id", lambda: "#V#server")
     monkeypatch.setattr(routes, "get_mutation_receipt_for_actor", lambda **_: None)
 
-    response = _app().test_client().get("/api/ontology-authority/receipts/secret")
+    response = _authenticated_client().get(
+        "/api/ontology-authority/receipts/secret"
+    )
 
     assert response.status_code == 404
     assert response.get_json() == {"error": "ontology_mutation_receipt_not_found"}
@@ -133,7 +191,6 @@ def test_receipt_read_does_not_disclose_another_actors_receipt(monkeypatch) -> N
 def test_role_route_uses_only_server_identity_not_forged_payload_identity(
     monkeypatch,
 ) -> None:
-    monkeypatch.setattr(routes, "get_effective_user_concept_id", lambda: "#V#member")
     captured = {}
 
     def grant(**kwargs):
@@ -142,8 +199,7 @@ def test_role_route_uses_only_server_identity_not_forged_payload_identity(
 
     monkeypatch.setattr(routes, "grant_ontology_authority_role", grant)
     response = (
-        _app()
-        .test_client()
+        _authenticated_client("#V#member")
         .post(
             "/api/ontology-authority/roles",
             json={
@@ -171,10 +227,102 @@ def test_role_route_uses_only_server_identity_not_forged_payload_identity(
     }
 
 
+@pytest.mark.parametrize(
+    ("path", "service_name"),
+    [
+        ("/api/ontology-authority/roles", "grant_ontology_authority_role"),
+        (
+            "/api/ontology-authority/roles/revoke",
+            "revoke_ontology_authority_role",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "header_name", ["X-User-Concept-ID", "X-User-Client-ID"]
+)
+def test_role_writes_reject_spoofed_legacy_identity_headers(
+    monkeypatch,
+    path: str,
+    service_name: str,
+    header_name: str,
+) -> None:
+    _accept_legacy_identity_header_for_regression(monkeypatch)
+    calls = []
+    monkeypatch.setattr(
+        routes,
+        service_name,
+        lambda **kwargs: calls.append(kwargs) or {"success": True},
+    )
+
+    response = _app().test_client().post(
+        path,
+        headers={header_name: "#V#spoofed_semantic_admin"},
+        json={
+            "subject_concept_id": "#V#target",
+            "role": "global_ontology_administrator",
+            "request_id": "spoofed-role-write",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.get_json() == {
+        "error": "authenticated_actor_context_required"
+    }
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("path", "service_name", "expected_status"),
+    [
+        (
+            "/api/ontology-authority/roles",
+            "grant_ontology_authority_role",
+            201,
+        ),
+        (
+            "/api/ontology-authority/roles/revoke",
+            "revoke_ontology_authority_role",
+            200,
+        ),
+    ],
+)
+def test_role_writes_accept_authenticated_session(
+    monkeypatch,
+    path: str,
+    service_name: str,
+    expected_status: int,
+) -> None:
+    calls = []
+    monkeypatch.setattr(
+        routes,
+        service_name,
+        lambda **kwargs: calls.append(kwargs) or {"success": True},
+    )
+
+    response = _authenticated_client("#V#semantic_admin").post(
+        path,
+        json={
+            "subject_concept_id": "#V#target",
+            "role": "global_ontology_administrator",
+            "request_id": "authenticated-role-write",
+        },
+    )
+
+    assert response.status_code == expected_status
+    assert calls == [
+        {
+            "subject_concept_id": "#V#target",
+            "role": "global_ontology_administrator",
+            "organisation_concept_id": None,
+            "request_id": "authenticated-role-write",
+            "reason": None,
+        }
+    ]
+
+
 def test_scope_read_returns_not_found_without_disclosing_inaccessible_concept(
     monkeypatch,
 ) -> None:
-    monkeypatch.setattr(routes, "get_effective_user_concept_id", lambda: "#V#member")
     monkeypatch.setattr(routes, "can_access_concept", lambda _concept_id: False)
     monkeypatch.setattr(
         routes,
@@ -183,8 +331,7 @@ def test_scope_read_returns_not_found_without_disclosing_inaccessible_concept(
     )
 
     response = (
-        _app()
-        .test_client()
+        _authenticated_client("#V#member")
         .get("/api/ontology-authority/concepts/%23V%23historical-secret/scope")
     )
 
@@ -193,7 +340,6 @@ def test_scope_read_returns_not_found_without_disclosing_inaccessible_concept(
 
 
 def test_scope_preview_and_execute_are_distinct_effects(monkeypatch) -> None:
-    monkeypatch.setattr(routes, "get_effective_user_concept_id", lambda: "#V#admin")
     calls = []
 
     def change(**kwargs):
@@ -205,7 +351,7 @@ def test_scope_preview_and_execute_are_distinct_effects(monkeypatch) -> None:
         }
 
     monkeypatch.setattr(routes, "change_concept_publication_scope", change)
-    client = _app().test_client()
+    client = _authenticated_client("#V#admin")
     preview = client.post(
         "/api/ontology-authority/concepts/%23V%23legacy/scope",
         json={
@@ -237,8 +383,42 @@ def test_scope_preview_and_execute_are_distinct_effects(monkeypatch) -> None:
     )
 
 
+@pytest.mark.parametrize("preview", [True, False])
+@pytest.mark.parametrize(
+    "header_name", ["X-User-Concept-ID", "X-User-Client-ID"]
+)
+def test_scope_changes_reject_spoofed_legacy_identity_headers(
+    monkeypatch,
+    header_name: str,
+    preview: bool,
+) -> None:
+    _accept_legacy_identity_header_for_regression(monkeypatch)
+    calls = []
+    monkeypatch.setattr(
+        routes,
+        "change_concept_publication_scope",
+        lambda **kwargs: calls.append(kwargs) or {"success": True},
+    )
+
+    response = _app().test_client().post(
+        "/api/ontology-authority/concepts/%23V%23legacy/scope",
+        headers={header_name: "#V#spoofed_semantic_admin"},
+        json={
+            "destination_kind": "global",
+            "expected_scope_fingerprint": "before",
+            "request_id": f"spoofed-scope-{preview}",
+            "preview": preview,
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.get_json() == {
+        "error": "authenticated_actor_context_required"
+    }
+    assert calls == []
+
+
 def test_scope_route_drops_forged_legacy_authority_payload(monkeypatch) -> None:
-    monkeypatch.setattr(routes, "get_effective_user_concept_id", lambda: "#V#member")
     captured = {}
 
     def change(**kwargs):
@@ -250,8 +430,7 @@ def test_scope_route_drops_forged_legacy_authority_payload(monkeypatch) -> None:
 
     monkeypatch.setattr(routes, "change_concept_publication_scope", change)
     response = (
-        _app()
-        .test_client()
+        _authenticated_client("#V#member")
         .post(
             "/api/ontology-authority/concepts/%23V%23legacy/scope",
             json={
@@ -305,11 +484,6 @@ def test_role_migration_apply_is_fixed_to_michael_and_inventory_fingerprint(
 ) -> None:
     monkeypatch.setenv("VON_ALLOW_ONTOLOGY_AUTHORITY_BOOTSTRAP", "true")
     monkeypatch.setenv("VON_ADMIN_TOKEN", "operator-secret")
-    monkeypatch.setattr(
-        routes,
-        "get_effective_user_concept_id",
-        lambda: routes.ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
-    )
     captured = {}
     invalidated: list[str] = []
 
@@ -366,9 +540,6 @@ def test_role_migration_apply_rejects_non_target_actor_before_service(
     monkeypatch.setenv("VON_ALLOW_ONTOLOGY_AUTHORITY_BOOTSTRAP", "true")
     monkeypatch.setenv("VON_ADMIN_TOKEN", "operator-secret")
     monkeypatch.setattr(
-        routes, "get_effective_user_concept_id", lambda: "#V#other_person"
-    )
-    monkeypatch.setattr(
         routes,
         "apply_ontology_authority_role_migration",
         lambda **_kwargs: (_ for _ in ()).throw(
@@ -396,11 +567,6 @@ def test_role_migration_apply_does_not_accept_legacy_identity_header(
 ) -> None:
     monkeypatch.setenv("VON_ALLOW_ONTOLOGY_AUTHORITY_BOOTSTRAP", "true")
     monkeypatch.setenv("VON_ADMIN_TOKEN", "operator-secret")
-    monkeypatch.setattr(
-        routes,
-        "get_effective_user_concept_id",
-        lambda: routes.ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
-    )
     monkeypatch.setattr(
         routes,
         "apply_ontology_authority_role_migration",

--- a/tests/backend/test_ontology_http_actor_provenance.py
+++ b/tests/backend/test_ontology_http_actor_provenance.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from flask import Flask
+
+from src.backend.security import access_control
+from src.backend.server.routes import concept_routes, vontology_routes
+from src.backend.services import ontology_mutation_command_service as command
+from src.backend.services import ontology_publication_authority_service as authority
+
+
+def _client():
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.register_blueprint(concept_routes.concept_bp, url_prefix="/api/concepts")
+    app.register_blueprint(vontology_routes.vontology_bp, url_prefix="/api/vontology")
+    return app.test_client()
+
+
+def _install_global_admin_authority_probe(monkeypatch) -> list[str]:
+    """Keep route parsing real while replacing only storage-bound effect work."""
+
+    calls: list[str] = []
+    role = authority.AuthorityRoleEvidence(
+        role=authority.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+        actor_concept_id="#V#existing_global_admin",
+        organisation_concept_id=None,
+        relation_id="role-existing-global-admin",
+        revision="role-revision-1",
+    )
+    monkeypatch.setattr(
+        access_control,
+        "_validate_person_concept",
+        lambda concept_id: concept_id,
+    )
+    monkeypatch.setattr(
+        authority,
+        "resolve_live_semantic_roles",
+        lambda actor_id: (role,) if actor_id == "#V#existing_global_admin" else (),
+    )
+    monkeypatch.setattr(authority, "_gateway_actor_trust_source", lambda: None)
+    monkeypatch.setattr(
+        command,
+        "resolve_governed_ontology_arguments",
+        lambda _method_name, arguments: dict(arguments),
+    )
+
+    def execute(
+        *,
+        method_name: str,
+        arguments: dict[str, Any],
+        mutate: Callable[[], Any],
+        preview: bool = False,
+    ) -> dict[str, Any]:
+        del arguments, mutate, preview
+        calls.append(method_name)
+        intent = authority.OntologyMutationIntent(
+            operation={
+                "add_relationship": "relationship.add",
+                "upsert_text_relation": "text.upsert",
+                "create_concepts": "concept.create",
+            }[method_name],
+            publication_context=authority.PublicationContext.global_context(),
+            target_concept_ids=("#V#governed_target",),
+            tool_name=method_name,
+            predicate=(
+                "#V#is_a_type_of" if method_name == "add_relationship" else None
+            ),
+        )
+        decision = authority.authorise_ontology_mutation(intent)
+        if not decision.allowed:
+            return authority.ontology_authority_denial_payload(decision, intent)
+        return {
+            "success": True,
+            "changed": True,
+            "relation_created": method_name == "upsert_text_relation",
+            "authority_decision": decision.public_projection(),
+        }
+
+    monkeypatch.setattr(command, "execute_governed_ontology_method", execute)
+    monkeypatch.setattr(
+        concept_routes,
+        "resolve_text_relation_predicate_for_write",
+        lambda predicate: SimpleNamespace(storage_predicate=predicate),
+    )
+    monkeypatch.setattr(
+        concept_routes,
+        "maybe_sync_concept_text_relations_to_rag",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(concept_routes, "_get_request_namespace", lambda: None)
+    return calls
+
+
+def _relationship_request(client, *, headers: dict[str, str]):
+    return client.post(
+        "/api/vontology/relationships/add",
+        headers=headers,
+        json={
+            "source_id": "#V#graduate_student",
+            "kind": "#V#is_a_type_of",
+            "target_id": "#V#university_student",
+        },
+    )
+
+
+def _text_request(client, *, headers: dict[str, str]):
+    return client.post(
+        "/api/concepts/%23V%23governed_target/texts",
+        headers=headers,
+        json={"predicate": "hasNote", "text": "Governed note"},
+    )
+
+
+def _create_request(client, *, headers: dict[str, str]):
+    return client.post(
+        "/api/concepts/",
+        headers=headers,
+        json={
+            "name": "Governed HTTP creation probe",
+            "concept_id": "#V#governed_http_creation_probe",
+            "scope_mode": "global_general",
+        },
+    )
+
+
+_GOVERNED_HTTP_REQUESTS = (
+    ("add_relationship", _relationship_request),
+    ("upsert_text_relation", _text_request),
+    ("create_concepts", _create_request),
+)
+
+
+@pytest.mark.parametrize("header_name", ["X-User-Concept-ID", "X-User-Client-ID"])
+@pytest.mark.parametrize(("method_name", "request_effect"), _GOVERNED_HTTP_REQUESTS)
+def test_governed_http_mutations_reject_spoofed_legacy_global_admin(
+    monkeypatch,
+    header_name: str,
+    method_name: str,
+    request_effect: Callable[..., Any],
+) -> None:
+    calls = _install_global_admin_authority_probe(monkeypatch)
+
+    response = request_effect(
+        _client(),
+        headers={header_name: "#V#existing_global_admin"},
+    )
+
+    assert response.status_code == 403
+    payload = response.get_json()
+    assert payload["error_code"] == "client_supplied_identity_is_not_authority"
+    assert payload["effect_status"] == "not_started"
+    assert payload["changed"] is False
+    assert payload["authority_decision"]["actor_concept_id"] is None
+    assert calls == [method_name]
+
+
+@pytest.mark.parametrize(("method_name", "request_effect"), _GOVERNED_HTTP_REQUESTS)
+def test_governed_http_mutations_accept_authenticated_flask_session(
+    monkeypatch,
+    method_name: str,
+    request_effect: Callable[..., Any],
+) -> None:
+    calls = _install_global_admin_authority_probe(monkeypatch)
+    client = _client()
+    with client.session_transaction() as flask_session:
+        flask_session["user_concept_id"] = "#V#existing_global_admin"
+
+    response = request_effect(client, headers={})
+
+    assert response.status_code in {200, 201}
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["authority_decision"]["allowed"] is True
+    assert payload["authority_decision"]["actor_concept_id"] == (
+        "#V#existing_global_admin"
+    )
+    assert calls == [method_name]

--- a/tests/backend/test_session_org_routes.py
+++ b/tests/backend/test_session_org_routes.py
@@ -269,15 +269,18 @@ def test_set_user_concept_updates_session_context_and_org_listing(
     assert orgs_data["organisations"][0]["concept_id"] == "#V#the_lu_witbrock_household"
 
 
-def test_set_user_concept_accepts_header_authenticated_identity(app_client, monkeypatch):
+def test_set_user_concept_rejects_bare_legacy_header_without_seeding_session(
+    app_client,
+    monkeypatch,
+):
     _, client = app_client
 
     import src.backend.security.access_control as access_control
 
     monkeypatch.setattr(
         access_control,
-        "get_effective_user_concept_id",
-        lambda: "#V#michael_witbrock",
+        "_validate_person_concept",
+        lambda concept_id: concept_id,
     )
 
     resp = client.post(
@@ -286,17 +289,22 @@ def test_set_user_concept_accepts_header_authenticated_identity(app_client, monk
         headers={"X-User-Concept-ID": "#V#michael_witbrock"},
     )
 
-    assert resp.status_code == 200
-    data = resp.get_json()
-    assert data["user_id"] == "#V#michael_witbrock"
-    assert data["namespace"] == "#V#michael_witbrock"
+    assert resp.status_code == 401
+    assert resp.get_json() == {"error": "Not authenticated"}
 
     with client.session_transaction() as sess:
-        assert sess["user_concept_id"] == "#V#michael_witbrock"
-        assert sess["user_id"] == "#V#michael_witbrock"
+        assert "user_concept_id" not in sess
+        assert "user_id" not in sess
+
+    # The rejected header cannot become a signed identity on a later request.
+    context = client.get("/von/api/session/context")
+    assert context.status_code == 200
+    assert context.get_json()["authenticated"] is False
 
 
-def test_set_user_concept_accepts_real_header_authenticated_identity(app_client):
+def test_set_user_concept_preserves_preexisting_session_identity_with_legacy_header(
+    app_client,
+):
     _, client = app_client
     real_user_concept_id = "#V#person_hugues_van_assel_b0cd25a1"
 

--- a/tests/backend/test_von_generate_rag_trace.py
+++ b/tests/backend/test_von_generate_rag_trace.py
@@ -34,6 +34,7 @@ def app(monkeypatch):
         "available_selectors": ["json_pointer", "query", "offset"],
     }
     adaptive_state = {
+        "adaptive_kwargs": None,
         "extra_messages": [
             {
                 "role": "tool",
@@ -68,6 +69,7 @@ def app(monkeypatch):
     }
 
     def _execute_adaptive_turn(**_kwargs):
+        adaptive_state["adaptive_kwargs"] = dict(_kwargs)
         return AdaptiveTurnResult(
             response_text="ok",
             extra_messages=tuple(adaptive_state["extra_messages"]),
@@ -128,6 +130,10 @@ def app(monkeypatch):
         "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
         lambda *_args, **_kwargs: [],
     )
+    monkeypatch.setattr(
+        "src.backend.security.access_control._validate_person_concept",
+        lambda concept_id: concept_id,
+    )
 
     flask_app = Flask(__name__)
     flask_app.secret_key = "test-secret"
@@ -141,6 +147,32 @@ def app(monkeypatch):
     flask_app.config["INTERNAL_MCP_GATEWAY"] = _StubGateway()
 
     return flask_app
+
+
+@pytest.mark.parametrize(
+    "header_name",
+    ("X-User-Concept-ID", "X-User-Client-ID"),
+)
+def test_generate_legacy_header_cannot_seed_session_or_adaptive_authority(
+    app,
+    header_name,
+):
+    client = app.test_client()
+
+    response = client.post(
+        "/von/generate",
+        json={"prompt": "Please change the shared ontology."},
+        headers={header_name: "#V#claimed_semantic_admin"},
+    )
+
+    assert response.status_code == 200
+    adaptive_kwargs = app.config["_ADAPTIVE_STATE"]["adaptive_kwargs"]
+    assert adaptive_kwargs["user_concept_id"] is None
+    assert adaptive_kwargs["org_concept_id"] is None
+    assert adaptive_kwargs["user_namespace"] is None
+    with client.session_transaction() as sess:
+        assert "user_concept_id" not in sess
+        assert "user_id" not in sess
 
 
 def test_generate_includes_rag_trace_when_authenticated(app):


### PR DESCRIPTION
## What changed

- Require authenticated Flask session identity for the ontology-authority management blueprint.
- Resolve actor provenance at the shared access-control seam while retaining legacy identity headers for compatibility reads.
- Reject header-derived identity at every governed ontology effect boundary, including direct concept/relationship/text HTTP writes.
- Prevent `/von/generate` and `/von/api/session/set_user_concept` from promoting a legacy header into signed session or adaptive-turn authority.
- Prevent InternalMCP from classifying header-derived ambient identity as trusted workflow/authentication context.
- Add both-header negative controls and authenticated-session positives across authority, HTTP, session, adaptive, gateway, scope, and stdio paths.

## Root cause

PR #371 reused a legacy identity resolver that validates `X-User-Concept-ID` / `X-User-Client-ID` as existing people. That was sufficient for historical compatibility reads but not authentication. The new semantic-authority surfaces initially treated that identity as a direct human actor, and two routes could persist it into signed session state.

## Impact

A client-supplied identity header can no longer grant, delegate, or exercise semantic ontology authority. Legitimate browser sessions and trusted in-process/workflow/adaptive contexts remain supported.

## Validation

- 87 end-to-end boundary tests passed across authority routes, direct HTTP, session setup, `/von/generate`, InternalMCP, stdio, and scope changes.
- 69 role lifecycle, migration, operator-role, vocabulary, and motivating Tier-3 tests passed.
- Independent bounded audit passed 27/27, 66/66, and 44/44 tranches and found no remaining legacy-header spoof path in this demonstrated class.
- Ruff F/E9, Python byte-compilation, and `git diff --check` passed.

Jira: JVNAUTOSCI-2632