### PR TITLE
Represent and verify meeting schedule facts

### DIFF
--- a/scripts/migrate_meeting_representation_file_copy_fast_path_v1.py
+++ b/scripts/migrate_meeting_representation_file_copy_fast_path_v1.py
@@ -91,6 +91,7 @@ ICS_PARTICIPANT_COUNT_KEY = "ics_participant_count"
 ICS_PARTICIPANTS_KEY = "ics_participants"
 ICS_MEETING_CONCEPT_ID_KEY = "meeting_concept_id"
 ICS_RELATIONSHIP_EFFECT_RECEIPT_KEY = "relationship_effect_receipt"
+ICS_TEMPORAL_EFFECT_RECEIPTS_KEY = "temporal_effect_receipts"
 VERIFY_EVIDENCE_STATE_KEY = "verify_file_copy_evidence"
 VERIFY_EVIDENCE_STATE_ID = (
     "#V#workflow_step_meeting_representation_workflow_verify_file_copy_evidence"
@@ -129,6 +130,20 @@ PARTICIPANT_EFFECT_VERIFIED_KEY = "meeting_participant_effects_readback_verified
 PARTICIPANT_EFFECT_RELATIONSHIPS_KEY = (
     "meeting_participant_effects_verified_relationships"
 )
+VERIFY_TEMPORAL_STATE_KEY = "verify_meeting_temporal_effects"
+VERIFY_TEMPORAL_STATE_ID = (
+    "#V#workflow_step_meeting_representation_workflow_verify_meeting_temporal_effects"
+)
+TEMPORAL_EFFECT_VERIFIED_KEY = "meeting_temporal_effects_readback_verified"
+TEMPORAL_EFFECT_CONCEPT_ID_KEY = "meeting_temporal_effects_concept_id"
+TEMPORAL_EFFECTS_KEY = "meeting_temporal_effects_verified"
+MEETING_DATE_PREDICATE_ID = "#V#date_of_event"
+MEETING_START_TIME_PREDICATE_ID = "#V#has_start_time"
+MEETING_END_TIME_PREDICATE_ID = "#V#has_end_time"
+REQUIRED_MEETING_TEMPORAL_PREDICATES = [
+    MEETING_DATE_PREDICATE_ID,
+    MEETING_START_TIME_PREDICATE_ID,
+]
 
 MEETING_REPRESENTATION_PROMPT = f"""[Versioned migration: {MIGRATION_ID}]
 
@@ -187,6 +202,18 @@ Representation:
   include UID, SUMMARY, DTSTART, DTEND, ORGANIZER, ATTENDEE, LOCATION,
   DESCRIPTION, URL, and STATUS. Preserve supplied names, addresses, titles,
   identifiers, URLs, and quoted text exactly unless normalisation is requested.
+- Represent a concrete meeting's schedule as canonical singleton text
+  relations, not as prose or ``#V#hasNote``: ``#V#date_of_event`` must contain
+  the ISO date, ``#V#has_start_time`` the ISO date/time (including its offset),
+  and ``#V#has_end_time`` the ISO date/time when the source supplies an end.
+  Preserve the IANA time-zone name in relation context when it is known. On the
+  ordinary semantic path, call ``upsert_singleton_text_relation`` idempotently
+  for date and start, plus end when supplied. A parsed-iCalendar predecessor
+  has already made those exact writes and provides their receipts, so do not
+  repeat them. A deterministic successor correlates either source of current-
+  run receipts with actor-effective canonical read-back. If the evidence cannot
+  support at least a date and start, report the representation as incomplete
+  rather than copying an ambiguous schedule into prose or inventing one.
 - An organiser or attendee is not represented by copying a display string into
   a meeting note. Treat each distinct ORGANIZER or ATTENDEE calendar address as
   evidence about a person. Deduplicate the same person appearing in both roles
@@ -248,6 +275,12 @@ Representation:
   and verifies that every distinct participant mutation from this run is
   present. A note-only participant list, a smaller number of distinct edges,
   or the wrong predicate will fail the workflow.
+- A final deterministic successor verifies the current run's exact
+  ``#V#date_of_event`` and ``#V#has_start_time`` writes, plus any receipted
+  ``#V#has_end_time`` write,
+  against actor-effective canonical text relations. A prose-only schedule,
+  missing temporal mutation receipt, or mismatched canonical value fails the
+  workflow.
 - Mutations are additive and provenance-bearing. Do not delete or rename
   existing concepts.
 
@@ -284,6 +317,7 @@ MEETING_REQUIRED_EFFECTS_CONTRACT: dict[str, Any] = {
             ),
             "required_tools": [
                 "workflow_control.relationship_effect_readback",
+                "workflow_control.text_effect_readback",
                 "add_relationship",
                 "upsert_text_relation",
                 "upsert_singleton_text_relation",
@@ -1243,6 +1277,180 @@ def _set_post_write_participant_readback(spec: dict[str, Any]) -> None:
     _upsert_managed_step(correlate_step, existing_correlate, readback_state_key)
 
 
+def _set_post_write_temporal_readback(spec: dict[str, Any]) -> None:
+    """Require canonical date/start text effects before meeting completion."""
+
+    steps = spec.get("steps")
+    if not isinstance(steps, list):
+        raise TypeError("workflow_authoring_spec_missing_steps")
+    completed_state_key = _resolve_terminal_state_key(
+        steps,
+        preferred_state_key=COMPLETED_STATE_KEY,
+        semantic_suffix=COMPLETED_STATE_KEY,
+    )
+    failed_state_key = _resolve_terminal_state_key(
+        steps,
+        preferred_state_key=FAILED_STATE_KEY,
+        semantic_suffix=FAILED_STATE_KEY,
+    )
+    existing_temporal, temporal_state_key = _managed_step(
+        steps,
+        logical_state_key=VERIFY_TEMPORAL_STATE_KEY,
+        concept_id=VERIFY_TEMPORAL_STATE_ID,
+        ambiguity_code="meeting_temporal_readback_state_ambiguous",
+    )
+
+    llm_step = _meeting_llm_step(spec)
+    if _clean_text(llm_step.get("next_state_key")) == completed_state_key:
+        llm_step["next_state_key"] = temporal_state_key
+
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        state_identity = {
+            _clean_text(step.get("state_id") or step.get("state_key")),
+            _clean_text(step.get("concept_id")),
+        }
+        if not state_identity.intersection(
+            {
+                CORRELATE_EVIDENCE_STATE_KEY,
+                CORRELATE_EVIDENCE_STATE_ID,
+                CORRELATE_PARTICIPANTS_STATE_KEY,
+                CORRELATE_PARTICIPANTS_STATE_ID,
+            }
+        ):
+            continue
+        transitions = step.get("conditional_transitions")
+        if isinstance(transitions, list):
+            for transition in transitions:
+                if (
+                    isinstance(transition, dict)
+                    and _clean_text(transition.get("to_state"))
+                    == completed_state_key
+                ):
+                    transition["to_state"] = temporal_state_key
+                    transition["reason"] = (
+                        "meeting_core_effects_require_temporal_readback"
+                    )
+
+    temporal_step: dict[str, Any] = {
+        "state_id": temporal_state_key,
+        "terminal": False,
+        "action_id": "workflow_control.text_effect_readback",
+        "execution_mode": "deterministic",
+        "static_input_bindings": [
+            {
+                "tool_param": "required_predicates",
+                "value": list(REQUIRED_MEETING_TEMPORAL_PREDICATES),
+            },
+            {
+                "tool_param": "optional_predicates",
+                "value": [MEETING_END_TIME_PREDICATE_ID],
+            },
+        ],
+        "context_input_mappings": [
+            _context_input_mapping(
+                state_key=VERIFY_TEMPORAL_STATE_KEY,
+                tool_param="tool_invocations",
+                context_key="tool_invocations",
+                required=False,
+            ),
+            _context_input_mapping(
+                state_key=VERIFY_TEMPORAL_STATE_KEY,
+                tool_param="text_effect_receipts",
+                context_key=ICS_TEMPORAL_EFFECT_RECEIPTS_KEY,
+                required=False,
+            ),
+            _context_input_mapping(
+                state_key=VERIFY_TEMPORAL_STATE_KEY,
+                tool_param="expected_concept_id",
+                context_key=EVIDENCE_EFFECT_TARGET_KEY,
+                required=False,
+            ),
+        ],
+        "tool_output_context_mappings": [
+            _tool_output_mapping(
+                state_key=VERIFY_TEMPORAL_STATE_KEY,
+                tool_output_field="text_effect_readback_verified",
+                context_key=TEMPORAL_EFFECT_VERIFIED_KEY,
+            ),
+            _tool_output_mapping(
+                state_key=VERIFY_TEMPORAL_STATE_KEY,
+                tool_output_field="represented_concept_id",
+                context_key=TEMPORAL_EFFECT_CONCEPT_ID_KEY,
+            ),
+            _tool_output_mapping(
+                state_key=VERIFY_TEMPORAL_STATE_KEY,
+                tool_output_field="verified_text_effects",
+                context_key=TEMPORAL_EFFECTS_KEY,
+            ),
+        ],
+        "writes_context_keys": [
+            TEMPORAL_EFFECT_VERIFIED_KEY,
+            TEMPORAL_EFFECT_CONCEPT_ID_KEY,
+            TEMPORAL_EFFECTS_KEY,
+        ],
+        "conditional_transitions": [
+            {
+                "to_state": completed_state_key,
+                "reason": "canonical_meeting_temporal_effects_verified",
+                "condition_spec": {
+                    "kind": "all",
+                    "conditions": [
+                        {
+                            "kind": "context_flag",
+                            "key": "last_action_succeeded",
+                            "expected": True,
+                        },
+                        {
+                            "kind": "context_flag",
+                            "key": TEMPORAL_EFFECT_VERIFIED_KEY,
+                            "expected": True,
+                        },
+                        {
+                            "kind": "context_exists",
+                            "key": TEMPORAL_EFFECT_CONCEPT_ID_KEY,
+                            "expected": True,
+                        },
+                        {
+                            "kind": "context_cardinality",
+                            "key": TEMPORAL_EFFECTS_KEY,
+                            "operator": "gte",
+                            "value": len(REQUIRED_MEETING_TEMPORAL_PREDICATES),
+                        },
+                    ],
+                },
+            }
+        ],
+        "on_unknown_state_key": failed_state_key,
+        "on_failure_state_key": failed_state_key,
+        "next_state_key": failed_state_key,
+    }
+    if temporal_state_key != VERIFY_TEMPORAL_STATE_ID or _clean_text(
+        existing_temporal.get("concept_id") if existing_temporal else None
+    ):
+        temporal_step["concept_id"] = VERIFY_TEMPORAL_STATE_ID
+    if existing_temporal and isinstance(existing_temporal.get("metadata"), Mapping):
+        temporal_step["metadata"] = copy.deepcopy(dict(existing_temporal["metadata"]))
+
+    if existing_temporal is not None:
+        index = next(
+            index
+            for index, item in enumerate(steps)
+            if item is not None and item == existing_temporal
+        )
+        steps[index] = temporal_step
+    else:
+        completed_index = next(
+            index
+            for index, item in enumerate(steps)
+            if isinstance(item, Mapping)
+            and _clean_text(item.get("state_id") or item.get("state_key"))
+            == completed_state_key
+        )
+        steps.insert(completed_index, temporal_step)
+
+
 def _set_ics_file_copy_fast_path(
     spec: dict[str, Any], llm_step: dict[str, Any]
 ) -> None:
@@ -1300,6 +1508,10 @@ def _set_ics_file_copy_fast_path(
             (
                 ICS_RELATIONSHIP_EFFECT_RECEIPT_KEY,
                 ICS_RELATIONSHIP_EFFECT_RECEIPT_KEY,
+            ),
+            (
+                ICS_TEMPORAL_EFFECT_RECEIPTS_KEY,
+                ICS_TEMPORAL_EFFECT_RECEIPTS_KEY,
             ),
             ("response_text", "response_text"),
         )
@@ -1433,6 +1645,10 @@ def _set_context_fields(policy: dict[str, Any]) -> None:
         (ICS_PARTICIPANT_COUNT_KEY, "Distinct organiser and attendee count"),
         (ICS_PARTICIPANTS_KEY, "Structured organiser and attendee evidence"),
         (ICS_MEETING_CONCEPT_ID_KEY, "UID-resolved meeting concept ID"),
+        (
+            ICS_TEMPORAL_EFFECT_RECEIPTS_KEY,
+            "Exact canonical temporal mutation receipts from structured ingestion",
+        ),
     )
     for context_key, label in authored_fields:
         matching_indexes = [
@@ -1552,6 +1768,7 @@ def rewrite_meeting_representation_workflow(
     _set_post_write_evidence_readback(spec, llm_step)
     _set_ics_file_copy_fast_path(spec, llm_step)
     _set_post_write_participant_readback(spec)
+    _set_post_write_temporal_readback(spec)
 
     metadata = spec.get("workflow_metadata")
     if not isinstance(metadata, dict):

--- a/src/backend/services/meeting_file_representation_service.py
+++ b/src/backend/services/meeting_file_representation_service.py
@@ -27,12 +27,15 @@ from .file_copy_entity_representation_vontology_service import (
     normalise_file_copy_meeting_candidate,
 )
 from .relationship_write_service import add_relationship
-from .text_value_service import get_texts_for_concept
+from .text_value_service import get_texts_for_concept, upsert_singleton_text_relation
 
 ICS_UID_IDENTIFIER_TYPE = "icalendar.uid"
 ICS_MEETING_CONCEPT_ID_PREFIX = "meeting_ics"
 MEETING_TYPE_ID = "#V#meeting"
 DOCUMENTARY_EVIDENCE_PREDICATE_ID = "#V#documentary_evidence_for"
+MEETING_DATE_PREDICATE_ID = "#V#date_of_event"
+MEETING_START_TIME_PREDICATE_ID = "#V#has_start_time"
+MEETING_END_TIME_PREDICATE_ID = "#V#has_end_time"
 
 
 class IcsMeetingMaterialisationError(RuntimeError):
@@ -314,14 +317,8 @@ def _persist_ics_uid_identity_marker(
     return dict(persistence)
 
 
-def _temporal_note(
-    property_name: str, temporal: Any
-) -> tuple[str, str, dict[str, Any]] | None:
-    iso_value = _clean_text(_object_value(temporal, "iso_value"))
-    if not iso_value:
-        return None
+def _temporal_context(property_name: str, temporal: Any) -> dict[str, Any]:
     context: dict[str, Any] = {
-        "note_type": f"ics_{property_name.lower()}",
         "icalendar_property": property_name,
         "source": "ics_meeting_representation",
     }
@@ -329,18 +326,56 @@ def _temporal_note(
         value = _object_value(temporal, key)
         if value is not None and value != "":
             context[key] = value
-    return "#V#hasNote", f"{property_name}: {iso_value}", context
+    tzid = _clean_text(_object_value(temporal, "tzid"))
+    if tzid:
+        context["time_zone"] = tzid
+    elif _object_value(temporal, "is_utc") is True:
+        context["time_zone"] = "UTC"
+    if (
+        property_name == "DTEND"
+        and _clean_text(_object_value(temporal, "value_type")).upper() == "DATE"
+    ):
+        context["end_semantics"] = "exclusive"
+    return context
 
 
-def _ics_fact_relation_specs(meeting: Any) -> list[tuple[str, str, dict[str, Any]]]:
+def _ics_temporal_relation_specs(
+    meeting: Any,
+) -> list[tuple[str, str, dict[str, Any]]]:
+    """Project parsed RFC 5545 time fields to canonical meeting predicates."""
+
     specs: list[tuple[str, str, dict[str, Any]]] = []
-    for property_name, field_name in (("DTSTART", "dtstart"), ("DTEND", "dtend")):
-        temporal_spec = _temporal_note(
-            property_name, _object_value(meeting, field_name)
+    dtstart = _object_value(meeting, "dtstart")
+    start_iso = _clean_text(_object_value(dtstart, "iso_value"))
+    if start_iso:
+        start_context = _temporal_context("DTSTART", dtstart)
+        date_value = start_iso.split("T", 1)[0]
+        specs.extend(
+            (
+                (MEETING_DATE_PREDICATE_ID, date_value, dict(start_context)),
+                (MEETING_START_TIME_PREDICATE_ID, start_iso, dict(start_context)),
+            )
         )
-        if temporal_spec is not None:
-            specs.append(temporal_spec)
 
+    dtend = _object_value(meeting, "dtend")
+    end_iso = _clean_text(_object_value(dtend, "iso_value"))
+    if end_iso:
+        specs.append(
+            (
+                MEETING_END_TIME_PREDICATE_ID,
+                end_iso,
+                _temporal_context("DTEND", dtend),
+            )
+        )
+    return specs
+
+
+def _ics_note_relation_specs(
+    meeting: Any,
+) -> list[tuple[str, str, dict[str, Any]]]:
+    """Return source-backed non-temporal ICS facts retained as notes."""
+
+    specs: list[tuple[str, str, dict[str, Any]]] = []
     for property_name, field_name in (
         ("LOCATION", "location"),
         ("DESCRIPTION", "description"),
@@ -360,6 +395,12 @@ def _ics_fact_relation_specs(meeting: Any) -> list[tuple[str, str, dict[str, Any
                     },
                 )
             )
+    return specs
+
+
+def _deduplicate_relation_specs(
+    specs: Sequence[tuple[str, str, dict[str, Any]]],
+) -> list[tuple[str, str, dict[str, Any]]]:
     deduplicated: list[tuple[str, str, dict[str, Any]]] = []
     seen: set[tuple[str, str, tuple[tuple[str, str], ...]]] = set()
     for predicate, text, context in specs:
@@ -373,6 +414,35 @@ def _ics_fact_relation_specs(meeting: Any) -> list[tuple[str, str, dict[str, Any
         seen.add(fingerprint)
         deduplicated.append((predicate, text, context))
     return deduplicated
+
+
+def _text_effect_receipt(
+    *,
+    concept_id: str,
+    predicate: str,
+    text: str,
+    result: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "tool": "upsert_singleton_text_relation",
+        "status": "ok",
+        "effective_arguments": {
+            "concept_id": concept_id,
+            "predicate": predicate,
+            "text": text,
+        },
+        "effective_payload": {
+            **dict(result),
+            "success": True,
+            "effect_status": "succeeded",
+            "concept_id": concept_id,
+            "predicate": predicate,
+        },
+    }
+
+
+def _ics_fact_relation_specs(meeting: Any) -> list[tuple[str, str, dict[str, Any]]]:
+    return _deduplicate_relation_specs(_ics_note_relation_specs(meeting))
 
 
 def _relationship_effect_receipt(
@@ -474,6 +544,63 @@ def materialise_ics_meeting_representation_for_file_copy(
         *_ics_fact_relation_specs(meeting),
     ]
     persisted_text_relations: list[dict[str, Any]] = []
+    temporal_effect_receipts: list[dict[str, Any]] = []
+    for predicate, text, raw_context in _deduplicate_relation_specs(
+        _ics_temporal_relation_specs(meeting)
+    ):
+        context = {
+            **dict(raw_context),
+            "source_file_copy_concept_id": source_id,
+        }
+        try:
+            temporal_result = upsert_singleton_text_relation(
+                subject_concept_id=meeting_concept_id,
+                predicate=predicate,
+                text=text,
+                context=context,
+            )
+        except Exception as exc:
+            raise IcsMeetingMaterialisationError(
+                "ics_meeting_temporal_fact_persist_failed",
+                details={
+                    "meeting_concept_id": meeting_concept_id,
+                    "predicate": predicate,
+                    "exception_type": type(exc).__name__,
+                    "created_meeting_concept": created,
+                    "persisted_text_relation_count": len(persisted_text_relations),
+                },
+            ) from exc
+        if not isinstance(temporal_result, Mapping) or temporal_result.get(
+            "success"
+        ) is not True:
+            raise IcsMeetingMaterialisationError(
+                "ics_meeting_temporal_fact_persist_failed",
+                details={
+                    "meeting_concept_id": meeting_concept_id,
+                    "predicate": predicate,
+                    "created_meeting_concept": created,
+                    "temporal_result": (
+                        dict(temporal_result)
+                        if isinstance(temporal_result, Mapping)
+                        else {"response_type": type(temporal_result).__name__}
+                    ),
+                },
+            )
+        persisted_text_relations.append(
+            {
+                "predicate": predicate,
+                "relation_id": temporal_result.get("kept_relation_id"),
+                "text": text,
+            }
+        )
+        temporal_effect_receipts.append(
+            _text_effect_receipt(
+                concept_id=meeting_concept_id,
+                predicate=predicate,
+                text=text,
+                result=temporal_result,
+            )
+        )
     for predicate, text, raw_context in relation_specs:
         context = {
             **dict(raw_context),
@@ -570,6 +697,7 @@ def materialise_ics_meeting_representation_for_file_copy(
             }
         ],
         "relationship_effect_receipt": effect_receipt,
+        "temporal_effect_receipts": temporal_effect_receipts,
         "response_text": (
             f"{operation.title()} meeting '{summary}' as {meeting_concept_id} "
             "from the supplied iCalendar invitation, including its iCalendar "

--- a/src/backend/services/text_effect_readback_service.py
+++ b/src/backend/services/text_effect_readback_service.py
@@ -1,0 +1,229 @@
+"""Canonical verification for text-relation effects emitted by a workflow.
+
+The represented workflow supplies the predicates that matter.  This service
+only correlates successful text-mutation receipts from the current execution
+with actor-effective canonical text-relation reads.  It does not decide which
+facts a meeting, paper, or other domain object ought to contain.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .text_value_service import get_texts_for_concept
+
+TEXT_EFFECT_READBACK_SCHEMA_VERSION = "workflow_text_effect_readback.v1"
+MAX_TEXT_EFFECT_RECORDS = 80
+MAX_REQUIRED_TEXT_PREDICATES = 20
+_TEXT_MUTATION_TOOLS = frozenset(
+    {"upsert_text_relation", "upsert_singleton_text_relation"}
+)
+
+
+def _clean_text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _mapping(value: Any) -> Mapping[str, Any] | None:
+    return value if isinstance(value, Mapping) else None
+
+
+def _records(value: Any) -> list[Mapping[str, Any]] | None:
+    if value is None:
+        return []
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return None
+    rows = [row for row in value if isinstance(row, Mapping)]
+    return rows if len(rows) == len(value) else None
+
+
+def _successful_text_effect(record: Mapping[str, Any]) -> dict[str, str] | None:
+    tool_name = _clean_text(record.get("tool"))
+    if tool_name not in _TEXT_MUTATION_TOOLS or record.get("status") != "ok":
+        return None
+    arguments = _mapping(record.get("effective_arguments"))
+    payload = _mapping(record.get("effective_payload"))
+    if arguments is None or payload is None or payload.get("success") is not True:
+        return None
+
+    concept_id = _clean_text(arguments.get("concept_id"))
+    predicate = _clean_text(arguments.get("predicate"))
+    text = _clean_text(arguments.get("text"))
+    if not concept_id or not predicate or not text:
+        return None
+
+    payload_concept_id = _clean_text(payload.get("concept_id"))
+    payload_predicate = _clean_text(
+        payload.get("predicate_concept_id") or payload.get("predicate")
+    )
+    if payload_concept_id and payload_concept_id != concept_id:
+        return None
+    if payload_predicate and payload_predicate != predicate:
+        return None
+    effect_status = _clean_text(payload.get("effect_status"))
+    if effect_status and effect_status != "succeeded":
+        return None
+    return {
+        "tool": tool_name,
+        "concept_id": concept_id,
+        "predicate": predicate,
+        "text": text,
+    }
+
+
+def verify_text_effect_readback(
+    *,
+    required_predicates: Any,
+    optional_predicates: Any = None,
+    tool_invocations: Any = None,
+    text_effect_receipts: Any = None,
+    expected_concept_id: Any = None,
+) -> dict[str, Any]:
+    """Verify required text effects against actor-effective canonical state.
+
+    Every required predicate must have a successful current-run mutation receipt
+    for the same single concept, and the exact receipted text must be present in
+    canonical read-back.  Extra receipted text predicates are also checked so a
+    represented workflow can require a small core while retaining exact proof of
+    richer source facts such as an end time.
+    """
+
+    expected_id = _clean_text(expected_concept_id)
+    if not isinstance(required_predicates, Sequence) or isinstance(
+        required_predicates, (str, bytes, bytearray)
+    ):
+        required: list[str] = []
+    else:
+        required = list(
+            dict.fromkeys(
+                predicate
+                for predicate in (
+                    _clean_text(item) for item in required_predicates
+                )
+                if predicate
+            )
+        )
+
+    if optional_predicates is None:
+        optional: list[str] = []
+        optional_predicates_invalid = False
+    elif not isinstance(optional_predicates, Sequence) or isinstance(
+        optional_predicates, (str, bytes, bytearray)
+    ):
+        optional = []
+        optional_predicates_invalid = True
+    else:
+        optional = list(
+            dict.fromkeys(
+                predicate
+                for predicate in (
+                    _clean_text(item) for item in optional_predicates
+                )
+                if predicate and predicate not in required
+            )
+        )
+        optional_predicates_invalid = False
+
+    invocations = _records(tool_invocations)
+    receipts = _records(text_effect_receipts)
+    failure_code: str | None = None
+    if (
+        not required
+        or len(required) + len(optional) > MAX_REQUIRED_TEXT_PREDICATES
+        or (optional_predicates is not None and optional_predicates_invalid)
+        or invocations is None
+        or receipts is None
+        or len(invocations) + len(receipts) > MAX_TEXT_EFFECT_RECORDS
+    ):
+        failure_code = "text_effect_readback_inputs_invalid"
+
+    effects: list[dict[str, str]] = []
+    if failure_code is None:
+        accepted_predicates = set(required) | set(optional)
+        for record in [*(invocations or []), *(receipts or [])]:
+            effect = _successful_text_effect(record)
+            if effect is not None and effect["predicate"] in accepted_predicates:
+                effects.append(effect)
+
+    concept_ids = list(dict.fromkeys(effect["concept_id"] for effect in effects))
+    if failure_code is None:
+        if expected_id:
+            effects = [effect for effect in effects if effect["concept_id"] == expected_id]
+            concept_id = expected_id
+        elif len(concept_ids) == 1:
+            concept_id = concept_ids[0]
+        else:
+            concept_id = ""
+            failure_code = (
+                "text_effect_concept_missing"
+                if not concept_ids
+                else "text_effect_concept_ambiguous"
+            )
+    else:
+        concept_id = expected_id
+
+    effects_by_predicate: dict[str, list[dict[str, str]]] = {}
+    for effect in effects:
+        effects_by_predicate.setdefault(effect["predicate"], []).append(effect)
+
+    missing_receipts = [
+        predicate for predicate in required if not effects_by_predicate.get(predicate)
+    ]
+    if failure_code is None and missing_receipts:
+        failure_code = "text_effect_required_mutation_missing"
+
+    verified_effects: list[dict[str, Any]] = []
+    canonical_rows: dict[str, list[dict[str, Any]]] = {}
+    if failure_code is None:
+        for predicate, predicate_effects in effects_by_predicate.items():
+            rows = get_texts_for_concept(
+                subject_concept_id=concept_id,
+                predicate=predicate,
+                limit=20,
+                context_view="actor_effective",
+            )
+            serialised_rows = [dict(row) for row in rows if isinstance(row, Mapping)]
+            canonical_rows[predicate] = serialised_rows
+            canonical_texts = {
+                text for text in (_clean_text(row.get("text")) for row in rows) if text
+            }
+            for effect in predicate_effects:
+                if effect["text"] not in canonical_texts:
+                    failure_code = "text_effect_exact_readback_missing"
+                    break
+                matching_row = next(
+                    row
+                    for row in serialised_rows
+                    if _clean_text(row.get("text")) == effect["text"]
+                )
+                verified_effects.append(
+                    {
+                        "concept_id": concept_id,
+                        "predicate": predicate,
+                        "text": effect["text"],
+                        "relation_id": matching_row.get("relation_id"),
+                    }
+                )
+            if failure_code is not None:
+                break
+
+    verified = failure_code is None
+    return {
+        "schema_version": TEXT_EFFECT_READBACK_SCHEMA_VERSION,
+        "success": verified,
+        "text_effect_readback_verified": verified,
+        "text_effect_readback_failure_code": failure_code,
+        "represented_concept_id": concept_id or None,
+        "required_predicates": required,
+        "optional_predicates": optional,
+        "missing_receipt_predicates": missing_receipts,
+        "verified_text_effects": verified_effects,
+        "canonical_readback": canonical_rows,
+    }
+
+
+__all__ = [
+    "TEXT_EFFECT_READBACK_SCHEMA_VERSION",
+    "verify_text_effect_readback",
+]

--- a/src/backend/workflows/durable/control_flow_actions.py
+++ b/src/backend/workflows/durable/control_flow_actions.py
@@ -21,6 +21,7 @@ from ...services.kr_relationship_readback_service import (
     verify_kr_relationship_readback,
     verify_relationship_effect_readback,
 )
+from ...services.text_effect_readback_service import verify_text_effect_readback
 from ..action_registry import (
     ActionRegistry,
     ActionSpec,
@@ -46,6 +47,7 @@ from ..execution_contracts import (
     WORKFLOW_CONTROL_ACTION_KR_RELATIONSHIP_RESOLUTION_ID,
     WORKFLOW_CONTROL_ACTION_PAUSE_AT_CHECKPOINT_ID,
     WORKFLOW_CONTROL_ACTION_RELATIONSHIP_EFFECT_READBACK_ID,
+    WORKFLOW_CONTROL_ACTION_TEXT_EFFECT_READBACK_ID,
     WORKFLOW_CONTROL_SIGNAL_BREAK,
     WORKFLOW_CONTROL_SIGNAL_CONTINUE,
     WORKFLOW_FOR_EACH_ALLOWED_SUCCESS_POLICIES,
@@ -1427,6 +1429,22 @@ def _handle_relationship_effect_readback(
     return WorkflowActionResult(status="success", outputs=outputs)
 
 
+def _handle_text_effect_readback(
+    request: WorkflowActionRequest,
+) -> WorkflowActionResult:
+    """Correlate current-run text writes with canonical text read-back."""
+
+    inputs = request.inputs if isinstance(request.inputs, Mapping) else {}
+    outputs = verify_text_effect_readback(
+        required_predicates=inputs.get("required_predicates"),
+        optional_predicates=inputs.get("optional_predicates"),
+        tool_invocations=inputs.get("tool_invocations"),
+        text_effect_receipts=inputs.get("text_effect_receipts"),
+        expected_concept_id=inputs.get("expected_concept_id"),
+    )
+    return WorkflowActionResult(status="success", outputs=outputs)
+
+
 def _normalise_field_name(value: Any) -> str:
     return str(value or "").strip()
 
@@ -1982,6 +2000,60 @@ def register_control_flow_actions(
             },
             side_effects="none",
             postconditions=("exact_relationship_effect_readback_correlated",),
+        )
+    )
+    registry.register_if_absent(
+        ActionSpec(
+            action_id=WORKFLOW_CONTROL_ACTION_TEXT_EFFECT_READBACK_ID,
+            handler=_handle_text_effect_readback,
+            description=(
+                "Bind successful text mutations from the current workflow to "
+                "exact actor-effective canonical text-relation read-back. The "
+                "workflow supplies the required predicates."
+            ),
+            input_schema={
+                "type": "object",
+                "required": ["required_predicates"],
+                "properties": {
+                    "required_predicates": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 20,
+                        "items": {"type": "string"},
+                    },
+                    "optional_predicates": {
+                        "type": "array",
+                        "maxItems": 20,
+                        "items": {"type": "string"},
+                    },
+                    "tool_invocations": {"type": "array"},
+                    "text_effect_receipts": {"type": "array"},
+                    "expected_concept_id": {"type": ["string", "null"]},
+                },
+                "additionalProperties": False,
+            },
+            output_schema={
+                "type": "object",
+                "required": [
+                    "text_effect_readback_verified",
+                    "text_effect_readback_failure_code",
+                    "represented_concept_id",
+                    "verified_text_effects",
+                ],
+                "properties": {
+                    "text_effect_readback_verified": {"type": "boolean"},
+                    "text_effect_readback_failure_code": {
+                        "type": ["string", "null"]
+                    },
+                    "represented_concept_id": {"type": ["string", "null"]},
+                    "verified_text_effects": {
+                        "type": "array",
+                        "items": {"type": "object"},
+                    },
+                },
+            },
+            side_effects="none",
+            postconditions=("exact_text_effect_readback_correlated",),
         )
     )
     registry.register_if_absent(

--- a/src/backend/workflows/durable/meeting_representation_workflow.py
+++ b/src/backend/workflows/durable/meeting_representation_workflow.py
@@ -257,8 +257,14 @@ def _handle_materialise_ics_file_copy(
         return _failure_result(code="ics_materialisation_response_invalid")
     meeting_concept_id = _clean_text(materialisation.get("meeting_concept_id"))
     receipt = materialisation.get("relationship_effect_receipt")
+    temporal_receipts = materialisation.get("temporal_effect_receipts")
     response_text = _clean_text(materialisation.get("response_text"))
-    if not meeting_concept_id or not isinstance(receipt, Mapping) or not response_text:
+    if (
+        not meeting_concept_id
+        or not isinstance(receipt, Mapping)
+        or not isinstance(temporal_receipts, list)
+        or not response_text
+    ):
         return _failure_result(code="ics_materialisation_response_incomplete")
     participants = _participant_projection(parse_result.meeting)
 
@@ -275,6 +281,9 @@ def _handle_materialise_ics_file_copy(
             "ics_participants": participants,
             "meeting_concept_id": meeting_concept_id,
             "relationship_effect_receipt": dict(receipt),
+            "temporal_effect_receipts": [
+                dict(row) for row in temporal_receipts if isinstance(row, Mapping)
+            ],
             "response_text": response_text,
         },
     )
@@ -352,6 +361,11 @@ def register_meeting_representation_actions(registry: ActionRegistry) -> None:
                     },
                     "meeting_concept_id": {"type": "string"},
                     "relationship_effect_receipt": {"type": "object"},
+                    "temporal_effect_receipts": {
+                        "type": "array",
+                        "maxItems": 20,
+                        "items": {"type": "object"},
+                    },
                     "response_text": {"type": "string"},
                 },
             },

--- a/src/backend/workflows/execution_contracts.py
+++ b/src/backend/workflows/execution_contracts.py
@@ -44,6 +44,9 @@ WORKFLOW_CONTROL_ACTION_KR_RELATIONSHIP_READBACK_ID = (
 WORKFLOW_CONTROL_ACTION_RELATIONSHIP_EFFECT_READBACK_ID = (
     "workflow_control.relationship_effect_readback"
 )
+WORKFLOW_CONTROL_ACTION_TEXT_EFFECT_READBACK_ID = (
+    "workflow_control.text_effect_readback"
+)
 WORKFLOW_CONTROL_ACTION_PAUSE_AT_CHECKPOINT_ID = (
     "workflow_control.pause_at_checkpoint"
 )

--- a/tests/backend/test_ics_meeting_materialisation.py
+++ b/tests/backend/test_ics_meeting_materialisation.py
@@ -7,6 +7,9 @@ import pytest
 from src.backend.services.ics_meeting_parser_service import parse_ics_meeting
 from src.backend.services.meeting_file_representation_service import (
     DOCUMENTARY_EVIDENCE_PREDICATE_ID,
+    MEETING_DATE_PREDICATE_ID,
+    MEETING_END_TIME_PREDICATE_ID,
+    MEETING_START_TIME_PREDICATE_ID,
     IcsMeetingMaterialisationError,
     materialise_ics_meeting_representation_for_file_copy,
 )
@@ -41,6 +44,44 @@ def _meeting(*, uid: str = "meeting-uid@example.org", summary: str = "Lab meetin
     )
     assert parsed.meeting is not None
     return parsed.meeting
+
+
+def _all_day_meeting():
+    parsed = parse_ics_meeting(
+        "BEGIN:VCALENDAR\r\n"
+        "VERSION:2.0\r\n"
+        "BEGIN:VEVENT\r\n"
+        "UID:all-day@example.org\r\n"
+        "SUMMARY:All-day workshop\r\n"
+        "DTSTART;VALUE=DATE:20260813\r\n"
+        "DTEND;VALUE=DATE:20260814\r\n"
+        "END:VEVENT\r\n"
+        "END:VCALENDAR"
+    )
+    assert parsed.meeting is not None
+    return parsed.meeting
+
+
+@pytest.fixture(autouse=True)
+def _patch_temporal_singleton_writes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[dict]:
+    from src.backend.services import meeting_file_representation_service as service
+
+    writes: list[dict] = []
+
+    def _upsert(**kwargs):
+        writes.append(dict(kwargs))
+        return {
+            "success": True,
+            "concept_id": kwargs["subject_concept_id"],
+            "predicate": kwargs["predicate"],
+            "kept_relation_id": f"temporal-{len(writes)}",
+            "relation_created": True,
+        }
+
+    monkeypatch.setattr(service, "upsert_singleton_text_relation", _upsert)
+    return writes
 
 
 def _patch_external_identity_persistence(
@@ -117,6 +158,7 @@ def _patch_external_identity_resolution(
 
 def test_ics_materialisation_uses_uid_identity_and_returns_real_effect_receipt(
     monkeypatch: pytest.MonkeyPatch,
+    _patch_temporal_singleton_writes: list[dict],
 ) -> None:
     from src.backend.services import meeting_file_representation_service as service
 
@@ -183,7 +225,20 @@ def test_ics_materialisation_uses_uid_identity_and_returns_real_effect_receipt(
         for row in text_writes
     )
     assert any(row["text"] == "Lab meeting" for row in text_writes)
-    assert any(row["text"].startswith("DTSTART: ") for row in text_writes)
+    assert not any(row["text"].startswith("DTSTART: ") for row in text_writes)
+    assert [
+        (row["predicate"], row["text"])
+        for row in _patch_temporal_singleton_writes
+    ] == [
+        (MEETING_DATE_PREDICATE_ID, "2026-08-12"),
+        (MEETING_START_TIME_PREDICATE_ID, "2026-08-12T10:00:00"),
+        (MEETING_END_TIME_PREDICATE_ID, "2026-08-12T11:00:00"),
+    ]
+    assert all(
+        row["context"]["time_zone"] == "Europe/London"
+        for row in _patch_temporal_singleton_writes
+    )
+    assert len(result["temporal_effect_receipts"]) == 3
     assert not any(
         row["text"].startswith(("ORGANIZER: ", "ATTENDEE: ")) for row in text_writes
     )
@@ -207,6 +262,47 @@ def test_ics_materialisation_uses_uid_identity_and_returns_real_effect_receipt(
         "added": True,
         "changed": True,
     }
+
+
+def test_ics_temporal_projection_preserves_all_day_exclusive_end() -> None:
+    from src.backend.services import meeting_file_representation_service as service
+
+    assert service._ics_temporal_relation_specs(_all_day_meeting()) == [
+        (
+            MEETING_DATE_PREDICATE_ID,
+            "2026-08-13",
+            {
+                "icalendar_property": "DTSTART",
+                "source": "ics_meeting_representation",
+                "value_type": "date",
+                "is_utc": False,
+                "raw_value": "20260813",
+            },
+        ),
+        (
+            MEETING_START_TIME_PREDICATE_ID,
+            "2026-08-13",
+            {
+                "icalendar_property": "DTSTART",
+                "source": "ics_meeting_representation",
+                "value_type": "date",
+                "is_utc": False,
+                "raw_value": "20260813",
+            },
+        ),
+        (
+            MEETING_END_TIME_PREDICATE_ID,
+            "2026-08-14",
+            {
+                "icalendar_property": "DTEND",
+                "source": "ics_meeting_representation",
+                "value_type": "date",
+                "is_utc": False,
+                "raw_value": "20260814",
+                "end_semantics": "exclusive",
+            },
+        ),
+    ]
 
 
 def test_ics_uid_identity_keeps_same_title_different_uids_distinct(
@@ -641,6 +737,7 @@ def test_ics_materialisation_fails_before_fact_writes_when_uid_marker_is_indeter
 
 def test_ics_materialisation_reports_partial_state_when_evidence_write_raises(
     monkeypatch: pytest.MonkeyPatch,
+    _patch_temporal_singleton_writes: list[dict],
 ) -> None:
     from src.backend.services import meeting_file_representation_service as service
 
@@ -682,9 +779,55 @@ def test_ics_materialisation_reports_partial_state_when_evidence_write_raises(
     assert error.value.details == {
         "meeting_concept_id": text_writes[0]["subject_concept_id"],
         "created_meeting_concept": True,
-        "persisted_text_relation_count": len(text_writes),
+        "persisted_text_relation_count": (
+            len(text_writes) + len(_patch_temporal_singleton_writes)
+        ),
         "exception_type": "RuntimeError",
     }
+
+
+def test_ics_materialisation_fails_before_notes_when_temporal_write_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.services import meeting_file_representation_service as service
+
+    _patch_external_identity_resolution(monkeypatch, service)
+    monkeypatch.setattr(
+        service.concept_service,
+        "get_concept_by_concept_id_exact",
+        lambda _concept_id: (_ for _ in ()).throw(
+            service.concept_service.ConceptNotFoundError("not found")
+        ),
+    )
+    monkeypatch.setattr(service.concept_service, "create_concept", lambda **_kwargs: {})
+    note_writes: list[dict] = []
+    monkeypatch.setattr(
+        service,
+        "write_text_relation",
+        lambda **kwargs: (
+            note_writes.append(dict(kwargs)) or {"relation_id": "unexpected"},
+            None,
+        ),
+    )
+    monkeypatch.setattr(
+        service,
+        "upsert_singleton_text_relation",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("temporal failed")),
+    )
+
+    with pytest.raises(IcsMeetingMaterialisationError) as error:
+        materialise_ics_meeting_representation_for_file_copy(
+            user_concept_id="#V#user",
+            organisation_concept_id="#V#org",
+            namespace="#V#user@org",
+            file_copy_concept_id="#V#file",
+            meeting=_meeting(),
+        )
+
+    assert error.value.code == "ics_meeting_temporal_fact_persist_failed"
+    assert error.value.details["predicate"] == MEETING_DATE_PREDICATE_ID
+    assert error.value.details["exception_type"] == "RuntimeError"
+    assert note_writes == []
 
 
 def _execute_action(*, inputs: dict, context: dict | None = None):
@@ -725,6 +868,7 @@ def _patch_successful_ics_action(
             "reason": "represented",
             "meeting_concept_id": "#V#meeting",
             "relationship_effect_receipt": {"success": True},
+            "temporal_effect_receipts": [{"tool": "upsert_singleton_text_relation"}],
             "response_text": "Represented the meeting.",
         },
     )
@@ -1003,6 +1147,9 @@ def test_ics_action_uses_only_trusted_actor_and_suppresses_nested_workflows(
                 "reason": "pending_readback",
                 "meeting_concept_id": "#V#meeting",
                 "relationship_effect_receipt": receipt,
+                "temporal_effect_receipts": [
+                    {"tool": "upsert_singleton_text_relation"}
+                ],
                 "response_text": "Represented the meeting.",
             }
         ),
@@ -1021,6 +1168,9 @@ def test_ics_action_uses_only_trusted_actor_and_suppresses_nested_workflows(
     assert result.outputs["ics_materialisation_outcome"] == "materialised"
     assert result.outputs["ics_materialisation_succeeded"] is True
     assert result.outputs["relationship_effect_receipt"] == receipt
+    assert result.outputs["temporal_effect_receipts"] == [
+        {"tool": "upsert_singleton_text_relation"}
+    ]
     assert "pending" not in result.outputs["response_text"].casefold()
     assert fetch_calls[0]["user_concept_id"] == "#V#trusted_user"
     assert fetch_calls[0]["organisation_concept_id"] == "#V#trusted_org"

--- a/tests/backend/test_migrate_meeting_representation_file_copy_fast_path_v1.py
+++ b/tests/backend/test_migrate_meeting_representation_file_copy_fast_path_v1.py
@@ -27,6 +27,64 @@ from src.backend.workflows.workflow_definition_identity_service import (
 )
 
 
+def _temporal_receipts(meeting_id: str) -> list[dict]:
+    values = (
+        (migration.MEETING_DATE_PREDICATE_ID, "2026-08-13"),
+        (
+            migration.MEETING_START_TIME_PREDICATE_ID,
+            "2026-08-13T13:05:00+01:00",
+        ),
+        (
+            migration.MEETING_END_TIME_PREDICATE_ID,
+            "2026-08-13T13:30:00+01:00",
+        ),
+    )
+    return [
+        {
+            "tool": "upsert_singleton_text_relation",
+            "status": "ok",
+            "effective_arguments": {
+                "concept_id": meeting_id,
+                "predicate": predicate,
+                "text": text,
+            },
+            "effective_payload": {
+                "success": True,
+                "effect_status": "succeeded",
+                "concept_id": meeting_id,
+                "predicate": predicate,
+                "kept_relation_id": f"temporal::{index}",
+            },
+        }
+        for index, (predicate, text) in enumerate(values, start=1)
+    ]
+
+
+def _patch_temporal_canonical_readback(
+    monkeypatch: pytest.MonkeyPatch,
+    meeting_id: str,
+) -> None:
+    from src.backend.services import text_effect_readback_service
+
+    rows = {
+        receipt["effective_arguments"]["predicate"]: [
+            {
+                "relation_id": receipt["effective_payload"]["kept_relation_id"],
+                "text": receipt["effective_arguments"]["text"],
+            }
+        ]
+        for receipt in _temporal_receipts(meeting_id)
+    }
+
+    def _read(*, subject_concept_id, predicate, limit, context_view):
+        assert subject_concept_id == meeting_id
+        assert limit == 20
+        assert context_view == "actor_effective"
+        return rows.get(predicate, [])
+
+    monkeypatch.setattr(text_effect_readback_service, "get_texts_for_concept", _read)
+
+
 def _sample_authoring_spec() -> dict:
     current_prompt = "Legacy meeting representation prompt."
     current_policy = {
@@ -239,10 +297,11 @@ def test_rewrite_adds_bounded_optional_file_copy_path_and_is_idempotent() -> Non
         migration.CORRELATE_EVIDENCE_STATE_KEY,
         migration.VERIFY_PARTICIPANTS_STATE_KEY,
         migration.CORRELATE_PARTICIPANTS_STATE_KEY,
+        migration.VERIFY_TEMPORAL_STATE_KEY,
         migration.COMPLETED_STATE_KEY,
         migration.FAILED_STATE_KEY,
     }
-    assert len(candidate["steps"]) == 8
+    assert len(candidate["steps"]) == 9
     fast_path = _step_with_action(candidate, migration.ICS_FAST_PATH_ACTION_ID)
     assert fast_path["state_id"] == migration.ICS_FAST_PATH_STATE_KEY
     assert fast_path["concept_id"] == migration.ICS_FAST_PATH_STATE_ID
@@ -282,6 +341,10 @@ def test_rewrite_adds_bounded_optional_file_copy_path_and_is_idempotent() -> Non
                 migration.ICS_RELATIONSHIP_EFFECT_RECEIPT_KEY,
                 migration.ICS_RELATIONSHIP_EFFECT_RECEIPT_KEY,
             ),
+            (
+                migration.ICS_TEMPORAL_EFFECT_RECEIPTS_KEY,
+                migration.ICS_TEMPORAL_EFFECT_RECEIPTS_KEY,
+            ),
             ("response_text", "response_text"),
         )
     ]
@@ -313,7 +376,7 @@ def test_rewrite_adds_bounded_optional_file_copy_path_and_is_idempotent() -> Non
             "condition_spec": (migration._file_copy_present_after_success_condition()),
         },
     ]
-    assert step["next_state_key"] == migration.COMPLETED_STATE_KEY
+    assert step["next_state_key"] == migration.VERIFY_TEMPORAL_STATE_KEY
     assert step["on_failure_state_key"] == migration.FAILED_STATE_KEY
     assert step["on_unknown_state_key"] == migration.FAILED_STATE_KEY
 
@@ -502,8 +565,8 @@ def test_rewrite_adds_bounded_optional_file_copy_path_and_is_idempotent() -> Non
             },
         },
         {
-            "to_state": migration.COMPLETED_STATE_KEY,
-            "reason": "exact_file_copy_evidence_effect_verified_without_ics_participants",
+            "to_state": migration.VERIFY_TEMPORAL_STATE_KEY,
+            "reason": "meeting_core_effects_require_temporal_readback",
             "condition_spec": {
                 "kind": "all",
                 "conditions": [
@@ -637,9 +700,43 @@ def test_rewrite_adds_bounded_optional_file_copy_path_and_is_idempotent() -> Non
         migration.PARTICIPANT_EFFECT_RELATIONSHIPS_KEY,
     ]
     assert participant_correlate["conditional_transitions"][0]["to_state"] == (
-        migration.COMPLETED_STATE_KEY
+        migration.VERIFY_TEMPORAL_STATE_KEY
     )
     assert participant_correlate["next_state_key"] == migration.FAILED_STATE_KEY
+
+    temporal = _step_with_state(candidate, migration.VERIFY_TEMPORAL_STATE_KEY)
+    assert temporal["concept_id"] == migration.VERIFY_TEMPORAL_STATE_ID
+    assert temporal["action_id"] == "workflow_control.text_effect_readback"
+    assert temporal["static_input_bindings"] == [
+        {
+            "tool_param": "required_predicates",
+            "value": list(migration.REQUIRED_MEETING_TEMPORAL_PREDICATES),
+        },
+        {
+            "tool_param": "optional_predicates",
+            "value": [migration.MEETING_END_TIME_PREDICATE_ID],
+        },
+    ]
+    assert temporal["context_input_mappings"] == [
+        migration._context_input_mapping(
+            state_key=migration.VERIFY_TEMPORAL_STATE_KEY,
+            tool_param=tool_param,
+            context_key=context_key,
+            required=False,
+        )
+        for tool_param, context_key in (
+            ("tool_invocations", "tool_invocations"),
+            (
+                "text_effect_receipts",
+                migration.ICS_TEMPORAL_EFFECT_RECEIPTS_KEY,
+            ),
+            ("expected_concept_id", migration.EVIDENCE_EFFECT_TARGET_KEY),
+        )
+    ]
+    assert temporal["conditional_transitions"][0]["to_state"] == (
+        migration.COMPLETED_STATE_KEY
+    )
+    assert temporal["next_state_key"] == migration.FAILED_STATE_KEY
 
     policy = step["llm_policy"]
     assert "read_file_copy" in policy["allowed_tools"]
@@ -676,6 +773,7 @@ def test_rewrite_adds_bounded_optional_file_copy_path_and_is_idempotent() -> Non
         migration.ICS_PARTICIPANT_COUNT_KEY,
         migration.ICS_PARTICIPANTS_KEY,
         migration.ICS_MEETING_CONCEPT_ID_KEY,
+        migration.ICS_TEMPORAL_EFFECT_RECEIPTS_KEY,
     }.issubset(context_keys)
     assert "meeting_source_text" not in context_keys
     assert "meeting_source_filename" not in context_keys
@@ -711,6 +809,7 @@ def test_rewrite_adds_bounded_optional_file_copy_path_and_is_idempotent() -> Non
     assert effect["required_tools_match"] == "any"
     assert effect["required_tools"] == [
         "workflow_control.relationship_effect_readback",
+        "workflow_control.text_effect_readback",
         "add_relationship",
         "upsert_text_relation",
         "upsert_singleton_text_relation",
@@ -917,7 +1016,7 @@ def test_rewrite_adds_bounded_optional_file_copy_path_and_is_idempotent() -> Non
     }
     assert [transition.to_state for transition in correlate_state.transitions] == [
         migration.VERIFY_PARTICIPANTS_STATE_KEY,
-        migration.COMPLETED_STATE_KEY,
+        migration.VERIFY_TEMPORAL_STATE_KEY,
         migration.FAILED_STATE_KEY,
         migration.FAILED_STATE_KEY,
         migration.FAILED_STATE_KEY,
@@ -996,6 +1095,22 @@ def test_rewrite_adds_bounded_optional_file_copy_path_and_is_idempotent() -> Non
     assert [
         transition.to_state for transition in participant_correlate_state.transitions
     ] == [
+        migration.VERIFY_TEMPORAL_STATE_KEY,
+        migration.FAILED_STATE_KEY,
+        migration.FAILED_STATE_KEY,
+        migration.FAILED_STATE_KEY,
+    ]
+
+    temporal_state = definition.states[migration.VERIFY_TEMPORAL_STATE_KEY]
+    temporal_action = temporal_state.actions[0]
+    assert temporal_action.action_id == "workflow_control.text_effect_readback"
+    assert temporal_action.inputs["required_predicates"] == list(
+        migration.REQUIRED_MEETING_TEMPORAL_PREDICATES
+    )
+    assert temporal_action.inputs["optional_predicates"] == [
+        migration.MEETING_END_TIME_PREDICATE_ID
+    ]
+    assert [transition.to_state for transition in temporal_state.transitions] == [
         migration.COMPLETED_STATE_KEY,
         migration.FAILED_STATE_KEY,
         migration.FAILED_STATE_KEY,
@@ -1238,6 +1353,8 @@ def test_migrated_workflow_correlates_llm_relationship_with_exact_readback(
 
     file_copy_id = "#V#uploaded_meeting_file_copy"
     represented_meeting_id = "#V#represented_meeting"
+    temporal_receipts = _temporal_receipts(represented_meeting_id)
+    _patch_temporal_canonical_readback(monkeypatch, represented_meeting_id)
     relation_id = "struct::uploaded-meeting-documentary-evidence"
     invocation = {
         "tool": "add_relationship",
@@ -1283,7 +1400,7 @@ def test_migrated_workflow_correlates_llm_relationship_with_exact_readback(
         assert request.data["file_copy_concept_id"] == file_copy_id
         return WorkflowActionResult(
             status="success",
-            outputs={"tool_invocations": [invocation]},
+            outputs={"tool_invocations": [invocation, *temporal_receipts]},
         )
 
     mcp_requests: list[WorkflowActionRequest] = []
@@ -1420,6 +1537,8 @@ def test_migrated_workflow_materialised_ics_enters_llm_and_verifies_participants
 
     file_copy_id = "#V#uploaded_ics_file_copy"
     meeting_id = "#V#materialised_ics_meeting"
+    temporal_receipts = _temporal_receipts(meeting_id)
+    _patch_temporal_canonical_readback(monkeypatch, meeting_id)
     participant_ids = ["#V#participant_one", "#V#participant_two"]
     participants = [
         {
@@ -1540,6 +1659,7 @@ def test_migrated_workflow_materialised_ics_enters_llm_and_verifies_participants
                 migration.ICS_PARTICIPANTS_KEY: participants,
                 migration.ICS_MEETING_CONCEPT_ID_KEY: meeting_id,
                 migration.ICS_RELATIONSHIP_EFFECT_RECEIPT_KEY: documentary_invocation,
+                migration.ICS_TEMPORAL_EFFECT_RECEIPTS_KEY: temporal_receipts,
                 "response_text": "Prepared structured iCalendar evidence.",
             },
         )
@@ -1628,6 +1748,9 @@ def test_migrated_workflow_materialised_ics_enters_llm_and_verifies_participants
     assert result.data[migration.ICS_RELATIONSHIP_EFFECT_RECEIPT_KEY] == (
         documentary_invocation
     )
+    assert result.data[migration.ICS_TEMPORAL_EFFECT_RECEIPTS_KEY] == (
+        temporal_receipts
+    )
     assert result.data[migration.EVIDENCE_EFFECT_VERIFIED_KEY] is True
     assert result.data[migration.EVIDENCE_EFFECT_TARGET_KEY] == meeting_id
     assert result.data[migration.EVIDENCE_EFFECT_RELATIONSHIP_KEY] == {
@@ -1653,6 +1776,8 @@ def test_migrated_workflow_materialised_ics_enters_llm_and_verifies_participants
                 migration.PARTICIPANT_EFFECT_RELATIONSHIPS_KEY
             ]
         ] == participant_ids
+        assert result.data[migration.TEMPORAL_EFFECT_VERIFIED_KEY] is True
+        assert result.data[migration.TEMPORAL_EFFECT_CONCEPT_ID_KEY] == meeting_id
     else:
         assert result.data[migration.PARTICIPANT_EFFECT_RELATIONSHIPS_KEY] == [
             {
@@ -1674,6 +1799,9 @@ def test_migrated_workflow_without_file_copy_falls_back_to_llm(
     from src.backend.workflows import llm_step_executor
 
     calls: list[str] = []
+    meeting_id = "#V#meeting_from_notes"
+    temporal_receipts = _temporal_receipts(meeting_id)
+    _patch_temporal_canonical_readback(monkeypatch, meeting_id)
 
     def _materialise_ics(request: WorkflowActionRequest) -> WorkflowActionResult:
         calls.append("ics")
@@ -1694,7 +1822,10 @@ def test_migrated_workflow_without_file_copy_falls_back_to_llm(
         calls.append("llm")
         return WorkflowActionResult(
             status="success",
-            outputs={"response_text": "Represented the supplied meeting notes."},
+            outputs={
+                "response_text": "Represented the supplied meeting notes.",
+                "tool_invocations": temporal_receipts,
+            },
         )
 
     monkeypatch.setattr(llm_step_executor, "execute_llm_step", _execute_llm_step)
@@ -1703,6 +1834,7 @@ def test_migrated_workflow_without_file_copy_falls_back_to_llm(
     )
     definition = build_workflow_definition_from_authoring_spec(candidate)
     registry = ActionRegistry()
+    register_control_flow_actions(registry, definition_loader=lambda _workflow_id: None)
     registry.register(
         ActionSpec(
             action_id=migration.ICS_FAST_PATH_ACTION_ID,
@@ -1710,7 +1842,7 @@ def test_migrated_workflow_without_file_copy_falls_back_to_llm(
         )
     )
 
-    result = WorkflowExecutor(registry=registry, max_transitions=5).run(
+    result = WorkflowExecutor(registry=registry, max_transitions=6).run(
         definition,
         environment=WorkflowEnvironment(llm_client=None),
         data={"prompt": "Represent these meeting notes."},
@@ -1719,6 +1851,8 @@ def test_migrated_workflow_without_file_copy_falls_back_to_llm(
     assert result.completed is True, result.data
     assert result.final_state == migration.COMPLETED_STATE_KEY
     assert calls == ["ics", "llm"]
+    assert result.data[migration.TEMPORAL_EFFECT_VERIFIED_KEY] is True
+    assert result.data[migration.TEMPORAL_EFFECT_CONCEPT_ID_KEY] == meeting_id
     assert result.data["response_text"] == "Represented the supplied meeting notes."
 
 

--- a/tests/backend/test_text_effect_readback_service.py
+++ b/tests/backend/test_text_effect_readback_service.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import pytest
+
+from src.backend.services import text_effect_readback_service as service
+from src.backend.workflows.action_registry import ActionRegistry, WorkflowEnvironment
+from src.backend.workflows.durable import control_flow_actions
+from src.backend.workflows.durable.control_flow_actions import (
+    register_control_flow_actions,
+)
+from src.backend.workflows.execution_contracts import (
+    WORKFLOW_CONTROL_ACTION_TEXT_EFFECT_READBACK_ID,
+)
+
+
+def _receipt(
+    predicate: str,
+    text: str,
+    *,
+    concept_id: str = "#V#meeting",
+    success: bool = True,
+) -> dict:
+    return {
+        "tool": "upsert_singleton_text_relation",
+        "status": "ok",
+        "effective_arguments": {
+            "concept_id": concept_id,
+            "predicate": predicate,
+            "text": text,
+        },
+        "effective_payload": {
+            "success": success,
+            "effect_status": "succeeded" if success else "failed",
+            "concept_id": concept_id,
+            "predicate": predicate,
+        },
+    }
+
+
+@pytest.fixture
+def canonical_rows(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[dict]]:
+    rows = {
+        "#V#date_of_event": [
+            {"relation_id": "date-rel", "text": "2026-08-13"}
+        ],
+        "#V#has_start_time": [
+            {"relation_id": "start-rel", "text": "2026-08-13T13:05:00+01:00"}
+        ],
+        "#V#has_end_time": [
+            {"relation_id": "end-rel", "text": "2026-08-13T13:30:00+01:00"}
+        ],
+    }
+
+    def _read(*, subject_concept_id, predicate, limit, context_view):
+        assert subject_concept_id == "#V#meeting"
+        assert limit == 20
+        assert context_view == "actor_effective"
+        return rows.get(predicate, [])
+
+    monkeypatch.setattr(service, "get_texts_for_concept", _read)
+    return rows
+
+
+def test_text_effect_readback_verifies_required_and_extra_receipted_facts(
+    canonical_rows: dict[str, list[dict]],
+) -> None:
+    receipts = [
+        _receipt("#V#date_of_event", "2026-08-13"),
+        _receipt("#V#has_start_time", "2026-08-13T13:05:00+01:00"),
+        _receipt("#V#has_end_time", "2026-08-13T13:30:00+01:00"),
+    ]
+
+    result = service.verify_text_effect_readback(
+        required_predicates=["#V#date_of_event", "#V#has_start_time"],
+        optional_predicates=["#V#has_end_time"],
+        text_effect_receipts=receipts,
+        expected_concept_id="#V#meeting",
+    )
+
+    assert result["text_effect_readback_verified"] is True
+    assert result["text_effect_readback_failure_code"] is None
+    assert result["represented_concept_id"] == "#V#meeting"
+    assert [row["predicate"] for row in result["verified_text_effects"]] == [
+        "#V#date_of_event",
+        "#V#has_start_time",
+        "#V#has_end_time",
+    ]
+
+
+def test_text_effect_readback_derives_concept_from_llm_tool_invocations(
+    canonical_rows: dict[str, list[dict]],
+) -> None:
+    result = service.verify_text_effect_readback(
+        required_predicates=["#V#date_of_event", "#V#has_start_time"],
+        tool_invocations=[
+            _receipt("#V#date_of_event", "2026-08-13"),
+            _receipt("#V#has_start_time", "2026-08-13T13:05:00+01:00"),
+        ],
+    )
+
+    assert result["text_effect_readback_verified"] is True
+    assert result["represented_concept_id"] == "#V#meeting"
+
+
+def test_text_effect_readback_rejects_note_only_schedule(
+    canonical_rows: dict[str, list[dict]],
+) -> None:
+    result = service.verify_text_effect_readback(
+        required_predicates=["#V#date_of_event", "#V#has_start_time"],
+        tool_invocations=[
+            _receipt("#V#hasNote", "Thursday 13 August 2026, 1:05 pm")
+        ],
+    )
+
+    assert result["text_effect_readback_verified"] is False
+    assert (
+        result["text_effect_readback_failure_code"]
+        == "text_effect_concept_missing"
+    )
+
+
+def test_text_effect_readback_rejects_wrong_canonical_value(
+    canonical_rows: dict[str, list[dict]],
+) -> None:
+    result = service.verify_text_effect_readback(
+        required_predicates=["#V#date_of_event", "#V#has_start_time"],
+        tool_invocations=[
+            _receipt("#V#date_of_event", "2026-08-13"),
+            _receipt("#V#has_start_time", "2026-08-13T14:05:00+01:00"),
+        ],
+    )
+
+    assert result["text_effect_readback_verified"] is False
+    assert (
+        result["text_effect_readback_failure_code"]
+        == "text_effect_exact_readback_missing"
+    )
+
+
+def test_text_effect_readback_rejects_ambiguous_concept_receipts(
+    canonical_rows: dict[str, list[dict]],
+) -> None:
+    result = service.verify_text_effect_readback(
+        required_predicates=["#V#date_of_event", "#V#has_start_time"],
+        tool_invocations=[
+            _receipt("#V#date_of_event", "2026-08-13", concept_id="#V#meeting"),
+            _receipt(
+                "#V#has_start_time",
+                "2026-08-13T13:05:00+01:00",
+                concept_id="#V#other_meeting",
+            ),
+        ],
+    )
+
+    assert result["text_effect_readback_verified"] is False
+    assert result["text_effect_readback_failure_code"] == (
+        "text_effect_concept_ambiguous"
+    )
+
+
+def test_control_action_registers_and_forwards_text_effect_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        control_flow_actions,
+        "verify_text_effect_readback",
+        lambda **kwargs: calls.append(dict(kwargs))
+        or {
+            "text_effect_readback_verified": True,
+            "text_effect_readback_failure_code": None,
+            "represented_concept_id": "#V#meeting",
+            "verified_text_effects": [],
+        },
+    )
+    registry = ActionRegistry()
+    register_control_flow_actions(registry, definition_loader=lambda _workflow_id: None)
+    spec = registry.get(WORKFLOW_CONTROL_ACTION_TEXT_EFFECT_READBACK_ID)
+    assert spec is not None
+
+    result = registry.execute(
+        WORKFLOW_CONTROL_ACTION_TEXT_EFFECT_READBACK_ID,
+        inputs={
+            "required_predicates": ["#V#date_of_event", "#V#has_start_time"],
+            "tool_invocations": [{"tool": "upsert_singleton_text_relation"}],
+            "text_effect_receipts": [{"tool": "upsert_singleton_text_relation"}],
+            "expected_concept_id": "#V#meeting",
+        },
+        context={},
+        env=WorkflowEnvironment(llm_client=None),
+    )
+
+    assert result.status == "success"
+    assert result.outputs["text_effect_readback_verified"] is True
+    assert calls == [
+        {
+            "required_predicates": [
+                "#V#date_of_event",
+                "#V#has_start_time",
+            ],
+            "optional_predicates": None,
+            "tool_invocations": [
+                {"tool": "upsert_singleton_text_relation"}
+            ],
+            "text_effect_receipts": [
+                {"tool": "upsert_singleton_text_relation"}
+            ],
+            "expected_concept_id": "#V#meeting",
+        }
+    ]


### PR DESCRIPTION
## Outcome

Meeting representation now persists canonical schedule facts instead of reducing DTSTART/DTEND to notes, and the represented workflow cannot complete without exact canonical date/start read-back.

## Changes

- write `#V#date_of_event`, `#V#has_start_time`, and supplied `#V#has_end_time` as singleton text relations with iCalendar/time-zone context
- add a reusable `workflow_control.text_effect_readback` action that correlates current-run text writes with actor-effective canonical state
- add the temporal read-back state to the Vontology migration input and strengthen its represented prompt
- retain all-day `DTEND` exclusive semantics

## Validation

- 208 focused backend tests passed
- targeted Ruff checks and Python compilation passed
- live Workflow Studio preview: valid, no errors or warnings, one temporal state added
- repaired `#V#nenad_and_michael_catch_up_13_august_2026` and read back date/start/end with `Europe/London` provenance

## Release boundary

Publish the revised Vontology workflow only after the merged code is active, because the graph references the new verifier action.