### PR TITLE
Optimise actor-scoped Vontology tree loading

### DIFF
--- a/src/backend/db/repositories/concepts_repository.py
+++ b/src/backend/db/repositories/concepts_repository.py
@@ -68,10 +68,16 @@ class _AccessControlledCursor:
 
     _SANITISATION_BATCH_SIZE = 64
 
-    def __init__(self, cursor):
+    def __init__(self, cursor, *, sanitisation_batch_size: int | None = None):
         self._cursor = cursor
         self._buffer: Deque[Dict[str, Any]] = deque()
         self._exhausted = False
+        requested_batch_size = (
+            self._SANITISATION_BATCH_SIZE
+            if sanitisation_batch_size is None
+            else sanitisation_batch_size
+        )
+        self._sanitisation_batch_size = max(1, requested_batch_size)
 
     def __iter__(self):
         return self
@@ -81,7 +87,7 @@ class _AccessControlledCursor:
             if self._exhausted:
                 raise StopIteration
             batch: List[Dict[str, Any]] = []
-            for _ in range(self._SANITISATION_BATCH_SIZE):
+            for _ in range(self._sanitisation_batch_size):
                 try:
                     batch.append(next(self._cursor))
                 except StopIteration:
@@ -131,6 +137,8 @@ class ConceptsRepository:
         skip: int = 0,
         limit: int = 0,
         max_time_ms: Optional[int] = None,
+        sanitisation_batch_size: Optional[int] = None,
+        cursor_batch_size: Optional[int] = None,
     ):
         coll = ConceptsRepository.collection()
         if coll is None:
@@ -139,13 +147,18 @@ class ConceptsRepository:
         cursor = coll.find(query, projection)
         if max_time_ms and max_time_ms > 0:
             cursor = cursor.max_time_ms(max_time_ms)
+        if cursor_batch_size and cursor_batch_size > 0:
+            cursor = cursor.batch_size(cursor_batch_size)
         if sort:
             cursor = cursor.sort(sort)
         if skip:
             cursor = cursor.skip(skip)
         if limit:
             cursor = cursor.limit(limit)
-        return _AccessControlledCursor(cursor)
+        return _AccessControlledCursor(
+            cursor,
+            sanitisation_batch_size=sanitisation_batch_size,
+        )
 
     @staticmethod
     def insert_one(document: Dict[str, Any]):

--- a/src/backend/security/access_control.py
+++ b/src/backend/security/access_control.py
@@ -7,6 +7,7 @@ from contextvars import ContextVar
 import logging
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+from bson import BSON
 from flask import g, has_request_context, request, session
 
 from ..db.mongo_client import get_concepts_collection
@@ -24,6 +25,10 @@ _log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 _MANUAL_USER: ContextVar[Optional[str]] = ContextVar("access_manual_user", default=None)
 _MANUAL_ORG: ContextVar[Optional[str]] = ContextVar("access_manual_org", default=None)
+_MANUAL_ACTOR_BOUND: ContextVar[bool] = ContextVar(
+    "access_manual_actor_bound",
+    default=False,
+)
 _BYPASS: ContextVar[bool] = ContextVar("access_bypass", default=False)
 _FORCE_ENFORCEMENT: ContextVar[bool] = ContextVar(
     "access_force_enforcement",
@@ -34,6 +39,9 @@ _EVALUATOR: ContextVar["AccessEvaluator | None"] = ContextVar(
 )
 
 _REMOVE = object()
+
+_ACCESS_ID_QUERY_MAX_COUNT = 10_000
+_ACCESS_ID_QUERY_MAX_BSON_BYTES = 8 * 1024 * 1024
 
 TRUSTED_IN_PROCESS_ACTOR_SOURCE = "trusted_in_process_actor"
 AUTHENTICATED_SESSION_ACTOR_SOURCE = "authenticated_session"
@@ -58,6 +66,28 @@ def _normalise_stored_org_concept_id(value: Any) -> Optional[str]:
     if not candidate:
         return None
     return candidate if candidate.startswith("#") else f"#V#{candidate}"
+
+
+def _bounded_access_id_query_batches(concept_ids: Iterable[str]) -> Iterable[list[str]]:
+    """Yield deterministic ``$in`` batches below count and BSON safety bounds."""
+
+    def split_to_bson_budget(batch: list[str]) -> Iterable[list[str]]:
+        if len(batch) <= 1:
+            yield batch
+            return
+        encoded_size = len(BSON.encode({"concept_id": {"$in": batch}}))
+        if encoded_size <= _ACCESS_ID_QUERY_MAX_BSON_BYTES:
+            yield batch
+            return
+        midpoint = len(batch) // 2
+        yield from split_to_bson_budget(batch[:midpoint])
+        yield from split_to_bson_budget(batch[midpoint:])
+
+    ordered_ids = sorted(concept_ids)
+    for offset in range(0, len(ordered_ids), _ACCESS_ID_QUERY_MAX_COUNT):
+        yield from split_to_bson_budget(
+            ordered_ids[offset : offset + _ACCESS_ID_QUERY_MAX_COUNT]
+        )
 
 
 def _specific_allows_user(spec: Any, user_id: Optional[str]) -> bool:
@@ -262,21 +292,25 @@ class AccessEvaluator:
             **{f"relationships.{p}": 1 for p in SPECIFIC_TO_ORG_PREDICATES_READ},
         }
         seen: set[str] = set()
-        cursor = coll.find({"concept_id": {"$in": sorted(uncached)}}, projection)
-        set_batch_size = getattr(cursor, "batch_size", None)
-        if callable(set_batch_size):
-            cursor = set_batch_size(min(len(uncached), 20_000))
-        for doc in cursor:
-            if not isinstance(doc, dict):
-                continue
-            concept_id = _normalise_concept_id(doc.get("concept_id"))
-            if concept_id is None:
-                continue
-            seen.add(concept_id)
-            is_visible = _document_visible_to_actor(doc, self.user_id, self.org_id)
-            self._cache[concept_id] = is_visible
-            if is_visible:
-                allowed.add(concept_id)
+        for concept_id_batch in _bounded_access_id_query_batches(uncached):
+            cursor: Any = coll.find(
+                {"concept_id": {"$in": concept_id_batch}},
+                projection,
+            )
+            set_batch_size = getattr(cursor, "batch_size", None)
+            if callable(set_batch_size):
+                cursor = set_batch_size(min(len(concept_id_batch), 20_000))
+            for doc in cursor:
+                if not isinstance(doc, dict):
+                    continue
+                concept_id = _normalise_concept_id(doc.get("concept_id"))
+                if concept_id is None:
+                    continue
+                seen.add(concept_id)
+                is_visible = _document_visible_to_actor(doc, self.user_id, self.org_id)
+                self._cache[concept_id] = is_visible
+                if is_visible:
+                    allowed.add(concept_id)
 
         for concept_id in uncached - seen:
             self._cache[concept_id] = False
@@ -359,6 +393,10 @@ def get_effective_user_concept_id_with_source() -> tuple[str | None, str | None]
     """
 
     manual = _MANUAL_USER.get()
+    if _MANUAL_ACTOR_BOUND.get():
+        if manual is None:
+            return None, None
+        return manual, TRUSTED_IN_PROCESS_ACTOR_SOURCE
     if manual is not None:
         return manual, TRUSTED_IN_PROCESS_ACTOR_SOURCE
     if not has_request_context():
@@ -412,7 +450,7 @@ def get_effective_user_concept_id() -> Optional[str]:
 
 def get_effective_organisation_concept_id() -> Optional[str]:
     manual = _MANUAL_ORG.get()
-    if manual is not None:
+    if _MANUAL_ACTOR_BOUND.get() or manual is not None:
         return manual
     if not has_request_context():
         return None
@@ -450,7 +488,11 @@ def should_enforce_access_control() -> bool:
         return False
     if _FORCE_ENFORCEMENT.get():
         return True
-    if _MANUAL_USER.get() is not None or _MANUAL_ORG.get() is not None:
+    if (
+        _MANUAL_ACTOR_BOUND.get()
+        or _MANUAL_USER.get() is not None
+        or _MANUAL_ORG.get() is not None
+    ):
         return True
     return has_request_context()
 
@@ -888,6 +930,7 @@ def override_current_actor(
 ):
     """Apply one explicit actor scope to access-controlled support lookups."""
 
+    bound_token = _MANUAL_ACTOR_BOUND.set(True)
     user_token = _MANUAL_USER.set(_normalise_concept_id(user_concept_id))
     org_token = _MANUAL_ORG.set(
         _normalise_stored_org_concept_id(organisation_concept_id)
@@ -899,6 +942,7 @@ def override_current_actor(
         _EVALUATOR.reset(eval_token)
         _MANUAL_ORG.reset(org_token)
         _MANUAL_USER.reset(user_token)
+        _MANUAL_ACTOR_BOUND.reset(bound_token)
 
 
 @contextmanager

--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -7,6 +7,7 @@ import uuid
 import time
 import logging
 from collections import defaultdict
+from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 try:
@@ -132,7 +133,28 @@ _TREE_CACHE = {  # key -> (timestamp, payload, build_secs, alloc_kb, hits)
     # 'Thing': (...)
 }
 _TREE_CACHE_TTL_SECONDS = int(os.environ.get("VONTOLOGY_TREE_TTL", "60"))  # default 60s
-_TREE_CACHE_LOCK = threading.Lock()
+_TREE_CACHE_LOCK = threading.RLock()
+_TreeCacheKey = tuple[str | None, str | None, str]
+
+
+@dataclass
+class _TreeBuildState:
+    cache_key: _TreeCacheKey
+    user_concept_id: str | None
+    organisation_concept_id: str | None
+    generation: int
+    completion: threading.Event = field(default_factory=threading.Event)
+    result: dict[str, Any] | None = None
+    error: str | None = None
+    progress: int = 0
+    build_secs: float = 0.0
+    alloc_kb: float = 0.0
+    completed_at_epoch: float | None = None
+    job_id: str | None = None
+
+
+_TREE_BUILD_GENERATION = 0
+_TREE_BUILDS_IN_FLIGHT: dict[_TreeCacheKey, _TreeBuildState] = {}
 """
 Simple progress cache for asynchronous tree builds.
 
@@ -141,7 +163,7 @@ creation. Completed results remain available briefly for polling and are then
 pruned; active jobs are never expired by result cleanup.
 """
 _TREE_BUILD_PROGRESS: dict[str, dict] = {}
-_TREE_BUILD_PROGRESS_LOCK = threading.Lock()
+_TREE_BUILD_PROGRESS_LOCK = _TREE_CACHE_LOCK
 _TREE_BUILD_RESULT_TTL_SECONDS = 10 * 60
 
 _RELATIONSHIP_ALIAS_TO_CANONICAL = {
@@ -466,181 +488,298 @@ def record_frontend_tree_load_route():
     return jsonify({"success": True}), 200
 
 
-@vontology_bp.route("/tree", methods=["GET"])
-def get_tree():
-    """Endpoint to fetch the Vontology directory tree structure with TTL caching.
+def _tree_cache_key(
+    actor_scope: tuple[str | None, str | None],
+) -> _TreeCacheKey:
+    return actor_scope[0], actor_scope[1], "Thing"
 
-    Query params:
-      refresh=1   Force rebuild bypassing cache
-    Env vars:
-      VONTOLOGY_TREE_TTL (seconds) default 60
-    """
-    current_app.logger.info("Received request for /api/vontology/tree")
-    force_refresh = request.args.get("refresh") in ("1", "true", "True")
-    now = time.time()
-    cache_scope = cache_scope_key()
-    cache_key = f"{cache_scope}|Thing"
-    cache_record = None
-    with _TREE_CACHE_LOCK:
-        cache_record = _TREE_CACHE.get(cache_key)
-        if cache_record:
-            ts, payload, build_secs, alloc_kb, hits = cache_record
-            if force_refresh or (now - ts) > _TREE_CACHE_TTL_SECONDS:
-                cache_record = None  # treat as expired
-    if cache_record:
-        _, payload, build_secs, alloc_kb, hits = cache_record
-        # Increment hit counter
-        with _TREE_CACHE_LOCK:
+
+def _fresh_tree_cache_record_locked(cache_key: _TreeCacheKey, *, now: float):
+    stale_keys = [
+        key
+        for key, record in _TREE_CACHE.items()
+        if (now - record[0]) > _TREE_CACHE_TTL_SECONDS
+    ]
+    for stale_key in stale_keys:
+        _TREE_CACHE.pop(stale_key, None)
+    cache_record = _TREE_CACHE.get(cache_key)
+    if cache_record is None:
+        return None
+    return cache_record
+
+
+def _update_tree_job_locked(state: _TreeBuildState) -> None:
+    if state.job_id is None:
+        return
+    job = _TREE_BUILD_PROGRESS.get(state.job_id)
+    if job is None or job.get("build_state") is not state:
+        return
+    job["total"] = 100
+    job["processed"] = state.progress
+    job["result"] = state.result
+    job["error"] = state.error
+    job["completed_at_epoch"] = state.completed_at_epoch
+
+
+def _execute_tree_build(state: _TreeBuildState) -> None:
+    """Execute and publish one actor-scoped physical tree build."""
+
+    stop_event: threading.Event | None = None
+    ticker_thread: threading.Thread | None = None
+    ticker_started = False
+    t0: float | None = None
+    snap_before = None
+    tree_data: dict[str, Any] | None = None
+    build_error: str | None = None
+    control_flow_error: BaseException | None = None
+    stats = []
+    build_secs = 0.0
+    alloc_kb = 0.0
+    completed_at_epoch = 0.0
+
+    def _record_failure(exc: BaseException, message: str) -> None:
+        nonlocal build_error, control_flow_error, tree_data
+        tree_data = None
+        if isinstance(exc, Exception):
+            if build_error is None:
+                build_error = message
+            return
+        if control_flow_error is None:
+            control_flow_error = exc
+        build_error = exc.__class__.__name__
+
+    def _tick_progress() -> None:
+        assert stop_event is not None
+        while not stop_event.wait(0.5):
+            with _TREE_CACHE_LOCK:
+                if state.completion.is_set():
+                    return
+                state.progress = min(95, max(5, state.progress + 5))
+                _update_tree_job_locked(state)
+
+    try:
+        try:
+            stop_event = threading.Event()
+            t0 = time.time()
+            if tracemalloc.is_tracing():
+                snap_before = tracemalloc.take_snapshot()
+            ticker_thread = threading.Thread(target=_tick_progress, daemon=True)
+            ticker_thread.start()
+            ticker_started = True
+            with (
+                force_access_control_enforcement(),
+                override_current_actor(
+                    state.user_concept_id,
+                    state.organisation_concept_id,
+                ),
+            ):
+                tree_data = get_vontology_tree("Thing")
+            if isinstance(tree_data, Mapping) and tree_data.get("error") is not None:
+                build_error = str(tree_data["error"]).strip() or "Tree build failed."
+                tree_data = None
+        except BaseException as exc:
+            _record_failure(
+                exc,
+                "Failed to retrieve Vontology structure due to an internal server error.",
+            )
+            if isinstance(exc, Exception):
+                logging.getLogger(__name__).exception(
+                    "Unexpected Vontology tree failure"
+                )
+        finally:
+            if stop_event is not None:
+                try:
+                    stop_event.set()
+                except BaseException as exc:
+                    _record_failure(exc, "Tree progress cleanup failed.")
+            if ticker_thread is not None and ticker_started:
+                try:
+                    ticker_thread.join(timeout=0.5)
+                except BaseException as exc:
+                    _record_failure(exc, "Tree progress cleanup failed.")
+
             try:
-                _TREE_CACHE[cache_key] = (
-                    cache_record[0],
-                    payload,
+                completed_at_epoch = time.time()
+                if t0 is not None:
+                    build_secs = completed_at_epoch - t0
+            except BaseException as exc:
+                _record_failure(exc, "Tree timing failed.")
+
+            try:
+                if tracemalloc.is_tracing() and snap_before is not None:
+                    stats = tracemalloc.take_snapshot().compare_to(
+                        snap_before,
+                        "filename",
+                    )
+                    alloc_kb = sum(stat.size_diff for stat in stats) / 1024.0
+            except BaseException as exc:
+                stats = []
+                if not isinstance(exc, Exception):
+                    _record_failure(exc, "Tree allocation tracing failed.")
+    finally:
+        with _TREE_CACHE_LOCK:
+            state.result = tree_data
+            state.error = build_error
+            state.progress = 100
+            state.build_secs = build_secs
+            state.alloc_kb = alloc_kb
+            state.completed_at_epoch = completed_at_epoch
+            if (
+                tree_data is not None
+                and build_error is None
+                and state.generation == _TREE_BUILD_GENERATION
+                and _TREE_BUILDS_IN_FLIGHT.get(state.cache_key) is state
+            ):
+                _TREE_CACHE[state.cache_key] = (
+                    completed_at_epoch,
+                    tree_data,
                     build_secs,
                     alloc_kb,
-                    hits + 1,
+                    0,
                 )
-                hits += 1
-            except Exception:
-                pass
-        current_app.logger.debug(
-            "Tree cache hit (age=%.1fs build=%.2fs alloc=%.1fKB size_nodes=%s)",
-            now - cache_record[0],
-            build_secs,
-            alloc_kb,
-            len(payload.get("nodes", [])) if isinstance(payload, dict) else "n/a",
-        )
-        return jsonify(
-            {
-                **payload,
-                "_cache": {
-                    "hit": True,
-                    "age_sec": now - cache_record[0],
-                    "build_sec": build_secs,
-                    "alloc_kb": alloc_kb,
-                    "ttl_sec": _TREE_CACHE_TTL_SECONDS,
-                    "hits": hits,
-                },
-            }
-        )
-    # Build fresh
-    current_app.logger.debug("Tree cache miss (refresh=%s); building...", force_refresh)
-    t0 = time.time()
-    phase_marks = []
-    phase_log_enabled = (
-        os.getenv("VON_TREE_PHASE_LOG") in ("1", "true", "TRUE", "True")
-    ) and (not getattr(current_app, "testing", False))
-
-    def _mark(phase_name):
-        if not phase_log_enabled:
-            return
-        now = time.time()
-        phase_marks.append((phase_name, now))
-
-    # Only take snapshots if tracemalloc is running
-    snap_before = None
-    if tracemalloc.is_tracing():
-        snap_before = tracemalloc.take_snapshot()
-    _mark("snapshot_before")
-    try:
-        tree_data = get_vontology_tree("Thing")
-        if "error" in tree_data:
-            current_app.logger.error(
-                "Error getting Vontology tree: %s", tree_data["error"]
-            )
-            return jsonify({"error": tree_data["error"]}), 500
-    except Exception as e:
-        current_app.logger.error(
-            "Unexpected error building Vontology tree: %s", e, exc_info=True
-        )
-        return (
-            jsonify(
-                {
-                    "error": "Failed to retrieve Vontology structure due to an internal server error."
-                }
-            ),
-            500,
-        )
-    _mark("tree_built")
-    build_secs = time.time() - t0
-    # Only take snapshots if tracemalloc is running
-    snap_after = None
-    alloc_kb = 0.0
-    if tracemalloc.is_tracing() and snap_before is not None:
-        snap_after = tracemalloc.take_snapshot()
-        _mark("snapshot_after")
-        stats = snap_after.compare_to(snap_before, "filename")
-        _mark("snapshot_compared")
-        alloc_kb = sum([s.size_diff for s in stats]) / 1024.0
-    else:
-        _mark("snapshot_after")
-        stats = []
-        _mark("snapshot_compared")
-
-    # Optional verbose allocation diff logging
-    try:
-        if os.getenv("VON_TRACE_TREE") in ("1", "true", "TRUE", "True") and stats:
-            top_n = 15
+            if _TREE_BUILDS_IN_FLIGHT.get(state.cache_key) is state:
+                _TREE_BUILDS_IN_FLIGHT.pop(state.cache_key, None)
             try:
-                env_n = int(os.getenv("VON_TRACE_TREE_N", "15"))
-                if 1 <= env_n <= 100:
-                    top_n = env_n
-            except Exception:
-                pass
-            # Sort by absolute size diff descending
-            sorted_stats = sorted(stats, key=lambda s: abs(s.size_diff), reverse=True)[
-                :top_n
-            ]
-            for s in sorted_stats:
-                if s.size_diff == 0:
-                    continue
-                current_app.logger.info(
-                    "[tree_alloc_diff] %s size_diff=%.1fKB count_diff=%d",
-                    s.traceback[0].filename if s.traceback else "unknown",
-                    s.size_diff / 1024.0,
-                    s.count_diff,
-                )
-    except Exception:
-        pass
-    _mark("pre_cache_store")
-    with _TREE_CACHE_LOCK:
-        _TREE_CACHE[cache_key] = (time.time(), tree_data, build_secs, alloc_kb, 0)
-    _mark("post_cache_store")
-    # Persist performance metrics (non-blocking best-effort)
-    try:
-        record_tree_build_performance(build_secs)
-    except Exception:
-        pass
-    current_app.logger.info(
-        "Built Vontology tree build=%.2fs alloc_diff=%.1fKB nodes=%s",
-        build_secs,
-        alloc_kb,
-        len(tree_data.get("nodes", [])) if isinstance(tree_data, dict) else "n/a",
-    )
-    if phase_log_enabled:
-        # Emit a compact phase timing summary
+                _update_tree_job_locked(state)
+            finally:
+                state.completion.set()
+
+    if tree_data is not None and build_error is None:
         try:
-            phases_out = []
-            last_t = t0
-            for name, ts in phase_marks:
-                phases_out.append(f"{name}={1000*(ts-last_t):.1f}ms")
-                last_t = ts
-            total_ms = (time.time() - t0) * 1000.0
-            current_app.logger.info(
-                "[tree_build_phase] %s total=%.1fms", " ".join(phases_out), total_ms
-            )
+            record_tree_build_performance(build_secs)
         except Exception:
             pass
+        logging.getLogger(__name__).info(
+            "Built Vontology tree build=%.2fs alloc_diff=%.1fKB",
+            build_secs,
+            alloc_kb,
+        )
+    if os.getenv("VON_TRACE_TREE") in ("1", "true", "TRUE", "True"):
+        top_n = 15
+        try:
+            requested_top_n = int(os.getenv("VON_TRACE_TREE_N", "15"))
+            if 1 <= requested_top_n <= 100:
+                top_n = requested_top_n
+        except (TypeError, ValueError):
+            pass
+        for stat in sorted(
+            stats, key=lambda item: abs(item.size_diff), reverse=True
+        )[:top_n]:
+            if stat.size_diff:
+                try:
+                    logging.getLogger(__name__).info(
+                        "[tree_alloc_diff] %s size_diff=%.1fKB count_diff=%d",
+                        stat.traceback[0].filename if stat.traceback else "unknown",
+                        stat.size_diff / 1024.0,
+                        stat.count_diff,
+                    )
+                except Exception:
+                    pass
+
+    if control_flow_error is not None:
+        raise control_flow_error
+
+
+def _claim_tree_build_locked(
+    actor_scope: tuple[str | None, str | None],
+) -> tuple[_TreeBuildState, bool]:
+    cache_key = _tree_cache_key(actor_scope)
+    state = _TREE_BUILDS_IN_FLIGHT.get(cache_key)
+    if state is not None and state.generation == _TREE_BUILD_GENERATION:
+        return state, False
+    state = _TreeBuildState(
+        cache_key=cache_key,
+        user_concept_id=actor_scope[0],
+        organisation_concept_id=actor_scope[1],
+        generation=_TREE_BUILD_GENERATION,
+    )
+    _TREE_BUILDS_IN_FLIGHT[cache_key] = state
+    return state, True
+
+
+def _tree_payload_with_cache_metadata(
+    payload: Mapping[str, Any],
+    *,
+    hit: bool,
+    build_secs: float,
+    alloc_kb: float,
+    hits: int,
+    age_sec: float | None = None,
+) -> dict[str, Any]:
+    cache_metadata: dict[str, Any] = {
+        "hit": hit,
+        "build_sec": build_secs,
+        "alloc_kb": alloc_kb,
+        "ttl_sec": _TREE_CACHE_TTL_SECONDS,
+        "hits": hits,
+    }
+    if age_sec is not None:
+        cache_metadata["age_sec"] = age_sec
+    return {**payload, "_cache": cache_metadata}
+
+
+@vontology_bp.route("/tree", methods=["GET"])
+def get_tree():
+    """Return the actor-scoped Vontology tree with cache and single-flight reuse."""
+
+    current_app.logger.info("Received request for /api/vontology/tree")
+    force_refresh = request.args.get("refresh") in ("1", "true", "True")
+    actor_scope = _current_tree_job_actor_scope()
+    cache_key = _tree_cache_key(actor_scope)
+    now = time.time()
+
+    cached_response: dict[str, Any] | None = None
+    state: _TreeBuildState | None = None
+    is_owner = False
+    with _TREE_CACHE_LOCK:
+        cache_record = (
+            None
+            if force_refresh
+            else _fresh_tree_cache_record_locked(
+                cache_key,
+                now=now,
+            )
+        )
+        if cache_record is not None:
+            timestamp, payload, build_secs, alloc_kb, hits = cache_record
+            hits += 1
+            _TREE_CACHE[cache_key] = (
+                timestamp,
+                payload,
+                build_secs,
+                alloc_kb,
+                hits,
+            )
+            cached_response = _tree_payload_with_cache_metadata(
+                payload,
+                hit=True,
+                age_sec=now - timestamp,
+                build_secs=build_secs,
+                alloc_kb=alloc_kb,
+                hits=hits,
+            )
+        else:
+            state, is_owner = _claim_tree_build_locked(actor_scope)
+
+    if cached_response is not None:
+        return jsonify(cached_response)
+    assert state is not None
+
+    if is_owner:
+        _execute_tree_build(state)
+    else:
+        state.completion.wait()
+
+    if state.error is not None or state.result is None:
+        return jsonify({"error": state.error or "Tree build failed."}), 500
     return jsonify(
-        {
-            **tree_data,
-            "_cache": {
-                "hit": False,
-                "build_sec": build_secs,
-                "alloc_kb": alloc_kb,
-                "ttl_sec": _TREE_CACHE_TTL_SECONDS,
-                "hits": 0,
-            },
-        }
+        _tree_payload_with_cache_metadata(
+            state.result,
+            hit=False,
+            build_secs=state.build_secs,
+            alloc_kb=state.alloc_kb,
+            hits=0,
+        )
     )
 
 
@@ -681,9 +820,8 @@ def ensure_thing_route():
             current_app.logger.error(f"Error ensuring Thing exists: {result['error']}")
             return jsonify({"success": False, "message": result["error"]}), 500
 
-        # Invalidate tree cache since we modified the ontology structure
-        with _TREE_CACHE_LOCK:
-            _TREE_CACHE.clear()
+        # Invalidate tree cache since we modified the ontology structure.
+        _invalidate_tree_cache()
 
         current_app.logger.info(
             f"Thing ensured: created={result['thing_created']}, orphans_linked={result['orphans_linked']}"
@@ -710,7 +848,7 @@ def ensure_thing_route():
 
 
 def _current_tree_job_actor_scope() -> tuple[str | None, str | None]:
-    """Return the trusted read scope for an asynchronous tree job.
+    """Return the trusted, canonical read scope for a tree build.
 
     Organisation context is meaningful only when it is attached to an
     effective user. Discarding an otherwise residual organisation value keeps
@@ -722,6 +860,16 @@ def _current_tree_job_actor_scope() -> tuple[str | None, str | None]:
         get_effective_organisation_concept_id() if user_concept_id else None
     )
     return user_concept_id, organisation_concept_id
+
+
+def _invalidate_tree_cache() -> None:
+    """Fence stale builders and clear all completed tree projections."""
+
+    global _TREE_BUILD_GENERATION
+    with _TREE_CACHE_LOCK:
+        _TREE_BUILD_GENERATION += 1
+        _TREE_CACHE.clear()
+        _TREE_BUILDS_IN_FLIGHT.clear()
 
 
 def _tree_build_job_is_terminal(job: Mapping[str, Any]) -> bool:
@@ -746,146 +894,102 @@ def _prune_tree_build_progress(*, now_epoch: float | None = None) -> None:
             _TREE_BUILD_PROGRESS.pop(job_id, None)
 
 
-def _build_tree_job(
-    job_id: str,
-    user_concept_id: str | None,
-    organisation_concept_id: str | None,
-) -> None:
-    """Construct one Vontology tree under its captured actor visibility scope."""
+def _build_tree_job(state: _TreeBuildState) -> None:
+    """Background entry point for the shared physical tree builder."""
 
-    stop_event = threading.Event()
-    ticker_thread: threading.Thread | None = None
-    ticker_started = False
-    try:
-        t0 = time.time()
-        with (
-            force_access_control_enforcement(),
-            override_current_actor(
-                user_concept_id,
-                organisation_concept_id,
-            ),
-        ):
-            docs = list(ConceptsRepository.find({}, {"concept_id": 1}))
-            total = len(docs)
-            with _TREE_BUILD_PROGRESS_LOCK:
-                job = _TREE_BUILD_PROGRESS.get(job_id)
-                if job is None:
-                    return
-                job["total"] = total
-                job["processed"] = 0
+    _execute_tree_build(state)
 
-            def ticker():
-                """Increment progress periodically so the client sees activity."""
-                while not stop_event.wait(0.5):
-                    with _TREE_BUILD_PROGRESS_LOCK:
-                        current_job = _TREE_BUILD_PROGRESS.get(job_id)
-                        if not current_job or _tree_build_job_is_terminal(current_job):
-                            break
-                        current = current_job.get("processed", 0)
-                        current_job["processed"] = min(
-                            total,
-                            current + max(1, total // 20),
-                        )
 
-            ticker_thread = threading.Thread(target=ticker, daemon=True)
-            ticker_thread.start()
-            ticker_started = True
-
-            tree_data = get_vontology_tree("Thing")
-
-        returned_error = None
-        if isinstance(tree_data, Mapping) and tree_data.get("error") is not None:
-            returned_error = str(tree_data["error"]).strip() or "Tree build failed."
-
-        with _TREE_BUILD_PROGRESS_LOCK:
-            job = _TREE_BUILD_PROGRESS.get(job_id)
-            if job is not None:
-                job["processed"] = total
-                if returned_error is not None:
-                    job["error"] = returned_error
-                else:
-                    job["result"] = tree_data
-                job["completed_at_epoch"] = time.time()
-
-        try:
-            if returned_error is not None:
-                return
-            if os.getenv("VON_TREE_PHASE_LOG") in ("1", "true", "TRUE", "True"):
-                logger = None
-                try:
-                    logger = current_app.logger
-                    if getattr(current_app, "testing", False):
-                        logger = None
-                except Exception:
-                    pass
-                if logger is None:
-                    logger = logging.getLogger(__name__)
-                total_ms = (time.time() - t0) * 1000.0
-                node_count = "n/a"
-                try:
-
-                    def _count_nodes_list(nodes):
-                        c = 0
-                        for n in nodes or []:
-                            c += 1
-                            try:
-                                c += _count_nodes_list(n.get("children", []))
-                            except Exception:
-                                continue
-                        return c
-
-                    if isinstance(tree_data, dict):
-                        roots = tree_data.get("tree", [])
-                        node_count = _count_nodes_list(roots)
-                except Exception:
-                    pass
-                logger.info(
-                    "[tree_build_async] total=%.1fms nodes=%s", total_ms, node_count
-                )
-        except Exception:
-            pass
-    except Exception as exc:
-        with _TREE_BUILD_PROGRESS_LOCK:
-            job = _TREE_BUILD_PROGRESS.get(job_id)
-            if job is not None:
-                job["error"] = str(exc).strip() or exc.__class__.__name__
-                job["completed_at_epoch"] = time.time()
-    finally:
-        stop_event.set()
-        if ticker_thread is not None and ticker_started:
-            ticker_thread.join(timeout=0.5)
+def _attach_tree_job_locked(
+    state: _TreeBuildState,
+    actor_scope: tuple[str | None, str | None],
+) -> str:
+    if state.job_id is not None and state.job_id in _TREE_BUILD_PROGRESS:
+        return state.job_id
+    job_id = uuid.uuid4().hex
+    state.job_id = job_id
+    _TREE_BUILD_PROGRESS[job_id] = {
+        "total": 100,
+        "processed": state.progress,
+        "result": state.result,
+        "error": state.error,
+        "owner_user_concept_id": actor_scope[0],
+        "owner_organisation_concept_id": actor_scope[1],
+        "completed_at_epoch": state.completed_at_epoch,
+        "build_state": state,
+    }
+    return job_id
 
 
 @vontology_bp.route("/tree_async", methods=["POST"])
 def build_tree_async_route():
-    """Initialise an asynchronous Vontology tree build."""
+    """Initialise or join an actor-scoped asynchronous Vontology tree build."""
+
     _prune_tree_build_progress()
-    job_id = uuid.uuid4().hex
-    user_concept_id, organisation_concept_id = _current_tree_job_actor_scope()
-    with _TREE_BUILD_PROGRESS_LOCK:
-        _TREE_BUILD_PROGRESS[job_id] = {
-            "total": 0,
-            "processed": 0,
-            "result": None,
-            "error": None,
-            "owner_user_concept_id": user_concept_id,
-            "owner_organisation_concept_id": organisation_concept_id,
-            "completed_at_epoch": None,
-        }
-    try:
-        thread = threading.Thread(
-            target=_build_tree_job,
-            args=(job_id, user_concept_id, organisation_concept_id),
-            daemon=True,
+    actor_scope = _current_tree_job_actor_scope()
+    cache_key = _tree_cache_key(actor_scope)
+    force_refresh = request.args.get("refresh") in ("1", "true", "True")
+    with _TREE_CACHE_LOCK:
+        cache_record = None if force_refresh else _fresh_tree_cache_record_locked(
+            cache_key,
+            now=time.time(),
         )
-        thread.start()
-    except Exception:
-        with _TREE_BUILD_PROGRESS_LOCK:
-            _TREE_BUILD_PROGRESS.pop(job_id, None)
-        current_app.logger.exception(
-            "Failed to start asynchronous Vontology tree build"
-        )
-        return jsonify({"error": "tree build could not be started"}), 500
+        if cache_record is not None:
+            timestamp, payload, build_secs, alloc_kb, hits = cache_record
+            hits += 1
+            _TREE_CACHE[cache_key] = (
+                timestamp,
+                payload,
+                build_secs,
+                alloc_kb,
+                hits,
+            )
+            state = _TreeBuildState(
+                cache_key=cache_key,
+                user_concept_id=actor_scope[0],
+                organisation_concept_id=actor_scope[1],
+                generation=_TREE_BUILD_GENERATION,
+                result=_tree_payload_with_cache_metadata(
+                    payload,
+                    hit=True,
+                    age_sec=time.time() - timestamp,
+                    build_secs=build_secs,
+                    alloc_kb=alloc_kb,
+                    hits=hits,
+                ),
+                progress=100,
+                build_secs=build_secs,
+                alloc_kb=alloc_kb,
+                completed_at_epoch=time.time(),
+            )
+            state.completion.set()
+            job_id = _attach_tree_job_locked(state, actor_scope)
+            return jsonify({"job_id": job_id}), 202
+
+        state, is_owner = _claim_tree_build_locked(actor_scope)
+        job_id = _attach_tree_job_locked(state, actor_scope)
+        if is_owner:
+            try:
+                thread = threading.Thread(
+                    target=_build_tree_job,
+                    args=(state,),
+                    daemon=True,
+                )
+                thread.start()
+            except BaseException as exc:
+                if _TREE_BUILDS_IN_FLIGHT.get(cache_key) is state:
+                    _TREE_BUILDS_IN_FLIGHT.pop(cache_key, None)
+                _TREE_BUILD_PROGRESS.pop(job_id, None)
+                state.error = "tree build could not be started"
+                state.progress = 100
+                state.completed_at_epoch = time.time()
+                state.completion.set()
+                current_app.logger.exception(
+                    "Failed to start asynchronous Vontology tree build"
+                )
+                if isinstance(exc, Exception):
+                    return jsonify({"error": "tree build could not be started"}), 500
+                raise
     return jsonify({"job_id": job_id}), 202
 
 

--- a/src/backend/services/concept_service.py
+++ b/src/backend/services/concept_service.py
@@ -208,6 +208,13 @@ def _invalidate_concept_mutation_caches() -> None:
         pass
 
     try:
+        from ..server.routes.vontology_routes import _invalidate_tree_cache
+
+        _invalidate_tree_cache()
+    except Exception:
+        pass
+
+    try:
         if get_workflow_discovery_cache_invalidation_enabled(default=True):
             from .workflow_discovery_service import (
                 invalidate_workflow_discovery_executability_caches,

--- a/src/backend/services/relationship_removal_service.py
+++ b/src/backend/services/relationship_removal_service.py
@@ -1447,6 +1447,7 @@ def undo_relationship_removal(
 
     restored_count = 0
     already_restored_count = 0
+    restored_concept_ids: set[str] = set()
     errors: list[dict[str, Any]] = []
 
     for tombstone in tombstones:
@@ -1478,6 +1479,7 @@ def undo_relationship_removal(
             )
             if changed:
                 restored_count += 1
+                restored_concept_ids.update((source_id, target))
             else:
                 already_restored_count += 1
         except Exception as exc:
@@ -1491,6 +1493,15 @@ def undo_relationship_removal(
                     "error_details": {"exception_type": type(exc).__name__},
                 }
             )
+
+    if restored_count > 0:
+        try:
+            invalidate_vontology_caches(
+                sorted(restored_concept_ids),
+                correlation_id=correlation_id,
+            )
+        except Exception:
+            logger.debug("Relationship undo cache invalidation failed", exc_info=True)
 
     status = "ok"
     if errors and restored_count > 0:

--- a/src/backend/services/relationship_write_service.py
+++ b/src/backend/services/relationship_write_service.py
@@ -77,6 +77,16 @@ SUGGESTED_SUPERTYPES: List[str] = [
 CORE_RELATIONSHIP_TEXT_PREDICATES: frozenset[str] = frozenset(
     {"hasContent", "hasDescription", "hasName"}
 )
+TREE_PROJECTION_RELATIONSHIP_PREDICATES: frozenset[str] = frozenset(
+    {
+        "is_a_type_of",
+        "has_subtype",
+        "is_an_instance_of",
+        "has_instance",
+        "most_salient_type",
+        *VISIBILITY_PREDICATE_ALIAS_TO_CANONICAL.values(),
+    }
+)
 
 
 def _emit_relationship_mutation_event(
@@ -170,6 +180,42 @@ def _invalidate_workflow_routing_projection_for_relationship_change(
         invalidate_workflow_discovery_executability_caches()
     except Exception:
         pass
+
+
+def _invalidate_vontology_projection_for_relationship_change(
+    *,
+    source_id: str,
+    predicate: str,
+    target_id: str,
+) -> None:
+    """Invalidate actor-scoped tree projections affected by an edge write."""
+
+    predicate_text = str(predicate or "").strip()
+    canonical_predicate = VISIBILITY_PREDICATE_ALIAS_TO_CANONICAL.get(
+        predicate_text,
+        predicate_text,
+    )
+    if canonical_predicate not in TREE_PROJECTION_RELATIONSHIP_PREDICATES:
+        return
+
+    try:
+        from ..vontology.utils_vontology import invalidate_vontology_caches
+
+        invalidate_vontology_caches(
+            [source_id, target_id],
+            correlation_id=(
+                "relationship-add:"
+                f"{source_id}:{canonical_predicate}:{target_id}"
+            ),
+        )
+    except Exception:
+        _logger.warning(
+            "relationship_write_service: Vontology projection invalidation failed for %s %s %s",
+            source_id,
+            predicate,
+            target_id,
+            exc_info=True,
+        )
 
 
 def _sync_relationship_extent_index_for_sources(source_ids: List[str]) -> None:
@@ -753,7 +799,8 @@ def add_relationship(
 
     normalised = normalise_structural_predicate(predicate)
 
-    if normalised in get_relationship_kinds_set():
+    is_structural = normalised in get_relationship_kinds_set()
+    if is_structural:
         result = add_structural_relationship(source_id, normalised, target, repo=repo)
         predicate_for_invalidation = normalised
     else:
@@ -763,11 +810,17 @@ def add_relationship(
     if isinstance(result, Mapping) and bool(result.get("success")):
         modified = (
             bool(result.get("forward_modified"))
+            or bool(result.get("inverse_modified"))
             or bool(result.get("modified"))
             or bool(result.get("created"))
         )
         if modified:
             _invalidate_workflow_routing_projection_for_relationship_change(
+                source_id=source_id,
+                predicate=predicate_for_invalidation,
+                target_id=target,
+            )
+            _invalidate_vontology_projection_for_relationship_change(
                 source_id=source_id,
                 predicate=predicate_for_invalidation,
                 target_id=target,

--- a/src/backend/vontology/utils_vontology.py
+++ b/src/backend/vontology/utils_vontology.py
@@ -1841,6 +1841,109 @@ def get_vontology_node_and_ancestor_instance_ids(
 
 
 # --- Function to get Vontology tree structure ---
+_VONTOLOGY_TREE_SANITISATION_BATCH_SIZE = 20_000
+_VONTOLOGY_TREE_DETAIL_QUERY_BATCH_SIZE = 10_000
+_VONTOLOGY_TREE_CURSOR_BATCH_SIZE = 10_000
+
+
+def _load_vontology_tree_type_documents() -> tuple[list[dict], int, int]:
+    """Load tree documents without repeatedly resolving relationship authority.
+
+    Structural fields must be sanitised before deciding whether a document is a
+    type.  In particular, an inaccessible relationship target is removed before
+    parent selection.  A large, tree-only sanitisation batch retains that
+    behaviour while collapsing the remote visibility-query fan-out.  Display
+    fields are fetched only for the documents that survive structural
+    classification.
+    """
+
+    structural_docs = list(
+        ConceptsRepository.find(
+            {},
+            {
+                "concept_id": 1,
+                "relationships.is_a_type_of": 1,
+                "relationships.most_salient_type": 1,
+                "relationships.is_an_instance_of": 1,
+                "_id": 0,
+            },
+            sanitisation_batch_size=_VONTOLOGY_TREE_SANITISATION_BATCH_SIZE,
+            cursor_batch_size=_VONTOLOGY_TREE_CURSOR_BATCH_SIZE,
+        )
+    )
+    existing_ids = {
+        doc.get("concept_id")
+        for doc in structural_docs
+        if isinstance(doc, dict) and isinstance(doc.get("concept_id"), str)
+    }
+
+    structural_types: list[dict] = []
+    skipped = 0
+    for doc in structural_docs:
+        if is_pure_instance(doc) and not is_predicate(doc):
+            skipped += 1
+            continue
+        if not isinstance(doc.get("concept_id"), str) or not doc["concept_id"]:
+            continue
+        structural_types.append(doc)
+
+    detail_by_id: dict[str, dict] = {}
+    type_ids = [doc["concept_id"] for doc in structural_types]
+    for offset in range(0, len(type_ids), _VONTOLOGY_TREE_DETAIL_QUERY_BATCH_SIZE):
+        detail_ids = type_ids[offset : offset + _VONTOLOGY_TREE_DETAIL_QUERY_BATCH_SIZE]
+        details = ConceptsRepository.find(
+            {"concept_id": {"$in": detail_ids}},
+            {
+                "concept_id": 1,
+                "name": 1,
+                "names": 1,
+                "path": 1,
+                "_id": 1,
+            },
+            sanitisation_batch_size=_VONTOLOGY_TREE_SANITISATION_BATCH_SIZE,
+            cursor_batch_size=_VONTOLOGY_TREE_CURSOR_BATCH_SIZE,
+        )
+        for detail in details:
+            concept_id = detail.get("concept_id") if isinstance(detail, dict) else None
+            if isinstance(concept_id, str) and concept_id:
+                detail_by_id[concept_id] = detail
+
+    types: list[dict] = []
+    for structural_doc in structural_types:
+        concept_id = structural_doc["concept_id"]
+        detail = detail_by_id.get(concept_id)
+        if detail is None:
+            # The concept disappeared or became inaccessible between the two
+            # reads.  Excluding it is safer than returning a stale projection.
+            continue
+        types.append({**structural_doc, **detail})
+
+    # Inject virtual code concepts so they can render in the tree even when not
+    # persisted as concept documents.  Existing IDs are calculated from the
+    # complete structural read, matching the previous all-document loader.
+    virtual_count = 0
+    try:
+        from .code_concepts_registry import (
+            build_virtual_concept_doc,
+            iter_code_concepts,
+        )
+
+        for code_concept in iter_code_concepts():
+            if code_concept.concept_id in existing_ids:
+                continue
+            virtual_doc = build_virtual_concept_doc(code_concept.concept_id)
+            if isinstance(virtual_doc, dict) and virtual_doc.get("concept_id"):
+                virtual_count += 1
+                if is_pure_instance(virtual_doc) and not is_predicate(virtual_doc):
+                    skipped += 1
+                    continue
+                types.append(virtual_doc)
+    except Exception:
+        pass
+
+    return types, len(structural_docs) + virtual_count, skipped
+
+
 def get_vontology_tree(root_concept: str = "Thing"):
     """Return a single-root ontology tree (root = Thing) with exactly one parent per non-root type.
 
@@ -1852,57 +1955,9 @@ def get_vontology_tree(root_concept: str = "Thing"):
     """
     logger.info(f"[get_vontology_tree] START (version={VONTOLOGY_UTILS_VERSION})")
     try:
-        docs = list(
-            ConceptsRepository.find(
-                {},
-                {
-                    "concept_id": 1,
-                    "name": 1,
-                    "names": 1,
-                    "relationships.is_a_type_of": 1,
-                    "relationships.most_salient_type": 1,
-                    "relationships.is_an_instance_of": 1,
-                    "path": 1,
-                    "_id": 1,
-                },
-            )
-        )
-        # Inject virtual code concepts so they can render in the tree even when not
-        # persisted as concept documents.
-        try:
-            from .code_concepts_registry import (
-                iter_code_concepts,
-                build_virtual_concept_doc,
-            )
-
-            existing_ids = {
-                d.get("concept_id")
-                for d in docs
-                if isinstance(d, dict) and isinstance(d.get("concept_id"), str)
-            }
-            for cc in iter_code_concepts():
-                if cc.concept_id in existing_ids:
-                    continue
-                vdoc = build_virtual_concept_doc(cc.concept_id)
-                if isinstance(vdoc, dict) and vdoc.get("concept_id"):
-                    docs.append(vdoc)
-        except Exception:
-            pass
-        total = len(docs)
+        types, total, skipped = _load_vontology_tree_type_documents()
         if not total:
             return {"tree": []}
-
-        # Separate out type docs
-        types: list[dict] = []
-        skipped = 0
-        for d in docs:
-            # Keep predicates in the tree even though they are often pure instances.
-            if is_pure_instance(d) and not is_predicate(d):
-                skipped += 1
-                continue
-            if not d.get("concept_id"):
-                continue
-            types.append(d)
         logger.info(
             f"[get_vontology_tree] Loaded {total} docs; types={len(types)}; skipped_pure_instances={skipped}"
         )
@@ -4560,9 +4615,9 @@ def invalidate_vontology_caches(
 
         # Clear tree cache
         try:
-            from ..server.routes.vontology_routes import _TREE_CACHE
+            from ..server.routes.vontology_routes import _invalidate_tree_cache
 
-            _TREE_CACHE.clear()
+            _invalidate_tree_cache()
             logger.info(f"Cleared tree cache for correlation_id {correlation_id}")
         except (ImportError, NameError):
             logger.debug("Tree cache not available for clearing")

--- a/src/frontend/web/von_interface/static/js/vontology.js
+++ b/src/frontend/web/von_interface/static/js/vontology.js
@@ -31,6 +31,7 @@ let __vontologyLatestEntityCounts = null;
 let __vontologyPreloadedTreeData = null;
 let __vontologyPreloadedEntityCounts = null;
 let __vontologyPreloadInFlight = null;
+let __vontologyPreloadGeneration = 0;
 // Global-ish busy indicator to signal heavy ontology operations (preload/build)
 if (typeof window !== 'undefined' && !window.__VONTOLOGY_BUSY) {
   window.__VONTOLOGY_BUSY = false;
@@ -738,8 +739,12 @@ export async function loadKeyConceptsForUser() {
   console.log('[loadKeyConceptsForUser] END - keyConceptIds Set size:', keyConceptIds.size);
 }
 
-export async function fetchAndRenderVontologyTree() {
+export async function fetchAndRenderVontologyTree({ forceRefresh = false } = {}) {
   console.log("[fetchAndRenderVontologyTree] Entered function.");
+
+  if (forceRefresh) {
+    retireVontologyPreload();
+  }
 
   // Load key concepts FIRST - this needs to happen regardless of tree rendering
   // Do this early so concept tabs that open can get the correct state
@@ -751,7 +756,7 @@ export async function fetchAndRenderVontologyTree() {
   const progressMgr = new ProgressManager((pct, text) => updateProgressBar(pct, text));
   // Determine whether to decouple counts from initial load based on global flag set during preload
   const decoupleCounts = !!(typeof window !== 'undefined' && window.__VONTOLOGY_DECOUPLE_COUNTS__);
-  if (__vontologyPreloadInFlight) {
+  if (!forceRefresh && __vontologyPreloadInFlight) {
     progressMgr.setPhase(ProgressPhase.FETCH);
     try {
       await __vontologyPreloadInFlight;
@@ -787,7 +792,7 @@ export async function fetchAndRenderVontologyTree() {
     let treeData;
     let entityCounts;
 
-    if (__vontologyPreloadedTreeData && (decoupleCounts || __vontologyPreloadedEntityCounts)) {
+    if (!forceRefresh && __vontologyPreloadedTreeData && (decoupleCounts || __vontologyPreloadedEntityCounts)) {
       // Fast path: use preloaded data, skip progress bar entirely (too fast to warrant one)
       treeData = __vontologyPreloadedTreeData;
       entityCounts = __vontologyPreloadedEntityCounts || {};
@@ -836,7 +841,10 @@ export async function fetchAndRenderVontologyTree() {
       let entityCountsResponseJson = null;
       const decouple = decoupleCounts;
       try {
-        const initResp = await vontologyFetch('/vontology/api/vontology/tree_async', { method: 'POST' });
+        const treeEndpoint = forceRefresh
+          ? '/vontology/api/vontology/tree_async?refresh=1'
+          : '/vontology/api/vontology/tree_async';
+        const initResp = await vontologyFetch(treeEndpoint, { method: 'POST' });
         if (!initResp.ok) throw new Error(`HTTP error! status: ${initResp.status}`);
         const { job_id } = await initResp.json();
 
@@ -4082,7 +4090,7 @@ async function handleRefreshTree() {
     setVontologyTreeData(null);
 
     // Force a fresh fetch and render
-    await fetchAndRenderVontologyTree();
+    await fetchAndRenderVontologyTree({ forceRefresh: true });
 
     console.log("[handleRefreshTree] Tree refresh completed");
 
@@ -4343,6 +4351,7 @@ export function preloadVontologyData() {
     return __vontologyPreloadInFlight;
   }
   console.log('[preloadVontologyData] Checking whether to preload Vontology tree...');
+  const preloadGeneration = __vontologyPreloadGeneration;
   __vontologyPreloadInFlight = (async () => {
     let preloadTask = null;
     try {
@@ -4393,8 +4402,17 @@ export function preloadVontologyData() {
         }
       }
       const tree = await treePromise;
-      __vontologyPreloadedTreeData = tree;
-      __vontologyPreloadedEntityCounts = countsJson?.entity_counts || null;
+      if (!publishVontologyPreload(preloadGeneration, tree, countsJson?.entity_counts || null)) {
+        console.log('[preloadVontologyData] Discarding a preload retired by an explicit refresh.');
+        if (preloadTask) {
+          finishBackgroundTask(preloadTask, {
+            status: 'success',
+            detail: 'Preload retired by explicit refresh'
+          });
+          preloadTask = null;
+        }
+        return null;
+      }
       // Also seed the global state so helpers that rely on stored tree can function sooner
       try { setVontologyTreeData(tree); } catch (_) { }
       console.log('[preloadVontologyData] Preload complete. counts_on_load=', fetchCountsOnLoad);
@@ -4425,6 +4443,21 @@ export function preloadVontologyData() {
 // Helper for other modules to query busy status without touching window directly
 export function isVontologyBusy() {
   try { return typeof window !== 'undefined' && !!window.__VONTOLOGY_BUSY; } catch (_) { return false; }
+}
+
+function retireVontologyPreload() {
+  __vontologyPreloadGeneration += 1;
+  __vontologyPreloadedTreeData = null;
+  __vontologyPreloadedEntityCounts = null;
+}
+
+function publishVontologyPreload(generation, tree, entityCounts) {
+  if (generation !== __vontologyPreloadGeneration) {
+    return false;
+  }
+  __vontologyPreloadedTreeData = tree;
+  __vontologyPreloadedEntityCounts = entityCounts;
+  return true;
 }
 
 function getCachedPreloadSetting() {
@@ -4779,6 +4812,21 @@ export function __test_setTreeReady(val) { if (typeof val === 'boolean') { __von
 export function __test_getPendingSelections() { return Array.isArray(__pendingTreeSelections) ? [...__pendingTreeSelections] : []; }
 // Export for testing
 export function __test_clearPendingSelections() { if (Array.isArray(__pendingTreeSelections)) { __pendingTreeSelections.length = 0; } }
+
+// Export for testing
+export function __test_getVontologyPreloadState() {
+  return {
+    generation: __vontologyPreloadGeneration,
+    tree: __vontologyPreloadedTreeData,
+    entityCounts: __vontologyPreloadedEntityCounts
+  };
+}
+// Export for testing
+export function __test_publishVontologyPreload(generation, tree, entityCounts) {
+  return publishVontologyPreload(generation, tree, entityCounts);
+}
+// Export for testing
+export function __test_retireVontologyPreload() { retireVontologyPreload(); }
 
 // Export for testing
 export function __test_selectSearchItem(item) { return selectSearchItem(item); }

--- a/tests/backend/test_access_control_identity_resolution.py
+++ b/tests/backend/test_access_control_identity_resolution.py
@@ -124,6 +124,34 @@ def test_header_identity_cache_is_request_local(monkeypatch) -> None:
         assert access_control.get_effective_user_concept_id() == "#V#actor_b"
 
 
+def test_explicit_anonymous_actor_suppresses_ambient_identity_without_a_source(
+    monkeypatch,
+) -> None:
+    import src.backend.security.access_control as access_control
+    from flask import session
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    monkeypatch.setattr(
+        access_control,
+        "_validate_person_concept",
+        lambda concept_id: concept_id,
+    )
+
+    with app.test_request_context("/tree"):
+        session["user_concept_id"] = "#V#ambient_user"
+        session["organisation_concept_id"] = "#V#ambient_org"
+        with access_control.override_current_actor(None, None):
+            assert access_control.get_effective_user_concept_id_with_source() == (
+                None,
+                None,
+            )
+            assert access_control.get_effective_organisation_concept_id() is None
+            assert access_control.should_enforce_access_control() is True
+
+        assert access_control.get_effective_user_concept_id() == "#V#ambient_user"
+
+
 def test_visibility_evaluator_is_rebuilt_for_each_request_after_revocation(
     monkeypatch,
 ) -> None:

--- a/tests/backend/test_concepts_repository_query_deadline.py
+++ b/tests/backend/test_concepts_repository_query_deadline.py
@@ -13,6 +13,10 @@ class _FakeCursor:
         self.operations.append(("max_time_ms", value))
         return self
 
+    def batch_size(self, value: int) -> _FakeCursor:
+        self.operations.append(("batch_size", value))
+        return self
+
     def sort(self, value: list[tuple[str, int]]) -> _FakeCursor:
         self.operations.append(("sort", value))
         return self
@@ -61,6 +65,7 @@ def test_find_applies_server_deadline_before_cursor_options(monkeypatch) -> None
         skip=2,
         limit=3,
         max_time_ms=5_000,
+        cursor_batch_size=10_000,
     )
 
     assert collection.find_calls == [
@@ -74,8 +79,9 @@ def test_find_applies_server_deadline_before_cursor_options(monkeypatch) -> None
     ]
     assert cursor.operations == [
         ("max_time_ms", 5_000),
+        ("batch_size", 10_000),
         ("sort", [("concept_id", 1)]),
         ("skip", 2),
         ("limit", 3),
     ]
-    assert result._cursor is cursor
+    assert getattr(result, "_cursor") is cursor

--- a/tests/backend/test_relationship_write_tree_invalidation.py
+++ b/tests/backend/test_relationship_write_tree_invalidation.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import pytest
+
+from src.backend.services import relationship_write_service
+from src.backend.services import relationship_removal_service
+from src.backend.security.visibility_predicates import (
+    VISIBILITY_PREDICATE_ALIAS_TO_CANONICAL,
+)
+from src.backend.vontology import utils_vontology
+
+
+def _normalise_for_test(predicate: str) -> str:
+    return VISIBILITY_PREDICATE_ALIAS_TO_CANONICAL.get(predicate, predicate)
+
+
+@pytest.mark.parametrize(
+    ("predicate", "structural_predicates"),
+    [
+        ("is_a_type_of", {"is_a_type_of"}),
+        ("specific_to_organisation", set()),
+        ("#V#specific_to_user", set()),
+    ],
+)
+def test_tree_relevant_relationship_addition_invalidates_vontology_projection(
+    monkeypatch,
+    predicate: str,
+    structural_predicates: set[str],
+) -> None:
+    invalidations: list[tuple[list[str], str]] = []
+    monkeypatch.setattr(
+        relationship_write_service,
+        "get_relationship_kinds_set",
+        lambda: structural_predicates,
+    )
+    monkeypatch.setattr(
+        relationship_write_service,
+        "normalise_structural_predicate",
+        _normalise_for_test,
+    )
+    monkeypatch.setattr(
+        relationship_write_service,
+        "add_structural_relationship",
+        lambda *_args, **_kwargs: {"success": True, "forward_modified": True},
+    )
+    monkeypatch.setattr(
+        relationship_write_service,
+        "add_dynamic_relationship",
+        lambda *_args, **_kwargs: {"success": True, "modified": True},
+    )
+    monkeypatch.setattr(
+        relationship_write_service,
+        "_invalidate_workflow_routing_projection_for_relationship_change",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        utils_vontology,
+        "invalidate_vontology_caches",
+        lambda affected, correlation_id: invalidations.append(
+            (affected, correlation_id)
+        ),
+    )
+
+    result = relationship_write_service.add_relationship(
+        "#V#source",
+        predicate,
+        "#V#target",
+    )
+
+    assert result["success"] is True
+    assert len(invalidations) == 1
+    affected, correlation_id = invalidations[0]
+    assert affected == ["#V#source", "#V#target"]
+    assert correlation_id.startswith("relationship-add:#V#source:")
+
+
+def test_inverse_only_hierarchy_repair_invalidates_tree(
+    monkeypatch,
+) -> None:
+    invalidations: list[list[str]] = []
+    monkeypatch.setattr(
+        relationship_write_service,
+        "get_relationship_kinds_set",
+        lambda: {"has_subtype"},
+    )
+    monkeypatch.setattr(
+        relationship_write_service,
+        "normalise_structural_predicate",
+        _normalise_for_test,
+    )
+    monkeypatch.setattr(
+        relationship_write_service,
+        "add_structural_relationship",
+        lambda *_args, **_kwargs: {
+            "success": True,
+            "forward_modified": False,
+            "inverse_modified": True,
+        },
+    )
+    monkeypatch.setattr(
+        relationship_write_service,
+        "_invalidate_workflow_routing_projection_for_relationship_change",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        utils_vontology,
+        "invalidate_vontology_caches",
+        lambda affected, **_kwargs: invalidations.append(affected),
+    )
+
+    relationship_write_service.add_relationship(
+        "#V#parent",
+        "has_subtype",
+        "#V#child",
+    )
+
+    assert invalidations == [["#V#parent", "#V#child"]]
+
+
+def test_unrelated_structural_relationship_does_not_invalidate_tree(
+    monkeypatch,
+) -> None:
+    invalidations = 0
+
+    def invalidate(*_args, **_kwargs) -> None:
+        nonlocal invalidations
+        invalidations += 1
+
+    monkeypatch.setattr(
+        relationship_write_service,
+        "get_relationship_kinds_set",
+        lambda: {"related_to"},
+    )
+    monkeypatch.setattr(
+        relationship_write_service,
+        "normalise_structural_predicate",
+        _normalise_for_test,
+    )
+    monkeypatch.setattr(
+        relationship_write_service,
+        "add_structural_relationship",
+        lambda *_args, **_kwargs: {"success": True, "forward_modified": True},
+    )
+    monkeypatch.setattr(
+        relationship_write_service,
+        "_invalidate_workflow_routing_projection_for_relationship_change",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        utils_vontology,
+        "invalidate_vontology_caches",
+        invalidate,
+    )
+
+    result = relationship_write_service.add_relationship(
+        "#V#source",
+        "related_to",
+        "#V#target",
+    )
+
+    assert result["success"] is True
+    assert invalidations == 0
+
+
+def test_relationship_undo_invalidates_vontology_projection(monkeypatch) -> None:
+    class Tombstones:
+        def find(self, *_args, **_kwargs):
+            return [
+                {
+                    "source_id": "#V#child",
+                    "predicate": "is_a_type_of",
+                    "target": "#V#parent",
+                }
+            ]
+
+    invalidations: list[tuple[list[str], str]] = []
+    monkeypatch.setattr(
+        relationship_removal_service,
+        "_tombstone_collection",
+        lambda: Tombstones(),
+    )
+    monkeypatch.setattr(
+        relationship_removal_service,
+        "_resolve_actor_context",
+        lambda: ("#V#actor", "user"),
+    )
+    monkeypatch.setattr(
+        relationship_removal_service,
+        "_append_audit_record",
+        lambda _record: None,
+    )
+    monkeypatch.setattr(
+        relationship_removal_service.ConceptsRepository,
+        "mutate_relationship_edge",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        relationship_removal_service,
+        "invalidate_vontology_caches",
+        lambda affected, correlation_id: invalidations.append(
+            (affected, correlation_id)
+        ),
+    )
+
+    result = relationship_removal_service.undo_relationship_removal(
+        undo_token="undo:test",
+        request_id="request-test",
+    )
+
+    assert result["success"] is True
+    assert result["restored_count"] == 1
+    assert invalidations == [(["#V#child", "#V#parent"], "request-test")]

--- a/tests/backend/test_virtual_code_predicate_concepts.py
+++ b/tests/backend/test_virtual_code_predicate_concepts.py
@@ -77,6 +77,9 @@ def test_tree_includes_virtual_code_predicates_under_predicate_type(monkeypatch)
     ids = _flatten_tree_ids(root)
 
     assert "#V#hasContent" in ids
+    assert "#V#organisation_ontology_administrator" not in ids
+    assert "#V#global_ontology_administrator" not in ids
+    assert "#V#von_operational_administrator" not in ids
 
     # Also check the structural expectation: hasContent is placed somewhere under #V#predicate.
     # We do this by locating the predicate node and verifying it contains the child.

--- a/tests/backend/test_vontology_tree_async_authority.py
+++ b/tests/backend/test_vontology_tree_async_authority.py
@@ -20,6 +20,7 @@ class _DeferredThread:
         target: Callable[..., Any],
         args: tuple[Any, ...] = (),
         daemon: bool | None = None,
+        **_kwargs: Any,
     ) -> None:
         self.target = target
         self.args = args
@@ -58,9 +59,13 @@ def _clear_tree_job_state():
     _DeferredThread.created.clear()
     with routes._TREE_BUILD_PROGRESS_LOCK:
         routes._TREE_BUILD_PROGRESS.clear()
+        routes._TREE_CACHE.clear()
+        routes._TREE_BUILDS_IN_FLIGHT.clear()
     yield
     with routes._TREE_BUILD_PROGRESS_LOCK:
         routes._TREE_BUILD_PROGRESS.clear()
+        routes._TREE_CACHE.clear()
+        routes._TREE_BUILDS_IN_FLIGHT.clear()
 
 
 @pytest.fixture
@@ -147,6 +152,7 @@ def _install_visible_tree(
 
     monkeypatch.setattr(routes.ConceptsRepository, "find", _find)
     monkeypatch.setattr(routes, "get_vontology_tree", _tree)
+    monkeypatch.setattr(routes, "record_tree_build_performance", lambda _secs: None)
     return observations
 
 
@@ -185,10 +191,7 @@ def test_authenticated_tree_worker_reapplies_exact_actor_scope(
         "#V#alice_private",
         "#V#org_a_private",
     }
-    assert observations == [
-        ("progress_scan", "#V#alice", "#V#org_a", True),
-        ("tree_build", "#V#alice", "#V#org_a", True),
-    ]
+    assert observations == [("tree_build", "#V#alice", "#V#org_a", True)]
     assert access_control.get_effective_user_concept_id() is None
     assert access_control.get_effective_organisation_concept_id() is None
     assert access_control.should_enforce_access_control() is False
@@ -206,16 +209,15 @@ def test_anonymous_tree_worker_discards_residual_org_and_is_global_only(
 
     assert created.status_code == 202
     job_id = created.get_json()["job_id"]
-    assert _DeferredThread.created[0].args == (job_id, None, None)
+    state = _DeferredThread.created[0].args[0]
+    assert state.job_id == job_id
+    assert (state.user_concept_id, state.organisation_concept_id) == (None, None)
     _run_route_worker()
     completed = client.get(f"/api/vontology/tree_progress/{job_id}")
 
     assert completed.status_code == 200
     assert _tree_ids(completed.get_json()) == {"#V#global"}
-    assert observations == [
-        ("progress_scan", None, None, True),
-        ("tree_build", None, None, True),
-    ]
+    assert observations == [("tree_build", None, None, True)]
 
 
 def test_route_preserves_scope_in_a_real_background_thread(monkeypatch) -> None:
@@ -249,10 +251,7 @@ def test_route_preserves_scope_in_a_real_background_thread(monkeypatch) -> None:
         "#V#alice_private",
         "#V#org_a_private",
     }
-    assert observations == [
-        ("progress_scan", "#V#alice", "#V#org_a", True),
-        ("tree_build", "#V#alice", "#V#org_a", True),
-    ]
+    assert observations == [("tree_build", "#V#alice", "#V#org_a", True)]
 
 
 def test_validated_legacy_read_header_remains_bound_to_its_job(
@@ -282,10 +281,7 @@ def test_validated_legacy_read_header_remains_bound_to_its_job(
         "#V#global",
         "#V#alice_private",
     }
-    assert observations == [
-        ("progress_scan", "#V#alice", None, True),
-        ("tree_build", "#V#alice", None, True),
-    ]
+    assert observations == [("tree_build", "#V#alice", None, True)]
     assert client.get(f"/api/vontology/tree_progress/{job_id}").status_code == 404
 
 
@@ -343,11 +339,6 @@ def test_tree_worker_failures_are_terminal(
     failure_mode: str,
 ) -> None:
     _, client = app_client
-    monkeypatch.setattr(
-        routes.ConceptsRepository,
-        "find",
-        lambda _query, _projection: [{"concept_id": "#V#global"}],
-    )
     if failure_mode == "returned":
         monkeypatch.setattr(
             routes,
@@ -370,7 +361,12 @@ def test_tree_worker_failures_are_terminal(
     assert completed.status_code == 200
     payload = completed.get_json()
     assert payload["done"] is True
-    assert failure_mode in payload["error"]
+    if failure_mode == "returned":
+        assert failure_mode in payload["error"]
+    else:
+        assert payload["error"] == (
+            "Failed to retrieve Vontology structure due to an internal server error."
+        )
     assert "result" not in payload
     with routes._TREE_BUILD_PROGRESS_LOCK:
         assert isinstance(

--- a/tests/backend/test_vontology_tree_bulk_loading.py
+++ b/tests/backend/test_vontology_tree_bulk_loading.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.backend.db.repositories import concepts_repository
+from src.backend.security import access_control
+from src.backend.vontology import code_concepts_registry, utils_vontology
+
+
+def _flatten_tree(node: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    flattened: dict[str, dict[str, Any]] = {}
+
+    def visit(current: dict[str, Any]) -> None:
+        flattened[current["id"]] = current
+        for child in current.get("children", []):
+            visit(child)
+
+    visit(node)
+    return flattened
+
+
+def test_tree_loader_bulk_sanitises_structure_before_fetching_display_fields(
+    monkeypatch,
+) -> None:
+    structural_docs = [
+        {"concept_id": "#V#thing", "relationships": {}},
+        {
+            "concept_id": "#V#parent",
+            "relationships": {"is_a_type_of": ["#V#thing"]},
+        },
+        {
+            "concept_id": "#V#child",
+            "relationships": {
+                "is_a_type_of": ["#V#thing", "#V#parent"],
+                "most_salient_type": "#V#parent",
+            },
+        },
+        {
+            "concept_id": "#V#pure_individual",
+            "relationships": {"is_an_instance_of": ["#V#person"]},
+        },
+        {
+            "concept_id": "#V#hidden_target_erased",
+            # This is the exact document shape after relationship sanitisation
+            # removes an inaccessible sole instance target.  Classification
+            # must continue to happen after that sanitisation.
+            "relationships": {},
+        },
+    ]
+    display_docs = {
+        document["concept_id"]: {
+            "concept_id": document["concept_id"],
+            "name": document["concept_id"].removeprefix("#V#").replace("_", " "),
+            "path": document["concept_id"],
+            "_id": document["concept_id"],
+        }
+        for document in structural_docs
+    }
+    calls: list[tuple[dict, dict, dict]] = []
+
+    def fake_find(query: dict, projection: dict, **kwargs: Any):
+        calls.append((query, projection, kwargs))
+        if query == {}:
+            return list(structural_docs)
+        requested = set(query["concept_id"]["$in"])
+        return [display_docs[concept_id] for concept_id in requested]
+
+    monkeypatch.setattr(utils_vontology.ConceptsRepository, "find", fake_find)
+    monkeypatch.setattr(code_concepts_registry, "iter_code_concepts", lambda: ())
+
+    payload = utils_vontology.get_vontology_tree()
+
+    assert "error" not in payload
+    nodes = _flatten_tree(payload["tree"][0])
+    assert set(nodes) == {
+        "#V#thing",
+        "#V#parent",
+        "#V#child",
+        "#V#hidden_target_erased",
+    }
+    assert nodes["#V#child"] in nodes["#V#parent"]["children"]
+    assert nodes["#V#hidden_target_erased"] in nodes["#V#thing"]["children"]
+
+    assert len(calls) == 2
+    structural_query, structural_projection, structural_options = calls[0]
+    assert structural_query == {}
+    assert "name" not in structural_projection
+    assert structural_projection["relationships.is_an_instance_of"] == 1
+    assert structural_options["sanitisation_batch_size"] == 20_000
+    assert structural_options["cursor_batch_size"] == 10_000
+
+    detail_query, detail_projection, detail_options = calls[1]
+    assert "#V#pure_individual" not in detail_query["concept_id"]["$in"]
+    assert "#V#hidden_target_erased" in detail_query["concept_id"]["$in"]
+    assert detail_projection == {
+        "concept_id": 1,
+        "name": 1,
+        "names": 1,
+        "path": 1,
+        "_id": 1,
+    }
+    assert detail_options["sanitisation_batch_size"] == 20_000
+    assert detail_options["cursor_batch_size"] == 10_000
+
+
+def test_access_controlled_cursor_supports_a_tree_only_bulk_batch(
+    monkeypatch,
+) -> None:
+    documents = [
+        {"concept_id": f"#V#source_{index}", "relationships": {}}
+        for index in range(130)
+    ]
+    prewarm_sizes: list[int] = []
+    monkeypatch.setattr(
+        concepts_repository,
+        "prewarm_concept_relationship_access",
+        lambda batch: prewarm_sizes.append(len(batch)),
+    )
+    monkeypatch.setattr(
+        concepts_repository,
+        "sanitize_concept_document",
+        lambda document: document,
+    )
+
+    cursor = concepts_repository._AccessControlledCursor(
+        iter(documents),
+        sanitisation_batch_size=100,
+    )
+
+    assert list(cursor) == documents
+    assert prewarm_sizes == [100, 30]
+
+
+def test_relationship_visibility_ids_are_bounded_by_count_and_bson_size(
+    monkeypatch,
+) -> None:
+    count_batches = list(
+        access_control._bounded_access_id_query_batches(
+            f"#V#target_{index}" for index in range(10_001)
+        )
+    )
+    assert [len(batch) for batch in count_batches] == [10_000, 1]
+
+    monkeypatch.setattr(access_control, "_ACCESS_ID_QUERY_MAX_BSON_BYTES", 100)
+    byte_batches = list(
+        access_control._bounded_access_id_query_batches(
+            ["#V#" + ("a" * 50), "#V#" + ("b" * 50)]
+        )
+    )
+    assert [len(batch) for batch in byte_batches] == [1, 1]
+
+
+def test_bulk_cursor_bounds_integrated_relationship_visibility_fanout(
+    monkeypatch,
+) -> None:
+    document_count = 40_001
+
+    class FakeCursor(list):
+        def batch_size(self, _size: int):
+            return self
+
+    class CountingCollection:
+        def __init__(self) -> None:
+            self.find_calls = 0
+
+        def find(self, query: dict, _projection: dict):
+            self.find_calls += 1
+            return FakeCursor(
+                {
+                    "concept_id": concept_id,
+                    "relationships": {},
+                }
+                for concept_id in query["concept_id"]["$in"]
+            )
+
+    collection = CountingCollection()
+    monkeypatch.setattr(
+        access_control,
+        "get_concepts_collection",
+        lambda: collection,
+    )
+    sources = [
+        {
+            "concept_id": f"#V#source_{index}",
+            "relationships": {"related_to": [f"#V#target_{index}"]},
+        }
+        for index in range(document_count)
+    ]
+
+    with (
+        access_control.force_access_control_enforcement(),
+        access_control.override_current_actor("#V#reader", None),
+    ):
+        result = list(
+            concepts_repository._AccessControlledCursor(
+                iter(sources),
+                sanitisation_batch_size=20_000,
+            )
+        )
+
+    assert result == sources
+    # Three 20,000-source sanitisation waves become 2 + 2 + 1 bounded target
+    # lookups, instead of at least 626 source waves at the generic size of 64.
+    assert collection.find_calls == 5

--- a/tests/backend/test_vontology_tree_cache_singleflight.py
+++ b/tests/backend/test_vontology_tree_cache_singleflight.py
@@ -1,0 +1,443 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+import threading
+import time
+from typing import Any
+
+import pytest
+from flask import Flask
+
+from src.backend.security import access_control
+from src.backend.server.routes import vontology_routes as routes
+from src.backend.services import concept_service
+from src.backend.vontology import utils_vontology
+
+
+@pytest.fixture
+def app(monkeypatch) -> Iterator[Flask]:
+    flask_app = Flask(__name__)
+    flask_app.secret_key = "tree-singleflight-test"
+    flask_app.config["TESTING"] = True
+    flask_app.register_blueprint(routes.vontology_bp, url_prefix="/api/vontology")
+    monkeypatch.setattr(routes, "record_tree_build_performance", lambda _secs: None)
+    monkeypatch.setattr(routes.tracemalloc, "is_tracing", lambda: False)
+    with routes._TREE_CACHE_LOCK:
+        routes._TREE_CACHE.clear()
+        routes._TREE_BUILDS_IN_FLIGHT.clear()
+        routes._TREE_BUILD_PROGRESS.clear()
+    yield flask_app
+    with routes._TREE_CACHE_LOCK:
+        routes._TREE_CACHE.clear()
+        routes._TREE_BUILDS_IN_FLIGHT.clear()
+        routes._TREE_BUILD_PROGRESS.clear()
+
+
+def _set_actor(client, user: str | None, organisation: str | None) -> None:
+    with client.session_transaction() as flask_session:
+        flask_session.clear()
+        if user is not None:
+            flask_session["user_concept_id"] = user
+        if organisation is not None:
+            flask_session["organisation_concept_id"] = organisation
+
+
+def _poll(client, job_id: str) -> dict[str, Any]:
+    response = client.get(f"/api/vontology/tree_progress/{job_id}")
+    assert response.status_code == 200
+    return response.get_json()
+
+
+def _await_completed(client, job_id: str) -> dict[str, Any]:
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        payload = _poll(client, job_id)
+        if payload["done"]:
+            return payload
+        time.sleep(0.01)
+    raise AssertionError("tree job did not complete")
+
+
+def test_sync_and_async_share_anonymous_global_cache_despite_residual_org(
+    app: Flask,
+    monkeypatch,
+) -> None:
+    observations: list[tuple[str | None, str | None, bool]] = []
+
+    def build(_root: str) -> dict[str, Any]:
+        observations.append(
+            (
+                access_control.get_effective_user_concept_id(),
+                access_control.get_effective_organisation_concept_id(),
+                access_control.should_enforce_access_control(),
+            )
+        )
+        return {"tree": [{"id": "#V#global", "children": []}]}
+
+    monkeypatch.setattr(routes, "get_vontology_tree", build)
+    client = app.test_client()
+    _set_actor(client, None, "#V#stale_org")
+
+    synchronous = client.get("/api/vontology/tree")
+    created = client.post("/api/vontology/tree_async")
+    completed = _poll(client, created.get_json()["job_id"])
+
+    assert synchronous.status_code == 200
+    assert created.status_code == 202
+    assert synchronous.get_json()["_cache"]["hit"] is False
+    assert completed["result"]["_cache"]["hit"] is True
+    assert completed["progress"] == 100
+    assert completed["done"] is True
+    assert observations == [(None, None, True)]
+    with routes._TREE_CACHE_LOCK:
+        assert list(routes._TREE_CACHE) == [(None, None, "Thing")]
+
+
+def test_tree_cache_lookup_prunes_expired_records_for_other_scopes(
+    app: Flask,
+    monkeypatch,
+) -> None:
+    del app
+    monkeypatch.setattr(routes, "_TREE_CACHE_TTL_SECONDS", 60)
+    current_key = ("#V#current", "#V#org", "Thing")
+    stale_key = ("#V#stale", "#V#org", "Thing")
+    with routes._TREE_CACHE_LOCK:
+        routes._TREE_CACHE[current_key] = (100.0, {"tree": []}, 1.0, 0.0, 0)
+        routes._TREE_CACHE[stale_key] = (1.0, {"tree": []}, 1.0, 0.0, 0)
+        record = routes._fresh_tree_cache_record_locked(current_key, now=120.0)
+
+    assert record is not None
+    with routes._TREE_CACHE_LOCK:
+        assert stale_key not in routes._TREE_CACHE
+
+
+def test_overlapping_async_and_sync_requests_share_one_physical_build(
+    app: Flask,
+    monkeypatch,
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    build_calls = 0
+
+    def build(_root: str) -> dict[str, Any]:
+        nonlocal build_calls
+        build_calls += 1
+        entered.set()
+        assert release.wait(timeout=3.0)
+        return {"tree": [{"id": "#V#thing", "children": []}]}
+
+    monkeypatch.setattr(routes, "get_vontology_tree", build)
+    first_client = app.test_client()
+    first = first_client.post("/api/vontology/tree_async")
+    assert first.status_code == 202
+    assert entered.wait(timeout=1.0)
+    job_id = first.get_json()["job_id"]
+
+    second = first_client.post("/api/vontology/tree_async")
+    assert second.status_code == 202
+    assert second.get_json()["job_id"] == job_id
+    running = _poll(first_client, job_id)
+    assert running["done"] is False
+    assert 0 <= running["progress"] < 100
+
+    sync_result: dict[str, Any] = {}
+
+    def sync_request() -> None:
+        with app.test_client() as sync_client:
+            response = sync_client.get("/api/vontology/tree")
+            sync_result["status"] = response.status_code
+            sync_result["payload"] = response.get_json()
+
+    sync_thread = threading.Thread(target=sync_request)
+    sync_thread.start()
+    release.set()
+    sync_thread.join(timeout=3.0)
+
+    assert sync_thread.is_alive() is False
+    assert sync_result["status"] == 200
+    assert sync_result["payload"]["_cache"]["hit"] is False
+    assert build_calls == 1
+    completed = _poll(first_client, job_id)
+    assert completed["done"] is True
+    assert completed["progress"] == 100
+
+
+def test_tree_cache_is_partitioned_by_exact_user_and_organisation(
+    app: Flask,
+    monkeypatch,
+) -> None:
+    observations: list[tuple[str | None, str | None]] = []
+
+    def build(_root: str) -> dict[str, Any]:
+        actor = (
+            access_control.get_effective_user_concept_id(),
+            access_control.get_effective_organisation_concept_id(),
+        )
+        observations.append(actor)
+        return {"tree": [{"id": "|".join(value or "none" for value in actor)}]}
+
+    monkeypatch.setattr(routes, "get_vontology_tree", build)
+    scopes = [
+        ("#V#alice", "#V#org_a"),
+        ("#V#alice", "#V#org_b"),
+        ("#V#bob", "#V#org_a"),
+        ("#V#a|org:#V#b", "#V#c"),
+        ("#V#a", "#V#b|org:#V#c"),
+    ]
+    clients = []
+    for user, organisation in scopes:
+        client = app.test_client()
+        _set_actor(client, user, organisation)
+        clients.append(client)
+        assert client.get("/api/vontology/tree").status_code == 200
+
+    assert observations == scopes
+    for client in clients:
+        response = client.get("/api/vontology/tree")
+        assert response.status_code == 200
+        assert response.get_json()["_cache"]["hit"] is True
+    assert observations == scopes
+
+
+def test_invalidation_fences_an_older_builder_from_overwriting_new_cache(
+    app: Flask,
+    monkeypatch,
+) -> None:
+    del app
+    old_entered = threading.Event()
+    release_old = threading.Event()
+    call_count = 0
+
+    def build(_root: str) -> dict[str, Any]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            old_entered.set()
+            assert release_old.wait(timeout=3.0)
+            return {"tree": [{"id": "old"}]}
+        return {"tree": [{"id": "new"}]}
+
+    monkeypatch.setattr(routes, "get_vontology_tree", build)
+    scope = (None, None)
+    with routes._TREE_CACHE_LOCK:
+        old_state, old_owner = routes._claim_tree_build_locked(scope)
+    assert old_owner is True
+    old_thread = threading.Thread(target=routes._execute_tree_build, args=(old_state,))
+    old_thread.start()
+    assert old_entered.wait(timeout=1.0)
+
+    monkeypatch.setattr(
+        "src.backend.services.vontology_concept_stats_service.invalidate_vontology_concept_stats_cache",
+        lambda **_kwargs: None,
+    )
+    utils_vontology.invalidate_vontology_caches(["#V#changed"], "tree-test")
+    with routes._TREE_CACHE_LOCK:
+        new_state, new_owner = routes._claim_tree_build_locked(scope)
+    assert new_owner is True
+    routes._execute_tree_build(new_state)
+    release_old.set()
+    old_thread.join(timeout=3.0)
+
+    assert old_thread.is_alive() is False
+    assert old_state.result == {"tree": [{"id": "old"}]}
+    assert new_state.result == {"tree": [{"id": "new"}]}
+    with routes._TREE_CACHE_LOCK:
+        assert routes._TREE_CACHE[routes._tree_cache_key(scope)][1] == new_state.result
+        assert routes._TREE_BUILDS_IN_FLIGHT == {}
+
+
+def test_async_refresh_bypasses_completed_cache(app: Flask, monkeypatch) -> None:
+    versions = iter(["first", "refreshed"])
+    build_calls = 0
+
+    def build(_root: str) -> dict[str, Any]:
+        nonlocal build_calls
+        build_calls += 1
+        return {"tree": [{"id": next(versions), "children": []}]}
+
+    monkeypatch.setattr(routes, "get_vontology_tree", build)
+    client = app.test_client()
+    assert client.get("/api/vontology/tree").status_code == 200
+
+    cached_job = client.post("/api/vontology/tree_async").get_json()["job_id"]
+    assert _poll(client, cached_job)["result"]["tree"][0]["id"] == "first"
+    assert build_calls == 1
+
+    refreshed = client.post("/api/vontology/tree_async?refresh=1")
+    assert refreshed.status_code == 202
+    refreshed_payload = _await_completed(client, refreshed.get_json()["job_id"])
+    assert refreshed_payload["result"]["tree"][0]["id"] == "refreshed"
+    assert build_calls == 2
+
+
+def test_snapshot_failure_releases_waiters_and_allows_retry(
+    app: Flask,
+    monkeypatch,
+) -> None:
+    client = app.test_client()
+    monkeypatch.setattr(routes.tracemalloc, "is_tracing", lambda: True)
+    monkeypatch.setattr(
+        routes.tracemalloc,
+        "take_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("snapshot failed")),
+    )
+
+    failed = client.get("/api/vontology/tree")
+
+    assert failed.status_code == 500
+    with routes._TREE_CACHE_LOCK:
+        assert routes._TREE_BUILDS_IN_FLIGHT == {}
+
+    monkeypatch.setattr(routes.tracemalloc, "is_tracing", lambda: False)
+    monkeypatch.setattr(
+        routes,
+        "get_vontology_tree",
+        lambda _root: {"tree": [{"id": "retry", "children": []}]},
+    )
+    assert client.get("/api/vontology/tree").status_code == 200
+
+
+def test_progress_event_construction_interrupt_releases_waiters(
+    app: Flask,
+    monkeypatch,
+) -> None:
+    del app
+    with routes._TREE_CACHE_LOCK:
+        state, is_owner = routes._claim_tree_build_locked((None, None))
+    assert is_owner is True
+    monkeypatch.setattr(
+        routes.threading,
+        "Event",
+        lambda: (_ for _ in ()).throw(KeyboardInterrupt),
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        routes._execute_tree_build(state)
+
+    assert state.completion.is_set()
+    assert state.error == "KeyboardInterrupt"
+    with routes._TREE_CACHE_LOCK:
+        assert routes._TREE_BUILDS_IN_FLIGHT == {}
+
+
+def test_progress_stop_interrupt_releases_waiters(
+    app: Flask,
+    monkeypatch,
+) -> None:
+    del app
+
+    class InterruptingEvent:
+        def set(self) -> None:
+            raise KeyboardInterrupt
+
+    class NoOpThread:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+        def join(self, *, timeout: float) -> None:
+            assert timeout == 0.5
+
+    with routes._TREE_CACHE_LOCK:
+        state, is_owner = routes._claim_tree_build_locked((None, None))
+    assert is_owner is True
+    monkeypatch.setattr(routes.threading, "Event", InterruptingEvent)
+    monkeypatch.setattr(routes.threading, "Thread", NoOpThread)
+    monkeypatch.setattr(
+        routes,
+        "get_vontology_tree",
+        lambda _root: {"tree": [{"id": "discarded", "children": []}]},
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        routes._execute_tree_build(state)
+
+    assert state.completion.is_set()
+    assert state.error == "KeyboardInterrupt"
+    with routes._TREE_CACHE_LOCK:
+        assert routes._TREE_BUILDS_IN_FLIGHT == {}
+        assert routes._TREE_CACHE == {}
+
+
+def test_progress_cleanup_interrupt_releases_waiters_and_allows_retry(
+    app: Flask,
+    monkeypatch,
+) -> None:
+    del app
+
+    class InterruptingJoinThread:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+        def join(self, *, timeout: float) -> None:
+            assert timeout == 0.5
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(routes.threading, "Thread", InterruptingJoinThread)
+    monkeypatch.setattr(
+        routes,
+        "get_vontology_tree",
+        lambda _root: {"tree": [{"id": "discarded", "children": []}]},
+    )
+    with routes._TREE_CACHE_LOCK:
+        state, is_owner = routes._claim_tree_build_locked((None, None))
+    assert is_owner is True
+
+    with pytest.raises(KeyboardInterrupt):
+        routes._execute_tree_build(state)
+
+    assert state.completion.is_set()
+    assert state.error == "KeyboardInterrupt"
+    with routes._TREE_CACHE_LOCK:
+        assert routes._TREE_BUILDS_IN_FLIGHT == {}
+        assert routes._TREE_CACHE == {}
+
+
+def test_async_control_flow_start_failure_cleans_all_state(
+    app: Flask,
+    monkeypatch,
+) -> None:
+    class InterruptingThread:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        def start(self) -> None:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(routes.threading, "Thread", InterruptingThread)
+
+    with pytest.raises(KeyboardInterrupt):
+        app.test_client().post("/api/vontology/tree_async")
+
+    with routes._TREE_CACHE_LOCK:
+        assert routes._TREE_BUILDS_IN_FLIGHT == {}
+        assert routes._TREE_BUILD_PROGRESS == {}
+
+
+def test_canonical_concept_mutation_invalidation_fences_tree_builds(
+    app: Flask,
+    monkeypatch,
+) -> None:
+    del app
+    invalidations = 0
+
+    def invalidate() -> None:
+        nonlocal invalidations
+        invalidations += 1
+
+    monkeypatch.setattr(routes, "_invalidate_tree_cache", invalidate)
+    monkeypatch.setattr(concept_service, "invalidate_phrase_cache", lambda: None)
+    monkeypatch.setattr(
+        concept_service,
+        "get_workflow_discovery_cache_invalidation_enabled",
+        lambda **_kwargs: False,
+    )
+
+    concept_service._invalidate_concept_mutation_caches()
+
+    assert invalidations == 1

--- a/tests/frontend/vontologyTreeRefresh.test.js
+++ b/tests/frontend/vontologyTreeRefresh.test.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+
+const source = fs.readFileSync(
+  path.join(
+    __dirname,
+    '../../src/frontend/web/von_interface/static/js/vontology.js',
+  ),
+  'utf8',
+);
+
+describe('Vontology tree refresh cache bypass', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('manual refresh requests a fresh asynchronous tree build', () => {
+    expect(source).toContain(
+      'fetchAndRenderVontologyTree({ forceRefresh = false } = {})',
+    );
+    expect(source).toContain(
+      "'/vontology/api/vontology/tree_async?refresh=1'",
+    );
+    expect(source).toMatch(
+      /handleRefreshTree[\s\S]*fetchAndRenderVontologyTree\(\{ forceRefresh: true \}\)/,
+    );
+    expect(source).toContain('if (!forceRefresh && __vontologyPreloadInFlight)');
+    expect(source).toMatch(/if \(forceRefresh\) \{\s*retireVontologyPreload\(\);/);
+  });
+
+  test('retired preload data cannot overwrite a later explicit refresh', () => {
+    const vontology = require(
+      '../../src/frontend/web/von_interface/static/js/vontology.js'
+    );
+    const initial = vontology.__test_getVontologyPreloadState();
+    const oldTree = { tree: [{ id: '#V#old' }] };
+
+    expect(
+      vontology.__test_publishVontologyPreload(
+        initial.generation,
+        oldTree,
+        { '#V#old': { entity_count: 1 } },
+      ),
+    ).toBe(true);
+    vontology.__test_retireVontologyPreload();
+
+    const retired = vontology.__test_getVontologyPreloadState();
+    expect(retired.tree).toBeNull();
+    expect(retired.entityCounts).toBeNull();
+    expect(retired.generation).toBe(initial.generation + 1);
+    expect(
+      vontology.__test_publishVontologyPreload(
+        initial.generation,
+        oldTree,
+        null,
+      ),
+    ).toBe(false);
+    expect(vontology.__test_getVontologyPreloadState().tree).toBeNull();
+  });
+});


### PR DESCRIPTION
Merge decision: ready — Vontology tree loads now preserve actor visibility while avoiding the remote Atlas round-trip fan-out that dominated the path.

## User outcome

Opening or manually refreshing the Vontology tree is materially faster and does not leak, mix, or retain another user or organisation's tree projection.

Tracked under JVNAUTOSCI-2631.

## Material changes

- Loads a narrow structural projection in a tree-only large sanitisation batch, then fetches display fields only for surviving tree concepts.
- Bounds relationship-target visibility queries by count and BSON size while leaving generic repository batching defaults unchanged.
- Shares actor-scoped cache and single-flight state between synchronous and asynchronous tree routes.
- Reapplies the captured user/organisation scope in background workers; anonymous work is forced to global-only visibility.
- Makes polling, invalidation, refresh, preload retirement, failure cleanup, and cache generation boundaries explicit.
- Invalidates tree projections after canonical concept, hierarchy, kind, salient-type, and visibility mutations, including inverse-only repair and undo.
- Removes the asynchronous route's redundant full concept-ID progress scan.

## Root cause

The previous tree path read roughly 51,000 concept documents and sanitised them in batches of 64. Each batch synchronously prewarmed relationship-target visibility over remote Atlas, creating most of the route's latency before Python tree assembly. The asynchronous path then repeated a full ID scan for synthetic progress.

## Evidence

- Recorded cold baseline: 43.70 s; 75 `concepts.find` plus 65 `concepts.getMore` operations.
- Exact allow-listed candidate route: HTTP 200, one root, cache miss, 10.781 s; 5 finds plus 6 getMores.
- This observed comparison indicates about 75% lower latency and 92% fewer find/getMore operations; it is not a same-moment statistical benchmark.
- 47 focused backend tests passed.
- 2 frontend Jest tests passed against the actual module.
- Pyright: 0 errors and 0 warnings across changed Python production/test files.
- Ruff undefined/unused checks, JavaScript syntax, ESLint with 0 errors (baseline warnings only), and `git diff --check` passed.
- Independent concurrency/authority review exercised forced-refresh coalescing, invalidation fencing, actor tuple isolation, and interruption cleanup.

## Ship boundary

- **Minimum ship criteria:** exact actor-scoped route completes successfully with materially fewer Atlas operations; ordinary tree structure and virtual predicate behaviour remain correct; cross-user/org caching and polling fail closed; refresh and mutation invalidation cannot publish stale shared state.
- **Stop-ship conditions:** cross-scope result exposure, stale pre-invalidation publication, stuck waiters/jobs, lost manual refresh, structural result regression, or no material Atlas command reduction.
- **Non-blocking observations:** cache/single-flight state is process-local; genuinely hung active jobs are not age-retired; direct out-of-process database writes rely on the 60-second TTL; performance-metric persistence was disabled during the live read replay.
- **Non-goals:** redesigning authentication headers, adding distributed cache coordination, changing general concept-query batching, or attributing the earlier Atlas alert to this path.