### PR TITLE
Fix async Vontology tree authority

### DIFF
--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -59,7 +59,14 @@ from ...services.relationship_extent_index_service import (
 from ...services.concept_search_service import (
     search_concepts as search_concepts_service,
 )
-from ...security.access_control import cache_scope_key, bypass_access_control
+from ...security.access_control import (
+    bypass_access_control,
+    cache_scope_key,
+    force_access_control_enforcement,
+    get_effective_organisation_concept_id,
+    get_effective_user_concept_id,
+    override_current_actor,
+)
 from ...security.visibility_predicates import VISIBILITY_PREDICATE_ALIAS_TO_CANONICAL
 from ...services.window_session_context_service import get_effective_context
 from ...utilities.salient_recompute import recompute_salient_predicates
@@ -129,10 +136,13 @@ _TREE_CACHE_LOCK = threading.Lock()
 """
 Simple progress cache for asynchronous tree builds.
 
-Structure: {job_id: {total: int, processed: int, result: dict | None, error: str | None}}
+Each job is bound to the exact user/organisation visibility scope captured at
+creation. Completed results remain available briefly for polling and are then
+pruned; active jobs are never expired by result cleanup.
 """
 _TREE_BUILD_PROGRESS: dict[str, dict] = {}
 _TREE_BUILD_PROGRESS_LOCK = threading.Lock()
+_TREE_BUILD_RESULT_TTL_SECONDS = 10 * 60
 
 _RELATIONSHIP_ALIAS_TO_CANONICAL = {
     "has_subtypes": "has_subtype",
@@ -699,45 +709,107 @@ def ensure_thing_route():
         return jsonify({"success": False, "message": f"Internal error: {str(e)}"}), 500
 
 
-def _build_tree_job(job_id: str) -> None:
-    """Background worker that constructs the Vontology tree whilst tracking progress."""
+def _current_tree_job_actor_scope() -> tuple[str | None, str | None]:
+    """Return the trusted read scope for an asynchronous tree job.
+
+    Organisation context is meaningful only when it is attached to an
+    effective user. Discarding an otherwise residual organisation value keeps
+    anonymous tree reads global-only.
+    """
+
+    user_concept_id = get_effective_user_concept_id()
+    organisation_concept_id = (
+        get_effective_organisation_concept_id() if user_concept_id else None
+    )
+    return user_concept_id, organisation_concept_id
+
+
+def _tree_build_job_is_terminal(job: Mapping[str, Any]) -> bool:
+    return job.get("result") is not None or job.get("error") is not None
+
+
+def _prune_tree_build_progress(*, now_epoch: float | None = None) -> None:
+    """Remove expired terminal results without abandoning active builds."""
+
+    cutoff = (
+        time.time() if now_epoch is None else float(now_epoch)
+    ) - _TREE_BUILD_RESULT_TTL_SECONDS
+    with _TREE_BUILD_PROGRESS_LOCK:
+        stale_job_ids = [
+            job_id
+            for job_id, job in _TREE_BUILD_PROGRESS.items()
+            if _tree_build_job_is_terminal(job)
+            and isinstance(job.get("completed_at_epoch"), (int, float))
+            and float(job["completed_at_epoch"]) <= cutoff
+        ]
+        for job_id in stale_job_ids:
+            _TREE_BUILD_PROGRESS.pop(job_id, None)
+
+
+def _build_tree_job(
+    job_id: str,
+    user_concept_id: str | None,
+    organisation_concept_id: str | None,
+) -> None:
+    """Construct one Vontology tree under its captured actor visibility scope."""
+
+    stop_event = threading.Event()
+    ticker_thread: threading.Thread | None = None
+    ticker_started = False
     try:
         t0 = time.time()
-        docs = list(ConceptsRepository.find({}, {"concept_id": 1}))
-        total = len(docs)
-        with _TREE_BUILD_PROGRESS_LOCK:
-            job = _TREE_BUILD_PROGRESS.get(job_id)
-            if job is not None:
+        with (
+            force_access_control_enforcement(),
+            override_current_actor(
+                user_concept_id,
+                organisation_concept_id,
+            ),
+        ):
+            docs = list(ConceptsRepository.find({}, {"concept_id": 1}))
+            total = len(docs)
+            with _TREE_BUILD_PROGRESS_LOCK:
+                job = _TREE_BUILD_PROGRESS.get(job_id)
+                if job is None:
+                    return
                 job["total"] = total
                 job["processed"] = 0
 
-        stop_event = threading.Event()
+            def ticker():
+                """Increment progress periodically so the client sees activity."""
+                while not stop_event.wait(0.5):
+                    with _TREE_BUILD_PROGRESS_LOCK:
+                        current_job = _TREE_BUILD_PROGRESS.get(job_id)
+                        if not current_job or _tree_build_job_is_terminal(current_job):
+                            break
+                        current = current_job.get("processed", 0)
+                        current_job["processed"] = min(
+                            total,
+                            current + max(1, total // 20),
+                        )
 
-        def ticker():
-            """Increment progress periodically so the client sees activity."""
-            while not stop_event.is_set():
-                time.sleep(0.5)
-                with _TREE_BUILD_PROGRESS_LOCK:
-                    j = _TREE_BUILD_PROGRESS.get(job_id)
-                    if not j or j.get("result") or j.get("error"):
-                        break
-                    current = j.get("processed", 0)
-                    j["processed"] = min(total, current + max(1, total // 20))
+            ticker_thread = threading.Thread(target=ticker, daemon=True)
+            ticker_thread.start()
+            ticker_started = True
 
-        t = threading.Thread(target=ticker, daemon=True)
-        t.start()
+            tree_data = get_vontology_tree("Thing")
 
-        tree_data = get_vontology_tree("Thing")
-        stop_event.set()
-        t.join(timeout=0.1)
+        returned_error = None
+        if isinstance(tree_data, Mapping) and tree_data.get("error") is not None:
+            returned_error = str(tree_data["error"]).strip() or "Tree build failed."
 
         with _TREE_BUILD_PROGRESS_LOCK:
             job = _TREE_BUILD_PROGRESS.get(job_id)
             if job is not None:
                 job["processed"] = total
-                job["result"] = tree_data
+                if returned_error is not None:
+                    job["error"] = returned_error
+                else:
+                    job["result"] = tree_data
+                job["completed_at_epoch"] = time.time()
 
         try:
+            if returned_error is not None:
+                return
             if os.getenv("VON_TREE_PHASE_LOG") in ("1", "true", "TRUE", "True"):
                 logger = None
                 try:
@@ -772,30 +844,66 @@ def _build_tree_job(job_id: str) -> None:
                 )
         except Exception:
             pass
-    except Exception as e:  # pragma: no cover
+    except Exception as exc:
         with _TREE_BUILD_PROGRESS_LOCK:
             job = _TREE_BUILD_PROGRESS.get(job_id)
             if job is not None:
-                job["error"] = str(e)
+                job["error"] = str(exc).strip() or exc.__class__.__name__
+                job["completed_at_epoch"] = time.time()
+    finally:
+        stop_event.set()
+        if ticker_thread is not None and ticker_started:
+            ticker_thread.join(timeout=0.5)
 
 
 @vontology_bp.route("/tree_async", methods=["POST"])
 def build_tree_async_route():
     """Initialise an asynchronous Vontology tree build."""
+    _prune_tree_build_progress()
     job_id = uuid.uuid4().hex
+    user_concept_id, organisation_concept_id = _current_tree_job_actor_scope()
     with _TREE_BUILD_PROGRESS_LOCK:
-        _TREE_BUILD_PROGRESS[job_id] = {"total": 0, "processed": 0, "result": None}
-    thread = threading.Thread(target=_build_tree_job, args=(job_id,), daemon=True)
-    thread.start()
+        _TREE_BUILD_PROGRESS[job_id] = {
+            "total": 0,
+            "processed": 0,
+            "result": None,
+            "error": None,
+            "owner_user_concept_id": user_concept_id,
+            "owner_organisation_concept_id": organisation_concept_id,
+            "completed_at_epoch": None,
+        }
+    try:
+        thread = threading.Thread(
+            target=_build_tree_job,
+            args=(job_id, user_concept_id, organisation_concept_id),
+            daemon=True,
+        )
+        thread.start()
+    except Exception:
+        with _TREE_BUILD_PROGRESS_LOCK:
+            _TREE_BUILD_PROGRESS.pop(job_id, None)
+        current_app.logger.exception(
+            "Failed to start asynchronous Vontology tree build"
+        )
+        return jsonify({"error": "tree build could not be started"}), 500
     return jsonify({"job_id": job_id}), 202
 
 
 @vontology_bp.route("/tree_progress/<job_id>", methods=["GET"])
 def tree_build_progress(job_id: str):
     """Return progress for a previously initialised tree build."""
+    _prune_tree_build_progress()
+    user_concept_id, organisation_concept_id = _current_tree_job_actor_scope()
     with _TREE_BUILD_PROGRESS_LOCK:
         status = _TREE_BUILD_PROGRESS.get(job_id)
-    if not status:
+        if status is not None and (
+            status.get("owner_user_concept_id") != user_concept_id
+            or status.get("owner_organisation_concept_id") != organisation_concept_id
+        ):
+            status = None
+        elif status is not None:
+            status = dict(status)
+    if status is None:
         return jsonify({"error": "unknown job"}), 404
     total = status.get("total", 0)
     processed = status.get("processed", 0)
@@ -803,7 +911,7 @@ def tree_build_progress(job_id: str):
     response = {
         "job_id": job_id,
         "progress": progress,
-        "done": bool(status.get("result") or status.get("error")),
+        "done": _tree_build_job_is_terminal(status),
     }
     if status.get("result") is not None:
         response["result"] = status["result"]

--- a/tests/backend/test_vontology_tree_async_authority.py
+++ b/tests/backend/test_vontology_tree_async_authority.py
@@ -1,0 +1,439 @@
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from typing import Any, ClassVar
+
+import pytest
+from flask import Flask
+
+from src.backend.security import access_control
+from src.backend.server.routes import vontology_routes as routes
+
+
+class _DeferredThread:
+    created: ClassVar[list[_DeferredThread]] = []
+
+    def __init__(
+        self,
+        *,
+        target: Callable[..., Any],
+        args: tuple[Any, ...] = (),
+        daemon: bool | None = None,
+    ) -> None:
+        self.target = target
+        self.args = args
+        self.daemon = daemon
+        self.started = False
+        self.joined = False
+        self.__class__.created.append(self)
+
+    def start(self) -> None:
+        self.started = True
+
+    def join(self, timeout: float | None = None) -> None:
+        del timeout
+        self.joined = True
+
+    def run(self) -> Any:
+        return self.target(*self.args)
+
+
+class _FailingThread:
+    def __init__(self, **_kwargs: Any) -> None:
+        raise RuntimeError("thread construction failed")
+
+
+class _ConceptCollection:
+    def __init__(self, documents: list[dict[str, Any]]) -> None:
+        self._documents = {document["concept_id"]: document for document in documents}
+
+    def find_one(self, query: dict[str, Any], projection: dict | None = None):
+        del projection
+        return self._documents.get(query.get("concept_id"))
+
+
+@pytest.fixture(autouse=True)
+def _clear_tree_job_state():
+    _DeferredThread.created.clear()
+    with routes._TREE_BUILD_PROGRESS_LOCK:
+        routes._TREE_BUILD_PROGRESS.clear()
+    yield
+    with routes._TREE_BUILD_PROGRESS_LOCK:
+        routes._TREE_BUILD_PROGRESS.clear()
+
+
+@pytest.fixture
+def app_client(monkeypatch):
+    app = Flask(__name__)
+    app.secret_key = "tree-authority-test"
+    app.config["TESTING"] = True
+    app.register_blueprint(routes.vontology_bp, url_prefix="/api/vontology")
+    monkeypatch.setattr(routes.threading, "Thread", _DeferredThread)
+    return app, app.test_client()
+
+
+def _set_actor(
+    client,
+    user_concept_id: str | None,
+    organisation_concept_id: str | None,
+) -> None:
+    with client.session_transaction() as flask_session:
+        flask_session.clear()
+        if user_concept_id is not None:
+            flask_session["user_concept_id"] = user_concept_id
+        if organisation_concept_id is not None:
+            flask_session["organisation_concept_id"] = organisation_concept_id
+
+
+def _install_visible_tree(
+    monkeypatch,
+) -> list[tuple[str, str | None, str | None, bool]]:
+    documents = [
+        {"concept_id": "#V#global", "relationships": {}},
+        {
+            "concept_id": "#V#alice_private",
+            "relationships": {"specific_to_user": ["#V#alice"]},
+        },
+        {
+            "concept_id": "#V#org_a_private",
+            "relationships": {"specific_to_org": ["#V#org_a"]},
+        },
+        {
+            "concept_id": "#V#bob_private",
+            "relationships": {"specific_to_user": ["#V#bob"]},
+        },
+        {
+            "concept_id": "#V#org_b_private",
+            "relationships": {"specific_to_org": ["#V#org_b"]},
+        },
+    ]
+    collection = _ConceptCollection(documents)
+    monkeypatch.setattr(
+        access_control,
+        "get_concepts_collection",
+        lambda: collection,
+    )
+    observations: list[tuple[str, str | None, str | None, bool]] = []
+
+    def _visible_concept_ids() -> list[str]:
+        return [
+            document["concept_id"]
+            for document in documents
+            if access_control.can_access_concept(document["concept_id"])
+        ]
+
+    def _find(_query: dict, _projection: dict):
+        observations.append(
+            (
+                "progress_scan",
+                access_control.get_effective_user_concept_id(),
+                access_control.get_effective_organisation_concept_id(),
+                access_control.should_enforce_access_control(),
+            )
+        )
+        return [{"concept_id": concept_id} for concept_id in _visible_concept_ids()]
+
+    def _tree(_root: str):
+        observations.append(
+            (
+                "tree_build",
+                access_control.get_effective_user_concept_id(),
+                access_control.get_effective_organisation_concept_id(),
+                access_control.should_enforce_access_control(),
+            )
+        )
+        return {"tree": [{"id": concept_id} for concept_id in _visible_concept_ids()]}
+
+    monkeypatch.setattr(routes.ConceptsRepository, "find", _find)
+    monkeypatch.setattr(routes, "get_vontology_tree", _tree)
+    return observations
+
+
+def _run_route_worker() -> None:
+    assert _DeferredThread.created
+    route_thread = _DeferredThread.created[0]
+    assert route_thread.target is routes._build_tree_job
+    assert route_thread.started is True
+    route_thread.run()
+
+
+def _tree_ids(payload: dict[str, Any]) -> set[str]:
+    return {node["id"] for node in payload["result"]["tree"]}
+
+
+def test_authenticated_tree_worker_reapplies_exact_actor_scope(
+    app_client,
+    monkeypatch,
+) -> None:
+    _, client = app_client
+    observations = _install_visible_tree(monkeypatch)
+    _set_actor(client, "#V#alice", "#V#org_a")
+
+    created = client.post("/api/vontology/tree_async")
+
+    assert created.status_code == 202
+    job_id = created.get_json()["job_id"]
+    _run_route_worker()
+    completed = client.get(f"/api/vontology/tree_progress/{job_id}")
+
+    assert completed.status_code == 200
+    payload = completed.get_json()
+    assert payload["done"] is True
+    assert _tree_ids(payload) == {
+        "#V#global",
+        "#V#alice_private",
+        "#V#org_a_private",
+    }
+    assert observations == [
+        ("progress_scan", "#V#alice", "#V#org_a", True),
+        ("tree_build", "#V#alice", "#V#org_a", True),
+    ]
+    assert access_control.get_effective_user_concept_id() is None
+    assert access_control.get_effective_organisation_concept_id() is None
+    assert access_control.should_enforce_access_control() is False
+
+
+def test_anonymous_tree_worker_discards_residual_org_and_is_global_only(
+    app_client,
+    monkeypatch,
+) -> None:
+    _, client = app_client
+    observations = _install_visible_tree(monkeypatch)
+    _set_actor(client, None, "#V#org_a")
+
+    created = client.post("/api/vontology/tree_async")
+
+    assert created.status_code == 202
+    job_id = created.get_json()["job_id"]
+    assert _DeferredThread.created[0].args == (job_id, None, None)
+    _run_route_worker()
+    completed = client.get(f"/api/vontology/tree_progress/{job_id}")
+
+    assert completed.status_code == 200
+    assert _tree_ids(completed.get_json()) == {"#V#global"}
+    assert observations == [
+        ("progress_scan", None, None, True),
+        ("tree_build", None, None, True),
+    ]
+
+
+def test_route_preserves_scope_in_a_real_background_thread(monkeypatch) -> None:
+    app = Flask(__name__)
+    app.secret_key = "tree-real-thread-test"
+    app.config["TESTING"] = True
+    app.register_blueprint(routes.vontology_bp, url_prefix="/api/vontology")
+    client = app.test_client()
+    observations = _install_visible_tree(monkeypatch)
+    worker_finished = threading.Event()
+    original_worker = routes._build_tree_job
+
+    def _observed_worker(*args: Any) -> None:
+        try:
+            original_worker(*args)
+        finally:
+            worker_finished.set()
+
+    monkeypatch.setattr(routes, "_build_tree_job", _observed_worker)
+    _set_actor(client, "#V#alice", "#V#org_a")
+
+    created = client.post("/api/vontology/tree_async")
+
+    assert created.status_code == 202
+    assert worker_finished.wait(timeout=2.0) is True
+    job_id = created.get_json()["job_id"]
+    completed = client.get(f"/api/vontology/tree_progress/{job_id}")
+    assert completed.status_code == 200
+    assert _tree_ids(completed.get_json()) == {
+        "#V#global",
+        "#V#alice_private",
+        "#V#org_a_private",
+    }
+    assert observations == [
+        ("progress_scan", "#V#alice", "#V#org_a", True),
+        ("tree_build", "#V#alice", "#V#org_a", True),
+    ]
+
+
+def test_validated_legacy_read_header_remains_bound_to_its_job(
+    app_client,
+    monkeypatch,
+) -> None:
+    _, client = app_client
+    observations = _install_visible_tree(monkeypatch)
+    monkeypatch.setattr(
+        access_control,
+        "_validate_person_concept",
+        lambda concept_id: concept_id,
+    )
+    headers = {"X-User-Concept-ID": "#V#alice"}
+
+    created = client.post("/api/vontology/tree_async", headers=headers)
+
+    assert created.status_code == 202
+    job_id = created.get_json()["job_id"]
+    _run_route_worker()
+    completed = client.get(
+        f"/api/vontology/tree_progress/{job_id}",
+        headers=headers,
+    )
+    assert completed.status_code == 200
+    assert _tree_ids(completed.get_json()) == {
+        "#V#global",
+        "#V#alice_private",
+    }
+    assert observations == [
+        ("progress_scan", "#V#alice", None, True),
+        ("tree_build", "#V#alice", None, True),
+    ]
+    assert client.get(f"/api/vontology/tree_progress/{job_id}").status_code == 404
+
+
+def test_tree_progress_conceals_job_from_incompatible_actor_scopes(
+    app_client,
+) -> None:
+    _, client = app_client
+    _set_actor(client, "#V#alice", "#V#org_a")
+    created = client.post("/api/vontology/tree_async")
+    job_id = created.get_json()["job_id"]
+    with routes._TREE_BUILD_PROGRESS_LOCK:
+        job = routes._TREE_BUILD_PROGRESS[job_id]
+        job["result"] = {"tree": [{"id": "#V#alice_private"}]}
+        job["completed_at_epoch"] = routes.time.time()
+
+    owner_response = client.get(f"/api/vontology/tree_progress/{job_id}")
+    assert owner_response.status_code == 200
+    assert not any("owner" in key for key in owner_response.get_json())
+
+    _set_actor(client, "#V#bob", "#V#org_a")
+    other_user = client.get(f"/api/vontology/tree_progress/{job_id}")
+    unknown = client.get("/api/vontology/tree_progress/not-a-job")
+    assert other_user.status_code == unknown.status_code == 404
+    assert other_user.get_json() == unknown.get_json() == {"error": "unknown job"}
+
+    _set_actor(client, "#V#alice", "#V#org_b")
+    other_org = client.get(f"/api/vontology/tree_progress/{job_id}")
+    assert other_org.status_code == 404
+    assert other_org.get_json() == {"error": "unknown job"}
+
+    _set_actor(client, "#V#alice", "#V#org_a")
+    assert client.get(f"/api/vontology/tree_progress/{job_id}").status_code == 200
+
+
+def test_tree_job_is_removed_when_worker_thread_cannot_start(
+    app_client,
+    monkeypatch,
+) -> None:
+    _, client = app_client
+    monkeypatch.setattr(routes.threading, "Thread", _FailingThread)
+    _set_actor(client, "#V#alice", "#V#org_a")
+
+    response = client.post("/api/vontology/tree_async")
+
+    assert response.status_code == 500
+    assert response.get_json() == {"error": "tree build could not be started"}
+    with routes._TREE_BUILD_PROGRESS_LOCK:
+        assert routes._TREE_BUILD_PROGRESS == {}
+
+
+@pytest.mark.parametrize("failure_mode", ["returned", "raised"])
+def test_tree_worker_failures_are_terminal(
+    app_client,
+    monkeypatch,
+    failure_mode: str,
+) -> None:
+    _, client = app_client
+    monkeypatch.setattr(
+        routes.ConceptsRepository,
+        "find",
+        lambda _query, _projection: [{"concept_id": "#V#global"}],
+    )
+    if failure_mode == "returned":
+        monkeypatch.setattr(
+            routes,
+            "get_vontology_tree",
+            lambda _root: {"error": "returned tree failure", "tree": []},
+        )
+    else:
+
+        def _raise(_root: str):
+            raise RuntimeError("raised tree failure")
+
+        monkeypatch.setattr(routes, "get_vontology_tree", _raise)
+    _set_actor(client, "#V#alice", "#V#org_a")
+    created = client.post("/api/vontology/tree_async")
+    job_id = created.get_json()["job_id"]
+
+    _run_route_worker()
+    completed = client.get(f"/api/vontology/tree_progress/{job_id}")
+
+    assert completed.status_code == 200
+    payload = completed.get_json()
+    assert payload["done"] is True
+    assert failure_mode in payload["error"]
+    assert "result" not in payload
+    with routes._TREE_BUILD_PROGRESS_LOCK:
+        assert isinstance(
+            routes._TREE_BUILD_PROGRESS[job_id]["completed_at_epoch"],
+            float,
+        )
+    assert _DeferredThread.created[1].joined is True
+
+
+def test_tree_result_cleanup_expires_only_old_terminal_jobs(
+    app_client,
+    monkeypatch,
+) -> None:
+    _, client = app_client
+    monkeypatch.setattr(routes, "_TREE_BUILD_RESULT_TTL_SECONDS", 10)
+    monkeypatch.setattr(routes.time, "time", lambda: 100.0)
+    base_job = {
+        "total": 1,
+        "processed": 1,
+        "owner_user_concept_id": None,
+        "owner_organisation_concept_id": None,
+    }
+    with routes._TREE_BUILD_PROGRESS_LOCK:
+        routes._TREE_BUILD_PROGRESS.update(
+            {
+                "old_success": {
+                    **base_job,
+                    "result": {"tree": []},
+                    "error": None,
+                    "completed_at_epoch": 90.0,
+                },
+                "old_failure": {
+                    **base_job,
+                    "result": None,
+                    "error": "failed",
+                    "completed_at_epoch": 89.0,
+                },
+                "recent_success": {
+                    **base_job,
+                    "result": {"tree": []},
+                    "error": None,
+                    "completed_at_epoch": 91.0,
+                },
+                "old_running": {
+                    **base_job,
+                    "processed": 0,
+                    "result": None,
+                    "error": None,
+                    "completed_at_epoch": None,
+                },
+            }
+        )
+
+    expired = client.get("/api/vontology/tree_progress/old_success")
+
+    assert expired.status_code == 404
+    with routes._TREE_BUILD_PROGRESS_LOCK:
+        assert set(routes._TREE_BUILD_PROGRESS) == {
+            "recent_success",
+            "old_running",
+        }
+    recent = client.get("/api/vontology/tree_progress/recent_success")
+    running = client.get("/api/vontology/tree_progress/old_running")
+    assert recent.status_code == running.status_code == 200
+    assert recent.get_json()["done"] is True
+    assert running.get_json()["done"] is False


### PR DESCRIPTION
Merge decision: ready — asynchronous Vontology tree reads now retain the requesting actor's exact visibility scope and cannot be retrieved from an incompatible scope.

## User outcome

Loading the Vontology tree asynchronously no longer drops user/organisation visibility in its background thread or exposes a completed result to another actor scope.

## Material changes

- Capture the trusted effective user and organisation when `/tree_async` creates a job.
- Force access-control enforcement and reapply that exact scope around both worker database reads.
- Treat anonymous requests as global-only, even if residual organisation session state exists.
- Bind progress/results to the creating user+organisation and conceal mismatches with the same 404 as an unknown job.
- Make returned and raised build errors terminal, stop ticker threads reliably, remove jobs when worker startup fails, and expire only old terminal results.
- Add focused authority and lifecycle regressions.

Tracks JVNAUTOSCI-2631. The existing tree query shape and synthetic progress scan are unchanged.

## Evidence

- Reproduced current-main scope loss directly: the request resolved `(#V#actor_a, #V#org_a, enforced=True)`; the old worker resolved `(None, None, enforced=False)`.
- 68 affected and neighbouring backend tests passed.
- The exact 9-test authority suite passed 20 consecutive runs.
- A real OS-thread route test verifies actor propagation after Flask request teardown.
- Negative cases cover anonymous/global-only, another user, the same user in another organisation, missing legacy read identity, returned and raised failures, worker-start failure, and terminal-only expiry.
- Pyright: 0 errors.
- Ruff on the new test suite and `git diff --check`: passed.
- Two independent reviews found no remaining stop-ship issue.

## Ship boundary

- **Minimum ship criteria:** exact actor-scoped worker reads; global-only anonymous reads; incompatible-scope polling denial; terminal failure behaviour; active-job retention; unchanged frontend response contract.
- **Stop-ship conditions:** foreign-scope result access, residual anonymous organisation access, disabled worker enforcement, non-terminal failures, active-job expiry, or changed synchronous tree visibility semantics.
- **Non-blocking observations:** jobs remain process-local; genuinely hung jobs are retained; the redundant full-ID progress scan remains a measured performance issue.
- **Non-goals:** tree-query optimisation, shared/multi-process job persistence, cancellation/deduplication, or changes to synchronous tree caching.