### PR TITLE
Repair file-copy workflow finality and governed recovery

### DIFF
--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -3523,6 +3523,105 @@ def _effect_result_target_ids(raw_payload: Any) -> list[str]:
     return collected
 
 
+def _scoped_assertion_text_identity_sha256(text: Any, language: Any) -> str | None:
+    """Return a content-safe identity for one persisted text assertion."""
+
+    if not isinstance(text, str) or not text.strip():
+        return None
+    language_token = str(language or "en-NZ").strip() or "en-NZ"
+    return hashlib.sha256(
+        _json_bytes(
+            {
+                "text": text.strip(),
+                "language": language_token,
+            }
+        )
+    ).hexdigest()
+
+
+def _scoped_assertion_trusted_scope_identity_sha256(
+    *,
+    scope_mode: Any,
+    user_concept_id: Any,
+    scope_organisation_concept_id: Any,
+    scope_namespace: Any,
+    scope_audience_keys: Any,
+    provenance_organisation_concept_id: Any,
+    provenance_namespace: Any,
+) -> str | None:
+    """Return a bounded identity for the actor-bound assertion scope."""
+
+    mode = str(scope_mode or "").strip().lower()
+    user_id = str(user_concept_id or "").strip()
+    scope_organisation_id = str(scope_organisation_concept_id or "").strip() or None
+    scope_namespace_id = str(scope_namespace or "").strip()
+    provenance_organisation_id = (
+        str(provenance_organisation_concept_id or "").strip() or None
+    )
+    provenance_namespace_id = str(provenance_namespace or "").strip()
+    if (
+        mode not in {"user", "organisation"}
+        or not user_id
+        or not scope_namespace_id
+        or not provenance_namespace_id
+    ):
+        return None
+    expected_scope_organisation_id = (
+        provenance_organisation_id if mode == "organisation" else None
+    )
+    if mode == "organisation" and expected_scope_organisation_id is None:
+        return None
+    if scope_organisation_id != expected_scope_organisation_id:
+        return None
+    if not isinstance(scope_audience_keys, Sequence) or isinstance(
+        scope_audience_keys,
+        (str, bytes, bytearray),
+    ):
+        return None
+    audience_keys = [
+        str(audience_key).strip()
+        for audience_key in scope_audience_keys
+        if str(audience_key).strip()
+    ]
+    expected_audience_key = (
+        f"user:{user_id}"
+        if mode == "user"
+        else f"org:{scope_organisation_id}"
+    )
+    if audience_keys != [expected_audience_key]:
+        return None
+    from .namespace_service import resolve_canonical_namespace
+
+    expected_scope_namespace = resolve_canonical_namespace(
+        None,
+        user_id,
+        scope_organisation_id,
+    )
+    expected_provenance_namespace = resolve_canonical_namespace(
+        None,
+        user_id,
+        provenance_organisation_id,
+    )
+    if (
+        scope_namespace_id != expected_scope_namespace
+        or provenance_namespace_id != expected_provenance_namespace
+    ):
+        return None
+    return hashlib.sha256(
+        _json_bytes(
+            {
+                "scope_mode": mode,
+                "user_concept_id": user_id,
+                "scope_organisation_concept_id": scope_organisation_id,
+                "scope_namespace": scope_namespace_id,
+                "scope_audience_key": expected_audience_key,
+                "provenance_organisation_concept_id": (provenance_organisation_id),
+                "provenance_namespace": provenance_namespace_id,
+            }
+        )
+    ).hexdigest()
+
+
 def _canonical_effect_readback_receipt(raw_payload: Any) -> dict[str, Any] | None:
     """Project an embedded canonical read-back without private message fields."""
 
@@ -3566,6 +3665,61 @@ def _canonical_effect_readback_receipt(raw_payload: Any) -> dict[str, Any] | Non
         )
         if key in readback
     }
+    assertion_id = str(readback.get("assertion_id") or "").strip()
+    subject_concept_id = str(readback.get("subject_concept_id") or "").strip()
+    object_kind = str(readback.get("object_kind") or "").strip().lower()
+    if assertion_id:
+        projected["assertion_id"] = assertion_id
+    if subject_concept_id:
+        projected["subject_concept_id"] = subject_concept_id
+    if object_kind in {"text", "concept"}:
+        projected["object_kind"] = object_kind
+    if object_kind == "text":
+        object_text = readback.get("object_text")
+        if isinstance(object_text, Mapping):
+            text_identity = _scoped_assertion_text_identity_sha256(
+                object_text.get("text"),
+                object_text.get("language"),
+            )
+            if text_identity is not None:
+                projected["object_text_identity_sha256"] = text_identity
+    elif object_kind == "concept":
+        object_concept_id = str(readback.get("object_concept_id") or "").strip()
+        if object_concept_id:
+            projected["object_concept_id"] = object_concept_id
+    scope = readback.get("scope")
+    if isinstance(scope, Mapping):
+        scope_mode = str(scope.get("mode") or "").strip().lower()
+        if scope_mode in {"user", "organisation"}:
+            projected["scope_mode"] = scope_mode
+        provenance = readback.get("provenance")
+        if isinstance(provenance, Mapping):
+            scope_user_id = str(scope.get("user_concept_id") or "").strip()
+            asserted_user_id = str(
+                provenance.get("asserted_by_user_concept_id") or ""
+            ).strip()
+            scope_organisation_id = str(
+                scope.get("organisation_concept_id") or ""
+            ).strip()
+            provenance_organisation_id = str(
+                provenance.get("organisation_concept_id") or ""
+            ).strip()
+            if scope_user_id == asserted_user_id:
+                trusted_scope_identity = (
+                    _scoped_assertion_trusted_scope_identity_sha256(
+                        scope_mode=scope_mode,
+                        user_concept_id=scope_user_id,
+                        scope_organisation_concept_id=scope_organisation_id,
+                        scope_namespace=scope.get("namespace"),
+                        scope_audience_keys=scope.get("audience_keys"),
+                        provenance_organisation_concept_id=(provenance_organisation_id),
+                        provenance_namespace=provenance.get("namespace"),
+                    )
+                )
+                if trusted_scope_identity is not None:
+                    projected["trusted_scope_identity_sha256"] = trusted_scope_identity
+    if isinstance(readback.get("canonical_publication"), bool):
+        projected["canonical_publication"] = readback["canonical_publication"]
     return projected or None
 
 
@@ -3653,6 +3807,103 @@ def _canonical_relation_readback_matches_invocation(
         return False
     return not bool(readback.get("inverse_predicate")) or (
         readback.get("inverse_relationship_present") is expected_present
+    )
+
+
+def _canonical_scoped_assertion_readback_matches_invocation(
+    invocation: Mapping[str, Any],
+    readback: Mapping[str, Any] | None,
+) -> bool:
+    """Verify an embedded scoped-assertion read-back against the exact write."""
+
+    if not isinstance(readback, Mapping):
+        return False
+    method = str(
+        invocation.get("execution_method") or invocation.get("tool") or ""
+    ).strip()
+    if method != "upsert_scoped_assertion":
+        return False
+    arguments = invocation.get("effective_arguments")
+    if not isinstance(arguments, Mapping):
+        return False
+    if not str(readback.get("assertion_id") or "").strip():
+        return False
+    if str(readback.get("status") or "").strip().lower() != "asserted":
+        return False
+    if readback.get("canonical_publication") is not False:
+        return False
+    expected_subject = str(arguments.get("subject_concept_id") or "").strip()
+    if (
+        not expected_subject
+        or str(readback.get("subject_concept_id") or "").strip() != expected_subject
+    ):
+        return False
+
+    def normalise_predicate(value: Any) -> str:
+        from .text_relation_predicate_validation_service import (
+            predicate_concept_id_for_storage,
+        )
+
+        predicate = str(value or "").strip()
+        return predicate_concept_id_for_storage(predicate) or predicate
+
+    expected_predicate = normalise_predicate(arguments.get("predicate"))
+    if (
+        not expected_predicate
+        or normalise_predicate(readback.get("predicate")) != expected_predicate
+    ):
+        return False
+    expected_scope_mode = str(arguments.get("scope_mode") or "user").strip().lower()
+    if readback.get("scope_mode") != expected_scope_mode:
+        return False
+    expected_scope_identity = _scoped_assertion_trusted_scope_identity_sha256(
+        scope_mode=expected_scope_mode,
+        user_concept_id=arguments.get("acting_user_concept_id"),
+        scope_organisation_concept_id=(
+            arguments.get("organisation_concept_id")
+            if expected_scope_mode == "organisation"
+            else None
+        ),
+        scope_namespace=(
+            arguments.get("namespace")
+            if expected_scope_mode == "organisation"
+            else str(arguments.get("acting_user_concept_id") or "").strip()
+        ),
+        scope_audience_keys=[
+            (
+                f"org:{str(arguments.get('organisation_concept_id') or '').strip()}"
+                if expected_scope_mode == "organisation"
+                else f"user:{str(arguments.get('acting_user_concept_id') or '').strip()}"
+            )
+        ],
+        provenance_organisation_concept_id=arguments.get("organisation_concept_id"),
+        provenance_namespace=arguments.get("namespace"),
+    )
+    if (
+        expected_scope_identity is None
+        or readback.get("trusted_scope_identity_sha256") != expected_scope_identity
+    ):
+        return False
+
+    target_text = arguments.get("target_text")
+    target_concept_id = str(arguments.get("target_concept_id") or "").strip()
+    has_text = isinstance(target_text, str) and bool(target_text.strip())
+    has_concept = bool(target_concept_id)
+    if has_text == has_concept:
+        return False
+    if has_text:
+        expected_identity = _scoped_assertion_text_identity_sha256(
+            target_text,
+            arguments.get("language"),
+        )
+        return (
+            readback.get("object_kind") == "text"
+            and expected_identity is not None
+            and readback.get("object_text_identity_sha256") == expected_identity
+        )
+    return (
+        readback.get("object_kind") == "concept"
+        and str(readback.get("object_concept_id") or "").strip() == target_concept_id
     )
 
 
@@ -3865,6 +4116,10 @@ def _canonically_verified_material_effect_ids(
                 == "verified"
             )
             or _canonical_relation_readback_matches_invocation(
+                invocation,
+                embedded_readback,
+            )
+            or _canonical_scoped_assertion_readback_matches_invocation(
                 invocation,
                 embedded_readback,
             )
@@ -4106,6 +4361,57 @@ def _effect_subject_authority_denial(
         }
     ]
     return payload
+
+
+def _with_exact_scoped_assertion_recovery_affordance(
+    payload: Mapping[str, Any],
+    *,
+    capability_name: str,
+    arguments: Mapping[str, Any],
+    scoped_assertion_available: bool,
+) -> dict[str, Any]:
+    """Replace a generic scoped recovery hint with one exact bounded action."""
+
+    result = dict(payload)
+    recovery_payload = _effect_subject_authority_denial(
+        capability_name=capability_name,
+        arguments=arguments,
+        scoped_assertion_available=scoped_assertion_available,
+    )
+    exact_affordances = recovery_payload.get("recovery_affordances")
+    if not isinstance(exact_affordances, Sequence) or isinstance(
+        exact_affordances,
+        (str, bytes, bytearray),
+    ):
+        return result
+    existing_affordances = result.get("recovery_affordances")
+    if not (
+        isinstance(existing_affordances, Sequence)
+        and not isinstance(existing_affordances, (str, bytes, bytearray))
+        and any(
+            isinstance(affordance, Mapping)
+            and affordance.get("action_type") == "create_scoped_assertion"
+            for affordance in existing_affordances
+        )
+    ):
+        return result
+    retained_affordances: list[dict[str, Any]] = []
+    if isinstance(existing_affordances, Sequence) and not isinstance(
+        existing_affordances,
+        (str, bytes, bytearray),
+    ):
+        retained_affordances = [
+            dict(affordance)
+            for affordance in existing_affordances
+            if isinstance(affordance, Mapping)
+            and affordance.get("action_type") != "create_scoped_assertion"
+            and affordance.get("tool") != "upsert_scoped_assertion"
+        ]
+    result["recovery_affordances"] = [
+        *(dict(affordance) for affordance in exact_affordances),
+        *retained_affordances,
+    ]
+    return result
 
 
 def _emit(progress_tracker: Any, payload: Mapping[str, Any]) -> None:
@@ -4690,7 +4996,9 @@ def execute_adaptive_turn(
                             failed_state = effect_states.get(attempted_effect_id)
                             if (
                                 failed_state is None
-                                or failed_state.get("effect_status") != "failed"
+                                or failed_state.get("effect_status")
+                                not in {"failed", "not_started"}
+                                or failed_state.get("changed") is not False
                             ):
                                 continue
                             failed_state["attempted_recovery_effect_id"] = (
@@ -4701,7 +5009,12 @@ def execute_adaptive_turn(
             return
         with effect_state_lock:
             failed_state = effect_states.get(failed_effect_id)
-            if failed_state is None or failed_state.get("effect_status") != "failed":
+            if (
+                failed_state is None
+                or failed_state.get("effect_status")
+                not in {"failed", "not_started"}
+                or failed_state.get("changed") is not False
+            ):
                 return
             failed_state["recovered_by_effect_id"] = recovery_effect_id
             failed_state["recovery_status"] = "succeeded"
@@ -5016,7 +5329,8 @@ def execute_adaptive_turn(
             in {"failed", "partial", "indeterminate", "not_started"}
             and state.get("turn_finality_required") is not False
             and not (
-                state.get("effect_status") == "failed"
+                state.get("effect_status") in {"failed", "not_started"}
+                and state.get("changed") is False
                 and state.get("recovery_status") == "succeeded"
                 and state.get("recovered_by_effect_id")
             )
@@ -5176,10 +5490,15 @@ def execute_adaptive_turn(
             failed_count = len(incomplete_effects)
             succeeded_count = len(succeeded_effects)
             if mixed_verified_workflow_fallback:
+                workflow_attempt_label = "attempt" if failed_count == 1 else "attempts"
+                workflow_failure_label = (
+                    "workflow failure" if failed_count == 1 else "workflow failures"
+                )
                 qualification = (
                     f"Effect receipts also report {succeeded_count} succeeded and "
-                    f"{failed_count} failed represented-workflow attempt. The "
-                    "workflow failure and the later changed targets were read back "
+                    f"{failed_count} failed represented-workflow "
+                    f"{workflow_attempt_label}. The {workflow_failure_label} and "
+                    "the later changed targets were read back "
                     "exactly, so the verified successful result is preserved while "
                     "the turn remains partial."
                 )
@@ -6616,13 +6935,30 @@ def execute_adaptive_turn(
                         turn_id=turn_id,
                     )
                 if not isinstance(delegation_result.get("delegation_id"), str):
+                    delegation_result = (
+                        _with_exact_scoped_assertion_recovery_affordance(
+                            delegation_result,
+                            capability_name=execution_method_name,
+                            arguments=arguments,
+                            scoped_assertion_available=(
+                                gateway.get_method_definition(
+                                    "upsert_scoped_assertion"
+                                )
+                                is not None
+                            ),
+                        )
+                    )
+                    delegation_effect_status = _effect_status(
+                        delegation_result,
+                        transport_result=None,
+                    )
                     persist_effect_observation_phase(
                         effect_id=effect_identifier,
                         phase="turn_terminal",
                         observation={
                             "call_id": call.call_id,
                             "capability_name": canonical_name,
-                            "effect_status": "failed",
+                            "effect_status": delegation_effect_status,
                             "changed": False,
                             "transport": {},
                             "receipt": dict(delegation_result),

--- a/src/backend/workflows/durable/file_copy_interpretation_workflow.py
+++ b/src/backend/workflows/durable/file_copy_interpretation_workflow.py
@@ -16,14 +16,37 @@ from ..engine import (
 from ..workflow_registry import WorkflowRegistration
 
 FILE_COPY_INTERPRETATION_WORKFLOW_ID = "#V#file_copy_interpretation_workflow"
-_FILE_COPY_CONTEXT_INPUTS = {
+FILE_COPY_INTERPRETATION_LAUNCH_INPUT_CONTRACT = {
+    "schema_version": "workflow_launch_input_contract.v1",
+    "required_inputs": ["file_copy_concept_id"],
+    "input_mappings": [
+        {
+            "target_context_key": "file_copy_concept_id",
+            "source_expression": "inputs.file_copy_concept_id",
+            "extractor": "identity",
+            "required": True,
+            "description": (
+                "Blob-backed #V#computer_file_copy concept to interpret and index."
+            ),
+        },
+    ],
+}
+_INTERPRET_FILE_COPY_INPUTS = {
     "concept_id": {
-        "$context_key": "concept_id",
-        "$mapping_concept_id": "#V#workflow_mapping_concept_id_to_concept_id_parameter",
-    },
-    "file_copy_concept_id": {
         "$context_key": "file_copy_concept_id",
-        "$mapping_concept_id": "#V#workflow_mapping_file_copy_concept_id_to_file_copy_concept_id_parameter",
+        "$mapping_concept_id": (
+            "#V#workflow_mapping_file_copy_interpretation_workflow_interpret_"
+            "file_copy_concept_id_to_concept_id_parameter"
+        ),
+    },
+}
+_INDEX_FILE_COPY_INPUTS = {
+    "concept_id": {
+        "$context_key": "file_copy_concept_id",
+        "$mapping_concept_id": (
+            "#V#workflow_mapping_file_copy_interpretation_workflow_index_"
+            "file_copy_concept_id_to_concept_id_parameter"
+        ),
     },
 }
 
@@ -34,7 +57,7 @@ def build_file_copy_interpretation_workflow_test_definition() -> WorkflowDefinit
         actions=(
             WorkflowActionInvocation(
                 action_id="interpret_file_copy",
-                inputs=dict(_FILE_COPY_CONTEXT_INPUTS),
+                inputs=dict(_INTERPRET_FILE_COPY_INPUTS),
                 description=(
                     "Extract structured interpretation from a blob-backed "
                     "#V#computer_file_copy and persist canonical text relations."
@@ -60,7 +83,7 @@ def build_file_copy_interpretation_workflow_test_definition() -> WorkflowDefinit
         actions=(
             WorkflowActionInvocation(
                 action_id="index_file_copy",
-                inputs=dict(_FILE_COPY_CONTEXT_INPUTS),
+                inputs=dict(_INDEX_FILE_COPY_INPUTS),
                 description="Index extracted file-copy text into RAG for the namespace.",
             ),
         ),
@@ -90,6 +113,10 @@ def build_file_copy_interpretation_workflow_test_definition() -> WorkflowDefinit
             "Interpret newly uploaded file-copy content (including screenshots/"
             "images) and persist rich concept descriptions, then index in RAG."
         ),
+        metadata={
+            "launch_input_contract": FILE_COPY_INTERPRETATION_LAUNCH_INPUT_CONTRACT,
+            "launch_input_contract_source": "built_in_test_definition",
+        },
     )
 
 

--- a/src/backend/workflows/repo_seed_bundles/canonical_workflow_publication_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/canonical_workflow_publication_seed_bundle.json
@@ -1,7 +1,7 @@
 {
   "family_id": "canonical_workflow_publication_seed_bundle",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "49",
+  "seed_version": "50",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#tool_calling_workflow": {
       "42": [
@@ -4682,6 +4682,21 @@
       "workflow_id": "#V#file_copy_upload_handler_workflow"
     },
     {
+      "launch_input_contract": {
+        "schema_version": "workflow_launch_input_contract.v1",
+        "required_inputs": [
+          "file_copy_concept_id"
+        ],
+        "input_mappings": [
+          {
+            "target_context_key": "file_copy_concept_id",
+            "source_expression": "inputs.file_copy_concept_id",
+            "extractor": "identity",
+            "required": true,
+            "description": "Blob-backed #V#computer_file_copy concept to interpret and index."
+          }
+        ]
+      },
       "publication_spec": {
         "initial_state": "interpret",
         "steps": [
@@ -4717,11 +4732,15 @@
                 "to_state": "complete"
               }
             ],
-            "context_input_mapping_specs": [],
-            "context_input_mappings": [
-              "#V#workflow_mapping_concept_id_to_concept_id_parameter",
-              "#V#workflow_mapping_file_copy_concept_id_to_file_copy_concept_id_parameter"
+            "context_input_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_file_copy_interpretation_workflow_interpret_file_copy_concept_id_to_concept_id_parameter",
+                "context_key": "file_copy_concept_id",
+                "required": true,
+                "tool_param": "concept_id"
+              }
             ],
+            "context_input_mappings": [],
             "effects": [],
             "execution_mode": null,
             "invoked_workflow_id": null,
@@ -4756,11 +4775,15 @@
                 "to_state": "complete"
               }
             ],
-            "context_input_mapping_specs": [],
-            "context_input_mappings": [
-              "#V#workflow_mapping_concept_id_to_concept_id_parameter",
-              "#V#workflow_mapping_file_copy_concept_id_to_file_copy_concept_id_parameter"
+            "context_input_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_file_copy_interpretation_workflow_index_file_copy_concept_id_to_concept_id_parameter",
+                "context_key": "file_copy_concept_id",
+                "required": true,
+                "tool_param": "concept_id"
+              }
             ],
+            "context_input_mappings": [],
             "effects": [],
             "execution_mode": null,
             "invoked_workflow_id": null,

--- a/src/backend/workflows/workflow_concept_authority_service.py
+++ b/src/backend/workflows/workflow_concept_authority_service.py
@@ -455,10 +455,6 @@ class _RuntimeStepPublicationDetails:
     writes_context_keys: tuple[str, ...] = ()
 
 
-_FILE_COPY_WORKFLOW_CONTEXT_INPUT_MAPPINGS: tuple[str, ...] = (
-    "#V#workflow_mapping_concept_id_to_concept_id_parameter",
-    "#V#workflow_mapping_file_copy_concept_id_to_file_copy_concept_id_parameter",
-)
 _PARENT_SPECIFICITY_DOSSIER_CONTEXT_INPUT_MAPPINGS: tuple[str, ...] = (
     PARENT_SPECIFICITY_DOSSIER_CONTEXT_INPUT_MAPPING_CONCEPT_ID,
 )

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -800,7 +800,7 @@ def _effect_gateway(
                     {
                         "organisation_concept_id": None,
                         "org_id": None,
-                        "scope_mode": "user_org_default",
+                        "scope_mode": "user_only_default",
                         "visibility_scope_mode": None,
                     }
                     if name == "create_concepts"
@@ -832,6 +832,25 @@ def _effect_gateway(
         ),
         enabled=True,
     )
+
+
+def _stub_same_turn_ontology_delegation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[dict[str, Any]]:
+    """Authorise governed fake effects whose tests target turn mechanics."""
+
+    issued: list[dict[str, Any]] = []
+
+    def issue(**kwargs: Any) -> dict[str, Any]:
+        issued.append(dict(kwargs))
+        return {"delegation_id": f"test-delegation-{kwargs['effect_id']}"}
+
+    monkeypatch.setattr(
+        "src.backend.services.ontology_mutation_command_service."
+        "issue_same_turn_method_delegation",
+        issue,
+    )
+    return issued
 
 
 def _workflow_gateway(
@@ -2139,7 +2158,10 @@ def test_default_final_answer_reserve_is_nonzero_and_clamped() -> None:
     assert allocation["model_call_hard_timeout_seconds"] is None
 
 
-def test_create_effect_scope_is_hidden_and_server_overrides_spoofed_values() -> None:
+def test_create_effect_scope_is_hidden_and_server_overrides_spoofed_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_same_turn_ontology_delegation(monkeypatch)
     seen: dict[str, Any] = {}
 
     def handler(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -2211,7 +2233,7 @@ def test_create_effect_scope_is_hidden_and_server_overrides_spoofed_values() -> 
     assert seen["created_by_concept_id"] == "#V#person"
     assert seen["organisation_concept_id"] is None
     assert seen["org_id"] is None
-    assert seen["scope_mode"] == "user_org_default"
+    assert seen["scope_mode"] == "user_only_default"
     assert seen["visibility_scope_mode"] is None
 
 
@@ -2330,7 +2352,8 @@ def test_effect_subject_authority_matches_actor_or_organisation_scope(
     from src.backend.db import mongo_client
 
     class _Collection:
-        relationships: dict[str, Any] = {}
+        def __init__(self) -> None:
+            self.relationships: dict[str, Any] = {}
 
         def find_one(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
             return {"relationships": dict(self.relationships)}
@@ -2366,7 +2389,7 @@ def test_effect_subject_authority_matches_actor_or_organisation_scope(
 
 
 def test_ordinary_effect_authorises_actor_profile_without_visibility_lookup(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from src.backend.db import mongo_client
 
@@ -2377,6 +2400,7 @@ def test_ordinary_effect_authorises_actor_profile_without_visibility_lookup(
             AssertionError("actor identity should not require visibility lookup")
         ),
     )
+    issued = _stub_same_turn_ontology_delegation(monkeypatch)
     invoked: list[str] = []
 
     def handler(name: str, _arguments: dict[str, Any]) -> dict[str, Any]:
@@ -2423,11 +2447,15 @@ def test_ordinary_effect_authorises_actor_profile_without_visibility_lookup(
     )
 
     assert invoked == ["add_relationship"]
+    assert [item["method_name"] for item in issued] == ["add_relationship"]
     assert result.tool_invocations[0]["effect_status"] == "succeeded"
     assert result.tool_invocations[0]["changed"] is True
 
 
-def test_finality_fallback_rejects_pre_reconciliation_situation() -> None:
+def test_finality_fallback_rejects_pre_reconciliation_situation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_same_turn_ontology_delegation(monkeypatch)
     current_situation = "The representation effect has not yet been observed."
     client = _SequenceClient(
         LLMResponse(
@@ -2533,7 +2561,10 @@ def test_model_error_after_read_rejects_interim_situation_sidecar() -> None:
     assert result.conversation_situation == current_situation
 
 
-def test_post_handler_output_validation_failure_is_indeterminate() -> None:
+def test_post_handler_output_validation_failure_is_indeterminate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_same_turn_ontology_delegation(monkeypatch)
     committed: list[str] = []
 
     def handler(_name: str, _arguments: dict[str, Any]) -> dict[str, Any]:
@@ -2598,7 +2629,9 @@ def test_post_handler_output_validation_failure_is_indeterminate() -> None:
 def test_effect_removes_false_draft_from_fresh_final_context(
     answer_reserve: float,
     effect_finished_at: float,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _stub_same_turn_ontology_delegation(monkeypatch)
     started = time.monotonic()
     clock = _ManualClock(started)
 
@@ -2665,6 +2698,7 @@ def test_late_effect_completion_is_persisted_without_rewriting_terminal_result(
 ) -> None:
     from src.backend.services import turn_execution_record_service
 
+    _stub_same_turn_ontology_delegation(monkeypatch)
     release_handler = Event()
     observation_persisted = Event()
     persisted: list[dict[str, Any]] = []
@@ -2746,6 +2780,7 @@ def test_late_effect_completion_is_persisted_without_rewriting_terminal_result(
 def test_effect_uses_its_method_liveness_window_not_a_turn_deadline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _stub_same_turn_ontology_delegation(monkeypatch)
     clock = _ManualClock()
     observed_deadlines: list[float | None] = []
     gateway = _effect_gateway(
@@ -2831,6 +2866,7 @@ def test_effect_uses_its_method_liveness_window_not_a_turn_deadline(
 def test_mixed_effect_batch_preserves_order_with_independent_admission(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _stub_same_turn_ontology_delegation(monkeypatch)
     clock = _ManualClock()
     observed: list[tuple[str, float | None]] = []
     gateway = _effect_gateway(
@@ -2918,6 +2954,7 @@ def test_mixed_effect_batch_preserves_order_with_independent_admission(
 def test_invalid_effect_does_not_reserve_window_or_block_valid_sibling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _stub_same_turn_ontology_delegation(monkeypatch)
     clock = _ManualClock()
     invoked: list[str] = []
     gateway = _effect_gateway(
@@ -3234,6 +3271,7 @@ def test_cited_ontology_success_without_relation_readback_is_rejected(
 def test_indeterminate_effect_stops_later_effect_but_allows_readback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _stub_same_turn_ontology_delegation(monkeypatch)
     invoked: list[str] = []
     gateway = _effect_gateway(
         lambda _name, _arguments: {"success": True},
@@ -3338,7 +3376,10 @@ def test_indeterminate_effect_stops_later_effect_but_allows_readback(
     assert blocked["error_code"] == "prior_effect_outcome_indeterminate"
 
 
-def test_per_method_minimum_admits_sequential_effects_below_hard_cap() -> None:
+def test_per_method_minimum_admits_sequential_effects_below_hard_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_same_turn_ontology_delegation(monkeypatch)
     invoked: list[str] = []
 
     def handler(name: str, _arguments: dict[str, Any]) -> dict[str, Any]:
@@ -3537,8 +3578,8 @@ def test_ordinary_effect_rejects_unscoped_subject_before_handler(
     )
 
     assert invoked == []
-    assert result.tool_invocations[0]["effect_status"] == "failed"
-    assert "effect_subject_not_authorised" in (
+    assert result.tool_invocations[0]["effect_status"] == "not_started"
+    assert "ontology_mutation_target_not_accessible" in (
         result.tool_invocations[0]["evidence"]["preview"]
     )
 
@@ -3779,9 +3820,9 @@ def test_canonical_relationship_denial_recovers_as_scoped_assertion(
     assert recovered_arguments["canonical_publication"] is False
 
     denial = result.tool_invocations[0]
-    assert denial["effect_status"] == "failed"
+    assert denial["effect_status"] == "not_started"
     preview = denial["evidence"]["preview"]
-    assert "effect_subject_not_authorised" in preview
+    assert "ontology_mutation_target_not_accessible" in preview
     assert "assert_in_actor_scope" in preview
     assert "#V#globally_visible_subject" in preview
     assert "#V#hasResearchInterest" in preview
@@ -3900,7 +3941,7 @@ def test_canonical_literal_relationship_denial_recovers_in_chosen_scope(
     assert recovered_arguments["scope_mode"] == "organisation"
     assert recovered_arguments["target_text"] == "Actor-relative observation."
     denial, recovery = result.tool_invocations
-    assert denial["effect_status"] == "failed"
+    assert denial["effect_status"] == "not_started"
     assert "target_text" in denial["evidence"]["preview"]
     assert recovery["effect_status"] == "succeeded"
     assert denial["recovery_status"] == "succeeded"
@@ -4019,11 +4060,11 @@ def test_canonical_literal_relationship_recovery_requires_same_object(
 
     denial = result.tool_invocations[0]
     unrelated_recovery = result.tool_invocations[1]
-    assert denial["effect_status"] == "failed"
+    assert denial["effect_status"] == "not_started"
     assert denial["recovery_status"] == "mismatched"
     assert denial["attempted_recovery_effect_id"] == unrelated_recovery["effect_id"]
     assert "recovered_by_effect_id" not in denial
-    assert result.terminal_status == "effect_failed"
+    assert result.terminal_status == "effect_not_started"
     assert result.response_text != "The scoped assertion was recorded."
 
 
@@ -4301,7 +4342,10 @@ def test_ordinary_relationship_effect_reserves_mail_profile_control_predicates(
     assert denial["error_code"] == "mail_profile_authority_effect_not_delegated"
 
 
-def test_ordinary_actor_cannot_self_grant_mail_profile_but_safe_relation_runs() -> None:
+def test_ordinary_actor_cannot_self_grant_mail_profile_but_safe_relation_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    issued = _stub_same_turn_ontology_delegation(monkeypatch)
     invoked: list[tuple[str, dict[str, Any]]] = []
 
     def handler(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -4369,6 +4413,7 @@ def test_ordinary_actor_cannot_self_grant_mail_profile_but_safe_relation_runs() 
             },
         )
     ]
+    assert [item["method_name"] for item in issued] == ["add_relationship"]
     assert result.tool_invocations[0]["effect_status"] == "failed"
     assert "mail_profile_authority_effect_not_delegated" in (
         result.tool_invocations[0]["evidence"]["preview"]
@@ -6393,10 +6438,8 @@ def test_repeated_tool_results_resolve_projection_contract_once_per_turn(
 
 
 def test_effect_batch_preserves_order_and_read_can_observe_prior_effect(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from src.backend.services import adaptive_turn_service
-
     seen: list[tuple[str, dict[str, Any]]] = []
     state = {"created": False}
 
@@ -6409,11 +6452,7 @@ def test_effect_batch_preserves_order_and_read_can_observe_prior_effect(
             return {"success": True, "created": state["created"]}
         return {"success": True, "effect_status": "succeeded", "changed": True}
 
-    monkeypatch.setattr(
-        adaptive_turn_service,
-        "_effect_subject_authorised",
-        lambda *_args: True,
-    )
+    _stub_same_turn_ontology_delegation(monkeypatch)
     client = _SequenceClient(
         LLMResponse(
             text_response="",
@@ -6476,16 +6515,10 @@ def test_effect_batch_preserves_order_and_read_can_observe_prior_effect(
 
 
 def test_relation_progress_emits_one_human_start_and_terminal_summary(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from src.backend.services import adaptive_turn_service
-
     progress_events: list[dict[str, Any]] = []
-    monkeypatch.setattr(
-        adaptive_turn_service,
-        "_effect_subject_authorised",
-        lambda *_args, **_kwargs: True,
-    )
+    _stub_same_turn_ontology_delegation(monkeypatch)
 
     client = _SequenceClient(
         LLMResponse(
@@ -6664,9 +6697,10 @@ def test_concept_search_progress_emits_query_and_bounded_results() -> None:
     }
 
 
-def test_effect_evidence_preserves_success_partial_failure_and_unknown_timeout() -> (
-    None
-):
+def test_effect_evidence_preserves_success_partial_failure_and_unknown_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_same_turn_ontology_delegation(monkeypatch)
     seen_cases: list[str] = []
     progress_events: list[dict[str, Any]] = []
     release_timeout_handler = Event()
@@ -6768,7 +6802,10 @@ def test_effect_evidence_preserves_success_partial_failure_and_unknown_timeout()
     assert not partial_progress["result_summary"].startswith("Finished ")
 
 
-def test_partial_effect_downgrades_nominal_model_completion() -> None:
+def test_partial_effect_downgrades_nominal_model_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_same_turn_ontology_delegation(monkeypatch)
     client = _SequenceClient(
         LLMResponse(
             text_response="",
@@ -9683,7 +9720,10 @@ def test_pending_durable_response_with_exact_handle_is_preserved(monkeypatch) ->
     )
 
 
-def test_workflow_instance_readback_does_not_reconcile_unrelated_effect() -> None:
+def test_workflow_instance_readback_does_not_reconcile_unrelated_effect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_same_turn_ontology_delegation(monkeypatch)
     instance_id = "shared-looking-instance-id"
     workflow_id = "#V#shared-looking-workflow-id"
 
@@ -10018,14 +10058,10 @@ def test_represented_workflow_retry_reuses_same_turn_idempotency_key(
 
 
 def test_unchanged_terminally_failed_effect_is_not_dispatched_twice(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     handler_calls: list[dict[str, Any]] = []
-
-    monkeypatch.setattr(
-        "src.backend.services.adaptive_turn_service." "_effect_subject_authorised",
-        lambda *_args, **_kwargs: True,
-    )
+    _stub_same_turn_ontology_delegation(monkeypatch)
 
     def handler(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         assert name == "add_relationship"

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -41,6 +41,7 @@ from src.backend.services.adaptive_turn_service import (
     _bounded_conversation_observation_projection,
     _canonical_effect_readback_receipt,
     _canonical_relation_readback_matches_invocation,
+    _canonical_scoped_assertion_readback_matches_invocation,
     _canonically_verified_material_effect_ids,
     _capability_catalogue,
     _cited_ontology_mutation_claim_conflicts,
@@ -235,6 +236,122 @@ def test_embedded_ontology_relation_readback_verifies_the_exact_effect() -> None
     assert not _canonical_relation_readback_matches_invocation(
         invocation,
         wrong_case_readback,
+    )
+
+
+def test_embedded_scoped_assertion_readback_verifies_the_exact_effect() -> None:
+    canonical_record = {
+        "assertion_id": "ska_research_description",
+        "subject_concept_id": "#V#student_a",
+        "predicate": "#V#has_research_description",
+        "object_kind": "text",
+        "object_text": {
+            "text": "Studies robust multimodal learning.",
+            "language": "en-NZ",
+        },
+        "scope": {
+            "mode": "organisation",
+            "user_concept_id": "#V#person",
+            "organisation_concept_id": "#V#org",
+            "namespace": "#V#person@org",
+            "audience_keys": ["org:#V#org"],
+        },
+        "provenance": {
+            "asserted_by_user_concept_id": "#V#person",
+            "organisation_concept_id": "#V#org",
+            "namespace": "#V#person@org",
+        },
+        "canonical_publication": False,
+        "status": "asserted",
+    }
+    readback = _canonical_effect_readback_receipt(
+        {"canonical_read_back": canonical_record}
+    )
+    invocation = {
+        "effect_id": "effect-scoped-assertion-1",
+        "status": "ok",
+        "execution_method": "upsert_scoped_assertion",
+        "effective_arguments": {
+            "subject_concept_id": "#V#student_a",
+            "predicate": "#V#has_research_description",
+            "target_text": "Studies robust multimodal learning.",
+            "language": "en-NZ",
+            "scope_mode": "organisation",
+            "acting_user_concept_id": "#V#person",
+            "organisation_concept_id": "#V#org",
+            "namespace": "#V#person@org",
+            "canonical_publication": False,
+        },
+    }
+    material, verified = _canonically_verified_material_effect_ids(
+        [invocation],
+        {
+            "effect-scoped-assertion-1": {
+                "effect_status": "succeeded",
+                "changed": True,
+                "turn_finality_required": True,
+                "canonical_readback": readback,
+            }
+        },
+    )
+
+    assert readback is not None
+    assert "object_text" not in readback
+    assert _canonical_scoped_assertion_readback_matches_invocation(
+        invocation,
+        readback,
+    )
+    assert material == {"effect-scoped-assertion-1"}
+    assert verified == {"effect-scoped-assertion-1"}
+    wrong_scope_readback = dict(readback)
+    wrong_scope_readback["scope_mode"] = "user"
+    assert not _canonical_scoped_assertion_readback_matches_invocation(
+        invocation,
+        wrong_scope_readback,
+    )
+    wrong_object_readback = dict(readback)
+    wrong_object_readback["object_text_identity_sha256"] = "wrong"
+    assert not _canonical_scoped_assertion_readback_matches_invocation(
+        invocation,
+        wrong_object_readback,
+    )
+    wrong_actor_readback = dict(readback)
+    wrong_actor_readback["trusted_scope_identity_sha256"] = "wrong"
+    assert not _canonical_scoped_assertion_readback_matches_invocation(
+        invocation,
+        wrong_actor_readback,
+    )
+    mismatched_namespace_record = json.loads(json.dumps(canonical_record))
+    mismatched_namespace_record["scope"]["namespace"] = "#V#other@org"
+    mismatched_namespace_readback = _canonical_effect_readback_receipt(
+        {"canonical_read_back": mismatched_namespace_record}
+    )
+    assert mismatched_namespace_readback is not None
+    assert "trusted_scope_identity_sha256" not in mismatched_namespace_readback
+    wrong_audience_record = json.loads(json.dumps(canonical_record))
+    wrong_audience_record["scope"]["audience_keys"] = ["org:#V#other"]
+    wrong_audience_readback = _canonical_effect_readback_receipt(
+        {"canonical_read_back": wrong_audience_record}
+    )
+    assert wrong_audience_readback is not None
+    assert "trusted_scope_identity_sha256" not in wrong_audience_readback
+    assert not _canonical_scoped_assertion_readback_matches_invocation(
+        invocation,
+        wrong_audience_readback,
+    )
+    extra_audience_record = json.loads(json.dumps(canonical_record))
+    extra_audience_record["scope"]["audience_keys"] = [
+        "org:#V#org",
+        "user:#V#person",
+    ]
+    extra_audience_readback = _canonical_effect_readback_receipt(
+        {"canonical_read_back": extra_audience_record}
+    )
+    assert extra_audience_readback is not None
+    assert "trusted_scope_identity_sha256" not in extra_audience_readback
+    assert not _canonical_scoped_assertion_readback_matches_invocation(
+        invocation,
+        extra_audience_readback,
     )
 
 
@@ -3430,6 +3547,7 @@ def test_canonical_text_denial_exposes_scoped_assertion_recovery(
     monkeypatch,
 ) -> None:
     from src.backend.db import mongo_client
+    from src.backend.services import ontology_mutation_command_service
 
     class _Collection:
         def find_one(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
@@ -3439,6 +3557,18 @@ def test_canonical_text_denial_exposes_scoped_assertion_recovery(
         mongo_client,
         "get_concepts_collection",
         lambda: _Collection(),
+    )
+    original_is_ontology_mutation_method = (
+        ontology_mutation_command_service.is_ontology_mutation_method
+    )
+    monkeypatch.setattr(
+        ontology_mutation_command_service,
+        "is_ontology_mutation_method",
+        lambda method: (
+            False
+            if method == "upsert_text_relation"
+            else original_is_ontology_mutation_method(method)
+        ),
     )
     invoked: list[tuple[str, dict[str, Any]]] = []
 
@@ -8798,8 +8928,22 @@ def test_failed_workflow_and_later_direct_trip_effects_preserve_only_verified_an
 ) -> None:
     """Regress request 95c16c12: a failed route must not erase verified recovery."""
 
+    from src.backend.services import ontology_mutation_command_service
     from src.backend.services.workflow_turn_capability_service import (
         WorkflowTurnCapability,
+    )
+
+    original_is_ontology_mutation_method = (
+        ontology_mutation_command_service.is_ontology_mutation_method
+    )
+    monkeypatch.setattr(
+        ontology_mutation_command_service,
+        "is_ontology_mutation_method",
+        lambda method: (
+            False
+            if method in {"create_concepts", "add_relationship"}
+            else original_is_ontology_mutation_method(method)
+        ),
     )
 
     workflow_capability = WorkflowTurnCapability(
@@ -9040,6 +9184,368 @@ def test_failed_workflow_and_later_direct_trip_effects_preserve_only_verified_an
         assert preservation["known_no_change_count"] == 0
     else:
         assert useful_answer not in result.response_text
+
+
+def test_failed_workflows_and_recovered_denials_preserve_verified_scoped_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regress c8df245c: exact scoped recoveries must survive mixed failures."""
+
+    from src.backend.services.workflow_turn_capability_service import (
+        WorkflowTurnCapability,
+    )
+
+    delegation_calls: list[dict[str, Any]] = []
+
+    def deny_global_publication_delegation(**kwargs: Any) -> dict[str, Any]:
+        delegation_calls.append(dict(kwargs))
+        return {
+            "success": False,
+            "effect_status": "not_started",
+            "mutation_outcome": "not_started",
+            "changed": False,
+            "error_code": "global_ontology_admin_authority_required",
+            "error": "Semantic ontology authority is required for this effect.",
+            "recovery_affordances": [
+                {"action_type": "create_scoped_assertion"},
+                {"action_type": "request_ontology_administrator_delegation"},
+            ],
+        }
+
+    monkeypatch.setattr(
+        "src.backend.services.ontology_mutation_command_service."
+        "issue_same_turn_method_delegation",
+        deny_global_publication_delegation,
+    )
+    workflow_capability = WorkflowTurnCapability(
+        name="represented_workflow_file_copy_interpretation_test",
+        workflow_id="#V#file_copy_interpretation_test_workflow",
+        display_name="File-copy interpretation test workflow",
+        description="Interpret one durable file copy.",
+        relevance_score=0.99,
+        semantic_effect=True,
+        semantic_effect_source="represented_workflow_declaration",
+        input_schema={
+            "type": "object",
+            "properties": {"inputs": {"type": "object", "additionalProperties": True}},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.workflow_turn_capability_service."
+        "discover_turn_workflow_capabilities",
+        lambda *_args, **_kwargs: (
+            [workflow_capability],
+            {
+                "schema_version": "workflow_turn_capability_discovery.v1",
+                "status": "completed",
+                "match_count": 1,
+            },
+        ),
+    )
+    instance_by_file_copy = {
+        "#V#file_copy_student_a": "workflow-file-copy-student-a-failed",
+        "#V#file_copy_student_b": "workflow-file-copy-student-b-failed",
+    }
+
+    def execute_workflow(**kwargs: Any) -> dict[str, Any]:
+        file_copy_id = kwargs["inputs"]["file_copy_concept_id"]
+        return {
+            "success": True,
+            "instance_id": instance_by_file_copy[file_copy_id],
+            "workflow_id": workflow_capability.workflow_id,
+            "created_new": True,
+            "final_status": "failed",
+            "workflow_execution": {
+                "final_status": "failed",
+                "error": ("metadata_read_context_key_missing:concept_id"),
+            },
+        }
+
+    def read_instance(**kwargs: Any) -> dict[str, Any]:
+        return {
+            "success": True,
+            "instance_id": kwargs["instance_id"],
+            "workflow_id": workflow_capability.workflow_id,
+            "status": "failed",
+        }
+
+    gateway = _workflow_gateway(
+        execute_workflow,
+        hard_timeout_enabled=False,
+        instance_handler=read_instance,
+    )
+    denied_handler_calls: list[dict[str, Any]] = []
+
+    def should_be_denied(**kwargs: Any) -> dict[str, Any]:
+        denied_handler_calls.append(dict(kwargs))
+        return {"success": True, "effect_status": "succeeded", "changed": True}
+
+    gateway._catalogue.register(
+        MethodDefinition(
+            name="upsert_text_relation",
+            handler=should_be_denied,
+            input_schema=Schema(allow_unknown=True),
+            output_schema=Schema(required={"success": bool}, allow_unknown=True),
+            category="write",
+            ordinary_turn_effect=True,
+            ordinary_turn_mutation_subject_argument="concept_id",
+            ordinary_turn_trusted_argument_bindings={
+                "namespace": "turn_namespace",
+            },
+            ordinary_turn_fixed_arguments={"provenance": None},
+        )
+    )
+
+    def persist_scoped_assertion(**kwargs: Any) -> dict[str, Any]:
+        subject_id = kwargs["subject_concept_id"]
+        assertion_id = f"ska_{subject_id.removeprefix('#V#')}"
+        readback = {
+            "schema_version": "scoped_knowledge_assertion.v1",
+            "assertion_id": assertion_id,
+            "subject_concept_id": subject_id,
+            "predicate": kwargs["predicate"],
+            "object_kind": "text",
+            "object_text": {
+                "text": kwargs["target_text"],
+                "language": kwargs.get("language") or "en-NZ",
+            },
+            "object_concept_id": None,
+            "scope": {
+                "mode": kwargs["scope_mode"],
+                "user_concept_id": kwargs["acting_user_concept_id"],
+                "organisation_concept_id": kwargs["organisation_concept_id"],
+                "namespace": kwargs["namespace"],
+                "audience_keys": [
+                    f"org:{kwargs['organisation_concept_id']}"
+                ],
+            },
+            "provenance": {
+                "asserted_by_user_concept_id": kwargs["acting_user_concept_id"],
+                "organisation_concept_id": kwargs["organisation_concept_id"],
+                "namespace": kwargs["namespace"],
+            },
+            "canonical_publication": False,
+            "status": "asserted",
+        }
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "assertion_id": assertion_id,
+            "assertion": readback,
+            "canonical_read_back": readback,
+            "canonical_publication": False,
+            "storage_surface": "scoped_knowledge_assertions",
+        }
+
+    gateway._catalogue.register(
+        MethodDefinition(
+            name="upsert_scoped_assertion",
+            handler=persist_scoped_assertion,
+            input_schema=Schema(allow_unknown=True),
+            output_schema=Schema(required={"success": bool}, allow_unknown=True),
+            category="write",
+            ordinary_turn_effect=True,
+            ordinary_turn_trusted_argument_bindings={
+                "acting_user_concept_id": "actor_user_concept_id",
+                "organisation_concept_id": "actor_organisation_concept_id",
+                "namespace": "turn_namespace",
+            },
+            ordinary_turn_fixed_arguments={"canonical_publication": False},
+        )
+    )
+    gateway.register_metrics_if_missing("upsert_text_relation")
+    gateway.register_metrics_if_missing("upsert_scoped_assertion")
+
+    descriptions = {
+        "#V#student_a": "Studies robust multimodal learning.",
+        "#V#student_b": "Studies gradient formation and reshaping.",
+    }
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_capabilities",
+                    call_id="discover-file-copy-workflow",
+                    payload={"query": "interpret the two durable file copies"},
+                )
+            ],
+        ),
+        *[
+            LLMResponse(
+                text_response="",
+                tool_calls=[
+                    ToolCall(
+                        tool_name="turn_invoke_capability",
+                        call_id=f"interpret-{index}",
+                        payload={
+                            "name": workflow_capability.name,
+                            "arguments": {
+                                "inputs": {
+                                    "file_copy_concept_id": file_copy_id,
+                                }
+                            },
+                        },
+                    )
+                ],
+            )
+            for index, file_copy_id in enumerate(instance_by_file_copy, start=1)
+        ],
+        *[
+            LLMResponse(
+                text_response="",
+                tool_calls=[
+                    ToolCall(
+                        tool_name="turn_invoke_capability",
+                        call_id=f"read-failed-workflow-{index}",
+                        payload={
+                            "name": "workflow_get_instance",
+                            "arguments": {"instance_id": instance_id},
+                        },
+                    )
+                ],
+            )
+            for index, instance_id in enumerate(
+                instance_by_file_copy.values(),
+                start=1,
+            )
+        ],
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id=f"deny-canonical-description-{index}",
+                    payload={
+                        "name": "upsert_text_relation",
+                        "arguments": {
+                            "concept_id": subject_id,
+                            "predicate": "hasDescription",
+                            "text": description,
+                            "language": "en-NZ",
+                        },
+                    },
+                )
+                for index, (subject_id, description) in enumerate(
+                    descriptions.items(),
+                    start=1,
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id=f"persist-scoped-description-{index}",
+                    payload={
+                        "name": "upsert_scoped_assertion",
+                        "arguments": {
+                            "subject_concept_id": subject_id,
+                            "predicate": "hasDescription",
+                            "target_text": description,
+                            "language": "en-NZ",
+                            "scope_mode": "organisation",
+                        },
+                    },
+                )
+                for index, (subject_id, description) in enumerate(
+                    descriptions.items(),
+                    start=1,
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response=(
+                "Both research descriptions were durably read back as "
+                "organisation-scoped assertions."
+            )
+        ),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=gateway,
+        prompt="Add research descriptions for those two students.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="turn-c8df245c-mixed-recovery",
+        turn_budget_seconds=20,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert denied_handler_calls == []
+    assert len(delegation_calls) == 2
+    assert all(
+        call["method_name"] == "upsert_text_relation"
+        for call in delegation_calls
+    )
+    assert {
+        call["arguments"]["concept_id"] for call in delegation_calls
+    } == set(descriptions)
+    assert all(call["actor_concept_id"] == "#V#person" for call in delegation_calls)
+    assert all(
+        call["organisation_concept_id"] == "#V#org"
+        for call in delegation_calls
+    )
+    assert result.terminal_status == "effect_partially_completed"
+    assert result.effect_finality_fallback is False
+    assert "Both research descriptions were durably read back" in (result.response_text)
+    assert "2 failed represented-workflow attempts" in result.response_text
+    effects = [
+        invocation
+        for invocation in result.tool_invocations
+        if invocation.get("effect_id")
+    ]
+    assert len(effects) == 6
+    workflows = [
+        invocation
+        for invocation in effects
+        if invocation.get("capability_kind") == "represented_workflow"
+    ]
+    assert len(workflows) == 2
+    assert all(invocation["effect_status"] == "failed" for invocation in workflows)
+    assert all(invocation["changed"] is True for invocation in workflows)
+    denials = [
+        invocation
+        for invocation in effects
+        if invocation.get("tool") == "upsert_text_relation"
+    ]
+    recoveries = [
+        invocation
+        for invocation in effects
+        if invocation.get("tool") == "upsert_scoped_assertion"
+    ]
+    assert len(denials) == len(recoveries) == 2
+    assert all(invocation["effect_status"] == "not_started" for invocation in denials)
+    assert all(
+        invocation["error_code"] == "global_ontology_admin_authority_required"
+        for invocation in denials
+    )
+    assert all(invocation["changed"] is False for invocation in denials)
+    assert all(invocation["recovery_status"] == "succeeded" for invocation in denials)
+    assert {invocation["recovered_by_effect_id"] for invocation in denials} == {
+        invocation["effect_id"] for invocation in recoveries
+    }
+    assert all(invocation["changed"] is True for invocation in recoveries)
+    assert all(
+        invocation["canonical_readback"]["scope_mode"] == "organisation"
+        for invocation in recoveries
+    )
+    preservation = next(
+        item
+        for item in result.aux_llm_calls
+        if item.get("type") == "adaptive_turn_mixed_effect_response_preserved"
+    )
+    assert preservation["preservation_basis"] == (
+        "failed_workflow_and_material_successes_exactly_read_back"
+    )
+    assert preservation["failed_workflow_count"] == 2
+    assert preservation["canonically_verified_succeeded_count"] == 2
 
 
 def test_pending_durable_response_with_exact_handle_is_preserved(monkeypatch) -> None:

--- a/tests/backend/test_file_copy_interpretation_workflow.py
+++ b/tests/backend/test_file_copy_interpretation_workflow.py
@@ -1,11 +1,28 @@
 from __future__ import annotations
 
-from src.backend.workflows.action_registry import ActionRegistry
+from src.backend.services.workflow_turn_capability_service import (
+    _workflow_model_input_schema,
+)
+from src.backend.workflows.action_registry import (
+    ActionRegistry,
+    ActionSpec,
+    WorkflowActionRequest,
+    WorkflowActionResult,
+    WorkflowEnvironment,
+)
 from src.backend.workflows.durable.file_copy_interpretation_workflow import (
+    FILE_COPY_INTERPRETATION_LAUNCH_INPUT_CONTRACT,
     FILE_COPY_INTERPRETATION_WORKFLOW_ID,
     build_file_copy_interpretation_workflow_test_definition,
     build_file_copy_interpretation_workflow_test_registration,
     register_file_copy_interpretation_actions,
+)
+from src.backend.workflows.engine import WorkflowExecutor
+from src.backend.workflows.workflow_concept_authority_service import (
+    build_repo_seed_workflow_definitions,
+)
+from src.backend.workflows.workflow_launch_input_contracts import (
+    resolve_workflow_launch_inputs,
 )
 
 
@@ -16,26 +33,29 @@ def test_build_file_copy_interpretation_workflow_test_definition_definition_shap
     assert workflow.initial_state == "interpret"
     assert set(workflow.states.keys()) == {"interpret", "index", "complete", "failed"}
     assert workflow.termination_states == ("complete", "failed")
+    assert workflow.metadata["launch_input_contract"] == (
+        FILE_COPY_INTERPRETATION_LAUNCH_INPUT_CONTRACT
+    )
 
     interpret_actions = [action.action_id for action in workflow.states["interpret"].actions]
     assert interpret_actions == ["interpret_file_copy"]
     interpret_inputs = dict(workflow.states["interpret"].actions[0].inputs)
-    assert interpret_inputs["concept_id"]["$context_key"] == "concept_id"
+    assert set(interpret_inputs) == {"concept_id"}
+    assert interpret_inputs["concept_id"]["$context_key"] == "file_copy_concept_id"
     assert (
         interpret_inputs["concept_id"]["$mapping_concept_id"]
-        == "#V#workflow_mapping_concept_id_to_concept_id_parameter"
-    )
-    assert (
-        interpret_inputs["file_copy_concept_id"]["$context_key"]
-        == "file_copy_concept_id"
+        == "#V#workflow_mapping_file_copy_interpretation_workflow_interpret_"
+        "file_copy_concept_id_to_concept_id_parameter"
     )
     index_actions = [action.action_id for action in workflow.states["index"].actions]
     assert index_actions == ["index_file_copy"]
     index_inputs = dict(workflow.states["index"].actions[0].inputs)
-    assert index_inputs["concept_id"]["$context_key"] == "concept_id"
+    assert set(index_inputs) == {"concept_id"}
+    assert index_inputs["concept_id"]["$context_key"] == "file_copy_concept_id"
     assert (
-        index_inputs["file_copy_concept_id"]["$mapping_concept_id"]
-        == "#V#workflow_mapping_file_copy_concept_id_to_file_copy_concept_id_parameter"
+        index_inputs["concept_id"]["$mapping_concept_id"]
+        == "#V#workflow_mapping_file_copy_interpretation_workflow_index_"
+        "file_copy_concept_id_to_concept_id_parameter"
     )
 
 
@@ -45,6 +65,99 @@ def test_build_file_copy_interpretation_workflow_test_registration() -> None:
     assert registration.workflow_id == FILE_COPY_INTERPRETATION_WORKFLOW_ID
     assert registration.source == "built_in"
     assert registration.definition.workflow_id == FILE_COPY_INTERPRETATION_WORKFLOW_ID
+
+
+def test_repo_seed_launch_contract_exposes_only_file_copy_identifier() -> None:
+    workflow = build_repo_seed_workflow_definitions(
+        target_workflow_ids=[FILE_COPY_INTERPRETATION_WORKFLOW_ID]
+    )[FILE_COPY_INTERPRETATION_WORKFLOW_ID]
+    launch_contract = workflow.metadata.get("launch_input_contract")
+
+    assert launch_contract == FILE_COPY_INTERPRETATION_LAUNCH_INPUT_CONTRACT
+    assert workflow.metadata.get("launch_input_contract_source") == (
+        "repo_seed_bundle:launch_input_contract"
+    )
+
+    file_copy_id = "#V#computer_file_copy_launch_contract_regression"
+    resolution = resolve_workflow_launch_inputs(
+        workflow_id=FILE_COPY_INTERPRETATION_WORKFLOW_ID,
+        contract=launch_contract,
+        inputs={"file_copy_concept_id": file_copy_id},
+        contract_source=workflow.metadata.get("launch_input_contract_source"),
+    )
+
+    assert resolution.unresolved_required_inputs == ()
+    assert resolution.resolved_inputs == {"file_copy_concept_id": file_copy_id}
+
+    model_schema = _workflow_model_input_schema(launch_contract)
+    inputs_schema = model_schema["properties"]["inputs"]
+    assert list(inputs_schema["properties"]) == ["file_copy_concept_id"]
+    assert inputs_schema["required"] == ["file_copy_concept_id"]
+    assert [
+        mapping["target_context_key"]
+        for mapping in model_schema["x-von-represented-launch-input-mappings"]
+    ] == ["file_copy_concept_id"]
+
+
+def test_repo_seed_single_file_copy_input_passes_metadata_validation() -> None:
+    workflow = build_repo_seed_workflow_definitions(
+        target_workflow_ids=[FILE_COPY_INTERPRETATION_WORKFLOW_ID]
+    )[FILE_COPY_INTERPRETATION_WORKFLOW_ID]
+    file_copy_id = "#V#computer_file_copy_metadata_regression"
+    conflicting_legacy_id = "#V#computer_file_copy_wrong_legacy_alias"
+    resolution = resolve_workflow_launch_inputs(
+        workflow_id=FILE_COPY_INTERPRETATION_WORKFLOW_ID,
+        contract=workflow.metadata.get("launch_input_contract"),
+        inputs={
+            "file_copy_concept_id": file_copy_id,
+            "concept_id": conflicting_legacy_id,
+        },
+        contract_source=workflow.metadata.get("launch_input_contract_source"),
+    )
+    execution_data = {
+        "file_copy_concept_id": file_copy_id,
+        "concept_id": conflicting_legacy_id,
+    }
+    execution_data.update(resolution.resolved_inputs)
+
+    for state_id in ("interpret", "index"):
+        state = workflow.states[state_id]
+        assert state.metadata["reads_context_keys"] == ["file_copy_concept_id"]
+        assert set(state.actions[0].inputs) == {"concept_id"}
+        assert state.actions[0].inputs["concept_id"]["$context_key"] == (
+            "file_copy_concept_id"
+        )
+
+    observed_inputs: list[dict[str, object]] = []
+
+    def record_inputs(request: WorkflowActionRequest) -> WorkflowActionResult:
+        observed_inputs.append(dict(request.inputs))
+        return WorkflowActionResult(status="success", outputs={})
+
+    registry = ActionRegistry()
+    registry.register(
+        ActionSpec(action_id="interpret_file_copy", handler=record_inputs)
+    )
+    registry.register(ActionSpec(action_id="index_file_copy", handler=record_inputs))
+
+    result = WorkflowExecutor(registry=registry, max_transitions=5).run(
+        workflow,
+        environment=WorkflowEnvironment(llm_client=None),
+        data=execution_data,
+    )
+
+    assert result.completed is True
+    assert result.final_state == "complete"
+    assert result.error is None
+    assert len(observed_inputs) == 2
+    assert observed_inputs == [
+        {"concept_id": file_copy_id},
+        {"concept_id": file_copy_id},
+    ]
+    validation_events = result.data.get("workflow_metadata_validation_events", [])
+    assert len(validation_events) == 2
+    assert all(event.get("phase") == "pre_action" for event in validation_events)
+    assert all(event.get("ok") is True for event in validation_events)
 
 
 def test_register_file_copy_interpretation_actions_is_noop() -> None:

--- a/tests/backend/test_workflow_concept_authority_service.py
+++ b/tests/backend/test_workflow_concept_authority_service.py
@@ -1023,6 +1023,65 @@ def test_bootstrap_publishes_explicit_step_conditions_for_canonical_durable_work
         },
     ]
 
+
+def test_repo_seed_materialises_file_copy_interpretation_single_input_contract(
+    _reset_mock_workflow_graph_db,
+):
+    from src.backend.services.workflow_repo_seed_bootstrap import (
+        bootstrap_repo_seed_workflow_bundle,
+    )
+    from src.backend.workflows.durable.file_copy_interpretation_workflow import (
+        FILE_COPY_INTERPRETATION_LAUNCH_INPUT_CONTRACT,
+        FILE_COPY_INTERPRETATION_WORKFLOW_ID,
+    )
+    from src.backend.workflows.vontology_loader import (
+        load_workflow_definition_from_vontology,
+    )
+
+    report = bootstrap_repo_seed_workflow_bundle(
+        asset_path=authority_service._CANONICAL_WORKFLOW_PUBLICATION_SEED_BUNDLE_PATH,
+        target_workflow_ids=(FILE_COPY_INTERPRETATION_WORKFLOW_ID,),
+    )
+
+    assert report["publication"]["errors_by_workflow_id"] == {}
+    loaded = load_workflow_definition_from_vontology(
+        FILE_COPY_INTERPRETATION_WORKFLOW_ID
+    )
+    assert loaded is not None
+    assert loaded.metadata["launch_input_contract"] == (
+        FILE_COPY_INTERPRETATION_LAUNCH_INPUT_CONTRACT
+    )
+    assert loaded.metadata["launch_input_contract_source"] == (
+        "text_relation:#V#hasWorkflowLaunchInputContractJson"
+    )
+
+    expected_mapping_ids = {
+        "interpret": (
+            "#V#workflow_mapping_file_copy_interpretation_workflow_interpret_"
+            "file_copy_concept_id_to_concept_id_parameter"
+        ),
+        "index": (
+            "#V#workflow_mapping_file_copy_interpretation_workflow_index_"
+            "file_copy_concept_id_to_concept_id_parameter"
+        ),
+    }
+    for state_id, mapping_id in expected_mapping_ids.items():
+        loaded_state_id = authority_service._step_concept_id(
+            workflow_id=FILE_COPY_INTERPRETATION_WORKFLOW_ID,
+            state_id=state_id,
+        )
+        state = loaded.states[loaded_state_id]
+        assert state.metadata["reads_context_keys"] == ["file_copy_concept_id"]
+        assert len(state.actions) == 1
+        assert state.actions[0].inputs == {
+            "concept_id": {
+                "$context_key": "file_copy_concept_id",
+                "$mapping_concept_id": mapping_id,
+                "$required": True,
+            }
+        }
+
+
 def test_bootstrap_publishes_file_copy_upload_handler_dynamic_subworkflow_contract(
     _reset_mock_workflow_graph_db,
 ):


### PR DESCRIPTION
## What changed

- repair the represented file-copy interpretation workflow so its launch contract requires only `file_copy_concept_id` and both workflow steps map that context value to the underlying `concept_id` tool argument
- publish the corrected contract in canonical workflow seed 50
- attach an exact `upsert_scoped_assertion` recovery action to governed canonical-write denials
- reconcile known-no-change `not_started` denials only after an exact successful scoped recovery
- verify scoped assertion read-back against subject, predicate, object and language, actor, organisation, namespace, singleton audience, status, provenance and non-publication
- preserve the useful verified answer when failed represented-workflow attempts coexist with canonically read-back scoped results
- align adaptive-turn fixtures with the current ontology-governance boundary

## Root cause

The file-copy workflow publication required both legacy `concept_id` and `file_copy_concept_id` context keys even though the invoked tools accept one concept identifier. The workflow therefore failed metadata validation before executing. In the recovery path, governed denials were recorded as `not_started`, but their generic recovery hint did not carry exact executable arguments and finality could not prove that the later scoped write recovered the denied semantic effect.

## Impact

A durable file copy can now launch the interpretation workflow with its single intended identifier. When canonical publication is correctly denied and an actor-scoped assertion succeeds, the turn reports the verified user outcome without misrepresenting the denied canonical mutation as successful.

## Validation

- `tests/backend/test_adaptive_turn_service.py`: 162 passed
- workflow publication/discovery group: 156 passed
- ontology publication/creation authority: 18 passed
- internal MCP scoped-assertion authority: 13 passed
- file-copy interpretation service: 4 passed
- JSON validation, seed-version guard and `git diff --check`: passed

## Known baseline limitation

Three scoped-assertion listing tests fail under `VON_USE_MOCK_DB=1` because their visibility fixtures do not populate or stub the concept visibility batch. The exact failures reproduce on `origin/main` and this branch does not modify that service or those tests.