### PR TITLE
Resolve represented authority role text references

### DIFF
--- a/src/backend/db/repositories/text_value_repository.py
+++ b/src/backend/db/repositories/text_value_repository.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, List, Optional
+
+from bson import ObjectId
+from bson.errors import InvalidId
 from pymongo.collection import Collection
 from pymongo.database import Database
-import logging
 
 from ..mongo_client import (
     get_db,
-    get_text_values_collection,
     get_text_relations_collection,
+    get_text_values_collection,
 )
 
 logger = logging.getLogger(__name__)
@@ -34,6 +37,31 @@ class TextValuesRepository:
         if coll is None:
             return None
         return coll.find_one(filter, projection)
+
+    @staticmethod
+    def find_one_by_id(
+        value: Any, projection: Optional[Dict[str, Any]] = None
+    ) -> Optional[Dict[str, Any]]:
+        """Resolve stored text references across string/ObjectId representations."""
+
+        if value is None:
+            return None
+        candidates: list[Any] = []
+        try:
+            candidates.append(ObjectId(str(value)))
+        except (InvalidId, TypeError):
+            pass
+        if value not in candidates:
+            candidates.append(value)
+        for candidate in candidates:
+            found = (
+                TextValuesRepository.find_one({"_id": candidate}, projection)
+                if projection is not None
+                else TextValuesRepository.find_one({"_id": candidate})
+            )
+            if found is not None:
+                return found
+        return None
 
     @staticmethod
     def find(

--- a/src/backend/services/ontology_authority_role_migration_service.py
+++ b/src/backend/services/ontology_authority_role_migration_service.py
@@ -71,9 +71,7 @@ _MIGRATION_RESOURCE_KEY = "ontology-authority-role-migration:michael-witbrock:v1
 _MIGRATION_OPERATION_NAME = "jvnautosci-2632-initial-administrator-roles-v1"
 _MIGRATION_REASON = "JVNAUTOSCI-2632 authorised administrator-role migration"
 _OWNER_ROLE = "owner"
-_NON_PRIVILEGED_ORGANISATION_ROLES = frozenset(
-    {"", "user", "viewer", "member"}
-)
+_NON_PRIVILEGED_ORGANISATION_ROLES = frozenset({"", "user", "viewer", "member"})
 _OPERATIONAL_ROLE_TOKENS = frozenset(
     {
         "von administrator",
@@ -237,9 +235,7 @@ def _assignment(
         "source": source,
         "subject_concept_id": subject_id,
         "role": _normalise_role(role),
-        "organisation_concept_id": _normalise_concept_id(
-            organisation_concept_id
-        ),
+        "organisation_concept_id": _normalise_concept_id(organisation_concept_id),
         "relation_id": _clean(relation_id) or None,
     }
 
@@ -287,9 +283,7 @@ def _text_privileged_role_assignments() -> list[dict[str, Any]]:
     for relation in TextRelationsRepository.find({"predicate": ROLE_PREDICATE}):
         if not isinstance(relation, Mapping):
             continue
-        text_value = TextValuesRepository.find_one(
-            {"_id": relation.get("object_text_id")}
-        )
+        text_value = TextValuesRepository.find_one_by_id(relation.get("object_text_id"))
         if not isinstance(text_value, Mapping):
             continue
         context = relation.get("context")
@@ -398,9 +392,7 @@ def _semantic_role_assignments() -> list[dict[str, Any]]:
     ):
         if not isinstance(relation, Mapping):
             continue
-        text_value = TextValuesRepository.find_one(
-            {"_id": relation.get("object_text_id")}
-        )
+        text_value = TextValuesRepository.find_one_by_id(relation.get("object_text_id"))
         if not isinstance(text_value, Mapping):
             continue
         context = relation.get("context")
@@ -449,9 +441,7 @@ def _target_membership_role_assignments() -> list[dict[str, Any]]:
         )
         if not organisation_id:
             continue
-        text_value = TextValuesRepository.find_one(
-            {"_id": relation.get("object_text_id")}
-        )
+        text_value = TextValuesRepository.find_one_by_id(relation.get("object_text_id"))
         if not isinstance(text_value, Mapping):
             continue
         role, stored_organisation_id = parse_organisation_role_storage_text(
@@ -480,9 +470,7 @@ def _target_membership_role_assignments() -> list[dict[str, Any]]:
 
 
 def _target_memberships() -> tuple[list[dict[str, Any]], list[str]]:
-    membership_payload = get_user_memberships(
-        ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET
-    )
+    membership_payload = get_user_memberships(ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET)
     memberships: list[dict[str, Any]] = []
     missing_organisations: list[str] = []
     seen: set[str] = set()
@@ -505,8 +493,7 @@ def _target_memberships() -> tuple[list[dict[str, Any]], list[str]]:
         memberships.append(
             {
                 "organisation_concept_id": organisation_id,
-                "legacy_role": _normalise_role(raw_membership.get("role"))
-                or "member",
+                "legacy_role": _normalise_role(raw_membership.get("role")) or "member",
             }
         )
     memberships.sort(key=lambda row: row["organisation_concept_id"])
@@ -530,12 +517,8 @@ def _collect_inventory() -> dict[str, Any]:
         "target_exists": target_exists,
         "memberships": memberships,
         "missing_membership_organisations": missing_organisations,
-        "legacy_privileged_role_assignments": (
-            _legacy_privileged_role_assignments()
-        ),
-        "target_membership_role_assignments": (
-            _target_membership_role_assignments()
-        ),
+        "legacy_privileged_role_assignments": (_legacy_privileged_role_assignments()),
+        "target_membership_role_assignments": (_target_membership_role_assignments()),
         "semantic_role_assignments": _semantic_role_assignments(),
         "operational_role_assignments": list_von_operational_administrators(),
     }
@@ -760,8 +743,7 @@ def _inventory_conflicts(inventory: Mapping[str, Any]) -> list[dict[str, Any]]:
         row
         for row in semantic_rows
         if isinstance(row, Mapping)
-        and _normalise_role(row.get("role"))
-        == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE
+        and _normalise_role(row.get("role")) == GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE
     ]
     if semantic_rows and not global_roles:
         conflicts.append(
@@ -801,9 +783,11 @@ def plan_ontology_authority_role_migration() -> dict[str, Any]:
     conflicts = _inventory_conflicts(inventory)
     semantic_rows = list(inventory.get("semantic_role_assignments") or [])
     operational_rows = list(inventory.get("operational_role_assignments") or [])
-    target_operational_role_present = len(operational_rows) == 1 and _clean(
-        operational_rows[0].get("subject_concept_id")
-    ) == ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET
+    target_operational_role_present = (
+        len(operational_rows) == 1
+        and _clean(operational_rows[0].get("subject_concept_id"))
+        == ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET
+    )
     actions: list[dict[str, Any]] = [
         {
             "operation": "bootstrap_von_operational_administrator",
@@ -828,7 +812,7 @@ def plan_ontology_authority_role_migration() -> dict[str, Any]:
                 )
                 else "required"
             ),
-        }
+        },
     ]
     for membership in inventory.get("memberships") or []:
         if not isinstance(membership, Mapping):
@@ -873,9 +857,10 @@ def plan_ontology_authority_role_migration() -> dict[str, Any]:
             and _normalise_concept_id(row.get("organisation_concept_id"))
             == organisation_id
         ]
-        exact_owner = len(exact_rows) == 1 and _normalise_role(
-            exact_rows[0].get("role")
-        ) == _OWNER_ROLE
+        exact_owner = (
+            len(exact_rows) == 1
+            and _normalise_role(exact_rows[0].get("role")) == _OWNER_ROLE
+        )
         actions.append(
             {
                 "operation": "replace_legacy_organisation_role_with_owner",
@@ -908,9 +893,7 @@ def plan_ontology_authority_role_migration() -> dict[str, Any]:
             "owner_permissions": sorted(get_effective_permissions(_OWNER_ROLE)),
         },
         "elevation_boundary": {
-            "allowed_subject_concept_ids": [
-                ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET
-            ],
+            "allowed_subject_concept_ids": [ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET],
             "other_subjects_elevated": False,
         },
     }
@@ -967,8 +950,7 @@ def _membership_role_read_back(organisation_concept_id: str) -> dict[str, Any]:
     rows = [
         row
         for row in _target_membership_role_assignments()
-        if _normalise_concept_id(row.get("organisation_concept_id"))
-        == organisation_id
+        if _normalise_concept_id(row.get("organisation_concept_id")) == organisation_id
     ]
     exact_owner = len(rows) == 1 and _normalise_role(rows[0].get("role")) == _OWNER_ROLE
     return {
@@ -1080,9 +1062,7 @@ def _replace_membership_role_with_owner(
 
 def _canonical_action_read_back(action: Mapping[str, Any]) -> dict[str, Any]:
     operation = _clean(action.get("operation"))
-    organisation_id = _normalise_concept_id(
-        action.get("organisation_concept_id")
-    )
+    organisation_id = _normalise_concept_id(action.get("organisation_concept_id"))
     if operation == "bootstrap_von_operational_administrator":
         return _verified_operational_read_back()
     if operation == "replace_legacy_organisation_role_with_owner":
@@ -1096,9 +1076,7 @@ def _canonical_action_read_back(action: Mapping[str, Any]) -> dict[str, Any]:
 def _execute_migration_action(action: Mapping[str, Any]) -> dict[str, Any]:
     operation = _clean(action.get("operation"))
     role = _normalise_role(action.get("role"))
-    organisation_id = _normalise_concept_id(
-        action.get("organisation_concept_id")
-    )
+    organisation_id = _normalise_concept_id(action.get("organisation_concept_id"))
     if operation == "bootstrap_von_operational_administrator":
         result = bootstrap_first_von_operational_administrator(
             subject_concept_id=ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
@@ -1347,17 +1325,13 @@ def apply_ontology_authority_role_migration(
                     "mode": "apply",
                     "success": True,
                     "changed": changed,
-                    "replayed": _clean(
-                        operation.get("source_inventory_fingerprint")
-                    )
+                    "replayed": _clean(operation.get("source_inventory_fingerprint"))
                     != _clean(plan.get("inventory_fingerprint")),
                     "target_concept_id": ONTOLOGY_AUTHORITY_ROLE_MIGRATION_TARGET,
                     "inventory_fingerprint_before": _clean(
                         operation.get("source_inventory_fingerprint")
                     ),
-                    "inventory_fingerprint_after": final_plan[
-                        "inventory_fingerprint"
-                    ],
+                    "inventory_fingerprint_after": final_plan["inventory_fingerprint"],
                     "effects": effects,
                     "canonical_read_back": {
                         "von_operational_administrator": (
@@ -1387,11 +1361,15 @@ def apply_ontology_authority_role_migration(
             "Another administrator-role migration is already in progress.",
         ) from exc
     except OntologyAuthorityRoleMigrationError as exc:
-        if exc.reason_code in {
-            "ontology_authority_role_migration_inventory_changed",
-            "ontology_authority_role_migration_inventory_conflict",
-            "ontology_authority_role_migration_completed_state_changed",
-        } and not effects_by_key:
+        if (
+            exc.reason_code
+            in {
+                "ontology_authority_role_migration_inventory_changed",
+                "ontology_authority_role_migration_inventory_conflict",
+                "ontology_authority_role_migration_completed_state_changed",
+            }
+            and not effects_by_key
+        ):
             raise
         completed_effects = _ordered_effects(
             list(plan.get("actions") or []) if isinstance(plan, Mapping) else [],

--- a/src/backend/services/ontology_authority_role_service.py
+++ b/src/backend/services/ontology_authority_role_service.py
@@ -150,9 +150,7 @@ def _role_rows(subject_concept_id: str | None = None) -> list[dict[str, Any]]:
     for relation in TextRelationsRepository.find(query):
         if not isinstance(relation, Mapping):
             continue
-        text_value = TextValuesRepository.find_one(
-            {"_id": relation.get("object_text_id")}
-        )
+        text_value = TextValuesRepository.find_one_by_id(relation.get("object_text_id"))
         if not isinstance(text_value, Mapping):
             continue
         relation_context = (

--- a/src/backend/services/ontology_authority_vocabulary_service.py
+++ b/src/backend/services/ontology_authority_vocabulary_service.py
@@ -75,7 +75,7 @@ def semantic_authority_has_been_bootstrapped() -> bool:
         if not isinstance(relation, Mapping):
             continue
         text_id = relation.get("object_text_id")
-        text_value = TextValuesRepository.find_one({"_id": text_id})
+        text_value = TextValuesRepository.find_one_by_id(text_id)
         if not isinstance(text_value, Mapping):
             continue
         role, _organisation_id = parse_authority_role_storage_text(
@@ -102,9 +102,7 @@ def semantic_authority_scope_has_been_bootstrapped(
     for relation in relations:
         if not isinstance(relation, Mapping):
             continue
-        text_value = TextValuesRepository.find_one(
-            {"_id": relation.get("object_text_id")}
-        )
+        text_value = TextValuesRepository.find_one_by_id(relation.get("object_text_id"))
         if not isinstance(text_value, Mapping):
             continue
         stored_role, stored_org = parse_authority_role_storage_text(
@@ -152,7 +150,9 @@ def bootstrap_first_semantic_authority(
                 f"ontology-authority-role:{role_value}:{organisation_id or 'global'}"
             ):
                 if semantic_authority_has_been_bootstrapped():
-                    raise PermissionError("ontology_authority_bootstrap_already_completed")
+                    raise PermissionError(
+                        "ontology_authority_bootstrap_already_completed"
+                    )
                 with bypass_access_control():
                     subject = ConceptsRepository.find_one({"concept_id": subject_id})
                 if not isinstance(subject, Mapping):

--- a/src/backend/services/ontology_publication_authority_service.py
+++ b/src/backend/services/ontology_publication_authority_service.py
@@ -606,7 +606,7 @@ def resolve_live_semantic_roles(
         object_text_id = relation.get("object_text_id")
         if object_text_id is None:
             continue
-        text_value = TextValuesRepository.find_one({"_id": object_text_id})
+        text_value = TextValuesRepository.find_one_by_id(object_text_id)
         if not isinstance(text_value, Mapping):
             continue
         context = relation.get("context")
@@ -666,9 +666,7 @@ def _organisation_authority_root_exists(organisation_concept_id: str) -> bool:
     for relation in relations:
         if not isinstance(relation, Mapping):
             continue
-        text_value = TextValuesRepository.find_one(
-            {"_id": relation.get("object_text_id")}
-        )
+        text_value = TextValuesRepository.find_one_by_id(relation.get("object_text_id"))
         if not isinstance(text_value, Mapping):
             continue
         role, role_org = parse_authority_role_storage_text(

--- a/src/backend/services/organisation_membership_service.py
+++ b/src/backend/services/organisation_membership_service.py
@@ -109,14 +109,11 @@ def resolve_user_organisation_membership(
     for membership in memberships.get("memberships", []):
         if not isinstance(membership, dict):
             continue
-        if _normalise_concept_id(
-            membership.get("organisation_concept_id")
-        ) == org_id:
+        if _normalise_concept_id(membership.get("organisation_concept_id")) == org_id:
             return {
                 "user_concept_id": user_id,
                 "organisation_concept_id": org_id,
-                "role": str(membership.get("role") or "member").strip()
-                or "member",
+                "role": str(membership.get("role") or "member").strip() or "member",
             }
     return None
 
@@ -297,7 +294,7 @@ def get_user_memberships(user_concept_id: str) -> dict[str, Any]:
             if text_value_id:
                 from ..db.repositories.text_value_repository import TextValuesRepository
 
-                tv = TextValuesRepository.find_one({"_id": text_value_id})
+                tv = TextValuesRepository.find_one_by_id(text_value_id)
                 if tv:
                     role, stored_org = parse_organisation_role_storage_text(
                         tv.get("text"),
@@ -345,7 +342,9 @@ def get_organisation_members(
     # access gate so cross-org org concepts can always be resolved by authenticated
     # callers regardless of which org window is currently active.
     with bypass_access_control():
-        org_concept = ConceptsRepository.find_one({"concept_id": organisation_concept_id})
+        org_concept = ConceptsRepository.find_one(
+            {"concept_id": organisation_concept_id}
+        )
     if not org_concept:
         raise ValueError(f"Organisation concept '{organisation_concept_id}' not found")
 
@@ -370,7 +369,7 @@ def get_organisation_members(
             if text_value_id:
                 from ..db.repositories.text_value_repository import TextValuesRepository
 
-                tv = TextValuesRepository.find_one({"_id": text_value_id})
+                tv = TextValuesRepository.find_one_by_id(text_value_id)
                 if tv:
                     role, stored_org = parse_organisation_role_storage_text(
                         tv.get("text"),
@@ -486,7 +485,7 @@ def update_user_role(
         if text_value_id:
             from ..db.repositories.text_value_repository import TextValuesRepository
 
-            tv = TextValuesRepository.find_one({"_id": text_value_id})
+            tv = TextValuesRepository.find_one_by_id(text_value_id)
             if tv:
                 old_role = tv.get("text", "member")
 

--- a/src/backend/services/von_operational_administrator_service.py
+++ b/src/backend/services/von_operational_administrator_service.py
@@ -12,6 +12,9 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any
 
+from bson import ObjectId
+from bson.errors import InvalidId
+
 from ..db.repositories.text_value_repository import (
     TextRelationsRepository,
     TextValuesRepository,
@@ -72,7 +75,20 @@ def _role_rows(subject_concept_id: str | None = None) -> list[dict[str, Any]]:
     for relation in TextRelationsRepository.find(query):
         if not isinstance(relation, Mapping):
             continue
-        text = TextValuesRepository.find_one({"_id": relation.get("object_text_id")})
+        object_text_id = relation.get("object_text_id")
+        text = None
+        candidates: list[object] = []
+        if object_text_id is not None:
+            try:
+                candidates.append(ObjectId(str(object_text_id)))
+            except (InvalidId, TypeError):
+                pass
+            if object_text_id not in candidates:
+                candidates.append(object_text_id)
+        for candidate in candidates:
+            text = TextValuesRepository.find_one({"_id": candidate})
+            if isinstance(text, Mapping):
+                break
         if not isinstance(text, Mapping) or text.get("text") != _ROLE_STORAGE_TEXT:
             continue
         subject_id = _normalise_concept_id(relation.get("subject_concept_id"))

--- a/src/backend/services/von_operational_administrator_service.py
+++ b/src/backend/services/von_operational_administrator_service.py
@@ -12,9 +12,6 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any
 
-from bson import ObjectId
-from bson.errors import InvalidId
-
 from ..db.repositories.text_value_repository import (
     TextRelationsRepository,
     TextValuesRepository,
@@ -75,20 +72,7 @@ def _role_rows(subject_concept_id: str | None = None) -> list[dict[str, Any]]:
     for relation in TextRelationsRepository.find(query):
         if not isinstance(relation, Mapping):
             continue
-        object_text_id = relation.get("object_text_id")
-        text = None
-        candidates: list[object] = []
-        if object_text_id is not None:
-            try:
-                candidates.append(ObjectId(str(object_text_id)))
-            except (InvalidId, TypeError):
-                pass
-            if object_text_id not in candidates:
-                candidates.append(object_text_id)
-        for candidate in candidates:
-            text = TextValuesRepository.find_one({"_id": candidate})
-            if isinstance(text, Mapping):
-                break
+        text = TextValuesRepository.find_one_by_id(relation.get("object_text_id"))
         if not isinstance(text, Mapping) or text.get("text") != _ROLE_STORAGE_TEXT:
             continue
         subject_id = _normalise_concept_id(relation.get("subject_concept_id"))

--- a/tests/backend/test_ontology_authority_role_service.py
+++ b/tests/backend/test_ontology_authority_role_service.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 
 import mongomock
 import pytest
+from bson import ObjectId
 
 from src.backend.security.access_control import override_current_actor
 from src.backend.services import ontology_authority_role_service as roles
@@ -108,6 +109,53 @@ def _with_roles(
 ) -> None:
     monkeypatch.setattr(authority, "resolve_live_semantic_roles", role_lookup)
     monkeypatch.setattr(roles, "resolve_live_semantic_roles", role_lookup)
+
+
+def test_semantic_role_readers_resolve_string_text_reference_to_object_id(
+    monkeypatch,
+) -> None:
+    relation_id = ObjectId()
+    text_id = ObjectId()
+    relation = {
+        "_id": relation_id,
+        "subject_concept_id": "#V#michael",
+        "predicate": authority.AUTHORITY_ROLE_PREDICATE,
+        "object_text_id": str(text_id),
+        "context": {"authority_scope": "global"},
+    }
+    text_value = {
+        "_id": text_id,
+        "text": authority.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+    }
+    monkeypatch.setattr(
+        roles.TextRelationsRepository,
+        "find",
+        lambda _query: [relation],
+    )
+    monkeypatch.setattr(
+        authority.TextRelationsRepository,
+        "find",
+        lambda _query: [relation],
+    )
+    monkeypatch.setattr(
+        roles.TextValuesRepository,
+        "find_one",
+        lambda query, _projection=None: (
+            text_value if query.get("_id") == text_id else None
+        ),
+    )
+
+    read_back = roles.authority_role_read_back(
+        subject_concept_id="#V#michael",
+        role=authority.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+        organisation_concept_id=None,
+    )
+    evidence = authority.resolve_live_semantic_roles("#V#michael")
+
+    assert read_back["active"] is True
+    assert read_back["grants"][0]["relation_id"] == str(relation_id)
+    assert len(evidence) == 1
+    assert evidence[0].relation_id == str(relation_id)
 
 
 def test_exact_org_admin_grants_and_revokes_only_its_own_org(

--- a/tests/backend/test_organisation_membership_service.py
+++ b/tests/backend/test_organisation_membership_service.py
@@ -76,6 +76,13 @@ def mock_text_repos():
             "src.backend.db.repositories.text_value_repository.TextValuesRepository"
         ) as text_vals,
     ):
+        def find_text_value_by_id(value, projection=None):
+            query = {"_id": value}
+            if projection is None:
+                return text_vals.find_one(query)
+            return text_vals.find_one(query, projection)
+
+        text_vals.find_one_by_id.side_effect = find_text_value_by_id
         yield text_rels, text_vals
 
 

--- a/tests/backend/test_von_operational_administrator_service.py
+++ b/tests/backend/test_von_operational_administrator_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from contextlib import nullcontext
 
 import pytest
+from bson import ObjectId
 
 from src.backend.services import von_operational_administrator_service as service
 
@@ -97,6 +98,42 @@ def test_bootstrap_grant_and_revoke_have_exact_read_back(monkeypatch) -> None:
         subject_concept_id="#V#other"
     )
     assert revoked["canonical_read_back"]["active"] is False
+
+
+def test_role_read_back_resolves_string_text_reference_to_object_id(
+    monkeypatch,
+) -> None:
+    relation_id = ObjectId()
+    text_id = ObjectId()
+    monkeypatch.setattr(
+        service.TextRelationsRepository,
+        "find",
+        lambda _query: [
+            {
+                "_id": relation_id,
+                "subject_concept_id": "#V#michael",
+                "predicate": service.VON_OPERATIONAL_ADMINISTRATOR_PREDICATE,
+                "object_text_id": str(text_id),
+                "context": {},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        service.TextValuesRepository,
+        "find_one",
+        lambda query: (
+            {"_id": text_id, "text": service._ROLE_STORAGE_TEXT}
+            if query.get("_id") == text_id
+            else None
+        ),
+    )
+
+    read_back = service.von_operational_administrator_read_back(
+        subject_concept_id="#V#michael"
+    )
+
+    assert read_back["active"] is True
+    assert read_back["grants"][0]["relation_id"] == str(relation_id)
 
 
 def test_last_operational_administrator_cannot_be_revoked(monkeypatch) -> None:


### PR DESCRIPTION
## Outcome
Restore exact canonical read-back for represented Von operational, semantic, and organisation-membership roles when a text relation stores `object_text_id` as a string while the referenced `TextValue._id` is a Mongo `ObjectId`.

## Live failure
JVNAUTOSCI-2632 role migration correctly persisted Michael's first operational-role relation, but read-back queried the string reference as `_id` and returned no grant. The canonical route honestly returned `ontology_authority_role_migration_partial`; no later role effects ran. Read-only reconciliation found exactly one persisted relation and no duplicate.

## Change
- Add one repository read seam that resolves canonical ObjectId-backed references and retains raw-string compatibility.
- Use it in operational-root, live semantic-authority, role-lifecycle, bootstrap, migration-inventory, and organisation membership/owner read-back.
- Add ObjectId-backed regressions for operational and semantic role resolution.
- Preserve the existing same-fingerprint partial-resume contract; the already-written first action is recognised as `already_satisfied`.

## Validation
- 123 focused authority, migration, MCP, and membership tests passed locally.
- Independent audit ran 138 relevant tests, with compilation and diff checks passing.
- Ruff F/E9/I, py_compile, and git diff check passed.
- Read-only live reconciliation using this candidate reports exactly one active Michael operational grant, no semantic grant yet, migration ready, and no conflicts.

Role migration remains partial. It will be resumed only through its original inventory fingerprint after this PR is merged and deployed.