### PR TITLE
Add Mongo query-stats telemetry

### DIFF
--- a/docs/engineering/mongo_query_targeting_diagnostics.md
+++ b/docs/engineering/mongo_query_targeting_diagnostics.md
@@ -3,17 +3,19 @@
 **Status:** Operational guide  
 **Related Jira:** `JVNAUTOSCI-2429`, `JVNAUTOSCI-2428`, `JVNAUTOSCI-2427`, `JVNAUTOSCI-2426`
 
-Von now has six complementary Mongo query-targeting and cost diagnostics
+Von now has seven complementary Mongo query-targeting and cost diagnostics
 surfaces:
 
 1. In-process slow command telemetry from the global PyMongo command listener.
 2. A bounded profiler report command over MongoDB `system.profile`.
-3. A read-only Atlas Admin API report for Query Shape Insights.
-4. A read-only Atlas report review loop that compares reports and drafts or
+3. A bounded, read-only `$queryStats` report from the configured MongoDB
+   deployment.
+4. A read-only Atlas Admin API report for Query Shape Insights.
+5. A read-only Atlas report review loop that compares reports and drafts or
    upserts Jira review tasks.
-5. A Von-internal MCP tool, `mongo_query_diagnostics_report`, for trusted
+6. A Von-internal MCP tool, `mongo_query_diagnostics_report`, for trusted
    operator conversation and VWL maintenance workflows.
-6. A compact cost guardrail report at `/api/settings/db/guardrails` and through
+7. A compact cost guardrail report at `/api/settings/db/guardrails` and through
    the Von-internal MCP tool `mongo_cost_guardrails_report`.
 
 These surfaces are designed as support plumbing only. They record query shape,
@@ -50,6 +52,8 @@ The report includes:
 - slow operation counts using `VON_MONGO_OPERATION_AUDIT_SLOW_MS`
 - background and poller route activity
 - ranked redacted query-shape telemetry
+- the last successful bounded `$queryStats` snapshot, its collection status,
+  and freshness metadata
 - size-only large write attempts observed by the PyMongo command listener
 - blob/debug/workflow hydration counters grouped by family and cache status
 - runtime posture: local, remote, or Atlas, with credentials removed
@@ -86,7 +90,8 @@ Slow command listener rows can retain:
 - returned count when available from the command reply
 - safe profiler comment attribution such as Von service, operation, and route
 
-Profiler, explain-backed, and Atlas rows can additionally include:
+`$queryStats`, profiler, explain-backed, and Atlas rows can additionally
+include:
 
 - `docsExamined`
 - `keysExamined`
@@ -134,7 +139,9 @@ profiler entries. The report prints execution stats and shapes, not returned
 documents. Keep the sample count low on a busy database.
 
 If `system.profile` is unavailable, use Atlas Query Insights or Performance
-Advisor for the same time window.
+Advisor for the same time window, or use the `query_stats` source described
+below. `$queryStats` counters are cumulative for the current MongoDB member and
+are not a substitute for an exact Atlas time window.
 
 ## Running The Atlas Report
 
@@ -232,9 +239,12 @@ Fields to inspect:
 ## Reconciling With Atlas
 
 Atlas Query Insights and Performance Advisor use cluster-side telemetry. Von's
-local command listener sees only operations from the current process, and the
+local command listener sees only operations from the current process, the
 profiler report sees only what Mongo profiling captured for the selected
-database and time window. Differences are expected.
+database and time window, and `$queryStats` exposes cumulative statistics for
+the current MongoDB member. Member restarts, Atlas sampling, topology, and the
+selected Atlas window can all produce different counts. Differences are
+expected.
 
 Recommended reconciliation loop:
 
@@ -365,10 +375,10 @@ sample counts and max time bounded.
 
 ## Running Diagnostics Through Von
 
-`JVNAUTOSCI-2450` exposes the local Mongo query-targeting diagnostic as the
-internal MCP tool `mongo_query_diagnostics_report`. This is the conversation and
-workflow-facing form of the local profiler/in-process report; it does not shell
-out to `scripts/mongo_query_targeting_report.py`.
+`JVNAUTOSCI-2450` exposes Mongo query-targeting diagnostics as the internal MCP
+tool `mongo_query_diagnostics_report`. This is the conversation and
+workflow-facing form of the in-process, profiler, and `$queryStats` reports; it
+does not shell out to `scripts/mongo_query_targeting_report.py`.
 
 The tool is read-only and requires an explicit operator gate:
 
@@ -390,7 +400,29 @@ Supported `source` values:
 - `in_process`: current-process command-listener telemetry only.
 - `profiler`: bounded `system.profile` samples, optionally with read-only
   `explain("executionStats")`.
-- `combined`: both surfaces, with a merged ranked summary.
+- `query_stats`: bounded, server-ranked `$queryStats` counters for the
+  configured database. The aggregation runs on `admin`, has a 5-second
+  `maxTimeMS`, groups by query-shape hash, and returns at most the bounded sample
+  limit plus one truncation sentinel before redaction.
+- `combined`: all three surfaces, with a merged ranked summary.
+
+`$queryStats` requires a compatible MongoDB deployment and the
+`queryStatsRead` privilege (included in `clusterMonitor`). When it is
+unsupported or unauthorised, the source returns a typed
+`query_stats_unavailable` report and `combined` continues with the other
+available sources. Von does not enable profiling or change MongoDB roles.
+
+The `$queryStats` adapter retains only database/collection names,
+field/operator shape strings, the query-shape hash, aggregate counters,
+scanned/returned ratios, timestamps, and sort/disk flags. Raw query-shape
+documents and literal values do not enter the returned report. A successful
+collection replaces an in-memory redacted snapshot used by
+`/api/settings/db/guardrails`; ordinary guardrail reads never issue a fresh
+MongoDB diagnostic query. Run the maintenance workflow or operator diagnostic
+again to refresh it, and inspect `snapshot_refresh` and
+`latest_seen_at_utc` before treating the data as current. The first/latest
+timestamps describe the selected server-ranked shapes, not every shape in the
+MongoDB query-statistics store.
 
 Use `mongo_namespace` for Mongo namespaces such as
 `von_db.workflow_instances`. The normal Von `namespace` argument is accepted for

--- a/src/backend/db/mongo_client.py
+++ b/src/backend/db/mongo_client.py
@@ -76,6 +76,23 @@ def _command_shape_from_started_command(event) -> dict[str, object]:
         return {"collection": coll, "filter_shape": filter_shape}
 
 
+def _is_query_stats_diagnostic_command(event) -> bool:
+    if str(getattr(event, "command_name", "") or "") != "aggregate":
+        return False
+    if str(getattr(event, "database_name", "") or "") != "admin":
+        return False
+    command = getattr(event, "command", None)
+    if not isinstance(command, Mapping):
+        return False
+    pipeline = command.get("pipeline")
+    return bool(
+        isinstance(pipeline, list)
+        and pipeline
+        and isinstance(pipeline[0], Mapping)
+        and "$queryStats" in pipeline[0]
+    )
+
+
 def _safe_mongo_failure_summary(failure) -> dict[str, object]:
     """Summarise a PyMongo command failure without raw command/server bodies."""
 
@@ -124,6 +141,8 @@ class _VonMongoFailureLogger(monitoring.CommandListener):
                 # only as missing context on subsequent failures.
                 return
             shape = _command_shape_from_started_command(event)
+            if _is_query_stats_diagnostic_command(event):
+                shape["skip_query_shape_telemetry"] = True
             self._in_flight[event.request_id] = shape
         warning = observe_mongo_write_command_size(
             command_name=str(getattr(event, "command_name", "") or ""),
@@ -168,6 +187,8 @@ class _VonMongoFailureLogger(monitoring.CommandListener):
         )
         if duration_ms < self._SLOW_COMMAND_DURATION_MS:
             return
+        if shape.get("skip_query_shape_telemetry"):
+            return
         n_returned = extract_n_returned_from_reply(
             command_name,
             getattr(event, "reply", None),
@@ -210,14 +231,15 @@ class _VonMongoFailureLogger(monitoring.CommandListener):
             success=False,
             error_type=type(getattr(event, "failure", None)).__name__,
         )
-        record_mongo_command_observation(
-            command_name=command_name,
-            database=str(getattr(event, "database_name", "") or ""),
-            command_shape=shape,
-            duration_ms=duration_ms if duration_ms >= 0 else None,
-            request_id=getattr(event, "request_id", ""),
-            source="command_listener_failure",
-        )
+        if not shape.get("skip_query_shape_telemetry"):
+            record_mongo_command_observation(
+                command_name=command_name,
+                database=str(getattr(event, "database_name", "") or ""),
+                command_shape=shape,
+                duration_ms=duration_ms if duration_ms >= 0 else None,
+                request_id=getattr(event, "request_id", ""),
+                source="command_listener_failure",
+            )
         logger.warning(
             "[mongo_command_failed] cmd=%s db=%s coll=%s filter_shape=%s sort_shape=%s "
             "projection_shape=%s duration_ms=%.1f request_id=%s failure_summary=%r",

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -23696,7 +23696,7 @@ def _mongo_query_diagnostics_report(**kwargs):
             details={"exception_type": type(exc).__name__},
             suggestions=[
                 "Retry with allow_operator_diagnostics=true only for trusted operator diagnostics",
-                "Use source='in_process' if Mongo profiler is unavailable",
+                "Use source='query_stats' or 'in_process' if Mongo profiler is unavailable",
                 "Use Atlas Query Insights for cluster-side evidence when Atlas credentials are configured",
             ],
         )
@@ -38709,7 +38709,12 @@ def _build_default_catalogue_diagnostics_and_research_definitions() -> List[
                 },
                 allow_unknown=True,
                 enum_values={
-                    "source": ("combined", "in_process", "profiler"),
+                    "source": (
+                        "combined",
+                        "in_process",
+                        "profiler",
+                        "query_stats",
+                    ),
                 },
                 description=(
                     "Build a bounded, redacted Mongo query-targeting diagnostics report. "
@@ -38725,8 +38730,9 @@ def _build_default_catalogue_diagnostics_and_research_definitions() -> List[
             description=(
                 "Run read-only Mongo query-targeting diagnostics for trusted operator "
                 "conversation or VWL maintenance workflows. Reports structural query "
-                "shapes, scanned/returned ratios, plan/index evidence where available, "
-                "and recommended next diagnostic steps. Never creates/drops indexes or "
+                "shapes, $queryStats scanned/returned ratios, plan/index evidence where "
+                "available, and recommended next diagnostic steps. Never creates/drops "
+                "indexes or "
                 "returns credentials, .env contents, query values, update values, or "
                 "document bodies."
             ),

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -3841,7 +3841,7 @@
         },
         {
             "name": "mongo_query_diagnostics_report",
-            "description": "Run read-only Mongo query-targeting diagnostics for trusted operator conversation or VWL maintenance workflows. Reports structural query shapes, scanned/returned ratios, plan/index evidence where available, and recommended next diagnostic steps. Never creates/drops indexes or returns credentials, .env contents, query values, update values, or document bodies.",
+            "description": "Run read-only Mongo query-targeting diagnostics for trusted operator conversation or VWL maintenance workflows. Reports structural query shapes, $queryStats scanned/returned ratios, plan/index evidence where available, and recommended next diagnostic steps. Never creates/drops indexes or returns credentials, .env contents, query values, update values, or document bodies.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -3856,7 +3856,8 @@
                         "enum": [
                             "combined",
                             "in_process",
-                            "profiler"
+                            "profiler",
+                            "query_stats"
                         ]
                     },
                     "mongo_namespace": {

--- a/src/backend/services/mongo_observability_service.py
+++ b/src/backend/services/mongo_observability_service.py
@@ -8,6 +8,7 @@ credentials, or raw diagnostics.
 
 from __future__ import annotations
 
+import copy
 import os
 import threading
 import time
@@ -51,11 +52,72 @@ _BLOB_HYDRATION_STATS: dict[tuple[str, str], dict[str, Any]] = defaultdict(
     }
 )
 _QUERY_SHAPE_STATS: dict[tuple[str, ...], dict[str, Any]] = {}
+_QUERY_STATS_SNAPSHOT_STATE: dict[str, Any] = {
+    "last_refresh_status": "not_collected",
+    "last_refresh_at_utc": None,
+    "last_refresh_error_type": None,
+    "last_refresh_error_code": None,
+    "report": None,
+}
 
 _QUERY_TARGETING_JIRA_KEY = "JVNAUTOSCI-2427"
 _DEFAULT_QUERY_SHAPE_MAX_ROWS = 512
 _QUERY_SHAPE_SAMPLE_REQUEST_IDS = 8
 _MAX_SHAPE_TEXT = 240
+
+_QUERY_STATS_SNAPSHOT_REPORT_FIELDS = (
+    "schema_version",
+    "attribution_jira",
+    "source",
+    "status",
+    "query_shape_telemetry_enabled",
+    "observed_shape_count",
+    "ranking",
+    "database",
+    "selected_shape_count",
+    "query_stats_filter",
+    "observation_scope",
+    "first_seen_at_utc",
+    "latest_seen_at_utc",
+    "collected_at_utc",
+    "truncated",
+    "recommended_next_step",
+)
+_QUERY_STATS_SNAPSHOT_ROW_FIELDS = (
+    "database",
+    "collection",
+    "namespace",
+    "command_name",
+    "filter_shape",
+    "sort_shape",
+    "projection_shape",
+    "update_shape",
+    "pipeline_shape",
+    "limit",
+    "count",
+    "total_duration_ms",
+    "average_duration_ms",
+    "max_duration_ms",
+    "total_returned",
+    "max_n_returned",
+    "total_docs_examined",
+    "total_keys_examined",
+    "max_docs_examined",
+    "max_keys_examined",
+    "docs_examined_per_returned",
+    "keys_examined_per_returned",
+    "max_docs_examined_per_returned",
+    "max_keys_examined_per_returned",
+    "estimated_waste_score",
+    "last_plan_summary",
+    "last_winning_index",
+    "last_in_memory_sort",
+    "last_used_disk",
+    "query_hash",
+    "sample_request_ids",
+    "sources",
+    "recommended_next_step",
+)
 
 
 def _parse_bool_env(name: str, default: bool) -> bool:
@@ -399,6 +461,7 @@ def _query_shape_key(row: Mapping[str, Any]) -> tuple[str, ...]:
         _safe_str(row.get("update_shape")),
         _safe_str(row.get("pipeline_shape")),
         _safe_str(row.get("limit"), max_len=32),
+        _safe_str(row.get("_query_shape_identity"), max_len=128),
     )
 
 
@@ -550,8 +613,14 @@ def _recommend_next_step(row: Mapping[str, Any]) -> str:
             'Collect profiler/Atlas Query Insights or run bounded explain("executionStats") '
             "for this redacted shape."
         )
-    docs_ratio = _safe_float(row.get("max_docs_examined_per_returned"))
-    keys_ratio = _safe_float(row.get("max_keys_examined_per_returned"))
+    docs_ratio = max(
+        float(_safe_float(row.get("docs_examined_per_returned")) or 0.0),
+        float(_safe_float(row.get("max_docs_examined_per_returned")) or 0.0),
+    )
+    keys_ratio = max(
+        float(_safe_float(row.get("keys_examined_per_returned")) or 0.0),
+        float(_safe_float(row.get("max_keys_examined_per_returned")) or 0.0),
+    )
     if (docs_ratio is not None and docs_ratio >= 1000) or (
         keys_ratio is not None and keys_ratio >= 1000
     ):
@@ -563,6 +632,8 @@ def _recommend_next_step(row: Mapping[str, Any]) -> str:
         return (
             "Investigate sort coverage; profiler/explain indicates an in-memory sort."
         )
+    if row.get("last_used_disk"):
+        return "Investigate this shape; $queryStats reports execution using disk."
     return "Keep under observation; compare with Atlas Query Insights if this recurs."
 
 
@@ -589,6 +660,8 @@ def _ranked_query_shape_rows(
         )
         row["estimated_waste_score"] = round(
             max(
+                float(row.get("docs_examined_per_returned") or 0.0),
+                float(row.get("keys_examined_per_returned") or 0.0),
                 float(row.get("max_docs_examined_per_returned") or 0.0),
                 float(row.get("max_keys_examined_per_returned") or 0.0),
                 0.0,
@@ -678,6 +751,8 @@ def aggregate_mongo_query_shape_rows(
             row["limit"] = _safe_int(raw.get("limit"))
         if raw.get("last_in_memory_sort") is not None:
             row["last_in_memory_sort"] = bool(raw.get("last_in_memory_sort"))
+        if raw.get("last_used_disk") is not None:
+            row["last_used_disk"] = bool(raw.get("last_used_disk"))
         sample_ids = row["sample_request_ids"]
         for request_id in raw.get("sample_request_ids") or []:
             request_text = _safe_str(request_id, max_len=96)
@@ -730,6 +805,86 @@ def get_mongo_query_targeting_report(
 def reset_mongo_query_shape_telemetry() -> None:
     with _QUERY_SHAPE_LOCK:
         _QUERY_SHAPE_STATS.clear()
+
+
+def record_mongo_query_stats_snapshot(report: Mapping[str, Any]) -> None:
+    """Retain the last bounded, already-redacted ``$queryStats`` report.
+
+    Only an explicit allowlist is copied. This keeps the cost-guardrail surface
+    independent of raw MongoDB query-shape documents even if the producer later
+    gains additional internal fields.
+    """
+
+    status = _safe_str(report.get("status"), max_len=64) or "unknown"
+    safe_report: dict[str, Any] | None = None
+    if status == "ok":
+        safe_report = {
+            field: copy.deepcopy(report.get(field))
+            for field in _QUERY_STATS_SNAPSHOT_REPORT_FIELDS
+            if field in report
+        }
+        raw_rows = report.get("rows")
+        safe_report["rows"] = [
+            {
+                field: copy.deepcopy(row.get(field))
+                for field in _QUERY_STATS_SNAPSHOT_ROW_FIELDS
+                if field in row
+            }
+            for row in raw_rows or []
+            if isinstance(row, Mapping)
+        ]
+
+    with _QUERY_SHAPE_LOCK:
+        _QUERY_STATS_SNAPSHOT_STATE["last_refresh_status"] = status
+        _QUERY_STATS_SNAPSHOT_STATE["last_refresh_at_utc"] = _utcnow_iso()
+        _QUERY_STATS_SNAPSHOT_STATE["last_refresh_error_type"] = (
+            _safe_str(report.get("error_type"), max_len=96) or None
+        )
+        _QUERY_STATS_SNAPSHOT_STATE["last_refresh_error_code"] = (
+            _safe_str(report.get("error_code"), max_len=96) or None
+        )
+        if safe_report is not None:
+            _QUERY_STATS_SNAPSHOT_STATE["report"] = safe_report
+
+
+def get_mongo_query_stats_snapshot(*, reset: bool = False) -> dict[str, Any]:
+    """Return the last successful redacted ``$queryStats`` collection result."""
+
+    with _QUERY_SHAPE_LOCK:
+        state = copy.deepcopy(_QUERY_STATS_SNAPSHOT_STATE)
+        if reset:
+            _QUERY_STATS_SNAPSHOT_STATE.update(
+                {
+                    "last_refresh_status": "not_collected",
+                    "last_refresh_at_utc": None,
+                    "last_refresh_error_type": None,
+                    "last_refresh_error_code": None,
+                    "report": None,
+                }
+            )
+
+    report = state.get("report")
+    if not isinstance(report, Mapping):
+        report = {
+            "schema_version": "mongo_query_targeting_report.v1",
+            "source": "$queryStats",
+            "status": state.get("last_refresh_status") or "not_collected",
+            "observed_shape_count": 0,
+            "rows": [],
+        }
+    else:
+        report = dict(report)
+    report["snapshot_refresh"] = {
+        "status": state.get("last_refresh_status") or "not_collected",
+        "at_utc": state.get("last_refresh_at_utc"),
+        "error_type": state.get("last_refresh_error_type"),
+        "error_code": state.get("last_refresh_error_code"),
+    }
+    return report
+
+
+def reset_mongo_query_stats_snapshot() -> None:
+    get_mongo_query_stats_snapshot(reset=True)
 
 
 def profiler_document_to_query_shape_row(
@@ -1287,8 +1442,14 @@ def _top_query_targeting_warning(report: Mapping[str, Any]) -> dict[str, Any] | 
     for row in rows:
         if not isinstance(row, Mapping):
             continue
-        docs_ratio = _safe_float(row.get("max_docs_examined_per_returned"))
-        keys_ratio = _safe_float(row.get("max_keys_examined_per_returned"))
+        docs_ratio = max(
+            float(_safe_float(row.get("docs_examined_per_returned")) or 0.0),
+            float(_safe_float(row.get("max_docs_examined_per_returned")) or 0.0),
+        )
+        keys_ratio = max(
+            float(_safe_float(row.get("keys_examined_per_returned")) or 0.0),
+            float(_safe_float(row.get("max_keys_examined_per_returned")) or 0.0),
+        )
         if (docs_ratio is not None and docs_ratio >= 1000) or (
             keys_ratio is not None and keys_ratio >= 1000
         ):
@@ -1322,6 +1483,7 @@ def build_mongo_cost_guardrail_report(
         )
     operations = get_mongo_operation_audit_snapshot(reset=reset)
     query_targeting = get_mongo_query_targeting_report(reset=reset)
+    query_stats_targeting = get_mongo_query_stats_snapshot(reset=reset)
     large_writes = get_mongo_large_write_snapshot(reset=reset)
     hydration = get_blob_hydration_snapshot(reset=reset)
 
@@ -1401,8 +1563,13 @@ def build_mongo_cost_guardrail_report(
                 ),
             }
         )
-    query_warning = _top_query_targeting_warning(query_targeting)
+    query_warning = _top_query_targeting_warning(query_stats_targeting)
+    query_warning_source = "query_stats"
+    if query_warning is None:
+        query_warning = _top_query_targeting_warning(query_targeting)
+        query_warning_source = "in_process"
     if query_warning is not None:
+        query_warning["source"] = query_warning_source
         warnings.append(query_warning)
 
     return {
@@ -1430,6 +1597,7 @@ def build_mongo_cost_guardrail_report(
         "recent_operations": recent_summary,
         "operation_audit": operations,
         "query_targeting": query_targeting,
+        "query_stats_targeting": query_stats_targeting,
         "large_write_attempts": large_writes,
         "cache_and_hydration": hydration,
         "privacy": {
@@ -1456,6 +1624,7 @@ __all__ = [
     "get_blob_hydration_snapshot",
     "get_mongo_large_write_snapshot",
     "get_mongo_operation_audit_snapshot",
+    "get_mongo_query_stats_snapshot",
     "get_mongo_query_targeting_report",
     "mongo_operation_audit_enabled",
     "mongo_operation_slow_threshold_ms",
@@ -1468,9 +1637,11 @@ __all__ = [
     "observe_mongo_operation",
     "record_mongo_command_observation",
     "record_mongo_operation",
+    "record_mongo_query_stats_snapshot",
     "record_mongo_query_shape_observation",
     "reset_blob_hydration_snapshot",
     "reset_mongo_large_write_snapshot",
     "reset_mongo_operation_audit_snapshot",
+    "reset_mongo_query_stats_snapshot",
     "reset_mongo_query_shape_telemetry",
 ]

--- a/src/backend/services/mongo_query_diagnostics_service.py
+++ b/src/backend/services/mongo_query_diagnostics_service.py
@@ -8,8 +8,10 @@ bodies, Mongo URIs, or credentials.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 from pymongo import DESCENDING
@@ -22,6 +24,7 @@ from src.backend.services.mongo_observability_service import (
     build_mongo_query_targeting_report_from_rows,
     get_mongo_query_targeting_report,
     profiler_document_to_query_shape_row,
+    record_mongo_query_stats_snapshot,
 )
 
 _JIRA_KEY = "JVNAUTOSCI-2450"
@@ -32,6 +35,8 @@ _MAX_SAMPLE_LIMIT = 500
 _MAX_REPORT_LIMIT = 50
 _MAX_EXPLAIN_SAMPLES = 5
 _MAX_EXPLAIN_TIME_MS = 5_000
+_QUERY_STATS_MAX_TIME_MS = 5_000
+_QUERY_SHAPE_HASH_PATTERN = re.compile(r"^[A-Fa-f0-9]{16,128}$")
 
 
 @dataclass(frozen=True)
@@ -84,7 +89,9 @@ def safe_mongo_diagnostic_error(exc: BaseException) -> dict[str, Any]:
         if isinstance(code_name, str) and code_name.strip():
             payload["code_name"] = code_name.strip()[:96]
         errmsg = details.get("errmsg")
-        if isinstance(errmsg, str) and "not authorized" in errmsg.lower():
+        if isinstance(errmsg, str) and any(
+            marker in errmsg.lower() for marker in ("not authorized", "not authorised")
+        ):
             payload["message"] = "not authorised for requested Mongo diagnostic read"
     payload.setdefault("message", "Mongo diagnostic read failed")
     return payload
@@ -105,7 +112,7 @@ def normalise_mongo_query_diagnostics_options(
 
     raw_source = _clean_optional_str(source, max_len=64) or "combined"
     source_value = raw_source.lower().replace("-", "_")
-    if source_value not in {"combined", "in_process", "profiler"}:
+    if source_value not in {"combined", "in_process", "profiler", "query_stats"}:
         source_value = "combined"
 
     options = MongoQueryDiagnosticsOptions(
@@ -147,7 +154,7 @@ def normalise_mongo_query_diagnostics_options(
         "source": {
             "requested": source,
             "effective": options.source,
-            "allowed": ["combined", "in_process", "profiler"],
+            "allowed": ["combined", "in_process", "profiler", "query_stats"],
         },
         "namespace": {
             "requested": namespace,
@@ -215,6 +222,306 @@ def fetch_profiler_documents(
         .limit(sample_limit)
     )
     return [dict(doc) for doc in cursor]
+
+
+def _query_stats_namespace_match(
+    *, database_name: str, namespace: str | None
+) -> dict[str, Any]:
+    match: dict[str, Any] = {"key.queryShape.cmdNs.db": database_name}
+    if not namespace:
+        return match
+    if "." in namespace:
+        requested_database, collection = namespace.split(".", 1)
+        if requested_database != database_name:
+            raise ValueError("Mongo namespace is outside the configured database")
+    else:
+        collection = namespace
+    collection = collection.strip()
+    if not collection:
+        raise ValueError("Mongo namespace does not include a collection")
+    match["key.queryShape.cmdNs.coll"] = collection
+    return match
+
+
+def _query_stats_pipeline(
+    *, database_name: str, namespace: str | None, sample_limit: int
+) -> list[dict[str, Any]]:
+    """Build a bounded pipeline that returns only approved diagnostic fields."""
+
+    match = _query_stats_namespace_match(
+        database_name=database_name,
+        namespace=namespace,
+    )
+    return [
+        {"$queryStats": {}},
+        {"$match": match},
+        {
+            "$group": {
+                "_id": "$queryShapeHash",
+                "query_shape": {"$first": "$key.queryShape"},
+                "exec_count": {"$sum": {"$ifNull": ["$metrics.execCount", 0]}},
+                "total_duration_micros": {
+                    "$sum": {"$ifNull": ["$metrics.totalExecMicros.sum", 0]}
+                },
+                "max_duration_micros": {
+                    "$max": {"$ifNull": ["$metrics.totalExecMicros.max", 0]}
+                },
+                "total_returned": {
+                    "$sum": {"$ifNull": ["$metrics.docsReturned.sum", 0]}
+                },
+                "max_returned": {"$max": {"$ifNull": ["$metrics.docsReturned.max", 0]}},
+                "total_docs_examined": {
+                    "$sum": {"$ifNull": ["$metrics.docsExamined.sum", 0]}
+                },
+                "max_docs_examined": {
+                    "$max": {"$ifNull": ["$metrics.docsExamined.max", 0]}
+                },
+                "total_keys_examined": {
+                    "$sum": {"$ifNull": ["$metrics.keysExamined.sum", 0]}
+                },
+                "max_keys_examined": {
+                    "$max": {"$ifNull": ["$metrics.keysExamined.max", 0]}
+                },
+                "has_sort_stage_count": {
+                    "$sum": {"$ifNull": ["$metrics.hasSortStage.true", 0]}
+                },
+                "used_disk_count": {"$sum": {"$ifNull": ["$metrics.usedDisk.true", 0]}},
+                "first_seen_at": {"$min": "$metrics.firstSeenTimestamp"},
+                "latest_seen_at": {"$max": "$metrics.latestSeenTimestamp"},
+            }
+        },
+        {
+            "$set": {
+                "targeting_ratio": {
+                    "$max": [
+                        {
+                            "$divide": [
+                                "$total_docs_examined",
+                                {"$max": ["$total_returned", 1]},
+                            ]
+                        },
+                        {
+                            "$divide": [
+                                "$total_keys_examined",
+                                {"$max": ["$total_returned", 1]},
+                            ]
+                        },
+                    ]
+                }
+            }
+        },
+        {
+            "$sort": {
+                "targeting_ratio": -1,
+                "total_duration_micros": -1,
+                "exec_count": -1,
+            }
+        },
+        {"$limit": sample_limit + 1},
+        {
+            "$project": {
+                "_id": 0,
+                "query_shape_hash": "$_id",
+                "query_shape": 1,
+                "exec_count": 1,
+                "total_duration_micros": 1,
+                "max_duration_micros": 1,
+                "total_returned": 1,
+                "max_returned": 1,
+                "total_docs_examined": 1,
+                "max_docs_examined": 1,
+                "total_keys_examined": 1,
+                "max_keys_examined": 1,
+                "has_sort_stage_count": 1,
+                "used_disk_count": 1,
+                "first_seen_at": 1,
+                "latest_seen_at": 1,
+            }
+        },
+    ]
+
+
+def fetch_query_stats_documents(
+    db: Database,
+    *,
+    namespace: str | None,
+    sample_limit: int,
+) -> list[dict[str, Any]]:
+    """Read a bounded, projected ``$queryStats`` sample from the admin DB."""
+
+    database_name = str(getattr(db, "name", "") or get_configured_database_name())
+    pipeline = _query_stats_pipeline(
+        database_name=database_name,
+        namespace=namespace,
+        sample_limit=sample_limit,
+    )
+    cursor = db.client["admin"].aggregate(
+        pipeline,
+        maxTimeMS=_QUERY_STATS_MAX_TIME_MS,
+    )
+    return [dict(doc) for doc in cursor]
+
+
+def _safe_nonnegative_int(value: Any) -> int:
+    try:
+        if hasattr(value, "to_decimal"):
+            value = value.to_decimal()
+        return max(0, int(value or 0))
+    except (TypeError, ValueError, ArithmeticError):
+        return 0
+
+
+def _safe_query_shape_hash(value: Any) -> str | None:
+    text = str(value or "").strip()
+    if not _QUERY_SHAPE_HASH_PATTERN.fullmatch(text):
+        return None
+    return text.upper()
+
+
+def _iso_utc(value: Any) -> str | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def query_stats_document_to_query_shape_row(
+    doc: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Convert one projected ``$queryStats`` result to a redacted shape row."""
+
+    query_shape = doc.get("query_shape")
+    if not isinstance(query_shape, Mapping):
+        return None
+    cmd_ns = query_shape.get("cmdNs")
+    if not isinstance(cmd_ns, Mapping):
+        return None
+    database = _clean_optional_str(cmd_ns.get("db"), max_len=96) or ""
+    collection = _clean_optional_str(cmd_ns.get("coll"), max_len=96) or ""
+    command_name = _clean_optional_str(query_shape.get("command"), max_len=64)
+    if not command_name:
+        return None
+
+    synthetic_command: dict[str, Any] = {command_name: collection}
+    for field in (
+        "filter",
+        "query",
+        "sort",
+        "projection",
+        "fields",
+        "pipeline",
+        "limit",
+        "skip",
+        "hint",
+        "collation",
+    ):
+        if field in query_shape:
+            synthetic_command[field] = query_shape[field]
+    shape = build_mongo_command_shape(command_name, synthetic_command)
+    query_hash = _safe_query_shape_hash(doc.get("query_shape_hash"))
+    total_duration_micros = _safe_nonnegative_int(doc.get("total_duration_micros"))
+    max_duration_micros = _safe_nonnegative_int(doc.get("max_duration_micros"))
+    row: dict[str, Any] = {
+        "database": database,
+        "collection": collection,
+        "namespace": f"{database}.{collection}" if database and collection else "",
+        "command_name": command_name,
+        "filter_shape": shape.get("filter_shape") or "",
+        "sort_shape": shape.get("sort_shape") or "",
+        "projection_shape": shape.get("projection_shape") or "",
+        "update_shape": shape.get("update_shape") or "",
+        "pipeline_shape": shape.get("pipeline_shape") or "",
+        "limit": shape.get("limit"),
+        "count": _safe_nonnegative_int(doc.get("exec_count")),
+        "total_duration_ms": total_duration_micros / 1000.0,
+        "max_duration_ms": max_duration_micros / 1000.0,
+        "total_returned": _safe_nonnegative_int(doc.get("total_returned")),
+        "max_n_returned": _safe_nonnegative_int(doc.get("max_returned")),
+        "total_docs_examined": _safe_nonnegative_int(doc.get("total_docs_examined")),
+        "max_docs_examined": _safe_nonnegative_int(doc.get("max_docs_examined")),
+        "total_keys_examined": _safe_nonnegative_int(doc.get("total_keys_examined")),
+        "max_keys_examined": _safe_nonnegative_int(doc.get("max_keys_examined")),
+        "last_in_memory_sort": _safe_nonnegative_int(doc.get("has_sort_stage_count"))
+        > 0,
+        "last_used_disk": _safe_nonnegative_int(doc.get("used_disk_count")) > 0,
+        "sample_request_ids": [query_hash] if query_hash else [],
+        "sources": ["$queryStats"],
+    }
+    if query_hash:
+        row["query_hash"] = query_hash
+        row["_query_shape_identity"] = query_hash
+    return row
+
+
+def build_query_stats_targeting_report(
+    db: Database,
+    *,
+    namespace: str | None,
+    sample_limit: int,
+    report_limit: int,
+) -> dict[str, Any]:
+    docs = fetch_query_stats_documents(
+        db,
+        namespace=namespace,
+        sample_limit=sample_limit,
+    )
+    truncated = len(docs) > sample_limit
+    selected_docs = docs[:sample_limit]
+    rows = [
+        row
+        for row in (
+            query_stats_document_to_query_shape_row(doc) for doc in selected_docs
+        )
+        if row is not None
+    ]
+    report = build_mongo_query_targeting_report_from_rows(
+        rows,
+        limit=report_limit,
+        source="$queryStats",
+    )
+    first_seen = [
+        value
+        for value in (_iso_utc(doc.get("first_seen_at")) for doc in selected_docs)
+        if value
+    ]
+    latest_seen = [
+        value
+        for value in (_iso_utc(doc.get("latest_seen_at")) for doc in selected_docs)
+        if value
+    ]
+    database_name = str(getattr(db, "name", "") or get_configured_database_name())
+    report.update(
+        {
+            "status": "ok",
+            "database": database_name,
+            "selected_shape_count": len(rows),
+            "query_stats_filter": {
+                "namespace": namespace,
+                "sample_limit": sample_limit,
+                "max_time_ms": _QUERY_STATS_MAX_TIME_MS,
+            },
+            "observation_scope": {
+                "kind": "current_mongodb_member_cumulative_query_stats",
+                "counter_semantics": (
+                    "cumulative_since_each_shape_first_seen_or_member_restart"
+                ),
+                "atlas_time_window_equivalent": False,
+                "freshness_scope": "selected_server_ranked_shapes",
+            },
+            "first_seen_at_utc": min(first_seen) if first_seen else None,
+            "latest_seen_at_utc": max(latest_seen) if latest_seen else None,
+            "collected_at_utc": datetime.now(timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "truncated": truncated,
+            "recommended_next_step": (
+                "Compare persistent high-ratio query hashes with Atlas Query "
+                "Insights over a bounded time window before changing indexes."
+            ),
+        }
+    )
+    return report
 
 
 def _find_stage(
@@ -459,8 +766,11 @@ def build_von_mongo_query_diagnostics_report(
             reset=options.reset_in_process,
         )
 
-    if options.source in {"combined", "profiler"}:
+    db = None
+    if options.source in {"combined", "profiler", "query_stats"}:
         db = get_db()
+
+    if options.source in {"combined", "profiler"}:
         if db is None:
             reports["profiler"] = {
                 "schema_version": "mongo_query_targeting_report.v1",
@@ -495,6 +805,61 @@ def build_von_mongo_query_diagnostics_report(
                     ),
                 }
 
+    if options.source in {"combined", "query_stats"}:
+        if db is None:
+            reports["query_stats"] = {
+                "schema_version": "mongo_query_targeting_report.v1",
+                "source": "$queryStats",
+                "status": "mongo_unavailable",
+                "database": get_configured_database_name(),
+                "rows": [],
+            }
+        else:
+            try:
+                reports["query_stats"] = build_query_stats_targeting_report(
+                    db,
+                    namespace=options.namespace,
+                    sample_limit=options.sample_limit,
+                    report_limit=options.report_limit,
+                )
+            except ValueError as exc:
+                reports["query_stats"] = {
+                    "schema_version": "mongo_query_targeting_report.v1",
+                    "source": "$queryStats",
+                    "status": "invalid_namespace",
+                    "database": get_configured_database_name(),
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                    "rows": [],
+                    "recommended_next_step": (
+                        "Use the configured database name and an optional collection."
+                    ),
+                }
+            except (
+                OperationFailure,
+                PyMongoError,
+                RuntimeError,
+                TypeError,
+                AttributeError,
+            ) as exc:
+                safe_error = safe_mongo_diagnostic_error(exc)
+                reports["query_stats"] = {
+                    "schema_version": "mongo_query_targeting_report.v1",
+                    "source": "$queryStats",
+                    "status": "query_stats_unavailable",
+                    "database": get_configured_database_name(),
+                    "error_type": safe_error.get("error_type"),
+                    "error_code": safe_error.get("code_name") or safe_error.get("code"),
+                    "error": safe_error.get("message"),
+                    "rows": [],
+                    "recommended_next_step": (
+                        "Use a MongoDB deployment that supports $queryStats with "
+                        "queryStatsRead/clusterMonitor, or reconcile with Atlas "
+                        "Query Insights."
+                    ),
+                }
+        record_mongo_query_stats_snapshot(reports["query_stats"])
+
     all_rows: list[Mapping[str, Any]] = []
     for report in reports.values():
         rows = report.get("rows") if isinstance(report, Mapping) else None
@@ -522,6 +887,14 @@ def build_von_mongo_query_diagnostics_report(
         },
         "summary": summary,
         "reports": reports,
+        "source_status": {
+            name: (
+                str(report.get("status") or "ok")
+                if isinstance(report, Mapping)
+                else "unknown"
+            )
+            for name, report in reports.items()
+        },
         "recommended_next_step": (
             "Review high-ratio rows against repo-owned indexes and Atlas Query "
             "Insights. Keep index creation/drop as explicit reviewed code or "

--- a/src/backend/workflows/durable/mongo_query_diagnostics_maintenance_workflow.py
+++ b/src/backend/workflows/durable/mongo_query_diagnostics_maintenance_workflow.py
@@ -76,6 +76,7 @@ def _handle_finalise(
     reports = _mapping(diagnostic_report.get("reports"))
     profiler = _mapping(reports.get("profiler"))
     in_process = _mapping(reports.get("in_process"))
+    query_stats = _mapping(reports.get("query_stats"))
     top_rows = _top_risk_rows(summary)
 
     result = {
@@ -94,6 +95,11 @@ def _handle_finalise(
         "top_risk_rows": top_rows,
         "profiler_status": profiler.get("status"),
         "in_process_observed_shape_count": in_process.get("observed_shape_count"),
+        "query_stats_status": query_stats.get("status"),
+        "query_stats_selected_shape_count": query_stats.get("selected_shape_count"),
+        "query_stats_latest_seen_at_utc": query_stats.get("latest_seen_at_utc"),
+        "query_stats_truncated": query_stats.get("truncated"),
+        "source_status": _mapping(diagnostic_report.get("source_status")),
         "recommended_next_step": diagnostic_report.get("recommended_next_step"),
         "privacy": _mapping(diagnostic_report.get("privacy")),
         "attribution_jira": diagnostic_report.get("attribution_jira"),

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -701,6 +701,23 @@ def test_failure_case_learning_reads_require_operator_provenance():
         assert result["error_code"] == "workflow_global_admin_authority_required"
 
 
+def test_internal_mcp_mongo_diagnostics_exposes_query_stats_source():
+    from src.backend.integrations.internal_mcp import build_default_catalogue
+    from src.backend.integrations.internal_mcp.schemas import schema_to_json_schema
+
+    method = build_default_catalogue().get("mongo_query_diagnostics_report")
+
+    assert method.input_schema.enum_values["source"] == (
+        "combined",
+        "in_process",
+        "profiler",
+        "query_stats",
+    )
+    assert schema_to_json_schema(method.input_schema)["properties"]["source"][
+        "enum"
+    ] == ["combined", "in_process", "profiler", "query_stats"]
+
+
 def test_internal_mcp_gmail_list_messages_accepts_max_results_aliases():
     from src.backend.integrations.internal_mcp import build_default_catalogue
     from src.backend.integrations.internal_mcp.schemas import (

--- a/tests/backend/test_mcp_stdio_server_exposes_turn_execution_diagnostics_tool.py
+++ b/tests/backend/test_mcp_stdio_server_exposes_turn_execution_diagnostics_tool.py
@@ -57,3 +57,12 @@ def test_vontology_mcp_manifest_includes_turn_execution_diagnostics_tool() -> No
     assert "turn_execution_get_live_progress" in names
     assert "workflow_list_use_episodes" in names
     assert "mongo_query_diagnostics_report" in names
+    mongo_tool = next(
+        tool for tool in tools if tool.get("name") == "mongo_query_diagnostics_report"
+    )
+    assert mongo_tool["inputSchema"]["properties"]["source"]["enum"] == [
+        "combined",
+        "in_process",
+        "profiler",
+        "query_stats",
+    ]

--- a/tests/backend/test_mongo_observability_service.py
+++ b/tests/backend/test_mongo_observability_service.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
 from flask import Flask
 from pymongo.errors import OperationFailure
 
 from src.backend.integrations.internal_mcp import build_default_catalogue
 from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
 from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
-from src.backend.db.mongo_client import _safe_mongo_failure_summary
+from src.backend.db.mongo_client import (
+    _VonMongoFailureLogger,
+    _safe_mongo_failure_summary,
+)
 from src.backend.services import chat_history_service
 from src.backend.services.mongo_observability_service import (
     build_mongo_operation_comment,
@@ -16,6 +22,7 @@ from src.backend.services.mongo_observability_service import (
     build_mongo_query_targeting_report_from_rows,
     get_mongo_operation_audit_snapshot,
     get_mongo_large_write_snapshot,
+    get_mongo_query_stats_snapshot,
     get_mongo_query_targeting_report,
     profiler_document_to_query_shape_row,
     record_blob_hydration_observation,
@@ -25,6 +32,7 @@ from src.backend.services.mongo_observability_service import (
     reset_blob_hydration_snapshot,
     reset_mongo_large_write_snapshot,
     reset_mongo_operation_audit_snapshot,
+    reset_mongo_query_stats_snapshot,
     reset_mongo_query_shape_telemetry,
 )
 from src.backend.services import mongo_query_diagnostics_service as diagnostics_service
@@ -73,6 +81,36 @@ def test_mongo_command_failure_summary_omits_raw_command_body():
     }
     assert "system.profile" not in rendered
     assert "secret" not in rendered
+
+
+def test_query_stats_diagnostic_does_not_record_itself_as_slow_query_shape():
+    reset_mongo_query_shape_telemetry()
+    listener = _VonMongoFailureLogger()
+    listener.started(
+        SimpleNamespace(
+            request_id=987,
+            command_name="aggregate",
+            database_name="admin",
+            command={
+                "aggregate": 1,
+                "pipeline": [
+                    {"$queryStats": {}},
+                    {"$match": {"key.queryShape.cmdNs.db": "von_db"}},
+                ],
+            },
+        )
+    )
+    listener.succeeded(
+        SimpleNamespace(
+            request_id=987,
+            command_name="aggregate",
+            database_name="admin",
+            duration_micros=2_000_000,
+            reply={"cursor": {"firstBatch": [{}]}},
+        )
+    )
+
+    assert get_mongo_query_targeting_report(reset=True)["rows"] == []
 
 
 def test_mongo_operation_audit_snapshot_aggregates_without_payload_content(monkeypatch):
@@ -381,6 +419,184 @@ def test_profiler_report_builder_uses_redacted_rows_without_printing_profile_val
     assert report["profile_sample_count"] == 1
     assert report["rows"][0]["namespace"] == "von_db.workflow_instances"
     assert "pending" not in str(report)
+
+
+def _query_stats_result_document() -> dict:
+    return {
+        "query_shape_hash": (
+            "5C4A9703881BD4599DEC5E2109E1FCB1B966DC65948E2EC2BC501E5098831BEF"
+        ),
+        "query_shape": {
+            "cmdNs": {"db": "von_db", "coll": "concepts"},
+            "command": "find",
+            "filter": {"has_author": {"$eq": "literal-must-not-escape"}},
+            "projection": {"_id": 1, "name": 1},
+            "limit": "?number",
+        },
+        "exec_count": 7,
+        "total_duration_micros": 2_100_000,
+        "max_duration_micros": 400_000,
+        "total_returned": 7,
+        "max_returned": 1,
+        "total_docs_examined": 8_755_985,
+        "max_docs_examined": 1_250_855,
+        "total_keys_examined": 0,
+        "max_keys_examined": 0,
+        "has_sort_stage_count": 0,
+        "used_disk_count": 1,
+        "first_seen_at": datetime(2026, 8, 13, 8, 0, tzinfo=timezone.utc),
+        "latest_seen_at": datetime(2026, 8, 14, 8, 0, tzinfo=timezone.utc),
+    }
+
+
+class _FakeQueryStatsAdmin:
+    def __init__(self, documents):
+        self.documents = documents
+        self.pipeline = None
+        self.kwargs = None
+
+    def aggregate(self, pipeline, **kwargs):
+        self.pipeline = pipeline
+        self.kwargs = kwargs
+        return list(self.documents)
+
+
+class _FakeQueryStatsClient:
+    def __init__(self, admin):
+        self.admin = admin
+
+    def __getitem__(self, name):
+        assert name == "admin"
+        return self.admin
+
+
+class _FakeQueryStatsDb:
+    name = "von_db"
+
+    def __init__(self, admin):
+        self.client = _FakeQueryStatsClient(admin)
+
+
+def test_query_stats_report_is_bounded_ranked_and_redacted():
+    admin = _FakeQueryStatsAdmin([_query_stats_result_document()])
+    report = diagnostics_service.build_query_stats_targeting_report(
+        _FakeQueryStatsDb(admin),
+        namespace="von_db.concepts",
+        sample_limit=10,
+        report_limit=5,
+    )
+
+    row = report["rows"][0]
+    rendered = str(report)
+    assert admin.pipeline[0] == {"$queryStats": {}}
+    assert admin.pipeline[1] == {
+        "$match": {
+            "key.queryShape.cmdNs.db": "von_db",
+            "key.queryShape.cmdNs.coll": "concepts",
+        }
+    }
+    assert admin.pipeline[-2] == {"$limit": 11}
+    assert admin.kwargs == {"maxTimeMS": 5000}
+    assert report["status"] == "ok"
+    assert report["selected_shape_count"] == 1
+    assert report["truncated"] is False
+    assert row["query_hash"].startswith("5C4A9703")
+    assert row["filter_shape"] == "has_author{$eq}"
+    assert row["docs_examined_per_returned"] == 1_250_855.0
+    assert row["last_used_disk"] is True
+    assert "High query targeting" in row["recommended_next_step"]
+    assert "literal-must-not-escape" not in rendered
+    assert "'query_shape':" not in rendered
+
+
+def test_query_stats_report_keeps_distinct_hashes_for_same_redacted_shape():
+    first = _query_stats_result_document()
+    second = {
+        **first,
+        "query_shape_hash": "A" * 64,
+        "exec_count": 1,
+        "total_docs_examined": 100,
+        "max_docs_examined": 100,
+    }
+    report = diagnostics_service.build_query_stats_targeting_report(
+        _FakeQueryStatsDb(_FakeQueryStatsAdmin([first, second])),
+        namespace="von_db.concepts",
+        sample_limit=10,
+        report_limit=10,
+    )
+
+    assert report["selected_shape_count"] == 2
+    assert report["observed_shape_count"] == 2
+    assert {row["query_hash"] for row in report["rows"]} == {
+        first["query_shape_hash"],
+        second["query_shape_hash"],
+    }
+
+
+def test_query_stats_diagnostic_refreshes_cost_guardrail_snapshot(monkeypatch):
+    reset_mongo_query_stats_snapshot()
+    admin = _FakeQueryStatsAdmin([_query_stats_result_document()])
+    monkeypatch.setattr(
+        diagnostics_service,
+        "get_db",
+        lambda: _FakeQueryStatsDb(admin),
+    )
+
+    diagnostic = diagnostics_service.build_von_mongo_query_diagnostics_report(
+        allow_operator_diagnostics=True,
+        source="query_stats",
+        sample_limit=10,
+        report_limit=5,
+    )
+    guardrail = build_mongo_cost_guardrail_report(local_development=True)
+
+    assert diagnostic["source_status"] == {"query_stats": "ok"}
+    assert diagnostic["summary"]["rows"][0]["collection"] == "concepts"
+    assert guardrail["query_stats_targeting"]["status"] == "ok"
+    assert guardrail["query_stats_targeting"]["snapshot_refresh"]["status"] == "ok"
+    query_warning = next(
+        warning
+        for warning in guardrail["warnings"]
+        if warning["code"] == "query_targeting_waste_high"
+    )
+    assert query_warning["source"] == "query_stats"
+    assert get_mongo_query_stats_snapshot()["rows"][0]["query_hash"].startswith(
+        "5C4A9703"
+    )
+    reset_mongo_query_stats_snapshot()
+
+
+def test_query_stats_unavailable_is_typed_and_does_not_leak_error_body(monkeypatch):
+    class UnauthorisedAdmin:
+        def aggregate(self, *_args, **_kwargs):
+            raise OperationFailure(
+                "raw command includes secret-filter-value",
+                code=13,
+                details={
+                    "codeName": "Unauthorized",
+                    "errmsg": "not authorized for queryStats with secret-filter-value",
+                },
+            )
+
+    monkeypatch.setattr(
+        diagnostics_service,
+        "get_db",
+        lambda: _FakeQueryStatsDb(UnauthorisedAdmin()),
+    )
+
+    report = diagnostics_service.build_von_mongo_query_diagnostics_report(
+        allow_operator_diagnostics=True,
+        source="query_stats",
+    )
+    source_report = report["reports"]["query_stats"]
+
+    assert report["success"] is True
+    assert report["source_status"] == {"query_stats": "query_stats_unavailable"}
+    assert source_report["error_code"] == "Unauthorized"
+    assert source_report["error"] == (
+        "not authorised for requested Mongo diagnostic read"
+    )
+    assert "secret-filter-value" not in str(source_report)
 
 
 def test_von_mongo_query_diagnostics_requires_explicit_operator_gate():

--- a/tests/backend/test_mongo_query_diagnostics_maintenance_workflow.py
+++ b/tests/backend/test_mongo_query_diagnostics_maintenance_workflow.py
@@ -96,6 +96,17 @@ class _FakeGateway:
                 "reports": {
                     "in_process": {"observed_shape_count": 1},
                     "profiler": {"status": "profiler_unavailable"},
+                    "query_stats": {
+                        "status": "ok",
+                        "selected_shape_count": 3,
+                        "latest_seen_at_utc": "2026-08-14T08:00:00Z",
+                        "truncated": False,
+                    },
+                },
+                "source_status": {
+                    "in_process": "ok",
+                    "profiler": "profiler_unavailable",
+                    "query_stats": "ok",
                 },
                 "recommended_next_step": (
                     "Review high-ratio rows against repo-owned indexes and Atlas "
@@ -185,6 +196,12 @@ def test_mongo_query_diagnostics_maintenance_workflow_invokes_diagnostic_tool() 
     assert maintenance_result["direct_index_mutation"] is False
     assert maintenance_result["observed_shape_count"] == 1
     assert maintenance_result["profiler_status"] == "profiler_unavailable"
+    assert maintenance_result["query_stats_status"] == "ok"
+    assert maintenance_result["query_stats_selected_shape_count"] == 3
+    assert maintenance_result["query_stats_latest_seen_at_utc"] == (
+        "2026-08-14T08:00:00Z"
+    )
+    assert maintenance_result["query_stats_truncated"] is False
     assert maintenance_result["top_risk_rows"][0]["namespace"] == (
         "von_db.text_relations"
     )


### PR DESCRIPTION
## What changed

- add a bounded, redacted MongoDB `$queryStats` source to `mongo_query_diagnostics_report`
- include it in combined diagnostics and expose typed source status, freshness, and truncation metadata
- retain the last successful redacted snapshot for the existing cost-guardrail report
- expose the source through internal MCP schemas and the maintenance workflow
- prevent the diagnostic aggregation from recording itself as a slow query shape
- document capability, privilege, freshness, and Atlas reconciliation boundaries

## Why

The existing in-process listener and `system.profile` surfaces could not reliably reproduce cluster-side high scanned-per-returned cases. `$queryStats` supplies the missing MongoDB-side counters without requiring Atlas Admin API access or profiler enablement.

## Impact

Trusted operator diagnostics can now detect and rank high-scan query shapes directly from the configured MongoDB deployment. Reports remain read-only and omit literal query values, document bodies, credentials, and raw query-shape records. No indexes, database roles, profiler settings, or schedules are changed.

## Validation

- 79 targeted tests passed
- fatal Ruff checks passed
- `git diff --check` passed
- live Atlas-backed `$queryStats` and combined-source reads succeeded
- live collection-specific read detected high scanned-per-returned shapes
- verified the diagnostic does not add itself to slow query-shape telemetry